### PR TITLE
fix(consolidation): separate tags from observation scopes

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2650,11 +2650,35 @@ class ConsolidationRequest(BaseModel):
     observation_scopes: list[list[str]] | None = Field(
         default=None,
         description=(
-            "Optional list of tag scopes to consolidate. Each scope is a list of tags. "
-            "Only unconsolidated memories whose tags contain all tags in at least one scope "
-            "will be processed. If omitted, all unconsolidated memories are processed."
+            "Optional exact observation write scopes to consolidate. A source fact is processed when at least "
+            "one of its resolved observation scopes exactly equals at least one requested scope, regardless of "
+            "tag order. Subset and superset scopes do not match; [[]] targets the shared/untagged scope."
         ),
     )
+    tags: list[str] | None = Field(
+        default=None,
+        description="Filter source facts by their ordinary tags. Mutually exclusive with tag_groups.",
+    )
+    tags_match: TagsMatch = Field(
+        default="any",
+        description=(
+            "How to match source-fact tags: 'any', 'all', 'any_strict', 'all_strict', or 'exact'. "
+            "With 'exact' and no tags (or []), only untagged source facts match."
+        ),
+    )
+    tag_groups: list[TagGroup] | None = Field(
+        default=None,
+        description=(
+            "Compound source-fact tag filter. Each entry is a leaf {tags, match} or compound "
+            "{and: [...]}, {or: [...]}, {not: ...}. Mutually exclusive with tags."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate_tags_exclusive(self) -> "ConsolidationRequest":
+        if self.tags is not None and self.tag_groups is not None:
+            raise ValueError("'tags' and 'tag_groups' are mutually exclusive. Use 'tag_groups' for compound filtering.")
+        return self
 
 
 class ConsolidationResponse(BaseModel):
@@ -6406,6 +6430,9 @@ def _register_routes(app: FastAPI):
                 bank_id=bank_id,
                 request_context=request_context,
                 observation_scopes=observation_scopes,
+                tags=request.tags if request else None,
+                tags_match=request.tags_match if request else "any",
+                tag_groups=request.tag_groups if request else None,
             )
             return ConsolidationResponse(
                 operation_id=result["operation_id"],

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -20,7 +20,7 @@ import json
 import logging
 import time
 import uuid
-from collections import defaultdict
+from collections import defaultdict, deque
 from contextlib import AsyncExitStack
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -29,10 +29,12 @@ from itertools import combinations
 from typing import TYPE_CHECKING, Any, Literal
 
 import asyncpg
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from ...config import get_config
 from ...worker.stage import set_stage
+from ..db.base import DatabaseConnection
+from ..db.result import ResultRow
 from ..db_utils import acquire_with_retry
 from ..llm_trace import (
     record_created_memory_ids,
@@ -44,6 +46,7 @@ from ..llm_trace import (
 from ..llm_wrapper import sanitize_llm_output
 from ..memory_engine import Budget, fq_table
 from ..retain import embedding_utils
+from ..search.tags import TagGroup, TagsMatch, build_tag_groups_where_clause, build_tags_where_clause
 from .prompts import (
     build_consolidation_input,
     build_consolidation_system_prompt,
@@ -367,17 +370,131 @@ class _BatchDeltas:
     cancelled: bool
 
 
-def _parse_observation_scopes(memory: dict[str, Any]) -> Any:
-    """Parse the per-memory ``observation_scopes`` column from a DB row.
-
-    asyncpg may return JSONB as a raw JSON string depending on driver settings;
-    accept both that and a pre-parsed value.
-    """
-    raw = memory.get("observation_scopes")
-    return json.loads(raw) if isinstance(raw, str) else raw
+ObservationScopesSpec = Literal["combined", "per_tag", "all_combinations", "shared"] | list[list[str]]
 
 
-def _resolve_obs_tags_list(memory: dict[str, Any]) -> list[list[str]] | None:
+class _ConsolidationMemory(BaseModel):
+    """Typed source-fact row consumed by the consolidation batch pipeline."""
+
+    id: uuid.UUID
+    text: str
+    occurred_start: datetime | None = None
+    occurred_end: datetime | None = None
+    event_date: datetime | None = None
+    tags: list[str] = Field(default_factory=list)
+    mentioned_at: datetime | None = None
+    observation_scopes: ObservationScopesSpec | None = None
+
+    @field_validator("occurred_start", "occurred_end", "event_date", "mentioned_at")
+    @classmethod
+    def ensure_temporal_timezone(cls, value: datetime | None) -> datetime | None:
+        if value is None or value.tzinfo is not None:
+            return value
+        return value.replace(tzinfo=timezone.utc)
+
+
+@dataclass(frozen=True)
+class _ScopeCandidateKey:
+    """Stable keyset position for the bounded observation-scope scan."""
+
+    created_at: datetime
+    id: uuid.UUID
+
+
+class _ScopeCandidate(BaseModel):
+    """Typed projection used while selecting sources by write scope."""
+
+    id: uuid.UUID
+    created_at: datetime
+    tags: list[str]
+    observation_scopes: ObservationScopesSpec | None
+
+    @field_validator("created_at")
+    @classmethod
+    def ensure_created_at_timezone(cls, value: datetime) -> datetime:
+        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+
+    @property
+    def key(self) -> _ScopeCandidateKey:
+        return _ScopeCandidateKey(created_at=self.created_at, id=self.id)
+
+
+_SCOPE_CANDIDATE_PAGE_SIZE = 500
+
+
+def _scope_candidate_from_row(conn: DatabaseConnection, row: ResultRow) -> _ScopeCandidate:
+    """Validate the known DB projection at the data-access boundary."""
+    return _ScopeCandidate(
+        id=row["id"],
+        created_at=row["created_at"],
+        tags=list(conn.parse_json(row["tags"]) or []),
+        observation_scopes=conn.parse_json(row["observation_scopes"]),
+    )
+
+
+def _consolidation_memory_from_row(conn: DatabaseConnection, row: ResultRow) -> _ConsolidationMemory:
+    """Validate a full source-fact projection at the database boundary."""
+    return _ConsolidationMemory(
+        id=row["id"],
+        text=row["text"],
+        occurred_start=row["occurred_start"],
+        occurred_end=row["occurred_end"],
+        event_date=row["event_date"],
+        tags=list(conn.parse_json(row["tags"]) or []),
+        mentioned_at=row["mentioned_at"],
+        observation_scopes=conn.parse_json(row["observation_scopes"]),
+    )
+
+
+async def _fetch_scope_candidate_page(
+    conn: DatabaseConnection,
+    source_tag_clause: str,
+    source_tag_params: list[Any],
+    snapshot_end: _ScopeCandidateKey,
+    after: _ScopeCandidateKey | None,
+    limit: int,
+) -> list[_ScopeCandidate]:
+    """Fetch one bounded keyset page from the scope-selection snapshot."""
+    params = list(source_tag_params)
+    snapshot_created_idx = len(params) + 1
+    params.append(snapshot_end.created_at)
+    snapshot_id_idx = len(params) + 1
+    params.append(snapshot_end.id)
+
+    cursor_clause = ""
+    if after is not None:
+        cursor_created_idx = len(params) + 1
+        params.append(after.created_at)
+        cursor_id_idx = len(params) + 1
+        params.append(after.id)
+        cursor_clause = (
+            f"AND (created_at > ${cursor_created_idx} OR "
+            f"(created_at = ${cursor_created_idx} AND id > ${cursor_id_idx}::uuid))"
+        )
+
+    limit_idx = len(params) + 1
+    params.append(limit)
+    rows = await conn.fetch(
+        f"""
+        SELECT id, created_at, tags, observation_scopes
+        FROM {fq_table("memory_units")}
+        WHERE bank_id = $1
+          AND consolidated_at IS NULL
+          AND consolidation_failed_at IS NULL
+          AND fact_type IN ('experience', 'world')
+          {source_tag_clause}
+          AND (created_at < ${snapshot_created_idx} OR
+               (created_at = ${snapshot_created_idx} AND id <= ${snapshot_id_idx}::uuid))
+          {cursor_clause}
+        ORDER BY created_at ASC, id ASC
+        LIMIT ${limit_idx}
+        """,
+        *params,
+    )
+    return [_scope_candidate_from_row(conn, row) for row in rows]
+
+
+def _resolve_obs_tags_list(memory: _ConsolidationMemory) -> list[list[str]] | None:
     """Resolve a memory's ``observation_scopes`` spec into concrete scope tags.
 
     Returns ``None`` for the default ``combined``-mode single pass (caller uses
@@ -392,8 +509,8 @@ def _resolve_obs_tags_list(memory: dict[str, Any]) -> list[list[str]] | None:
     provenance tags (e.g. per-session ids) without dropping those tags from the
     source facts.
     """
-    parsed = _parse_observation_scopes(memory)
-    tags = list(memory.get("tags") or [])
+    parsed = memory.observation_scopes
+    tags = memory.tags
 
     if parsed == "per_tag":
         return [[t] for t in tags] if tags else None
@@ -408,7 +525,7 @@ def _resolve_obs_tags_list(memory: dict[str, Any]) -> list[list[str]] | None:
     return parsed  # explicit list[list[str]]
 
 
-def _resolve_write_scopes(memory: dict[str, Any]) -> list[frozenset[str]]:
+def _resolve_write_scopes(memory: _ConsolidationMemory | _ScopeCandidate) -> list[frozenset[str]]:
     """Return the observation scopes a memory will write to, as frozensets.
 
     Used by the parallel dispatcher to acquire one lock per scope before
@@ -425,20 +542,38 @@ def _resolve_write_scopes(memory: dict[str, Any]) -> list[frozenset[str]]:
     Empty-tag memories collapse to a single ``frozenset()`` in all modes so they
     still take exactly one lock and serialise against other untagged work.
     """
-    parsed = _parse_observation_scopes(memory)
-    tags = list(memory.get("tags") or [])
-
+    tags = memory.tags
+    parsed = memory.observation_scopes
     if parsed == "per_tag":
-        return [frozenset([t]) for t in tags] if tags else [frozenset()]
+        return [frozenset([tag]) for tag in tags] if tags else [frozenset()]
     if parsed == "all_combinations":
         if not tags:
             return [frozenset()]
-        return [frozenset(c) for r in range(1, len(tags) + 1) for c in combinations(tags, r)]
+        return [frozenset(combo) for size in range(1, len(tags) + 1) for combo in combinations(tags, size)]
     if parsed == "shared":
         return [frozenset()]
     if parsed == "combined" or parsed is None:
         return [frozenset(tags)]
-    return [frozenset(s) for s in parsed]  # explicit list[list[str]]
+    return [frozenset(scope) for scope in parsed]
+
+
+def _matches_requested_observation_scopes(
+    candidate: _ScopeCandidate,
+    requested_scopes: set[frozenset[str]] | None,
+) -> bool:
+    """Return whether a source fact writes to any requested exact scope.
+
+    Observation scopes are addresses, not ordinary tag queries: a requested
+    subset must not select a source that only writes to a superset scope.  Both
+    sides are normalised to frozensets so tag order and duplicate tags do not
+    affect scope identity.  ``None`` means no observation-scope filter, while an
+    explicit empty outer list selects no source facts; ``[[]]`` targets only
+    sources whose resolved write scopes include the shared/untagged scope.
+    """
+    if requested_scopes is None:
+        return True
+    resolved = _resolve_write_scopes(candidate)
+    return bool(requested_scopes.intersection(resolved))
 
 
 def _scope_sort_key(scope: frozenset[str]) -> tuple[str, ...]:
@@ -555,7 +690,10 @@ class _SourceAggregation:
     tags: list[str]
 
 
-def _aggregate_source_fields(source_mems: list[dict[str, Any]], tags: list[str] | None = None) -> _SourceAggregation:
+def _aggregate_source_fields(
+    source_mems: list[_ConsolidationMemory],
+    tags: list[str] | None = None,
+) -> _SourceAggregation:
     """Compute the observation fields inherited from a set of source memories.
 
     Temporal aggregation rules:
@@ -570,12 +708,12 @@ def _aggregate_source_fields(source_mems: list[dict[str, Any]], tags: list[str] 
     ``tags`` defaults to those of the first source memory when not explicitly
     provided (all memories in a consolidation batch share the same tag set).
     """
-    effective_tags = tags if tags is not None else (source_mems[0].get("tags") or [] if source_mems else [])
+    effective_tags = tags if tags is not None else (source_mems[0].tags if source_mems else [])
     return _SourceAggregation(
-        event_date=_min_date(m.get("event_date") for m in source_mems),
-        occurred_start=_min_date(m.get("occurred_start") for m in source_mems),
-        occurred_end=_max_date(m.get("occurred_end") for m in source_mems),
-        mentioned_at=_max_date(m.get("mentioned_at") for m in source_mems),
+        event_date=_min_date(m.event_date for m in source_mems),
+        occurred_start=_min_date(m.occurred_start for m in source_mems),
+        occurred_end=_max_date(m.occurred_end for m in source_mems),
+        mentioned_at=_max_date(m.mentioned_at for m in source_mems),
         tags=effective_tags,
     )
 
@@ -762,6 +900,9 @@ async def run_consolidation_job(
     request_context: "RequestContext",
     operation_id: str | None = None,
     observation_scopes: list[list[str]] | None = None,
+    tags: list[str] | None = None,
+    tags_match: TagsMatch = "any",
+    tag_groups: list[TagGroup] | None = None,
 ) -> dict[str, Any]:
     """
     Run consolidation job for a bank.
@@ -773,9 +914,12 @@ async def run_consolidation_job(
         bank_id: Bank identifier
         request_context: Request context for authentication
         operation_id: Optional operation ID for tracking
-        observation_scopes: Optional list of tag scopes. When provided, only
-            unconsolidated memories whose tags contain all tags in at least one
-            scope are processed.
+        observation_scopes: Optional exact observation write scopes. A source
+            fact is processed when at least one resolved write scope equals a
+            requested scope.
+        tags: Optional ordinary source-fact tags to filter by.
+        tags_match: Matching mode for ``tags``.
+        tag_groups: Optional compound filter over ordinary source-fact tags.
 
     Returns:
         Dict with consolidation results
@@ -795,7 +939,16 @@ async def run_consolidation_job(
     trace_token = set_trace_context(trace_ctx) if trace_ctx is not None else None
     try:
         return await _run_consolidation_job(
-            memory_engine, bank_id, request_context, config, llm_config, operation_id, observation_scopes
+            memory_engine,
+            bank_id,
+            request_context,
+            config,
+            llm_config,
+            operation_id,
+            observation_scopes,
+            tags,
+            tags_match,
+            tag_groups,
         )
     finally:
         if trace_token is not None:
@@ -813,8 +966,14 @@ async def _run_consolidation_job(
     llm_config: Any,
     operation_id: str | None = None,
     observation_scopes: list[list[str]] | None = None,
+    tags: list[str] | None = None,
+    tags_match: TagsMatch = "any",
+    tag_groups: list[TagGroup] | None = None,
 ) -> dict[str, Any]:
     """Core consolidation flow. See ``run_consolidation_job`` for the public entrypoint."""
+    if tags is not None and tag_groups is not None:
+        raise ValueError("'tags' and 'tag_groups' are mutually exclusive")
+
     perf = ConsolidationPerfLog(bank_id)
     max_memories_per_batch = config.consolidation_batch_size
     max_memories_per_round = config.consolidation_max_memories_per_round
@@ -845,44 +1004,104 @@ async def _run_consolidation_job(
 
         perf.record_timing("fetch_bank", time.time() - t0)
 
-        # Build optional scope filter clause.  When observation_scopes is provided,
-        # only process memories whose tags contain all tags in at least one scope.
-        scope_clause = ""
-        scope_params: list[Any] = [bank_id]
-        if observation_scopes:
-            or_parts: list[str] = []
-            for scope_tags in observation_scopes:
-                idx = len(scope_params) + 1
-                or_parts.append(f"tags @> ${idx}::varchar[]")
-                scope_params.append(scope_tags)
-            scope_clause = " AND (" + " OR ".join(or_parts) + ")"
+        if observation_scopes == []:
+            logger.debug(f"No observation scopes requested for bank {bank_id}")
+            return {"status": "no_new_memories", "bank_id": bank_id, "memories_processed": 0}
 
-        # Count total unconsolidated memories for progress logging
-        total_count = await conn.fetchval(
-            f"""
-            SELECT COUNT(*)
-            FROM {fq_table("memory_units")}
-            WHERE bank_id = $1
-              AND consolidated_at IS NULL
-              AND consolidation_failed_at IS NULL
-              AND fact_type IN ('experience', 'world')
-              {scope_clause}
-            """,
-            *scope_params,
+        requested_observation_scopes = (
+            None if observation_scopes is None else {frozenset(scope) for scope in observation_scopes}
         )
 
-    if total_count == 0:
+        # Ordinary source tags use the same filter vocabulary as recall.  This
+        # is deliberately separate from observation_scopes: those are resolved
+        # write addresses and use exact scope identity below, not tag containment.
+        source_tag_clause = ""
+        source_tag_params: list[Any] = [bank_id]
+        next_param = 2
+        # ``tags_match`` belongs to the flat ``tags`` filter.  The sole
+        # no-tags exception is exact-empty (select untagged sources); when a
+        # compound tag_groups filter is present, its leaves carry their own
+        # match modes and must not be intersected with an implicit empty scope.
+        if tags is not None or (not tag_groups and tags_match == "exact"):
+            tag_clause, tag_params, next_param = build_tags_where_clause(
+                tags,
+                param_offset=next_param,
+                match=tags_match,
+            )
+            source_tag_clause += f" {tag_clause}"
+            source_tag_params.extend(tag_params)
+        if tag_groups:
+            groups_clause, groups_params, _ = build_tag_groups_where_clause(
+                tag_groups,
+                param_offset=next_param,
+            )
+            source_tag_clause += f" {groups_clause}"
+            source_tag_params.extend(groups_params)
+
+        scope_snapshot_end: _ScopeCandidateKey | None = None
+        if observation_scopes is not None:
+            # observation_scopes may be symbolic (per_tag/all_combinations/shared)
+            # or explicit. Capture an upper keyset boundary, then resolve and
+            # process each bounded page in one pass. We deliberately omit an
+            # exact progress total until the scan reaches its boundary: the
+            # previous pre-count doubled database transfer and scope-resolution
+            # work on large or sparse banks.
+            boundary_row = await conn.fetchrow(
+                f"""
+                SELECT id, created_at
+                FROM {fq_table("memory_units")}
+                WHERE bank_id = $1
+                  AND consolidated_at IS NULL
+                  AND consolidation_failed_at IS NULL
+                  AND fact_type IN ('experience', 'world')
+                  {source_tag_clause}
+                ORDER BY created_at DESC, id DESC
+                LIMIT 1
+                """,
+                *source_tag_params,
+            )
+            if boundary_row is not None:
+                boundary_created_at = boundary_row["created_at"]
+                if boundary_created_at.tzinfo is None:
+                    boundary_created_at = boundary_created_at.replace(tzinfo=timezone.utc)
+                scope_snapshot_end = _ScopeCandidateKey(
+                    created_at=boundary_created_at,
+                    id=boundary_row["id"],
+                )
+            total_count: int | None = None
+        else:
+            total_count = await conn.fetchval(
+                f"""
+                SELECT COUNT(*)
+                FROM {fq_table("memory_units")}
+                WHERE bank_id = $1
+                  AND consolidated_at IS NULL
+                  AND consolidation_failed_at IS NULL
+                  AND fact_type IN ('experience', 'world')
+                  {source_tag_clause}
+                """,
+                *source_tag_params,
+            )
+
+    if total_count == 0 or (observation_scopes is not None and scope_snapshot_end is None):
         logger.debug(f"No new memories to consolidate for bank {bank_id}")
         return {"status": "no_new_memories", "bank_id": bank_id, "memories_processed": 0}
 
-    logger.info(f"[CONSOLIDATION] bank={bank_id} total_unconsolidated={total_count}")
-    perf.log(f"[1] Found {total_count} pending memories to consolidate")
+    if total_count is None:
+        logger.info(f"[CONSOLIDATION] bank={bank_id} total_unconsolidated=pending_scope_scan")
+        perf.log("[1] Scanning pending memories for matching observation scopes")
+    else:
+        logger.info(f"[CONSOLIDATION] bank={bank_id} total_unconsolidated={total_count}")
+        perf.log(f"[1] Found {total_count} pending memories to consolidate")
+
+    scope_candidate_cursor: _ScopeCandidateKey | None = None
+    pending_scope_ids: deque[uuid.UUID] = deque()
+    scope_scan_exhausted = False
 
     # Initial durable progress snapshot so an operator polling the operation status
-    # API sees the job has started and how much work it found, before the first batch
-    # of LLM work completes (which can take minutes on a dense bank). Uses the same
-    # "consolidating" stage as the per-batch heartbeat so the operator sees a single
-    # phase advancing 0/N -> N/N rather than an opaque "scanning" -> "processing" hop.
+    # API sees the job has started before the first batch of LLM work completes
+    # (which can take minutes on a dense bank). Scope-targeted jobs omit the total
+    # until their one-pass keyset scan is exhausted.
     set_stage("consolidation.consolidating")
     await memory_engine._write_operation_progress(operation_id, stage="consolidating", processed=0, total=total_count)
 
@@ -902,13 +1121,18 @@ async def _run_consolidation_job(
                   AND consolidated_at IS NULL
                   AND consolidation_failed_at IS NULL
                   AND fact_type IN ('experience', 'world')
-                  {scope_clause}
+                  {source_tag_clause}
                 """,
-                *scope_params,
+                *source_tag_params,
             )
         return pending or 0
 
-    async def _progress_total(processed: int) -> int:
+    async def _progress_total(processed: int) -> int | None:
+        if observation_scopes is not None:
+            # A numeric total is only trustworthy after every candidate page is
+            # resolved. At that point all unprocessed matches are queued.
+            return processed + len(pending_scope_ids) if scope_scan_exhausted else None
+        assert total_count is not None
         # Cheap path: while we're still within the start-of-job estimate it's exact, so
         # no extra query. Only re-count once the estimate is exhausted (≈the final batch
         # normally, or repeatedly only if memories keep arriving mid-run).
@@ -957,57 +1181,100 @@ async def _run_consolidation_job(
         # Fetch next batch of unconsolidated memories
         async with acquire_with_retry(pool) as conn:
             t0 = time.time()
-            # scope_params[0] is bank_id; append fetch_limit after scope params
-            fetch_params = list(scope_params) + [fetch_limit]
-            limit_idx = len(fetch_params)
-            memories = await conn.fetch(
-                f"""
-                SELECT id, text, fact_type, occurred_start, occurred_end, event_date, tags, mentioned_at,
-                       observation_scopes
-                FROM {fq_table("memory_units")}
-                WHERE bank_id = $1
-                  AND consolidated_at IS NULL
-                  AND consolidation_failed_at IS NULL
-                  AND fact_type IN ('experience', 'world')
-                  {scope_clause}
-                ORDER BY created_at ASC
-                LIMIT ${limit_idx}
-                """,
-                *fetch_params,
-            )
+            if observation_scopes is not None:
+                assert scope_snapshot_end is not None
+                while len(pending_scope_ids) < fetch_limit and not scope_scan_exhausted:
+                    candidate_page = await _fetch_scope_candidate_page(
+                        conn,
+                        source_tag_clause,
+                        source_tag_params,
+                        scope_snapshot_end,
+                        scope_candidate_cursor,
+                        _SCOPE_CANDIDATE_PAGE_SIZE,
+                    )
+                    if not candidate_page:
+                        scope_scan_exhausted = True
+                        break
+                    scope_candidate_cursor = candidate_page[-1].key
+                    pending_scope_ids.extend(
+                        candidate.id
+                        for candidate in candidate_page
+                        if _matches_requested_observation_scopes(candidate, requested_observation_scopes)
+                    )
+
+                batch_ids = [pending_scope_ids.popleft() for _ in range(min(fetch_limit, len(pending_scope_ids)))]
+                if not batch_ids:
+                    break
+                memory_rows = await conn.fetch(
+                    f"""
+                    SELECT id, text, occurred_start, occurred_end, event_date, tags, mentioned_at,
+                           observation_scopes
+                    FROM {fq_table("memory_units")}
+                    WHERE bank_id = $1
+                      AND id = ANY($2::uuid[])
+                      AND consolidated_at IS NULL
+                      AND consolidation_failed_at IS NULL
+                      AND fact_type IN ('experience', 'world')
+                    ORDER BY created_at ASC, id ASC
+                    """,
+                    bank_id,
+                    batch_ids,
+                )
+            else:
+                fetch_params = list(source_tag_params) + [fetch_limit]
+                limit_idx = len(fetch_params)
+                memory_rows = await conn.fetch(
+                    f"""
+                    SELECT id, text, occurred_start, occurred_end, event_date, tags, mentioned_at,
+                           observation_scopes
+                    FROM {fq_table("memory_units")}
+                    WHERE bank_id = $1
+                      AND consolidated_at IS NULL
+                      AND consolidation_failed_at IS NULL
+                      AND fact_type IN ('experience', 'world')
+                      {source_tag_clause}
+                    ORDER BY created_at ASC, id ASC
+                    LIMIT ${limit_idx}
+                    """,
+                    *fetch_params,
+                )
+            memories = [_consolidation_memory_from_row(conn, row) for row in memory_rows]
             perf.record_timing("fetch_memories", time.time() - t0)
 
         if not memories:
+            if observation_scopes is not None and (pending_scope_ids or not scope_scan_exhausted):
+                continue  # A snapshotted source vanished; later candidates may still be live.
             break  # No more unconsolidated memories
 
-        # Group memories by exact tag set before batching — security requirement:
-        # memories with different tags must never share an LLM call.
-        tag_groups: dict[tuple[str, ...], list[dict[str, Any]]] = {}
-        for m in memories:
-            tag_key = tuple(sorted(m.get("tags") or []))
-            tag_groups.setdefault(tag_key, []).append(dict(m))
+        # Group by exact source tags and resolved write scopes before batching.
+        # Different source tags must never share an LLM call, and different
+        # write scopes need separate pass plans rather than inheriting the
+        # first memory's observation_scopes configuration.
+        memory_tag_groups: dict[
+            tuple[tuple[str, ...], tuple[tuple[str, ...], ...]],
+            list[_ConsolidationMemory],
+        ] = {}
+        for memory in memories:
+            tag_key = tuple(sorted(memory.tags))
+            write_scope_key = tuple(sorted((_scope_sort_key(scope) for scope in _resolve_write_scopes(memory))))
+            memory_tag_groups.setdefault((tag_key, write_scope_key), []).append(memory)
 
         # Split each tag group into LLM batches respecting llm_batch_size, keeping
         # the group boundary intact so the dispatcher can parallelise across
         # distinct groups while running each group's batches serially.
-        grouped_batches: list[list[list[dict[str, Any]]]] = []
-        for group in tag_groups.values():
-            grouped_batches.append([group[i : i + llm_batch_size] for i in range(0, len(group), llm_batch_size)])
-
-        # Compute each group's union write-scope set. Used below to acquire
-        # per-scope locks: any two groups whose write-scope sets share a scope S
-        # will serialise on the lock for S, leaving truly disjoint groups to run
-        # concurrently. We union over every memory because per-memory
-        # observation_scopes can differ within a group.
+        grouped_batches: list[list[list[_ConsolidationMemory]]] = []
         group_scopes: list[list[frozenset[str]]] = []
-        for batches in grouped_batches:
-            scopes: set[frozenset[str]] = set()
-            for batch in batches:
-                for memory in batch:
-                    scopes.update(_resolve_write_scopes(memory))
-            group_scopes.append(sorted(scopes, key=_scope_sort_key))
+        for (_, write_scope_key), group in memory_tag_groups.items():
+            grouped_batches.append([group[i : i + llm_batch_size] for i in range(0, len(group), llm_batch_size)])
+            # The resolved write-scope set is part of the grouping key, so all
+            # memories in this group already share it. Reuse the key rather than
+            # resolving every memory again before lock acquisition.
+            group_scopes.append(sorted({frozenset(scope) for scope in write_scope_key}, key=_scope_sort_key))
 
-        async def _process_one_llm_batch(llm_batch_local: list[dict[str, Any]], batch_num_local: int) -> _BatchDeltas:
+        async def _process_one_llm_batch(
+            llm_batch_local: list[_ConsolidationMemory],
+            batch_num_local: int,
+        ) -> _BatchDeltas:
             """Process one LLM batch independently. Returns local deltas + cancelled flag.
 
             Each batch records timings/llm-call counters into its OWN
@@ -1022,9 +1289,8 @@ async def _run_consolidation_job(
 
             local_tags: set[str] = set()
             for memory in llm_batch_local:
-                memory_tags = memory.get("tags") or []
-                if memory_tags:
-                    local_tags.update(memory_tags)
+                if memory.tags:
+                    local_tags.update(memory.tags)
 
             # Adaptive splitting: on LLM failure, halve the sub-batch and retry,
             # down to batch_size=1. Only if a single-memory batch still fails is
@@ -1034,7 +1300,7 @@ async def _run_consolidation_job(
             succeeded_ids: list[Any] = []
             failed_ids: list[Any] = []
 
-            pending: list[list[dict[str, Any]]] = [llm_batch_local]
+            pending: list[list[_ConsolidationMemory]] = [llm_batch_local]
             while pending:
                 sub_batch = pending.pop(0)
 
@@ -1104,14 +1370,14 @@ async def _run_consolidation_job(
                     )
                     pending[0:0] = [sub_batch[:mid], sub_batch[mid:]]
                 elif sub_llm_failed:
-                    failed_ids.append(sub_batch[0]["id"])
+                    failed_ids.append(sub_batch[0].id)
                     all_results.append({"action": "failed"})
                     logger.warning(
                         f"[CONSOLIDATION] bank={bank_id} LLM failed for single memory"
-                        f" {sub_batch[0]['id']}, marking consolidation_failed_at"
+                        f" {sub_batch[0].id}, marking consolidation_failed_at"
                     )
                 else:
-                    succeeded_ids.extend(m["id"] for m in sub_batch)
+                    succeeded_ids.extend(memory.id for memory in sub_batch)
                     all_results.extend(sub_results)
 
             async with acquire_with_retry(pool) as conn:
@@ -1194,10 +1460,12 @@ async def _run_consolidation_job(
                 if key in batch_perf.timings
             ]
             input_tokens = int(batch_perf.total_prompt_chars / 4)
+            reported_total = await _progress_total(cum_processed)
+            total_label = str(reported_total) if reported_total is not None else "?"
             logger.info(
                 f"[CONSOLIDATION] bank={bank_id} llm_batch #{batch_num_local}"
                 f" ({len(llm_batch_local)} memories, {batch_perf.llm_calls} llm calls)"
-                f" | processed={cum_processed}/{total_count}"
+                f" | processed={cum_processed}/{total_label}"
                 f" | {', '.join(timing_parts)}"
                 f" | created={local_stats['observations_created']}"
                 f" updated={local_stats['observations_updated']}"
@@ -1218,7 +1486,7 @@ async def _run_consolidation_job(
                 operation_id,
                 stage="consolidating",
                 processed=cum_processed,
-                total=await _progress_total(cum_processed),
+                total=reported_total,
                 detail={
                     "observations_created": cum_snapshot["observations_created"],
                     "observations_updated": cum_snapshot["observations_updated"],
@@ -1240,16 +1508,16 @@ async def _run_consolidation_job(
         # Number every batch up front so log line numbering is deterministic
         # regardless of dispatch order under parallelism. Each group keeps its own
         # (batch, number) list so it can be processed as one serial unit.
-        numbered_groups: list[list[tuple[list[dict[str, Any]], int]]] = []
+        numbered_groups: list[list[tuple[list[_ConsolidationMemory], int]]] = []
         for batches in grouped_batches:
-            numbered: list[tuple[list[dict[str, Any]], int]] = []
+            numbered: list[tuple[list[_ConsolidationMemory], int]] = []
             for b in batches:
                 llm_batch_num += 1
                 numbered.append((b, llm_batch_num))
             numbered_groups.append(numbered)
 
         async def _process_tag_group(
-            group_batches: list[tuple[list[dict[str, Any]], int]],
+            group_batches: list[tuple[list[_ConsolidationMemory], int]],
         ) -> list[_BatchDeltas]:
             # Batches within a group share a tag set and observation scope, so
             # they MUST run serially. Stop early if the op was cancelled mid-group.
@@ -1274,7 +1542,7 @@ async def _run_consolidation_job(
             scope_locks: defaultdict[frozenset[str], asyncio.Lock] = defaultdict(asyncio.Lock)
 
             async def _run_group(
-                group_batches: list[tuple[list[dict[str, Any]], int]],
+                group_batches: list[tuple[list[_ConsolidationMemory], int]],
                 scopes: list[frozenset[str]],
             ) -> list[_BatchDeltas]:
                 async with sem:
@@ -1313,6 +1581,16 @@ async def _run_consolidation_job(
                 hit_round_limit = True
                 break
 
+    if observation_scopes is not None and stats["memories_processed"] == 0:
+        logger.debug(f"No matching observation scopes to consolidate for bank {bank_id}")
+        await memory_engine._write_operation_progress(
+            operation_id,
+            stage="consolidating",
+            processed=0,
+            total=0,
+        )
+        return {"status": "no_new_memories", "bank_id": bank_id, "memories_processed": 0}
+
     # Re-submit consolidation if we hit the round limit and there's likely more work.
     # Any failure here must propagate: swallowing it (the prior behavior) leaves the
     # bank with backlog and no queued work — silently stuck — because the outer op
@@ -1321,15 +1599,24 @@ async def _run_consolidation_job(
     # consolidator skips already-consolidated rows via the consolidated_at filter and
     # picks up the remainder. Issue #1842.
     if hit_round_limit:
-        remaining = total_count - stats["memories_processed"]
-        logger.info(
-            f"[CONSOLIDATION] bank={bank_id} hit round limit of {max_memories_per_round} memories,"
-            f" ~{remaining} remaining. Re-queuing consolidation."
-        )
+        if total_count is None:
+            logger.info(
+                f"[CONSOLIDATION] bank={bank_id} hit round limit of {max_memories_per_round} memories;"
+                " scoped candidates remain uncounted. Re-queuing consolidation."
+            )
+        else:
+            remaining = total_count - stats["memories_processed"]
+            logger.info(
+                f"[CONSOLIDATION] bank={bank_id} hit round limit of {max_memories_per_round} memories,"
+                f" ~{remaining} remaining. Re-queuing consolidation."
+            )
         await memory_engine.submit_async_consolidation(
             bank_id=bank_id,
             request_context=request_context,
             observation_scopes=observation_scopes,
+            tags=tags,
+            tags_match=tags_match,
+            tag_groups=tag_groups,
         )
 
     # Build summary
@@ -1494,7 +1781,7 @@ async def _process_memory_batch(
     memory_engine: "MemoryEngine",
     llm_config: Any,
     bank_id: str,
-    memories: list[dict[str, Any]],
+    memories: list[_ConsolidationMemory],
     request_context: "RequestContext",
     perf: ConsolidationPerfLog | None = None,
     config: Any = None,
@@ -1523,7 +1810,7 @@ async def _process_memory_batch(
     import asyncio
 
     # Map the source memories this batch consumes onto the consolidation trace.
-    record_source_memory_ids([str(m["id"]) for m in memories])
+    record_source_memory_ids([str(memory.id) for memory in memories])
 
     # 1. Parallel recalls — one per fact
     # When obs_tags_override is set, use it as the observation scope for all facts.
@@ -1533,11 +1820,11 @@ async def _process_memory_batch(
         _find_related_observations(
             memory_engine=memory_engine,
             bank_id=bank_id,
-            query=m["text"],
+            query=memory.text,
             request_context=request_context,
-            tags=observation_scope_tags if observation_scope_tags is not None else (m.get("tags") or []),
+            tags=observation_scope_tags if observation_scope_tags is not None else memory.tags,
         )
-        for m in memories
+        for memory in memories
     ]
     per_fact_recalls = await asyncio.gather(*recall_tasks)
     if perf:
@@ -1545,7 +1832,7 @@ async def _process_memory_batch(
 
     # 2. Build per-fact observation sets (keyed by memory ID string) for secure action validation
     per_fact_obs_ids: dict[str, set[str]] = {
-        str(memories[i]["id"]): {str(obs.id) for obs in r.results} for i, r in enumerate(per_fact_recalls)
+        str(memories[i].id): {str(obs.id) for obs in recall.results} for i, recall in enumerate(per_fact_recalls)
     }
 
     # Union all observations (deduped by id)
@@ -1567,7 +1854,7 @@ async def _process_memory_batch(
         fact_tags = obs_tags_override
     else:
         # All memories in the batch share the same tag set (enforced by batching)
-        fact_tags = memories[0].get("tags") or [] if memories else []
+        fact_tags = memories[0].tags if memories else []
 
     # 2b. Compute remaining observation slots for this scope (if limit configured).
     # The cap is resolved per-scope: an observation_scope_limits rule may override
@@ -1606,7 +1893,7 @@ async def _process_memory_batch(
     per_memory_created: set[str] = set()
     per_memory_updated: set[str] = set()
 
-    mem_by_id = {str(m["id"]): m for m in memories}
+    mem_by_id = {str(memory.id): memory for memory in memories}
 
     # Semantic dedup: when enabled, an observation that is >= the threshold cosine to a DIFFERENT
     # existing observation is reconciled by a focused 1-by-1 LLM merge (anchored on the observation
@@ -1639,7 +1926,7 @@ async def _process_memory_batch(
         if not source_mems:
             continue
         # Security: the observation must have been recalled for at least one of the source facts
-        if not any(update.observation_id in per_fact_obs_ids.get(str(m["id"]), set()) for m in source_mems):
+        if not any(update.observation_id in per_fact_obs_ids.get(str(memory.id), set()) for memory in source_mems):
             logger.debug(
                 f"Batch consolidation: rejected update — observation {update.observation_id} "
                 f"not in any source fact's recall"
@@ -1650,7 +1937,7 @@ async def _process_memory_batch(
             conn=conn,
             memory_engine=memory_engine,
             bank_id=bank_id,
-            source_memory_ids=[m["id"] for m in source_mems],
+            source_memory_ids=[memory.id for memory in source_mems],
             observation_id=update.observation_id,
             new_text=update.text,
             observations=union_observations,
@@ -1660,8 +1947,8 @@ async def _process_memory_batch(
             source_mentioned_at=agg.mentioned_at,
             perf=perf,
         )
-        for m in source_mems:
-            per_memory_updated.add(str(m["id"]))
+        for memory in source_mems:
+            per_memory_updated.add(str(memory.id))
         # Reconcile the rewritten observation against its neighbours: the re-embed may have
         # drifted it into a near-twin of another existing observation (the residual-duplicate
         # source). updated_emb_str is None when the update was skipped — nothing to reconcile.
@@ -1694,7 +1981,7 @@ async def _process_memory_batch(
         if not source_mems:
             continue
         agg = _aggregate_source_fields(source_mems, tags=fact_tags)
-        create_source_ids = [m["id"] for m in source_mems]
+        create_source_ids = [memory.id for memory in source_mems]
 
         # Reconcile against observations shown to the LLM: an exact-text match means
         # this CREATE reproduces verbatim an observation the model already had in context.
@@ -1723,8 +2010,8 @@ async def _process_memory_batch(
                     merged_into[:8],
                     config.consolidation_dedup_threshold,
                 )
-                for m in source_mems:
-                    per_memory_created.add(str(m["id"]))
+                for memory in source_mems:
+                    per_memory_created.add(str(memory.id))
                 continue
 
         await _execute_create_action(
@@ -1740,13 +2027,13 @@ async def _process_memory_batch(
             mentioned_at=agg.mentioned_at,
             perf=perf,
         )
-        for m in source_mems:
-            per_memory_created.add(str(m["id"]))
+        for memory in source_mems:
+            per_memory_created.add(str(memory.id))
 
     # Build per-memory result dicts for the stats tracker in the outer loop
     results: list[dict[str, Any]] = []
-    for m in memories:
-        mid = str(m["id"])
+    for memory in memories:
+        mid = str(memory.id)
         created = mid in per_memory_created
         updated = mid in per_memory_updated
         if created and updated:
@@ -2195,7 +2482,7 @@ def _dedupe_updates(updates: list[_UpdateAction], *, batch_label: str) -> list[_
 
 async def _consolidate_batch_with_llm(
     llm_config: Any,
-    memories: list[dict[str, Any]],
+    memories: list[_ConsolidationMemory],
     union_observations: "list[MemoryFact]",
     union_source_facts: "dict[str, MemoryFact]",
     config: Any,
@@ -2211,15 +2498,15 @@ async def _consolidate_batch_with_llm(
     else:
         observations_text = "[]"
 
-    def _fact_line(m: dict[str, Any]) -> str:
-        text = f"[{m['id']}] {m['text']}"
+    def _fact_line(memory: _ConsolidationMemory) -> str:
+        text = f"[{memory.id}] {memory.text}"
         temporal_parts = []
-        if m.get("occurred_start"):
-            temporal_parts.append(f"occurred_start={m['occurred_start']}")
-        if m.get("occurred_end"):
-            temporal_parts.append(f"occurred_end={m['occurred_end']}")
-        if m.get("mentioned_at"):
-            temporal_parts.append(f"mentioned_at={m['mentioned_at']}")
+        if memory.occurred_start:
+            temporal_parts.append(f"occurred_start={memory.occurred_start}")
+        if memory.occurred_end:
+            temporal_parts.append(f"occurred_end={memory.occurred_end}")
+        if memory.mentioned_at:
+            temporal_parts.append(f"mentioned_at={memory.mentioned_at}")
         if temporal_parts:
             text += f" ({', '.join(temporal_parts)})"
         return text
@@ -2283,7 +2570,7 @@ async def _consolidate_batch_with_llm(
     # exact memories whose consolidation is failing — without this, an opaque
     # "LLM batch call failed" line gives operators no way to find the offending
     # input until adaptive bisection narrows the batch down to a single memory.
-    memory_ids = [str(m.get("id")) for m in memories]
+    memory_ids = [str(memory.id) for memory in memories]
     if len(memory_ids) <= 5:
         ids_label = ", ".join(memory_ids)
     else:

--- a/hindsight-api-slim/hindsight_api/engine/db/oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/oracle.py
@@ -544,6 +544,21 @@ def _rewrite_pg_to_oracle(query: str) -> RewriteResult:
         query,
     )
 
+    # PG array contained-by: tags <@ :N → Oracle: every element from the
+    # stored JSON array exists in the requested JSON array. Exact tag matching
+    # is expressed as @> AND <@ by the shared tag-filter builder, so both
+    # directions must be translated for consolidation and recall to agree.
+    def _rewrite_array_contained_by(m: re.Match[str]) -> str:
+        col = m.group(1)
+        param = m.group(2)
+        return (
+            f"(SELECT COUNT(*) FROM JSON_TABLE({col}, '$[*]' COLUMNS (val VARCHAR2(256) PATH '$')) jt "
+            f"WHERE JSON_EXISTS({param}, '$[*]?(@ == $v)' PASSING jt.val AS \"v\")) = "
+            f"JSON_VALUE({col}, '$.size()' RETURNING NUMBER)"
+        )
+
+    query = re.sub(r"(\w+)\s*<@\s*(:\w+)", _rewrite_array_contained_by, query)
+
     # ILIKE → UPPER(...) LIKE UPPER(...)
     query = re.sub(
         r"(\w+)\s+ILIKE\s+(:\w+)",

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, Literal, ParamSpec, TypeVar, cast, overlo
 
 import asyncpg
 import httpx
+from pydantic import BaseModel, ConfigDict
 
 from .._vector_index import ann_search_tuning_settings, configured_vector_extension
 from ..cancellation import OperationCancelledError
@@ -816,6 +817,33 @@ class RefreshTagFiltering:
     tags: list[str] | None
     tags_match: TagsMatch
     tag_groups: list[TagGroup] | None
+
+
+class _ConsolidationTaskFilters(BaseModel):
+    """Typed filter projection from a pending consolidation payload."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    observation_scopes: list[list[str]] | None = None
+    tags: list[str] | None = None
+    tags_match: TagsMatch = "any"
+    tag_groups: list[TagGroup] | None = None
+
+
+def _is_targeted_consolidation(filters: _ConsolidationTaskFilters) -> bool:
+    """Return whether a request narrows the source set or is an explicit no-op.
+
+    Empty ordinary-tag filters generate no SQL predicate and therefore belong
+    to the full-bank dedupe class. Exact matching is the exception: exact with
+    no tags deliberately selects only untagged source facts. An explicitly
+    empty observation-scope list remains targeted because it selects nothing.
+    """
+    return (
+        filters.observation_scopes is not None
+        or bool(filters.tags)
+        or filters.tags_match == "exact"
+        or bool(filters.tag_groups)
+    )
 
 
 def _resolve_refresh_tag_filtering(
@@ -1758,12 +1786,16 @@ class MemoryEngine(MemoryEngineInterface):
             api_key_id=task_dict.get("_api_key_id"),
             retry_count=task_dict.get("_retry_count", 0),
         )
+        filters = _ConsolidationTaskFilters.model_validate(task_dict)
         result = await run_consolidation_job(
             memory_engine=self,
             bank_id=bank_id,
             request_context=internal_context,
             operation_id=task_dict.get("operation_id"),
-            observation_scopes=task_dict.get("observation_scopes"),
+            observation_scopes=filters.observation_scopes,
+            tags=filters.tags,
+            tags_match=filters.tags_match,
+            tag_groups=filters.tag_groups,
         )
 
         logger.info(f"[CONSOLIDATION] bank={bank_id} completed: {result.get('memories_processed', 0)} processed")
@@ -12550,16 +12582,20 @@ class MemoryEngine(MemoryEngineInterface):
                         bank_id,
                         operation_type,
                     )
-                    # Dedup only against an existing *unscoped* (full-bank) pending op.
-                    # A pending scoped consolidation covers only its tag subset, so it
-                    # must not swallow a full-bank sweep (#1842). The scope check is in
-                    # Python because the JSON predicate isn't portable — Oracle's
-                    # JSON_VALUE returns NULL for the array-valued observation_scopes.
-                    # (Scoped submits never reach here: they pass dedupe_by_bank=False.)
+                    # Dedup only against an existing unfiltered full-bank pending op.
+                    # A targeted consolidation covers only a source subset, so it must
+                    # not swallow a later full-bank sweep (#1842). Inspect the payload
+                    # in Python because portable SQL JSON predicates cannot reliably
+                    # distinguish missing, null, and array-valued fields on Oracle.
+                    # (Targeted submits never reach here: they pass
+                    # dedupe_by_bank=False.)
                     for row in pending:
                         row_payload = row["task_payload"]
                         row_dict = json.loads(row_payload) if isinstance(row_payload, str) else (row_payload or {})
-                        if row_dict.get("observation_scopes") is None:
+                        targeted_consolidation = operation_type == "consolidation" and _is_targeted_consolidation(
+                            _ConsolidationTaskFilters.model_validate(row_dict)
+                        )
+                        if not targeted_consolidation:
                             logger.debug(
                                 f"{operation_type} task already pending for bank_id={bank_id}, "
                                 f"skipping duplicate (existing operation_id={row['operation_id']})"
@@ -12918,21 +12954,30 @@ class MemoryEngine(MemoryEngineInterface):
         *,
         request_context: "RequestContext",
         observation_scopes: list[list[str]] | None = None,
+        tags: list[str] | None = None,
+        tags_match: TagsMatch = "any",
+        tag_groups: list[TagGroup] | None = None,
     ) -> dict[str, Any]:
         """Submit a consolidation operation to run asynchronously.
 
-        Deduplicates by bank_id - if there's already a pending consolidation for this bank,
-        returns the existing operation_id instead of creating a new one.
+        Full-bank runs deduplicate by bank ID against another pending full-bank
+        consolidation. Targeted runs never deduplicate because they cover only a
+        source subset and have explicit timing semantics.
 
         Args:
             bank_id: Bank identifier
             request_context: Request context for authentication
-            observation_scopes: Optional list of tag scopes to consolidate. When provided,
-                only unconsolidated memories matching at least one scope are processed.
+            observation_scopes: Optional exact resolved observation write scopes.
+            tags: Optional ordinary source-fact tags to filter by.
+            tags_match: Matching mode for ``tags``.
+            tag_groups: Optional compound ordinary source-fact tag filter.
 
         Returns:
             Dict with operation_id
         """
+        if tags is not None and tag_groups is not None:
+            raise ValueError("'tags' and 'tag_groups' are mutually exclusive")
+
         await self._authenticate_tenant(request_context)
         if self._operation_validator:
             from hindsight_api.extensions import BankWriteContext, BankWriteOperation
@@ -12952,12 +12997,25 @@ class MemoryEngine(MemoryEngineInterface):
             task_payload["_tenant_id"] = request_context.tenant_id
         if request_context.api_key_id:
             task_payload["_api_key_id"] = request_context.api_key_id
-        if observation_scopes is not None:
-            task_payload["observation_scopes"] = observation_scopes
+        filters = _ConsolidationTaskFilters(
+            observation_scopes=observation_scopes,
+            tags=tags,
+            tags_match=tags_match,
+            tag_groups=tag_groups,
+        )
+        task_payload.update(
+            filters.model_dump(
+                by_alias=True,
+                exclude_none=True,
+                exclude_defaults=True,
+            )
+        )
 
-        # Skip bank-level deduplication when scoped — the caller wants a
-        # targeted run that should not be merged into a pending full-bank sweep.
-        dedupe = observation_scopes is None
+        # Skip bank-level deduplication for every targeted run: merging one
+        # source filter into a pending full-bank sweep would lose its explicit
+        # timing and progress semantics.
+        targeted = _is_targeted_consolidation(filters)
+        dedupe = not targeted
 
         return await self._submit_async_operation(
             bank_id=bank_id,

--- a/hindsight-api-slim/hindsight_api/engine/search/tags.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/tags.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
+from typing_extensions import TypeAliasType
 
 TagsMatch = Literal["any", "all", "any_strict", "all_strict", "exact"]
 
@@ -237,30 +238,37 @@ class TagGroupAnd(BaseModel):
     """Compound AND group: all child filters must match."""
 
     model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
-    filters: list[TagGroup] = Field(alias="and")
+    filters: list[_TagGroupNode] = Field(alias="and")
 
 
 class TagGroupOr(BaseModel):
     """Compound OR group: at least one child filter must match."""
 
     model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
-    filters: list[TagGroup] = Field(alias="or")
+    filters: list[_TagGroupNode] = Field(alias="or")
 
 
 class TagGroupNot(BaseModel):
     """Compound NOT group: child filter must NOT match."""
 
     model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
-    filter: TagGroup = Field(alias="not")
+    filter: _TagGroupNode = Field(alias="not")
 
 
 # TagGroup is a discriminated union; Pydantic will try left-to-right.
 # TagGroupLeaf is identified by the presence of 'tags'.
 # TagGroupAnd / TagGroupOr / TagGroupNot are compound (no 'tags' key).
-TagGroup = Annotated[
+# Keep recursion on an anonymous node so client generators retain the existing
+# nested Not/Not1 model names. The public alias gives request fields one shared
+# OpenAPI schema; generator name mappings preserve the legacy SDK type name.
+_TagGroupNode = Annotated[
     TagGroupLeaf | TagGroupAnd | TagGroupOr | TagGroupNot,
     Field(union_mode="left_to_right"),
 ]
+TagGroup = TypeAliasType(
+    "TagGroup",
+    _TagGroupNode,
+)
 
 # Rebuild forward-reference models so recursive TagGroup is resolved.
 TagGroupAnd.model_rebuild()

--- a/hindsight-api-slim/tests/test_async_submit_bank_not_found.py
+++ b/hindsight-api-slim/tests/test_async_submit_bank_not_found.py
@@ -67,7 +67,7 @@ async def test_scoped_consolidation_submit_on_missing_bank_raises_validation_err
         await memory.submit_async_consolidation(
             bank_id=missing_bank,
             request_context=request_context,
-            observation_scopes=[{"tag": "anything"}],
+            observation_scopes=[["anything"]],
         )
 
     assert exc_info.value.status_code == 404

--- a/hindsight-api-slim/tests/test_consolidation.py
+++ b/hindsight-api-slim/tests/test_consolidation.py
@@ -4,8 +4,10 @@ These tests exercise the real consolidation implementation with actual database 
 Note: Consolidation runs automatically after retain via SyncTaskBackend in tests.
 """
 
+import json
 import uuid
 from datetime import datetime, timezone
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -14,6 +16,7 @@ from hindsight_api.config import _get_raw_config
 from hindsight_api.engine.consolidation.consolidator import (
     _aggregate_source_fields,
     _build_response_model,
+    _ConsolidationMemory,
     _count_observations_for_scope,
     _find_related_observations,
     run_consolidation_job,
@@ -24,6 +27,7 @@ from hindsight_api.engine.reflect.tools import (
     tool_search_mental_models,
     tool_search_observations,
 )
+from hindsight_api.engine.search.tags import TagGroupLeaf, TagGroupOr
 from tests.llm_judge import assert_meets_criteria
 
 
@@ -2270,14 +2274,18 @@ def _dt(year: int, month: int, day: int) -> datetime:
     return datetime(year, month, day, tzinfo=timezone.utc)
 
 
+def _source_memory(**fields: Any) -> _ConsolidationMemory:
+    return _ConsolidationMemory(id=uuid.uuid4(), text="source fact", **fields)
+
+
 class TestAggregateSourceFields:
     """Unit tests for _aggregate_source_fields – no database required."""
 
     def test_all_none_temporal_fields_stay_none(self):
         """When source memories carry no temporal data, all fields must remain None."""
         source_mems = [
-            {"tags": ["t1"], "event_date": None, "occurred_start": None, "occurred_end": None, "mentioned_at": None},
-            {"tags": ["t1"], "event_date": None, "occurred_start": None, "occurred_end": None, "mentioned_at": None},
+            _source_memory(tags=["t1"]),
+            _source_memory(tags=["t1"]),
         ]
         agg = _aggregate_source_fields(source_mems)
         assert agg.event_date is None
@@ -2290,20 +2298,18 @@ class TestAggregateSourceFields:
         early = _dt(2023, 1, 1)
         late = _dt(2024, 6, 15)
         source_mems = [
-            {
-                "tags": [],
-                "event_date": late,
-                "occurred_start": late,
-                "occurred_end": early,
-                "mentioned_at": early,
-            },
-            {
-                "tags": [],
-                "event_date": early,
-                "occurred_start": early,
-                "occurred_end": late,
-                "mentioned_at": late,
-            },
+            _source_memory(
+                event_date=late,
+                occurred_start=late,
+                occurred_end=early,
+                mentioned_at=early,
+            ),
+            _source_memory(
+                event_date=early,
+                occurred_start=early,
+                occurred_end=late,
+                mentioned_at=late,
+            ),
         ]
         agg = _aggregate_source_fields(source_mems)
         assert agg.event_date == early
@@ -2315,8 +2321,8 @@ class TestAggregateSourceFields:
         """None values in individual sources do not corrupt the min/max from sources that do have dates."""
         d = _dt(2023, 3, 10)
         source_mems = [
-            {"tags": [], "event_date": None, "occurred_start": None, "occurred_end": None, "mentioned_at": None},
-            {"tags": [], "event_date": d, "occurred_start": d, "occurred_end": d, "mentioned_at": d},
+            _source_memory(),
+            _source_memory(event_date=d, occurred_start=d, occurred_end=d, mentioned_at=d),
         ]
         agg = _aggregate_source_fields(source_mems)
         assert agg.event_date == d
@@ -2327,49 +2333,21 @@ class TestAggregateSourceFields:
     def test_tags_inherited_from_first_source_memory(self):
         """Tags default to those of the first source memory (batch invariant)."""
         source_mems = [
-            {
-                "tags": ["user:alice"],
-                "event_date": None,
-                "occurred_start": None,
-                "occurred_end": None,
-                "mentioned_at": None,
-            },
-            {
-                "tags": ["user:alice"],
-                "event_date": None,
-                "occurred_start": None,
-                "occurred_end": None,
-                "mentioned_at": None,
-            },
+            _source_memory(tags=["user:alice"]),
+            _source_memory(tags=["user:alice"]),
         ]
         agg = _aggregate_source_fields(source_mems)
         assert agg.tags == ["user:alice"]
 
     def test_tags_override_takes_precedence(self):
         """Explicit tags parameter overrides the source-memory tags."""
-        source_mems = [
-            {
-                "tags": ["user:alice"],
-                "event_date": None,
-                "occurred_start": None,
-                "occurred_end": None,
-                "mentioned_at": None,
-            },
-        ]
+        source_mems = [_source_memory(tags=["user:alice"])]
         agg = _aggregate_source_fields(source_mems, tags=["scope:override"])
         assert agg.tags == ["scope:override"]
 
     def test_empty_tags_override_is_respected(self):
         """An explicit empty list override must not fall back to source tags."""
-        source_mems = [
-            {
-                "tags": ["user:alice"],
-                "event_date": None,
-                "occurred_start": None,
-                "occurred_end": None,
-                "mentioned_at": None,
-            },
-        ]
+        source_mems = [_source_memory(tags=["user:alice"])]
         agg = _aggregate_source_fields(source_mems, tags=[])
         assert agg.tags == []
 
@@ -2377,7 +2355,7 @@ class TestAggregateSourceFields:
         """Single-source aggregation should just pass through that memory's fields."""
         d = _dt(2024, 11, 5)
         source_mems = [
-            {"tags": ["x"], "event_date": d, "occurred_start": d, "occurred_end": d, "mentioned_at": d},
+            _source_memory(tags=["x"], event_date=d, occurred_start=d, occurred_end=d, mentioned_at=d),
         ]
         agg = _aggregate_source_fields(source_mems)
         assert agg.event_date == d
@@ -3008,20 +2986,27 @@ async def test_count_observations_for_scope(memory: MemoryEngine, request_contex
         await memory.delete_bank(bank_id, request_context=request_context)
 
 
-async def _insert_memories_with_tags(conn, bank_id: str, texts: list[str], tags: list[str] | None = None) -> list:
+async def _insert_memories_with_tags(
+    conn: Any,
+    bank_id: str,
+    texts: list[str],
+    tags: list[str] | None = None,
+    observation_scopes: str | list[list[str]] | None = None,
+) -> list[uuid.UUID]:
     """Insert experience memories directly with optional tags, bypassing LLM-based retain."""
     ids = []
     for text in texts:
         mem_id = uuid.uuid4()
         await conn.execute(
             """
-            INSERT INTO memory_units (id, bank_id, text, fact_type, tags, created_at)
-            VALUES ($1, $2, $3, 'experience', $4, now())
+            INSERT INTO memory_units (id, bank_id, text, fact_type, tags, observation_scopes, created_at)
+            VALUES ($1, $2, $3, 'experience', $4, $5::jsonb, now())
             """,
             mem_id,
             bank_id,
             text,
             tags or [],
+            json.dumps(observation_scopes) if observation_scopes is not None else None,
         )
         ids.append(mem_id)
     return ids
@@ -3465,6 +3450,73 @@ async def test_targeted_consolidation_multiple_scopes(memory: MemoryEngine, requ
 
 
 @pytest.mark.asyncio
+async def test_empty_observation_scopes_skips_candidate_scan(memory: MemoryEngine, request_context):
+    bank_id = f"test-targeted-empty-scopes-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    try:
+        with patch(
+            "hindsight_api.engine.consolidation.consolidator._fetch_scope_candidate_page",
+            new_callable=AsyncMock,
+        ) as fetch_page:
+            result = await run_consolidation_job(
+                memory_engine=memory,
+                bank_id=bank_id,
+                request_context=request_context,
+                observation_scopes=[],
+            )
+
+        assert result == {
+            "status": "no_new_memories",
+            "bank_id": bank_id,
+            "memories_processed": 0,
+        }
+        fetch_page.assert_not_awaited()
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_targeted_consolidation_without_matching_scope_returns_no_new(
+    memory: MemoryEngine,
+    request_context,
+):
+    bank_id = f"test-targeted-no-scope-match-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    try:
+        async with memory._pool.acquire() as conn:
+            memory_ids = await _insert_memories_with_tags(
+                conn,
+                bank_id,
+                ["Writes somewhere else."],
+                tags=["source:web"],
+                observation_scopes=[["scope:other"]],
+            )
+
+        result = await run_consolidation_job(
+            memory_engine=memory,
+            bank_id=bank_id,
+            request_context=request_context,
+            observation_scopes=[["scope:target"]],
+        )
+
+        assert result == {
+            "status": "no_new_memories",
+            "bank_id": bank_id,
+            "memories_processed": 0,
+        }
+        async with memory._pool.acquire() as conn:
+            consolidated_at = await conn.fetchval(
+                "SELECT consolidated_at FROM memory_units WHERE id = $1",
+                memory_ids[0],
+            )
+        assert consolidated_at is None
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
 async def test_targeted_consolidation_no_scopes_processes_all(memory: MemoryEngine, request_context):
     """Consolidation without observation_scopes processes all unconsolidated memories (backward compat)."""
     bank_id = f"test-targeted-all-{uuid.uuid4().hex[:8]}"
@@ -3494,8 +3546,8 @@ async def test_targeted_consolidation_no_scopes_processes_all(memory: MemoryEngi
 
 
 @pytest.mark.asyncio
-async def test_targeted_consolidation_contains_semantics(memory: MemoryEngine, request_context):
-    """Scope ["user:alice"] matches memories tagged ["user:alice", "team:eng"] (contains)."""
+async def test_targeted_consolidation_source_tags_all_strict(memory: MemoryEngine, request_context):
+    """Source tag filtering supports containment independently of observation scopes."""
     bank_id = f"test-targeted-contains-{uuid.uuid4().hex[:8]}"
     await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
 
@@ -3509,16 +3561,326 @@ async def test_targeted_consolidation_contains_semantics(memory: MemoryEngine, r
             await _insert_memories_with_tags(conn, bank_id, ["Alice works on infra."], tags=["user:alice", "team:eng"])
             await _insert_memories_with_tags(conn, bank_id, ["Bob likes swimming."], tags=["user:bob"])
 
-        # Scope is ["user:alice"] — should match the multi-tag memory
+        # all_strict requires every requested source tag and permits extra tags.
         result = await run_consolidation_job(
             memory_engine=memory,
             bank_id=bank_id,
             request_context=request_context,
-            observation_scopes=[["user:alice"]],
+            tags=["user:alice"],
+            tags_match="all_strict",
         )
 
         assert result["memories_processed"] == 1
         assert result["observations_created"] == 1
+    finally:
+        memory._consolidation_llm_config = original_llm
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tags_match", "expected_processed"),
+    [
+        ("any", 3),
+        ("all", 2),
+        ("any_strict", 2),
+        ("all_strict", 1),
+        ("exact", 1),
+    ],
+)
+async def test_targeted_consolidation_supports_source_tag_match_modes(
+    memory: MemoryEngine,
+    request_context,
+    tags_match,
+    expected_processed,
+):
+    bank_id = f"test-targeted-tag-mode-{tags_match}-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    wrapper, _ = _make_mock_llm_one_obs_per_fact()
+    original_llm = memory._consolidation_llm_config
+    memory._consolidation_llm_config = wrapper
+
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memories_with_tags(conn, bank_id, ["Both tags."], tags=["a", "b"])
+            await _insert_memories_with_tags(conn, bank_id, ["One tag."], tags=["a"])
+            await _insert_memories_with_tags(conn, bank_id, ["Other tag."], tags=["c"])
+            await _insert_memories_with_tags(conn, bank_id, ["No tags."], tags=[])
+
+        result = await run_consolidation_job(
+            memory_engine=memory,
+            bank_id=bank_id,
+            request_context=request_context,
+            tags=["a", "b"],
+            tags_match=tags_match,
+        )
+
+        assert result["memories_processed"] == expected_processed
+    finally:
+        memory._consolidation_llm_config = original_llm
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_empty_tag_groups_preserve_exact_untagged_filter(memory: MemoryEngine, request_context):
+    """An empty compound filter behaves like omission, so exact-empty still applies."""
+    bank_id = f"test-targeted-empty-groups-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    wrapper, _ = _make_mock_llm_one_obs_per_fact()
+    original_llm = memory._consolidation_llm_config
+    memory._consolidation_llm_config = wrapper
+
+    try:
+        async with memory._pool.acquire() as conn:
+            tagged_ids = await _insert_memories_with_tags(conn, bank_id, ["Tagged."], tags=["source:web"])
+            untagged_ids = await _insert_memories_with_tags(conn, bank_id, ["Untagged."], tags=[])
+
+        result = await run_consolidation_job(
+            memory_engine=memory,
+            bank_id=bank_id,
+            request_context=request_context,
+            tags_match="exact",
+            tag_groups=[],
+        )
+
+        assert result["memories_processed"] == 1
+        async with memory._pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT id, consolidated_at FROM memory_units WHERE id = ANY($1::uuid[])",
+                tagged_ids + untagged_ids,
+            )
+        consolidated = {row["id"]: row["consolidated_at"] is not None for row in rows}
+        assert not consolidated[tagged_ids[0]]
+        assert consolidated[untagged_ids[0]]
+    finally:
+        memory._consolidation_llm_config = original_llm
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_targeted_consolidation_filters_by_exact_resolved_observation_scope(
+    memory: MemoryEngine,
+    request_context,
+):
+    """Candidate selection uses resolved observation scopes, never ordinary source tags."""
+    bank_id = f"test-targeted-resolved-scope-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    wrapper, _ = _make_mock_llm_one_obs_per_fact()
+    original_llm = memory._consolidation_llm_config
+    memory._consolidation_llm_config = wrapper
+
+    try:
+        async with memory._pool.acquire() as conn:
+            matching_ids = await _insert_memories_with_tags(
+                conn,
+                bank_id,
+                ["Alice exercises."],
+                tags=["source:fitness-app"],
+                observation_scopes=[
+                    ["user:alice", "topic:exercise"],
+                    ["scope:sibling"],
+                ],
+            )
+            wrong_field_ids = await _insert_memories_with_tags(
+                conn,
+                bank_id,
+                ["Ordinary tags happen to match."],
+                tags=["user:alice", "topic:exercise"],
+                observation_scopes=[["scope:other"]],
+            )
+            superset_ids = await _insert_memories_with_tags(
+                conn,
+                bank_id,
+                ["Only a superset scope."],
+                tags=["source:other"],
+                observation_scopes=[["user:alice", "topic:exercise", "tier:summary"]],
+            )
+
+        result = await run_consolidation_job(
+            memory_engine=memory,
+            bank_id=bank_id,
+            request_context=request_context,
+            observation_scopes=[["topic:exercise", "user:alice"]],
+        )
+
+        assert result["memories_processed"] == 1
+        async with memory._pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT id, consolidated_at FROM memory_units WHERE id = ANY($1::uuid[])",
+                matching_ids + wrong_field_ids + superset_ids,
+            )
+        consolidated = {row["id"]: row["consolidated_at"] is not None for row in rows}
+        assert consolidated[matching_ids[0]]
+        assert not consolidated[wrong_field_ids[0]]
+        assert not consolidated[superset_ids[0]]
+    finally:
+        memory._consolidation_llm_config = original_llm
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_observation_scope_candidates_are_keyset_paginated(memory: MemoryEngine, request_context):
+    from hindsight_api.engine.consolidation.consolidator import _fetch_scope_candidate_page
+
+    bank_id = f"test-targeted-scope-pages-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    wrapper, _ = _make_mock_llm_one_obs_per_fact()
+    original_llm = memory._consolidation_llm_config
+    memory._consolidation_llm_config = wrapper
+
+    try:
+        async with memory._pool.acquire() as conn:
+            matching_ids = await _insert_memories_with_tags(
+                conn,
+                bank_id,
+                ["Matching one.", "Matching two.", "Matching three."],
+                tags=["source:paged"],
+                observation_scopes=[["scope:target"]],
+            )
+            other_ids = await _insert_memories_with_tags(
+                conn,
+                bank_id,
+                ["Other one.", "Other two.", "Other three."],
+                tags=["source:paged"],
+                observation_scopes=[["scope:other"]],
+            )
+            # Give every row the same timestamp so the test also proves the UUID
+            # tie-breaker advances the keyset cursor without skips or repeats.
+            await conn.execute(
+                "UPDATE memory_units SET created_at = $1 WHERE id = ANY($2::uuid[])",
+                datetime(2025, 1, 1, tzinfo=timezone.utc),
+                matching_ids + other_ids,
+            )
+
+        with (
+            patch(
+                "hindsight_api.engine.consolidation.consolidator._SCOPE_CANDIDATE_PAGE_SIZE",
+                2,
+            ),
+            patch(
+                "hindsight_api.engine.consolidation.consolidator._fetch_scope_candidate_page",
+                wraps=_fetch_scope_candidate_page,
+            ) as fetch_page,
+        ):
+            result = await run_consolidation_job(
+                memory_engine=memory,
+                bank_id=bank_id,
+                request_context=request_context,
+                observation_scopes=[["scope:target"]],
+            )
+
+        assert result["memories_processed"] == 3
+        # Three data pages plus the terminating empty page: candidates are no
+        # longer scanned once for counting and then again for processing.
+        assert fetch_page.await_count == 4
+        assert all(awaited.args[-1] == 2 for awaited in fetch_page.await_args_list)
+
+        async with memory._pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT id, consolidated_at FROM memory_units WHERE id = ANY($1::uuid[])",
+                matching_ids + other_ids,
+            )
+        consolidated = {row["id"]: row["consolidated_at"] is not None for row in rows}
+        assert all(consolidated[memory_id] for memory_id in matching_ids)
+        assert all(not consolidated[memory_id] for memory_id in other_ids)
+    finally:
+        memory._consolidation_llm_config = original_llm
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_targeted_consolidation_supports_compound_source_tag_groups(
+    memory: MemoryEngine,
+    request_context,
+):
+    bank_id = f"test-targeted-tag-groups-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    wrapper, _ = _make_mock_llm_one_obs_per_fact()
+    original_llm = memory._consolidation_llm_config
+    memory._consolidation_llm_config = wrapper
+
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memories_with_tags(conn, bank_id, ["Alice engineering."], tags=["user:alice", "team:eng"])
+            await _insert_memories_with_tags(conn, bank_id, ["Bob exact."], tags=["user:bob"])
+            await _insert_memories_with_tags(conn, bank_id, ["Bob extra."], tags=["user:bob", "team:sales"])
+            await _insert_memories_with_tags(conn, bank_id, ["Charlie."], tags=["user:charlie"])
+
+        result = await run_consolidation_job(
+            memory_engine=memory,
+            bank_id=bank_id,
+            request_context=request_context,
+            # Flat tags_match is irrelevant when tag_groups supplies per-leaf modes.
+            tags_match="exact",
+            tag_groups=[
+                TagGroupOr(
+                    **{
+                        "or": [
+                            TagGroupLeaf(tags=["user:alice", "team:eng"], match="all_strict"),
+                            TagGroupLeaf(tags=["user:bob"], match="exact"),
+                        ]
+                    }
+                )
+            ],
+        )
+
+        assert result["memories_processed"] == 2
+    finally:
+        memory._consolidation_llm_config = original_llm
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_same_source_tags_with_different_observation_scopes_use_separate_passes(
+    memory: MemoryEngine,
+    request_context,
+):
+    """Batching must not let the first fact's write scopes override a sibling fact's scopes."""
+    bank_id = f"test-distinct-write-scopes-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    wrapper, _ = _make_mock_llm_one_obs_per_fact()
+    original_llm = memory._consolidation_llm_config
+    memory._consolidation_llm_config = wrapper
+
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memories_with_tags(
+                conn,
+                bank_id,
+                ["Alice fact."],
+                tags=["source:shared"],
+                observation_scopes=[["user:alice"]],
+            )
+            await _insert_memories_with_tags(
+                conn,
+                bank_id,
+                ["Bob fact."],
+                tags=["source:shared"],
+                observation_scopes=[["user:bob"]],
+            )
+
+        result = await run_consolidation_job(
+            memory_engine=memory,
+            bank_id=bank_id,
+            request_context=request_context,
+        )
+
+        assert result["memories_processed"] == 2
+        async with memory._pool.acquire() as conn:
+            observation_tags = await conn.fetch(
+                "SELECT tags FROM memory_units WHERE bank_id = $1 AND fact_type = 'observation'",
+                bank_id,
+            )
+        assert {frozenset(row["tags"] or []) for row in observation_tags} == {
+            frozenset({"user:alice"}),
+            frozenset({"user:bob"}),
+        }
     finally:
         memory._consolidation_llm_config = original_llm
         await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_consolidation_retry_budget.py
+++ b/hindsight-api-slim/tests/test_consolidation_retry_budget.py
@@ -1,10 +1,18 @@
 """Tests for consolidation retry budget configurability (issue #1042)."""
 
+import uuid
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from hindsight_api.engine.consolidation.consolidator import _consolidate_batch_with_llm
+from hindsight_api.engine.consolidation.consolidator import (
+    _consolidate_batch_with_llm,
+    _ConsolidationMemory,
+)
+
+
+def _memory() -> _ConsolidationMemory:
+    return _ConsolidationMemory(id=uuid.uuid4(), text="test")
 
 
 @pytest.fixture
@@ -35,7 +43,7 @@ class TestConsolidationRetryBudget:
         with pytest.raises(ValueError, match="config is required"):
             await _consolidate_batch_with_llm(
                 llm_config=mock_llm_config,
-                memories=[{"id": "m1", "text": "test"}],
+                memories=[_memory()],
                 union_observations=[],
                 union_source_facts={},
                 config=None,
@@ -48,7 +56,7 @@ class TestConsolidationRetryBudget:
         mock_llm_config.call.side_effect = RuntimeError("fail")
         result = await _consolidate_batch_with_llm(
             llm_config=mock_llm_config,
-            memories=[{"id": "m1", "text": "test"}],
+            memories=[_memory()],
             union_observations=[],
             union_source_facts={},
             config=mock_config,
@@ -62,7 +70,7 @@ class TestConsolidationRetryBudget:
         mock_config.consolidation_llm_max_retries = 3
         await _consolidate_batch_with_llm(
             llm_config=mock_llm_config,
-            memories=[{"id": "m1", "text": "test"}],
+            memories=[_memory()],
             union_observations=[],
             union_source_facts={},
             config=mock_config,
@@ -75,7 +83,7 @@ class TestConsolidationRetryBudget:
         mock_config.consolidation_max_completion_tokens = 8192
         await _consolidate_batch_with_llm(
             llm_config=mock_llm_config,
-            memories=[{"id": "m1", "text": "test"}],
+            memories=[_memory()],
             union_observations=[],
             union_source_facts={},
             config=mock_config,
@@ -88,7 +96,7 @@ class TestConsolidationRetryBudget:
         mock_config.consolidation_max_completion_tokens = None
         await _consolidate_batch_with_llm(
             llm_config=mock_llm_config,
-            memories=[{"id": "m1", "text": "test"}],
+            memories=[_memory()],
             union_observations=[],
             union_source_facts={},
             config=mock_config,
@@ -101,7 +109,7 @@ class TestConsolidationRetryBudget:
         mock_config.consolidation_llm_max_retries = None
         await _consolidate_batch_with_llm(
             llm_config=mock_llm_config,
-            memories=[{"id": "m1", "text": "test"}],
+            memories=[_memory()],
             union_observations=[],
             union_source_facts={},
             config=mock_config,
@@ -116,7 +124,7 @@ class TestConsolidationRetryBudget:
         mock_llm_config.call.side_effect = RuntimeError("upstream 503")
         result = await _consolidate_batch_with_llm(
             llm_config=mock_llm_config,
-            memories=[{"id": "m1", "text": "test"}],
+            memories=[_memory()],
             union_observations=[],
             union_source_facts={},
             config=mock_config,

--- a/hindsight-api-slim/tests/test_consolidation_round_limit.py
+++ b/hindsight-api-slim/tests/test_consolidation_round_limit.py
@@ -77,7 +77,14 @@ async def test_round_limit_caps_processed_memories(memory: MemoryEngine, request
     assert result["memories_processed"] <= round_limit
 
     # Must have re-queued consolidation for remaining work
-    mock_requeue.assert_called_once_with(bank_id=bank_id, request_context=request_context, observation_scopes=None)
+    mock_requeue.assert_called_once_with(
+        bank_id=bank_id,
+        request_context=request_context,
+        observation_scopes=None,
+        tags=None,
+        tags_match="any",
+        tag_groups=None,
+    )
 
     # Mental model refresh should be skipped on intermediate round
     assert result.get("mental_models_refreshed", 0) == 0

--- a/hindsight-api-slim/tests/test_consolidation_submit_atomic_dedup.py
+++ b/hindsight-api-slim/tests/test_consolidation_submit_atomic_dedup.py
@@ -7,14 +7,18 @@ the round-limit re-queue) each saw no pending row and each inserted, leaking
 duplicate pending ops that then piled up as `retry_blocked` and starved the bank.
 
 The submit now serializes per bank (SELECT ... FOR UPDATE on the bank row) so the
-check-and-insert is atomic. Scoped runs (`observation_scopes` set) are exempt and
-may have multiple pending ops.
+check-and-insert is atomic. Runs targeted by observation scopes or source-tag
+filters are exempt and may have multiple pending ops.
 """
 
 import asyncio
+import json
 import uuid
+from unittest.mock import AsyncMock, patch
 
 import pytest
+
+from hindsight_api.engine.search.tags import TagGroupLeaf, TagGroupOr
 
 
 @pytest.fixture
@@ -55,6 +59,86 @@ async def _cleanup(pool, bank_id: str) -> None:
 
 
 @pytest.mark.asyncio
+async def test_source_filters_are_serialized_into_targeted_task_payload(
+    memory,
+    request_context,
+    no_inline_execution,
+):
+    bank_id = f"test-filter-payload-{uuid.uuid4().hex[:8]}"
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    try:
+        result = await memory.submit_async_consolidation(
+            bank_id=bank_id,
+            request_context=request_context,
+            observation_scopes=[["user:alice"]],
+            tags_match="exact",
+            tag_groups=[
+                TagGroupOr(
+                    **{
+                        "or": [
+                            TagGroupLeaf(tags=["source:app"], match="exact"),
+                            TagGroupLeaf(tags=["source:web"], match="all_strict"),
+                        ]
+                    }
+                )
+            ],
+        )
+
+        raw_payload = await pool.fetchval(
+            "SELECT task_payload FROM async_operations WHERE operation_id = $1",
+            uuid.UUID(result["operation_id"]),
+        )
+        payload = json.loads(raw_payload) if isinstance(raw_payload, str) else raw_payload
+        assert payload["observation_scopes"] == [["user:alice"]]
+        assert payload["tags_match"] == "exact"
+        assert payload["tag_groups"] == [
+            {
+                "or": [
+                    {"tags": ["source:app"], "match": "exact"},
+                    {"tags": ["source:web"], "match": "all_strict"},
+                ]
+            }
+        ]
+        assert not result.get("deduplicated")
+    finally:
+        await _cleanup(pool, bank_id)
+
+
+@pytest.mark.asyncio
+async def test_source_filters_are_deserialized_by_consolidation_task_handler(memory):
+    run_job = AsyncMock(return_value={"memories_processed": 0})
+    with patch("hindsight_api.engine.consolidation.run_consolidation_job", new=run_job):
+        await memory._handle_consolidation(
+            {
+                "bank_id": "test-filter-handler",
+                "observation_scopes": [["user:alice"]],
+                "tags_match": "exact",
+                "tag_groups": [
+                    {
+                        "or": [
+                            {"tags": ["source:app"], "match": "exact"},
+                            {"tags": ["source:web"], "match": "all_strict"},
+                        ]
+                    }
+                ],
+            }
+        )
+
+    kwargs = run_job.await_args.kwargs
+    assert kwargs["observation_scopes"] == [["user:alice"]]
+    assert kwargs["tags_match"] == "exact"
+    assert [group.model_dump(by_alias=True) for group in kwargs["tag_groups"]] == [
+        {
+            "or": [
+                {"tags": ["source:app"], "match": "exact"},
+                {"tags": ["source:web"], "match": "all_strict"},
+            ]
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_concurrent_submits_leave_one_pending(memory, request_context, no_inline_execution):
     """Five concurrent unscoped submits on a bank with no pending op must end with
     exactly one pending row, and all calls must resolve to that one operation_id."""
@@ -91,25 +175,75 @@ async def test_sequential_submit_dedups(memory, request_context, no_inline_execu
 
 
 @pytest.mark.asyncio
-async def test_unscoped_not_deduped_against_scoped_pending(memory, request_context, no_inline_execution):
-    """A full-bank (unscoped) submit must still run when only a scoped op is pending —
-    a scoped run covers a tag subset and must not swallow the full-bank sweep."""
+@pytest.mark.parametrize(
+    "empty_filter_kwargs",
+    [
+        {"tags": []},
+        {"tag_groups": []},
+    ],
+    ids=["empty-tags", "empty-tag-groups"],
+)
+async def test_effectively_empty_tag_filters_use_full_bank_dedup(
+    memory,
+    request_context,
+    no_inline_execution,
+    empty_filter_kwargs,
+):
+    """Empty ordinary-tag filters execute full-bank work and share its dedupe class."""
+    bank_id = f"test-atomic-empty-{uuid.uuid4().hex[:8]}"
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    try:
+        first = await memory.submit_async_consolidation(
+            bank_id=bank_id,
+            request_context=request_context,
+            **empty_filter_kwargs,
+        )
+        second = await memory.submit_async_consolidation(bank_id=bank_id, request_context=request_context)
+
+        assert second["operation_id"] == first["operation_id"]
+        assert second.get("deduplicated") is True
+        assert await _count_pending(pool, bank_id) == 1
+    finally:
+        await _cleanup(pool, bank_id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "targeted_kwargs",
+    [
+        {"observation_scopes": [["proj-a"]]},
+        {"tags": ["source:app"]},
+        {"tag_groups": [TagGroupLeaf(tags=["source:web"], match="all_strict")]},
+        {"tags_match": "exact"},
+    ],
+    ids=["observation-scopes", "tags", "tag-groups", "exact-untagged"],
+)
+async def test_full_bank_not_deduped_against_targeted_pending(
+    memory,
+    request_context,
+    no_inline_execution,
+    targeted_kwargs,
+):
+    """A targeted pending task must not swallow a later full-bank sweep."""
     bank_id = f"test-atomic-{uuid.uuid4().hex[:8]}"
     pool = await memory._get_pool()
     await _ensure_bank(pool, bank_id)
     try:
-        scoped = await memory.submit_async_consolidation(
-            bank_id=bank_id, request_context=request_context, observation_scopes=[["proj-a"]]
+        targeted = await memory.submit_async_consolidation(
+            bank_id=bank_id,
+            request_context=request_context,
+            **targeted_kwargs,
         )
-        unscoped = await memory.submit_async_consolidation(bank_id=bank_id, request_context=request_context)
-        assert not unscoped.get("deduplicated"), "full-bank submit must not dedup against a scoped pending op"
-        assert unscoped["operation_id"] != scoped["operation_id"]
+        full_bank = await memory.submit_async_consolidation(bank_id=bank_id, request_context=request_context)
+        assert not full_bank.get("deduplicated"), "full-bank submit must not dedup against a targeted pending op"
+        assert full_bank["operation_id"] != targeted["operation_id"]
         assert await _count_pending(pool, bank_id) == 2
 
-        # A second unscoped submit, however, dedups against the now-pending unscoped op.
-        unscoped2 = await memory.submit_async_consolidation(bank_id=bank_id, request_context=request_context)
-        assert unscoped2["operation_id"] == unscoped["operation_id"]
-        assert unscoped2.get("deduplicated") is True
+        # A second full-bank submit still dedups against the full-bank pending op.
+        full_bank_2 = await memory.submit_async_consolidation(bank_id=bank_id, request_context=request_context)
+        assert full_bank_2["operation_id"] == full_bank["operation_id"]
+        assert full_bank_2.get("deduplicated") is True
         assert await _count_pending(pool, bank_id) == 2
     finally:
         await _cleanup(pool, bank_id)

--- a/hindsight-api-slim/tests/test_consolidation_write_scopes.py
+++ b/hindsight-api-slim/tests/test_consolidation_write_scopes.py
@@ -9,14 +9,50 @@ mapping for every observation_scopes mode the dispatcher recognises.
 """
 
 import json
+import uuid
+from datetime import datetime, timezone
 
 import pytest
 
 from hindsight_api.engine.consolidation.consolidator import (
+    ObservationScopesSpec,
+    _consolidation_memory_from_row,
+    _ConsolidationMemory,
+    _matches_requested_observation_scopes,
     _resolve_obs_tags_list,
     _resolve_write_scopes,
     _scope_sort_key,
+    _ScopeCandidate,
 )
+
+
+def _scope_candidate(
+    tags: list[str],
+    observation_scopes: ObservationScopesSpec | None,
+) -> _ScopeCandidate:
+    return _ScopeCandidate(
+        id=uuid.uuid4(),
+        created_at=datetime.now(timezone.utc),
+        tags=tags,
+        observation_scopes=observation_scopes,
+    )
+
+
+def _memory(
+    tags: list[str] | None = None,
+    observation_scopes: ObservationScopesSpec | str | None = None,
+) -> _ConsolidationMemory:
+    if isinstance(observation_scopes, str):
+        try:
+            observation_scopes = json.loads(observation_scopes)
+        except json.JSONDecodeError:
+            pass
+    return _ConsolidationMemory(
+        id=uuid.uuid4(),
+        text="source fact",
+        tags=tags or [],
+        observation_scopes=observation_scopes,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -39,33 +75,58 @@ def _as_json_string(value):
 class TestResolveWriteScopesCombined:
     @pytest.mark.parametrize("scopes_value", [None, _as_json_string("combined")])
     def test_default_uses_full_tag_set(self, scopes_value):
-        memory = {"tags": ["alice", "session"], "observation_scopes": scopes_value}
+        memory = _memory(["alice", "session"], scopes_value)
         assert _resolve_write_scopes(memory) == [frozenset({"alice", "session"})]
 
     def test_empty_tags_collapses_to_untagged_scope(self):
-        memory = {"tags": [], "observation_scopes": None}
+        memory = _memory([])
         assert _resolve_write_scopes(memory) == [frozenset()]
 
     def test_missing_tags_collapses_to_untagged_scope(self):
-        memory = {"observation_scopes": None}
+        memory = _memory()
         assert _resolve_write_scopes(memory) == [frozenset()]
+
+
+def test_database_row_is_parsed_into_typed_consolidation_memory():
+    memory_id = uuid.uuid4()
+    row = {
+        "id": memory_id,
+        "text": "source fact",
+        "occurred_start": None,
+        "occurred_end": None,
+        "event_date": None,
+        "tags": '["source:fitness-app"]',
+        "mentioned_at": None,
+        "observation_scopes": '[["user:alice", "topic:exercise"]]',
+    }
+
+    class _JsonConnection:
+        @staticmethod
+        def parse_json(value):
+            return json.loads(value) if value is not None else None
+
+    memory = _consolidation_memory_from_row(_JsonConnection(), row)
+
+    assert memory.id == memory_id
+    assert memory.tags == ["source:fitness-app"]
+    assert memory.observation_scopes == [["user:alice", "topic:exercise"]]
 
 
 class TestResolveWriteScopesPerTag:
     def test_emits_one_scope_per_tag(self):
-        memory = {"tags": ["alice", "session", "thread"], "observation_scopes": _as_json_string("per_tag")}
+        memory = _memory(["alice", "session", "thread"], "per_tag")
         scopes = _resolve_write_scopes(memory)
         assert set(scopes) == {frozenset({"alice"}), frozenset({"session"}), frozenset({"thread"})}
         assert len(scopes) == 3  # no dedupe surprises
 
     def test_empty_tags_collapses_to_untagged_scope(self):
-        memory = {"tags": [], "observation_scopes": _as_json_string("per_tag")}
+        memory = _memory([], "per_tag")
         assert _resolve_write_scopes(memory) == [frozenset()]
 
 
 class TestResolveWriteScopesAllCombinations:
     def test_two_tags_yields_three_scopes(self):
-        memory = {"tags": ["alice", "session"], "observation_scopes": _as_json_string("all_combinations")}
+        memory = _memory(["alice", "session"], "all_combinations")
         scopes = set(_resolve_write_scopes(memory))
         assert scopes == {
             frozenset({"alice"}),
@@ -74,7 +135,7 @@ class TestResolveWriteScopesAllCombinations:
         }
 
     def test_three_tags_yields_seven_scopes(self):
-        memory = {"tags": ["a", "b", "c"], "observation_scopes": _as_json_string("all_combinations")}
+        memory = _memory(["a", "b", "c"], "all_combinations")
         scopes = set(_resolve_write_scopes(memory))
         # C(3,1) + C(3,2) + C(3,3) = 3 + 3 + 1 = 7
         assert scopes == {
@@ -88,7 +149,7 @@ class TestResolveWriteScopesAllCombinations:
         }
 
     def test_empty_tags_collapses_to_untagged_scope(self):
-        memory = {"tags": [], "observation_scopes": _as_json_string("all_combinations")}
+        memory = _memory([], "all_combinations")
         assert _resolve_write_scopes(memory) == [frozenset()]
 
 
@@ -96,20 +157,17 @@ class TestResolveWriteScopesShared:
     def test_collapses_to_single_untagged_scope_regardless_of_tags(self):
         # "shared" ignores the memory's own tags and writes to one global scope,
         # so every memory deduplicates against the same observation.
-        memory = {"tags": ["alice", "session"], "observation_scopes": _as_json_string("shared")}
+        memory = _memory(["alice", "session"], "shared")
         assert _resolve_write_scopes(memory) == [frozenset()]
 
     def test_empty_tags_also_untagged_scope(self):
-        memory = {"tags": [], "observation_scopes": _as_json_string("shared")}
+        memory = _memory([], "shared")
         assert _resolve_write_scopes(memory) == [frozenset()]
 
 
 class TestResolveWriteScopesExplicitList:
     def test_uses_declared_scopes_verbatim(self):
-        memory = {
-            "tags": ["alice", "session"],
-            "observation_scopes": _as_json_string([["alice"], ["session"], ["alice", "session"]]),
-        }
+        memory = _memory(["alice", "session"], [["alice"], ["session"], ["alice", "session"]])
         scopes = set(_resolve_write_scopes(memory))
         assert scopes == {
             frozenset({"alice"}),
@@ -120,28 +178,73 @@ class TestResolveWriteScopesExplicitList:
     def test_ignores_memory_tags(self):
         # An explicit scope list overrides per-mode logic — even if the memory's
         # own tags don't match, the declared scopes are what gets written.
-        memory = {"tags": ["alice"], "observation_scopes": _as_json_string([["unrelated_scope"]])}
+        memory = _memory(["alice"], [["unrelated_scope"]])
         assert _resolve_write_scopes(memory) == [frozenset({"unrelated_scope"})]
 
     def test_with_empty_inner_scope(self):
-        memory = {"tags": ["alice"], "observation_scopes": _as_json_string([[], ["alice"]])}
+        memory = _memory(["alice"], [[], ["alice"]])
         scopes = set(_resolve_write_scopes(memory))
         assert scopes == {frozenset(), frozenset({"alice"})}
 
 
 class TestResolveWriteScopesPrepackedValues:
-    """When the caller hands a memory dict with already-parsed observation_scopes
-    (e.g. a unit test fixture passing a Python value directly), the helper must
-    not try to JSON-decode it again. The shape gate is ``isinstance(_, str)``,
-    so non-string Python values flow through untouched."""
+    """Already-parsed observation scopes flow through the typed model."""
 
     def test_list_passed_directly(self):
-        memory = {"tags": ["alice"], "observation_scopes": [["alice"], ["other"]]}
+        memory = _memory(["alice"], [["alice"], ["other"]])
         assert set(_resolve_write_scopes(memory)) == {frozenset({"alice"}), frozenset({"other"})}
 
     def test_none_passed_directly(self):
-        memory = {"tags": ["alice"], "observation_scopes": None}
+        memory = _memory(["alice"])
         assert _resolve_write_scopes(memory) == [frozenset({"alice"})]
+
+
+class TestRequestedObservationScopeMatching:
+    def test_matches_explicit_scope_even_when_ordinary_tags_differ(self):
+        candidate = _scope_candidate(
+            ["source:fitness-app"],
+            [["user:alice", "topic:exercise"]],
+        )
+        assert _matches_requested_observation_scopes(
+            candidate,
+            {frozenset({"topic:exercise", "user:alice"})},
+        )
+
+    @pytest.mark.parametrize(
+        "requested_scope",
+        [
+            ["user:alice"],
+            ["user:alice", "topic:exercise", "tier:summary"],
+        ],
+    )
+    def test_rejects_subset_and_superset_scopes(self, requested_scope):
+        candidate = _scope_candidate(
+            ["source:fitness-app"],
+            [["user:alice", "topic:exercise"]],
+        )
+        assert not _matches_requested_observation_scopes(candidate, {frozenset(requested_scope)})
+
+    @pytest.mark.parametrize(
+        ("spec", "tags", "requested"),
+        [
+            (None, ["a", "b"], ["b", "a"]),
+            ("combined", ["a", "b"], ["a", "b"]),
+            ("per_tag", ["a", "b"], ["b"]),
+            ("all_combinations", ["a", "b"], ["a", "b"]),
+            ("shared", ["a", "b"], []),
+        ],
+    )
+    def test_matches_resolved_scope_modes(self, spec, tags, requested):
+        candidate = _scope_candidate(tags, spec)
+        assert _matches_requested_observation_scopes(candidate, {frozenset(requested)})
+
+    def test_empty_outer_list_matches_no_source(self):
+        candidate = _scope_candidate([], "shared")
+        assert not _matches_requested_observation_scopes(candidate, set())
+
+    def test_none_disables_observation_scope_filter(self):
+        candidate = _scope_candidate(["a"], [["x"]])
+        assert _matches_requested_observation_scopes(candidate, None)
 
 
 # ---------------------------------------------------------------------------
@@ -155,15 +258,15 @@ class TestResolveObsTagsList:
     scopes are touched."""
 
     def test_combined_returns_none(self):
-        assert _resolve_obs_tags_list({"tags": ["a"], "observation_scopes": None}) is None
-        assert _resolve_obs_tags_list({"tags": ["a"], "observation_scopes": json.dumps("combined")}) is None
+        assert _resolve_obs_tags_list(_memory(["a"])) is None
+        assert _resolve_obs_tags_list(_memory(["a"], json.dumps("combined"))) is None
 
     def test_per_tag_returns_one_list_per_tag(self):
-        memory = {"tags": ["a", "b"], "observation_scopes": json.dumps("per_tag")}
+        memory = _memory(["a", "b"], "per_tag")
         assert _resolve_obs_tags_list(memory) == [["a"], ["b"]]
 
     def test_all_combinations_returns_all_nonempty_subsets(self):
-        memory = {"tags": ["a", "b"], "observation_scopes": json.dumps("all_combinations")}
+        memory = _memory(["a", "b"], "all_combinations")
         result = _resolve_obs_tags_list(memory)
         assert result is not None
         assert {tuple(sorted(r)) for r in result} == {("a",), ("b",), ("a", "b")}
@@ -171,17 +274,17 @@ class TestResolveObsTagsList:
     def test_per_tag_empty_tags_returns_none(self):
         # Falls back to the default single-pass behaviour; the dispatcher then
         # uses the memory's (empty) tag set, matching combined-mode behaviour.
-        assert _resolve_obs_tags_list({"tags": [], "observation_scopes": json.dumps("per_tag")}) is None
+        assert _resolve_obs_tags_list(_memory([], "per_tag")) is None
 
     def test_explicit_list_passthrough(self):
         spec = [["a"], ["a", "b"]]
-        memory = {"tags": ["a", "b"], "observation_scopes": json.dumps(spec)}
+        memory = _memory(["a", "b"], spec)
         assert _resolve_obs_tags_list(memory) == spec
 
     def test_shared_returns_single_empty_scope(self):
         # One pass over the empty (untagged) scope; the memory's own tags are
         # ignored so cross-tag memories consolidate into one observation.
-        memory = {"tags": ["a", "b"], "observation_scopes": json.dumps("shared")}
+        memory = _memory(["a", "b"], "shared")
         assert _resolve_obs_tags_list(memory) == [[]]
 
 
@@ -212,12 +315,13 @@ class TestDispatchLockAgreement:
         ],
     )
     def test_every_dispatched_scope_has_a_lock(self, memory):
-        dispatched = _resolve_obs_tags_list(memory)
-        write_scopes = set(_resolve_write_scopes(memory))
+        typed_memory = _memory(memory.get("tags"), memory.get("observation_scopes"))
+        dispatched = _resolve_obs_tags_list(typed_memory)
+        write_scopes = set(_resolve_write_scopes(typed_memory))
 
         if dispatched is None:
             # Combined-mode single pass: memory's own tags are the write scope.
-            expected = {frozenset(memory.get("tags") or [])}
+            expected = {frozenset(typed_memory.tags)}
         else:
             expected = {frozenset(s) for s in dispatched}
 

--- a/hindsight-api-slim/tests/test_db_abstraction.py
+++ b/hindsight-api-slim/tests/test_db_abstraction.py
@@ -553,6 +553,17 @@ class TestOracleQueryRewriter:
         assert "JSON_VALUE" in query
         assert "->>" not in query
 
+    def test_exact_array_match_rewrites_both_containment_directions(self):
+        from hindsight_api.engine.db.oracle import _rewrite_pg_to_oracle
+
+        query, _, _ = _rewrite_pg_to_oracle("WHERE tags @> $1::varchar[] AND tags <@ $1::varchar[]")
+
+        assert "@>" not in query
+        assert "<@" not in query
+        assert query.count("JSON_TABLE") == 2
+        assert "JSON_TABLE(:1" in query
+        assert "JSON_TABLE(tags" in query
+
 
 # ---------------------------------------------------------------------------
 # PostgreSQLBackend unit tests (no live DB)

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -5,12 +5,14 @@ Tests all endpoints by starting a FastAPI server and making HTTP requests.
 """
 
 from datetime import datetime
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
 import pytest_asyncio
 
 from hindsight_api.api import create_app
+from hindsight_api.api.http import ConsolidationRequest, MentalModelTrigger, RecallRequest, ReflectRequest
 from tests.llm_judge import assert_meets_criteria
 
 
@@ -31,6 +33,72 @@ async def api_client_real_llm(memory_real_llm):
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         yield client
+
+
+@pytest.mark.asyncio
+async def test_consolidation_api_forwards_independent_source_filters(api_client, memory):
+    with patch.object(
+        memory,
+        "submit_async_consolidation",
+        new=AsyncMock(return_value={"operation_id": "op-2852"}),
+    ) as submit:
+        response = await api_client.post(
+            "/v1/default/banks/test-bank/consolidate",
+            json={
+                "tags": ["source:fitness-app"],
+                "tags_match": "all_strict",
+                "observation_scopes": [["user:alice", "topic:exercise"]],
+            },
+        )
+
+        assert response.status_code == 200
+        submit.assert_awaited_once()
+        kwargs = submit.await_args.kwargs
+        assert kwargs["tags"] == ["source:fitness-app"]
+        assert kwargs["tags_match"] == "all_strict"
+        assert kwargs["observation_scopes"] == [["user:alice", "topic:exercise"]]
+        assert kwargs["tag_groups"] is None
+
+
+@pytest.mark.asyncio
+async def test_consolidation_api_rejects_tags_with_tag_groups(api_client):
+    response = await api_client.post(
+        "/v1/default/banks/test-bank/consolidate",
+        json={
+            "tags": ["source:fitness-app"],
+            "tag_groups": [{"tags": ["source:web"], "match": "exact"}],
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_tag_groups_use_a_stable_shared_schema():
+    for request_model in (RecallRequest, ReflectRequest, MentalModelTrigger, ConsolidationRequest):
+        schema = request_model.model_json_schema()
+        assert "TagGroup" in schema["$defs"]
+        tag_group_items = schema["properties"]["tag_groups"]["anyOf"][0]["items"]
+        assert tag_group_items == {"$ref": "#/$defs/TagGroup"}
+
+
+@pytest.mark.asyncio
+async def test_empty_tag_groups_survives_http_async_execution(api_client, memory, request_context):
+    bank_id = f"test-empty-tag-groups-{datetime.now().timestamp()}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    run_job = AsyncMock(return_value={"memories_processed": 0})
+    try:
+        with patch("hindsight_api.engine.consolidation.run_consolidation_job", new=run_job):
+            response = await api_client.post(
+                f"/v1/default/banks/{bank_id}/consolidate",
+                json={"tag_groups": [], "tags_match": "exact"},
+            )
+
+        assert response.status_code == 200
+        kwargs = run_job.await_args.kwargs
+        assert kwargs["tag_groups"] == []
+        assert kwargs["tags_match"] == "exact"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
 
 
 @pytest.fixture

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -4966,17 +4966,53 @@ components:
     ConsolidationRequest:
       description: Request model for consolidation trigger endpoint.
       example:
+        tag_groups:
+        - match: any_strict
+          tags:
+          - tags
+          - tags
+        - match: any_strict
+          tags:
+          - tags
+          - tags
         observation_scopes:
         - - observation_scopes
           - observation_scopes
         - - observation_scopes
           - observation_scopes
+        tags_match: any
+        tags:
+        - tags
+        - tags
       properties:
         observation_scopes:
           items:
             items:
               type: string
             type: array
+          nullable: true
+          type: array
+        tags:
+          items:
+            type: string
+          nullable: true
+          type: array
+        tags_match:
+          default: any
+          description: "How to match source-fact tags: 'any', 'all', 'any_strict',\
+            \ 'all_strict', or 'exact'. With 'exact' and no tags (or []), only untagged\
+            \ source facts match."
+          enum:
+          - any
+          - all
+          - any_strict
+          - all_strict
+          - exact
+          title: Tags Match
+          type: string
+        tag_groups:
+          items:
+            $ref: '#/components/schemas/TagGroup-Input'
           nullable: true
           type: array
       title: ConsolidationRequest
@@ -6799,7 +6835,7 @@ components:
           type: string
         tag_groups:
           items:
-            $ref: '#/components/schemas/MentalModelTrigger_Input_tag_groups_inner'
+            $ref: '#/components/schemas/TagGroup-Input'
           nullable: true
           type: array
         include_chunks:
@@ -6892,7 +6928,7 @@ components:
           type: string
         tag_groups:
           items:
-            $ref: '#/components/schemas/MentalModelTrigger_Output_tag_groups_inner'
+            $ref: '#/components/schemas/TagGroup-Output'
           nullable: true
           type: array
         include_chunks:
@@ -7225,7 +7261,7 @@ components:
           type: string
         tag_groups:
           items:
-            $ref: '#/components/schemas/MentalModelTrigger_Input_tag_groups_inner'
+            $ref: '#/components/schemas/TagGroup-Input'
           nullable: true
           type: array
         min_scores:
@@ -7579,7 +7615,7 @@ components:
           type: string
         tag_groups:
           items:
-            $ref: '#/components/schemas/MentalModelTrigger_Input_tag_groups_inner'
+            $ref: '#/components/schemas/TagGroup-Input'
           nullable: true
           type: array
         fact_types:
@@ -7837,12 +7873,24 @@ components:
           title: Max Tokens Per Observation
           type: integer
       title: SourceFactsIncludeOptions
+    TagGroup-Input:
+      anyOf:
+      - $ref: '#/components/schemas/TagGroupLeaf'
+      - $ref: '#/components/schemas/TagGroupAnd-Input'
+      - $ref: '#/components/schemas/TagGroupOr-Input'
+      - $ref: '#/components/schemas/TagGroupNot-Input'
+    TagGroup-Output:
+      anyOf:
+      - $ref: '#/components/schemas/TagGroupLeaf'
+      - $ref: '#/components/schemas/TagGroupAnd-Output'
+      - $ref: '#/components/schemas/TagGroupOr-Output'
+      - $ref: '#/components/schemas/TagGroupNot-Output'
     TagGroupAnd-Input:
       description: "Compound AND group: all child filters must match."
       properties:
         and:
           items:
-            $ref: '#/components/schemas/MentalModelTrigger_Input_tag_groups_inner'
+            $ref: '#/components/schemas/TagGroupAnd_Input_and_inner'
           type: array
       required:
       - and
@@ -7852,7 +7900,7 @@ components:
       properties:
         and:
           items:
-            $ref: '#/components/schemas/MentalModelTrigger_Output_tag_groups_inner'
+            $ref: '#/components/schemas/TagGroupAnd_Output_and_inner'
           type: array
       required:
       - and
@@ -7903,7 +7951,7 @@ components:
       properties:
         or:
           items:
-            $ref: '#/components/schemas/MentalModelTrigger_Input_tag_groups_inner'
+            $ref: '#/components/schemas/TagGroupAnd_Input_and_inner'
           type: array
       required:
       - or
@@ -7913,7 +7961,7 @@ components:
       properties:
         or:
           items:
-            $ref: '#/components/schemas/MentalModelTrigger_Output_tag_groups_inner'
+            $ref: '#/components/schemas/TagGroupAnd_Output_and_inner'
           type: array
       required:
       - or
@@ -8491,13 +8539,13 @@ components:
         \ list, giving full control over which combinations to use."
       nullable: true
       title: ObservationScopes
-    MentalModelTrigger_Input_tag_groups_inner:
+    TagGroupAnd_Input_and_inner:
       anyOf:
       - $ref: '#/components/schemas/TagGroupLeaf'
       - $ref: '#/components/schemas/TagGroupAnd-Input'
       - $ref: '#/components/schemas/TagGroupOr-Input'
       - $ref: '#/components/schemas/TagGroupNot-Input'
-    MentalModelTrigger_Output_tag_groups_inner:
+    TagGroupAnd_Output_and_inner:
       anyOf:
       - $ref: '#/components/schemas/TagGroupLeaf'
       - $ref: '#/components/schemas/TagGroupAnd-Output'

--- a/hindsight-clients/go/model_consolidation_request.go
+++ b/hindsight-clients/go/model_consolidation_request.go
@@ -20,6 +20,10 @@ var _ MappedNullable = &ConsolidationRequest{}
 // ConsolidationRequest Request model for consolidation trigger endpoint.
 type ConsolidationRequest struct {
 	ObservationScopes [][]string `json:"observation_scopes,omitempty"`
+	Tags []string `json:"tags,omitempty"`
+	// How to match source-fact tags: 'any', 'all', 'any_strict', 'all_strict', or 'exact'. With 'exact' and no tags (or []), only untagged source facts match.
+	TagsMatch *string `json:"tags_match,omitempty"`
+	TagGroups []MentalModelTriggerInputTagGroupsInner `json:"tag_groups,omitempty"`
 }
 
 // NewConsolidationRequest instantiates a new ConsolidationRequest object
@@ -28,6 +32,8 @@ type ConsolidationRequest struct {
 // will change when the set of required properties is changed
 func NewConsolidationRequest() *ConsolidationRequest {
 	this := ConsolidationRequest{}
+	var tagsMatch string = "any"
+	this.TagsMatch = &tagsMatch
 	return &this
 }
 
@@ -36,6 +42,8 @@ func NewConsolidationRequest() *ConsolidationRequest {
 // but it doesn't guarantee that properties required by API are set
 func NewConsolidationRequestWithDefaults() *ConsolidationRequest {
 	this := ConsolidationRequest{}
+	var tagsMatch string = "any"
+	this.TagsMatch = &tagsMatch
 	return &this
 }
 
@@ -72,6 +80,104 @@ func (o *ConsolidationRequest) SetObservationScopes(v [][]string) {
 	o.ObservationScopes = v
 }
 
+// GetTags returns the Tags field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *ConsolidationRequest) GetTags() []string {
+	if o == nil {
+		var ret []string
+		return ret
+	}
+	return o.Tags
+}
+
+// GetTagsOk returns a tuple with the Tags field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *ConsolidationRequest) GetTagsOk() ([]string, bool) {
+	if o == nil || IsNil(o.Tags) {
+		return nil, false
+	}
+	return o.Tags, true
+}
+
+// HasTags returns a boolean if a field has been set.
+func (o *ConsolidationRequest) HasTags() bool {
+	if o != nil && !IsNil(o.Tags) {
+		return true
+	}
+
+	return false
+}
+
+// SetTags gets a reference to the given []string and assigns it to the Tags field.
+func (o *ConsolidationRequest) SetTags(v []string) {
+	o.Tags = v
+}
+
+// GetTagsMatch returns the TagsMatch field value if set, zero value otherwise.
+func (o *ConsolidationRequest) GetTagsMatch() string {
+	if o == nil || IsNil(o.TagsMatch) {
+		var ret string
+		return ret
+	}
+	return *o.TagsMatch
+}
+
+// GetTagsMatchOk returns a tuple with the TagsMatch field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ConsolidationRequest) GetTagsMatchOk() (*string, bool) {
+	if o == nil || IsNil(o.TagsMatch) {
+		return nil, false
+	}
+	return o.TagsMatch, true
+}
+
+// HasTagsMatch returns a boolean if a field has been set.
+func (o *ConsolidationRequest) HasTagsMatch() bool {
+	if o != nil && !IsNil(o.TagsMatch) {
+		return true
+	}
+
+	return false
+}
+
+// SetTagsMatch gets a reference to the given string and assigns it to the TagsMatch field.
+func (o *ConsolidationRequest) SetTagsMatch(v string) {
+	o.TagsMatch = &v
+}
+
+// GetTagGroups returns the TagGroups field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *ConsolidationRequest) GetTagGroups() []MentalModelTriggerInputTagGroupsInner {
+	if o == nil {
+		var ret []MentalModelTriggerInputTagGroupsInner
+		return ret
+	}
+	return o.TagGroups
+}
+
+// GetTagGroupsOk returns a tuple with the TagGroups field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *ConsolidationRequest) GetTagGroupsOk() ([]MentalModelTriggerInputTagGroupsInner, bool) {
+	if o == nil || IsNil(o.TagGroups) {
+		return nil, false
+	}
+	return o.TagGroups, true
+}
+
+// HasTagGroups returns a boolean if a field has been set.
+func (o *ConsolidationRequest) HasTagGroups() bool {
+	if o != nil && !IsNil(o.TagGroups) {
+		return true
+	}
+
+	return false
+}
+
+// SetTagGroups gets a reference to the given []MentalModelTriggerInputTagGroupsInner and assigns it to the TagGroups field.
+func (o *ConsolidationRequest) SetTagGroups(v []MentalModelTriggerInputTagGroupsInner) {
+	o.TagGroups = v
+}
+
 func (o ConsolidationRequest) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -84,6 +190,15 @@ func (o ConsolidationRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if o.ObservationScopes != nil {
 		toSerialize["observation_scopes"] = o.ObservationScopes
+	}
+	if o.Tags != nil {
+		toSerialize["tags"] = o.Tags
+	}
+	if !IsNil(o.TagsMatch) {
+		toSerialize["tags_match"] = o.TagsMatch
+	}
+	if o.TagGroups != nil {
+		toSerialize["tag_groups"] = o.TagGroups
 	}
 	return toSerialize, nil
 }

--- a/hindsight-clients/go/tag_group_compatibility_test.go
+++ b/hindsight-clients/go/tag_group_compatibility_test.go
@@ -1,0 +1,10 @@
+package hindsight
+
+import "testing"
+
+func TestLegacyTagGroupTypesRemainAvailable(t *testing.T) {
+	var _ MentalModelTriggerInputTagGroupsInner
+	var _ MentalModelTriggerOutputTagGroupsInner
+	var _ Not
+	var _ Not1
+}

--- a/hindsight-clients/python/hindsight_client_api/models/consolidation_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/consolidation_request.py
@@ -17,8 +17,9 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictStr
+from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
+from hindsight_client_api.models.mental_model_trigger_input_tag_groups_inner import MentalModelTriggerInputTagGroupsInner
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -27,7 +28,20 @@ class ConsolidationRequest(BaseModel):
     Request model for consolidation trigger endpoint.
     """ # noqa: E501
     observation_scopes: Optional[List[List[StrictStr]]] = None
-    __properties: ClassVar[List[str]] = ["observation_scopes"]
+    tags: Optional[List[StrictStr]] = None
+    tags_match: Optional[StrictStr] = Field(default='any', description="How to match source-fact tags: 'any', 'all', 'any_strict', 'all_strict', or 'exact'. With 'exact' and no tags (or []), only untagged source facts match.")
+    tag_groups: Optional[List[MentalModelTriggerInputTagGroupsInner]] = None
+    __properties: ClassVar[List[str]] = ["observation_scopes", "tags", "tags_match", "tag_groups"]
+
+    @field_validator('tags_match')
+    def tags_match_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in set(['any', 'all', 'any_strict', 'all_strict', 'exact']):
+            raise ValueError("must be one of enum values ('any', 'all', 'any_strict', 'all_strict', 'exact')")
+        return value
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -68,10 +82,27 @@ class ConsolidationRequest(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of each item in tag_groups (list)
+        _items = []
+        if self.tag_groups:
+            for _item_tag_groups in self.tag_groups:
+                if _item_tag_groups:
+                    _items.append(_item_tag_groups.to_dict())
+            _dict['tag_groups'] = _items
         # set to None if observation_scopes (nullable) is None
         # and model_fields_set contains the field
         if self.observation_scopes is None and "observation_scopes" in self.model_fields_set:
             _dict['observation_scopes'] = None
+
+        # set to None if tags (nullable) is None
+        # and model_fields_set contains the field
+        if self.tags is None and "tags" in self.model_fields_set:
+            _dict['tags'] = None
+
+        # set to None if tag_groups (nullable) is None
+        # and model_fields_set contains the field
+        if self.tag_groups is None and "tag_groups" in self.model_fields_set:
+            _dict['tag_groups'] = None
 
         return _dict
 
@@ -85,7 +116,10 @@ class ConsolidationRequest(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "observation_scopes": obj.get("observation_scopes")
+            "observation_scopes": obj.get("observation_scopes"),
+            "tags": obj.get("tags"),
+            "tags_match": obj.get("tags_match") if obj.get("tags_match") is not None else 'any',
+            "tag_groups": [MentalModelTriggerInputTagGroupsInner.from_dict(_item) for _item in obj["tag_groups"]] if obj.get("tag_groups") is not None else None
         })
         return _obj
 

--- a/hindsight-clients/python/openapi-generator-config.yaml
+++ b/hindsight-clients/python/openapi-generator-config.yaml
@@ -9,3 +9,8 @@ globalProperties:
   modelTests: false
   apiDocs: false
   modelDocs: false
+modelNameMappings:
+  TagGroup-Input: MentalModelTriggerInputTagGroupsInner
+  TagGroup-Output: MentalModelTriggerOutputTagGroupsInner
+  TagGroupAnd_Input_and_inner: MentalModelTriggerInputTagGroupsInner
+  TagGroupAnd_Output_and_inner: MentalModelTriggerOutputTagGroupsInner

--- a/hindsight-clients/python/tests/test_tag_group_compatibility.py
+++ b/hindsight-clients/python/tests/test_tag_group_compatibility.py
@@ -1,0 +1,17 @@
+"""Pin the public tag-group model names emitted by older SDK releases."""
+
+from hindsight_client_api.models.mental_model_trigger_input_tag_groups_inner import (
+    MentalModelTriggerInputTagGroupsInner,
+)
+from hindsight_client_api.models.mental_model_trigger_output_tag_groups_inner import (
+    MentalModelTriggerOutputTagGroupsInner,
+)
+from hindsight_client_api.models.model_not import ModelNot
+from hindsight_client_api.models.not1 import Not1
+
+
+def test_legacy_tag_group_models_remain_importable():
+    assert MentalModelTriggerInputTagGroupsInner.__name__ == "MentalModelTriggerInputTagGroupsInner"
+    assert MentalModelTriggerOutputTagGroupsInner.__name__ == "MentalModelTriggerOutputTagGroupsInner"
+    assert ModelNot.__name__ == "ModelNot"
+    assert Not1.__name__ == "Not1"

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -994,9 +994,27 @@ export type ConsolidationRequest = {
   /**
    * Observation Scopes
    *
-   * Optional list of tag scopes to consolidate. Each scope is a list of tags. Only unconsolidated memories whose tags contain all tags in at least one scope will be processed. If omitted, all unconsolidated memories are processed.
+   * Optional exact observation write scopes to consolidate. A source fact is processed when at least one of its resolved observation scopes exactly equals at least one requested scope, regardless of tag order. Subset and superset scopes do not match; [[]] targets the shared/untagged scope.
    */
   observation_scopes?: Array<Array<string>> | null;
+  /**
+   * Tags
+   *
+   * Filter source facts by their ordinary tags. Mutually exclusive with tag_groups.
+   */
+  tags?: Array<string> | null;
+  /**
+   * Tags Match
+   *
+   * How to match source-fact tags: 'any', 'all', 'any_strict', 'all_strict', or 'exact'. With 'exact' and no tags (or []), only untagged source facts match.
+   */
+  tags_match?: "any" | "all" | "any_strict" | "all_strict" | "exact";
+  /**
+   * Tag Groups
+   *
+   * Compound source-fact tag filter. Each entry is a leaf {tags, match} or compound {and: [...]}, {or: [...]}, {not: ...}. Mutually exclusive with tags.
+   */
+  tag_groups?: Array<TagGroupInput> | null;
 };
 
 /**
@@ -2556,7 +2574,7 @@ export type MentalModelTriggerInput = {
    *
    * Compound boolean tag expressions to use during refresh instead of the model's own tags. When set, these tag groups are passed to reflect and the model's flat tags are NOT used for filtering. Supports nested and/or/not expressions for complex tag-based scoping.
    */
-  tag_groups?: Array<TagGroupLeaf | TagGroupAndInput | TagGroupOrInput | TagGroupNotInput> | null;
+  tag_groups?: Array<TagGroupInput> | null;
   /**
    * Include Chunks
    *
@@ -2630,9 +2648,7 @@ export type MentalModelTriggerOutput = {
    *
    * Compound boolean tag expressions to use during refresh instead of the model's own tags. When set, these tag groups are passed to reflect and the model's flat tags are NOT used for filtering. Supports nested and/or/not expressions for complex tag-based scoping.
    */
-  tag_groups?: Array<
-    TagGroupLeaf | TagGroupAndOutput | TagGroupOrOutput | TagGroupNotOutput
-  > | null;
+  tag_groups?: Array<TagGroupOutput> | null;
   /**
    * Include Chunks
    *
@@ -2996,7 +3012,7 @@ export type RecallRequest = {
    *
    * Compound tag filter using boolean groups. Groups in the list are AND-ed. Each group is a leaf {tags, match} or compound {and: [...]}, {or: [...]}, {not: ...}.
    */
-  tag_groups?: Array<TagGroupLeaf | TagGroupAndInput | TagGroupOrInput | TagGroupNotInput> | null;
+  tag_groups?: Array<TagGroupInput> | null;
   /**
    * Optional per-stage score floors (all inclusive, AND-ed). `semantic` and `keyword` are retrieval-level cutoffs pushed into the SQL arms (overriding the global similarity/BM25 minimums for this request); `reranker` and `final` are post-ranking filters on the scored results. Any field left unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering. Use with care — the reranker's absolute scores are not calibrated across queries (a clearly-relevant match may score ~0.001 even though it is ranked first).
    */
@@ -3360,7 +3376,7 @@ export type ReflectRequest = {
    *
    * Compound tag filter using boolean groups. Groups in the list are AND-ed. Each group is a leaf {tags, match} or compound {and: [...]}, {or: [...]}, {not: ...}.
    */
-  tag_groups?: Array<TagGroupLeaf | TagGroupAndInput | TagGroupOrInput | TagGroupNotInput> | null;
+  tag_groups?: Array<TagGroupInput> | null;
   /**
    * Fact Types
    *
@@ -3604,6 +3620,14 @@ export type SourceFactsIncludeOptions = {
    */
   max_tokens_per_observation?: number;
 };
+
+export type TagGroupInput = TagGroupLeaf | TagGroupAndInput | TagGroupOrInput | TagGroupNotInput;
+
+export type TagGroupOutput =
+  | TagGroupLeaf
+  | TagGroupAndOutput
+  | TagGroupOrOutput
+  | TagGroupNotOutput;
 
 /**
  * TagGroupAnd

--- a/hindsight-docs/docs/developer/api/operations.mdx
+++ b/hindsight-docs/docs/developer/api/operations.mdx
@@ -72,9 +72,9 @@ Triggered automatically:
 
 - After every retain that added world/experience facts (gated by per-bank `enable_auto_consolidation` and `enable_observations`).
 - After deletes that invalidated existing observations (the source memory disappeared → derived observations are stale → re-run with the surviving co-source memories).
-- Manually via `POST /v1/default/banks/{bank_id}/consolidate`. Pass `observation_scopes` to consolidate only memories matching specific tag combinations.
+- Manually via `POST /v1/default/banks/{bank_id}/consolidate`. Pass `tags`/`tag_groups` to filter ordinary source tags, or `observation_scopes` to select sources with an exact resolved observation write scope.
 
-**Bank-deduped**: while one `consolidation` job is pending for a bank, repeat submits return the existing `operation_id` instead of stacking. Once the job starts processing, the next submit becomes the next pending slot.
+**Full-bank jobs are bank-deduped**: while one unfiltered `consolidation` job is pending for a bank, repeat unfiltered submits return the existing `operation_id` instead of stacking. Targeted jobs that provide non-empty `tags`, non-empty `tag_groups`, any explicit `observation_scopes`, or `tags_match: "exact"` are queued separately so their requested source set is preserved. Exact matching remains targeted when `tags` is omitted or empty because that combination selects only untagged source facts; empty tag filters under other match modes are equivalent to a full-bank request.
 
 ### `refresh_mental_model`
 

--- a/hindsight-docs/docs/developer/observations.mdx
+++ b/hindsight-docs/docs/developer/observations.mdx
@@ -70,25 +70,38 @@ This is useful when you want full control over consolidation timing — for exam
 
 ### Targeted Consolidation
 
-By default, consolidation processes **all** unconsolidated memories in a bank. You can scope it to specific tag sets using the `observation_scopes` parameter on the consolidate endpoint:
+By default, consolidation processes **all** unconsolidated source facts in a bank. The consolidate endpoint exposes two independent ways to target that source set.
 
-```python
-# Consolidate only memories tagged with user:alice
-client.consolidate(
-    bank_id="my-bank",
-    observation_scopes=[["user:alice"]]
-)
+Use `tags` with `tags_match` to filter the ordinary tags stored on source facts:
 
-# Consolidate memories for alice OR the engineering team
-client.consolidate(
-    bank_id="my-bank",
-    observation_scopes=[["user:alice"], ["team:engineering"]]
-)
+```json
+{
+  "tags": ["source:fitness-app"],
+  "tags_match": "exact"
+}
 ```
 
-Each scope is a list of tags. A memory matches a scope if its tags **contain all** tags in that scope. For example, scope `["user:alice"]` matches memories tagged `["user:alice", "team:eng"]`.
+The supported modes are `any`, `all`, `any_strict`, `all_strict`, and `exact`, matching the semantics used by recall. Use `tag_groups` for compound `and`/`or`/`not` expressions.
 
-When `observation_scopes` is omitted, all unconsolidated memories are processed (backward compatible).
+Use `observation_scopes` when you want to select source facts by where they are configured to write observations:
+
+```json
+{
+  "observation_scopes": [
+    ["user:alice", "topic:exercise"]
+  ]
+}
+```
+
+Hindsight first resolves each source fact's concrete write scopes from its retain-time `observation_scopes` configuration (`combined`, `per_tag`, `all_combinations`, `shared`, or an explicit scope list). A source fact is selected if at least one resolved scope exactly equals a requested scope. Scope equality is order-independent; subsets and supersets do not match. Use `[[]]` to target facts that write to the shared/untagged scope.
+
+:::caution Compatibility change
+
+Earlier releases incorrectly interpreted consolidate-request `observation_scopes` as containment filters over a source fact's ordinary `tags`. That behavior now belongs to `tags` with `tags_match: "all_strict"`. The `observation_scopes` request field now exclusively performs exact matching against the source fact's resolved observation write scopes.
+
+:::
+
+The two filters may be combined. In that case a source fact must satisfy both its ordinary tag filter and its exact observation-scope filter.
 
 ### Evidence-Based Evolution
 
@@ -251,7 +264,9 @@ POST /v1/default/banks/{bank_id}/consolidate
 Content-Type: application/json
 
 {
-  "observation_scopes": [["user:alice"], ["team:engineering"]]
+  "tags": ["source:fitness-app"],
+  "tags_match": "all_strict",
+  "observation_scopes": [["user:alice", "topic:exercise"]]
 }
 ```
 
@@ -259,7 +274,12 @@ The request body is optional. When omitted (or sent as an empty body), all uncon
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `observation_scopes` | `list[list[str]]` \| `null` | Optional list of tag scopes. Only memories whose tags contain all tags in at least one scope are processed. Omit for a full-bank sweep. |
+| `tags` | `list[str]` \| `null` | Filter source facts by their ordinary tags. |
+| `tags_match` | `any` \| `all` \| `any_strict` \| `all_strict` \| `exact` | Match mode for `tags`; defaults to `any`. |
+| `tag_groups` | `list[TagGroup]` \| `null` | Compound ordinary-tag filter using `and`, `or`, and `not`; mutually exclusive with `tags`. |
+| `observation_scopes` | `list[list[str]]` \| `null` | Filter source facts by their resolved observation write scopes. At least one resolved scope must equal one requested scope exactly; order does not matter, but subsets and supersets do not match. |
+
+Ordinary source tags and observation write scopes are separate fields and can be filtered independently. In the example above, the source fact must have the ordinary tag `source:fitness-app` and must be configured to write to the exact scope `{"user:alice", "topic:exercise"}`.
 
 ## Configuration
 

--- a/hindsight-docs/static/bank-template-schema.json
+++ b/hindsight-docs/static/bank-template-schema.json
@@ -645,20 +645,7 @@
           "anyOf": [
             {
               "items": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/TagGroupLeaf"
-                  },
-                  {
-                    "$ref": "#/$defs/TagGroupAnd"
-                  },
-                  {
-                    "$ref": "#/$defs/TagGroupOr"
-                  },
-                  {
-                    "$ref": "#/$defs/TagGroupNot"
-                  }
-                ]
+                "$ref": "#/$defs/TagGroup"
               },
               "type": "array"
             },
@@ -712,6 +699,22 @@
       },
       "title": "MentalModelTrigger",
       "type": "object"
+    },
+    "TagGroup": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TagGroupLeaf"
+        },
+        {
+          "$ref": "#/$defs/TagGroupAnd"
+        },
+        {
+          "$ref": "#/$defs/TagGroupOr"
+        },
+        {
+          "$ref": "#/$defs/TagGroupNot"
+        }
+      ]
     },
     "TagGroupAnd": {
       "description": "Compound AND group: all child filters must match.",

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -7478,7 +7478,50 @@
               }
             ],
             "title": "Observation Scopes",
-            "description": "Optional list of tag scopes to consolidate. Each scope is a list of tags. Only unconsolidated memories whose tags contain all tags in at least one scope will be processed. If omitted, all unconsolidated memories are processed."
+            "description": "Optional exact observation write scopes to consolidate. A source fact is processed when at least one of its resolved observation scopes exactly equals at least one requested scope, regardless of tag order. Subset and superset scopes do not match; [[]] targets the shared/untagged scope."
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags",
+            "description": "Filter source facts by their ordinary tags. Mutually exclusive with tag_groups."
+          },
+          "tags_match": {
+            "type": "string",
+            "enum": [
+              "any",
+              "all",
+              "any_strict",
+              "all_strict",
+              "exact"
+            ],
+            "title": "Tags Match",
+            "description": "How to match source-fact tags: 'any', 'all', 'any_strict', 'all_strict', or 'exact'. With 'exact' and no tags (or []), only untagged source facts match.",
+            "default": "any"
+          },
+          "tag_groups": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/TagGroup-Input"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tag Groups",
+            "description": "Compound source-fact tag filter. Each entry is a leaf {tags, match} or compound {and: [...]}, {or: [...]}, {not: ...}. Mutually exclusive with tags."
           }
         },
         "type": "object",
@@ -10148,20 +10191,7 @@
             "anyOf": [
               {
                 "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/TagGroupLeaf"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupAnd-Input"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupOr-Input"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupNot-Input"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TagGroup-Input"
                 },
                 "type": "array"
               },
@@ -10307,20 +10337,7 @@
             "anyOf": [
               {
                 "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/TagGroupLeaf"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupAnd-Output"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupOr-Output"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupNot-Output"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TagGroup-Output"
                 },
                 "type": "array"
               },
@@ -10981,20 +10998,7 @@
             "anyOf": [
               {
                 "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/TagGroupLeaf"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupAnd-Input"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupOr-Input"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupNot-Input"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TagGroup-Input"
                 },
                 "type": "array"
               },
@@ -11711,20 +11715,7 @@
             "anyOf": [
               {
                 "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/TagGroupLeaf"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupAnd-Input"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupOr-Input"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupNot-Input"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TagGroup-Input"
                 },
                 "type": "array"
               },
@@ -12205,6 +12196,38 @@
         "type": "object",
         "title": "SourceFactsIncludeOptions",
         "description": "Options for including source facts for observation-type results."
+      },
+      "TagGroup-Input": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/TagGroupLeaf"
+          },
+          {
+            "$ref": "#/components/schemas/TagGroupAnd-Input"
+          },
+          {
+            "$ref": "#/components/schemas/TagGroupOr-Input"
+          },
+          {
+            "$ref": "#/components/schemas/TagGroupNot-Input"
+          }
+        ]
+      },
+      "TagGroup-Output": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/TagGroupLeaf"
+          },
+          {
+            "$ref": "#/components/schemas/TagGroupAnd-Output"
+          },
+          {
+            "$ref": "#/components/schemas/TagGroupOr-Output"
+          },
+          {
+            "$ref": "#/components/schemas/TagGroupNot-Output"
+          }
+        ]
       },
       "TagGroupAnd-Input": {
         "properties": {

--- a/scripts/generate-clients.sh
+++ b/scripts/generate-clients.sh
@@ -7,6 +7,10 @@ set -e
 
 # Pin openapi-generator version for reproducible builds across local and CI
 OPENAPI_GENERATOR_VERSION="v7.10.0"
+TAG_GROUP_MODEL_MAPPINGS="TagGroup-Input=MentalModelTriggerInputTagGroupsInner,"\
+"TagGroup-Output=MentalModelTriggerOutputTagGroupsInner,"\
+"TagGroupAnd_Input_and_inner=MentalModelTriggerInputTagGroupsInner,"\
+"TagGroupAnd_Output_and_inner=MentalModelTriggerOutputTagGroupsInner"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -445,6 +449,8 @@ else
         --package-name hindsight \
         --git-user-id vectorize-io \
         --git-repo-id hindsight/hindsight-clients/go \
+        --model-name-mappings \
+        "$TAG_GROUP_MODEL_MAPPINGS" \
         --global-property apiDocs=false,apiTests=false,modelDocs=false,modelTests=false
 
     # Remove OpenAPI Generator boilerplate files

--- a/skills/hindsight-docs/references/developer/api/operations.md
+++ b/skills/hindsight-docs/references/developer/api/operations.md
@@ -60,9 +60,9 @@ Triggered automatically:
 
 - After every retain that added world/experience facts (gated by per-bank `enable_auto_consolidation` and `enable_observations`).
 - After deletes that invalidated existing observations (the source memory disappeared → derived observations are stale → re-run with the surviving co-source memories).
-- Manually via `POST /v1/default/banks/{bank_id}/consolidate`. Pass `observation_scopes` to consolidate only memories matching specific tag combinations.
+- Manually via `POST /v1/default/banks/{bank_id}/consolidate`. Pass `tags`/`tag_groups` to filter ordinary source tags, or `observation_scopes` to select sources with an exact resolved observation write scope.
 
-**Bank-deduped**: while one `consolidation` job is pending for a bank, repeat submits return the existing `operation_id` instead of stacking. Once the job starts processing, the next submit becomes the next pending slot.
+**Full-bank jobs are bank-deduped**: while one unfiltered `consolidation` job is pending for a bank, repeat unfiltered submits return the existing `operation_id` instead of stacking. Targeted jobs that provide non-empty `tags`, non-empty `tag_groups`, any explicit `observation_scopes`, or `tags_match: "exact"` are queued separately so their requested source set is preserved. Exact matching remains targeted when `tags` is omitted or empty because that combination selects only untagged source facts; empty tag filters under other match modes are equivalent to a full-bank request.
 
 ### `refresh_mental_model`
 

--- a/skills/hindsight-docs/references/developer/observations.md
+++ b/skills/hindsight-docs/references/developer/observations.md
@@ -64,25 +64,37 @@ This is useful when you want full control over consolidation timing — for exam
 
 ### Targeted Consolidation
 
-By default, consolidation processes **all** unconsolidated memories in a bank. You can scope it to specific tag sets using the `observation_scopes` parameter on the consolidate endpoint:
+By default, consolidation processes **all** unconsolidated source facts in a bank. The consolidate endpoint exposes two independent ways to target that source set.
 
-```python
-# Consolidate only memories tagged with user:alice
-client.consolidate(
-    bank_id="my-bank",
-    observation_scopes=[["user:alice"]]
-)
+Use `tags` with `tags_match` to filter the ordinary tags stored on source facts:
 
-# Consolidate memories for alice OR the engineering team
-client.consolidate(
-    bank_id="my-bank",
-    observation_scopes=[["user:alice"], ["team:engineering"]]
-)
+```json
+{
+  "tags": ["source:fitness-app"],
+  "tags_match": "exact"
+}
 ```
 
-Each scope is a list of tags. A memory matches a scope if its tags **contain all** tags in that scope. For example, scope `["user:alice"]` matches memories tagged `["user:alice", "team:eng"]`.
+The supported modes are `any`, `all`, `any_strict`, `all_strict`, and `exact`, matching the semantics used by recall. Use `tag_groups` for compound `and`/`or`/`not` expressions.
 
-When `observation_scopes` is omitted, all unconsolidated memories are processed (backward compatible).
+Use `observation_scopes` when you want to select source facts by where they are configured to write observations:
+
+```json
+{
+  "observation_scopes": [
+    ["user:alice", "topic:exercise"]
+  ]
+}
+```
+
+Hindsight first resolves each source fact's concrete write scopes from its retain-time `observation_scopes` configuration (`combined`, `per_tag`, `all_combinations`, `shared`, or an explicit scope list). A source fact is selected if at least one resolved scope exactly equals a requested scope. Scope equality is order-independent; subsets and supersets do not match. Use `[[]]` to target facts that write to the shared/untagged scope.
+
+> **🚨 Compatibility change**
+>
+
+Earlier releases incorrectly interpreted consolidate-request `observation_scopes` as containment filters over a source fact's ordinary `tags`. That behavior now belongs to `tags` with `tags_match: "all_strict"`. The `observation_scopes` request field now exclusively performs exact matching against the source fact's resolved observation write scopes.
+
+The two filters may be combined. In that case a source fact must satisfy both its ordinary tag filter and its exact observation-scope filter.
 
 ### Evidence-Based Evolution
 
@@ -259,7 +271,9 @@ POST /v1/default/banks/{bank_id}/consolidate
 Content-Type: application/json
 
 {
-  "observation_scopes": [["user:alice"], ["team:engineering"]]
+  "tags": ["source:fitness-app"],
+  "tags_match": "all_strict",
+  "observation_scopes": [["user:alice", "topic:exercise"]]
 }
 ```
 
@@ -267,7 +281,12 @@ The request body is optional. When omitted (or sent as an empty body), all uncon
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `observation_scopes` | `list[list[str]]` \| `null` | Optional list of tag scopes. Only memories whose tags contain all tags in at least one scope are processed. Omit for a full-bank sweep. |
+| `tags` | `list[str]` \| `null` | Filter source facts by their ordinary tags. |
+| `tags_match` | `any` \| `all` \| `any_strict` \| `all_strict` \| `exact` | Match mode for `tags`; defaults to `any`. |
+| `tag_groups` | `list[TagGroup]` \| `null` | Compound ordinary-tag filter using `and`, `or`, and `not`; mutually exclusive with `tags`. |
+| `observation_scopes` | `list[list[str]]` \| `null` | Filter source facts by their resolved observation write scopes. At least one resolved scope must equal one requested scope exactly; order does not matter, but subsets and supersets do not match. |
+
+Ordinary source tags and observation write scopes are separate fields and can be filtered independently. In the example above, the source fact must have the ordinary tag `source:fitness-app` and must be configured to write to the exact scope `{"user:alice", "topic:exercise"}`.
 
 ## Configuration
 

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -7478,7 +7478,50 @@
               }
             ],
             "title": "Observation Scopes",
-            "description": "Optional list of tag scopes to consolidate. Each scope is a list of tags. Only unconsolidated memories whose tags contain all tags in at least one scope will be processed. If omitted, all unconsolidated memories are processed."
+            "description": "Optional exact observation write scopes to consolidate. A source fact is processed when at least one of its resolved observation scopes exactly equals at least one requested scope, regardless of tag order. Subset and superset scopes do not match; [[]] targets the shared/untagged scope."
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags",
+            "description": "Filter source facts by their ordinary tags. Mutually exclusive with tag_groups."
+          },
+          "tags_match": {
+            "type": "string",
+            "enum": [
+              "any",
+              "all",
+              "any_strict",
+              "all_strict",
+              "exact"
+            ],
+            "title": "Tags Match",
+            "description": "How to match source-fact tags: 'any', 'all', 'any_strict', 'all_strict', or 'exact'. With 'exact' and no tags (or []), only untagged source facts match.",
+            "default": "any"
+          },
+          "tag_groups": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/TagGroup-Input"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tag Groups",
+            "description": "Compound source-fact tag filter. Each entry is a leaf {tags, match} or compound {and: [...]}, {or: [...]}, {not: ...}. Mutually exclusive with tags."
           }
         },
         "type": "object",
@@ -10148,20 +10191,7 @@
             "anyOf": [
               {
                 "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/TagGroupLeaf"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupAnd-Input"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupOr-Input"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupNot-Input"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TagGroup-Input"
                 },
                 "type": "array"
               },
@@ -10307,20 +10337,7 @@
             "anyOf": [
               {
                 "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/TagGroupLeaf"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupAnd-Output"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupOr-Output"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupNot-Output"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TagGroup-Output"
                 },
                 "type": "array"
               },
@@ -10981,20 +10998,7 @@
             "anyOf": [
               {
                 "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/TagGroupLeaf"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupAnd-Input"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupOr-Input"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupNot-Input"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TagGroup-Input"
                 },
                 "type": "array"
               },
@@ -11711,20 +11715,7 @@
             "anyOf": [
               {
                 "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/TagGroupLeaf"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupAnd-Input"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupOr-Input"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TagGroupNot-Input"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TagGroup-Input"
                 },
                 "type": "array"
               },
@@ -12205,6 +12196,38 @@
         "type": "object",
         "title": "SourceFactsIncludeOptions",
         "description": "Options for including source facts for observation-type results."
+      },
+      "TagGroup-Input": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/TagGroupLeaf"
+          },
+          {
+            "$ref": "#/components/schemas/TagGroupAnd-Input"
+          },
+          {
+            "$ref": "#/components/schemas/TagGroupOr-Input"
+          },
+          {
+            "$ref": "#/components/schemas/TagGroupNot-Input"
+          }
+        ]
+      },
+      "TagGroup-Output": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/TagGroupLeaf"
+          },
+          {
+            "$ref": "#/components/schemas/TagGroupAnd-Output"
+          },
+          {
+            "$ref": "#/components/schemas/TagGroupOr-Output"
+          },
+          {
+            "$ref": "#/components/schemas/TagGroupNot-Output"
+          }
+        ]
       },
       "TagGroupAnd-Input": {
         "properties": {


### PR DESCRIPTION
## Context

Targeted consolidation accepts `observation_scopes`, but the previous implementation applied each requested scope to the source fact ordinary `tags` column with array containment. The API name therefore described observation write scopes while the runtime behavior performed an ordinary source-tag query.

This distinction is observable because the fields can intentionally be unrelated. A source fact may use `tags: ["source:fitness-app"]` for provenance while using `observation_scopes: [["user:alice", "topic:exercise"]]` to control where derived observations are written. Filtering the first field through an API named after the second made the request ambiguous and provided no way to target the actual write-scope configuration.

## Problem statement

| Source-fact field | Meaning | Example |
| --- | --- | --- |
| `tags` | Ordinary metadata attached to the source fact and used by tag-filtering APIs | `["source:fitness-app"]` |
| `observation_scopes` | Configuration that resolves into one or more scopes used as tags on derived observations | `[["user:alice", "topic:exercise"]]` |

The old implementation effectively evaluated `source.tags @> requested_observation_scope`. It did not inspect or resolve `source.observation_scopes`. A request could therefore select a source merely because the requested strings happened to be ordinary tags, while missing a source that was actually configured to write to the requested observation scope.

## Goals

- Expose the existing source-fact tag query as an explicitly named `tags` filter.
- Reuse the complete tag matching vocabulary already implemented elsewhere.
- Give `observation_scopes` its literal meaning: select source facts by their resolved observation write scopes.
- Define observation-scope equality as exact, order-independent set equality.
- Preserve both filter dimensions through async submission, worker deserialization, round-limit requeues, progress accounting, and generated API clients.
- Keep PostgreSQL and Oracle behavior aligned.

## Non-goals

- Preserve the previous misuse of `observation_scopes` as an alternate source-tag filter.
- Introduce a compatibility alias or silently infer which field a caller intended.
- Change how a selected source fact generates observations after it enters consolidation.
- Change recall or reflect tag semantics.

## API design

`POST /v1/default/banks/{bank_id}/consolidate` now accepts two independent source-selection dimensions:

| Field | Type | Semantics |
| --- | --- | --- |
| `tags` | `list[str] | null` | Flat filter over the source fact ordinary `tags` field |
| `tags_match` | `any | all | any_strict | all_strict | exact` | Match mode for the flat `tags` filter; defaults to `any` |
| `tag_groups` | `list[TagGroup] | null` | Recursive boolean filter over ordinary source tags; mutually exclusive with `tags` |
| `observation_scopes` | `list[list[str]] | null` | Exact filter over the source fact resolved observation write scopes |

`tags` and `tag_groups` are mutually exclusive because `tag_groups` is the compound form of the same ordinary-tag dimension. `observation_scopes` is separate and may be combined with either ordinary-tag form. When dimensions are combined, a source fact must satisfy both.

### Flat tag matching

The endpoint delegates to the existing tag filter builder, so consolidation uses the same matching vocabulary as the other tag-aware APIs:

| Mode | Source-fact match rule | Untagged sources |
| --- | --- | --- |
| `any` | At least one requested tag is present | Included |
| `all` | Every requested tag is present; extra tags are allowed | Included |
| `any_strict` | At least one requested tag is present | Excluded |
| `all_strict` | Every requested tag is present; extra tags are allowed | Excluded |
| `exact` | The complete source tag set equals the requested tag set | Excluded, except omitted `tags` or `[]` selects only the untagged set |

`tag_groups` supports `{tags, match}` leaf nodes and recursive `{and: [...]}`, `{or: [...]}`, and `{not: ...}` nodes. Each leaf owns its match mode, and top-level groups are ANDed. A flat `tags_match` value does not add an implicit empty-tag filter when `tag_groups` is present.

### Exact observation-scope matching

Each source fact retain-time configuration is resolved through the same helper used by consolidation dispatch:

| Source configuration | Resolved write scopes |
| --- | --- |
| omitted or `combined` | One scope containing the complete ordinary source tag set |
| `per_tag` | One singleton scope per source tag |
| `all_combinations` | Every non-empty combination of source tags |
| `shared` | One empty/global scope |
| explicit `list[list[str]]` | The explicitly declared scopes |

Requested and resolved scopes are normalized to sets. A source is eligible when their intersection is non-empty:

```python
bool(resolve_write_scopes(source_fact) & requested_observation_scopes)
```

Scope equality is exact set equality. Tag order and duplicate entries do not affect identity, but missing or additional tags do. `["user:alice"]` does not match `["user:alice", "topic:exercise"]`, and the reverse does not match either. `[[]]` targets only sources whose resolved scopes include the empty/shared scope. An explicit empty outer list `[]` returns `no_new_memories` before any candidate boundary or page scan, while omitting `observation_scopes` disables this filter.

### Example

Given this source fact:

```json
{
  "text": "Alice exercises three times per week.",
  "tags": ["source:fitness-app"],
  "observation_scopes": [["user:alice", "topic:exercise"]]
}
```

Ordinary source metadata can be targeted explicitly:

```json
{
  "tags": ["source:fitness-app"],
  "tags_match": "exact"
}
```

The actual observation destination can be targeted independently, even though those values are absent from the ordinary source tags:

```json
{
  "observation_scopes": [["topic:exercise", "user:alice"]]
}
```

Both dimensions can be required:

```json
{
  "tags": ["source:fitness-app"],
  "tags_match": "all_strict",
  "observation_scopes": [["user:alice", "topic:exercise"]]
}
```

A source whose only resolved scope is `["user:alice", "topic:exercise", "tier:summary"]` is not selected by the requested two-tag scope.

## Execution design

### HTTP validation and task submission

`ConsolidationRequest` validates the new fields, rejects simultaneous `tags` and `tag_groups`, and forwards both dimensions to `submit_async_consolidation`. Omitting the body retains the existing full-bank behavior.

The submission path serializes `observation_scopes`, `tags`, `tags_match`, and aliased recursive `tag_groups` into the async payload. `tag_groups` is serialized whenever it is not `null`, including an explicit empty list, so the HTTP-to-worker path preserves caller input exactly. Filter assembly then applies effective-filter semantics: an empty `tag_groups` list contributes no compound predicate and is omission-equivalent, so `tags_match: "exact"` with no flat tags still selects only untagged source facts.

Unfiltered full-bank jobs retain bank-level pending-operation deduplication. Targeted requests bypass that deduplication so they cannot be merged into a pending full-bank sweep and lose their requested source set. Submission and pending-row inspection share one effective-filter predicate: non-empty `tags`, non-empty `tag_groups`, any explicit `observation_scopes`, or `tags_match: "exact"`. Empty ordinary-tag arrays therefore deduplicate as full-bank work, while exact-empty remains targeted because it selects only untagged sources. A targeted pending task cannot swallow a later full-bank sweep. Round-limit continuations carry all filters unchanged.

### Candidate selection

Ordinary tag predicates are pushed into SQL through the shared parameterized tag builders. The base candidate set remains unconsolidated, non-failed `world` and `experience` source facts in the requested bank.

When `observation_scopes` is present, the job first captures the last candidate key ordered by `(created_at, id)` using only the `id` and `created_at` projection. That key is the upper boundary of the targeted run: sources retained after the boundary are intentionally left for a later request. Candidate projection rows are then read with bounded keyset pagination ordered by the same pair. The implementation never materializes the full candidate row set or the complete eligible UUID set, so worker memory is bounded by one candidate page plus the current consolidation batch rather than growing with bank size.

The bounded candidate set is scanned once. Each page resolves scope configuration, queues only eligible IDs for the next consolidation batch, and is then discarded. Exact totals are intentionally omitted from operation progress until the keyset boundary is exhausted; this avoids doubling database transfer and scope-resolution work merely to pre-count a large or sparse bank. Every candidate projection row is converted at the database boundary into an internal Pydantic model containing `id`, `created_at`, `tags`, and `observation_scopes`. Full source rows are separately parsed into a typed `_ConsolidationMemory` model at the same boundary.

Scope resolution stays in Python because the configuration may be symbolic or explicit and must behave identically across PostgreSQL and Oracle. Reusing the dispatch resolver avoids maintaining a second interpretation of retain-time scope configuration.

### Fetching, progress, and round limits

Scope-targeted jobs fetch full source rows in bounded consolidation batches and recheck pending and failure state before processing. While the keyset scan is still discovering eligible sources, progress reports the processed count without inventing a total. Once the boundary is exhausted, the exact total is the processed count plus the bounded queue of remaining eligible IDs. If a selected candidate disappears before its full row is fetched, the job continues scanning later pages rather than terminating early.

Tag-only jobs retain the dynamic count and fetch path, including progress recounting when new facts arrive during a run. Both paths respect the configured per-round memory limit and preserve filters on continuation.

### Batch isolation

Consolidation previously grouped sources only by ordinary tag set and derived the pass plan from the first source in a group. Once ordinary tags and write scopes are independent, two facts can share identical source tags but require different scope passes.

Batches are now keyed by both the exact ordinary source tag set and the resolved write-scope set. This preserves the existing rule that different source tags never share an LLM call and prevents one source scope configuration from being applied to another fact with the same ordinary tags.

### Database portability

All source-tag predicates remain parameterized and use the shared query builders. Exact matching is represented as both containment directions. PostgreSQL supports `@>` and `<@`; the Oracle rewriter now translates the contained-by direction so exact tag set equality behaves consistently on both backends.

## Selected-source behavior

`observation_scopes` is a source-fact eligibility filter, not a per-pass suppression filter. If a source has resolved scopes A and B and the request matches A, the source is selected and runs its normal consolidation plan for A and B. This implements the requested source-oriented rule: at least one exact resolved scope admits the source, after which consolidation behaves normally.

## Compatibility boundary

The previous behavior is treated as a field-selection bug, not as a second valid meaning of `observation_scopes`. No fallback preserves tag containment under that name. A caller relying on the old behavior should move those values to `tags` and choose the appropriate `tags_match` mode or express the condition with `tag_groups`.

## Alternatives considered

### Rename only the existing behavior

Adding `tags` without real observation-scope targeting would make the old behavior honest but leave no way to select sources by their actual scope configuration.

### Keep containment semantics for observation scopes

Containment would make `["user:alice"]` select a source that writes only to `["user:alice", "topic:exercise"]`. Observation scopes are isolation addresses, so subset matching can cross boundaries and conflicts with exact scope handling elsewhere.

### Resolve scopes entirely in SQL

A SQL-only predicate would require separate equivalent implementations for symbolic and explicit configurations on PostgreSQL and Oracle. Reusing the Python resolver provides one definition of scope identity and avoids cross-database semantic drift.

## Generated surfaces and documentation

The recursive tag-group union now has an explicit shared OpenAPI schema (`TagGroup-Input` / `TagGroup-Output`). Generator model-name mappings deliberately preserve the existing public Python and Go names, including `MentalModelTriggerInputTagGroupsInner`, `MentalModelTriggerOutputTagGroupsInner`, Python `ModelNot` / `Not1`, and Go `Not` / `Not1`. Recall, reflect, mental-model triggers, and the new consolidation field all continue using the legacy input name, avoiding an SDK source compatibility break while keeping the OpenAPI schema stable for future consumers.

The OpenAPI schema, bank-template JSON Schema, Go client, Python client, TypeScript types, developer documentation, operations documentation, and bundled `hindsight-docs` skill are regenerated or synchronized. The public documentation now presents ordinary source tags and observation write scopes as separate, composable selectors.

## Validation

- Unit coverage for exact scope identity, order independence, subset and superset rejection, omitted filters, empty outer lists, `[[]]`, and every symbolic scope mode.
- PostgreSQL integration coverage for all five flat tag modes, compound tag groups, differing ordinary tags and scope configurations, exact resolved-scope selection, and sources with identical ordinary tags but different scope plans.
- HTTP coverage for forwarding independent filters, rejecting simultaneous `tags` and `tag_groups`, preserving explicit empty tag groups through actual async execution, and keeping all tag-group consumers on the shared schema.
- Async operation coverage for payload serialization, worker deserialization, `null` versus `[]`, targeted deduplication behavior, and filter-preserving round-limit requeues.
- Keyset-pagination integration coverage with a two-row page size and identical timestamps, proving that the UUID tie-breaker neither skips nor repeats candidates and that each page is scanned only once.
- Effective-filter deduplication coverage proving empty `tags` and `tag_groups` share full-bank pending operations while exact-empty remains targeted.
- Oracle rewrite coverage for both directions required by exact tag equality.
- `./scripts/hooks/lint.sh`.
- `uv run ty check hindsight_api/api/http.py hindsight_api/engine/memory_engine.py hindsight_api/engine/consolidation/consolidator.py hindsight_api/engine/db/oracle.py`.
- OpenAPI, bank-template schema, generated client, documentation build, and bundled documentation skill generation.
- Generated Python and Go compatibility tests pin the legacy public tag-group imports and recursive type names.
- Consolidation suite: 124 tests passed; 13 real-LLM tests could not initialize because no local LLM API key was configured.

Closes #2852
