### PR TITLE
chore(db): remove the dead advisory_lock dialect helper

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/sql/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/base.py
@@ -300,19 +300,6 @@ class SQLDialect(ABC):
         """FOR UPDATE SKIP LOCKED clause (same on both PG and Oracle)."""
         ...
 
-    @abstractmethod
-    def advisory_lock(self, id_param: str) -> str:
-        """Advisory lock expression.
-
-        Args:
-            id_param: Parameter placeholder for the lock ID.
-
-        Returns:
-            PG: "pg_try_advisory_lock($1)"
-            Oracle: "SELECT ... FOR UPDATE NOWAIT" equivalent.
-        """
-        ...
-
     # -- UUID generation -------------------------------------------------
 
     @abstractmethod

--- a/hindsight-api-slim/hindsight_api/engine/sql/oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/oracle.py
@@ -203,10 +203,6 @@ class OracleDialect(SQLDialect):
     def for_update_skip_locked(self) -> str:
         return "FOR UPDATE SKIP LOCKED"
 
-    def advisory_lock(self, id_param: str) -> str:
-        # Oracle doesn't have advisory locks. Use SELECT FOR UPDATE NOWAIT on a lock row.
-        return "SELECT 1 FROM dual FOR UPDATE NOWAIT"
-
     # -- UUID generation -------------------------------------------------
 
     def generate_uuid(self) -> str:

--- a/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
@@ -118,9 +118,6 @@ class PostgreSQLDialect(SQLDialect):
     def for_update_skip_locked(self) -> str:
         return "FOR UPDATE SKIP LOCKED"
 
-    def advisory_lock(self, id_param: str) -> str:
-        return f"pg_try_advisory_lock({id_param})"
-
     # -- UUID generation -------------------------------------------------
 
     def generate_uuid(self) -> str:

--- a/hindsight-api-slim/tests/test_db_abstraction.py
+++ b/hindsight-api-slim/tests/test_db_abstraction.py
@@ -176,9 +176,6 @@ class TestPostgreSQLDialect:
     def test_for_update_skip_locked(self, d):
         assert d.for_update_skip_locked() == "FOR UPDATE SKIP LOCKED"
 
-    def test_advisory_lock(self, d):
-        assert d.advisory_lock("$1") == "pg_try_advisory_lock($1)"
-
     def test_generate_uuid(self, d):
         assert d.generate_uuid() == "gen_random_uuid()"
 


### PR DESCRIPTION
## Summary

`DatabaseDialect.advisory_lock()` has **no production callers** — the only reference in the whole tree was a test asserting its output string (`test_db_abstraction.py`).

It advertised PostgreSQL advisory locks as a supported dialect primitive, which directly contradicts the **Database Locking** standard added in #2817: advisory locks are unusable here because Hindsight runs behind connection poolers and managed PG services (session-level locks leak/vanish on session reassignment; callers can block forever). A dead helper offering `pg_try_advisory_lock(...)` is a trap for the next author who needs a lock.

## Change

Removes:
- the `@abstractmethod advisory_lock` on `DatabaseDialect` (`base.py`)
- the PostgreSQL implementation (`postgresql.py`)
- the Oracle implementation (`oracle.py`)
- the lone test assertion (`test_db_abstraction.py`)

Deletions only, 4 files, 23 lines.

## Not affected

The grandfathered raw `pg_try_advisory_lock` in `migrations.py` — the coordinator that serializes concurrent per-schema migration processes — is untouched. It calls the primitive directly and never went through this helper. Per the standard, that usage is grandfathered and tracked for removal separately.

## Testing

- `tests/test_db_abstraction.py` — 106 passed.
- `ruff check` / `ty check hindsight_api/engine/sql/`: clean.
- Confirmed zero `.advisory_lock(` call sites repo-wide before removing.