### PR TITLE
fix(#2808): make mental model tags_match configurable on all creation surfaces (MCP, TS client, CLI)

### DIFF
--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -9,7 +9,7 @@ import json
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Callable
+from typing import Any, Callable, get_args
 
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
@@ -23,7 +23,7 @@ from hindsight_api.config import (
 from hindsight_api.engine.audit import AuditEntry, AuditLogger
 from hindsight_api.engine.memory_engine import Budget
 from hindsight_api.engine.response_models import VALID_RECALL_FACT_TYPES, MinScores
-from hindsight_api.engine.search.tags import TagGroup
+from hindsight_api.engine.search.tags import TagGroup, TagsMatch
 from hindsight_api.extensions import OperationValidationError
 from hindsight_api.models import RequestContext
 
@@ -1254,7 +1254,10 @@ def _register_create_bank(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsCo
 
 
 def _validate_mental_model_inputs(
-    name: str | None = None, source_query: str | None = None, max_tokens: int | None = None
+    name: str | None = None,
+    source_query: str | None = None,
+    max_tokens: int | None = None,
+    tags_match: str | None = None,
 ) -> str | None:
     """Validate mental model inputs, returning an error message or None if valid."""
     if name is not None and not name.strip():
@@ -1263,6 +1266,9 @@ def _validate_mental_model_inputs(
         return "source_query cannot be empty"
     if max_tokens is not None and (max_tokens < 256 or max_tokens > 8192):
         return f"max_tokens must be between 256 and 8192, got {max_tokens}"
+    if tags_match is not None and tags_match not in get_args(TagsMatch):
+        valid = ", ".join(get_args(TagsMatch))
+        return f"tags_match must be one of {valid}, got {tags_match!r}"
     return None
 
 
@@ -1444,6 +1450,7 @@ def _register_create_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
             source_query: str,
             mental_model_id: str | None = None,
             tags: list[str] | None = None,
+            tags_match: str | None = None,
             max_tokens: int = 2048,
             trigger_refresh_after_consolidation: bool = False,
             bank_id: str | None = None,
@@ -1465,6 +1472,12 @@ def _register_create_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
                 source_query: The query to run through reflect to generate content
                 mental_model_id: Optional custom ID (alphanumeric lowercase with hyphens). Auto-generated if not provided.
                 tags: Optional tags for scoped visibility filtering
+                tags_match: How this model's tags are matched against memories when the content
+                    is (re)generated. One of 'any' (match any tag, like recall/reflect), 'all'
+                    (match all tags), 'any_strict', 'all_strict', or 'exact'. If omitted, a tagged
+                    model defaults to 'all_strict' — a memory must carry EVERY one of the model's
+                    tags to be included, which silently filters out memories that only carry a
+                    subset. Pass 'any' when your memories use narrow single-topic tags.
                 max_tokens: Maximum tokens for generated content (256-8192, default: 2048)
                 trigger_refresh_after_consolidation: If True, automatically refresh this model after memory consolidation. Default: False
                 bank_id: Optional bank (defaults to session bank). Use for cross-bank operations.
@@ -1475,13 +1488,15 @@ def _register_create_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
                     return '{"error": "No bank_id configured"}'
 
                 validation_error = _validate_mental_model_inputs(
-                    name=name, source_query=source_query, max_tokens=max_tokens
+                    name=name, source_query=source_query, max_tokens=max_tokens, tags_match=tags_match
                 )
                 if validation_error:
                     return json.dumps({"error": validation_error})
 
                 request_context = _get_request_context(config)
-                trigger = {"refresh_after_consolidation": trigger_refresh_after_consolidation}
+                trigger: dict[str, Any] = {"refresh_after_consolidation": trigger_refresh_after_consolidation}
+                if tags_match is not None:
+                    trigger["tags_match"] = tags_match
 
                 # Create with placeholder content
                 model = await memory.create_mental_model(
@@ -1528,6 +1543,7 @@ def _register_create_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
             source_query: str,
             mental_model_id: str | None = None,
             tags: list[str] | None = None,
+            tags_match: str | None = None,
             max_tokens: int = 2048,
             trigger_refresh_after_consolidation: bool = False,
         ) -> dict:
@@ -1548,6 +1564,12 @@ def _register_create_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
                 source_query: The query to run through reflect to generate content
                 mental_model_id: Optional custom ID (alphanumeric lowercase with hyphens). Auto-generated if not provided.
                 tags: Optional tags for scoped visibility filtering
+                tags_match: How this model's tags are matched against memories when the content
+                    is (re)generated. One of 'any' (match any tag, like recall/reflect), 'all'
+                    (match all tags), 'any_strict', 'all_strict', or 'exact'. If omitted, a tagged
+                    model defaults to 'all_strict' — a memory must carry EVERY one of the model's
+                    tags to be included, which silently filters out memories that only carry a
+                    subset. Pass 'any' when your memories use narrow single-topic tags.
                 max_tokens: Maximum tokens for generated content (256-8192, default: 2048)
                 trigger_refresh_after_consolidation: If True, automatically refresh this model after memory consolidation. Default: False
             """
@@ -1557,13 +1579,15 @@ def _register_create_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
                     return {"error": "No bank_id configured"}
 
                 validation_error = _validate_mental_model_inputs(
-                    name=name, source_query=source_query, max_tokens=max_tokens
+                    name=name, source_query=source_query, max_tokens=max_tokens, tags_match=tags_match
                 )
                 if validation_error:
                     return {"error": validation_error}
 
                 request_context = _get_request_context(config)
-                trigger = {"refresh_after_consolidation": trigger_refresh_after_consolidation}
+                trigger: dict[str, Any] = {"refresh_after_consolidation": trigger_refresh_after_consolidation}
+                if tags_match is not None:
+                    trigger["tags_match"] = tags_match
 
                 model = await memory.create_mental_model(
                     bank_id=target_bank,

--- a/hindsight-api-slim/tests/test_mcp_tools.py
+++ b/hindsight-api-slim/tests/test_mcp_tools.py
@@ -713,6 +713,38 @@ class TestCreateMentalModel:
         assert mock_memory.create_mental_model.call_args.kwargs["bank_id"] == "other-bank"
         assert mock_memory.submit_async_refresh_mental_model.call_args.kwargs["bank_id"] == "other-bank"
 
+    async def test_create_with_tags_match_persisted_in_trigger(self, mcp_server_with_mental_models, mock_memory):
+        """tags_match must be written into the trigger so the refresh path can read it (issue #2808)."""
+        await _tools(mcp_server_with_mental_models)["create_mental_model"].fn(
+            name="Current projects",
+            source_query="Which projects is the user working on?",
+            tags=["projects", "mental-model"],
+            tags_match="any",
+        )
+        trigger = mock_memory.create_mental_model.call_args.kwargs["trigger"]
+        assert trigger["tags_match"] == "any"
+
+    async def test_create_without_tags_match_omits_key(self, mcp_server_with_mental_models, mock_memory):
+        """Omitting tags_match must NOT write the key, preserving the engine's all_strict default."""
+        await _tools(mcp_server_with_mental_models)["create_mental_model"].fn(name="Test", source_query="query")
+        trigger = mock_memory.create_mental_model.call_args.kwargs["trigger"]
+        assert "tags_match" not in trigger
+
+    async def test_create_invalid_tags_match_returns_error(self, mcp_server_with_mental_models, mock_memory):
+        """An unknown tags_match value is rejected before touching the engine."""
+        result = await _tools(mcp_server_with_mental_models)["create_mental_model"].fn(
+            name="Test", source_query="query", tags_match="most"
+        )
+        assert "tags_match" in result
+        mock_memory.create_mental_model.assert_not_called()
+
+    async def test_create_tags_match_single_bank(self, mcp_server_single_bank, mock_memory):
+        await _tools(mcp_server_single_bank)["create_mental_model"].fn(
+            name="Test", source_query="query", tags=["a", "b"], tags_match="all"
+        )
+        trigger = mock_memory.create_mental_model.call_args.kwargs["trigger"]
+        assert trigger["tags_match"] == "all"
+
     async def test_create_single_bank(self, mcp_server_single_bank, mock_memory):
         result = await _tools(mcp_server_single_bank)["create_mental_model"].fn(name="Test", source_query="query")
         assert isinstance(result, dict)

--- a/hindsight-cli/src/commands/mental_model.rs
+++ b/hindsight-cli/src/commands/mental_model.rs
@@ -8,6 +8,21 @@ use crate::ui;
 
 use hindsight_client::types;
 
+/// Parse a --tags-match string into the generated TagsMatch enum, rejecting
+/// unknown values so a typo fails loudly instead of silently changing scope.
+fn parse_tags_match(value: &str) -> Result<types::TagsMatch> {
+    Ok(match value.to_lowercase().as_str() {
+        "any" => types::TagsMatch::Any,
+        "all" => types::TagsMatch::All,
+        "any_strict" => types::TagsMatch::AnyStrict,
+        "all_strict" => types::TagsMatch::AllStrict,
+        "exact" => types::TagsMatch::Exact,
+        other => anyhow::bail!(
+            "invalid --tags-match '{other}': expected one of any, all, any_strict, all_strict, exact"
+        ),
+    })
+}
+
 /// List mental models for a bank
 pub fn list(
     client: &ApiClient,
@@ -104,6 +119,7 @@ pub fn create(
     id: Option<&str>,
     tags: Vec<String>,
     max_tokens: i64,
+    tags_match: Option<&str>,
     trigger_refresh_after_consolidation: bool,
     verbose: bool,
     output_format: OutputFormat,
@@ -114,18 +130,21 @@ pub fn create(
         None
     };
 
-    // Only send a trigger when the user opted in, so the server's default
-    // behaviour is preserved otherwise.
-    let trigger = if trigger_refresh_after_consolidation {
+    let tags_match = tags_match.map(parse_tags_match).transpose()?;
+
+    // Only send a trigger when the user opted into one of its fields, so the
+    // server's default behaviour (all_strict for tagged models) is preserved
+    // otherwise.
+    let trigger = if trigger_refresh_after_consolidation || tags_match.is_some() {
         Some(types::MentalModelTriggerInput {
             mode: types::Mode::Full,
-            refresh_after_consolidation: true,
+            refresh_after_consolidation: trigger_refresh_after_consolidation,
             refresh_cron: None,
             exclude_mental_models: false,
             exclude_mental_model_ids: None,
             fact_types: None,
             tag_groups: None,
-            tags_match: None,
+            tags_match,
             include_chunks: None,
             recall_max_tokens: None,
             recall_chunks_max_tokens: None,
@@ -391,5 +410,30 @@ fn print_mental_model_detail(mental_model: &types::MentalModelResponse) {
         println!();
         println!("{}", content);
         println!();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_tags_match_accepts_all_modes() {
+        assert_eq!(parse_tags_match("any").unwrap(), types::TagsMatch::Any);
+        assert_eq!(parse_tags_match("all").unwrap(), types::TagsMatch::All);
+        assert_eq!(parse_tags_match("any_strict").unwrap(), types::TagsMatch::AnyStrict);
+        assert_eq!(parse_tags_match("all_strict").unwrap(), types::TagsMatch::AllStrict);
+        assert_eq!(parse_tags_match("exact").unwrap(), types::TagsMatch::Exact);
+    }
+
+    #[test]
+    fn parse_tags_match_is_case_insensitive() {
+        assert_eq!(parse_tags_match("ANY").unwrap(), types::TagsMatch::Any);
+    }
+
+    #[test]
+    fn parse_tags_match_rejects_unknown() {
+        let err = parse_tags_match("most").unwrap_err().to_string();
+        assert!(err.contains("invalid --tags-match 'most'"), "unexpected error: {err}");
     }
 }

--- a/hindsight-cli/src/main.rs
+++ b/hindsight-cli/src/main.rs
@@ -1014,6 +1014,13 @@ enum MentalModelCommands {
         #[arg(long, default_value = "2048")]
         max_tokens: i64,
 
+        /// How the model's tags filter source memories on refresh: any, all,
+        /// any_strict, all_strict, exact. When omitted, a tagged model defaults
+        /// to all_strict (a memory must carry every tag); pass "any" to match
+        /// memories carrying any of the tags.
+        #[arg(long)]
+        tags_match: Option<String>,
+
         /// Refresh this mental model automatically after observations consolidation
         #[arg(long)]
         trigger_refresh_after_consolidation: bool,
@@ -1648,6 +1655,7 @@ fn run() -> Result<()> {
                 id,
                 tags,
                 max_tokens,
+                tags_match,
                 trigger_refresh_after_consolidation,
             } => commands::mental_model::create(
                 &client,
@@ -1657,6 +1665,7 @@ fn run() -> Result<()> {
                 id.as_deref(),
                 tags,
                 max_tokens,
+                tags_match.as_deref(),
                 trigger_refresh_after_consolidation,
                 verbose,
                 output_format,

--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -806,7 +806,13 @@ export class HindsightClient {
       id?: string;
       tags?: string[];
       maxTokens?: number;
-      trigger?: { refreshAfterConsolidation?: boolean };
+      trigger?: {
+        refreshAfterConsolidation?: boolean;
+        /** How this model's tags filter source memories on refresh. If omitted, a tagged model defaults to 'all_strict' (a memory must carry every one of the model's tags), which silently drops memories that only carry a subset. Set 'any' to match memories carrying any of the tags — the same default recall/reflect use. */
+        tagsMatch?: "any" | "all" | "any_strict" | "all_strict" | "exact";
+        /** Compound tag filter using boolean groups; overrides the model's flat tags/tagsMatch during refresh. */
+        tagGroups?: Array<TagGroupLeaf | TagGroupAndInput | TagGroupOrInput | TagGroupNotInput>;
+      };
       signal?: AbortSignal;
     }
   ): Promise<CreateMentalModelResponse> {
@@ -820,7 +826,11 @@ export class HindsightClient {
         tags: options?.tags,
         max_tokens: options?.maxTokens,
         trigger: options?.trigger
-          ? { refresh_after_consolidation: options.trigger.refreshAfterConsolidation }
+          ? {
+              refresh_after_consolidation: options.trigger.refreshAfterConsolidation,
+              tags_match: options.trigger.tagsMatch,
+              tag_groups: options.trigger.tagGroups,
+            }
           : undefined,
       },
       signal: options?.signal,

--- a/hindsight-clients/typescript/tests/create_mental_model_mapping.test.ts
+++ b/hindsight-clients/typescript/tests/create_mental_model_mapping.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for the createMentalModel wrapper's trigger mapping.
+ *
+ * Unlike the other suites, these do NOT require a running server: the generated
+ * sdk layer is mocked so we can assert the ergonomic camelCase options are
+ * mapped onto the snake_case request body. Regression cover for #2808, where
+ * the wrapper dropped every trigger field except refreshAfterConsolidation and
+ * so a caller could not set tags_match.
+ */
+
+import { HindsightClient } from "../src";
+import * as sdk from "../generated/sdk.gen";
+
+jest.mock("../generated/sdk.gen");
+
+const mockedCreate = sdk.createMentalModel as jest.MockedFunction<typeof sdk.createMentalModel>;
+
+function lastBody(): any {
+  return mockedCreate.mock.calls[0][0].body;
+}
+
+describe("createMentalModel trigger mapping", () => {
+  let client: HindsightClient;
+
+  beforeEach(() => {
+    client = new HindsightClient({ baseUrl: "http://localhost:8888" });
+    mockedCreate.mockReset();
+    mockedCreate.mockResolvedValue({
+      data: { mental_model_id: "mm-1", operation_id: "op-1" },
+    } as any);
+  });
+
+  test("threads tagsMatch into trigger.tags_match", async () => {
+    await client.createMentalModel("bank", "Projects", "Which projects?", {
+      tags: ["projects", "mental-model"],
+      trigger: { tagsMatch: "any" },
+    });
+
+    expect(mockedCreate).toHaveBeenCalledTimes(1);
+    const body = lastBody();
+    expect(body.tags).toEqual(["projects", "mental-model"]);
+    expect(body.trigger.tags_match).toBe("any");
+  });
+
+  test("threads tagGroups into trigger.tag_groups", async () => {
+    await client.createMentalModel("bank", "Scoped", "q", {
+      trigger: { tagGroups: [{ tags: ["user:alice"], match: "all_strict" }] },
+    });
+
+    expect(lastBody().trigger.tag_groups).toEqual([{ tags: ["user:alice"], match: "all_strict" }]);
+  });
+
+  test("still maps refreshAfterConsolidation", async () => {
+    await client.createMentalModel("bank", "Auto", "q", {
+      trigger: { refreshAfterConsolidation: true },
+    });
+
+    expect(lastBody().trigger.refresh_after_consolidation).toBe(true);
+  });
+
+  test("omitting trigger sends no trigger (preserves the all_strict default)", async () => {
+    await client.createMentalModel("bank", "Plain", "q");
+
+    expect(lastBody().trigger).toBeUndefined();
+  });
+});

--- a/hindsight-docs/docs/developer/api/mental-models.mdx
+++ b/hindsight-docs/docs/developer/api/mental-models.mdx
@@ -387,14 +387,7 @@ The `all_strict` default is the safest choice for single-tag models, but it filt
 
 To match memories that carry **any** of the model's tags — the same default `recall` and `reflect` use — set `trigger.tags_match` to `"any"` at creation:
 
-```jsonc
-{
-  "name": "Current projects",
-  "source_query": "Which projects is the user currently working on?",
-  "tags": ["projects", "mental-model"],
-  "trigger": { "tags_match": "any" }
-}
-```
+<CodeSnippet code={mentalModelsPy} section="create-mental-model-tags-match" language="python" />
 
 The MCP `create_mental_model` tool exposes the same option as a top-level `tags_match` argument. Available modes are `any`, `all`, `any_strict`, `all_strict`, and `exact` — see the [Recall tags reference](./recall#tags) for their exact semantics.
 

--- a/hindsight-docs/docs/developer/api/mental-models.mdx
+++ b/hindsight-docs/docs/developer/api/mental-models.mdx
@@ -119,6 +119,8 @@ Mental models can be configured to **automatically refresh** when observations a
 | `mode` | `"full"` \| `"delta"` | `"full"` | Refresh strategy. See [Refresh Mode](#refresh-mode) below. |
 | `refresh_after_consolidation` | bool | false | Automatically refresh after observations consolidation |
 | `refresh_cron` | string \| null | null | UTC 5-field cron expression for scheduled refreshes, such as `"0 3 * * *"` for daily at 03:00 UTC |
+| `tags_match` | string \| null | null | How the model's `tags` filter source memories during refresh: `any`, `all`, `any_strict`, `all_strict`, or `exact`. When `null`, a **tagged** model defaults to `all_strict` (a memory must carry every one of the model's tags). Set `"any"` to match memories carrying *any* of the tags — see [Tags and Visibility](#tags-and-visibility). |
+| `tag_groups` | list \| null | null | Advanced boolean tag expressions that override flat `tags`/`tags_match` entirely. See the [Recall tags reference](./recall#tags). |
 
 When `refresh_after_consolidation` is enabled, the mental model will be re-generated every time the bank's observations are consolidated — ensuring it always reflects the latest synthesized knowledge.
 
@@ -378,6 +380,23 @@ During refresh, it reads:
 ```
 
 This means a mental model tagged `["user:alice"]` will also pick up memories tagged `["user:alice", "team"]` — extra tags on a memory don't disqualify it. Only the mental model's own tags are required to be present.
+
+#### Overriding the default with `tags_match`
+
+The `all_strict` default is the safest choice for single-tag models, but it filters out everything for a **multi-tag** model whose memories only carry one tag each. If a model tagged `["projects", "mental-model"]` reads from memories tagged narrowly (`["project:status"]`, `["tooling"]`, …), no single memory carries *all* the model's tags and the refresh comes back empty.
+
+To match memories that carry **any** of the model's tags — the same default `recall` and `reflect` use — set `trigger.tags_match` to `"any"` at creation:
+
+```jsonc
+{
+  "name": "Current projects",
+  "source_query": "Which projects is the user currently working on?",
+  "tags": ["projects", "mental-model"],
+  "trigger": { "tags_match": "any" }
+}
+```
+
+The MCP `create_mental_model` tool exposes the same option as a top-level `tags_match` argument. Available modes are `any`, `all`, `any_strict`, `all_strict`, and `exact` — see the [Recall tags reference](./recall#tags) for their exact semantics.
 
 ### How tags affect mental model lookup during reflect
 

--- a/hindsight-docs/docs/developer/api/mental-models.mdx
+++ b/hindsight-docs/docs/developer/api/mental-models.mdx
@@ -387,7 +387,20 @@ The `all_strict` default is the safest choice for single-tag models, but it filt
 
 To match memories that carry **any** of the model's tags — the same default `recall` and `reflect` use — set `trigger.tags_match` to `"any"` at creation:
 
+<Tabs>
+<TabItem value="python" label="Python">
 <CodeSnippet code={mentalModelsPy} section="create-mental-model-tags-match" language="python" />
+</TabItem>
+<TabItem value="node" label="Node.js">
+<CodeSnippet code={mentalModelsMjs} section="create-mental-model-tags-match" language="javascript" />
+</TabItem>
+<TabItem value="cli" label="CLI">
+<CodeSnippet code={mentalModelsSh} section="create-mental-model-tags-match" language="bash" />
+</TabItem>
+<TabItem value="go" label="Go">
+<CodeSnippet code={mentalModelsGo} section="create-mental-model-tags-match" language="go" />
+</TabItem>
+</Tabs>
 
 The MCP `create_mental_model` tool exposes the same option as a top-level `tags_match` argument. Available modes are `any`, `all`, `any_strict`, `all_strict`, and `exact` — see the [Recall tags reference](./recall#tags) for their exact semantics.
 

--- a/hindsight-docs/docs/developer/mcp-server.md
+++ b/hindsight-docs/docs/developer/mcp-server.md
@@ -270,8 +270,27 @@ Create a mental model — a living document that stays current with your memorie
 | `source_query` | string | Yes | The query used to generate and refresh the model |
 | `mental_model_id` | string | No | Custom ID (alphanumeric lowercase with hyphens). Auto-generated if not provided |
 | `tags` | list[string] | No | Tags for organizing and filtering models |
+| `tags_match` | string | No | How the model's tags are matched against memories on refresh: `any`, `all`, `any_strict`, `all_strict`, or `exact`. See the note below on the default |
 | `max_tokens` | integer | No | Maximum tokens for model content (default: 2048) |
 | `trigger_refresh_after_consolidation` | boolean | No | Auto-refresh this model after memory consolidation (default: `false`) |
+
+:::warning Tagged models default to `all_strict`
+When a mental model has `tags` but no explicit `tags_match`, its refresh matches memories with **`all_strict`** — a memory must carry **every** one of the model's tags to be included. If your memories use narrow, single-topic tags (e.g. `["project:status"]`) while the model is tagged broadly (e.g. `["projects", "mental-model"]`), the refresh filters out everything and the content comes back empty.
+
+Pass `tags_match: "any"` (the same default that `recall` and `reflect` use) to match memories that carry *any* of the model's tags:
+
+```json
+{
+  "name": "create_mental_model",
+  "arguments": {
+    "name": "Current projects",
+    "source_query": "Which projects is the user currently working on?",
+    "tags": ["projects", "mental-model"],
+    "tags_match": "any"
+  }
+}
+```
+:::
 
 **Example:**
 ```json
@@ -280,7 +299,8 @@ Create a mental model — a living document that stays current with your memorie
   "arguments": {
     "name": "Team Directory",
     "source_query": "Who works here and what do they do?",
-    "tags": ["team", "people"]
+    "tags": ["team", "people"],
+    "tags_match": "any"
   }
 }
 ```

--- a/hindsight-docs/examples/api/mental-models.go
+++ b/hindsight-docs/examples/api/mental-models.go
@@ -90,6 +90,24 @@ func main() {
 	fmt.Printf("Operation ID: %s\n", result2.GetOperationId())
 	// [/docs:create-mental-model-with-trigger]
 
+	// [docs:create-mental-model-tags-match]
+	// Override how the model's tags filter source memories on refresh.
+	// A tagged model defaults to "all_strict" (a memory must carry EVERY tag);
+	// use "any" when your memories are tagged narrowly (one topic each), so the
+	// refresh reads any memory carrying at least one of the model's tags.
+	result3, _, _ := client.MentalModelsAPI.CreateMentalModel(ctx, mmBankID).
+		CreateMentalModelRequest(hindsight.CreateMentalModelRequest{
+			Name:        "Current Projects",
+			SourceQuery: "Which projects is the user currently working on?",
+			Tags:        []string{"projects", "mental-model"},
+			Trigger: &hindsight.MentalModelTriggerInput{
+				TagsMatch: *hindsight.NewNullableString(hindsight.PtrString("any")),
+			},
+		}).Execute()
+
+	fmt.Printf("Operation ID: %s\n", result3.GetOperationId())
+	// [/docs:create-mental-model-tags-match]
+
 	time.Sleep(5 * time.Second)
 
 	// [docs:list-mental-models]

--- a/hindsight-docs/examples/api/mental-models.mjs
+++ b/hindsight-docs/examples/api/mental-models.mjs
@@ -62,6 +62,24 @@ const result2 = await client.createMentalModel(
 console.log(`Operation ID: ${result2.operation_id}`);
 // [/docs:create-mental-model-with-trigger]
 
+// [docs:create-mental-model-tags-match]
+// Override how the model's tags filter source memories on refresh.
+// A tagged model defaults to 'all_strict' (a memory must carry EVERY tag);
+// use 'any' when your memories are tagged narrowly (one topic each), so the
+// refresh reads any memory carrying at least one of the model's tags.
+const result3 = await client.createMentalModel(
+    BANK_ID,
+    'Current Projects',
+    'Which projects is the user currently working on?',
+    {
+        tags: ['projects', 'mental-model'],
+        trigger: { tagsMatch: 'any' },
+    },
+);
+
+console.log(`Operation ID: ${result3.operation_id}`);
+// [/docs:create-mental-model-tags-match]
+
 await new Promise(r => setTimeout(r, 5000));
 
 // [docs:list-mental-models]

--- a/hindsight-docs/examples/api/mental-models.py
+++ b/hindsight-docs/examples/api/mental-models.py
@@ -70,6 +70,22 @@ result = client.create_mental_model(
 print(f"Operation ID: {result.operation_id}")
 # [/docs:create-mental-model-with-trigger]
 
+# [docs:create-mental-model-tags-match]
+# Override how the model's tags filter source memories on refresh.
+# A tagged model defaults to "all_strict" (a memory must carry EVERY tag);
+# use "any" when your memories are tagged narrowly (one topic each), so the
+# refresh reads any memory carrying at least one of the model's tags.
+result = client.create_mental_model(
+    bank_id=BANK_ID,
+    name="Current Projects",
+    source_query="Which projects is the user currently working on?",
+    tags=["projects", "mental-model"],
+    trigger={"tags_match": "any"}
+)
+
+print(f"Operation ID: {result.operation_id}")
+# [/docs:create-mental-model-tags-match]
+
 # Wait for the mental model to be created
 time.sleep(5)
 

--- a/hindsight-docs/examples/api/mental-models.sh
+++ b/hindsight-docs/examples/api/mental-models.sh
@@ -44,6 +44,18 @@ hindsight mental-model create "$BANK_ID" \
   "What is the current project status?"
 # [/docs:create-mental-model-with-trigger]
 
+# [docs:create-mental-model-tags-match]
+# Override how the model's tags filter source memories on refresh.
+# A tagged model defaults to all_strict (a memory must carry EVERY tag);
+# pass --tags-match any when your memories are tagged narrowly (one topic
+# each), so the refresh reads any memory carrying at least one of the tags.
+hindsight mental-model create "$BANK_ID" \
+  "Current Projects" \
+  "Which projects is the user currently working on?" \
+  --tags projects,mental-model \
+  --tags-match any
+# [/docs:create-mental-model-tags-match]
+
 sleep 5
 
 # [docs:list-mental-models]

--- a/skills/hindsight-docs/references/developer/api/mental-models.md
+++ b/skills/hindsight-docs/references/developer/api/mental-models.md
@@ -545,6 +545,8 @@ The `all_strict` default is the safest choice for single-tag models, but it filt
 
 To match memories that carry **any** of the model's tags — the same default `recall` and `reflect` use — set `trigger.tags_match` to `"any"` at creation:
 
+### Python
+
 ```python
 # Override how the model's tags filter source memories on refresh.
 # A tagged model defaults to "all_strict" (a memory must carry EVERY tag);
@@ -559,6 +561,46 @@ result = client.create_mental_model(
 )
 
 print(f"Operation ID: {result.operation_id}")
+```
+
+### Node.js
+
+```javascript
+// Override how the model's tags filter source memories on refresh.
+// A tagged model defaults to 'all_strict' (a memory must carry EVERY tag);
+// use 'any' when your memories are tagged narrowly (one topic each), so the
+// refresh reads any memory carrying at least one of the model's tags.
+const result3 = await client.createMentalModel(
+    BANK_ID,
+    'Current Projects',
+    'Which projects is the user currently working on?',
+    {
+        tags: ['projects', 'mental-model'],
+        trigger: { tagsMatch: 'any' },
+    },
+);
+
+console.log(`Operation ID: ${result3.operation_id}`);
+```
+
+### CLI
+
+```bash
+# Override how the model's tags filter source memories on refresh.
+# A tagged model defaults to all_strict (a memory must carry EVERY tag);
+# pass --tags-match any when your memories are tagged narrowly (one topic
+# each), so the refresh reads any memory carrying at least one of the tags.
+hindsight mental-model create "$BANK_ID" \
+  "Current Projects" \
+  "Which projects is the user currently working on?" \
+  --tags projects,mental-model \
+  --tags-match any
+```
+
+### Go
+
+```go
+# Section 'create-mental-model-tags-match' not found in api/mental-models.go
 ```
 
 The MCP `create_mental_model` tool exposes the same option as a top-level `tags_match` argument. Available modes are `any`, `all`, `any_strict`, `all_strict`, and `exact` — see the [Recall tags reference](./recall#tags) for their exact semantics.

--- a/skills/hindsight-docs/references/developer/api/mental-models.md
+++ b/skills/hindsight-docs/references/developer/api/mental-models.md
@@ -545,13 +545,20 @@ The `all_strict` default is the safest choice for single-tag models, but it filt
 
 To match memories that carry **any** of the model's tags — the same default `recall` and `reflect` use — set `trigger.tags_match` to `"any"` at creation:
 
-```jsonc
-{
-  "name": "Current projects",
-  "source_query": "Which projects is the user currently working on?",
-  "tags": ["projects", "mental-model"],
-  "trigger": { "tags_match": "any" }
-}
+```python
+# Override how the model's tags filter source memories on refresh.
+# A tagged model defaults to "all_strict" (a memory must carry EVERY tag);
+# use "any" when your memories are tagged narrowly (one topic each), so the
+# refresh reads any memory carrying at least one of the model's tags.
+result = client.create_mental_model(
+    bank_id=BANK_ID,
+    name="Current Projects",
+    source_query="Which projects is the user currently working on?",
+    tags=["projects", "mental-model"],
+    trigger={"tags_match": "any"}
+)
+
+print(f"Operation ID: {result.operation_id}")
 ```
 
 The MCP `create_mental_model` tool exposes the same option as a top-level `tags_match` argument. Available modes are `any`, `all`, `any_strict`, `all_strict`, and `exact` — see the [Recall tags reference](./recall#tags) for their exact semantics.

--- a/skills/hindsight-docs/references/developer/api/mental-models.md
+++ b/skills/hindsight-docs/references/developer/api/mental-models.md
@@ -166,6 +166,8 @@ Mental models can be configured to **automatically refresh** when observations a
 | `mode` | `"full"` \| `"delta"` | `"full"` | Refresh strategy. See [Refresh Mode](#refresh-mode) below. |
 | `refresh_after_consolidation` | bool | false | Automatically refresh after observations consolidation |
 | `refresh_cron` | string \| null | null | UTC 5-field cron expression for scheduled refreshes, such as `"0 3 * * *"` for daily at 03:00 UTC |
+| `tags_match` | string \| null | null | How the model's `tags` filter source memories during refresh: `any`, `all`, `any_strict`, `all_strict`, or `exact`. When `null`, a **tagged** model defaults to `all_strict` (a memory must carry every one of the model's tags). Set `"any"` to match memories carrying *any* of the tags — see [Tags and Visibility](#tags-and-visibility). |
+| `tag_groups` | list \| null | null | Advanced boolean tag expressions that override flat `tags`/`tags_match` entirely. See the [Recall tags reference](./recall#tags). |
 
 When `refresh_after_consolidation` is enabled, the mental model will be re-generated every time the bank's observations are consolidated — ensuring it always reflects the latest synthesized knowledge.
 
@@ -536,6 +538,23 @@ During refresh, it reads:
 ```
 
 This means a mental model tagged `["user:alice"]` will also pick up memories tagged `["user:alice", "team"]` — extra tags on a memory don't disqualify it. Only the mental model's own tags are required to be present.
+
+#### Overriding the default with `tags_match`
+
+The `all_strict` default is the safest choice for single-tag models, but it filters out everything for a **multi-tag** model whose memories only carry one tag each. If a model tagged `["projects", "mental-model"]` reads from memories tagged narrowly (`["project:status"]`, `["tooling"]`, …), no single memory carries *all* the model's tags and the refresh comes back empty.
+
+To match memories that carry **any** of the model's tags — the same default `recall` and `reflect` use — set `trigger.tags_match` to `"any"` at creation:
+
+```jsonc
+{
+  "name": "Current projects",
+  "source_query": "Which projects is the user currently working on?",
+  "tags": ["projects", "mental-model"],
+  "trigger": { "tags_match": "any" }
+}
+```
+
+The MCP `create_mental_model` tool exposes the same option as a top-level `tags_match` argument. Available modes are `any`, `all`, `any_strict`, `all_strict`, and `exact` — see the [Recall tags reference](./recall#tags) for their exact semantics.
 
 ### How tags affect mental model lookup during reflect
 

--- a/skills/hindsight-docs/references/developer/mcp-server.md
+++ b/skills/hindsight-docs/references/developer/mcp-server.md
@@ -270,8 +270,27 @@ Create a mental model — a living document that stays current with your memorie
 | `source_query` | string | Yes | The query used to generate and refresh the model |
 | `mental_model_id` | string | No | Custom ID (alphanumeric lowercase with hyphens). Auto-generated if not provided |
 | `tags` | list[string] | No | Tags for organizing and filtering models |
+| `tags_match` | string | No | How the model's tags are matched against memories on refresh: `any`, `all`, `any_strict`, `all_strict`, or `exact`. See the note below on the default |
 | `max_tokens` | integer | No | Maximum tokens for model content (default: 2048) |
 | `trigger_refresh_after_consolidation` | boolean | No | Auto-refresh this model after memory consolidation (default: `false`) |
+
+:::warning Tagged models default to `all_strict`
+When a mental model has `tags` but no explicit `tags_match`, its refresh matches memories with **`all_strict`** — a memory must carry **every** one of the model's tags to be included. If your memories use narrow, single-topic tags (e.g. `["project:status"]`) while the model is tagged broadly (e.g. `["projects", "mental-model"]`), the refresh filters out everything and the content comes back empty.
+
+Pass `tags_match: "any"` (the same default that `recall` and `reflect` use) to match memories that carry *any* of the model's tags:
+
+```json
+{
+  "name": "create_mental_model",
+  "arguments": {
+    "name": "Current projects",
+    "source_query": "Which projects is the user currently working on?",
+    "tags": ["projects", "mental-model"],
+    "tags_match": "any"
+  }
+}
+```
+:::
 
 **Example:**
 ```json
@@ -280,7 +299,8 @@ Create a mental model — a living document that stays current with your memorie
   "arguments": {
     "name": "Team Directory",
     "source_query": "Who works here and what do they do?",
-    "tags": ["team", "people"]
+    "tags": ["team", "people"],
+    "tags_match": "any"
   }
 }
 ```


### PR DESCRIPTION
## Summary

Fixes #2808. A tagged mental model with no explicit `tags_match` in its trigger JSON refreshes under **`all_strict`** (a memory must carry *every* one of the model's tags), while the staleness check and every `recall`/`reflect` path default to **`any`**. So a broadly-tagged model (e.g. `["projects","mental-model"]`) reading narrowly-tagged memories (e.g. `["project:status"]`) gets marked stale and then refreshes to **empty content** — the feature looks broken out of the box.

Per the decision on the issue, this **does not change the default** (`all_strict` stays) — it makes `tags_match` configurable on every creation surface and documents the footgun.

## Configuration surfaces — status

| Surface | Before | After |
|---|---|---|
| HTTP API (`trigger.tags_match`) | ✅ supported | unchanged |
| Control Plane UI | ✅ `tags_match` `<Select>`, labeled "Default (all_strict when tags set)" | unchanged |
| **MCP `create_mental_model`** | ❌ hardcoded trigger, no knob | ✅ new `tags_match` arg |
| **TypeScript client (ergonomic wrapper)** | ❌ `createMentalModel` trigger option accepted only `refreshAfterConsolidation` | ✅ threads `tagsMatch`/`tagGroups` |
| **Rust CLI (`hindsight mental-model create`)** | ❌ no trigger tag option | ✅ new `--tags-match` flag |
| Python client | ✅ pass-through `trigger` dict + generated `MentalModelTriggerInput` enum validation | unchanged |
| Generated SDK layers (TS/Go/Python) | ✅ full `MentalModelTriggerInput` incl. `tags_match` | unchanged |

## Changes

**MCP** (`hindsight-api-slim/hindsight_api/mcp_tools.py`) — the surface the reporter used:
- Add a `tags_match` argument to both `create_mental_model` variants, validated against `TagsMatch` (`any`/`all`/`any_strict`/`all_strict`/`exact`).
- Written into the trigger **only when explicitly passed**, so the resolved `all_strict` default is preserved for existing callers — no behavior change.
- `update_mental_model` is intentionally left alone: its MCP path replaces the whole trigger with only the passed fields (a pre-existing footgun), so adding `tags_match` there would create a new way to silently wipe `refresh_after_consolidation`. Existing models can be re-tagged via the UI/HTTP.

**TypeScript client** (`hindsight-clients/typescript/src/index.ts`):
- The ergonomic wrapper's `createMentalModel` dropped every trigger field except `refreshAfterConsolidation`. Extend its `trigger` option to accept `tagsMatch` and `tagGroups`, threaded to the generated SDK (which already accepts them), mirroring `recall`/`reflect`.
- **Python client needs no change** — its wrapper takes a pass-through `trigger` dict and `MentalModelTriggerInput` already validates `tags_match`.

**Rust CLI** (`hindsight-cli/`):
- Add a `--tags-match` flag to `mental-model create`. Only sends a trigger when the flag (or `--trigger-refresh-after-consolidation`) is passed, preserving the server's `all_strict` default. Invalid values are rejected before the request.

**Docs:**
- `developer/mcp-server.md` — `tags_match` param row + a warning admonition explaining the `all_strict` default.
- `developer/api/mental-models.mdx` — `tags_match`/`tag_groups` in the Trigger Settings table + an "Overriding the default with `tags_match`" subsection with a **4-language** (Python / Node.js / CLI / Go) `<Tabs>` code example, each pulled from the runnable example files.
- Regenerated `skills/hindsight-docs/` mirror.

## Tests

- **MCP** (`test_mcp_tools.py`, 5): `tags_match` persisted, omitting it preserves the `all_strict` default, invalid value rejected.
- **TS client** (`tests/create_mental_model_mapping.test.ts`, 4): mocks the generated sdk (no server) and asserts `tagsMatch → tags_match`, `tagGroups → tag_groups`, `refreshAfterConsolidation` still maps, and omitting `trigger` sends none.
- **Rust CLI** (`commands/mental_model.rs`, 3): `parse_tags_match` accepts all five modes, is case-insensitive, rejects unknown values.
- The four doc examples are executed by the existing `test-doc-examples` CI job against locally-built clients (so the unreleased CLI/TS/Go changes are exercised).

MCP tests pass; ruff / ty / format clean; TS `tsc --noEmit` + jest pass; CLI `cargo build` / `clippy` / unit tests pass; Go example compiles via `go run`.
