### PR TITLE
fix(retain): reassert resolved entities before linking units (#2662)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops.py
@@ -174,6 +174,25 @@ class DataAccessOps(ABC):
         ...
 
     @abstractmethod
+    async def bulk_reassert_entities(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        bank_id: str,
+        entity_ids: list[str],
+        canonical_names: list[str],
+    ) -> None:
+        """Lock resolved parents and re-create any pruned since Phase-1 resolution.
+
+        Closes the retain Phase-1/prune race (#2662): existing rows are locked
+        (PG ``FOR KEY SHARE`` / Oracle ``FOR UPDATE``) so a concurrent
+        ``prune_orphan_entities`` blocks until the caller's transaction commits,
+        while rows already deleted are re-inserted idempotently. ``entity_ids``
+        must be sorted by the caller for a stable lock order.
+        """
+        ...
+
+    @abstractmethod
     async def bulk_insert_unit_entities(
         self,
         conn: DatabaseConnection,

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -218,7 +218,7 @@ class OracleOps(DataAccessOps):
         for orig_name in missing_names:
             row = await conn.fetchrow(
                 f"""
-                SELECT id, LOWER(canonical_name) AS name_lower
+                SELECT id, canonical_name, LOWER(canonical_name) AS name_lower
                 FROM {table}
                 WHERE bank_id = $1 AND LOWER(canonical_name) = LOWER($2)
                 """,
@@ -226,9 +226,36 @@ class OracleOps(DataAccessOps):
                 orig_name,
             )
             if row:
-                # Wrap in a dict-like to include input_name for downstream compat
                 results.append(row)
         return results
+
+    async def bulk_reassert_entities(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        bank_id: str,
+        entity_ids: list[str],
+        canonical_names: list[str],
+    ) -> None:
+        # Oracle has no FOR KEY SHARE; FOR UPDATE is the row-lock equivalent that
+        # blocks a concurrent prune DELETE until this transaction commits. Lock
+        # each surviving parent in the caller's stable id order (pruned ids are
+        # simply absent here), then re-insert any that vanished. The translation
+        # layer rewrites ON CONFLICT DO NOTHING to strip-and-catch ORA-00001, so
+        # a name recreated under a new id is suppressed rather than raising.
+        for entity_id in entity_ids:
+            await conn.fetchrow(
+                f"SELECT id FROM {table} WHERE id = $1 FOR UPDATE",
+                entity_id,
+            )
+        await conn.executemany(
+            f"""
+            INSERT INTO {table} (id, bank_id, canonical_name)
+            VALUES ($1, $2, $3)
+            ON CONFLICT DO NOTHING
+            """,
+            [(entity_id, bank_id, canonical_name) for entity_id, canonical_name in zip(entity_ids, canonical_names)],
+        )
 
     async def bulk_insert_unit_entities(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -277,7 +277,7 @@ class PostgreSQLOps(DataAccessOps):
     ) -> list[ResultRow]:
         return await conn.fetch(
             f"""
-            SELECT e.id, LOWER(e.canonical_name) AS name_lower, inputs.input_name
+            SELECT e.id, e.canonical_name, LOWER(e.canonical_name) AS name_lower, inputs.input_name
             FROM {table} e
             JOIN (
                 SELECT LOWER(n) AS input_name_lower, n AS input_name
@@ -287,6 +287,42 @@ class PostgreSQLOps(DataAccessOps):
             """,
             bank_id,
             missing_names,
+        )
+
+    async def bulk_reassert_entities(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        bank_id: str,
+        entity_ids: list[str],
+        canonical_names: list[str],
+    ) -> None:
+        # One statement, one round-trip (same shape as bulk_insert_links):
+        #   * the CTE takes FOR KEY SHARE on every parent that still exists,
+        #     held to COMMIT, so a concurrent prune_orphan_entities DELETE blocks
+        #     until the caller's unit_entities insert has committed;
+        #   * the INSERT re-creates only the parents that were already pruned
+        #     (NOT IN locked), carrying the canonical_name resolved in Phase 1.
+        # ON CONFLICT DO NOTHING (no target) keeps the rare case where another
+        # worker recreated the name under a new id from raising — that row stays
+        # absent and its unit link is the sole casualty, never the whole batch.
+        await conn.execute(
+            f"""
+            WITH locked AS (
+                SELECT id FROM {table}
+                WHERE id = ANY($2::uuid[])
+                ORDER BY id
+                FOR KEY SHARE
+            )
+            INSERT INTO {table} (id, bank_id, canonical_name)
+            SELECT t.entity_id, $1, t.canonical_name
+            FROM unnest($2::uuid[], $3::text[]) AS t(entity_id, canonical_name)
+            WHERE t.entity_id NOT IN (SELECT id FROM locked)
+            ON CONFLICT DO NOTHING
+            """,
+            bank_id,
+            entity_ids,
+            canonical_names,
         )
 
     async def bulk_insert_unit_entities(

--- a/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
+++ b/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
@@ -13,7 +13,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from difflib import SequenceMatcher
-from typing import Any, Final
+from typing import Any, Final, cast
 
 from .db_utils import acquire_with_retry
 from .memory_engine import fq_table
@@ -26,6 +26,7 @@ from .retain.entity_labels import (
 from .retain.entity_labels import (
     parse_entity_labels as _parse_entity_labels,
 )
+from .retain.types import ResolvedEntity
 
 logger = logging.getLogger(__name__)
 
@@ -247,7 +248,7 @@ class EntityResolver:
         unit_event_date,
         conn=None,
         entity_labels: list | None = None,
-    ) -> list[str]:
+    ) -> list[ResolvedEntity]:
         """
         Resolve multiple entities in batch (MUCH faster than sequential).
 
@@ -262,7 +263,8 @@ class EntityResolver:
             conn: Optional connection to use (if None, acquires from pool)
 
         Returns:
-            List of entity IDs in same order as input
+            Resolved entity identities (id + stored canonical name) in the same
+            order as input.
         """
         if not entities_data:
             return []
@@ -288,7 +290,7 @@ class EntityResolver:
         unit_event_date,
         taxonomy_lookup: set[str] | None = None,
         labels_cfg=None,
-    ) -> list[str]:
+    ) -> list[ResolvedEntity]:
         if self.entity_lookup == "trigram":
             # Route to backend-specific fuzzy strategy.
             # Non-PG backends (Oracle) use UTL_MATCH instead of pg_trgm.
@@ -328,7 +330,7 @@ class EntityResolver:
         unit_event_date,
         taxonomy_lookup: set[str] | None = None,
         labels_cfg=None,
-    ) -> list[str]:
+    ) -> list[ResolvedEntity]:
         """Original strategy: load all bank entities then match in Python."""
         # Query ALL candidates for this bank
         all_entities = await conn.fetch(
@@ -412,7 +414,7 @@ class EntityResolver:
         unit_event_date,
         taxonomy_lookup: set[str] | None = None,
         labels_cfg=None,
-    ) -> list[str]:
+    ) -> list[ResolvedEntity]:
         """
         Trigram strategy: fetch only similar candidates per entity name using pg_trgm.
 
@@ -516,7 +518,7 @@ class EntityResolver:
         unit_event_date: datetime | None,
         taxonomy_lookup: set[str] | None = None,
         labels_cfg=None,
-    ) -> list[str]:
+    ) -> list[ResolvedEntity]:
         """
         Oracle strategy: fetch similar candidates using UTL_MATCH.JARO_WINKLER_SIMILARITY.
 
@@ -624,11 +626,14 @@ class EntityResolver:
         cooccurrence_map: dict[str, set[str]],
         taxonomy_lookup: set[str] | None = None,
         labels_cfg=None,
-    ) -> list[str]:
+    ) -> list[ResolvedEntity]:
         """Shared scoring + upsert logic used by both lookup strategies."""
 
-        # Resolve each entity using pre-fetched candidates
-        entity_ids = [None] * len(entities_data)
+        # Resolve each entity using pre-fetched candidates. A slot stays None
+        # only if find-or-create fails to produce a row for a mention (a DB
+        # inconsistency); it surfaces as a clear error at the reassert boundary
+        # rather than a silent NOT NULL violation deeper in Phase 2.
+        resolved: list[ResolvedEntity | None] = [None] * len(entities_data)
         entities_to_update: list[_EntityStat] = []
         entities_to_create: list[_EntityToCreate] = []
 
@@ -655,21 +660,23 @@ class EntityResolver:
 
             if is_label:
                 # Exact case-insensitive match only for label entities
-                exact_match = None
+                exact_match: ResolvedEntity | None = None
                 entity_text_lower = entity_text.lower()
                 for candidate_id, canonical_name, metadata, last_seen, mention_count in candidates:
                     if canonical_name.lower() == entity_text_lower:
-                        exact_match = candidate_id
+                        exact_match = ResolvedEntity(entity_id=candidate_id, canonical_name=canonical_name)
                         break
                 if exact_match:
-                    entity_ids[idx] = exact_match
-                    entities_to_update.append(_EntityStat(entity_id=exact_match, event_date=entity_event_date))
+                    resolved[idx] = exact_match
+                    entities_to_update.append(
+                        _EntityStat(entity_id=exact_match.entity_id, event_date=entity_event_date)
+                    )
                 else:
                     entities_to_create.append(_EntityToCreate(idx=idx, name=entity_text, event_date=entity_event_date))
                 continue
 
             # Score candidates
-            best_candidate = None
+            best_candidate: ResolvedEntity | None = None
             best_score = 0.0
 
             nearby_entity_set = {e["text"].lower() for e in nearby_entities if e["text"] != entity_text}
@@ -702,14 +709,14 @@ class EntityResolver:
 
                 if score > best_score:
                     best_score = score
-                    best_candidate = candidate_id
+                    best_candidate = ResolvedEntity(entity_id=candidate_id, canonical_name=canonical_name)
 
             # Apply unified threshold
             threshold = 0.6
 
-            if best_score > threshold:
-                entity_ids[idx] = best_candidate
-                entities_to_update.append(_EntityStat(entity_id=best_candidate, event_date=entity_event_date))
+            if best_score > threshold and best_candidate is not None:
+                resolved[idx] = best_candidate
+                entities_to_update.append(_EntityStat(entity_id=best_candidate.entity_id, event_date=entity_event_date))
             else:
                 entities_to_create.append(
                     _EntityToCreate(idx=idx, name=entity_data["text"], event_date=entity_event_date)
@@ -742,6 +749,9 @@ class EntityResolver:
             sorted_groups = sorted(groups.items())
             entity_names = [g.name for _, g in sorted_groups]
             entity_dates = [g.event_date for _, g in sorted_groups]
+            # Stored canonical name per lowercase key, so a resurrected parent
+            # keeps the name it was created/matched with rather than a fallback.
+            canonical_by_name = {name_lower: g.name for name_lower, g in sorted_groups}
 
             # INSERT ... ON CONFLICT DO NOTHING — no row lock on already-existing entities.
             # mention_count starts at 0 here; flush_pending_stats() is the sole source of
@@ -776,11 +786,14 @@ class EntityResolver:
                 )
                 for row in existing_rows:
                     id_by_name[row["name_lower"]] = row["id"]
+                    canonical_by_name[row["name_lower"]] = row["canonical_name"]
                     # Also index by Python's lower() of the original input name so the
                     # assignment loop (which uses Python-lowercased keys) finds it even
                     # when Python and the database produce different lowercase strings.
                     if "input_name" in row:
-                        id_by_name[row["input_name"].lower()] = row["id"]
+                        input_name_lower = row["input_name"].lower()
+                        id_by_name[input_name_lower] = row["id"]
+                        canonical_by_name[input_name_lower] = row["canonical_name"]
 
             # Assign entity IDs back and queue one stat per original mention so that
             # flush_pending_stats() increments mention_count by the true mention count,
@@ -788,16 +801,64 @@ class EntityResolver:
             for name_lower, g in sorted_groups:
                 entity_id = id_by_name.get(name_lower)
                 if entity_id:
+                    canonical_name = canonical_by_name.get(name_lower, g.name)
                     for original_idx in g.indices:
-                        entity_ids[original_idx] = entity_id
-                        pending.append(_EntityStat(entity_id=entity_id, event_date=g.event_date))
+                        resolved[original_idx] = ResolvedEntity(entity_id=entity_id, canonical_name=canonical_name)
+                        pending.append(_EntityStat(entity_id=str(entity_id), event_date=g.event_date))
 
         # Accumulate into the resolver's pending list; the orchestrator flushes
         # these with await entity_resolver.flush_pending_stats() after the txn.
         key = self._task_key()
         self._pending_stats.setdefault(key, []).extend(pending)
 
-        return entity_ids
+        missing = [i for i, entity in enumerate(resolved) if entity is None]
+        if missing:
+            raise RuntimeError(
+                f"Entity resolution produced no row for {len(missing)} mention(s) "
+                f"(indices {missing[:5]}); refusing to link units to a missing parent."
+            )
+        return cast(list[ResolvedEntity], resolved)
+
+    async def reassert_entities_batch(
+        self,
+        bank_id: str,
+        resolved_entities: list[ResolvedEntity],
+        conn,
+    ) -> None:
+        """Lock (and, if pruned, re-create) resolved parents before linking units.
+
+        Phase-1 resolution and the Phase-2 ``unit_entities`` insert run on
+        different transactions. In the gap, ``prune_orphan_entities`` can delete
+        a just-resolved parent — it legitimately has no ``unit_entities`` row
+        yet — and the Phase-2 FK insert then fails, dropping the whole batch as
+        non-retryable (silent memory loss, #2662).
+
+        Called on the Phase-2 connection immediately before
+        ``link_units_to_entities_batch``, this locks the parents that still
+        exist (so the pruner blocks until we commit) and re-inserts any that
+        already vanished, in one round-trip. An entity referenced by a live unit
+        is by definition not an orphan, so resurrecting it is correct.
+        """
+        # Deduplicate by id and lock in a stable order so concurrent reasserts
+        # acquire row locks consistently (same convention as bulk_insert_links).
+        seen: set[str] = set()
+        unique: list[ResolvedEntity] = []
+        for entity in sorted(resolved_entities, key=lambda e: e.entity_id):
+            if entity.entity_id in seen:
+                continue
+            seen.add(entity.entity_id)
+            unique.append(entity)
+
+        if not unique:
+            return
+
+        await self._ops.bulk_reassert_entities(
+            conn,
+            fq_table("entities"),
+            bank_id,
+            [entity.entity_id for entity in unique],
+            [entity.canonical_name for entity in unique],
+        )
 
     async def link_units_to_entities_batch(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -6784,7 +6784,7 @@ class MemoryEngine(MemoryEngineInterface):
                     # the graph-maintenance run this edit submits.
                     if new_entities is not None:
                         entity_date = new_occ_start or live["mentioned_at"]
-                        _resolved_ids, _e2u, unit_to_entity_ids = await resolve_entities_only(
+                        entity_resolution = await resolve_entities_only(
                             self.entity_resolver,
                             conn,
                             bank_id,
@@ -6796,8 +6796,15 @@ class MemoryEngine(MemoryEngineInterface):
                             entity_labels=entity_labels,
                         )
                         await conn.execute(f"DELETE FROM {ue} WHERE unit_id = $1", str(memory_uuid))
-                        resolved_for_unit = unit_to_entity_ids.get(str(memory_uuid), [])
+                        resolved_for_unit = entity_resolution.unit_to_entity_ids.get(str(memory_uuid), [])
                         if resolved_for_unit:
+                            # Same prune race as retain (#2662): a found (not newly
+                            # created) parent can be deleted by graph maintenance
+                            # between resolution and this link. Reassert on this
+                            # connection first so the pruner blocks until commit.
+                            await self.entity_resolver.reassert_entities_batch(
+                                bank_id, entity_resolution.resolved_entities, conn=conn
+                            )
                             await self.entity_resolver.link_units_to_entities_batch(
                                 [(str(memory_uuid), eid, entity_date) for eid in resolved_for_unit],
                                 conn=conn,

--- a/hindsight-api-slim/hindsight_api/engine/retain/entity_processing.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/entity_processing.py
@@ -7,7 +7,7 @@ Handles entity extraction and resolution for stored facts.
 import logging
 
 from . import link_utils
-from .types import ProcessedFact
+from .types import EntityResolutionResult, ProcessedFact
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ async def resolve_entities(
     log_buffer: list[str] = None,
     user_entities_per_content: dict[int, list[dict]] = None,
     entity_labels: list | None = None,
-) -> tuple[list[str], list[tuple], dict[str, list[str]]]:
+) -> EntityResolutionResult:
     """
     Phase 1: Resolve entity names to canonical IDs (read-heavy).
 
@@ -76,10 +76,10 @@ async def resolve_entities(
         entity_labels: Optional entity label taxonomy
 
     Returns:
-        Tuple of (resolved_entity_ids, entity_to_unit, unit_to_entity_ids).
+        EntityResolutionResult with the resolved identities and unit mappings.
     """
     if not unit_ids or not facts:
-        return [], [], {}
+        return EntityResolutionResult(resolved_entities=[], entity_to_unit=[], unit_to_entity_ids={})
 
     if len(unit_ids) != len(facts):
         raise ValueError(f"Mismatch between unit_ids ({len(unit_ids)}) and facts ({len(facts)})")

--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -11,7 +11,7 @@ from ..causal_links import CANONICAL_CAUSAL_LINK_TYPES, LEGACY_CAUSAL_LINK_TYPES
 from ..db.base import DatabaseConnection
 from ..db.ops import DataAccessOps
 from ..memory_engine import fq_table
-from .types import CausalRelation
+from .types import CausalRelation, EntityResolutionResult
 
 logger = logging.getLogger(__name__)
 
@@ -304,7 +304,7 @@ async def resolve_entities_only(
     llm_entities: list[list[dict]],
     log_buffer: list[str] = None,
     entity_labels: list | None = None,
-) -> tuple[list[str], list[tuple], dict[str, list[str]]]:
+) -> EntityResolutionResult:
     """
     Phase 1 of entity processing: resolve entity names to canonical IDs.
 
@@ -325,10 +325,10 @@ async def resolve_entities_only(
         entity_labels: Optional entity label taxonomy
 
     Returns:
-        Tuple of (resolved_entity_ids, entity_to_unit, unit_to_entity_ids) where:
-        - resolved_entity_ids: list of entity IDs in same order as flattened entities
-        - entity_to_unit: maps flat index to (unit_id, local_index, fact_date)
-        - unit_to_entity_ids: maps unit_id to list of resolved entity IDs
+        EntityResolutionResult carrying the resolved entity identities (id +
+        stored canonical name, in flattened order), the flat-index → unit map,
+        and the unit → entity-id map used to remap placeholder unit IDs in
+        Phase 2.
     """
     all_entities_flat, _all_entities, entity_to_unit = _prepare_entities_for_resolution(
         unit_ids, sentences, fact_dates, llm_entities, log_buffer
@@ -336,10 +336,10 @@ async def resolve_entities_only(
 
     if not all_entities_flat:
         _log(log_buffer, "  [6.2] Entity resolution (batched): 0 entities", level="debug")
-        return [], [], {}
+        return EntityResolutionResult(resolved_entities=[], entity_to_unit=[], unit_to_entity_ids={})
 
     step_start = time.time()
-    resolved_entity_ids = await entity_resolver.resolve_entities_batch(
+    resolved_entities = await entity_resolver.resolve_entities_batch(
         bank_id=bank_id,
         entities_data=all_entities_flat,
         context=context,
@@ -358,7 +358,7 @@ async def resolve_entities_only(
     for idx, (unit_id, _local_idx, _fact_date) in enumerate(entity_to_unit):
         if unit_id not in unit_to_entity_ids:
             unit_to_entity_ids[unit_id] = []
-        unit_to_entity_ids[unit_id].append(resolved_entity_ids[idx])
+        unit_to_entity_ids[unit_id].append(resolved_entities[idx].entity_id)
 
     _log(
         log_buffer,
@@ -366,7 +366,11 @@ async def resolve_entities_only(
         level="debug",
     )
 
-    return resolved_entity_ids, entity_to_unit, unit_to_entity_ids
+    return EntityResolutionResult(
+        resolved_entities=resolved_entities,
+        entity_to_unit=entity_to_unit,
+        unit_to_entity_ids=unit_to_entity_ids,
+    )
 
 
 async def create_temporal_links_batch_per_fact(

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -247,9 +247,9 @@ from . import (
 )
 from .types import (
     ChunkMetadata,
-    EntityResolutionResult,
     Phase1Result,
     ProcessedFact,
+    ResolvedEntity,
     RetainContent,
     RetainContentDict,
 )
@@ -344,7 +344,7 @@ async def _pre_resolve_phase1(
     embeddings = [fact.embedding for fact in processed_facts]
 
     async with acquire_with_retry(pool) as resolve_conn:
-        resolved_entity_ids, entity_to_unit, unit_to_entity_ids = await entity_processing.resolve_entities(
+        entity_resolution = await entity_processing.resolve_entities(
             entity_resolver,
             resolve_conn,
             bank_id,
@@ -366,11 +366,7 @@ async def _pre_resolve_phase1(
             )
 
     return Phase1Result(
-        entities=EntityResolutionResult(
-            resolved_entity_ids=resolved_entity_ids,
-            entity_to_unit=entity_to_unit,
-            unit_to_entity_ids=unit_to_entity_ids,
-        ),
+        entities=entity_resolution,
         semantic_ann_links=semantic_ann_links,
     )
 
@@ -421,7 +417,7 @@ async def _insert_facts_and_links(
     processed_facts: list[ProcessedFact],
     config,
     log_buffer: list[str],
-    resolved_entity_ids: list[str],
+    resolved_entities: list[ResolvedEntity],
     entity_to_unit: list[tuple],
     unit_to_entity_ids: dict[str, list[str]],
     semantic_ann_links: list[tuple],
@@ -448,6 +444,7 @@ async def _insert_facts_and_links(
         # Entity resolution was done in Phase 1 (separate connection).
         # Remap placeholder IDs to actual unit IDs.
         step_start = time.time()
+        resolved_entity_ids = [entity.entity_id for entity in resolved_entities]
         remapped_entity_to_unit, _remapped_unit_to_entity_ids, remapped_semantic = _remap_phase1_results(
             resolved_entity_ids, entity_to_unit, unit_to_entity_ids, semantic_ann_links or [], unit_ids
         )
@@ -460,6 +457,10 @@ async def _insert_facts_and_links(
             (unit_id, resolved_entity_ids[idx], fact_date)
             for idx, (unit_id, _local_idx, fact_date) in enumerate(remapped_entity_to_unit)
         ]
+        # Lock/re-create the resolved parents on THIS transaction before linking,
+        # closing the window where prune_orphan_entities could have deleted one
+        # between Phase-1 resolution and this insert (#2662).
+        await entity_resolver.reassert_entities_batch(bank_id, resolved_entities, conn=conn)
         await entity_resolver.link_units_to_entities_batch(unit_entity_pairs, conn=conn)
         log_buffer.append(f"  Insert unit_entities: {len(unit_entity_pairs)} pairs in {time.time() - step_start:.3f}s")
 
@@ -1606,7 +1607,7 @@ async def _streaming_retain_batch(
                         batch_processed,
                         config,
                         log_buffer,
-                        resolved_entity_ids=phase1.entities.resolved_entity_ids,
+                        resolved_entities=phase1.entities.resolved_entities,
                         entity_to_unit=phase1.entities.entity_to_unit,
                         unit_to_entity_ids=phase1.entities.unit_to_entity_ids,
                         semantic_ann_links=[],
@@ -2202,7 +2203,7 @@ async def _try_delta_retain(
                     processed_facts,
                     config,
                     log_buffer,
-                    resolved_entity_ids=phase1.entities.resolved_entity_ids,
+                    resolved_entities=phase1.entities.resolved_entities,
                     entity_to_unit=phase1.entities.entity_to_unit,
                     unit_to_entity_ids=phase1.entities.unit_to_entity_ids,
                     semantic_ann_links=phase1.semantic_ann_links,

--- a/hindsight-api-slim/hindsight_api/engine/retain/types.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/types.py
@@ -278,17 +278,41 @@ class ProcessedFact:
 
 
 @dataclass
+class ResolvedEntity:
+    """Identity of a resolved entity carried across the retain phase boundary.
+
+    ``canonical_name`` is the value stored on the entity row (NOT the raw input
+    mention), captured during Phase-1 resolution. It is threaded to Phase 2 so a
+    parent pruned between phases can be re-created with its real name — the row
+    is gone by then, so the name is otherwise unrecoverable (#2662).
+    """
+
+    entity_id: str
+    canonical_name: str
+
+    def __post_init__(self) -> None:
+        # Callers pass UUID objects or strings; normalize once so downstream
+        # comparisons, set membership, and SQL binds all see a plain str.
+        self.entity_id = str(self.entity_id)
+
+
+@dataclass
 class EntityResolutionResult:
     """
     Result of Phase 1 entity resolution.
 
-    Contains resolved entity IDs and the mapping data needed to remap
+    Contains resolved entity identities and the mapping data needed to remap
     placeholder unit IDs to real IDs after fact insertion in Phase 2.
     """
 
-    resolved_entity_ids: list[str]
+    resolved_entities: list[ResolvedEntity]
     entity_to_unit: list[tuple]
     unit_to_entity_ids: dict[str, list[str]]
+
+    @property
+    def resolved_entity_ids(self) -> list[str]:
+        """Entity IDs in flattened resolution order (used by link remapping)."""
+        return [entity.entity_id for entity in self.resolved_entities]
 
 
 @dataclass

--- a/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
@@ -542,7 +542,7 @@ async def _import_one_document(
                 processed_facts,
                 config,
                 log_buffer,
-                resolved_entity_ids=phase1.entities.resolved_entity_ids,
+                resolved_entities=phase1.entities.resolved_entities,
                 entity_to_unit=phase1.entities.entity_to_unit,
                 unit_to_entity_ids=phase1.entities.unit_to_entity_ids,
                 semantic_ann_links=phase1.semantic_ann_links,

--- a/hindsight-api-slim/tests/test_entity_labels.py
+++ b/hindsight-api-slim/tests/test_entity_labels.py
@@ -9,7 +9,6 @@ and verify label entities are extracted and stored correctly.
 """
 
 import uuid
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -2188,7 +2187,7 @@ async def test_entity_resolution_does_not_merge_distinct_label_values(memory, re
         ]
 
         async with memory._pool.acquire() as conn:
-            resolved_entity_ids, entity_to_unit, unit_to_entity_ids = await resolve_entities(
+            resolution = await resolve_entities(
                 entity_resolver=memory.entity_resolver,
                 conn=conn,
                 bank_id=bank_id,
@@ -2196,6 +2195,7 @@ async def test_entity_resolution_does_not_merge_distinct_label_values(memory, re
                 facts=facts,
                 entity_labels=entity_labels,
             )
+        resolved_entity_ids = resolution.resolved_entity_ids
 
         # We should get 2 DISTINCT entity IDs, not the same ID twice
         assert len(resolved_entity_ids) == 2, f"Expected 2 resolved entity IDs, got {len(resolved_entity_ids)}"

--- a/hindsight-api-slim/tests/test_entity_resolver.py
+++ b/hindsight-api-slim/tests/test_entity_resolver.py
@@ -6,13 +6,14 @@ import itertools
 import json
 import uuid
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from hindsight_api.engine.db import create_database_backend
 from hindsight_api.engine.db.result import DictResultRow as ResultRow
 from hindsight_api.engine.entity_resolver import EntityResolver, _canonical_cooccurrence_pairs
+from hindsight_api.engine.retain.types import ResolvedEntity
 from hindsight_api.pg0 import resolve_database_url
 
 # ---------------------------------------------------------------------------
@@ -126,7 +127,7 @@ async def test_resolve_entities_batch_handles_unicode_lower_conflicts(pg0_db_url
                 event_date,
             )
 
-            resolved_ids = await resolver.resolve_entities_batch(
+            resolved_entities = await resolver.resolve_entities_batch(
                 bank_id=bank_id,
                 entities_data=[
                     {
@@ -150,7 +151,7 @@ async def test_resolve_entities_batch_handles_unicode_lower_conflicts(pg0_db_url
                 bank_id,
             )
 
-        assert resolved_ids == [existing_entity_id]
+        assert resolved_entities == [ResolvedEntity(entity_id=existing_entity_id, canonical_name="İstanbul")]
         assert len(entity_rows) == 1
         assert entity_rows[0]["id"] == existing_entity_id
         assert entity_rows[0]["canonical_name"] == "İstanbul"

--- a/hindsight-api-slim/tests/test_retain_entity_prune_race.py
+++ b/hindsight-api-slim/tests/test_retain_entity_prune_race.py
@@ -1,0 +1,227 @@
+"""Regression coverage for the retain Phase-1 / orphan-prune FK race (#2662).
+
+Between Phase-1 entity resolution (a separate, already-committed connection) and
+the Phase-2 ``unit_entities`` insert, ``prune_orphan_entities`` can delete a
+just-resolved parent that has no ``unit_entities`` row yet. The Phase-2 FK insert
+then fails and the whole batch is dropped as non-retryable — silent memory loss.
+
+The fix reasserts the resolved parents on the Phase-2 connection immediately
+before linking: existing rows are locked so the pruner blocks, and rows already
+pruned are re-created with their stored canonical name.
+"""
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import asyncpg
+import pytest
+
+from hindsight_api.engine.db import create_database_backend
+from hindsight_api.engine.db.ops_oracle import OracleOps
+from hindsight_api.engine.db.ops_postgresql import PostgreSQLOps
+from hindsight_api.engine.db.postgresql import PostgresConnection
+from hindsight_api.engine.entity_resolver import EntityResolver
+from hindsight_api.engine.memory_engine import fq_table
+from hindsight_api.engine.retain.orchestrator import (
+    _insert_facts_and_links,
+    _pre_resolve_phase1,
+)
+from hindsight_api.engine.retain.types import EntityRef, ProcessedFact, ResolvedEntity, RetainContent
+from hindsight_api.pg0 import resolve_database_url
+
+_ID_A = "00000000-0000-0000-0000-000000000001"
+_ID_B = "00000000-0000-0000-0000-000000000002"
+
+
+@pytest.mark.asyncio
+async def test_oracle_reassert_locks_in_stable_order_then_reinserts():
+    """Oracle adapter: lock every parent (FOR UPDATE) in sorted id order, then
+    idempotently re-insert the same rows in that order."""
+    resolver = EntityResolver(pool=SimpleNamespace(ops=OracleOps()))
+    conn = AsyncMock()
+    # Deliberately out of order and duplicated on the way in.
+    resolved_entities = [
+        ResolvedEntity(entity_id=_ID_B, canonical_name="Bob"),
+        ResolvedEntity(entity_id=_ID_A, canonical_name="Alice"),
+        ResolvedEntity(entity_id=_ID_B, canonical_name="Bob"),
+    ]
+
+    await resolver.reassert_entities_batch("bank-1", resolved_entities, conn)
+
+    lock_ids = [call.args[1] for call in conn.fetchrow.await_args_list]
+    assert lock_ids == [_ID_A, _ID_B], "parents must be locked once each, in stable id order"
+    assert all("FOR UPDATE" in call.args[0] for call in conn.fetchrow.await_args_list)
+
+    insert_sql, rows = conn.executemany.await_args.args
+    assert "ON CONFLICT DO NOTHING" in insert_sql
+    assert rows == [(_ID_A, "bank-1", "Alice"), (_ID_B, "bank-1", "Bob")]
+
+
+@pytest.mark.asyncio
+async def test_reassert_of_empty_batch_is_a_noop():
+    """No resolved entities → no SQL issued (avoids a pointless round-trip)."""
+    resolver = EntityResolver(pool=SimpleNamespace(ops=OracleOps()))
+    conn = AsyncMock()
+
+    await resolver.reassert_entities_batch("bank-1", [], conn)
+
+    conn.fetchrow.assert_not_awaited()
+    conn.executemany.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reassert_locks_existing_parent_until_child_insert(pg0_db_url):
+    """A parent that still exists at reassert time is locked FOR KEY SHARE, so a
+    concurrent prune DELETE blocks until the child link commits."""
+    bank_id = f"test-reassert-lock-{uuid.uuid4().hex[:8]}"
+    setup = await asyncpg.connect(pg0_db_url)
+    phase2_conn = await asyncpg.connect(pg0_db_url)
+    prune_conn = await asyncpg.connect(pg0_db_url)
+    ops = PostgreSQLOps()
+
+    try:
+        entity_id = await setup.fetchval(
+            "INSERT INTO entities (bank_id, canonical_name) VALUES ($1, 'Alice Smith') RETURNING id",
+            bank_id,
+        )
+
+        phase2_tx = phase2_conn.transaction()
+        await phase2_tx.start()
+        unit_id = await phase2_conn.fetchval(
+            """
+            INSERT INTO memory_units (bank_id, text, event_date, fact_type)
+            VALUES ($1, 'Alice Smith joined the project.', now(), 'world')
+            RETURNING id
+            """,
+            bank_id,
+        )
+        wrapped_phase2 = PostgresConnection(phase2_conn)
+        await ops.bulk_reassert_entities(wrapped_phase2, "entities", bank_id, [str(entity_id)], ["Alice Smith"])
+
+        # The pruner cannot delete the locked parent — it blocks and times out.
+        await prune_conn.execute("SET statement_timeout = '500ms'")
+        with pytest.raises(asyncpg.QueryCanceledError):
+            await prune_conn.execute("DELETE FROM entities WHERE id = $1", entity_id)
+
+        await ops.bulk_insert_unit_entities(wrapped_phase2, "unit_entities", [str(unit_id)], [str(entity_id)])
+        await phase2_tx.commit()
+
+        # Positive control: once committed, the link exists and the parent is present.
+        assert (
+            await setup.fetchval(
+                "SELECT count(*) FROM unit_entities WHERE unit_id = $1 AND entity_id = $2",
+                unit_id,
+                entity_id,
+            )
+            == 1
+        )
+    finally:
+        await setup.execute("DELETE FROM memory_units WHERE bank_id = $1", bank_id)
+        await setup.execute("DELETE FROM entities WHERE bank_id = $1", bank_id)
+        await setup.close()
+        await phase2_conn.close()
+        await prune_conn.close()
+
+
+@pytest.mark.asyncio
+async def test_phase2_reasserts_entity_pruned_after_resolution(pg0_db_url):
+    """End-to-end: a prune between the two retain phases must not become data loss.
+
+    The input is a fuzzy alias ("Alice Smit"), so Phase 2 must carry the stored
+    canonical name ("Alice Smith") — it is unrecoverable once the row is pruned.
+    """
+    resolved_url = await resolve_database_url(pg0_db_url)
+    backend = create_database_backend("postgresql")
+    await backend.initialize(resolved_url, min_size=1, max_size=3, command_timeout=30)
+
+    bank_id = f"test-retain-prune-race-{uuid.uuid4().hex[:8]}"
+    event_date = datetime(2026, 7, 13, 12, tzinfo=UTC)
+    resolver = EntityResolver(pool=backend, entity_lookup="full")
+    config = SimpleNamespace(entity_labels=None)
+    contents = [RetainContent(content="Alice Smit joined the project.")]
+    processed_facts = [
+        ProcessedFact(
+            fact_text="Alice Smit joined the project.",
+            fact_type="world",
+            embedding=[0.0] * 384,
+            occurred_start=event_date,
+            occurred_end=None,
+            mentioned_at=event_date,
+            context="",
+            metadata={},
+            entities=[EntityRef(name="Alice Smit")],
+        )
+    ]
+
+    try:
+        async with backend.acquire() as conn:
+            original_entity_id = await conn.fetchval(
+                f"""
+                INSERT INTO {fq_table("entities")}
+                    (bank_id, canonical_name, first_seen, last_seen, mention_count)
+                VALUES ($1, 'Alice Smith', $2, $2, 1)
+                RETURNING id
+                """,
+                bank_id,
+                event_date,
+            )
+
+        phase1 = await _pre_resolve_phase1(
+            backend, resolver, bank_id, contents, processed_facts, config, [], skip_semantic_ann=True
+        )
+        assert phase1.entities.resolved_entities[0].entity_id == str(original_entity_id)
+        assert phase1.entities.resolved_entities[0].canonical_name == "Alice Smith"
+
+        # Prune the resolved parent in the window before Phase 2 links it.
+        async with backend.acquire() as prune_conn:
+            async with prune_conn.transaction():
+                pruned = await backend.ops.prune_orphan_entities(
+                    prune_conn, fq_table("entities"), fq_table("unit_entities"), bank_id
+                )
+        assert pruned == 1
+
+        async with backend.acquire() as phase2_conn:
+            async with phase2_conn.transaction():
+                unit_id_groups = await _insert_facts_and_links(
+                    phase2_conn,
+                    resolver,
+                    bank_id,
+                    contents,
+                    [],
+                    processed_facts,
+                    config,
+                    [],
+                    resolved_entities=phase1.entities.resolved_entities,
+                    entity_to_unit=phase1.entities.entity_to_unit,
+                    unit_to_entity_ids=phase1.entities.unit_to_entity_ids,
+                    semantic_ann_links=[],
+                    skip_semantic_links=True,
+                    ops=backend.ops,
+                )
+
+        assert len(unit_id_groups[0]) == 1
+        async with backend.acquire() as verify_conn:
+            restored = await verify_conn.fetchrow(
+                f"SELECT id, canonical_name FROM {fq_table('entities')} WHERE id = $1",
+                original_entity_id,
+            )
+            linked_entity_id = await verify_conn.fetchval(
+                f"""
+                SELECT ue.entity_id
+                FROM {fq_table("unit_entities")} ue
+                JOIN {fq_table("memory_units")} mu ON mu.id = ue.unit_id
+                WHERE mu.bank_id = $1
+                """,
+                bank_id,
+            )
+
+        assert restored is not None, "the pruned parent must be re-created"
+        assert restored["canonical_name"] == "Alice Smith", "reassert must restore the stored canonical name"
+        assert linked_entity_id == original_entity_id, "the unit must link back to the original entity id"
+    finally:
+        async with backend.acquire() as conn:
+            await conn.execute(f"DELETE FROM {fq_table('memory_units')} WHERE bank_id = $1", bank_id)
+            await conn.execute(f"DELETE FROM {fq_table('entities')} WHERE bank_id = $1", bank_id)
+        await backend.shutdown()


### PR DESCRIPTION
## Summary

Closes the FK race in #2662 where `prune_orphan_entities` deletes an entity between retain **Phase-1 resolution** (separate, already-committed connection) and the **Phase-2 `unit_entities` insert** (new transaction). In that window the just-resolved parent legitimately has no `unit_entities` row, so the pruner's orphan predicate matches it; the Phase-2 FK insert then raises `ForeignKeyViolationError`, which is classified non-retryable, so the **entire batch is dropped — silent memory loss** (worst on the document re-ingest path).

This is a consolidation of the two community PRs for this issue (#2697, #2787), taking the correct semantics from each and dropping their respective gaps.

## Fix

Carry each resolved entity's id **and its stored `canonical_name`** across the phase boundary (new `ResolvedEntity`), then reassert the parents on the Phase-2 connection immediately before linking:

- **PostgreSQL** — one statement, one round-trip (same shape as the existing `bulk_insert_links`): a CTE locks the surviving parents `FOR KEY SHARE` (held to commit, so a concurrent prune `DELETE` blocks) and re-inserts only the already-pruned ones. `ON CONFLICT DO NOTHING` keeps the rare "another worker recreated the name under a new id" case from raising.
- **Oracle** — `FOR UPDATE` locks in the caller's stable id order, then an idempotent insert.

The **stored canonical name** (not the raw input mention) is what gets restored — a fuzzy alias like `Alice Smit` → `Alice Smith` no longer permanently mislabels a resurrected row. The same reassert is applied to the **curation edit path**, which shares the same resolve/link window.

### Why carry `canonical_name`
The name is `NOT NULL` and unrecoverable once the row is pruned, so it must come from Phase 1. #2787 carried the *input* text (wrong for fuzzy matches); this PR carries the *stored* value, as the maintainer called for in the issue thread.

### Why `FOR KEY SHARE`
`ON CONFLICT DO NOTHING` alone takes **no lock** on an existing row, so it leaves a residual "exists-at-reassert, pruned-before-FK-insert" window. Locking closes it while still permitting the concurrent non-key stat updates (`mention_count`/`last_seen`) that `flush_pending_stats()` issues.

### Known residual
If a concurrent worker re-creates the same name under a **new** id after the prune, the old id can't be resurrected (unique name index) and that single unit link is dropped — the memory itself still persists; the batch is never lost. Documented inline.

## Tests

- **End-to-end** Phase-1 → prune → Phase-2 regression using a fuzzy alias, asserting the original id **and** canonical name are restored and linked.
- **Real-PG concurrency** test proving a prune `DELETE` blocks (statement-timeout) until the child link commits.
- **Oracle adapter** coverage for stable lock order + idempotent reinsert, plus an empty-batch no-op.
- Updated the resolver/label tests for the `ResolvedEntity` return type.
- Ruff + `ty check hindsight_api` pass.

Fixes #2662