### PR TITLE
fix(opencode): derive session-start recall query from user messages (#2856)

### DIFF
--- a/hindsight-integrations/opencode/src/e2e.test.ts
+++ b/hindsight-integrations/opencode/src/e2e.test.ts
@@ -115,8 +115,9 @@ describeLive("live: OpenCode plugin against Hindsight", () => {
   it("session.created + system transform injects recalled context on first prompt", async () => {
     const sessionId = "first-prompt-session";
 
-    // Seed with content that matches the hardcoded system-transform query
-    // ("project context and recent work").
+    // Seed with content that matches the generic fallback query. This session
+    // has no user messages (empty transcript), so system.transform falls back to
+    // "project context and recent work" rather than a user-derived query.
     await client.retain(
       BANK,
       "Project context: TypeScript monorepo; recent work was on the hindsight-opencode plugin's Cloud-default config."

--- a/hindsight-integrations/opencode/src/hooks.test.ts
+++ b/hindsight-integrations/opencode/src/hooks.test.ts
@@ -462,4 +462,66 @@ describe("system transform hook", () => {
     expect(output.system.length).toBe(0);
     expect(client.recall).not.toHaveBeenCalled();
   });
+
+  it("queries on the user's latest message instead of a fixed string", async () => {
+    const client = makeClient();
+    const messages = [
+      {
+        info: { role: "user" },
+        parts: [{ type: "text", text: "How do I configure Oracle vector search?" }],
+      },
+    ];
+    const state = makeState();
+    const output = { system: [] as string[] };
+    const hooks = createHooks(
+      client,
+      "bank",
+      makeConfig({ recallContextTurns: 1 }),
+      state,
+      makeOpencodeClient(messages)
+    );
+
+    await hooks["experimental.chat.system.transform"]({ sessionID: "sess-1", model: {} }, output);
+
+    expect(client.recall).toHaveBeenCalledTimes(1);
+    expect(client.recall.mock.calls[0][1]).toBe("How do I configure Oracle vector search?");
+  });
+
+  it("includes prior turns when recallContextTurns > 1", async () => {
+    const client = makeClient();
+    const messages = [
+      { info: { role: "user" }, parts: [{ type: "text", text: "Set up the database" }] },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "Which engine?" }] },
+      { info: { role: "user" }, parts: [{ type: "text", text: "Use Postgres with pgvector" }] },
+    ];
+    const state = makeState();
+    const output = { system: [] as string[] };
+    const hooks = createHooks(
+      client,
+      "bank",
+      makeConfig({ recallContextTurns: 3 }),
+      state,
+      makeOpencodeClient(messages)
+    );
+
+    await hooks["experimental.chat.system.transform"]({ sessionID: "sess-1", model: {} }, output);
+
+    const query = client.recall.mock.calls[0][1] as string;
+    expect(query).toContain("Use Postgres with pgvector");
+    expect(query).toContain("Prior context:");
+    expect(query).toContain("Set up the database");
+  });
+
+  it("falls back to the generic query when there is no user message yet", async () => {
+    const client = makeClient();
+    const state = makeState();
+    const output = { system: [] as string[] };
+    // No messages available on the session.
+    const hooks = createHooks(client, "bank", makeConfig(), state, makeOpencodeClient());
+
+    await hooks["experimental.chat.system.transform"]({ sessionID: "sess-1", model: {} }, output);
+
+    expect(client.recall).toHaveBeenCalledTimes(1);
+    expect(client.recall.mock.calls[0][1]).toBe("project context and recent work");
+  });
 });

--- a/hindsight-integrations/opencode/src/hooks.ts
+++ b/hindsight-integrations/opencode/src/hooks.ts
@@ -2,8 +2,9 @@
  * Hook implementations for the Hindsight OpenCode plugin.
  *
  * Hooks:
- *   - experimental.chat.system.transform → recall memories once per session and
- *     inject them into the system prompt (order-independent; see #1758)
+ *   - experimental.chat.system.transform → recall memories once per session
+ *     (querying on the user's own messages when available) and inject them into
+ *     the system prompt (order-independent; see #1758)
  *   - event (session.idle) → auto-retain conversation transcript
  *   - experimental.session.compacting → inject memories into compaction context
  */
@@ -300,8 +301,24 @@ export function createHooks(
 
       await ensureBankMission(hindsightClient, bankId, config, state.missionsSet, logger);
 
-      // Use a generic project-context query for session start
-      const query = `project context and recent work`;
+      // Build the recall query from the user's own messages so session-start
+      // recall adapts to what they actually asked, instead of a fixed string.
+      // We fetch messages directly (the hook input only carries sessionID/model)
+      // — reusing the same dynamic-query path as the compaction hook. Fetching
+      // rather than relying on event ordering also sidesteps the
+      // session.created-vs-system.transform race noted above (#1758). When there
+      // is no user text yet, fall back to a generic project-context query.
+      const messages = await getSessionMessages(sessionId);
+      const lastUserMsg = [...messages].reverse().find((m) => m.role === "user");
+      let query = `project context and recent work`;
+      if (lastUserMsg && lastUserMsg.content.trim()) {
+        const composed = composeRecallQuery(
+          lastUserMsg.content,
+          messages,
+          config.recallContextTurns
+        );
+        query = truncateRecallQuery(composed, lastUserMsg.content, config.recallMaxQueryChars);
+      }
       const { context, ok } = await recallForContext(query);
 
       // Mark as recalled only after a successful API round-trip (even with 0


### PR DESCRIPTION
## Summary

Fixes #2856. The OpenCode plugin's session-start auto-recall (`experimental.chat.system.transform`) used a hardcoded query — `"project context and recent work"` — for every session, so recall never adapted to what the user actually asked.

This wires the session-start recall to the user's own messages, reusing the **exact same dynamic-query path the compaction hook already uses** (`composeRecallQuery` + `truncateRecallQuery`):

- Fetch the session transcript via `getSessionMessages` (the `system.transform` hook input only carries `sessionID`/`model`, so the message content isn't handed in directly).
- Build the recall query from the latest user message (plus prior turns when `recallContextTurns > 1`).
- Fall back to the generic `"project context and recent work"` query only when there's no user text yet.

Fetching the transcript directly (rather than keying off event order) also keeps this independent of the `session.created`-vs-`system.transform` ordering race documented in #1758.

## Note on the issue's framing

The report claimed *all* auto-recall was hardcoded and "dynamic context recall is impossible." That was overstated — the compaction hook already built dynamic queries. The real gap was narrow: only the once-per-session start recall was static. This PR closes that gap.

## Tests

- `queries on the user's latest message instead of a fixed string`
- `includes prior turns when recallContextTurns > 1`
- `falls back to the generic query when there is no user message yet`

All 120 opencode unit tests pass; build + lint green.
