### PR TITLE
fix(retain): queue retain.completed webhook on boundary and zero-fact batches

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -1220,6 +1220,14 @@ async def _streaming_retain_batch(
     retain_params, merged_tags = _build_retain_params(contents_dicts, document_tags)
     # Track whether document tracking has been done (by the first batch)
     doc_tracking_done = [False]
+    # Track whether the transactional-outbox callback has already fired inside a
+    # batch write TXN. The in-TXN fire only runs on a final facts-bearing batch
+    # (is_last=True); two success paths never reach it — a committed-chunk count
+    # that lands exactly on a chunk_batch_size boundary (the sentinel drains an
+    # empty batch), and a final batch that extracts zero facts (it returns before
+    # the insert). A post-loop fallback fires the callback in those cases, so this
+    # flag exists to guarantee the callback fires exactly once.
+    outbox_fired = [False]
 
     # ---------------------------------------------------------------------------
     # Producer-consumer pipeline: LLM extraction runs concurrently with DB writes
@@ -1617,6 +1625,12 @@ async def _streaming_retain_batch(
 
                 logger.info(f"[streaming] Phase 2 (write txn): {time.time() - p2_start:.3f}s")
 
+                # The write TXN above committed the transactional-outbox row in the
+                # same transaction as this batch's facts. Record it so the post-loop
+                # fallback doesn't queue a duplicate delivery.
+                if is_last and outbox_callback is not None:
+                    outbox_fired[0] = True
+
                 # Best-effort: flush entity_cooccurrences and other deferred stats.
                 try:
                     await entity_resolver.flush_pending_stats()
@@ -1749,6 +1763,21 @@ async def _streaming_retain_batch(
                     # read again — release the per-document text now.
                     combined_content = ""
                     log_buffer.append(f"[streaming] Document {effective_doc_id} tracked (no facts extracted)")
+
+        # Transactional-outbox fallback. The in-TXN fire only runs on a final
+        # facts-bearing batch (is_last=True). When the committed-chunk count lands
+        # exactly on a chunk_batch_size boundary the sentinel drains an empty batch
+        # and never marks one last; when the final batch extracts zero facts it
+        # returns before the insert; and when every chunk is skipped as already
+        # committed no batch runs at all. In each of those the retain still
+        # succeeded, so the retain.completed delivery must be queued — exactly once,
+        # in its own transaction (there is no batch TXN left to attach it to). Skip
+        # it on a concurrent takeover: an aborted request must not emit completion.
+        if outbox_callback is not None and not outbox_fired[0] and not pipeline_aborted[0]:
+            async with acquire_with_retry(pool) as conn:
+                async with conn.transaction():
+                    await outbox_callback(conn)
+            outbox_fired[0] = True
 
         # Mark facts as committed in operation metadata (crash recovery checkpoint)
         if operation_id and all_unit_ids:

--- a/hindsight-api-slim/tests/test_webhooks.py
+++ b/hindsight-api-slim/tests/test_webhooks.py
@@ -979,6 +979,140 @@ class TestRetainCompletedWebhook:
                 )
                 await conn.execute("DELETE FROM webhooks WHERE id = $1", webhook_id)
 
+    @staticmethod
+    async def _count_retain_deliveries(pool, bank_id: str) -> int:
+        async with pool.acquire() as conn:
+            return await conn.fetchval(
+                """
+                SELECT count(*)
+                FROM async_operations
+                WHERE operation_type = 'webhook_delivery'
+                  AND bank_id = $1
+                  AND task_payload->>'event_type' = 'retain.completed'
+                """,
+                bank_id,
+            )
+
+    @pytest.mark.asyncio
+    async def test_retain_fires_outbox_on_chunk_batch_boundary(self, memory: MemoryEngine, request_context):
+        """A committed-chunk count that lands exactly on a ``retain_chunk_batch_size``
+        boundary must still queue retain.completed exactly once.
+
+        Regression: the streaming consumer flushes full batches with
+        ``is_last=False`` and only marks the *leftover* partial batch as last.
+        When the chunk count is an exact multiple of the batch size the sentinel
+        drains an empty batch, so the in-TXN outbox fire never runs and the
+        delivery was silently dropped. Batch size 1 makes every retain hit this
+        boundary, so it reproduces the drop deterministically.
+        """
+        bank_id = f"wh-boundary-{uuid.uuid4().hex[:8]}"
+        webhook_id = uuid.uuid4()
+        original_manager = memory._webhook_manager
+        resolver_config = memory._config_resolver._global_config
+        original_batch_size = resolver_config.retain_chunk_batch_size
+        try:
+            memory._webhook_manager = WebhookManager(backend=memory._backend, global_webhooks=[])
+            resolver_config.retain_chunk_batch_size = 1
+
+            await _ensure_bank(memory._pool, bank_id)
+            async with memory._pool.acquire() as conn:
+                await conn.execute(
+                    """
+                    INSERT INTO webhooks (id, bank_id, url, secret, event_types, enabled, created_at, updated_at)
+                    VALUES ($1, $2, $3, NULL, $4, true, NOW(), NOW())
+                    """,
+                    webhook_id,
+                    bank_id,
+                    "https://example.com/retain-hook",
+                    ["retain.completed"],
+                )
+
+            contents = [{"content": "Alice works at Google", "document_id": "doc-boundary"}]
+            callback = memory._build_retain_outbox_callback(
+                bank_id=bank_id, contents=contents, operation_id="op-boundary"
+            )
+            assert callback is not None
+            await memory.retain_batch_async(
+                bank_id=bank_id,
+                contents=contents,
+                request_context=request_context,
+                outbox_callback=callback,
+            )
+
+            deliveries = await self._count_retain_deliveries(memory._pool, bank_id)
+            assert deliveries == 1, f"expected exactly one retain.completed delivery, got {deliveries}"
+        finally:
+            memory._webhook_manager = original_manager
+            resolver_config.retain_chunk_batch_size = original_batch_size
+            async with memory._pool.acquire() as conn:
+                await conn.execute(
+                    "DELETE FROM async_operations WHERE operation_type = 'webhook_delivery' AND bank_id = $1",
+                    bank_id,
+                )
+                await conn.execute("DELETE FROM webhooks WHERE id = $1", webhook_id)
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_retain_fires_outbox_when_final_batch_extracts_zero_facts(
+        self, memory: MemoryEngine, request_context, monkeypatch
+    ):
+        """A retain whose final batch extracts zero facts must still queue
+        retain.completed exactly once.
+
+        Regression: ``_process_db_batch`` returns before the fact-insert call
+        site (which carries the outbox callback) when a batch has no facts, so a
+        document that extracts nothing — common for boilerplate content — never
+        queued its delivery.
+        """
+        from hindsight_api.engine.response_models import TokenUsage
+        from hindsight_api.engine.retain import fact_extraction
+
+        bank_id = f"wh-zerofact-{uuid.uuid4().hex[:8]}"
+        webhook_id = uuid.uuid4()
+        original_manager = memory._webhook_manager
+
+        async def _extract_no_facts(*args, **kwargs):
+            return [], [], TokenUsage()
+
+        try:
+            memory._webhook_manager = WebhookManager(backend=memory._backend, global_webhooks=[])
+            monkeypatch.setattr(fact_extraction, "extract_facts_from_contents", _extract_no_facts)
+
+            await _ensure_bank(memory._pool, bank_id)
+            async with memory._pool.acquire() as conn:
+                await conn.execute(
+                    """
+                    INSERT INTO webhooks (id, bank_id, url, secret, event_types, enabled, created_at, updated_at)
+                    VALUES ($1, $2, $3, NULL, $4, true, NOW(), NOW())
+                    """,
+                    webhook_id,
+                    bank_id,
+                    "https://example.com/retain-hook",
+                    ["retain.completed"],
+                )
+
+            contents = [{"content": "nothing extractable here", "document_id": "doc-zero"}]
+            callback = memory._build_retain_outbox_callback(bank_id=bank_id, contents=contents, operation_id="op-zero")
+            assert callback is not None
+            await memory.retain_batch_async(
+                bank_id=bank_id,
+                contents=contents,
+                request_context=request_context,
+                outbox_callback=callback,
+            )
+
+            deliveries = await self._count_retain_deliveries(memory._pool, bank_id)
+            assert deliveries == 1, f"expected exactly one retain.completed delivery, got {deliveries}"
+        finally:
+            memory._webhook_manager = original_manager
+            async with memory._pool.acquire() as conn:
+                await conn.execute(
+                    "DELETE FROM async_operations WHERE operation_type = 'webhook_delivery' AND bank_id = $1",
+                    bank_id,
+                )
+                await conn.execute("DELETE FROM webhooks WHERE id = $1", webhook_id)
+            await memory.delete_bank(bank_id, request_context=request_context)
+
 
 # ---------------------------------------------------------------------------
 # Schema-isolation tests


### PR DESCRIPTION
## Summary

The transactional-outbox callback that queues the `retain.completed` webhook delivery only fires inside the **final facts-bearing batch's** write transaction (`is_last=True`). Two successful retain paths never reach that fire, so the webhook delivery is **silently dropped** — no error, no log, no retry — even though the memory data is stored correctly.

This is a lost *notification*, not lost data: facts, chunks, entities and the document are all written. But a caller relying on `retain.completed` to learn "my ingest finished" (advance a pipeline, mark a job done, trigger downstream indexing) never hears back.

## The two drop paths (in `_streaming_retain_batch`)

The streaming consumer drains extracted chunks in batches of `retain_chunk_batch_size` (default 100). Full batches flush with `is_last=False`; only the *leftover partial batch* drained by the queue sentinel is marked `is_last=True`, and the callback is threaded into the write TXN at exactly one place (`outbox_callback=outbox_callback if is_last else None`).

1. **Exact chunk-batch boundary.** When the committed-chunk count is an exact multiple of `retain_chunk_batch_size`, there is no leftover — the last full batch already flushed as `is_last=False`, and the sentinel drains an *empty* batch (guarded by `if batch and not pipeline_aborted[0]`), so `is_last=True` is never passed. A document that extracts into exactly 100/200/300… chunks loses its webhook; 199 or 201 fire fine.

2. **Zero-fact final batch.** `_process_db_batch` returns early when a batch extracts no facts, *before* reaching the fact-insert call site that carries the callback. Any retain whose final (or only) batch yields no facts — common for boilerplate content — never queues its delivery, regardless of `is_last`.

There is **no backstop**: the delivery row is only ever inserted by this callback, and the worker poller re-delivers rows that *exist* — a never-inserted row is gone.

## Fix

Track whether the callback fired in-TXN (`outbox_fired`). On any successful, non-aborted retain that didn't fire it, queue the delivery **exactly once** in a dedicated transaction after the consumer loop — the same place the existing no-batch document-tracking fallback already runs. This covers both drop paths (and the all-chunks-skipped case) without having to reason about *why* `is_last` didn't fire, which is what made a chunk-counting approach fragile. Concurrent-takeover (`pipeline_aborted`) retains are skipped so an aborted request never emits a completion event.

## Verification

Two regression tests, both **fail with `0` deliveries on `main`** and pass with the fix, asserting exactly one `retain.completed` delivery through the real retain pipeline + a real `WebhookManager`:

- `test_retain_fires_outbox_on_chunk_batch_boundary` — `retain_chunk_batch_size=1` makes every retain land on a boundary, reproducing the drop deterministically.
- `test_retain_fires_outbox_when_final_batch_extracts_zero_facts` — extraction stubbed to return no facts.

Full `tests/test_webhooks.py`, `test_delta_retain.py`, `test_large_document_replacement.py`, `test_async_batch_retain.py` green (92 passed). `ruff` + `ty check` clean.

## Scope

Deliberately minimal — this fixes only the confirmed outbox drop. A separate, lower-priority cost issue (an oversized `replace` whose slice-1 prefix changes re-extracts trailing history one time via the `removed_indices` deletion path) is **not** in scope here; it produces correct state and is a cost optimization, tracked separately.

_Supersedes #2728, which diagnosed a different mechanism and whose `is_last` fix counted against `total_chunks` rather than queued chunks (so it didn't fire on the recovery/skip path)._
