### PR TITLE
fix: advance watermark after no-op delta refresh

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -10837,6 +10837,21 @@ class MemoryEngine(MemoryEngineInterface):
 
             tag_filtering = _resolve_refresh_tag_filtering(mental_model.get("tags"), trigger_data)
 
+            # Bound this refresh to a database-time snapshot. Facts arriving while
+            # reflect is running must remain newer than the persisted watermark so
+            # a later refresh can still see them.
+            backend = await self._get_backend()
+            assert self._dialect is not None
+            async with acquire_with_retry(backend) as conn:
+                refresh_cutoff = await conn.fetchval(
+                    f"SELECT {self._dialect.current_timestamp()} "
+                    f"FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
+                    bank_id,
+                    mental_model_id,
+                )
+            if refresh_cutoff is None:
+                return None
+
             # Run reflect with the source query, excluding the mental model being refreshed
             # Skip creating a nested "hindsight.reflect" span since we already have "hindsight.mental_model_refresh"
             # Build context to guide the reflect agent: tell it what this mental
@@ -10873,6 +10888,7 @@ class MemoryEngine(MemoryEngineInterface):
                 # Attribute these LLM calls to the mental-model refresh, not a
                 # plain reflect, so traces group under the right operation.
                 _operation_label="refresh_mental_model",
+                created_before=refresh_cutoff,
             )
             # Forward the per-model max_tokens so the final synthesis is capped at the
             # user-configured limit rather than the reflect_async default.
@@ -11005,6 +11021,7 @@ class MemoryEngine(MemoryEngineInterface):
                             mental_model_id,
                             reflect_response=reflect_response_payload,
                             last_refreshed_source_query=current_source_query,
+                            refresh_watermark=refresh_cutoff,
                             request_context=request_context,
                         )
 
@@ -11112,6 +11129,7 @@ class MemoryEngine(MemoryEngineInterface):
                 content=final_content,
                 reflect_response=reflect_response_payload,
                 last_refreshed_source_query=current_source_query,
+                refresh_watermark=refresh_cutoff,
                 structured_content=(final_structured.model_dump() if final_structured is not None else None),
                 request_context=request_context,
             )
@@ -11129,6 +11147,7 @@ class MemoryEngine(MemoryEngineInterface):
         trigger: dict[str, Any] | None = None,
         reflect_response: dict[str, Any] | None = None,
         last_refreshed_source_query: str | None = None,
+        refresh_watermark: datetime | None = None,
         structured_content: dict[str, Any] | None = None,
         request_context: "RequestContext",
     ) -> dict[str, Any] | None:
@@ -11144,6 +11163,7 @@ class MemoryEngine(MemoryEngineInterface):
             tags: New tags (if changing)
             trigger: New trigger settings (if changing)
             reflect_response: Full reflect API response payload (if changing)
+            refresh_watermark: Snapshot cutoff consumed by a successful refresh
             request_context: Request context for authentication
 
         Returns:
@@ -11195,7 +11215,12 @@ class MemoryEngine(MemoryEngineInterface):
                 updates.append(f"content = ${param_idx}")
                 params.append(content)
                 param_idx += 1
-                updates.append("last_refreshed_at = NOW()")
+                if refresh_watermark is None:
+                    updates.append("last_refreshed_at = NOW()")
+                else:
+                    updates.append(f"last_refreshed_at = ${param_idx}")
+                    params.append(refresh_watermark)
+                    param_idx += 1
                 # Snapshot the previous version for history. The actual write goes
                 # into the dedicated mental_model_history table after the UPDATE
                 # (see _append_mental_model_history); we only store the slim slice
@@ -11216,6 +11241,13 @@ class MemoryEngine(MemoryEngineInterface):
                     updates.append(f"embedding = ${param_idx}")
                     params.append(str(embedding[0]))
                     param_idx += 1
+            elif refresh_watermark is not None:
+                # A successful delta refresh can find no topic-relevant facts even
+                # though the coarse staleness query found new rows. Consume that
+                # window without re-embedding unchanged content or adding history.
+                updates.append(f"last_refreshed_at = ${param_idx}")
+                params.append(refresh_watermark)
+                param_idx += 1
 
             if reflect_response is not None:
                 updates.append(f"reflect_response = ${param_idx}")

--- a/hindsight-api-slim/tests/test_mental_model_delta.py
+++ b/hindsight-api-slim/tests/test_mental_model_delta.py
@@ -28,7 +28,9 @@ import pytest
 
 from hindsight_api import MemoryEngine, RequestContext
 from hindsight_api.engine.llm_wrapper import LLMConfig
+from hindsight_api.engine.maintenance import MaintenanceLoop
 from hindsight_api.engine.response_models import ReflectResult
+from hindsight_api.engine.retain import embedding_utils
 
 
 def _canned_reflect_result(text: str, facts: list[dict] | None = None) -> ReflectResult:
@@ -270,6 +272,203 @@ class TestDeltaRefreshPlumbing:
 
         assert refreshed["content"] == "# Customers\n\nBrand new topic."
         assert len(llm_calls) == 0, "Source-query change must bypass the delta merge"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_delta_no_new_facts_advances_refresh_watermark(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+        patch_llm_call,
+        monkeypatch,
+    ):
+        """A successful no-op refresh must consume the current stale window.
+
+        The scheduled-refresh gate uses ``last_refreshed_at`` as its watermark. If
+        reflect finds no topic-relevant facts and that watermark stays unchanged,
+        the same unrelated memory makes every maintenance tick submit another LLM
+        refresh even though the previous operation completed successfully.
+        """
+        bank_id = f"test-delta-watermark-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        existing = "# Preferences\n\nThe user prefers concise answers.\n"
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="User Preferences",
+            source_query="What are the user's durable collaboration preferences?",
+            content=existing,
+            trigger={"mode": "delta", "refresh_cron": "* * * * *"},
+            request_context=request_context,
+        )
+
+        # Reproduce an established model whose cron is overdue, then add a fresh
+        # but topic-irrelevant fact. The coarse staleness query sees this row while
+        # the reflect agent correctly returns no supporting facts for the model.
+        assert memory._pool is not None
+        async with memory._pool.acquire() as conn:
+            before = await conn.fetchval(
+                """
+                UPDATE mental_models
+                SET last_refreshed_at = NOW() - INTERVAL '1 day',
+                    last_refreshed_source_query = source_query
+                WHERE bank_id = $1 AND id = $2
+                RETURNING last_refreshed_at
+                """,
+                bank_id,
+                mm["id"],
+            )
+            await conn.execute(
+                """
+                INSERT INTO memory_units (id, bank_id, text, fact_type, tags, created_at, updated_at)
+                VALUES ($1, $2, 'The build server uses Linux.', 'world', ARRAY[]::varchar[], NOW(), NOW())
+                """,
+                uuid.uuid4(),
+                bank_id,
+            )
+            stale_row = await conn.fetchrow(
+                "SELECT id, tags, trigger, last_refreshed_at FROM mental_models WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                mm["id"],
+            )
+            assert stale_row is not None
+            assert await memory.compute_mental_model_is_stale(conn, bank_id, stale_row) is True
+
+        patch_reflect(memory, text="No relevant preference changes.", facts=[])
+        delta_llm_calls = patch_llm_call(memory, returns="should-not-be-called")
+
+        async def fail_embedding_generation(*args, **kwargs):
+            raise AssertionError("A no-op delta refresh must not regenerate the embedding")
+
+        monkeypatch.setattr(embedding_utils, "generate_embeddings_batch", fail_embedding_generation)
+
+        refreshed = await memory.refresh_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            request_context=request_context,
+        )
+
+        assert refreshed is not None
+        assert refreshed["content"] == existing
+        assert len(delta_llm_calls) == 0
+        assert (refreshed.get("reflect_response") or {}).get("delta_skipped_reason") == "no_new_facts"
+
+        async with memory._pool.acquire() as conn:
+            mm_row = await conn.fetchrow(
+                "SELECT id, tags, trigger, last_refreshed_at FROM mental_models WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                mm["id"],
+            )
+            assert mm_row is not None
+            after = mm_row["last_refreshed_at"]
+            is_stale = await memory.compute_mental_model_is_stale(conn, bank_id, mm_row)
+            history_count = await conn.fetchval(
+                "SELECT COUNT(*) FROM mental_model_history WHERE bank_id = $1 AND mental_model_id = $2",
+                bank_id,
+                mm["id"],
+            )
+        assert after > before
+        assert is_stale is False
+        assert history_count == 0
+
+        submitted: list[str] = []
+
+        async def record_submit(
+            *, bank_id: str, mental_model_id: str, request_context: RequestContext
+        ) -> dict[str, str]:
+            submitted.append(mental_model_id)
+            return {"operation_id": str(uuid.uuid4())}
+
+        monkeypatch.setattr(memory, "submit_async_refresh_mental_model", record_submit)
+        await MaintenanceLoop(memory)._run_scheduled_mm_refresh()
+        assert mm["id"] not in submitted
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_delta_no_new_facts_preserves_memories_arriving_during_refresh(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+        patch_llm_call,
+        monkeypatch,
+    ):
+        """The refresh watermark must not pass facts excluded from its recall snapshot."""
+        bank_id = f"test-delta-cutoff-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="User Preferences",
+            source_query="What are the user's durable collaboration preferences?",
+            content="# Preferences\n\nThe user prefers concise answers.\n",
+            trigger={"mode": "delta", "refresh_cron": "* * * * *"},
+            request_context=request_context,
+        )
+
+        assert memory._pool is not None
+        async with memory._pool.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE mental_models
+                SET last_refreshed_at = NOW() - INTERVAL '1 day',
+                    last_refreshed_source_query = source_query
+                WHERE bank_id = $1 AND id = $2
+                """,
+                bank_id,
+                mm["id"],
+            )
+
+        reflect_calls = patch_reflect(memory, text="No relevant preference changes.", facts=[])
+        delta_llm_calls = patch_llm_call(memory, returns="should-not-be-called")
+        original_update = memory.update_mental_model
+        late_fact_id = uuid.uuid4()
+
+        async def insert_late_fact_then_update(*args, **kwargs):
+            # refresh_mental_model has already consumed the reflect result when it
+            # reaches update_mental_model. Insert a fact in that exact race window.
+            assert memory._pool is not None
+            async with memory._pool.acquire() as conn:
+                await conn.execute(
+                    """
+                    INSERT INTO memory_units
+                        (id, bank_id, text, fact_type, tags, created_at, updated_at)
+                    VALUES
+                        ($1, $2, 'The user now prefers detailed answers.', 'world',
+                         ARRAY[]::varchar[], NOW(), NOW())
+                    """,
+                    late_fact_id,
+                    bank_id,
+                )
+            return await original_update(*args, **kwargs)
+
+        monkeypatch.setattr(memory, "update_mental_model", insert_late_fact_then_update)
+
+        refreshed = await memory.refresh_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            request_context=request_context,
+        )
+
+        assert refreshed is not None
+        assert len(reflect_calls) == 1
+        assert reflect_calls[0].get("created_before") is not None
+        assert len(delta_llm_calls) == 0
+
+        async with memory._pool.acquire() as conn:
+            mm_row = await conn.fetchrow(
+                "SELECT id, tags, trigger, last_refreshed_at FROM mental_models WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                mm["id"],
+            )
+            late_updated_at = await conn.fetchval(
+                "SELECT updated_at FROM memory_units WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                late_fact_id,
+            )
+            assert mm_row is not None
+            assert late_updated_at > mm_row["last_refreshed_at"]
+            assert await memory.compute_mental_model_is_stale(conn, bank_id, mm_row) is True
 
         await memory.delete_bank(bank_id, request_context=request_context)
 


### PR DESCRIPTION
## Summary

Advance a delta mental model's refresh watermark when reflection completes successfully but finds no topic-relevant facts, while preserving facts that arrive during the refresh for a later run.

Without this, the scheduled-refresh maintenance loop sees the same model as due and stale on every tick, repeatedly invoking the Reflect LLM against the same memory window.

## Root cause

The `no_new_facts` path persists `reflect_response` and `last_refreshed_source_query` without passing `content`. `update_mental_model()` previously advanced `last_refreshed_at` only when content was rewritten, so a successful no-op refresh left the scheduler watermark unchanged.

This can happen when the coarse staleness query sees a new memory row but Reflect correctly determines that the row is unrelated to the mental model's source query.

A naive post-reflect `NOW()` update would stop the loop but introduce a data-loss race: a fact arriving after recall but before the watermark write could fall behind the new watermark without ever being considered.

## Fix

- Capture a database-time `refresh_cutoff` before Reflect starts.
- Pass that cutoff as Reflect's `created_before` upper bound.
- Persist the exact cutoff as `last_refreshed_at` after a successful refresh, including the `no_new_facts` path.
- Preserve the existing content and embedding, and do not create a history snapshot for a no-op refresh.
- Keep facts arriving after the cutoff newer than the watermark so a later refresh can still process them.

## Regression tests

The no-op regression test reproduces the scheduler loop:

1. Create an established cron-scheduled delta mental model.
2. Make its refresh watermark old and add a fresh but unrelated memory.
3. Verify the model is stale before refresh.
4. Mock Reflect to return no supporting facts.
5. Verify the refresh advances the watermark, preserves content, performs no embedding generation, creates no history entry, clears staleness, and prevents the next maintenance pass from submitting another refresh.

A second deterministic race test inserts a fact after Reflect has returned but before `update_mental_model()` writes the watermark. It verifies that:

- Reflect received `created_before=refresh_cutoff`;
- `last_refreshed_at` remains earlier than the late fact's `updated_at`;
- the mental model remains stale so the late fact will be reconsidered.

Both tests fail before the fix.

## Impact observed

On Hindsight 0.8.4, one affected scheduled delta model produced 1,408 refresh operations and 1,398 actual LLM requests (2,110,981 tokens) in 24 hours before its cron was temporarily disabled. The configured cron itself was daily; the repeated requests came from the maintenance retry loop.

## Testing

- `uv run pytest tests/test_mental_model_delta.py tests/test_mental_model_scheduled_refresh.py -q -n 0`
  - 17 passed, 4 skipped (real-provider evaluation tests)
- `./scripts/hooks/lint.sh`
  - all lints passed
- Targeted Ruff formatting/checks and `ty` type checking
  - all checks passed
- `uv run pytest tests/test_recall_time_range.py tests/test_temporal_recall_selection.py -q -n 0`
  - 13 passed

## Related work

- #1192 introduced the delta `no_new_facts` short-circuit.
- #2377 introduced scheduled mental model refreshes.
- #1679 fixed a related first-refresh placeholder case, but does not cover established models repeatedly scheduled after a successful no-op delta refresh.
