### PR TITLE
fix(cli): sync regenerated OpenAPI operation changes

### DIFF
--- a/hindsight-cli/src/api.rs
+++ b/hindsight-cli/src/api.rs
@@ -1269,6 +1269,21 @@ impl ApiClient {
         })
     }
 
+    pub fn delete_operation(
+        &self,
+        bank_id: &str,
+        operation_id: &str,
+        _verbose: bool,
+    ) -> Result<types::DeleteOperationResponse> {
+        self.runtime.block_on(async {
+            let response = self
+                .client
+                .delete_operation(bank_id, operation_id, None)
+                .await?;
+            Ok(response.into_inner())
+        })
+    }
+
     // --- Consolidation Recovery ---
 
     pub fn recover_consolidation(

--- a/hindsight-cli/src/api.rs
+++ b/hindsight-cli/src/api.rs
@@ -543,6 +543,8 @@ impl ApiClient {
                     offset.map(|o| o as u64),
                     q,
                     None, // state
+                    None, // tags
+                    None, // tags_match
                     type_filter,
                     None, // authorization
                 )

--- a/hindsight-cli/src/commands/operation.rs
+++ b/hindsight-cli/src/commands/operation.rs
@@ -215,3 +215,48 @@ pub fn retry(
     }
     Ok(())
 }
+
+/// Permanently delete a terminal async operation
+pub fn delete(
+    client: &ApiClient,
+    bank_id: &str,
+    operation_id: &str,
+    yes: bool,
+    verbose: bool,
+    output_format: OutputFormat,
+) -> Result<()> {
+    if !yes && output_format == OutputFormat::Pretty {
+        let message = format!(
+            "Are you sure you want to permanently delete operation '{}'? This cannot be undone.",
+            operation_id
+        );
+        if !ui::prompt_confirmation(&message)? {
+            ui::print_info("Operation cancelled");
+            return Ok(());
+        }
+    }
+
+    let spinner = if output_format == OutputFormat::Pretty {
+        Some(ui::create_spinner("Deleting operation..."))
+    } else {
+        None
+    };
+
+    let response = client.delete_operation(bank_id, operation_id, verbose);
+
+    if let Some(mut sp) = spinner {
+        sp.finish();
+    }
+
+    let result = response?;
+    if output_format == OutputFormat::Pretty {
+        if result.success {
+            ui::print_success(&result.message);
+        } else {
+            ui::print_error(&result.message);
+        }
+    } else {
+        output::print_output(&result, output_format)?;
+    }
+    Ok(())
+}

--- a/hindsight-cli/src/main.rs
+++ b/hindsight-cli/src/main.rs
@@ -97,7 +97,7 @@ enum Commands {
     #[command(subcommand)]
     Chunk(ChunkCommands),
 
-    /// Manage async operations (list, get, cancel)
+    /// Manage async operations (list, get, cancel, retry, delete)
     #[command(subcommand)]
     Operation(OperationCommands),
 
@@ -809,6 +809,19 @@ enum OperationCommands {
 
         /// Operation ID
         operation_id: String,
+    },
+
+    /// Permanently delete a terminal async operation
+    Delete {
+        /// Bank ID
+        bank_id: String,
+
+        /// Operation ID
+        operation_id: String,
+
+        /// Skip confirmation prompt
+        #[arg(short = 'y', long)]
+        yes: bool,
     },
 }
 
@@ -1631,6 +1644,18 @@ fn run() -> Result<()> {
             } => {
                 commands::operation::retry(&client, &bank_id, &operation_id, verbose, output_format)
             }
+            OperationCommands::Delete {
+                bank_id,
+                operation_id,
+                yes,
+            } => commands::operation::delete(
+                &client,
+                &bank_id,
+                &operation_id,
+                yes,
+                verbose,
+                output_format,
+            ),
         },
 
         // Mental model commands
@@ -2126,6 +2151,38 @@ fn handle_profile(cmd: ProfileCommands, output_format: OutputFormat) -> Result<(
                 )?;
             }
             Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Cli, Commands, OperationCommands};
+    use clap::Parser;
+
+    #[test]
+    fn parses_operation_delete_with_confirmation_bypass() {
+        let cli = Cli::try_parse_from([
+            "hindsight",
+            "operation",
+            "delete",
+            "bank-1",
+            "operation-1",
+            "--yes",
+        ])
+        .expect("operation delete should be a valid command");
+
+        match cli.command {
+            Commands::Operation(OperationCommands::Delete {
+                bank_id,
+                operation_id,
+                yes,
+            }) => {
+                assert_eq!(bank_id, "bank-1");
+                assert_eq!(operation_id, "operation-1");
+                assert!(yes);
+            }
+            _ => panic!("expected operation delete command"),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Expose `hindsight operation delete <BANK_ID> <OPERATION_ID>` with an interactive confirmation prompt, `--yes` support, and structured JSON/YAML output.
- Pass `None` for the new `tags` and `tags_match` arguments when the existing memory list command calls the regenerated Rust client.

## Background

PR #2777 added the `delete_operation` OpenAPI operation and regenerated several SDKs, but it neither exposed the operation in the Rust CLI nor added a CLI coverage exception. Because the coverage check requires every OpenAPI operation to be implemented or explicitly skipped, branches rebased onto that change failed with `MISSING OP delete_operation`.

PR #2848 then added the optional `tags` and `tags_match` query parameters to `list_memories`. The Rust client is generated from the OpenAPI document at build time, so its positional method signature gained two arguments while the CLI wrapper still supplied the old argument list, causing Rust compilation to fail with E0061.

This PR implements operation deletion instead of suppressing the coverage check and preserves the current CLI memory-list behavior by passing `None` for both newly generated filter arguments.

## Impact

The Rust CLI builds against the current OpenAPI specification, the CLI coverage check recognizes `delete_operation` as implemented, and users can permanently remove failed, cancelled, or completed operation records from the CLI.

## Validation

- `cargo test --bin hindsight` (69 passed)
- `uv run cli-coverage-check`
- `./scripts/hooks/lint.sh`
- `hindsight operation delete --help`
