### PR TITLE
Fix unsafe delta refresh visibility watermark

### DIFF
--- a/hindsight-api-slim/hindsight_api/config_resolver.py
+++ b/hindsight-api-slim/hindsight_api/config_resolver.py
@@ -98,7 +98,12 @@ class ConfigResolver:
 
         return config_dict
 
-    async def resolve_full_config(self, bank_id: str, context: RequestContext | None = None) -> HindsightConfig:
+    async def resolve_full_config(
+        self,
+        bank_id: str,
+        context: RequestContext | None = None,
+        conn: Any | None = None,
+    ) -> HindsightConfig:
         """
         Resolve full HindsightConfig for a bank with hierarchical overrides applied.
 
@@ -113,6 +118,7 @@ class ConfigResolver:
         Args:
             bank_id: Bank identifier
             context: Request context for tenant config resolution
+            conn: Existing database connection to reuse when one is already held
 
         Returns:
             Complete HindsightConfig with hierarchical overrides applied
@@ -120,7 +126,7 @@ class ConfigResolver:
         config_dict = await self._resolve_parent_config_dict(bank_id, context)
 
         # Load bank config overrides
-        bank_overrides = await self._load_bank_config(bank_id)
+        bank_overrides = await self._load_bank_config(bank_id, conn)
         if bank_overrides:
             config_dict.update(bank_overrides)
             logger.debug(f"Applied bank config overrides for bank {bank_id}: {list(bank_overrides.keys())}")
@@ -149,7 +155,12 @@ class ConfigResolver:
         )
         return resolved_config
 
-    async def get_bank_config(self, bank_id: str, context: RequestContext | None = None) -> dict[str, Any]:
+    async def get_bank_config(
+        self,
+        bank_id: str,
+        context: RequestContext | None = None,
+        conn: Any | None = None,
+    ) -> dict[str, Any]:
         """
         Get fully resolved config for a bank (filtered by permissions).
 
@@ -169,12 +180,13 @@ class ConfigResolver:
         Args:
             bank_id: Bank identifier
             context: Request context for tenant config resolution and permissions
+            conn: Existing database connection to reuse when one is already held
 
         Returns:
             Dict of allowed configurable fields only (never includes credentials or static fields)
         """
         # Resolve full config with all hierarchical overrides
-        resolved_config = await self.resolve_full_config(bank_id, context)
+        resolved_config = await self.resolve_full_config(bank_id, context, conn)
         config_dict = asdict(resolved_config)
 
         # SECURITY: drop static/infrastructure + credential fields, then permission-filter.
@@ -255,42 +267,35 @@ class ConfigResolver:
         )
         return dict(zip(bank_ids, permission_filtered, strict=True))
 
-    async def _load_bank_config(self, bank_id: str) -> dict[str, Any]:
-        """
-        Load bank config overrides from banks.config JSONB column.
+    async def _load_bank_config(self, bank_id: str, conn: Any | None = None) -> dict[str, Any]:
+        """Load active bank overrides, reusing an existing connection when supplied."""
 
-        Args:
-            bank_id: Bank identifier
+        async def load(active_conn: Any) -> dict[str, Any]:
+            row = await active_conn.fetchrow(
+                f"""
+                SELECT config FROM {fq_table("banks")} WHERE bank_id = $1
+                """,
+                bank_id,
+            )
+            if not row or not row["config"]:
+                return {}
 
-        Returns:
-            Dict of config overrides (only configurable fields, normalized keys)
-        """
+            config_data = row["config"]
+            if isinstance(config_data, str):
+                config_data = json.loads(config_data)
+            normalized = normalize_config_dict(config_data)
+            # JSON null is a tombstone for "Server Default" and must not
+            # override the inherited tenant/global value.
+            return {k: v for k, v in normalized.items() if k in self._configurable_fields and v is not None}
+
         try:
-            async with self._backend.acquire() as conn:
-                row = await conn.fetchrow(
-                    f"""
-                    SELECT config FROM {fq_table("banks")} WHERE bank_id = $1
-                    """,
-                    bank_id,
-                )
-
-                if row and row["config"]:
-                    config_data = row["config"]
-
-                    # Handle case where JSONB is returned as JSON string
-                    if isinstance(config_data, str):
-                        config_data = json.loads(config_data)
-
-                    # Normalize keys (handle both env var format and Python field format)
-                    normalized = normalize_config_dict(config_data)
-
-                    # Only return active overrides for configurable fields. JSON null is a tombstone
-                    # for "Server Default" in the bank-config UI and should not override defaults.
-                    return {k: v for k, v in normalized.items() if k in self._configurable_fields and v is not None}
+            if conn is not None:
+                return await load(conn)
+            async with self._backend.acquire() as acquired_conn:
+                return await load(acquired_conn)
         except Exception as e:
             logger.error(f"Failed to load bank config for {bank_id}: {e}")
-
-        return {}
+            return {}
 
     async def _load_bank_configs(self, bank_ids: list[str]) -> dict[str, dict[str, Any]]:
         """Bulk variant of :meth:`_load_bank_config`: load many banks' overrides in one query.

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -1454,7 +1454,12 @@ async def _trigger_mental_model_refreshes(
 
         rows = []
         for candidate in candidates:
-            if await memory_engine.compute_mental_model_is_stale(conn, bank_id, candidate):
+            if await memory_engine.compute_mental_model_is_stale(
+                conn,
+                bank_id,
+                candidate,
+                request_context,
+            ):
                 rows.append(candidate)
 
     if not rows:

--- a/hindsight-api-slim/hindsight_api/engine/maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/maintenance.py
@@ -65,6 +65,10 @@ class MaintenanceLoop:
         self._stop = asyncio.Event()
         # Monotonic timestamps of the last run per job, keyed by job name.
         self._last_run: dict[str, float] = {}
+        # Scoped-memory checks are idempotent within one cron fire. This prevents
+        # an old semantic watermark from re-hashing the same no-op window on every
+        # maintenance poll while preserving a fresh check at the next cron fire.
+        self._scheduled_mm_checked_fires: dict[tuple[str, str, str], datetime] = {}
 
     # ── lifecycle ──────────────────────────────────────────────────────────
 
@@ -345,12 +349,13 @@ class MaintenanceLoop:
             logger.warning(f"Scheduled mental model refresh discovery failed: {e}")
             return
         if not rows:
+            self._scheduled_mm_checked_fires.clear()
             return
 
         from croniter import croniter
 
         now = datetime.now(timezone.utc)
-        due = []
+        due: list[tuple[Any, datetime]] = []
         for row in rows:
             cron = row["refresh_cron"]
             last = row["last_refreshed_at"]
@@ -363,9 +368,19 @@ class MaintenanceLoop:
                 )
                 continue
             if last is None or prev_fire > last:
-                due.append(row)
+                due.append((row, prev_fire))
         if not due:
+            self._scheduled_mm_checked_fires.clear()
             return
+
+        due_fires = {
+            (row["schema_name"], row["bank_id"], str(row["mental_model_id"])): prev_fire for row, prev_fire in due
+        }
+        self._scheduled_mm_checked_fires = {
+            key: checked_fire
+            for key, checked_fire in self._scheduled_mm_checked_fires.items()
+            if due_fires.get(key) == checked_fire
+        }
 
         # Only enqueue into schemas the worker actually polls (tenant discovery),
         # otherwise the op would never be claimed. The tenant_id (when provided)
@@ -383,10 +398,14 @@ class MaintenanceLoop:
         submitted = 0
         skipped_unknown = 0
         skipped_fresh = 0
-        for row in due:
+        for row, prev_fire in due:
             schema = row["schema_name"]
             bank_id = row["bank_id"]
             mm_id = row["mental_model_id"]
+            check_key = (schema, bank_id, str(mm_id))
+            if self._scheduled_mm_checked_fires.get(check_key) == prev_fire:
+                skipped_fresh += 1
+                continue
             tenant = tenant_by_schema.get(schema)
             if tenant is None and schema != default_schema:
                 skipped_unknown += 1
@@ -402,20 +421,34 @@ class MaintenanceLoop:
                 # the row under the bank's schema context.
                 async with acquire_with_retry(engine._backend, max_retries=1) as conn:
                     mm_row = await conn.fetchrow(
-                        f"SELECT id, tags, trigger, last_refreshed_at FROM {fq_table('mental_models')} "
-                        "WHERE bank_id = $1 AND id = $2",
+                        f"""
+                        SELECT id, name, tags, trigger, source_query, reflect_response,
+                               last_refreshed_at, max_tokens
+                        FROM {fq_table("mental_models")}
+                        WHERE bank_id = $1 AND id = $2
+                        """,
                         bank_id,
                         mm_id,
                     )
                     if mm_row is None:
                         continue
-                    is_stale = await engine.compute_mental_model_is_stale(conn, bank_id, mm_row)
+                    is_stale = await engine.compute_mental_model_is_stale(
+                        conn,
+                        bank_id,
+                        mm_row,
+                        context,
+                    )
                 if not is_stale:
+                    self._scheduled_mm_checked_fires[check_key] = prev_fire
                     skipped_fresh += 1
                     continue
                 await engine.submit_async_refresh_mental_model(
                     bank_id=bank_id, mental_model_id=mm_id, request_context=context
                 )
+                # Checkpoint a successful submission for this cron fire. A task that
+                # later fails is retried at the next fire rather than being enqueued
+                # every maintenance tick during the current fire.
+                self._scheduled_mm_checked_fires[check_key] = prev_fire
                 submitted += 1
             except Exception as e:
                 logger.warning(f"Scheduled mental model refresh failed for {mm_id} in {schema}: {e}")

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -12,6 +12,7 @@ This implements a sophisticated memory architecture that combines:
 import asyncio
 import contextvars
 import functools
+import hashlib
 import inspect
 import json
 import logging
@@ -816,6 +817,146 @@ class RefreshTagFiltering:
     tags: list[str] | None
     tags_match: TagsMatch
     tag_groups: list[TagGroup] | None
+
+
+@dataclass(frozen=True)
+class _EffectiveRefreshInputs:
+    """Resolved evidence-retrieval inputs used by a mental-model refresh."""
+
+    include_chunks: bool
+    recall_max_tokens: int
+    recall_chunks_max_tokens: int
+    reflect_source_facts_max_tokens: int
+    store_document_text: bool
+
+
+@dataclass(frozen=True)
+class _MentalModelScopeOptions:
+    """Canonical fixed-schema inputs hashed into a delta acknowledgement."""
+
+    since: str
+    model_name: str | None
+    source_query: str | None
+    mode: str
+    max_tokens: int | None
+    effective_refresh: _EffectiveRefreshInputs
+    exclude_mental_models: bool
+    exclude_mental_model_ids: tuple[str, ...]
+    tags: tuple[str, ...]
+    tags_match: TagsMatch
+    tag_groups: tuple[str, ...]
+    fact_types: tuple[str, ...]
+
+    def canonical_json(self) -> str:
+        return json.dumps(
+            {
+                "since": self.since,
+                "model_name": self.model_name,
+                "source_query": self.source_query,
+                "mode": self.mode,
+                "max_tokens": self.max_tokens,
+                "effective_refresh": {
+                    "include_chunks": self.effective_refresh.include_chunks,
+                    "recall_max_tokens": self.effective_refresh.recall_max_tokens,
+                    "recall_chunks_max_tokens": self.effective_refresh.recall_chunks_max_tokens,
+                    "reflect_source_facts_max_tokens": self.effective_refresh.reflect_source_facts_max_tokens,
+                    "store_document_text": self.effective_refresh.store_document_text,
+                },
+                "exclude_mental_models": self.exclude_mental_models,
+                "exclude_mental_model_ids": self.exclude_mental_model_ids,
+                "tags": self.tags,
+                "tags_match": self.tags_match,
+                "tag_groups": self.tag_groups,
+                "fact_types": self.fact_types,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+
+@dataclass(frozen=True)
+class _MentalModelFactState:
+    """Canonical row version hashed into a delta acknowledgement."""
+
+    id: str
+    updated_at: str
+    text: str
+    fact_type: str
+    tags: tuple[str, ...]
+
+    def canonical_json(self) -> str:
+        return json.dumps(
+            {
+                "id": self.id,
+                "updated_at": self.updated_at,
+                "text": self.text,
+                "fact_type": self.fact_type,
+                "tags": self.tags,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+
+@dataclass(frozen=True)
+class _MentalModelVisibleScopeState:
+    """Stored fixed-size acknowledgement of a visible delta scope."""
+
+    version: int
+    since: str
+    count: int
+    sha256: str
+
+    def as_dict(self) -> dict[str, int | str]:
+        return {
+            "version": self.version,
+            "since": self.since,
+            "count": self.count,
+            "sha256": self.sha256,
+        }
+
+    @classmethod
+    def from_raw(cls, value: Any) -> "_MentalModelVisibleScopeState | None":
+        expected_fields = {"version", "since", "count", "sha256"}
+        if not isinstance(value, dict) or set(value) != expected_fields:
+            return None
+
+        version = value["version"]
+        since = value["since"]
+        count = value["count"]
+        sha256 = value["sha256"]
+        if type(version) is not int or version != 3:  # noqa: E721 - bool must be rejected
+            return None
+        if type(count) is not int or count < 0:  # noqa: E721 - bool must be rejected
+            return None
+        if not isinstance(since, str) or not isinstance(sha256, str):
+            return None
+        try:
+            if _canonical_scope_timestamp(since) != since:
+                return None
+        except (TypeError, ValueError):
+            return None
+        if len(sha256) != 64 or any(char not in "0123456789abcdef" for char in sha256):
+            return None
+        return cls(version=version, since=since, count=count, sha256=sha256)
+
+
+@dataclass(frozen=True)
+class _MentalModelScopeQuery:
+    """Canonical scoped-memory query used by refresh tokens and staleness checks."""
+
+    last_refreshed_at: datetime | None
+    where: list[str]
+    params: list[Any]
+    options: _MentalModelScopeOptions | None
+
+
+def _canonical_scope_timestamp(value: datetime | str) -> str:
+    """Normalize backend datetime representations to UTC microseconds."""
+    parsed = datetime.fromisoformat(value) if isinstance(value, str) else value
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
 
 
 def _resolve_refresh_tag_filtering(
@@ -9301,6 +9442,7 @@ class MemoryEngine(MemoryEngineInterface):
                     tags_match=tags_match,
                     tag_groups=tag_groups,
                     exclude_ids=exclude_mental_model_ids,
+                    request_context=request_context,
                 )
 
         # Get reflect source facts config (hierarchical: env → tenant → bank)
@@ -10570,7 +10712,12 @@ class MemoryEngine(MemoryEngineInterface):
 
             result = self._row_to_mental_model(row, detail=detail) if row else None
             if result is not None and detail == "full":
-                result["is_stale"] = await self.compute_mental_model_is_stale(conn, bank_id, row)
+                result["is_stale"] = await self.compute_mental_model_is_stale(
+                    conn,
+                    bank_id,
+                    row,
+                    request_context,
+                )
 
         # Post-operation hook (usage recording)
         if result and self._operation_validator:
@@ -10765,7 +10912,8 @@ class MemoryEngine(MemoryEngineInterface):
         1. Gets the pinned mental model
         2. Runs the source_query through reflect
         3. Updates the content with the new synthesis
-        4. Updates last_refreshed_at
+        4. Advances the timestamp watermark for full refreshes, or stores a
+           visible-state token for safe delta refreshes
 
         Args:
             bank_id: Bank identifier
@@ -10836,21 +10984,16 @@ class MemoryEngine(MemoryEngineInterface):
                         stored_structured_content = raw_struct
 
             tag_filtering = _resolve_refresh_tag_filtering(mental_model.get("tags"), trigger_data)
-
-            # Bound this refresh to a database-time snapshot. Facts arriving while
-            # reflect is running must remain newer than the persisted watermark so
-            # a later refresh can still see them.
-            backend = await self._get_backend()
-            assert self._dialect is not None
-            async with acquire_with_retry(backend) as conn:
-                refresh_cutoff = await conn.fetchval(
-                    f"SELECT {self._dialect.current_timestamp()} "
-                    f"FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
-                    bank_id,
-                    mental_model_id,
-                )
-            if refresh_cutoff is None:
-                return None
+            delta_scope_state: _MentalModelVisibleScopeState | None = None
+            if use_delta:
+                backend = await self._get_backend()
+                async with acquire_with_retry(backend) as conn:
+                    delta_scope_state = await self._compute_mental_model_scope_state(
+                        conn,
+                        bank_id,
+                        mental_model,
+                        request_context,
+                    )
 
             # Run reflect with the source query, excluding the mental model being refreshed
             # Skip creating a nested "hindsight.reflect" span since we already have "hindsight.mental_model_refresh"
@@ -10888,7 +11031,6 @@ class MemoryEngine(MemoryEngineInterface):
                 # Attribute these LLM calls to the mental-model refresh, not a
                 # plain reflect, so traces group under the right operation.
                 _operation_label="refresh_mental_model",
-                created_before=refresh_cutoff,
             )
             # Forward the per-model max_tokens so the final synthesis is capped at the
             # user-configured limit rather than the reflect_async default.
@@ -11016,12 +11158,14 @@ class MemoryEngine(MemoryEngineInterface):
                         )
                         reflect_response_payload["delta_applied"] = False
                         reflect_response_payload["delta_skipped_reason"] = "no_new_facts"
+                        reflect_response_payload["delta_scope_state"] = (
+                            delta_scope_state.as_dict() if delta_scope_state is not None else None
+                        )
                         return await self.update_mental_model(
                             bank_id,
                             mental_model_id,
                             reflect_response=reflect_response_payload,
                             last_refreshed_source_query=current_source_query,
-                            refresh_watermark=refresh_cutoff,
                             request_context=request_context,
                         )
 
@@ -11123,15 +11267,24 @@ class MemoryEngine(MemoryEngineInterface):
             # Update the mental model with new content and reflect_response.
             # Passing last_refreshed_source_query records the query used for this
             # refresh so a future delta-mode run can detect a topic change.
+            if use_delta:
+                # A completion-time watermark cannot safely describe what Reflect
+                # observed: a transaction may commit after the final retrieval with
+                # an older updated_at. Preserve the semantic watermark and use the
+                # pre-Reflect visible-state token for every successful delta update,
+                # not only the no-op path.
+                reflect_response_payload["delta_scope_state"] = (
+                    delta_scope_state.as_dict() if delta_scope_state is not None else None
+                )
             return await self.update_mental_model(
                 bank_id,
                 mental_model_id,
                 content=final_content,
                 reflect_response=reflect_response_payload,
                 last_refreshed_source_query=current_source_query,
-                refresh_watermark=refresh_cutoff,
                 structured_content=(final_structured.model_dump() if final_structured is not None else None),
                 request_context=request_context,
+                _advance_refresh_watermark=not use_delta,
             )
 
     async def update_mental_model(
@@ -11147,9 +11300,9 @@ class MemoryEngine(MemoryEngineInterface):
         trigger: dict[str, Any] | None = None,
         reflect_response: dict[str, Any] | None = None,
         last_refreshed_source_query: str | None = None,
-        refresh_watermark: datetime | None = None,
         structured_content: dict[str, Any] | None = None,
         request_context: "RequestContext",
+        _advance_refresh_watermark: bool = True,
     ) -> dict[str, Any] | None:
         """Update a pinned mental model.
 
@@ -11163,8 +11316,8 @@ class MemoryEngine(MemoryEngineInterface):
             tags: New tags (if changing)
             trigger: New trigger settings (if changing)
             reflect_response: Full reflect API response payload (if changing)
-            refresh_watermark: Snapshot cutoff consumed by a successful refresh
             request_context: Request context for authentication
+            _advance_refresh_watermark: Internal override used by safe delta refreshes.
 
         Returns:
             Updated pinned mental model dict or None if not found
@@ -11215,12 +11368,8 @@ class MemoryEngine(MemoryEngineInterface):
                 updates.append(f"content = ${param_idx}")
                 params.append(content)
                 param_idx += 1
-                if refresh_watermark is None:
+                if _advance_refresh_watermark:
                     updates.append("last_refreshed_at = NOW()")
-                else:
-                    updates.append(f"last_refreshed_at = ${param_idx}")
-                    params.append(refresh_watermark)
-                    param_idx += 1
                 # Snapshot the previous version for history. The actual write goes
                 # into the dedicated mental_model_history table after the UPDATE
                 # (see _append_mental_model_history); we only store the slim slice
@@ -11241,14 +11390,6 @@ class MemoryEngine(MemoryEngineInterface):
                     updates.append(f"embedding = ${param_idx}")
                     params.append(str(embedding[0]))
                     param_idx += 1
-            elif refresh_watermark is not None:
-                # A successful delta refresh can find no topic-relevant facts even
-                # though the coarse staleness query found new rows. Consume that
-                # window without re-embedding unchanged content or adding history.
-                updates.append(f"last_refreshed_at = ${param_idx}")
-                params.append(refresh_watermark)
-                param_idx += 1
-
             if reflect_response is not None:
                 updates.append(f"reflect_response = ${param_idx}")
                 params.append(json.dumps(reflect_response))
@@ -11442,42 +11583,102 @@ class MemoryEngine(MemoryEngineInterface):
 
         return result == "DELETE 1"
 
-    async def compute_mental_model_is_stale(
+    @staticmethod
+    def _mental_model_row_value(mm_row: Any, key: str) -> Any:
+        if isinstance(mm_row, dict):
+            return mm_row.get(key)
+        try:
+            return mm_row[key]
+        except (KeyError, TypeError):
+            return None
+
+    @staticmethod
+    def _mental_model_row_has_key(mm_row: Any, key: str) -> bool:
+        if isinstance(mm_row, dict):
+            return key in mm_row
+        try:
+            return key in mm_row.keys()
+        except (AttributeError, TypeError):
+            return False
+
+    async def _complete_mental_model_scope_row(self, conn, bank_id: str, mm_row: Any) -> Any:
+        """Load token inputs omitted by lightweight staleness callers."""
+        required = ("name", "source_query", "reflect_response", "max_tokens")
+        if all(self._mental_model_row_has_key(mm_row, key) for key in required):
+            return mm_row
+        mental_model_id = self._mental_model_row_value(mm_row, "id")
+        if mental_model_id is None:
+            return mm_row
+        complete_row = await conn.fetchrow(
+            f"""
+            SELECT id, name, tags, trigger, source_query, reflect_response,
+                   last_refreshed_at, max_tokens
+            FROM {fq_table("mental_models")}
+            WHERE bank_id = $1 AND id = $2
+            """,
+            bank_id,
+            mental_model_id,
+        )
+        return complete_row or mm_row
+
+    async def _resolve_effective_refresh_inputs(
         self,
         conn,
         bank_id: str,
+        trigger: dict[str, Any],
+        request_context: "RequestContext | None",
+    ) -> _EffectiveRefreshInputs:
+        """Resolve the same hierarchical evidence settings consumed by Reflect."""
+        config_dict = await self._config_resolver.get_bank_config(bank_id, request_context, conn)
+        static_config = get_config()
+        store_document_text = static_config.store_document_text
+        include_chunks = (
+            bool(trigger["include_chunks"])
+            if trigger.get("include_chunks") is not None
+            else bool(config_dict.get("recall_include_chunks", DEFAULT_RECALL_INCLUDE_CHUNKS))
+        )
+        if not store_document_text:
+            include_chunks = False
+        return _EffectiveRefreshInputs(
+            include_chunks=include_chunks,
+            recall_max_tokens=int(
+                trigger["recall_max_tokens"]
+                if trigger.get("recall_max_tokens") is not None
+                else config_dict.get("recall_max_tokens", DEFAULT_RECALL_MAX_TOKENS)
+            ),
+            recall_chunks_max_tokens=int(
+                trigger["recall_chunks_max_tokens"]
+                if trigger.get("recall_chunks_max_tokens") is not None
+                else config_dict.get("recall_chunks_max_tokens", DEFAULT_RECALL_CHUNKS_MAX_TOKENS)
+            ),
+            reflect_source_facts_max_tokens=int(
+                config_dict.get("reflect_source_facts_max_tokens", DEFAULT_REFLECT_SOURCE_FACTS_MAX_TOKENS)
+            ),
+            store_document_text=store_document_text,
+        )
+
+    def _mental_model_scope_query(
+        self,
+        bank_id: str,
         mm_row: Any,
-    ) -> bool:
-        """Check whether a mental model is out of date.
-
-        A mental model is stale when a memory in its **scope** has been ingested after
-        ``last_refreshed_at``. The scope uses the same resolved flat-tag or compound
-        ``trigger.tag_groups`` filtering as the refresh it gates, plus the
-        ``trigger.fact_types`` filter when set. Memories still pending consolidation are
-        included because they are already rows in ``memory_units``; no separate
-        ``pending_consolidation`` signal is needed — it would bypass the tag scope and
-        falsely flag unrelated MMs.
-
-        Untagged mental model defaults to ``tags_match="any"`` so it matches any memory
-        ingested in the bank (what a user would expect for a "global" MM).
-        """
-
-        def _get(key: str) -> Any:
-            if isinstance(mm_row, dict):
-                return mm_row.get(key)
-            try:
-                return mm_row[key]
-            except (KeyError, TypeError):
-                return None
-
-        last_refreshed_at = _get("last_refreshed_at")
+        effective_refresh: _EffectiveRefreshInputs | None = None,
+    ) -> _MentalModelScopeQuery:
+        """Build the shared fact scope used by scheduled staleness and no-op state tokens."""
+        last_refreshed_at = self._mental_model_row_value(mm_row, "last_refreshed_at")
+        if isinstance(last_refreshed_at, str):
+            last_refreshed_at = datetime.fromisoformat(last_refreshed_at)
         if not last_refreshed_at:
-            return True
+            return _MentalModelScopeQuery(None, [], [], None)
 
-        raw_tags = _get("tags")
-        mm_tags: list[str] = list(raw_tags) if raw_tags else []
+        raw_tags = self._mental_model_row_value(mm_row, "tags")
+        if isinstance(raw_tags, str):
+            try:
+                raw_tags = json.loads(raw_tags)
+            except json.JSONDecodeError:
+                raw_tags = [raw_tags]
+        mm_tags: list[str] = [str(tag) for tag in (raw_tags or [])]
 
-        trigger = _get("trigger")
+        trigger = self._mental_model_row_value(mm_row, "trigger")
         if isinstance(trigger, str):
             try:
                 trigger = json.loads(trigger)
@@ -11512,9 +11713,138 @@ class MemoryEngine(MemoryEngineInterface):
             params.append(fact_types)
             where.append(f"fact_type = ANY(${len(params)}::text[])")
 
+        canonical_tag_groups = tuple(
+            sorted(
+                json.dumps(group.model_dump(mode="json", by_alias=True), sort_keys=True, separators=(",", ":"))
+                for group in (tag_filtering.tag_groups or [])
+            )
+        )
+        options = None
+        if effective_refresh is not None:
+            options = _MentalModelScopeOptions(
+                since=_canonical_scope_timestamp(last_refreshed_at),
+                model_name=self._mental_model_row_value(mm_row, "name"),
+                source_query=self._mental_model_row_value(mm_row, "source_query"),
+                mode=trigger.get("mode") or "full",
+                max_tokens=self._mental_model_row_value(mm_row, "max_tokens"),
+                effective_refresh=effective_refresh,
+                exclude_mental_models=bool(trigger.get("exclude_mental_models", False)),
+                exclude_mental_model_ids=tuple(
+                    sorted(str(value) for value in (trigger.get("exclude_mental_model_ids") or []))
+                ),
+                tags=tuple(sorted(tag_filtering.tags or [])),
+                tags_match=tag_filtering.tags_match,
+                tag_groups=canonical_tag_groups,
+                fact_types=tuple(sorted(fact_types)),
+            )
+        return _MentalModelScopeQuery(last_refreshed_at, where, params, options)
+
+    async def _compute_mental_model_scope_state(
+        self,
+        conn,
+        bank_id: str,
+        mm_row: Any,
+        request_context: "RequestContext | None" = None,
+    ) -> _MentalModelVisibleScopeState | None:
+        """Hash the exact visible stale fact set without advancing its time watermark."""
+        trigger = self._mental_model_row_value(mm_row, "trigger")
+        if isinstance(trigger, str):
+            try:
+                trigger = json.loads(trigger)
+            except json.JSONDecodeError:
+                trigger = None
+        effective_refresh = await self._resolve_effective_refresh_inputs(
+            conn,
+            bank_id,
+            trigger or {},
+            request_context,
+        )
+        scope_query = self._mental_model_scope_query(bank_id, mm_row, effective_refresh)
+        if scope_query.last_refreshed_at is None or scope_query.options is None:
+            return None
+
+        rows = await conn.fetch(
+            f"""
+            SELECT id, updated_at, text, fact_type, tags
+            FROM {fq_table("memory_units")}
+            WHERE {" AND ".join(scope_query.where)}
+            ORDER BY id
+            """,
+            *scope_query.params,
+        )
+
+        digest = hashlib.sha256()
+        digest.update(scope_query.options.canonical_json().encode())
+        for row in rows:
+            raw_fact_tags = row["tags"]
+            if isinstance(raw_fact_tags, str):
+                try:
+                    raw_fact_tags = json.loads(raw_fact_tags)
+                except json.JSONDecodeError:
+                    raw_fact_tags = [raw_fact_tags]
+            fact_state = _MentalModelFactState(
+                id=str(row["id"]),
+                updated_at=_canonical_scope_timestamp(row["updated_at"]),
+                text=row["text"],
+                fact_type=row["fact_type"],
+                tags=tuple(sorted(str(tag) for tag in (raw_fact_tags or []))),
+            )
+            digest.update(b"\n")
+            digest.update(fact_state.canonical_json().encode())
+
+        return _MentalModelVisibleScopeState(
+            version=3,
+            since=_canonical_scope_timestamp(scope_query.last_refreshed_at),
+            count=len(rows),
+            sha256=digest.hexdigest(),
+        )
+
+    async def compute_mental_model_is_stale(
+        self,
+        conn,
+        bank_id: str,
+        mm_row: Any,
+        request_context: "RequestContext | None" = None,
+    ) -> bool:
+        """Check whether a mental model is out of date.
+
+        A mental model is stale when a memory in its **scope** has been ingested after
+        ``last_refreshed_at``. After any successful delta refresh, an exact digest of
+        the visible scoped rows suppresses repeat refreshes without moving that timestamp;
+        any later-visible insert, update, delete, or effective input change remains stale.
+        """
+        mm_row = await self._complete_mental_model_scope_row(conn, bank_id, mm_row)
+        scope_query = self._mental_model_scope_query(bank_id, mm_row)
+        if scope_query.last_refreshed_at is None:
+            return True
+
+        reflect_response = self._mental_model_row_value(mm_row, "reflect_response")
+        if isinstance(reflect_response, str):
+            try:
+                reflect_response = json.loads(reflect_response)
+            except json.JSONDecodeError:
+                reflect_response = None
+        stored_scope_state_raw = (
+            reflect_response.get("delta_scope_state") if isinstance(reflect_response, dict) else None
+        )
+        stored_scope_state = _MentalModelVisibleScopeState.from_raw(stored_scope_state_raw)
+        if stored_scope_state_raw is not None and stored_scope_state is None:
+            # Legacy/malformed acknowledgement formats cannot prove parity with
+            # the v3 effective-input digest. Refresh once to migrate safely.
+            return True
+        if stored_scope_state is not None:
+            current_scope_state = await self._compute_mental_model_scope_state(
+                conn,
+                bank_id,
+                mm_row,
+                request_context,
+            )
+            if current_scope_state is not None:
+                return current_scope_state != stored_scope_state
+
         row = await conn.fetchrow(
-            f"SELECT 1 FROM {fq_table('memory_units')} WHERE {' AND '.join(where)} LIMIT 1",
-            *params,
+            f"SELECT 1 FROM {fq_table('memory_units')} WHERE {' AND '.join(scope_query.where)} LIMIT 1",
+            *scope_query.params,
         )
         return row is not None
 

--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
@@ -67,6 +67,7 @@ async def tool_search_mental_models(
     tags_match: str = "any",
     tag_groups: "list | None" = None,
     exclude_ids: list[str] | None = None,
+    request_context: "RequestContext | None" = None,
 ) -> dict[str, Any]:
     """
     Search user-curated mental models by semantic similarity.
@@ -134,7 +135,12 @@ async def tool_search_mental_models(
             last_refreshed_at = last_refreshed_at.replace(tzinfo=timezone.utc)
 
         # Per-MM staleness: new in-scope memories since last refresh (includes pending).
-        is_stale = await memory_engine.compute_mental_model_is_stale(conn, bank_id, row)
+        is_stale = await memory_engine.compute_mental_model_is_stale(
+            conn,
+            bank_id,
+            row,
+            request_context,
+        )
         staleness_reason = "new in-scope memories ingested since last refresh" if is_stale else None
 
         mental_models.append(

--- a/hindsight-api-slim/tests/test_mental_model_delta.py
+++ b/hindsight-api-slim/tests/test_mental_model_delta.py
@@ -20,6 +20,8 @@ This file contains two kinds of tests:
    updates — format preservation, surgical edits, observation-grounding.
 """
 
+import asyncio
+import json
 import os
 import uuid
 from typing import Any
@@ -275,7 +277,7 @@ class TestDeltaRefreshPlumbing:
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
-    async def test_delta_no_new_facts_advances_refresh_watermark(
+    async def test_delta_no_new_facts_records_visible_scope_state(
         self,
         memory: MemoryEngine,
         request_context: RequestContext,
@@ -283,13 +285,7 @@ class TestDeltaRefreshPlumbing:
         patch_llm_call,
         monkeypatch,
     ):
-        """A successful no-op refresh must consume the current stale window.
-
-        The scheduled-refresh gate uses ``last_refreshed_at`` as its watermark. If
-        reflect finds no topic-relevant facts and that watermark stays unchanged,
-        the same unrelated memory makes every maintenance tick submit another LLM
-        refresh even though the previous operation completed successfully.
-        """
+        """A successful no-op must suppress the same visible stale set without moving its watermark."""
         bank_id = f"test-delta-watermark-{uuid.uuid4().hex[:8]}"
         await memory.get_bank_profile(bank_id, request_context=request_context)
 
@@ -307,6 +303,7 @@ class TestDeltaRefreshPlumbing:
         # but topic-irrelevant fact. The coarse staleness query sees this row while
         # the reflect agent correctly returns no supporting facts for the model.
         assert memory._pool is not None
+        stale_fact_id = uuid.uuid4()
         async with memory._pool.acquire() as conn:
             before = await conn.fetchval(
                 """
@@ -324,7 +321,7 @@ class TestDeltaRefreshPlumbing:
                 INSERT INTO memory_units (id, bank_id, text, fact_type, tags, created_at, updated_at)
                 VALUES ($1, $2, 'The build server uses Linux.', 'world', ARRAY[]::varchar[], NOW(), NOW())
                 """,
-                uuid.uuid4(),
+                stale_fact_id,
                 bank_id,
             )
             stale_row = await conn.fetchrow(
@@ -356,21 +353,133 @@ class TestDeltaRefreshPlumbing:
 
         async with memory._pool.acquire() as conn:
             mm_row = await conn.fetchrow(
-                "SELECT id, tags, trigger, last_refreshed_at FROM mental_models WHERE bank_id = $1 AND id = $2",
+                """
+                SELECT id, name, tags, trigger, source_query, reflect_response,
+                       last_refreshed_at, max_tokens
+                FROM mental_models WHERE bank_id = $1 AND id = $2
+                """,
                 bank_id,
                 mm["id"],
             )
             assert mm_row is not None
             after = mm_row["last_refreshed_at"]
             is_stale = await memory.compute_mental_model_is_stale(conn, bank_id, mm_row)
+            partial_row = await conn.fetchrow(
+                "SELECT id, tags, trigger, last_refreshed_at FROM mental_models WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                mm["id"],
+            )
+            assert partial_row is not None
+            assert await memory.compute_mental_model_is_stale(conn, bank_id, partial_row) is False
             history_count = await conn.fetchval(
                 "SELECT COUNT(*) FROM mental_model_history WHERE bank_id = $1 AND mental_model_id = $2",
                 bank_id,
                 mm["id"],
             )
-        assert after > before
+        assert after == before
         assert is_stale is False
         assert history_count == 0
+        scope_state = (refreshed.get("reflect_response") or {}).get("delta_scope_state")
+        assert scope_state is not None
+        assert scope_state["count"] == 1
+
+        # Every option that changes refresh strategy or visible evidence must
+        # invalidate the token even when the currently matching rows are unchanged.
+        base_row = dict(mm_row)
+        base_trigger = base_row["trigger"]
+        if isinstance(base_trigger, str):
+            base_trigger = json.loads(base_trigger)
+        else:
+            base_trigger = dict(base_trigger)
+        trigger_changes = [
+            {"mode": "full"},
+            {"include_chunks": False},
+            {"recall_max_tokens": 1234},
+            {"recall_chunks_max_tokens": 567},
+            {"exclude_mental_models": True},
+            {"exclude_mental_model_ids": ["another-model"]},
+            {"fact_types": ["experience"]},
+            {"tag_groups": [{"tags": ["scope:other"], "match": "any"}]},
+        ]
+        async with memory._pool.acquire() as conn:
+            for change in trigger_changes:
+                candidate = dict(base_row)
+                candidate["trigger"] = {**base_trigger, **change}
+                candidate_state = await memory._compute_mental_model_scope_state(conn, bank_id, candidate)
+                assert candidate_state is not None
+                assert candidate_state.as_dict() != scope_state
+            for key, value in (
+                ("name", "Changed model name"),
+                ("source_query", "A changed source query"),
+                ("max_tokens", (base_row["max_tokens"] or 0) + 1),
+                ("tags", ["scope:other"]),
+            ):
+                candidate = {**base_row, key: value}
+                candidate_state = await memory._compute_mental_model_scope_state(conn, bank_id, candidate)
+                assert candidate_state is not None
+                assert candidate_state.as_dict() != scope_state
+
+            stored_response = base_row["reflect_response"] or {}
+            if isinstance(stored_response, str):
+                stored_response = json.loads(stored_response)
+            else:
+                stored_response = dict(stored_response)
+
+            legacy_row = dict(base_row)
+            legacy_response = dict(stored_response)
+            legacy_response["delta_scope_state"] = {**scope_state, "version": 2}
+            legacy_row["reflect_response"] = legacy_response
+            assert (
+                await memory.compute_mental_model_is_stale(
+                    conn,
+                    bank_id,
+                    legacy_row,
+                    request_context,
+                )
+                is True
+            )
+
+            malformed_scope_states = [
+                {**scope_state, "version": "3"},
+                {**scope_state, "version": True},
+                {**scope_state, "count": str(scope_state["count"])},
+                {**scope_state, "count": True},
+                {**scope_state, "count": -1},
+                {**scope_state, "since": None},
+                {**scope_state, "since": scope_state["since"].replace("Z", "+00:00")},
+                {**scope_state, "sha256": 123},
+                {**scope_state, "sha256": f"g{scope_state['sha256'][1:]}"},
+                {key: value for key, value in scope_state.items() if key != "sha256"},
+                {**scope_state, "extra": "unexpected"},
+            ]
+            for malformed_scope_state in malformed_scope_states:
+                malformed_row = dict(base_row)
+                malformed_response = dict(stored_response)
+                malformed_response["delta_scope_state"] = malformed_scope_state
+                malformed_row["reflect_response"] = malformed_response
+                assert (
+                    await memory.compute_mental_model_is_stale(
+                        conn,
+                        bank_id,
+                        malformed_row,
+                        request_context,
+                    )
+                    is True
+                )
+
+            def fail_nested_acquire(*args, **kwargs):
+                raise AssertionError("Scope-state config resolution must reuse the held DB connection")
+
+            with monkeypatch.context() as nested_patch:
+                nested_patch.setattr(memory._config_resolver._backend, "acquire", fail_nested_acquire)
+                same_scope_state = await memory._compute_mental_model_scope_state(
+                    conn,
+                    bank_id,
+                    base_row,
+                    request_context,
+                )
+            assert same_scope_state is not None
+            assert same_scope_state.as_dict() == scope_state
 
         submitted: list[str] = []
 
@@ -381,12 +490,131 @@ class TestDeltaRefreshPlumbing:
             return {"operation_id": str(uuid.uuid4())}
 
         monkeypatch.setattr(memory, "submit_async_refresh_mental_model", record_submit)
-        await MaintenanceLoop(memory)._run_scheduled_mm_refresh()
+        original_scope_state = memory._compute_mental_model_scope_state
+        scope_checks = 0
+
+        async def count_scope_checks(*args, **kwargs):
+            nonlocal scope_checks
+            scope_checks += 1
+            return await original_scope_state(*args, **kwargs)
+
+        monkeypatch.setattr(memory, "_compute_mental_model_scope_state", count_scope_checks)
+        maintenance = MaintenanceLoop(memory)
+        await maintenance._run_scheduled_mm_refresh()
+        checked_fire = next(iter(maintenance._scheduled_mm_checked_fires.values()))
+        orphaned_key = ("deleted-schema", "deleted-bank", "deleted-model")
+        maintenance._scheduled_mm_checked_fires[orphaned_key] = checked_fire
+        await maintenance._run_scheduled_mm_refresh()
+        assert orphaned_key not in maintenance._scheduled_mm_checked_fires
         assert mm["id"] not in submitted
+        assert scope_checks == 1
+
+        trigger_without_cron = {key: value for key, value in base_trigger.items() if key != "refresh_cron"}
+        await memory.update_mental_model(
+            bank_id,
+            mm["id"],
+            trigger=trigger_without_cron,
+            request_context=request_context,
+        )
+        maintenance._scheduled_mm_checked_fires[orphaned_key] = checked_fire
+        await maintenance._run_scheduled_mm_refresh()
+        assert maintenance._scheduled_mm_checked_fires == {}
+
+        await memory.update_mental_model(
+            bank_id,
+            mm["id"],
+            trigger=base_trigger,
+            request_context=request_context,
+        )
+        async with memory._pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE mental_models SET last_refreshed_at = NOW() WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                mm["id"],
+            )
+        maintenance._scheduled_mm_checked_fires[orphaned_key] = checked_fire
+        await maintenance._run_scheduled_mm_refresh()
+        assert maintenance._scheduled_mm_checked_fires == {}
+        async with memory._pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE mental_models SET last_refreshed_at = $3 WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                mm["id"],
+                after,
+            )
+
+        await maintenance._run_scheduled_mm_refresh()
+        valid_checkpoints = dict(maintenance._scheduled_mm_checked_fires)
+        assert len(valid_checkpoints) == 1
+        maintenance._scheduled_mm_checked_fires[orphaned_key] = checked_fire
+
+        async def fail_tenant_discovery():
+            raise RuntimeError("simulated tenant discovery failure")
+
+        with monkeypatch.context() as tenant_failure_patch:
+            tenant_failure_patch.setattr(memory._tenant_extension, "list_tenants", fail_tenant_discovery)
+            await maintenance._run_scheduled_mm_refresh()
+        assert maintenance._scheduled_mm_checked_fires == valid_checkpoints
+
+        # Trigger fields are null here, so Reflect resolves these values through
+        # env/tenant/bank config. Changing the effective value must invalidate the
+        # token even though the stored trigger and visible facts are unchanged.
+        effective_config = await memory._config_resolver.get_bank_config(bank_id, request_context)
+        effective_changes = {
+            "recall_include_chunks": not effective_config["recall_include_chunks"],
+            "recall_max_tokens": effective_config["recall_max_tokens"] + 1,
+            "recall_chunks_max_tokens": effective_config["recall_chunks_max_tokens"] + 1,
+            "reflect_source_facts_max_tokens": effective_config["reflect_source_facts_max_tokens"] + 1,
+        }
+        for config_key, changed_value in effective_changes.items():
+            await memory._config_resolver.update_bank_config(
+                bank_id,
+                {config_key: changed_value},
+                request_context,
+            )
+            async with memory._pool.acquire() as conn:
+                assert (
+                    await memory.compute_mental_model_is_stale(
+                        conn,
+                        bank_id,
+                        mm_row,
+                        request_context,
+                    )
+                    is True
+                )
+            await memory._config_resolver.update_bank_config(
+                bank_id,
+                {config_key: None},
+                request_context,
+            )
+            async with memory._pool.acquire() as conn:
+                assert (
+                    await memory.compute_mental_model_is_stale(
+                        conn,
+                        bank_id,
+                        mm_row,
+                        request_context,
+                    )
+                    is False
+                )
+
+        async with memory._pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE memory_units SET text = 'Changed' WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                stale_fact_id,
+            )
+            assert await memory.compute_mental_model_is_stale(conn, bank_id, mm_row) is True
+            await conn.execute(
+                "DELETE FROM memory_units WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                stale_fact_id,
+            )
+            assert await memory.compute_mental_model_is_stale(conn, bank_id, mm_row) is True
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
-    async def test_delta_no_new_facts_preserves_memories_arriving_during_refresh(
+    async def test_delta_no_new_facts_preserves_inflight_memory_transaction(
         self,
         memory: MemoryEngine,
         request_context: RequestContext,
@@ -419,45 +647,70 @@ class TestDeltaRefreshPlumbing:
                 mm["id"],
             )
 
+        async with memory._pool.acquire() as conn:
+            stale_last_refreshed_at = await conn.fetchval(
+                "SELECT last_refreshed_at FROM mental_models WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                mm["id"],
+            )
+
+        # Start a transaction before refresh captures its state, but do not commit
+        # it until after reflect has returned. Its timestamp is old enough to fall
+        # behind a wall-clock cutoff even though recall cannot see the row.
+        late_conn = await memory._pool.acquire()
+        late_tx = late_conn.transaction()
+        await late_tx.start()
+        late_fact_id = uuid.uuid4()
+        await late_conn.execute(
+            """
+            INSERT INTO memory_units
+                (id, bank_id, text, fact_type, tags, created_at, updated_at)
+            VALUES
+                ($1, $2, 'The user now prefers detailed answers.', 'world',
+                 ARRAY[]::varchar[], NOW(), NOW())
+            """,
+            late_fact_id,
+            bank_id,
+        )
+
         reflect_calls = patch_reflect(memory, text="No relevant preference changes.", facts=[])
         delta_llm_calls = patch_llm_call(memory, returns="should-not-be-called")
         original_update = memory.update_mental_model
-        late_fact_id = uuid.uuid4()
+        late_tx_committed = False
 
-        async def insert_late_fact_then_update(*args, **kwargs):
+        async def commit_late_fact_then_update(*args, **kwargs):
+            nonlocal late_tx_committed
             # refresh_mental_model has already consumed the reflect result when it
-            # reaches update_mental_model. Insert a fact in that exact race window.
-            assert memory._pool is not None
-            async with memory._pool.acquire() as conn:
-                await conn.execute(
-                    """
-                    INSERT INTO memory_units
-                        (id, bank_id, text, fact_type, tags, created_at, updated_at)
-                    VALUES
-                        ($1, $2, 'The user now prefers detailed answers.', 'world',
-                         ARRAY[]::varchar[], NOW(), NOW())
-                    """,
-                    late_fact_id,
-                    bank_id,
-                )
+            # reaches update_mental_model. Commit the previously invisible fact in
+            # that exact race window.
+            await late_tx.commit()
+            late_tx_committed = True
             return await original_update(*args, **kwargs)
 
-        monkeypatch.setattr(memory, "update_mental_model", insert_late_fact_then_update)
+        monkeypatch.setattr(memory, "update_mental_model", commit_late_fact_then_update)
 
-        refreshed = await memory.refresh_mental_model(
-            bank_id=bank_id,
-            mental_model_id=mm["id"],
-            request_context=request_context,
-        )
+        try:
+            refreshed = await memory.refresh_mental_model(
+                bank_id=bank_id,
+                mental_model_id=mm["id"],
+                request_context=request_context,
+            )
+        finally:
+            if not late_tx_committed:
+                await late_tx.rollback()
+            await memory._pool.release(late_conn)
 
         assert refreshed is not None
         assert len(reflect_calls) == 1
-        assert reflect_calls[0].get("created_before") is not None
         assert len(delta_llm_calls) == 0
 
         async with memory._pool.acquire() as conn:
             mm_row = await conn.fetchrow(
-                "SELECT id, tags, trigger, last_refreshed_at FROM mental_models WHERE bank_id = $1 AND id = $2",
+                """
+                SELECT id, name, tags, trigger, source_query, reflect_response,
+                       last_refreshed_at, max_tokens
+                FROM mental_models WHERE bank_id = $1 AND id = $2
+                """,
                 bank_id,
                 mm["id"],
             )
@@ -467,7 +720,295 @@ class TestDeltaRefreshPlumbing:
                 late_fact_id,
             )
             assert mm_row is not None
+            assert mm_row["last_refreshed_at"] == stale_last_refreshed_at
             assert late_updated_at > mm_row["last_refreshed_at"]
+            stored_response = mm_row["reflect_response"]
+            if isinstance(stored_response, str):
+                stored_response = json.loads(stored_response)
+            stored_scope_state = stored_response["delta_scope_state"]
+            current_scope_state = await memory._compute_mental_model_scope_state(conn, bank_id, mm_row)
+            assert stored_scope_state["count"] == 0
+            assert current_scope_state is not None
+            assert current_scope_state.count == 1
+            assert current_scope_state.as_dict() != stored_scope_state
+            assert await memory.compute_mental_model_is_stale(conn, bank_id, mm_row) is True
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_contentful_delta_preserves_inflight_memory_transaction(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+        patch_llm_call,
+        monkeypatch,
+    ):
+        """A content-changing delta must not advance past evidence it could not see."""
+        bank_id = f"test-delta-content-race-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="User Preferences",
+            source_query="What are the user's durable collaboration preferences?",
+            content="# Preferences\n\nThe user prefers concise answers.\n",
+            trigger={"mode": "delta"},
+            request_context=request_context,
+        )
+
+        assert memory._pool is not None
+        async with memory._pool.acquire() as conn:
+            stale_last_refreshed_at = await conn.fetchval(
+                """
+                UPDATE mental_models
+                SET last_refreshed_at = NOW() - INTERVAL '1 day',
+                    last_refreshed_source_query = source_query
+                WHERE bank_id = $1 AND id = $2
+                RETURNING last_refreshed_at
+                """,
+                bank_id,
+                mm["id"],
+            )
+
+        late_conn = await memory._pool.acquire()
+        late_tx = late_conn.transaction()
+        await late_tx.start()
+        late_fact_id = uuid.uuid4()
+        await late_conn.execute(
+            """
+            INSERT INTO memory_units
+                (id, bank_id, text, fact_type, tags, created_at, updated_at)
+            VALUES
+                ($1, $2, 'The user now prefers detailed answers.', 'world',
+                 ARRAY[]::varchar[], NOW(), NOW())
+            """,
+            late_fact_id,
+            bank_id,
+        )
+
+        patch_reflect(
+            memory,
+            text="The user prefers concise answers with examples.",
+            facts=[
+                {
+                    "id": "visible-supporting-fact",
+                    "text": "The user prefers examples.",
+                    "type": "world",
+                    "context": None,
+                }
+            ],
+        )
+        patch_llm_call(
+            memory,
+            returns=[
+                {
+                    "op": "append_block",
+                    "section_id": "preferences",
+                    "block": {"type": "paragraph", "text": "The user prefers examples."},
+                }
+            ],
+        )
+        original_update = memory.update_mental_model
+        late_tx_committed = False
+
+        async def commit_late_fact_then_update(*args, **kwargs):
+            nonlocal late_tx_committed
+            await late_tx.commit()
+            late_tx_committed = True
+            return await original_update(*args, **kwargs)
+
+        monkeypatch.setattr(memory, "update_mental_model", commit_late_fact_then_update)
+        try:
+            refreshed = await memory.refresh_mental_model(
+                bank_id=bank_id,
+                mental_model_id=mm["id"],
+                request_context=request_context,
+            )
+        finally:
+            if not late_tx_committed:
+                await late_tx.rollback()
+            await memory._pool.release(late_conn)
+
+        assert refreshed is not None
+        assert "The user prefers examples." in refreshed["content"]
+        async with memory._pool.acquire() as conn:
+            mm_row = await conn.fetchrow(
+                """
+                SELECT id, name, tags, trigger, source_query, reflect_response,
+                       last_refreshed_at, max_tokens
+                FROM mental_models WHERE bank_id = $1 AND id = $2
+                """,
+                bank_id,
+                mm["id"],
+            )
+            late_updated_at = await conn.fetchval(
+                "SELECT updated_at FROM memory_units WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                late_fact_id,
+            )
+            assert mm_row is not None
+            assert mm_row["last_refreshed_at"] == stale_last_refreshed_at
+            assert late_updated_at > mm_row["last_refreshed_at"]
+            stored_response = mm_row["reflect_response"]
+            if isinstance(stored_response, str):
+                stored_response = json.loads(stored_response)
+            stored_scope_state = stored_response["delta_scope_state"]
+            current_scope_state = await memory._compute_mental_model_scope_state(conn, bank_id, mm_row)
+            assert stored_scope_state["count"] == 0
+            assert current_scope_state is not None
+            assert current_scope_state.count == 1
+            assert current_scope_state.as_dict() != stored_scope_state
+            assert await memory.compute_mental_model_is_stale(conn, bank_id, mm_row) is True
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_contentful_delta_reverse_completion_remains_stale(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        monkeypatch,
+    ):
+        """An older contentful worker finishing last must leave a retry signal."""
+        from hindsight_api.engine.reflect.delta_ops import DeltaOperationList
+
+        bank_id = f"test-delta-reverse-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="User Preferences",
+            source_query="What are the user's durable collaboration preferences?",
+            content="# Preferences\n\nThe user prefers concise answers.\n",
+            trigger={"mode": "delta"},
+            request_context=request_context,
+        )
+        assert memory._pool is not None
+        async with memory._pool.acquire() as conn:
+            stale_last_refreshed_at = await conn.fetchval(
+                """
+                UPDATE mental_models
+                SET last_refreshed_at = NOW() - INTERVAL '1 day',
+                    last_refreshed_source_query = source_query
+                WHERE bank_id = $1 AND id = $2
+                RETURNING last_refreshed_at
+                """,
+                bank_id,
+                mm["id"],
+            )
+
+        first_reflect_started = asyncio.Event()
+        release_first_reflect = asyncio.Event()
+        reflect_count = 0
+
+        async def ordered_reflect(**kwargs):
+            nonlocal reflect_count
+            reflect_count += 1
+            if reflect_count == 1:
+                first_reflect_started.set()
+                await release_first_reflect.wait()
+                return _canned_reflect_result(
+                    "Older worker candidate.",
+                    [
+                        {
+                            "id": "older-support",
+                            "text": "Older supporting fact.",
+                            "type": "world",
+                            "context": None,
+                        }
+                    ],
+                )
+            return _canned_reflect_result(
+                "Newer worker candidate.",
+                [
+                    {
+                        "id": "newer-support",
+                        "text": "Newer supporting fact.",
+                        "type": "world",
+                        "context": None,
+                    }
+                ],
+            )
+
+        async def content_specific_delta(*, messages, **kwargs):
+            prompt = str(messages)
+            text = "Newer update." if "Newer supporting fact" in prompt else "Older update."
+            return DeltaOperationList.model_validate(
+                {
+                    "operations": [
+                        {
+                            "op": "append_block",
+                            "section_id": "preferences",
+                            "block": {"type": "paragraph", "text": text},
+                        }
+                    ]
+                }
+            )
+
+        monkeypatch.setattr(memory, "reflect_async", ordered_reflect)
+        monkeypatch.setattr(memory._reflect_llm_config, "call", content_specific_delta)
+
+        original_update = memory.update_mental_model
+        newer_update_done = asyncio.Event()
+
+        async def reverse_updates(*args, **kwargs):
+            content = kwargs.get("content") or ""
+            if "Older update." in content:
+                await newer_update_done.wait()
+                return await original_update(*args, **kwargs)
+            result = await original_update(*args, **kwargs)
+            newer_update_done.set()
+            return result
+
+        monkeypatch.setattr(memory, "update_mental_model", reverse_updates)
+        older_task = asyncio.create_task(
+            memory.refresh_mental_model(
+                bank_id=bank_id,
+                mental_model_id=mm["id"],
+                request_context=request_context,
+            )
+        )
+        await first_reflect_started.wait()
+
+        async with memory._pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO memory_units (id, bank_id, text, fact_type, tags, created_at, updated_at)
+                VALUES ($1, $2, 'A fact visible only to the newer worker.', 'world',
+                        ARRAY[]::varchar[], NOW(), NOW())
+                """,
+                uuid.uuid4(),
+                bank_id,
+            )
+
+        newer_result = await memory.refresh_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            request_context=request_context,
+        )
+        assert newer_result is not None
+        assert "Newer update." in newer_result["content"]
+        release_first_reflect.set()
+        older_result = await older_task
+        assert older_result is not None
+        assert "Older update." in older_result["content"]
+
+        async with memory._pool.acquire() as conn:
+            mm_row = await conn.fetchrow(
+                """
+                SELECT id, name, tags, trigger, source_query, reflect_response,
+                       last_refreshed_at, max_tokens
+                FROM mental_models WHERE bank_id = $1 AND id = $2
+                """,
+                bank_id,
+                mm["id"],
+            )
+            assert mm_row is not None
+            assert mm_row["last_refreshed_at"] == stale_last_refreshed_at
+            stored_response = mm_row["reflect_response"]
+            if isinstance(stored_response, str):
+                stored_response = json.loads(stored_response)
+            assert stored_response["delta_scope_state"]["count"] == 0
+            current_scope_state = await memory._compute_mental_model_scope_state(conn, bank_id, mm_row)
+            assert current_scope_state is not None
+            assert current_scope_state.count == 1
             assert await memory.compute_mental_model_is_stale(conn, bank_id, mm_row) is True
 
         await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## Summary

Follow-up to #2866, which was merged with a wall-clock cutoff that does not safely order transaction visibility.

A transaction may receive an `updated_at` before the refresh snapshot but remain uncommitted until after Reflect finishes. Advancing a delta model to either a pre-Reflect cutoff or a completion-time `NOW()` can then permanently hide that fact.

This PR replaces delta-refresh timestamp advancement with an exact visible-state acknowledgement:

1. before Reflect, hash the complete currently visible scoped row state newer than the existing semantic watermark;
2. run Reflect and apply the delta normally;
3. for every successful delta result — contentful or no-op — preserve `last_refreshed_at` and store the pre-Reflect visible-state token;
4. recompute that token for staleness checks; equal means fresh, any later-visible insert/update/delete/effective-input change means stale.

This deliberately favors safe reprocessing over permanent omission. A future database-native commit-order revision could compact/advance the semantic cursor, but a wall-clock timestamp cannot provide that guarantee across PostgreSQL and Oracle.

## What changed

- Removed the `refresh_cutoff` / `created_before` design from delta refreshes.
- Removed `last_refreshed_at` advancement from every successful delta path, including content-changing updates.
- Preserved normal content, embedding, structured-content, provenance, and history updates for contentful deltas.
- Stored `delta_scope_state` in `reflect_response` for both contentful and no-op delta refreshes.
- Added an internal update override so full refreshes and direct user content updates retain existing timestamp behavior.
- Added token-aware staleness to every caller:
  - consolidation
  - search/recall mental-model inclusion
  - scheduled maintenance
- Lightweight callers self-fetch the token/config columns before deciding staleness.
- Propagated `RequestContext` through all staleness callers so tenant-resolved config and permission filtering match actual Reflect behavior.
- Reused an already-held database connection when resolving bank config, avoiding a nested-acquire deadlock when the pool maximum is one.
- Added a per-cron-fire in-process checkpoint and bounded it by pruning deleted/inactive model keys before tenant discovery, including empty and no-due cycles.

## Token v3

The token uses frozen, fixed-schema dataclasses internally and covers:

- mental-model name, source query, mode, and max tokens;
- effective hierarchical `recall_include_chunks`;
- effective `recall_max_tokens` and `recall_chunks_max_tokens`;
- effective `reflect_source_facts_max_tokens`;
- effective `store_document_text`;
- mental-model exclusion options;
- resolved tags, tag matching, tag groups, and fact types;
- canonical visible row ID, UTC-microsecond timestamp, text, fact type, and normalized tags.

Legacy v2 or malformed tokens are conservatively considered stale once, causing a safe refresh and migration to v3 rather than trusting an incomplete acknowledgement. The v3 boundary requires exactly the fixed four-field schema, exact integer types, a non-negative count, canonical UTC-microsecond timestamp, and a 64-character lowercase SHA-256 digest; values are never coerced.

## Why it is safe

The token is computed from committed rows visible to the refresh connection before Reflect.

- Same visible state after refresh: token matches, model is fresh.
- A transaction commits after the snapshot: current token differs, model remains stale.
- A contentful refresh finishes after such a commit: its timestamp is not advanced past the unseen row.
- Two contentful refreshes finish in reverse order: an older worker may temporarily overwrite newer content, but its older token no longer matches current state, so a retry signal remains.
- Rows are inserted, updated, deleted, or move into/out of scope: token differs.
- Effective hierarchical refresh configuration or model prompt inputs change: token differs.

The scoped hash query runs only for due scheduled models, and the per-fire checkpoint prevents re-running it every maintenance tick.

## Deterministic concurrency coverage

Two PostgreSQL transaction tests exercise the invisible-row interleaving:

1. A transaction inserts a relevant memory without committing.
2. Refresh captures its visible-state token and completes Reflect.
3. The transaction commits before the mental-model update.
4. Both no-op and contentful refresh paths preserve the old watermark.
5. Stored token count is `0`, current token count is `1`, and the model remains stale.

A third test runs two contentful refreshes concurrently and forces reverse completion:

1. older worker captures state S0 and blocks;
2. a new fact commits;
3. newer worker captures S1 and completes first;
4. older worker completes last with S0;
5. final state is still stale because S0 != S1.

Additional tests cover content/fact-type/tag changes without timestamp changes, deletion, effective-config invalidation, v2 and malformed-v3 migration, lightweight callers, bounded same-fire maintenance across empty/no-due/tenant-discovery-failure paths, and proving scope-state config resolution does not perform a nested database acquire.

## Validation

- delta suite: `13 passed, 4 skipped`
- scheduled-refresh suite: `6 passed`
- hierarchical ConfigResolver regression: `27 passed`
- wider mental-model suite: `60 passed`; 8 real-LLM fixtures stop during setup because no Groq API key is configured and do not reach product assertions
- Ruff full package: passed
- Ruff format: passed
- `ty check hindsight_api`: passed
- package sdist/wheel build: passed
- `git diff --check`: passed
- repository commit hooks (`check-unused`, generated docs skill, lint): passed
- independent read-only review: no remaining code blocker; malformed-v3 and checkpoint coverage findings addressed

## Operational note

Affected scheduled models remain disabled with `refresh_cron: null` until this follow-up is merged and deployed.
