### PR TITLE
fix(claude-code): detach SessionEnd work so CLI shutdown cannot cancel the final retain

### DIFF
--- a/hindsight-integrations/claude-code/CHANGELOG.md
+++ b/hindsight-integrations/claude-code/CHANGELOG.md
@@ -22,6 +22,19 @@
   `HINDSIGHT_USER_ID` is unset) are now dropped from retain requests. Previously
   such tags were sent as-is. Tags without `:` are unaffected.
 
+### Fixed
+
+- The `SessionEnd` hook now hands its work (forced final retain + daemon stop)
+  to a detached child process and returns within milliseconds. Claude Code
+  cancels `SessionEnd` hooks that are still running when shutdown teardown
+  finishes (reproducible with Ctrl+C Ctrl+C exits in MCP-heavy projects:
+  `SessionEnd hook [...] failed: Hook cancelled`; anthropics/claude-code#32712,
+  anthropics/claude-code#41577). Previously this silently dropped the final
+  retain — sessions shorter than `retainEveryNTurns` turns lost their memories
+  entirely. The detached child (own session via `start_new_session`) survives
+  the CLI's process-group teardown and delivers the retain regardless of how
+  the session exits.
+
 ## [0.1.0] - 2025-03-23
 
 ### Added

--- a/hindsight-integrations/claude-code/scripts/session_end.py
+++ b/hindsight-integrations/claude-code/scripts/session_end.py
@@ -1,8 +1,16 @@
 #!/usr/bin/env python3
-"""SessionEnd hook: daemon cleanup.
+"""SessionEnd hook: final retain + daemon cleanup, detached from the CLI.
 
-Fires once when a Claude Code session terminates. If the plugin
-auto-started a hindsight-embed daemon, this is where we stop it.
+Fires once when a Claude Code session terminates. Claude Code cancels
+SessionEnd hooks that are still running when its shutdown teardown finishes
+(reliably reproducible with Ctrl+C Ctrl+C exits in MCP-heavy projects:
+"SessionEnd hook [...] failed: Hook cancelled" — see anthropics/claude-code
+issues #32712 and #41577), which silently loses the forced final retain.
+
+The hook entry therefore does no real work itself: it re-execs this script as
+a detached child (own session, so it survives the CLI's process-group
+teardown) and returns within milliseconds. The child performs the final
+retain and stops the auto-managed daemon if we started one.
 
 Port of: Openclaw's service.stop() in index.js
 """
@@ -20,7 +28,17 @@ from lib.daemon import stop_daemon
 def main():
     config = load_config()
 
-    # Consume stdin
+    if os.environ.get("HINDSIGHT_SESSION_END_DETACHED"):
+        # Detached child: do the real work, immune to the parent's fate.
+        try:
+            hook_input = json.loads(sys.argv[1]) if len(sys.argv) > 1 else {}
+        except json.JSONDecodeError:
+            hook_input = {}
+        _do_session_end(config, hook_input)
+        return
+
+    # Hook entry: hand off to a detached child and return immediately, so the
+    # CLI's shutdown cancellation window has nothing left to kill.
     try:
         hook_input = json.load(sys.stdin)
     except (json.JSONDecodeError, EOFError):
@@ -28,6 +46,21 @@ def main():
 
     debug_log(config, f"SessionEnd hook, reason: {hook_input.get('reason', 'unknown')}")
 
+    import subprocess
+
+    env = dict(os.environ)
+    env["HINDSIGHT_SESSION_END_DETACHED"] = "1"
+    subprocess.Popen(
+        [sys.executable, os.path.abspath(__file__), json.dumps(hook_input)],
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+def _do_session_end(config: dict, hook_input: dict) -> None:
     # Force a final retain before stopping the daemon — guarantees short sessions
     # (fewer turns than retainEveryNTurns) still land on disk.
     if config.get("autoRetain") and hook_input.get("transcript_path"):

--- a/hindsight-integrations/claude-code/tests/test_hooks.py
+++ b/hindsight-integrations/claude-code/tests/test_hooks.py
@@ -875,3 +875,100 @@ class TestRetainHook:
             mod.main()
 
         assert "called" not in captured
+
+
+# ---------------------------------------------------------------------------
+# session_end hook
+# ---------------------------------------------------------------------------
+
+
+class TestSessionEndHook:
+    # Intention: Claude Code cancels SessionEnd hooks that are still running when
+    # shutdown teardown finishes (reproducible with Ctrl+C Ctrl+C exits in
+    # MCP-heavy projects; see anthropics/claude-code#32712 / #41577), which
+    # silently loses the final forced retain. The hook entry must therefore do
+    # NO real work itself: it hands off to a detached child (own session, so it
+    # survives the CLI's process-group teardown) and returns immediately.
+
+    def test_hook_entry_spawns_detached_child_and_does_no_inline_work(self, monkeypatch, tmp_path):
+        # Input: normal hook invocation (no detach marker env), transcript present.
+        # Expected: exactly one subprocess.Popen call — detached (start_new_session),
+        # re-invoking session_end.py with hook_input as argv, marker env set —
+        # and NO retain HTTP call from the hook process itself.
+        messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript)
+
+        network = {}
+
+        def capture(req, timeout=None):
+            network["called"] = True
+            return FakeHTTPResponse({})
+
+        popen_calls = []
+
+        def fake_popen(*args, **kwargs):
+            popen_calls.append((args, kwargs))
+            return MagicMock()
+
+        with patch("subprocess.Popen", side_effect=fake_popen):
+            _run_hook("session_end", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
+
+        assert len(popen_calls) == 1, "hook entry must hand off to exactly one detached child"
+        args, kwargs = popen_calls[0]
+        argv = args[0]
+        assert kwargs.get("start_new_session") is True, "child must run in its own session to survive CLI teardown"
+        assert argv[0] == sys.executable
+        assert argv[1].endswith("session_end.py")
+        assert json.loads(argv[2]) == hook_input
+        assert kwargs["env"].get("HINDSIGHT_SESSION_END_DETACHED") == "1"
+        assert "called" not in network, "hook entry must not do network work inline (it can be cancelled)"
+
+    def test_detached_child_posts_final_retain(self, monkeypatch, tmp_path):
+        # Input: detach marker env set, hook_input arrives via argv (NOT stdin —
+        # stdin carries an empty hook_input to prove argv is the source).
+        # Expected: the forced final retain POSTs the transcript to /memories.
+        messages = [{"role": "user", "content": "remember the sessionend fix"}, {"role": "assistant", "content": "noted"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript)
+
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({"status": "accepted"})
+
+        monkeypatch.setattr(sys, "argv", ["session_end.py", json.dumps(hook_input)])
+        _run_hook(
+            "session_end",
+            make_hook_input(transcript_path=""),  # stdin input is deliberately inert
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=capture,
+            extra_env={"HINDSIGHT_SESSION_END_DETACHED": "1"},
+        )
+
+        assert "body" in captured, "detached child must perform the final retain"
+        assert "remember the sessionend fix" in captured["body"]["items"][0]["content"]
+
+    def test_detached_child_skips_retain_without_transcript(self, monkeypatch, tmp_path):
+        # Input: detached mode with no transcript_path (e.g. empty session).
+        # Expected: no retain HTTP call — nothing to save.
+        captured = {}
+
+        def capture(req, timeout=None):
+            captured["called"] = True
+            return FakeHTTPResponse({})
+
+        monkeypatch.setattr(sys, "argv", ["session_end.py", json.dumps(make_hook_input(transcript_path=""))])
+        _run_hook(
+            "session_end",
+            make_hook_input(transcript_path=""),
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=capture,
+            extra_env={"HINDSIGHT_SESSION_END_DETACHED": "1"},
+        )
+
+        assert "called" not in captured


### PR DESCRIPTION
**Every session shorter than `retainEveryNTurns` (default 10) loses its memories entirely.** Claude Code cancels the `SessionEnd` hook at shutdown teardown, so the forced final retain never runs — **zero SessionEnd retains landed across 36 hours of real sessions**. The fix detaches the work into a child process the CLI cannot cancel.

---

## Problem

Claude Code cancels `SessionEnd` hooks that are still in flight when its shutdown teardown finishes. With this plugin installed, every shutdown of a session in an MCP-heavy project prints:

```
SessionEnd hook [python3 "${CLAUDE_PLUGIN_ROOT}/scripts/session_end.py" || python "${CLAUDE_PLUGIN_ROOT}/scripts/session_end.py"] failed: Hook cancelled
```

The visible error is the small part. The silent part is **data loss**: the cancelled hook never delivers the forced final retain, so any session shorter than `retainEveryNTurns` turns (default 10) loses its memories entirely, and longer sessions lose the tail after the last Stop-hook retain. Checking my self-hosted server logs: **zero SessionEnd retains arrived over 36 hours of real sessions** — the only retains that landed were mid-session Stop-hook ones.

## Root cause

This is not a timeout and not a plugin bug per se — `session_end.py` measures ~0.2s end-to-end against a 1.4MB transcript, far under its 10s hook budget. Claude Code kills the hook at the session-exit signal level (`Hook cancelled`, as distinct from `timed out`). Known upstream behavior: anthropics/claude-code#32712, anthropics/claude-code#41577.

Reproduction matrix (Claude Code v2.1.216, tmux-driven interactive sessions):

| Exit path | Bare directory | MCP-heavy project |
|---|---|---|
| `/exit` | clean | clean |
| Ctrl+C Ctrl+C | clean | **`Hook cancelled`, retain lost** |

## Fix

The hook entry now does no real work. It re-execs `session_end.py` as a detached child — `start_new_session=True`, `hook_input` passed via argv, guarded by `HINDSIGHT_SESSION_END_DETACHED` — and returns in ~85ms, leaving the CLI's cancellation window nothing to kill. The child runs in its own session, survives the CLI's process-group teardown, and performs the forced final retain + daemon stop exactly as before. This is the same detach pattern the plugin already uses in `prestart_daemon_background()`, and the workaround recommended in anthropics/claude-code#41577.

Trade-off: the child's stderr is discarded (it can outlive the terminal), so final-retain errors are no longer visible at shutdown. Given the alternative is the retain being silently killed, this seems like the right side of the trade.

## Testing

- 3 new tests in `tests/test_hooks.py` (`TestSessionEndHook`): hook entry spawns exactly one detached child with the marker env + hook_input argv and does **no** inline network work; detached child performs the final retain from argv; detached child skips retain when there is no transcript.
- Full integration suite: **209 passed**.
- Live verification on v2.1.216: the previously-failing scenario (MCP-heavy project, real turn, Ctrl+C Ctrl+C) now exits with no hook error **and** the final retain arrives at the Hindsight server (confirmed in server logs).

https://claude.ai/code/session_01MTPDCvguQvm5xLKeWuCYY4
