### PR TITLE
feat(config): make embedding thresholds configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -207,6 +207,15 @@ HINDSIGHT_API_LOG_LEVEL=info
 # DeepSeek note: DeepSeek is supported for LLM calls, but not for embeddings.
 # If using DeepSeek as LLM provider, keep embeddings on local/openai/cohere/google/etc.
 
+# Embedding similarity thresholds. These defaults preserve the behavior calibrated
+# for BAAI/bge-small-en-v1.5. Recalibrate each threshold independently when changing
+# embedding models because cosine-similarity distributions are model-dependent.
+# HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY=0.3
+# HINDSIGHT_API_GRAPH_SEED_MIN_SIMILARITY=0.3
+# HINDSIGHT_API_TEMPORAL_SEMANTIC_MIN_SIMILARITY=0.1
+# HINDSIGHT_API_SEMANTIC_LINK_MIN_SIMILARITY=0.7
+# HINDSIGHT_API_CONSOLIDATION_DEDUP_THRESHOLD=0.97
+
 # Reranker Configuration (Optional - uses local by default)
 # Provider: "local" (default) or "tei" (HuggingFace Text Embeddings Inference)
 # HINDSIGHT_API_RERANKER_PROVIDER=local

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -429,6 +429,9 @@ ENV_RERANKER_LITELLM_SDK_TIMEOUT = "HINDSIGHT_API_RERANKER_LITELLM_SDK_TIMEOUT"
 ENV_RERANKER_GOOGLE_TIMEOUT = "HINDSIGHT_API_RERANKER_GOOGLE_TIMEOUT"
 ENV_RERANKER_MAX_CANDIDATES = "HINDSIGHT_API_RERANKER_MAX_CANDIDATES"
 ENV_SEMANTIC_MIN_SIMILARITY = "HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY"
+ENV_GRAPH_SEED_MIN_SIMILARITY = "HINDSIGHT_API_GRAPH_SEED_MIN_SIMILARITY"
+ENV_TEMPORAL_SEMANTIC_MIN_SIMILARITY = "HINDSIGHT_API_TEMPORAL_SEMANTIC_MIN_SIMILARITY"
+ENV_SEMANTIC_LINK_MIN_SIMILARITY = "HINDSIGHT_API_SEMANTIC_LINK_MIN_SIMILARITY"
 ENV_RERANKER_FLASHRANK_MODEL = "HINDSIGHT_API_RERANKER_FLASHRANK_MODEL"
 ENV_RERANKER_FLASHRANK_CACHE_DIR = "HINDSIGHT_API_RERANKER_FLASHRANK_CACHE_DIR"
 ENV_RERANKER_FLASHRANK_CPU_MEM_ARENA = "HINDSIGHT_API_RERANKER_FLASHRANK_CPU_MEM_ARENA"
@@ -828,6 +831,9 @@ DEFAULT_RERANKER_LITELLM_SDK_TIMEOUT = 60.0
 DEFAULT_RERANKER_GOOGLE_TIMEOUT = 60.0
 DEFAULT_RERANKER_MAX_CANDIDATES = 300
 DEFAULT_SEMANTIC_MIN_SIMILARITY = 0.3
+DEFAULT_GRAPH_SEED_MIN_SIMILARITY = 0.3
+DEFAULT_TEMPORAL_SEMANTIC_MIN_SIMILARITY = 0.1
+DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY = 0.7
 # Minimum BM25 score a row must exceed to enter fusion. 0.0 gates out
 # zero-score (non-matching) rows on backends — notably VectorChord — whose
 # operator ranks every document rather than pre-filtering to term matches.
@@ -1830,6 +1836,9 @@ class HindsightConfig:
     reranker_tei_http_timeout: float
     reranker_max_candidates: int
     semantic_min_similarity: float
+    graph_seed_min_similarity: float
+    temporal_semantic_min_similarity: float
+    semantic_link_min_similarity: float
     bm25_min_score: float
     recall_max_candidates_per_source: int
     recall_strategy_boosts: dict[str, str]
@@ -2311,10 +2320,15 @@ class HindsightConfig:
             self.text_search_extension_pg_search_tokenizer
         )
 
-        if not 0.0 <= self.semantic_min_similarity <= 1.0:
-            raise ValueError(
-                f"Invalid semantic_min_similarity: {self.semantic_min_similarity}. Must be between 0.0 and 1.0"
-            )
+        for field_name in (
+            "semantic_min_similarity",
+            "graph_seed_min_similarity",
+            "temporal_semantic_min_similarity",
+            "semantic_link_min_similarity",
+        ):
+            value = getattr(self, field_name)
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(f"Invalid {field_name}: {value}. Must be between 0.0 and 1.0")
 
         if self.bm25_max_query_terms < 0:
             raise ValueError(f"Invalid bm25_max_query_terms: {self.bm25_max_query_terms}. Must be >= 0")
@@ -2771,6 +2785,15 @@ class HindsightConfig:
             ),
             reranker_max_candidates=int(os.getenv(ENV_RERANKER_MAX_CANDIDATES, str(DEFAULT_RERANKER_MAX_CANDIDATES))),
             semantic_min_similarity=float(os.getenv(ENV_SEMANTIC_MIN_SIMILARITY, str(DEFAULT_SEMANTIC_MIN_SIMILARITY))),
+            graph_seed_min_similarity=float(
+                os.getenv(ENV_GRAPH_SEED_MIN_SIMILARITY, str(DEFAULT_GRAPH_SEED_MIN_SIMILARITY))
+            ),
+            temporal_semantic_min_similarity=float(
+                os.getenv(ENV_TEMPORAL_SEMANTIC_MIN_SIMILARITY, str(DEFAULT_TEMPORAL_SEMANTIC_MIN_SIMILARITY))
+            ),
+            semantic_link_min_similarity=float(
+                os.getenv(ENV_SEMANTIC_LINK_MIN_SIMILARITY, str(DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY))
+            ),
             bm25_min_score=float(os.getenv(ENV_BM25_MIN_SCORE, str(DEFAULT_BM25_MIN_SCORE))),
             bm25_max_query_terms=_parse_non_negative_int(
                 ENV_BM25_MAX_QUERY_TERMS,

--- a/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
@@ -39,6 +39,7 @@ import uuid as uuid_module
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from ..config import get_config
 from ..models import RequestContext
 from .db.base import DatabaseConnection
 from .retain.link_utils import (
@@ -182,6 +183,7 @@ async def run_graph_maintenance_job(
 
     result = JobResult()
     job_start = time.time()
+    semantic_link_min_similarity = get_config().semantic_link_min_similarity
 
     # --- Pass 1: relink ---
     # Per-iteration loop: claim → top up → commit. We rely on submit-time
@@ -202,7 +204,14 @@ async def run_graph_maintenance_job(
                 if not unit_ids:
                     break
 
-                result.relink_links_added += await _relink_batch(conn, bank_id, unit_ids, ops, backend)
+                result.relink_links_added += await _relink_batch(
+                    conn,
+                    bank_id,
+                    unit_ids,
+                    ops,
+                    backend,
+                    semantic_link_min_similarity,
+                )
 
         result.relink_units_processed += len(unit_ids)
         iterations += 1
@@ -276,6 +285,7 @@ async def _relink_batch(
     victim_ids: list[str],
     ops: Any,
     backend: Any,
+    semantic_link_min_similarity: float,
 ) -> int:
     """Top up temporal/semantic links for a batch of victim units. Returns rows inserted."""
     # Load each victim's metadata. Victims whose units were deleted between
@@ -372,6 +382,7 @@ async def _relink_batch(
                     seed_ids,
                     seed_embs,
                     fact_types=seed_ftypes,
+                    threshold=semantic_link_min_similarity,
                 )
                 # Strip self-links (rare but possible because the ANN probe
                 # has no exclude list — see the comment in compute_semantic_links_ann).

--- a/hindsight-api-slim/hindsight_api/engine/retain/link_creation.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_creation.py
@@ -37,6 +37,7 @@ async def create_semantic_links_batch(
     bank_id: str,
     unit_ids: list[str],
     embeddings: list[list[float]],
+    threshold: float,
     pre_computed_ann_links: list[tuple] | None = None,
     ops=None,
 ) -> int:
@@ -52,6 +53,7 @@ async def create_semantic_links_batch(
         bank_id: Bank identifier
         unit_ids: List of unit IDs to create links for
         embeddings: List of embedding vectors (same length as unit_ids)
+        threshold: Minimum cosine similarity for semantic links
         pre_computed_ann_links: Pre-computed ANN results from Phase 1
 
     Returns:
@@ -64,7 +66,14 @@ async def create_semantic_links_batch(
         raise ValueError(f"Mismatch between unit_ids ({len(unit_ids)}) and embeddings ({len(embeddings)})")
 
     return await link_utils.create_semantic_links_batch(
-        conn, bank_id, unit_ids, embeddings, log_buffer=[], pre_computed_ann_links=pre_computed_ann_links, ops=ops
+        conn,
+        bank_id,
+        unit_ids,
+        embeddings,
+        threshold=threshold,
+        log_buffer=[],
+        pre_computed_ann_links=pre_computed_ann_links,
+        ops=ops,
     )
 
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -7,6 +7,7 @@ import time
 from datetime import UTC, datetime, timedelta
 
 from ..._vector_index import ann_search_tuning_settings, configured_vector_extension
+from ...config import DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY
 from ..causal_links import CANONICAL_CAUSAL_LINK_TYPES, LEGACY_CAUSAL_LINK_TYPES
 from ..db.base import DatabaseConnection
 from ..db.ops import DataAccessOps
@@ -520,7 +521,7 @@ async def compute_semantic_links_ann(
     embeddings: list[list[float]],
     fact_types: list[str] | None = None,
     top_k: int = 50,
-    threshold: float = 0.7,
+    threshold: float = DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY,
     log_buffer: list[str] = None,
 ) -> list[tuple]:
     """
@@ -661,7 +662,7 @@ def compute_semantic_links_within_batch(
     unit_ids: list[str],
     embeddings: list[list[float]],
     top_k: int = 50,
-    threshold: float = 0.7,
+    threshold: float = DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY,
 ) -> list[tuple]:
     """
     Compute semantic links between units within the same batch (no DB needed).
@@ -711,7 +712,7 @@ async def create_semantic_links_batch(
     unit_ids: list[str],
     embeddings: list[list[float]],
     top_k: int = 50,
-    threshold: float = 0.7,
+    threshold: float = DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY,
     log_buffer: list[str] = None,
     pre_computed_ann_links: list[tuple] | None = None,
     ops=None,

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -377,7 +377,13 @@ async def _pre_resolve_phase1(
         if not skip_semantic_ann:
             fact_types = [fact.fact_type for fact in processed_facts]
             semantic_ann_links = await compute_semantic_links_ann(
-                resolve_conn, bank_id, placeholder_unit_ids, embeddings, fact_types=fact_types, log_buffer=log_buffer
+                resolve_conn,
+                bank_id,
+                placeholder_unit_ids,
+                embeddings,
+                fact_types=fact_types,
+                threshold=config.semantic_link_min_similarity,
+                log_buffer=log_buffer,
             )
 
     return Phase1Result(
@@ -496,6 +502,7 @@ async def _insert_facts_and_links(
                 bank_id,
                 unit_ids,
                 embeddings_for_links,
+                threshold=config.semantic_link_min_similarity,
                 pre_computed_ann_links=semantic_ann_links,
                 ops=ops,
             )
@@ -1098,6 +1105,7 @@ async def _run_final_semantic_ann(
     pool: Any,
     bank_id: str,
     unit_ids: list[str],
+    threshold: float,
     log_buffer: list[str],
 ) -> None:
     """
@@ -1176,6 +1184,7 @@ async def _run_final_semantic_ann(
                     chunk_embs,
                     fact_types=chunk_ftypes,
                     top_k=20,  # Recall uses at most 20 neighbors
+                    threshold=threshold,
                     log_buffer=log_buffer,
                 )
                 if ann_links:
@@ -1944,7 +1953,13 @@ async def _streaming_retain_batch(
     if all_unit_ids and not pipeline_aborted[0]:
         ann_start = time.time()
         try:
-            await _run_final_semantic_ann(pool, bank_id, all_unit_ids, log_buffer)
+            await _run_final_semantic_ann(
+                pool,
+                bank_id,
+                all_unit_ids,
+                config.semantic_link_min_similarity,
+                log_buffer,
+            )
         except Exception:
             # ANN pass is best-effort. FK violations can occur if a concurrent
             # retain cascade-deleted our units between the batch commit and here.

--- a/hindsight-api-slim/hindsight_api/engine/search/link_expansion_retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/link_expansion_retrieval.py
@@ -9,8 +9,8 @@ first-class signals stored in memory_links:
                    COUNT(DISTINCT entity_id). Uses a LATERAL per-entity cap
                    (graph_per_entity_limit, default 200) to prevent high-fanout entities
                    from exploding the self-join intermediate rows.
-2. Semantic links — precomputed kNN graph (each new fact linked to its top-5 most
-                    similar existing facts at insert time, similarity >= 0.7). Checked
+2. Semantic links — precomputed kNN graph (each new fact linked to its most
+                    similar existing facts at insert time, subject to the configured threshold). Checked
                     in both directions since the graph is not symmetric. Score = weight.
 3. Causal links  — explicit causal chains (causes/caused_by/enables/prevents).
                    Score = weight + 1.0 (boosted as highest-quality signal).
@@ -31,7 +31,7 @@ import time
 from datetime import datetime
 from typing import Any
 
-from ...config import get_config
+from ...config import DEFAULT_GRAPH_SEED_MIN_SIMILARITY, get_config
 from ..db_utils import acquire_with_retry
 from ..memory_engine import fq_table
 from .graph_retrieval import GraphRetriever
@@ -47,7 +47,7 @@ async def _find_semantic_seeds(
     bank_id: str,
     fact_type: str,
     limit: int = 20,
-    threshold: float = 0.3,
+    threshold: float = DEFAULT_GRAPH_SEED_MIN_SIMILARITY,
     tags: list[str] | None = None,
     tags_match: TagsMatch = "any",
     tag_groups: list[TagGroup] | None = None,
@@ -152,6 +152,7 @@ class LinkExpansionRetriever(GraphRetriever):
         """
         start_time = time.time()
         timings = GraphRetrievalTimings(fact_type=fact_type)
+        graph_seed_min_similarity = get_config().graph_seed_min_similarity
 
         async with acquire_with_retry(pool) as conn:
             # Graph traversal deliberately chooses its own bounded seeds. The semantic and temporal
@@ -164,7 +165,7 @@ class LinkExpansionRetriever(GraphRetriever):
                 bank_id,
                 fact_type,
                 limit=20,
-                threshold=0.3,
+                threshold=graph_seed_min_similarity,
                 tags=tags,
                 tags_match=tags_match,
                 tag_groups=tag_groups,
@@ -203,7 +204,7 @@ class LinkExpansionRetriever(GraphRetriever):
         #
         # Entity score: tanh(count × 0.5) maps shared-entity count to [0, 1]:
         #   1 entity → 0.46,  2 → 0.76,  3 → 0.91,  4 → 0.96  (saturates naturally)
-        # Semantic score: similarity weight, already ∈ [0.7, 1.0].
+        # Semantic score: similarity weight, already above the configured construction floor.
         # Causal score:   link weight, already ∈ [0, 1].
         #
         # Facts appearing in multiple signals accumulate higher scores, rewarding

--- a/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Optional
 
-from ...config import DEFAULT_BM25_MAX_QUERY_TERMS, get_config
+from ...config import DEFAULT_BM25_MAX_QUERY_TERMS, DEFAULT_TEMPORAL_SEMANTIC_MIN_SIMILARITY, get_config
 from ..db_utils import acquire_with_retry
 from ..memory_engine import fq_table
 from ..sql import create_sql_dialect
@@ -393,7 +393,7 @@ async def retrieve_temporal_combined(
     start_date: datetime,
     end_date: datetime,
     budget: int,
-    semantic_threshold: float = 0.1,
+    semantic_threshold: float = DEFAULT_TEMPORAL_SEMANTIC_MIN_SIMILARITY,
     tags: list[str] | None = None,
     tags_match: TagsMatch = "any",
     tag_groups: list[TagGroup] | None = None,
@@ -747,6 +747,7 @@ async def retrieve_all_fact_types_parallel(
     import time
 
     retriever = graph_retriever or get_default_graph_retriever()
+    config = get_config()
     start_time = time.time()
     timings: dict[str, float] = {}
 
@@ -798,7 +799,7 @@ async def retrieve_all_fact_types_parallel(
                 tc_start,
                 tc_end,
                 budget=thinking_budget,
-                semantic_threshold=0.1,
+                semantic_threshold=config.temporal_semantic_min_similarity,
                 tags=tags,
                 tags_match=tags_match,
                 tag_groups=tag_groups,

--- a/hindsight-api-slim/tests/test_config_validation.py
+++ b/hindsight-api-slim/tests/test_config_validation.py
@@ -27,6 +27,10 @@ def setup_test_env():
         "HINDSIGHT_API_LLM_BEDROCK_SERVICE_TIER",
         "HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER",
         "HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY",
+        "HINDSIGHT_API_GRAPH_SEED_MIN_SIMILARITY",
+        "HINDSIGHT_API_TEMPORAL_SEMANTIC_MIN_SIMILARITY",
+        "HINDSIGHT_API_SEMANTIC_LINK_MIN_SIMILARITY",
+        "HINDSIGHT_API_CONSOLIDATION_DEDUP_THRESHOLD",
         "HINDSIGHT_API_DATABASE_URL",
         "HINDSIGHT_API_MIGRATION_DATABASE_URL",
     ]
@@ -227,23 +231,74 @@ def test_retain_strategy_structured_chunk_size_validation():
     assert resolved.retain_structured_chunk_size == 2000
 
 
-def test_semantic_min_similarity_reads_from_env():
-    """Semantic retrieval min similarity can be configured at the server level."""
-    from hindsight_api.config import HindsightConfig
+def test_embedding_similarity_threshold_defaults_are_backward_compatible(monkeypatch):
+    """Unset threshold settings preserve the five existing operating points."""
+    from hindsight_api.config import (
+        ENV_CONSOLIDATION_DEDUP_THRESHOLD,
+        ENV_GRAPH_SEED_MIN_SIMILARITY,
+        ENV_SEMANTIC_LINK_MIN_SIMILARITY,
+        ENV_SEMANTIC_MIN_SIMILARITY,
+        ENV_TEMPORAL_SEMANTIC_MIN_SIMILARITY,
+        HindsightConfig,
+    )
 
-    os.environ["HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY"] = "0.58"
+    for env_name in (
+        ENV_SEMANTIC_MIN_SIMILARITY,
+        ENV_GRAPH_SEED_MIN_SIMILARITY,
+        ENV_TEMPORAL_SEMANTIC_MIN_SIMILARITY,
+        ENV_SEMANTIC_LINK_MIN_SIMILARITY,
+        ENV_CONSOLIDATION_DEDUP_THRESHOLD,
+    ):
+        monkeypatch.delenv(env_name, raising=False)
 
     config = HindsightConfig.from_env()
-    assert config.semantic_min_similarity == 0.58
+
+    assert config.semantic_min_similarity == 0.3
+    assert config.graph_seed_min_similarity == 0.3
+    assert config.temporal_semantic_min_similarity == 0.1
+    assert config.semantic_link_min_similarity == 0.7
+    assert config.consolidation_dedup_threshold == 0.97
 
 
-def test_semantic_min_similarity_must_be_between_zero_and_one():
-    """Invalid semantic min similarity fails fast during configuration loading."""
+@pytest.mark.parametrize(
+    ("env_name", "field_name", "value"),
+    [
+        ("HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY", "semantic_min_similarity", 0.58),
+        ("HINDSIGHT_API_GRAPH_SEED_MIN_SIMILARITY", "graph_seed_min_similarity", 0.41),
+        ("HINDSIGHT_API_TEMPORAL_SEMANTIC_MIN_SIMILARITY", "temporal_semantic_min_similarity", 0.22),
+        ("HINDSIGHT_API_SEMANTIC_LINK_MIN_SIMILARITY", "semantic_link_min_similarity", 0.81),
+    ],
+)
+def test_embedding_similarity_thresholds_read_from_env(env_name: str, field_name: str, value: float):
+    """Each configurable similarity gate has an independent environment setting."""
     from hindsight_api.config import HindsightConfig
 
-    os.environ["HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY"] = "1.5"
+    os.environ[env_name] = str(value)
 
-    with pytest.raises(ValueError, match="semantic_min_similarity"):
+    config = HindsightConfig.from_env()
+
+    assert getattr(config, field_name) == value
+
+
+@pytest.mark.parametrize(
+    ("env_name", "field_name"),
+    [
+        ("HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY", "semantic_min_similarity"),
+        ("HINDSIGHT_API_GRAPH_SEED_MIN_SIMILARITY", "graph_seed_min_similarity"),
+        ("HINDSIGHT_API_TEMPORAL_SEMANTIC_MIN_SIMILARITY", "temporal_semantic_min_similarity"),
+        ("HINDSIGHT_API_SEMANTIC_LINK_MIN_SIMILARITY", "semantic_link_min_similarity"),
+    ],
+)
+@pytest.mark.parametrize("invalid_value", ["-0.01", "1.01"])
+def test_embedding_similarity_thresholds_must_be_between_zero_and_one(
+    env_name: str, field_name: str, invalid_value: str
+):
+    """All embedding-dependent gates fail fast outside the supported range."""
+    from hindsight_api.config import HindsightConfig
+
+    os.environ[env_name] = invalid_value
+
+    with pytest.raises(ValueError, match=field_name):
         HindsightConfig.from_env()
 
 

--- a/hindsight-api-slim/tests/test_graph_maintenance.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance.py
@@ -12,14 +12,20 @@ The fixture's task backend is ``SyncTaskBackend`` (see conftest), so
 from __future__ import annotations
 
 import uuid
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
+import hindsight_api.engine.graph_maintenance as graph_maintenance_module
+import hindsight_api.engine.memory_engine as memory_engine_module
 from hindsight_api import RequestContext
 from hindsight_api.engine.graph_maintenance import (
     MAX_SEMANTIC_LINKS_PER_UNIT,
     MAX_TEMPORAL_LINKS_PER_UNIT,
+    _relink_batch,
     enqueue_relink_victims,
     run_graph_maintenance_job,
 )
@@ -267,6 +273,54 @@ class TestDeleteDocumentEnqueue:
 
 
 class TestRelinkPass:
+    @pytest.mark.asyncio
+    async def test_semantic_topup_uses_configured_link_threshold(self, monkeypatch):
+        """Maintenance relinking must use the same construction gate as retain."""
+        victim_id = str(uuid.uuid4())
+        conn = SimpleNamespace(
+            fetch=AsyncMock(
+                side_effect=[
+                    [
+                        {
+                            "id": victim_id,
+                            "event_date": None,
+                            "fact_type": "world",
+                            "embedding": "[1.0]",
+                        }
+                    ],
+                    [],
+                ]
+            )
+        )
+        captured_thresholds: list[float] = []
+
+        @asynccontextmanager
+        async def fake_acquire_with_retry(_backend):
+            yield object()
+
+        async def fake_compute_semantic_links_ann(*_args, **kwargs):
+            captured_thresholds.append(kwargs["threshold"])
+            return []
+
+        monkeypatch.setattr(memory_engine_module, "acquire_with_retry", fake_acquire_with_retry)
+        monkeypatch.setattr(
+            graph_maintenance_module,
+            "compute_semantic_links_ann",
+            fake_compute_semantic_links_ann,
+        )
+
+        added = await _relink_batch(
+            conn=conn,
+            bank_id="bank",
+            victim_ids=[victim_id],
+            ops=object(),
+            backend=object(),
+            semantic_link_min_similarity=0.86,
+        )
+
+        assert added == 0
+        assert captured_thresholds == [0.86]
+
     @pytest.mark.asyncio
     async def test_drains_empty_queue_cleanly(self, memory: MemoryEngine, request_context: RequestContext):
         bank_id = f"test-gm-empty-{uuid.uuid4().hex[:8]}"

--- a/hindsight-api-slim/tests/test_link_expansion_config.py
+++ b/hindsight-api-slim/tests/test_link_expansion_config.py
@@ -1,0 +1,47 @@
+"""Configuration wiring tests for Link Expansion retrieval."""
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+import pytest
+
+from hindsight_api.engine.search import link_expansion_retrieval
+from hindsight_api.engine.search.link_expansion_retrieval import LinkExpansionRetriever
+from hindsight_api.engine.search.types import RetrievalResult
+
+
+@pytest.mark.asyncio
+async def test_retrieve_passes_configured_graph_seed_threshold(monkeypatch):
+    """Graph seed selection must use its dedicated configured threshold."""
+    retriever = LinkExpansionRetriever()
+    seed_thresholds: list[float] = []
+
+    @asynccontextmanager
+    async def fake_acquire_with_retry(_pool):
+        yield object()
+
+    async def fake_find_semantic_seeds(_conn, _embedding, _bank_id, fact_type, **kwargs):
+        seed_thresholds.append(kwargs["threshold"])
+        return [RetrievalResult(id="seed", text="seed", fact_type=fact_type)]
+
+    async def fake_expand_combined(_conn, _seed_ids, _fact_type, _budget, *, ops):
+        return [], [], []
+
+    monkeypatch.setattr(link_expansion_retrieval, "acquire_with_retry", fake_acquire_with_retry)
+    monkeypatch.setattr(link_expansion_retrieval, "_find_semantic_seeds", fake_find_semantic_seeds)
+    monkeypatch.setattr(
+        link_expansion_retrieval,
+        "get_config",
+        lambda: SimpleNamespace(graph_seed_min_similarity=0.47),
+    )
+    monkeypatch.setattr(retriever, "_expand_combined", fake_expand_combined)
+
+    await retriever.retrieve(
+        SimpleNamespace(ops=object()),
+        query_embedding_str="unused",
+        bank_id="bank",
+        fact_type="world",
+        budget=2,
+    )
+
+    assert seed_thresholds == [0.47]

--- a/hindsight-api-slim/tests/test_retain_orchestrator_mapping.py
+++ b/hindsight-api-slim/tests/test_retain_orchestrator_mapping.py
@@ -8,18 +8,28 @@ extracted facts and the generated embeddings caused
 from __future__ import annotations
 
 import asyncio
+from contextlib import asynccontextmanager
 from datetime import datetime
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from hindsight_api.engine.retain import embedding_utils
+from hindsight_api.engine.retain import embedding_utils, entity_processing, link_creation, link_utils, orchestrator
 from hindsight_api.engine.retain.orchestrator import (
     _map_results_to_contents,
+    _pre_resolve_phase1,
     _process_extracted_facts,
     _remap_causal_relations,
+    _run_final_semantic_ann,
 )
-from hindsight_api.engine.retain.types import CausalRelation, ExtractedFact, ProcessedFact, RetainContent
+from hindsight_api.engine.retain.types import (
+    CausalRelation,
+    EntityResolutionResult,
+    ExtractedFact,
+    ProcessedFact,
+    RetainContent,
+)
 
 
 def _make_processed_fact(content_index: int, text: str = "fact") -> ProcessedFact:
@@ -240,3 +250,82 @@ class TestEmbeddingsBatchLengthGuarantee:
 
         with pytest.raises(RuntimeError, match="embedding 1 has dimension 2; expected 3"):
             asyncio.run(embedding_utils.generate_embeddings_batch(backend, ["a", "b"]))
+
+
+class TestSemanticLinkThresholdPropagation:
+    @pytest.mark.asyncio
+    async def test_phase1_ann_uses_resolved_semantic_link_threshold(self, monkeypatch):
+        """Normal retain must pass the resolved threshold into its pre-write ANN probe."""
+        captured_thresholds: list[float] = []
+
+        @asynccontextmanager
+        async def fake_acquire_with_retry(_pool):
+            yield object()
+
+        async def fake_resolve_entities(*_args, **_kwargs):
+            return EntityResolutionResult(resolved_entities=[], entity_to_unit=[], unit_to_entity_ids={})
+
+        async def fake_compute_semantic_links_ann(*_args, **kwargs):
+            captured_thresholds.append(kwargs["threshold"])
+            return []
+
+        monkeypatch.setattr(orchestrator, "acquire_with_retry", fake_acquire_with_retry)
+        monkeypatch.setattr(entity_processing, "resolve_entities", fake_resolve_entities)
+        monkeypatch.setattr(link_utils, "compute_semantic_links_ann", fake_compute_semantic_links_ann)
+
+        await _pre_resolve_phase1(
+            pool=object(),
+            entity_resolver=object(),
+            bank_id="bank",
+            contents=[_make_content()],
+            processed_facts=[_make_processed_fact(0)],
+            config=SimpleNamespace(entity_labels=None, semantic_link_min_similarity=0.82),
+            log_buffer=[],
+        )
+
+        assert captured_thresholds == [0.82]
+
+    @pytest.mark.asyncio
+    async def test_link_creation_passes_threshold_to_within_batch_path(self, monkeypatch):
+        """The Phase 2 wrapper must not fall back to link_utils' default threshold."""
+        captured_thresholds: list[float] = []
+
+        async def fake_create_semantic_links_batch(*_args, **kwargs):
+            captured_thresholds.append(kwargs["threshold"])
+            return 0
+
+        monkeypatch.setattr(link_utils, "create_semantic_links_batch", fake_create_semantic_links_batch)
+
+        await link_creation.create_semantic_links_batch(
+            conn=object(),
+            bank_id="bank",
+            unit_ids=["unit"],
+            embeddings=[[1.0]],
+            threshold=0.83,
+        )
+
+        assert captured_thresholds == [0.83]
+
+    @pytest.mark.asyncio
+    async def test_streaming_final_ann_uses_resolved_threshold(self, monkeypatch):
+        """Streaming retain's deferred ANN pass uses the same configured construction gate."""
+        captured_thresholds: list[float] = []
+        conn = SimpleNamespace(
+            fetch=AsyncMock(return_value=[{"id": "unit", "embedding": "[1.0]", "fact_type": "world"}])
+        )
+        pool = SimpleNamespace(ops=object())
+
+        @asynccontextmanager
+        async def fake_acquire_with_retry(_pool):
+            yield conn
+
+        async def fake_compute_semantic_links_ann(*_args, **kwargs):
+            captured_thresholds.append(kwargs["threshold"])
+            return []
+
+        monkeypatch.setattr(orchestrator, "acquire_with_retry", fake_acquire_with_retry)
+        monkeypatch.setattr(link_utils, "compute_semantic_links_ann", fake_compute_semantic_links_ann)
+
+        await _run_final_semantic_ann(pool, "bank", ["unit"], 0.84, [])
+
+        assert captured_thresholds == [0.84]

--- a/hindsight-api-slim/tests/test_temporal_recall_selection.py
+++ b/hindsight-api-slim/tests/test_temporal_recall_selection.py
@@ -12,6 +12,7 @@ These are pure mechanics (no LLM), so they assert directly.
 
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 
 import pytest
 
@@ -199,6 +200,11 @@ async def test_min_semantic_does_not_tighten_temporal_seed_threshold(monkeypatch
     monkeypatch.setattr(retrieval_module, "retrieve_semantic_bm25_combined", fake_semantic_bm25_combined)
     monkeypatch.setattr(retrieval_module, "retrieve_temporal_combined", fake_temporal_combined)
     monkeypatch.setattr(
+        retrieval_module,
+        "get_config",
+        lambda: SimpleNamespace(temporal_semantic_min_similarity=0.24),
+    )
+    monkeypatch.setattr(
         "hindsight_api.engine.search.temporal_extraction.extract_temporal_constraint",
         lambda *args, **kwargs: (start, end),
     )
@@ -214,7 +220,7 @@ async def test_min_semantic_does_not_tighten_temporal_seed_threshold(monkeypatch
         min_semantic=0.5,
     )
 
-    assert temporal_thresholds == [0.1]
+    assert temporal_thresholds == [0.24]
     assert graph_call_kwargs == [
         {
             "pool",

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1059,6 +1059,9 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | `HINDSIGHT_API_RECALL_MAX_QUERY_TOKENS` | Maximum token length of a recall query; requests exceeding this limit are rejected with HTTP 400 | `500` |
 | `HINDSIGHT_API_RERANKER_MAX_CANDIDATES` | Max candidates to rerank per recall (RRF pre-filters the rest) | `300` |
 | `HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY` | Minimum cosine similarity a candidate must reach to be returned by the semantic retrieval strategy. Must be between `0` and `1`. | `0.3` |
+| `HINDSIGHT_API_GRAPH_SEED_MIN_SIMILARITY` | Minimum cosine similarity for a memory to seed graph retrieval. This is independent from the main semantic retrieval threshold. Must be between `0` and `1`. | `0.3` |
+| `HINDSIGHT_API_TEMPORAL_SEMANTIC_MIN_SIMILARITY` | Minimum cosine similarity for temporal retrieval entry points and spread neighbors. This is independent from the main semantic retrieval threshold. Must be between `0` and `1`. | `0.1` |
+| `HINDSIGHT_API_SEMANTIC_LINK_MIN_SIMILARITY` | Minimum cosine similarity for creating semantic links during normal retain, streaming retain, and graph-maintenance relinking. This directly controls semantic graph density. Must be between `0` and `1`. | `0.7` |
 | `HINDSIGHT_API_BM25_MIN_SCORE` | Minimum BM25 score a row must exceed to enter fusion. Gates out zero-score, non-matching rows on backends (notably `vchord`) whose operator ranks every document instead of pre-filtering to query-term matches. `0` keeps only genuine term matches; raise it to require stronger matches. | `0` |
 | `HINDSIGHT_API_RECALL_MAX_CANDIDATES_PER_SOURCE` | Cap on candidates each retrieval source (semantic, BM25, graph, temporal) contributes to RRF, applied before the global reranker cap. Prevents one over-expanding backend from filling the reranker budget on its own. `0` disables the cap. | `0` |
 | `HINDSIGHT_API_RECALL_STRATEGY_BOOSTS` | Prioritise one or more retrieval sources over the others on recall, as a comma-separated `strategy:level` list (e.g. `graph:high` to strongly favour graph hits, or `graph:high,bm25:low`). Strategies: `semantic`, `bm25`, `graph`, `temporal`. Levels: `low` (gentle — mainly protects the source's candidates from being dropped before reranking), `medium` (moderate preference), `high` (strong — the source dominates the candidate pool and outranks most other matches, only a strong direct match still wins). The boost is applied in two places: before the reranker cap (so favoured candidates survive the `HINDSIGHT_API_RERANKER_MAX_CANDIDATES` budget) and after reranking (to nudge them up the final order); a named level is used because those two stages live on different score scales. Only the strategies you list are boosted — any you omit keep their normal weight (no implicit boost). A strategy written without a level (`graph` or `graph:`) defaults to `medium`. Empty disables the feature. | _(empty)_ |
@@ -1068,6 +1071,18 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | `HINDSIGHT_API_MENTAL_MODEL_REFRESH_CONCURRENCY` | Max concurrent mental model refreshes | `8` |
 | `HINDSIGHT_API_ENABLE_MENTAL_MODEL_HISTORY` | Track history of content changes to each mental model (previous content + timestamp), stored one row per change in the `mental_model_history` table. Set to `false` to disable entirely — no history rows are written, reducing storage if audit trails are not needed. **This is how you turn the feature off** (not a zero cap). | `true` |
 | `HINDSIGHT_API_MENTAL_MODEL_HISTORY_MAX_ENTRIES` | Max history rows kept per mental model. On each refresh the previous version is inserted into the `mental_model_history` table and the oldest rows beyond this cap are deleted, so per-model history can't grow without bound. `0` or a negative value **removes the cap** (history then grows with every refresh — unbounded); to turn history off entirely set `HINDSIGHT_API_ENABLE_MENTAL_MODEL_HISTORY=false` instead. | `50` |
+
+The five embedding-dependent gates—main semantic retrieval, graph seeds, temporal retrieval, semantic-link
+construction, and observation deduplication—serve different precision/recall tradeoffs and are intentionally
+configured independently. Their defaults preserve the behavior calibrated for `BAAI/bge-small-en-v1.5`.
+Changing embedding models can shift cosine-similarity distributions even when both models return normalized
+vectors, so recalibrate all five values against their respective tasks before production use.
+
+Changes to `HINDSIGHT_API_SEMANTIC_LINK_MIN_SIMILARITY` are not retroactive. The new value applies when new
+semantic links are created during retain, streaming retain, or graph maintenance; maintenance does not remove
+existing links below a raised threshold, and nodes that already have enough semantic links are not recomputed
+when the threshold is lowered. To make an existing semantic graph fully conform to a new threshold, rebuild the
+graph or re-ingest the source data into a new memory bank.
 
 #### Graph Retrieval Algorithm
 

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -207,6 +207,15 @@ HINDSIGHT_API_LOG_LEVEL=info
 # DeepSeek note: DeepSeek is supported for LLM calls, but not for embeddings.
 # If using DeepSeek as LLM provider, keep embeddings on local/openai/cohere/google/etc.
 
+# Embedding similarity thresholds. These defaults preserve the behavior calibrated
+# for BAAI/bge-small-en-v1.5. Recalibrate each threshold independently when changing
+# embedding models because cosine-similarity distributions are model-dependent.
+# HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY=0.3
+# HINDSIGHT_API_GRAPH_SEED_MIN_SIMILARITY=0.3
+# HINDSIGHT_API_TEMPORAL_SEMANTIC_MIN_SIMILARITY=0.1
+# HINDSIGHT_API_SEMANTIC_LINK_MIN_SIMILARITY=0.7
+# HINDSIGHT_API_CONSOLIDATION_DEDUP_THRESHOLD=0.97
+
 # Reranker Configuration (Optional - uses local by default)
 # Provider: "local" (default) or "tei" (HuggingFace Text Embeddings Inference)
 # HINDSIGHT_API_RERANKER_PROVIDER=local

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1059,6 +1059,9 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | `HINDSIGHT_API_RECALL_MAX_QUERY_TOKENS` | Maximum token length of a recall query; requests exceeding this limit are rejected with HTTP 400 | `500` |
 | `HINDSIGHT_API_RERANKER_MAX_CANDIDATES` | Max candidates to rerank per recall (RRF pre-filters the rest) | `300` |
 | `HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY` | Minimum cosine similarity a candidate must reach to be returned by the semantic retrieval strategy. Must be between `0` and `1`. | `0.3` |
+| `HINDSIGHT_API_GRAPH_SEED_MIN_SIMILARITY` | Minimum cosine similarity for a memory to seed graph retrieval. This is independent from the main semantic retrieval threshold. Must be between `0` and `1`. | `0.3` |
+| `HINDSIGHT_API_TEMPORAL_SEMANTIC_MIN_SIMILARITY` | Minimum cosine similarity for temporal retrieval entry points and spread neighbors. This is independent from the main semantic retrieval threshold. Must be between `0` and `1`. | `0.1` |
+| `HINDSIGHT_API_SEMANTIC_LINK_MIN_SIMILARITY` | Minimum cosine similarity for creating semantic links during normal retain, streaming retain, and graph-maintenance relinking. This directly controls semantic graph density. Must be between `0` and `1`. | `0.7` |
 | `HINDSIGHT_API_BM25_MIN_SCORE` | Minimum BM25 score a row must exceed to enter fusion. Gates out zero-score, non-matching rows on backends (notably `vchord`) whose operator ranks every document instead of pre-filtering to query-term matches. `0` keeps only genuine term matches; raise it to require stronger matches. | `0` |
 | `HINDSIGHT_API_RECALL_MAX_CANDIDATES_PER_SOURCE` | Cap on candidates each retrieval source (semantic, BM25, graph, temporal) contributes to RRF, applied before the global reranker cap. Prevents one over-expanding backend from filling the reranker budget on its own. `0` disables the cap. | `0` |
 | `HINDSIGHT_API_RECALL_STRATEGY_BOOSTS` | Prioritise one or more retrieval sources over the others on recall, as a comma-separated `strategy:level` list (e.g. `graph:high` to strongly favour graph hits, or `graph:high,bm25:low`). Strategies: `semantic`, `bm25`, `graph`, `temporal`. Levels: `low` (gentle — mainly protects the source's candidates from being dropped before reranking), `medium` (moderate preference), `high` (strong — the source dominates the candidate pool and outranks most other matches, only a strong direct match still wins). The boost is applied in two places: before the reranker cap (so favoured candidates survive the `HINDSIGHT_API_RERANKER_MAX_CANDIDATES` budget) and after reranking (to nudge them up the final order); a named level is used because those two stages live on different score scales. Only the strategies you list are boosted — any you omit keep their normal weight (no implicit boost). A strategy written without a level (`graph` or `graph:`) defaults to `medium`. Empty disables the feature. | _(empty)_ |
@@ -1068,6 +1071,18 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | `HINDSIGHT_API_MENTAL_MODEL_REFRESH_CONCURRENCY` | Max concurrent mental model refreshes | `8` |
 | `HINDSIGHT_API_ENABLE_MENTAL_MODEL_HISTORY` | Track history of content changes to each mental model (previous content + timestamp), stored one row per change in the `mental_model_history` table. Set to `false` to disable entirely — no history rows are written, reducing storage if audit trails are not needed. **This is how you turn the feature off** (not a zero cap). | `true` |
 | `HINDSIGHT_API_MENTAL_MODEL_HISTORY_MAX_ENTRIES` | Max history rows kept per mental model. On each refresh the previous version is inserted into the `mental_model_history` table and the oldest rows beyond this cap are deleted, so per-model history can't grow without bound. `0` or a negative value **removes the cap** (history then grows with every refresh — unbounded); to turn history off entirely set `HINDSIGHT_API_ENABLE_MENTAL_MODEL_HISTORY=false` instead. | `50` |
+
+The five embedding-dependent gates—main semantic retrieval, graph seeds, temporal retrieval, semantic-link
+construction, and observation deduplication—serve different precision/recall tradeoffs and are intentionally
+configured independently. Their defaults preserve the behavior calibrated for `BAAI/bge-small-en-v1.5`.
+Changing embedding models can shift cosine-similarity distributions even when both models return normalized
+vectors, so recalibrate all five values against their respective tasks before production use.
+
+Changes to `HINDSIGHT_API_SEMANTIC_LINK_MIN_SIMILARITY` are not retroactive. The new value applies when new
+semantic links are created during retain, streaming retain, or graph maintenance; maintenance does not remove
+existing links below a raised threshold, and nodes that already have enough semantic links are not recomputed
+when the threshold is lowered. To make an existing semantic graph fully conform to a new threshold, rebuild the
+graph or re-ingest the source data into a new memory bank.
 
 #### Graph Retrieval Algorithm
 


### PR DESCRIPTION
## Summary

This PR completes configuration coverage for Hindsight's five embedding-dependent similarity thresholds by adding settings for the three previously hardcoded gates while preserving the two existing settings and all current defaults calibrated for `BAAI/bge-small-en-v1.5`.

Cosine-similarity distributions differ across embedding models even when their output vectors are L2-normalized. Reusing thresholds calibrated for one model can reduce recall, admit irrelevant candidates, create an overly dense or sparse semantic graph, or change observation deduplication behavior. Keeping these gates separate allows each task to be recalibrated for a different embedding model without coupling unrelated precision/recall tradeoffs.

## Configuration behavior and scope

| Purpose | Configuration | Default | Status | Behavior and scope |
| --- | --- | ---: | --- | --- |
| Main semantic recall | `semantic_min_similarity` / `HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY` | `0.3` | Existing | Controls only the main semantic retrieval arm. `min_scores.semantic` can override it for a single recall request. It does not control graph seed selection or temporal retrieval. Its existing `[0, 1]` validation and default remain unchanged. |
| Graph retrieval semantic seed | `graph_seed_min_similarity` / `HINDSIGHT_API_GRAPH_SEED_MIN_SIMILARITY` | `0.3` | Added | Controls which memories can seed Link Expansion graph retrieval. It is independent of the main semantic recall threshold and its request-level override. Valid range is `[0, 1]`. |
| Temporal retrieval semantic gate | `temporal_semantic_min_similarity` / `HINDSIGHT_API_TEMPORAL_SEMANTIC_MIN_SIMILARITY` | `0.1` | Added | Controls the semantic gate used by temporal retrieval for both entry points and spread neighbors. It is independent of the main semantic recall threshold and its request-level override. Valid range is `[0, 1]`. |
| Semantic-link graph construction | `semantic_link_min_similarity` / `HINDSIGHT_API_SEMANTIC_LINK_MIN_SIMILARITY` | `0.7` | Added | Controls semantic links created by normal retain ANN lookup, within-batch linking, streaming retain's final ANN pass, and graph-maintenance relinking. Valid range is `[0, 1]`. The setting applies only when links are created; it does not delete old links or rebuild an existing graph. |
| Observation semantic deduplication | `consolidation_dedup_threshold` / `HINDSIGHT_API_CONSOLIDATION_DEDUP_THRESHOLD` | `0.97` | Existing | Controls semantic candidate generation for observation consolidation. Values below `1.0` are active thresholds; values greater than or equal to `1.0` retain the existing disable behavior. There is no per-request override, and this PR does not add `[0, 1]` validation to this setting. |

## What changed

- Added the three new fields, defaults, environment parsing, and `[0, 1]` validation to `HindsightConfig`.
- Passed the resolved graph seed threshold through Link Expansion retrieval.
- Passed the resolved temporal threshold through temporal entry-point and neighbor selection.
- Passed the resolved semantic-link threshold through normal retain, within-batch link creation, streaming retain, and graph maintenance.
- Preserved all five existing default values, so deployments that do not set the new environment variables keep their previous behavior.
- Updated both environment templates, developer configuration documentation, and the generated documentation skill mirror.
- Documented that changing the semantic-link threshold is not retroactive: raising it does not remove existing low-weight links, and lowering it does not recompute nodes that graph maintenance already considers sufficiently linked. A full transition requires rebuilding the graph or re-ingesting source data into a new memory bank.
- Added regression coverage for defaults, environment overrides, validation, graph seed wiring, temporal wiring, retain and streaming paths, and graph-maintenance relinking.

## Compatibility

This is backward compatible when the new variables are unset: graph seeds remain at `0.3`, the temporal semantic gate remains at `0.1`, and semantic-link construction remains at `0.7`. The existing main semantic recall default remains `0.3`, and observation semantic deduplication remains `0.97` with its existing `>=1.0` disable semantics.

## Validation

- Targeted API test suites: 119 passed.
- Configuration validation suite: 81 passed.
- Environment template tests: 7 passed.
- `./scripts/hooks/lint.sh`: passed.
- `uv run ty check hindsight_api/`: passed.

Closes #2874.