### PR TITLE
fix(cline): support the Cline CLI's hook directory layout (#2711)

### DIFF
--- a/hindsight-integrations/cline/README.md
+++ b/hindsight-integrations/cline/README.md
@@ -42,14 +42,28 @@ Install globally (applies to all projects):
 hindsight-cline install --global --api-url https://api.hindsight.vectorize.io --api-token YOUR_KEY
 ```
 
-To remove it later: `hindsight-cline uninstall` (add `--global` if you installed globally).
+### Cline CLI
 
-This copies four hook scripts (`TaskStart`, `UserPromptSubmit`, `TaskComplete`, `TaskCancel`) plus their `lib/` and `settings.json` into:
+The Cline **CLI** discovers hooks from a different directory than the VS Code extension, so add `--cli`:
 
-- `.clinerules/hooks/` (project install — commit it to share with your team), or
-- `~/Documents/Cline/Rules/Hooks/` (global install).
+```bash
+hindsight-cline install --cli --api-url https://api.hindsight.vectorize.io --api-token YOUR_KEY
+```
 
-**Final step — enable hooks in Cline:** Settings → Features → Hooks.
+To remove it later: `hindsight-cline uninstall` (add `--global` and/or `--cli` to match how you installed).
+
+This copies four hook scripts (`TaskStart`, `UserPromptSubmit`, `TaskComplete`, `TaskCancel`) plus their `lib/` and `settings.json` into the directory your Cline client reads:
+
+| Client | Project install (default) | Global install (`--global`) |
+| --- | --- | --- |
+| VS Code extension | `.clinerules/hooks/` | `~/Documents/Cline/Rules/Hooks/` |
+| CLI (`--cli`) | `.cline/hooks/` | `~/.cline/hooks/` |
+
+Commit the project directory to share the hooks with your team.
+
+**Final step:**
+- **VS Code extension:** enable hooks in Settings → Features → Hooks.
+- **CLI:** nothing — the CLI reads its hooks directory automatically (no toggle). To install the hooks somewhere else, point the CLI at them with `CLINE_HOOKS_DIR=<dir>` or `cline --hooks-dir <dir>`.
 
 ## How It Works
 
@@ -83,8 +97,8 @@ Every key can also be set via `HINDSIGHT_*` environment variables (e.g. `HINDSIG
 
 ## Verifying Setup
 
-1. Start Hindsight (`hindsight-api` or Hindsight Cloud) and run `hindsight-cline install` with your URL/key.
-2. Enable hooks in Cline (Settings → Features → Hooks).
+1. Start Hindsight (`hindsight-api` or Hindsight Cloud) and run `hindsight-cline install` with your URL/key (add `--cli` for the Cline CLI).
+2. VS Code extension only: enable hooks in Cline (Settings → Features → Hooks). The CLI needs no toggle.
 3. Start a task — recalled memories appear in context as a `<hindsight_memories>` block.
 4. Complete a task, then check the `cline` bank (via the API or dashboard) — a memory should appear.
 

--- a/hindsight-integrations/cline/hindsight_cline/cli.py
+++ b/hindsight-integrations/cline/hindsight_cline/cli.py
@@ -5,6 +5,7 @@ Exposed as the ``hindsight-cline`` console script:
     hindsight-cline install
     hindsight-cline install --api-url https://api.hindsight.vectorize.io --api-token hsk_...
     hindsight-cline install --global
+    hindsight-cline install --cli            # Cline CLI instead of the VS Code extension
     hindsight-cline uninstall
 """
 
@@ -21,12 +22,13 @@ def _run_install(args: argparse.Namespace) -> int:
         api_token=args.api_token,
         project_dir=Path(args.project_dir),
         global_install=args.global_install,
+        cli=args.cli,
     )
     return 0
 
 
 def _run_uninstall(args: argparse.Namespace) -> int:
-    run_uninstall(project_dir=Path(args.project_dir), global_install=args.global_install)
+    run_uninstall(project_dir=Path(args.project_dir), global_install=args.global_install, cli=args.cli)
     return 0
 
 
@@ -37,10 +39,22 @@ def _add_target_args(parser: argparse.ArgumentParser) -> None:
         help="Project directory to install into (default: current directory)",
     )
     parser.add_argument(
+        "--cli",
+        action="store_true",
+        help=(
+            "Target the Cline CLI instead of the VS Code extension. The CLI reads "
+            "~/.cline/hooks (with --global) or <project>/.cline/hooks; the extension "
+            "reads ~/Documents/Cline/Rules/Hooks or <project>/.clinerules/hooks."
+        ),
+    )
+    parser.add_argument(
         "--global",
         dest="global_install",
         action="store_true",
-        help="Use ~/Documents/Cline/Rules/Hooks/ instead of the project's .clinerules/hooks/",
+        help=(
+            "Install globally for all projects. Extension: ~/Documents/Cline/Rules/Hooks/; "
+            "CLI (with --cli): ~/.cline/hooks. Default is the current project's hooks dir."
+        ),
     )
 
 

--- a/hindsight-integrations/cline/hindsight_cline/install.py
+++ b/hindsight-integrations/cline/hindsight_cline/install.py
@@ -30,7 +30,21 @@ def _payload_root():
     return resources.files(PACKAGE).joinpath("hooks")
 
 
-def get_hooks_dir(project_dir: Path, global_install: bool) -> Path:
+def get_hooks_dir(project_dir: Path, global_install: bool, cli: bool = False) -> Path:
+    """Resolve the hooks directory for the target Cline client.
+
+    The Cline CLI and the VS Code extension discover hooks from *different*
+    directories, so installing into the extension's paths leaves the CLI unable
+    to find the hooks (they list but never fire — see issue #2711):
+
+    - CLI: ``~/.cline/hooks`` (global) or ``<project>/.cline/hooks`` (project).
+    - Extension: ``~/Documents/Cline/Rules/Hooks`` (global) or
+      ``<project>/.clinerules/hooks`` (project).
+    """
+    if cli:
+        if global_install:
+            return Path.home() / ".cline" / "hooks"
+        return project_dir / ".cline" / "hooks"
     if global_install:
         return Path.home() / "Documents" / "Cline" / "Rules" / "Hooks"
     return project_dir / ".clinerules" / "hooks"
@@ -89,11 +103,12 @@ def run_install(
     api_token: str | None = None,
     project_dir: Path | None = None,
     global_install: bool = False,
+    cli: bool = False,
 ) -> None:
     """Install the hook scripts into Cline and record connection settings."""
-    hooks_dir = get_hooks_dir((project_dir or Path(".")).resolve(), global_install)
+    hooks_dir = get_hooks_dir((project_dir or Path(".")).resolve(), global_install, cli)
 
-    print("Installing Hindsight memory for Cline...")
+    print(f"Installing Hindsight memory for Cline ({'CLI' if cli else 'VS Code extension'})...")
     print(f"  Hooks dir : {hooks_dir}")
     print(f"  API URL   : {api_url or '(set later in ~/.hindsight/cline.json)'}")
     print()
@@ -102,15 +117,21 @@ def run_install(
     write_user_config(api_url, api_token)
 
     print()
-    print("Done. Final step — enable hooks in Cline:")
-    print("  Settings → Features → Hooks (toggle on)")
+    if cli:
+        # The CLI has no enable toggle — it reads its hooks directory directly.
+        print("Done. The Cline CLI reads this directory automatically — no toggle needed.")
+        print("To install elsewhere, point the CLI at these hooks with:")
+        print(f"  export CLINE_HOOKS_DIR={hooks_dir}   # or: cline --hooks-dir {hooks_dir}")
+    else:
+        print("Done. Final step — enable hooks in Cline:")
+        print("  Settings → Features → Hooks (toggle on)")
     print()
     print("Note: Cline hooks run on macOS and Linux only.")
 
 
-def run_uninstall(project_dir: Path | None = None, global_install: bool = False) -> None:
+def run_uninstall(project_dir: Path | None = None, global_install: bool = False, cli: bool = False) -> None:
     """Remove the deployed hook scripts, ``lib/`` and ``settings.json``."""
-    hooks_dir = get_hooks_dir((project_dir or Path(".")).resolve(), global_install)
+    hooks_dir = get_hooks_dir((project_dir or Path(".")).resolve(), global_install, cli)
 
     removed = False
     for name in [*HOOK_FILES, "settings.json"]:

--- a/hindsight-integrations/cline/tests/test_install.py
+++ b/hindsight-integrations/cline/tests/test_install.py
@@ -2,9 +2,10 @@
 
 import json
 import os
+from pathlib import Path
 
 import pytest
-from hindsight_cline import install_hooks, write_user_config
+from hindsight_cline import get_hooks_dir, install_hooks, write_user_config
 from hindsight_cline.cli import main
 
 HOOK_FILES = ["TaskStart", "UserPromptSubmit", "TaskComplete", "TaskCancel"]
@@ -73,3 +74,47 @@ def test_cli_requires_subcommand():
     with pytest.raises(SystemExit) as exc:
         main([])
     assert exc.value.code != 0
+
+
+# ── Cline CLI hook layout (#2711) ─────────────────────────────────────────────
+
+
+def test_get_hooks_dir_targets_are_client_specific():
+    project = Path("/proj")
+    # Extension (default) — the VS Code paths.
+    assert get_hooks_dir(project, global_install=False) == project / ".clinerules" / "hooks"
+    assert get_hooks_dir(project, global_install=True) == Path.home() / "Documents" / "Cline" / "Rules" / "Hooks"
+    # CLI — the paths the cline CLI actually reads.
+    assert get_hooks_dir(project, global_install=False, cli=True) == project / ".cline" / "hooks"
+    assert get_hooks_dir(project, global_install=True, cli=True) == Path.home() / ".cline" / "hooks"
+
+
+def test_cli_flag_installs_into_dot_cline_hooks(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    rc = main(["install", "--cli", "--project-dir", str(tmp_path)])
+    assert rc == 0
+    cli_hooks = tmp_path / ".cline" / "hooks"
+    assert all((cli_hooks / name).exists() for name in HOOK_FILES)
+    assert (cli_hooks / "lib" / "hooks_impl.py").exists()
+    assert (cli_hooks / "settings.json").exists()
+    # The extension path must NOT be written when targeting the CLI.
+    assert not (tmp_path / ".clinerules" / "hooks").exists()
+
+
+def test_cli_global_flag_installs_into_home_dot_cline_hooks(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    rc = main(["install", "--cli", "--global"])
+    assert rc == 0
+    assert (tmp_path / ".cline" / "hooks" / "TaskStart").exists()
+
+
+def test_cli_uninstall_removes_dot_cline_hooks(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    main(["install", "--cli", "--project-dir", str(tmp_path)])
+    cli_hooks = tmp_path / ".cline" / "hooks"
+    assert (cli_hooks / "TaskStart").exists()
+
+    rc = main(["uninstall", "--cli", "--project-dir", str(tmp_path)])
+    assert rc == 0
+    assert not (cli_hooks / "TaskStart").exists()
+    assert not (cli_hooks / "lib").exists()


### PR DESCRIPTION
Fixes #2711.

## Problem

The Cline **CLI** and the **VS Code extension** discover lifecycle hooks from *different* directories, but `hindsight-cline install` only wrote the extension's paths and told users to flip the extension's Settings toggle:

| Client | Hook discovery | Enablement |
|---|---|---|
| VS Code extension | `~/Documents/Cline/Rules/Hooks/` + `.clinerules/hooks/` | Settings → Features → Hooks toggle |
| **CLI** | `~/.cline/hooks` + `<project>/.cline/hooks/` | `--hooks-dir` / `CLINE_HOOKS_DIR` — **no toggle** |

So on the CLI the hooks landed in a directory the CLI never reads (`.clinerules/hooks`). They listed under `/settings` but never fired, and the bank stayed empty — while a **manual** invocation of the same script worked (it was run directly). The reporter also (correctly) found no enable toggle in the CLI, because the CLI doesn't have one.

Confirmed against Cline's own `docs/cli/cli-reference.mdx` (`apps/cli/src/main.ts`, `apps/cli/src/commands/program.ts`): CLI default `~/.cline/hooks`, `--hooks-dir`, `CLINE_HOOKS_DIR`; `.clinerules/hooks` is extension-only.

## Fix

Add a `--cli` install/uninstall mode that targets the CLI's directories:
- project (default): `<project>/.cline/hooks/`
- `--global`: `~/.cline/hooks`

and prints CLI-appropriate guidance — no toggle, and how to point the CLI elsewhere via `CLINE_HOOKS_DIR` / `cline --hooks-dir`. The hook bundle is already self-contained (each script resolves its `lib/` and `settings.json` relative to its own path), so it runs unchanged from the new location. **Extension behaviour and messaging are unchanged when `--cli` is omitted.**

```bash
hindsight-cline install --cli --api-url ... --api-token ...   # project .cline/hooks
hindsight-cline install --cli --global ...                    # ~/.cline/hooks
```

## Tests

- `get_hooks_dir` returns the correct path for all four combinations (extension/CLI × project/global).
- End-to-end `--cli` install writes `.cline/hooks` (+ `lib/` + `settings.json`) and **does not** write the extension `.clinerules/hooks` path; `--cli --global` writes `~/.cline/hooks`; `--cli` uninstall removes them.
- Existing extension-path tests unchanged. 40 tests pass; lint/format clean.

README updated with the `--cli` flag, a per-client directory table, and the no-toggle CLI setup.

Reported by @mmarras, who did the legwork confirming the hook script itself works when invoked manually.