### PR TITLE
fix(mental-model): anchor delta refresh watermark to newest processed memory

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -819,6 +819,15 @@ class RefreshTagFiltering:
     tag_groups: list[TagGroup] | None
 
 
+@dataclass(frozen=True)
+class _MentalModelScopeFilter:
+    """SQL scope (tag + fact-type filter) shared by the staleness check and the
+    processed-watermark query, so both see an identical set of in-scope memories."""
+
+    where: list[str]
+    params: list[Any]
+
+
 def _resolve_refresh_tag_filtering(
     model_tags: list[str] | None,
     trigger_data: dict[str, Any],
@@ -10814,6 +10823,43 @@ class MemoryEngine(MemoryEngineInterface):
                 mental_model_id,
             )
 
+    async def _mental_model_processed_watermark(
+        self,
+        bank_id: str,
+        mental_model_id: str,
+        scope_filter: "_MentalModelScopeFilter",
+        refresh_cutoff: datetime,
+    ) -> datetime | None:
+        """Watermark to persist after a refresh: the newest in-scope memory visible at
+        the snapshot, clamped so it never regresses below the current ``last_refreshed_at``.
+
+        A still-uncommitted straddling row is excluded from this max, so when it commits
+        it stays newer than the watermark and is caught next time. Returns ``None`` when
+        no in-scope memory is visible (leave ``last_refreshed_at`` untouched, so an
+        in-flight first row is not skipped). Kept as its own method — like
+        ``_mental_model_refresh_cutoff`` — so mock unit tests of the refresh wiring can
+        stub it instead of reaching a real pool.
+        """
+        backend = await self._get_backend()
+        assert self._dialect is not None
+        watermark_params = [*scope_filter.params, refresh_cutoff]
+        watermark_where = [*scope_filter.where, f"updated_at <= ${len(watermark_params)}"]
+        async with acquire_with_retry(backend) as conn:
+            current_last_refreshed_at = await conn.fetchval(
+                f"SELECT last_refreshed_at FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                mental_model_id,
+            )
+            newest_in_scope = await conn.fetchval(
+                f"SELECT MAX(updated_at) FROM {fq_table('memory_units')} WHERE {' AND '.join(watermark_where)}",
+                *watermark_params,
+            )
+        if newest_in_scope is None:
+            return None
+        if current_last_refreshed_at is not None:
+            return max(newest_in_scope, current_last_refreshed_at)
+        return newest_in_scope
+
     async def refresh_mental_model(
         self,
         bank_id: str,
@@ -10899,12 +10945,22 @@ class MemoryEngine(MemoryEngineInterface):
 
             tag_filtering = _resolve_refresh_tag_filtering(mental_model.get("tags"), trigger_data)
 
-            # Bound this refresh to a database-time snapshot. Facts arriving while
-            # reflect is running must remain newer than the persisted watermark so
-            # a later refresh can still see them.
+            # Bound this refresh to a database-time snapshot. Reflect only reads facts
+            # committed at/before this cutoff (``created_before`` below), so a fact
+            # arriving while reflect runs stays unseen this round.
             refresh_cutoff = await self._mental_model_refresh_cutoff(bank_id, mental_model_id)
             if refresh_cutoff is None:
                 return None
+            # Persist the watermark as the newest in-scope memory actually visible at the
+            # snapshot — NOT now(). now() can sit ahead of the real data: updated_at is the
+            # writing transaction's start time, but a row only becomes visible at COMMIT,
+            # which can land after this snapshot. Anchoring to the newest row we saw means
+            # such a straddling commit stays newer than the watermark and is caught next
+            # time, instead of being stamped "already processed" and dropped forever.
+            scope_filter = self._build_mm_scope_filter(bank_id, tag_filtering, fact_types)
+            processed_watermark = await self._mental_model_processed_watermark(
+                bank_id, mental_model_id, scope_filter, refresh_cutoff
+            )
 
             # Run reflect with the source query, excluding the mental model being refreshed
             # Skip creating a nested "hindsight.reflect" span since we already have "hindsight.mental_model_refresh"
@@ -11075,7 +11131,7 @@ class MemoryEngine(MemoryEngineInterface):
                             mental_model_id,
                             reflect_response=reflect_response_payload,
                             last_refreshed_source_query=current_source_query,
-                            refresh_watermark=refresh_cutoff,
+                            refresh_watermark=processed_watermark,
                             request_context=request_context,
                         )
 
@@ -11183,7 +11239,7 @@ class MemoryEngine(MemoryEngineInterface):
                 content=final_content,
                 reflect_response=reflect_response_payload,
                 last_refreshed_source_query=current_source_query,
-                refresh_watermark=refresh_cutoff,
+                refresh_watermark=processed_watermark,
                 structured_content=(final_structured.model_dump() if final_structured is not None else None),
                 request_context=request_context,
             )
@@ -11217,7 +11273,13 @@ class MemoryEngine(MemoryEngineInterface):
             tags: New tags (if changing)
             trigger: New trigger settings (if changing)
             reflect_response: Full reflect API response payload (if changing)
-            refresh_watermark: Snapshot cutoff consumed by a successful refresh
+            refresh_watermark: Watermark persisted by a successful refresh — the newest
+                ``updated_at`` among the in-scope memories visible at the refresh
+                snapshot (not ``now()``), so a row that commits after the snapshot stays
+                newer than the watermark and is not silently dropped. None means "no
+                in-scope memory was visible": on the no-op path ``last_refreshed_at`` is
+                left unchanged (so an in-flight row is not skipped); on the content path
+                it falls back to NOW().
             request_context: Request context for authentication
 
         Returns:
@@ -11296,9 +11358,11 @@ class MemoryEngine(MemoryEngineInterface):
                     params.append(str(embedding[0]))
                     param_idx += 1
             elif refresh_watermark is not None:
-                # A successful delta refresh can find no topic-relevant facts even
-                # though the coarse staleness query found new rows. Consume that
-                # window without re-embedding unchanged content or adding history.
+                # A successful delta refresh can find no topic-relevant facts even though
+                # the coarse staleness query found new rows. Advance the watermark to the
+                # newest in-scope memory we saw (without re-embedding unchanged content or
+                # adding history) so this no-op window stops re-triggering, while any row
+                # that commits later stays newer than the watermark and is still caught.
                 updates.append(f"last_refreshed_at = ${param_idx}")
                 params.append(refresh_watermark)
                 param_idx += 1
@@ -11496,6 +11560,46 @@ class MemoryEngine(MemoryEngineInterface):
 
         return result == "DELETE 1"
 
+    def _build_mm_scope_filter(
+        self,
+        bank_id: str,
+        tag_filtering: RefreshTagFiltering,
+        fact_types: list[str] | None,
+    ) -> _MentalModelScopeFilter:
+        """Build the tag + fact-type WHERE clause for a mental model's memory scope.
+
+        Deliberately excludes any ``updated_at`` bound so both callers add their own:
+        the staleness check appends ``updated_at > last_refreshed_at``; the refresh
+        appends ``updated_at <= cutoff`` under ``MAX(updated_at)``. ``bank_id`` is
+        ``$1``; the caller appends its extra param last and references it by index.
+        """
+        params: list[Any] = [bank_id]
+        where = ["bank_id = $1"]
+
+        tag_clause, tag_params, next_param = build_tags_where_clause(
+            tag_filtering.tags,
+            param_offset=len(params) + 1,
+            match=tag_filtering.tags_match,
+        )
+        if tag_clause:
+            where.append(tag_clause.removeprefix("AND "))
+            params.extend(tag_params)
+
+        group_clause, group_params, _ = build_tag_groups_where_clause(
+            tag_filtering.tag_groups,
+            param_offset=next_param,
+        )
+        if group_clause:
+            where.append(group_clause.removeprefix("AND "))
+            params.extend(group_params)
+        # Untagged MM without tag_groups → no tag constraint, matching any bank memory.
+
+        if fact_types:
+            params.append(list(fact_types))
+            where.append(f"fact_type = ANY(${len(params)}::text[])")
+
+        return _MentalModelScopeFilter(where=where, params=params)
+
     async def compute_mental_model_is_stale(
         self,
         conn,
@@ -11541,30 +11645,9 @@ class MemoryEngine(MemoryEngineInterface):
         fact_types: list[str] = list(trigger.get("fact_types") or [])
         tag_filtering = _resolve_refresh_tag_filtering(mm_tags, trigger)
 
-        params: list[Any] = [bank_id, last_refreshed_at]
-        where = ["bank_id = $1", "updated_at > $2"]
-
-        tag_clause, tag_params, next_param = build_tags_where_clause(
-            tag_filtering.tags,
-            param_offset=len(params) + 1,
-            match=tag_filtering.tags_match,
-        )
-        if tag_clause:
-            where.append(tag_clause.removeprefix("AND "))
-            params.extend(tag_params)
-
-        group_clause, group_params, _ = build_tag_groups_where_clause(
-            tag_filtering.tag_groups,
-            param_offset=next_param,
-        )
-        if group_clause:
-            where.append(group_clause.removeprefix("AND "))
-            params.extend(group_params)
-        # Untagged MM without tag_groups → no tag constraint, matching any bank memory.
-
-        if fact_types:
-            params.append(fact_types)
-            where.append(f"fact_type = ANY(${len(params)}::text[])")
+        scope_filter = self._build_mm_scope_filter(bank_id, tag_filtering, fact_types)
+        params = [*scope_filter.params, last_refreshed_at]
+        where = [*scope_filter.where, f"updated_at > ${len(params)}"]
 
         row = await conn.fetchrow(
             f"SELECT 1 FROM {fq_table('memory_units')} WHERE {' AND '.join(where)} LIMIT 1",

--- a/hindsight-api-slim/tests/test_mental_model_delta.py
+++ b/hindsight-api-slim/tests/test_mental_model_delta.py
@@ -275,7 +275,7 @@ class TestDeltaRefreshPlumbing:
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
-    async def test_delta_no_new_facts_advances_refresh_watermark(
+    async def test_delta_no_new_facts_advances_watermark_to_newest_processed(
         self,
         memory: MemoryEngine,
         request_context: RequestContext,
@@ -283,12 +283,15 @@ class TestDeltaRefreshPlumbing:
         patch_llm_call,
         monkeypatch,
     ):
-        """A successful no-op refresh must consume the current stale window.
+        """A successful no-op refresh advances ``last_refreshed_at`` to the newest
+        in-scope memory it actually saw — not ``now()``.
 
-        The scheduled-refresh gate uses ``last_refreshed_at`` as its watermark. If
-        reflect finds no topic-relevant facts and that watermark stays unchanged,
-        the same unrelated memory makes every maintenance tick submit another LLM
-        refresh even though the previous operation completed successfully.
+        The scheduled-refresh gate uses ``last_refreshed_at`` as its watermark. If a
+        no-op refresh left it unchanged, one unrelated memory would make every
+        maintenance tick submit another LLM refresh forever. Anchoring the watermark to
+        the newest processed memory stops that storm without jumping ahead of the real
+        data, so a row that commits later stays newer than the watermark (see
+        ``test_delta_refresh_watermark_survives_straddling_commit``).
         """
         bank_id = f"test-delta-watermark-{uuid.uuid4().hex[:8]}"
         await memory.get_bank_profile(bank_id, request_context=request_context)
@@ -303,9 +306,9 @@ class TestDeltaRefreshPlumbing:
             request_context=request_context,
         )
 
-        # Reproduce an established model whose cron is overdue, then add a fresh
-        # but topic-irrelevant fact. The coarse staleness query sees this row while
-        # the reflect agent correctly returns no supporting facts for the model.
+        # Established model whose cron is overdue, plus a topic-irrelevant but in-scope
+        # fact committed a couple of minutes ago. The coarse staleness query sees the
+        # row while the reflect agent correctly returns no supporting facts.
         assert memory._pool is not None
         async with memory._pool.acquire() as conn:
             before = await conn.fetchval(
@@ -319,10 +322,12 @@ class TestDeltaRefreshPlumbing:
                 bank_id,
                 mm["id"],
             )
-            await conn.execute(
+            fact_updated_at = await conn.fetchval(
                 """
                 INSERT INTO memory_units (id, bank_id, text, fact_type, tags, created_at, updated_at)
-                VALUES ($1, $2, 'The build server uses Linux.', 'world', ARRAY[]::varchar[], NOW(), NOW())
+                VALUES ($1, $2, 'The build server uses Linux.', 'world', ARRAY[]::varchar[],
+                        NOW() - INTERVAL '2 minutes', NOW() - INTERVAL '2 minutes')
+                RETURNING updated_at
                 """,
                 uuid.uuid4(),
                 bank_id,
@@ -368,6 +373,9 @@ class TestDeltaRefreshPlumbing:
                 bank_id,
                 mm["id"],
             )
+        # Watermark advanced to the newest in-scope memory actually seen — exactly its
+        # updated_at, not now() — so the settled window no longer re-triggers.
+        assert after == fact_updated_at
         assert after > before
         assert is_stale is False
         assert history_count == 0
@@ -386,7 +394,7 @@ class TestDeltaRefreshPlumbing:
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
-    async def test_delta_no_new_facts_preserves_memories_arriving_during_refresh(
+    async def test_delta_refresh_watermark_survives_straddling_commit(
         self,
         memory: MemoryEngine,
         request_context: RequestContext,
@@ -394,8 +402,18 @@ class TestDeltaRefreshPlumbing:
         patch_llm_call,
         monkeypatch,
     ):
-        """The refresh watermark must not pass facts excluded from its recall snapshot."""
-        bank_id = f"test-delta-cutoff-{uuid.uuid4().hex[:8]}"
+        """A memory whose transaction starts before the refresh snapshot but commits
+        after it must remain visible to a later refresh.
+
+        ``memory_units.updated_at`` is the writing transaction's start time, but the row
+        only becomes visible at COMMIT. A refresh that persisted its exact snapshot
+        cutoff (or ``now()``) would leave such a straddling row below the watermark — its
+        start time predates the cutoff — even though reflect never saw it, dropping it
+        forever. Anchoring the watermark to ``max(updated_at)`` of the rows the refresh
+        *actually saw* excludes the still-uncommitted straddler, so it stays strictly
+        newer than the watermark and is picked up next time.
+        """
+        bank_id = f"test-delta-straddle-{uuid.uuid4().hex[:8]}"
         await memory.get_bank_profile(bank_id, request_context=request_context)
         mm = await memory.create_mental_model(
             bank_id=bank_id,
@@ -418,42 +436,70 @@ class TestDeltaRefreshPlumbing:
                 bank_id,
                 mm["id"],
             )
+            # A committed baseline in-scope fact. This is the newest row the refresh can
+            # see, so it becomes the max(seen) watermark.
+            baseline_updated_at = await conn.fetchval(
+                """
+                INSERT INTO memory_units (id, bank_id, text, fact_type, tags, created_at, updated_at)
+                VALUES ($1, $2, 'The user is on the platform team.', 'world', ARRAY[]::varchar[],
+                        NOW() - INTERVAL '2 minutes', NOW() - INTERVAL '2 minutes')
+                RETURNING updated_at
+                """,
+                uuid.uuid4(),
+                bank_id,
+            )
 
         reflect_calls = patch_reflect(memory, text="No relevant preference changes.", facts=[])
         delta_llm_calls = patch_llm_call(memory, returns="should-not-be-called")
         original_update = memory.update_mental_model
-        late_fact_id = uuid.uuid4()
 
-        async def insert_late_fact_then_update(*args, **kwargs):
-            # refresh_mental_model has already consumed the reflect result when it
-            # reaches update_mental_model. Insert a fact in that exact race window.
-            assert memory._pool is not None
-            async with memory._pool.acquire() as conn:
-                await conn.execute(
-                    """
-                    INSERT INTO memory_units
-                        (id, bank_id, text, fact_type, tags, created_at, updated_at)
-                    VALUES
-                        ($1, $2, 'The user now prefers detailed answers.', 'world',
-                         ARRAY[]::varchar[], NOW(), NOW())
-                    """,
-                    late_fact_id,
-                    bank_id,
-                )
+        # Open a transaction and insert a NEWER relevant memory, but hold the commit so
+        # it is invisible at the refresh snapshot. Its updated_at (transaction-start) is
+        # still before the cutoff, so an exact-cutoff/now() watermark would drop it.
+        straddle_conn = await memory._pool.acquire()
+        straddle_tx = straddle_conn.transaction()
+        await straddle_tx.start()
+        straddle_fact_id = uuid.uuid4()
+        await straddle_conn.execute(
+            """
+            INSERT INTO memory_units
+                (id, bank_id, text, fact_type, tags, created_at, updated_at)
+            VALUES
+                ($1, $2, 'The user now prefers detailed answers.', 'world',
+                 ARRAY[]::varchar[], NOW(), NOW())
+            """,
+            straddle_fact_id,
+            bank_id,
+        )
+
+        straddle_committed = False
+
+        async def commit_straddle_then_update(*args, **kwargs):
+            nonlocal straddle_committed
+            # refresh has already captured its snapshot and finished reflect. Commit the
+            # previously-invisible row in this exact window, after the snapshot.
+            await straddle_tx.commit()
+            straddle_committed = True
             return await original_update(*args, **kwargs)
 
-        monkeypatch.setattr(memory, "update_mental_model", insert_late_fact_then_update)
+        monkeypatch.setattr(memory, "update_mental_model", commit_straddle_then_update)
 
-        refreshed = await memory.refresh_mental_model(
-            bank_id=bank_id,
-            mental_model_id=mm["id"],
-            request_context=request_context,
-        )
+        try:
+            refreshed = await memory.refresh_mental_model(
+                bank_id=bank_id,
+                mental_model_id=mm["id"],
+                request_context=request_context,
+            )
+        finally:
+            if not straddle_committed:
+                await straddle_tx.rollback()
+            await memory._pool.release(straddle_conn)
 
         assert refreshed is not None
         assert len(reflect_calls) == 1
-        assert reflect_calls[0].get("created_before") is not None
         assert len(delta_llm_calls) == 0
+        cutoff = reflect_calls[0].get("created_before")
+        assert cutoff is not None
 
         async with memory._pool.acquire() as conn:
             mm_row = await conn.fetchrow(
@@ -461,13 +507,19 @@ class TestDeltaRefreshPlumbing:
                 bank_id,
                 mm["id"],
             )
-            late_updated_at = await conn.fetchval(
+            straddle_updated_at = await conn.fetchval(
                 "SELECT updated_at FROM memory_units WHERE bank_id = $1 AND id = $2",
                 bank_id,
-                late_fact_id,
+                straddle_fact_id,
             )
             assert mm_row is not None
-            assert late_updated_at > mm_row["last_refreshed_at"]
+            after = mm_row["last_refreshed_at"]
+            # Watermark advanced only to the committed baseline the refresh actually saw.
+            assert after == baseline_updated_at
+            # The straddler was stamped before the cutoff (an exact-cutoff/now() watermark
+            # would drop it), yet it is newer than max(seen), so the model reads stale.
+            assert straddle_updated_at < cutoff
+            assert after < straddle_updated_at
             assert await memory.compute_mental_model_is_stale(conn, bank_id, mm_row) is True
 
         await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -1929,6 +1929,7 @@ class TestMentalModelRefreshMaxTokens:
         engine._mental_model_refresh_cutoff = AsyncMock(  # type: ignore[method-assign]
             return_value=datetime(2026, 1, 1, tzinfo=timezone.utc)
         )
+        engine._mental_model_processed_watermark = AsyncMock(return_value=None)  # type: ignore[method-assign]
 
         await engine.refresh_mental_model(
             bank_id="bank-1",

--- a/hindsight-api-slim/tests/test_recall_config.py
+++ b/hindsight-api-slim/tests/test_recall_config.py
@@ -200,6 +200,7 @@ class TestRefreshTriggerWiring:
         # DB-time refresh watermark — stub so this mock test doesn't reach a real
         # pool (matches the other collaborator stubs above).
         engine._mental_model_refresh_cutoff = AsyncMock(return_value=datetime(2026, 1, 1, tzinfo=timezone.utc))
+        engine._mental_model_processed_watermark = AsyncMock(return_value=None)
 
         await engine.refresh_mental_model(
             bank_id="bank-1",
@@ -241,6 +242,7 @@ class TestRefreshTriggerWiring:
         # DB-time refresh watermark — stub so this mock test doesn't reach a real
         # pool (matches the other collaborator stubs above).
         engine._mental_model_refresh_cutoff = AsyncMock(return_value=datetime(2026, 1, 1, tzinfo=timezone.utc))
+        engine._mental_model_processed_watermark = AsyncMock(return_value=None)
 
         await engine.refresh_mental_model(
             bank_id="bank-1",


### PR DESCRIPTION
## Summary

Follow-up to #2866. That PR stopped the scheduled no-op refresh storm by advancing a delta model's `last_refreshed_at` to the pre-Reflect snapshot cutoff (a wall-clock `now()`). But a wall-clock watermark is unsafe against commit visibility and can permanently drop a memory.

`memory_units.updated_at` is stamped with the writing transaction's start time (Postgres `now()`), but a row only becomes visible at **COMMIT**, which can land *after* a concurrent refresh captured its snapshot. Such a straddling row is invisible to Reflect (uncommitted at snapshot time) yet carries a timestamp `<=` the snapshot instant — so once the watermark is set to that instant, `updated_at > last_refreshed_at` is never true again and the memory is silently excluded from every future refresh. This hazard existed on the contentful path (`last_refreshed_at = NOW()`) before #2866; #2866 extended it to the no-op path.

**Fix:** persist the watermark as the **newest `updated_at` among the in-scope memories the refresh actually saw** — `MAX(updated_at)` over the model's scope, restricted to rows visible at the snapshot — instead of `now()`. A straddler is still uncommitted at that snapshot, so it is *excluded* from the max; when it commits it is strictly newer than the watermark and is picked up on the next refresh.

## Why max(seen), not now() and not a time margin

- **`now()` overshoots.** It can sit ahead of the real data, which is exactly what strands a late-committing row below the watermark. `max(seen)` never advances past a row the refresh didn't see.
- **A margin off `now()` re-introduces a storm knob.** Backing `now()` off by a fixed margin does cover straddlers, but it also keeps the newest real fact above the watermark for the margin window, re-firing refreshes on every tick until it ages out. `max(seen)` needs no margin: the newest fact seen *is* the watermark, so it does not re-trigger.
- **No reprocessing.** Delta recall's `created_after` uses the prior watermark, which is now the newest fact already processed — so the next refresh recalls only genuinely newer facts, with no backfill window.

## What changed

- `refresh_mental_model` computes `MAX(updated_at)` over the model's tag/fact-type scope, bounded by the snapshot cutoff, in the same connection that takes the snapshot, and persists that as `last_refreshed_at` (both the no-op and contentful delta paths).
- Reflect recall is still bounded by the exact snapshot cutoff (`created_before`).
- The watermark is clamped monotonic — `max(newest_seen, current last_refreshed_at)` — so a refresh over only-older memories never moves it backwards (which would resurface already-processed rows and break the "a refresh advances last_refreshed_at" invariant other paths rely on, e.g. refresh-after-consolidation).
- Extracted `_build_mm_scope_filter` so the staleness check and the watermark query use an identical scope; refactored `compute_mental_model_is_stale` onto it.
- If no in-scope memory is visible at the snapshot (`MAX` is `NULL`), `last_refreshed_at` is left unchanged, so a first/only row that is still in-flight is not skipped.

## Residual / honest limits

Fully closing the commit-visibility gap requires a real commit-order signal (Postgres commit timestamps / Oracle SCN) or an identity ledger — neither portable/cheap here (the PK is a random UUID; a sequence or UUIDv7 is assigned at insert time and carries the same gap). `max(seen)` catches every straddler whose timestamp is newer than the newest row the refresh saw (the common case). It can still miss a straddler whose start-time predates a *different* fact that committed and was seen first — a narrower window than the wall-clock version, and only closable with commit-order tracking. This PR deliberately trades that rare residual for a ~10-line change with no new per-check cost.

## Relationship to #2868

#2868 solves the same bug with a versioned hash of the full visible scope + effective config, compared on every staleness check — correct, but ~490 lines, threads `RequestContext`/`conn` through every caller, resolves full hierarchical config on the hot recall path, replaces `SELECT 1 … LIMIT 1` with a full-scope hash, and folds in a separate "config change ⇒ stale" behavior. This PR is the lighter alternative; the config-sensitivity can land separately if wanted.

## Tests

- `test_delta_refresh_watermark_survives_straddling_commit` — a committed baseline fact establishes the `max(seen)` watermark; a newer relevant memory is inserted in a held transaction and committed mid-refresh (after the snapshot). Asserts the watermark advanced only to the baseline, the straddler is stamped before the cutoff (an exact-cutoff/`now()` watermark would drop it), and the model reads stale so the straddler is recovered. Fails on the #2866 behavior, passes here.
- `test_delta_no_new_facts_advances_watermark_to_newest_processed` (rewritten from #2866's `…advances_refresh_watermark`) — asserts a no-op refresh sets `last_refreshed_at` to exactly the newest in-scope memory's `updated_at` (not `now()`), does not re-embed or write history, and does not re-storm the scheduler.
