### PR TITLE
chore(deps): pin adm-zip >=0.6.0 in zapier (clears last fixable high alert)

### DIFF
--- a/hindsight-integrations/zapier/package-lock.json
+++ b/hindsight-integrations/zapier/package-lock.json
@@ -3781,13 +3781,13 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {

--- a/hindsight-integrations/zapier/package.json
+++ b/hindsight-integrations/zapier/package.json
@@ -35,7 +35,8 @@
     "serialize-javascript": "^7.0.3",
     "tar": "^7.5.11",
     "tmp": "^0.2.6",
-    "yeoman-environment": "^6.0.1"
+    "yeoman-environment": "^6.0.1",
+    "adm-zip": ">=0.6.0"
   },
   "engines": {
     "node": ">=20",


### PR DESCRIPTION
Clears the last **fixable** high-severity Dependabot alert: `adm-zip` 0.5.16 → 0.6.0 in `hindsight-integrations/zapier` (GHSA high; arbitrary file overwrite via path traversal).

adm-zip is transitive (via zapier-platform tooling) and a parent pins it to the 0.5.x line, so `npm update` won't move it. Added an **override** — the same mechanism zapier already uses for `form-data`/`tar`/`tmp`/`yeoman-environment` — to force the patched 0.6.0.

Verified `npm ci` installs the lock cleanly with adm-zip 0.6.0; lint clean.

After this and #2833 (nltk), the only remaining high alerts are `agno` (no upstream patch) and `json-repair` (crewai pins `~=0.25.2`), both genuinely blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)