### PR TITLE
fix(integrations): derive recall hook timeout from requestTimeoutSeconds

### DIFF
--- a/hindsight-integrations/claude-code/hooks/hooks.json
+++ b/hindsight-integrations/claude-code/hooks/hooks.json
@@ -17,7 +17,7 @@
           {
             "type": "command",
             "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/recall.py\" || python \"${CLAUDE_PLUGIN_ROOT}/scripts/recall.py\"",
-            "timeout": 12
+            "timeout": 45
           }
         ]
       }

--- a/hindsight-integrations/claude-code/scripts/setup_hooks.py
+++ b/hindsight-integrations/claude-code/scripts/setup_hooks.py
@@ -14,6 +14,44 @@ import os
 import sys
 
 SETTINGS_PATH = os.path.expanduser("~/.claude/settings.json")
+USER_CONFIG_PATH = os.path.expanduser("~/.hindsight/claude-code.json")
+
+# Default hook timeout for UserPromptSubmit (auto-recall).
+# Raised from 12s to 45s — the hooks.json shipped with the plugin also
+# uses this floor, but setup_hooks.py can tighten it further when the
+# user has set a lower requestTimeoutSeconds (see build_hooks).
+HOOK_RECALL_TIMEOUT_DEFAULT = 45
+HOOK_RECALL_TIMEOUT_MIN = 30
+
+
+def _read_request_timeout() -> int | None:
+    """Return user-configured requestTimeoutSeconds, or None if unavailable."""
+    if not os.path.isfile(USER_CONFIG_PATH):
+        return None
+    try:
+        with open(USER_CONFIG_PATH) as f:
+            cfg = json.load(f)
+        value = cfg.get("requestTimeoutSeconds")
+        if isinstance(value, (int, float)) and value > 0:
+            return int(value)
+    except (json.JSONDecodeError, OSError):
+        pass
+    return None
+
+
+def _recall_timeout() -> int:
+    """Compute the recall hook timeout.
+
+    When the user has set requestTimeoutSeconds, the hook timeout is that
+    value plus a 15s margin so the hook process is never killed before the
+    MCP request it wraps has a chance to complete (see #2854).
+
+    Otherwise a safe default is used.
+    """
+    req_timeout = _read_request_timeout()
+    if req_timeout is not None:
+        return max(req_timeout + 15, HOOK_RECALL_TIMEOUT_MIN)
+    return HOOK_RECALL_TIMEOUT_DEFAULT
 
 
 def find_plugin_root() -> str:
@@ -31,6 +69,7 @@ def find_plugin_root() -> str:
 
 
 def build_hooks(plugin_root: str) -> dict:
+    recall_timeout = _recall_timeout()
     return {
         "UserPromptSubmit": [
             {
@@ -38,7 +77,7 @@ def build_hooks(plugin_root: str) -> dict:
                     {
                         "type": "command",
                         "command": f'python3 "{plugin_root}/scripts/recall.py"',
-                        "timeout": 12,
+                        "timeout": recall_timeout,
                     }
                 ]
             }

--- a/hindsight-integrations/codex/hooks/hooks.json
+++ b/hindsight-integrations/codex/hooks/hooks.json
@@ -17,7 +17,7 @@
           {
             "type": "command",
             "command": "python3 \"__SCRIPTS_DIR__/recall.py\"",
-            "timeout": 12
+            "timeout": 45
           }
         ]
       }

--- a/hindsight-integrations/cursor-cli/hindsight_cursor_cli/hooks/hooks.json
+++ b/hindsight-integrations/cursor-cli/hindsight_cursor_cli/hooks/hooks.json
@@ -10,7 +10,7 @@
     "beforeSubmitPrompt": [
       {
         "command": "python3 \"__SCRIPTS_DIR__/recall.py\"",
-        "timeout": 12
+        "timeout": 45
       }
     ],
     "stop": [

--- a/hindsight-integrations/omo/hooks/hooks.json
+++ b/hindsight-integrations/omo/hooks/hooks.json
@@ -17,7 +17,7 @@
           {
             "type": "command",
             "command": "python3 \"${PLUGIN_ROOT}/scripts/recall.py\" || python \"${PLUGIN_ROOT}/scripts/recall.py\"",
-            "timeout": 12
+            "timeout": 45
           }
         ]
       }

--- a/hindsight-integrations/zcode/hooks/hooks.json
+++ b/hindsight-integrations/zcode/hooks/hooks.json
@@ -17,7 +17,7 @@
           {
             "type": "command",
             "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hindsight_zcode/hooks/scripts/recall.py\" || python \"${CLAUDE_PLUGIN_ROOT}/hindsight_zcode/hooks/scripts/recall.py\"",
-            "timeout": 12
+            "timeout": 45
           }
         ]
       }


### PR DESCRIPTION
## Summary

Fixes #2854 — the hardcoded 12s hook timeout kills the recall process before the MCP request it wraps (which respects the user-configurable `requestTimeoutSeconds`, default 30s) has a chance to complete.

## What changed

### `setup_hooks.py` (Claude Code)
- Now reads `requestTimeoutSeconds` from `~/.hindsight/claude-code.json`
- Derives the hook timeout as `max(requestTimeoutSeconds + 15, 30s)`
- Falls back to 45s when no user config exists

### All 5 integration hook manifests
Bumped the static `"timeout": 12` → `"timeout": 45` in:
- `claude-code/hooks/hooks.json`
- `cursor-cli/hindsight_cursor_cli/hooks/hooks.json`
- `codex/hooks/hooks.json`
- `omo/hooks/hooks.json`
- `zcode/hooks/hooks.json`

## Why

| Stage | Before | After |
|---|---|---|
| Hook process timeout | **12s** (hardcoded) | **45s** default, or `requestTimeoutSeconds + 15` |
| MCP recall request timeout | **30s** (configurable) | unchanged |

A successful auto-recall against a remote server measures ~10s end-to-end. Any extra latency (cold server, larger bank, brief contention) pushes past 12s, and the hook is killed — silently discarding the recall context for that turn.

The same 12s was copy-pasted across all integration hook configs, so any server slow enough to exceed it hit this on every platform.

## Verification

- No other hardcoded `"timeout": 12` instances remain in hook configs
- `setup_hooks.py` gracefully handles missing/invalid user config files
- Minimum timeout floor of 30s prevents accidentally setting a too-low value