### PR TITLE
fix(engine): resolve pg0 database URL before running startup migrations

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -2997,6 +2997,26 @@ class MemoryEngine(MemoryEngineInterface):
         # Run database migrations if enabled
         if self._run_migrations:
             if not self.db_url:
+                # In pg0 mode the URL is resolved asynchronously by start_pg0()
+                # above, but edge cases (Docker with pre-existing pg0 data from a
+                # prior version, slow embedded-postgres startup, or a parallel
+                # init failure that left db_url unset) can leave it empty here.
+                # Fall back to the same canonical resolver the CLI uses
+                # successfully (resolve_database_url) — see #2602.
+                try:
+                    from ..pg0 import resolve_database_url
+
+                    config = get_config()
+                    self.db_url = await resolve_database_url(config.database_url)
+                    if self.db_url:
+                        logger.info(
+                            "Resolved database URL via fallback for migrations: %s",
+                            mask_network_location(self.db_url),
+                        )
+                except Exception:
+                    pass
+
+            if not self.db_url:
                 raise ValueError("Database URL is required for migrations")
 
             config = get_config()


### PR DESCRIPTION
## Summary

Fixes #2602 — when running in pg0 mode (no explicit `HINDSIGHT_API_DATABASE_URL`), the embedded Postgres URL is resolved asynchronously by `start_pg0()`. In edge cases — Docker with pre-existing pg0 data from a prior version, slow embedded-postgres startup, or a parallel init failure — `self.db_url` may still be `None` by the time the migration check runs, causing a crash-loop with:

```
ValueError: Database URL is required for migrations
Error stopping pg0: Failed to stop PostgreSQL: cannot schedule new futures after interpreter shutdown
```

## What changed

Added a fallback in `MemoryEngine.initialize()` that uses `resolve_database_url()` (the same canonical resolver the CLI's `hindsight-admin run-db-migration` command already uses successfully) before raising the error.

```python
if not self.db_url:
    try:
        from ..pg0 import resolve_database_url
        config = get_config()
        self.db_url = await resolve_database_url(config.database_url)
    except Exception:
        pass
```

## Why this approach

- `resolve_database_url()` is already the proven, canonical pg0 URL resolver — the CLI `run-db-migration` path uses it and works correctly
- The fallback is defensive: it only activates when `self.db_url` is still unset after `start_pg0()`, so the normal fast path is unaffected
- Exceptions in the fallback are silently caught — if resolution fails here, we still raise the original `ValueError` with the same message, preserving the existing error contract

## Verification

- Normal path: `start_pg0()` populates `self.db_url` → migration check passes → fallback never reached
- Edge case path: `self.db_url` is None → `resolve_database_url()` resolves pg0 → migration proceeds
- Failure path: both `start_pg0()` and `resolve_database_url()` fail → original `ValueError` is raised