### PR TITLE
fix(control-plane): preserve inherited observations configuration

### DIFF
--- a/hindsight-control-plane/src/components/bank-config-view.tsx
+++ b/hindsight-control-plane/src/components/bank-config-view.tsx
@@ -11,6 +11,13 @@ import {
   type RetainStrategy,
   type RetainStrategyValues,
 } from "@/lib/retain-strategy-config";
+import {
+  mergeObservationsOverrides,
+  mergeResolvedObservations,
+  observationsSlice,
+  reconcileObservationsEdits,
+  type ObservationsEdits,
+} from "@/lib/observations-config";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -60,15 +67,6 @@ type RetainEdits = {
 type StrategiesEdits = {
   retain_default_strategy: string | null;
   retain_strategies: Record<string, Record<string, any>> | null;
-};
-
-type ObservationsEdits = {
-  enable_observations: boolean | null;
-  consolidation_llm_batch_size: number | null;
-  consolidation_source_facts_max_tokens: number | null;
-  consolidation_source_facts_max_tokens_per_observation: number | null;
-  observations_mission: string | null;
-  max_observations_per_scope: number | null;
 };
 
 type LabelValue = { value: string; description: string };
@@ -274,18 +272,6 @@ function strategiesSlice(config: Record<string, any>): StrategiesEdits {
   };
 }
 
-function observationsSlice(config: Record<string, any>): ObservationsEdits {
-  return {
-    enable_observations: config.enable_observations ?? null,
-    consolidation_llm_batch_size: config.consolidation_llm_batch_size ?? null,
-    consolidation_source_facts_max_tokens: config.consolidation_source_facts_max_tokens ?? null,
-    consolidation_source_facts_max_tokens_per_observation:
-      config.consolidation_source_facts_max_tokens_per_observation ?? null,
-    observations_mission: config.observations_mission ?? null,
-    max_observations_per_scope: config.max_observations_per_scope ?? null,
-  };
-}
-
 function mcpSlice(config: Record<string, any>): MCPEdits {
   return {
     mcp_enabled_tools: config.mcp_enabled_tools ?? null,
@@ -340,7 +326,7 @@ export function BankConfigView() {
   const [retainEdits, setRetainEdits] = useState<RetainEdits>(retainSlice({}));
   const [strategiesEdits, setStrategiesEdits] = useState<StrategiesEdits>(strategiesSlice({}));
   const [observationsEdits, setObservationsEdits] = useState<ObservationsEdits>(
-    observationsSlice({})
+    observationsSlice({}, {})
   );
   const [reflectEdits, setReflectEdits] = useState<ProfileData>(DEFAULT_PROFILE);
   const [mcpEdits, setMcpEdits] = useState<MCPEdits>(mcpSlice({}));
@@ -370,8 +356,10 @@ export function BankConfigView() {
     [retainEdits, strategiesEdits, baseConfig]
   );
   const observationsDirty = useMemo(
-    () => JSON.stringify(observationsEdits) !== JSON.stringify(observationsSlice(baseConfig)),
-    [observationsEdits, baseConfig]
+    () =>
+      JSON.stringify(observationsEdits) !==
+      JSON.stringify(observationsSlice(baseConfig, baseOverrides)),
+    [observationsEdits, baseConfig, baseOverrides]
   );
   const reflectDirty = useMemo(
     () => JSON.stringify(reflectEdits) !== JSON.stringify(baseProfile),
@@ -406,6 +394,7 @@ export function BankConfigView() {
         client.getBankProfile(bankId),
       ]);
       const cfg = configResp.config;
+      const overrides = configResp.overrides ?? {};
       const prof: ProfileData = {
         reflect_mission: profileResp.mission ?? "",
         disposition_skepticism:
@@ -415,16 +404,16 @@ export function BankConfigView() {
         disposition_empathy: cfg.disposition_empathy ?? profileResp.disposition?.empathy ?? 3,
       };
       setBaseConfig(cfg);
-      setBaseOverrides(configResp.overrides ?? {});
+      setBaseOverrides(overrides);
       setBaseProfile(prof);
       setRetainEdits(retainSlice(cfg));
       setStrategiesEdits(strategiesSlice(cfg));
-      setObservationsEdits(observationsSlice(cfg));
+      setObservationsEdits(observationsSlice(cfg, overrides));
       setReflectEdits(prof);
       setMcpEdits(mcpSlice(cfg));
       setGeminiEdits(geminiSlice(cfg));
-      setAuditEdits(auditSlice(configResp.overrides ?? {}));
-      setDocStorageEdits(docStorageSlice(configResp.overrides ?? {}));
+      setAuditEdits(auditSlice(overrides));
+      setDocStorageEdits(docStorageSlice(overrides));
     } catch (err) {
       console.error("Failed to load bank data:", err);
     } finally {
@@ -451,9 +440,17 @@ export function BankConfigView() {
     if (!bankId) return;
     setObservationsSaving(true);
     setObservationsError(null);
+    const submittedEdits = observationsEdits;
     try {
-      await client.updateBankConfig(bankId, observationsEdits);
-      setBaseConfig((prev) => ({ ...prev, ...observationsEdits }));
+      const response = await client.updateBankConfig(bankId, submittedEdits);
+      // Overrides are a complete bank-only snapshot. Resolved config may omit
+      // permission-filtered fields, so merge it against the accepted payload.
+      const overrides = response.overrides ?? {};
+      setBaseConfig((prev) => mergeResolvedObservations(prev, submittedEdits, response.config));
+      setBaseOverrides((prev) => mergeObservationsOverrides(prev, overrides));
+      setObservationsEdits((current) =>
+        reconcileObservationsEdits(current, submittedEdits, response.config, overrides)
+      );
     } catch (err: any) {
       setObservationsError(err.message || t("observationsFailedToSave"));
     } finally {
@@ -622,14 +619,38 @@ export function BankConfigView() {
             label={t("enableObservationsLabel")}
             description={t("enableObservationsDescription")}
           >
-            <div className="flex justify-end">
-              <Switch
-                checked={observationsEdits.enable_observations ?? false}
-                onCheckedChange={(v) =>
-                  setObservationsEdits((prev) => ({ ...prev, enable_observations: v }))
-                }
-              />
-            </div>
+            <Select
+              value={
+                observationsEdits.enable_observations === null
+                  ? INHERIT_SENTINEL
+                  : String(observationsEdits.enable_observations)
+              }
+              onValueChange={(v) =>
+                setObservationsEdits((prev) => ({
+                  ...prev,
+                  enable_observations: v === INHERIT_SENTINEL ? null : v === "true",
+                }))
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={INHERIT_SENTINEL}>
+                  {/* The resolved value reveals the parent default only when
+                      there is no bank override. */}
+                  {(baseOverrides.enable_observations === undefined ||
+                    baseOverrides.enable_observations === null) &&
+                  typeof baseConfig.enable_observations === "boolean"
+                    ? t("auditServerDefault", {
+                        state: baseConfig.enable_observations ? t("enabled") : t("disabled"),
+                      })
+                    : t("serverDefault")}
+                </SelectItem>
+                <SelectItem value="true">{t("enabled")}</SelectItem>
+                <SelectItem value="false">{t("disabled")}</SelectItem>
+              </SelectContent>
+            </Select>
           </FieldRow>
           <TextareaRow
             label={t("missionLabel")}

--- a/hindsight-control-plane/src/lib/observations-config.ts
+++ b/hindsight-control-plane/src/lib/observations-config.ts
@@ -1,0 +1,111 @@
+export type ObservationsEdits = {
+  enable_observations: boolean | null;
+  consolidation_llm_batch_size: number | null;
+  consolidation_source_facts_max_tokens: number | null;
+  consolidation_source_facts_max_tokens_per_observation: number | null;
+  observations_mission: string | null;
+  max_observations_per_scope: number | null;
+};
+
+type ObservationsConfig = Partial<ObservationsEdits> & Record<string, unknown>;
+type ObservationsOverridesSnapshot = Pick<Partial<ObservationsEdits>, "enable_observations"> &
+  Record<string, unknown>;
+type ObservationsOverridesResponse = ObservationsOverridesSnapshot | null | undefined;
+const OBSERVATIONS_KEYS = [
+  "enable_observations",
+  "consolidation_llm_batch_size",
+  "consolidation_source_facts_max_tokens",
+  "consolidation_source_facts_max_tokens_per_observation",
+  "observations_mission",
+  "max_observations_per_scope",
+] as const satisfies readonly (keyof ObservationsEdits)[];
+
+function resolvedObservationsSlice(resolvedConfig: ObservationsConfig): ObservationsEdits {
+  return {
+    enable_observations: resolvedConfig.enable_observations ?? null,
+    consolidation_llm_batch_size: resolvedConfig.consolidation_llm_batch_size ?? null,
+    consolidation_source_facts_max_tokens:
+      resolvedConfig.consolidation_source_facts_max_tokens ?? null,
+    consolidation_source_facts_max_tokens_per_observation:
+      resolvedConfig.consolidation_source_facts_max_tokens_per_observation ?? null,
+    observations_mission: resolvedConfig.observations_mission ?? null,
+    max_observations_per_scope: resolvedConfig.max_observations_per_scope ?? null,
+  };
+}
+
+export function observationsSlice(
+  resolvedConfig: ObservationsConfig,
+  overrides: ObservationsOverridesResponse
+): ObservationsEdits {
+  return {
+    ...resolvedObservationsSlice(resolvedConfig),
+    // The resolved value cannot distinguish inheritance from an explicit bank
+    // override. Keep only this field override-aware so the other controls retain
+    // their existing resolved-value behavior.
+    enable_observations: overrides?.enable_observations ?? null,
+  };
+}
+
+export function mergeResolvedObservations(
+  currentConfig: Record<string, unknown>,
+  submittedEdits: ObservationsEdits,
+  resolvedConfig: ObservationsConfig
+): Record<string, unknown> {
+  // A section save must not move another editor's baseline if the response also
+  // reflects a concurrent or canonicalized value outside Observations. Config
+  // may omit permission-filtered fields, so accepted submitted values become
+  // their baseline unless the response supplies a canonical value.
+  const next = { ...currentConfig };
+  for (const key of OBSERVATIONS_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(resolvedConfig, key)) {
+      next[key] = resolvedConfig[key] ?? null;
+    } else if (key === "enable_observations" && submittedEdits[key] === null) {
+      // After clearing an override, the old resolved value represented that
+      // override. Drop it when permissions hide the new parent value.
+      delete next[key];
+    } else {
+      next[key] = submittedEdits[key];
+    }
+  }
+  return next;
+}
+
+export function mergeObservationsOverrides(
+  currentOverrides: Record<string, unknown>,
+  responseOverrides: ObservationsOverridesResponse
+): Record<string, unknown> {
+  // PATCH returns a complete bank-override snapshot. An absent key therefore
+  // means the null tombstone was applied and the bank now inherits its parent.
+  const next = { ...currentOverrides };
+  const value = responseOverrides?.enable_observations;
+  if (value === null || value === undefined) delete next.enable_observations;
+  else next.enable_observations = value;
+  return next;
+}
+
+export function reconcileObservationsEdits(
+  currentEdits: ObservationsEdits,
+  submittedEdits: ObservationsEdits,
+  resolvedConfig: ObservationsConfig,
+  responseOverrides: ObservationsOverridesResponse
+): ObservationsEdits {
+  const responseEdits = observationsSlice(
+    { ...submittedEdits, ...resolvedConfig },
+    responseOverrides
+  );
+  const reconcileField = <K extends keyof ObservationsEdits>(key: K): ObservationsEdits[K] =>
+    Object.is(currentEdits[key], submittedEdits[key]) ? responseEdits[key] : currentEdits[key];
+
+  // Inputs remain editable during a save. Preserve only fields changed after
+  // submission, while accepting canonical response values for untouched fields.
+  return {
+    enable_observations: reconcileField("enable_observations"),
+    consolidation_llm_batch_size: reconcileField("consolidation_llm_batch_size"),
+    consolidation_source_facts_max_tokens: reconcileField("consolidation_source_facts_max_tokens"),
+    consolidation_source_facts_max_tokens_per_observation: reconcileField(
+      "consolidation_source_facts_max_tokens_per_observation"
+    ),
+    observations_mission: reconcileField("observations_mission"),
+    max_observations_per_scope: reconcileField("max_observations_per_scope"),
+  };
+}

--- a/hindsight-control-plane/tests/lib/observations-config.test.ts
+++ b/hindsight-control-plane/tests/lib/observations-config.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  mergeObservationsOverrides,
+  mergeResolvedObservations,
+  observationsSlice,
+  reconcileObservationsEdits,
+} from "../../src/lib/observations-config";
+
+describe("observations config state", () => {
+  it.each([true, false])(
+    "keeps a resolved %s value inherited when the bank has no override",
+    (resolvedValue) => {
+      const edits = observationsSlice(
+        {
+          enable_observations: resolvedValue,
+          consolidation_llm_batch_size: 12,
+          observations_mission: "Resolve from the parent configuration",
+        },
+        {}
+      );
+
+      expect(edits).toMatchObject({
+        enable_observations: null,
+        consolidation_llm_batch_size: 12,
+        observations_mission: "Resolve from the parent configuration",
+      });
+    }
+  );
+
+  it.each([true, false])("preserves an explicit %s bank override", (overrideValue) => {
+    const edits = observationsSlice(
+      { enable_observations: overrideValue },
+      { enable_observations: overrideValue }
+    );
+
+    expect(edits.enable_observations).toBe(overrideValue);
+  });
+
+  it("uses the PATCH response layers when resetting the saved state", () => {
+    const edits = observationsSlice(
+      {
+        enable_observations: false,
+        consolidation_llm_batch_size: 24,
+        consolidation_source_facts_max_tokens: 10_000,
+        consolidation_source_facts_max_tokens_per_observation: 2_000,
+        observations_mission: "Returned resolved state",
+        max_observations_per_scope: 8,
+      },
+      { enable_observations: true, consolidation_llm_batch_size: 6 }
+    );
+
+    expect(edits).toEqual({
+      enable_observations: true,
+      consolidation_llm_batch_size: 24,
+      consolidation_source_facts_max_tokens: 10_000,
+      consolidation_source_facts_max_tokens_per_observation: 2_000,
+      observations_mission: "Returned resolved state",
+      max_observations_per_scope: 8,
+    });
+  });
+
+  it("updates only observation baselines from a PATCH response", () => {
+    const submitted = observationsSlice(
+      { enable_observations: false, consolidation_llm_batch_size: 24 },
+      { enable_observations: false }
+    );
+    const nextConfig = mergeResolvedObservations(
+      {
+        retain_chunk_size: 3_000,
+        audit_log_enabled: true,
+        enable_observations: true,
+        consolidation_llm_batch_size: 12,
+      },
+      submitted,
+      {
+        // Unrelated response values must not move another section's baseline.
+        enable_observations: false,
+        consolidation_llm_batch_size: 24,
+        retain_chunk_size: 9_000,
+        audit_log_enabled: false,
+      }
+    );
+
+    expect(nextConfig).toMatchObject({
+      retain_chunk_size: 3_000,
+      audit_log_enabled: true,
+      enable_observations: false,
+      consolidation_llm_batch_size: 24,
+    });
+  });
+
+  it("uses accepted values for permission-filtered response fields", () => {
+    const submitted = observationsSlice(
+      {
+        enable_observations: true,
+        consolidation_llm_batch_size: 24,
+        observations_mission: "Accepted mission",
+      },
+      {}
+    );
+    const nextConfig = mergeResolvedObservations(
+      {
+        enable_observations: true,
+        consolidation_llm_batch_size: 12,
+        observations_mission: "Old mission",
+      },
+      submitted,
+      { enable_observations: true }
+    );
+
+    expect(nextConfig).toMatchObject({
+      enable_observations: true,
+      consolidation_llm_batch_size: 24,
+      observations_mission: "Accepted mission",
+    });
+  });
+
+  it("drops a stale resolved boolean when the cleared parent value is filtered", () => {
+    const submitted = observationsSlice({ enable_observations: false }, {});
+    const nextConfig = mergeResolvedObservations({ enable_observations: false }, submitted, {});
+
+    expect(nextConfig).not.toHaveProperty("enable_observations");
+  });
+
+  it("preserves unrelated overrides while applying the boolean tombstone", () => {
+    const currentOverrides = {
+      audit_log_enabled: true,
+      enable_observations: false,
+    };
+
+    expect(mergeObservationsOverrides(currentOverrides, {})).toEqual({
+      audit_log_enabled: true,
+    });
+    expect(mergeObservationsOverrides(currentOverrides, { enable_observations: true })).toEqual({
+      audit_log_enabled: true,
+      enable_observations: true,
+    });
+  });
+
+  it.each([undefined, null])("treats a %s override snapshot as empty", (overrides) => {
+    expect(
+      observationsSlice({ enable_observations: true }, overrides).enable_observations
+    ).toBeNull();
+    expect(
+      mergeObservationsOverrides({ audit_log_enabled: true, enable_observations: false }, overrides)
+    ).toEqual({ audit_log_enabled: true });
+  });
+
+  it("does not discard edits made while a PATCH is in flight", () => {
+    const submitted = observationsSlice(
+      {
+        enable_observations: true,
+        consolidation_llm_batch_size: 12,
+        observations_mission: "Submitted mission",
+      },
+      {}
+    );
+    const editedDuringSave = { ...submitted, observations_mission: "Newer mission" };
+    const responseConfig = {
+      enable_observations: true,
+      consolidation_llm_batch_size: 10,
+      observations_mission: "Submitted mission",
+    };
+
+    expect(reconcileObservationsEdits(submitted, submitted, responseConfig, {})).toEqual({
+      ...submitted,
+      consolidation_llm_batch_size: 10,
+    });
+    expect(reconcileObservationsEdits(editedDuringSave, submitted, responseConfig, {})).toEqual({
+      ...editedDuringSave,
+      consolidation_llm_batch_size: 10,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- model `enable_observations` as an inherited/enabled/disabled bank setting instead of collapsing inheritance into a boolean switch
- derive the boolean from bank-only overrides while keeping the other Observations fields on their resolved values
- reconcile PATCH responses per field so server canonicalization and edits made during an in-flight save are both preserved

## Why

#2827 called out the same latent inheritance gap for `enable_observations`. The bank config endpoint returns both the resolved hierarchy and bank-only overrides, but the UI initialized the Observations boolean from the resolved value and sent it back on every section save. Saving an unrelated Observations field could therefore create a sticky bank override and prevent later tenant or server policy changes from propagating.

The tri-state control sends `null` to clear the bank override. It shows the current inherited state when the resolved value is available, and stays neutral when permission filtering makes that parent value unavailable.

## Test plan

- `npm test -w @vectorize-io/hindsight-control-plane` (86 tests)
- `npm exec -w @vectorize-io/hindsight-control-plane tsc -- --noEmit`
- `npm run i18n:check -w @vectorize-io/hindsight-control-plane`
- `./scripts/hooks/lint.sh`
- `npm run build -w @vectorize-io/hindsight-control-plane`
