### PR TITLE
feat(control-plane): display API version in sidebar footer

### DIFF
--- a/hindsight-control-plane/src/components/sidebar.tsx
+++ b/hindsight-control-plane/src/components/sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useBank } from "@/lib/bank-context";
 import { bankRoute } from "@/lib/bank-url";
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
+import { client } from "@/lib/api";
 
 type NavItem = "recall" | "reflect" | "data" | "documents" | "entities" | "profile";
 
@@ -29,6 +30,14 @@ export function Sidebar({ currentTab, onTabChange }: SidebarProps) {
   const tBank = useTranslations("bank");
   const { currentBank } = useBank();
   const [isCollapsed, setIsCollapsed] = useState(true);
+  const [apiVersion, setApiVersion] = useState<string | null>(null);
+
+  useEffect(() => {
+    client
+      .getVersion()
+      .then((v) => setApiVersion(v.api_version))
+      .catch(() => setApiVersion(null));
+  }, []);
 
   if (!currentBank) {
     return null;
@@ -90,6 +99,17 @@ export function Sidebar({ currentTab, onTabChange }: SidebarProps) {
 
       {/* Collapse/Expand button at bottom */}
       <div className="p-3 border-t border-border">
+        {apiVersion && (
+          <div
+            className={cn(
+              "mb-2 text-xs text-muted-foreground/60 text-center select-none",
+              isCollapsed ? "px-0" : "px-1"
+            )}
+            title={`Hindsight API v${apiVersion}`}
+          >
+            {isCollapsed ? `v${apiVersion}` : `Hindsight v${apiVersion}`}
+          </div>
+        )}
         <button
           onClick={() => setIsCollapsed(!isCollapsed)}
           className={cn(


### PR DESCRIPTION
## Summary

Fixes #776 — the Hindsight web UI (control plane, port 9999) now shows the API version fetched from `GET /version` in the sidebar footer.

## What changed

`hindsight-control-plane/src/components/sidebar.tsx`:
- Imports `useEffect` and the existing `client.getVersion()` helper
- Fetches `api_version` on mount (one call, cached by React strict mode dedup)
- Renders the version in the sidebar footer, above the collapse/expand button:
  - **Collapsed:** `v0.8.4`
  - **Expanded:** `Hindsight v0.8.4`
- Gracefully degrades: if the fetch fails, no version is shown (no error UI clutter)

## Why

The `/version` endpoint has existed in the API since the beginning, and the control plane already calls it in `bank-selector.tsx` for feature-flag detection. But the version was never surfaced anywhere visible to the user. For self-hosted deployments and Docker Desktop extensions, this makes debugging and support harder — there is no way to tell which version is running by looking at the UI.

## Verification

- Uses the existing `client.getVersion()` (same path as `bank-selector.tsx`, already covered by the middleware whitelist)
- No new dependencies or API calls
- One file changed, 21 insertions