### PR TITLE
fix(providers): skip strict json_schema for MiniMax — degrades output

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -83,6 +83,12 @@ def _validate_ollama_num_ctx(value: Any) -> int | None:
 # intentionally excluded (#1179).
 _TOOL_CHOICE_REQUIRED_UNSUPPORTED_PROVIDERS = frozenset({"lmstudio", "ollama"})
 
+# Providers that accept a json_schema / strict:true response_format but do not
+# actually grammar-enforce the output — and perversely output *worse* JSON
+# (e.g. fence-wrapped) than the default json_object mode.
+# See #2674 (MiniMax-M3).
+_STRICT_SCHEMA_UNSUPPORTED_PROVIDERS = frozenset({"minimax"})
+
 
 class ProviderResponseError(RuntimeError):
     """Raised when a provider returns a success response without usable content."""
@@ -829,7 +835,7 @@ class OpenAICompatibleLLM(LLMInterface):
             if hasattr(response_format, "model_json_schema"):
                 schema = strict_json_schema(response_format) if strict_schema else response_format.model_json_schema()
 
-            if strict_schema and schema is not None:
+            if strict_schema and schema is not None and self.provider not in _STRICT_SCHEMA_UNSUPPORTED_PROVIDERS:
                 # Use OpenAI's strict JSON schema enforcement
                 call_params["response_format"] = {
                     "type": "json_schema",


### PR DESCRIPTION
## Summary

Fixes #2674 — MiniMax-M3 accepts `json_schema` with `strict: true` (HTTP 200, no error) but does not actually grammar-enforce the output. Worse, enabling `strict: true` makes the output *degrade*: the model wraps valid JSON in markdown code fences, while the default `json_object` mode produces clean, bare JSON.

## What changed

`hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py`:

- Added `_STRICT_SCHEMA_UNSUPPORTED_PROVIDERS` (analogous to the existing `_TOOL_CHOICE_REQUIRED_UNSUPPORTED_PROVIDERS`) containing `"minimax"`
- The `strict_schema` path now checks `self.provider not in _STRICT_SCHEMA_UNSUPPORTED_PROVIDERS` before emitting `json_schema` with `strict: true`

Providers in this set fall through to the existing `json_object` mode, which injects the schema into the system prompt — the path that already produces clean, parseable JSON for MiniMax-M3.

## Evidence (from issue #2674)

| Mode | MiniMax-M3 output | `json.loads` |
|------|-------------------|-------------|
| `json_object` (default) | `{"name":"Alice","age":30}` | ✅ |
| `json_schema` WITHOUT strict | `{"name": "Alice", "age": 30}` | ✅ |
| `json_schema` WITH `strict: true` | ` ```json\n{"name":"Alice","age":30}\n``` ` | ❌ |

## Why this approach

- Follows the same pattern as `_TOOL_CHOICE_REQUIRED_UNSUPPORTED_PROVIDERS` (line 84)
- Easy to extend: add any future provider that exhibits the same behavior
- Zero overhead for providers that *do* support strict schema (the check is a `frozenset` membership test)
- The fallback path (schema-in-prompt + `json_object`) is already battle-tested — it is what MiniMax users have been using successfully with `strict_schema=false`