### PR TITLE
Fix within-batch cosine similarity for non-unit embeddings

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -666,7 +666,7 @@ def compute_semantic_links_within_batch(
     """
     Compute semantic links between units within the same batch (no DB needed).
 
-    Uses numpy dot product on embeddings already in memory — instant.
+    Uses cosine similarity on embeddings already in memory — instant.
 
     Args:
         unit_ids: Unit IDs (real IDs from insert_facts_batch)
@@ -683,15 +683,25 @@ def compute_semantic_links_within_batch(
     import numpy as np
 
     links = []
-    new_embeddings_matrix = np.array(embeddings)
+    new_embeddings_matrix = np.asarray(embeddings, dtype=float)
+    norms = np.linalg.norm(new_embeddings_matrix, axis=1)
+    valid_embeddings = np.isfinite(new_embeddings_matrix).all(axis=1) & np.isfinite(norms) & (norms > 0)
+    normalized_embeddings = np.zeros_like(new_embeddings_matrix)
+    normalized_embeddings[valid_embeddings] = (
+        new_embeddings_matrix[valid_embeddings] / norms[valid_embeddings, np.newaxis]
+    )
 
     for i, unit_id in enumerate(unit_ids):
+        if not valid_embeddings[i]:
+            continue
+
         other_indices = [j for j in range(len(unit_ids)) if j != i]
         if not other_indices:
             continue
 
-        other_embeddings = new_embeddings_matrix[other_indices]
-        similarities = np.dot(other_embeddings, new_embeddings_matrix[i])
+        other_embeddings = normalized_embeddings[other_indices]
+        similarities = np.dot(other_embeddings, normalized_embeddings[i])
+        similarities[~valid_embeddings[other_indices]] = -np.inf
 
         above_threshold = np.where(similarities >= threshold)[0]
         if len(above_threshold) > 0:

--- a/hindsight-api-slim/tests/test_link_utils.py
+++ b/hindsight-api-slim/tests/test_link_utils.py
@@ -348,6 +348,22 @@ class TestComputeSemanticLinksWithinBatch:
         links = compute_semantic_links_within_batch(["u1", "u2"], [emb1, emb2])
         assert len(links) == 0
 
+    def test_non_unit_embeddings_use_cosine_similarity(self):
+        """Vector magnitude must not turn a below-threshold cosine pair into a link."""
+        emb1 = [10.0, 0.0]
+        emb2 = [1.0, 1.0]
+
+        links = compute_semantic_links_within_batch(["u1", "u2"], [emb1, emb2], threshold=0.9)
+
+        assert links == []
+
+    @pytest.mark.parametrize("invalid", [[0.0, 0.0], [float("nan"), 1.0], [float("inf"), 1.0]])
+    def test_invalid_cosine_embeddings_do_not_link(self, invalid):
+        """Zero-norm and non-finite vectors have no defined cosine similarity."""
+        links = compute_semantic_links_within_batch(["invalid", "valid"], [invalid, [1.0, 0.0]], threshold=0.0)
+
+        assert links == []
+
     def test_respects_threshold(self):
         """Links below threshold should be excluded."""
         emb1 = np.random.randn(384).tolist()


### PR DESCRIPTION
Closes #2873.

Within-batch semantic links currently use a raw dot product even though the configured threshold is cosine similarity and the database path uses pgvector cosine distance. This makes link creation depend on vector magnitude for providers that return non-unit embeddings.

This change normalizes finite, non-zero vectors before the dot product and excludes zero-norm/non-finite vectors, whose cosine similarity is undefined. It adds regression coverage for both the magnitude mismatch and invalid vectors.

Verification:
- `uv run --project hindsight-api-slim pytest hindsight-api-slim/tests/test_link_utils.py -q` (44 passed)
- `uv run --project hindsight-api-slim ruff check hindsight-api-slim/hindsight_api/engine/retain/link_utils.py`
- `uv run --project hindsight-api-slim ruff format --check hindsight-api-slim/hindsight_api/engine/retain/link_utils.py hindsight-api-slim/tests/test_link_utils.py`
- `git diff --check`

Note: the repository-wide pre-commit lint reached unrelated frontend checks without installed `@eslint/js`; the focused Python tests and source lint above pass.