### PR TITLE
fix(curation): preserve causal links across invalidation

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/f3a9c1e7b2d4_add_causal_link_provenance.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/f3a9c1e7b2d4_add_causal_link_provenance.py
@@ -1,0 +1,86 @@
+"""Add durable causal-link provenance to live and archived memories.
+
+``memory_links`` remains the materialized graph used by retrieval. The new
+JSON field carries the small causal descriptor set with both endpoint memories
+so curation can restore an edge after both endpoints become live again.
+
+Revision ID: f3a9c1e7b2d4
+Revises: d7b2f8a1c934
+Create Date: 2026-07-22
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "f3a9c1e7b2d4"
+down_revision: str | Sequence[str] | None = "d7b2f8a1c934"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _pg_schema_prefix() -> str:
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def _pg_upgrade() -> None:
+    schema = _pg_schema_prefix()
+    for table in ("memory_units", "invalidated_memory_units"):
+        op.execute(
+            f"ALTER TABLE {schema}{table} "
+            "ADD COLUMN IF NOT EXISTS suspended_causal_links JSONB NOT NULL DEFAULT '[]'::jsonb"
+        )
+
+
+def _pg_downgrade() -> None:
+    schema = _pg_schema_prefix()
+    for table in ("invalidated_memory_units", "memory_units"):
+        op.execute(f"ALTER TABLE {schema}{table} DROP COLUMN IF EXISTS suspended_causal_links")
+
+
+def _oracle_add_column(table: str, constraint: str) -> None:
+    op.execute(
+        f"""
+        BEGIN
+            EXECUTE IMMEDIATE 'ALTER TABLE {table} ADD (
+                suspended_causal_links CLOB DEFAULT ''[]'' NOT NULL
+                CONSTRAINT {constraint} CHECK (suspended_causal_links IS JSON)
+            )';
+        EXCEPTION WHEN OTHERS THEN
+            IF SQLCODE != -1430 THEN RAISE; END IF;
+        END;
+        """
+    )
+
+
+def _oracle_drop_column(table: str) -> None:
+    op.execute(
+        f"""
+        BEGIN
+            EXECUTE IMMEDIATE 'ALTER TABLE {table} DROP COLUMN suspended_causal_links';
+        EXCEPTION WHEN OTHERS THEN
+            IF SQLCODE != -904 THEN RAISE; END IF;
+        END;
+        """
+    )
+
+
+def _oracle_upgrade() -> None:
+    _oracle_add_column("memory_units", "ck_mu_suspended_causal_json")
+    _oracle_add_column("invalidated_memory_units", "ck_imu_suspended_causal_json")
+
+
+def _oracle_downgrade() -> None:
+    _oracle_drop_column("invalidated_memory_units")
+    _oracle_drop_column("memory_units")
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade, oracle=_oracle_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade, oracle=_oracle_downgrade)

--- a/hindsight-api-slim/hindsight_api/engine/causal_links.py
+++ b/hindsight-api-slim/hindsight_api/engine/causal_links.py
@@ -5,9 +5,32 @@ preserves historical relationship types so existing banks keep their graph
 semantics without allowing new retain output to create those types.
 """
 
-CANONICAL_CAUSAL_LINK_TYPE = "caused_by"
-LEGACY_CAUSAL_LINK_TYPE_NAMES = ("causes", "enables", "prevents")
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+CausalLinkType = Literal["caused_by", "causes", "enables", "prevents"]
+
+CANONICAL_CAUSAL_LINK_TYPE: CausalLinkType = "caused_by"
+LEGACY_CAUSAL_LINK_TYPE_NAMES: tuple[CausalLinkType, ...] = ("causes", "enables", "prevents")
 
 CANONICAL_CAUSAL_LINK_TYPES = frozenset({CANONICAL_CAUSAL_LINK_TYPE})
 LEGACY_CAUSAL_LINK_TYPES = frozenset(LEGACY_CAUSAL_LINK_TYPE_NAMES)
 CAUSAL_LINK_TYPES = (CANONICAL_CAUSAL_LINK_TYPE, *LEGACY_CAUSAL_LINK_TYPE_NAMES)
+
+
+class CausalLinkDescriptor(BaseModel):
+    """Durable causal provenance carried by both endpoint memory units."""
+
+    model_config = ConfigDict(frozen=True)
+
+    from_unit_id: UUID
+    to_unit_id: UUID
+    link_type: CausalLinkType
+    weight: float = Field(ge=0.0, le=1.0)
+
+    @property
+    def identity(self) -> str:
+        """Stable key used to deduplicate materialized and persisted copies."""
+        return f"{self.from_unit_id}:{self.to_unit_id}:{self.link_type}"

--- a/hindsight-api-slim/hindsight_api/engine/db/oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/oracle.py
@@ -155,6 +155,7 @@ _JSON_COL_NAMES = {
     "result_metadata",
     "task_payload",
     "history",
+    "suspended_causal_links",
 }
 # NOTE: the history tables' JSON payload column is named ``content`` — deliberately
 # NOT added here, because ``mental_models.content`` is plain text (adding "content"

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -6150,13 +6150,31 @@ class MemoryEngine(MemoryEngineInterface):
         bank_id_for_graph_maintenance: str | None = None
         async with acquire_with_retry(backend) as conn:
             async with conn.transaction():
-                # Get bank_id and fact_type before deletion
+                # Get bank_id and fact_type before deletion.
                 row = await conn.fetchrow(
                     f"SELECT bank_id, fact_type FROM {fq_table('memory_units')} WHERE id = $1",
                     str(unit_uuid),
                 )
+                if row:
+                    from .retain.link_utils import clear_incident_causal_links, lock_incident_causal_link_endpoints
+
+                    # The discovery read above is intentionally unlocked. Acquire
+                    # the shared endpoint lock set, then re-read the live row so a
+                    # concurrent invalidation cannot make this delete clear causal
+                    # state for a memory it no longer deletes.
+                    await lock_incident_causal_link_endpoints(conn, row["bank_id"], unit_uuid)
+                    row = await conn.fetchrow(
+                        f"SELECT bank_id, fact_type FROM {fq_table('memory_units')} WHERE id = $1",
+                        str(unit_uuid),
+                    )
+
                 bank_id = row["bank_id"] if row else None
                 fact_type = row["fact_type"] if row else None
+
+                if bank_id:
+                    # Remove the durable descriptor from the surviving endpoint
+                    # before this row and its materialized links disappear.
+                    await clear_incident_causal_links(conn, bank_id, unit_uuid, endpoints_locked=True)
 
                 # Capture relink victims BEFORE the cascade — once the row is
                 # gone, the join finding them returns nothing.
@@ -6676,15 +6694,16 @@ class MemoryEngine(MemoryEngineInterface):
         - **Edit** (``text``/``context``/``occurred_start``/``occurred_end``/
           ``new_fact_type``/``entities``): correct what the LLM extracted.
           Re-embeds (text + dates + entities feed the embedding), drops derived
-          observations + links, and re-consolidates. For date/context fields,
-          ``""`` clears to NULL and ``None`` leaves unchanged; ``new_fact_type``
-          must be world/experience. ``entities`` (when not None) replaces the
-          unit's entity set: names are resolved/find-or-created via the same
-          resolver retain uses, ``unit_entities`` + cooccurrence are rebuilt, and
-          ``[]`` detaches all entities. Entities orphaned by the swap, and any
-          now-stale cooccurrence rows, are reclaimed by the graph-maintenance
-          sweep that this edit submits (entity edges live in ``unit_entities``,
-          not ``memory_links``, so there is nothing to relink directly).
+          observations and temporal/semantic links, and re-consolidates. Causal
+          links are dropped only when the stored text actually changes. For
+          date/context fields, ``""`` clears to NULL and ``None`` leaves unchanged;
+          ``new_fact_type`` must be world/experience. ``entities`` (when not None)
+          replaces the unit's entity set: names are resolved/find-or-created via
+          the same resolver retain uses, ``unit_entities`` + cooccurrence are
+          rebuilt, and ``[]`` detaches all entities. Entities orphaned by the swap,
+          and any now-stale cooccurrence rows, are reclaimed by the graph-maintenance
+          sweep that this edit submits (entity edges live in ``unit_entities``, not
+          ``memory_links``, so there is nothing to relink directly).
         - **Invalidate** (``state='invalidated'``): move the row to the archive
           (cascade-pruning its links/entity associations and re-deriving dependent
           observations). The archive is cold storage, so the embedding is dropped
@@ -6738,7 +6757,13 @@ class MemoryEngine(MemoryEngineInterface):
 
         backend = await self._get_backend()
         from .graph_maintenance import enqueue_relink_victims
-        from .retain.link_utils import resolve_entities_only
+        from .retain.link_utils import (
+            clear_incident_causal_links,
+            hydrate_incident_causal_descriptors,
+            lock_incident_causal_link_endpoints,
+            materialize_live_causal_descriptors,
+            resolve_entities_only,
+        )
 
         # Resolve the bank's entity-label taxonomy once when re-resolving entities,
         # so corrected entities are matched with the same rules retain uses.
@@ -6759,6 +6784,14 @@ class MemoryEngine(MemoryEngineInterface):
 
         async with acquire_with_retry(backend) as conn:
             async with conn.transaction():
+                # Text edits and state moves can invalidate, suspend, or restore
+                # causal assertions. Lock the complete endpoint set before reading
+                # the actionable state. In particular, restore must lock while the
+                # target still lives only in the archive; otherwise two concurrent
+                # endpoint restores can each miss the other's uncommitted live row.
+                if text is not None or state is not None:
+                    await lock_incident_causal_link_endpoints(conn, bank_id, memory_uuid)
+
                 live = await conn.fetchrow(
                     f"SELECT text, context, fact_type, event_date, occurred_start, occurred_end, mentioned_at "
                     f"FROM {mu} WHERE id = $1 AND bank_id = $2",
@@ -6805,6 +6838,7 @@ class MemoryEngine(MemoryEngineInterface):
                     if not live:
                         raise ValueError("Cannot edit an invalidated memory; revert it to 'valid' first.")
                     new_text = text if text is not None else live["text"]
+                    text_changed = new_text != live["text"]
                     new_context = (context or None) if context is not None else live["context"]
                     new_fact = new_fact_type if new_fact_type is not None else live["fact_type"]
                     new_occ_start = (
@@ -6872,6 +6906,11 @@ class MemoryEngine(MemoryEngineInterface):
                         f",\n                            search_vector = {sv_expr}" if sv_expr else ""
                     )
                     await enqueue_relink_victims(conn, bank_id, [memory_id], ops=backend.ops)
+                    if text_changed:
+                        # Causal links are retain-time assertions, not graph-derived
+                        # data. A changed proposition invalidates both incoming and
+                        # outgoing assertions; non-text edits leave them untouched.
+                        await clear_incident_causal_links(conn, bank_id, memory_uuid, endpoints_locked=True)
                     await conn.execute(
                         f"""
                         UPDATE {mu}
@@ -6891,13 +6930,25 @@ class MemoryEngine(MemoryEngineInterface):
                         new_event_date,
                         new_emb,
                     )
-                    await conn.execute(f"DELETE FROM {ml} WHERE from_unit_id = $1 OR to_unit_id = $1", str(memory_uuid))
+                    await conn.execute(
+                        f"DELETE FROM {ml} WHERE (from_unit_id = $1 OR to_unit_id = $1) "
+                        f"AND link_type IN ('temporal', 'semantic')",
+                        str(memory_uuid),
+                    )
                     await self._delete_stale_observations_for_memories(conn, bank_id, [memory_id])
                     need_consolidation = True
                     need_graph = True
 
                 # --- Invalidate: move live → archive ---
                 if state == "invalidated" and live:
+                    # Persist causal provenance on both endpoint rows before the
+                    # memory-unit delete cascades through memory_links.
+                    await hydrate_incident_causal_descriptors(
+                        conn,
+                        bank_id,
+                        memory_uuid,
+                        endpoints_locked=True,
+                    )
                     entity_ids = [
                         r["entity_id"]
                         for r in await conn.fetch(f"SELECT entity_id FROM {ue} WHERE unit_id = $1", str(memory_uuid))
@@ -6955,7 +7006,9 @@ class MemoryEngine(MemoryEngineInterface):
                             str(memory_uuid),
                             bank_id,
                         )
-                    # Re-consolidate from scratch; links are rebuilt by graph maintenance.
+                    # Re-consolidate from scratch. Graph maintenance rebuilds
+                    # temporal/semantic links; suspended causal links are restored
+                    # explicitly below once both endpoints are live.
                     await conn.execute(
                         f"UPDATE {mu} SET consolidated_at = NULL, consolidation_failed_at = NULL, updated_at = now() "
                         f"WHERE id = $1 AND bank_id = $2",
@@ -7003,6 +7056,13 @@ class MemoryEngine(MemoryEngineInterface):
                                 bank_id,
                                 new_emb,
                             )
+                    await materialize_live_causal_descriptors(
+                        conn,
+                        bank_id,
+                        memory_uuid,
+                        backend.ops,
+                        endpoints_locked=True,
+                    )
                     await conn.execute(f"DELETE FROM {arch} WHERE id = $1 AND bank_id = $2", str(memory_uuid), bank_id)
                     need_consolidation = True
                     need_graph = True

--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -1,13 +1,20 @@
-"""
-Link creation utilities for temporal, semantic, and entity links.
-"""
+"""Link creation utilities for temporal, semantic, entity, and causal links."""
 
+import json
 import logging
 import time
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID
 
 from ..._vector_index import ann_search_tuning_settings, configured_vector_extension
-from ..causal_links import CANONICAL_CAUSAL_LINK_TYPES, LEGACY_CAUSAL_LINK_TYPES
+from ..causal_links import (
+    CANONICAL_CAUSAL_LINK_TYPES,
+    CAUSAL_LINK_TYPES,
+    LEGACY_CAUSAL_LINK_TYPES,
+    CausalLinkDescriptor,
+)
 from ..db.base import DatabaseConnection
 from ..db.ops import DataAccessOps
 from ..memory_engine import fq_table
@@ -100,6 +107,273 @@ async def _bulk_insert_links(
         _NIL_ENTITY_UUID,
         exists_clause,
         chunk_size,
+    )
+
+
+@dataclass(frozen=True)
+class _StoredSuspendedCausalLinks:
+    """Locked causal provenance for one live or archived memory row."""
+
+    table: str
+    links: list[CausalLinkDescriptor]
+
+
+def _decode_suspended_causal_links(value: Any) -> list[CausalLinkDescriptor]:
+    if not value:
+        return []
+    payload = json.loads(value) if isinstance(value, str) else value
+    if not isinstance(payload, list):
+        raise ValueError("suspended_causal_links must be a JSON array")
+    return [CausalLinkDescriptor.model_validate(item) for item in payload]
+
+
+def _encode_suspended_causal_links(links: list[CausalLinkDescriptor]) -> str:
+    ordered = sorted(links, key=lambda link: link.identity)
+    return json.dumps([link.model_dump(mode="json") for link in ordered], separators=(",", ":"))
+
+
+async def _read_stored_suspended_causal_links(
+    conn: DatabaseConnection,
+    bank_id: str,
+    unit_id: UUID,
+    *,
+    for_update: bool,
+) -> _StoredSuspendedCausalLinks | None:
+    live_table = fq_table("memory_units")
+    archive_table = fq_table("invalidated_memory_units")
+    # A restore briefly has copies in both tables within its transaction, so
+    # always prefer live. A locking read also rechecks live after archive: an
+    # archive -> live move may commit while the archive probe waits for its lock.
+    tables = (live_table, archive_table, live_table) if for_update else (live_table, archive_table)
+    lock_clause = " FOR UPDATE" if for_update else ""
+    for table in tables:
+        row = await conn.fetchrow(
+            f"SELECT suspended_causal_links FROM {table} WHERE id = $1 AND bank_id = $2{lock_clause}",
+            unit_id,
+            bank_id,
+        )
+        if row:
+            return _StoredSuspendedCausalLinks(
+                table=table,
+                links=_decode_suspended_causal_links(row["suspended_causal_links"]),
+            )
+    return None
+
+
+async def lock_incident_causal_link_endpoints(
+    conn: DatabaseConnection,
+    bank_id: str,
+    unit_id: UUID,
+) -> None:
+    """Lock every endpoint involved in the unit's causal state.
+
+    The first reads only discover the lock set. Callers must re-read after this
+    function returns: another curation transaction may have changed or moved a
+    row before these locks were acquired. Every causal curation path uses this
+    same UUID order, preventing opposite-endpoint operations from deadlocking.
+    """
+    stored = await get_suspended_causal_link_descriptors(conn, bank_id, unit_id)
+    materialized = await _get_materialized_incident_causal_descriptors(conn, bank_id, unit_id)
+    unit_ids = {unit_id}
+    for descriptor in (*stored, *materialized):
+        unit_ids.update((descriptor.from_unit_id, descriptor.to_unit_id))
+    for endpoint_id in sorted(unit_ids, key=str):
+        await _read_stored_suspended_causal_links(conn, bank_id, endpoint_id, for_update=True)
+
+
+async def _write_suspended_causal_links(
+    conn: DatabaseConnection,
+    bank_id: str,
+    unit_id: UUID,
+    stored: _StoredSuspendedCausalLinks,
+    links: list[CausalLinkDescriptor],
+) -> None:
+    await conn.execute(
+        f"UPDATE {stored.table} SET suspended_causal_links = $3::jsonb WHERE id = $1 AND bank_id = $2",
+        unit_id,
+        bank_id,
+        _encode_suspended_causal_links(links),
+    )
+
+
+async def _add_suspended_causal_link_descriptors(
+    conn: DatabaseConnection,
+    bank_id: str,
+    descriptors: list[CausalLinkDescriptor],
+) -> None:
+    """Persist descriptors after the caller has locked every endpoint row."""
+    if not descriptors:
+        return
+
+    unit_ids = sorted(
+        {unit_id for link in descriptors for unit_id in (link.from_unit_id, link.to_unit_id)},
+        key=str,
+    )
+    for unit_id in unit_ids:
+        stored = await _read_stored_suspended_causal_links(conn, bank_id, unit_id, for_update=False)
+        if stored is None:
+            continue
+        existing = {link.identity: link for link in stored.links}
+        merged = existing.copy()
+        for descriptor in descriptors:
+            if unit_id in (descriptor.from_unit_id, descriptor.to_unit_id):
+                merged[descriptor.identity] = descriptor
+        if merged != existing:
+            await _write_suspended_causal_links(conn, bank_id, unit_id, stored, list(merged.values()))
+
+
+async def get_suspended_causal_link_descriptors(
+    conn: DatabaseConnection,
+    bank_id: str,
+    unit_id: UUID,
+) -> list[CausalLinkDescriptor]:
+    """Read the durable causal descriptors attached to one memory."""
+    stored = await _read_stored_suspended_causal_links(conn, bank_id, unit_id, for_update=False)
+    return stored.links if stored else []
+
+
+async def _get_materialized_incident_causal_descriptors(
+    conn: DatabaseConnection,
+    bank_id: str,
+    unit_id: UUID,
+) -> list[CausalLinkDescriptor]:
+    """Read causal rows currently materialized for one memory."""
+    rows = await conn.fetch(
+        f"""
+        SELECT from_unit_id, to_unit_id, link_type, weight
+        FROM {fq_table("memory_links")}
+        WHERE bank_id = $1
+          AND (from_unit_id = $2 OR to_unit_id = $2)
+          AND link_type = ANY($3::text[])
+        """,
+        bank_id,
+        unit_id,
+        list(CAUSAL_LINK_TYPES),
+    )
+    return [
+        CausalLinkDescriptor(
+            from_unit_id=row["from_unit_id"],
+            to_unit_id=row["to_unit_id"],
+            link_type=row["link_type"],
+            weight=float(row["weight"]),
+        )
+        for row in rows
+    ]
+
+
+async def hydrate_incident_causal_descriptors(
+    conn: DatabaseConnection,
+    bank_id: str,
+    unit_id: UUID,
+    *,
+    endpoints_locked: bool = False,
+) -> None:
+    """Snapshot currently materialized incident causal rows before invalidation."""
+    if not endpoints_locked:
+        await lock_incident_causal_link_endpoints(conn, bank_id, unit_id)
+    descriptors = await _get_materialized_incident_causal_descriptors(conn, bank_id, unit_id)
+    await _add_suspended_causal_link_descriptors(conn, bank_id, descriptors)
+
+
+async def _remove_suspended_causal_link_descriptors(
+    conn: DatabaseConnection,
+    bank_id: str,
+    descriptors: list[CausalLinkDescriptor],
+) -> None:
+    """Remove descriptor copies after the caller has locked every endpoint row."""
+    if not descriptors:
+        return
+
+    identities = {descriptor.identity for descriptor in descriptors}
+    unit_ids = sorted(
+        {unit_id for link in descriptors for unit_id in (link.from_unit_id, link.to_unit_id)},
+        key=str,
+    )
+    for unit_id in unit_ids:
+        stored = await _read_stored_suspended_causal_links(conn, bank_id, unit_id, for_update=False)
+        if stored is None:
+            continue
+        remaining = [link for link in stored.links if link.identity not in identities]
+        if len(remaining) != len(stored.links):
+            await _write_suspended_causal_links(conn, bank_id, unit_id, stored, remaining)
+
+
+async def clear_incident_causal_links(
+    conn: DatabaseConnection,
+    bank_id: str,
+    unit_id: UUID,
+    *,
+    endpoints_locked: bool = False,
+) -> None:
+    """Remove all durable and materialized causal links incident to a unit."""
+    if not endpoints_locked:
+        await lock_incident_causal_link_endpoints(conn, bank_id, unit_id)
+    stored = await get_suspended_causal_link_descriptors(conn, bank_id, unit_id)
+    materialized = await _get_materialized_incident_causal_descriptors(conn, bank_id, unit_id)
+    descriptors = {descriptor.identity: descriptor for descriptor in (*stored, *materialized)}
+    await _remove_suspended_causal_link_descriptors(conn, bank_id, list(descriptors.values()))
+    await conn.execute(
+        f"""
+        DELETE FROM {fq_table("memory_links")}
+        WHERE bank_id = $1
+          AND (from_unit_id = $2 OR to_unit_id = $2)
+          AND link_type = ANY($3::text[])
+        """,
+        bank_id,
+        unit_id,
+        list(CAUSAL_LINK_TYPES),
+    )
+
+
+async def materialize_live_causal_descriptors(
+    conn: DatabaseConnection,
+    bank_id: str,
+    unit_id: UUID,
+    ops: DataAccessOps,
+    *,
+    endpoints_locked: bool = False,
+) -> None:
+    """Materialize stored causal descriptors whose two endpoints are live."""
+    if not endpoints_locked:
+        await lock_incident_causal_link_endpoints(conn, bank_id, unit_id)
+    descriptors = await get_suspended_causal_link_descriptors(conn, bank_id, unit_id)
+    if not descriptors:
+        return
+
+    endpoint_ids = sorted(
+        {endpoint for link in descriptors for endpoint in (link.from_unit_id, link.to_unit_id)},
+        key=str,
+    )
+    rows = await conn.fetch(
+        f"SELECT id FROM {fq_table('memory_units')} WHERE bank_id = $1 AND id = ANY($2::uuid[])",
+        bank_id,
+        endpoint_ids,
+    )
+    live_ids = {row["id"] for row in rows}
+    eligible = [
+        descriptor
+        for descriptor in descriptors
+        if descriptor.from_unit_id in live_ids and descriptor.to_unit_id in live_ids
+    ]
+    # Snapshots are needed only while at least one endpoint is invalidated.
+    # Consume eligible copies in the same transaction that recreates the edge;
+    # an insertion failure rolls the descriptor removal back as well.
+    await _remove_suspended_causal_link_descriptors(conn, bank_id, eligible)
+    await _bulk_insert_links(
+        conn,
+        [
+            (
+                descriptor.from_unit_id,
+                descriptor.to_unit_id,
+                descriptor.link_type,
+                descriptor.weight,
+                None,
+            )
+            for descriptor in eligible
+        ],
+        bank_id=bank_id,
+        skip_exists_check=True,
+        ops=ops,
     )
 
 

--- a/hindsight-api-slim/tests/test_memory_curation.py
+++ b/hindsight-api-slim/tests/test_memory_curation.py
@@ -6,6 +6,7 @@ These tests cover the move semantics, lossless revert (incl. entity
 associations), edit, the guards, listing, and recall exclusion.
 """
 
+import asyncio
 import json
 import uuid
 from unittest.mock import AsyncMock, patch
@@ -13,8 +14,10 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from hindsight_api import RequestContext
+from hindsight_api.engine.causal_links import CAUSAL_LINK_TYPES, CausalLinkDescriptor, CausalLinkType
+from hindsight_api.engine.db.base import DatabaseConnection
 from hindsight_api.engine.memory_engine import MemoryEngine
-from hindsight_api.engine.retain import embedding_processing
+from hindsight_api.engine.retain import embedding_processing, link_utils
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -76,6 +79,83 @@ async def _insert_link(conn, bank_id: str, from_id: uuid.UUID, to_id: uuid.UUID)
         to_id,
         bank_id,
     )
+
+
+async def _insert_causal_link(
+    conn: DatabaseConnection,
+    bank_id: str,
+    from_id: uuid.UUID,
+    to_id: uuid.UUID,
+    link_type: CausalLinkType = "caused_by",
+) -> CausalLinkDescriptor:
+    descriptor = CausalLinkDescriptor(
+        from_unit_id=from_id,
+        to_unit_id=to_id,
+        link_type=link_type,
+        weight=1.0,
+    )
+    await conn.execute(
+        """
+        INSERT INTO memory_links (from_unit_id, to_unit_id, link_type, weight, bank_id)
+        VALUES ($1, $2, $3, 1.0, $4)
+        """,
+        from_id,
+        to_id,
+        link_type,
+        bank_id,
+    )
+    return descriptor
+
+
+async def _causal_link_count(
+    conn: DatabaseConnection,
+    bank_id: str,
+    from_id: uuid.UUID,
+    to_id: uuid.UUID,
+    link_type: CausalLinkType = "caused_by",
+) -> int:
+    return await conn.fetchval(
+        """
+        SELECT COUNT(*)
+        FROM memory_links
+        WHERE bank_id = $1 AND from_unit_id = $2 AND to_unit_id = $3 AND link_type = $4
+        """,
+        bank_id,
+        from_id,
+        to_id,
+        link_type,
+    )
+
+
+async def _suspended_causal_links_for(
+    conn: DatabaseConnection,
+    table: str,
+    memory_id: uuid.UUID,
+) -> list[CausalLinkDescriptor]:
+    value = await conn.fetchval(f"SELECT suspended_causal_links FROM {table} WHERE id = $1", memory_id)
+    payload = json.loads(value) if isinstance(value, str) else value
+    if not isinstance(payload, list):
+        raise AssertionError(f"Expected suspended_causal_links to be a list, got {type(payload).__name__}")
+    return [CausalLinkDescriptor.model_validate(item) for item in payload]
+
+
+class _CausalLockBarrier:
+    def __init__(self, bank_id: str, endpoints: frozenset[uuid.UUID]) -> None:
+        self.call_count = 0
+        self._arrivals = 0
+        self._bank_id = bank_id
+        self._endpoints = endpoints
+        self._ready = asyncio.Event()
+        self._original = link_utils.lock_incident_causal_link_endpoints
+
+    async def __call__(self, conn: DatabaseConnection, bank_id: str, unit_id: uuid.UUID) -> None:
+        self.call_count += 1
+        if bank_id == self._bank_id and unit_id in self._endpoints and self._arrivals < 2:
+            self._arrivals += 1
+            if self._arrivals == 2:
+                self._ready.set()
+            await asyncio.wait_for(self._ready.wait(), timeout=5)
+        await self._original(conn, bank_id, unit_id)
 
 
 async def _insert_entity(conn, bank_id: str, name: str) -> uuid.UUID:
@@ -154,6 +234,102 @@ async def _ensure_bank(memory: MemoryEngine, bank_id: str, request_context: Requ
 
 
 class TestInvalidate:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("link_type", CAUSAL_LINK_TYPES)
+    async def test_causal_link_reappears_only_after_both_endpoints_are_restored(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        link_type: CausalLinkType,
+    ):
+        bank_id = f"test-curation-causal-restore-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            effect = await _insert_memory(conn, memory, bank_id, "The deployment failed.")
+            cause = await _insert_memory(conn, memory, bank_id, "The configuration was invalid.")
+            # Snapshots remain empty until an endpoint is first invalidated.
+            expected = await _insert_causal_link(conn, bank_id, effect, cause, link_type)
+
+        with (
+            patch.object(memory, "submit_async_consolidation", new=AsyncMock()),
+            patch.object(memory, "submit_async_graph_maintenance", new=AsyncMock()),
+        ):
+            await memory.update_memory_unit(bank_id, str(effect), state="invalidated", request_context=request_context)
+            await memory.update_memory_unit(bank_id, str(cause), state="invalidated", request_context=request_context)
+
+            async with pool.acquire() as conn:
+                assert await _causal_link_count(conn, bank_id, effect, cause, link_type) == 0
+                assert await _suspended_causal_links_for(conn, "invalidated_memory_units", effect) == [expected]
+                assert await _suspended_causal_links_for(conn, "invalidated_memory_units", cause) == [expected]
+
+            await memory.update_memory_unit(bank_id, str(effect), state="valid", request_context=request_context)
+            async with pool.acquire() as conn:
+                assert await _causal_link_count(conn, bank_id, effect, cause, link_type) == 0
+                assert await _suspended_causal_links_for(conn, "memory_units", effect) == [expected]
+                assert await _suspended_causal_links_for(conn, "invalidated_memory_units", cause) == [expected]
+
+            await memory.update_memory_unit(bank_id, str(cause), state="valid", request_context=request_context)
+
+        async with pool.acquire() as conn:
+            assert await _causal_link_count(conn, bank_id, effect, cause, link_type) == 1
+            assert await _suspended_causal_links_for(conn, "memory_units", effect) == []
+            assert await _suspended_causal_links_for(conn, "memory_units", cause) == []
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_endpoint_restores_materialize_causal_link_once(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+    ):
+        bank_id = f"test-curation-causal-concurrent-restore-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            effect = await _insert_memory(conn, memory, bank_id, "The deployment failed.")
+            cause = await _insert_memory(conn, memory, bank_id, "The configuration was invalid.")
+            await _insert_causal_link(conn, bank_id, effect, cause)
+
+        lock_barrier = _CausalLockBarrier(bank_id, frozenset({effect, cause}))
+
+        with (
+            patch.object(memory, "submit_async_consolidation", new=AsyncMock()),
+            patch.object(memory, "submit_async_graph_maintenance", new=AsyncMock()),
+        ):
+            await memory.update_memory_unit(bank_id, str(effect), state="invalidated", request_context=request_context)
+            await memory.update_memory_unit(bank_id, str(cause), state="invalidated", request_context=request_context)
+
+            with patch.object(link_utils, "lock_incident_causal_link_endpoints", new=lock_barrier):
+                await asyncio.wait_for(
+                    asyncio.gather(
+                        memory.update_memory_unit(
+                            bank_id,
+                            str(effect),
+                            state="valid",
+                            request_context=request_context,
+                        ),
+                        memory.update_memory_unit(
+                            bank_id,
+                            str(cause),
+                            state="valid",
+                            request_context=request_context,
+                        ),
+                    ),
+                    timeout=20,
+                )
+
+        assert lock_barrier.call_count == 2
+        async with pool.acquire() as conn:
+            assert await _causal_link_count(conn, bank_id, effect, cause) == 1
+            assert await _suspended_causal_links_for(conn, "memory_units", effect) == []
+            assert await _suspended_causal_links_for(conn, "memory_units", cause) == []
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
     @pytest.mark.asyncio
     async def test_invalidate_moves_to_archive_and_prunes(self, memory: MemoryEngine, request_context: RequestContext):
         bank_id = f"test-curation-inv-{uuid.uuid4().hex[:8]}"
@@ -277,6 +453,94 @@ class TestInvalidate:
 
 class TestEdit:
     @pytest.mark.asyncio
+    async def test_text_edit_removes_causal_link_and_archived_endpoint_descriptor(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        bank_id = f"test-curation-causal-text-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            effect = await _insert_memory(conn, memory, bank_id, "The deployment failed.")
+            cause = await _insert_memory(conn, memory, bank_id, "The configuration was invalid.")
+            expected = await _insert_causal_link(conn, bank_id, effect, cause)
+
+        with (
+            patch.object(memory, "submit_async_consolidation", new=AsyncMock()),
+            patch.object(memory, "submit_async_graph_maintenance", new=AsyncMock()),
+        ):
+            await memory.update_memory_unit(bank_id, str(cause), state="invalidated", request_context=request_context)
+
+            async with pool.acquire() as conn:
+                assert await _suspended_causal_links_for(conn, "memory_units", effect) == [expected]
+                assert await _suspended_causal_links_for(conn, "invalidated_memory_units", cause) == [expected]
+
+            await memory.update_memory_unit(
+                bank_id,
+                str(effect),
+                text="The deployment succeeded.",
+                request_context=request_context,
+            )
+
+        async with pool.acquire() as conn:
+            assert await _causal_link_count(conn, bank_id, effect, cause) == 0
+            assert await _suspended_causal_links_for(conn, "memory_units", effect) == []
+            assert await _suspended_causal_links_for(conn, "invalidated_memory_units", cause) == []
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_invalidation_and_peer_text_edit_do_not_leave_stale_causal_state(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+    ):
+        bank_id = f"test-curation-causal-concurrent-edit-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            effect = await _insert_memory(conn, memory, bank_id, "The deployment failed.")
+            cause = await _insert_memory(conn, memory, bank_id, "The configuration was invalid.")
+            await _insert_causal_link(conn, bank_id, effect, cause)
+
+        lock_barrier = _CausalLockBarrier(bank_id, frozenset({effect, cause}))
+
+        with (
+            patch.object(memory, "submit_async_consolidation", new=AsyncMock()),
+            patch.object(memory, "submit_async_graph_maintenance", new=AsyncMock()),
+            patch.object(link_utils, "lock_incident_causal_link_endpoints", new=lock_barrier),
+        ):
+            await asyncio.wait_for(
+                asyncio.gather(
+                    memory.update_memory_unit(
+                        bank_id,
+                        str(effect),
+                        state="invalidated",
+                        request_context=request_context,
+                    ),
+                    memory.update_memory_unit(
+                        bank_id,
+                        str(cause),
+                        text="The configuration was valid.",
+                        request_context=request_context,
+                    ),
+                ),
+                timeout=20,
+            )
+
+        assert lock_barrier.call_count == 2
+        async with pool.acquire() as conn:
+            assert await _causal_link_count(conn, bank_id, effect, cause) == 0
+            assert await _suspended_causal_links_for(conn, "invalidated_memory_units", effect) == []
+            assert await _suspended_causal_links_for(conn, "memory_units", cause) == []
+            assert await conn.fetchval("SELECT text FROM memory_units WHERE id = $1", cause) == (
+                "The configuration was valid."
+            )
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
     async def test_edit_changes_text_and_rederives(self, memory: MemoryEngine, request_context: RequestContext):
         bank_id = f"test-curation-edit-{uuid.uuid4().hex[:8]}"
         await _ensure_bank(memory, bank_id, request_context)
@@ -329,6 +593,8 @@ class TestEdit:
         pool = await memory._get_pool()
         async with pool.acquire() as conn:
             m1 = await _insert_memory(conn, memory, bank_id, "A world fact.", fact_type="world")
+            cause = await _insert_memory(conn, memory, bank_id, "A related cause.")
+            await _insert_causal_link(conn, bank_id, m1, cause)
 
         with (
             patch.object(memory, "submit_async_consolidation", new=AsyncMock()),
@@ -357,6 +623,7 @@ class TestEdit:
             assert row["context"] == "from a chat"
             assert row["occurred_start"].date().isoformat() == "2023-06-01"
             assert row["event_date"].date().isoformat() == "2023-06-01", "event_date tracks occurred_start"
+            assert await _causal_link_count(conn, bank_id, m1, cause) == 1
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
@@ -368,6 +635,8 @@ class TestEdit:
         pool = await memory._get_pool()
         async with pool.acquire() as conn:
             m1 = await _insert_memory(conn, memory, bank_id, "Alice met Bob in Paris.")
+            cause = await _insert_memory(conn, memory, bank_id, "The meeting was scheduled.")
+            await _insert_causal_link(conn, bank_id, m1, cause)
             # Pre-link a wrong entity the LLM extracted.
             wrong = await _insert_entity(conn, bank_id, "Carol")
             await _link_entity(conn, m1, wrong)
@@ -395,6 +664,7 @@ class TestEdit:
             )
             assert {r["canonical_name"] for r in names} == {"Alice", "Bob"}, "unit_entities rebuilt"
             assert wrong not in await _entity_ids_for(conn, m1), "wrong entity detached"
+            assert await _causal_link_count(conn, bank_id, m1, cause) == 1
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
@@ -437,6 +707,42 @@ class TestEdit:
             await memory.update_memory_unit(bank_id, str(m1), state="invalidated", request_context=request_context)
             with pytest.raises(ValueError, match="revert"):
                 await memory.update_memory_unit(bank_id, str(m1), text="corrected", request_context=request_context)
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+# ---------------------------------------------------------------------------
+# Permanent delete
+# ---------------------------------------------------------------------------
+
+
+class TestPermanentDelete:
+    @pytest.mark.asyncio
+    async def test_delete_removes_causal_descriptor_from_surviving_endpoint(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        bank_id = f"test-curation-causal-delete-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            cause = await _insert_memory(conn, memory, bank_id, "The configuration was invalid.")
+            effect = await _insert_memory(conn, memory, bank_id, "The deployment failed.")
+            await _insert_causal_link(conn, bank_id, effect, cause)
+
+        with (
+            patch.object(memory, "submit_async_consolidation", new=AsyncMock()),
+            patch.object(memory, "submit_async_graph_maintenance", new=AsyncMock()),
+        ):
+            # Populate a paused-edge snapshot, then delete the still-live peer.
+            await memory.update_memory_unit(bank_id, str(effect), state="invalidated", request_context=request_context)
+            result = await memory.delete_memory_unit(str(cause), request_context=request_context)
+
+        assert result["success"] is True
+        async with pool.acquire() as conn:
+            assert not await _in_live(conn, cause)
+            assert await _causal_link_count(conn, bank_id, effect, cause) == 0
+            assert await _suspended_causal_links_for(conn, "invalidated_memory_units", effect) == []
 
         await memory.delete_bank(bank_id, request_context=request_context)
 


### PR DESCRIPTION
## Summary

This PR preserves raw-fact causal relationships across memory curation without introducing a new archive table or rerunning LLM extraction. It stores only causal edges that are currently suspended because at least one endpoint is invalidated, and rematerializes an edge when both endpoints are live again.

The change covers the canonical `caused_by` relation and the historical `causes`, `enables`, and `prevents` relation types.

## Problem

Causal edges are retain-time extraction results stored in `memory_links`. Unlike temporal and semantic links, they cannot be deterministically reconstructed from dates or embeddings.

Invalidating a memory moves it out of `memory_units`, so foreign-key cascades remove all incident physical edges. Restoring the memory later submits graph maintenance, but graph maintenance only rebuilds temporal and semantic links. The original causal assertion is therefore permanently lost.

Editing had a related failure mode: curation deleted every incident `memory_links` row even when only non-text fields changed. A context, date, fact-type, or entity edit could therefore erase a causal assertion even though the underlying proposition remained unchanged.

## Design goals

- Preserve the exact direction, relation type, and weight of suspended causal edges.
- Restore both incoming and outgoing causal edges.
- Keep an edge out of the active graph while either endpoint is invalidated.
- Make restoration independent of endpoint invalidation and restoration order.
- Treat a real text change as invalidating the old causal assertion instead of silently preserving or guessing it.
- Keep restoration idempotent and safe under concurrent edits, invalidations, restorations, and deletion.
- Avoid a new table, a new graph-maintenance queue responsibility, and LLM re-extraction.
- Avoid migration-time scans or backfills across existing banks.
- Leave temporal and semantic curation behavior outside this PR.

## Data model

The migration adds `suspended_causal_links` to both `memory_units` and `invalidated_memory_units`.

- PostgreSQL stores the value as `JSONB NOT NULL DEFAULT '[]'::jsonb`.
- Oracle stores the value as a JSON-validated `CLOB` with an empty-array default.
- The field is intentionally unindexed because it is read by memory ID during low-frequency curation operations, not searched globally.

Each descriptor contains `from_unit_id`, `to_unit_id`, `link_type`, and `weight`. Its stable identity is `(from_unit_id, to_unit_id, link_type)`.

`memory_links` remains the materialized active graph used by retrieval and traversal. `suspended_causal_links` is not a second permanent graph: it contains only edges that are currently paused because at least one endpoint is invalidated. Once an edge is successfully rematerialized, its descriptor is consumed from both endpoints.

## Why the descriptor is stored on both endpoints

Duplicating the small descriptor on both endpoint memories makes restoration local and independent of ordering.

For an edge `A --caused_by--> B`, suppose both memories become invalidated. If only A is restored, the edge remains suspended because B is not live. If B is restored later, B carries the same descriptor and can determine that both endpoints are now live. The same result is reached when B is restored first.

Storing the descriptor on only the first invalidated endpoint would require scanning or transferring state between archive rows. It would also make the second restore unable to discover the edge when the restore order is reversed. Storing it on both endpoints avoids that additional lifecycle mechanism.

## Lifecycle

### Retain and imported data

Retain continues to write causal relationships only to `memory_links`. It does not eagerly populate `suspended_causal_links`, avoiding two extra memory-row updates on the high-frequency ingestion path.

Existing and newly retained memories use the same lazy snapshot path. The first invalidation of either endpoint reads the currently materialized causal edges and stores any missing descriptors on both endpoint rows.

### Non-text edits

Changes to context, dates, fact type, or entities preserve physical causal edges and any already suspended descriptors. These fields may affect other derived graph data, but they do not by themselves invalidate the retained proposition's causal meaning.

### Text edits

When the stored text actually changes, the old causal assertion is no longer trusted. The transaction removes every incoming and outgoing causal edge incident to the edited memory and removes the matching suspended descriptors from both live or archived peer endpoints.

This PR deliberately does not rerun the LLM or infer replacement causal relationships. A future API that accepts explicit causal updates can reuse the same descriptor and materialization helpers without changing this lifecycle.

### Invalidation

Before moving a live memory into `invalidated_memory_units`, the transaction reads all materialized incident causal edges and merges their descriptors into both endpoints. The existing move then carries the local snapshot into the archive, and the foreign-key cascade removes the physical edges from the active graph.

Repeated invalidation does not duplicate descriptors because merges use the descriptor identity.

### Restoration

After restoring a memory to `memory_units`, the transaction examines its suspended descriptors. A descriptor is eligible only when both referenced endpoints exist in the same bank's live table.

Eligible edges are inserted through the existing idempotent bulk-insert path. Descriptor copies are removed from both endpoints in the same transaction. If either endpoint remains invalidated, the descriptor is retained and no dangling physical edge is created.

### Permanent deletion

Single-memory permanent deletion is not currently exposed to users. This PR still adapts the internal deletion path so a future public API cannot leave stale causal descriptors on surviving endpoints.

Before deleting a live memory, the transaction removes all of its materialized causal edges and removes their suspended descriptor copies from surviving live or archived peers. Bank deletion needs no per-edge cleanup because all endpoint rows are deleted together.

## Concurrency and locking

Every causal curation operation first discovers the target's materialized and suspended incident edges. It then locks the target and all discovered endpoint rows with `SELECT ... FOR UPDATE` in deterministic UUID order, regardless of whether a row currently lives in `memory_units` or `invalidated_memory_units`.

The operation rereads actionable state after acquiring the locks and performs descriptor updates, row movement, edge deletion, or edge materialization in the same transaction. Locking before an archive-to-live move is important: otherwise concurrent restores of opposite endpoints could each miss the other's uncommitted live row.

Each operation performs the complete endpoint discovery and lock acquisition once. Internal snapshot, cleanup, and materialization stages reuse those transaction-held locks rather than repeating `FOR UPDATE`. Unrelated memories and ordinary reads are not serialized.

## Existing data and migration behavior

There is no full-table backfill. A preexisting causal edge is captured lazily when one endpoint is first invalidated. Text editing and permanent deletion merge the current physical and already suspended representations only for cleanup; they do not create a snapshot that would immediately be removed.

Causal edges that were already lost before this migration cannot be reconstructed exactly and are intentionally not guessed.

## Alternatives considered

### Dedicated causal archive table

A separate table would centralize descriptors but add a new persistence lifecycle, cleanup rules, tenancy considerations, and another source that every restore and delete path must coordinate. The endpoint field is sufficient for a sparse relation and keeps the change local.

### Store snapshots only on archived rows

This requires transferring pending edge state as endpoints move independently between live and archived tables. It also makes restoration order significant unless the restore path scans other archive rows.

### Keep dangling rows in `memory_links`

Weakening foreign keys or retaining links to archived endpoints would make the active graph contain invalid references and complicate every retrieval query.

### Re-extract causal relations with an LLM

Re-extraction lacks the original retain context, is nondeterministic, and can change direction, type, or edge existence. It is also much heavier than preserving the exact extracted assertion.

### Use graph maintenance

Graph maintenance can derive temporal and semantic relationships from stored data, but it cannot reconstruct a retain-time causal assertion. Adding causal restoration there would mix persisted provenance with derived graph maintenance and would still require storing the original descriptor somewhere.

## Validation

- `uv run pytest tests/test_memory_curation.py tests/test_causal_link_taxonomy.py tests/test_link_utils.py -q -n 0` — 67 passed.
- `./scripts/hooks/lint.sh` — passed.
- `uv run ty check hindsight_api/` — passed.
- Concurrency coverage verifies that two endpoint restores materialize one edge and that concurrent invalidation plus peer text editing leaves no stale descriptor.
- The lifecycle tests cover all four supported causal types, one- and two-endpoint invalidation, deferred restoration, text cleanup, non-text preservation, and permanent-delete cleanup.

Closes #2864.


