### PR TITLE
fix(graph): queue edited and restored memories for relinking

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
@@ -103,37 +103,48 @@ class JobResult:
 async def enqueue_relink_victims(
     conn: DatabaseConnection,
     bank_id: str,
-    deleted_unit_ids: list[str],
+    affected_unit_ids: list[str],
     ops: Any,
     include_affected_units: bool = False,
 ) -> int:
     """Enqueue surviving units whose outgoing temporal/semantic links pointed at
-    ``deleted_unit_ids`` for later link top-up.
+    ``affected_unit_ids`` for later link top-up.
 
-    Must run inside the same transaction that deletes the units, *before* the
-    cascade fires — once the rows are gone, the join that finds the victims
-    returns nothing.
+    Must run inside the same transaction that drops those links, *before* the
+    delete (or cascade) fires — once the rows are gone, the join that finds the
+    victims returns nothing.
+
+    ``include_affected_units`` covers the case where the affected units are NOT
+    being removed: an edit deletes every link incident to the edited unit but
+    leaves it live, so the unit needs its own outgoing adjacency rebuilt too.
+    Passing it for a unit that will be gone at commit is harmless but pointless
+    — the drain skips queue rows with no live unit — so callers should only set
+    it when the unit survives the transaction.
 
     Args:
-        conn: Database connection inside the active delete transaction.
-        bank_id: Bank owning the deleted units.
-        deleted_unit_ids: Memory_unit IDs about to be (or being) deleted.
+        conn: Database connection inside the active transaction.
+        bank_id: Bank owning the affected units.
+        affected_unit_ids: Memory_unit IDs whose incident temporal/semantic
+            links are about to be (or are being) removed.
         ops: ``DataAccessOps`` instance, supplies the dialect-specific
             bulk-insert path.
-        include_affected_units: Also enqueue the supplied units when they remain
-            live and need their own outgoing links rebuilt.
+        include_affected_units: Also enqueue ``affected_unit_ids`` themselves,
+            for callers that leave them live. One combined insert (rather than a
+            second call) keeps the queue's sorted lock ordering intact: two
+            transactions editing mutually linked units would otherwise take the
+            ``(bank_id, unit_id)`` keys in opposite orders and deadlock.
 
     Returns:
         Number of distinct units passed to the queue insert.
     """
-    if not deleted_unit_ids:
+    if not affected_unit_ids:
         return 0
 
-    deleted_uuids = [uuid_module.UUID(uid) if isinstance(uid, str) else uid for uid in deleted_unit_ids]
-    deleted_str_set = {str(uid) for uid in deleted_uuids}
+    affected_uuids = [uuid_module.UUID(uid) if isinstance(uid, str) else uid for uid in affected_unit_ids]
+    affected_str_set = {str(uid) for uid in affected_uuids}
 
-    # Find units (other than the ones being deleted) that have an outgoing
-    # temporal/semantic link pointing at a doomed unit. Entity links are
+    # Find units (other than the affected ones) that have an outgoing
+    # temporal/semantic link pointing at an affected unit. Entity links are
     # intentionally excluded — they're scheduled for removal and would only
     # add noise to the recompute job.
     victim_rows = await conn.fetch(
@@ -144,13 +155,13 @@ async def enqueue_relink_victims(
           AND bank_id = $2
           AND link_type IN ('temporal', 'semantic')
         """,
-        deleted_uuids,
+        affected_uuids,
         bank_id,
     )
 
-    relink_ids = {row["from_unit_id"] for row in victim_rows if str(row["from_unit_id"]) not in deleted_str_set}
+    relink_ids = {row["from_unit_id"] for row in victim_rows if str(row["from_unit_id"]) not in affected_str_set}
     if include_affected_units:
-        relink_ids.update(deleted_uuids)
+        relink_ids.update(affected_uuids)
 
     if not relink_ids:
         return 0
@@ -164,7 +175,7 @@ async def enqueue_relink_victims(
 
     logger.debug(
         f"[GRAPH_MAINT] Enqueued {len(relink_ids)} units for relinking in "
-        f"bank={bank_id} (deleted {len(deleted_unit_ids)} units)"
+        f"bank={bank_id} ({len(affected_unit_ids)} units affected)"
     )
     return len(relink_ids)
 

--- a/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
@@ -105,6 +105,7 @@ async def enqueue_relink_victims(
     bank_id: str,
     deleted_unit_ids: list[str],
     ops: Any,
+    include_affected_units: bool = False,
 ) -> int:
     """Enqueue surviving units whose outgoing temporal/semantic links pointed at
     ``deleted_unit_ids`` for later link top-up.
@@ -119,10 +120,11 @@ async def enqueue_relink_victims(
         deleted_unit_ids: Memory_unit IDs about to be (or being) deleted.
         ops: ``DataAccessOps`` instance, supplies the dialect-specific
             bulk-insert path.
+        include_affected_units: Also enqueue the supplied units when they remain
+            live and need their own outgoing links rebuilt.
 
     Returns:
-        Number of distinct victim units enqueued (after dedup against rows
-        already in the queue).
+        Number of distinct units passed to the queue insert.
     """
     if not deleted_unit_ids:
         return 0
@@ -146,23 +148,25 @@ async def enqueue_relink_victims(
         bank_id,
     )
 
-    victim_ids = [row["from_unit_id"] for row in victim_rows if str(row["from_unit_id"]) not in deleted_str_set]
+    relink_ids = {row["from_unit_id"] for row in victim_rows if str(row["from_unit_id"]) not in deleted_str_set}
+    if include_affected_units:
+        relink_ids.update(deleted_uuids)
 
-    if not victim_ids:
+    if not relink_ids:
         return 0
 
     await ops.enqueue_graph_maintenance(
         conn,
         fq_table("graph_maintenance_queue"),
         bank_id,
-        victim_ids,
+        list(relink_ids),
     )
 
     logger.debug(
-        f"[GRAPH_MAINT] Enqueued {len(victim_ids)} relink victims in "
+        f"[GRAPH_MAINT] Enqueued {len(relink_ids)} units for relinking in "
         f"bank={bank_id} (deleted {len(deleted_unit_ids)} units)"
     )
-    return len(victim_ids)
+    return len(relink_ids)
 
 
 async def run_graph_maintenance_job(

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7166,7 +7166,15 @@ class MemoryEngine(MemoryEngineInterface):
                     search_vector_clause = (
                         f",\n                            search_vector = {sv_expr}" if sv_expr else ""
                     )
-                    await enqueue_relink_victims(conn, bank_id, [memory_id], ops=backend.ops)
+                    # Queue victims and the edited unit in one sorted insert. Separate
+                    # inserts can deadlock when concurrently edited units point at each other.
+                    await enqueue_relink_victims(
+                        conn,
+                        bank_id,
+                        [memory_id],
+                        ops=backend.ops,
+                        include_affected_units=state != "invalidated",
+                    )
                     await conn.execute(
                         f"""
                         UPDATE {mu}
@@ -7330,6 +7338,14 @@ class MemoryEngine(MemoryEngineInterface):
                                 bank_id,
                                 new_emb,
                             )
+                    # Restoring the row does not recreate its outgoing temporal or
+                    # semantic links; graph maintenance only processes queued units.
+                    await backend.ops.enqueue_graph_maintenance(
+                        conn,
+                        fq_table("graph_maintenance_queue"),
+                        bank_id,
+                        [memory_uuid],
+                    )
                     await conn.execute(f"DELETE FROM {arch} WHERE id = $1 AND bank_id = $2", str(memory_uuid), bank_id)
                     need_consolidation = True
                     need_graph = True

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7166,8 +7166,17 @@ class MemoryEngine(MemoryEngineInterface):
                     search_vector_clause = (
                         f",\n                            search_vector = {sv_expr}" if sv_expr else ""
                     )
-                    # Queue victims and the edited unit in one sorted insert. Separate
-                    # inserts can deadlock when concurrently edited units point at each other.
+                    # The DELETE below drops this unit's incident DERIVED edges (causal
+                    # ones are preserved, #2864), so the unit itself needs its outgoing
+                    # temporal/semantic adjacency rebuilt — not just the neighbours that
+                    # lost an edge to it. Skip that when this same call also invalidates
+                    # the unit (the block below archives it, and the drain no-ops on a
+                    # queue row with no live unit).
+                    #
+                    # Victims and the edited unit go in ONE insert: the queue insert
+                    # sorts its ids, so a single call keeps the (bank_id, unit_id) lock
+                    # order global. Two separate inserts can deadlock when concurrently
+                    # edited units point at each other.
                     await enqueue_relink_victims(
                         conn,
                         bank_id,
@@ -7338,8 +7347,19 @@ class MemoryEngine(MemoryEngineInterface):
                                 bank_id,
                                 new_emb,
                             )
-                    # Restoring the row does not recreate its outgoing temporal or
-                    # semantic links; graph maintenance only processes queued units.
+                    # Invalidation cascaded away every link incident to this unit. The
+                    # causal ones came back from the archive snapshot above (#2864); the
+                    # derived ones are graph maintenance's job, and it only rebuilds units
+                    # present in the queue — it never scans memory_units for missing
+                    # adjacency. Without this enqueue the submission below short-circuits
+                    # on an empty queue (no_work) and the reverted fact stays off the
+                    # temporal/semantic graph.
+                    # Enqueued last, so the row is fully searchable (text, entities,
+                    # search_vector, embedding) before the drain reads it, and atomic
+                    # with the archive→live move: a rollback takes the work item too.
+                    # Scope: this rebuilds the reverted unit's OUTGOING links. Units
+                    # that pointed at it were relinked elsewhere at invalidation time
+                    # and are not re-queued here.
                     await backend.ops.enqueue_graph_maintenance(
                         conn,
                         fq_table("graph_maintenance_queue"),

--- a/hindsight-api-slim/tests/test_graph_maintenance.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance.py
@@ -15,7 +15,7 @@ import uuid
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -233,6 +233,86 @@ class TestEnqueueRelinkVictims:
                 await enqueue_relink_victims(conn, bank_id, [str(doomed2)], ops=backend.ops)
 
             assert await _queue_unit_ids(conn, bank_id) == [str(survivor)]
+
+    @pytest.mark.asyncio
+    async def test_include_affected_enqueues_self_without_victims(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """Outgoing-only unit: nothing points at it, so the victim lookup is empty.
+
+        This is the case that made an edit a silent no-op (#2889) — the helper
+        returned 0, the queue stayed empty and submission short-circuited on
+        ``no_work``, so the edited unit's own outgoing links were never rebuilt.
+        """
+        bank_id = f"test-gm-self-live-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            edited = await _insert_unit(conn, bank_id, "edited")
+            target = await _insert_unit(conn, bank_id, "target")
+            # edited → target only; no incoming derived links.
+            await _insert_link(conn, bank_id, edited, target, "temporal")
+
+            backend = await memory._get_backend()
+            async with conn.transaction():
+                count = await enqueue_relink_victims(
+                    conn, bank_id, [str(edited)], ops=backend.ops, include_affected_units=True
+                )
+
+            assert count == 1
+            assert await _queue_unit_ids(conn, bank_id) == [str(edited)]
+
+    @pytest.mark.asyncio
+    async def test_include_affected_combines_self_and_victims_in_one_insert(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """Mutually linked units share a single sorted insert.
+
+        Splitting them across two inserts would let concurrent edits take the
+        ``(bank_id, unit_id)`` keys in opposite orders and deadlock.
+        """
+        bank_id = f"test-gm-self-both-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            a = await _insert_unit(conn, bank_id, "a")
+            b = await _insert_unit(conn, bank_id, "b")
+            await _insert_link(conn, bank_id, a, b, "temporal")
+            await _insert_link(conn, bank_id, b, a, "temporal")
+
+            backend = await memory._get_backend()
+            with patch.object(
+                backend.ops, "enqueue_graph_maintenance", wraps=backend.ops.enqueue_graph_maintenance
+            ) as enqueue_mock:
+                async with conn.transaction():
+                    count = await enqueue_relink_victims(
+                        conn, bank_id, [str(a)], ops=backend.ops, include_affected_units=True
+                    )
+
+            assert count == 2
+            assert enqueue_mock.await_count == 1, "self and victims must share one lock-ordered insert"
+            assert await _queue_unit_ids(conn, bank_id) == sorted([str(a), str(b)])
+
+    @pytest.mark.asyncio
+    async def test_include_affected_is_opt_in(self, memory: MemoryEngine, request_context: RequestContext):
+        """Delete callers keep the default: a doomed unit must not queue itself."""
+        bank_id = f"test-gm-optin-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            doomed = await _insert_unit(conn, bank_id, "doomed")
+            target = await _insert_unit(conn, bank_id, "target")
+            await _insert_link(conn, bank_id, doomed, target, "temporal")
+
+            backend = await memory._get_backend()
+            async with conn.transaction():
+                count = await enqueue_relink_victims(conn, bank_id, [str(doomed)], ops=backend.ops)
+
+            assert count == 0
+            assert await _queue_unit_ids(conn, bank_id) == []
 
 
 # ---------------------------------------------------------------------------

--- a/hindsight-api-slim/tests/test_memory_curation.py
+++ b/hindsight-api-slim/tests/test_memory_curation.py
@@ -114,6 +114,23 @@ async def _archived_causal_links(conn, mem_id: uuid.UUID) -> list[dict]:
     return json.loads(raw) if raw else []
 
 
+async def _link_exists(conn, bank_id: str, from_id: uuid.UUID, to_id: uuid.UUID, link_type: str = "temporal") -> bool:
+    return bool(
+        await conn.fetchval(
+            "SELECT 1 FROM memory_links "
+            "WHERE bank_id = $1 AND from_unit_id = $2 AND to_unit_id = $3 AND link_type = $4",
+            bank_id,
+            from_id,
+            to_id,
+            link_type,
+        )
+    )
+
+
+async def _queue_empty(conn, bank_id: str) -> bool:
+    return not await conn.fetchval("SELECT 1 FROM graph_maintenance_queue WHERE bank_id = $1", bank_id)
+
+
 async def _insert_entity(conn, bank_id: str, name: str) -> uuid.UUID:
     eid = uuid.uuid4()
     await conn.execute(
@@ -261,9 +278,7 @@ class TestInvalidate:
                 arch = await _archive_row(conn, m1)
                 assert arch is not None and e1 in (arch["entity_ids"] or []), "entity ids snapshotted on invalidate"
                 assert await _entity_ids_for(conn, m1) == [], "unit_entities cascade-pruned on move"
-                assert not await conn.fetchval("SELECT 1 FROM graph_maintenance_queue WHERE bank_id = $1", bank_id), (
-                    "an outgoing-only link has no surviving source victim"
-                )
+                assert await _queue_empty(conn, bank_id), "an outgoing-only link has no surviving source victim"
 
             result = await memory.update_memory_unit(bank_id, str(m1), state="valid", request_context=request_context)
 
@@ -492,6 +507,110 @@ class TestEdit:
             await memory.update_memory_unit(bank_id, str(m1), state="invalidated", request_context=request_context)
             with pytest.raises(ValueError, match="revert"):
                 await memory.update_memory_unit(bank_id, str(m1), text="corrected", request_context=request_context)
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+# ---------------------------------------------------------------------------
+# Graph relinking after curation (#2889)
+# ---------------------------------------------------------------------------
+
+
+class TestCurationRelinking:
+    """Curation drops a memory's incident temporal/semantic links; the memory
+    must be queued so graph maintenance rebuilds its OWN outgoing adjacency.
+
+    ``enqueue_relink_victims`` alone only queues *other* sources that lost an
+    edge, so a memory with outgoing links but no incoming ones left the queue
+    empty and the submission short-circuited on ``no_work``.
+
+    The fixture's task backend is ``SyncTaskBackend``, so the two end-to-end
+    tests below drain the queue inline: by the time ``update_memory_unit``
+    returns, the links are already rebuilt.
+    """
+
+    @pytest.mark.asyncio
+    async def test_edit_with_only_outgoing_links_queues_itself(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """The clearest pre-fix failure: no incoming edge, so no victim, so no work."""
+        bank_id = f"test-curation-outonly-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            m1 = await _insert_memory(conn, memory, bank_id, "The assistant visited Paris in 2023.")
+            m2 = await _insert_memory(conn, memory, bank_id, "Paris is in France.")
+            await _insert_link(conn, bank_id, m1, m2)  # outgoing only — nothing points at m1
+
+        with (
+            patch.object(memory, "submit_async_consolidation", new=AsyncMock()),
+            patch.object(memory, "submit_async_graph_maintenance", new=AsyncMock()),
+        ):
+            await memory.update_memory_unit(
+                bank_id,
+                str(m1),
+                text="The user visited Paris in 2023.",
+                request_context=request_context,
+            )
+
+        async with pool.acquire() as conn:
+            queued = await conn.fetch("SELECT unit_id FROM graph_maintenance_queue WHERE bank_id = $1", bank_id)
+            assert {row["unit_id"] for row in queued} == {m1}, "edited memory queued even with no incoming victim"
+            assert not await _link_exists(conn, bank_id, m1, m2), "edit drops the unit's own outgoing links"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_edit_rebuilds_outgoing_links(self, memory: MemoryEngine, request_context: RequestContext):
+        """End-to-end: the queued edit actually gets its temporal link back."""
+        bank_id = f"test-curation-relink-edit-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            m1 = await _insert_memory(conn, memory, bank_id, "The assistant visited Paris in 2023.")
+            m2 = await _insert_memory(conn, memory, bank_id, "Paris is in France.")
+            await _insert_link(conn, bank_id, m1, m2)
+
+        # Graph maintenance is NOT patched here — it runs inline and drains the queue.
+        with patch.object(memory, "submit_async_consolidation", new=AsyncMock()):
+            await memory.update_memory_unit(
+                bank_id,
+                str(m1),
+                text="The user visited Paris in 2023.",
+                request_context=request_context,
+            )
+
+        async with pool.acquire() as conn:
+            assert await _link_exists(conn, bank_id, m1, m2), "edited memory's outgoing temporal link rebuilt"
+            assert await _queue_empty(conn, bank_id), "queue drained by the inline worker"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_revert_rebuilds_outgoing_links(self, memory: MemoryEngine, request_context: RequestContext):
+        """End-to-end: invalidate cascades the links away, revert brings them back."""
+        bank_id = f"test-curation-relink-revert-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            m1 = await _insert_memory(conn, memory, bank_id, "The assistant visited Paris in 2023.")
+            m2 = await _insert_memory(conn, memory, bank_id, "Paris is in France.")
+            await _insert_link(conn, bank_id, m1, m2)
+
+        with patch.object(memory, "submit_async_consolidation", new=AsyncMock()):
+            await memory.update_memory_unit(bank_id, str(m1), state="invalidated", request_context=request_context)
+
+            async with pool.acquire() as conn:
+                assert not await _link_exists(conn, bank_id, m1, m2), "archive cascade removed the link"
+
+            await memory.update_memory_unit(bank_id, str(m1), state="valid", request_context=request_context)
+
+        async with pool.acquire() as conn:
+            assert await _link_exists(conn, bank_id, m1, m2), "reverted memory's outgoing temporal link rebuilt"
+            assert await _queue_empty(conn, bank_id), "queue drained by the inline worker"
 
         await memory.delete_bank(bank_id, request_context=request_context)
 

--- a/hindsight-api-slim/tests/test_memory_curation.py
+++ b/hindsight-api-slim/tests/test_memory_curation.py
@@ -246,8 +246,10 @@ class TestInvalidate:
         pool = await memory._get_pool()
         async with pool.acquire() as conn:
             m1 = await _insert_memory(conn, memory, bank_id, "Alice prefers tea over coffee.")
+            m2 = await _insert_memory(conn, memory, bank_id, "Bob prefers coffee over tea.")
             e1 = await _insert_entity(conn, bank_id, "Alice")
             await _link_entity(conn, m1, e1)
+            await _insert_link(conn, bank_id, m1, m2)
 
         with (
             patch.object(memory, "submit_async_consolidation", new=AsyncMock()),
@@ -259,6 +261,9 @@ class TestInvalidate:
                 arch = await _archive_row(conn, m1)
                 assert arch is not None and e1 in (arch["entity_ids"] or []), "entity ids snapshotted on invalidate"
                 assert await _entity_ids_for(conn, m1) == [], "unit_entities cascade-pruned on move"
+                assert not await conn.fetchval("SELECT 1 FROM graph_maintenance_queue WHERE bank_id = $1", bank_id), (
+                    "an outgoing-only link has no surviving source victim"
+                )
 
             result = await memory.update_memory_unit(bank_id, str(m1), state="valid", request_context=request_context)
 
@@ -275,6 +280,8 @@ class TestInvalidate:
             # revert so the reverted fact is keyword-searchable again (archive keeps none, #2503).
             reverted_sv = await conn.fetchval("SELECT search_vector FROM memory_units WHERE id = $1", m1)
             assert reverted_sv is not None, "search_vector recomputed on revert (archive keeps none)"
+            queued_ids = await conn.fetch("SELECT unit_id FROM graph_maintenance_queue WHERE bank_id = $1", bank_id)
+            assert {row["unit_id"] for row in queued_ids} == {m1}, "reverted memory queued to rebuild outgoing links"
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
@@ -320,13 +327,22 @@ class TestEdit:
         pool = await memory._get_pool()
         async with pool.acquire() as conn:
             m1 = await _insert_memory(conn, memory, bank_id, "The assistant visited Paris in 2023.")
+            m2 = await _insert_memory(conn, memory, bank_id, "Paris is in France.")
+            await _insert_link(conn, bank_id, m1, m2)
+            await _insert_link(conn, bank_id, m2, m1)
             await conn.execute(
                 "UPDATE memory_units SET search_vector = to_tsvector('english'::regconfig, text) WHERE id = $1",
                 m1,
             )
             obs_id = await _insert_observation(conn, bank_id, "The assistant went to Paris.", [m1])
 
+        backend = await memory._get_backend()
         with (
+            patch.object(
+                backend.ops,
+                "enqueue_graph_maintenance",
+                wraps=backend.ops.enqueue_graph_maintenance,
+            ) as enqueue_mock,
             patch.object(memory, "submit_async_consolidation", new=AsyncMock()),
             patch.object(memory, "submit_async_graph_maintenance", new=AsyncMock()),
         ):
@@ -340,6 +356,7 @@ class TestEdit:
 
         assert result["text"] == "The user visited Paris in 2023."
         assert result["state"] == "valid"
+        assert enqueue_mock.await_count == 1, "self and victims must share one lock-ordered queue insert"
         async with pool.acquire() as conn:
             assert await _in_live(conn, m1), "edited row stays live"
             row = dict(
@@ -354,6 +371,8 @@ class TestEdit:
             assert "'assist'" not in row["search_vector"], "old text must not stay in native FTS search_vector"
             assert "'user'" in row["search_vector"], "new text must refresh native FTS search_vector"
             assert str(obs_id) not in await _obs_ids(conn, bank_id), "stale observation re-derived"
+            queued_ids = await conn.fetch("SELECT unit_id FROM graph_maintenance_queue WHERE bank_id = $1", bank_id)
+            assert {row["unit_id"] for row in queued_ids} == {m1, m2}, "edited memory and incoming victim both queued"
 
         await memory.delete_bank(bank_id, request_context=request_context)
 


### PR DESCRIPTION
## Summary

Memory curation removes or recreates temporal and semantic graph state, but graph maintenance only rebuilds outgoing adjacency for memory units explicitly present in `graph_maintenance_queue`. Edited and restored memories were not queued themselves, so their outgoing temporal and semantic links could remain permanently absent.

This change makes edit and restore explicitly enqueue the affected live memory while preserving the existing victim-relink behavior for neighboring source units.

Closes #2889.

## Problem model

A graph-maintenance queue entry represents a source memory whose outgoing temporal and semantic adjacency must be regenerated. If the graph contains `A -> B`, `A -> C`, and `D -> A`, processing D can rebuild `D -> A`, but it does not rebuild A's outgoing links.

The existing `enqueue_relink_victims()` helper is deletion-oriented. It finds other source units whose outgoing links point to an affected unit and deliberately excludes the affected unit itself. This is correct for permanent removal or invalidation, because the affected unit will no longer be live, but it is incomplete for edit, where the unit remains live after all incident links are deleted.

Restore has the complementary problem. It recreates the live row, entity associations, search vector, and embedding, then submits graph maintenance without first inserting a queue row. `submit_async_graph_maintenance()` only drains existing work and does not scan `memory_units` to discover missing adjacency, so an empty queue causes a `no_work` short circuit.

## Design goals

- Rebuild outgoing temporal and semantic links for every edited or restored memory that remains live.
- Preserve relinking of neighboring source units that lose an outgoing edge to the affected memory.
- Reuse the existing queue and worker instead of adding a new table, maintenance mode, or graph reconstruction path.
- Keep queue writes atomic with the curation transaction so rolled-back edits or restores cannot leave orphan work.
- Preserve the queue's global lock ordering under concurrent edits.
- Avoid queuing a memory that is edited and immediately invalidated in the same operation.

## Design

### Edit

`enqueue_relink_victims()` now accepts `include_affected_units`. When enabled, it combines the affected memory IDs with all discovered incoming-link victims before calling the backend queue insertion method.

The edit path enables this option only when the memory remains live. The resulting set contains both the edited memory and every neighboring source unit that lost an outgoing temporal or semantic edge. The backend then performs one sorted, deduplicated queue insertion for the complete set.

Combining these IDs is also important for concurrency. Two transactions editing mutually linked memories must not enqueue a victim set first and the edited memory second, because that can acquire `(bank_id, unit_id)` unique-key locks in opposite orders. A single combined call lets the existing PostgreSQL and Oracle implementations sort the complete set before acquiring queue-key locks.

### Restore

The restore path enqueues the restored memory after the live row, entity associations, search vector, and embedding have been reconstructed. This ensures the graph worker observes all inputs required to compute fresh outgoing temporal and semantic links.

The enqueue occurs in the same transaction as the archive-to-live move. The subsequent graph-maintenance submission therefore cannot observe the queue row before the restored memory is ready, and a rollback removes both the restored state and its work item.

### Idempotency and worker behavior

The existing `(bank_id, unit_id)` primary key deduplicates repeated queue writes. PostgreSQL uses `ON CONFLICT DO NOTHING`, while Oracle uses its duplicate-key hint. The graph worker claims and removes queue rows before topping up outgoing links and does not enqueue itself, so this change does not introduce recursive maintenance or a self-sustaining drain loop.

## Scope

This change is limited to scheduling temporal and semantic relinking after edit and restore.

## Behavioral examples

For an outgoing-only graph such as `A -> B`, editing A previously left the queue empty because no other source pointed to A. A is now queued and its outgoing links are regenerated.

For a bidirectional graph such as `A -> B` and `B -> A`, editing A now queues A and B in one sorted insert. A rebuilds its outgoing adjacency, while B rebuilds the outgoing edge it lost when A's incident rows were removed.

When A is invalidated and later restored, invalidation still queues only surviving victims. Restore separately queues A after its searchable fields are ready.

## Validation

- `uv run pytest tests/test_memory_curation.py tests/test_graph_maintenance.py tests/test_enqueue_graph_maintenance_ordered.py -q -n 0` — 32 passed.
- The final edit regression verifies that mutually linked units produce one queue write containing both the edited unit and its victim.
- `uv run ty check hindsight_api/` — passed.
- `./scripts/hooks/lint.sh` — passed.
