### PR TITLE
fix(curation): make edit maintenance field-aware

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
@@ -104,6 +104,9 @@ async def enqueue_relink_victims(
     bank_id: str,
     deleted_unit_ids: list[str],
     ops: Any,
+    *,
+    relink_temporal: bool = True,
+    relink_semantic: bool = True,
 ) -> int:
     """Enqueue surviving units whose outgoing temporal/semantic links pointed at
     ``deleted_unit_ids`` for later link top-up.
@@ -118,28 +121,35 @@ async def enqueue_relink_victims(
         deleted_unit_ids: Memory_unit IDs about to be (or being) deleted.
         ops: ``DataAccessOps`` instance, supplies the dialect-specific
             bulk-insert path.
+        relink_temporal: Include sources that lost temporal links.
+        relink_semantic: Include sources that lost semantic links.
 
     Returns:
         Number of distinct victim units enqueued (after dedup against rows
         already in the queue).
     """
-    if not deleted_unit_ids:
+    if not deleted_unit_ids or not (relink_temporal or relink_semantic):
         return 0
 
     deleted_uuids = [uuid_module.UUID(uid) if isinstance(uid, str) else uid for uid in deleted_unit_ids]
     deleted_str_set = {str(uid) for uid in deleted_uuids}
 
-    # Find units (other than the ones being deleted) that have an outgoing
-    # temporal/semantic link pointing at a doomed unit. Entity links are
-    # intentionally excluded — they're scheduled for removal and would only
-    # add noise to the recompute job.
+    if relink_temporal and relink_semantic:
+        link_type_predicate = "link_type IN ('temporal', 'semantic')"
+    elif relink_temporal:
+        link_type_predicate = "link_type = 'temporal'"
+    else:
+        link_type_predicate = "link_type = 'semantic'"
+
+    # An edit may preserve one derived link type, so only queue sources whose
+    # outgoing links will actually be removed. Delete callers keep both defaults.
     victim_rows = await conn.fetch(
         f"""
         SELECT DISTINCT from_unit_id
         FROM {fq_table("memory_links")}
         WHERE to_unit_id = ANY($1::uuid[])
           AND bank_id = $2
-          AND link_type IN ('temporal', 'semantic')
+          AND {link_type_predicate}
         """,
         deleted_uuids,
         bank_id,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -6675,16 +6675,14 @@ class MemoryEngine(MemoryEngineInterface):
 
         - **Edit** (``text``/``context``/``occurred_start``/``occurred_end``/
           ``new_fact_type``/``entities``): correct what the LLM extracted.
-          Re-embeds (text + dates + entities feed the embedding), drops derived
-          observations + links, and re-consolidates. For date/context fields,
-          ``""`` clears to NULL and ``None`` leaves unchanged; ``new_fact_type``
-          must be world/experience. ``entities`` (when not None) replaces the
-          unit's entity set: names are resolved/find-or-created via the same
-          resolver retain uses, ``unit_entities`` + cooccurrence are rebuilt, and
-          ``[]`` detaches all entities. Entities orphaned by the swap, and any
-          now-stale cooccurrence rows, are reclaimed by the graph-maintenance
-          sweep that this edit submits (entity edges live in ``unit_entities``,
-          not ``memory_links``, so there is nothing to relink directly).
+          Recomputes only the derived state affected by values that actually
+          changed, then re-consolidates. For date/context fields, ``""`` clears
+          to NULL and ``None`` leaves unchanged; ``new_fact_type`` must be
+          world/experience. ``entities`` (when not None) replaces the unit's
+          entity set: names are resolved/find-or-created via the same resolver
+          retain uses, ``unit_entities`` + cooccurrence are rebuilt, and ``[]``
+          detaches all entities. Entities orphaned by the swap, and any now-stale
+          cooccurrence rows, are reclaimed by graph maintenance.
         - **Invalidate** (``state='invalidated'``): move the row to the archive
           (cascade-pruning its links/entity associations and re-deriving dependent
           observations). The archive is cold storage, so the embedding is dropped
@@ -6815,12 +6813,37 @@ class MemoryEngine(MemoryEngineInterface):
                     # tracks the occurred start when it's set.
                     new_event_date = new_occ_start or live["event_date"]
 
+                    current_entity_names: list[str] = []
+                    if new_entities is not None:
+                        current_entity_names = [
+                            row["canonical_name"]
+                            for row in await conn.fetch(
+                                f"SELECT e.canonical_name FROM {ue} ue JOIN {ent} e ON ue.entity_id = e.id "
+                                f"WHERE ue.unit_id = $1",
+                                str(memory_uuid),
+                            )
+                        ]
+
+                    text_changed = new_text != live["text"]
+                    context_changed = new_context != live["context"]
+                    dates_changed = new_occ_start != live["occurred_start"] or new_occ_end != live["occurred_end"]
+                    event_date_changed = new_event_date != live["event_date"]
+                    fact_type_changed = new_fact != live["fact_type"]
+                    # Entity associations are a set, and the resolver also
+                    # deduplicates names case-insensitively.
+                    entities_changed = new_entities is not None and {name.lower() for name in new_entities} != {
+                        name.lower() for name in current_entity_names
+                    }
+                    anything_changed = (
+                        text_changed or context_changed or dates_changed or fact_type_changed or entities_changed
+                    )
+
                     # Rebuild the unit's entity set FIRST, so the re-embed below picks
                     # up the corrected canonical names. Reuses retain's resolver
                     # (find-or-create + cooccurrence) rather than touching entities
                     # directly. Orphaned entities + stale cooccurrence are swept by
                     # the graph-maintenance run this edit submits.
-                    if new_entities is not None:
+                    if entities_changed and new_entities is not None:
                         entity_date = new_occ_start or live["mentioned_at"]
                         entity_resolution = await resolve_entities_only(
                             self.entity_resolver,
@@ -6848,53 +6871,97 @@ class MemoryEngine(MemoryEngineInterface):
                                 conn=conn,
                             )
 
-                    ent_rows = await conn.fetch(
-                        f"SELECT e.canonical_name FROM {ue} ue JOIN {ent} e ON ue.entity_id = e.id "
-                        f"WHERE ue.unit_id = $1",
-                        str(memory_uuid),
-                    )
-                    new_emb = await self._reembed_memory_text(
-                        text=new_text,
-                        occurred_start=new_occ_start,
-                        occurred_end=new_occ_end,
-                        mentioned_at=live["mentioned_at"],
-                        entities=[r["canonical_name"] for r in ent_rows],
-                    )
+                    embedding_changed = text_changed or dates_changed or entities_changed
+                    semantic_changed = embedding_changed or fact_type_changed
+                    # Temporal neighbors depend on event_date and fact_type;
+                    # occurred_end still affects semantic embedding content.
+                    temporal_changed = event_date_changed or fact_type_changed
+
+                    new_emb: str | None = None
+                    if embedding_changed:
+                        ent_rows = await conn.fetch(
+                            f"SELECT e.canonical_name FROM {ue} ue JOIN {ent} e ON ue.entity_id = e.id "
+                            f"WHERE ue.unit_id = $1",
+                            str(memory_uuid),
+                        )
+                        new_emb = await self._reembed_memory_text(
+                            text=new_text,
+                            occurred_start=new_occ_start,
+                            occurred_end=new_occ_end,
+                            mentioned_at=live["mentioned_at"],
+                            entities=[r["canonical_name"] for r in ent_rows],
+                        )
+
                     # Keep the stored text-search vector in sync with curated
                     # text/context edits. Use the incoming parameters here:
                     # PostgreSQL evaluates UPDATE RHS expressions before the
                     # sibling SET assignments take effect, so column references
                     # would see the pre-edit text/context.
-                    from .db.ops_postgresql import pg_search_vector_expr
+                    sv_expr = None
+                    if text_changed or context_changed:
+                        from .db.ops_postgresql import pg_search_vector_expr
 
-                    sv_expr = pg_search_vector_expr(get_config(), text_col="$3", context_col="$4")
+                        sv_expr = pg_search_vector_expr(get_config(), text_col="$3", context_col="$4")
                     search_vector_clause = (
                         f",\n                            search_vector = {sv_expr}" if sv_expr else ""
                     )
-                    await enqueue_relink_victims(conn, bank_id, [memory_id], ops=backend.ops)
-                    await conn.execute(
-                        f"""
-                        UPDATE {mu}
-                        SET text = $3, context = $4, fact_type = $5, occurred_start = $6,
-                            occurred_end = $7, event_date = $8, embedding = $9::vector,
-                            consolidated_at = NULL, consolidation_failed_at = NULL,
-                            edited_at = now(), updated_at = now(){search_vector_clause}
-                        WHERE id = $1 AND bank_id = $2
-                        """,
-                        str(memory_uuid),
-                        bank_id,
-                        new_text,
-                        new_context,
-                        new_fact,
-                        new_occ_start,
-                        new_occ_end,
-                        new_event_date,
-                        new_emb,
-                    )
-                    await conn.execute(f"DELETE FROM {ml} WHERE from_unit_id = $1 OR to_unit_id = $1", str(memory_uuid))
-                    await self._delete_stale_observations_for_memories(conn, bank_id, [memory_id])
-                    need_consolidation = True
-                    need_graph = True
+
+                    if anything_changed:
+                        if semantic_changed or temporal_changed:
+                            await enqueue_relink_victims(
+                                conn,
+                                bank_id,
+                                [memory_id],
+                                ops=backend.ops,
+                                relink_temporal=temporal_changed,
+                                relink_semantic=semantic_changed,
+                            )
+
+                        embedding_clause = ", embedding = $9::vector" if embedding_changed else ""
+                        update_args = (
+                            str(memory_uuid),
+                            bank_id,
+                            new_text,
+                            new_context,
+                            new_fact,
+                            new_occ_start,
+                            new_occ_end,
+                            new_event_date,
+                        )
+                        await conn.execute(
+                            f"""
+                            UPDATE {mu}
+                            SET text = $3, context = $4, fact_type = $5, occurred_start = $6,
+                                occurred_end = $7, event_date = $8{embedding_clause},
+                                consolidated_at = NULL, consolidation_failed_at = NULL,
+                                edited_at = now(), updated_at = now(){search_vector_clause}
+                            WHERE id = $1 AND bank_id = $2
+                            """,
+                            *update_args,
+                            *([new_emb] if embedding_changed else []),
+                        )
+
+                        deleted_link_types: list[str] = []
+                        if semantic_changed:
+                            deleted_link_types.append("semantic")
+                        if temporal_changed:
+                            deleted_link_types.append("temporal")
+                        if text_changed:
+                            from .causal_links import CAUSAL_LINK_TYPES
+
+                            deleted_link_types.extend(CAUSAL_LINK_TYPES)
+                        if deleted_link_types:
+                            quoted_link_types = ", ".join(f"'{link_type}'" for link_type in deleted_link_types)
+                            await conn.execute(
+                                f"DELETE FROM {ml} WHERE (from_unit_id = $1 OR to_unit_id = $1) "
+                                f"AND bank_id = $2 AND link_type IN ({quoted_link_types})",
+                                str(memory_uuid),
+                                bank_id,
+                            )
+
+                        await self._delete_stale_observations_for_memories(conn, bank_id, [memory_id])
+                        need_consolidation = True
+                        need_graph = semantic_changed or temporal_changed
 
                 # --- Invalidate: move live → archive ---
                 if state == "invalidated" and live:

--- a/hindsight-api-slim/tests/test_memory_curation.py
+++ b/hindsight-api-slim/tests/test_memory_curation.py
@@ -66,14 +66,21 @@ async def _insert_observation(conn, bank_id: str, text: str, source_memory_ids: 
     return obs_id
 
 
-async def _insert_link(conn, bank_id: str, from_id: uuid.UUID, to_id: uuid.UUID) -> None:
+async def _insert_link(
+    conn,
+    bank_id: str,
+    from_id: uuid.UUID,
+    to_id: uuid.UUID,
+    link_type: str = "temporal",
+) -> None:
     await conn.execute(
         """
         INSERT INTO memory_links (from_unit_id, to_unit_id, link_type, weight, bank_id)
-        VALUES ($1, $2, 'temporal', 0.5, $3)
+        VALUES ($1, $2, $3, 0.5, $4)
         """,
         from_id,
         to_id,
+        link_type,
         bank_id,
     )
 
@@ -125,6 +132,14 @@ async def _link_count(conn, mem_id: uuid.UUID) -> int:
         "SELECT COUNT(*) FROM memory_links WHERE from_unit_id = $1 OR to_unit_id = $1",
         mem_id,
     )
+
+
+async def _link_types_for(conn, mem_id: uuid.UUID) -> set[str]:
+    rows = await conn.fetch(
+        "SELECT link_type FROM memory_links WHERE from_unit_id = $1 OR to_unit_id = $1",
+        mem_id,
+    )
+    return {row["link_type"] for row in rows}
 
 
 async def _entity_ids_for(conn, unit_id: uuid.UUID) -> list[uuid.UUID]:
@@ -284,6 +299,11 @@ class TestEdit:
         pool = await memory._get_pool()
         async with pool.acquire() as conn:
             m1 = await _insert_memory(conn, memory, bank_id, "The assistant visited Paris in 2023.")
+            temporal_source = await _insert_memory(conn, memory, bank_id, "Paris was visited in 2023.")
+            semantic_source = await _insert_memory(conn, memory, bank_id, "The trip was to Paris.")
+            await _insert_link(conn, bank_id, temporal_source, m1, "temporal")
+            await _insert_link(conn, bank_id, semantic_source, m1, "semantic")
+            await _insert_link(conn, bank_id, semantic_source, m1, "caused_by")
             await conn.execute(
                 "UPDATE memory_units SET search_vector = to_tsvector('english'::regconfig, text) WHERE id = $1",
                 m1,
@@ -318,6 +338,52 @@ class TestEdit:
             assert "'assist'" not in row["search_vector"], "old text must not stay in native FTS search_vector"
             assert "'user'" in row["search_vector"], "new text must refresh native FTS search_vector"
             assert str(obs_id) not in await _obs_ids(conn, bank_id), "stale observation re-derived"
+            assert await _link_types_for(conn, m1) == {"temporal"}, (
+                "text edits rebuild semantic links, invalidate causal links, and preserve temporal links"
+            )
+            queued = await conn.fetch("SELECT unit_id FROM graph_maintenance_queue WHERE bank_id = $1", bank_id)
+            assert {row["unit_id"] for row in queued} == {semantic_source}, (
+                "only sources that lost an affected derived link are queued"
+            )
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_context_only_preserves_embedding_and_graph(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        bank_id = f"test-curation-context-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            m1 = await _insert_memory(conn, memory, bank_id, "Alice visited Paris.")
+            m2 = await _insert_memory(conn, memory, bank_id, "Paris is in France.")
+            for link_type in ("temporal", "semantic", "caused_by"):
+                await _insert_link(conn, bank_id, m2, m1, link_type)
+            original_embedding = await conn.fetchval("SELECT embedding::text FROM memory_units WHERE id = $1", m1)
+
+        with (
+            patch.object(memory, "_reembed_memory_text", new=AsyncMock()) as reembed_mock,
+            patch.object(memory, "submit_async_consolidation", new=AsyncMock()) as consolidation_mock,
+            patch.object(memory, "submit_async_graph_maintenance", new=AsyncMock()) as graph_mock,
+        ):
+            result = await memory.update_memory_unit(
+                bank_id,
+                str(m1),
+                context="from a chat",
+                request_context=request_context,
+            )
+
+        assert result["context"] == "from a chat"
+        reembed_mock.assert_not_awaited()
+        consolidation_mock.assert_awaited_once()
+        graph_mock.assert_not_awaited()
+        async with pool.acquire() as conn:
+            assert (
+                await conn.fetchval("SELECT embedding::text FROM memory_units WHERE id = $1", m1) == original_embedding
+            )
+            assert await _link_types_for(conn, m1) == {"temporal", "semantic", "caused_by"}
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
@@ -329,6 +395,13 @@ class TestEdit:
         pool = await memory._get_pool()
         async with pool.acquire() as conn:
             m1 = await _insert_memory(conn, memory, bank_id, "A world fact.", fact_type="world")
+            m2 = await _insert_memory(conn, memory, bank_id, "A related fact.")
+            for link_type in ("temporal", "semantic", "caused_by"):
+                await _insert_link(conn, bank_id, m2, m1, link_type)
+            end_only = await _insert_memory(conn, memory, bank_id, "An event with an end date.")
+            end_source = await _insert_memory(conn, memory, bank_id, "A related event.")
+            for link_type in ("temporal", "semantic", "caused_by"):
+                await _insert_link(conn, bank_id, end_source, end_only, link_type)
 
         with (
             patch.object(memory, "submit_async_consolidation", new=AsyncMock()),
@@ -340,6 +413,12 @@ class TestEdit:
                 context="from a chat",
                 occurred_start="2023-06-01",
                 new_fact_type="experience",
+                request_context=request_context,
+            )
+            end_result = await memory.update_memory_unit(
+                bank_id,
+                str(end_only),
+                occurred_end="2023-06-02",
                 request_context=request_context,
             )
 
@@ -357,6 +436,13 @@ class TestEdit:
             assert row["context"] == "from a chat"
             assert row["occurred_start"].date().isoformat() == "2023-06-01"
             assert row["event_date"].date().isoformat() == "2023-06-01", "event_date tracks occurred_start"
+            assert await _link_types_for(conn, m1) == {"caused_by"}, (
+                "date/fact-type edits rebuild temporal and semantic links but preserve causal links"
+            )
+            assert end_result["occurred_end"].startswith("2023-06-02")
+            assert await _link_types_for(conn, end_only) == {"temporal", "caused_by"}, (
+                "occurred_end edits rebuild semantic links without touching temporal links"
+            )
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
@@ -371,6 +457,9 @@ class TestEdit:
             # Pre-link a wrong entity the LLM extracted.
             wrong = await _insert_entity(conn, bank_id, "Carol")
             await _link_entity(conn, m1, wrong)
+            m2 = await _insert_memory(conn, memory, bank_id, "Bob met Alice.")
+            for link_type in ("temporal", "semantic", "caused_by"):
+                await _insert_link(conn, bank_id, m2, m1, link_type)
 
         with (
             patch.object(memory, "submit_async_consolidation", new=AsyncMock()),
@@ -395,6 +484,47 @@ class TestEdit:
             )
             assert {r["canonical_name"] for r in names} == {"Alice", "Bob"}, "unit_entities rebuilt"
             assert wrong not in await _entity_ids_for(conn, m1), "wrong entity detached"
+            assert await _link_types_for(conn, m1) == {"temporal", "caused_by"}, (
+                "entity edits rebuild semantic links and preserve unrelated link types"
+            )
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_unchanged_values_skip_derived_maintenance(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        bank_id = f"test-curation-noop-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            m1 = await _insert_memory(conn, memory, bank_id, "Alice met Bob.")
+            alice = await _insert_entity(conn, bank_id, "Alice")
+            await _link_entity(conn, m1, alice)
+            m2 = await _insert_memory(conn, memory, bank_id, "Bob met Alice.")
+            await _insert_link(conn, bank_id, m2, m1, "semantic")
+
+        with (
+            patch.object(memory, "_reembed_memory_text", new=AsyncMock()) as reembed_mock,
+            patch.object(memory, "submit_async_consolidation", new=AsyncMock()) as consolidation_mock,
+            patch.object(memory, "submit_async_graph_maintenance", new=AsyncMock()) as graph_mock,
+        ):
+            result = await memory.update_memory_unit(
+                bank_id,
+                str(m1),
+                text="Alice met Bob.",
+                new_fact_type="experience",
+                entities=["alice", "ALICE"],
+                request_context=request_context,
+            )
+
+        assert result["edited_at"] is None
+        reembed_mock.assert_not_awaited()
+        consolidation_mock.assert_not_awaited()
+        graph_mock.assert_not_awaited()
+        async with pool.acquire() as conn:
+            assert await _link_types_for(conn, m1) == {"semantic"}
 
         await memory.delete_bank(bank_id, request_context=request_context)
 


### PR DESCRIPTION
## Summary

Memory edits currently send every editable field through the same destructive maintenance path. Even a context-only correction recomputes the embedding, deletes every incident graph link, invalidates observations, and submits graph maintenance.

This change derives maintenance work from values that actually changed. It preserves unrelated graph state, avoids unnecessary embedding and graph work, and leaves delete, invalidate, restore, and document-replacement maintenance unchanged.

Closes #2862.

## Problem model

Each editable field feeds a different set of derived data. Treating all fields alike is both wasteful and destructive: context is not part of the embedding input, fact type affects candidate scopes without changing the embedding vector, occurred dates affect the augmented embedding, `event_date` determines temporal placement, and entities affect the embedding plus entity associations.

The previous edit path did not compare requested values with stored values. Supplying an unchanged value still rebuilt all derived state and updated the memory's edit marker.

## Design goals

- Base maintenance on normalized values that actually changed.
- Recompute only derived state that depends on those values.
- Preserve materialized link types whose inputs remain valid.
- Keep consolidation and graph-maintenance scheduling independent.
- Preserve the behavior of every non-edit caller of the shared victim-enqueue helper.
- Avoid a queue schema change or a second graph-maintenance mechanism.

## Dependency model

| Changed value | Embedding | Semantic links | Temporal links | Causal links | Text search |
|---|---:|---:|---:|---:|---:|
| `context` | Preserve | Preserve | Preserve | Preserve | Refresh |
| `text` | Recompute | Invalidate | Preserve | Invalidate | Refresh |
| `occurred_start` | Recompute | Invalidate | Invalidate when `event_date` changes | Preserve | Preserve |
| `occurred_end` | Recompute | Invalidate | Preserve | Preserve | Preserve |
| `fact_type` | Preserve | Invalidate | Invalidate | Preserve | Preserve |
| `entities` | Recompute | Invalidate | Preserve | Preserve | Preserve |

Occurred dates invalidate semantic links because the retain pipeline includes temporal augmentation in the embedding input. Temporal neighbors depend only on `event_date` and `fact_type`, so changing `occurred_end` does not invalidate temporal links. Text invalidates causal assertions because those assertions describe the proposition represented by the stored text; non-text edits do not change that proposition.

## Design

### Change detection

The edit path first normalizes requested values using the existing API semantics, then compares them with the live row. Entity names are treated as a case-insensitive set, so ordering, casing, and duplicate inputs do not create false changes.

If no normalized value changed, the operation does not recompute the embedding, replace entity associations, delete links or observations, update `edited_at`, or submit background maintenance.

### Selective embedding and search maintenance

The embedding is recomputed only when text, occurred dates, or entities changed. Entity names are loaded only when they are needed for comparison or embedding reconstruction.

The text-search expression is regenerated only for text or context changes. A context-only edit therefore updates its searchable and consolidation inputs without touching vector or graph state.

### Selective link invalidation

The edit path constructs the affected link-type set from the dependency model and deletes only those incident rows. Semantic and temporal rows are independently selectable, all causal relation types are removed only after a real text change, and unrelated rows remain materialized.

### Type-aware victim scheduling

`enqueue_relink_victims()` accepts independent temporal and semantic selectors. An edit queues only surviving source memories whose outgoing links belong to a type that will actually be removed.

All existing delete-oriented callers use the default selectors, which retain the previous `temporal OR semantic` query exactly. This covers document deletion, single-memory deletion, invalidation, and document replacement during retain without changing their behavior.

The queue remains unit-granular. A queued worker may still inspect both derived-link caps for that source, but unaffected physical rows are preserved and unaffected incoming sources are not scheduled. Encoding work types in the queue would require a schema and worker-protocol change that is not justified for this fix.

### Background task separation

Every real edit still invalidates derived observations and requests consolidation. Graph maintenance is submitted only when semantic or temporal links changed. Entity edits still submit it through their semantic invalidation, while context-only edits do not create an empty graph-maintenance operation.

## Compatibility and concurrency

No database migration or new storage is introduced. Queue insertion, ordering, deduplication, claiming, and worker drain behavior are unchanged.

The new helper parameters default to full temporal and semantic victim discovery, and every pre-existing caller continues to omit them. The edit path performs one victim-enqueue call for the complete affected type set rather than separate calls per type.

## Scope

This PR is limited to deciding which derived state a memory edit invalidates. Invalidation, restore, hard-delete, queue-worker behavior, and causal provenance storage are not changed here.

## Behavioral examples

A context-only correction refreshes text search and derived observations while preserving the embedding and every graph link.

A text correction recomputes the embedding, removes semantic and causal rows, preserves temporal rows, and queues only incoming sources that lost semantic links.

An `occurred_start` correction that changes `event_date`, or a fact-type correction, removes semantic and temporal rows while preserving causal assertions. An `occurred_end` correction recomputes the embedding and removes semantic rows while preserving temporal and causal links. An entity correction replaces entity associations, recomputes the entity-augmented embedding, and removes semantic rows while preserving temporal and causal links.

Submitting values equal to the stored memory produces no derived maintenance. Entity inputs that differ only by ordering, casing, or duplicates are also treated as unchanged.

## Validation

- `uv run pytest tests/test_memory_curation.py tests/test_graph_maintenance.py -q -n 0` — 30 passed.
- Delete-memory, delete-document, document-replacement, observation-cleanup, and graph deadlock paths were exercised without regression; 38 additional relevant tests passed. Three real-LLM fixtures in the same local run could not initialize because no Groq API key was configured and did not enter the tested code paths.
- `uv run ty check hindsight_api/` — passed.
- `./scripts/hooks/lint.sh` — passed.
