### PR TITLE
feat(engine): filter list_memory_units by ingest age (created_before)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/interface.py
+++ b/hindsight-api-slim/hindsight_api/engine/interface.py
@@ -275,6 +275,7 @@ class MemoryEngineInterface(ABC):
         *,
         fact_type: str | None = None,
         search_query: str | None = None,
+        created_before: datetime | None = None,
         limit: int = 100,
         offset: int = 0,
         request_context: "RequestContext",
@@ -286,6 +287,7 @@ class MemoryEngineInterface(ABC):
             bank_id: The memory bank ID.
             fact_type: Filter by fact type.
             search_query: Full-text search query.
+            created_before: Keep units with ``created_at`` before this instant.
             limit: Maximum results.
             offset: Pagination offset.
             request_context: Request context for authentication.

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7583,6 +7583,7 @@ class MemoryEngine(MemoryEngineInterface):
         document_id: str | None = None,
         tags: list[str] | None = None,
         tags_match: TagsMatch = "any",
+        created_before: datetime | None = None,
         limit: int = 100,
         offset: int = 0,
         request_context: "RequestContext",
@@ -7595,6 +7596,9 @@ class MemoryEngine(MemoryEngineInterface):
             fact_type: Filter by fact type (world, experience)
             search_query: Full-text search query (searches text and context fields)
             document_id: Optional filter to a single source document.
+            created_before: Keep only units ingested strictly before this instant
+                (``created_at < created_before``). An ingest-age filter for
+                retention / bulk-maintenance sweeps.
             tags: Optional list of tag names to filter by. When omitted, no tag
                 filtering is applied (except tags_match='exact', which then selects
                 the untagged/global scope).
@@ -7687,6 +7691,11 @@ class MemoryEngine(MemoryEngineInterface):
                 # Exact match with no tags is the "global" scope: rows that carry no
                 # tags at all. (Other match modes treat empty tags as "no filter".)
                 query_conditions.append("(tags IS NULL OR tags = '{}')")
+
+            if created_before is not None:
+                param_count += 1
+                query_conditions.append(f"created_at < ${param_count}")
+                query_params.append(created_before)
 
             where_clause = "WHERE " + " AND ".join(query_conditions) if query_conditions else ""
 

--- a/hindsight-api-slim/tests/test_list_memory_units_filters.py
+++ b/hindsight-api-slim/tests/test_list_memory_units_filters.py
@@ -1,0 +1,73 @@
+"""Tests for the ``list_memory_units`` ingest-age filter: ``created_before``.
+
+Lets maintenance-loop callers (retention sweeps, bulk maintenance) select units
+by ingest age through the engine instead of hand-writing SQL against
+``memory_units``. Filtering runs against a real Postgres via the ``memory``
+fixture.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from hindsight_api import RequestContext
+from hindsight_api.engine.memory_engine import MemoryEngine
+from hindsight_api.engine.retain import embedding_processing
+
+
+async def _ensure_bank(memory: MemoryEngine, bank_id: str, request_context: RequestContext) -> None:
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+
+async def _seed_unit(
+    conn,
+    memory: MemoryEngine,
+    bank_id: str,
+    text: str,
+    *,
+    created_at: datetime,
+) -> str:
+    """Insert a live memory unit with an explicit ingest timestamp."""
+    mem_id = uuid.uuid4()
+    emb = await embedding_processing.generate_embeddings_batch(memory.embeddings, [text])
+    await conn.execute(
+        """
+        INSERT INTO memory_units (
+            id, bank_id, text, fact_type, embedding, event_date,
+            created_at, updated_at, consolidated_at
+        )
+        VALUES ($1, $2, $3, 'experience', $4::vector, NOW(), $5, $5, $5)
+        """,
+        mem_id,
+        bank_id,
+        text,
+        str(emb[0]),
+        created_at,
+    )
+    return str(mem_id)
+
+
+def _ids(result: dict) -> set[str]:
+    return {item["id"] for item in result["items"]}
+
+
+@pytest.mark.asyncio
+async def test_created_before_filter(memory: MemoryEngine, request_context: RequestContext):
+    bank_id = f"test-lmu-created-{uuid.uuid4().hex[:8]}"
+    await _ensure_bank(memory, bank_id, request_context)
+    now = datetime.now(UTC)
+    old = now - timedelta(days=30)
+
+    pool = await memory._get_pool()
+    async with pool.acquire() as conn:
+        old_id = await _seed_unit(conn, memory, bank_id, "old fact", created_at=old)
+        _new_id = await _seed_unit(conn, memory, bank_id, "new fact", created_at=now)
+
+    res = await memory.list_memory_units(
+        bank_id, created_before=now - timedelta(days=1), request_context=request_context
+    )
+    assert _ids(res) == {old_id}
+    assert res["total"] == 1
+
+    await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## Summary

Adds a `created_before` filter to `MemoryEngine.list_memory_units` so
maintenance-loop callers (retention sweeps, bulk maintenance) can select units
by ingest age through the engine — `created_at < <instant>` — instead of
open-coding SQL against `memory_units`. Composes with the existing
`tags` / `tags_match` filters.

## Scope note

An earlier version also added a `last_recalled_before` (dormancy) filter.
**Dropped** along with the `last_recalled_at` column — recency moves to a
Cloud-owned side table, so the dormancy read lives in the extension (a JOIN of
that table against `memory_units`), not core. `created_before` stays because
`created_at` is genuinely core.

## Notes for review

- Stacked on #2659; base is that branch, retarget to `main` once it merges.
- Additive; same `{items, total, limit, offset}` return shape.

## Test plan

- [x] `test_list_memory_units_filters.py::test_created_before_filter` against real Postgres
- [x] `ruff` + `ty` clean
