### PR TITLE
fix(worker): fence async operation writes by claim generation

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops.py
@@ -546,7 +546,8 @@ class DataAccessOps(ABC):
                 When set, consolidation tasks are claimed in priority tiers.
                 None preserves current behavior (pure created_at ordering).
 
-        Returns claimed rows with operation_id, operation_type, task_payload, retry_count.
+        Returns claimed rows with operation_id, operation_type, task_payload,
+        retry_count, worker_id, and the exact database-stored claimed_at value.
         The caller is responsible for building ClaimedTask objects.
         """
         ...

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -1395,4 +1395,15 @@ class OracleOps(DataAccessOps):
             operation_ids,
         )
 
-        return all_rows
+        claimed_rows = await conn.fetch(
+            f"""
+            SELECT operation_id, operation_type, task_payload, retry_count, worker_id, claimed_at
+            FROM {table}
+            WHERE operation_id = ANY($1)
+            """,
+            operation_ids,
+        )
+        claimed_by_id = {row["operation_id"]: row for row in claimed_rows}
+        if len(claimed_by_id) != len(operation_ids):
+            raise RuntimeError("Failed to read back every claimed async operation")
+        return [claimed_by_id[operation_id] for operation_id in operation_ids]

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -1408,4 +1408,15 @@ class PostgreSQLOps(DataAccessOps):
             operation_ids,
         )
 
-        return all_rows
+        claimed_rows = await conn.fetch(
+            f"""
+            SELECT operation_id, operation_type, task_payload, retry_count, worker_id, claimed_at
+            FROM {table}
+            WHERE operation_id = ANY($1)
+            """,
+            operation_ids,
+        )
+        claimed_by_id = {row["operation_id"]: row for row in claimed_rows}
+        if len(claimed_by_id) != len(operation_ids):
+            raise RuntimeError("Failed to read back every claimed async operation")
+        return [claimed_by_id[operation_id] for operation_id in operation_ids]

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -41,6 +41,7 @@ from ..config import (
 )
 from ..tracing import create_operation_span
 from ..utils import mask_network_location
+from ..worker.claim import get_operation_claim
 from ..worker.exceptions import DeferOperation, RetryTaskAt
 from ..worker.stage import set_stage
 from .audit import AuditLogger, audit_context
@@ -1631,32 +1632,6 @@ class MemoryEngine(MemoryEngineInterface):
             f"document_id={document_id}, {len(markdown_content)} chars. Submitting retain task."
         )
 
-        # Fire file conversion hook (e.g., for Iris billing)
-        if self._operation_validator:
-            try:
-                from hindsight_api.extensions.operation_validator import FileConvertResult
-                from hindsight_api.models import RequestContext
-
-                convert_context = RequestContext(
-                    internal=True,
-                    user_initiated=True,
-                    tenant_id=task_dict.get("_tenant_id"),
-                    api_key_id=task_dict.get("_api_key_id"),
-                    retry_count=task_dict.get("_retry_count", 0),
-                )
-                await self._operation_validator.on_file_convert_complete(
-                    FileConvertResult(
-                        bank_id=bank_id,
-                        parser_name=winning_parser,
-                        filename=filename,
-                        output_chars=len(markdown_content),
-                        output_text=markdown_content,
-                        request_context=convert_context,
-                    )
-                )
-            except Exception as e:
-                logger.warning(f"[FILE_CONVERT_RETAIN] on_file_convert_complete hook failed: {e}")
-
         # Build retain task payload
         retain_content: dict[str, Any] = {
             "content": markdown_content,
@@ -1709,6 +1684,31 @@ class MemoryEngine(MemoryEngineInterface):
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
             async with conn.transaction():
+                if operation_id:
+                    claim = get_operation_claim()
+                    claim_filter = "status NOT IN ('completed', 'failed', 'cancelled')"
+                    claim_args: tuple[Any, ...] = ()
+                    if claim is not None:
+                        claim_filter = "status = 'processing' AND worker_id = $2 AND claimed_at = $3"
+                        claim_args = (claim.worker_id, claim.claimed_at)
+                    row = await conn.fetchrow(
+                        f"""
+                        UPDATE {fq_table("async_operations")}
+                        SET status = 'completed', updated_at = NOW(), completed_at = NOW()
+                        WHERE operation_id = $1 AND {claim_filter}
+                        RETURNING operation_id
+                        """,
+                        uuid.UUID(operation_id),
+                        *claim_args,
+                    )
+                    if row is None:
+                        if claim is not None:
+                            logger.warning(
+                                f"File conversion {operation_id} lost claim before completion "
+                                f"(worker_id={claim.worker_id}, claimed_at={claim.claimed_at})"
+                            )
+                        return
+
                 await conn.execute(
                     f"""
                     INSERT INTO {fq_table("async_operations")}
@@ -1723,15 +1723,32 @@ class MemoryEngine(MemoryEngineInterface):
                     payload_json,
                 )
 
-                if operation_id:
-                    await conn.execute(
-                        f"""
-                        UPDATE {fq_table("async_operations")}
-                        SET status = 'completed', updated_at = NOW(), completed_at = NOW()
-                        WHERE operation_id = $1
-                        """,
-                        uuid.UUID(operation_id),
+        # Fire the completion hook only after this claim atomically wins the
+        # conversion-to-retain handoff, so stale workers cannot bill or emit it.
+        if self._operation_validator:
+            try:
+                from hindsight_api.extensions.operation_validator import FileConvertResult
+                from hindsight_api.models import RequestContext
+
+                convert_context = RequestContext(
+                    internal=True,
+                    user_initiated=True,
+                    tenant_id=task_dict.get("_tenant_id"),
+                    api_key_id=task_dict.get("_api_key_id"),
+                    retry_count=task_dict.get("_retry_count", 0),
+                )
+                await self._operation_validator.on_file_convert_complete(
+                    FileConvertResult(
+                        bank_id=bank_id,
+                        parser_name=winning_parser,
+                        filename=filename,
+                        output_chars=len(markdown_content),
+                        output_text=markdown_content,
+                        request_context=convert_context,
                     )
+                )
+            except Exception as e:
+                logger.warning(f"[FILE_CONVERT_RETAIN] on_file_convert_complete hook failed: {e}")
 
         # For SyncTaskBackend: executes the retain task inline.
         # For BrokerTaskBackend: no-op (submit_task's UPDATE skips rows whose
@@ -2033,25 +2050,28 @@ class MemoryEngine(MemoryEngineInterface):
                     # invalid embedding dimensions, etc.) will not succeed by rerunning
                     # the same payload. Retrying just burns worker capacity.
                     logger.error(f"Not retrying task {task_type} (deterministic failure): {type(e).__name__}")
-                    if task_type == "consolidation" and operation_id:
-                        await self._fire_consolidation_webhook(
-                            bank_id=task_dict.get("bank_id", ""),
-                            operation_id=operation_id,
-                            status="failed",
-                            result=None,
-                            error_message=str(e),
-                            schema=schema,
-                        )
                     if operation_id:
-                        await self._mark_operation_failed(operation_id, str(e), error_traceback)
+                        marked_failed = await self._mark_operation_failed(operation_id, str(e), error_traceback)
+                        if task_type == "consolidation" and marked_failed:
+                            await self._fire_consolidation_webhook(
+                                bank_id=task_dict.get("bank_id", ""),
+                                operation_id=operation_id,
+                                status="failed",
+                                operation_status="failed",
+                                result=None,
+                                error_message=str(e),
+                                schema=schema,
+                            )
                 else:
                     if task_type == "consolidation" and operation_id:
-                        # Fire failure webhook (non-transactional — operation not yet marked failed;
-                        # poller will mark it failed after this raise)
+                        # Queue the attempt-failure webhook only while this exact
+                        # processing claim is still current. The poller schedules
+                        # the retry after this handler raises.
                         await self._fire_consolidation_webhook(
                             bank_id=task_dict.get("bank_id", ""),
                             operation_id=operation_id,
                             status="failed",
+                            operation_status="processing",
                             result=None,
                             error_message=str(e),
                             schema=schema,
@@ -2106,11 +2126,12 @@ class MemoryEngine(MemoryEngineInterface):
         bank_id: str,
         operation_id: str,
         status: str,
+        operation_status: str,
         result: dict | None,
         error_message: str | None = None,
         schema: str | None = None,
     ) -> None:
-        """Fire a consolidation webhook event. Non-fatal - logs errors but does not raise."""
+        """Queue a consolidation webhook, fenced to the current claim when present."""
         if not self._webhook_manager:
             return
         try:
@@ -2132,7 +2153,34 @@ class MemoryEngine(MemoryEngineInterface):
                 timestamp=datetime.now(timezone.utc),
                 data=data,
             )
-            await self._webhook_manager.fire_event(event, schema=schema)
+            claim = get_operation_claim()
+            if claim is None:
+                await self._webhook_manager.fire_event(event, schema=schema)
+                return
+
+            backend = await self._get_backend()
+            async with acquire_with_retry(backend) as conn:
+                async with conn.transaction():
+                    row = await conn.fetchrow(
+                        f"""
+                        SELECT operation_id
+                        FROM {fq_table("async_operations")}
+                        WHERE operation_id = $1 AND status = $2
+                          AND worker_id = $3 AND claimed_at = $4
+                        FOR UPDATE
+                        """,
+                        uuid.UUID(operation_id),
+                        operation_status,
+                        claim.worker_id,
+                        claim.claimed_at,
+                    )
+                    if row is None:
+                        logger.warning(
+                            f"Operation {operation_id} lost claim before consolidation webhook "
+                            f"(worker_id={claim.worker_id}, claimed_at={claim.claimed_at})"
+                        )
+                        return
+                    await self._webhook_manager.fire_event_with_conn(event, conn, schema=schema)
         except Exception as e:
             logger.error(f"Failed to fire consolidation webhook for operation {operation_id}: {e}")
 
@@ -2306,9 +2354,29 @@ class MemoryEngine(MemoryEngineInterface):
         try:
             backend = await self._get_backend()
             async with acquire_with_retry(backend) as conn:
-                await conn.execute(
-                    f"DELETE FROM {fq_table('async_operations')} WHERE operation_id = $1", uuid.UUID(operation_id)
+                claim = get_operation_claim()
+                if claim is None:
+                    await conn.execute(
+                        f"DELETE FROM {fq_table('async_operations')} WHERE operation_id = $1",
+                        uuid.UUID(operation_id),
+                    )
+                    return
+                row = await conn.fetchrow(
+                    f"""
+                    DELETE FROM {fq_table("async_operations")}
+                    WHERE operation_id = $1 AND status = 'processing'
+                      AND worker_id = $2 AND claimed_at = $3
+                    RETURNING operation_id
+                    """,
+                    uuid.UUID(operation_id),
+                    claim.worker_id,
+                    claim.claimed_at,
                 )
+                if row is None:
+                    logger.warning(
+                        f"Operation {operation_id} lost claim before unknown-task deletion "
+                        f"(worker_id={claim.worker_id}, claimed_at={claim.claimed_at})"
+                    )
         except Exception as e:
             logger.error(f"Failed to delete async operation record {operation_id}: {e}")
 
@@ -2373,7 +2441,7 @@ class MemoryEngine(MemoryEngineInterface):
         except Exception as e:
             logger.debug(f"Failed to write operation progress for {operation_id}: {e}")
 
-    async def _mark_operation_failed(self, operation_id: str, error_message: str, error_traceback: str):
+    async def _mark_operation_failed(self, operation_id: str, error_message: str, error_traceback: str) -> bool:
         """Helper to mark an operation as failed in the database.
 
         Also checks if this is a child operation and updates the parent if all siblings are done.
@@ -2384,6 +2452,12 @@ class MemoryEngine(MemoryEngineInterface):
             # Truncate error message to avoid extremely long strings
             full_error = f"{error_message}\n\nTraceback:\n{error_traceback}"
             truncated_error = full_error[:5000] if len(full_error) > 5000 else full_error
+            claim = get_operation_claim()
+            claim_filter = ""
+            claim_args: tuple[Any, ...] = ()
+            if claim is not None:
+                claim_filter = " AND status = 'processing' AND worker_id = $3 AND claimed_at = $4"
+                claim_args = (claim.worker_id, claim.claimed_at)
 
             async with acquire_with_retry(backend) as conn:
                 async with conn.transaction():
@@ -2392,24 +2466,35 @@ class MemoryEngine(MemoryEngineInterface):
                         f"""
                         UPDATE {fq_table("async_operations")}
                         SET status = 'failed', error_message = $2, updated_at = NOW()
-                        WHERE operation_id = $1
+                        WHERE operation_id = $1{claim_filter}
                         RETURNING operation_id
                         """,
                         uuid.UUID(operation_id),
                         truncated_error,
+                        *claim_args,
                     )
                     if row is None:
-                        logger.info(f"Operation {operation_id} no longer exists (bank deleted), skipping mark-failed")
-                        return
+                        if claim is None:
+                            logger.info(
+                                f"Operation {operation_id} no longer exists (bank deleted), skipping mark-failed"
+                            )
+                        else:
+                            logger.warning(
+                                f"Operation {operation_id} lost claim before mark-failed "
+                                f"(worker_id={claim.worker_id}, claimed_at={claim.claimed_at})"
+                            )
+                        return False
                     logger.info(f"Marked async operation as failed: {operation_id}")
 
                     # Check if this is a child operation and update parent if all siblings are done
                     # This happens in the same transaction after the child status is updated
                     await self._maybe_update_parent_operation(operation_id, conn)
+                    return True
         except Exception as e:
             logger.error(f"Failed to mark operation as failed {operation_id}: {e}")
+            return False
 
-    async def _mark_operation_completed(self, operation_id: str):
+    async def _mark_operation_completed(self, operation_id: str) -> bool:
         """Helper to mark an operation as completed in the database.
 
         Also checks if this is a child operation and updates the parent if all siblings are done.
@@ -2422,6 +2507,7 @@ class MemoryEngine(MemoryEngineInterface):
         than a clean success. Default is off, so existing behavior is unchanged (see issue #2700).
         """
         try:
+            claim = get_operation_claim()
             backend = await self._get_backend()
             async with acquire_with_retry(backend) as conn:
                 async with conn.transaction():
@@ -2443,49 +2529,79 @@ class MemoryEngine(MemoryEngineInterface):
                             "marked failed because HINDSIGHT_API_FAIL_ON_EXTRACTION_ERRORS is enabled. "
                             "See result_metadata.extraction_errors_sample for details."
                         )
+                        claim_filter = "status NOT IN ('completed', 'failed', 'cancelled')"
+                        claim_args: tuple[Any, ...] = ()
+                        if claim is not None:
+                            claim_filter = "status = 'processing' AND worker_id = $3 AND claimed_at = $4"
+                            claim_args = (claim.worker_id, claim.claimed_at)
                         row = await conn.fetchrow(
                             f"""
                             UPDATE {fq_table("async_operations")}
                             SET status = 'failed', error_message = $2, updated_at = NOW(), completed_at = NOW()
-                            WHERE operation_id = $1 AND status NOT IN ('completed', 'failed', 'cancelled')
+                            WHERE operation_id = $1 AND {claim_filter}
                             RETURNING operation_id
                             """,
                             uuid.UUID(operation_id),
                             error_message,
+                            *claim_args,
                         )
                         if row is None:
-                            logger.info(f"Operation {operation_id} already terminal or deleted, skipping mark-failed")
-                            return
+                            if claim is None:
+                                logger.info(
+                                    f"Operation {operation_id} already terminal or deleted, skipping mark-failed"
+                                )
+                            else:
+                                logger.warning(
+                                    f"Operation {operation_id} lost claim before extraction-error mark-failed "
+                                    f"(worker_id={claim.worker_id}, claimed_at={claim.claimed_at})"
+                                )
+                            return False
                         logger.warning(
                             f"Marked async operation as failed due to {extraction_errors_count} "
                             f"extraction error(s): {operation_id}"
                         )
                         await self._maybe_update_parent_operation(operation_id, conn)
-                        return
+                        return True
 
                     # Mark this operation as completed. Guarded so an already-terminal
                     # row is never re-terminalized: this keeps the engine idempotent
                     # with the worker poller's completion backstop (PR #2608) and never
                     # re-runs parent aggregation on a row that is already done.
+                    claim_filter = "status NOT IN ('completed', 'failed', 'cancelled')"
+                    claim_args = ()
+                    if claim is not None:
+                        claim_filter = "status = 'processing' AND worker_id = $2 AND claimed_at = $3"
+                        claim_args = (claim.worker_id, claim.claimed_at)
                     row = await conn.fetchrow(
                         f"""
                         UPDATE {fq_table("async_operations")}
                         SET status = 'completed', updated_at = NOW(), completed_at = NOW()
-                        WHERE operation_id = $1 AND status NOT IN ('completed', 'failed', 'cancelled')
+                        WHERE operation_id = $1 AND {claim_filter}
                         RETURNING operation_id
                         """,
                         uuid.UUID(operation_id),
+                        *claim_args,
                     )
                     if row is None:
-                        logger.info(f"Operation {operation_id} already terminal or deleted, skipping mark-completed")
-                        return
+                        if claim is None:
+                            logger.info(
+                                f"Operation {operation_id} already terminal or deleted, skipping mark-completed"
+                            )
+                        else:
+                            logger.warning(
+                                f"Operation {operation_id} lost claim before mark-completed "
+                                f"(worker_id={claim.worker_id}, claimed_at={claim.claimed_at})"
+                            )
+                        return False
                     logger.info(f"Marked async operation as completed: {operation_id}")
 
                     # Check if this is a child operation and update parent if all siblings are done
                     # This happens in the same transaction after the child status is updated
                     await self._maybe_update_parent_operation(operation_id, conn)
+                    return True
         except Exception as e:
             logger.error(f"Failed to mark operation as completed {operation_id}: {e}")
+            return False
 
     async def _write_retain_outcome_metadata(self, operation_id: str | None, unit_ids: list[list[str]]) -> None:
         """Persist completed retain outcome fields before the operation is marked completed."""
@@ -2598,6 +2714,13 @@ class MemoryEngine(MemoryEngineInterface):
         """
         from ..webhooks.models import ConsolidationEventData, WebhookEvent, WebhookEventType
 
+        claim = get_operation_claim()
+        completion_filter = "status NOT IN ('completed', 'failed', 'cancelled')"
+        completion_args: tuple[Any, ...] = ()
+        if claim is not None:
+            completion_filter = "status = 'processing' AND worker_id = $2 AND claimed_at = $3"
+            completion_args = (claim.worker_id, claim.claimed_at)
+
         try:
             backend = await self._get_backend()
             async with acquire_with_retry(backend) as conn:
@@ -2606,13 +2729,22 @@ class MemoryEngine(MemoryEngineInterface):
                         f"""
                         UPDATE {fq_table("async_operations")}
                         SET status = 'completed', updated_at = NOW(), completed_at = NOW()
-                        WHERE operation_id = $1 AND status NOT IN ('completed', 'failed', 'cancelled')
+                        WHERE operation_id = $1 AND {completion_filter}
                         RETURNING operation_id
                         """,
                         uuid.UUID(operation_id),
+                        *completion_args,
                     )
                     if row is None:
-                        logger.info(f"Operation {operation_id} already terminal or deleted, skipping mark-completed")
+                        if claim is None:
+                            logger.info(
+                                f"Operation {operation_id} already terminal or deleted, skipping mark-completed"
+                            )
+                        else:
+                            logger.warning(
+                                f"Operation {operation_id} lost claim before mark-completed+webhook "
+                                f"(worker_id={claim.worker_id}, claimed_at={claim.claimed_at})"
+                            )
                         return
                     logger.info(f"Marked async operation as completed: {operation_id}")
                     await self._maybe_update_parent_operation(operation_id, conn)
@@ -2657,10 +2789,11 @@ class MemoryEngine(MemoryEngineInterface):
                         f"""
                         UPDATE {fq_table("async_operations")}
                         SET status = 'completed', updated_at = NOW(), completed_at = NOW()
-                        WHERE operation_id = $1 AND status NOT IN ('completed', 'failed', 'cancelled')
+                        WHERE operation_id = $1 AND {completion_filter}
                         RETURNING operation_id
                         """,
                         uuid.UUID(operation_id),
+                        *completion_args,
                     )
                     if row is not None:
                         completed_in_fallback = True
@@ -2675,6 +2808,7 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id,
                 operation_id=operation_id,
                 status=status,
+                operation_status="completed",
                 result=result,
                 error_message=error_message,
                 schema=schema,

--- a/hindsight-api-slim/hindsight_api/worker/claim.py
+++ b/hindsight-api-slim/hindsight_api/worker/claim.py
@@ -1,0 +1,52 @@
+"""Execution-scoped identity for a claimed async operation."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+
+@dataclass(frozen=True)
+class OperationClaim:
+    """The exact database lease held by one execution attempt."""
+
+    worker_id: str
+    claimed_at: datetime
+
+    @classmethod
+    def from_database(cls, worker_id: object, claimed_at: object) -> "OperationClaim":
+        """Build a claim from PostgreSQL or Oracle result values."""
+
+        if not isinstance(worker_id, str):
+            raise TypeError("Claimed operation returned a non-string worker_id")
+        if isinstance(claimed_at, str):
+            try:
+                claimed_at = datetime.fromisoformat(claimed_at)
+            except ValueError as exc:
+                raise ValueError("Claimed operation returned an invalid claimed_at timestamp") from exc
+        if not isinstance(claimed_at, datetime):
+            raise TypeError("Claimed operation returned a non-datetime claimed_at")
+        if claimed_at.tzinfo is None:
+            claimed_at = claimed_at.replace(tzinfo=UTC)
+        return cls(worker_id=worker_id, claimed_at=claimed_at)
+
+
+_current_operation_claim: ContextVar[OperationClaim | None] = ContextVar("current_operation_claim", default=None)
+
+
+@contextmanager
+def bind_operation_claim(claim: OperationClaim | None) -> Iterator[None]:
+    """Bind a claim to the current task without altering its persisted payload."""
+
+    token = _current_operation_claim.set(claim)
+    try:
+        yield
+    finally:
+        _current_operation_claim.reset(token)
+
+
+def get_operation_claim() -> OperationClaim | None:
+    """Return the claim owned by the current task execution, if any."""
+
+    return _current_operation_claim.get()

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 
 from ..engine.schema import fq_table_explicit as fq_table
 from ..metrics import get_metrics_collector
+from .claim import OperationClaim, bind_operation_claim, get_operation_claim
 from .exceptions import DeferOperation, RetryTaskAt
 from .stage import StageHolder, bind_holder
 
@@ -122,6 +123,7 @@ class ClaimedTask:
     operation_id: str
     task_dict: dict[str, Any]
     schema: str | None
+    claim: OperationClaim | None = None
 
 
 @dataclass
@@ -518,6 +520,7 @@ class WorkerPoller:
                             operation_id=str(row["operation_id"]),
                             task_dict=task_dict,
                             schema=schema,
+                            claim=OperationClaim.from_database(row["worker_id"], row["claimed_at"]),
                         )
                     )
                 return result
@@ -525,15 +528,22 @@ class WorkerPoller:
     async def _mark_completed(self, operation_id: str, schema: str | None):
         """Mark a processing task as completed, then propagate to parent if needed."""
         table = fq_table("async_operations", schema)
+        claim = get_operation_claim()
+        claim_filter = ""
+        claim_args: tuple[Any, ...] = ()
+        if claim is not None:
+            claim_filter = " AND worker_id = $2 AND claimed_at = $3"
+            claim_args = (claim.worker_id, claim.claimed_at)
         async with self._backend.acquire() as conn:
             async with conn.transaction():
                 result = await conn.execute(
                     f"""
                     UPDATE {table}
                     SET status = 'completed', completed_at = now(), updated_at = now()
-                    WHERE operation_id = $1 AND status = 'processing'
+                    WHERE operation_id = $1 AND status = 'processing'{claim_filter}
                     """,
                     operation_id,
+                    *claim_args,
                 )
                 if _updated_row_count(result):
                     await self._maybe_update_parent_operation(operation_id, schema, conn)
@@ -541,21 +551,34 @@ class WorkerPoller:
     async def _mark_failed(self, operation_id: str, error_message: str, schema: str | None):
         """Mark a task as failed with error message, then propagate to parent if applicable."""
         table = fq_table("async_operations", schema)
+        claim = get_operation_claim()
+        claim_filter = ""
+        claim_args: tuple[Any, ...] = ()
+        if claim is not None:
+            claim_filter = " AND status = 'processing' AND worker_id = $3 AND claimed_at = $4"
+            claim_args = (claim.worker_id, claim.claimed_at)
         # Truncate error message if too long (max 5000 chars in schema)
         error_message = error_message[:5000] if len(error_message) > 5000 else error_message
 
         async with self._backend.acquire() as conn:
             async with conn.transaction():
-                await conn.execute(
+                result = await conn.execute(
                     f"""
                     UPDATE {table}
                     SET status = 'failed', error_message = $2, completed_at = now(), updated_at = now()
-                    WHERE operation_id = $1
+                    WHERE operation_id = $1{claim_filter}
                     """,
                     operation_id,
                     error_message,
+                    *claim_args,
                 )
-                await self._maybe_update_parent_operation(operation_id, schema, conn)
+                if _updated_row_count(result):
+                    await self._maybe_update_parent_operation(operation_id, schema, conn)
+                elif claim is not None:
+                    logger.warning(
+                        f"Task {operation_id} lost claim before mark-failed "
+                        f"(worker_id={claim.worker_id}, claimed_at={claim.claimed_at})"
+                    )
 
     async def _maybe_update_parent_operation(self, child_operation_id: str, schema: str | None, conn) -> None:
         """If this operation is a child of a batch_retain, update the parent status when all siblings are done.
@@ -647,20 +670,33 @@ class WorkerPoller:
     async def _schedule_retry(self, operation_id: str, retry_at: "Any", error_message: str, schema: str | None):
         """Reset task to pending with a future retry timestamp."""
         table = fq_table("async_operations", schema)
+        claim = get_operation_claim()
+        claim_filter = ""
+        claim_args: tuple[Any, ...] = ()
+        if claim is not None:
+            claim_filter = " AND status = 'processing' AND worker_id = $4 AND claimed_at = $5"
+            claim_args = (claim.worker_id, claim.claimed_at)
         error_message = error_message[:5000] if len(error_message) > 5000 else error_message
         async with self._backend.acquire() as conn:
-            await conn.execute(
+            result = await conn.execute(
                 f"""
                 UPDATE {table}
                 SET status = 'pending', next_retry_at = $2, worker_id = NULL, claimed_at = NULL,
                     retry_count = retry_count + 1, error_message = $3, updated_at = now()
-                WHERE operation_id = $1
+                WHERE operation_id = $1{claim_filter}
                 """,
                 operation_id,
                 retry_at,
                 error_message,
+                *claim_args,
             )
-        logger.warning(f"Task {operation_id} scheduled for retry at {retry_at}: {error_message}")
+        if _updated_row_count(result):
+            logger.warning(f"Task {operation_id} scheduled for retry at {retry_at}: {error_message}")
+        elif claim is not None:
+            logger.warning(
+                f"Task {operation_id} lost claim before retry scheduling "
+                f"(worker_id={claim.worker_id}, claimed_at={claim.claimed_at})"
+            )
 
     async def _defer_operation(self, operation_id: str, exec_date: "Any", reason: str, schema: str | None):
         """Reset task to pending for re-pickup at exec_date without counting as a retry.
@@ -669,18 +705,31 @@ class WorkerPoller:
         populate `error_message` — defer is intentional backpressure, not a failure.
         """
         table = fq_table("async_operations", schema)
+        claim = get_operation_claim()
+        claim_filter = ""
+        claim_args: tuple[Any, ...] = ()
+        if claim is not None:
+            claim_filter = " AND status = 'processing' AND worker_id = $3 AND claimed_at = $4"
+            claim_args = (claim.worker_id, claim.claimed_at)
         async with self._backend.acquire() as conn:
-            await conn.execute(
+            result = await conn.execute(
                 f"""
                 UPDATE {table}
                 SET status = 'pending', next_retry_at = $2, worker_id = NULL, claimed_at = NULL,
                     updated_at = now()
-                WHERE operation_id = $1
+                WHERE operation_id = $1{claim_filter}
                 """,
                 operation_id,
                 exec_date,
+                *claim_args,
             )
-        logger.info(f"Task {operation_id} deferred until {exec_date}: {reason}")
+        if _updated_row_count(result):
+            logger.info(f"Task {operation_id} deferred until {exec_date}: {reason}")
+        elif claim is not None:
+            logger.warning(
+                f"Task {operation_id} lost claim before deferral "
+                f"(worker_id={claim.worker_id}, claimed_at={claim.claimed_at})"
+            )
 
     async def execute_task(self, task: ClaimedTask):
         """Execute a single task as a background job (fire-and-forget)."""
@@ -728,6 +777,10 @@ class WorkerPoller:
                         del self._in_flight_by_type[operation_type]
 
     async def _execute_task_inner(self, task: ClaimedTask, holder: StageHolder | None = None):
+        with bind_operation_claim(task.claim):
+            await self._execute_task_under_claim(task, holder)
+
+    async def _execute_task_under_claim(self, task: ClaimedTask, holder: StageHolder | None = None):
         """Inner task execution with retry/fail handling.
 
         Tasks that want to be retried raise RetryTaskAt; the poller sets next_retry_at

--- a/hindsight-api-slim/tests/test_file_retain.py
+++ b/hindsight-api-slim/tests/test_file_retain.py
@@ -5,7 +5,9 @@ End-to-end tests for file retain (upload, convert, retain) functionality.
 import asyncio
 import io
 import json
+import uuid
 from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -615,6 +617,88 @@ async def test_file_conversion_creates_separate_retain_operation(memory_no_llm_v
     assert doc["file_content_type"] == "text/plain"
     assert doc["original_text"] is not None
     assert len(doc["original_text"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_file_conversion_losing_claim_does_not_create_retain_operation():
+    """A stale conversion result must not enqueue retain work or delete source bytes."""
+    from hindsight_api.engine.memory_engine import MemoryEngine
+    from hindsight_api.worker.claim import OperationClaim, bind_operation_claim
+
+    class _Transaction:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _Acquire:
+        def __init__(self, conn):
+            self._conn = conn
+
+        async def __aenter__(self):
+            return self._conn
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _Backend:
+        _wraps_backend = True
+
+        def __init__(self, conn):
+            self._conn = conn
+
+        def acquire(self):
+            return _Acquire(self._conn)
+
+    conn = MagicMock()
+    conn.transaction.return_value = _Transaction()
+    conn.fetchrow = AsyncMock(return_value=None)
+    conn.execute = AsyncMock()
+
+    engine = MemoryEngine.__new__(MemoryEngine)
+    engine._get_backend = AsyncMock(return_value=_Backend(conn))
+    engine._file_storage = MagicMock()
+    engine._file_storage.retrieve = AsyncMock(return_value=b"source")
+    engine._file_storage.delete = AsyncMock()
+    engine._parser_registry = MagicMock()
+    engine._parser_registry.convert_with_fallback = AsyncMock(
+        return_value=MagicMock(content="converted", parser_name="test-parser")
+    )
+    engine._operation_validator = None
+    engine._task_backend = MagicMock()
+    engine._task_backend.submit_task = AsyncMock()
+
+    operation_id = str(uuid.uuid4())
+    claim = OperationClaim(worker_id="worker-a", claimed_at=datetime(2026, 7, 21, 8, 0, tzinfo=timezone.utc))
+    task_dict = {
+        "type": "file_convert_retain",
+        "operation_id": operation_id,
+        "bank_id": "bank-1",
+        "storage_key": "source-key",
+        "document_id": "doc-1",
+        "original_filename": "source.txt",
+        "content_type": "text/plain",
+        "parser": ["test-parser"],
+    }
+
+    with (
+        bind_operation_claim(claim),
+        patch(
+            "hindsight_api.engine.memory_engine.get_config",
+            return_value=MagicMock(file_delete_after_retain=False),
+        ),
+    ):
+        await engine._handle_file_convert_retain(task_dict)
+
+    query, *args = conn.fetchrow.await_args.args
+    assert "status = 'processing'" in query
+    assert "worker_id = $2" in query
+    assert "claimed_at = $3" in query
+    assert tuple(args) == (uuid.UUID(operation_id), claim.worker_id, claim.claimed_at)
+    conn.execute.assert_not_awaited()
+    engine._task_backend.submit_task.assert_not_awaited()
+    engine._file_storage.delete.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_operation_completion.py
+++ b/hindsight-api-slim/tests/test_operation_completion.py
@@ -8,11 +8,13 @@ consolidation webhook must still be delivered on the fallback path.
 """
 
 import uuid
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from hindsight_api.engine.memory_engine import MemoryEngine
+from hindsight_api.worker.claim import OperationClaim, bind_operation_claim
 
 
 class _FakeTx:
@@ -27,13 +29,20 @@ class _FakeConn:
     def __init__(self, fetchrow_result):
         self._fetchrow_result = fetchrow_result
         self.fetchrow_calls: list[tuple[str, tuple]] = []
+        self.execute_calls: list[tuple[str, tuple]] = []
 
     def transaction(self):
         return _FakeTx()
 
     async def fetchrow(self, query, *args):
         self.fetchrow_calls.append((query, args))
+        if isinstance(self._fetchrow_result, list):
+            return self._fetchrow_result.pop(0)
         return self._fetchrow_result
+
+    async def execute(self, query, *args):
+        self.execute_calls.append((query, args))
+        return "DELETE 0"
 
 
 class _FakeAcquire:
@@ -71,6 +80,7 @@ def _make_engine(fetchrow_result, *, webhook_raises: bool):
         webhook_manager.fire_event_with_conn = AsyncMock(side_effect=RuntimeError("outbox insert failed"))
     else:
         webhook_manager.fire_event_with_conn = AsyncMock()
+    webhook_manager.fire_event = AsyncMock()
     engine._webhook_manager = webhook_manager
     return engine, conn
 
@@ -123,6 +133,152 @@ class TestMarkOperationCompletedAndFireWebhook:
         )
 
         assert len(conn.fetchrow_calls) == 1
+        engine._maybe_update_parent_operation.assert_not_awaited()
+        engine._webhook_manager.fire_event_with_conn.assert_not_awaited()
+        engine._fire_consolidation_webhook.assert_not_awaited()
+
+
+class TestOperationTerminalClaimFences:
+    async def test_unknown_task_delete_fences_on_exact_claim(self):
+        op_id = str(uuid.uuid4())
+        engine, conn = _make_engine(None, webhook_raises=False)
+        claim = OperationClaim(worker_id="worker-a", claimed_at=datetime(2026, 7, 21, 8, 0, tzinfo=UTC))
+
+        with bind_operation_claim(claim):
+            await engine._delete_operation_record(op_id)
+
+        query, args = conn.fetchrow_calls[0]
+        assert "status = 'processing'" in query
+        assert "worker_id = $2" in query
+        assert "claimed_at = $3" in query
+        assert args == (uuid.UUID(op_id), claim.worker_id, claim.claimed_at)
+
+    async def test_mark_failed_fences_on_exact_claim(self):
+        op_id = str(uuid.uuid4())
+        engine, conn = _make_engine(None, webhook_raises=False)
+        claim = OperationClaim(worker_id="worker-a", claimed_at=datetime(2026, 7, 21, 8, 0, tzinfo=UTC))
+
+        with bind_operation_claim(claim):
+            await engine._mark_operation_failed(op_id, "late failure", "traceback")
+
+        query, args = conn.fetchrow_calls[0]
+        assert "status = 'processing'" in query
+        assert "worker_id = $3" in query
+        assert "claimed_at = $4" in query
+        assert args[0] == uuid.UUID(op_id)
+        assert args[2:] == (claim.worker_id, claim.claimed_at)
+        engine._maybe_update_parent_operation.assert_not_awaited()
+
+    async def test_mark_completed_fences_on_exact_claim(self):
+        op_id = str(uuid.uuid4())
+        engine, conn = _make_engine(None, webhook_raises=False)
+        claim = OperationClaim(worker_id="worker-a", claimed_at=datetime(2026, 7, 21, 8, 0, tzinfo=UTC))
+
+        with bind_operation_claim(claim):
+            await engine._mark_operation_completed(op_id)
+
+        query, args = conn.fetchrow_calls[1]
+        assert "status = 'processing'" in query
+        assert "worker_id = $2" in query
+        assert "claimed_at = $3" in query
+        assert args == (uuid.UUID(op_id), claim.worker_id, claim.claimed_at)
+        engine._maybe_update_parent_operation.assert_not_awaited()
+
+    async def test_lost_non_retryable_failure_does_not_fire_consolidation_webhook(self):
+        op_id = str(uuid.uuid4())
+        engine, _conn = _make_engine({"status": "processing"}, webhook_raises=False)
+        engine._audit_logger = None
+        engine._ext_ctx = MagicMock()
+        engine._handle_consolidation = AsyncMock(side_effect=ValueError("embedding 0 has dimension 0; expected 384"))
+        engine._mark_operation_failed = AsyncMock(return_value=False)
+        claim = OperationClaim(worker_id="worker-a", claimed_at=datetime(2026, 7, 21, 8, 0, tzinfo=UTC))
+
+        with bind_operation_claim(claim):
+            await engine.execute_task(
+                {
+                    "type": "consolidation",
+                    "operation_id": op_id,
+                    "bank_id": "bank-1",
+                }
+            )
+
+        engine._mark_operation_failed.assert_awaited_once()
+        engine._fire_consolidation_webhook.assert_not_awaited()
+
+    async def test_lost_transient_failure_does_not_queue_consolidation_webhook(self):
+        from hindsight_api.worker.exceptions import RetryTaskAt
+
+        op_id = str(uuid.uuid4())
+        engine, conn = _make_engine([{"status": "processing"}, None], webhook_raises=False)
+        engine._audit_logger = None
+        engine._ext_ctx = MagicMock()
+        engine._handle_consolidation = AsyncMock(side_effect=RuntimeError("transient upstream failure"))
+        engine._has_other_pending_consolidation = AsyncMock(return_value=False)
+        engine._fire_consolidation_webhook = MemoryEngine._fire_consolidation_webhook.__get__(engine)
+        claim = OperationClaim(worker_id="worker-a", claimed_at=datetime(2026, 7, 21, 8, 0, tzinfo=UTC))
+
+        with bind_operation_claim(claim), pytest.raises(RetryTaskAt):
+            await engine.execute_task(
+                {
+                    "type": "consolidation",
+                    "operation_id": op_id,
+                    "bank_id": "bank-1",
+                }
+            )
+
+        claim_query, claim_args = conn.fetchrow_calls[1]
+        assert "status = $2" in claim_query
+        assert "worker_id = $3" in claim_query
+        assert "claimed_at = $4" in claim_query
+        assert claim_args == (uuid.UUID(op_id), "processing", claim.worker_id, claim.claimed_at)
+        engine._webhook_manager.fire_event_with_conn.assert_not_awaited()
+        engine._webhook_manager.fire_event.assert_not_awaited()
+
+    async def test_current_claim_queues_consolidation_webhook_in_fenced_transaction(self):
+        op_id = str(uuid.uuid4())
+        engine, conn = _make_engine({"operation_id": op_id}, webhook_raises=False)
+        engine._fire_consolidation_webhook = MemoryEngine._fire_consolidation_webhook.__get__(engine)
+        claim = OperationClaim(worker_id="worker-a", claimed_at=datetime(2026, 7, 21, 8, 0, tzinfo=UTC))
+
+        with bind_operation_claim(claim):
+            await engine._fire_consolidation_webhook(
+                bank_id="bank-1",
+                operation_id=op_id,
+                status="failed",
+                operation_status="processing",
+                result=None,
+                error_message="transient upstream failure",
+            )
+
+        query, args = conn.fetchrow_calls[0]
+        assert "status = $2" in query
+        assert "worker_id = $3" in query
+        assert "claimed_at = $4" in query
+        assert args == (uuid.UUID(op_id), "processing", claim.worker_id, claim.claimed_at)
+        event, event_conn = engine._webhook_manager.fire_event_with_conn.await_args.args
+        assert event.operation_id == op_id
+        assert event.status == "failed"
+        assert event_conn is conn
+        engine._webhook_manager.fire_event.assert_not_awaited()
+
+    async def test_lost_claim_does_not_queue_webhook_or_update_parent(self):
+        op_id = str(uuid.uuid4())
+        engine, conn = _make_engine(None, webhook_raises=False)
+        claim = OperationClaim(worker_id="worker-a", claimed_at=datetime(2026, 7, 21, 8, 0, tzinfo=UTC))
+
+        with bind_operation_claim(claim):
+            await engine._mark_operation_completed_and_fire_webhook(
+                operation_id=op_id,
+                bank_id="bank-1",
+                status="completed",
+                result=None,
+            )
+
+        query, args = conn.fetchrow_calls[0]
+        assert "status = 'processing'" in query
+        assert "worker_id = $2" in query
+        assert "claimed_at = $3" in query
+        assert args == (uuid.UUID(op_id), claim.worker_id, claim.claimed_at)
         engine._maybe_update_parent_operation.assert_not_awaited()
         engine._webhook_manager.fire_event_with_conn.assert_not_awaited()
         engine._fire_consolidation_webhook.assert_not_awaited()

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -170,6 +170,43 @@ class TestWorkerOperationMetrics:
         collector = await self._run(retry)
         collector.record_operation_result.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_execute_task_inner_binds_and_restores_database_claim(self):
+        from hindsight_api.worker.claim import OperationClaim, bind_operation_claim, get_operation_claim
+        from hindsight_api.worker.poller import ClaimedTask
+
+        task_claim = OperationClaim(worker_id="worker-a", claimed_at=datetime(2026, 7, 21, 8, 0, tzinfo=UTC))
+        outer_claim = OperationClaim(worker_id="outer", claimed_at=datetime(2026, 7, 21, 7, 0, tzinfo=UTC))
+        observed_claims = []
+
+        async def executor(_task_dict):
+            observed_claims.append(get_operation_claim())
+
+        poller = self._make_poller(executor)
+        poller._mark_completed.side_effect = lambda *_args: observed_claims.append(get_operation_claim())
+        task = ClaimedTask(
+            operation_id="op-1",
+            task_dict={"type": "test", "operation_type": "test", "bank_id": "bank-1"},
+            schema=None,
+            claim=task_claim,
+        )
+
+        with bind_operation_claim(outer_claim):
+            await poller._execute_task_inner(task)
+            assert get_operation_claim() == outer_claim
+
+        assert observed_claims == [task_claim, task_claim]
+        assert get_operation_claim() is None
+
+
+def test_operation_claim_normalizes_oracle_timestamp_string():
+    from hindsight_api.worker.claim import OperationClaim
+
+    claim = OperationClaim.from_database("worker-a", "2026-07-21T08:00:00.123456+00:00")
+
+    assert claim.worker_id == "worker-a"
+    assert claim.claimed_at == datetime(2026, 7, 21, 8, 0, 0, 123456, tzinfo=UTC)
+
 
 class _AsyncContext:
     def __init__(self, value):
@@ -232,6 +269,73 @@ class TestWorkerMarkCompleted:
 
         assert conn.execute_calls
         poller._maybe_update_parent_operation.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_mark_completed_fences_on_exact_claim(self):
+        from hindsight_api.worker.claim import OperationClaim, bind_operation_claim
+
+        poller, conn = self._make_poller("UPDATE 1")
+        claim = OperationClaim(worker_id="worker-a", claimed_at=datetime(2026, 7, 21, 8, 0, tzinfo=UTC))
+
+        with bind_operation_claim(claim):
+            await poller._mark_completed("op-1", schema=None)
+
+        query, args = conn.execute_calls[0]
+        assert "status = 'processing'" in query
+        assert "worker_id = $2" in query
+        assert "claimed_at = $3" in query
+        assert args == ("op-1", claim.worker_id, claim.claimed_at)
+
+    @pytest.mark.asyncio
+    async def test_mark_failed_skips_parent_when_claim_is_lost(self):
+        from hindsight_api.worker.claim import OperationClaim, bind_operation_claim
+
+        poller, conn = self._make_poller("UPDATE 0")
+        claim = OperationClaim(worker_id="worker-a", claimed_at=datetime(2026, 7, 21, 8, 0, tzinfo=UTC))
+
+        with bind_operation_claim(claim):
+            await poller._mark_failed("op-1", "late failure", schema=None)
+
+        query, args = conn.execute_calls[0]
+        assert "status = 'processing'" in query
+        assert "worker_id = $3" in query
+        assert "claimed_at = $4" in query
+        assert args == ("op-1", "late failure", claim.worker_id, claim.claimed_at)
+        poller._maybe_update_parent_operation.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_retry_fences_on_exact_claim(self):
+        from hindsight_api.worker.claim import OperationClaim, bind_operation_claim
+
+        poller, conn = self._make_poller("UPDATE 0")
+        claim = OperationClaim(worker_id="worker-a", claimed_at=datetime(2026, 7, 21, 8, 0, tzinfo=UTC))
+        retry_at = datetime(2026, 7, 21, 8, 5, tzinfo=UTC)
+
+        with bind_operation_claim(claim):
+            await poller._schedule_retry("op-1", retry_at, "transient", schema=None)
+
+        query, args = conn.execute_calls[0]
+        assert "status = 'processing'" in query
+        assert "worker_id = $4" in query
+        assert "claimed_at = $5" in query
+        assert args == ("op-1", retry_at, "transient", claim.worker_id, claim.claimed_at)
+
+    @pytest.mark.asyncio
+    async def test_defer_fences_on_exact_claim(self):
+        from hindsight_api.worker.claim import OperationClaim, bind_operation_claim
+
+        poller, conn = self._make_poller("UPDATE 0")
+        claim = OperationClaim(worker_id="worker-a", claimed_at=datetime(2026, 7, 21, 8, 0, tzinfo=UTC))
+        exec_date = datetime(2026, 7, 21, 8, 5, tzinfo=UTC)
+
+        with bind_operation_claim(claim):
+            await poller._defer_operation("op-1", exec_date, "backpressure", schema=None)
+
+        query, args = conn.execute_calls[0]
+        assert "status = 'processing'" in query
+        assert "worker_id = $3" in query
+        assert "claimed_at = $4" in query
+        assert args == ("op-1", exec_date, claim.worker_id, claim.claimed_at)
 
 
 def test_all_operation_types_have_slot_reservation_config():
@@ -429,6 +533,9 @@ class TestWorkerPoller:
         for task in my_claims:
             assert task.operation_id is not None
             assert task.task_dict is not None
+            assert task.claim is not None
+            assert task.claim.worker_id == "test-worker-1"
+            assert task.claim.claimed_at is not None
 
         # Verify tasks are marked as processing with worker_id
         rows = await pool.fetch(
@@ -438,6 +545,72 @@ class TestWorkerPoller:
         for row in rows:
             assert row["status"] == "processing"
             assert row["worker_id"] == "test-worker-1"
+
+    @pytest.mark.asyncio
+    async def test_same_worker_stale_claim_cannot_complete_reclaimed_task(self, pool, backend, clean_operations):
+        from hindsight_api.worker import WorkerPoller
+        from hindsight_api.worker.claim import OperationClaim, bind_operation_claim
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        operation_id = uuid.uuid4()
+        worker_id = "stable-worker-id"
+        await _ensure_bank(pool, bank_id)
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload)
+            VALUES ($1, $2, 'test', 'pending', $3::jsonb)
+            """,
+            operation_id,
+            bank_id,
+            json.dumps({"type": "test_task", "bank_id": bank_id}),
+        )
+        poller = WorkerPoller(
+            backend=backend,
+            worker_id=worker_id,
+            executor=AsyncMock(),
+            max_slots=1,
+            slot_reservations={},
+        )
+
+        claimed = await poller.claim_batch()
+        task = next(task for task in claimed if task.operation_id == str(operation_id))
+        assert task.claim is not None
+        replacement_claim = OperationClaim(
+            worker_id=worker_id,
+            claimed_at=task.claim.claimed_at + timedelta(seconds=1),
+        )
+        await pool.execute(
+            """
+            UPDATE async_operations
+            SET status = 'processing', worker_id = $2, claimed_at = $3
+            WHERE operation_id = $1
+            """,
+            operation_id,
+            replacement_claim.worker_id,
+            replacement_claim.claimed_at,
+        )
+
+        with bind_operation_claim(task.claim):
+            await poller._mark_completed(task.operation_id, schema=None)
+
+        stale_result = await pool.fetchrow(
+            "SELECT status, worker_id, claimed_at FROM async_operations WHERE operation_id = $1",
+            operation_id,
+        )
+        assert stale_result["status"] == "processing"
+        assert stale_result["worker_id"] == replacement_claim.worker_id
+        assert stale_result["claimed_at"] == replacement_claim.claimed_at
+
+        with bind_operation_claim(replacement_claim):
+            await poller._mark_completed(task.operation_id, schema=None)
+
+        assert (
+            await pool.fetchval(
+                "SELECT status FROM async_operations WHERE operation_id = $1",
+                operation_id,
+            )
+            == "completed"
+        )
 
     @pytest.mark.asyncio
     async def test_claim_batch_respects_max_slots(self, pool, backend, clean_operations):


### PR DESCRIPTION
Closes #2816.

## Summary

- Carry each execution attempt's exact database claim identity, `(worker_id, claimed_at)`, from claim readback through the worker task context.
- Fence completion, failure, retry, defer, and unknown-task deletion writes against that exact claim.
- Make dependent side effects conditional on winning the fence: parent aggregation, consolidation webhook enqueue, and the file-conversion-to-retain handoff.
- Normalize Oracle timestamp strings before binding `claimed_at` back into compare-and-swap queries.

## Why `claimed_at`

`worker_id` alone is not a claim generation: a stable worker ID can reclaim an operation while an older coroutine from the same worker is still running. The claim path now reads back the exact database-stored `claimed_at` value after the claim update and uses it together with `worker_id` for subsequent compare-and-swap predicates.

This reuses existing columns, so there is no schema migration. It also does not change persisted task payloads, executor signatures, or public APIs. Direct/non-worker call paths retain their existing idempotency guards.

## Safety properties

- A stale attempt cannot complete, fail, retry, defer, or delete a newer claim.
- Parent aggregation and consolidation webhook delivery are skipped after claim loss.
- Claimed-owner webhook enqueue is checked and inserted in one transaction while the operation row is locked.
- File conversion completion and downstream retain creation remain atomic; a stale conversion creates no child task and emits no completion hook.
- PostgreSQL and Oracle both return the exact stored claim timestamp; Oracle string timestamps are normalized before reuse.

## Verification

- `./scripts/hooks/lint.sh`
- 116 operation-completion and worker tests passed.
- 115 file-handoff, cancellation-compatibility, and database-adapter tests passed.
- Post-rebase critical regression run: 12 passed, including a real PostgreSQL same-worker reclaim case.
- Independent review: no remaining Critical or Important findings.
