### PR TITLE
fix: propagate Codex reasoning effort

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
@@ -172,8 +172,8 @@ class CodexLLM(LLMInterface):
         if self.model.startswith("openai/"):
             self.model = self.model[len("openai/") :]
 
-        # Map reasoning effort to Codex reasoning summary format
-        # Codex supports: "auto", "concise", "detailed"
+        # Reasoning summary controls presentation separately from the backend's
+        # reasoning effort, which is sent unchanged in each request payload.
         self.reasoning_summary = self._map_reasoning_effort(reasoning_effort)
 
         # HTTP client for SSE streaming
@@ -448,7 +448,7 @@ class CodexLLM(LLMInterface):
             "tools": [],
             "tool_choice": "auto",
             "parallel_tool_calls": True,
-            "reasoning": {"summary": reasoning_summary},
+            "reasoning": {"effort": self.reasoning_effort, "summary": reasoning_summary},
             "store": False,  # Codex uses stateless mode
             "stream": True,  # SSE streaming
             "include": ["reasoning.encrypted_content"],
@@ -831,7 +831,7 @@ class CodexLLM(LLMInterface):
                 else tool_choice.mode.value
             ),
             "parallel_tool_calls": True,
-            "reasoning": {"summary": reasoning_summary},
+            "reasoning": {"effort": self.reasoning_effort, "summary": reasoning_summary},
             "store": False,
             "stream": True,
             "include": ["reasoning.encrypted_content"],

--- a/hindsight-api-slim/tests/test_codex_reasoning_effort.py
+++ b/hindsight-api-slim/tests/test_codex_reasoning_effort.py
@@ -1,0 +1,64 @@
+"""Regression tests for Codex reasoning-effort request serialization."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from hindsight_api.engine.providers.codex_llm import CodexLLM
+
+
+def build_llm(reasoning_effort: str = "high") -> CodexLLM:
+    with (
+        patch.object(CodexLLM, "_load_codex_auth", return_value=("token", "account")),
+        patch.object(CodexLLM, "_load_codex_refresh_token", return_value=None),
+    ):
+        return CodexLLM(
+            provider="openai-codex",
+            api_key="ignored",
+            base_url="https://chatgpt.com/backend-api",
+            model="gpt-5.6-luna",
+            reasoning_effort=reasoning_effort,
+        )
+
+
+@pytest.mark.asyncio
+async def test_call_sends_reasoning_effort_separately_from_summary() -> None:
+    llm = build_llm("high")
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+
+    with (
+        patch.object(llm._client, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(llm, "_parse_sse_stream", new_callable=AsyncMock, return_value="ok"),
+    ):
+        mock_post.return_value = response
+        await llm.call(messages=[{"role": "user", "content": "hello"}], max_retries=0)
+
+    assert mock_post.call_args.kwargs["json"]["reasoning"] == {
+        "effort": "high",
+        "summary": "detailed",
+    }
+
+
+@pytest.mark.asyncio
+async def test_call_with_tools_sends_reasoning_effort_separately_from_summary() -> None:
+    llm = build_llm("low")
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+
+    with (
+        patch.object(llm._client, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(llm, "_parse_sse_tool_stream", new_callable=AsyncMock, return_value=(None, [])),
+    ):
+        mock_post.return_value = response
+        await llm.call_with_tools(
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[],
+            max_retries=0,
+        )
+
+    assert mock_post.call_args.kwargs["json"]["reasoning"] == {
+        "effort": "low",
+        "summary": "concise",
+    }


### PR DESCRIPTION
## Summary

- send the configured Codex `reasoning_effort` as `reasoning.effort`
- keep reasoning-summary selection separate and unchanged
- cover both regular and tool-enabled request payloads with regression tests

## Why

The Codex provider currently maps `reasoning_effort` to `reasoning.summary`, but it never sends the effort itself. As a result, settings such as `high` and `xhigh` only change summary detail while the backend continues to use its default reasoning effort.

This change passes the configured effort through and preserves the existing summary mapping, including the special detailed-summary behavior for GPT-5.2 models.

## Validation

- `uv run python -m pytest tests/test_codex_reasoning_effort.py -q` (2 passed)
- `uv run python -m pytest tests/test_codex_*.py -q` (50 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check hindsight_api/engine/providers/codex_llm.py`
- `uv run ty check tests/test_codex_reasoning_effort.py`
- direct provider canaries covered both a normal response and a tool call

## Risk / impact

The request shape changes only for the `openai-codex` provider. Supported configured effort values now reach the backend as intended. An unsupported value may now be rejected by the backend instead of being silently ignored.

## Scope boundaries

- no changes to OAuth handling, token refresh, streaming, or tool schemas
- no changes to provider defaults or configuration parsing
- no changes to other LLM providers

## Known out-of-scope CI failure

`verify-generated-files` currently fails because `main` contains `skills/hindsight-docs/references/openapi.json` at version `0.8.4`, while `./scripts/generate-docs-skill.sh` regenerates it as `0.8.5`. This reproduces on the unchanged base commit `4dc8348348f3e0b50da9071357955a2995c4f0e0` and is unrelated to this provider change.

PRs #2913 and #2916 already include that same generated one-line sync, so this PR deliberately does not duplicate it.

## Rollout / operator notes

No migration is required. Existing installations keep their configured/default effort; the Codex backend will now receive it explicitly.

## Reviewer focus

Please check the Codex request shape in both `call()` and `call_with_tools()`, and confirm that effort propagation stays independent from summary selection.
