### PR TITLE
fix backup restore schema compatibility

### DIFF
--- a/hindsight-api-slim/hindsight_api/admin/cli.py
+++ b/hindsight-api-slim/hindsight_api/admin/cli.py
@@ -9,6 +9,7 @@ import io
 import json
 import logging
 import zipfile
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -67,7 +68,59 @@ BACKUP_TABLES = [
     "graph_maintenance_queue",
 ]
 
-MANIFEST_VERSION = "1"
+MANIFEST_VERSION = "2"
+
+
+@dataclass(frozen=True)
+class BackupColumn:
+    """A PostgreSQL column shape required to decode a binary COPY stream."""
+
+    name: str
+    type_name: str
+
+
+async def _table_columns(conn: asyncpg.Connection, schema: str, table: str) -> list[BackupColumn]:
+    rows = await conn.fetch(
+        """
+        SELECT a.attname AS name, pg_catalog.format_type(a.atttypid, a.atttypmod) AS type_name
+        FROM pg_catalog.pg_attribute AS a
+        JOIN pg_catalog.pg_class AS c ON c.oid = a.attrelid
+        JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace
+        WHERE n.nspname = $1 AND c.relname = $2 AND a.attnum > 0 AND NOT a.attisdropped
+          AND a.attgenerated = ''
+        ORDER BY a.attnum
+        """,
+        schema,
+        table,
+    )
+    return [BackupColumn(name=row["name"], type_name=row["type_name"]) for row in rows]
+
+
+async def _validate_restore_schema(
+    conn: asyncpg.Connection, manifest: dict[str, Any], schema: str
+) -> dict[str, list[str]]:
+    """Validate every COPY stream against the target before destructive work starts."""
+    restore_columns: dict[str, list[str]] = {}
+    errors: list[str] = []
+    for table, table_manifest in manifest["tables"].items():
+        source_columns = [BackupColumn(**column) for column in table_manifest["columns"]]
+        target_by_name = {column.name: column for column in await _table_columns(conn, schema, table)}
+        missing = [column.name for column in source_columns if column.name not in target_by_name]
+        mismatched = [
+            f"{column.name} ({column.type_name} in backup, {target_by_name[column.name].type_name} in target)"
+            for column in source_columns
+            if column.name in target_by_name and target_by_name[column.name].type_name != column.type_name
+        ]
+        if missing:
+            errors.append(f"{table}: target is missing backup columns {', '.join(missing)}")
+        if mismatched:
+            errors.append(f"{table}: incompatible column types: {', '.join(mismatched)}")
+        restore_columns[table] = [column.name for column in source_columns]
+
+    if errors:
+        details = "; ".join(errors)
+        raise ValueError(f"Backup schema is incompatible with target schema '{schema}': {details}")
+    return restore_columns
 
 
 async def _admin_connect(db_url: str) -> asyncpg.Connection:
@@ -111,9 +164,19 @@ async def _backup(database_url: str, output_path: Path, schema: str = "public") 
 
                     buffer = io.BytesIO()
 
-                    # Use binary COPY for exact type preservation
+                    columns = await _table_columns(conn, schema, table)
+
+                    # Pin the ordered columns into both the stream and manifest.
+                    # PostgreSQL binary COPY does not encode column identities, so
+                    # restore must validate this shape before truncating any data.
                     # asyncpg requires schema_name as separate parameter
-                    await conn.copy_from_table(table, schema_name=schema, output=buffer, format="binary")
+                    await conn.copy_from_table(
+                        table,
+                        schema_name=schema,
+                        columns=[column.name for column in columns],
+                        output=buffer,
+                        format="binary",
+                    )
 
                     data = buffer.getvalue()
                     zf.writestr(f"{table}.bin", data)
@@ -124,6 +187,7 @@ async def _backup(database_url: str, output_path: Path, schema: str = "public") 
                     tables[table] = {
                         "rows": row_count,
                         "size_bytes": len(data),
+                        "columns": [{"name": column.name, "type_name": column.type_name} for column in columns],
                     }
 
                     typer.echo(f" {row_count} rows")
@@ -144,6 +208,11 @@ async def _restore(database_url: str, input_path: Path, schema: str = "public") 
             manifest: dict[str, Any] = json.loads(zf.read("manifest.json"))
             if manifest.get("version") != MANIFEST_VERSION:
                 raise ValueError(f"Unsupported backup version: {manifest.get('version')}")
+
+            # Complete the compatibility check before entering the transaction
+            # that truncates tables. This turns historical schema drift into an
+            # actionable error without risking the target's existing data.
+            restore_columns = await _validate_restore_schema(conn, manifest, schema)
 
             # Use a transaction for atomic restore - either all tables are
             # restored or none are, preventing partial/inconsistent state.
@@ -167,7 +236,13 @@ async def _restore(database_url: str, input_path: Path, schema: str = "public") 
                     data = zf.read(filename)
                     buffer = io.BytesIO(data)
                     # asyncpg requires schema_name as separate parameter
-                    await conn.copy_to_table(table, schema_name=schema, source=buffer, format="binary")
+                    await conn.copy_to_table(
+                        table,
+                        schema_name=schema,
+                        columns=restore_columns[table],
+                        source=buffer,
+                        format="binary",
+                    )
 
                 # Refresh materialized view
                 typer.echo("  Refreshing materialized views...")

--- a/hindsight-api-slim/hindsight_api/admin/cli.py
+++ b/hindsight-api-slim/hindsight_api/admin/cli.py
@@ -99,7 +99,15 @@ async def _table_columns(conn: asyncpg.Connection, schema: str, table: str) -> l
 async def _validate_restore_schema(
     conn: asyncpg.Connection, manifest: dict[str, Any], schema: str
 ) -> dict[str, list[str]]:
-    """Validate every COPY stream against the target before destructive work starts."""
+    """Validate every COPY stream against the target before destructive work starts.
+
+    Type equality is an exact ``format_type`` string match. This is deliberately
+    stricter than binary-COPY wire compatibility (e.g. ``varchar`` and ``text``
+    share a binary format yet compare unequal here): we would rather fail a
+    genuinely-restorable backup with a clear, actionable error than silently risk
+    a subtle binary mismatch. Restores blocked this way can be recovered by
+    aligning the target schema.
+    """
     restore_columns: dict[str, list[str]] = {}
     errors: list[str] = []
     for table, table_manifest in manifest["tables"].items():

--- a/hindsight-api-slim/tests/test_admin_backup_restore.py
+++ b/hindsight-api-slim/tests/test_admin_backup_restore.py
@@ -173,11 +173,12 @@ async def test_backup_restore_roundtrip(backup_test_schema):
         assert backup_path.stat().st_size > 0
 
         # Verify manifest
-        assert manifest["version"] == "1"
+        assert manifest["version"] == "2"
         assert "created_at" in manifest
         for table in BACKUP_TABLES:
             assert table in manifest["tables"]
             assert manifest["tables"][table]["rows"] == counts_before[table]
+            assert manifest["tables"][table]["columns"]
 
         # Verify zip contents
         with zipfile.ZipFile(backup_path, "r") as zf:
@@ -351,6 +352,43 @@ async def test_backup_restore_preserves_all_column_types(backup_test_schema):
         assert restored_bank["bank_id"] == original_bank["bank_id"], "Bank ID should match"
         assert restored_bank["created_at"] == original_bank["created_at"], "Bank created_at should match"
 
+    finally:
+        if backup_path.exists():
+            backup_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_restore_rejects_legacy_extra_column_before_truncating(backup_test_schema):
+    """Schema drift must fail preflight without deleting existing target data."""
+    db_url, schema_name, _fq, _embeddings = backup_test_schema
+    conn = await asyncpg.connect(db_url)
+    try:
+        await conn.execute(f"ALTER TABLE {_fq('documents')} ADD COLUMN legacy_metadata JSONB")
+        await conn.execute(f"INSERT INTO {_fq('banks')} (bank_id) VALUES ('source-bank')")
+    finally:
+        await conn.close()
+
+    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as f:
+        backup_path = Path(f.name)
+
+    try:
+        await _backup(db_url, backup_path, schema=schema_name)
+        conn = await asyncpg.connect(db_url)
+        try:
+            await conn.execute(f"ALTER TABLE {_fq('documents')} DROP COLUMN legacy_metadata")
+            await conn.execute(f"INSERT INTO {_fq('banks')} (bank_id) VALUES ('target-bank')")
+        finally:
+            await conn.close()
+
+        with pytest.raises(ValueError, match=r"documents: target is missing backup columns legacy_metadata"):
+            await _restore(db_url, backup_path, schema=schema_name)
+
+        conn = await asyncpg.connect(db_url)
+        try:
+            banks = await conn.fetch(f"SELECT bank_id FROM {_fq('banks')} ORDER BY bank_id")
+        finally:
+            await conn.close()
+        assert [row["bank_id"] for row in banks] == ["source-bank", "target-bank"]
     finally:
         if backup_path.exists():
             backup_path.unlink()

--- a/hindsight-api-slim/tests/test_admin_backup_restore.py
+++ b/hindsight-api-slim/tests/test_admin_backup_restore.py
@@ -395,6 +395,86 @@ async def test_restore_rejects_legacy_extra_column_before_truncating(backup_test
 
 
 @pytest.mark.asyncio
+async def test_restore_rejects_incompatible_column_type_before_truncating(backup_test_schema):
+    """A column present in both schemas but with a different type must fail preflight."""
+    db_url, schema_name, _fq, _embeddings = backup_test_schema
+    conn = await asyncpg.connect(db_url)
+    try:
+        await conn.execute(f"ALTER TABLE {_fq('documents')} ADD COLUMN drift_col INTEGER")
+        await conn.execute(f"INSERT INTO {_fq('banks')} (bank_id) VALUES ('source-bank')")
+    finally:
+        await conn.close()
+
+    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as f:
+        backup_path = Path(f.name)
+
+    try:
+        await _backup(db_url, backup_path, schema=schema_name)
+        conn = await asyncpg.connect(db_url)
+        try:
+            # Same column name, incompatible type in the target.
+            await conn.execute(f"ALTER TABLE {_fq('documents')} DROP COLUMN drift_col")
+            await conn.execute(f"ALTER TABLE {_fq('documents')} ADD COLUMN drift_col TEXT")
+            await conn.execute(f"INSERT INTO {_fq('banks')} (bank_id) VALUES ('target-bank')")
+        finally:
+            await conn.close()
+
+        with pytest.raises(ValueError, match=r"documents: incompatible column types: drift_col"):
+            await _restore(db_url, backup_path, schema=schema_name)
+
+        conn = await asyncpg.connect(db_url)
+        try:
+            banks = await conn.fetch(f"SELECT bank_id FROM {_fq('banks')} ORDER BY bank_id")
+        finally:
+            await conn.close()
+        assert [row["bank_id"] for row in banks] == ["source-bank", "target-bank"]
+    finally:
+        if backup_path.exists():
+            backup_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_restore_succeeds_when_target_has_additional_nullable_column(backup_test_schema):
+    """A target with an extra nullable column not in the backup restores cleanly.
+
+    Binary COPY without an explicit column list would fail this with a field-count
+    error; pinning the source column list is what lets these restores succeed.
+    """
+    db_url, schema_name, _fq, _embeddings = backup_test_schema
+    conn = await asyncpg.connect(db_url)
+    try:
+        await conn.execute(f"INSERT INTO {_fq('banks')} (bank_id) VALUES ('roundtrip-bank')")
+    finally:
+        await conn.close()
+
+    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as f:
+        backup_path = Path(f.name)
+
+    try:
+        await _backup(db_url, backup_path, schema=schema_name)
+        conn = await asyncpg.connect(db_url)
+        try:
+            await conn.execute(f"ALTER TABLE {_fq('banks')} ADD COLUMN target_only_note TEXT")
+        finally:
+            await conn.close()
+
+        # The extra target column is not in the backup, so validation passes and
+        # restore copies only the source columns; the new column stays NULL.
+        await _restore(db_url, backup_path, schema=schema_name)
+
+        conn = await asyncpg.connect(db_url)
+        try:
+            rows = await conn.fetch(f"SELECT bank_id, target_only_note FROM {_fq('banks')} ORDER BY bank_id")
+        finally:
+            await conn.close()
+        assert [row["bank_id"] for row in rows] == ["roundtrip-bank"]
+        assert rows[0]["target_only_note"] is None
+    finally:
+        if backup_path.exists():
+            backup_path.unlink()
+
+
+@pytest.mark.asyncio
 async def test_run_migration_without_schema_discovers_and_deduplicates_schemas(monkeypatch):
     """run-db-migration without --schema should include the base schema and deduplicate tenant schemas."""
     calls: dict[str, list] = {

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -10,7 +10,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "0.8.4"
+    "version": "0.8.5"
   },
   "paths": {
     "/health": {


### PR DESCRIPTION
## Summary

- Bump the database backup manifest format to version 2.
- Record each table's ordered source column names and PostgreSQL types in the manifest.
- Validate all source columns against the target schema before truncating any existing data.
- Restore binary COPY streams using the explicit source column list.
- Return a clear compatibility error when the target is missing a source column or has an incompatible column type.

## Why

Binary PostgreSQL COPY streams do not contain column identities. Previously, backups only recorded row counts and byte sizes, so a backup created from a database with legacy schema drift could fail during restore with an opaque field-count error.

The new preflight detects incompatible schemas before destructive restore operations begin, ensuring the target database remains unchanged when validation fails.

## Testing

- `uv run pytest tests/test_admin_backup_restore.py -q`
- `./scripts/hooks/lint.sh`
- Pre-commit hooks

Added a regression test covering a backup whose `documents` table contains a legacy extra column. The test verifies that restore fails before truncating the target database.

Fixes #2918