### PR TITLE
fix(engine): make mental-model refresh cutoff stubbable (fix red test-api on main)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -10761,6 +10761,26 @@ class MemoryEngine(MemoryEngineInterface):
         logger.info(f"[MENTAL_MODELS] Created pinned mental model '{name}' for bank {bank_id}")
         return self._row_to_mental_model(row)
 
+    async def _mental_model_refresh_cutoff(self, bank_id: str, mental_model_id: str) -> datetime | None:
+        """Database-time snapshot bounding a mental-model refresh.
+
+        Returns the DB's current timestamp scoped to the mental-model row (or
+        ``None`` if the row no longer exists — treated as "refresh nothing").
+        Reflect uses it as ``created_before`` so facts arriving mid-refresh stay
+        newer than the persisted watermark and a later refresh can still see
+        them. Kept as its own method so mock-based unit tests of the refresh
+        kwarg-wiring can stub it instead of reaching a real pool.
+        """
+        backend = await self._get_backend()
+        assert self._dialect is not None
+        async with acquire_with_retry(backend) as conn:
+            return await conn.fetchval(
+                f"SELECT {self._dialect.current_timestamp()} "
+                f"FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                mental_model_id,
+            )
+
     async def refresh_mental_model(
         self,
         bank_id: str,
@@ -10849,15 +10869,7 @@ class MemoryEngine(MemoryEngineInterface):
             # Bound this refresh to a database-time snapshot. Facts arriving while
             # reflect is running must remain newer than the persisted watermark so
             # a later refresh can still see them.
-            backend = await self._get_backend()
-            assert self._dialect is not None
-            async with acquire_with_retry(backend) as conn:
-                refresh_cutoff = await conn.fetchval(
-                    f"SELECT {self._dialect.current_timestamp()} "
-                    f"FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
-                    bank_id,
-                    mental_model_id,
-                )
+            refresh_cutoff = await self._mental_model_refresh_cutoff(bank_id, mental_model_id)
             if refresh_cutoff is None:
                 return None
 

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -1900,6 +1900,7 @@ class TestMentalModelRefreshMaxTokens:
     """
 
     async def test_refresh_passes_stored_max_tokens_to_reflect(self, request_context):
+        from datetime import datetime, timezone
         from unittest.mock import AsyncMock
 
         from hindsight_api.engine.memory_engine import MemoryEngine
@@ -1924,6 +1925,10 @@ class TestMentalModelRefreshMaxTokens:
             return_value=ReflectResult(text="stub synthesis", based_on={})
         )
         engine.update_mental_model = AsyncMock(return_value=mental_model)  # type: ignore[method-assign]
+        # DB-time refresh watermark — stub so this mock test doesn't reach a real pool.
+        engine._mental_model_refresh_cutoff = AsyncMock(  # type: ignore[method-assign]
+            return_value=datetime(2026, 1, 1, tzinfo=timezone.utc)
+        )
 
         await engine.refresh_mental_model(
             bank_id="bank-1",

--- a/hindsight-api-slim/tests/test_recall_config.py
+++ b/hindsight-api-slim/tests/test_recall_config.py
@@ -163,6 +163,8 @@ class TestRefreshTriggerWiring:
 
     @pytest.mark.asyncio
     async def test_trigger_overrides_passed_to_reflect_async(self, mock_request_context):
+        from datetime import datetime, timezone
+
         from hindsight_api.engine.memory_engine import MemoryEngine
         from hindsight_api.engine.response_models import ReflectResult
 
@@ -195,6 +197,9 @@ class TestRefreshTriggerWiring:
         engine.update_mental_model = fake_update_mental_model
         engine._operation_validator = None
         engine._tenant_extension = None
+        # DB-time refresh watermark — stub so this mock test doesn't reach a real
+        # pool (matches the other collaborator stubs above).
+        engine._mental_model_refresh_cutoff = AsyncMock(return_value=datetime(2026, 1, 1, tzinfo=timezone.utc))
 
         await engine.refresh_mental_model(
             bank_id="bank-1",
@@ -209,6 +214,8 @@ class TestRefreshTriggerWiring:
 
     @pytest.mark.asyncio
     async def test_missing_trigger_fields_pass_none(self, mock_request_context):
+        from datetime import datetime, timezone
+
         from hindsight_api.engine.memory_engine import MemoryEngine
         from hindsight_api.engine.response_models import ReflectResult
 
@@ -231,6 +238,9 @@ class TestRefreshTriggerWiring:
         engine.update_mental_model = fake_update_mental_model
         engine._operation_validator = None
         engine._tenant_extension = None
+        # DB-time refresh watermark — stub so this mock test doesn't reach a real
+        # pool (matches the other collaborator stubs above).
+        engine._mental_model_refresh_cutoff = AsyncMock(return_value=datetime(2026, 1, 1, tzinfo=timezone.utc))
 
         await engine.refresh_mental_model(
             bank_id="bank-1",


### PR DESCRIPTION
## Summary

Fixes three `test-api` failures that are currently red on `main` (unrelated to
whoever's PR happens to be running — they fail on a clean `main` checkout):

- `test_recall_config.py::TestRefreshTriggerWiring::test_trigger_overrides_passed_to_reflect_async`
- `test_recall_config.py::TestRefreshTriggerWiring::test_missing_trigger_fields_pass_none`
- `test_mental_models.py::TestMentalModelRefreshMaxTokens::test_refresh_passes_stored_max_tokens_to_reflect`

all failing with `AttributeError: 'MemoryEngine' object has no attribute '_initialized'`.

## Root cause

`refresh_mental_model` gained an **unconditional** DB-time snapshot query — it
calls `_get_backend()` and `SELECT current_timestamp FROM mental_models …` to
bound the refresh watermark (passed to reflect as `created_before`). These are
mock-based unit tests that deliberately build `MemoryEngine.__new__(MemoryEngine)`
and stub the collaborators ("without spinning up a DB or LLM"). The new snapshot
query reaches `_get_backend()` → `self._initialized`, which was never set because
`__init__` didn't run. (The delta-mode branch above it was already written to be
mock-safe; this snapshot query wasn't.)

## Fix

Extract the snapshot into `_mental_model_refresh_cutoff(bank_id, mental_model_id)`
— a **pure refactor, no behaviour change** — so the mock tests can stub it the
same way they already stub `get_mental_model` / `reflect_async` /
`update_mental_model`. Stub it in the three affected tests (returns a fixed
timestamp).

## Test plan

- [x] The 3 tests pass (`-p no:randomly`), and unchanged behaviour for the real-DB
      `test_refresh_content_respects_max_tokens`.
- [x] `ruff` (added lines) + `ruff format` + `ty` clean. (Pre-existing F841s in the
      file are ignored by the root `ruff.toml` and untouched here.)
