### PR TITLE
chore: regen skills/hindsight-docs openapi.json (unblocks verify-generated-files)

### DIFF
--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -10,7 +10,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "0.8.4"
+    "version": "0.8.5"
   },
   "paths": {
     "/health": {


### PR DESCRIPTION
`skills/hindsight-docs/references/openapi.json` still carried `"version": "0.8.4"` — its source moved to `0.8.5` (the v0.8.5 release) but the skill copy was never regenerated.

Because `verify-generated-files` runs the generate scripts and fails on any diff, this drift has been **red on every open PR** regardless of its own changes (e.g. #2899, #2907), and the local `generate-docs-skill` pre-commit hook blocks commits until it's resolved.

Regenerated via `./scripts/generate-openapi.sh` + `./scripts/generate-docs-skill.sh`. Generated-file sync only — a single `0.8.4`→`0.8.5` version line.