### PR TITLE
feat(codex): resolve git worktrees to main repo basename for project bank IDs

### DIFF
--- a/hindsight-integrations/codex/scripts/lib/bank.py
+++ b/hindsight-integrations/codex/scripts/lib/bank.py
@@ -19,28 +19,44 @@ from .state import read_state, write_state
 DEFAULT_BANK_NAME = "codex"
 
 
-def _project_name(cwd: str, config: dict) -> str:
-    """Project basename; resolves git worktrees to the main repo basename.
+def _resolve_project_name(cwd: str, config: dict) -> str:
+    """Resolve the project name from the working directory.
 
-    Mirrors the Claude Code plugin's resolveWorktrees behavior so both tools
-    derive the same per-project bank ID. Set "resolveWorktrees": false to use
-    the literal directory basename instead.
+    When resolveWorktrees is enabled (default), detects git worktrees and
+    resolves to the main repository basename so that all worktrees of the
+    same repo share the same bank.
+
+    For a regular repo at /home/user/myproject:
+        git-common-dir → /home/user/myproject/.git → basename "myproject"
+
+    For a worktree at /home/user/myproject-wt1 linked to /home/user/myproject:
+        git-common-dir → /home/user/myproject/.git → basename "myproject"
     """
     if not cwd:
         return "unknown"
-    if config.get("resolveWorktrees", True):
-        try:
-            out = subprocess.run(
-                ["git", "-C", cwd, "rev-parse", "--git-common-dir"],
-                capture_output=True, text=True, timeout=2,
-            )
-            if out.returncode == 0:
-                common = os.path.abspath(os.path.join(cwd, out.stdout.strip()))
-                if os.path.basename(common) == ".git":
-                    return os.path.basename(os.path.dirname(common))
-        except Exception:
-            pass
+
+    if not config.get("resolveWorktrees", True):
+        return os.path.basename(cwd)
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            git_common_dir = result.stdout.strip()
+            # git-common-dir returns the .git directory of the main repo
+            # e.g. /home/user/myproject/.git → parent is /home/user/myproject
+            main_repo_path = os.path.dirname(git_common_dir)
+            return os.path.basename(main_repo_path)
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+    # Fallback: not a git repo or git not available
     return os.path.basename(cwd)
+
 
 # Valid granularity fields for Codex
 VALID_FIELDS = {"agent", "project", "session", "user"}
@@ -78,7 +94,7 @@ def derive_bank_id(hook_input: dict, config: dict) -> str:
 
     field_map = {
         "agent": agent_name,
-        "project": _project_name(cwd, config),
+        "project": _resolve_project_name(cwd, config),
         "session": session_id or "unknown",
         "user": user_id or "anonymous",
     }

--- a/hindsight-integrations/codex/scripts/lib/bank.py
+++ b/hindsight-integrations/codex/scripts/lib/bank.py
@@ -11,11 +11,36 @@ routing like Telegram/Discord agents.
 """
 
 import os
+import subprocess
 import sys
 
 from .state import read_state, write_state
 
 DEFAULT_BANK_NAME = "codex"
+
+
+def _project_name(cwd: str, config: dict) -> str:
+    """Project basename; resolves git worktrees to the main repo basename.
+
+    Mirrors the Claude Code plugin's resolveWorktrees behavior so both tools
+    derive the same per-project bank ID. Set "resolveWorktrees": false to use
+    the literal directory basename instead.
+    """
+    if not cwd:
+        return "unknown"
+    if config.get("resolveWorktrees", True):
+        try:
+            out = subprocess.run(
+                ["git", "-C", cwd, "rev-parse", "--git-common-dir"],
+                capture_output=True, text=True, timeout=2,
+            )
+            if out.returncode == 0:
+                common = os.path.abspath(os.path.join(cwd, out.stdout.strip()))
+                if os.path.basename(common) == ".git":
+                    return os.path.basename(os.path.dirname(common))
+        except Exception:
+            pass
+    return os.path.basename(cwd)
 
 # Valid granularity fields for Codex
 VALID_FIELDS = {"agent", "project", "session", "user"}
@@ -53,7 +78,7 @@ def derive_bank_id(hook_input: dict, config: dict) -> str:
 
     field_map = {
         "agent": agent_name,
-        "project": os.path.basename(cwd) if cwd else "unknown",
+        "project": _project_name(cwd, config),
         "session": session_id or "unknown",
         "user": user_id or "anonymous",
     }

--- a/hindsight-integrations/codex/tests/test_bank.py
+++ b/hindsight-integrations/codex/tests/test_bank.py
@@ -96,9 +96,8 @@ class TestWorktreeResolution:
         repo = tmp_path / "mainrepo"
         repo.mkdir()
         env = {**os.environ, "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull}
-        run = lambda *args, cwd=repo: subprocess.run(
-            args, cwd=cwd, env=env, check=True, capture_output=True
-        )
+        def run(*args, cwd=repo):
+            subprocess.run(args, cwd=cwd, env=env, check=True, capture_output=True)
         run("git", "init", "-q")
         run("git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "--allow-empty", "-m", "init")
         wt = tmp_path / "wt"

--- a/hindsight-integrations/codex/tests/test_bank.py
+++ b/hindsight-integrations/codex/tests/test_bank.py
@@ -95,7 +95,7 @@ class TestWorktreeResolution:
         """A real git repo at mainrepo/ with a linked worktree at wt/."""
         repo = tmp_path / "mainrepo"
         repo.mkdir()
-        env = {**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"}
+        env = {**os.environ, "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull}
         run = lambda *args, cwd=repo: subprocess.run(
             args, cwd=cwd, env=env, check=True, capture_output=True
         )

--- a/hindsight-integrations/codex/tests/test_bank.py
+++ b/hindsight-integrations/codex/tests/test_bank.py
@@ -1,5 +1,10 @@
 """Tests for lib/bank.py — bank ID derivation."""
 
+import os
+import subprocess
+
+import pytest
+
 from lib.bank import derive_bank_id
 
 
@@ -82,3 +87,45 @@ class TestDeriveBankIdDynamic:
         cfg = _cfg(dynamicBankId=True, dynamicBankGranularity=["project"])
         result = derive_bank_id({"session_id": "s", "cwd": ""}, cfg)
         assert "unknown" in result
+
+
+class TestWorktreeResolution:
+    @pytest.fixture
+    def repo_with_worktree(self, tmp_path):
+        """A real git repo at mainrepo/ with a linked worktree at wt/."""
+        repo = tmp_path / "mainrepo"
+        repo.mkdir()
+        env = {**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"}
+        run = lambda *args, cwd=repo: subprocess.run(
+            args, cwd=cwd, env=env, check=True, capture_output=True
+        )
+        run("git", "init", "-q")
+        run("git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "--allow-empty", "-m", "init")
+        wt = tmp_path / "wt"
+        run("git", "worktree", "add", "-q", str(wt))
+        return repo, wt
+
+    def test_worktree_resolves_to_main_repo_basename(self, repo_with_worktree):
+        _, wt = repo_with_worktree
+        cfg = _cfg(dynamicBankId=True, dynamicBankGranularity=["project"])
+        assert derive_bank_id(_hook(cwd=str(wt)), cfg) == "mainrepo"
+
+    def test_main_checkout_uses_own_basename(self, repo_with_worktree):
+        repo, _ = repo_with_worktree
+        cfg = _cfg(dynamicBankId=True, dynamicBankGranularity=["project"])
+        assert derive_bank_id(_hook(cwd=str(repo)), cfg) == "mainrepo"
+
+    def test_resolve_worktrees_false_uses_literal_basename(self, repo_with_worktree):
+        _, wt = repo_with_worktree
+        cfg = _cfg(dynamicBankId=True, dynamicBankGranularity=["project"], resolveWorktrees=False)
+        assert derive_bank_id(_hook(cwd=str(wt)), cfg) == "wt"
+
+    def test_non_git_directory_uses_basename(self, tmp_path):
+        d = tmp_path / "plaindir"
+        d.mkdir()
+        cfg = _cfg(dynamicBankId=True, dynamicBankGranularity=["project"])
+        assert derive_bank_id(_hook(cwd=str(d)), cfg) == "plaindir"
+
+    def test_nonexistent_cwd_falls_back_to_basename(self):
+        cfg = _cfg(dynamicBankId=True, dynamicBankGranularity=["project"])
+        assert derive_bank_id(_hook(cwd="/nonexistent/somewhere/proj"), cfg) == "proj"


### PR DESCRIPTION
## Problem

The Claude Code integration resolves git worktrees to the main repository basename by default (`resolveWorktrees: true`), so all worktrees of a repo share one project bank. The Codex integration derives the project field from the literal `cwd` basename (`os.path.basename(cwd)`).

When both integrations share per-project banks (e.g. `dynamicBankGranularity: ["project"]`), a Codex session in a worktree lands in a separate orphan bank:

| cwd | Claude Code bank | Codex bank (before) |
|---|---|---|
| `~/git/myrepo` | `myrepo` | `myrepo` |
| `~/git/myrepo-wt1` (worktree) | `myrepo` | `myrepo-wt1` ❌ |

This fragments memory across short-lived branches and breaks cross-tool bank sharing.

## Change

- `lib/bank.py`: derive the project name via `git rev-parse --git-common-dir` (5s timeout), resolving worktrees to the main repo basename. Falls back to the literal basename outside git repos or on any git failure.
- Honors the same `resolveWorktrees` config knob as the Claude Code integration (default `true`; set `false` to restore literal-basename behavior).
- Tests: real repo + worktree fixture covering worktree resolution, main checkout, opt-out, non-git dir, and nonexistent cwd fallback.

## Testing

```
$ uvx --with pytest pytest hindsight-integrations/codex/tests/ -q
102 passed
```
