### PR TITLE
fix(retain): stop append replay when an oversized doc's first transport slice extracts zero facts

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -71,6 +71,25 @@ def _redact_document_body(body: str, config: Any) -> str:
     return apply_redaction(body).content
 
 
+def _is_strict_append_of_stored_document(
+    stored_original_text: str | None,
+    document_body_override: str | None,
+    config: Any,
+) -> bool:
+    """Return whether an oversized document body strictly appends stored text.
+
+    ``documents.original_text`` is sanitized and may also be Memory Defense
+    redacted before persistence. Apply those same transformations to the
+    complete incoming body before comparing it with the stored prefix.
+    """
+    if stored_original_text is None or document_body_override is None:
+        return False
+
+    redacted_body = _redact_document_body(document_body_override, config)
+    sanitized_body = fact_extraction._sanitize_text(redacted_body) or ""
+    return len(sanitized_body) > len(stored_original_text) and sanitized_body.startswith(stored_original_text)
+
+
 async def _fire_memory_defense_webhook(
     webhook_manager: Any,
     *,
@@ -2058,12 +2077,26 @@ async def _try_delta_retain(
     # between this read and the write. The write TXN verifies the hash hasn't
     # changed; if it has, we fall back to streaming (which has full protection).
     async with acquire_with_retry(pool) as conn:
+        if document_body_override is not None:
+            doc_row_at_load = await conn.fetchrow(
+                f"SELECT content_hash, original_text FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2",
+                effective_doc_id,
+                bank_id,
+            )
+            doc_hash_at_load = doc_row_at_load["content_hash"] if doc_row_at_load else None
+            original_text_at_load = doc_row_at_load["original_text"] if doc_row_at_load else None
+        else:
+            doc_hash_at_load = await conn.fetchval(
+                f"SELECT content_hash FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2",
+                effective_doc_id,
+                bank_id,
+            )
+            original_text_at_load = None
+
+        # Load chunks after the document version. If a concurrent writer commits
+        # between these reads, the hash precondition on metadata-only writes (or
+        # the extraction freshness recheck below) forces a streaming fallback.
         existing_chunks = await chunk_storage.load_existing_chunks(conn, bank_id, effective_doc_id)
-        doc_hash_at_load = await conn.fetchval(
-            f"SELECT content_hash FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2",
-            effective_doc_id,
-            bank_id,
-        )
 
     if not existing_chunks:
         return None
@@ -2095,6 +2128,30 @@ async def _try_delta_retain(
     )
 
     if not unchanged_indices:
+        if _is_strict_append_of_stored_document(
+            original_text_at_load,
+            document_body_override,
+            config,
+        ):
+            log_buffer.append(
+                "[delta] First oversized slice has no stored chunk match, but "
+                "the complete document strictly appends the stored source — "
+                "preserving historical chunks and advancing document metadata"
+            )
+            return await _delta_metadata_only(
+                pool,
+                bank_id,
+                contents_dicts,
+                contents,
+                effective_doc_id,
+                document_tags,
+                log_buffer,
+                start_time,
+                outbox_callback,
+                document_body_override=document_body_override,
+                config=config,
+                expected_content_hash=doc_hash_at_load,
+            )
         logger.info(f"Delta retain: no unchanged chunks for {effective_doc_id}, falling back to full retain")
         return None
 
@@ -2115,6 +2172,7 @@ async def _try_delta_retain(
             outbox_callback,
             document_body_override=document_body_override,
             config=config,
+            expected_content_hash=doc_hash_at_load,
         )
 
     # Build content items for only the changed/new chunks
@@ -2133,6 +2191,7 @@ async def _try_delta_retain(
             outbox_callback,
             document_body_override=document_body_override,
             config=config,
+            expected_content_hash=doc_hash_at_load,
         )
 
     # Freshness recheck BEFORE the (expensive) LLM extraction.
@@ -2185,6 +2244,7 @@ async def _try_delta_retain(
                 outbox_callback,
                 document_body_override=document_body_override,
                 config=config,
+                expected_content_hash=recheck_hash,
             )
         log_buffer.append(
             f"[delta] Recheck: {len(recheck.changed) + len(recheck.new) + len(recheck.removed)} chunks still differ — "
@@ -2393,16 +2453,22 @@ async def _delta_metadata_only(
     *,
     document_body_override: str | None = None,
     config: Any = None,
-):
+    expected_content_hash: str | None = None,
+) -> tuple[list[list[str]], TokenUsage, int] | None:
     """Handle the case where no chunks changed — just update document metadata and tags."""
     async with acquire_with_retry(pool) as conn:
         async with conn.transaction():
             # Lock the document row to serialize with concurrent retains
-            await conn.fetchval(
+            current_content_hash = await conn.fetchval(
                 f"SELECT content_hash FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2 FOR UPDATE",
                 document_id,
                 bank_id,
             )
+            if expected_content_hash is not None and current_content_hash != expected_content_hash:
+                log_buffer.append(
+                    f"[delta] Document {document_id} changed before metadata update — falling back to full retain"
+                )
+                return None
             # When this sub-batch is a slice of an oversized item, write the
             # full original body (issue #1838) instead of just the slice.
             # Redact the override since it bypassed per-chunk screening.

--- a/hindsight-api-slim/tests/test_large_document_replacement.py
+++ b/hindsight-api-slim/tests/test_large_document_replacement.py
@@ -14,10 +14,14 @@ stored ``original_text`` exactly matches the submitted replacement body.
 """
 
 from datetime import datetime, timezone
+from typing import Any
 
 import pytest
 
 from hindsight_api.config import clear_config_cache
+from hindsight_api.engine.memory_engine import _split_contents_into_sub_batches
+from hindsight_api.engine.response_models import TokenUsage
+from hindsight_api.engine.retain.types import ChunkMetadata, ExtractedFact, RetainContent
 
 
 def _ts() -> float:
@@ -142,5 +146,123 @@ async def test_repeated_large_same_id_replacement_is_idempotent(memory, request_
                 f"submitted {len(replacement_body)} chars)"
             )
 
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_append_after_zero_fact_header_slice_skips_unchanged_history(
+    memory,
+    request_context,
+    monkeypatch,
+):
+    """An append-only oversized replacement must not replay historical slices.
+
+    Markdown transcripts can split into a small header-only first sub-batch.
+    If that header extracts zero facts, Hindsight stores no chunk at index 0.
+    A later append must still recognize the complete stored document as a
+    stable prefix and leave historical chunks untouched.
+    """
+    from hindsight_api.engine.retain import fact_extraction
+
+    bank_id = f"test_large_append_zero_fact_header_{_ts()}"
+    document_id = "chat-session-zero-fact-header"
+    header = "# Stable Chat Session\nSession id: session-1\nCreated at: 2026-07-09T00:00:00Z"
+    history = "\n".join(
+        f"[role: user] turn {turn}: "
+        f"{'UNCHANGED_HEAD' if turn == 0 else 'UNCHANGED_MIDDLE' if turn == 30 else 'historical'} "
+        "alpha bravo charlie delta echo foxtrot golf hotel india juliet"
+        for turn in range(60)
+    )
+    initial_body = f"{header}\n\n{history}"
+    tail_marker = "NEW_APPEND_ONLY_TAIL"
+    appended_body = f"{initial_body}\n[role: user] turn 60: {tail_marker} alpha bravo charlie delta"
+
+    split = _split_contents_into_sub_batches(
+        [{"content": initial_body, "document_id": document_id}],
+        100,
+    )
+    assert len(split.sub_batches) > 3
+    assert "[role:" not in split.sub_batches[0][0]["content"]
+
+    extracted_contents: list[str] = []
+
+    async def _record_extraction(
+        contents: list[RetainContent],
+        *args: Any,
+        **kwargs: Any,
+    ) -> tuple[list[ExtractedFact], list[ChunkMetadata], TokenUsage]:
+        extracted_contents.extend(item.content for item in contents)
+        facts: list[ExtractedFact] = []
+        chunks: list[ChunkMetadata] = []
+        for index, item in enumerate(contents):
+            is_header_only = "[role:" not in item.content
+            chunks.append(
+                ChunkMetadata(
+                    chunk_text=item.content,
+                    fact_count=0 if is_header_only else 1,
+                    content_index=index,
+                    chunk_index=index,
+                )
+            )
+            if not is_header_only:
+                facts.append(
+                    ExtractedFact(
+                        fact_text=f"Synthetic extracted fact {index}",
+                        fact_type="world",
+                        content_index=index,
+                        chunk_index=index,
+                        context=item.context,
+                        tags=item.tags,
+                    )
+                )
+        return facts, chunks, TokenUsage()
+
+    monkeypatch.setattr(
+        fact_extraction,
+        "extract_facts_from_contents",
+        _record_extraction,
+    )
+    monkeypatch.setattr(
+        memory.embeddings,
+        "encode_documents",
+        lambda texts: [[0.0] * memory.embeddings.dimension for _ in texts],
+    )
+
+    try:
+        await memory.retain_async(
+            bank_id=bank_id,
+            content=initial_body,
+            context="session transcript",
+            document_id=document_id,
+            request_context=request_context,
+        )
+
+        baseline_extractions = len(extracted_contents)
+        assert baseline_extractions > 3
+        extracted_contents.clear()
+
+        await memory.retain_async(
+            bank_id=bank_id,
+            content=appended_body,
+            context="session transcript",
+            document_id=document_id,
+            request_context=request_context,
+        )
+
+        extracted_text = "\n".join(extracted_contents)
+        assert tail_marker in extracted_text
+        assert len(extracted_contents) <= 2, "append-only replacement replayed more than two unchanged/edge slices"
+        assert len(extracted_contents) < baseline_extractions / 2
+        assert "UNCHANGED_HEAD" not in extracted_text
+        assert "UNCHANGED_MIDDLE" not in extracted_text
+
+        document = await memory.get_document(
+            document_id,
+            bank_id,
+            request_context=request_context,
+        )
+        assert document is not None
+        assert document["original_text"] == appended_body
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
> This pull request was prepared by an AI agent under direct user supervision.

## Why this is operationally critical

This is not only a retain optimization. It is currently a release blocker for a production chat-memory workload that stores each conversation as one canonical session document and periodically replaces that document after new messages arrive.

For the affected oversized-document cohort, appending one new chat turn can silently abandon Delta Retain and send **every historical transport slice** back through fact extraction. In the production-shaped canary below, a tail-only update went from the expected **3,164 input tokens on 1/4 slices** to **140,438 input tokens across 4/4 slices**—about **44× more input** and effectively another full ingestion of the conversation.

That makes cost grow with the complete lifetime transcript instead of the newly appended tail. Long, active sessions can pay this cost repeatedly on ordinary sync runs. Re-extracting historical slices can also churn derived facts, chunks, entities, and associations even though the canonical source text remains correct.

The failure is conditional, not universal: it affects strict append-only oversized documents whose first transport slice previously produced zero stored facts/chunks. However, callers cannot reliably identify that cohort through the public retain response before paying the extraction cost. Our rollout therefore has to stop before staging reconstruction unless this path is fixed or every target is independently proven unaffected.

## Summary

Append-only oversized documents no longer replay their full history when a header-only first transport slice previously produced zero facts. That edge left no stored chunk at index 0, so every later append appeared to have no unchanged chunks and fell back to full extraction.

The fix compares the complete sanitized/redacted incoming document with the stored source. A strict append advances document metadata under the observed content-hash precondition, preserving historical chunks so subsequent transport slices can use the existing recovery path. Non-append replacements, missing stored source text, and concurrent version changes retain the full-streaming fallback.

This is intentionally narrower than the approach in #2728: it preserves the current transport/recovery design and covers the repeated head-slice edge exposed by a real chat-transcript workload.

## Cost evidence

| Probe | Before | After |
|---|---:|---:|
| Deterministic zero-fact-header regression | 22/22 slices extracted | 1/22 slices extracted |
| Production-shaped local canary, real LLM | 140,438 input tokens across 4/4 slices | 3,164 input + 404 output tokens on 1/4 slices |

The deterministic regression isolates the engine behavior. The real-LLM canary corroborates the cost shape under the v0.8.5 production chunking configuration; exact token totals remain provider-response dependent.

Related: #2728

## Validation

- `./scripts/hooks/lint.sh`
- Ruff and `ty` on the changed engine and test files
- `24 passed` across `test_large_document_replacement.py` and `test_delta_retain.py`
- Production-shaped local PGlite canary with isolated development bank, cleanup verification, and no staging/production data access
