### PR TITLE
fix(retain): offset causal targets from the extraction-group start

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -2604,17 +2604,6 @@ async def extract_facts_from_contents(
     for content_index, (content, (facts_from_llm, chunks_from_llm, content_usage)) in enumerate(valid_results):
         total_usage = total_usage + content_usage
         chunk_start_idx = global_chunk_idx
-        if any(
-            not isinstance(chunk_fact_count, int) or isinstance(chunk_fact_count, bool) or chunk_fact_count < 0
-            for _, chunk_fact_count in chunks_from_llm
-        ):
-            raise RuntimeError(f"Invalid chunk fact count for content {content_index}")
-        declared_fact_count = sum(chunk_fact_count for _, chunk_fact_count in chunks_from_llm)
-        if declared_fact_count != len(facts_from_llm):
-            raise RuntimeError(
-                f"Fact count mismatch for content {content_index}: "
-                f"chunks declare {declared_fact_count}, extraction returned {len(facts_from_llm)}"
-            )
 
         # Convert chunk tuples to ChunkMetadata objects
         for chunk_index_in_content, (chunk_text, chunk_fact_count) in enumerate(chunks_from_llm):

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -2425,6 +2425,7 @@ async def extract_facts_from_contents_batch_api(
 
     for chunk_meta, chunk_facts in facts_by_chunk:
         content = contents[chunk_meta.content_index]
+        extraction_group_start_idx = global_fact_idx
 
         for fact_from_llm in chunk_facts:
             extracted_fact = ExtractedFactType(
@@ -2433,7 +2434,9 @@ async def extract_facts_from_contents_batch_api(
                 entities=list(fact_from_llm.entities or []),
                 occurred_start=_parse_datetime(fact_from_llm.occurred_start) if fact_from_llm.occurred_start else None,
                 occurred_end=_parse_datetime(fact_from_llm.occurred_end) if fact_from_llm.occurred_end else None,
-                causal_relations=_convert_causal_relations(fact_from_llm.causal_relations or [], global_fact_idx),
+                causal_relations=_convert_causal_relations(
+                    fact_from_llm.causal_relations or [], extraction_group_start_idx, len(chunk_facts)
+                ),
                 content_index=chunk_meta.content_index,
                 chunk_index=chunk_meta.chunk_index,
                 context=content.context,
@@ -2601,6 +2604,17 @@ async def extract_facts_from_contents(
     for content_index, (content, (facts_from_llm, chunks_from_llm, content_usage)) in enumerate(valid_results):
         total_usage = total_usage + content_usage
         chunk_start_idx = global_chunk_idx
+        if any(
+            not isinstance(chunk_fact_count, int) or isinstance(chunk_fact_count, bool) or chunk_fact_count < 0
+            for _, chunk_fact_count in chunks_from_llm
+        ):
+            raise RuntimeError(f"Invalid chunk fact count for content {content_index}")
+        declared_fact_count = sum(chunk_fact_count for _, chunk_fact_count in chunks_from_llm)
+        if declared_fact_count != len(facts_from_llm):
+            raise RuntimeError(
+                f"Fact count mismatch for content {content_index}: "
+                f"chunks declare {declared_fact_count}, extraction returned {len(facts_from_llm)}"
+            )
 
         # Convert chunk tuples to ChunkMetadata objects
         for chunk_index_in_content, (chunk_text, chunk_fact_count) in enumerate(chunks_from_llm):
@@ -2617,40 +2631,37 @@ async def extract_facts_from_contents(
         fact_idx_in_content = 0
         for chunk_idx_in_content, (chunk_text, chunk_fact_count) in enumerate(chunks_from_llm):
             chunk_global_idx = chunk_start_idx + chunk_idx_in_content
+            extraction_group_start_idx = global_fact_idx
+            chunk_facts = facts_from_llm[fact_idx_in_content : fact_idx_in_content + chunk_fact_count]
 
-            for _ in range(chunk_fact_count):
-                if fact_idx_in_content < len(facts_from_llm):
-                    fact_from_llm = facts_from_llm[fact_idx_in_content]
+            for fact_from_llm in chunk_facts:
+                # Convert Fact model from LLM to ExtractedFactType dataclass
+                # mentioned_at is always the event_date (when the conversation/document occurred)
+                extracted_fact = ExtractedFactType(
+                    fact_text=fact_from_llm.fact,
+                    fact_type=fact_from_llm.fact_type,
+                    entities=list(fact_from_llm.entities or []),
+                    # occurred_start/end: from LLM only, leave None if not provided
+                    occurred_start=_parse_datetime(fact_from_llm.occurred_start)
+                    if fact_from_llm.occurred_start
+                    else None,
+                    occurred_end=_parse_datetime(fact_from_llm.occurred_end) if fact_from_llm.occurred_end else None,
+                    causal_relations=_convert_causal_relations(
+                        fact_from_llm.causal_relations or [], extraction_group_start_idx, len(chunk_facts)
+                    ),
+                    content_index=content_index,
+                    chunk_index=chunk_global_idx,
+                    context=content.context,
+                    # mentioned_at: always the event_date (when the conversation/document occurred)
+                    mentioned_at=content.event_date,
+                    metadata=content.metadata,
+                    tags=content.tags,
+                    observation_scopes=content.observation_scopes,
+                )
 
-                    # Convert Fact model from LLM to ExtractedFactType dataclass
-                    # mentioned_at is always the event_date (when the conversation/document occurred)
-                    extracted_fact = ExtractedFactType(
-                        fact_text=fact_from_llm.fact,
-                        fact_type=fact_from_llm.fact_type,
-                        entities=list(fact_from_llm.entities or []),
-                        # occurred_start/end: from LLM only, leave None if not provided
-                        occurred_start=_parse_datetime(fact_from_llm.occurred_start)
-                        if fact_from_llm.occurred_start
-                        else None,
-                        occurred_end=_parse_datetime(fact_from_llm.occurred_end)
-                        if fact_from_llm.occurred_end
-                        else None,
-                        causal_relations=_convert_causal_relations(
-                            fact_from_llm.causal_relations or [], global_fact_idx
-                        ),
-                        content_index=content_index,
-                        chunk_index=chunk_global_idx,
-                        context=content.context,
-                        # mentioned_at: always the event_date (when the conversation/document occurred)
-                        mentioned_at=content.event_date,
-                        metadata=content.metadata,
-                        tags=content.tags,
-                        observation_scopes=content.observation_scopes,
-                    )
-
-                    extracted_facts.append(extracted_fact)
-                    global_fact_idx += 1
-                    fact_idx_in_content += 1
+                extracted_facts.append(extracted_fact)
+                global_fact_idx += 1
+                fact_idx_in_content += 1
 
     # Step 4: For verbatim mode, collapse to one fact per chunk with original text
     if config.retain_extraction_mode == "verbatim":
@@ -2702,7 +2713,9 @@ def _parse_datetime(date_str: str):
         return None
 
 
-def _convert_causal_relations(relations_from_llm, fact_start_idx: int) -> list[CausalRelationType]:
+def _convert_causal_relations(
+    relations_from_llm, extraction_group_start_idx: int, extraction_group_size: int
+) -> list[CausalRelationType]:
     """
     Convert causal relations from LLM format to ExtractedFact format.
 
@@ -2710,9 +2723,16 @@ def _convert_causal_relations(relations_from_llm, fact_start_idx: int) -> list[C
     """
     causal_relations = []
     for rel in relations_from_llm:
+        target_fact_index = rel.target_fact_index
+        if (
+            not isinstance(target_fact_index, int)
+            or isinstance(target_fact_index, bool)
+            or not 0 <= target_fact_index < extraction_group_size
+        ):
+            continue
         causal_relation = CausalRelationType(
             relation_type=rel.relation_type,
-            target_fact_index=fact_start_idx + rel.target_fact_index,
+            target_fact_index=extraction_group_start_idx + target_fact_index,
         )
         causal_relations.append(causal_relation)
     return causal_relations

--- a/hindsight-api-slim/tests/test_causal_relation_offsets.py
+++ b/hindsight-api-slim/tests/test_causal_relation_offsets.py
@@ -89,43 +89,6 @@ def test_invalid_local_causal_targets_are_dropped():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("declared_count", [1, 3])
-async def test_sync_extraction_rejects_chunk_fact_count_mismatch(monkeypatch, declared_count):
-    async def extract_facts_from_text(**_kwargs):
-        facts = [Fact(fact="one", fact_type="world"), Fact(fact="two", fact_type="world")]
-        return facts, [("chunk", declared_count)], TokenUsage()
-
-    monkeypatch.setattr(fact_extraction, "extract_facts_from_text", extract_facts_from_text)
-
-    config = SimpleNamespace(retain_extraction_mode="normal", retain_batch_enabled=False)
-    with pytest.raises(RuntimeError, match="Fact count mismatch"):
-        await fact_extraction.extract_facts_from_contents(
-            [RetainContent(content="mismatch")],
-            llm_config=None,
-            agent_name="test",
-            config=config,
-        )
-
-
-@pytest.mark.asyncio
-async def test_sync_extraction_rejects_negative_chunk_fact_counts(monkeypatch):
-    async def extract_facts_from_text(**_kwargs):
-        facts = [Fact(fact="one", fact_type="world"), Fact(fact="two", fact_type="world")]
-        return facts, [("first", 3), ("second", -1)], TokenUsage()
-
-    monkeypatch.setattr(fact_extraction, "extract_facts_from_text", extract_facts_from_text)
-
-    config = SimpleNamespace(retain_extraction_mode="normal", retain_batch_enabled=False)
-    with pytest.raises(RuntimeError, match="Invalid chunk fact count"):
-        await fact_extraction.extract_facts_from_contents(
-            [RetainContent(content="negative")],
-            llm_config=None,
-            agent_name="test",
-            config=config,
-        )
-
-
-@pytest.mark.asyncio
 async def test_batch_causal_targets_use_each_chunk_start(monkeypatch):
     fact_groups = [
         [{"what": f"prior {index}", "fact_type": "world"} for index in range(4)],

--- a/hindsight-api-slim/tests/test_causal_relation_offsets.py
+++ b/hindsight-api-slim/tests/test_causal_relation_offsets.py
@@ -1,0 +1,201 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from hindsight_api.engine.response_models import TokenUsage
+from hindsight_api.engine.retain import fact_extraction
+from hindsight_api.engine.retain.fact_extraction import CausalRelation, Fact
+from hindsight_api.engine.retain.types import RetainContent
+
+
+@pytest.mark.asyncio
+async def test_causal_targets_are_offset_from_extraction_group_start(monkeypatch):
+    async def extract_facts_from_text(*, text, **_kwargs):
+        if text == "preceding":
+            facts = [Fact(fact=f"prior {index}", fact_type="world") for index in range(4)]
+            return facts, [(text, len(facts))], TokenUsage()
+
+        facts = [
+            Fact(fact="cause", fact_type="world"),
+            Fact(
+                fact="effect",
+                fact_type="world",
+                causal_relations=[CausalRelation(target_fact_index=0, relation_type="caused_by")],
+            ),
+        ]
+        return facts, [(text, len(facts))], TokenUsage()
+
+    monkeypatch.setattr(fact_extraction, "extract_facts_from_text", extract_facts_from_text)
+    monkeypatch.setattr(fact_extraction, "_add_temporal_offsets", lambda *_args: None)
+    monkeypatch.setattr(fact_extraction, "_inject_label_tags", lambda *_args: None)
+
+    config = SimpleNamespace(retain_extraction_mode="normal", retain_batch_enabled=False)
+    facts, _, _ = await fact_extraction.extract_facts_from_contents(
+        [RetainContent(content="preceding"), RetainContent(content="causal group")],
+        llm_config=None,
+        agent_name="test",
+        config=config,
+    )
+
+    assert facts[5].causal_relations[0].target_fact_index == 4
+
+
+@pytest.mark.asyncio
+async def test_each_chunk_uses_its_own_causal_index_base(monkeypatch):
+    async def extract_facts_from_text(**_kwargs):
+        facts = [
+            Fact(fact="first cause", fact_type="world"),
+            Fact(
+                fact="first effect",
+                fact_type="world",
+                causal_relations=[CausalRelation(target_fact_index=0, relation_type="caused_by")],
+            ),
+            Fact(fact="second cause", fact_type="world"),
+            Fact(
+                fact="second effect",
+                fact_type="world",
+                causal_relations=[CausalRelation(target_fact_index=0, relation_type="caused_by")],
+            ),
+        ]
+        return facts, [("first", 2), ("second", 2)], TokenUsage()
+
+    monkeypatch.setattr(fact_extraction, "extract_facts_from_text", extract_facts_from_text)
+    monkeypatch.setattr(fact_extraction, "_add_temporal_offsets", lambda *_args: None)
+    monkeypatch.setattr(fact_extraction, "_inject_label_tags", lambda *_args: None)
+
+    config = SimpleNamespace(retain_extraction_mode="normal", retain_batch_enabled=False)
+    facts, _, _ = await fact_extraction.extract_facts_from_contents(
+        [RetainContent(content="two chunks")],
+        llm_config=None,
+        agent_name="test",
+        config=config,
+    )
+
+    assert facts[1].causal_relations[0].target_fact_index == 0
+    assert facts[3].causal_relations[0].target_fact_index == 2
+
+
+def test_invalid_local_causal_targets_are_dropped():
+    relations = [
+        CausalRelation(target_fact_index=-1, relation_type="caused_by"),
+        CausalRelation(target_fact_index=2, relation_type="caused_by"),
+        SimpleNamespace(target_fact_index=True, relation_type="caused_by"),
+        SimpleNamespace(target_fact_index=0.5, relation_type="caused_by"),
+        SimpleNamespace(target_fact_index="0", relation_type="caused_by"),
+    ]
+
+    assert fact_extraction._convert_causal_relations(relations, 4, 2) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("declared_count", [1, 3])
+async def test_sync_extraction_rejects_chunk_fact_count_mismatch(monkeypatch, declared_count):
+    async def extract_facts_from_text(**_kwargs):
+        facts = [Fact(fact="one", fact_type="world"), Fact(fact="two", fact_type="world")]
+        return facts, [("chunk", declared_count)], TokenUsage()
+
+    monkeypatch.setattr(fact_extraction, "extract_facts_from_text", extract_facts_from_text)
+
+    config = SimpleNamespace(retain_extraction_mode="normal", retain_batch_enabled=False)
+    with pytest.raises(RuntimeError, match="Fact count mismatch"):
+        await fact_extraction.extract_facts_from_contents(
+            [RetainContent(content="mismatch")],
+            llm_config=None,
+            agent_name="test",
+            config=config,
+        )
+
+
+@pytest.mark.asyncio
+async def test_sync_extraction_rejects_negative_chunk_fact_counts(monkeypatch):
+    async def extract_facts_from_text(**_kwargs):
+        facts = [Fact(fact="one", fact_type="world"), Fact(fact="two", fact_type="world")]
+        return facts, [("first", 3), ("second", -1)], TokenUsage()
+
+    monkeypatch.setattr(fact_extraction, "extract_facts_from_text", extract_facts_from_text)
+
+    config = SimpleNamespace(retain_extraction_mode="normal", retain_batch_enabled=False)
+    with pytest.raises(RuntimeError, match="Invalid chunk fact count"):
+        await fact_extraction.extract_facts_from_contents(
+            [RetainContent(content="negative")],
+            llm_config=None,
+            agent_name="test",
+            config=config,
+        )
+
+
+@pytest.mark.asyncio
+async def test_batch_causal_targets_use_each_chunk_start(monkeypatch):
+    fact_groups = [
+        [{"what": f"prior {index}", "fact_type": "world"} for index in range(4)],
+        [
+            {"what": "first cause", "fact_type": "world"},
+            {
+                "what": "first effect",
+                "fact_type": "world",
+                "causal_relations": [{"target_index": 0, "relation_type": "caused_by"}],
+            },
+        ],
+        [
+            {"what": "second cause", "fact_type": "world"},
+            {
+                "what": "second effect",
+                "fact_type": "world",
+                "causal_relations": [
+                    {"target_index": 0, "relation_type": "caused_by"},
+                    {"target_index": 2, "relation_type": "caused_by"},
+                ],
+            },
+        ],
+    ]
+
+    class Provider:
+        async def supports_batch_api(self):
+            return True
+
+        async def submit_batch(self, _requests):
+            return {"batch_id": "test"}
+
+        async def get_batch_status(self, _batch_id):
+            return {"status": "completed", "request_counts": {"completed": 3, "total": 3}}
+
+        async def retrieve_batch_results(self, _batch_id):
+            return [
+                {
+                    "custom_id": f"chunk_{index}",
+                    "response": {
+                        "body": {
+                            "choices": [{"message": {"content": json.dumps({"facts": facts})}}],
+                            "usage": {},
+                        }
+                    },
+                }
+                for index, facts in enumerate(fact_groups)
+            ]
+
+    monkeypatch.setattr(fact_extraction, "chunk_text", lambda text, **_kwargs: text.split("|"))
+    monkeypatch.setattr(fact_extraction, "_build_extraction_prompt_and_schema", lambda _config: ("", object))
+    monkeypatch.setattr(fact_extraction, "_retain_mission_preamble", lambda _config: "")
+    monkeypatch.setattr(fact_extraction, "_build_user_message", lambda *_args, **_kwargs: "")
+    monkeypatch.setattr(fact_extraction, "_build_request_body", lambda *_args: {})
+    monkeypatch.setattr(fact_extraction, "_add_temporal_offsets", lambda *_args: None)
+    monkeypatch.setattr(fact_extraction, "_inject_label_tags", lambda *_args: None)
+
+    config = SimpleNamespace(
+        retain_extract_causal_links=True,
+        retain_chunk_size=100,
+        retain_structured_chunk_size=100,
+        retain_batch_poll_interval_seconds=0,
+    )
+    llm_config = SimpleNamespace(_provider_impl=Provider(), provider="test")
+    facts, _, _ = await fact_extraction.extract_facts_from_contents_batch_api(
+        [RetainContent(content="preceding"), RetainContent(content="first|second")],
+        llm_config=llm_config,
+        agent_name="test",
+        config=config,
+    )
+
+    assert facts[5].causal_relations[0].target_fact_index == 4
+    assert facts[7].causal_relations[0].target_fact_index == 6
+    assert len(facts[7].causal_relations) == 1


### PR DESCRIPTION
## Summary

- offset chunk-local causal targets from each extraction group's stable start instead of the current fact index
- reject malformed causal target indexes and invalid chunk-count partitions before they can corrupt graph links
- cover synchronous and batch extraction, multi-chunk groups, malformed targets, and count mismatches

Fixes #2934.

## Testing

- `uv run ruff check hindsight_api/engine/retain/fact_extraction.py tests/test_causal_relation_offsets.py`
- `uv run pytest tests/test_causal_relation_offsets.py -q` (7 passed)
- `git diff --check`

The pre-existing LLM-backed `tests/test_causal_relations.py` requires `HINDSIGHT_API_LLM_API_KEY` and could not run in the cron environment.
