### PR TITLE
fix(retain): make async retries idempotent

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/e8f1a2b3c4d5_add_retain_idempotency.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/e8f1a2b3c4d5_add_retain_idempotency.py
@@ -1,0 +1,60 @@
+"""Add optional async retain idempotency identity.
+
+Revision ID: e8f1a2b3c4d5
+Revises: d7b2f8a1c934
+Create Date: 2026-07-23
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "e8f1a2b3c4d5"
+down_revision: str | Sequence[str] | None = "d7b2f8a1c934"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _pg_upgrade() -> None:
+    op.add_column("async_operations", sa.Column("idempotency_key", sa.Text(), nullable=True))
+    op.add_column("async_operations", sa.Column("request_fingerprint", sa.String(length=64), nullable=True))
+    op.create_unique_constraint(
+        "uq_async_operations_idempotency",
+        "async_operations",
+        ["bank_id", "operation_type", "idempotency_key"],
+    )
+
+
+def _pg_downgrade() -> None:
+    op.drop_constraint("uq_async_operations_idempotency", "async_operations", type_="unique")
+    op.drop_column("async_operations", "request_fingerprint")
+    op.drop_column("async_operations", "idempotency_key")
+
+
+def _oracle_upgrade() -> None:
+    # Oracle defaults VARCHAR2 length semantics to bytes. The API accepts 256
+    # Unicode characters, so declare character semantics explicitly.
+    op.execute("ALTER TABLE async_operations ADD idempotency_key VARCHAR2(256 CHAR)")
+    op.add_column("async_operations", sa.Column("request_fingerprint", sa.String(length=64), nullable=True))
+    op.create_unique_constraint(
+        "uq_async_operations_idempotency",
+        "async_operations",
+        ["bank_id", "operation_type", "idempotency_key"],
+    )
+
+
+def _oracle_downgrade() -> None:
+    op.drop_constraint("uq_async_operations_idempotency", "async_operations", type_="unique")
+    op.drop_column("async_operations", "request_fingerprint")
+    op.drop_column("async_operations", "idempotency_key")
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade, oracle=_oracle_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade, oracle=_oracle_downgrade)

--- a/hindsight-api-slim/hindsight_api/alembic/versions/f9a2b3c4d5e6_add_retain_serialization.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/f9a2b3c4d5e6_add_retain_serialization.py
@@ -1,0 +1,88 @@
+"""Serialize idempotent async retains for the same document.
+
+Revision ID: f9a2b3c4d5e6
+Revises: e8f1a2b3c4d5
+Create Date: 2026-07-24
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "f9a2b3c4d5e6"
+down_revision: str | Sequence[str] | None = "e8f1a2b3c4d5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _pg_upgrade() -> None:
+    op.add_column("async_operations", sa.Column("serialization_key", sa.String(length=64), nullable=True))
+    op.add_column(
+        "async_operations",
+        sa.Column("blocked_by_operation_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_index(
+        "idx_async_operations_retain_serialization",
+        "async_operations",
+        ["bank_id", "operation_type", "serialization_key"],
+    )
+    op.create_index(
+        "idx_async_operations_blocked_by",
+        "async_operations",
+        ["blocked_by_operation_id"],
+    )
+
+
+def _pg_downgrade() -> None:
+    op.execute(
+        """
+        UPDATE async_operations
+        SET next_retry_at = NULL
+        WHERE status = 'pending' AND blocked_by_operation_id IS NOT NULL
+        """
+    )
+    op.drop_index("idx_async_operations_blocked_by", table_name="async_operations")
+    op.drop_index("idx_async_operations_retain_serialization", table_name="async_operations")
+    op.drop_column("async_operations", "blocked_by_operation_id")
+    op.drop_column("async_operations", "serialization_key")
+
+
+def _oracle_upgrade() -> None:
+    op.add_column("async_operations", sa.Column("serialization_key", sa.String(length=64), nullable=True))
+    op.execute("ALTER TABLE async_operations ADD blocked_by_operation_id RAW(16)")
+    op.create_index(
+        "idx_async_operations_retain_serialization",
+        "async_operations",
+        ["bank_id", "operation_type", "serialization_key"],
+    )
+    op.create_index(
+        "idx_async_operations_blocked_by",
+        "async_operations",
+        ["blocked_by_operation_id"],
+    )
+
+
+def _oracle_downgrade() -> None:
+    op.execute(
+        """
+        UPDATE async_operations
+        SET next_retry_at = NULL
+        WHERE status = 'pending' AND blocked_by_operation_id IS NOT NULL
+        """
+    )
+    op.drop_index("idx_async_operations_blocked_by", table_name="async_operations")
+    op.drop_index("idx_async_operations_retain_serialization", table_name="async_operations")
+    op.drop_column("async_operations", "blocked_by_operation_id")
+    op.drop_column("async_operations", "serialization_key")
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade, oracle=_oracle_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade, oracle=_oracle_downgrade)

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -149,7 +149,12 @@ def FieldWithDefault(default_factory: Callable, **kwargs) -> Any:
 
 
 from hindsight_api.config import get_config
-from hindsight_api.engine.memory_engine import Budget, _current_schema, _get_tiktoken_encoding
+from hindsight_api.engine.memory_engine import (
+    Budget,
+    RetainIdempotencyConflictError,
+    _current_schema,
+    _get_tiktoken_encoding,
+)
 from hindsight_api.engine.providers.none_llm import LLMNotAvailableError
 from hindsight_api.engine.response_models import (
     VALID_RECALL_FACT_TYPES,
@@ -722,6 +727,25 @@ class RetainRequest(BaseModel):
         description="Deprecated. Use item-level tags instead.",
         deprecated=True,
     )
+    idempotency_key: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=256,
+        description=(
+            "Optional identity for an async retain submission. Reusing the key with the same semantic payload "
+            "returns the original operation; reusing it with a different payload returns HTTP 409. "
+            "The key is ignored for synchronous retain."
+        ),
+    )
+
+    @field_validator("idempotency_key")
+    @classmethod
+    def validate_idempotency_key(cls, value: str | None) -> str | None:
+        if value is not None and not value.strip():
+            raise ValueError("idempotency_key cannot be blank")
+        if value is not None and "\x00" in value:
+            raise ValueError("idempotency_key cannot contain NUL bytes")
+        return value
 
 
 class FileRetainMetadata(BaseModel):
@@ -2831,6 +2855,10 @@ class AsyncOperationSubmitResponse(BaseModel):
 class FeaturesInfo(BaseModel):
     """Feature flags indicating which capabilities are enabled."""
 
+    retain_idempotency: bool = Field(description="Whether async Retain requests accept durable idempotency keys")
+    retain_serialized_upsert: bool = Field(
+        description="Whether single-document async Retain upserts are serialized server-side"
+    )
     observations: bool = Field(description="Whether observations (auto-consolidation) are enabled")
     mcp: bool = Field(description="Whether MCP (Model Context Protocol) server is enabled")
     worker: bool = Field(description="Whether the background worker is enabled")
@@ -2854,6 +2882,8 @@ class VersionResponse(BaseModel):
             "example": {
                 "api_version": "0.4.0",
                 "features": {
+                    "retain_idempotency": True,
+                    "retain_serialized_upsert": True,
                     "observations": False,
                     "mcp": True,
                     "worker": True,
@@ -3524,6 +3554,8 @@ def _register_routes(app: FastAPI):
         return VersionResponse(
             api_version=__version__,
             features=FeaturesInfo(
+                retain_idempotency=True,
+                retain_serialized_upsert=True,
                 observations=config.enable_observations,
                 mcp=config.mcp_enabled,
                 worker=config.worker_enabled,
@@ -6833,6 +6865,11 @@ def _register_routes(app: FastAPI):
                 strategy_groups[effective].append(content_dict)
 
             if request.async_:
+                if request.idempotency_key is not None and len(strategy_groups) != 1:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="idempotency_key requires all retain items to use the same strategy",
+                    )
                 # Async processing: one submit per strategy group
                 all_operation_ids = []
                 total_items_count = 0
@@ -6843,6 +6880,7 @@ def _register_routes(app: FastAPI):
                         document_tags=request.document_tags,
                         strategy=group_strategy,
                         request_context=request_context,
+                        idempotency_key=request.idempotency_key,
                     )
                     all_operation_ids.append(result["operation_id"])
                     total_items_count += result["items_count"]
@@ -6909,6 +6947,8 @@ def _register_routes(app: FastAPI):
                 )
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)
+        except RetainIdempotencyConflictError as e:
+            raise HTTPException(status_code=409, detail=str(e))
         except (AuthenticationError, HTTPException):
             raise
         except ValueError as e:

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -1269,6 +1269,7 @@ class OracleOps(DataAccessOps):
         consolidation_bank_priority=None,
     ):
         """Oracle two-step claiming to avoid ORA-02014 with NOT EXISTS + FOR UPDATE."""
+        await self._release_serialized_retain_tasks(conn, table)
         all_rows = []
         claimed_ids = []
 
@@ -1302,6 +1303,7 @@ class OracleOps(DataAccessOps):
                     WHERE status = 'pending'
                       AND task_payload IS NOT NULL
                       AND operation_type = $1
+                      AND blocked_by_operation_id IS NULL
                       AND (next_retry_at IS NULL OR next_retry_at <= NOW())
                     ORDER BY created_at
                     LIMIT $2
@@ -1327,6 +1329,7 @@ class OracleOps(DataAccessOps):
                     WHERE status = 'pending'
                       AND task_payload IS NOT NULL
                       AND operation_type != 'consolidation'
+                      AND blocked_by_operation_id IS NULL
                       AND (next_retry_at IS NULL OR next_retry_at <= NOW())
                       AND operation_id != ALL($1::uuid[])
                     ORDER BY created_at
@@ -1344,6 +1347,7 @@ class OracleOps(DataAccessOps):
                     WHERE status = 'pending'
                       AND task_payload IS NOT NULL
                       AND operation_type != 'consolidation'
+                      AND blocked_by_operation_id IS NULL
                       AND (next_retry_at IS NULL OR next_retry_at <= NOW())
                     ORDER BY created_at
                     LIMIT $1
@@ -1396,3 +1400,22 @@ class OracleOps(DataAccessOps):
         )
 
         return all_rows
+
+    async def _release_serialized_retain_tasks(self, conn, table: str) -> None:
+        """Release every task whose serialized predecessor is terminal."""
+        await conn.execute(
+            f"""
+            UPDATE {table} blocked
+            SET blocked_by_operation_id = NULL,
+                next_retry_at = NULL,
+                updated_at = NOW()
+            WHERE blocked.status = 'pending'
+              AND blocked.blocked_by_operation_id IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM {table} predecessor
+                  WHERE predecessor.operation_id = blocked.blocked_by_operation_id
+                    AND predecessor.status IN ('pending', 'processing')
+              )
+            """
+        )

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -1282,6 +1282,7 @@ class PostgreSQLOps(DataAccessOps):
         *,
         consolidation_bank_priority=None,
     ):
+        await self._release_serialized_retain_tasks(conn, table)
         all_rows = []
         claimed_ids = []
 
@@ -1315,6 +1316,7 @@ class PostgreSQLOps(DataAccessOps):
                     WHERE status = 'pending'
                       AND task_payload IS NOT NULL
                       AND operation_type = $1
+                      AND blocked_by_operation_id IS NULL
                       AND (next_retry_at IS NULL OR next_retry_at <= NOW())
                     ORDER BY created_at
                     LIMIT $2
@@ -1340,6 +1342,7 @@ class PostgreSQLOps(DataAccessOps):
                     WHERE status = 'pending'
                       AND task_payload IS NOT NULL
                       AND operation_type != 'consolidation'
+                      AND blocked_by_operation_id IS NULL
                       AND (next_retry_at IS NULL OR next_retry_at <= NOW())
                       AND operation_id != ALL($1::uuid[])
                     ORDER BY created_at
@@ -1357,6 +1360,7 @@ class PostgreSQLOps(DataAccessOps):
                     WHERE status = 'pending'
                       AND task_payload IS NOT NULL
                       AND operation_type != 'consolidation'
+                      AND blocked_by_operation_id IS NULL
                       AND (next_retry_at IS NULL OR next_retry_at <= NOW())
                     ORDER BY created_at
                     LIMIT $1
@@ -1409,3 +1413,22 @@ class PostgreSQLOps(DataAccessOps):
         )
 
         return all_rows
+
+    async def _release_serialized_retain_tasks(self, conn, table: str) -> None:
+        """Release every task whose serialized predecessor is terminal."""
+        await conn.execute(
+            f"""
+            UPDATE {table} blocked
+            SET blocked_by_operation_id = NULL,
+                next_retry_at = NULL,
+                updated_at = NOW()
+            WHERE blocked.status = 'pending'
+              AND blocked.blocked_by_operation_id IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM {table} predecessor
+                  WHERE predecessor.operation_id = blocked.blocked_by_operation_id
+                    AND predecessor.status IN ('pending', 'processing')
+              )
+            """
+        )

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -11,7 +11,9 @@ This implements a sophisticated memory architecture that combines:
 
 import asyncio
 import contextvars
+import copy
 import functools
+import hashlib
 import inspect
 import json
 import logging
@@ -267,6 +269,72 @@ class UnqualifiedTableError(Exception):
     """Raised when SQL contains unqualified table references."""
 
     pass
+
+
+class RetainIdempotencyConflictError(ValueError):
+    """Raised when a retain idempotency key is reused for different work."""
+
+
+def _canonical_retain_submission(
+    contents: list[dict[str, Any]],
+    document_tags: list[str] | None,
+    strategy: str | None,
+) -> dict[str, Any]:
+    """Return the operation-defining retain payload in a stable form.
+
+    Item order is retained because it controls batching and result ordering.
+    Tags, explicit entities, and observation scopes are set-like API fields,
+    so their ordering is normalized before hashing.
+    """
+
+    canonical_contents: list[dict[str, Any]] = []
+    for content in contents:
+        canonical = dict(content)
+        if canonical.get("tags") is not None:
+            canonical["tags"] = sorted(set(canonical["tags"]))
+        if canonical.get("entities") is not None:
+            entities_by_value = {
+                json.dumps(entity, sort_keys=True, separators=(",", ":"), default=_json_default): entity
+                for entity in canonical["entities"]
+            }
+            canonical["entities"] = [entities_by_value[key] for key in sorted(entities_by_value)]
+        scopes = canonical.get("observation_scopes")
+        if isinstance(scopes, list):
+            canonical["observation_scopes"] = [
+                list(scope) for scope in sorted({tuple(sorted(scope)) for scope in scopes})
+            ]
+        canonical_contents.append(canonical)
+    return {
+        "contents": canonical_contents,
+        "document_tags": sorted(set(document_tags)) if document_tags else None,
+        "strategy": strategy,
+    }
+
+
+def _retain_submission_fingerprint(
+    contents: list[dict[str, Any]],
+    document_tags: list[str] | None,
+    strategy: str | None,
+) -> str:
+    canonical = _canonical_retain_submission(contents, document_tags, strategy)
+    encoded = json.dumps(canonical, sort_keys=True, separators=(",", ":"), default=_json_default).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _retain_serialization_key(
+    original_contents: list[dict[str, Any]],
+    validated_contents: list[dict[str, Any]],
+    idempotency_key: str | None,
+) -> str | None:
+    """Identify a single-document upsert lane without exposing the document ID."""
+    if idempotency_key is None or len(original_contents) != 1:
+        return None
+    original_document_id = original_contents[0].get("document_id")
+    if not isinstance(original_document_id, str) or not original_document_id:
+        return None
+    if not any(item.get("document_id") == original_document_id for item in validated_contents):
+        return None
+    return hashlib.sha256(original_document_id.encode()).hexdigest()
 
 
 class MentalModelRefreshError(Exception):
@@ -1520,6 +1588,10 @@ class MemoryEngine(MemoryEngineInterface):
         document_tags = task_dict.get("document_tags")
         operation_id = task_dict.get("operation_id")  # For batch API crash recovery
         strategy = task_dict.get("strategy")
+        blocked_by_operation_id = task_dict.get("_blocked_by_operation_id")
+
+        if blocked_by_operation_id:
+            await self._wait_for_retain_predecessor(str(blocked_by_operation_id))
 
         logger.info(
             f"[BATCH_RETAIN_TASK] Starting background batch retain for bank_id={bank_id}, {len(contents)} items, operation_id={operation_id}"
@@ -1576,6 +1648,31 @@ class MemoryEngine(MemoryEngineInterface):
                     )
 
         logger.info(f"[BATCH_RETAIN_TASK] Completed background batch retain for bank_id={bank_id}")
+
+    async def _wait_for_retain_predecessor(self, operation_id: str) -> None:
+        """Defer a worker task until the prior upsert for its document is terminal.
+
+        Distributed workers normally never reach this guard because claim-time
+        release clears the dependency first. It remains a race backstop. The
+        synchronous backend has no poller, so it waits locally instead.
+        """
+        backend = await self._get_backend()
+        synchronous = self._task_backend.__class__.__name__ == "SyncTaskBackend"
+
+        while True:
+            async with acquire_with_retry(backend) as conn:
+                status = await conn.fetchval(
+                    f"SELECT status FROM {fq_table('async_operations')} WHERE operation_id = $1",
+                    uuid.UUID(operation_id),
+                )
+            if status is None or status in ("completed", "failed", "cancelled"):
+                return
+            if not synchronous:
+                raise DeferOperation(
+                    exec_date=utcnow() + timedelta(seconds=5),
+                    reason=f"serialized retain waiting for predecessor {operation_id}",
+                )
+            await asyncio.sleep(0.05)
 
     async def _handle_file_convert_retain(self, task_dict: dict[str, Any]):
         """
@@ -12177,13 +12274,26 @@ class MemoryEngine(MemoryEngineInterface):
         async with acquire_with_retry(backend) as conn:
             # Check if operation exists, belongs to this bank, and is in a cancellable state
             result = await conn.fetchrow(
-                f"SELECT bank_id, status FROM {fq_table('async_operations')} WHERE operation_id = $1 AND bank_id = $2",
+                f"""
+                SELECT bank_id, status, serialization_key
+                FROM {fq_table("async_operations")}
+                WHERE operation_id = $1 AND bank_id = $2
+                """,
                 op_uuid,
                 bank_id,
             )
 
             if not result:
                 raise ValueError(f"Operation {operation_id} not found for bank {bank_id}")
+
+            if result["serialization_key"] is not None:
+                from hindsight_api.extensions import OperationValidationError
+
+                raise OperationValidationError(
+                    "Serialized retain operations cannot be cancelled because a later "
+                    "same-document retain may already depend on their terminal state",
+                    409,
+                )
 
             if result["status"] != "pending":
                 from hindsight_api.extensions import OperationValidationError
@@ -12247,6 +12357,7 @@ class MemoryEngine(MemoryEngineInterface):
                 WHERE operation_id = $1
                   AND bank_id = $2
                   AND status IN ('failed', 'cancelled')
+                  AND serialization_key IS NULL
                 RETURNING operation_id
                 """,
                 op_uuid,
@@ -12255,12 +12366,22 @@ class MemoryEngine(MemoryEngineInterface):
 
             if updated is None:
                 row = await conn.fetchrow(
-                    f"SELECT status FROM {fq_table('async_operations')} WHERE operation_id = $1 AND bank_id = $2",
+                    f"""
+                    SELECT status, serialization_key
+                    FROM {fq_table("async_operations")}
+                    WHERE operation_id = $1 AND bank_id = $2
+                    """,
                     op_uuid,
                     bank_id,
                 )
                 if not row:
                     raise ValueError(f"Operation {operation_id} not found for bank {bank_id}")
+                if row["serialization_key"] is not None:
+                    raise OperationValidationError(
+                        "Serialized retain operations cannot be retried because a later "
+                        "same-document retain may already have been released",
+                        409,
+                    )
                 raise OperationValidationError(
                     f"Operation {operation_id} cannot be retried: status is '{row['status']}', expected 'failed' or 'cancelled'",
                     409,
@@ -12771,6 +12892,7 @@ class MemoryEngine(MemoryEngineInterface):
         request_context: "RequestContext",
         document_tags: list[str] | None = None,
         strategy: str | None = None,
+        idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Submit a batch retain operation to run asynchronously.
 
@@ -12778,19 +12900,50 @@ class MemoryEngine(MemoryEngineInterface):
         into smaller sub-batches and creates a parent operation that tracks all children.
         """
         await self._authenticate_tenant(request_context)
-
+        original_contents = copy.deepcopy(contents)
+        original_items_count = len(original_contents)
+        request_fingerprint = (
+            _retain_submission_fingerprint(original_contents, document_tags, strategy)
+            if idempotency_key is not None
+            else None
+        )
         # Run operation validator (bank access, credits, etc.) before queuing
         if self._operation_validator:
             from hindsight_api.extensions import RetainContext
 
             ctx = RetainContext(
                 bank_id=bank_id,
-                contents=[dict(c) for c in contents],
+                contents=copy.deepcopy(original_contents),
                 request_context=request_context,
             )
             result = await self._validate_operation(self._operation_validator.validate_retain(ctx))
             if result and result.contents is not None:
                 contents = result.contents
+        serialization_key = _retain_serialization_key(original_contents, contents, idempotency_key)
+
+        backend = await self._get_backend()
+        if idempotency_key is not None:
+            async with acquire_with_retry(backend) as conn:
+                existing = await conn.fetchrow(
+                    f"""
+                    SELECT operation_id, request_fingerprint
+                    FROM {fq_table("async_operations")}
+                    WHERE bank_id = $1
+                      AND operation_type = 'batch_retain'
+                      AND idempotency_key = $2
+                    """,
+                    bank_id,
+                    idempotency_key,
+                )
+            if existing is not None:
+                if existing["request_fingerprint"] != request_fingerprint:
+                    raise RetainIdempotencyConflictError(
+                        "idempotency_key was already used for a different async retain payload"
+                    )
+                return {
+                    "operation_id": str(existing["operation_id"]),
+                    "items_count": original_items_count,
+                }
 
         # Validate no duplicate document_ids in the batch
         # Having duplicate document_ids causes race conditions in document upserts during parallel processing
@@ -12838,8 +12991,6 @@ class MemoryEngine(MemoryEngineInterface):
         import uuid
 
         parent_operation_id = uuid.uuid4()
-        backend = await self._get_backend()
-
         # Create typed metadata for parent operation
         parent_metadata = BatchRetainParentMetadata(
             items_count=len(contents),
@@ -12871,6 +13022,8 @@ class MemoryEngine(MemoryEngineInterface):
         # are effectively no-ops for already-populated task_payload, but we
         # defer them all uniformly for clarity.
         deferred_child_payloads: list[dict[str, Any]] = []
+        blocked_by_operation_id: uuid.UUID | None = None
+        blocked_until = datetime(9999, 1, 1, tzinfo=UTC)
 
         async with acquire_with_retry(backend) as conn:
             async with conn.transaction():
@@ -12882,17 +13035,96 @@ class MemoryEngine(MemoryEngineInterface):
                     request_context,
                     conn=conn,
                 )
-                await conn.execute(
-                    f"""
-                    INSERT INTO {fq_table("async_operations")} (operation_id, bank_id, operation_type, result_metadata, status)
-                    VALUES ($1, $2, $3, $4, $5)
-                    """,
-                    parent_operation_id,
-                    bank_id,
-                    "batch_retain",
-                    json.dumps(parent_metadata.to_dict()),
-                    "pending",  # Will be updated by status aggregation
-                )
+                if serialization_key is not None:
+                    bank_exists = await conn.fetchval(
+                        f"SELECT 1 FROM {fq_table('banks')} WHERE bank_id = $1 FOR NO KEY UPDATE",
+                        bank_id,
+                    )
+                    if bank_exists is None:
+                        raise RuntimeError(f"Bank '{bank_id}' was not found after ensuring it exists")
+                    predecessor = await conn.fetchrow(
+                        f"""
+                        SELECT candidate.operation_id
+                        FROM {fq_table("async_operations")} candidate
+                        WHERE candidate.bank_id = $1
+                          AND candidate.operation_type = 'batch_retain'
+                          AND candidate.serialization_key = $2
+                          AND candidate.status IN ('pending', 'processing')
+                          AND NOT EXISTS (
+                              SELECT 1
+                              FROM {fq_table("async_operations")} successor
+                              WHERE successor.operation_type = 'batch_retain'
+                                AND successor.status IN ('pending', 'processing')
+                                AND successor.blocked_by_operation_id = candidate.operation_id
+                          )
+                        LIMIT 1
+                        """,
+                        bank_id,
+                        serialization_key,
+                    )
+                    if predecessor is not None:
+                        blocked_by_operation_id = predecessor["operation_id"]
+                if idempotency_key is None:
+                    await conn.execute(
+                        f"""
+                        INSERT INTO {fq_table("async_operations")}
+                            (operation_id, bank_id, operation_type, result_metadata, status,
+                             serialization_key, blocked_by_operation_id)
+                        VALUES ($1, $2, $3, $4, $5, $6, $7)
+                        """,
+                        parent_operation_id,
+                        bank_id,
+                        "batch_retain",
+                        json.dumps(parent_metadata.to_dict()),
+                        "pending",  # Will be updated by status aggregation
+                        serialization_key,
+                        blocked_by_operation_id,
+                    )
+                else:
+                    # The unique constraint is the concurrency authority. Both
+                    # PostgreSQL and the Oracle query adapter implement this
+                    # INSERT ... ON CONFLICT path transactionally.
+                    await conn.execute(
+                        f"""
+                        INSERT INTO {fq_table("async_operations")}
+                            (operation_id, bank_id, operation_type, result_metadata, status,
+                             idempotency_key, request_fingerprint, serialization_key,
+                             blocked_by_operation_id)
+                        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                        ON CONFLICT (bank_id, operation_type, idempotency_key) DO NOTHING
+                        """,
+                        parent_operation_id,
+                        bank_id,
+                        "batch_retain",
+                        json.dumps(parent_metadata.to_dict()),
+                        "pending",
+                        idempotency_key,
+                        request_fingerprint,
+                        serialization_key,
+                        blocked_by_operation_id,
+                    )
+                    claimed = await conn.fetchrow(
+                        f"""
+                        SELECT operation_id, request_fingerprint
+                        FROM {fq_table("async_operations")}
+                        WHERE bank_id = $1
+                          AND operation_type = 'batch_retain'
+                          AND idempotency_key = $2
+                        """,
+                        bank_id,
+                        idempotency_key,
+                    )
+                    if claimed is None:
+                        raise RuntimeError("idempotent retain claim was not readable after insert")
+                    if claimed["request_fingerprint"] != request_fingerprint:
+                        raise RetainIdempotencyConflictError(
+                            "idempotency_key was already used for a different async retain payload"
+                        )
+                    if str(claimed["operation_id"]) != str(parent_operation_id):
+                        return {
+                            "operation_id": str(claimed["operation_id"]),
+                            "items_count": original_items_count,
+                        }
 
                 for i, sub_batch in enumerate(sub_batches, 1):
                     if len(sub_batches) > 1:
@@ -12926,11 +13158,16 @@ class MemoryEngine(MemoryEngineInterface):
                         "bank_id": bank_id,
                         **task_payload,
                     }
+                    if blocked_by_operation_id is not None:
+                        full_payload["_blocked_by_operation_id"] = str(blocked_by_operation_id)
 
                     await conn.execute(
                         f"""
-                        INSERT INTO {fq_table("async_operations")} (operation_id, bank_id, operation_type, result_metadata, status, task_payload)
-                        VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+                        INSERT INTO {fq_table("async_operations")}
+                            (operation_id, bank_id, operation_type, result_metadata, status,
+                             task_payload, serialization_key, blocked_by_operation_id,
+                             next_retry_at)
+                        VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9)
                         """,
                         child_operation_id,
                         bank_id,
@@ -12938,6 +13175,9 @@ class MemoryEngine(MemoryEngineInterface):
                         json.dumps(child_metadata.to_dict(), default=_json_default),
                         "pending",
                         json.dumps(full_payload, default=_json_default),
+                        serialization_key,
+                        blocked_by_operation_id,
+                        blocked_until if blocked_by_operation_id is not None else None,
                     )
                     deferred_child_payloads.append(full_payload)
 
@@ -12956,7 +13196,7 @@ class MemoryEngine(MemoryEngineInterface):
 
         return {
             "operation_id": str(parent_operation_id),
-            "items_count": len(contents),
+            "items_count": original_items_count if idempotency_key is not None else len(contents),
         }
 
     async def submit_async_file_retain(

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -1105,6 +1105,8 @@ async def test_version_endpoint_returns_correct_version(api_client):
 
     # Verify features field structure
     features = result["features"]
+    assert features["retain_idempotency"] is True
+    assert features["retain_serialized_upsert"] is True
     assert "observations" in features
     assert "mcp" in features
     assert "worker" in features

--- a/hindsight-api-slim/tests/test_retain_idempotency.py
+++ b/hindsight-api-slim/tests/test_retain_idempotency.py
@@ -1,0 +1,656 @@
+"""Regression tests for async Retain submission idempotency."""
+
+import asyncio
+from dataclasses import dataclass
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from hindsight_api.api import create_app
+from hindsight_api.engine.memory_engine import (
+    MemoryEngine,
+    RetainIdempotencyConflictError,
+    _retain_submission_fingerprint,
+)
+from hindsight_api.engine.task_backend import WorkerTaskBackend
+from hindsight_api.extensions import OperationValidationError, OperationValidatorExtension, ValidationResult
+
+
+class _NoopEmbeddings:
+    provider_name = "test"
+    dimension = 384
+
+    async def initialize(self) -> None:
+        return None
+
+
+class _NoopCrossEncoder:
+    provider_name = "test"
+
+    async def initialize(self) -> None:
+        return None
+
+
+class _NoopQueryAnalyzer:
+    def load(self) -> None:
+        return None
+
+
+@pytest_asyncio.fixture
+async def idempotency_memory(pg0_db_url):
+    memory = MemoryEngine(
+        db_url=pg0_db_url,
+        memory_llm_provider="mock",
+        memory_llm_api_key="",
+        memory_llm_model="mock",
+        embeddings=_NoopEmbeddings(),
+        cross_encoder=_NoopCrossEncoder(),
+        query_analyzer=_NoopQueryAnalyzer(),
+        run_migrations=False,
+        task_backend=WorkerTaskBackend(),
+    )
+    await memory.initialize()
+    yield memory
+    await memory.close()
+
+
+@pytest_asyncio.fixture
+async def idempotency_api_client(idempotency_memory):
+    app = create_app(idempotency_memory, initialize_memory=False)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+@dataclass(frozen=True)
+class _OperationCounts:
+    parents: int
+    children: int
+
+
+async def _operation_counts(memory, bank_id: str) -> _OperationCounts:
+    pool = await memory._get_pool()
+    parent_count = await pool.fetchval(
+        """
+        SELECT COUNT(*) FROM async_operations
+        WHERE bank_id = $1 AND operation_type = 'batch_retain'
+        """,
+        bank_id,
+    )
+    child_count = await pool.fetchval(
+        """
+        SELECT COUNT(*) FROM async_operations
+        WHERE bank_id = $1 AND operation_type = 'retain'
+        """,
+        bank_id,
+    )
+    return _OperationCounts(parents=parent_count, children=child_count)
+
+
+async def _child_for_parent(memory, parent_operation_id: str):
+    pool = await memory._get_pool()
+    return await pool.fetchrow(
+        """
+        SELECT operation_id, blocked_by_operation_id, next_retry_at
+        FROM async_operations
+        WHERE operation_type = 'retain'
+          AND result_metadata->>'parent_operation_id' = $1
+        """,
+        parent_operation_id,
+    )
+
+
+async def _parent(memory, parent_operation_id: str):
+    pool = await memory._get_pool()
+    return await pool.fetchrow(
+        """
+        SELECT operation_id, blocked_by_operation_id, serialization_key, status
+        FROM async_operations
+        WHERE operation_id = $1
+        """,
+        parent_operation_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_retain_without_key_preserves_create_each_time(idempotency_memory, request_context):
+    memory = idempotency_memory
+    bank_id = "retain-idempotency-unkeyed"
+    contents = [{"content": "One stable fact.", "document_id": "unkeyed-doc"}]
+
+    first = await memory.submit_async_retain(bank_id, contents, request_context=request_context)
+    second = await memory.submit_async_retain(bank_id, contents, request_context=request_context)
+
+    assert first["operation_id"] != second["operation_id"]
+    assert await _operation_counts(memory, bank_id) == _OperationCounts(parents=2, children=2)
+
+
+@pytest.mark.asyncio
+async def test_identical_key_returns_original_operation_without_new_work(idempotency_memory, request_context):
+    memory = idempotency_memory
+    bank_id = "retain-idempotency-repeat"
+    contents = [{"content": "One stable fact.", "document_id": "repeat-doc", "tags": ["b", "a"]}]
+
+    first = await memory.submit_async_retain(
+        bank_id,
+        contents,
+        request_context=request_context,
+        idempotency_key="repeat-key",
+    )
+    second = await memory.submit_async_retain(
+        bank_id,
+        [{"content": "One stable fact.", "document_id": "repeat-doc", "tags": ["a", "b"]}],
+        request_context=request_context,
+        idempotency_key="repeat-key",
+    )
+
+    assert second["operation_id"] == first["operation_id"]
+    assert await _operation_counts(memory, bank_id) == _OperationCounts(parents=1, children=1)
+
+
+@pytest.mark.asyncio
+async def test_same_key_different_payload_fails_without_mutation(idempotency_memory, request_context):
+    memory = idempotency_memory
+    bank_id = "retain-idempotency-conflict"
+    first = await memory.submit_async_retain(
+        bank_id,
+        [{"content": "Original fact.", "document_id": "conflict-doc"}],
+        request_context=request_context,
+        idempotency_key="conflict-key",
+    )
+    counts_before = await _operation_counts(memory, bank_id)
+
+    with pytest.raises(RetainIdempotencyConflictError, match="different async retain payload"):
+        await memory.submit_async_retain(
+            bank_id,
+            [{"content": "Different fact.", "document_id": "conflict-doc"}],
+            request_context=request_context,
+            idempotency_key="conflict-key",
+        )
+
+    assert first["operation_id"]
+    assert await _operation_counts(memory, bank_id) == counts_before
+
+
+@pytest.mark.asyncio
+async def test_retry_still_requires_current_retain_authorization(idempotency_memory, request_context):
+    memory = idempotency_memory
+    bank_id = "retain-idempotency-revoked"
+    contents = [{"content": "Authorized once.", "document_id": "revoked-doc"}]
+    first = await memory.submit_async_retain(
+        bank_id,
+        contents,
+        request_context=request_context,
+        idempotency_key="revoked-key",
+    )
+    counts_before = await _operation_counts(memory, bank_id)
+
+    class _RejectingValidator:
+        async def validate_retain(self, ctx):
+            return ValidationResult.reject("bank access revoked", status_code=403)
+
+    memory._operation_validator = _RejectingValidator()
+
+    with pytest.raises(OperationValidationError, match="bank access revoked"):
+        await memory.submit_async_retain(
+            bank_id,
+            contents,
+            request_context=request_context,
+            idempotency_key="revoked-key",
+        )
+
+    assert first["operation_id"]
+    assert await _operation_counts(memory, bank_id) == counts_before
+
+
+@pytest.mark.asyncio
+async def test_validator_rewrites_do_not_change_caller_payload_identity(idempotency_memory, request_context):
+    memory = idempotency_memory
+    bank_id = "retain-idempotency-validator-rewrite"
+    contents = [{"content": "Stable caller payload.", "document_id": "validator-doc"}]
+
+    class _StatefulValidator(OperationValidatorExtension):
+        calls = 0
+
+        async def validate_retain(self, ctx):
+            self.calls += 1
+            rewritten = [dict(item) for item in ctx.contents]
+            rewritten[0]["content"] = f"validated-version-{self.calls}"
+            if self.calls > 1:
+                rewritten.append({"content": "extra validator item", "document_id": "validator-extra"})
+            return ValidationResult.accept_with(contents=rewritten)
+
+        async def validate_recall(self, ctx):
+            return ValidationResult.accept()
+
+        async def validate_reflect(self, ctx):
+            return ValidationResult.accept()
+
+    validator = _StatefulValidator({})
+    memory._operation_validator = validator
+
+    first = await memory.submit_async_retain(
+        bank_id,
+        contents,
+        request_context=request_context,
+        idempotency_key="validator-rewrite-key",
+    )
+    second = await memory.submit_async_retain(
+        bank_id,
+        contents,
+        request_context=request_context,
+        idempotency_key="validator-rewrite-key",
+    )
+
+    assert validator.calls == 2
+    assert second["operation_id"] == first["operation_id"]
+    assert first["items_count"] == second["items_count"] == 1
+    assert await _operation_counts(memory, bank_id) == _OperationCounts(parents=1, children=1)
+
+
+@pytest.mark.asyncio
+async def test_validator_enrichment_preserves_same_document_serialization(idempotency_memory, request_context):
+    memory = idempotency_memory
+    bank_id = "retain-serialization-validator-enrichment"
+
+    class _AddingValidator(OperationValidatorExtension):
+        async def validate_retain(self, ctx):
+            return ValidationResult.accept_with(
+                contents=[
+                    *ctx.contents,
+                    {"content": "validator-added", "document_id": f"extra-{ctx.contents[0]['content']}"},
+                ]
+            )
+
+        async def validate_recall(self, ctx):
+            return ValidationResult.accept()
+
+        async def validate_reflect(self, ctx):
+            return ValidationResult.accept()
+
+    memory._operation_validator = _AddingValidator({})
+    first = await memory.submit_async_retain(
+        bank_id,
+        [{"content": "first", "document_id": "validator-shared-doc"}],
+        request_context=request_context,
+        idempotency_key="validator-serialization-1",
+    )
+    second = await memory.submit_async_retain(
+        bank_id,
+        [{"content": "second", "document_id": "validator-shared-doc"}],
+        request_context=request_context,
+        idempotency_key="validator-serialization-2",
+    )
+
+    assert str((await _parent(memory, second["operation_id"]))["blocked_by_operation_id"]) == first["operation_id"]
+
+
+def test_nullable_entity_type_has_a_stable_fingerprint():
+    fingerprint = _retain_submission_fingerprint(
+        [
+            {
+                "content": "Entities with optional types.",
+                "entities": [
+                    {"text": "same", "type": None},
+                    {"text": "same", "type": "PERSON"},
+                ],
+            }
+        ],
+        None,
+        None,
+    )
+
+    assert len(fingerprint) == 64
+
+
+def test_empty_document_tags_match_omitted_document_tags():
+    contents = [{"content": "same", "document_id": "doc"}]
+
+    assert _retain_submission_fingerprint(
+        contents,
+        [],
+        None,
+    ) == _retain_submission_fingerprint(
+        contents,
+        None,
+        None,
+    )
+
+
+def test_set_like_fields_ignore_duplicate_values():
+    one_each = [
+        {
+            "content": "same",
+            "document_id": "doc",
+            "tags": ["a"],
+            "entities": [{"text": "Vitor", "type": "PERSON"}],
+            "observation_scopes": [["work", "project"]],
+        }
+    ]
+    duplicated = [
+        {
+            "content": "same",
+            "document_id": "doc",
+            "tags": ["a", "a"],
+            "entities": [
+                {"text": "Vitor", "type": "PERSON"},
+                {"type": "PERSON", "text": "Vitor"},
+            ],
+            "observation_scopes": [
+                ["project", "work"],
+                ["work", "project"],
+            ],
+        }
+    ]
+
+    assert _retain_submission_fingerprint(
+        one_each,
+        ["session"],
+        None,
+    ) == _retain_submission_fingerprint(
+        duplicated,
+        ["session", "session"],
+        None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_unkeyed_response_preserves_processed_item_count(idempotency_memory, request_context):
+    memory = idempotency_memory
+
+    class _AddingValidator(OperationValidatorExtension):
+        async def validate_retain(self, ctx):
+            return ValidationResult.accept_with(
+                contents=[
+                    *ctx.contents,
+                    {"content": "validator-added", "document_id": "validator-added-doc"},
+                ]
+            )
+
+        async def validate_recall(self, ctx):
+            return ValidationResult.accept()
+
+        async def validate_reflect(self, ctx):
+            return ValidationResult.accept()
+
+    memory._operation_validator = _AddingValidator({})
+    result = await memory.submit_async_retain(
+        "retain-unkeyed-validator-count",
+        [{"content": "caller item", "document_id": "caller-doc"}],
+        request_context=request_context,
+    )
+
+    assert result["items_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_identical_submissions_converge(idempotency_memory, request_context):
+    memory = idempotency_memory
+    bank_id = "retain-idempotency-concurrent"
+    contents = [{"content": "Concurrent fact.", "document_id": "concurrent-doc"}]
+
+    first, second = await asyncio.gather(
+        memory.submit_async_retain(
+            bank_id,
+            contents,
+            request_context=request_context,
+            idempotency_key="concurrent-key",
+        ),
+        memory.submit_async_retain(
+            bank_id,
+            contents,
+            request_context=request_context,
+            idempotency_key="concurrent-key",
+        ),
+    )
+
+    assert first["operation_id"] == second["operation_id"]
+    assert await _operation_counts(memory, bank_id) == _OperationCounts(parents=1, children=1)
+
+
+@pytest.mark.asyncio
+async def test_same_document_distinct_requests_are_serialized(idempotency_memory, request_context):
+    memory = idempotency_memory
+    bank_id = "retain-serialization-same-document"
+    first = await memory.submit_async_retain(
+        bank_id,
+        [{"content": "First snapshot.", "document_id": "shared-doc"}],
+        request_context=request_context,
+        idempotency_key="snapshot-1",
+    )
+    second = await memory.submit_async_retain(
+        bank_id,
+        [{"content": "Second snapshot.", "document_id": "shared-doc"}],
+        request_context=request_context,
+        idempotency_key="snapshot-2",
+    )
+
+    first_child = await _child_for_parent(memory, first["operation_id"])
+    second_child = await _child_for_parent(memory, second["operation_id"])
+
+    assert first_child["blocked_by_operation_id"] is None
+    assert str(second_child["blocked_by_operation_id"]) == first["operation_id"]
+    assert second_child["next_retry_at"].year == 9999
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_document_requests_form_one_serialized_pair(idempotency_memory, request_context):
+    memory = idempotency_memory
+    bank_id = "retain-serialization-concurrent-same-document"
+    first, second = await asyncio.gather(
+        memory.submit_async_retain(
+            bank_id,
+            [{"content": "Concurrent snapshot A.", "document_id": "shared-doc"}],
+            request_context=request_context,
+            idempotency_key="concurrent-snapshot-a",
+        ),
+        memory.submit_async_retain(
+            bank_id,
+            [{"content": "Concurrent snapshot B.", "document_id": "shared-doc"}],
+            request_context=request_context,
+            idempotency_key="concurrent-snapshot-b",
+        ),
+    )
+
+    first_child = await _child_for_parent(memory, first["operation_id"])
+    second_child = await _child_for_parent(memory, second["operation_id"])
+    dependencies = {
+        first["operation_id"]: first_child["blocked_by_operation_id"],
+        second["operation_id"]: second_child["blocked_by_operation_id"],
+    }
+    unblocked = [operation_id for operation_id, dependency in dependencies.items() if dependency is None]
+    blocked = [
+        (operation_id, str(dependency)) for operation_id, dependency in dependencies.items() if dependency is not None
+    ]
+
+    assert len(unblocked) == 1
+    assert len(blocked) == 1
+    assert blocked[0][0] != unblocked[0]
+    assert blocked[0][1] == unblocked[0]
+
+
+@pytest.mark.asyncio
+async def test_serialization_forms_a_chain_not_a_fan_in(idempotency_memory, request_context):
+    memory = idempotency_memory
+    bank_id = "retain-serialization-chain"
+    operations = []
+    for number in range(3):
+        operations.append(
+            await memory.submit_async_retain(
+                bank_id,
+                [{"content": f"Snapshot {number}.", "document_id": "chain-doc"}],
+                request_context=request_context,
+                idempotency_key=f"chain-{number}",
+            )
+        )
+
+    second_child = await _child_for_parent(memory, operations[1]["operation_id"])
+    third_child = await _child_for_parent(memory, operations[2]["operation_id"])
+
+    assert str(second_child["blocked_by_operation_id"]) == operations[0]["operation_id"]
+    assert str(third_child["blocked_by_operation_id"]) == operations[1]["operation_id"]
+
+
+@pytest.mark.asyncio
+async def test_serialization_tail_does_not_depend_on_created_at(idempotency_memory, request_context):
+    memory = idempotency_memory
+    bank_id = "retain-serialization-created-at-inversion"
+    first = await memory.submit_async_retain(
+        bank_id,
+        [{"content": "first", "document_id": "inverted-doc"}],
+        request_context=request_context,
+        idempotency_key="inverted-1",
+    )
+    second = await memory.submit_async_retain(
+        bank_id,
+        [{"content": "second", "document_id": "inverted-doc"}],
+        request_context=request_context,
+        idempotency_key="inverted-2",
+    )
+    pool = await memory._get_pool()
+    await pool.execute(
+        "UPDATE async_operations SET created_at = created_at - INTERVAL '1 day' WHERE operation_id = $1",
+        second["operation_id"],
+    )
+
+    third = await memory.submit_async_retain(
+        bank_id,
+        [{"content": "third", "document_id": "inverted-doc"}],
+        request_context=request_context,
+        idempotency_key="inverted-3",
+    )
+
+    assert str((await _parent(memory, second["operation_id"]))["blocked_by_operation_id"]) == first["operation_id"]
+    assert str((await _parent(memory, third["operation_id"]))["blocked_by_operation_id"]) == second["operation_id"]
+
+
+@pytest.mark.asyncio
+async def test_serialized_operations_reject_manual_cancel_and_retry(idempotency_memory, request_context):
+    memory = idempotency_memory
+    bank_id = "retain-serialization-lifecycle"
+    operation = await memory.submit_async_retain(
+        bank_id,
+        [{"content": "snapshot", "document_id": "lifecycle-doc"}],
+        request_context=request_context,
+        idempotency_key="lifecycle-1",
+    )
+    child = await _child_for_parent(memory, operation["operation_id"])
+
+    with pytest.raises(OperationValidationError, match="cannot be cancelled"):
+        await memory.cancel_operation(
+            bank_id,
+            str(child["operation_id"]),
+            request_context=request_context,
+        )
+
+    pool = await memory._get_pool()
+    await pool.execute(
+        "UPDATE async_operations SET status = 'failed' WHERE operation_id = $1",
+        child["operation_id"],
+    )
+    with pytest.raises(OperationValidationError, match="cannot be retried"):
+        await memory.retry_operation(
+            bank_id,
+            str(child["operation_id"]),
+            request_context=request_context,
+        )
+
+
+@pytest.mark.asyncio
+async def test_different_documents_remain_parallel(idempotency_memory, request_context):
+    memory = idempotency_memory
+    bank_id = "retain-serialization-different-documents"
+    first, second = await asyncio.gather(
+        memory.submit_async_retain(
+            bank_id,
+            [{"content": "First document.", "document_id": "doc-a"}],
+            request_context=request_context,
+            idempotency_key="doc-a-key",
+        ),
+        memory.submit_async_retain(
+            bank_id,
+            [{"content": "Second document.", "document_id": "doc-b"}],
+            request_context=request_context,
+            idempotency_key="doc-b-key",
+        ),
+    )
+
+    assert (await _child_for_parent(memory, first["operation_id"]))["blocked_by_operation_id"] is None
+    assert (await _child_for_parent(memory, second["operation_id"]))["blocked_by_operation_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_terminal_predecessor_releases_child_for_claim(idempotency_memory, request_context):
+    memory = idempotency_memory
+    bank_id = "retain-serialization-release"
+    first = await memory.submit_async_retain(
+        bank_id,
+        [{"content": "First snapshot.", "document_id": "release-doc"}],
+        request_context=request_context,
+        idempotency_key="release-1",
+    )
+    second = await memory.submit_async_retain(
+        bank_id,
+        [{"content": "Second snapshot.", "document_id": "release-doc"}],
+        request_context=request_context,
+        idempotency_key="release-2",
+    )
+
+    pool = await memory._get_pool()
+    await pool.execute(
+        """
+        UPDATE async_operations
+        SET status = 'completed', completed_at = NOW(), updated_at = NOW()
+        WHERE operation_id = $1
+        """,
+        first["operation_id"],
+    )
+    async with memory._backend.acquire() as conn:
+        async with conn.transaction():
+            await memory._backend.ops._release_serialized_retain_tasks(conn, "async_operations")
+
+    released = await _child_for_parent(memory, second["operation_id"])
+    assert released["blocked_by_operation_id"] is None
+    assert released["next_retry_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_http_conflict_is_explicit(idempotency_api_client):
+    api_client = idempotency_api_client
+    bank_id = "retain-idempotency-http"
+    first = await api_client.post(
+        f"/v1/default/banks/{bank_id}/memories",
+        json={
+            "items": [{"content": "Original HTTP fact.", "document_id": "http-doc"}],
+            "async": True,
+            "idempotency_key": "http-key",
+        },
+    )
+    conflict = await api_client.post(
+        f"/v1/default/banks/{bank_id}/memories",
+        json={
+            "items": [{"content": "Changed HTTP fact.", "document_id": "http-doc"}],
+            "async": True,
+            "idempotency_key": "http-key",
+        },
+    )
+
+    assert first.status_code == 200
+    assert conflict.status_code == 409
+    assert "different async retain payload" in conflict.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_http_rejects_nul_in_idempotency_key(idempotency_api_client):
+    response = await idempotency_api_client.post(
+        "/v1/default/banks/retain-idempotency-nul/memories",
+        json={
+            "items": [{"content": "Never queued.", "document_id": "nul-doc"}],
+            "async": True,
+            "idempotency_key": "invalid\u0000key",
+        },
+    )
+
+    assert response.status_code == 422
+    assert "cannot contain NUL bytes" in response.text

--- a/hindsight-api-slim/tests/test_retain_idempotency_migration.py
+++ b/hindsight-api-slim/tests/test_retain_idempotency_migration.py
@@ -1,0 +1,64 @@
+"""Focused migration contract tests for Retain idempotency."""
+
+import importlib
+
+
+def test_oracle_idempotency_key_uses_character_semantics(monkeypatch):
+    migration = importlib.import_module("hindsight_api.alembic.versions.e8f1a2b3c4d5_add_retain_idempotency")
+    executed = []
+
+    monkeypatch.setattr(migration.op, "execute", executed.append)
+    monkeypatch.setattr(migration.op, "add_column", lambda *args, **kwargs: None)
+    monkeypatch.setattr(migration.op, "create_unique_constraint", lambda *args, **kwargs: None)
+
+    migration._oracle_upgrade()
+
+    assert executed == ["ALTER TABLE async_operations ADD idempotency_key VARCHAR2(256 CHAR)"]
+
+
+def test_oracle_serialization_dependency_uses_raw_uuid(monkeypatch):
+    migration = importlib.import_module("hindsight_api.alembic.versions.f9a2b3c4d5e6_add_retain_serialization")
+    executed = []
+
+    monkeypatch.setattr(migration.op, "execute", executed.append)
+    monkeypatch.setattr(migration.op, "add_column", lambda *args, **kwargs: None)
+    monkeypatch.setattr(migration.op, "create_index", lambda *args, **kwargs: None)
+
+    migration._oracle_upgrade()
+
+    assert executed == ["ALTER TABLE async_operations ADD blocked_by_operation_id RAW(16)"]
+
+
+def test_oracle_rewrites_serialization_bank_lock():
+    from hindsight_api.engine.db.oracle import _rewrite_pg_to_oracle
+
+    query, _, _ = _rewrite_pg_to_oracle("SELECT 1 FROM banks WHERE bank_id = $1 FOR NO KEY UPDATE")
+
+    assert "FOR UPDATE" in query
+    assert "NO KEY" not in query
+
+
+def test_serialization_downgrade_unparks_pending_tasks(monkeypatch):
+    migration = importlib.import_module("hindsight_api.alembic.versions.f9a2b3c4d5e6_add_retain_serialization")
+    executed = []
+    dropped = []
+
+    monkeypatch.setattr(migration.op, "execute", executed.append)
+    monkeypatch.setattr(
+        migration.op,
+        "drop_index",
+        lambda name, **kwargs: dropped.append(("index", name)),
+    )
+    monkeypatch.setattr(
+        migration.op,
+        "drop_column",
+        lambda table, column: dropped.append(("column", column)),
+    )
+
+    migration._pg_downgrade()
+
+    assert "SET next_retry_at = NULL" in executed[0]
+    assert dropped[-2:] == [
+        ("column", "blocked_by_operation_id"),
+        ("column", "serialization_key"),
+    ]

--- a/hindsight-docs/docs-integrations/codex.md
+++ b/hindsight-docs/docs-integrations/codex.md
@@ -34,6 +34,7 @@ curl -fsSL https://hindsight.vectorize.io/get-codex | bash -s -- --uninstall
 - **Auto-retain** — after each Codex response, stores the conversation transcript to Hindsight for future recall
 - **Dynamic bank IDs** — supports per-project memory isolation based on the working directory
 - **Session-level upsert** — uses the session ID as the document ID so re-running the same session updates rather than duplicates stored content
+- **Lost-response-safe retain** — durably queues each due submission before POST and reuses its identity until Hindsight acknowledges the original async operation
 - **Zero dependencies** — pure Python stdlib, no pip install required
 
 ## Architecture
@@ -59,6 +60,32 @@ Current time - 2026-03-27 09:14
 ```
 
 On `Stop`, the hook reads the session transcript, strips previously injected memory tags (to prevent feedback loops), and POSTs the conversation to Hindsight asynchronously.
+If the response times out after the server accepted the request, the next
+`Stop` retries the exact pending payload with the same `idempotency_key`.
+Non-coalescible later windows remain queued in order instead of being lost.
+Cadence is keyed by the parsed transcript identity, so retrying an unchanged
+`Stop` does not consume the next turn while a genuinely newer transcript does.
+Due work is persisted before API discovery, preserving the window across local
+daemon or endpoint discovery failures.
+After Hindsight acknowledges the POST, the hook removes that request from its
+local queue and can submit the next window immediately. Hindsight serializes
+keyed async upserts for the same session document on the server, while retains
+for different documents remain parallel. This also delivers the final queued
+window without requiring a later `Stop` event to poll its predecessor.
+During an outage, `full-session` mode keeps the possibly accepted request and
+coalesces later, definitely-unsent snapshots to the newest session state.
+Non-coalescible `chunked` queues are capped at 128 requests or 64 MiB and stop
+advancing cadence when that limit is reached while continuing to drain already
+persisted work.
+Pending transcript data is bound to the intended API URL before discovery or
+health checks and is replayed only to that same URL, authentication context,
+and bank; changing any of them leaves the queue untouched for explicit
+recovery.
+Before the first Retain POST, the hook requires the server's `/version`
+response to advertise both `features.retain_idempotency=true` and
+`features.retain_serialized_upsert=true`. Older servers that do not implement
+the complete contract receive no queued Retain request, preventing a silent
+downgrade to duplicate-prone or concurrently reordered retries.
 
 ## Connection Modes
 

--- a/hindsight-docs/docs/developer/api/retain.mdx
+++ b/hindsight-docs/docs/developer/api/retain.mdx
@@ -333,6 +333,45 @@ For large batches, use async ingestion to avoid blocking your application:
 
 When `async: true`, the call returns immediately with an `operation_id`. Processing runs in the background via the worker service. No `usage` metrics are returned for async operations.
 
+### Retrying Async Retain Safely
+
+Set the optional top-level `idempotency_key` when a caller may retry after a
+timeout or lost response:
+
+```json
+{
+  "items": [{"content": "New conversation delta", "document_id": "session-123", "update_mode": "append"}],
+  "async": true,
+  "idempotency_key": "retain-session-123-delta-7"
+}
+```
+
+- The first request creates the async operation.
+- Reusing the key with the same semantic payload returns the original
+  `operation_id` and creates no additional worker task.
+- Reusing the key with a different payload returns HTTP 409 and creates
+  nothing.
+- Omitting the key preserves the existing create-on-every-request behavior.
+
+When a keyed async request contains exactly one item with a `document_id`,
+Hindsight serializes it behind any earlier non-terminal keyed request for the
+same bank and document. The later request is accepted immediately, but its
+worker task becomes claimable only after the predecessor completes, fails, is
+cancelled, or has been pruned. Requests for different documents remain
+parallel. This makes ordered full-document snapshots safe without requiring
+the client to poll one operation before submitting the next.
+
+The fingerprint covers the caller-submitted operation-defining items, document
+tags, and retain strategy before any validator enrichment. Validators still run
+on every retry so current authorization remains authoritative. Object-key order
+is ignored; order is also ignored for set-like fields such as tags, explicit
+entities, and observation scopes. Item order is preserved because it controls
+batching and result ordering.
+
+Idempotency lasts as long as the original operation row is retained. Keyed
+requests currently require every item in the request to use the same retain
+strategy.
+
 ### Cut Costs 50% with Provider Batch APIs
 
 When using async retain, enable the provider Batch API to reduce LLM fact-extraction costs by 50%. OpenAI, Groq, and Gemini all offer this discount in exchange for a processing window of up to 24 hours — a trade-off that's typically invisible when retain already runs in the background.

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -8964,6 +8964,16 @@
       },
       "FeaturesInfo": {
         "properties": {
+          "retain_idempotency": {
+            "type": "boolean",
+            "title": "Retain Idempotency",
+            "description": "Whether async Retain requests accept durable idempotency keys"
+          },
+          "retain_serialized_upsert": {
+            "type": "boolean",
+            "title": "Retain Serialized Upsert",
+            "description": "Whether single-document async Retain upserts are serialized server-side"
+          },
           "observations": {
             "type": "boolean",
             "title": "Observations",
@@ -9022,6 +9032,8 @@
         },
         "type": "object",
         "required": [
+          "retain_idempotency",
+          "retain_serialized_upsert",
           "observations",
           "mcp",
           "worker",
@@ -12188,6 +12200,20 @@
             "title": "Document Tags",
             "description": "Deprecated. Use item-level tags instead.",
             "deprecated": true
+          },
+          "idempotency_key": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 256,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Idempotency Key",
+            "description": "Optional identity for an async retain submission. Reusing the key with the same semantic payload returns the original operation; reusing it with a different payload returns HTTP 409. The key is ignored for synchronous retain."
           }
         },
         "type": "object",
@@ -13071,6 +13097,8 @@
             "file_upload_api": true,
             "mcp": true,
             "observations": false,
+            "retain_idempotency": true,
+            "retain_serialized_upsert": true,
             "worker": true
           }
         }

--- a/hindsight-integrations/codex/scripts/lib/client.py
+++ b/hindsight-integrations/codex/scripts/lib/client.py
@@ -4,6 +4,7 @@ Communicates with a Hindsight server via HTTP. Mirrors the HTTP mode of the
 Openclaw HindsightClient (client.js), adapted for Python stdlib.
 """
 
+import hashlib
 import json
 import urllib.error
 import urllib.parse
@@ -31,6 +32,12 @@ def _plugin_version() -> str:
 USER_AGENT = f"hindsight-codex/{_plugin_version()}"
 
 
+def auth_context_id(api_token: Optional[str]) -> str:
+    """Return a non-secret identity for the current authentication context."""
+    auth_material = f"bearer:{api_token}" if api_token else "anonymous"
+    return hashlib.sha256(auth_material.encode()).hexdigest()
+
+
 def _validate_api_url(url: str) -> str:
     """Validate and normalize the API URL. Reject non-HTTP schemes."""
     parsed = urllib.parse.urlparse(url)
@@ -47,6 +54,7 @@ class HindsightClient:
     def __init__(self, api_url: str, api_token: Optional[str] = None):
         self.api_url = _validate_api_url(api_url)
         self.api_token = api_token
+        self.auth_context_id = auth_context_id(api_token)
 
     def _headers(self) -> dict:
         headers = {
@@ -93,6 +101,16 @@ class HindsightClient:
                 time.sleep(HEALTH_CHECK_DELAY)
         return False
 
+    def supports_durable_retain_delivery(self, timeout: int = 5) -> bool:
+        """Check the complete server contract required by the durable queue."""
+        version = self._request("GET", "/version", timeout=timeout)
+        features = version.get("features")
+        return (
+            isinstance(features, dict)
+            and features.get("retain_idempotency") is True
+            and features.get("retain_serialized_upsert") is True
+        )
+
     def recall(
         self,
         bank_id: str,
@@ -126,6 +144,7 @@ class HindsightClient:
         metadata: Optional[dict] = None,
         tags: Optional[list] = None,
         timeout: int = 15,
+        idempotency_key: Optional[str] = None,
     ) -> dict:
         """Retain content into a bank's memory.
 
@@ -147,6 +166,8 @@ class HindsightClient:
             "items": [item],
             "async": True,
         }
+        if idempotency_key:
+            body["idempotency_key"] = idempotency_key
         return self._request("POST", path, body, timeout=timeout)
 
     def set_bank_mission(

--- a/hindsight-integrations/codex/scripts/lib/daemon.py
+++ b/hindsight-integrations/codex/scripts/lib/daemon.py
@@ -88,6 +88,14 @@ def _check_health(base_url: str, timeout: int = 10) -> bool:
         return False
 
 
+def get_intended_api_url(config: dict) -> str:
+    """Resolve the configured destination without probing or starting it."""
+    external_url = config.get("hindsightApiUrl")
+    if external_url:
+        return external_url.rstrip("/")
+    return f"http://127.0.0.1:{config.get('apiPort', 9077)}"
+
+
 def get_api_url(config: dict, debug_fn=None, allow_daemon_start: bool = False) -> str:
     """Determine the API URL, optionally starting daemon if needed.
 
@@ -105,7 +113,7 @@ def get_api_url(config: dict, debug_fn=None, allow_daemon_start: bool = False) -
 
     # Mode 2 & 3: Local server
     port = config.get("apiPort", 9077)
-    base_url = f"http://127.0.0.1:{port}"
+    base_url = get_intended_api_url(config)
 
     if _check_health(base_url):
         if debug_fn:

--- a/hindsight-integrations/codex/scripts/lib/state.py
+++ b/hindsight-integrations/codex/scripts/lib/state.py
@@ -4,22 +4,54 @@ Codex hooks are ephemeral processes — state must be persisted to files.
 Uses ~/.hindsight/codex/state/ as the storage directory.
 """
 
+from __future__ import annotations
+
+import hashlib
 import json
 import os
 import re
 import sys
+import tempfile
+import time
+from contextlib import contextmanager
+from typing import Any, Iterator, Optional, TypedDict
 
 # fcntl is Unix-only; import conditionally so the module loads on Windows
 if sys.platform != "win32":
     import fcntl
+
+    msvcrt = None
 else:
+    import msvcrt
+
     fcntl = None
+
+WINDOWS_LOCK_TIMEOUT_SECONDS = 30
+WINDOWS_LOCK_RETRY_SECONDS = 0.1
+
+
+class PendingRetain(TypedDict, total=False):
+    idempotency_key: str
+    bank_id: str
+    api_url: str | None
+    auth_context_id: str
+    source_fingerprint: str
+    turn_count: int
+    request: dict[str, Any]
+    post_attempted: bool
+    operation_id: str
+
+
+class RetainCadence(TypedDict):
+    turn_count: int
+    source_fingerprint: str
 
 
 def _state_dir() -> str:
     """Get the state directory, creating it if needed."""
     state_dir = os.path.join(os.path.expanduser("~"), ".hindsight", "codex", "state")
-    os.makedirs(state_dir, exist_ok=True)
+    os.makedirs(state_dir, mode=0o700, exist_ok=True)
+    os.chmod(state_dir, 0o700)
     return state_dir
 
 
@@ -41,6 +73,39 @@ def _state_file(name: str) -> str:
     if not resolved.startswith(expected_dir + os.sep) and resolved != expected_dir:
         raise ValueError(f"State file path escapes state directory: {name!r}")
     return path
+
+
+def _retain_state_name(session_id: str, suffix: str) -> str:
+    digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+    return f"retain-{digest}.{suffix}"
+
+
+def _lock(lock_fd) -> None:
+    if fcntl is not None:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+    elif msvcrt is not None:
+        lock_fd.seek(0)
+        if not lock_fd.read(1):
+            lock_fd.write(b"\0")
+            lock_fd.flush()
+        deadline = time.monotonic() + WINDOWS_LOCK_TIMEOUT_SECONDS
+        while True:
+            lock_fd.seek(0)
+            try:
+                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
+                return
+            except OSError:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError("retain state lock timed out")
+                time.sleep(WINDOWS_LOCK_RETRY_SECONDS)
+
+
+def _unlock(lock_fd) -> None:
+    if fcntl is not None:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+    elif msvcrt is not None:
+        lock_fd.seek(0)
+        msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
 
 
 def read_state(name: str, default=None):
@@ -111,3 +176,182 @@ def increment_turn_count(session_id: str) -> int:
             del turns[k]
     write_state("turns.json", turns)
     return turns[session_id]
+
+
+def set_turn_count(session_id: str, turn_count: int) -> None:
+    """Durably set one session's checkpoint without losing parallel updates."""
+    lock_path = _state_file("turns.lock")
+    lock_fd = os.fdopen(os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600), "a+b")
+    _lock(lock_fd)
+    try:
+        turns = read_state("turns.json", {})
+        turns[session_id] = turn_count
+        if len(turns) > 10000:
+            sorted_keys = sorted(turns.keys())
+            for key in sorted_keys[: len(sorted_keys) // 2]:
+                del turns[key]
+        _write_private_json_atomic(_state_file("turns.json"), turns)
+    finally:
+        _unlock(lock_fd)
+        lock_fd.close()
+
+
+def read_retain_cadence(session_id: str) -> RetainCadence:
+    """Read the last transcript identity counted by the retain hook."""
+    path = _state_file(_retain_state_name(session_id, "cadence.json"))
+    try:
+        with open(path) as handle:
+            value = json.load(handle)
+    except FileNotFoundError:
+        return {
+            "turn_count": get_turn_count(session_id),
+            "source_fingerprint": "",
+        }
+    if (
+        not isinstance(value, dict)
+        or not isinstance(value.get("turn_count"), int)
+        or not isinstance(value.get("source_fingerprint"), str)
+    ):
+        raise ValueError("invalid_retain_cadence")
+    return value
+
+
+def write_retain_cadence(session_id: str, cadence: RetainCadence) -> None:
+    """Durably record one counted transcript identity."""
+    _write_private_json_atomic(
+        _state_file(_retain_state_name(session_id, "cadence.json")),
+        cadence,
+    )
+
+
+@contextmanager
+def retain_submission_lock(session_id: str) -> Iterator[bool]:
+    """Serialize checkpoint and pending-retain changes for one Codex session."""
+    lock_path = _state_file(_retain_state_name(session_id, "lock"))
+    lock_fd = os.fdopen(os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600), "a+b")
+    os.chmod(lock_path, 0o600)
+    try:
+        _lock(lock_fd)
+    except TimeoutError:
+        lock_fd.close()
+        yield False
+        return
+    try:
+        yield True
+    finally:
+        _unlock(lock_fd)
+        lock_fd.close()
+
+
+def read_pending_retain(session_id: str) -> Optional[PendingRetain]:
+    """Return the unacknowledged Retain submission for a session, if any."""
+    pending = read_pending_retains(session_id)
+    return pending[0] if pending else None
+
+
+def read_pending_retains(session_id: str) -> list[PendingRetain]:
+    """Return every unacknowledged submission in original turn order."""
+    path = _state_file(_retain_state_name(session_id, "json"))
+    try:
+        with open(path) as handle:
+            value = json.load(handle)
+    except FileNotFoundError:
+        return []
+    if isinstance(value, dict):
+        return [value]
+    if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+        raise ValueError("invalid_pending_retain_queue")
+    return value
+
+
+def read_deferred_retain(session_id: str) -> Optional[PendingRetain]:
+    """Return the single overflow submission held behind the bounded queue."""
+    path = _state_file(_retain_state_name(session_id, "overflow.json"))
+    try:
+        with open(path) as handle:
+            value = json.load(handle)
+    except FileNotFoundError:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError("invalid_deferred_retain")
+    return value
+
+
+def _write_private_json_atomic(path: str, value: Any) -> None:
+    fd, tmp_path = tempfile.mkstemp(prefix=os.path.basename(path) + ".", dir=_state_dir())
+    try:
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, 0o600)
+        else:
+            os.chmod(tmp_path, 0o600)
+        with os.fdopen(fd, "w") as handle:
+            json.dump(value, handle)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+        os.chmod(path, 0o600)
+        if sys.platform != "win32":
+            state_dir_fd = os.open(_state_dir(), os.O_RDONLY)
+            try:
+                os.fsync(state_dir_fd)
+            finally:
+                os.close(state_dir_fd)
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def write_pending_retain(session_id: str, submission: PendingRetain) -> None:
+    """Durably persist the exact Retain request before sending it.
+
+    Unlike generic hook state, losing this file after the POST can create a
+    duplicate retain. Fail closed and keep transcript-bearing files private.
+    """
+    _write_private_json_atomic(_state_file(_retain_state_name(session_id, "json")), submission)
+
+
+def write_pending_retains(session_id: str, submissions: list[PendingRetain]) -> None:
+    """Durably replace one session's ordered retry queue."""
+    if not submissions:
+        clear_pending_retain(session_id)
+        return
+    _write_private_json_atomic(_state_file(_retain_state_name(session_id, "json")), submissions)
+
+
+def write_deferred_retain(session_id: str, submission: PendingRetain) -> None:
+    """Persist one exact due submission that did not fit in the bounded queue."""
+    _write_private_json_atomic(
+        _state_file(_retain_state_name(session_id, "overflow.json")),
+        submission,
+    )
+
+
+def _clear_retain_file(session_id: str, suffix: str) -> None:
+    path = _state_file(_retain_state_name(session_id, suffix))
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        return
+    if sys.platform != "win32":
+        state_dir_fd = os.open(_state_dir(), os.O_RDONLY)
+        try:
+            os.fsync(state_dir_fd)
+        finally:
+            os.close(state_dir_fd)
+
+
+def clear_pending_retain(session_id: str) -> None:
+    """Clear a Retain submission only after the server acknowledges it."""
+    _clear_retain_file(session_id, "json")
+
+
+def clear_deferred_retain(session_id: str) -> None:
+    """Clear the overflow submission only after the server acknowledges it."""
+    _clear_retain_file(session_id, "overflow.json")

--- a/hindsight-integrations/codex/scripts/retain.py
+++ b/hindsight-integrations/codex/scripts/retain.py
@@ -17,23 +17,138 @@ Exit codes:
   0 — always (graceful degradation on any error)
 """
 
+import hashlib
 import json
 import os
 import sys
 import time
+import uuid
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from lib.bank import derive_bank_id, ensure_bank_mission
-from lib.client import HindsightClient
+from lib.client import HindsightClient, auth_context_id
 from lib.config import debug_log, load_config
 from lib.content import (
     prepare_retention_transcript,
     read_transcript,
     slice_last_turns_by_user_boundary,
 )
-from lib.daemon import get_api_url
-from lib.state import increment_turn_count
+from lib.daemon import get_api_url, get_intended_api_url
+from lib.state import (
+    PendingRetain,
+    clear_deferred_retain,
+    read_deferred_retain,
+    read_pending_retains,
+    read_retain_cadence,
+    retain_submission_lock,
+    write_deferred_retain,
+    write_pending_retains,
+    write_retain_cadence,
+)
+
+MAX_PENDING_RETAINS = 128
+MAX_PENDING_RETAIN_BYTES = 64 * 1024 * 1024
+
+
+def _matches_destination(submission, api_url, auth_context, bank_id):
+    return (
+        submission.get("api_url") == api_url
+        and submission.get("auth_context_id") == auth_context
+        and submission.get("bank_id") == bank_id
+    )
+
+
+def _queue_size_bytes(submissions):
+    return len(json.dumps(submissions, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+
+
+def _build_request_args(
+    config,
+    transcript_path,
+    session_id,
+    bank_id,
+    retain_mode,
+    retain_every_n,
+    include_tool_calls,
+):
+    """Read the latest transcript and freeze one retain request."""
+    all_messages = read_transcript(transcript_path, include_tool_calls=include_tool_calls)
+    if not all_messages:
+        debug_log(config, "No messages in transcript, skipping current retain")
+        return None, None
+
+    debug_log(config, f"Read {len(all_messages)} messages from transcript")
+    messages_to_retain = all_messages
+    if retain_mode == "chunked" and retain_every_n > 1:
+        overlap_turns = config.get("retainOverlapTurns", 0)
+        window_turns = retain_every_n + overlap_turns
+        messages_to_retain = slice_last_turns_by_user_boundary(all_messages, window_turns)
+        debug_log(
+            config,
+            f"Chunked retain firing (window: {window_turns} turns, {len(messages_to_retain)} messages)",
+        )
+    else:
+        debug_log(config, f"Full session retain: {len(all_messages)} messages")
+
+    retain_roles = config.get("retainRoles", ["user", "assistant"])
+    transcript, message_count = prepare_retention_transcript(
+        messages_to_retain,
+        retain_roles,
+        True,
+        include_tool_calls=include_tool_calls,
+    )
+    if not transcript:
+        debug_log(config, "Empty transcript after formatting, skipping current retain")
+        return None, None
+
+    if retain_mode == "chunked" and retain_every_n > 1:
+        document_id = f"{session_id}-{int(time.time() * 1000)}"
+    else:
+        document_id = session_id
+
+    template_vars = {
+        "session_id": session_id,
+        "bank_id": bank_id,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+    def resolve_template(value):
+        for key, replacement in template_vars.items():
+            value = value.replace(f"{{{key}}}", replacement)
+        return value
+
+    raw_tags = config.get("retainTags", [])
+    tags = [resolve_template(tag) for tag in raw_tags] if raw_tags else None
+    metadata = {
+        "retained_at": template_vars["timestamp"],
+        "message_count": str(message_count),
+        "session_id": session_id,
+    }
+    for key, value in config.get("retainMetadata", {}).items():
+        metadata[key] = resolve_template(str(value))
+
+    debug_log(
+        config,
+        f"Retaining to bank '{bank_id}', doc '{document_id}', {message_count} messages, {len(transcript)} chars",
+    )
+    if tags:
+        debug_log(config, f"Tags: {tags}")
+
+    source_fingerprint = hashlib.sha256(
+        json.dumps(all_messages, sort_keys=True, separators=(",", ":"), default=str).encode()
+    ).hexdigest()
+    return (
+        {
+            "bank_id": bank_id,
+            "content": transcript,
+            "document_id": document_id,
+            "context": config.get("retainContext", "codex"),
+            "metadata": metadata,
+            "tags": tags,
+        },
+        source_fingerprint,
+    )
 
 
 def main():
@@ -54,124 +169,258 @@ def main():
 
     session_id = hook_input.get("session_id", "unknown")
     transcript_path = hook_input.get("transcript_path", "")
-
-    # Read full transcript
     include_tool_calls = config.get("retainToolCalls", True)
-    all_messages = read_transcript(transcript_path, include_tool_calls=include_tool_calls)
-    if not all_messages:
-        debug_log(config, "No messages in transcript, skipping retain")
-        return
-
-    debug_log(config, f"Read {len(all_messages)} messages from transcript")
-
-    # Retention mode: full session (default) or chunked (legacy)
     retain_mode = config.get("retainMode", "full-session")
     retain_every_n = max(1, config.get("retainEveryNTurns", 1))
-    retain_full_window = False
-    messages_to_retain = all_messages
 
-    # Respect retainEveryNTurns in both modes
-    if retain_every_n > 1:
-        turn_count = increment_turn_count(session_id)
-        if turn_count % retain_every_n != 0:
-            next_at = ((turn_count // retain_every_n) + 1) * retain_every_n
-            debug_log(config, f"Turn {turn_count}/{retain_every_n}, skipping retain (next at turn {next_at})")
-            return
-
-    if retain_mode == "chunked" and retain_every_n > 1:
-        overlap_turns = config.get("retainOverlapTurns", 0)
-        window_turns = retain_every_n + overlap_turns
-        messages_to_retain = slice_last_turns_by_user_boundary(all_messages, window_turns)
-        retain_full_window = True
-        debug_log(
-            config,
-            f"Chunked retain firing (window: {window_turns} turns, {len(messages_to_retain)} messages)",
-        )
-    else:
-        retain_full_window = True
-        debug_log(config, f"Full session retain: {len(all_messages)} messages")
-
-    # Format transcript
-    retain_roles = config.get("retainRoles", ["user", "assistant"])
-    transcript, message_count = prepare_retention_transcript(
-        messages_to_retain, retain_roles, retain_full_window, include_tool_calls=include_tool_calls
-    )
-
-    if not transcript:
-        debug_log(config, "Empty transcript after formatting, skipping retain")
-        return
-
-    # Resolve API URL
     def _dbg(*a):
         debug_log(config, *a)
 
-    try:
-        api_url = get_api_url(config, debug_fn=_dbg, allow_daemon_start=True)
-    except RuntimeError as e:
-        print(f"[Hindsight] {e}", file=sys.stderr)
-        return
-
     api_token = config.get("hindsightApiToken")
-    try:
-        client = HindsightClient(api_url, api_token)
-    except ValueError as e:
-        print(f"[Hindsight] Invalid API URL: {e}", file=sys.stderr)
-        return
-
-    # Derive bank ID and ensure mission
     bank_id = derive_bank_id(hook_input, config)
-    ensure_bank_mission(client, bank_id, config, debug_fn=_dbg)
+    expected_auth_context = auth_context_id(api_token)
+    intended_api_url = get_intended_api_url(config)
 
-    # Document ID: use session_id so the same session always upserts.
-    # In chunked mode, append timestamp to create distinct documents per chunk.
-    if retain_mode == "chunked" and retain_every_n > 1:
-        document_id = f"{session_id}-{int(time.time() * 1000)}"
-    else:
-        document_id = session_id
-
-    # Resolve template variables in tags and metadata
-    template_vars = {
-        "session_id": session_id,
-        "bank_id": bank_id,
-        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-    }
-
-    def _resolve_template(value: str) -> str:
-        for k, v in template_vars.items():
-            value = value.replace(f"{{{k}}}", v)
-        return value
-
-    raw_tags = config.get("retainTags", [])
-    tags = [_resolve_template(t) for t in raw_tags] if raw_tags else None
-
-    metadata = {
-        "retained_at": template_vars["timestamp"],
-        "message_count": str(message_count),
-        "session_id": session_id,
-    }
-    for k, v in config.get("retainMetadata", {}).items():
-        metadata[k] = _resolve_template(str(v))
-
-    debug_log(
-        config, f"Retaining to bank '{bank_id}', doc '{document_id}', {message_count} messages, {len(transcript)} chars"
-    )
-    if tags:
-        debug_log(config, f"Tags: {tags}")
-
-    # POST to Hindsight retain API
-    try:
-        response = client.retain(
-            bank_id=bank_id,
-            content=transcript,
-            document_id=document_id,
-            context=config.get("retainContext", "codex"),
-            metadata=metadata,
-            tags=tags,
-            timeout=15,
+    # Serialize one session's checkpoint, lost-ack replay, and current
+    # submission. Other sessions remain fully concurrent.
+    with retain_submission_lock(session_id) as lock_acquired:
+        if not lock_acquired:
+            print(
+                "[Hindsight] Retain state is busy; leaving this Stop event for the next retry",
+                file=sys.stderr,
+            )
+            return
+        request_args, source_fingerprint = _build_request_args(
+            config,
+            transcript_path,
+            session_id,
+            bank_id,
+            retain_mode,
+            retain_every_n,
+            include_tool_calls,
         )
-        debug_log(config, f"Retain response: {json.dumps(response)[:200]}")
-    except Exception as e:
-        print(f"[Hindsight] Retain failed: {e}", file=sys.stderr)
+        try:
+            pending_submissions = read_pending_retains(session_id)
+            deferred_submission = read_deferred_retain(session_id)
+            cadence = read_retain_cadence(session_id)
+        except (OSError, ValueError) as e:
+            print(
+                f"[Hindsight] Retain state is unreadable: {e}; leaving it untouched for operator recovery",
+                file=sys.stderr,
+            )
+            return
+        durable_submissions = [
+            *pending_submissions,
+            *([deferred_submission] if deferred_submission is not None else []),
+        ]
+        if durable_submissions and not all(
+            _matches_destination(
+                submission,
+                intended_api_url,
+                expected_auth_context,
+                bank_id,
+            )
+            for submission in durable_submissions
+        ):
+            print(
+                "[Hindsight] Pending retain belongs to a different API, authentication context, or bank; "
+                "leaving it untouched for operator recovery",
+                file=sys.stderr,
+            )
+            return
+
+        if request_args is not None and deferred_submission is None:
+            matching_pending = next(
+                (
+                    submission
+                    for submission in pending_submissions
+                    if submission.get("source_fingerprint") == source_fingerprint
+                ),
+                None,
+            )
+            already_counted = cadence["source_fingerprint"] == source_fingerprint
+            if matching_pending is not None:
+                turn_count = matching_pending["turn_count"]
+                if not already_counted:
+                    try:
+                        write_retain_cadence(
+                            session_id,
+                            {
+                                "turn_count": turn_count,
+                                "source_fingerprint": source_fingerprint,
+                            },
+                        )
+                    except Exception as e:
+                        print(f"[Hindsight] Failed to recover retain cadence: {e}", file=sys.stderr)
+                        return
+            elif already_counted:
+                turn_count = cadence["turn_count"]
+            else:
+                turn_count = (
+                    max([cadence["turn_count"]] + [submission["turn_count"] for submission in pending_submissions]) + 1
+                )
+                if turn_count % retain_every_n == 0:
+                    submission = {
+                        "idempotency_key": uuid.uuid4().hex,
+                        "bank_id": bank_id,
+                        "api_url": intended_api_url,
+                        "auth_context_id": expected_auth_context,
+                        "source_fingerprint": source_fingerprint,
+                        "turn_count": turn_count,
+                        "request": request_args,
+                        "post_attempted": False,
+                    }
+                    candidate_submissions = list(pending_submissions)
+                    if (
+                        retain_mode == "full-session"
+                        and candidate_submissions
+                        and not candidate_submissions[-1].get("operation_id")
+                        and candidate_submissions[-1].get("post_attempted", True) is False
+                    ):
+                        candidate_submissions[-1] = submission
+                    else:
+                        candidate_submissions.append(submission)
+                    if (
+                        len(candidate_submissions) > MAX_PENDING_RETAINS
+                        or _queue_size_bytes(candidate_submissions) > MAX_PENDING_RETAIN_BYTES
+                    ):
+                        deferred_submission = submission
+                        try:
+                            write_deferred_retain(session_id, submission)
+                        except Exception as e:
+                            print(
+                                f"[Hindsight] Failed to persist deferred retain submission: {e}",
+                                file=sys.stderr,
+                            )
+                            return
+                        print(
+                            "[Hindsight] Pending retain queue limit reached; "
+                            "draining acknowledged work before retrying the current transcript",
+                            file=sys.stderr,
+                        )
+                    else:
+                        pending_submissions = candidate_submissions
+                        try:
+                            write_pending_retains(session_id, pending_submissions)
+                        except Exception as e:
+                            print(f"[Hindsight] Failed to persist retain submission: {e}", file=sys.stderr)
+                            return
+                else:
+                    next_at = ((turn_count // retain_every_n) + 1) * retain_every_n
+                    debug_log(
+                        config,
+                        f"Turn {turn_count}/{retain_every_n}, skipping retain (next at turn {next_at})",
+                    )
+                if deferred_submission is None:
+                    try:
+                        write_retain_cadence(
+                            session_id,
+                            {
+                                "turn_count": turn_count,
+                                "source_fingerprint": source_fingerprint,
+                            },
+                        )
+                    except Exception as e:
+                        print(f"[Hindsight] Failed to persist retain cadence: {e}", file=sys.stderr)
+                        return
+
+        if not pending_submissions and deferred_submission is None:
+            return
+
+        try:
+            api_url = get_api_url(config, debug_fn=_dbg, allow_daemon_start=True)
+            client = HindsightClient(api_url, api_token)
+        except (RuntimeError, ValueError) as e:
+            print(f"[Hindsight] {e}", file=sys.stderr)
+            return
+
+        try:
+            supports_durable_delivery = client.supports_durable_retain_delivery()
+        except Exception as e:
+            print(
+                f"[Hindsight] Could not verify durable Retain support: {e}; leaving queued work untouched",
+                file=sys.stderr,
+            )
+            return
+        if not supports_durable_delivery:
+            print(
+                "[Hindsight] Server does not advertise idempotent serialized Retain support; "
+                "leaving queued work untouched",
+                file=sys.stderr,
+            )
+            return
+
+        if any(
+            not _matches_destination(
+                submission,
+                client.api_url,
+                client.auth_context_id,
+                bank_id,
+            )
+            for submission in [
+                *pending_submissions,
+                *([deferred_submission] if deferred_submission is not None else []),
+            ]
+        ):
+            print(
+                "[Hindsight] Pending retain belongs to a different API, authentication context, or bank; "
+                "leaving it untouched for operator recovery",
+                file=sys.stderr,
+            )
+            return
+
+        ensure_bank_mission(client, bank_id, config, debug_fn=_dbg)
+
+        while True:
+            processing_deferred = not pending_submissions and deferred_submission is not None
+            if not pending_submissions and not processing_deferred:
+                return
+
+            pending_submission = deferred_submission if processing_deferred else pending_submissions[0]
+            if pending_submission is None:
+                return
+            try:
+                if pending_submission.get("post_attempted", True) is False:
+                    pending_submission["post_attempted"] = True
+                    if processing_deferred:
+                        write_deferred_retain(session_id, pending_submission)
+                    else:
+                        write_pending_retains(session_id, pending_submissions)
+                response = client.retain(
+                    **pending_submission["request"],
+                    idempotency_key=pending_submission["idempotency_key"],
+                    timeout=15,
+                )
+                operation_id = response.get("operation_id")
+                if not operation_id:
+                    raise RuntimeError("retain response did not include operation_id")
+            except Exception as e:
+                print(f"[Hindsight] Pending retain submission failed: {e}", file=sys.stderr)
+                return
+
+            debug_log(config, f"Retain response: {json.dumps(response)[:200]}")
+            try:
+                if processing_deferred:
+                    write_retain_cadence(
+                        session_id,
+                        {
+                            "turn_count": pending_submission["turn_count"],
+                            "source_fingerprint": pending_submission["source_fingerprint"],
+                        },
+                    )
+                    clear_deferred_retain(session_id)
+                    deferred_submission = None
+                else:
+                    remaining_submissions = pending_submissions[1:]
+                    write_pending_retains(session_id, remaining_submissions)
+                    pending_submissions = remaining_submissions
+            except Exception as e:
+                print(
+                    f"[Hindsight] Retain was acknowledged but retry state could not be updated: {e}; "
+                    "leaving the durable submission for an idempotent replay",
+                    file=sys.stderr,
+                )
+                return
 
 
 if __name__ == "__main__":

--- a/hindsight-integrations/codex/tests/test_client.py
+++ b/hindsight-integrations/codex/tests/test_client.py
@@ -1,9 +1,9 @@
 """Tests for lib/client.py — Hindsight REST API client."""
 
+import json
 from unittest.mock import patch
 
 from conftest import FakeHTTPResponse
-
 from lib.client import USER_AGENT, HindsightClient
 
 
@@ -40,3 +40,75 @@ class TestUserAgentHeader:
             c.health_check(timeout=1)
 
         assert captured["ua"] == USER_AGENT
+
+
+def test_retain_sends_idempotency_key():
+    client = HindsightClient("http://localhost:9077")
+    captured = {}
+
+    def fake_open(req, timeout=None):
+        captured["body"] = json.loads(req.data.decode())
+        return FakeHTTPResponse({"operation_id": "op-1"})
+
+    with patch("urllib.request.urlopen", side_effect=fake_open):
+        client.retain("bank", "content", idempotency_key="stable-key")
+
+    assert captured["body"]["idempotency_key"] == "stable-key"
+
+
+def test_retain_preserves_positional_timeout():
+    client = HindsightClient("http://localhost:9077")
+    captured = {}
+
+    def fake_open(req, timeout=None):
+        captured["timeout"] = timeout
+        captured["body"] = json.loads(req.data.decode())
+        return FakeHTTPResponse({"operation_id": "op-1"})
+
+    with patch("urllib.request.urlopen", side_effect=fake_open):
+        client.retain("bank", "content", "doc", "codex", {}, [], 37)
+
+    assert captured["timeout"] == 37
+    assert "idempotency_key" not in captured["body"]
+
+
+def test_auth_context_identity_changes_without_exposing_token():
+    first = HindsightClient("http://localhost:9077", "secret-one")
+    same = HindsightClient("http://localhost:9077", "secret-one")
+    second = HindsightClient("http://localhost:9077", "secret-two")
+    anonymous = HindsightClient("http://localhost:9077")
+
+    assert first.auth_context_id == same.auth_context_id
+    assert first.auth_context_id != second.auth_context_id
+    assert first.auth_context_id != anonymous.auth_context_id
+    assert "secret-one" not in first.auth_context_id
+
+
+def test_durable_retain_delivery_requires_both_capabilities():
+    client = HindsightClient("http://localhost:9077")
+
+    with patch(
+        "urllib.request.urlopen",
+        return_value=FakeHTTPResponse(
+            {
+                "api_version": "0.8.5",
+                "features": {
+                    "retain_idempotency": True,
+                    "retain_serialized_upsert": True,
+                },
+            }
+        ),
+    ):
+        assert client.supports_durable_retain_delivery() is True
+
+    incomplete_feature_sets = (
+        {},
+        {"retain_idempotency": True},
+        {"retain_serialized_upsert": True},
+    )
+    for features in incomplete_feature_sets:
+        with patch(
+            "urllib.request.urlopen",
+            return_value=FakeHTTPResponse({"api_version": "0.8.5", "features": features}),
+        ):
+            assert client.supports_durable_retain_delivery() is False

--- a/hindsight-integrations/codex/tests/test_hooks.py
+++ b/hindsight-integrations/codex/tests/test_hooks.py
@@ -15,16 +15,26 @@ import sys
 from unittest.mock import patch
 
 import pytest
-
 from conftest import FakeHTTPResponse, make_hook_input, make_memory, make_transcript_file, make_user_config
-
+from lib import state
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-def _run_hook(module_name, hook_input, monkeypatch, tmp_path, urlopen_side_effect=None, user_config=None):
+def _run_hook(
+    module_name,
+    hook_input,
+    monkeypatch,
+    tmp_path,
+    urlopen_side_effect=None,
+    user_config=None,
+    api_url="http://fake:9077",
+    retain_idempotency_capability=True,
+    retain_serialized_upsert_capability=True,
+    module_mutator=None,
+):
     """Import and run a hook script's main() with mocked stdin/stdout/HTTP."""
     # Isolate HOME so ~/.hindsight/codex.json and state land in tmp_path
     monkeypatch.setenv("HOME", str(tmp_path))
@@ -35,7 +45,7 @@ def _run_hook(module_name, hook_input, monkeypatch, tmp_path, urlopen_side_effec
             monkeypatch.delenv(k, raising=False)
 
     # Set required API URL via env var
-    monkeypatch.setenv("HINDSIGHT_API_URL", "http://fake:9077")
+    monkeypatch.setenv("HINDSIGHT_API_URL", api_url)
 
     # Write user config (enables retain on every turn + any overrides)
     cfg = {"retainEveryNTurns": 1, "autoRecall": True, "autoRetain": True}
@@ -56,15 +66,32 @@ def _run_hook(module_name, hook_input, monkeypatch, tmp_path, urlopen_side_effec
     default_response = FakeHTTPResponse({"results": []})
     side_effect = urlopen_side_effect or (lambda *a, **kw: default_response)
 
+    def route_request(req, *args, **kwargs):
+        if req.get_method() == "GET" and req.full_url.endswith("/version"):
+            features = {}
+            if retain_idempotency_capability:
+                features["retain_idempotency"] = True
+            if retain_serialized_upsert_capability:
+                features["retain_serialized_upsert"] = True
+            return FakeHTTPResponse({"api_version": "test", "features": features})
+        return side_effect(req, *args, **kwargs)
+
     with (
         patch("sys.stdin", stdin_data),
         patch("sys.stdout", stdout_capture),
-        patch("urllib.request.urlopen", side_effect=side_effect),
+        patch("urllib.request.urlopen", side_effect=route_request),
     ):
         spec.loader.exec_module(mod)
+        if module_mutator is not None:
+            module_mutator(mod)
         mod.main()
 
     return stdout_capture.getvalue()
+
+
+def _pending_retain_files(tmp_path):
+    state_dir = tmp_path / ".hindsight" / "codex" / "state"
+    return [path for path in state_dir.glob("retain-*.json") if not path.name.endswith(".cadence.json")]
 
 
 # ---------------------------------------------------------------------------
@@ -78,8 +105,7 @@ class TestRecallHook:
         response = FakeHTTPResponse({"results": [memory]})
 
         hook_input = make_hook_input(prompt="What is the capital of France?")
-        output = _run_hook("recall", hook_input, monkeypatch, tmp_path,
-                           urlopen_side_effect=lambda *a, **kw: response)
+        output = _run_hook("recall", hook_input, monkeypatch, tmp_path, urlopen_side_effect=lambda *a, **kw: response)
 
         data = json.loads(output)
         context = data["hookSpecificOutput"]["additionalContext"]
@@ -153,8 +179,7 @@ class TestRecallHook:
         response = FakeHTTPResponse({"results": [memory]})
 
         hook_input = make_hook_input(prompt="What language should I use?")
-        output = _run_hook("recall", hook_input, monkeypatch, tmp_path,
-                           urlopen_side_effect=lambda *a, **kw: response)
+        output = _run_hook("recall", hook_input, monkeypatch, tmp_path, urlopen_side_effect=lambda *a, **kw: response)
 
         data = json.loads(output)
         assert data["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
@@ -176,9 +201,14 @@ class TestRecallHook:
             return FakeHTTPResponse({"results": []})
 
         hook_input = make_hook_input(prompt="What language should I use?", transcript_path=transcript)
-        _run_hook("recall", hook_input, monkeypatch, tmp_path,
-                  urlopen_side_effect=capture_and_respond,
-                  user_config={"recallContextTurns": 2})
+        _run_hook(
+            "recall",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=capture_and_respond,
+            user_config={"recallContextTurns": 2},
+        )
 
         if "body" in captured_body:
             assert "Python" in captured_body["body"].get("query", "")
@@ -207,8 +237,7 @@ class TestRecallHook:
 
     def test_disabled_auto_recall_produces_no_output(self, monkeypatch, tmp_path):
         hook_input = make_hook_input(prompt="What is the capital of France?")
-        output = _run_hook("recall", hook_input, monkeypatch, tmp_path,
-                           user_config={"autoRecall": False})
+        output = _run_hook("recall", hook_input, monkeypatch, tmp_path, user_config={"autoRecall": False})
         assert output.strip() == ""
 
 
@@ -218,6 +247,47 @@ class TestRecallHook:
 
 
 class TestRetainHook:
+    @pytest.mark.parametrize(
+        ("retain_idempotency_capability", "retain_serialized_upsert_capability"),
+        [(False, True), (True, False)],
+    )
+    def test_old_server_is_not_sent_retain_and_pending_work_is_preserved(
+        self,
+        monkeypatch,
+        tmp_path,
+        retain_idempotency_capability,
+        retain_serialized_upsert_capability,
+    ):
+        transcript = make_transcript_file(
+            tmp_path,
+            [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "world"},
+            ],
+        )
+        hook_input = make_hook_input(
+            transcript_path=transcript,
+            session_id="sess-old-server",
+        )
+        requests = []
+
+        def capture(req, *args, **kwargs):
+            requests.append((req.get_method(), req.full_url))
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=capture,
+            retain_idempotency_capability=retain_idempotency_capability,
+            retain_serialized_upsert_capability=retain_serialized_upsert_capability,
+        )
+
+        assert requests == []
+        assert _pending_retain_files(tmp_path)
+
     def test_posts_transcript_to_hindsight(self, monkeypatch, tmp_path):
         messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
         transcript = make_transcript_file(tmp_path, messages)
@@ -312,14 +382,20 @@ class TestRetainHook:
 
         hook_input = make_hook_input(transcript_path=transcript)
         # retainEveryNTurns=3 — first call should be skipped
-        _run_hook("retain", hook_input, monkeypatch, tmp_path,
-                  urlopen_side_effect=capture,
-                  user_config={"retainEveryNTurns": 3})
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=capture,
+            user_config={"retainEveryNTurns": 3},
+        )
         assert "called" not in captured
 
     def test_retain_uses_session_id_as_document_id(self, monkeypatch, tmp_path):
         messages = [
-            {"role": "user", "content": "question"}, {"role": "assistant", "content": "answer"},
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "answer"},
         ]
         transcript = make_transcript_file(tmp_path, messages)
         hook_input = make_hook_input(transcript_path=transcript, session_id="sess-doc-test")
@@ -348,6 +424,812 @@ class TestRetainHook:
         # Should not raise
         _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=raise_error)
 
+    def test_lost_ack_retries_same_submission_before_advancing_current_chunk(self, monkeypatch, tmp_path):
+        messages = [{"role": "user", "content": "stable"}, {"role": "assistant", "content": "answer"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-lost-ack")
+        captured = []
+
+        def lose_ack(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured.append(json.loads(req.data.decode()))
+                raise TimeoutError("response lost")
+            return FakeHTTPResponse({})
+
+        # First turn advances the checkpoint but does not retain.
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=lambda *args, **kwargs: FakeHTTPResponse({}),
+            user_config={"retainEveryNTurns": 2},
+        )
+        messages.extend([{"role": "user", "content": "second"}, {"role": "assistant", "content": "second answer"}])
+        make_transcript_file(tmp_path, messages)
+        # Second turn is accepted server-side but its acknowledgment is lost.
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=lose_ack,
+            user_config={"retainEveryNTurns": 2},
+        )
+
+        # The transcript may grow before the next Stop hook. The pending request
+        # must still be replayed byte-for-byte with the same identity.
+        messages.extend([{"role": "user", "content": "newer"}, {"role": "assistant", "content": "reply"}])
+        make_transcript_file(tmp_path, messages)
+
+        def acknowledge(req, timeout=None):
+            if req.get_method() == "GET" and "/operations/" in req.full_url:
+                return FakeHTTPResponse({"status": "completed"})
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured.append(json.loads(req.data.decode()))
+            return FakeHTTPResponse({"operation_id": "original-op"})
+
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=acknowledge,
+            user_config={"retainEveryNTurns": 2},
+        )
+
+        assert len(captured) == 2
+        assert captured[1] == captured[0]
+        cadence = state.read_retain_cadence("sess-lost-ack")
+        assert cadence["turn_count"] == 3
+        assert not _pending_retain_files(tmp_path)
+
+    def test_due_chunk_is_submitted_after_pending_retry(self, monkeypatch, tmp_path):
+        messages = [{"role": "user", "content": "old"}, {"role": "assistant", "content": "answer"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-pending-and-current")
+        captured = []
+
+        def lose_ack(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured.append(json.loads(req.data.decode()))
+                raise TimeoutError("response lost")
+            return FakeHTTPResponse({})
+
+        # Turn 1 skips. Turn 2 persists and sends the first chunk, but loses its
+        # acknowledgment. Turn 3 retries and still fails, leaving it pending.
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=lambda *args, **kwargs: FakeHTTPResponse({}),
+            user_config={"retainEveryNTurns": 2},
+        )
+        messages.extend([{"role": "user", "content": "turn-two"}, {"role": "assistant", "content": "turn-two answer"}])
+        make_transcript_file(tmp_path, messages)
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=lose_ack,
+            user_config={"retainEveryNTurns": 2},
+        )
+        messages.extend(
+            [{"role": "user", "content": "turn-three"}, {"role": "assistant", "content": "turn-three answer"}]
+        )
+        make_transcript_file(tmp_path, messages)
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=lose_ack,
+            user_config={"retainEveryNTurns": 2},
+        )
+
+        messages.extend([{"role": "user", "content": "current"}, {"role": "assistant", "content": "new answer"}])
+        make_transcript_file(tmp_path, messages)
+
+        def acknowledge(req, timeout=None):
+            if req.get_method() == "GET" and "/operations/" in req.full_url:
+                return FakeHTTPResponse({"status": "completed"})
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured.append(json.loads(req.data.decode()))
+            return FakeHTTPResponse({"operation_id": "ok"})
+
+        # Turn 4 is itself due. It must replay the pending request first and
+        # then submit the newly-derived current chunk with a new identity.
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=acknowledge,
+            user_config={"retainEveryNTurns": 2},
+        )
+
+        assert len(captured) == 4
+        assert captured[1] == captured[0]
+        assert captured[2] == captured[0]
+        assert captured[3]["idempotency_key"] != captured[0]["idempotency_key"]
+        assert "current" in captured[3]["items"][0]["content"]
+        assert state.read_retain_cadence("sess-pending-and-current")["turn_count"] == 4
+
+    def test_acknowledged_retain_allows_immediate_followup_for_same_session(self, monkeypatch, tmp_path):
+        session_id = "sess-one-in-flight"
+        transcript = make_transcript_file(
+            tmp_path,
+            [{"role": "user", "content": "first"}, {"role": "assistant", "content": "answer"}],
+        )
+        hook_input = make_hook_input(transcript_path=transcript, session_id=session_id)
+        posts = []
+
+        def respond(req, timeout=None):
+            if req.get_method() == "POST" and "/memories" in req.full_url:
+                posts.append(json.loads(req.data.decode()))
+                return FakeHTTPResponse({"operation_id": f"op-{len(posts)}"})
+            return FakeHTTPResponse({})
+
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=respond)
+        make_transcript_file(
+            tmp_path,
+            [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "answer"},
+                {"role": "user", "content": "second"},
+                {"role": "assistant", "content": "new answer"},
+            ],
+        )
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=respond)
+
+        assert len(posts) == 2
+        assert "second" in posts[1]["items"][0]["content"]
+
+    def test_pruned_acknowledged_operation_unblocks_queue_without_repost(self, monkeypatch, tmp_path):
+        session_id = "sess-pruned-operation"
+        transcript = make_transcript_file(
+            tmp_path,
+            [
+                {"role": "user", "content": "already retained"},
+                {"role": "assistant", "content": "answer"},
+            ],
+        )
+        hook_input = make_hook_input(transcript_path=transcript, session_id=session_id)
+        posts = []
+
+        def first_pass(req, *args, **kwargs):
+            if req.get_method() == "POST" and "/memories" in req.full_url:
+                posts.append(json.loads(req.data.decode()))
+                return FakeHTTPResponse({"operation_id": "op-pruned"})
+            if req.get_method() == "GET" and "/operations/" in req.full_url:
+                return FakeHTTPResponse({"status": "processing"})
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=first_pass,
+        )
+
+        def pruned(req, *args, **kwargs):
+            if req.get_method() == "POST" and "/memories" in req.full_url:
+                posts.append(json.loads(req.data.decode()))
+            if req.get_method() == "GET" and "/operations/" in req.full_url:
+                return FakeHTTPResponse({"status": "not_found"})
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=pruned,
+        )
+
+        assert len(posts) == 1
+        assert state.read_pending_retains(session_id) == []
+
+    def test_pending_retain_is_not_replayed_to_a_different_api(self, monkeypatch, tmp_path):
+        messages = [{"role": "user", "content": "private"}, {"role": "assistant", "content": "answer"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-api-change")
+        calls = []
+
+        def lose_ack(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                calls.append(req.full_url)
+                raise TimeoutError("response lost")
+            return FakeHTTPResponse({})
+
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=lose_ack)
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=lose_ack,
+            api_url="http://other:9077",
+        )
+
+        assert calls == ["http://fake:9077/v1/default/banks/codex/memories"]
+        assert list((tmp_path / ".hindsight" / "codex" / "state").glob("retain-*.json"))
+
+    def test_pending_retain_is_not_replayed_with_different_credentials(self, monkeypatch, tmp_path):
+        messages = [{"role": "user", "content": "private"}, {"role": "assistant", "content": "answer"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-auth-change")
+        calls = []
+
+        def lose_ack(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                calls.append(req.get_header("Authorization"))
+                raise TimeoutError("response lost")
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=lose_ack,
+            user_config={"hindsightApiToken": "token-one"},
+        )
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=lose_ack,
+            user_config={"hindsightApiToken": "token-two"},
+        )
+
+        assert calls == ["Bearer token-one"]
+        assert list((tmp_path / ".hindsight" / "codex" / "state").glob("retain-*.json"))
+
+    def test_prolonged_failure_queues_every_due_chunk_window(self, monkeypatch, tmp_path):
+        session_id = "sess-prolonged-outage"
+        transcript = make_transcript_file(tmp_path, [])
+        hook_input = make_hook_input(transcript_path=transcript, session_id=session_id)
+        captured = []
+
+        def fail_retain(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                raise TimeoutError("still unavailable")
+            return FakeHTTPResponse({})
+
+        def acknowledge(req, timeout=None):
+            if req.get_method() == "GET" and "/operations/" in req.full_url:
+                return FakeHTTPResponse({"status": "completed"})
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured.append(json.loads(req.data.decode()))
+            return FakeHTTPResponse({"operation_id": "ok"})
+
+        messages = []
+        for turn in range(1, 7):
+            messages.extend(
+                [
+                    {"role": "user", "content": f"user-turn-{turn}"},
+                    {"role": "assistant", "content": f"assistant-turn-{turn}"},
+                ]
+            )
+            make_transcript_file(tmp_path, messages)
+            _run_hook(
+                "retain",
+                hook_input,
+                monkeypatch,
+                tmp_path,
+                urlopen_side_effect=fail_retain,
+                user_config={
+                    "retainEveryNTurns": 2,
+                    "retainMode": "chunked",
+                    "retainOverlapTurns": 0,
+                },
+            )
+
+        messages.extend(
+            [
+                {"role": "user", "content": "user-turn-7"},
+                {"role": "assistant", "content": "assistant-turn-7"},
+            ]
+        )
+        make_transcript_file(tmp_path, messages)
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=acknowledge,
+            user_config={
+                "retainEveryNTurns": 2,
+                "retainMode": "chunked",
+                "retainOverlapTurns": 0,
+            },
+        )
+
+        assert len(captured) == 3
+        retained = [body["items"][0]["content"] for body in captured]
+        assert "user-turn-1" in retained[0] and "user-turn-2" in retained[0]
+        assert "user-turn-3" in retained[1] and "user-turn-4" in retained[1]
+        assert "user-turn-5" in retained[2] and "user-turn-6" in retained[2]
+        assert not _pending_retain_files(tmp_path)
+
+    def test_full_session_outage_coalesces_unsent_snapshots(self, monkeypatch, tmp_path):
+        session_id = "sess-every-turn-outage"
+        transcript = make_transcript_file(tmp_path, [])
+        hook_input = make_hook_input(transcript_path=transcript, session_id=session_id)
+        captured = []
+
+        def fail_retain(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                raise TimeoutError("still unavailable")
+            return FakeHTTPResponse({})
+
+        def acknowledge(req, timeout=None):
+            if req.get_method() == "GET" and "/operations/" in req.full_url:
+                return FakeHTTPResponse({"status": "completed"})
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured.append(json.loads(req.data.decode()))
+            return FakeHTTPResponse({"operation_id": "ok"})
+
+        messages = []
+        for turn in range(1, 4):
+            messages.extend(
+                [
+                    {"role": "user", "content": f"user-turn-{turn}"},
+                    {"role": "assistant", "content": f"assistant-turn-{turn}"},
+                ]
+            )
+            make_transcript_file(tmp_path, messages)
+            _run_hook(
+                "retain",
+                hook_input,
+                monkeypatch,
+                tmp_path,
+                urlopen_side_effect=fail_retain,
+            )
+
+        messages.extend(
+            [
+                {"role": "user", "content": "user-turn-4"},
+                {"role": "assistant", "content": "assistant-turn-4"},
+            ]
+        )
+        make_transcript_file(tmp_path, messages)
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=acknowledge,
+        )
+
+        assert len(captured) == 2
+        retained = [body["items"][0]["content"] for body in captured]
+        assert "user-turn-1" in retained[0]
+        assert "user-turn-4" in retained[1]
+        assert not _pending_retain_files(tmp_path)
+
+    def test_chunked_queue_limit_applies_backpressure_without_advancing_cadence(self, monkeypatch, tmp_path):
+        session_id = "sess-chunked-limit"
+        messages = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "answer"},
+        ]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id=session_id)
+
+        def fail_retain(req, *args, **kwargs):
+            if req.get_method() == "POST" and "/memories" in req.full_url:
+                raise TimeoutError("response lost")
+            return FakeHTTPResponse({})
+
+        def limit_to_one(module):
+            module.MAX_PENDING_RETAINS = 1
+
+        config = {"retainMode": "chunked", "retainEveryNTurns": 1}
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=fail_retain,
+            user_config=config,
+            module_mutator=limit_to_one,
+        )
+
+        messages.extend(
+            [
+                {"role": "user", "content": "second"},
+                {"role": "assistant", "content": "second answer"},
+            ]
+        )
+        make_transcript_file(tmp_path, messages)
+        completed_posts = []
+
+        def acknowledge(req, *args, **kwargs):
+            if req.get_method() == "POST" and "/memories" in req.full_url:
+                completed_posts.append(json.loads(req.data.decode()))
+                return FakeHTTPResponse({"operation_id": f"op-{len(completed_posts)}"})
+            if req.get_method() == "GET" and "/operations/" in req.full_url:
+                return FakeHTTPResponse({"status": "completed"})
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=acknowledge,
+            user_config=config,
+            module_mutator=limit_to_one,
+        )
+
+        assert len(completed_posts) == 2
+        assert state.read_pending_retains(session_id) == []
+        assert state.read_retain_cadence(session_id)["turn_count"] == 2
+
+    def test_chunked_backpressure_persists_exact_window_across_outage(self, monkeypatch, tmp_path):
+        session_id = "sess-chunked-overflow"
+        messages = [
+            {"role": "user", "content": "first-window"},
+            {"role": "assistant", "content": "first-answer"},
+        ]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id=session_id)
+
+        def fail_retain(req, *args, **kwargs):
+            if req.get_method() == "POST" and "/memories" in req.full_url:
+                raise TimeoutError("outage")
+            return FakeHTTPResponse({})
+
+        def limit_to_one(module):
+            module.MAX_PENDING_RETAINS = 1
+
+        config = {"retainMode": "chunked", "retainEveryNTurns": 1}
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=fail_retain,
+            user_config=config,
+            module_mutator=limit_to_one,
+        )
+        messages.extend(
+            [
+                {"role": "user", "content": "second-window"},
+                {"role": "assistant", "content": "second-answer"},
+            ]
+        )
+        make_transcript_file(tmp_path, messages)
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=fail_retain,
+            user_config=config,
+            module_mutator=limit_to_one,
+        )
+        deferred = state.read_deferred_retain(session_id)
+        assert deferred is not None
+        assert "second-window" in deferred["request"]["content"]
+
+        messages.extend(
+            [
+                {"role": "user", "content": "third-window"},
+                {"role": "assistant", "content": "third-answer"},
+            ]
+        )
+        make_transcript_file(tmp_path, messages)
+        completed_posts = []
+
+        def acknowledge(req, *args, **kwargs):
+            if req.get_method() == "POST" and "/memories" in req.full_url:
+                completed_posts.append(json.loads(req.data.decode()))
+                return FakeHTTPResponse({"operation_id": f"op-{len(completed_posts)}"})
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=acknowledge,
+            user_config=config,
+            module_mutator=limit_to_one,
+        )
+
+        assert len(completed_posts) == 2
+        assert "second-window" in completed_posts[1]["items"][0]["content"]
+        assert "third-window" not in completed_posts[1]["items"][0]["content"]
+        assert state.read_deferred_retain(session_id) is None
+
+    def test_ack_state_write_failure_keeps_submission_for_idempotent_replay(self, monkeypatch, tmp_path, capsys):
+        session_id = "sess-ack-write-failure"
+        transcript = make_transcript_file(
+            tmp_path,
+            [{"role": "user", "content": "private"}, {"role": "assistant", "content": "answer"}],
+        )
+        hook_input = make_hook_input(transcript_path=transcript, session_id=session_id)
+
+        def fail_after_initial_persist(module):
+            original_write = module.write_pending_retains
+            calls = 0
+
+            def write_then_fail_on_ack(current_session_id, submissions):
+                nonlocal calls
+                calls += 1
+                if calls == 3:
+                    raise OSError("directory fsync failed")
+                return original_write(current_session_id, submissions)
+
+            module.write_pending_retains = write_then_fail_on_ack
+
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=lambda req, *args, **kwargs: (
+                FakeHTTPResponse({"operation_id": "acknowledged"})
+                if req.get_method() == "POST" and "/memories" in req.full_url
+                else FakeHTTPResponse({})
+            ),
+            module_mutator=fail_after_initial_persist,
+        )
+
+        assert len(state.read_pending_retains(session_id)) == 1
+        assert "idempotent replay" in capsys.readouterr().err
+
+    def test_pending_state_write_failure_prevents_post(self, monkeypatch, tmp_path):
+        messages = [{"role": "user", "content": "private"}, {"role": "assistant", "content": "answer"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-write-fail")
+        calls = []
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=lambda *args, **kwargs: FakeHTTPResponse({}),
+            user_config={"retainEveryNTurns": 2},
+        )
+        messages.extend([{"role": "user", "content": "second"}, {"role": "assistant", "content": "second answer"}])
+        make_transcript_file(tmp_path, messages)
+
+        def fail_replace(source, destination):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(state.os, "replace", fail_replace)
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                calls.append(req.full_url)
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=capture,
+            user_config={"retainEveryNTurns": 2},
+        )
+
+        assert calls == []
+        assert state.read_retain_cadence("sess-write-fail")["turn_count"] == 1
+
+    def test_corrupt_pending_state_fails_closed_without_post(self, monkeypatch, tmp_path):
+        session_id = "sess-corrupt-state"
+        transcript = make_transcript_file(
+            tmp_path,
+            [
+                {"role": "user", "content": "private"},
+                {"role": "assistant", "content": "answer"},
+            ],
+        )
+        hook_input = make_hook_input(transcript_path=transcript, session_id=session_id)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        pending_path = state._state_file(state._retain_state_name(session_id, "json"))
+        with open(pending_path, "w") as handle:
+            handle.write("{corrupt")
+        calls = []
+
+        def capture(req, *args, **kwargs):
+            calls.append(req.full_url)
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=capture,
+        )
+
+        assert calls == []
+        with open(pending_path) as handle:
+            assert handle.read() == "{corrupt"
+
+    def test_checkpoint_failure_does_not_duplicate_durable_due_turn(self, monkeypatch, tmp_path):
+        session_id = "sess-checkpoint-fail"
+        messages = [{"role": "user", "content": "private"}, {"role": "assistant", "content": "answer"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id=session_id)
+        posts = []
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=lambda *args, **kwargs: FakeHTTPResponse({}),
+            user_config={"retainEveryNTurns": 2},
+        )
+        messages.extend([{"role": "user", "content": "second"}, {"role": "assistant", "content": "second answer"}])
+        make_transcript_file(tmp_path, messages)
+        real_write_cadence = state.write_retain_cadence
+
+        def fail_checkpoint(*args, **kwargs):
+            raise OSError("checkpoint disk full")
+
+        monkeypatch.setattr(state, "write_retain_cadence", fail_checkpoint)
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=lambda *args, **kwargs: FakeHTTPResponse({}),
+            user_config={"retainEveryNTurns": 2},
+        )
+
+        assert state.read_retain_cadence(session_id)["turn_count"] == 1
+        assert _pending_retain_files(tmp_path)
+
+        monkeypatch.setattr(state, "write_retain_cadence", real_write_cadence)
+
+        def acknowledge(req, timeout=None):
+            if req.get_method() == "POST" and "/memories" in req.full_url:
+                posts.append(json.loads(req.data.decode()))
+                return FakeHTTPResponse({"operation_id": "checkpoint-op"})
+            if req.get_method() == "GET" and "/operations/" in req.full_url:
+                return FakeHTTPResponse({"status": "completed"})
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=acknowledge,
+            user_config={"retainEveryNTurns": 2},
+        )
+
+        assert len(posts) == 1
+        assert state.read_retain_cadence(session_id)["turn_count"] == 2
+        assert not _pending_retain_files(tmp_path)
+
+    def test_api_discovery_failure_preserves_due_window_and_cadence(self, monkeypatch, tmp_path):
+        session_id = "sess-api-discovery-fail"
+        messages = [{"role": "user", "content": "turn-one"}, {"role": "assistant", "content": "answer-one"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id=session_id)
+
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            user_config={"retainEveryNTurns": 2},
+        )
+        messages.extend([{"role": "user", "content": "turn-two"}, {"role": "assistant", "content": "answer-two"}])
+        make_transcript_file(tmp_path, messages)
+
+        from lib import daemon
+
+        real_get_api_url = daemon.get_api_url
+        monkeypatch.setattr(
+            daemon,
+            "get_api_url",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("API unavailable")),
+        )
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            user_config={"retainEveryNTurns": 2},
+        )
+
+        assert state.read_retain_cadence(session_id)["turn_count"] == 2
+        assert _pending_retain_files(tmp_path)
+
+        messages.extend([{"role": "user", "content": "turn-three"}, {"role": "assistant", "content": "answer-three"}])
+        make_transcript_file(tmp_path, messages)
+        monkeypatch.setattr(daemon, "get_api_url", real_get_api_url)
+        posts = []
+
+        def acknowledge(req, timeout=None):
+            if req.get_method() == "POST" and "/memories" in req.full_url:
+                posts.append(json.loads(req.data.decode()))
+                return FakeHTTPResponse({"operation_id": "recovered-op"})
+            if req.get_method() == "GET" and "/operations/" in req.full_url:
+                return FakeHTTPResponse({"status": "completed"})
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=acknowledge,
+            user_config={"retainEveryNTurns": 2},
+        )
+
+        assert len(posts) == 1
+        retained = posts[0]["items"][0]["content"]
+        assert "turn-two" in retained
+        assert "turn-three" not in retained
+        assert state.read_retain_cadence(session_id)["turn_count"] == 3
+        assert not _pending_retain_files(tmp_path)
+
+    def test_api_discovery_failure_does_not_allow_later_endpoint_rebind(self, monkeypatch, tmp_path):
+        session_id = "sess-api-discovery-rebind"
+        transcript = make_transcript_file(
+            tmp_path,
+            [
+                {"role": "user", "content": "private"},
+                {"role": "assistant", "content": "answer"},
+            ],
+        )
+        hook_input = make_hook_input(transcript_path=transcript, session_id=session_id)
+
+        from lib import daemon
+
+        monkeypatch.setattr(
+            daemon,
+            "get_api_url",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("API unavailable")),
+        )
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            api_url="http://first:9077",
+        )
+
+        pending = state.read_pending_retain(session_id)
+        assert pending["api_url"] == "http://first:9077"
+
+        monkeypatch.undo()
+        posts = []
+
+        def capture(req, *args, **kwargs):
+            if req.get_method() == "POST" and "/memories" in req.full_url:
+                posts.append(req.full_url)
+            return FakeHTTPResponse({"operation_id": "unexpected"})
+
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=capture,
+            api_url="http://second:9077",
+        )
+
+        assert posts == []
+        assert state.read_pending_retain(session_id)["api_url"] == "http://first:9077"
+
     def test_disabled_auto_retain_does_not_call_api(self, monkeypatch, tmp_path):
         messages = [{"role": "user", "content": "hello"}]
         transcript = make_transcript_file(tmp_path, messages)
@@ -358,9 +1240,9 @@ class TestRetainHook:
             captured["called"] = True
             return FakeHTTPResponse({})
 
-        _run_hook("retain", hook_input, monkeypatch, tmp_path,
-                  urlopen_side_effect=capture,
-                  user_config={"autoRetain": False})
+        _run_hook(
+            "retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture, user_config={"autoRetain": False}
+        )
         assert "called" not in captured
 
     def test_reads_codex_response_item_format(self, monkeypatch, tmp_path):

--- a/hindsight-integrations/codex/tests/test_state.py
+++ b/hindsight-integrations/codex/tests/test_state.py
@@ -1,0 +1,225 @@
+"""Tests for cross-process Codex state primitives."""
+
+import stat
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from lib import state
+
+
+def test_pending_retain_names_do_not_collide_after_filename_sanitization(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    first = {"idempotency_key": "first", "bank_id": "bank", "request": {}}
+    second = {"idempotency_key": "second", "bank_id": "bank", "request": {}}
+
+    state.write_pending_retain("session/a", first)
+    state.write_pending_retain("session:a", second)
+
+    assert state.read_pending_retain("session/a") == first
+    assert state.read_pending_retain("session:a") == second
+    assert len(list((tmp_path / ".hindsight" / "codex" / "state").glob("retain-*.json"))) == 2
+
+
+def test_pending_retain_queue_round_trips_in_order(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    first = {
+        "idempotency_key": "first",
+        "bank_id": "bank",
+        "api_url": "http://one",
+        "auth_context_id": "auth-one",
+        "turn_count": 2,
+        "request": {},
+    }
+    second = {
+        "idempotency_key": "second",
+        "bank_id": "bank",
+        "api_url": "http://one",
+        "auth_context_id": "auth-one",
+        "turn_count": 4,
+        "request": {},
+    }
+
+    state.write_pending_retains("session-queue", [first, second])
+
+    assert state.read_pending_retains("session-queue") == [first, second]
+    assert state.read_pending_retain("session-queue") == first
+
+
+def test_deferred_retain_round_trips_and_clears(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    submission = {
+        "idempotency_key": "overflow",
+        "bank_id": "bank",
+        "api_url": "http://one",
+        "auth_context_id": "auth-one",
+        "turn_count": 9,
+        "request": {"content": "exact due window"},
+    }
+
+    state.write_deferred_retain("session-overflow", submission)
+    assert state.read_deferred_retain("session-overflow") == submission
+
+    state.clear_deferred_retain("session-overflow")
+    assert state.read_deferred_retain("session-overflow") is None
+
+
+def test_retain_cadence_round_trips_transcript_identity(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cadence = {"turn_count": 7, "source_fingerprint": "abc123"}
+
+    state.write_retain_cadence("session-cadence", cadence)
+
+    assert state.read_retain_cadence("session-cadence") == cadence
+
+
+def test_retain_cadence_starts_from_legacy_turn_counter(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    state.set_turn_count("session-upgrade", 7)
+
+    assert state.read_retain_cadence("session-upgrade") == {
+        "turn_count": 7,
+        "source_fingerprint": "",
+    }
+
+
+def test_windows_retain_lock_uses_msvcrt_boundary(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    calls = []
+
+    class _FakeMsvcrt:
+        LK_NBLCK = 1
+        LK_UNLCK = 2
+
+        @staticmethod
+        def locking(fd, mode, length):
+            calls.append((mode, length))
+
+    monkeypatch.setattr(state, "fcntl", None)
+    monkeypatch.setattr(state, "msvcrt", _FakeMsvcrt)
+
+    with state.retain_submission_lock("windows/session"):
+        assert calls == [(_FakeMsvcrt.LK_NBLCK, 1)]
+
+    assert calls == [(_FakeMsvcrt.LK_NBLCK, 1), (_FakeMsvcrt.LK_UNLCK, 1)]
+
+
+def test_windows_retain_lock_times_out_without_entering_critical_section(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    class _ContendedMsvcrt:
+        LK_NBLCK = 1
+        LK_UNLCK = 2
+
+        @staticmethod
+        def locking(fd, mode, length):
+            raise OSError("lock held")
+
+    times = iter([0.0, 31.0])
+    monkeypatch.setattr(state, "fcntl", None)
+    monkeypatch.setattr(state, "msvcrt", _ContendedMsvcrt)
+    monkeypatch.setattr(state.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(state.time, "sleep", lambda _: None)
+
+    with state.retain_submission_lock("windows/contended") as acquired:
+        assert acquired is False
+
+
+def test_pending_retain_state_is_private(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    submission = {"idempotency_key": "private", "bank_id": "bank", "request": {"content": "private transcript"}}
+
+    state.write_pending_retain("session-private", submission)
+
+    state_dir = tmp_path / ".hindsight" / "codex" / "state"
+    pending = next(state_dir.glob("retain-*.json"))
+    assert stat.S_IMODE(state_dir.stat().st_mode) == 0o700
+    assert stat.S_IMODE(pending.stat().st_mode) == 0o600
+
+
+def test_private_state_write_works_without_fchmod(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delattr(state.os, "fchmod", raising=False)
+
+    state.write_pending_retain(
+        "session-no-fchmod",
+        {"idempotency_key": "private", "bank_id": "bank", "request": {}},
+    )
+
+    pending = next((tmp_path / ".hindsight" / "codex" / "state").glob("retain-*.json"))
+    assert stat.S_IMODE(pending.stat().st_mode) == 0o600
+
+
+def test_pending_retain_write_failure_is_not_swallowed(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    def fail_replace(source, destination):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(state.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="disk full"):
+        state.write_pending_retain(
+            "session-fail",
+            {"idempotency_key": "fail", "bank_id": "bank", "request": {"content": "must not send"}},
+        )
+
+
+def test_pending_retain_corruption_fails_closed(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    path = state._state_file(state._retain_state_name("session-corrupt", "json"))
+    with open(path, "w") as handle:
+        handle.write("{not-json")
+
+    with pytest.raises(state.json.JSONDecodeError):
+        state.read_pending_retain("session-corrupt")
+
+
+def test_pending_retain_write_fsyncs_file_and_directory(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    real_fsync = state.os.fsync
+    fsynced_modes = []
+
+    def record_fsync(fd):
+        fsynced_modes.append(stat.S_IFMT(state.os.fstat(fd).st_mode))
+        real_fsync(fd)
+
+    monkeypatch.setattr(state.os, "fsync", record_fsync)
+    state.write_pending_retain(
+        "session-durable",
+        {"idempotency_key": "durable", "bank_id": "bank", "request": {}},
+    )
+
+    assert stat.S_IFREG in fsynced_modes
+    if state.sys.platform != "win32":
+        assert stat.S_IFDIR in fsynced_modes
+
+
+def test_pending_retain_clear_fsyncs_directory(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    state.write_pending_retain(
+        "session-clear-durable",
+        {"idempotency_key": "durable", "bank_id": "bank", "request": {}},
+    )
+    real_fsync = state.os.fsync
+    fsynced_modes = []
+
+    def record_fsync(fd):
+        fsynced_modes.append(stat.S_IFMT(state.os.fstat(fd).st_mode))
+        real_fsync(fd)
+
+    monkeypatch.setattr(state.os, "fsync", record_fsync)
+    state.clear_pending_retain("session-clear-durable")
+
+    if state.sys.platform != "win32":
+        assert fsynced_modes == [stat.S_IFDIR]
+
+
+def test_global_turn_counter_preserves_parallel_session_updates(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    sessions = [f"session-{index}" for index in range(8)]
+
+    with ThreadPoolExecutor(max_workers=len(sessions)) as pool:
+        counts = list(pool.map(state.increment_turn_count, sessions))
+
+    assert counts == [1] * len(sessions)
+    assert {session: state.get_turn_count(session) for session in sessions} == {session: 1 for session in sessions}


### PR DESCRIPTION
# Fix async Retain replay idempotency across API and Codex

Fixes #2937

## Summary

Adds optional request-level idempotency to async Retain, serializes distinct
keyed upserts for the same document, and makes the Codex integration retry lost
acknowledgements without duplicating work or stranding the final due window.

## API and engine

- Accept optional `idempotency_key` for async Retain.
- Fingerprint the canonical caller-submitted operation payload.
- Store the key/fingerprint on the parent async operation.
- Use a database uniqueness constraint as the concurrency authority.
- Return the original operation for same-key/same-payload retries.
- Return HTTP 409 for same-key/different-payload reuse.
- Preserve create-each-time behavior when the key is absent.
- Re-run authentication and operation validation on every retry.
- Serialize keyed single-document upserts behind the latest non-terminal
  predecessor while leaving different documents parallel.

## Codex integration

- Persist the exact request and identity before POST.
- Fail closed when pending state cannot be written.
- Store transcript-bearing pending files as owner-only (`0700` directory, `0600` files).
- Serialize Retain state per Codex session while preserving the global turn-counter lock.
- Retry an unacknowledged request before submitting later due work.
- Preserve one exact due window in a durable overflow slot when the normal
  queue reaches its bounded capacity.
- Submit every acknowledged queued window immediately; server-side ordering
  removes the need for client polling or a later hook event.
- Require the server to advertise both request idempotency and serialized
  upsert support before draining queued work.
- Remove pending state only after an acknowledgement.

## Docs

- Document the Retain idempotency contract.
- Update Codex integration behavior.
- Regenerate the OpenAPI schema.

## Compatibility

- The field is optional.
- Synchronous Retain is unchanged.
- Existing integrations that omit the key are unchanged.
- This complements rather than replaces internal chunk-insert idempotency (#986).

## Proof

- `24 passed`: PostgreSQL-backed engine/API, concurrency, HTTP, and migration tests.
- `133 passed`: Codex hooks, state, and client tests.
- `157 passed`: combined focused tests in the structured review gate.
- Version endpoint and real async Retain integration tests passed.
- OpenAPI was regenerated with the official repository generator.
- Ruff and diff checks passed.
- Oracle adapter query shape was checked by two focused rewrite tests; live
  Oracle runtime proof remains unavailable.
- Structured Codex Auto Review completed. Its sole remaining finding claimed
  that the Oracle lock rewrite was absent; source inspection and both passing
  rewrite tests prove that upstream `engine/db/oracle.py` already performs the
  required `FOR NO KEY UPDATE` to `FOR UPDATE` conversion.
