### PR TITLE
fix(llm): normalize bare LM Studio / Ollama base URL to /v1 (#2922)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -83,6 +83,30 @@ def _validate_ollama_num_ctx(value: Any) -> int | None:
 # intentionally excluded (#1179).
 _TOOL_CHOICE_REQUIRED_UNSUPPORTED_PROVIDERS = frozenset({"lmstudio", "ollama"})
 
+# Local providers whose OpenAI-compatible surface always lives under a `/v1`
+# path (LM Studio: http://localhost:1234/v1, Ollama: http://localhost:11434/v1).
+# For these we know the exact endpoint shape, so a bare host base URL can be
+# normalized safely. Cloud/proxy endpoints are left untouched — their path is
+# provider-specific and must be supplied verbatim.
+_V1_PATH_LOCAL_PROVIDERS = frozenset({"lmstudio", "ollama"})
+
+
+def _ensure_v1_base_url(base_url: str) -> str:
+    """Append the OpenAI-compatible ``/v1`` prefix to a bare local base URL.
+
+    LM Studio's server UI advertises its address as ``http://localhost:1234``,
+    so users commonly set ``HINDSIGHT_API_LLM_BASE_URL`` to that bare host. The
+    OpenAI SDK then POSTs to ``<host>/chat/completions`` and LM Studio rejects it
+    with ``Unexpected endpoint or method`` — its OpenAI-compatible routes live
+    under ``/v1``. Only a base URL with no meaningful path (bare host or a lone
+    trailing slash) is rewritten; anything with an explicit path (e.g. a reverse
+    proxy mount or an already-correct ``/v1``) is returned unchanged. See #2922.
+    """
+    parsed = urlparse(base_url)
+    if parsed.path.strip("/"):
+        return base_url
+    return urlunparse(parsed._replace(path="/v1"))
+
 
 class ProviderResponseError(RuntimeError):
     """Raised when a provider returns a success response without usable content."""
@@ -576,6 +600,11 @@ class OpenAICompatibleLLM(LLMInterface):
                 # OpenAI-compatible inference host (online path). The batch API
                 # lives on a separate control-plane host — see FireworksLLM.
                 self.base_url = "https://api.fireworks.ai/inference/v1"
+
+        # Normalize bare local base URLs (e.g. a user pasting the address shown
+        # in the LM Studio UI) so the OpenAI SDK targets the `/v1` routes. See #2922.
+        if self.provider in _V1_PATH_LOCAL_PROVIDERS and self.base_url:
+            self.base_url = _ensure_v1_base_url(self.base_url)
 
         # For ollama/lmstudio, use dummy key if not provided
         if self.provider in ("ollama", "lmstudio") and not self.api_key:

--- a/hindsight-api-slim/tests/test_local_provider_base_url.py
+++ b/hindsight-api-slim/tests/test_local_provider_base_url.py
@@ -1,0 +1,46 @@
+"""Base URL normalization for local OpenAI-compatible providers (LM Studio, Ollama).
+
+LM Studio's server UI advertises its address as a bare host (``http://localhost:1234``),
+so users commonly set ``HINDSIGHT_API_LLM_BASE_URL`` to that. Without normalization the
+OpenAI SDK POSTs to ``<host>/chat/completions`` and LM Studio rejects it with
+``Unexpected endpoint or method`` — its OpenAI-compatible routes live under ``/v1``. See #2922.
+"""
+
+import pytest
+
+from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+
+
+def _base_url(provider: str, base_url: str, api_key: str = "") -> str:
+    return OpenAICompatibleLLM(provider=provider, api_key=api_key, base_url=base_url, model="test-model").base_url
+
+
+@pytest.mark.parametrize("provider", ["lmstudio", "ollama"])
+@pytest.mark.parametrize(
+    ("given", "expected"),
+    [
+        # Bare host (the #2922 footgun) — /v1 is appended.
+        ("http://localhost:1234", "http://localhost:1234/v1"),
+        # Lone trailing slash is treated as "no path".
+        ("http://localhost:1234/", "http://localhost:1234/v1"),
+        # Already correct — left unchanged.
+        ("http://localhost:1234/v1", "http://localhost:1234/v1"),
+        # Explicit trailing slash on /v1 is preserved (SDK strips it anyway).
+        ("http://localhost:1234/v1/", "http://localhost:1234/v1/"),
+        # An explicit reverse-proxy mount is a deliberate path — untouched.
+        ("http://proxy.internal/lmstudio", "http://proxy.internal/lmstudio"),
+    ],
+)
+def test_local_provider_base_url_normalized(provider: str, given: str, expected: str):
+    assert _base_url(provider, given) == expected
+
+
+def test_lmstudio_bare_host_targets_v1_chat_completions():
+    """The constructed OpenAI client must POST to /v1/chat/completions, not /chat/completions."""
+    llm = OpenAICompatibleLLM(provider="lmstudio", api_key="", base_url="http://localhost:1234", model="qwen")
+    assert str(llm._client.base_url).rstrip("/") == "http://localhost:1234/v1"
+
+
+def test_non_local_provider_base_url_untouched():
+    """Cloud/proxy providers keep an explicit host with no path verbatim (path is provider-specific)."""
+    assert _base_url("openrouter", "https://gateway.example.com", api_key="sk-x") == "https://gateway.example.com"


### PR DESCRIPTION
## Problem

Hindsight fails against LM Studio when the base URL is set to the bare host that LM Studio's server UI advertises (`http://localhost:1234`, without `/v1`). The OpenAI SDK appends `/chat/completions` to the base URL, so it POSTs to `http://localhost:1234/chat/completions`, and LM Studio rejects it:

```
ProviderResponseError: Provider returned error payload
(lmstudio/..., scope=retain_extract_facts): Unexpected endpoint or method. (POST /chat/completions)
```

LM Studio's OpenAI-compatible routes live under `/v1` (`/v1/chat/completions`) — the bare host has no such route. Its newer native REST endpoints (`/api/v1/chat`) are **not** OpenAI-compatible, so the OpenAI SDK can't target them anyway; `/v1/chat/completions` remains the correct endpoint and it still works.

Fixes #2922.

## Fix

For `lmstudio` and `ollama` — the two local providers whose OpenAI-compatible surface is known to live under `/v1` — normalize a base URL that has no meaningful path by appending `/v1`. Base URLs with an explicit path (an already-correct `/v1`, or a reverse-proxy mount) are left untouched, and cloud/proxy providers are not affected.

| Input (lmstudio/ollama) | Result |
| --- | --- |
| `http://localhost:1234` | `http://localhost:1234/v1` |
| `http://localhost:1234/` | `http://localhost:1234/v1` |
| `http://localhost:1234/v1` | unchanged |
| `http://proxy.internal/lmstudio` | unchanged |

## Verification

- New unit tests in `test_local_provider_base_url.py` cover the normalization matrix and assert the constructed OpenAI client targets `/v1/chat/completions`.
- Verified end-to-end against a real LM Studio instance: a fact-extraction-style call configured with the bare host `http://localhost:1234` (the exact config from the issue) now succeeds instead of returning `Unexpected endpoint or method`.
