### PR TITLE
fix(repair): stop the shared-DB deadlock flake in test-api (CONCURRENTLY test DDL + retry transient deadlocks)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -800,10 +800,16 @@ class PostgreSQLOps(DataAccessOps):
         internal_id: str,
         fact_types: dict[str, str],
     ) -> None:
+        # CONCURRENTLY so the drop takes ShareUpdateExclusive, not ACCESS
+        # EXCLUSIVE, on the shared memory_units table. A plain DROP INDEX blocks
+        # (and deadlocks with) every other bank's concurrent reads/writes on the
+        # table; CONCURRENTLY does not conflict with DML. The caller
+        # (delete_bank) runs this on an autocommit connection after its delete
+        # transaction has committed — CONCURRENTLY cannot run inside a tx.
         for ft, suffix in fact_types.items():
             uid = str(internal_id).replace("-", "")[:16]
             idx = f"idx_mu_emb_{suffix}_{uid}"
-            await conn.execute(f"DROP INDEX IF EXISTS {schema}.{idx}")
+            await conn.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {schema}.{idx}")
 
     def get_entity_resolution_strategy(self) -> str:
         return "trigram"

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -759,7 +759,7 @@ def _recall_scoring_now(question_date: datetime | None) -> datetime:
 # Logger for memory system
 logger = logging.getLogger(__name__)
 
-from .db_utils import acquire_with_retry
+from .db_utils import acquire_with_retry, retry_with_backoff
 
 
 def _get_tiktoken_encoding():
@@ -6362,11 +6362,16 @@ class MemoryEngine(MemoryEngineInterface):
                 except Exception as e:
                     raise Exception(f"Failed to delete agent data: {str(e)}")
 
-            # Drop per-bank vector indexes AFTER the transaction commits to avoid
-            # AccessExclusiveLock deadlocks with concurrent bank deletions.
-            # (DROP INDEX on memory_units conflicts with RowExclusiveLock from DELETE inside tx)
+            # Drop per-bank vector indexes AFTER the transaction commits: the
+            # drop runs CONCURRENTLY (see ops.drop_bank_vector_indexes), which
+            # cannot run inside a transaction block. retry_with_backoff absorbs
+            # the residual transient deadlock a concurrent index build/drop on
+            # the shared memory_units table can still trigger (sqlstate 40P01 /
+            # ORA-00060) so a delete is never lost to a transient lock cycle.
             if bank_internal_id:
-                await bank_utils.drop_bank_vector_indexes(conn, bank_internal_id, ops=self._backend.ops)
+                await retry_with_backoff(
+                    lambda: bank_utils.drop_bank_vector_indexes(conn, bank_internal_id, ops=self._backend.ops)
+                )
 
         # Drop any cached stats for this bank — counts have changed and the
         # TTL would otherwise serve pre-delete values for up to a minute.

--- a/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, Field
 
 from ..._vector_index import index_using_clause, uses_per_bank_vector_indexes
 from ...config import get_config
-from ..db_utils import acquire_with_retry
+from ..db_utils import acquire_with_retry, retry_with_backoff
 from ..memory_engine import fq_table, get_current_schema
 from ..response_models import DispositionTraits
 
@@ -188,9 +188,19 @@ async def get_or_create_bank_profile(pool, bank_id: str) -> BankProfileResult:
     or rolls back atomically with the caller's write), use
     ``get_or_create_bank_profile_on_conn`` instead.
     """
-    async with acquire_with_retry(pool) as conn:
-        async with conn.transaction():
-            return await get_or_create_bank_profile_on_conn(conn, bank_id, ops=pool.ops)
+
+    # A fresh bank builds its per-(bank, fact_type) partial vector indexes with
+    # a plain CREATE INDEX (it must — this runs inside the bank-create tx, and
+    # CONCURRENTLY cannot). That CREATE takes a ShareLock on the shared
+    # memory_units table, which can deadlock with concurrent writers. The build
+    # is idempotent (INSERT ... ON CONFLICT + CREATE INDEX IF NOT EXISTS), so a
+    # transient deadlock (40P01 / ORA-00060) is safe to retry as a whole tx.
+    async def _create() -> BankProfileResult:
+        async with acquire_with_retry(pool) as conn:
+            async with conn.transaction():
+                return await get_or_create_bank_profile_on_conn(conn, bank_id, ops=pool.ops)
+
+    return await retry_with_backoff(_create)
 
 
 async def get_or_create_bank_profile_on_conn(conn, bank_id: str, *, ops) -> BankProfileResult:

--- a/hindsight-api-slim/hindsight_api/engine/vector_index_health.py
+++ b/hindsight-api-slim/hindsight_api/engine/vector_index_health.py
@@ -19,6 +19,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
+from .db_utils import retry_with_backoff
 from .retain.bank_utils import _BANK_INDEX_FACT_TYPES, _bank_index_name
 
 logger = logging.getLogger(__name__)
@@ -142,16 +143,33 @@ async def _repair_schema(
 
             qindex = _quote_identifier(index_name)
             qualified = f"{qschema}.{qindex}"
-            try:
-                # An unhealthy-but-present index (INVALID leftover, wrong access
-                # method) must be dropped first — IF NOT EXISTS cannot repair it.
-                if healthy is False:
-                    await conn.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {qualified}")
+
+            async def _rebuild(
+                qindex: str = qindex,
+                qualified: str = qualified,
+                ft: str = ft,
+                bank_id_literal: str = bank_id_literal,
+            ) -> None:
+                # Always drop first. An unhealthy-but-present index (INVALID
+                # leftover, wrong access method) can't be repaired by
+                # IF NOT EXISTS, and a prior deadlocked CONCURRENTLY build leaves
+                # an INVALID stub that IF NOT EXISTS would likewise skip — so a
+                # retry must clear it. DROP ... IF EXISTS is a no-op when the
+                # index is simply absent (healthy is None).
+                await conn.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {qualified}")
                 await conn.execute(
                     f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {qindex} "
                     f"ON {qschema}.memory_units {index_clause} "
                     f"WHERE fact_type = '{ft}' AND bank_id = {bank_id_literal}"
                 )
+
+            try:
+                # CREATE INDEX CONCURRENTLY on the live, concurrently-written
+                # memory_units table can be chosen as a deadlock victim
+                # (sqlstate 40P01 / ORA-00060). That is transient — Postgres
+                # aborts one side to break the cycle — so retry the drop+build a
+                # few times before recording a permanent failure.
+                await retry_with_backoff(_rebuild)
                 result.created += 1
             except Exception as exc:  # noqa: BLE001 — one failed index must not abort the rest
                 result.failed += 1

--- a/hindsight-api-slim/tests/test_bank_lifecycle_deadlock_retry.py
+++ b/hindsight-api-slim/tests/test_bank_lifecycle_deadlock_retry.py
@@ -1,0 +1,75 @@
+"""Per-bank vector index DDL on create/delete must survive a transient deadlock.
+
+The test-api shard runs 8 pytest-xdist workers against one shared pg0 database
+(``public`` schema), so every bank create/delete does index DDL on the same
+``memory_units`` table other workers are writing. A fresh bank builds its
+partial indexes with a plain ``CREATE INDEX`` inside the bank-create tx
+(ShareLock), and ``delete_bank`` drops them (CONCURRENTLY, post-commit); both
+can be chosen as a deadlock victim. These are the exact production paths that
+flaked in CI — they must retry the transient deadlock, not surface it.
+
+The deadlock is injected via monkeypatch (one-shot ``DeadlockDetectedError``)
+so the retry path is exercised deterministically, without racing real workers.
+"""
+
+import uuid
+
+import pytest
+from asyncpg.exceptions import DeadlockDetectedError
+
+from hindsight_api import RequestContext
+from hindsight_api.engine.memory_engine import MemoryEngine
+from hindsight_api.engine.retain import bank_utils
+
+
+@pytest.mark.asyncio
+async def test_bank_create_retries_transient_deadlock(
+    memory: MemoryEngine, request_context: RequestContext, monkeypatch
+):
+    """A deadlock during the lazy bank-create tx retries the whole tx."""
+    backend = await memory._get_backend()
+    real = bank_utils.get_or_create_bank_profile_on_conn
+    calls = 0
+
+    async def flaky(conn, bank_id, *, ops):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise DeadlockDetectedError("deadlock detected")
+        return await real(conn, bank_id, ops=ops)
+
+    monkeypatch.setattr(bank_utils, "get_or_create_bank_profile_on_conn", flaky)
+
+    bank_id = f"test-deadlock-{uuid.uuid4().hex[:8]}"
+    try:
+        result = await bank_utils.get_or_create_bank_profile(backend, bank_id)
+        assert calls == 2, "expected exactly one retry after the injected deadlock"
+        assert result.created is True
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_bank_delete_retries_transient_deadlock(
+    memory: MemoryEngine, request_context: RequestContext, monkeypatch
+):
+    """A deadlock while dropping per-bank indexes on delete is retried."""
+    bank_id = f"test-deadlock-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    backend = await memory._get_backend()
+    real = backend.ops.drop_bank_vector_indexes
+    calls = 0
+
+    async def flaky(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise DeadlockDetectedError("deadlock detected")
+        return await real(*args, **kwargs)
+
+    monkeypatch.setattr(backend.ops, "drop_bank_vector_indexes", flaky)
+
+    result = await memory.delete_bank(bank_id, request_context=request_context)
+    assert calls == 2, "expected exactly one retry after the injected deadlock"
+    assert result["bank_deleted"] is True

--- a/hindsight-api-slim/tests/test_repair_bank_vector_indexes.py
+++ b/hindsight-api-slim/tests/test_repair_bank_vector_indexes.py
@@ -21,14 +21,16 @@ no LLM is needed, so memory_units are inserted directly.
 import uuid
 
 import pytest
+from asyncpg.exceptions import DeadlockDetectedError
 
 from hindsight_api import RequestContext
 from hindsight_api.admin import cli
 from hindsight_api.admin.cli import _run_repair_bank
 from hindsight_api.engine.db_utils import acquire_with_retry
 from hindsight_api.engine.memory_engine import MemoryEngine
-from hindsight_api.engine.retain.bank_utils import _BANK_INDEX_FACT_TYPES, _bank_index_name
+from hindsight_api.engine.retain.bank_utils import _BANK_INDEX_FACT_TYPES, _bank_index_name, _vector_index_clause
 from hindsight_api.engine.transfer import export_bank
+from hindsight_api.engine.vector_index_health import _repair_schema
 
 _TEST_SCHEMA = "public"
 
@@ -87,11 +89,40 @@ async def _seed_bank(memory: MemoryEngine, request_context: RequestContext) -> s
 
 
 async def _drop_bank_indexes(conn, bank_id: str) -> list[str]:
-    """Drop every per-(bank, fact_type) index to simulate the restore/upgrade gap."""
+    """Drop every per-(bank, fact_type) index to simulate the restore/upgrade gap.
+
+    CONCURRENTLY so the drop never takes ACCESS EXCLUSIVE on the shared
+    ``memory_units`` table: the test suite runs 8 xdist workers against one pg0
+    database, and a blocking DDL here deadlocks unrelated workers' DML.
+    """
     names = await _expected_index_names(conn, bank_id)
     for name in names:
-        await conn.execute(f"DROP INDEX IF EXISTS {_TEST_SCHEMA}.{name}")
+        await conn.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_TEST_SCHEMA}.{name}")
     return names
+
+
+class _DeadlockOnceOnCreate:
+    """Wrap a real asyncpg connection and raise a single deadlock on the first
+    ``CREATE INDEX CONCURRENTLY``, delegating everything else.
+
+    Simulates the transient deadlock that CI's 8 xdist workers hit when a
+    concurrent build on the shared ``memory_units`` table is picked as the
+    victim, so the repair's retry path can be exercised deterministically.
+    """
+
+    def __init__(self, real):
+        self._real = real
+        self.create_calls = 0
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+    async def execute(self, query, *args, **kwargs):
+        if "CREATE INDEX CONCURRENTLY" in query:
+            self.create_calls += 1
+            if self.create_calls == 1:
+                raise DeadlockDetectedError("deadlock detected")
+        return await self._real.execute(query, *args, **kwargs)
 
 
 class TestRepairBankCommand:
@@ -165,8 +196,10 @@ class TestRepairBankCommand:
                 names = await _drop_bank_indexes(conn, bank_id)
                 # Recreate the FIRST expected index name with the WRONG definition:
                 # a plain btree with no partial predicate. Name matches, shape does not.
+                # CONCURRENTLY so building the decoy never takes ACCESS EXCLUSIVE on
+                # the shared memory_units table (see _drop_bank_indexes).
                 bogus = names[0]
-                await conn.execute(f"CREATE INDEX {bogus} ON memory_units (bank_id)")
+                await conn.execute(f"CREATE INDEX CONCURRENTLY {bogus} ON memory_units (bank_id)")
                 assert await _index_exists(conn, bogus)
                 assert not await _index_is_partial_vector(conn, bogus)
 
@@ -178,6 +211,34 @@ class TestRepairBankCommand:
             async with acquire_with_retry(backend) as conn:
                 for name in names:
                     assert await _index_is_partial_vector(conn, name), f"{name} should now be the partial vector index"
+        finally:
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_transient_deadlock_is_retried_not_failed(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """A transient deadlock during the CONCURRENTLY build is retried, not
+        recorded as a permanent failure.
+
+        This is the exact CI flake: 8 xdist workers share one memory_units
+        table, so a concurrent build gets picked as the deadlock victim. Repair
+        must converge (rebuild the index) rather than leave result.failed > 0.
+        """
+        bank_id = await _seed_bank(memory, request_context)
+        backend = await memory._get_backend()
+        index_clause = _vector_index_clause()
+        assert index_clause is not None  # per-bank-index backend (see other tests)
+        try:
+            async with acquire_with_retry(backend) as conn:
+                names = await _drop_bank_indexes(conn, bank_id)
+                flaky = _DeadlockOnceOnCreate(conn)
+                result = await _repair_schema(flaky, _TEST_SCHEMA, index_clause, dry_run=False, bank_id=bank_id)
+                assert flaky.create_calls >= 2, "expected a retry after the injected deadlock"
+                assert result.failed == 0, result.failed_indexes
+                assert result.created == len(_BANK_INDEX_FACT_TYPES)
+                for name in names:
+                    assert await _index_exists(conn, name), f"{name} should be rebuilt after the retry"
         finally:
             await memory.delete_bank(bank_id, request_context=request_context)
 


### PR DESCRIPTION
## Problem

The `test-api` shard flakes on `asyncpg.exceptions.DeadlockDetectedError`, taking down a rotating set of unrelated tests. Surfaced on #2923; reproduces on clean re-runs → persistent, pre-existing flake.

## Root cause

CI runs `-n 8 --dist loadgroup` — **8 xdist workers against one shared pg0 database, all in `public`**. Every test creates and deletes banks, and each does per-bank vector-index DDL on the same `memory_units` table the other 7 workers are writing. The server-side deadlock detail points at `relation memory_units`:

- **`delete_bank`** dropped per-bank indexes with a plain `DROP INDEX` → **ACCESS EXCLUSIVE** on `memory_units`, blocking/deadlocking every other bank's reads & writes.
- **fresh-bank creation** builds partial indexes with a plain `CREATE INDEX` inside the bank-create transaction → **ShareLock**, which also deadlocks with concurrent writers.
- the `test_repair_bank_vector_indexes` decoy index used a plain `CREATE INDEX` too.

These are genuine production lock-contention issues (deleting/creating one bank shouldn't lock the whole shared table), not merely test noise — they just show up loudest under 8-way parallelism.

## Fix

**Production**
- `delete_bank` → `ops_postgresql.drop_bank_vector_indexes`: `DROP INDEX` → **`DROP INDEX CONCURRENTLY`** (ShareUpdateExclusive, never conflicts with DML), run post-commit on an autocommit connection, wrapped in `retry_with_backoff` for the residual transient deadlock.
- `get_or_create_bank_profile`: the fresh-bank `CREATE INDEX` must stay non-concurrent (it's inside the bank-create tx), so the **whole transaction is wrapped in `retry_with_backoff`**. The build is idempotent (`INSERT ... ON CONFLICT` + `CREATE INDEX IF NOT EXISTS`), so a deadlock victim retries cleanly.
- repair path (`vector_index_health.py`): retries a `CREATE/DROP INDEX CONCURRENTLY` deadlock victim instead of recording a permanent failure (always drop-then-create so a retry clears the INVALID stub a deadlocked build leaves behind).

**Tests**
- repair test builds/drops its decoy index `CONCURRENTLY` (matches production, stops the collateral storm).
- new regression tests inject a one-shot deadlock into each of the create, delete, and repair paths and assert they retry and converge (`failed == 0` / bank created / bank deleted).

No advisory locks (project rule) — concurrency stays handled by idempotent DDL + `CONCURRENTLY` + transient-deadlock retry, consistent with `retry_with_backoff` usage elsewhere (graph maintenance, doc-concurrency).

## Validation

`uv run pytest tests/test_repair_bank_vector_indexes.py tests/test_recall_chunks_independence.py tests/test_bank_lifecycle_deadlock_retry.py` → all green; `lint.sh` + `ty` clean.

Note: the Oracle-client job failures seen on earlier runs were **job-level timeouts / an "I/O operation failed during extraction" CI infra error**, separate from this deadlock and not addressed here.
