### PR TITLE
fix(retain): make async retries idempotent via caller-supplied operation_id (#2937)

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -149,7 +149,12 @@ def FieldWithDefault(default_factory: Callable, **kwargs) -> Any:
 
 
 from hindsight_api.config import get_config
-from hindsight_api.engine.memory_engine import Budget, _current_schema, _get_tiktoken_encoding
+from hindsight_api.engine.memory_engine import (
+    Budget,
+    RetainOperationConflictError,
+    _current_schema,
+    _get_tiktoken_encoding,
+)
 from hindsight_api.engine.providers.none_llm import LLMNotAvailableError
 from hindsight_api.engine.response_models import (
     VALID_RECALL_FACT_TYPES,
@@ -722,6 +727,25 @@ class RetainRequest(BaseModel):
         description="Deprecated. Use item-level tags instead.",
         deprecated=True,
     )
+    operation_id: str | None = Field(
+        default=None,
+        description=(
+            "Optional client-supplied UUID used as the identity of an async retain operation. "
+            "Re-submitting with the same operation_id returns the original operation and creates no new "
+            "work, so retrying after a lost or timed-out acknowledgement will not enqueue a duplicate. "
+            "Reusing an id that belongs to a different operation returns HTTP 409. Ignored for synchronous retain."
+        ),
+    )
+
+    @field_validator("operation_id")
+    @classmethod
+    def validate_operation_id(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        try:
+            return str(uuid.UUID(value))
+        except (ValueError, AttributeError, TypeError) as exc:
+            raise ValueError("operation_id must be a valid UUID") from exc
 
 
 class FileRetainMetadata(BaseModel):
@@ -6833,6 +6857,11 @@ def _register_routes(app: FastAPI):
                 strategy_groups[effective].append(content_dict)
 
             if request.async_:
+                if request.operation_id is not None and len(strategy_groups) != 1:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="operation_id requires all retain items to resolve to a single strategy",
+                    )
                 # Async processing: one submit per strategy group
                 all_operation_ids = []
                 total_items_count = 0
@@ -6843,6 +6872,7 @@ def _register_routes(app: FastAPI):
                         document_tags=request.document_tags,
                         strategy=group_strategy,
                         request_context=request_context,
+                        operation_id=request.operation_id,
                     )
                     all_operation_ids.append(result["operation_id"])
                     total_items_count += result["items_count"]
@@ -6909,6 +6939,10 @@ def _register_routes(app: FastAPI):
                 )
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)
+        except RetainOperationConflictError as e:
+            # Caller reused an async retain operation_id that already belongs to
+            # a different operation.
+            raise HTTPException(status_code=409, detail=str(e))
         except (AuthenticationError, HTTPException):
             raise
         except ValueError as e:

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -12862,6 +12862,16 @@ class MemoryEngine(MemoryEngineInterface):
 
         # Idempotency fast path: a caller-supplied id that already resolves to a
         # prior submission is a retried request — return the original operation.
+        #
+        # This read is deliberately NOT in the creation transaction below. The
+        # parent primary key — not this SELECT — is the concurrency authority:
+        # two concurrent first submissions both pass this check (neither has
+        # committed), then collide on the INSERT, and the loser is recovered by
+        # the unique-violation backstop. Coupling the read into the transaction
+        # would add nothing under READ COMMITTED (the snapshot still wouldn't see
+        # the other session's uncommitted row); real mutual exclusion would need
+        # SERIALIZABLE or a row lock, both heavier for no benefit. So this stays a
+        # cheap short-circuit for the common sequential-retry case.
         client_operation_id: uuid.UUID | None = uuid.UUID(operation_id) if operation_id is not None else None
         if client_operation_id is not None:
             replay = await self._resolve_retain_replay(client_operation_id, bank_id)

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -269,6 +269,15 @@ class UnqualifiedTableError(Exception):
     pass
 
 
+class RetainOperationConflictError(ValueError):
+    """Raised when a caller-supplied async retain operation_id is already in use.
+
+    The id resolves to an existing operation that is not this bank's own
+    batch_retain parent (a different bank, or a different operation type), so it
+    cannot be reused as an idempotency identity. Surfaced to callers as HTTP 409.
+    """
+
+
 class MentalModelRefreshError(Exception):
     """Raised when refresh_mental_model cannot produce new content.
 
@@ -12784,6 +12793,35 @@ class MemoryEngine(MemoryEngineInterface):
             "operation_id": str(operation_id),
         }
 
+    async def _resolve_retain_replay(self, operation_id: uuid.UUID, bank_id: str) -> dict[str, Any] | None:
+        """Resolve a caller-supplied async retain operation_id to a prior submission.
+
+        Returns the replay response when the id is this bank's own batch_retain
+        parent (a retried submission after a lost acknowledgement — no new work),
+        ``None`` when the id is unused (free to create), and raises
+        RetainOperationConflictError when the id is already used by a different
+        bank or a different operation type.
+        """
+        backend = await self._get_backend()
+        async with acquire_with_retry(backend) as conn:
+            row = await conn.fetchrow(
+                f"""
+                SELECT bank_id, operation_type, result_metadata
+                FROM {fq_table("async_operations")}
+                WHERE operation_id = $1
+                """,
+                operation_id,
+            )
+        if row is None:
+            return None
+        if row["bank_id"] != bank_id or row["operation_type"] != "batch_retain":
+            raise RetainOperationConflictError(f"operation_id {operation_id} is already in use")
+        metadata = row["result_metadata"]
+        if isinstance(metadata, str):
+            metadata = json.loads(metadata)
+        items_count = int(metadata.get("items_count", 0)) if metadata else 0
+        return {"operation_id": str(operation_id), "items_count": items_count}
+
     async def submit_async_retain(
         self,
         bank_id: str,
@@ -12792,15 +12830,24 @@ class MemoryEngine(MemoryEngineInterface):
         request_context: "RequestContext",
         document_tags: list[str] | None = None,
         strategy: str | None = None,
+        operation_id: str | None = None,
     ) -> dict[str, Any]:
         """Submit a batch retain operation to run asynchronously.
 
         For large batches (exceeding retain_batch_chars threshold), automatically splits
         into smaller sub-batches and creates a parent operation that tracks all children.
+
+        ``operation_id`` is an optional caller-supplied UUID used as the parent
+        operation identity. Re-submitting with the same id returns the original
+        operation and creates no new work, so a client that retries after a lost
+        acknowledgement does not enqueue a duplicate. The parent primary key is
+        the concurrency authority; no extra bookkeeping columns are needed.
         """
         await self._authenticate_tenant(request_context)
 
-        # Run operation validator (bank access, credits, etc.) before queuing
+        # Run operation validator (bank access, credits, etc.) before queuing.
+        # This runs on every retry too, so a replay cannot bypass access/credit
+        # checks even though it performs no ingestion work.
         if self._operation_validator:
             from hindsight_api.extensions import RetainContext
 
@@ -12812,6 +12859,14 @@ class MemoryEngine(MemoryEngineInterface):
             result = await self._validate_operation(self._operation_validator.validate_retain(ctx))
             if result and result.contents is not None:
                 contents = result.contents
+
+        # Idempotency fast path: a caller-supplied id that already resolves to a
+        # prior submission is a retried request — return the original operation.
+        client_operation_id: uuid.UUID | None = uuid.UUID(operation_id) if operation_id is not None else None
+        if client_operation_id is not None:
+            replay = await self._resolve_retain_replay(client_operation_id, bank_id)
+            if replay is not None:
+                return replay
 
         # Validate no duplicate document_ids in the batch
         # Having duplicate document_ids causes race conditions in document upserts during parallel processing
@@ -12855,10 +12910,9 @@ class MemoryEngine(MemoryEngineInterface):
                     f"max={max(sub_batch_sizes)}, total={sum(sub_batch_sizes)})"
                 )
 
-        # Always create parent operation (even for single batch - simpler, more reliable code path)
-        import uuid
-
-        parent_operation_id = uuid.uuid4()
+        # Always create parent operation (even for single batch - simpler, more reliable code path).
+        # A caller-supplied id becomes the parent id so retries are idempotent.
+        parent_operation_id = client_operation_id if client_operation_id is not None else uuid.uuid4()
         backend = await self._get_backend()
 
         # Create typed metadata for parent operation
@@ -12893,74 +12947,89 @@ class MemoryEngine(MemoryEngineInterface):
         # defer them all uniformly for clarity.
         deferred_child_payloads: list[dict[str, Any]] = []
 
-        async with acquire_with_retry(backend) as conn:
-            async with conn.transaction():
-                # async_operations.bank_id has a FK to banks. Create the bank
-                # lazily inside this same transaction so it is atomic with the
-                # parent + child operation rows.
-                created = await self._ensure_bank_exists(
-                    bank_id,
-                    request_context,
-                    conn=conn,
-                )
-                await conn.execute(
-                    f"""
-                    INSERT INTO {fq_table("async_operations")} (operation_id, bank_id, operation_type, result_metadata, status)
-                    VALUES ($1, $2, $3, $4, $5)
-                    """,
-                    parent_operation_id,
-                    bank_id,
-                    "batch_retain",
-                    json.dumps(parent_metadata.to_dict()),
-                    "pending",  # Will be updated by status aggregation
-                )
-
-                for i, sub_batch in enumerate(sub_batches, 1):
-                    if len(sub_batches) > 1:
-                        sub_batch_tokens = sum(count_tokens(item.get("content", "")) for item in sub_batch)
-                        logger.info(
-                            f"Submitting child {i}/{len(sub_batches)}: {len(sub_batch)} items, {sub_batch_tokens:,} tokens"
-                        )
-
-                    task_payload: dict[str, Any] = {"contents": sub_batch}
-                    if document_tags:
-                        task_payload["document_tags"] = document_tags
-                    if strategy:
-                        task_payload["strategy"] = strategy
-                    # Pass tenant_id and api_key_id through task payload
-                    if request_context.tenant_id:
-                        task_payload["_tenant_id"] = request_context.tenant_id
-                    if request_context.api_key_id:
-                        task_payload["_api_key_id"] = request_context.api_key_id
-
-                    child_metadata = BatchRetainChildMetadata(
-                        items_count=len(sub_batch),
-                        parent_operation_id=str(parent_operation_id),
-                        sub_batch_index=i,
-                        total_sub_batches=len(sub_batches),
+        try:
+            async with acquire_with_retry(backend) as conn:
+                async with conn.transaction():
+                    # async_operations.bank_id has a FK to banks. Create the bank
+                    # lazily inside this same transaction so it is atomic with the
+                    # parent + child operation rows.
+                    created = await self._ensure_bank_exists(
+                        bank_id,
+                        request_context,
+                        conn=conn,
                     )
-
-                    child_operation_id = uuid.uuid4()
-                    full_payload = {
-                        "type": "batch_retain",
-                        "operation_id": str(child_operation_id),
-                        "bank_id": bank_id,
-                        **task_payload,
-                    }
-
                     await conn.execute(
                         f"""
-                        INSERT INTO {fq_table("async_operations")} (operation_id, bank_id, operation_type, result_metadata, status, task_payload)
-                        VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+                        INSERT INTO {fq_table("async_operations")} (operation_id, bank_id, operation_type, result_metadata, status)
+                        VALUES ($1, $2, $3, $4, $5)
                         """,
-                        child_operation_id,
+                        parent_operation_id,
                         bank_id,
-                        "retain",
-                        json.dumps(child_metadata.to_dict(), default=_json_default),
-                        "pending",
-                        json.dumps(full_payload, default=_json_default),
+                        "batch_retain",
+                        json.dumps(parent_metadata.to_dict()),
+                        "pending",  # Will be updated by status aggregation
                     )
-                    deferred_child_payloads.append(full_payload)
+
+                    for i, sub_batch in enumerate(sub_batches, 1):
+                        if len(sub_batches) > 1:
+                            sub_batch_tokens = sum(count_tokens(item.get("content", "")) for item in sub_batch)
+                            logger.info(
+                                f"Submitting child {i}/{len(sub_batches)}: {len(sub_batch)} items, {sub_batch_tokens:,} tokens"
+                            )
+
+                        task_payload: dict[str, Any] = {"contents": sub_batch}
+                        if document_tags:
+                            task_payload["document_tags"] = document_tags
+                        if strategy:
+                            task_payload["strategy"] = strategy
+                        # Pass tenant_id and api_key_id through task payload
+                        if request_context.tenant_id:
+                            task_payload["_tenant_id"] = request_context.tenant_id
+                        if request_context.api_key_id:
+                            task_payload["_api_key_id"] = request_context.api_key_id
+
+                        child_metadata = BatchRetainChildMetadata(
+                            items_count=len(sub_batch),
+                            parent_operation_id=str(parent_operation_id),
+                            sub_batch_index=i,
+                            total_sub_batches=len(sub_batches),
+                        )
+
+                        child_operation_id = uuid.uuid4()
+                        full_payload = {
+                            "type": "batch_retain",
+                            "operation_id": str(child_operation_id),
+                            "bank_id": bank_id,
+                            **task_payload,
+                        }
+
+                        await conn.execute(
+                            f"""
+                            INSERT INTO {fq_table("async_operations")} (operation_id, bank_id, operation_type, result_metadata, status, task_payload)
+                            VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+                            """,
+                            child_operation_id,
+                            bank_id,
+                            "retain",
+                            json.dumps(child_metadata.to_dict(), default=_json_default),
+                            "pending",
+                            json.dumps(full_payload, default=_json_default),
+                        )
+                        deferred_child_payloads.append(full_payload)
+        except Exception as e:
+            # Concurrency backstop: a caller-supplied id that lost the parent
+            # primary-key race against a simultaneous first submission of the
+            # same id must resolve to the winner's operation, not a 500. Only
+            # a unique violation on our id qualifies; anything else propagates.
+            is_unique_violation = isinstance(
+                e, asyncpg.exceptions.UniqueViolationError
+            ) or _is_oracledb_integrity_error(e)
+            if client_operation_id is None or not is_unique_violation:
+                raise
+            replay = await self._resolve_retain_replay(client_operation_id, bank_id)
+            if replay is not None:
+                return replay
+            raise
 
         # Best-effort default-template hook runs after the bank-create commits.
         if created:

--- a/hindsight-api-slim/tests/test_async_retain_operation_id.py
+++ b/hindsight-api-slim/tests/test_async_retain_operation_id.py
@@ -1,0 +1,206 @@
+"""Idempotent async retain via a caller-supplied operation_id.
+
+A client that retries an async retain after a lost or timed-out acknowledgement
+must not enqueue a second parent operation. Supplying the same ``operation_id``
+returns the original operation and creates no new work; the parent primary key
+is the concurrency authority, so no extra schema is involved.
+"""
+
+import asyncio
+import uuid
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from hindsight_api.api import create_app
+from hindsight_api.engine.memory_engine import RetainOperationConflictError
+
+# These tests submit async operations against the shared pool. Share the
+# "worker_tests" xdist group with test_async_batch_retain / test_worker so a
+# concurrently running poller cannot steal each other's pending rows.
+pytestmark = pytest.mark.xdist_group("worker_tests")
+
+
+@pytest_asyncio.fixture
+async def pool(pg0_db_url):
+    import asyncpg
+
+    from hindsight_api.pg0 import resolve_database_url
+
+    resolved_url = await resolve_database_url(pg0_db_url)
+    p = await asyncpg.create_pool(resolved_url, min_size=1, max_size=5, command_timeout=30)
+    yield p
+    await p.close()
+
+
+@pytest_asyncio.fixture
+async def api_client(memory):
+    app = create_app(memory, initialize_memory=False)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+async def _count_batch_parents(pool, bank_id: str) -> int:
+    return await pool.fetchval(
+        "SELECT count(*) FROM async_operations WHERE bank_id = $1 AND operation_type = 'batch_retain'",
+        bank_id,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Engine-level behaviour
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_replay_returns_same_operation_and_no_new_work(memory, request_context, pool):
+    """Re-submitting with the same operation_id returns the original, creating no new op."""
+    bank_id = "test_retain_idem_replay"
+    operation_id = str(uuid.uuid4())
+    contents = [{"content": "Alice works at Google", "document_id": "doc1"}]
+
+    first = await memory.submit_async_retain(
+        bank_id=bank_id,
+        contents=contents,
+        request_context=request_context,
+        operation_id=operation_id,
+    )
+    await asyncio.sleep(0.1)
+    second = await memory.submit_async_retain(
+        bank_id=bank_id,
+        contents=contents,
+        request_context=request_context,
+        operation_id=operation_id,
+    )
+
+    assert first["operation_id"] == operation_id
+    assert second["operation_id"] == operation_id
+    assert second["items_count"] == 1
+    # Exactly one parent operation exists — the retry created no duplicate.
+    assert await _count_batch_parents(pool, bank_id) == 1
+
+
+@pytest.mark.asyncio
+async def test_no_operation_id_creates_distinct_operations(memory, request_context, pool):
+    """Omitting operation_id keeps the legacy create-each-time behaviour."""
+    bank_id = "test_retain_idem_legacy"
+    contents = [{"content": "Bob went hiking", "document_id": "doc1"}]
+
+    first = await memory.submit_async_retain(bank_id=bank_id, contents=contents, request_context=request_context)
+    second = await memory.submit_async_retain(bank_id=bank_id, contents=contents, request_context=request_context)
+
+    assert first["operation_id"] != second["operation_id"]
+    assert await _count_batch_parents(pool, bank_id) == 2
+
+
+@pytest.mark.asyncio
+async def test_conflict_when_id_belongs_to_different_bank(memory, request_context):
+    """An operation_id owned by another bank cannot be reused (global PK collision)."""
+    operation_id = str(uuid.uuid4())
+    contents = [{"content": "Shared id content", "document_id": "doc1"}]
+
+    await memory.submit_async_retain(
+        bank_id="test_retain_idem_bankA",
+        contents=contents,
+        request_context=request_context,
+        operation_id=operation_id,
+    )
+
+    with pytest.raises(RetainOperationConflictError):
+        await memory.submit_async_retain(
+            bank_id="test_retain_idem_bankB",
+            contents=contents,
+            request_context=request_context,
+            operation_id=operation_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_replay_ignores_payload_differences(memory, request_context, pool):
+    """A replay resolves purely by id; a differing payload still returns the original.
+
+    Reusing an id you generated for different content is a client bug, and
+    returning the original operation is the safe idempotent answer — no new
+    work is enqueued.
+    """
+    bank_id = "test_retain_idem_payload"
+    operation_id = str(uuid.uuid4())
+
+    first = await memory.submit_async_retain(
+        bank_id=bank_id,
+        contents=[{"content": "original", "document_id": "doc1"}],
+        request_context=request_context,
+        operation_id=operation_id,
+    )
+    await asyncio.sleep(0.1)
+    second = await memory.submit_async_retain(
+        bank_id=bank_id,
+        contents=[{"content": "totally different", "document_id": "doc2"}],
+        request_context=request_context,
+        operation_id=operation_id,
+    )
+
+    assert second["operation_id"] == first["operation_id"]
+    assert await _count_batch_parents(pool, bank_id) == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_submissions_with_same_id_create_one_operation(memory, request_context, pool):
+    """Two simultaneous first submissions of the same id resolve to one operation."""
+    bank_id = "test_retain_idem_concurrent"
+    operation_id = str(uuid.uuid4())
+    contents = [{"content": "Concurrent content", "document_id": "doc1"}]
+
+    async def submit():
+        return await memory.submit_async_retain(
+            bank_id=bank_id,
+            contents=contents,
+            request_context=request_context,
+            operation_id=operation_id,
+        )
+
+    results = await asyncio.gather(submit(), submit())
+
+    assert {r["operation_id"] for r in results} == {operation_id}
+    assert await _count_batch_parents(pool, bank_id) == 1
+
+
+# --------------------------------------------------------------------------- #
+# HTTP-level validation
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_http_invalid_operation_id_is_rejected(api_client):
+    bank_id = "test_retain_idem_http_invalid"
+    response = await api_client.post(
+        f"/v1/default/banks/{bank_id}/memories",
+        json={
+            "items": [{"content": "hello", "document_id": "doc1"}],
+            "async": True,
+            "operation_id": "not-a-uuid",
+        },
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_http_replay_returns_same_operation_id(api_client):
+    bank_id = "test_retain_idem_http_replay"
+    operation_id = str(uuid.uuid4())
+    payload = {
+        "items": [{"content": "Alice works at Google", "document_id": "doc1"}],
+        "async": True,
+        "operation_id": operation_id,
+    }
+
+    first = await api_client.post(f"/v1/default/banks/{bank_id}/memories", json=payload)
+    assert first.status_code == 200
+    await asyncio.sleep(0.1)
+    second = await api_client.post(f"/v1/default/banks/{bank_id}/memories", json=payload)
+    assert second.status_code == 200
+
+    assert first.json()["operation_id"] == operation_id
+    assert second.json()["operation_id"] == operation_id

--- a/hindsight-cli/src/commands/memory.rs
+++ b/hindsight-cli/src/commands/memory.rs
@@ -470,6 +470,8 @@ pub fn retain(
         items: vec![item],
         async_: r#async,
         document_tags,
+        // The CLI does not expose idempotency keys; each invocation is a new operation.
+        operation_id: None,
     };
 
     let response = client.retain(agent_id, &request, r#async, verbose);

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -7850,6 +7850,9 @@ components:
             type: string
           nullable: true
           type: array
+        operation_id:
+          nullable: true
+          type: string
       required:
       - items
       title: RetainRequest

--- a/hindsight-clients/go/model_retain_request.go
+++ b/hindsight-clients/go/model_retain_request.go
@@ -25,6 +25,7 @@ type RetainRequest struct {
 	// If true, process asynchronously in background. If false, wait for completion (default: false)
 	Async *bool `json:"async,omitempty"`
 	DocumentTags []string `json:"document_tags,omitempty"`
+	OperationId NullableString `json:"operation_id,omitempty"`
 }
 
 type _RetainRequest RetainRequest
@@ -140,6 +141,48 @@ func (o *RetainRequest) SetDocumentTags(v []string) {
 	o.DocumentTags = v
 }
 
+// GetOperationId returns the OperationId field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *RetainRequest) GetOperationId() string {
+	if o == nil || IsNil(o.OperationId.Get()) {
+		var ret string
+		return ret
+	}
+	return *o.OperationId.Get()
+}
+
+// GetOperationIdOk returns a tuple with the OperationId field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *RetainRequest) GetOperationIdOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.OperationId.Get(), o.OperationId.IsSet()
+}
+
+// HasOperationId returns a boolean if a field has been set.
+func (o *RetainRequest) HasOperationId() bool {
+	if o != nil && o.OperationId.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetOperationId gets a reference to the given NullableString and assigns it to the OperationId field.
+func (o *RetainRequest) SetOperationId(v string) {
+	o.OperationId.Set(&v)
+}
+// SetOperationIdNil sets the value for OperationId to be an explicit nil
+func (o *RetainRequest) SetOperationIdNil() {
+	o.OperationId.Set(nil)
+}
+
+// UnsetOperationId ensures that no value is present for OperationId, not even an explicit nil
+func (o *RetainRequest) UnsetOperationId() {
+	o.OperationId.Unset()
+}
+
 func (o RetainRequest) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -156,6 +199,9 @@ func (o RetainRequest) ToMap() (map[string]interface{}, error) {
 	}
 	if o.DocumentTags != nil {
 		toSerialize["document_tags"] = o.DocumentTags
+	}
+	if o.OperationId.IsSet() {
+		toSerialize["operation_id"] = o.OperationId.Get()
 	}
 	return toSerialize, nil
 }

--- a/hindsight-clients/python/hindsight_client_api/models/retain_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/retain_request.py
@@ -30,7 +30,8 @@ class RetainRequest(BaseModel):
     items: List[MemoryItem]
     var_async: Optional[StrictBool] = Field(default=False, description="If true, process asynchronously in background. If false, wait for completion (default: false)", alias="async")
     document_tags: Optional[List[StrictStr]] = None
-    __properties: ClassVar[List[str]] = ["items", "async", "document_tags"]
+    operation_id: Optional[StrictStr] = None
+    __properties: ClassVar[List[str]] = ["items", "async", "document_tags", "operation_id"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -83,6 +84,11 @@ class RetainRequest(BaseModel):
         if self.document_tags is None and "document_tags" in self.model_fields_set:
             _dict['document_tags'] = None
 
+        # set to None if operation_id (nullable) is None
+        # and model_fields_set contains the field
+        if self.operation_id is None and "operation_id" in self.model_fields_set:
+            _dict['operation_id'] = None
+
         return _dict
 
     @classmethod
@@ -97,7 +103,8 @@ class RetainRequest(BaseModel):
         _obj = cls.model_validate({
             "items": [MemoryItem.from_dict(_item) for _item in obj["items"]] if obj.get("items") is not None else None,
             "async": obj.get("async") if obj.get("async") is not None else False,
-            "document_tags": obj.get("document_tags")
+            "document_tags": obj.get("document_tags"),
+            "operation_id": obj.get("operation_id")
         })
         return _obj
 

--- a/hindsight-clients/rust/src/lib.rs
+++ b/hindsight-clients/rust/src/lib.rs
@@ -128,6 +128,7 @@ mod tests {
                 },
             ],
             document_tags: None,
+            operation_id: None,
         };
         let retain_response = client
             .retain_memories(&bank_id, None, &retain_request)

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -3541,6 +3541,12 @@ export type RetainRequest = {
    * @deprecated
    */
   document_tags?: Array<string> | null;
+  /**
+   * Operation Id
+   *
+   * Optional client-supplied UUID used as the identity of an async retain operation. Re-submitting with the same operation_id returns the original operation and creates no new work, so retrying after a lost or timed-out acknowledgement will not enqueue a duplicate. Reusing an id that belongs to a different operation returns HTTP 409. Ignored for synchronous retain.
+   */
+  operation_id?: string | null;
 };
 
 /**

--- a/hindsight-docs/docs/developer/api/retain.mdx
+++ b/hindsight-docs/docs/developer/api/retain.mdx
@@ -333,6 +333,25 @@ For large batches, use async ingestion to avoid blocking your application:
 
 When `async: true`, the call returns immediately with an `operation_id`. Processing runs in the background via the worker service. No `usage` metrics are returned for async operations.
 
+### Safe Retries with `operation_id`
+
+If an async retain response is lost or times out, you can't tell whether the operation was created. Retrying blindly risks enqueuing the same work twice — duplicate extraction, embeddings, and provider spend.
+
+Supply your own `operation_id` (any UUID) to make retries safe:
+
+```json
+{
+  "items": [{ "content": "Alice works at Google", "document_id": "conv_123" }],
+  "async": true,
+  "operation_id": "3f2b8c1a-9d4e-4a7b-9c2f-1e6d5a4b3c2d"
+}
+```
+
+- Re-submitting with the same `operation_id` returns the original operation and creates no new work, so a retry after a lost acknowledgement is a no-op.
+- Reusing an `operation_id` that already belongs to a different operation returns HTTP `409`.
+- Omitting `operation_id` keeps the default behavior — each request creates a new operation.
+- Generate the id **before** you send the request and reuse it across retries. `operation_id` is ignored for synchronous retain, and requires all items in the request to resolve to a single strategy.
+
 ### Cut Costs 50% with Provider Batch APIs
 
 When using async retain, enable the provider Batch API to reduce LLM fact-extraction costs by 50%. OpenAI, Groq, and Gemini all offer this discount in exchange for a processing window of up to 24 hours — a trade-off that's typically invisible when retain already runs in the background.

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -12188,6 +12188,18 @@
             "title": "Document Tags",
             "description": "Deprecated. Use item-level tags instead.",
             "deprecated": true
+          },
+          "operation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Operation Id",
+            "description": "Optional client-supplied UUID used as the identity of an async retain operation. Re-submitting with the same operation_id returns the original operation and creates no new work, so retrying after a lost or timed-out acknowledgement will not enqueue a duplicate. Reusing an id that belongs to a different operation returns HTTP 409. Ignored for synchronous retain."
           }
         },
         "type": "object",

--- a/skills/hindsight-docs/references/developer/api/retain.md
+++ b/skills/hindsight-docs/references/developer/api/retain.md
@@ -522,6 +522,25 @@ hindsight memory retain my-bank "Meeting notes" --async
 
 When `async: true`, the call returns immediately with an `operation_id`. Processing runs in the background via the worker service. No `usage` metrics are returned for async operations.
 
+### Safe Retries with `operation_id`
+
+If an async retain response is lost or times out, you can't tell whether the operation was created. Retrying blindly risks enqueuing the same work twice — duplicate extraction, embeddings, and provider spend.
+
+Supply your own `operation_id` (any UUID) to make retries safe:
+
+```json
+{
+  "items": [{ "content": "Alice works at Google", "document_id": "conv_123" }],
+  "async": true,
+  "operation_id": "3f2b8c1a-9d4e-4a7b-9c2f-1e6d5a4b3c2d"
+}
+```
+
+- Re-submitting with the same `operation_id` returns the original operation and creates no new work, so a retry after a lost acknowledgement is a no-op.
+- Reusing an `operation_id` that already belongs to a different operation returns HTTP `409`.
+- Omitting `operation_id` keeps the default behavior — each request creates a new operation.
+- Generate the id **before** you send the request and reuse it across retries. `operation_id` is ignored for synchronous retain, and requires all items in the request to resolve to a single strategy.
+
 ### Cut Costs 50% with Provider Batch APIs
 
 When using async retain, enable the provider Batch API to reduce LLM fact-extraction costs by 50%. OpenAI, Groq, and Gemini all offer this discount in exchange for a processing window of up to 24 hours — a trade-off that's typically invisible when retain already runs in the background.

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -12188,6 +12188,18 @@
             "title": "Document Tags",
             "description": "Deprecated. Use item-level tags instead.",
             "deprecated": true
+          },
+          "operation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Operation Id",
+            "description": "Optional client-supplied UUID used as the identity of an async retain operation. Re-submitting with the same operation_id returns the original operation and creates no new work, so retrying after a lost or timed-out acknowledgement will not enqueue a duplicate. Reusing an id that belongs to a different operation returns HTTP 409. Ignored for synchronous retain."
           }
         },
         "type": "object",


### PR DESCRIPTION
## Problem

An async Retain whose HTTP acknowledgement is lost or times out leaves the caller unable to tell whether the operation was created. Retrying the same request enqueues a **second** parent async operation and repeats extraction, embeddings, relationships, and provider spend. This is request-level idempotency — the existing chunk-insert idempotency (#986) protects an internal persistence stage, not the operation identity across a lost acknowledgement.

Fixes #2937.

## Approach

Let the caller supply the operation UUID and reuse the primary key that already exists — the idempotent-`PUT` pattern.

- `RetainRequest` gains an optional `operation_id` (validated as a UUID).
- For async retain it becomes the parent `async_operations.operation_id`.
- Re-submitting with the same id returns the original operation and creates **no new work** — a retry after a lost ack is a no-op.
- The parent **primary key** is the concurrency authority: two truly-simultaneous first submissions race on it, the loser resolves to the winner's operation instead of erroring.
- Reusing an id that already belongs to a **different bank or operation type** returns **HTTP 409**.
- Omitting `operation_id` keeps today's create-each-time behavior. Ignored for synchronous retain; requires a single strategy group (400 otherwise).

## Why no migration / no new columns

The identity *is* `async_operations.operation_id`, which is already the table's `PRIMARY KEY`. Nothing to add — no `idempotency_key` column, no `request_fingerprint`, no uniqueness constraint, no Alembic migration. Authentication and the operation validator still run on every retry, so a replay cannot bypass access/credit checks.

This is a deliberately minimal alternative to #2938, which introduced two migrations, a canonical-payload fingerprint, and a separate server-side upsert-serialization subsystem + Codex durable-queue rework (~3.1k lines). Those are separable concerns; if the same-document ordering / client durable-queue behavior is wanted, it belongs in its own issue with a concrete repro (note that concurrent same-document chunk writes are already convergent via `ON CONFLICT (chunk_id)` from #986/#1916).

### Trade-off: no payload-mismatch 409

Reusing an id you generated for *different* content returns the original operation rather than a 409. Reusing a UUID across semantically different requests is a client bug, and idempotent replay is the safe answer — no duplicate work is enqueued. A `request_fingerprint` column could add that check later, but it's orthogonal and not needed for the filed bug.

## Changes

- `api/http.py` — `operation_id` field + UUID validator, single-strategy guard, thread-through, 409 mapping. No DB access in the handler.
- `engine/memory_engine.py` — `RetainOperationConflictError`, `_resolve_retain_replay`, `submit_async_retain(operation_id=...)` with the up-front replay path and the PK-race backstop.
- Regenerated OpenAPI + Python/TS/Go clients (only the new optional field).
- Docs: "Safe Retries with `operation_id`" section in `retain.mdx`.

## Tests

`tests/test_async_retain_operation_id.py` (7, PostgreSQL-backed, deterministic MockLLM):

- replay returns the same operation and creates no second parent
- omitting the id preserves legacy create-each-time
- cross-bank id reuse raises conflict (409)
- differing payload with the same id still replays (no new work)
- two concurrent submissions of the same id resolve to one operation
- HTTP: invalid UUID → 422; replay → same `operation_id`

Deterministic mechanics only — no LLM-behavior change, so no judge test.
