### PR TITLE
fix(oracle): unblock Oracle CI — free runner disk space + fix the retain deadlock

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1872,19 +1872,23 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || '' }}
 
     # The Oracle 23ai `free` service image is large; combined with the Python ML
-    # deps (torch) it exhausts the runner's ~14 GB root disk. uv then fails to
-    # extract a wheel with "No space left on device (os error 28)", and a
-    # near-full disk starves I/O enough to also trip the 30-minute job timeout.
-    # Reclaim ~20 GB of preinstalled tooling first. docker-images stays false:
-    # the Oracle service container is already running and pruning could break it.
+    # deps (torch) it exhausts the runner's ~14 GB root disk, so uv fails to
+    # extract a wheel with "No space left on device (os error 28)".
+    # Only the cheap, high-yield reclaims are enabled — the Android/.NET/Haskell
+    # dirs plus swap are a few `rm -rf`s worth ~16-21 GB, which is ample headroom:
+    #   - large-packages runs apt-get remove and costs minutes for little gain;
+    #   - tool-cache would delete the preinstalled Python that actions/setup-python
+    #     then has to re-download, making the job slower, not faster;
+    #   - docker-images is pointless here (the Oracle service container is already
+    #     running, so its image is in use and cannot be pruned anyway).
     - name: Free Disk Space
       uses: jlumbroso/free-disk-space@main
       with:
-        tool-cache: true
+        tool-cache: false
         android: true
         dotnet: true
         haskell: true
-        large-packages: true
+        large-packages: false
         docker-images: false
         swap-storage: true
 
@@ -2249,19 +2253,23 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || '' }}
 
     # The Oracle 23ai `free` service image is large; combined with the Python ML
-    # deps (torch) it exhausts the runner's ~14 GB root disk. uv then fails to
-    # extract a wheel with "No space left on device (os error 28)", and a
-    # near-full disk starves I/O enough to also trip the 30-minute job timeout.
-    # Reclaim ~20 GB of preinstalled tooling first. docker-images stays false:
-    # the Oracle service container is already running and pruning could break it.
+    # deps (torch) it exhausts the runner's ~14 GB root disk, so uv fails to
+    # extract a wheel with "No space left on device (os error 28)".
+    # Only the cheap, high-yield reclaims are enabled — the Android/.NET/Haskell
+    # dirs plus swap are a few `rm -rf`s worth ~16-21 GB, which is ample headroom:
+    #   - large-packages runs apt-get remove and costs minutes for little gain;
+    #   - tool-cache would delete the preinstalled Python that actions/setup-python
+    #     then has to re-download, making the job slower, not faster;
+    #   - docker-images is pointless here (the Oracle service container is already
+    #     running, so its image is in use and cannot be pruned anyway).
     - name: Free Disk Space
       uses: jlumbroso/free-disk-space@main
       with:
-        tool-cache: true
+        tool-cache: false
         android: true
         dotnet: true
         haskell: true
-        large-packages: true
+        large-packages: false
         docker-images: false
         swap-storage: true
 
@@ -2426,19 +2434,23 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || '' }}
 
     # The Oracle 23ai `free` service image is large; combined with the Python ML
-    # deps (torch) it exhausts the runner's ~14 GB root disk. uv then fails to
-    # extract a wheel with "No space left on device (os error 28)", and a
-    # near-full disk starves I/O enough to also trip the 30-minute job timeout.
-    # Reclaim ~20 GB of preinstalled tooling first. docker-images stays false:
-    # the Oracle service container is already running and pruning could break it.
+    # deps (torch) it exhausts the runner's ~14 GB root disk, so uv fails to
+    # extract a wheel with "No space left on device (os error 28)".
+    # Only the cheap, high-yield reclaims are enabled — the Android/.NET/Haskell
+    # dirs plus swap are a few `rm -rf`s worth ~16-21 GB, which is ample headroom:
+    #   - large-packages runs apt-get remove and costs minutes for little gain;
+    #   - tool-cache would delete the preinstalled Python that actions/setup-python
+    #     then has to re-download, making the job slower, not faster;
+    #   - docker-images is pointless here (the Oracle service container is already
+    #     running, so its image is in use and cannot be pruned anyway).
     - name: Free Disk Space
       uses: jlumbroso/free-disk-space@main
       with:
-        tool-cache: true
+        tool-cache: false
         android: true
         dotnet: true
         haskell: true
-        large-packages: true
+        large-packages: false
         docker-images: false
         swap-storage: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1871,6 +1871,23 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha || '' }}
 
+    # The Oracle 23ai `free` service image is large; combined with the Python ML
+    # deps (torch) it exhausts the runner's ~14 GB root disk. uv then fails to
+    # extract a wheel with "No space left on device (os error 28)", and a
+    # near-full disk starves I/O enough to also trip the 30-minute job timeout.
+    # Reclaim ~20 GB of preinstalled tooling first. docker-images stays false:
+    # the Oracle service container is already running and pruning could break it.
+    - name: Free Disk Space
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: true
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: false
+        swap-storage: true
+
     - name: Setup Oracle test user
       # The SYSTEM tablespace uses manual segment space management which
       # doesn't support VECTOR types. Create an ASSM tablespace and a
@@ -2231,6 +2248,23 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha || '' }}
 
+    # The Oracle 23ai `free` service image is large; combined with the Python ML
+    # deps (torch) it exhausts the runner's ~14 GB root disk. uv then fails to
+    # extract a wheel with "No space left on device (os error 28)", and a
+    # near-full disk starves I/O enough to also trip the 30-minute job timeout.
+    # Reclaim ~20 GB of preinstalled tooling first. docker-images stays false:
+    # the Oracle service container is already running and pruning could break it.
+    - name: Free Disk Space
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: true
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: false
+        swap-storage: true
+
     - name: Setup Oracle test user
       run: |
         pip install oracledb
@@ -2390,6 +2424,23 @@ jobs:
     - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.sha || '' }}
+
+    # The Oracle 23ai `free` service image is large; combined with the Python ML
+    # deps (torch) it exhausts the runner's ~14 GB root disk. uv then fails to
+    # extract a wheel with "No space left on device (os error 28)", and a
+    # near-full disk starves I/O enough to also trip the 30-minute job timeout.
+    # Reclaim ~20 GB of preinstalled tooling first. docker-images stays false:
+    # the Oracle service container is already running and pruning could break it.
+    - name: Free Disk Space
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: true
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: false
+        swap-storage: true
 
     - name: Setup Oracle test user
       run: |

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -1771,13 +1771,21 @@ async def _streaming_retain_batch(
                 if is_last and outbox_callback is not None:
                     outbox_fired[0] = True
 
-                # Best-effort: flush entity_cooccurrences and other deferred stats.
-                try:
-                    await entity_resolver.flush_pending_stats()
-                except Exception:
-                    logger.warning(
-                        f"Entity stats flush (consumer batch {consumer_batch_idx + 1}) failed", exc_info=True
-                    )
+            # Best-effort: flush entity_cooccurrences and other deferred stats.
+            #
+            # This MUST run after the `acquire_with_retry` block above has exited,
+            # not inside it: flush_pending_stats() acquires its own connection, and
+            # the write above is only committed when the enclosing acquire() block
+            # exits. On Oracle (oracledb does not autocommit — the backend commits
+            # on clean exit of acquire()) doing this inside the block deadlocks
+            # permanently: connection #2 waits on the row locks the still-open
+            # connection #1 holds on `entities`, while connection #1 cannot commit
+            # until this call returns. Oracle never reports ORA-00060 for it,
+            # because session #1 is blocked in Python rather than on the database.
+            try:
+                await entity_resolver.flush_pending_stats()
+            except Exception:
+                logger.warning(f"Entity stats flush (consumer batch {consumer_batch_idx + 1}) failed", exc_info=True)
 
             logger.info(
                 f"[streaming] Consumer batch {consumer_batch_idx + 1} total "
@@ -2427,12 +2435,6 @@ async def _try_delta_retain(
                     ops=pool.ops,
                 )
 
-            # Flush deferred entity_cooccurrences stats (post-transaction, best-effort).
-            try:
-                await entity_resolver.flush_pending_stats()
-            except Exception:
-                logger.warning("Entity stats flush failed — retrieval unaffected", exc_info=True)
-
             total_time = time.time() - start_time
             log_buffer.append(f"{'=' * 60}")
             log_buffer.append(
@@ -2442,6 +2444,14 @@ async def _try_delta_retain(
             log_buffer.append(f"Document: {effective_doc_id}")
             log_buffer.append(f"{'=' * 60}")
             logger.info("\n" + "\n".join(log_buffer) + "\n")
+
+        # Flush deferred entity_cooccurrences stats (best-effort). Must run after
+        # the acquire() block above has exited — see the streaming path for why
+        # doing this while still holding the connection deadlocks on Oracle.
+        try:
+            await entity_resolver.flush_pending_stats()
+        except Exception:
+            logger.warning("Entity stats flush failed — retrieval unaffected", exc_info=True)
 
     if db_semaphore is not None:
         async with db_semaphore:

--- a/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
@@ -633,10 +633,14 @@ async def _import_one_document(
                     ops=ops,
                 )
 
-        try:
-            await entity_resolver.flush_pending_stats()
-        except Exception:
-            logger.warning("[transfer] Entity stats flush failed for document %s", target_id, exc_info=True)
+    # Best-effort, and only after the acquire() block above has exited: this
+    # takes its own connection, and on Oracle the write above is not committed
+    # until that block exits, so flushing while still holding the connection
+    # deadlocks (see the retain orchestrator for the full explanation).
+    try:
+        await entity_resolver.flush_pending_stats()
+    except Exception:
+        logger.warning("[transfer] Entity stats flush failed for document %s", target_id, exc_info=True)
 
     logger.debug("[transfer] Imported document %s:\n%s", target_id, "\n".join(log_buffer))
     # Single content item -> result_unit_ids[0] follows the retained fact order.

--- a/hindsight-api-slim/tests/test_flush_stats_outside_connection.py
+++ b/hindsight-api-slim/tests/test_flush_stats_outside_connection.py
@@ -1,0 +1,89 @@
+"""Lint test: ``flush_pending_stats()`` must never run while a pooled connection is held.
+
+``flush_pending_stats()`` acquires its own connection. The write that precedes it
+is only committed when the enclosing ``acquire_with_retry(...)`` block exits — on
+Oracle explicitly (oracledb does not autocommit; the backend commits on clean exit
+of ``acquire()``), on PostgreSQL implicitly.
+
+Calling it *inside* that block therefore deadlocks permanently on Oracle:
+connection #2 waits on the row locks the still-open connection #1 holds on
+``entities``, while connection #1 cannot commit until the call returns. Oracle
+never raises ORA-00060 for this, because session #1 is blocked in Python rather
+than on the database — so retain simply hangs forever.
+
+This regressed in three separate call sites at once (both retain paths and the
+transfer importer) and only showed up as a CI timeout, so it is guarded
+structurally rather than behaviourally: the deadlock cannot be reproduced against
+PostgreSQL, which is what the test suite runs on.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_ENGINE = Path(__file__).resolve().parent.parent / "hindsight_api" / "engine"
+
+# Files that call flush_pending_stats() after a write.
+_FILES = [
+    _ENGINE / "retain" / "orchestrator.py",
+    _ENGINE / "transfer" / "importer.py",
+]
+
+
+def _acquires_connection(node: ast.AsyncWith) -> bool:
+    """True if this ``async with`` checks a connection out of the pool."""
+    for item in node.items:
+        call = item.context_expr
+        if isinstance(call, ast.Call):
+            func = call.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            if name in {"acquire_with_retry", "acquire"}:
+                return True
+    return False
+
+
+def _flush_calls(node: ast.AST) -> list[int]:
+    """Line numbers of every flush_pending_stats() call under ``node``."""
+    return [
+        child.lineno
+        for child in ast.walk(node)
+        if isinstance(child, ast.Call)
+        and isinstance(child.func, ast.Attribute)
+        and child.func.attr == "flush_pending_stats"
+    ]
+
+
+@pytest.mark.parametrize("path", _FILES, ids=lambda p: p.name)
+def test_flush_pending_stats_is_not_called_while_holding_a_connection(path: Path):
+    tree = ast.parse(path.read_text(), filename=str(path))
+
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncWith) and _acquires_connection(node):
+            for lineno in _flush_calls(node):
+                offenders.append(f"{path.name}:{lineno}")
+
+    assert not offenders, (
+        "flush_pending_stats() is called inside a connection-holding block at "
+        f"{', '.join(offenders)}. It acquires its own connection, so on Oracle this "
+        "deadlocks forever (the outer connection cannot commit and release its row "
+        "locks until the call returns). Move the call after the acquire block exits."
+    )
+
+
+def test_guard_detects_the_bug_it_is_meant_to_catch():
+    """The guard must actually fire on the offending shape (not vacuously pass)."""
+    bad = ast.parse(
+        "async def f():\n"
+        "    async with acquire_with_retry(pool) as conn:\n"
+        "        await conn.execute('...')\n"
+        "        await entity_resolver.flush_pending_stats()\n"
+    )
+    found = [
+        lineno
+        for node in ast.walk(bad)
+        if isinstance(node, ast.AsyncWith) and _acquires_connection(node)
+        for lineno in _flush_calls(node)
+    ]
+    assert found == [4]

--- a/hindsight-api-slim/tests/test_repair_bank_vector_indexes.py
+++ b/hindsight-api-slim/tests/test_repair_bank_vector_indexes.py
@@ -26,7 +26,7 @@ from asyncpg.exceptions import DeadlockDetectedError
 from hindsight_api import RequestContext
 from hindsight_api.admin import cli
 from hindsight_api.admin.cli import _run_repair_bank
-from hindsight_api.engine.db_utils import acquire_with_retry
+from hindsight_api.engine.db_utils import acquire_with_retry, retry_with_backoff
 from hindsight_api.engine.memory_engine import MemoryEngine
 from hindsight_api.engine.retain.bank_utils import _BANK_INDEX_FACT_TYPES, _bank_index_name, _vector_index_clause
 from hindsight_api.engine.transfer import export_bank
@@ -94,10 +94,18 @@ async def _drop_bank_indexes(conn, bank_id: str) -> list[str]:
     CONCURRENTLY so the drop never takes ACCESS EXCLUSIVE on the shared
     ``memory_units`` table: the test suite runs 8 xdist workers against one pg0
     database, and a blocking DDL here deadlocks unrelated workers' DML.
+
+    Retried on deadlock: CONCURRENTLY still takes ShareUpdateExclusive, which
+    conflicts with the ShareLock a *fresh bank's* plain CREATE INDEX holds (that
+    one cannot be made concurrent — it runs inside the bank-create transaction).
+    So a drop here can still be picked as the victim while another worker seeds
+    a bank. That is transient, and the drop is idempotent.
     """
     names = await _expected_index_names(conn, bank_id)
     for name in names:
-        await conn.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_TEST_SCHEMA}.{name}")
+        await retry_with_backoff(
+            lambda name=name: conn.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_TEST_SCHEMA}.{name}")
+        )
     return names
 
 


### PR DESCRIPTION
`test-python-client-oracle` and `test-typescript-client-oracle` have been red on **every** open PR (#2941, #2942, #2943), independent of the code under test. There were **two independent causes**; this PR fixes both.

## 1. Runner disk exhaustion (CI)

```
##[warning]You are running out of disk space. Free space left: 87 MB
  ├─▶ I/O operation failed during extraction
  ╰─▶ No space left on device (os error 28)
```

The Oracle 23ai `free` service image plus the Python ML deps (torch) exhaust the hosted runner's ~14 GB root disk, so `uv` can't extract a wheel.

**Fix:** add the same `jlumbroso/free-disk-space` step the Docker build job already uses to the three Oracle jobs. Only the cheap, high-yield reclaims are enabled (Android/.NET/Haskell/swap ≈ 16-21 GB, a few `rm -rf`s):
- `large-packages` runs `apt-get remove` and cost ~4 min for little gain;
- `tool-cache` would delete the preinstalled Python that `actions/setup-python` then re-downloads;
- `docker-images` is pointless — the Oracle service container is already running, so its image is in use and can't be pruned.

Verified: `No space left on device` is gone (0 occurrences).

## 2. Retain deadlocks on Oracle (the real blocker)

With disk fixed, the jobs still timed out. The server was **not** slow — it was deadlocked. Server logs showed the retain work finishing in under a second and then the process sitting completely idle for 7 minutes while the client waited out its 120s timeout:

```
12:38:57.992  Phase 2 (write txn): 0.335s     ← work done
12:39:22 … 12:45:54   [WORKER_STATS] slots=0/10   ← idle
```

`[streaming] Consumer batch … total` — the very next log line — never appeared. The only statement in between is `await entity_resolver.flush_pending_stats()`.

**Cause.** `flush_pending_stats()` acquires its own connection, but was called while the enclosing `acquire_with_retry(...)` block still held one:

```python
async with acquire_with_retry(pool) as conn:      # conn checked out
    async with conn.transaction():                # SAVEPOINT only
        ...write facts/entities...
    await entity_resolver.flush_pending_stats()   # takes a 2nd connection
```

`oracledb` does not autocommit and `OracleConnection.transaction()` is only a `SAVEPOINT`, so the write is committed by `OracleBackend.acquire()` when *its* block exits. Connection #2's `UPDATE entities …` waits on row locks held by the still-open connection #1, which cannot commit until the call returns — a circular wait. Oracle never raises `ORA-00060`, because session #1 is blocked in Python rather than on the database, so it hangs indefinitely instead of erroring. (3× `Phase 1` but only 1× `Phase 2` in the logs: once retain #1 wedged, later retains blocked in their own write txn.)

**Fix.** Move the flush after the acquire block in all three call sites — streaming retain, delta retain, and the transfer importer. This is what its own docstring already required (*"Must be called AFTER the retain transaction commits"*); PostgreSQL satisfied it only by accident, via asyncpg autocommit.

**Test.** Guarded with an AST lint test (in the spirit of `test_migration_shape.py`) rather than a behavioural one — the deadlock cannot be reproduced against PostgreSQL, which is what the suite runs on. It includes a self-check so it can't pass vacuously.

## Validation

This PR touches `.github/workflows/**`, so both Oracle client jobs run here and the fixes validate themselves. `lint.sh` + `ty` clean; retain suites pass locally (25/25).

Not addressed: the pre-existing `ORA-00903: invalid table name` warning when writing `llm_traces` on Oracle. It's caught and logged best-effort on every retain and does not block — worth a separate fix.
