### PR TITLE
fix(curation): keep causal links across edit and invalidate/restore

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/c7d1e9a4b3f2_add_archive_causal_links.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/c7d1e9a4b3f2_add_archive_causal_links.py
@@ -1,0 +1,90 @@
+"""Add ``causal_links`` to the curation archive (invalidated_memory_units).
+
+Causal edges (``caused_by`` and the historical ``causes``/``enables``/
+``prevents``) are retain-time extraction output: unlike temporal and semantic
+links they cannot be recomputed from dates or embeddings, and graph maintenance
+never rebuilds them. Invalidation MOVES a fact out of ``memory_units``, so the
+``memory_links → memory_units`` FK cascade deletes every incident edge — and
+revert had no way to bring the causal ones back (#2864).
+
+This column parks the descriptors of the causal edges incident to an archived
+fact — ``[{"from_unit_id", "to_unit_id", "link_type", "weight"}, ...]`` — so
+revert can rematerialize them. It is deliberately unindexed and lives only on
+the archive: live facts keep their causal edges in ``memory_links`` (curation
+edits no longer delete them), and the archive is small, cold, and only read by
+low-frequency curation operations.
+
+Revision ID: c7d1e9a4b3f2
+Revises: d7b2f8a1c934
+Create Date: 2026-07-24
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "c7d1e9a4b3f2"
+down_revision: str | Sequence[str] | None = "d7b2f8a1c934"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _pg_schema_prefix() -> str:
+    """Schema-qualifier for raw SQL on PG (multi-tenant search_path)."""
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def _pg_upgrade() -> None:
+    schema = _pg_schema_prefix()
+    # NOT NULL DEFAULT is metadata-only on PG 11+, so this is cheap even on a
+    # large archive. Existing rows read as "no causal edges captured" — edges
+    # lost before this migration cannot be reconstructed and are not guessed.
+    op.execute(
+        f"ALTER TABLE {schema}invalidated_memory_units "
+        f"ADD COLUMN IF NOT EXISTS causal_links JSONB NOT NULL DEFAULT '[]'::jsonb"
+    )
+
+
+def _pg_downgrade() -> None:
+    schema = _pg_schema_prefix()
+    op.execute(f"ALTER TABLE {schema}invalidated_memory_units DROP COLUMN IF EXISTS causal_links")
+
+
+def _oracle_upgrade() -> None:
+    # Kept in sync with PG for schema parity (curation itself is PostgreSQL-only
+    # today — it introspects pg_attribute to move rows between the two tables).
+    # Swallow ORA-01430 (column already exists) so the migration is idempotent.
+    op.execute(
+        """
+        BEGIN
+            EXECUTE IMMEDIATE 'ALTER TABLE invalidated_memory_units ADD (causal_links CLOB DEFAULT ''[]''
+                CONSTRAINT imu_causal_links_json CHECK (causal_links IS JSON))';
+        EXCEPTION WHEN OTHERS THEN
+            IF SQLCODE != -1430 THEN RAISE; END IF;
+        END;
+        """
+    )
+
+
+def _oracle_downgrade() -> None:
+    # Swallow ORA-00904 (column does not exist).
+    op.execute(
+        """
+        BEGIN
+            EXECUTE IMMEDIATE 'ALTER TABLE invalidated_memory_units DROP COLUMN causal_links';
+        EXCEPTION WHEN OTHERS THEN
+            IF SQLCODE != -904 THEN RAISE; END IF;
+        END;
+        """
+    )
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade, oracle=_oracle_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade, oracle=_oracle_downgrade)

--- a/hindsight-api-slim/hindsight_api/engine/causal_links.py
+++ b/hindsight-api-slim/hindsight_api/engine/causal_links.py
@@ -5,9 +5,66 @@ preserves historical relationship types so existing banks keep their graph
 semantics without allowing new retain output to create those types.
 """
 
+from dataclasses import dataclass
+from typing import Any
+
 CANONICAL_CAUSAL_LINK_TYPE = "caused_by"
 LEGACY_CAUSAL_LINK_TYPE_NAMES = ("causes", "enables", "prevents")
 
 CANONICAL_CAUSAL_LINK_TYPES = frozenset({CANONICAL_CAUSAL_LINK_TYPE})
 LEGACY_CAUSAL_LINK_TYPES = frozenset(LEGACY_CAUSAL_LINK_TYPE_NAMES)
 CAUSAL_LINK_TYPES = (CANONICAL_CAUSAL_LINK_TYPE, *LEGACY_CAUSAL_LINK_TYPE_NAMES)
+
+DEFAULT_CAUSAL_LINK_WEIGHT = 1.0
+
+
+@dataclass(frozen=True)
+class CausalLinkDescriptor:
+    """One causal edge, parked on the curation archive while an endpoint is invalidated.
+
+    Invalidation moves a fact out of ``memory_units``, so the FK cascade deletes
+    its ``memory_links`` rows — and nothing could recreate a causal edge, which
+    is extraction output rather than derived data. The descriptor is what the
+    archive row stores so revert can rematerialize the edge (#2864).
+    """
+
+    from_unit_id: str
+    to_unit_id: str
+    link_type: str
+    weight: float = DEFAULT_CAUSAL_LINK_WEIGHT
+
+    def as_json_dict(self) -> dict[str, Any]:
+        """Serializable form written to ``invalidated_memory_units.causal_links``.
+
+        The key names double as the column list of the ``jsonb_to_recordset``
+        read in ``snapshot_causal_links`` — keep them in sync.
+        """
+        return {
+            "from_unit_id": self.from_unit_id,
+            "to_unit_id": self.to_unit_id,
+            "link_type": self.link_type,
+            "weight": self.weight,
+        }
+
+    @classmethod
+    def from_json_dict(cls, raw: Any) -> "CausalLinkDescriptor | None":
+        """Parse one stored descriptor, or None when it isn't a usable causal edge.
+
+        The archive column is plain JSON with no schema enforcement (a restore
+        from an older backup, or a hand-edited row, can put anything there), and
+        ``memory_links`` has a ``link_type`` CHECK constraint — so an unusable
+        entry is skipped rather than allowed to abort the whole revert.
+        """
+        if not isinstance(raw, dict):
+            return None
+        from_unit_id = raw.get("from_unit_id")
+        to_unit_id = raw.get("to_unit_id")
+        link_type = raw.get("link_type")
+        if not from_unit_id or not to_unit_id or link_type not in CAUSAL_LINK_TYPES:
+            return None
+        return cls(
+            from_unit_id=str(from_unit_id),
+            to_unit_id=str(to_unit_id),
+            link_type=str(link_type),
+            weight=float(raw.get("weight") or DEFAULT_CAUSAL_LINK_WEIGHT),
+        )

--- a/hindsight-api-slim/hindsight_api/engine/db/oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/oracle.py
@@ -148,6 +148,7 @@ _JSON_COL_NAMES = {
     "config",
     "observation_scopes",
     "source_memory_ids",
+    "causal_links",
     "trigger",
     "http_config",
     "event_types",

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -6932,7 +6932,7 @@ class MemoryEngine(MemoryEngineInterface):
         - **Edit** (``text``/``context``/``occurred_start``/``occurred_end``/
           ``new_fact_type``/``entities``): correct what the LLM extracted.
           Re-embeds (text + dates + entities feed the embedding), drops derived
-          observations + links, and re-consolidates. For date/context fields,
+          observations + temporal/semantic links, and re-consolidates. For date/context fields,
           ``""`` clears to NULL and ``None`` leaves unchanged; ``new_fact_type``
           must be world/experience. ``entities`` (when not None) replaces the
           unit's entity set: names are resolved/find-or-created via the same
@@ -6944,9 +6944,19 @@ class MemoryEngine(MemoryEngineInterface):
         - **Invalidate** (``state='invalidated'``): move the row to the archive
           (cascade-pruning its links/entity associations and re-deriving dependent
           observations). The archive is cold storage, so the embedding is dropped
-          (only an entity-id snapshot travels with it).
+          (an entity-id snapshot and the causal-edge descriptors travel with it).
         - **Revert** (``state='valid'``): move the row back, restore its entity
-          associations, recompute its embedding, and re-consolidate.
+          associations and causal edges, recompute its embedding, and re-consolidate.
+
+        Causal edges (``caused_by`` and the historical ``causes``/``enables``/
+        ``prevents``) are retain-time extraction output that nothing recreates —
+        graph maintenance only rebuilds temporal/semantic links, and no curation
+        path re-runs the extractor. So curation preserves them (#2864): edits
+        leave them in place, and invalidate/revert round-trips them through the
+        archive's ``causal_links`` snapshot instead of losing them to the FK
+        cascade. Correcting a fact's text therefore keeps the causality the
+        extractor asserted for it — preserving the assertion is the reversible
+        choice; deleting it is not, since there is no path that could re-derive it.
 
         Only ``world``/``experience`` facts can be curated — observations are
         derived and regenerate from their sources. Returns the updated memory
@@ -6993,8 +7003,9 @@ class MemoryEngine(MemoryEngineInterface):
             await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
 
         backend = await self._get_backend()
+        from .causal_links import CAUSAL_LINK_TYPES
         from .graph_maintenance import enqueue_relink_victims
-        from .retain.link_utils import resolve_entities_only
+        from .retain.link_utils import rematerialize_causal_links, resolve_entities_only, snapshot_causal_links
 
         # Resolve the bank's entity-label taxonomy once when re-resolving entities,
         # so corrected entities are matched with the same rules retain uses.
@@ -7147,7 +7158,18 @@ class MemoryEngine(MemoryEngineInterface):
                         new_event_date,
                         new_emb,
                     )
-                    await conn.execute(f"DELETE FROM {ml} WHERE from_unit_id = $1 OR to_unit_id = $1", str(memory_uuid))
+                    # Drop only the DERIVED edges — graph maintenance (submitted
+                    # below) recomputes temporal/semantic from the edited dates
+                    # and embedding. Causal edges are retain-time extraction
+                    # output that nothing recreates, so an edit preserves them
+                    # rather than silently destroying them (#2864); a corrected
+                    # fact keeps the causality the extractor asserted for it.
+                    await conn.execute(
+                        f"DELETE FROM {ml} WHERE (from_unit_id = $1 OR to_unit_id = $1) "
+                        f"AND NOT (link_type = ANY($2::text[]))",
+                        str(memory_uuid),
+                        list(CAUSAL_LINK_TYPES),
+                    )
                     await self._delete_stale_observations_for_memories(conn, bank_id, [memory_id])
                     need_consolidation = True
                     need_graph = True
@@ -7160,13 +7182,20 @@ class MemoryEngine(MemoryEngineInterface):
                     ]
                     # Capture relink victims BEFORE the row (and its links) disappear.
                     await enqueue_relink_victims(conn, bank_id, [memory_id], ops=backend.ops)
+                    # Same for the causal edges: temporal/semantic are recomputed
+                    # by graph maintenance on revert, but causal edges are
+                    # retain-time extraction output the cascade would destroy for
+                    # good. Park their descriptors on the archive row (#2864).
+                    causal_links = await snapshot_causal_links(conn, bank_id, str(memory_uuid))
                     await conn.execute(
-                        f"INSERT INTO {arch} ({arch_cols}, invalidation_reason, invalidated_at, entity_ids) "
-                        f"SELECT {arch_cols}, $2, now(), $3::uuid[] FROM {mu} WHERE id = $1 AND bank_id = $4",
+                        f"INSERT INTO {arch} ({arch_cols}, invalidation_reason, invalidated_at, entity_ids, "
+                        f"causal_links) "
+                        f"SELECT {arch_cols}, $2, now(), $3::uuid[], $5::jsonb FROM {mu} WHERE id = $1 AND bank_id = $4",
                         str(memory_uuid),
                         reason,
                         entity_ids,
                         bank_id,
+                        json.dumps([descriptor.as_json_dict() for descriptor in causal_links]),
                     )
                     # Cascade prunes unit_entities + memory_links; sweep runs after
                     # the delete so it also catches a racing observation insert.
@@ -7186,7 +7215,9 @@ class MemoryEngine(MemoryEngineInterface):
                 # --- Revert: move archive → live ---
                 elif state == "valid" and archived:
                     arch_row = await conn.fetchrow(
-                        f"SELECT entity_ids FROM {arch} WHERE id = $1 AND bank_id = $2", str(memory_uuid), bank_id
+                        f"SELECT entity_ids, causal_links FROM {arch} WHERE id = $1 AND bank_id = $2",
+                        str(memory_uuid),
+                        bank_id,
                     )
                     # The archive keeps neither embedding nor search_vector (see arch_cols
                     # above), so both default to NULL on the way back and are recomputed here:
@@ -7229,6 +7260,18 @@ class MemoryEngine(MemoryEngineInterface):
                             str(memory_uuid),
                             arch_row["entity_ids"],
                             bank_id,
+                        )
+                    # Rematerialize the causal edges parked at invalidation time.
+                    # Edges whose peer is still archived (or was permanently
+                    # deleted) are skipped — the peer keeps its own copy of the
+                    # descriptor and recreates the edge when it reverts, so the
+                    # restore is order-independent and idempotent.
+                    if arch_row and arch_row["causal_links"]:
+                        await rematerialize_causal_links(
+                            conn,
+                            bank_id,
+                            conn.parse_json(arch_row["causal_links"]) or [],
+                            ops=backend.ops,
                         )
                     # Recompute the embedding (the archive doesn't keep one) so the reverted
                     # unit is searchable again, using the now-current model's dimension and the

--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -8,7 +8,13 @@ from datetime import UTC, datetime, timedelta
 
 from ..._vector_index import ann_search_tuning_settings, configured_vector_extension
 from ...config import DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY
-from ..causal_links import CANONICAL_CAUSAL_LINK_TYPES, LEGACY_CAUSAL_LINK_TYPES
+from ..causal_links import (
+    CANONICAL_CAUSAL_LINK_TYPES,
+    CAUSAL_LINK_TYPES,
+    DEFAULT_CAUSAL_LINK_WEIGHT,
+    LEGACY_CAUSAL_LINK_TYPES,
+    CausalLinkDescriptor,
+)
 from ..db.base import DatabaseConnection
 from ..db.ops import DataAccessOps
 from ..memory_engine import fq_table
@@ -898,3 +904,108 @@ async def _write_causal_links_batch(
 
         traceback.print_exc()
         raise
+
+
+async def snapshot_causal_links(conn: DatabaseConnection, bank_id: str, unit_id: str) -> list[CausalLinkDescriptor]:
+    """Collect the causal edges that must survive a unit's move to the archive.
+
+    Causal edges are retain-time extraction output: unlike temporal/semantic
+    links they can't be recomputed from dates or embeddings, and nothing
+    rebuilds them (graph maintenance only relinks temporal/semantic, and
+    consolidation regenerates observations, not raw-fact edges). Invalidation
+    removes the live row, so the FK cascade takes every incident edge with it —
+    hence this snapshot, parked on the archive row (#2864).
+
+    The snapshot merges two sources:
+
+    * the unit's currently materialized causal edges, and
+    * descriptors already parked on *archived* peers that name this unit — an
+      edge whose other endpoint was invalidated first is no longer in
+      ``memory_links``, so the peer's snapshot is the only copy left.
+
+    Keeping a copy on every archived endpoint makes revert order irrelevant:
+    whichever endpoint comes back last sees both sides live and rematerializes.
+
+    Returns:
+        The descriptors to store on the archive row (deduplicated across both
+        sources by the UNION).
+    """
+    rows = await conn.fetch(
+        f"""
+        SELECT from_unit_id, to_unit_id, link_type, weight
+        FROM {fq_table("memory_links")}
+        WHERE (from_unit_id = $1 OR to_unit_id = $1)
+          AND bank_id = $2
+          AND link_type = ANY($3::text[])
+        UNION
+        SELECT d.from_unit_id, d.to_unit_id, d.link_type, d.weight
+        FROM {fq_table("invalidated_memory_units")} a
+        CROSS JOIN LATERAL jsonb_to_recordset(a.causal_links)
+            AS d(from_unit_id uuid, to_unit_id uuid, link_type text, weight float8)
+        WHERE a.bank_id = $2
+          AND a.causal_links <> '[]'::jsonb
+          AND (d.from_unit_id = $1 OR d.to_unit_id = $1)
+          -- Same guard as CausalLinkDescriptor.from_json_dict: the column is
+          -- schemaless JSON, and a malformed entry would otherwise be copied
+          -- forward as a NULL-endpoint descriptor.
+          AND d.from_unit_id IS NOT NULL
+          AND d.to_unit_id IS NOT NULL
+          AND d.link_type = ANY($3::text[])
+        """,
+        unit_id,
+        bank_id,
+        list(CAUSAL_LINK_TYPES),
+    )
+    return [
+        CausalLinkDescriptor(
+            from_unit_id=str(row["from_unit_id"]),
+            to_unit_id=str(row["to_unit_id"]),
+            link_type=row["link_type"],
+            weight=float(row["weight"]) if row["weight"] is not None else DEFAULT_CAUSAL_LINK_WEIGHT,
+        )
+        for row in rows
+    ]
+
+
+async def rematerialize_causal_links(
+    conn: DatabaseConnection,
+    bank_id: str,
+    stored_descriptors: list,
+    ops: DataAccessOps | None = None,
+) -> int:
+    """Recreate archived causal edges whose endpoints are both live again.
+
+    Counterpart of :func:`snapshot_causal_links`, called when a fact reverts to
+    ``valid``. Descriptors whose peer is still archived (or was permanently
+    deleted) are silently dropped from this insert: the bulk writer only takes
+    links whose endpoints exist in ``memory_units``. That is the point — a
+    still-archived peer keeps its own copy of the descriptor and materializes
+    the edge when *it* reverts.
+
+    Insertion is ``ON CONFLICT DO NOTHING``, so repeated invalidate/revert
+    cycles never duplicate an edge.
+
+    Args:
+        stored_descriptors: The archive row's ``causal_links`` payload, already
+            decoded from JSON. Entries that don't parse as a causal edge are
+            skipped (see :meth:`CausalLinkDescriptor.from_json_dict`).
+
+    Returns:
+        Number of descriptors submitted (not all of which may materialize).
+    """
+    parsed = [CausalLinkDescriptor.from_json_dict(raw) for raw in stored_descriptors]
+    links = [
+        (
+            descriptor.from_unit_id,
+            descriptor.to_unit_id,
+            descriptor.link_type,
+            descriptor.weight,
+            None,
+        )
+        for descriptor in parsed
+        if descriptor is not None
+    ]
+    if not links:
+        return 0
+    await _bulk_insert_links(conn, links, bank_id=bank_id, ops=ops)
+    return len(links)

--- a/hindsight-api-slim/tests/test_causal_link_taxonomy.py
+++ b/hindsight-api-slim/tests/test_causal_link_taxonomy.py
@@ -8,6 +8,7 @@ from hindsight_api.engine.causal_links import (
     CANONICAL_CAUSAL_LINK_TYPES,
     CAUSAL_LINK_TYPES,
     LEGACY_CAUSAL_LINK_TYPES,
+    CausalLinkDescriptor,
 )
 from hindsight_api.engine.retain.fact_extraction import CausalRelation, FactCausalRelation
 
@@ -32,3 +33,42 @@ def test_causal_link_taxonomy_keeps_canonical_and_legacy_types_separate() -> Non
     assert CANONICAL_CAUSAL_LINK_TYPES == {CANONICAL_CAUSAL_LINK_TYPE}
     assert LEGACY_CAUSAL_LINK_TYPES == {"causes", "enables", "prevents"}
     assert CAUSAL_LINK_TYPES == (CANONICAL_CAUSAL_LINK_TYPE, "causes", "enables", "prevents")
+
+
+def test_causal_link_descriptor_round_trips_through_json() -> None:
+    """The archive stores descriptors as plain JSON; the round-trip must be lossless."""
+    descriptor = CausalLinkDescriptor(
+        from_unit_id="11111111-1111-1111-1111-111111111111",
+        to_unit_id="22222222-2222-2222-2222-222222222222",
+        link_type="caused_by",
+        weight=0.75,
+    )
+    assert CausalLinkDescriptor.from_json_dict(descriptor.as_json_dict()) == descriptor
+
+
+def test_causal_link_descriptor_defaults_missing_weight() -> None:
+    parsed = CausalLinkDescriptor.from_json_dict(
+        {
+            "from_unit_id": "11111111-1111-1111-1111-111111111111",
+            "to_unit_id": "22222222-2222-2222-2222-222222222222",
+            "link_type": "enables",
+        }
+    )
+    assert parsed is not None
+    assert parsed.weight == 1.0
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "not-a-dict",
+        {"from_unit_id": None, "to_unit_id": "2", "link_type": "caused_by"},
+        {"from_unit_id": "1", "to_unit_id": None, "link_type": "caused_by"},
+        # 'temporal' is derived data, not a causal edge — and memory_links has a
+        # link_type CHECK constraint, so an unusable entry must not abort a revert.
+        {"from_unit_id": "1", "to_unit_id": "2", "link_type": "temporal"},
+        {"from_unit_id": "1", "to_unit_id": "2"},
+    ],
+)
+def test_causal_link_descriptor_skips_unusable_entries(raw) -> None:
+    assert CausalLinkDescriptor.from_json_dict(raw) is None

--- a/hindsight-api-slim/tests/test_memory_curation.py
+++ b/hindsight-api-slim/tests/test_memory_curation.py
@@ -78,6 +78,42 @@ async def _insert_link(conn, bank_id: str, from_id: uuid.UUID, to_id: uuid.UUID)
     )
 
 
+async def _insert_causal_link(
+    conn,
+    bank_id: str,
+    from_id: uuid.UUID,
+    to_id: uuid.UUID,
+    link_type: str = "caused_by",
+    weight: float = 1.0,
+) -> None:
+    await conn.execute(
+        """
+        INSERT INTO memory_links (from_unit_id, to_unit_id, link_type, weight, bank_id)
+        VALUES ($1, $2, $3, $4, $5)
+        """,
+        from_id,
+        to_id,
+        link_type,
+        weight,
+        bank_id,
+    )
+
+
+async def _causal_links(conn, bank_id: str) -> set[tuple[str, str, str]]:
+    """(from, to, link_type) of every materialized causal edge in the bank."""
+    rows = await conn.fetch(
+        "SELECT from_unit_id, to_unit_id, link_type FROM memory_links "
+        "WHERE bank_id = $1 AND link_type IN ('caused_by', 'causes', 'enables', 'prevents')",
+        bank_id,
+    )
+    return {(str(r["from_unit_id"]), str(r["to_unit_id"]), r["link_type"]) for r in rows}
+
+
+async def _archived_causal_links(conn, mem_id: uuid.UUID) -> list[dict]:
+    raw = await conn.fetchval("SELECT causal_links FROM invalidated_memory_units WHERE id = $1", mem_id)
+    return json.loads(raw) if raw else []
+
+
 async def _insert_entity(conn, bank_id: str, name: str) -> uuid.UUID:
     eid = uuid.uuid4()
     await conn.execute(
@@ -673,5 +709,205 @@ class TestGuardsAndListing:
             bank_id, "Anaconda XR7 telescope focal length", request_context=request_context
         )
         assert not _hit(after), "invalidated fact must be excluded from recall"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+# ---------------------------------------------------------------------------
+# Causal links (#2864)
+# ---------------------------------------------------------------------------
+
+
+class TestCausalLinkPreservation:
+    """Causal edges are retain-time extraction output: nothing recreates them.
+
+    Graph maintenance only rebuilds temporal/semantic links and consolidation
+    regenerates observations, so any curation path that drops a ``caused_by``
+    edge drops it for good. Edits must leave them alone, and the
+    invalidate/revert round-trip must carry them through the archive.
+    """
+
+    @pytest.mark.asyncio
+    async def test_edit_preserves_causal_links_and_drops_derived(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        bank_id = f"test-curation-causal-edit-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            cause = await _insert_memory(conn, memory, bank_id, "Alice lost her job.")
+            effect = await _insert_memory(conn, memory, bank_id, "Alice could not pay rent.")
+            unrelated = await _insert_memory(conn, memory, bank_id, "Alice moved to Berlin.")
+            await _insert_causal_link(conn, bank_id, effect, cause)  # outgoing
+            await _insert_causal_link(conn, bank_id, cause, effect, link_type="causes")  # incoming
+            await _insert_link(conn, bank_id, effect, unrelated)  # temporal, derived
+
+        with (
+            patch.object(memory, "submit_async_consolidation", new=AsyncMock()),
+            patch.object(memory, "submit_async_graph_maintenance", new=AsyncMock()),
+        ):
+            # A context-only edit doesn't touch the proposition at all...
+            await memory.update_memory_unit(
+                bank_id, str(effect), context="Said during the March review.", request_context=request_context
+            )
+            async with pool.acquire() as conn:
+                assert await _causal_links(conn, bank_id) == {
+                    (str(effect), str(cause), "caused_by"),
+                    (str(cause), str(effect), "causes"),
+                }, "context edit must not delete causal links"
+
+            # ...and a text edit corrects the fact without discarding the
+            # extractor's causal assertion (nothing could re-derive it).
+            await memory.update_memory_unit(
+                bank_id, str(effect), text="Alice could not pay her rent.", request_context=request_context
+            )
+
+        async with pool.acquire() as conn:
+            assert await _causal_links(conn, bank_id) == {
+                (str(effect), str(cause), "caused_by"),
+                (str(cause), str(effect), "causes"),
+            }, "text edit must preserve causal links in both directions"
+            temporal = await conn.fetchval(
+                "SELECT COUNT(*) FROM memory_links WHERE link_type = 'temporal' AND from_unit_id = $1", effect
+            )
+            assert temporal == 0, "derived temporal links are still dropped (graph maintenance rebuilds them)"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_invalidate_snapshots_and_revert_restores(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        bank_id = f"test-curation-causal-inv-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            cause = await _insert_memory(conn, memory, bank_id, "The deploy pipeline was misconfigured.")
+            effect = await _insert_memory(conn, memory, bank_id, "The release shipped a broken build.")
+            await _insert_causal_link(conn, bank_id, effect, cause, weight=0.75)
+            await _insert_causal_link(conn, bank_id, cause, effect, link_type="enables")
+
+        with (
+            patch.object(memory, "submit_async_consolidation", new=AsyncMock()),
+            patch.object(memory, "submit_async_graph_maintenance", new=AsyncMock()),
+        ):
+            await memory.update_memory_unit(bank_id, str(effect), state="invalidated", request_context=request_context)
+
+            async with pool.acquire() as conn:
+                assert await _causal_links(conn, bank_id) == set(), "invalidation removes edges from the live graph"
+                snapshot = await _archived_causal_links(conn, effect)
+                assert {(d["from_unit_id"], d["to_unit_id"], d["link_type"]) for d in snapshot} == {
+                    (str(effect), str(cause), "caused_by"),
+                    (str(cause), str(effect), "enables"),
+                }, "both directions snapshotted on the archive row"
+                assert [d["weight"] for d in snapshot if d["link_type"] == "caused_by"] == [0.75], "weight preserved"
+
+            await memory.update_memory_unit(bank_id, str(effect), state="valid", request_context=request_context)
+
+        async with pool.acquire() as conn:
+            assert await _causal_links(conn, bank_id) == {
+                (str(effect), str(cause), "caused_by"),
+                (str(cause), str(effect), "enables"),
+            }, "revert restores incoming and outgoing causal links"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_restore_deferred_until_both_endpoints_live(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """With both endpoints archived, whichever reverts last recreates the edge."""
+        bank_id = f"test-curation-causal-both-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            cause = await _insert_memory(conn, memory, bank_id, "The cache was never invalidated.")
+            effect = await _insert_memory(conn, memory, bank_id, "Users saw stale prices.")
+            await _insert_causal_link(conn, bank_id, effect, cause)
+
+        with (
+            patch.object(memory, "submit_async_consolidation", new=AsyncMock()),
+            patch.object(memory, "submit_async_graph_maintenance", new=AsyncMock()),
+        ):
+            await memory.update_memory_unit(bank_id, str(effect), state="invalidated", request_context=request_context)
+            await memory.update_memory_unit(bank_id, str(cause), state="invalidated", request_context=request_context)
+
+            async with pool.acquire() as conn:
+                # The edge is gone from memory_links by the time `cause` is
+                # invalidated, so it can only come from the peer's snapshot.
+                assert len(await _archived_causal_links(conn, cause)) == 1, "descriptor copied from the archived peer"
+
+            await memory.update_memory_unit(bank_id, str(effect), state="valid", request_context=request_context)
+            async with pool.acquire() as conn:
+                assert await _causal_links(conn, bank_id) == set(), "peer still archived: edge stays suspended"
+
+            await memory.update_memory_unit(bank_id, str(cause), state="valid", request_context=request_context)
+
+        async with pool.acquire() as conn:
+            assert await _causal_links(conn, bank_id) == {(str(effect), str(cause), "caused_by")}, (
+                "last endpoint back materializes the edge"
+            )
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_repeated_cycles_do_not_duplicate(self, memory: MemoryEngine, request_context: RequestContext):
+        bank_id = f"test-curation-causal-idem-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            cause = await _insert_memory(conn, memory, bank_id, "The disk filled up.")
+            effect = await _insert_memory(conn, memory, bank_id, "The service stopped accepting writes.")
+            await _insert_causal_link(conn, bank_id, effect, cause)
+
+        with (
+            patch.object(memory, "submit_async_consolidation", new=AsyncMock()),
+            patch.object(memory, "submit_async_graph_maintenance", new=AsyncMock()),
+        ):
+            for _ in range(2):
+                await memory.update_memory_unit(
+                    bank_id, str(effect), state="invalidated", request_context=request_context
+                )
+                await memory.update_memory_unit(bank_id, str(effect), state="valid", request_context=request_context)
+
+        async with pool.acquire() as conn:
+            count = await conn.fetchval(
+                "SELECT COUNT(*) FROM memory_links WHERE bank_id = $1 AND link_type = 'caused_by'", bank_id
+            )
+            assert count == 1, "invalidate/revert cycles are idempotent"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_revert_skips_permanently_deleted_peer(self, memory: MemoryEngine, request_context: RequestContext):
+        """A snapshot naming a hard-deleted peer must be dropped, not resurrected as a dangling FK."""
+        bank_id = f"test-curation-causal-gone-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            cause = await _insert_memory(conn, memory, bank_id, "The vendor changed the API contract.")
+            effect = await _insert_memory(conn, memory, bank_id, "Nightly sync failed.")
+            await _insert_causal_link(conn, bank_id, effect, cause)
+
+        with (
+            patch.object(memory, "submit_async_consolidation", new=AsyncMock()),
+            patch.object(memory, "submit_async_graph_maintenance", new=AsyncMock()),
+        ):
+            await memory.update_memory_unit(bank_id, str(effect), state="invalidated", request_context=request_context)
+            async with pool.acquire() as conn:
+                await conn.execute("DELETE FROM memory_units WHERE id = $1", cause)
+
+            result = await memory.update_memory_unit(
+                bank_id, str(effect), state="valid", request_context=request_context
+            )
+
+        assert result["state"] == "valid"
+        async with pool.acquire() as conn:
+            assert await _causal_links(conn, bank_id) == set(), "no edge to a deleted memory"
 
         await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-docs/docs/developer/api/memories.mdx
+++ b/hindsight-docs/docs/developer/api/memories.mdx
@@ -107,6 +107,8 @@ Only raw **world** and **experience** facts can be curated. Observations are *de
 
 Correct what the LLM extracted. You can change the **text**, **context**, **occurred dates**, **fact type**, and **entities** — anything the extractor could have gotten wrong. Hindsight re-embeds the fact, drops the observations and links derived from the old version, and re-consolidates, so downstream knowledge reflects the correction. Edited facts are marked with an `edited_at` timestamp (surfaced as an **Edited** badge in the control plane).
 
+Correcting a fact never discards the **cause-and-effect relationships** it takes part in: those come from reading the original source, so an edit (or an invalidate/restore round-trip) keeps them intact rather than dropping links nothing could rebuild.
+
 You don't need to rebuild anything yourself: an edit **automatically recomputes the knowledge graph and links** in the background. The fact's entity associations are re-resolved from the new text/entities, its temporal and semantic links are re-derived, and consolidation re-runs — all triggered by the edit. The PATCH returns as soon as the change is committed; the graph/observation rebuild happens asynchronously right after.
 
 <Tabs>
@@ -146,7 +148,7 @@ You can correct the dates, fact type, and entities the same way. For `context`, 
 Soft-retire a fact. An invalidated memory:
 
 - **disappears from recall**, consolidation, and the knowledge graph,
-- has its **links pruned** and its **derived observations re-computed** without it,
+- has its **links pruned** and its **derived observations re-computed** without it (cause-and-effect relationships are kept aside and come back if you restore it),
 - **stays in the bank** for audit (visible via the memory and document views), and
 - can be **restored** at any time.
 
@@ -165,7 +167,7 @@ Soft-retire a fact. An invalidated memory:
 </TabItem>
 </Tabs>
 
-Restoring moves the fact back into the active set and re-consolidates:
+Restoring moves the fact back into the active set, brings back the cause-and-effect relationships it took part in, and re-consolidates:
 
 <Tabs>
 <TabItem value="python" label="Python">

--- a/skills/hindsight-docs/references/developer/api/memories.md
+++ b/skills/hindsight-docs/references/developer/api/memories.md
@@ -140,6 +140,8 @@ Only raw **world** and **experience** facts can be curated. Observations are *de
 
 Correct what the LLM extracted. You can change the **text**, **context**, **occurred dates**, **fact type**, and **entities** — anything the extractor could have gotten wrong. Hindsight re-embeds the fact, drops the observations and links derived from the old version, and re-consolidates, so downstream knowledge reflects the correction. Edited facts are marked with an `edited_at` timestamp (surfaced as an **Edited** badge in the control plane).
 
+Correcting a fact never discards the **cause-and-effect relationships** it takes part in: those come from reading the original source, so an edit (or an invalidate/restore round-trip) keeps them intact rather than dropping links nothing could rebuild.
+
 You don't need to rebuild anything yourself: an edit **automatically recomputes the knowledge graph and links** in the background. The fact's entity associations are re-resolved from the new text/entities, its temporal and semantic links are re-derived, and consolidation re-runs — all triggered by the edit. The PATCH returns as soon as the change is committed; the graph/observation rebuild happens asynchronously right after.
 
 ### Python
@@ -205,7 +207,7 @@ await patchMemory(memoryId, {
 Soft-retire a fact. An invalidated memory:
 
 - **disappears from recall**, consolidation, and the knowledge graph,
-- has its **links pruned** and its **derived observations re-computed** without it,
+- has its **links pruned** and its **derived observations re-computed** without it (cause-and-effect relationships are kept aside and come back if you restore it),
 - **stays in the bank** for audit (visible via the memory and document views), and
 - can be **restored** at any time.
 
@@ -235,7 +237,7 @@ await patchMemory(memoryId, { state: 'invalidated', reason: 'server decommission
 # Section 'invalidate-memory' not found in api/memories.go
 ```
 
-Restoring moves the fact back into the active set and re-consolidates:
+Restoring moves the fact back into the active set, brings back the cause-and-effect relationships it took part in, and re-consolidates:
 
 ### Python
 


### PR DESCRIPTION
## Summary

Curation no longer destroys causal links. Two changes, both scoped to `update_memory_unit`:

- **Edit** deletes only the *derived* link types (`temporal`/`semantic`) — the ones graph maintenance rebuilds. Causal edges stay in place, so a context-only (or text) correction no longer silently erases them.
- **Invalidate/restore** round-trips causal edges through a new `causal_links` JSONB column on `invalidated_memory_units`. Invalidation snapshots the incident edges before the FK cascade removes them; restore rematerializes the ones whose peer endpoint is live again.

Closes #2864.

## Why this shape

Causal edges are retain-time extraction output. Graph maintenance only rebuilds temporal/semantic links and consolidation regenerates observations, so a dropped `caused_by` edge is gone for good — which is exactly what made edit and invalidate lossy.

Two designs were considered:

1. **Keep the rows and filter them out** while an endpoint is archived. This needs the `memory_links → memory_units` FKs dropped (invalidation *moves* the row, so the cascade is what deletes the edges), which turns a local fix into a schema-wide invariant change: eight hard-delete paths currently rely on that cascade, and both the deferrable-FK deadlock fix and the Oracle schema are built on it.
2. **Park the descriptors on the archive row** (this PR). No FK or delete-path changes, no dangling rows, no new table — the archive is cold storage that only curation reads.

For text edits the issue offers three policies; this PR takes "preserve by default". Preserving an assertion is reversible, deleting one is not, and nothing in the pipeline could re-derive it.

## How restore stays order-independent

The snapshot merges the unit's materialized causal edges **and** any descriptors already parked on archived peers that name it. So when both endpoints of an edge are invalidated, both archive rows carry a copy, and whichever endpoint is restored last recreates the edge — restore order doesn't matter, and neither does whether the peer was invalidated before or after.

Rematerialization goes through the existing bulk-insert path, which only takes links whose endpoints exist in `memory_units` and is `ON CONFLICT DO NOTHING`. That gives idempotent invalidate/restore cycles and drops descriptors naming a permanently deleted memory instead of failing the restore.

## Relationship to #2892

Same bug, smaller surface. #2892 stores descriptors on *both* live and archived rows, adds explicit `SELECT … FOR UPDATE` endpoint locking, and re-runs cleanup on text edits and permanent deletes (~770 lines). This PR keeps the state on the archive only — where the row is already being rewritten inside the curation transaction — so no live-row column, no extra locking protocol, and no cleanup path is needed.

## Migration

`c7d1e9a4b3f2` adds `causal_links JSONB NOT NULL DEFAULT '[]'` to `invalidated_memory_units` (metadata-only on PG 11+), with the matching Oracle `CLOB … IS JSON` for schema parity. No backfill: edges lost before this migration can't be reconstructed and aren't guessed.

## Tests

`tests/test_memory_curation.py::TestCausalLinkPreservation` — context and text edits preserve incoming + outgoing causal edges while still dropping temporal ones; invalidate snapshots both directions (with weight) and revert restores them; a two-endpoint invalidation only materializes when the second endpoint returns; repeated cycles don't duplicate; a snapshot naming a hard-deleted peer is dropped rather than resurrected. Plus fast unit tests for the descriptor parse/round-trip in `tests/test_causal_link_taxonomy.py`.

```
uv run pytest tests/test_memory_curation.py tests/test_causal_link_taxonomy.py tests/test_link_utils.py \
  tests/test_migration_shape.py tests/test_admin_backup_restore.py tests/test_document_transfer.py \
  tests/test_graph_maintenance.py -q -n 0   →  all passed
./scripts/hooks/lint.sh                     →  passed
uv run ty check hindsight_api/              →  passed
```
