### PR TITLE
docs(consolidation): define every input field in the consolidation prompt

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/prompts.py
@@ -37,19 +37,38 @@ _PROCESSING_RULES = """## PROCESSING RULES
 
 9. KEEP DISTINCT TOPICS DISTINCT: do not merge observations about different people, entities, or unrelated topics. Merging is for the same canonical fact recurring — not for related-but-distinct claims."""
 
+# Field-by-field definitions of the input shape, shared by the cached system
+# prefix (_INPUT_FORMAT_NOTE) and the single-message prompt (_INPUT_SECTION) so
+# the two descriptions cannot drift apart. Both call sites run .format(), so
+# these strings must contain no braces.
+_FACT_FIELDS = """One per line, formatted as `[uuid] fact text (temporal fields)`:
+- `[uuid]`: the fact's identifier — copy it verbatim into `source_fact_ids`
+- `occurred_start` / `occurred_end`: when the described event happened. This can be long before the fact was stated — a fact recorded today may describe a 2019 event.
+- `mentioned_at`: when the source material that states this fact was written. This is the fact's recency: how up to date the statement is, NOT when it was added to memory. A fact taken from an old document keeps its old `mentioned_at` even if it was only just processed."""
+
+_OBSERVATION_FIELDS = """- `id`: unique identifier — copy this exactly when issuing an UPDATE or DELETE
+- `text`: the observation content
+- `proof_count`: how many source facts this observation has already merged
+- `occurred_start` / `occurred_end`: the span of the events behind the observation — earliest start and latest end across its source facts
+- `mentioned_at`: the latest of the `mentioned_at` values of its source facts — the most recent point at which this observation was stated
+- `source_memories`: the supporting facts behind this observation. May be partial or absent for large observations — the count above remains the true total. Each entry carries the same `text` and temporal fields as a new fact, plus:
+  - `context`: optional surrounding context for that fact"""
+
 # Stable description of the input shape. For the cached split path this lives in
 # the system prefix (build_consolidation_system_prompt) so it is not re-sent on
 # every batch; the per-batch user message then carries only the actual data.
-_INPUT_FORMAT_NOTE = """## INPUT FORMAT
+_INPUT_FORMAT_NOTE = f"""## INPUT FORMAT
 
-Each request provides new facts and existing observations:
-- New facts: one per line, each prefixed with its `[uuid]`, followed by the fact text and optional temporal fields.
-- Existing observations: a JSON array pooled from recalls across the new facts. Each entry has:
-  - `id`: unique identifier — copy this exactly when issuing an UPDATE or DELETE
-  - `text`: the observation content
-  - `proof_count`: number of supporting memories
-  - `occurred_start` / `occurred_end`: temporal range of source facts
-  - `source_memories`: array of supporting facts with their text and dates"""
+Each request provides new facts and existing observations. Every temporal field is optional and is omitted when unknown.
+
+### New facts
+
+{_FACT_FIELDS}
+
+### Existing observations
+
+A JSON array pooled from recalls across the new facts. Each entry has:
+{_OBSERVATION_FIELDS}"""
 
 # Per-batch data section for the cached split path — the stable format
 # explanation above is omitted here (it lives in the cached prefix); only the
@@ -65,22 +84,22 @@ _SPLIT_INPUT_SECTION = """## INPUT
 {observations_text}"""
 
 # Data section — format placeholders {facts_text} and {observations_text} are substituted at call time
-_INPUT_SECTION = """## INPUT
+_INPUT_SECTION = f"""## INPUT
+
+Every temporal field below is optional and is omitted when unknown.
 
 ### New facts
 
-{facts_text}
+{_FACT_FIELDS}
+
+{{facts_text}}
 
 ### Existing observations
 
 JSON array, pooled from recalls across all new facts above. Each entry has:
-- `id`: unique identifier — copy this exactly when issuing an UPDATE or DELETE
-- `text`: the observation content
-- `proof_count`: number of supporting memories
-- `occurred_start` / `occurred_end`: temporal range of source facts
-- `source_memories`: array of supporting facts with their text and dates
+{_OBSERVATION_FIELDS}
 
-{observations_text}"""
+{{observations_text}}"""
 
 _DECISION_GUIDE = """## DECISION GUIDE
 

--- a/hindsight-api-slim/tests/test_consolidation.py
+++ b/hindsight-api-slim/tests/test_consolidation.py
@@ -4,6 +4,7 @@ These tests exercise the real consolidation implementation with actual database 
 Note: Consolidation runs automatically after retain via SyncTaskBackend in tests.
 """
 
+import re
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, call, patch
@@ -2823,6 +2824,73 @@ class TestFullAssembledConsolidationPrompt:
         print(prompt)
         print("=" * 80)
         print(f"length: {len(prompt)} chars")
+
+    def test_every_emitted_input_field_is_defined_in_the_prompt(self):
+        """Each field the consolidator serializes must be defined in the INPUT section.
+
+        The prompt is the only place the LLM learns what `mentioned_at` means, so a
+        field that is emitted but never explained is dead metadata the model can't
+        reason about (issue #2550: `mentioned_at` shipped in the JSON for both
+        observations and their source memories while the INPUT section documented
+        neither). Both prompt paths are checked — the single-message template and
+        the cached system prefix — since they carry independent copies of the
+        format description.
+        """
+        from hindsight_api.engine.consolidation.consolidator import _build_observations_for_llm
+        from hindsight_api.engine.consolidation.prompts import build_consolidation_system_prompt
+
+        f = self._build_fixture()
+
+        # Field names taken from what the serializer ACTUALLY emits, not a
+        # hand-maintained list — so adding a key to `_build_observations_for_llm`
+        # without documenting it fails here.
+        obs_list = _build_observations_for_llm(f["observations"], f["source_facts"])
+        assert obs_list, "fixture must render at least one existing observation"
+        observation_fields: set[str] = set()
+        for obs in obs_list:
+            observation_fields.update(obs.keys())
+            for sm in obs.get("source_memories", []):
+                observation_fields.update(sm.keys())
+        # The temporal fields the new-fact lines carry (see `_fact_line`).
+        fact_fields = {"occurred_start", "occurred_end", "mentioned_at"}
+        # Sanity-check the fixture really exercises the fields this test guards.
+        assert {"mentioned_at", "proof_count", "source_memories", "context"} <= observation_fields
+
+        def _defined_fields(section: str) -> set[str]:
+            """Field names carrying a real definition bullet: ``- `name`[ / `other`]: ...``.
+
+            Only the part before the colon counts. A field merely *referenced* in
+            another bullet's prose is not a definition, and counting it would let
+            a deleted definition slip through unnoticed.
+            """
+            defined: set[str] = set()
+            for line in section.splitlines():
+                stripped = line.strip()
+                if not stripped.startswith("- `") or ":" not in stripped:
+                    continue
+                defined.update(re.findall(r"`([a-z_]+)`", stripped.split(":", 1)[0]))
+            return defined
+
+        # Both prompt paths are checked, and within each, a field must be defined in
+        # the subsection describing ITS input — a definition of `mentioned_at` under
+        # "New facts" does not tell the model what `mentioned_at` means on an
+        # observation, so the two halves are sliced apart rather than searched whole.
+        for path_name, prompt, start_header in (
+            ("single-message", f["rendered"], "## INPUT"),
+            ("cached prefix", build_consolidation_system_prompt(), "## INPUT FORMAT"),
+        ):
+            body = prompt[prompt.index(start_header) : prompt.index("## DECISION GUIDE")]
+            facts_section, _, observations_section = body.partition("### Existing observations")
+
+            undefined = fact_fields - _defined_fields(facts_section)
+            assert not undefined, (
+                f"{path_name}: new-fact lines carry {sorted(undefined)} but the New facts section defines no such field"
+            )
+            undefined = observation_fields - _defined_fields(observations_section)
+            assert not undefined, (
+                f"{path_name}: observation JSON emits {sorted(undefined)} but the "
+                f"Existing observations section defines no such field"
+            )
 
     def test_default_mission_appears_when_no_mission_supplied(self):
         """Without an explicit mission the built-in default text must appear verbatim."""


### PR DESCRIPTION
Partially addresses #2550.

## Problem

The consolidation prompt sends the LLM temporal metadata it never explains.

`_fact_line` and `_build_observations_for_llm` emit `mentioned_at` in three
places — on every new-fact line, on each existing observation, and on each
embedded source memory — and all three are genuinely populated (recall selects
`mentioned_at` and maps it through to `MemoryFact`, and an observation's
`mentioned_at` is maintained as the max across its source facts).

But the INPUT section documented only `id`, `text`, `proof_count`,
`occurred_start` / `occurred_end` and "source_memories: array of supporting
facts with their text and dates". So the model received the timestamp with no
statement of what it means — in particular, that it tracks *when the source
material was written*, not when it was ingested. That's exactly the signal
#2550 needs the model to reason about when documents arrive out of temporal
order.

## Change

Prompt text only — no behavioural logic touched.

- Define each field the serializer actually emits, including `mentioned_at` on
  both new facts and observations, and `context` on source memories.
- State explicitly that `mentioned_at` is the fact's recency (how up to date the
  statement is) and **not** ingestion time, and that `occurred_start` /
  `occurred_end` can be far earlier than when the fact was stated.
- Note that `source_memories` may be truncated under the token budget while
  `proof_count` stays the true total (they can legitimately disagree — see the
  `max_source_facts_tokens` capping in `recall_async`).
- The two copies of the format description — the cached bank-agnostic system
  prefix and the single-message template — now derive from shared constants, so
  they can't drift apart.

The cached Gemini prefix stays bank-agnostic and byte-stable, so a single
`CachedContent` still serves every bank; this just changes its content once.

## Test

`test_every_emitted_input_field_is_defined_in_the_prompt` derives the field
names from what `_build_observations_for_llm` **actually emits** rather than a
hand-maintained list, then asserts each one has a real definition bullet in the
subsection describing its own input — checked separately for the new-facts and
existing-observations halves, and for both prompt paths.

Verified by mutation: deleting any one of the observation `mentioned_at`,
observation `proof_count`, source-memory `context`, or new-fact `mentioned_at`
definitions makes the test fail. (An earlier substring-presence version of this
assertion passed under those same mutations — a field named in another bullet's
prose looked like a definition — hence the before-the-colon parsing.)

## Scope

Deliberately limited to documenting fields already being sent. The other two
halves of #2550 are **not** included:

- ordering the consolidation fetch by `mentioned_at` instead of `created_at`
  (`consolidator.py:974`) — needs a replacement partial index, since
  `idx_memory_units_unconsolidated` is keyed on `(bank_id, created_at)` and an
  expression sort would re-sort the whole pending set on every batch;
- a DECISION GUIDE rule making the later `mentioned_at` win on conflict, which
  is the part that covers facts arriving in a *later* consolidation round than
  the observation they contradict.

## Test plan

- [x] `./scripts/hooks/lint.sh`
- [x] `uv run ty check hindsight_api/engine/consolidation/`
- [x] Prompt/mission tests in `test_consolidation.py` + `test_prompt_brace_escape.py` (34 passed)
- [ ] DB-backed consolidation tests not run locally — embedded pg0 fails to start
      in this worktree; confirmed identical failure on a clean tree, so it's
      environmental. Covered by CI.
