### PR TITLE
fix: return free-form entities from dry-run extraction

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7929,7 +7929,7 @@ class MemoryEngine(MemoryEngineInterface):
                 fact_type=fact.fact_type,
                 occurred_start=fact.occurred_start,
                 occurred_end=fact.occurred_end,
-                entities=[e.text for e in (fact.entities or []) if getattr(e, "text", None)],
+                entities=list(fact.entities or []),
             )
             for fact in facts
         ]

--- a/hindsight-api-slim/tests/test_extract_dry_run_http.py
+++ b/hindsight-api-slim/tests/test_extract_dry_run_http.py
@@ -78,6 +78,25 @@ async def test_dry_run_extracts_without_persisting(api_client, memory):
 
 
 @pytest.mark.asyncio
+async def test_dry_run_honors_free_form_entities_override(api_client, memory):
+    bank_id = f"dryrun-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=RequestContext())
+
+    resp = await api_client.post(
+        f"/v1/default/banks/{bank_id}/memories/dry-run-extract",
+        json={
+            "content": "Alice moved to Berlin in 2021 and works as a nurse.",
+            "entities_allow_free_form": True,
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    entities = [entity for fact in resp.json()["facts"] for entity in fact["entities"]]
+    assert entities
+    assert all(isinstance(entity, str) for entity in entities)
+
+
+@pytest.mark.asyncio
 async def test_dry_run_does_not_create_missing_bank(api_client, memory):
     bank_id = f"dryrun-missing-{uuid.uuid4().hex[:8]}"
     request_context = RequestContext()


### PR DESCRIPTION
## Summary

- preserve validated entity strings when mapping dry-run extraction results
- handle extraction results with no entities as an empty list
- add an HTTP regression test for `entities_allow_free_form=true`

## Root cause

`extract_facts_from_text()` returns entity names as strings, but the dry-run response mapper treated them as objects with a `.text` attribute. Every string was therefore filtered out.

## Testing

- `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 ... pytest tests/test_extract_dry_run_http.py -q -n 0` (`8 passed`)
- `ruff check` and `ruff format --check` on changed files
- `ty check --python /tmp/hindsight-forgetting/.venv/bin/python hindsight_api/`
- `git diff --check`

The repository-wide `./scripts/hooks/lint.sh` was attempted twice, but its initial `uv sync --frozen` remained blocked in LiteLLM 1.93.0 Rust `cargo metadata`; the relevant Python lint, format, type, and regression checks above completed successfully.

Closes #2956