### PR TITLE
fix(litellm): serialize named tool_choice with flat Responses API shape

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
@@ -437,10 +437,7 @@ class LiteLLMLLM(LLMInterface):
         call_kwargs = self._build_common_kwargs(messages, max_completion_tokens, temperature)
         call_kwargs["tools"] = tools
         call_kwargs["tool_choice"] = (
-            {
-                "type": "function",
-                "function": {"name": tool_choice.selected_function_name},
-            }
+            {"type": "function", "name": tool_choice.function_name}
             if tool_choice.mode is LLMToolChoiceMode.NAMED
             else tool_choice.mode.value
         )


### PR DESCRIPTION
## Problem

`LiteLLMLLM.call_with_tools` built the named `tool_choice` with the nested Chat Completions shape and referenced a field that doesn't exist on the `LLMToolChoice` dataclass.

```python
call_kwargs["tool_choice"] = {
    "type": "function",
    "function": {"name": tool_choice.selected_function_name},  # AttributeError — field is 'function_name'
}
```

Two bugs:
1. `selected_function_name` is not an attribute of `LLMToolChoice` (the field is `function_name`) — would raise `AttributeError` on any named-tool reflect iteration.
2. The nested `{"function": {"name": ...}}` shape is rejected by LiteLLM's Responses API path (Copilot/Luna). Reflect routed through a Copilot model via LiteLLM fails end-to-end: LiteLLM raises a validation error before the request reaches the provider, and the reflect run times out / 422s.

## Fix

Serialize named `tool_choice` to the **flat** Responses API shape and reference the correct field:

```python
call_kwargs["tool_choice"] = (
    {"type": "function", "name": tool_choice.function_name}
    if tool_choice.mode is LLMToolChoiceMode.NAMED
    else tool_choice.mode.value
)
```

This matches the shape already used by the Codex provider (`codex_llm.py`).

## Verification

Before the fix, reflect on a ~27k-memory bank routed through Copilot/Luna via LiteLLM never succeeded — only 422 (validation) and 504 (timeout) responses. After applying the fix locally:

- Reflect returns HTTP 200 end-to-end.
- Latency on a 26k-memory bank: ~123s (under the 300s wall-clock limit).

## Scope

Single-file, 3-line change. No new dependencies, no API surface changes.

Refs #2953
