### PR TITLE
fix: avoid dotenv side effects on library import

### DIFF
--- a/hindsight-api-slim/hindsight_api/admin/cli.py
+++ b/hindsight-api-slim/hindsight_api/admin/cli.py
@@ -17,7 +17,7 @@ from typing import Any
 import asyncpg
 import typer
 
-from ..config import DEFAULT_DATABASE_SCHEMA, HindsightConfig
+from ..config import DEFAULT_DATABASE_SCHEMA, HindsightConfig, load_dotenv_for_cli
 from ..engine.memory_engine import _current_schema
 from ..engine.retain.bank_utils import _vector_index_clause
 from ..engine.schema import fq_table_explicit as _fq_table
@@ -960,6 +960,7 @@ def worker_status(
 
 
 def main():
+    load_dotenv_for_cli()
     app()
 
 

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -19,10 +19,17 @@ from ._pg_search import normalize_pg_search_tokenizer
 from ._vector_index import validate_extension
 from .utils import mask_network_location
 
-# Load .env file, searching current and parent directories (overrides existing env vars)
-load_dotenv(find_dotenv(usecwd=True), override=True)
-
 logger = logging.getLogger(__name__)
+
+
+def load_dotenv_for_cli() -> None:
+    """Load a discovered .env file for Hindsight command-line entry points.
+
+    Library imports must not mutate the host application's environment. Standalone
+    commands retain .env convenience, while ``override=False`` ensures that values
+    explicitly supplied by the process take precedence over discovered files.
+    """
+    load_dotenv(find_dotenv(usecwd=True), override=False)
 
 
 class ConfigFieldAccessError(AttributeError):

--- a/hindsight-api-slim/hindsight_api/main.py
+++ b/hindsight-api-slim/hindsight_api/main.py
@@ -32,6 +32,7 @@ from .config import (
     ENV_WORKERS,
     HindsightConfig,
     _get_raw_config,
+    load_dotenv_for_cli,
 )
 from .daemon import (
     DEFAULT_DAEMON_PORT,
@@ -196,6 +197,8 @@ def _parse_cli_args(argv: list[str], config: HindsightConfig) -> ParsedCliArgs:
 def main():
     """Main entry point for the CLI."""
     global _memory
+
+    load_dotenv_for_cli()
 
     # Load configuration from environment (for CLI args defaults)
     config = _get_raw_config()

--- a/hindsight-api-slim/hindsight_api/worker/main.py
+++ b/hindsight-api-slim/hindsight_api/worker/main.py
@@ -18,7 +18,7 @@ import sys
 import warnings
 from collections.abc import Callable
 
-from ..config import get_config
+from ..config import get_config, load_dotenv_for_cli
 from ..engine.task_backend import WorkerTaskBackend
 from .poller import WorkerPoller
 
@@ -125,6 +125,8 @@ def create_worker_app(poller: WorkerPoller, memory):
 
 def main():
     """Main entry point for the hindsight-worker CLI."""
+    load_dotenv_for_cli()
+
     # Load configuration from environment
     config = get_config()
 

--- a/hindsight-api-slim/tests/test_dotenv_loading.py
+++ b/hindsight-api-slim/tests/test_dotenv_loading.py
@@ -1,0 +1,48 @@
+"""Tests for side-effect-free library imports and explicit CLI dotenv loading."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_importing_config_does_not_modify_environment(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text("HOST_APP_SECRET=from-dotenv\n")
+    child_dir = tmp_path / "child"
+    child_dir.mkdir()
+
+    env = os.environ.copy()
+    env["HOST_APP_SECRET"] = "from-application"
+    api_source = str(Path(__file__).parents[1])
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, (api_source, env.get("PYTHONPATH"))))
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import os; import hindsight_api.config; print(os.environ['HOST_APP_SECRET'])",
+        ],
+        cwd=child_dir,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == "from-application"
+
+
+def test_cli_dotenv_loading_only_fills_missing_values(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / ".env").write_text("HOST_APP_SECRET=from-dotenv\nHINDSIGHT_TEST_MISSING=loaded\n")
+    child_dir = tmp_path / "child"
+    child_dir.mkdir()
+    monkeypatch.chdir(child_dir)
+    monkeypatch.setenv("HOST_APP_SECRET", "from-application")
+    monkeypatch.delenv("HINDSIGHT_TEST_MISSING", raising=False)
+
+    from hindsight_api.config import load_dotenv_for_cli
+
+    load_dotenv_for_cli()
+
+    assert os.environ["HOST_APP_SECRET"] == "from-application"
+    assert os.environ["HINDSIGHT_TEST_MISSING"] == "loaded"

--- a/hindsight-dev/benchmarks/perf/recall_perf.py
+++ b/hindsight-dev/benchmarks/perf/recall_perf.py
@@ -44,10 +44,6 @@ import statistics
 import time
 from typing import Any
 
-# Capture DB URL early before hindsight_api imports trigger dotenv override
-# (config.py uses load_dotenv(override=True) which stomps env vars)
-_EARLY_DB_URL = os.environ.get("HINDSIGHT_API_DATABASE_URL")
-
 from rich.console import Console
 from rich.progress import BarColumn, MofNCompleteColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 from rich.table import Table
@@ -567,7 +563,7 @@ def _build_engine(*, disable_observations: bool = False) -> "Any":
     """Create a MemoryEngine using mock LLM and DB from env."""
     from hindsight_api import MemoryEngine
 
-    db_url = _EARLY_DB_URL or os.getenv("HINDSIGHT_API_DATABASE_URL", "pg0")
+    db_url = os.getenv("HINDSIGHT_API_DATABASE_URL", "pg0")
     if disable_observations:
         os.environ["HINDSIGHT_API_ENABLE_OBSERVATIONS"] = "false"
     engine = MemoryEngine(


### PR DESCRIPTION
## Summary

- stop loading ancestor `.env` files when `hindsight_api.config` is imported
- preserve `.env` convenience in the API, worker, and admin CLI entry points
- use `override=False` so explicit process environment values always win
- remove the recall benchmark workaround for import-time environment replacement
- add regression coverage for side-effect-free imports and CLI dotenv precedence

## Root cause

`hindsight_api.config` called `load_dotenv(find_dotenv(usecwd=True), override=True)` at module scope. Importing Hindsight therefore searched upward from the host application cwd and replaced arbitrary existing environment variables.

## Testing

- `pytest tests/test_dotenv_loading.py tests/test_main_module.py tests/test_worker_main.py -q -n 0` (`12 passed`)
- `pytest tests/test_config_validation.py tests/test_server_module.py -q -n 0` (`86 passed`)
- Ruff check and format validation for all changed Python files
- Ty checks for `hindsight_api`, `hindsight_dev`, and benchmarks
- `git diff --check`
- `./scripts/hooks/lint.sh`: all Python checks passed; frontend tasks could not start because the isolated worktree has no installed ESLint/Prettier binaries (`@eslint/js` / executables missing). No frontend files are changed by this PR.

Closes #2961