### PR TITLE
perf: eliminate redundant graph seed and UUID scans

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -209,7 +209,7 @@ async def _dedup_adjudicate(
     grouped = await retrieve_semantic_bm25_combined(
         conn, anchor_emb_str, anchor_text, bank_id, ["observation"], _DEDUP_TOP_K, tags=tags, tags_match=tags_match
     )
-    results = grouped.get("observation", ([], []))[0]
+    results = grouped["observation"].semantic
     best_id: str | None = None
     best_text = ""
     best_sim = threshold  # only candidates at/above the threshold are considered

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -481,11 +481,21 @@ class PostgreSQLOps(DataAccessOps):
         mu_table: str,
         unit_ids: list[str],
     ) -> list[ResultRow]:
+        # Cast only canonical UUID text inputs, never the indexed column. The old
+        # ``id::text`` predicate silently ignored malformed, uppercase, braced,
+        # and unhyphenated inputs; filtering before the cast preserves that
+        # behavior while allowing the primary-key index to serve the lookup.
         return await conn.fetch(
             f"""
             SELECT id, event_date, fact_type
             FROM {mu_table}
-            WHERE id::text = ANY($1)
+            WHERE id = ANY(
+                ARRAY(
+                    SELECT input.unit_id::uuid
+                    FROM unnest($1::text[]) AS input(unit_id)
+                    WHERE input.unit_id ~ '^[0-9a-f]{{8}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{12}}$'
+                )
+            )
             """,
             unit_ids,
         )

--- a/hindsight-api-slim/hindsight_api/engine/search/graph_retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/graph_retrieval.py
@@ -46,6 +46,7 @@ class GraphRetriever(ABC):
         tag_groups: list[TagGroup] | None = None,  # Compound boolean tag filter groups
         created_after: datetime | None = None,  # Only include memory_units created after this time
         created_before: datetime | None = None,  # Only include memory_units created before this time
+        preselected_semantic_seeds: list[RetrievalResult] | None = None,
     ) -> tuple[list[RetrievalResult], GraphRetrievalTimings | None]:
         """
         Retrieve relevant facts via graph traversal.
@@ -59,6 +60,7 @@ class GraphRetriever(ABC):
             query_text: Original query text (optional, for some strategies)
             adjacency: Pre-loaded typed adjacency graph (optional)
             tags: Optional list of tags for visibility filtering (OR matching)
+            preselected_semantic_seeds: Independently thresholded graph entry points already fetched by the caller
 
         Returns:
             Tuple of (List of RetrievalResult with activation scores, optional timing info)

--- a/hindsight-api-slim/hindsight_api/engine/search/link_expansion_retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/link_expansion_retrieval.py
@@ -40,6 +40,8 @@ from .types import GraphRetrievalTimings, RetrievalResult
 
 logger = logging.getLogger(__name__)
 
+GRAPH_SEED_LIMIT = 20
+
 
 async def _find_semantic_seeds(
     conn,
@@ -133,6 +135,7 @@ class LinkExpansionRetriever(GraphRetriever):
         tag_groups: list[TagGroup] | None = None,
         created_after: "datetime | None" = None,
         created_before: "datetime | None" = None,
+        preselected_semantic_seeds: list[RetrievalResult] | None = None,
     ) -> tuple[list[RetrievalResult], GraphRetrievalTimings | None]:
         """
         Retrieve facts by expanding links from seeds.
@@ -146,36 +149,43 @@ class LinkExpansionRetriever(GraphRetriever):
             query_text: Original query text (unused)
             adjacency: Unused, kept for interface compatibility
             tags: Optional list of tags for visibility filtering
+            preselected_semantic_seeds: Graph-specific entry points derived from a shared semantic candidate pool
 
         Returns:
             Tuple of (results, timings)
         """
         start_time = time.time()
         timings = GraphRetrievalTimings(fact_type=fact_type)
-        graph_seed_min_similarity = get_config().graph_seed_min_similarity
 
         async with acquire_with_retry(pool) as conn:
-            # Graph traversal deliberately chooses its own bounded seeds. The semantic and temporal
-            # retrieval arms have independent candidate limits and thresholds, so reusing their
-            # results would silently change graph-retrieval recall behavior.
-            seeds_start = time.time()
-            all_seeds = await _find_semantic_seeds(
-                conn,
-                query_embedding_str,
-                bank_id,
-                fact_type,
-                limit=20,
-                threshold=graph_seed_min_similarity,
-                tags=tags,
-                tags_match=tags_match,
-                tag_groups=tag_groups,
-                created_after=created_after,
-                created_before=created_before,
-            )
-            timings.seeds_time = time.time() - seeds_start
+            if preselected_semantic_seeds is None:
+                # A shared semantic pool is reusable only when its SQL threshold
+                # covers the independently configured graph threshold. Otherwise
+                # retain graph retrieval's own query and result semantics.
+                seeds_start = time.time()
+                all_seeds = await _find_semantic_seeds(
+                    conn,
+                    query_embedding_str,
+                    bank_id,
+                    fact_type,
+                    limit=GRAPH_SEED_LIMIT,
+                    threshold=get_config().graph_seed_min_similarity,
+                    tags=tags,
+                    tags_match=tags_match,
+                    tag_groups=tag_groups,
+                    created_after=created_after,
+                    created_before=created_before,
+                )
+                timings.seeds_time = time.time() - seeds_start
+            else:
+                all_seeds = preselected_semantic_seeds
+
             logger.debug(
-                f"[LinkExpansion] Found {len(all_seeds)} semantic seeds for fact_type={fact_type} "
-                f"(tags={tags}, tags_match={tags_match})"
+                "LinkExpansion found %s semantic seeds for fact_type=%s (tags=%s, tags_match=%s)",
+                len(all_seeds),
+                fact_type,
+                tags,
+                tags_match,
             )
 
             if not all_seeds:

--- a/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
@@ -20,7 +20,7 @@ from ..db_utils import acquire_with_retry
 from ..memory_engine import fq_table
 from ..sql import create_sql_dialect
 from .graph_retrieval import GraphRetriever
-from .link_expansion_retrieval import LinkExpansionRetriever
+from .link_expansion_retrieval import GRAPH_SEED_LIMIT, LinkExpansionRetriever
 from .tags import TagGroup, TagsMatch, build_tag_groups_where_clause, build_tags_where_clause_simple
 from .types import GraphRetrievalTimings, RetrievalResult
 
@@ -67,6 +67,15 @@ class MultiFactTypeRetrievalResult:
     max_conn_wait: float = 0.0
 
 
+@dataclass
+class SemanticBm25Result:
+    """Per-fact-type candidates returned by the shared semantic/BM25 query."""
+
+    semantic: list[RetrievalResult]
+    bm25: list[RetrievalResult]
+    graph_seeds: list[RetrievalResult] | None
+
+
 # Default graph retriever instance (can be overridden)
 _default_graph_retriever: GraphRetriever | None = None
 
@@ -106,7 +115,8 @@ async def retrieve_semantic_bm25_combined(
     created_before: datetime | None = None,
     min_semantic: float | None = None,
     min_keyword: float | None = None,
-) -> dict[str, tuple[list[RetrievalResult], list[RetrievalResult]]]:
+    graph_seed_min_similarity: float | None = None,
+) -> dict[str, SemanticBm25Result]:
     """
     Combined semantic + BM25 retrieval for multiple fact types in a single query.
 
@@ -138,9 +148,10 @@ async def retrieve_semantic_bm25_combined(
         tags_match: Tag matching mode
 
     Returns:
-        Dict mapping fact_type -> (semantic_results, bm25_results)
+        Candidate groups for each fact type. ``graph_seeds`` is ``None`` when
+        the semantic query's threshold is too strict to cover graph entry points.
     """
-    result_dict: dict[str, tuple[list[RetrievalResult], list[RetrievalResult]]] = {ft: ([], []) for ft in fact_types}
+    result_dict = {ft: SemanticBm25Result(semantic=[], bm25=[], graph_seeds=None) for ft in fact_types}
 
     config = get_config()
     tokens = tokenize_query(query_text)
@@ -307,8 +318,18 @@ async def retrieve_semantic_bm25_combined(
         else:
             raise
 
-    # Group results; trim semantic to limit (over-fetched for HNSW approximation).
-    sem_counts: dict[str, int] = {ft: 0 for ft in fact_types}
+    # Group results. The semantic SQL deliberately over-fetches for HNSW recall;
+    # when that pool also covers the graph threshold, derive graph entry points
+    # from the same ordered rows instead of issuing one duplicate ANN query per
+    # fact type. Convert only the prefix either consumer can observe, not the
+    # entire HNSW over-fetch pool.
+    graph_seed_threshold = (
+        graph_seed_min_similarity
+        if graph_seed_min_similarity is not None and sem_min <= graph_seed_min_similarity
+        else None
+    )
+    semantic_candidate_limit = max(limit, GRAPH_SEED_LIMIT if graph_seed_threshold is not None else 0)
+    semantic_candidates: dict[str, list[RetrievalResult]] = {ft: [] for ft in fact_types}
     for r in rows:
         row = dict(r)
         source = row.pop("source")
@@ -316,11 +337,19 @@ async def retrieve_semantic_bm25_combined(
         if ft not in result_dict:
             continue
         if source == "semantic":
-            if sem_counts[ft] < limit:
-                result_dict[ft][0].append(RetrievalResult.from_db_row(row))
-                sem_counts[ft] += 1
+            if len(semantic_candidates[ft]) < semantic_candidate_limit:
+                semantic_candidates[ft].append(RetrievalResult.from_db_row(row))
         else:
-            result_dict[ft][1].append(RetrievalResult.from_db_row(row))
+            result_dict[ft].bm25.append(RetrievalResult.from_db_row(row))
+
+    for ft, candidates in semantic_candidates.items():
+        result_dict[ft].semantic.extend(candidates[:limit])
+        if graph_seed_threshold is not None:
+            result_dict[ft].graph_seeds = [
+                candidate
+                for candidate in candidates
+                if candidate.similarity is not None and candidate.similarity >= graph_seed_threshold
+            ][:GRAPH_SEED_LIMIT]
 
     return result_dict
 
@@ -784,6 +813,7 @@ async def retrieve_all_fact_types_parallel(
             created_before=created_before,
             min_semantic=min_semantic,
             min_keyword=min_keyword,
+            graph_seed_min_similarity=config.graph_seed_min_similarity,
         )
         semantic_bm25_time = time.time() - semantic_bm25_start
 
@@ -828,6 +858,7 @@ async def retrieve_all_fact_types_parallel(
             tag_groups=tag_groups,
             created_after=created_after,
             created_before=created_before,
+            preselected_semantic_seeds=semantic_bm25_results[ft].graph_seeds,
         )
         return ft, results, time.time() - graph_start, graph_timing
 
@@ -842,7 +873,8 @@ async def retrieve_all_fact_types_parallel(
 
     for ft in fact_types:
         # Get semantic + bm25 results for this fact type
-        semantic_results, bm25_results = semantic_bm25_results.get(ft, ([], []))
+        semantic_results = semantic_bm25_results[ft].semantic
+        bm25_results = semantic_bm25_results[ft].bm25
 
         # Find graph results for this fact type
         graph_results = []

--- a/hindsight-api-slim/tests/test_consolidation_dedup.py
+++ b/hindsight-api-slim/tests/test_consolidation_dedup.py
@@ -23,6 +23,7 @@ from hindsight_api.engine.consolidation.consolidator import (
     _duplicate_create_target,
     _norm_obs_text,
 )
+from hindsight_api.engine.search.retrieval import SemanticBm25Result
 from hindsight_api.engine.search.types import RetrievalResult
 
 
@@ -107,7 +108,7 @@ def _ctx(threshold: float = 0.97):
 def _patch_probe(results):
     return patch(
         "hindsight_api.engine.search.retrieval.retrieve_semantic_bm25_combined",
-        AsyncMock(return_value={"observation": (results, [])}),
+        AsyncMock(return_value={"observation": SemanticBm25Result(results, [], None)}),
     )
 
 

--- a/hindsight-api-slim/tests/test_hnsw_indexes.py
+++ b/hindsight-api-slim/tests/test_hnsw_indexes.py
@@ -189,6 +189,8 @@ async def test_retrieve_semantic_bm25_grouped_by_fact_type(memory, request_conte
 @pytest.mark.asyncio
 async def test_fetch_unit_dates_ignores_noncanonical_uuid_inputs(memory, request_context):
     """The indexed UUID lookup preserves the old text-comparison input behavior."""
+    from hindsight_api.engine.db.ops_postgresql import PostgreSQLOps
+
     bank_id = f"test_unit_dates_{uuid.uuid4().hex[:8]}"
     try:
         await memory.retain_async(
@@ -202,12 +204,76 @@ async def test_fetch_unit_dates_ignores_noncanonical_uuid_inputs(memory, request
                 "SELECT id::text FROM memory_units WHERE bank_id = $1 ORDER BY created_at LIMIT 1",
                 bank_id,
             )
-            rows = await memory._pool.ops.fetch_unit_dates(
+            rows = await PostgreSQLOps().fetch_unit_dates(
                 conn,
                 "memory_units",
                 [unit_id, "not-a-uuid", unit_id.upper(), unit_id.replace("-", "")],
             )
 
         assert [str(row["id"]) for row in rows] == [unit_id]
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_recall_reuses_semantic_pool_for_graph_seeds(memory, request_context, monkeypatch):
+    """Default recall must not issue a second ANN query for graph entry points."""
+    from hindsight_api.engine.search import link_expansion_retrieval
+
+    async def fail_find_semantic_seeds(*args, **kwargs):
+        raise AssertionError("default recall should reuse the combined semantic candidate pool")
+
+    bank_id = f"test_graph_seed_reuse_{uuid.uuid4().hex[:8]}"
+    try:
+        await memory.retain_async(
+            bank_id=bank_id,
+            content="Alice is a software engineer at TechCorp.",
+            request_context=request_context,
+        )
+        monkeypatch.setattr(link_expansion_retrieval, "_find_semantic_seeds", fail_find_semantic_seeds)
+
+        result = await memory.recall_async(
+            bank_id=bank_id,
+            query="Where does Alice work?",
+            fact_type=["world"],
+            request_context=request_context,
+        )
+
+        assert result.results
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_recall_keeps_graph_seed_query_for_stricter_semantic_floor(memory, request_context, monkeypatch):
+    """A semantic floor above the graph floor must retain the dedicated seed query."""
+    from hindsight_api.engine.response_models import MinScores
+    from hindsight_api.engine.search import link_expansion_retrieval
+
+    original_find_semantic_seeds = link_expansion_retrieval._find_semantic_seeds
+    graph_seed_fact_types: list[str] = []
+
+    async def record_find_semantic_seeds(*args, **kwargs):
+        graph_seed_fact_types.append(args[3])
+        return await original_find_semantic_seeds(*args, **kwargs)
+
+    bank_id = f"test_graph_seed_fallback_{uuid.uuid4().hex[:8]}"
+    try:
+        await memory.retain_async(
+            bank_id=bank_id,
+            content="Alice is a software engineer at TechCorp.",
+            request_context=request_context,
+        )
+        monkeypatch.setattr(link_expansion_retrieval, "_find_semantic_seeds", record_find_semantic_seeds)
+
+        await memory.recall_async(
+            bank_id=bank_id,
+            query="Where does Alice work?",
+            fact_type=["world"],
+            min_scores=MinScores(semantic=0.9),
+            request_context=request_context,
+        )
+
+        assert graph_seed_fact_types == ["world"]
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_hnsw_indexes.py
+++ b/hindsight-api-slim/tests/test_hnsw_indexes.py
@@ -15,7 +15,6 @@ import pytest
 
 from hindsight_api.engine.retain.bank_utils import _BANK_INDEX_FACT_TYPES, _bank_index_name
 
-
 # ---------------------------------------------------------------------------
 # Unit tests — no DB required
 # ---------------------------------------------------------------------------
@@ -176,15 +175,15 @@ async def test_retrieve_semantic_bm25_grouped_by_fact_type(memory, request_conte
         # Must return an entry for every requested fact_type
         assert set(results.keys()) == set(fact_types)
 
-        for ft, (sem, bm25) in results.items():
+        for ft, result in results.items():
             # Semantic and BM25 lists must be lists
-            assert isinstance(sem, list)
-            assert isinstance(bm25, list)
+            assert isinstance(result.semantic, list)
+            assert isinstance(result.bm25, list)
             # All semantic results must declare the correct fact_type
-            for r in sem:
+            for r in result.semantic:
                 assert r.fact_type == ft, f"Semantic result has wrong fact_type: {r.fact_type}"
             # All BM25 results must declare the correct fact_type
-            for r in bm25:
+            for r in result.bm25:
                 assert r.fact_type == ft, f"BM25 result has wrong fact_type: {r.fact_type}"
 
     finally:

--- a/hindsight-api-slim/tests/test_hnsw_indexes.py
+++ b/hindsight-api-slim/tests/test_hnsw_indexes.py
@@ -141,11 +141,7 @@ async def test_retain_idempotent_bank_creation(memory, request_context):
 
 @pytest.mark.asyncio
 async def test_retrieve_semantic_bm25_grouped_by_fact_type(memory, request_context):
-    """
-    retrieve_semantic_bm25_combined must return a dict keyed by fact_type with
-    (semantic_list, bm25_list) tuples.  All returned facts must belong to their
-    declared fact_type.
-    """
+    """Combined retrieval groups typed semantic and BM25 candidates by fact type."""
     from hindsight_api.engine.search.retrieval import retrieve_semantic_bm25_combined
 
     bank_id = f"test_retrieval_{uuid.uuid4().hex[:8]}"
@@ -186,5 +182,32 @@ async def test_retrieve_semantic_bm25_grouped_by_fact_type(memory, request_conte
             for r in result.bm25:
                 assert r.fact_type == ft, f"BM25 result has wrong fact_type: {r.fact_type}"
 
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_fetch_unit_dates_ignores_noncanonical_uuid_inputs(memory, request_context):
+    """The indexed UUID lookup preserves the old text-comparison input behavior."""
+    bank_id = f"test_unit_dates_{uuid.uuid4().hex[:8]}"
+    try:
+        await memory.retain_async(
+            bank_id=bank_id,
+            content="Alice joined TechCorp in 2023.",
+            request_context=request_context,
+        )
+
+        async with memory._pool.acquire() as conn:
+            unit_id = await conn.fetchval(
+                "SELECT id::text FROM memory_units WHERE bank_id = $1 ORDER BY created_at LIMIT 1",
+                bank_id,
+            )
+            rows = await memory._pool.ops.fetch_unit_dates(
+                conn,
+                "memory_units",
+                [unit_id, "not-a-uuid", unit_id.upper(), unit_id.replace("-", "")],
+            )
+
+        assert [str(row["id"]) for row in rows] == [unit_id]
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_link_expansion_scoring.py
+++ b/hindsight-api-slim/tests/test_link_expansion_scoring.py
@@ -63,3 +63,39 @@ async def test_activation_preserves_additive_score_across_fact_types(monkeypatch
     assert [result.id for result in combined] == ["a", "b"]
     assert world_results[0].activation == pytest.approx(math.tanh(0.5) + 0.9 + 0.3)
     assert experience_results[0].activation == pytest.approx(math.tanh(1.0) + 0.7)
+
+
+@pytest.mark.asyncio
+async def test_preselected_semantic_seeds_skip_seed_query(monkeypatch):
+    retriever = LinkExpansionRetriever()
+
+    @asynccontextmanager
+    async def fake_acquire_with_retry(_pool):
+        yield object()
+
+    async def fail_find_semantic_seeds(*args, **kwargs):
+        raise AssertionError("preselected seeds must bypass the graph seed query")
+
+    async def fake_expand_combined(_conn, seed_ids, fact_type, _budget, *, ops):
+        assert set(seed_ids) == {"seed-a", "seed-b"}
+        return [_row("result", 1.0, fact_type)], [], []
+
+    monkeypatch.setattr(link_expansion_retrieval, "acquire_with_retry", fake_acquire_with_retry)
+    monkeypatch.setattr(link_expansion_retrieval, "_find_semantic_seeds", fail_find_semantic_seeds)
+    monkeypatch.setattr(retriever, "_expand_combined", fake_expand_combined)
+
+    results, timings = await retriever.retrieve(
+        SimpleNamespace(ops=object()),
+        query_embedding_str="unused",
+        bank_id="bank",
+        fact_type="world",
+        budget=2,
+        preselected_semantic_seeds=[
+            RetrievalResult(id="seed-a", text="seed", fact_type="world"),
+            RetrievalResult(id="seed-b", text="seed", fact_type="world"),
+        ],
+    )
+
+    assert [result.id for result in results] == ["result"]
+    assert timings is not None
+    assert timings.seeds_time == 0.0

--- a/hindsight-api-slim/tests/test_link_expansion_scoring.py
+++ b/hindsight-api-slim/tests/test_link_expansion_scoring.py
@@ -99,3 +99,32 @@ async def test_preselected_semantic_seeds_skip_seed_query(monkeypatch):
     assert [result.id for result in results] == ["result"]
     assert timings is not None
     assert timings.seeds_time == 0.0
+
+
+@pytest.mark.asyncio
+async def test_empty_preselected_semantic_seeds_do_not_fall_back(monkeypatch):
+    retriever = LinkExpansionRetriever()
+
+    @asynccontextmanager
+    async def fake_acquire_with_retry(_pool):
+        yield object()
+
+    async def fail_find_semantic_seeds(*args, **kwargs):
+        raise AssertionError("an empty shared pool must not trigger a second seed query")
+
+    monkeypatch.setattr(link_expansion_retrieval, "acquire_with_retry", fake_acquire_with_retry)
+    monkeypatch.setattr(link_expansion_retrieval, "_find_semantic_seeds", fail_find_semantic_seeds)
+
+    results, timings = await retriever.retrieve(
+        SimpleNamespace(ops=object()),
+        query_embedding_str="unused",
+        bank_id="bank",
+        fact_type="world",
+        budget=2,
+        preselected_semantic_seeds=[],
+    )
+
+    assert results == []
+    assert timings is not None
+    assert timings.seeds_time == 0.0
+    assert timings.db_queries == 0

--- a/hindsight-api-slim/tests/test_multilingual_bm25.py
+++ b/hindsight-api-slim/tests/test_multilingual_bm25.py
@@ -241,5 +241,68 @@ async def test_combined_retrieval_uses_default_bm25_cap_for_legacy_config(monkey
         5,
     )
 
-    assert result == {"observation": ([], [])}
+    assert result == {"observation": retrieval_mod.SemanticBm25Result(semantic=[], bm25=[], graph_seeds=None)}
     assert fake_dialect.max_query_terms == 0
+
+
+@pytest.mark.asyncio
+async def test_combined_retrieval_reuses_raw_semantic_pool_for_graph_seeds(monkeypatch):
+    class FakeDialect:
+        def build_semantic_arm(self, **kwargs):
+            return "SELECT 'semantic' AS source"
+
+    class FakeConn:
+        backend_type = "postgresql"
+
+        async def fetch(self, query, *params):
+            return [
+                {"id": "best", "text": "best", "fact_type": "world", "source": "semantic", "similarity": 0.9},
+                {"id": "graph", "text": "graph", "fact_type": "world", "source": "semantic", "similarity": 0.6},
+                {"id": "weak", "text": "weak", "fact_type": "world", "source": "semantic", "similarity": 0.2},
+            ]
+
+    config = SimpleNamespace(semantic_min_similarity=0.1, bm25_min_score=0.0)
+    monkeypatch.setattr(retrieval_mod, "get_config", lambda: config)
+    monkeypatch.setattr(retrieval_mod, "create_sql_dialect", lambda backend: FakeDialect())
+
+    result = await retrieval_mod.retrieve_semantic_bm25_combined(
+        FakeConn(),
+        "[0.0]",
+        "",
+        "bank-1",
+        ["world"],
+        1,
+        graph_seed_min_similarity=0.5,
+    )
+
+    assert [candidate.id for candidate in result["world"].semantic] == ["best"]
+    assert [candidate.id for candidate in result["world"].graph_seeds or []] == ["best", "graph"]
+
+
+@pytest.mark.asyncio
+async def test_combined_retrieval_keeps_graph_query_when_semantic_threshold_is_stricter(monkeypatch):
+    class FakeDialect:
+        def build_semantic_arm(self, **kwargs):
+            return "SELECT 'semantic' AS source"
+
+    class FakeConn:
+        backend_type = "postgresql"
+
+        async def fetch(self, query, *params):
+            return []
+
+    config = SimpleNamespace(semantic_min_similarity=0.7, bm25_min_score=0.0)
+    monkeypatch.setattr(retrieval_mod, "get_config", lambda: config)
+    monkeypatch.setattr(retrieval_mod, "create_sql_dialect", lambda backend: FakeDialect())
+
+    result = await retrieval_mod.retrieve_semantic_bm25_combined(
+        FakeConn(),
+        "[0.0]",
+        "",
+        "bank-1",
+        ["world"],
+        10,
+        graph_seed_min_similarity=0.3,
+    )
+
+    assert result["world"].graph_seeds is None

--- a/hindsight-api-slim/tests/test_temporal_recall_selection.py
+++ b/hindsight-api-slim/tests/test_temporal_recall_selection.py
@@ -185,7 +185,7 @@ async def test_min_semantic_does_not_tighten_temporal_seed_threshold(monkeypatch
         yield object()
 
     async def fake_semantic_bm25_combined(*args, **kwargs):
-        return {"world": ([], [])}
+        return {"world": retrieval_module.SemanticBm25Result(semantic=[], bm25=[], graph_seeds=None)}
 
     async def fake_temporal_combined(*args, **kwargs):
         temporal_thresholds.append(kwargs["semantic_threshold"])
@@ -202,7 +202,10 @@ async def test_min_semantic_does_not_tighten_temporal_seed_threshold(monkeypatch
     monkeypatch.setattr(
         retrieval_module,
         "get_config",
-        lambda: SimpleNamespace(temporal_semantic_min_similarity=0.24),
+        lambda: SimpleNamespace(
+            graph_seed_min_similarity=0.3,
+            temporal_semantic_min_similarity=0.24,
+        ),
     )
     monkeypatch.setattr(
         "hindsight_api.engine.search.temporal_extraction.extract_temporal_constraint",
@@ -229,6 +232,7 @@ async def test_min_semantic_does_not_tighten_temporal_seed_threshold(monkeypatch
             "fact_type",
             "budget",
             "query_text",
+            "preselected_semantic_seeds",
             "tags",
             "tags_match",
             "tag_groups",


### PR DESCRIPTION
## Summary

- derive graph-specific semantic seeds from the combined semantic/BM25 query's existing HNSW over-fetch pool when its threshold covers the independently configured graph threshold
- retain the dedicated graph seed query when the semantic threshold is stricter, preserving graph candidate semantics
- compare `memory_units.id` as UUID instead of casting the indexed column to text
- filter canonical UUID text before casting so malformed, uppercase, braced, and unhyphenated inputs remain silently unmatched as before

## Production evidence

All measurements are read-only against an 8-vCPU AlloyDB primary over 2026-07-19 through 2026-07-26.

- graph seed query hash `10423161873194026836`: 302,602 calls, 2,071.913 seconds accumulated load
- UUID date lookup hash `8287897089562102294`: 5,115 calls, 867.790 seconds accumulated load
- ten production embedding/tag samples produced the same 20 graph seed IDs from the existing 100-row semantic pool as from the dedicated 20-row query
- UUID lookup: 120.049 ms median +/- 2.847 ms MAD -> 0.240 ms +/- 0.009 ms on the same 20 valid IDs plus malformed/noncanonical inputs (500.2x)
- UUID plan: sequential scan with 68,213 shared-buffer hits -> `pk_memory_units` index scan with 80 hits
- prepared `text[]` statement: 0.274 ms, same 20 returned rows

## Expanded verification

### PostgreSQL 18 + pgvector

Used the repository's `pgvector/pgvector:pg18` external-database image through `HINDSIGHT_API_DATABASE_URL`.

- UUID regression passed with canonical, malformed, uppercase, braced, and unhyphenated inputs
- default recall passed while `_find_semantic_seeds()` was forbidden, proving the shared semantic pool supplies graph seeds
- stricter `MinScores(semantic=0.9)` passed while recording one dedicated graph seed query, proving the fallback remains intact
- an empty shared seed list is covered and does not fall back to a second query
- 100,000-row scale benchmark, five warm-ups plus 30 alternating measured executions:
  - old form: 9.005 ms median +/- 0.163 ms MAD, sequential scan, 2,440 shared-buffer hits
  - new form: 0.0795 ms median +/- 0.0075 ms MAD, `pk_memory_units`, 23 hits
  - same returned IDs; 113.3x faster

### API suite and quality gates

- external-PostgreSQL bulk run: 4,238 passed, 216 skipped, 1 xfailed
- remaining bulk-run failures: two credential-backed extraction tests and one unrelated webhook timing flake; the webhook test passed immediately in isolation
- nine environment/concurrency-sensitive tests passed serially, including bank-index repair and tool-choice coverage
- graph/dedup focused regressions: 35 passed
- `tests/test_db_abstraction.py`: 106 passed
- `ruff check`: passed
- `ty check`: passed
- `scripts/hooks/lint.sh`: passed
- `scripts/hooks/check-unused.sh`: only existing advisory findings
- upstream CI run [30199494931](https://github.com/vectorize-io/hindsight/actions/runs/30199494931): success; API/secret-backed jobs were skipped by the workflow

## Remaining test-environment gaps

- pg0-only migration tests cannot start pg0's bundled PostgreSQL on this NixOS host
- SeaweedFS tests require their service fixture
- credential-backed LLM extraction tests require repository/provider secrets

None of these gaps exercise the changed graph-seed reuse or UUID lookup paths; both modified PostgreSQL paths have direct integration coverage above.
