### PR TITLE
fix: accept text alias in fact extraction for schema-drift resilience

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1485,6 +1485,8 @@ async def _extract_facts_from_chunk(
                 if not what:
                     what = get_value("factual_core")
                 if not what:
+                    what = get_value("text")
+                if not what:
                     # In verbatim mode, 'what' is intentionally absent — text is backfilled from chunk
                     if extraction_mode != "verbatim":
                         logger.warning(f"Skipping fact {i}: missing 'what' field")
@@ -2246,6 +2248,8 @@ async def extract_facts_from_contents_batch_api(
             what = get_value("what")
             if not what:
                 what = get_value("factual_core")
+            if not what:
+                what = get_value("text")
             if not what:
                 continue
 

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -204,6 +204,52 @@ async def test_top_level_fact_list_is_accepted_without_retry():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("fact_fields", "expected_count", "expected_text"),
+    [
+        ({"text": "Alice visited Paris"}, 1, "Alice visited Paris"),
+        ({"what": "Alice visited Paris"}, 1, "Alice visited Paris"),
+        ({}, 0, None),
+    ],
+)
+async def test_fact_text_alias_is_recovered_without_accepting_empty_facts(
+    fact_fields, expected_count, expected_text
+):
+    """Recover schema-drifted ``text`` facts while still skipping empty facts."""
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
+
+    config = _make_config(llm_max_retries=0, retain_llm_max_retries=None)
+    llm_config = _make_llm_config(
+        mock_response=[
+            {
+                **fact_fields,
+                "fact_type": "world",
+                "fact_kind": "conversation",
+            }
+        ]
+    )
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        facts, _usage = await _extract_facts_from_chunk(
+            chunk="Alice visited Paris.",
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            context="travel notes",
+            llm_config=llm_config,
+            config=config,
+            agent_name="test-agent",
+        )
+
+    assert len(facts) == expected_count
+    if expected_text:
+        assert expected_text in facts[0].fact
+
+
+@pytest.mark.asyncio
 async def test_non_dict_json_with_default_max_retries_raises():
     """
     Same scenario with the default llm_max_retries=10 (matching real default config):


### PR DESCRIPTION
## Summary

Some LLMs return extracted facts with `text` instead of the schema-requested `what` field. Fact extraction already accepts `factual_core` as a legacy alias, but without a `text` fallback these schema-drifted facts are silently discarded.

This change accepts `text` as an additional fallback in both fact-extraction paths while preserving the existing `what`/`factual_core` precedence and empty-fact skipping behavior.

## Changes

- Add `text` as a fallback alias for `what` in the standard extraction path.
- Add the same fallback in the batch API extraction path.
- Add regression coverage for `text`, `what`, and empty facts.

## Testing

- `pytest -q tests/test_fact_extraction_retry.py`

## Scope

This is intentionally a minimal compatibility fix for provider/model schema drift. No schema contract is changed; the requested canonical field remains `what`.