### PR TITLE
fix(files): reject misplaced retain metadata instead of discarding it

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -795,6 +795,26 @@ class FileRetainRequest(BaseModel):
         description="Metadata for each file (optional, must match number of files if provided)",
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def reject_misplaced_file_metadata(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+
+        misplaced = sorted(name for name in _FILE_RETAIN_PER_FILE_FIELDS if data.get(name) is not None)
+        errors = []
+        if misplaced:
+            fields = ", ".join(misplaced)
+            errors.append(f"Per-file fields ({fields}) must be placed in the corresponding 'files_metadata' entry")
+        if data.get("update_mode") is not None:
+            errors.append("'update_mode' is not supported by /files/retain, which always processes asynchronously")
+        if errors:
+            raise ValueError("; ".join(errors))
+        return data
+
+
+_FILE_RETAIN_PER_FILE_FIELDS = frozenset(FileRetainMetadata.model_fields) - frozenset(FileRetainRequest.model_fields)
+
 
 class RetainResponse(BaseModel):
     """Response model for retain endpoint."""

--- a/hindsight-api-slim/tests/test_file_retain.py
+++ b/hindsight-api-slim/tests/test_file_retain.py
@@ -242,6 +242,62 @@ async def test_file_retain_validation_errors(memory_no_llm_verify):
         assert response.status_code == 400
         assert "files_metadata count" in response.json()["detail"]
 
+        # Per-file fields at the request root used to be silently discarded,
+        # leaving the uploaded document with a generated ID and empty metadata.
+        request_data = {
+            "document_id": "stable-id",
+            "metadata": {"source": "page-1"},
+            "tags": ["report"],
+            "update_mode": "replace",
+            "async": True,
+        }
+        data = {"request": json.dumps(request_data)}
+
+        response = await client.post(
+            "/v1/default/banks/test-validation-bank/files/retain",
+            files=files,
+            data=data,
+        )
+
+        assert response.status_code == 400
+        detail = response.json()["detail"]
+        assert "document_id, metadata, tags" in detail
+        assert "'files_metadata' entry" in detail
+        assert "'update_mode' is not supported" in detail
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("context", "quarterly report"),
+        ("document_id", "report-2026-q2"),
+        ("metadata", {"page": 1}),
+        ("strategy", "default"),
+        ("tags", ["quarterly"]),
+        ("timestamp", "2026-07-27T00:00:00Z"),
+    ],
+)
+def test_file_retain_rejects_per_file_fields_only_at_request_root(field, value):
+    from hindsight_api.api.http import FileRetainRequest
+
+    with pytest.raises(ValueError, match="'files_metadata' entry"):
+        FileRetainRequest.model_validate({field: value})
+
+    request = FileRetainRequest.model_validate({"files_metadata": [{field: value}]})
+    assert request.files_metadata is not None
+    assert getattr(request.files_metadata[0], field) == value
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["context", "document_id", "metadata", "strategy", "tags", "timestamp", "update_mode"],
+)
+def test_file_retain_tolerates_null_legacy_root_fields(field):
+    from hindsight_api.api.http import FileRetainRequest
+
+    request = FileRetainRequest.model_validate({field: None})
+    assert request.files_metadata is None
+
 
 @pytest.mark.asyncio
 async def test_file_retain_no_files(memory_no_llm_verify):


### PR DESCRIPTION
Fixes #2970.

## Summary

- reject non-null per-file fields at the `/files/retain` request root instead of silently discarding them
- direct callers to the corresponding `files_metadata` entry and reject the unsupported root-level `update_mode`
- derive the checked field set from `FileRetainMetadata` and preserve compatibility with explicit legacy `null` values

## Rationale

The request model currently ignores extra fields. A caller can therefore send
`document_id`, `metadata`, or `tags` in the same shape accepted by the text
retain endpoint, receive a successful response, and only later discover that
the durable fields were lost. Returning an actionable 400 response prevents
that silent data-contract failure while retaining the existing multi-file
shape.

## Testing

- `pytest -q tests/test_file_retain.py` (`37 passed`)
- Ruff check/format, ty, and `git diff --check`
