### PR TITLE
fix(claude-code): send MemoryItem.timestamp so the extractor can resolve relative dates

### DIFF
--- a/hindsight-integrations/claude-code/CHANGELOG.md
+++ b/hindsight-integrations/claude-code/CHANGELOG.md
@@ -22,6 +22,20 @@
   `HINDSIGHT_USER_ID` is unset) are now dropped from retain requests. Previously
   such tags were sent as-is. Tags without `:` are unaffected.
 
+### Fixed
+
+- Retain requests now send the `MemoryItem.timestamp` field, using the same
+  wall-clock instant already recorded as `retained_at` metadata. Previously the
+  hook never sent one, so the extractor had no reference time to resolve
+  relative expressions: a transcript saying "yesterday" or "last week" was
+  stored with that phrase unresolved in the fact text (e.g.
+  `"When: Today (relative to conversation)"`), which conveys nothing once the
+  fact is recalled weeks later. Measured against a self-hosted server, adding
+  the anchor turned "last week we soldered the tamper pull-down" into a fact
+  dated `2026-07-19`, and "yesterday" into `2026-07-25`. Hindsight's own
+  best-practices guide lists omitting `timestamp` as an anti-pattern
+  ("Missing `timestamp` on retain — disables temporal retrieval strategies").
+
 ## [0.1.0] - 2025-03-23
 
 ### Added

--- a/hindsight-integrations/claude-code/scripts/lib/client.py
+++ b/hindsight-integrations/claude-code/scripts/lib/client.py
@@ -145,6 +145,7 @@ class HindsightClient:
         context: Optional[str] = None,
         metadata: Optional[dict] = None,
         tags: Optional[list] = None,
+        timestamp: Optional[str] = None,
         timeout: int = 15,
     ) -> dict:
         """Retain content into a bank's memory.
@@ -152,6 +153,11 @@ class HindsightClient:
         Posts with async=true so the server processes in the background.
         The context field helps Hindsight cluster memories by provenance
         (e.g. "claude-code" vs manual retains).
+
+        timestamp (ISO 8601) is the MemoryItem reference time the extractor
+        uses to resolve relative expressions in the transcript. Omitting it
+        leaves phrases like "yesterday" unresolved in the stored fact text,
+        which is meaningless once the fact is recalled weeks later.
         """
         path = f"/v1/default/banks/{urllib.parse.quote(bank_id, safe='')}/memories"
         item = {
@@ -163,6 +169,8 @@ class HindsightClient:
             item["context"] = context
         if tags:
             item["tags"] = tags
+        if timestamp:
+            item["timestamp"] = timestamp
         body = {
             "items": [item],
             "async": True,

--- a/hindsight-integrations/claude-code/scripts/retain.py
+++ b/hindsight-integrations/claude-code/scripts/retain.py
@@ -237,6 +237,7 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
             context=config.get("retainContext", "claude-code"),
             metadata=metadata,
             tags=tags,
+            timestamp=template_vars["timestamp"],
             timeout=15,
         )
         if retention_progress is not None:

--- a/hindsight-integrations/claude-code/tests/test_hooks.py
+++ b/hindsight-integrations/claude-code/tests/test_hooks.py
@@ -11,6 +11,7 @@ import importlib
 import io
 import json
 import os
+import re
 import sys
 import time
 from unittest.mock import MagicMock, patch
@@ -875,3 +876,54 @@ class TestRetainHook:
             mod.main()
 
         assert "called" not in captured
+
+    # Intention: the Hindsight API's MemoryItem accepts a `timestamp` — the
+    # reference time the extractor uses to resolve relative expressions. The
+    # hook previously never sent one, so a transcript saying "yesterday" was
+    # stored with that phrase unresolved (and `occurred_start` left null),
+    # which is meaningless once the fact is recalled weeks later. The retain
+    # hook must stamp every request with the session's wall-clock time.
+
+    def test_retain_sends_timestamp_for_relative_date_resolution(self, monkeypatch, tmp_path):
+        # Input: an ordinary retain with a transcript present.
+        # Expected: the posted item carries an ISO-8601 `timestamp`, and it
+        # matches the `retained_at` metadata so both describe the same instant.
+        messages = [{"role": "user", "content": "yesterday we shipped v0.17.2"}, {"role": "assistant", "content": "ok"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({"status": "accepted"})
+
+        hook_input = make_hook_input(transcript_path=transcript)
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
+
+        assert "body" in captured, "retain API was not called"
+        item = captured["body"]["items"][0]
+        assert "timestamp" in item, "retain must send a reference timestamp"
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", item["timestamp"]), item["timestamp"]
+        assert item["timestamp"] == item["metadata"]["retained_at"]
+
+    def test_client_omits_timestamp_field_when_not_supplied(self, monkeypatch, tmp_path):
+        # Input: HindsightClient.retain called without a timestamp.
+        # Expected: no `timestamp` key at all — the server then falls back to
+        # ingestion time rather than receiving an explicit null.
+        scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts"))
+        sys.path.insert(0, scripts_dir)
+        try:
+            from lib.client import HindsightClient
+        finally:
+            sys.path.remove(scripts_dir)
+
+        captured = {}
+
+        def capture(req, timeout=None):
+            captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({"status": "accepted"})
+
+        with patch("urllib.request.urlopen", side_effect=capture):
+            HindsightClient("http://localhost:9077", None).retain(bank_id="b", content="hello")
+
+        assert "timestamp" not in captured["body"]["items"][0]


### PR DESCRIPTION
**Of ~1,400 facts accumulated in a real bank, exactly 1 carried a usable date.** The retain hook never sends `MemoryItem.timestamp`, so the extractor has no anchor: "yesterday" and "last week" are stored verbatim, `occurred_start` stays null, and the memory never reaches the Timeline. The hook already computes the value — it just never reaches the request body.

---

## Problem

The Claude Code retain hook never sends `MemoryItem.timestamp`, so the extractor has no reference time to resolve relative expressions in a transcript.

The result is facts that are stored but not usable later. A session saying "yesterday the sensors phantom-cascaded" is extracted as:

```
occurred_start=None | ... | When: Today (relative to conversation)
occurred_start=None | ... | When: Last week
```

"Last week" relative to *what*? The anchor is exactly the information that was dropped. Once that fact is recalled weeks later it conveys nothing, and `occurred_start` stays null so the memory never reaches the Timeline.

This is listed as an anti-pattern in Hindsight's own best-practices guide:

> **Missing `timestamp` on retain** — Disables temporal retrieval strategies — *Always set from actual content timestamps*

and in the `timestamp` field docs:

> Set whenever you have temporal context. Enables temporal retrieval strategies.

## Measurement

Same transcript, same `retain_mission`, run through `dry-run-extract` on a self-hosted server with the anchor as the only variable:

| transcript phrase | without `timestamp` | with `timestamp` |
|---|---|---|
| "last week we soldered the tamper pull-down" | `When: Last week` | **`on 2026-07-19`** |
| "yesterday the sensors phantom-cascaded" | *(unresolved)* | **`on 2026-07-25`** |
| "today I want to plan Phase B" | `When: Today (relative to conversation)` | **`on 2026-07-26`** |

On a bank of ~1,400 facts accumulated without the anchor, exactly **1** carried an `occurred_start`.

## Fix

The hook already computes the instant it needs. `run_retain` builds `template_vars["timestamp"]` (`time.gmtime()`, ISO 8601) and records it as `retained_at` metadata — it just never reached the request body. This passes that same value through as the MemoryItem reference time.

- No new configuration.
- No behaviour change for callers that omit it: `HindsightClient.retain(timestamp=None)` sends no `timestamp` key at all, so the server keeps its existing ingestion-time fallback rather than receiving an explicit null.

## Tests

Two added to `TestRetainHook` (203 pass, up from 201):

- `test_retain_sends_timestamp_for_relative_date_resolution` — asserts the posted item carries an ISO-8601 `timestamp` and that it matches the `retained_at` metadata, so both describe the same instant.
- `test_client_omits_timestamp_field_when_not_supplied` — pins the omission path.

Mutation-checked: deleting the `item["timestamp"] = timestamp` assignment fails the first test; restoring it passes.

## Scope note

This only supplies the anchor. Whether the extractor then populates `occurred_start` is model-dependent — a local qwen3.6 resolved relative dates into the fact *text* but still left `occurred_start` null, while a hosted model populated it 3/5 of the time on the same input. Sending the timestamp is a precondition for either, and improves the stored text regardless of which model is behind the extractor.

