### PR TITLE
fix(clients): expose async retain operation_id

### DIFF
--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -283,6 +283,7 @@ class Hindsight:
         tags: list[str] | None = None,
         update_mode: str | None = None,
         retain_async: bool = False,
+        operation_id: str | None = None,
     ) -> RetainResponse:
         """
         Store a single memory (sync wrapper — prefer :meth:`aretain` in async code).
@@ -298,6 +299,7 @@ class Hindsight:
             tags: Optional list of tags for filtering memories during recall/reflect
             update_mode: How to handle existing documents ('replace' or 'append')
             retain_async: If True, process asynchronously in background (default: False)
+            operation_id: Optional caller-supplied UUID for idempotent async retries; ignored by sync retain
 
         Returns:
             RetainResponse with success status
@@ -312,12 +314,15 @@ class Hindsight:
         }
         if update_mode is not None:
             item["update_mode"] = update_mode
-        return self.retain_batch(
-            bank_id=bank_id,
-            items=[item],
-            document_id=document_id,
-            retain_async=retain_async,
-        )
+        batch_kwargs: dict[str, Any] = {
+            "bank_id": bank_id,
+            "items": [item],
+            "document_id": document_id,
+            "retain_async": retain_async,
+        }
+        if retain_async and operation_id is not None:
+            batch_kwargs["operation_id"] = operation_id
+        return self.retain_batch(**batch_kwargs)
 
     def retain_batch(
         self,
@@ -326,6 +331,7 @@ class Hindsight:
         document_id: str | None = None,
         document_tags: list[str] | None = None,
         retain_async: bool = False,
+        operation_id: str | None = None,
     ) -> RetainResponse:
         """
         Store multiple memories in batch (sync wrapper — prefer :meth:`aretain_batch` in async code).
@@ -338,19 +344,21 @@ class Hindsight:
             document_id: Optional document ID for grouping memories (applied to items that don't have their own)
             document_tags: Optional list of tags applied to all items in this batch (merged with per-item tags)
             retain_async: If True, process asynchronously in background (default: False)
+            operation_id: Optional caller-supplied UUID for idempotent async retries; ignored by sync retain
 
         Returns:
             RetainResponse with success status and item count
         """
-        return _run_async(
-            self.aretain_batch(
-                bank_id=bank_id,
-                items=items,
-                document_id=document_id,
-                document_tags=document_tags,
-                retain_async=retain_async,
-            )
-        )
+        batch_kwargs: dict[str, Any] = {
+            "bank_id": bank_id,
+            "items": items,
+            "document_id": document_id,
+            "document_tags": document_tags,
+            "retain_async": retain_async,
+        }
+        if retain_async and operation_id is not None:
+            batch_kwargs["operation_id"] = operation_id
+        return _run_async(self.aretain_batch(**batch_kwargs))
 
     def retain_files(
         self,
@@ -781,6 +789,7 @@ class Hindsight:
         document_id: str | None = None,
         document_tags: list[str] | None = None,
         retain_async: bool = False,
+        operation_id: str | None = None,
     ) -> RetainResponse:
         """
         Store multiple memories in batch (async — preferred over :meth:`retain_batch`).
@@ -793,6 +802,7 @@ class Hindsight:
             document_id: Optional document ID for grouping memories (applied to items that don't have their own)
             document_tags: Optional list of tags applied to all items in this batch (merged with per-item tags)
             retain_async: If True, process asynchronously in background (default: False)
+            operation_id: Optional caller-supplied UUID for idempotent async retries; ignored by sync retain
 
         Returns:
             RetainResponse with success status and item count
@@ -827,11 +837,14 @@ class Hindsight:
                 )
             )
 
-        request_obj = retain_request.RetainRequest(
-            items=memory_items,
-            var_async=retain_async,
-            document_tags=document_tags,
-        )
+        request_kwargs: dict[str, Any] = {
+            "items": memory_items,
+            "var_async": retain_async,
+            "document_tags": document_tags,
+        }
+        if retain_async and operation_id is not None:
+            request_kwargs["operation_id"] = operation_id
+        request_obj = retain_request.RetainRequest(**request_kwargs)
 
         return await self._memory_api.retain_memories(bank_id, request_obj, _request_timeout=self._timeout)
 
@@ -847,6 +860,7 @@ class Hindsight:
         tags: list[str] | None = None,
         update_mode: str | None = None,
         retain_async: bool = False,
+        operation_id: str | None = None,
     ) -> RetainResponse:
         """
         Store a single memory (async — preferred over :meth:`retain`).
@@ -862,6 +876,7 @@ class Hindsight:
             tags: Optional list of tags for filtering memories during recall/reflect
             update_mode: How to handle existing documents ('replace' or 'append')
             retain_async: If True, process asynchronously in background (default: False)
+            operation_id: Optional caller-supplied UUID for idempotent async retries; ignored by sync retain
 
         Returns:
             RetainResponse with success status
@@ -876,12 +891,15 @@ class Hindsight:
         }
         if update_mode is not None:
             item["update_mode"] = update_mode
-        return await self.aretain_batch(
-            bank_id=bank_id,
-            items=[item],
-            document_id=document_id,
-            retain_async=retain_async,
-        )
+        batch_kwargs: dict[str, Any] = {
+            "bank_id": bank_id,
+            "items": [item],
+            "document_id": document_id,
+            "retain_async": retain_async,
+        }
+        if retain_async and operation_id is not None:
+            batch_kwargs["operation_id"] = operation_id
+        return await self.aretain_batch(**batch_kwargs)
 
     async def arecall(
         self,

--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -7,6 +7,7 @@ easy-to-use interface on top of the auto-generated OpenAPI client.
 
 import asyncio
 import json
+import warnings
 from datetime import datetime
 from importlib import metadata
 from pathlib import Path
@@ -58,6 +59,20 @@ def _run_async(coro):
         asyncio.set_event_loop(loop)
 
     return loop.run_until_complete(coro)
+
+
+def _warn_if_operation_id_dropped(retain_async: bool, operation_id: str | None) -> None:
+    """Warn when a caller-supplied operation_id will be silently ignored.
+
+    operation_id only enables idempotent retries for asynchronous retain; on a
+    synchronous request it is dropped before reaching the API, so surface the
+    likely mistake instead of failing silently.
+    """
+    if operation_id is not None and not retain_async:
+        warnings.warn(
+            "operation_id is ignored for synchronous retain; pass retain_async=True to enable idempotent retries.",
+            stacklevel=3,
+        )
 
 
 class Hindsight:
@@ -320,6 +335,7 @@ class Hindsight:
             "document_id": document_id,
             "retain_async": retain_async,
         }
+        _warn_if_operation_id_dropped(retain_async, operation_id)
         if retain_async and operation_id is not None:
             batch_kwargs["operation_id"] = operation_id
         return self.retain_batch(**batch_kwargs)
@@ -356,6 +372,7 @@ class Hindsight:
             "document_tags": document_tags,
             "retain_async": retain_async,
         }
+        _warn_if_operation_id_dropped(retain_async, operation_id)
         if retain_async and operation_id is not None:
             batch_kwargs["operation_id"] = operation_id
         return _run_async(self.aretain_batch(**batch_kwargs))
@@ -842,6 +859,7 @@ class Hindsight:
             "var_async": retain_async,
             "document_tags": document_tags,
         }
+        _warn_if_operation_id_dropped(retain_async, operation_id)
         if retain_async and operation_id is not None:
             request_kwargs["operation_id"] = operation_id
         request_obj = retain_request.RetainRequest(**request_kwargs)
@@ -897,6 +915,7 @@ class Hindsight:
             "document_id": document_id,
             "retain_async": retain_async,
         }
+        _warn_if_operation_id_dropped(retain_async, operation_id)
         if retain_async and operation_id is not None:
             batch_kwargs["operation_id"] = operation_id
         return await self.aretain_batch(**batch_kwargs)

--- a/hindsight-clients/python/tests/test_retain_async_kwarg.py
+++ b/hindsight-clients/python/tests/test_retain_async_kwarg.py
@@ -1,17 +1,48 @@
 """
-Test that retain() and aretain() forward retain_async to the batch methods.
+Test that retain helpers forward async and idempotency options.
 
 Prevents silent regressions where retain_async is accepted in the signature
-but dropped before reaching the API request (similar to the bug fixed in #709).
+but dropped before reaching the API request (similar to the bug fixed in #709),
+or where operation_id is unavailable through the high-level client surface.
 """
 
 from unittest.mock import AsyncMock, MagicMock
 
 from hindsight_client import Hindsight
 
+OPERATION_ID = "123e4567-e89b-12d3-a456-426614174000"
+
 
 def _make_client():
     return Hindsight(base_url="http://localhost:8888")
+
+
+def _captured_request(client):
+    return client._memory_api.retain_memories.call_args.args[1]
+
+
+class _LegacyBatchOverrides(Hindsight):
+    """Models subclasses written before operation_id was added."""
+
+    def retain_batch(
+        self,
+        bank_id,
+        items,
+        document_id=None,
+        document_tags=None,
+        retain_async=False,
+    ):
+        return MagicMock()
+
+    async def aretain_batch(
+        self,
+        bank_id,
+        items,
+        document_id=None,
+        document_tags=None,
+        retain_async=False,
+    ):
+        return MagicMock()
 
 
 async def test_aretain_forwards_retain_async_default():
@@ -32,6 +63,15 @@ async def test_aretain_forwards_retain_async_true():
     assert client.aretain_batch.call_args.kwargs["retain_async"] is True
 
 
+async def test_aretain_forwards_operation_id():
+    """aretain() should forward a caller-supplied idempotency key."""
+    client = _make_client()
+    client.aretain_batch = AsyncMock()
+
+    await client.aretain("bank", "content", retain_async=True, operation_id=OPERATION_ID)
+    assert client.aretain_batch.call_args.kwargs["operation_id"] == OPERATION_ID
+
+
 def test_retain_forwards_retain_async_default():
     """retain() should forward retain_async=False by default."""
     client = _make_client()
@@ -48,3 +88,74 @@ def test_retain_forwards_retain_async_true():
 
     client.retain("bank", "content", retain_async=True)
     assert client.retain_batch.call_args.kwargs["retain_async"] is True
+
+
+def test_retain_forwards_operation_id():
+    """retain() should forward a caller-supplied idempotency key."""
+    client = _make_client()
+    client.retain_batch = MagicMock()
+
+    client.retain("bank", "content", retain_async=True, operation_id=OPERATION_ID)
+    assert client.retain_batch.call_args.kwargs["operation_id"] == OPERATION_ID
+
+
+def test_retain_batch_forwards_operation_id():
+    """retain_batch() should forward operation_id to the async implementation."""
+    client = _make_client()
+    client.aretain_batch = AsyncMock()
+
+    client.retain_batch("bank", [{"content": "content"}], retain_async=True, operation_id=OPERATION_ID)
+    assert client.aretain_batch.call_args.kwargs["operation_id"] == OPERATION_ID
+
+
+async def test_aretain_batch_sets_operation_id_on_request():
+    """aretain_batch() should put a supplied UUID on the generated request."""
+    client = _make_client()
+    client._memory_api.retain_memories = AsyncMock()
+
+    await client.aretain_batch("bank", [{"content": "content"}], retain_async=True, operation_id=OPERATION_ID)
+
+    request = _captured_request(client)
+    assert request.operation_id == OPERATION_ID
+    assert request.to_dict()["operation_id"] == OPERATION_ID
+
+
+async def test_aretain_batch_omits_operation_id_by_default():
+    """The legacy request shape should not gain an operation_id null field."""
+    client = _make_client()
+    client._memory_api.retain_memories = AsyncMock()
+
+    await client.aretain_batch("bank", [{"content": "content"}])
+
+    assert "operation_id" not in _captured_request(client).to_dict()
+
+
+async def test_aretain_batch_omits_operation_id_for_sync_retain():
+    """A supplied idempotency key should stay off synchronous requests."""
+    client = _make_client()
+    client._memory_api.retain_memories = AsyncMock()
+
+    await client.aretain_batch("bank", [{"content": "content"}], operation_id=OPERATION_ID)
+
+    assert "operation_id" not in _captured_request(client).to_dict()
+
+
+def test_retain_preserves_legacy_batch_override_for_default_call():
+    """Default retain() calls should not pass new kwargs to old overrides."""
+    client = _LegacyBatchOverrides(base_url="http://localhost:8888")
+
+    Hindsight.retain(client, "bank", "content")
+
+
+def test_retain_batch_preserves_legacy_async_override_for_default_call():
+    """Default retain_batch() calls should keep old async overrides callable."""
+    client = _LegacyBatchOverrides(base_url="http://localhost:8888")
+
+    Hindsight.retain_batch(client, "bank", [{"content": "content"}])
+
+
+async def test_aretain_preserves_legacy_batch_override_for_default_call():
+    """Default aretain() calls should not pass new kwargs to old overrides."""
+    client = _LegacyBatchOverrides(base_url="http://localhost:8888")
+
+    await Hindsight.aretain(client, "bank", "content")

--- a/hindsight-clients/python/tests/test_retain_async_kwarg.py
+++ b/hindsight-clients/python/tests/test_retain_async_kwarg.py
@@ -6,7 +6,10 @@ but dropped before reaching the API request (similar to the bug fixed in #709),
 or where operation_id is unavailable through the high-level client surface.
 """
 
+import warnings
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from hindsight_client import Hindsight
 
@@ -159,3 +162,47 @@ async def test_aretain_preserves_legacy_batch_override_for_default_call():
     client = _LegacyBatchOverrides(base_url="http://localhost:8888")
 
     await Hindsight.aretain(client, "bank", "content")
+
+
+def test_retain_warns_once_when_operation_id_dropped_on_sync():
+    """A supplied operation_id on a sync retain should warn exactly once.
+
+    Runs the full retain -> retain_batch -> aretain_batch delegation so a
+    duplicated warning across the chain would be caught.
+    """
+    client = _make_client()
+    client._memory_api.retain_memories = AsyncMock()
+
+    with pytest.warns(UserWarning, match="operation_id is ignored for synchronous retain") as records:
+        client.retain("bank", "content", operation_id=OPERATION_ID)
+
+    assert len(records) == 1
+
+
+async def test_aretain_batch_warns_when_operation_id_dropped_on_sync():
+    """A supplied operation_id on a sync aretain_batch should warn."""
+    client = _make_client()
+    client._memory_api.retain_memories = AsyncMock()
+
+    with pytest.warns(UserWarning, match="operation_id is ignored for synchronous retain"):
+        await client.aretain_batch("bank", [{"content": "content"}], operation_id=OPERATION_ID)
+
+
+async def test_aretain_does_not_warn_when_operation_id_used_on_async():
+    """A supplied operation_id on an async retain must not warn."""
+    client = _make_client()
+    client.aretain_batch = AsyncMock()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        await client.aretain("bank", "content", retain_async=True, operation_id=OPERATION_ID)
+
+
+def test_retain_does_not_warn_by_default():
+    """A plain sync retain without operation_id must not warn."""
+    client = _make_client()
+    client.retain_batch = MagicMock()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        client.retain("bank", "content")

--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -123,6 +123,24 @@ export interface MemoryItemInput {
   update_mode?: "replace" | "append";
 }
 
+/**
+ * Warn when a caller-supplied operationId will be silently ignored.
+ *
+ * operationId only enables idempotent retries for asynchronous retain; on a
+ * synchronous request it is dropped before reaching the API, so surface the
+ * likely mistake instead of failing silently.
+ */
+function warnIfOperationIdDropped(
+  async: boolean | undefined,
+  operationId: string | null | undefined
+): void {
+  if (operationId != null && async !== true) {
+    console.warn(
+      "operationId is ignored for synchronous retain; pass async: true to enable idempotent retries."
+    );
+  }
+}
+
 export class HindsightClient {
   private client: Client;
 
@@ -206,6 +224,7 @@ export class HindsightClient {
       signal?: AbortSignal;
     }
   ): Promise<RetainResponse> {
+    warnIfOperationIdDropped(options?.async, options?.operationId);
     return this.retainBatch(
       bankId,
       [
@@ -247,6 +266,7 @@ export class HindsightClient {
       signal?: AbortSignal;
     }
   ): Promise<RetainResponse> {
+    warnIfOperationIdDropped(options?.async, options?.operationId);
     const processedItems = items.map((item) => ({
       content: item.content,
       context: item.context,

--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -192,6 +192,8 @@ export class HindsightClient {
       metadata?: Record<string, string>;
       documentId?: string;
       async?: boolean;
+      /** Optional caller-supplied UUID for idempotent async retries */
+      operationId?: string;
       entities?: EntityInput[];
       /** Optional list of tags for this memory */
       tags?: string[];
@@ -220,7 +222,13 @@ export class HindsightClient {
           strategy: options?.strategy,
         },
       ],
-      { async: options?.async, signal: options?.signal }
+      {
+        async: options?.async,
+        signal: options?.signal,
+        ...(options?.async === true && options.operationId != null
+          ? { operationId: options.operationId }
+          : {}),
+      }
     );
   }
 
@@ -234,6 +242,8 @@ export class HindsightClient {
       documentId?: string;
       documentTags?: string[];
       async?: boolean;
+      /** Optional caller-supplied UUID for idempotent async retries */
+      operationId?: string;
       signal?: AbortSignal;
     }
   ): Promise<RetainResponse> {
@@ -263,6 +273,9 @@ export class HindsightClient {
         items: itemsWithDocId,
         document_tags: options?.documentTags,
         async: options?.async,
+        ...(options?.async === true && options.operationId != null
+          ? { operation_id: options.operationId }
+          : {}),
       },
       signal: options?.signal,
     });

--- a/hindsight-clients/typescript/tests/main_operations.test.ts
+++ b/hindsight-clients/typescript/tests/main_operations.test.ts
@@ -561,6 +561,54 @@ const canSpyOnModules = typeof (globalThis as any).Deno === "undefined";
     }
     spy.mockRestore();
   });
+
+  test("retain warns exactly once when operationId is dropped on a sync request", async () => {
+    const sdkSpy = jest.spyOn(sdk, "retainMemories").mockResolvedValue({
+      data: { success: true, items_count: 1 },
+    } as any);
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    await client.retain(randomBankId(), "test", {
+      operationId: "123e4567-e89b-12d3-a456-426614174004",
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("operationId is ignored for synchronous retain");
+    warnSpy.mockRestore();
+    sdkSpy.mockRestore();
+  });
+
+  test("retainBatch warns when operationId is dropped on a sync request", async () => {
+    const sdkSpy = jest.spyOn(sdk, "retainMemories").mockResolvedValue({
+      data: { success: true, items_count: 1 },
+    } as any);
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    await client.retainBatch(randomBankId(), [{ content: "test" }], {
+      operationId: "123e4567-e89b-12d3-a456-426614174005",
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+    sdkSpy.mockRestore();
+  });
+
+  test("retain does not warn for async operationId or default calls", async () => {
+    const sdkSpy = jest.spyOn(sdk, "retainMemories").mockResolvedValue({
+      data: { success: true, items_count: 1 },
+    } as any);
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    await client.retain(randomBankId(), "async", {
+      async: true,
+      operationId: "123e4567-e89b-12d3-a456-426614174006",
+    });
+    await client.retain(randomBankId(), "default");
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+    sdkSpy.mockRestore();
+  });
 });
 
 (canSpyOnModules ? describe : describe.skip)("TestAbortSignal", () => {

--- a/hindsight-clients/typescript/tests/main_operations.test.ts
+++ b/hindsight-clients/typescript/tests/main_operations.test.ts
@@ -474,6 +474,95 @@ describe("TestMission", () => {
 // properties are frozen. These unit tests are covered by the Jest suite.
 const canSpyOnModules = typeof (globalThis as any).Deno === "undefined";
 
+(canSpyOnModules ? describe : describe.skip)("TestRetainRequestOptions", () => {
+  test("retain threads operationId into the request body", async () => {
+    const operationId = "123e4567-e89b-12d3-a456-426614174000";
+    const spy = jest.spyOn(sdk, "retainMemories").mockResolvedValue({
+      data: { success: true, items_count: 1 },
+    } as any);
+
+    await client.retain(randomBankId(), "test", { async: true, operationId });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({ operation_id: operationId }),
+      })
+    );
+    spy.mockRestore();
+  });
+
+  test("retainBatch threads operationId into the request body", async () => {
+    const operationId = "123e4567-e89b-12d3-a456-426614174001";
+    const spy = jest.spyOn(sdk, "retainMemories").mockResolvedValue({
+      data: { success: true, items_count: 1 },
+    } as any);
+
+    await client.retainBatch(randomBankId(), [{ content: "test" }], {
+      async: true,
+      operationId,
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({ operation_id: operationId }),
+      })
+    );
+    spy.mockRestore();
+  });
+
+  test("retainBatch omits operation_id by default", async () => {
+    const spy = jest.spyOn(sdk, "retainMemories").mockResolvedValue({
+      data: { success: true, items_count: 1 },
+    } as any);
+
+    await client.retainBatch(randomBankId(), [{ content: "test" }]);
+
+    const request = spy.mock.calls[0][0] as any;
+    expect(request.body).not.toHaveProperty("operation_id");
+    spy.mockRestore();
+  });
+
+  test("retainBatch omits operation_id for sync and nullish requests", async () => {
+    const spy = jest.spyOn(sdk, "retainMemories").mockResolvedValue({
+      data: { success: true, items_count: 1 },
+    } as any);
+
+    await client.retainBatch(randomBankId(), [{ content: "sync" }], {
+      operationId: "123e4567-e89b-12d3-a456-426614174002",
+    });
+    await client.retainBatch(randomBankId(), [{ content: "null" }], {
+      async: true,
+      operationId: null,
+    } as any);
+
+    for (const [request] of spy.mock.calls) {
+      expect((request as any).body).not.toHaveProperty("operation_id");
+    }
+    spy.mockRestore();
+  });
+
+  test("retain omits operationId from default, sync, and nullish delegation", async () => {
+    const spy = jest.spyOn(client, "retainBatch").mockResolvedValue({
+      success: true,
+      items_count: 1,
+    } as any);
+
+    await client.retain(randomBankId(), "default");
+    await client.retain(randomBankId(), "sync", {
+      operationId: "123e4567-e89b-12d3-a456-426614174003",
+    });
+    await client.retain(randomBankId(), "null", {
+      async: true,
+      operationId: null,
+    } as any);
+
+    for (const call of spy.mock.calls) {
+      expect(call[2]).not.toHaveProperty("operationId");
+    }
+    spy.mockRestore();
+  });
+});
+
 (canSpyOnModules ? describe : describe.skip)("TestAbortSignal", () => {
   test("retain passes abort signal to SDK", async () => {
     const bankId = randomBankId();


### PR DESCRIPTION
## Summary

- expose `operation_id` through the high-level Python `retain`/`retain_batch` helpers
- expose the same option as `operationId` through the TypeScript `retain`/`retainBatch` helpers
- serialize the wire field only for asynchronous, non-null requests, preserving the legacy request shape and old Python helper overrides

Follow-up to #2947. That change added caller-supplied operation IDs to the generated request models, but the hand-maintained convenience clients did not expose them. Users of the normal Python and TypeScript surfaces therefore could not safely retry an async retain after a lost acknowledgement without dropping to the generated client.

The scope is limited to the two high-level clients and focused regressions; server behavior and generated clients are unchanged.

## Verification

- Python retain/request tests: 17 passed
- TypeScript request-option tests: 5 passed
- `npx tsc --noEmit`
- `npm run build`
- Ruff checks and format checks on the changed Python regions
