### PR TITLE
fix: avoid dotenv side effects on library import

### DIFF
--- a/hindsight-api-slim/hindsight_api/admin/cli.py
+++ b/hindsight-api-slim/hindsight_api/admin/cli.py
@@ -17,7 +17,7 @@ from typing import Any
 import asyncpg
 import typer
 
-from ..config import DEFAULT_DATABASE_SCHEMA, HindsightConfig
+from ..config import DEFAULT_DATABASE_SCHEMA, HindsightConfig, load_dotenv_for_entrypoint
 from ..engine.memory_engine import _current_schema
 from ..engine.retain.bank_utils import _vector_index_clause
 from ..engine.schema import fq_table_explicit as _fq_table
@@ -960,6 +960,7 @@ def worker_status(
 
 
 def main():
+    load_dotenv_for_entrypoint()
     app()
 
 

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -19,10 +19,26 @@ from ._pg_search import normalize_pg_search_tokenizer
 from ._vector_index import validate_extension
 from .utils import mask_network_location
 
-# Load .env file, searching current and parent directories (overrides existing env vars)
-load_dotenv(find_dotenv(usecwd=True), override=True)
-
 logger = logging.getLogger(__name__)
+
+
+def load_dotenv_for_entrypoint() -> None:
+    """Load a discovered ``.env`` file for Hindsight's own entry points.
+
+    Importing ``hindsight_api`` (or anything that pulls it in) must NOT mutate
+    the host application's ``os.environ``. See issue #2961: doing so at module
+    scope let an upward ``.env`` walk from the process cwd silently overwrite an
+    embedding application's own configuration.
+
+    This helper is therefore called explicitly from Hindsight's standalone entry
+    points only — the API server (CLI and ``hindsight_api.server:app``), the
+    worker, and the admin CLI. ``override=True`` is deliberate: it preserves the
+    exact precedence those entry points have always had (a discovered ``.env``
+    is authoritative over the ambient process environment). Because a library
+    import never reaches this code path, that precedence no longer leaks into
+    embedders.
+    """
+    load_dotenv(find_dotenv(usecwd=True), override=True)
 
 
 class ConfigFieldAccessError(AttributeError):

--- a/hindsight-api-slim/hindsight_api/main.py
+++ b/hindsight-api-slim/hindsight_api/main.py
@@ -32,6 +32,7 @@ from .config import (
     ENV_WORKERS,
     HindsightConfig,
     _get_raw_config,
+    load_dotenv_for_entrypoint,
 )
 from .daemon import (
     DEFAULT_DAEMON_PORT,
@@ -196,6 +197,8 @@ def _parse_cli_args(argv: list[str], config: HindsightConfig) -> ParsedCliArgs:
 def main():
     """Main entry point for the CLI."""
     global _memory
+
+    load_dotenv_for_entrypoint()
 
     # Load configuration from environment (for CLI args defaults)
     config = _get_raw_config()

--- a/hindsight-api-slim/hindsight_api/server.py
+++ b/hindsight-api-slim/hindsight_api/server.py
@@ -17,13 +17,20 @@ warnings.filterwarnings("ignore", message="websockets.server.WebSocketServerProt
 
 from hindsight_api import MemoryEngine
 from hindsight_api.api import create_app
-from hindsight_api.config import get_config
+from hindsight_api.config import get_config, load_dotenv_for_entrypoint
 from hindsight_api.extensions import (
     DefaultExtensionContext,
     OperationValidatorExtension,
     TenantExtension,
     load_extension,
 )
+
+# This module IS an entry point: it is the ASGI app targeted by
+# `uvicorn hindsight_api.server:app`, and the import string uvicorn re-imports
+# in each worker process when `hindsight-api` runs with --workers/--reload. Load
+# .env here (like the CLI entry points) so those worker processes see the same
+# configuration. Importing hindsight_api as a library never reaches this module.
+load_dotenv_for_entrypoint()
 
 # Disable tokenizers parallelism to avoid warnings
 os.environ["TOKENIZERS_PARALLELISM"] = "false"

--- a/hindsight-api-slim/hindsight_api/worker/main.py
+++ b/hindsight-api-slim/hindsight_api/worker/main.py
@@ -18,7 +18,7 @@ import sys
 import warnings
 from collections.abc import Callable
 
-from ..config import get_config
+from ..config import get_config, load_dotenv_for_entrypoint
 from ..engine.task_backend import WorkerTaskBackend
 from .poller import WorkerPoller
 
@@ -125,6 +125,8 @@ def create_worker_app(poller: WorkerPoller, memory):
 
 def main():
     """Main entry point for the hindsight-worker CLI."""
+    load_dotenv_for_entrypoint()
+
     # Load configuration from environment
     config = get_config()
 

--- a/hindsight-api-slim/tests/conftest.py
+++ b/hindsight-api-slim/tests/conftest.py
@@ -127,7 +127,10 @@ def pytest_configure(config):
     # Look for .env in the workspace root (two levels up from tests dir)
     env_file = Path(__file__).parent.parent.parent / ".env"
     if env_file.exists():
-        load_dotenv(env_file)
+        # override=True keeps the workspace .env authoritative for the test
+        # session, matching the precedence hindsight_api used to apply at import
+        # time (removed in #2961 so library imports are side-effect-free).
+        load_dotenv(env_file, override=True)
     else:
         print(f"Warning: {env_file} not found, tests may fail without proper configuration")
 
@@ -415,8 +418,8 @@ async def oracle_memory(oracle_db_url, embeddings, cross_encoder, query_analyzer
     try:
         mem = MemoryEngine(
             db_url=oracle_db_url,
-            # Note: config.py loads ../.env with override=True, so these defaults
-            # only apply if no .env file is found. The .env file is authoritative.
+            # Note: conftest loads ../.env with override=True at session start, so
+            # these defaults only apply if no .env file is found. .env is authoritative.
             memory_llm_provider=os.getenv("HINDSIGHT_API_LLM_PROVIDER", "openai"),
             memory_llm_api_key=os.getenv("HINDSIGHT_API_LLM_API_KEY"),
             memory_llm_model=os.getenv("HINDSIGHT_API_LLM_MODEL", "gpt-4o-mini"),

--- a/hindsight-api-slim/tests/test_dotenv_loading.py
+++ b/hindsight-api-slim/tests/test_dotenv_loading.py
@@ -1,0 +1,72 @@
+"""Regression tests for issue #2961: importing Hindsight must not mutate the
+host application's environment, while Hindsight's own entry points keep their
+``.env`` convenience with unchanged precedence.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+API_SOURCE = str(Path(__file__).parents[1])
+
+
+def _run_import(module: str, tmp_path: Path) -> str:
+    """Import ``module`` from a child dir whose parent holds a hostile .env and
+    return the resulting value of HOST_APP_SECRET as seen by that process."""
+    (tmp_path / ".env").write_text("HOST_APP_SECRET=from-dotenv\n")
+    child_dir = tmp_path / "child"
+    child_dir.mkdir()
+
+    env = os.environ.copy()
+    env["HOST_APP_SECRET"] = "from-application"
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, (API_SOURCE, env.get("PYTHONPATH"))))
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            f"import os; import {module}; print(os.environ['HOST_APP_SECRET'])",
+        ],
+        cwd=child_dir,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def test_importing_config_does_not_modify_environment(tmp_path: Path) -> None:
+    # The reporter's exact repro: importing config walked up to the parent .env
+    # and overwrote the application's own value. It must not any more.
+    assert _run_import("hindsight_api.config", tmp_path) == "from-application"
+
+
+def test_importing_package_does_not_modify_environment(tmp_path: Path) -> None:
+    # `import hindsight_api` pulls in .config transitively; still no side effect.
+    assert _run_import("hindsight_api", tmp_path) == "from-application"
+
+
+def test_entrypoint_dotenv_loading_is_authoritative(tmp_path: Path, monkeypatch) -> None:
+    # The entry-point loader keeps override=True: a discovered .env wins over the
+    # ambient process environment (unchanged precedence) AND fills missing keys.
+    (tmp_path / ".env").write_text("HINDSIGHT_TEST_OVERRIDDEN=from-dotenv\nHINDSIGHT_TEST_FILLED=from-dotenv\n")
+    child_dir = tmp_path / "child"
+    child_dir.mkdir()
+    monkeypatch.chdir(child_dir)
+    monkeypatch.setenv("HINDSIGHT_TEST_OVERRIDDEN", "from-process")
+    monkeypatch.delenv("HINDSIGHT_TEST_FILLED", raising=False)
+
+    from hindsight_api.config import load_dotenv_for_entrypoint
+
+    load_dotenv_for_entrypoint()
+
+    # override=True: the .env value wins over the pre-set process value.
+    assert os.environ["HINDSIGHT_TEST_OVERRIDDEN"] == "from-dotenv"
+    # A key absent from the process is filled from .env.
+    assert os.environ["HINDSIGHT_TEST_FILLED"] == "from-dotenv"
+
+    # Don't leak the .env-loaded key into the rest of the session; monkeypatch
+    # cannot undo it because load_dotenv set it directly.
+    monkeypatch.delenv("HINDSIGHT_TEST_FILLED", raising=False)

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -212,9 +212,7 @@ async def test_top_level_fact_list_is_accepted_without_retry():
         ({}, 0, None),
     ],
 )
-async def test_fact_text_alias_is_recovered_without_accepting_empty_facts(
-    fact_fields, expected_count, expected_text
-):
+async def test_fact_text_alias_is_recovered_without_accepting_empty_facts(fact_fields, expected_count, expected_text):
     """Recover schema-drifted ``text`` facts while still skipping empty facts."""
     from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
 

--- a/hindsight-dev/benchmarks/perf/recall_perf.py
+++ b/hindsight-dev/benchmarks/perf/recall_perf.py
@@ -44,10 +44,6 @@ import statistics
 import time
 from typing import Any
 
-# Capture DB URL early before hindsight_api imports trigger dotenv override
-# (config.py uses load_dotenv(override=True) which stomps env vars)
-_EARLY_DB_URL = os.environ.get("HINDSIGHT_API_DATABASE_URL")
-
 from rich.console import Console
 from rich.progress import BarColumn, MofNCompleteColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 from rich.table import Table
@@ -567,7 +563,7 @@ def _build_engine(*, disable_observations: bool = False) -> "Any":
     """Create a MemoryEngine using mock LLM and DB from env."""
     from hindsight_api import MemoryEngine
 
-    db_url = _EARLY_DB_URL or os.getenv("HINDSIGHT_API_DATABASE_URL", "pg0")
+    db_url = os.getenv("HINDSIGHT_API_DATABASE_URL", "pg0")
     if disable_observations:
         os.environ["HINDSIGHT_API_ENABLE_OBSERVATIONS"] = "false"
     engine = MemoryEngine(


### PR DESCRIPTION
## Summary

Fixes #2961 — importing `hindsight_api` (or anything that pulls it in: `import hindsight`, `HindsightEmbedded`) rewrote the host application's `os.environ` at import time, from a `.env` chosen by walking up from the process cwd, with `override=True` beating values the app had set deliberately. For a process embedding Hindsight this is silent, action-at-a-distance config corruption.

This is a **backwards-compatible alternative to #2964**: it removes the import-time side effect (the actual bug) while preserving Hindsight's own `.env` behavior *exactly* — same precedence, and **all** entry points covered.

## Changes

- **Move the load out of module scope** in `config.py` into a `load_dotenv_for_entrypoint()` helper. Library import is now side-effect-free.
- **Call it from every standalone entry point**: the API CLI (`main.py`), the worker, the admin CLI, **and `server.py`**.
- **Keep `override=True`** in the helper — a discovered `.env` stays authoritative over the ambient process env, i.e. unchanged precedence for our deployments. Since a library import never reaches this code path, that precedence no longer leaks into embedders.
- `tests/conftest.py` now loads the workspace `.env` with `override=True`, matching the precedence `config.py` used to apply at import time (the oracle fixture documents `.env` as authoritative).
- Drop the now-obsolete `_EARLY_DB_URL` workaround in `recall_perf.py`.

## Why `server.py` matters (the gap vs #2964)

`server.py` is not just the documented `uvicorn hindsight_api.server:app` deploy target — it is also the **import string uvicorn re-imports in each worker process** when `hindsight-api` runs with `--workers`/`--reload` (`main.py` passes `"hindsight_api.server:app"` in that mode). Those worker processes never run `main()`, so loading `.env` only in the CLI entry points would silently break `.env` loading in our own multi-worker mode. Covering `server.py` keeps that path intact.

## Testing

- `tests/test_dotenv_loading.py` (new): the reporter's exact repro — importing `hindsight_api.config` and `hindsight_api` from a child dir no longer overwrites the app's env — plus a check that the entry-point loader keeps `override=True` precedence (a `.env` value wins over a pre-set process value and fills missing keys).
- `pytest tests/test_main_module.py tests/test_worker_main.py tests/test_server_module.py tests/test_config_validation.py -n 0` — all pass.
- `./scripts/hooks/lint.sh` — all Python checks pass; ty clean.

Closes #2961