### PR TITLE
fix(claude-code): reflect tool calls + honor configured model (#2966, #2881)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/claude_code_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/claude_code_llm.py
@@ -238,6 +238,13 @@ class ClaudeCodeLLM(LLMInterface):
             max_turns=1,  # Single-turn for API-style interactions
             tools=[],  # Disable built-in tools so nothing forces a ToolSearch deferral
             allowed_tools=[],  # Disable tools for standard LLM calls
+            # Pin the configured model (issue #2881). Without this the spawned CLI
+            # runs its own default model — an Opus-class model on Pro/Max OAuth —
+            # regardless of HINDSIGHT_API_*_LLM_MODEL, while metrics/logs still print
+            # self.model, so the mismatch is invisible. The isolated CLAUDE_CONFIG_DIR
+            # (fresh temp dir) means a host settings.json can't reach the CLI either,
+            # so passing it through here is the only channel.
+            model=self.model or None,
             env=_get_isolated_claude_env(),
         )
 
@@ -532,16 +539,33 @@ class ClaudeCodeLLM(LLMInterface):
         # else: tool_choice == "auto" or unspecified - use default behavior (no changes needed)
 
         # Configure SDK options with MCP server
+        #
         # tools=[] disables built-in CLI tools (Read, Write, Bash, ToolSearch, etc.)
         # Without this, Claude Code CLI defers MCP tools when too many built-in tools
-        # are loaded, forcing Claude to use ToolSearch first — which wastes the max_turns
+        # are loaded, forcing Claude to use ToolSearch first — which wastes the turn
         # budget and prevents direct MCP tool calls.
+        #
+        # max_turns=1 is critical (issue #2966). call_with_tools() is one *round* of
+        # an agentic loop the caller drives: the model proposes tool calls, we return
+        # them, and the orchestrator (reflect/agent.py) executes the REAL tools and
+        # feeds the results back on the next call. The SDK, however, runs its own
+        # in-process loop: it invokes our SDK MCP handlers — which are deliberate
+        # placeholders returning "[Tool <name> called successfully]" (no real data) —
+        # and lets the model react. With max_turns >= 2 the model calls recall, sees
+        # the empty placeholder, re-queries with reworded searches, exhausts the turn
+        # budget, and the run ends in error_max_turns with its tool calls discarded —
+        # exactly the "0 tool calls / no information" failure in #2966. Capping at a
+        # single turn stops the SDK from acting on the placeholder results: the model
+        # emits its first tool call (or a text answer) and we return that to the caller
+        # unchanged, matching how every other provider's call_with_tools() behaves.
         options = ClaudeAgentOptions(
             system_prompt=system_prompt if system_prompt else None,
             tools=[],  # Disable built-in tools so MCP tools load eagerly
-            max_turns=2,  # Allow tool call + tool result round-trip
+            max_turns=1,  # One round: propose tool calls (or answer); caller drives the loop
             mcp_servers=mcp_servers_config,
             allowed_tools=allowed_tool_names,
+            # Pin the configured model (issue #2881) — see the call() options block.
+            model=self.model or None,
             env=_get_isolated_claude_env(),
         )
 
@@ -560,9 +584,6 @@ class ClaudeCodeLLM(LLMInterface):
 
                     # Receive response
                     async for message in client.receive_response():
-                        if isinstance(message, ResultMessage) and message.is_error:
-                            # Surface the CLI's actual error text (issue #2702).
-                            raise RuntimeError(_result_error_detail(message))
                         if isinstance(message, AssistantMessage):
                             for block in message.content:
                                 if isinstance(block, TextBlock):
@@ -581,6 +602,21 @@ class ClaudeCodeLLM(LLMInterface):
                                             arguments=block.input,
                                         )
                                     )
+                            if tool_calls:
+                                # This round proposed tool call(s). Stop consuming the
+                                # stream so the SDK does not run another turn against our
+                                # placeholder handlers (issue #2966) — the caller executes
+                                # the real tools and calls us again with the results.
+                                break
+                        elif isinstance(message, ResultMessage) and message.is_error:
+                            # With max_turns=1 the CLI reports error_max_turns whenever
+                            # the model spent its single turn issuing a tool call (there
+                            # was no follow-up turn to emit final text). That is expected
+                            # here and not a failure: we already captured the tool call
+                            # above and break before reaching this branch. Only a genuine
+                            # error with nothing to return should surface (issue #2702).
+                            if not tool_calls:
+                                raise RuntimeError(_result_error_detail(message))
 
                 # Record metrics
                 duration = time.time() - start_time

--- a/hindsight-api-slim/tests/test_claude_code_llm_error_result.py
+++ b/hindsight-api-slim/tests/test_claude_code_llm_error_result.py
@@ -34,6 +34,7 @@ class _FakeOptions:
     tools: list[str] = field(default_factory=list)
     env: dict[str, str] = field(default_factory=dict)
     mcp_servers: dict[str, Any] = field(default_factory=dict)
+    model: str | None = None
 
 
 class _FakeAssistantMessage:

--- a/hindsight-api-slim/tests/test_claude_code_llm_isolation.py
+++ b/hindsight-api-slim/tests/test_claude_code_llm_isolation.py
@@ -31,6 +31,7 @@ class _FakeOptions:
     tools: list[str] = field(default_factory=list)
     env: dict[str, str] = field(default_factory=dict)
     mcp_servers: dict[str, Any] = field(default_factory=dict)
+    model: str | None = None
 
 
 class _FakeAssistantMessage:

--- a/hindsight-api-slim/tests/test_claude_code_llm_tool_round.py
+++ b/hindsight-api-slim/tests/test_claude_code_llm_tool_round.py
@@ -1,0 +1,347 @@
+"""Regression tests for issue #2966.
+
+``call_with_tools()`` is a *single round* of an agentic loop the caller drives:
+the model proposes tool call(s), the provider returns them, and the orchestrator
+(reflect/agent.py) executes the REAL tools and feeds the results back on the next
+call. See providers/openai_compatible_llm.py for the reference contract.
+
+The Claude Agent SDK, however, runs its own in-process loop and invokes our SDK
+MCP handlers — which are deliberate placeholders returning
+``[Tool <name> called successfully]`` with no real data. With ``max_turns >= 2``
+the model calls a search tool, sees the empty placeholder, re-queries, exhausts
+the turn budget, and the run ends in ``error_max_turns`` *with its tool calls
+discarded* — the "0 tool calls / no information" reflect failure in #2966.
+
+The fix caps the SDK at ``max_turns=1`` and:
+  * breaks out of the stream as soon as a tool call is proposed (so the SDK never
+    acts on a placeholder result), returning the call to the caller; and
+  * treats the ``error_max_turns`` ResultMessage that necessarily follows a
+    single-turn tool call as non-fatal — the tool call is the result, not an error.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from hindsight_api.engine.llm_interface import LLM_TOOL_CHOICE_AUTO
+
+
+@dataclass
+class _FakeOptions:
+    """Stand-in for ClaudeAgentOptions; captures kwargs without importing the SDK."""
+
+    system_prompt: str | None = None
+    max_turns: int | None = None
+    allowed_tools: list[str] = field(default_factory=list)
+    tools: list[str] = field(default_factory=list)
+    env: dict[str, str] = field(default_factory=dict)
+    mcp_servers: dict[str, Any] = field(default_factory=dict)
+    model: str | None = None
+
+
+class _FakeAssistantMessage:
+    def __init__(self, content: list[Any]) -> None:
+        self.content = content
+
+
+class _FakeTextBlock:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _FakeToolUseBlock:
+    def __init__(self, id: str, name: str, input: dict[str, Any]) -> None:
+        self.id = id
+        self.name = name
+        self.input = input
+
+
+class _FakeResultMessage:
+    def __init__(self, subtype: str, is_error: bool, result: str | None) -> None:
+        self.subtype = subtype
+        self.is_error = is_error
+        self.result = result
+
+
+@dataclass
+class _FakeSdkMcpTool:
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+    handler: Any
+
+
+def _fake_create_sdk_mcp_server(name: str, version: str, tools=None):
+    return {"name": name, "version": version, "tools": tools}
+
+
+def _install_fake_sdk(monkeypatch, client_cls) -> None:
+    import claude_agent_sdk
+
+    monkeypatch.setattr(claude_agent_sdk, "ClaudeAgentOptions", _FakeOptions)
+    monkeypatch.setattr(claude_agent_sdk, "AssistantMessage", _FakeAssistantMessage)
+    monkeypatch.setattr(claude_agent_sdk, "TextBlock", _FakeTextBlock)
+    monkeypatch.setattr(claude_agent_sdk, "ToolUseBlock", _FakeToolUseBlock)
+    monkeypatch.setattr(claude_agent_sdk, "ResultMessage", _FakeResultMessage)
+    monkeypatch.setattr(claude_agent_sdk, "ClaudeSDKClient", client_cls)
+    monkeypatch.setattr(claude_agent_sdk, "SdkMcpTool", _FakeSdkMcpTool)
+    monkeypatch.setattr(claude_agent_sdk, "create_sdk_mcp_server", _fake_create_sdk_mcp_server)
+
+
+def _instantiate_provider():
+    from hindsight_api.engine.providers.claude_code_llm import ClaudeCodeLLM
+
+    return ClaudeCodeLLM(
+        provider="claude-code",
+        api_key="",
+        base_url="",
+        model="claude-haiku-4-5",
+        reasoning_effort="low",
+    )
+
+
+_RECALL_TOOL = {
+    "function": {
+        "name": "recall",
+        "description": "Search the memory bank.",
+        "parameters": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+    }
+}
+
+
+@pytest.mark.asyncio
+async def test_tool_call_returned_despite_error_max_turns(monkeypatch):
+    """A single-turn tool call followed by error_max_turns must be returned, not raised.
+
+    This is the exact #2966 failure shape: the model emits a tool call and, because
+    the single turn was spent on it, the CLI reports ``error_max_turns``. The tool
+    call is the intended result and must reach the caller.
+    """
+    captured_options: dict[str, Any] = {}
+
+    class _FakeClient:
+        def __init__(self, options: _FakeOptions) -> None:
+            captured_options["opts"] = options
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def query(self, prompt: str) -> None:
+            return None
+
+        async def receive_response(self):
+            yield _FakeAssistantMessage(
+                content=[
+                    _FakeToolUseBlock(
+                        id="tu_1",
+                        name="mcp__hindsight_tools__recall",
+                        input={"query": "domain family repositories"},
+                    )
+                ]
+            )
+            # With max_turns=1, the tool call consumes the only turn, so the CLI
+            # necessarily follows up with error_max_turns.
+            yield _FakeResultMessage(subtype="error_max_turns", is_error=True, result=None)
+
+    _install_fake_sdk(monkeypatch, _FakeClient)
+
+    provider = _instantiate_provider()
+    result = await provider.call_with_tools(
+        messages=[{"role": "user", "content": "What repos are in the domain family?"}],
+        tools=[_RECALL_TOOL],
+        max_retries=0,
+        scope="reflect",
+        tool_choice=LLM_TOOL_CHOICE_AUTO,
+    )
+
+    assert result.finish_reason == "tool_calls"
+    assert [tc.name for tc in result.tool_calls] == ["recall"]
+    assert result.tool_calls[0].arguments == {"query": "domain family repositories"}
+    # The MCP prefix must be stripped for the caller.
+    assert not result.tool_calls[0].name.startswith("mcp__")
+    # The provider must cap the SDK at one turn so it never acts on placeholder results.
+    assert captured_options["opts"].max_turns == 1
+    # The configured model must be pinned on the SDK options (issue #2881), otherwise
+    # the CLI silently runs its own default model.
+    assert captured_options["opts"].model == "claude-haiku-4-5"
+
+
+@pytest.mark.asyncio
+async def test_stops_after_first_tool_round(monkeypatch):
+    """The provider must stop consuming the stream once a tool call is proposed.
+
+    If it kept reading, the SDK's next placeholder-driven turn would append more
+    (duplicate/reworded) recall calls — the runaway loop that exhausts the budget.
+    """
+    later_turns_consumed = {"value": False}
+
+    class _FakeClient:
+        def __init__(self, options: _FakeOptions) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def query(self, prompt: str) -> None:
+            return None
+
+        async def receive_response(self):
+            yield _FakeAssistantMessage(
+                content=[
+                    _FakeToolUseBlock(
+                        id="tu_1",
+                        name="mcp__hindsight_tools__recall",
+                        input={"query": "first"},
+                    )
+                ]
+            )
+            # These would only be produced by the SDK re-prompting the model with a
+            # placeholder result. The provider must break before pulling them.
+            later_turns_consumed["value"] = True
+            yield _FakeAssistantMessage(
+                content=[
+                    _FakeToolUseBlock(
+                        id="tu_2",
+                        name="mcp__hindsight_tools__recall",
+                        input={"query": "reworded"},
+                    )
+                ]
+            )
+
+    _install_fake_sdk(monkeypatch, _FakeClient)
+
+    provider = _instantiate_provider()
+    result = await provider.call_with_tools(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[_RECALL_TOOL],
+        max_retries=0,
+        scope="reflect",
+        tool_choice=LLM_TOOL_CHOICE_AUTO,
+    )
+
+    assert [tc.arguments["query"] for tc in result.tool_calls] == ["first"]
+    assert later_turns_consumed["value"] is False
+
+
+@pytest.mark.asyncio
+async def test_text_only_answer_returned(monkeypatch):
+    """A text-only turn (no tool call) is returned as a normal 'stop' response.
+
+    This is the loop's final round: the orchestrator has already fed tool results
+    back and the model answers in prose.
+    """
+
+    class _FakeClient:
+        def __init__(self, options: _FakeOptions) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def query(self, prompt: str) -> None:
+            return None
+
+        async def receive_response(self):
+            yield _FakeAssistantMessage(content=[_FakeTextBlock(text="The domain family has 8 repositories.")])
+            yield _FakeResultMessage(subtype="success", is_error=False, result="done")
+
+    _install_fake_sdk(monkeypatch, _FakeClient)
+
+    provider = _instantiate_provider()
+    result = await provider.call_with_tools(
+        messages=[{"role": "user", "content": "answer now"}],
+        tools=[_RECALL_TOOL],
+        max_retries=0,
+        scope="reflect",
+        tool_choice=LLM_TOOL_CHOICE_AUTO,
+    )
+
+    assert result.finish_reason == "stop"
+    assert result.tool_calls == []
+    assert result.content == "The domain family has 8 repositories."
+
+
+@pytest.mark.asyncio
+async def test_call_pins_configured_model(monkeypatch):
+    """call() must pass the configured model to the SDK (issue #2881).
+
+    Without model= the spawned CLI runs its own default model regardless of
+    HINDSIGHT_API_*_LLM_MODEL, while metrics/logs still print the configured one.
+    """
+    import claude_agent_sdk
+
+    captured: dict[str, Any] = {}
+
+    async def fake_query(prompt: str, options: _FakeOptions):
+        captured["opts"] = options
+        yield _FakeAssistantMessage(content=[_FakeTextBlock(text="ok")])
+        yield _FakeResultMessage(subtype="success", is_error=False, result="ok")
+
+    monkeypatch.setattr(claude_agent_sdk, "ClaudeAgentOptions", _FakeOptions)
+    monkeypatch.setattr(claude_agent_sdk, "AssistantMessage", _FakeAssistantMessage)
+    monkeypatch.setattr(claude_agent_sdk, "TextBlock", _FakeTextBlock)
+    monkeypatch.setattr(claude_agent_sdk, "ResultMessage", _FakeResultMessage)
+    monkeypatch.setattr(claude_agent_sdk, "query", fake_query)
+
+    provider = _instantiate_provider()
+    result = await provider.call(
+        messages=[{"role": "user", "content": "hi"}],
+        max_retries=0,
+        scope="test",
+    )
+
+    assert result == "ok"
+    assert captured["opts"].model == "claude-haiku-4-5"
+
+
+@pytest.mark.asyncio
+async def test_genuine_error_without_tool_calls_still_raises(monkeypatch):
+    """An error ResultMessage with nothing collected must still surface (issue #2702)."""
+
+    class _FakeClient:
+        def __init__(self, options: _FakeOptions) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def query(self, prompt: str) -> None:
+            return None
+
+        async def receive_response(self):
+            yield _FakeResultMessage(
+                subtype="success",
+                is_error=True,
+                result="You've hit your weekly limit · resets Jul 18, 12pm (UTC)",
+            )
+
+    _install_fake_sdk(monkeypatch, _FakeClient)
+
+    provider = _instantiate_provider()
+    with pytest.raises(RuntimeError, match="weekly limit"):
+        await provider.call_with_tools(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[_RECALL_TOOL],
+            max_retries=0,
+            scope="reflect",
+            tool_choice=LLM_TOOL_CHOICE_AUTO,
+        )


### PR DESCRIPTION
Fixes #2966 and #2881 — two independent defects in the same two `ClaudeAgentOptions` blocks in `claude_code_llm.py`.

## #2966 — reflect agent makes 0 tool calls

**The issue's diagnosis ("MCP tools never become callable") is wrong.** Instrumenting the real SDK stream shows the `recall` tool *is* registered and *is* called — 3× per run. The real defect is a contract violation:

`call_with_tools()` is meant to be **one round** of an agentic loop the caller drives: the model proposes tool calls, we return them, and `reflect/agent.py` executes the **real** tools and feeds results back on the next call. But the Claude Agent SDK runs its **own** in-process loop and invokes our SDK MCP handlers — deliberate placeholders returning `"[Tool <name> called successfully]"` (no data). With `max_turns=2` the model calls `recall`, sees the empty placeholder, re-queries with reworded searches, exhausts the turn budget → `error_max_turns` → and the old code **raised on that error, discarding the tool calls it had already made**. That discard is why the trace reads `tools=[none]` and the "raise max_turns to 8" experiment still showed 0 — more turns just means more wasted placeholder-driven retries ending the same way.

**Fix:** cap the SDK at `max_turns=1`, break out of the stream as soon as a tool call is proposed (so the SDK never acts on a placeholder result), and treat the trailing `error_max_turns` as non-fatal when tool calls were already captured. This matches every other provider's single-round `call_with_tools` semantics. #2702 error surfacing is preserved for genuine errors.

## #2881 — configured model never reaches the CLI

Neither options block passed `model=`, so every retain/reflect/consolidation call ran the CLI's own default (Opus-class on Pro/Max OAuth) while metrics/logs still printed `self.model`. The isolated `CLAUDE_CONFIG_DIR` (fresh temp dir) means a host `settings.json` can't reach the CLI either — `model=` is the only channel.

**Fix:** pass `model=self.model` in both `call()` and `call_with_tools()`.

> Behavior note: instances that (unknowingly) relied on the buggy CLI-default-Opus behavior will now run their **configured** model — the claude-code default is `claude-sonnet-4-5-20250929`. That is the intended fix.

## Testing

- New `test_claude_code_llm_tool_round.py` (fake-SDK): tool call returned despite `error_max_turns`, stops after first round, text-only answer returned as `stop`, model pinned on both `call()` and `call_with_tools()`, genuine error with no tool calls still raises.
- Existing `test_claude_code_llm_error_result.py` / `_isolation.py` fakes updated for the new `model` option field.
- Both fixes verified **end-to-end against the real Claude Agent SDK**: a two-round reflect loop now proposes `recall`, grounds its answer in injected results; and the configured model (`claude-haiku-4-5`) appears in the CLI session transcript (previously the CLI default).

Not addressed here (separate concern noted in #2966): reflect overwriting a good mental model with an empty answer — that lives in the reflect orchestrator, not this provider.