### PR TITLE
fix(oracle): don't COALESCE a bind against the CLOB mission column in update_bank

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -13269,18 +13269,27 @@ class MemoryEngine(MemoryEngineInterface):
             backend = await self._get_backend()
 
         if name is not None or mission is not None:
+            # Only assign the columns actually supplied, rather than
+            # COALESCE($n, col) for every column. On Oracle ``mission`` is a CLOB
+            # and COALESCE takes its result type from the first argument: with the
+            # bind ($n, a VARCHAR2) first and the CLOB column second, Oracle
+            # evaluates the CLOB in a "CHAR expected" context and raises ORA-00932.
+            # A direct ``SET mission = $n`` assigns the string straight into the
+            # CLOB (as set_bank_mission already does) and keeps the untouched
+            # column unchanged — same result, no cross-type COALESCE.
+            set_clauses = []
+            params: list[Any] = [bank_id]
+            if name is not None:
+                params.append(name)
+                set_clauses.append(f"name = ${len(params)}")
+            if mission is not None:
+                params.append(mission)
+                set_clauses.append(f"mission = ${len(params)}")
+            set_clauses.append("updated_at = NOW()")
             async with acquire_with_retry(backend) as conn:
                 await conn.execute(
-                    f"""
-                    UPDATE {fq_table("banks")}
-                    SET name = COALESCE($2, name),
-                        mission = COALESCE($3, mission),
-                        updated_at = NOW()
-                    WHERE bank_id = $1
-                    """,
-                    bank_id,
-                    name,
-                    mission,
+                    f"UPDATE {fq_table('banks')} SET {', '.join(set_clauses)} WHERE bank_id = $1",
+                    *params,
                 )
         profile = await self._get_bank_profile_authenticated(
             bank_id,

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -1548,6 +1548,35 @@ async def test_update_bank_combines_profile_and_config_with_one_authentication(m
 
 
 @pytest.mark.asyncio
+async def test_update_bank_persists_name_and_mission(memory):
+    """update_bank must round-trip name and mission, and support a mission-only
+    update. Guards the dynamic SET-clause build (only supplied columns are
+    written) that replaced per-column COALESCE — the latter broke Oracle's CLOB
+    ``mission`` (ORA-00932); this asserts the shared behaviour on the default backend.
+    """
+    bank_id = f"name_mission_update_{datetime.now().timestamp()}"
+    request_context = RequestContext()
+    try:
+        await memory.update_bank(
+            bank_id,
+            name="Profile name",
+            mission="Do the thing well",
+            request_context=request_context,
+        )
+        profile = await memory.get_bank_profile(bank_id, request_context=request_context)
+        assert profile["name"] == "Profile name"
+        assert profile["mission"] == "Do the thing well"
+
+        # Mission-only update must not disturb the name.
+        await memory.update_bank(bank_id, mission="Do the other thing", request_context=request_context)
+        profile = await memory.get_bank_profile(bank_id, request_context=request_context)
+        assert profile["mission"] == "Do the other thing"
+        assert profile["name"] == "Profile name"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
 async def test_put_name_only_preserves_name_for_new_bank(api_client):
     """A name-only PUT creates the bank before updating its row."""
     bank_id = f"name_only_put_{datetime.now().timestamp()}"

--- a/hindsight-api-slim/tests/test_oracle_integration.py
+++ b/hindsight-api-slim/tests/test_oracle_integration.py
@@ -285,7 +285,10 @@ class TestCoreCRUD:
             profile = await oracle_memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
             assert profile["bank_id"] == bank_id
 
-            # Update
+            # Update. mission is an Oracle CLOB; regression guard for ORA-00932 —
+            # update_bank must not COALESCE a VARCHAR2 bind against the CLOB column
+            # (that evaluates the CLOB in a CHAR context and fails). Assert both the
+            # name and the mission round-trip.
             await oracle_memory.update_bank(
                 bank_id=bank_id,
                 name="Test Oracle Bank",
@@ -294,6 +297,17 @@ class TestCoreCRUD:
             )
             updated = await oracle_memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
             assert updated["name"] == "Test Oracle Bank"
+            assert updated["mission"] == "Testing Oracle integration"
+
+            # Update only the mission — exercises the single-column SET path.
+            await oracle_memory.update_bank(
+                bank_id=bank_id,
+                mission="Revised Oracle mission",
+                request_context=request_context,
+            )
+            remissioned = await oracle_memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+            assert remissioned["mission"] == "Revised Oracle mission"
+            assert remissioned["name"] == "Test Oracle Bank"
         finally:
             await _safe_cleanup(oracle_memory, bank_id, request_context)
 


### PR DESCRIPTION
## Summary

Fixes the persistently-red `test-typescript-client-oracle` CI job. `createBank`/bank updates that set a **mission** fail on Oracle with:

```
ORA-00932: expression ("BANKS"."MISSION") is of data type CLOB, which is incompatible with expected data type CHAR
```

## Root cause

`MemoryEngine.update_bank` wrote:

```sql
UPDATE banks
SET name = COALESCE($2, name),
    mission = COALESCE($3, mission),
    updated_at = NOW()
WHERE bank_id = $1
```

On Oracle `banks.mission` is a **CLOB**. `COALESCE` takes its result type from the *first* argument — the bind `$3`, which `oracledb` sends as a `VARCHAR2`. Oracle then evaluates the CLOB column in a "CHAR expected" context and raises ORA-00932. (`name` is a `VARCHAR2`, so its COALESCE is fine; and `set_bank_mission` already works because it assigns the CLOB directly rather than via COALESCE.)

## Fix

Build the `SET` clause from only the columns actually supplied and assign them directly (`SET mission = $n`) — the same way `set_bank_mission` writes the CLOB. Assigning a string straight into a CLOB is fine on Oracle; only the cross-type COALESCE fails. A column that wasn't passed is simply not written, which is exactly what `COALESCE(NULL, col)` produced before. **PostgreSQL behaviour is unchanged.**

## Tests

- **`test_http_api_integration.py`** — new deterministic PG regression `test_update_bank_persists_name_and_mission`: asserts name+mission round-trip and a mission-only update leaves the name intact. Runs on every CI shard.
- **`test_oracle_integration.py`** — `test_bank_profile_crud` already exercised `update_bank(name=…, mission=…)` on Oracle but only asserted the name; it now asserts the mission round-trips and adds a mission-only update. (The `@pytest.mark.oracle` suite is skipped in normal PR CI, which is why the live coverage was only the TypeScript client job.)

Verified locally against PostgreSQL (pg0); Oracle assertions run in the Oracle CI path.