### PR TITLE
fix(control-plane): gate audit-log & observations tabs on resolved per-bank config

### DIFF
--- a/hindsight-control-plane/src/app/[locale]/banks/[bankId]/page.tsx
+++ b/hindsight-control-plane/src/app/[locale]/banks/[bankId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
@@ -79,11 +79,45 @@ export default function BankPage() {
   const view = (searchParams.get("view") || "profile") as NavItem;
   const subTab = (searchParams.get("subTab") || "world") as DataSubTab;
   const bankConfigTab = (searchParams.get("bankConfigTab") || "general") as BankConfigTab;
-  const observationsEnabled = features?.observations ?? false;
   const bankConfigEnabled = features?.bank_config_api ?? false;
-  const auditLogEnabled = features?.audit_log ?? false;
   const llmTraceEnabled = features?.llm_trace ?? false;
   const llmHealthEnabled = features?.bank_llm_health ?? false;
+
+  // `audit_log_enabled` and `enable_observations` are hierarchical
+  // (env -> tenant -> bank): a bank can opt in even when the deployment default
+  // is off. The /version feature flags only report the global default, so gate
+  // these tabs on the bank's *resolved* config instead. Fall back to the global
+  // flag when the bank config API is disabled (per-bank overrides can't exist
+  // then) or the field is unavailable.
+  const [bankAuditLogEnabled, setBankAuditLogEnabled] = useState<boolean | null>(null);
+  const [bankObservationsEnabled, setBankObservationsEnabled] = useState<boolean | null>(null);
+  useEffect(() => {
+    if (!bankId || !bankConfigEnabled) {
+      setBankAuditLogEnabled(null);
+      setBankObservationsEnabled(null);
+      return;
+    }
+    let cancelled = false;
+    client
+      .getBankConfig(bankId)
+      .then((r) => {
+        if (cancelled) return;
+        const audit = r.config?.audit_log_enabled;
+        const observations = r.config?.enable_observations;
+        setBankAuditLogEnabled(typeof audit === "boolean" ? audit : null);
+        setBankObservationsEnabled(typeof observations === "boolean" ? observations : null);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setBankAuditLogEnabled(null);
+        setBankObservationsEnabled(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [bankId, bankConfigEnabled]);
+  const auditLogEnabled = bankAuditLogEnabled ?? features?.audit_log ?? false;
+  const observationsEnabled = bankObservationsEnabled ?? features?.observations ?? false;
 
   // Bank actions state
   const [showLlmHealthDialog, setShowLlmHealthDialog] = useState(false);


### PR DESCRIPTION
## Problem

Setting `audit_log_enabled=true` on a **bank** left the control-plane UI still showing **"Audit Logs Not Enabled"**, even though the bank was being audited.

The bank page gated the audit-logs (and observations) tabs on `features.audit_log` / `features.observations`, which come from the `/version` endpoint. That endpoint reports **only the global/server-level default** (`_get_raw_config()`), and even documents this:

> Note: the observations and audit_log flags show the global default. Individual banks may override these via bank-specific configuration.

But both `audit_log_enabled` and `enable_observations` are **hierarchical** (`env → tenant → bank`, see `_CONFIGURABLE_FIELDS`). When a bank opts in while the deployment default is off, the global flag stays `false`, so the UI kept hiding the tab. The data was actually there — the `list_audit_logs` engine method doesn't re-gate on the flag, it just returns the bank's rows.

## Fix

Gate the audit-logs and observations tabs on the bank's **resolved** config (`client.getBankConfig(bankId).config`) instead of the global feature flag:

- Falls back to the global flag when the bank config API is disabled (per-bank overrides can't exist in that case) or when the field isn't present in the response.
- Single `getBankConfig` fetch resolves both fields.

`llm_trace_enabled` is intentionally left gating on the global flag — it is a **static** server-level switch (not in `_CONFIGURABLE_FIELDS`), so the global flag is the correct source there.

## Testing

- `./scripts/hooks/lint.sh` passes.
- No render-test infra exists for control-plane page components, so no unit test was added for this gating (the change is a resolved-config coalesce). Verified manually against the described repro.
