### PR TITLE
fix(llm): send reasoning_effort on the tool path, matching call()

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -541,7 +541,10 @@ class OpenAICompatibleLLM(LLMInterface):
             api_key: API key (optional for ollama/lmstudio).
             base_url: Base URL for the API (uses defaults for groq/ollama/lmstudio if empty).
             model: Model name.
-            reasoning_effort: Reasoning effort level for supported models ("low", "medium", "high").
+            reasoning_effort: Reasoning effort level for supported models
+                ("none", "low", "medium", "high"). "none" is required when calling
+                function tools on some reasoning models, which reject every other
+                value — including omitting the parameter entirely.
             timeout: Request timeout in seconds (uses env var or 120s default).
             groq_service_tier: Groq service tier ("on_demand", "flex", "auto").
             extra_body: Extra body params merged into every API call.
@@ -1255,6 +1258,13 @@ class OpenAICompatibleLLM(LLMInterface):
             if self.provider == "minimax":
                 temperature = max(0.01, min(temperature, 1.0))
             call_params["temperature"] = temperature
+
+        # Set reasoning_effort for reasoning models, matching call(). Omitting it
+        # here is not a neutral default: OpenAI rejects function tools on a
+        # reasoning model unless reasoning_effort is present and set to "none",
+        # so leaving it out fails exactly like sending an unsupported value.
+        if self._supports_reasoning_model():
+            call_params["reasoning_effort"] = self.reasoning_effort
 
         # Provider-specific parameters
         extra_body: dict[str, Any] = {**self._config_extra_body}

--- a/hindsight-api-slim/tests/test_tool_path_reasoning_effort.py
+++ b/hindsight-api-slim/tests/test_tool_path_reasoning_effort.py
@@ -1,0 +1,160 @@
+"""
+`call_with_tools()` must send `reasoning_effort` for reasoning models, like `call()` does.
+
+`call()` sets it; `call_with_tools()` built its own `call_params` and left it out.
+Omitting it is not a neutral default — OpenAI rejects function tools on a
+reasoning model unless `reasoning_effort` is present and set to "none":
+
+    Function tools with reasoning_effort are not supported for gpt-5.6-terra in
+    /v1/chat/completions. To use function tools, use /v1/responses or set
+    reasoning_effort to 'none'.
+
+Verified directly against the API for gpt-5.6-terra + function tools:
+  reasoning_effort="low"  -> HTTP 400
+  reasoning_effort absent -> HTTP 400
+  reasoning_effort="none" -> tool call succeeds
+
+So the omission makes `HINDSIGHT_API_LLM_REASONING_EFFORT` unable to fix the
+failure, because that setting only ever reached the non-tool path. In practice
+reflect (a tool-calling search loop) degrades to a no-search fallback while
+still stamping `last_refreshed_at`, so the mental model looks refreshed.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "search_observations",
+            "description": "Search raw observations",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+    },
+]
+
+
+def _make_llm(model: str, reasoning_effort: str = "none") -> OpenAICompatibleLLM:
+    return OpenAICompatibleLLM(
+        provider="openai",
+        api_key="test",
+        base_url="https://api.openai.com/v1",
+        model=model,
+        reasoning_effort=reasoning_effort,
+    )
+
+
+def _make_tool_call_response() -> MagicMock:
+    mock_tc = MagicMock()
+    mock_tc.id = "call_abc123"
+    mock_tc.function.name = "search_observations"
+    mock_tc.function.arguments = json.dumps({"query": "x"})
+
+    mock_response = MagicMock()
+    mock_response.usage.prompt_tokens = 120
+    mock_response.usage.completion_tokens = 40
+    mock_response.usage.total_tokens = 160
+    # Explicit None: an auto-MagicMock is truthy and the reasoning-token
+    # accounting would do arithmetic on it and crash.
+    mock_response.usage.completion_tokens_details = None
+    mock_response.choices[0].finish_reason = "tool_calls"
+    mock_response.choices[0].message.content = None
+    mock_response.choices[0].message.tool_calls = [mock_tc]
+    return mock_response
+
+
+async def _capture_call_params(llm: OpenAICompatibleLLM) -> dict:
+    """Run call_with_tools against a mocked client and return the request kwargs."""
+    with patch.object(llm._client.chat.completions, "create", new_callable=AsyncMock) as create:
+        create.return_value = _make_tool_call_response()
+        await llm.call_with_tools(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=TOOLS,
+            max_retries=0,
+        )
+    return create.await_args.kwargs
+
+
+class TestToolPathReasoningEffort:
+    @pytest.mark.asyncio
+    async def test_reasoning_model_receives_reasoning_effort_on_tool_path(self):
+        # Intention: a reasoning model must get reasoning_effort on the tool path.
+        # Expected: the configured value is forwarded verbatim — "none" in
+        # particular, which is the only value OpenAI accepts alongside function
+        # tools, so it must not be dropped or coerced.
+        params = await _capture_call_params(_make_llm("gpt-5.6-terra", "none"))
+        assert params["reasoning_effort"] == "none"
+
+    @pytest.mark.asyncio
+    async def test_configured_effort_is_forwarded_verbatim(self):
+        # Intention: the tool path must not substitute its own default.
+        # Expected: "high" arrives as "high", proving the value comes from config
+        # rather than the constructor default ("low").
+        params = await _capture_call_params(_make_llm("gpt-5.6-terra", "high"))
+        assert params["reasoning_effort"] == "high"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("provider", ["openai", "openrouter", "deepseek"])
+    async def test_blast_radius_is_the_capability_check_not_the_provider(self, provider):
+        # Intention: pin the intended contract deliberately. `_supports_reasoning_model()`
+        # is a model-name check, not a provider check, and `call()` already sends the
+        # parameter to these same provider/model pairs. Gating the tool path by provider
+        # would reintroduce exactly the asymmetry this fix removes, so the tool path
+        # must follow the capability check alone.
+        # Expected: every OpenAI-compatible provider gets the value for a reasoning model.
+        model = "deepseek-reasoner" if provider == "deepseek" else "gpt-5.6-terra"
+        llm = OpenAICompatibleLLM(
+            provider=provider,
+            api_key="test",
+            base_url="https://example.invalid/v1",
+            model=model,
+            reasoning_effort="none",
+        )
+        params = await _capture_call_params(llm)
+        assert params["reasoning_effort"] == "none"
+
+    @pytest.mark.asyncio
+    async def test_non_reasoning_model_gets_no_reasoning_effort(self):
+        # Intention: don't start sending the param to models that reject it.
+        # Expected: gpt-4o is not a reasoning model, so the key is absent —
+        # matching call()'s behaviour exactly.
+        params = await _capture_call_params(_make_llm("gpt-4o", "none"))
+        assert "reasoning_effort" not in params
+
+    @pytest.mark.asyncio
+    async def test_tool_path_matches_plain_path_for_same_model(self):
+        # Intention: pin the two paths together so they cannot drift again —
+        # this asymmetry is the whole bug.
+        # Expected: call() and call_with_tools() agree on whether the param is
+        # sent and on its value.
+        llm = _make_llm("gpt-5.6-terra", "none")
+        tool_params = await _capture_call_params(llm)
+
+        plain_response = MagicMock()
+        # call() inspects .error and model_dump() for a provider error payload;
+        # auto-MagicMock values are truthy and would look like an error.
+        plain_response.error = None
+        plain_response.model_dump.return_value = {}
+        plain_response.usage.prompt_tokens = 10
+        plain_response.usage.completion_tokens = 5
+        plain_response.usage.total_tokens = 15
+        plain_response.usage.completion_tokens_details = None
+        plain_response.choices[0].finish_reason = "stop"
+        plain_response.choices[0].message.content = "ok"
+        plain_response.choices[0].message.tool_calls = None
+        with patch.object(llm._client.chat.completions, "create", new_callable=AsyncMock) as create:
+            create.return_value = plain_response
+            await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=0)
+        plain_params = create.await_args.kwargs
+
+        assert ("reasoning_effort" in tool_params) == ("reasoning_effort" in plain_params)
+        assert tool_params["reasoning_effort"] == plain_params["reasoning_effort"]


### PR DESCRIPTION
## Problem

`OpenAICompatibleLLM` builds request parameters in two independent places:

- `call()` sets `call_params["reasoning_effort"]` when `_supports_reasoning_model()`
- `call_with_tools()` builds its own `call_params` and **never set it**

Omitting the parameter is not a neutral default. Measured directly against the OpenAI API for `gpt-5.6-terra` with function tools:

| `reasoning_effort` | result |
|---|---|
| `"low"` | HTTP 400 |
| **absent** | **HTTP 400** |
| `"none"` | succeeds |

```
Function tools with reasoning_effort are not supported for gpt-5.6-terra in
/v1/chat/completions. To use function tools, use /v1/responses or set
reasoning_effort to 'none'.
```

That "absent also fails" row is the crux: a code path that *skips* the parameter fails exactly like one that sets it wrong.

## Why this is worse than a plain 400

`HINDSIGHT_API_LLM_REASONING_EFFORT=none` cannot fix it, because that setting only ever reached `call()`.

Reflect is a tool-calling search loop, so on an affected model every tool call 400s, retries, and then falls back to a tool-less completion. **The fallback still returns content and still stamps `last_refreshed_at` and clears `is_stale`** — so a mental model shows as freshly refreshed while never having searched memory.

Every health signal reads normal: refreshes "complete", timestamps advance, cron fires on schedule, `is_stale` goes false. In our deployment the only outward tell was input-token volume — **~800 tokens per call while degraded, versus 2.4k–8.2k when healthy.**

## Fix

One hunk in `call_with_tools()`, mirroring `call()`:

```python
if self._supports_reasoning_model():
    call_params["reasoning_effort"] = self.reasoning_effort
```

**On blast radius** — the alternative was gating the tool path to `provider == "openai"`. We deliberately didn't: `call()` already sends this parameter to the same provider/model pairs under the same capability check, so gating only the tool path would replace one asymmetry with another. `_supports_reasoning_model()` is the contract, and a parameterized test now pins that across `openai` / `openrouter` / `deepseek` so the decision is explicit rather than incidental.

Providers with their own `call_with_tools` (anthropic, gemini, litellm, codex, claude-code, llamacpp, nous) are unaffected. No subclass overrides `_supports_reasoning_model()`.

## Deliberately not fixed here

`call_with_tools()` diverges from `call()` in three further ways. None has a reproduction, and bundling them would make this hard to review and hard to revert:

1. **temperature** — `call()` guards with `not is_reasoning_model`; the tool path applies it unconditionally. Reasoning models generally reject an explicit temperature, so this looks like the same class of latent bug.
2. **groq `service_tier`** — set by `call()`, absent on the tool path.
3. **groq `include_reasoning=False`** — set by `call()` for reasoning models, absent on the tool path.

Longer term, the two builders sharing a helper would stop this drift recurring. Happy to follow up on any of these if maintainers want them.

## Tests

7 tests in `tests/test_tool_path_reasoning_effort.py`:

- value forwarded verbatim on the tool path (`"none"` specifically, since it must not be coerced)
- a non-default value (`"high"`) proves it comes from config, not the constructor default
- non-reasoning model (`gpt-4o`) gets no parameter
- **parity test** pinning `call()` and `call_with_tools()` together so they can't drift again
- parameterized blast-radius test across three providers

Verification:
- 7 pass; **deleting the hunk fails 6 of 7** (the survivor asserts the negative branch)
- 161 provider tests pass, 8 skipped — `-k "tool_choice or reasoning or openai_compat or litellm or deepseek or groq"`
- `ruff check` and `ruff format --check` clean
- Live end-to-end: reflect went from 20 errors and the 806-token fallback to **zero errors and 2.4k–7.5k-token real searches**, refreshing 5 mental models in 91s

Also updated the constructor docstring, which listed `("low", "medium", "high")` and so implied `"none"` was invalid — it's now the required value for this case.
