### PR TITLE
fix(recall): retry get_or_create_bank_profile on per-bank index deadlock

### DIFF
--- a/hindsight-api-slim/tests/test_bank_utils.py
+++ b/hindsight-api-slim/tests/test_bank_utils.py
@@ -1,6 +1,8 @@
+import asyncio
 from contextlib import asynccontextmanager
 
 import pytest
+from asyncpg.exceptions import DeadlockDetectedError
 
 from hindsight_api.engine.retain import bank_utils
 
@@ -8,6 +10,18 @@ from hindsight_api.engine.retain import bank_utils
 class _FailingIndexOps:
     async def create_bank_vector_indexes(self, *args, **kwargs) -> None:
         raise RuntimeError("simulated per-bank vector index DDL failure")
+
+
+class _DeadlockOnceIndexOps:
+    """Raises a deadlock on the first per-bank index DDL, then succeeds."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def create_bank_vector_indexes(self, *args, **kwargs) -> None:
+        self.calls += 1
+        if self.calls == 1:
+            raise DeadlockDetectedError("deadlock detected")
 
 
 class _FakeTransaction:
@@ -52,9 +66,9 @@ class _FakeConnection:
 
 
 class _FakePool:
-    def __init__(self, conn: _FakeConnection) -> None:
+    def __init__(self, conn: _FakeConnection, ops=None) -> None:
         self.conn = conn
-        self.ops = _FailingIndexOps()
+        self.ops = ops if ops is not None else _FailingIndexOps()
 
 
 @pytest.mark.asyncio
@@ -74,3 +88,35 @@ async def test_lazy_bank_create_rolls_back_on_vector_index_failure(monkeypatch: 
 
     profile = await bank_utils.get_bank_profile_if_exists(pool, "atomicity-test-bank")
     assert profile is None, "bank row should roll back when per-bank vector index creation fails"
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_bank_profile_retries_on_deadlock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A deadlock during per-bank index DDL is retried on a fresh transaction.
+
+    Concurrent bank creation issues CREATE INDEX against the shared memory_units
+    table, which can deadlock (asyncpg DeadlockDetectedError). The pool-owning
+    get_or_create_bank_profile must retry rather than surface the deadlock.
+    """
+    conn = _FakeConnection()
+    ops = _DeadlockOnceIndexOps()
+    pool = _FakePool(conn, ops=ops)
+
+    @asynccontextmanager
+    async def acquire(*args, **kwargs):
+        yield conn
+
+    monkeypatch.setattr(bank_utils, "acquire_with_retry", acquire)
+
+    async def _noop_sleep(*_args, **_kwargs) -> None:
+        return None
+
+    # Keep the retry backoff instant so the test doesn't actually sleep.
+    monkeypatch.setattr(asyncio, "sleep", _noop_sleep)
+
+    result = await bank_utils.get_or_create_bank_profile(pool, "deadlock-retry-bank")
+
+    assert result.created is True
+    assert ops.calls == 2, "index DDL should be attempted twice (deadlock, then success)"
+    profile = await bank_utils.get_bank_profile_if_exists(pool, "deadlock-retry-bank")
+    assert profile is not None, "bank must exist after the retry succeeds"


### PR DESCRIPTION
## Problem

`test_repair_bank_vector_indexes.py::test_import_bank_creates_per_bank_indexes` flakes on ~30% of `test-api (3/3)` runs (2 of the last 7) with:

```
asyncpg.exceptions.DeadlockDetectedError: deadlock detected
```

Fresh-bank creation issues per-bank `CREATE INDEX` statements against the shared `memory_units` table. The test suite runs all pytest-xdist workers against **one shared embedded Postgres** (per `conftest.py`), so two banks being created concurrently on different workers deadlock on that index DDL.

This surfaced on **#2950** (litellm), but that PR merely merged past the flake — a litellm bump can't cause a DB deadlock. It's ambient and pre-existing.

## Fix

Wrap the pool-owning `get_or_create_bank_profile` in `retry_with_backoff`, which already treats `DeadlockDetectedError` as retryable (equal-jitter backoff). Each retry runs on a **brand-new connection + transaction**, and the operation is idempotent (`SELECT` → `INSERT ... ON CONFLICT DO NOTHING` → per-bank indexes named on `internal_id`), so the deadlock-aborted transaction leaves nothing committed and the retry re-runs cleanly.

Only this variant retries — `get_or_create_bank_profile_on_conn` runs inside the *caller's* transaction, which the caller owns and must retry itself (documented in a comment).

This is the right layer: `import_bank_async` → `_ensure_bank_exists(conn=None)` → `get_or_create_bank_profile` (pool variant), which owns its transaction.

## Test

Adds a deterministic unit test (no DB) in `test_bank_utils.py`: an ops stub that raises `DeadlockDetectedError` once then succeeds, asserting the profile creation retries (two index-DDL attempts) and the bank ends up created. `retry_with_backoff` and type-check pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)