### PR TITLE
fix(worker): reconcile stranded batch_retain parents on recovery (#2985)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -13096,6 +13096,7 @@ class MemoryEngine(MemoryEngineInterface):
                 WHERE operation_id = $1
                   AND bank_id = $2
                   AND status IN ('failed', 'cancelled')
+                  AND NOT (operation_type = 'batch_retain' AND task_payload IS NULL)
                 RETURNING operation_id
                 """,
                 op_uuid,
@@ -13104,12 +13105,24 @@ class MemoryEngine(MemoryEngineInterface):
 
             if updated is None:
                 row = await conn.fetchrow(
-                    f"SELECT status FROM {fq_table('async_operations')} WHERE operation_id = $1 AND bank_id = $2",
+                    f"SELECT status, operation_type, task_payload FROM {fq_table('async_operations')} "
+                    f"WHERE operation_id = $1 AND bank_id = $2",
                     op_uuid,
                     bank_id,
                 )
                 if not row:
                     raise ValueError(f"Operation {operation_id} not found for bank {bank_id}")
+                # A batch_retain parent is a payload-less status aggregator. Retrying
+                # it would only re-strand it 'pending' — no worker can claim a
+                # NULL-payload row, and its already-terminal children won't re-run.
+                # Point the caller at the supported recovery instead. See issue #2985.
+                if row["operation_type"] == "batch_retain" and row["task_payload"] is None:
+                    raise OperationValidationError(
+                        f"Operation {operation_id} is a batch_retain parent (a status aggregator with no "
+                        f"payload) and cannot be retried directly. Resubmit the source documents, then "
+                        f"delete this record via DELETE /operations/{operation_id}/delete.",
+                        409,
+                    )
                 raise OperationValidationError(
                     f"Operation {operation_id} cannot be retried: status is '{row['status']}', expected 'failed' or 'cancelled'",
                     409,

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -880,6 +880,13 @@ class WorkerPoller:
                         async with conn.transaction():
                             await self._maybe_update_parent_operation(str(failed_row["operation_id"]), schema, conn)
 
+                # Finalize batch_retain parents that the aggregation left behind
+                # (crash between a child's terminal commit and the parent update,
+                # or children that never committed). These sit 'pending' with a
+                # NULL payload — unclaimable and invisible to failed_operations —
+                # until reconciled. See issue #2985.
+                await self._reconcile_orphaned_parents(schema)
+
                 pending_count = int(result.split()[-1]) if result else 0
                 failed_count = len(failed_rows)
                 total_count += pending_count
@@ -967,6 +974,126 @@ class WorkerPoller:
             schema_display = f'"{schema}"' if schema else str(schema)
             logger.error(f"Failed to recover batch operations for schema {schema_display}: {e}")
             return 0
+
+    async def _reconcile_orphaned_parents(self, schema: str | None) -> int:
+        """Drive stranded batch_retain parent operations to a terminal state.
+
+        A batch_retain parent is a status *aggregator*: it carries no
+        task_payload (workers never claim it) and is normally promoted to a
+        terminal state by ``_maybe_update_parent_operation`` when its last child
+        sub-batch finishes. Two crash windows can strand a parent 'pending'
+        forever:
+
+          * every child reached a terminal state but the promotion was skipped
+            (the aggregation swallows and logs errors rather than failing the
+            child, so a transient error there leaves the parent behind), or
+          * the children never committed at all, leaving a parent with zero
+            children (older non-atomic create paths, a hard kill mid-submission).
+
+        Either way the parent sits 'pending' with ``task_payload IS NULL``: it is
+        unclaimable, never counted in ``failed_operations``, unretryable via the
+        API, and its documents are silently absent. See issue #2985.
+
+        On worker startup we reconcile every such parent:
+
+          * children present, all terminal -> completed / failed (mirrors the
+            aggregator, inheriting a representative child error on failure),
+          * no children at all -> failed, with an explicit reason so an operator
+            can see the loss and resubmit the source documents.
+
+        Parents with at least one still-live child are left untouched — the
+        normal aggregation path will finish them once their children drain.
+
+        Returns the number of parents driven to a terminal state.
+        """
+        table = fq_table("async_operations", schema)
+        schema_display = f'"{schema}"' if schema else str(schema)
+        reconciled = 0
+        try:
+            async with self._backend.acquire() as conn:
+                parents = await conn.fetch(
+                    f"""
+                    SELECT operation_id, bank_id FROM {table}
+                    WHERE operation_type = 'batch_retain'
+                      AND status = 'pending'
+                      AND task_payload IS NULL
+                    """
+                )
+
+            for parent in parents:
+                parent_id = parent["operation_id"]
+                bank_id = parent["bank_id"]
+                # One transaction per parent so a single problematic row can't
+                # roll back the others (mirrors the per-child rollup above).
+                async with self._backend.acquire() as conn:
+                    async with conn.transaction():
+                        # Re-read under a row lock: skip if the normal aggregation
+                        # path (or another worker) already moved it off 'pending'.
+                        locked = await conn.fetchrow(
+                            f"SELECT status FROM {table} WHERE operation_id = $1 FOR UPDATE",
+                            parent_id,
+                        )
+                        if locked is None or locked["status"] != "pending":
+                            continue
+
+                        siblings = await conn.fetch(
+                            f"""
+                            SELECT status, error_message FROM {table}
+                            WHERE bank_id = $1
+                              AND result_metadata::jsonb @> $2::jsonb
+                            """,
+                            bank_id,
+                            json.dumps({"parent_operation_id": str(parent_id)}),
+                        )
+
+                        # A still-live child will drive the aggregation itself.
+                        if any(s["status"] not in ("completed", "failed") for s in siblings):
+                            continue
+
+                        if not siblings:
+                            await conn.execute(
+                                f"""
+                                UPDATE {table}
+                                SET status = 'failed', error_message = $2,
+                                    completed_at = now(), updated_at = now()
+                                WHERE operation_id = $1
+                                """,
+                                parent_id,
+                                "orphaned batch_retain parent: no child sub-batches were "
+                                "persisted (worker crashed mid-submission); resubmit the "
+                                "source documents",
+                            )
+                        elif any(s["status"] == "failed" for s in siblings):
+                            await conn.execute(
+                                f"""
+                                UPDATE {table}
+                                SET status = 'failed', error_message = $2, updated_at = now()
+                                WHERE operation_id = $1
+                                """,
+                                parent_id,
+                                _summarise_child_error_messages(siblings),
+                            )
+                        else:
+                            await conn.execute(
+                                f"""
+                                UPDATE {table}
+                                SET status = 'completed', completed_at = now(), updated_at = now()
+                                WHERE operation_id = $1
+                                """,
+                                parent_id,
+                            )
+                        reconciled += 1
+
+            if reconciled:
+                logger.warning(
+                    f"Worker {self._worker_id} reconciled {reconciled} stranded "
+                    f"batch_retain parent(s) in schema {schema_display}"
+                )
+        except Exception as e:
+            logger.warning(
+                f"Worker {self._worker_id} failed to reconcile orphaned parents in schema {schema_display}: {e}"
+            )
+        return reconciled
 
     async def run(self):
         """

--- a/hindsight-api-slim/tests/test_operation_status.py
+++ b/hindsight-api-slim/tests/test_operation_status.py
@@ -272,6 +272,45 @@ async def test_retry_rejects_non_retriable_statuses(api_client, memory, test_ban
 
 
 @pytest.mark.asyncio
+async def test_retry_rejects_batch_retain_parent(api_client, memory, test_bank_id):
+    """A failed batch_retain parent (no payload) must not be retried into a re-stranded state.
+
+    The parent is a payload-less status aggregator: retrying it would set it back to
+    'pending' where no worker can ever claim it and its terminal children won't re-run
+    (issue #2985). The 409 should point the caller at resubmit + delete instead.
+    """
+    pool = memory._pool
+    await _ensure_bank(pool, test_bank_id)
+
+    op_id = uuid.uuid4()
+    await pool.execute(
+        """
+        INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload)
+        VALUES ($1, $2, 'batch_retain', 'failed', NULL)
+        """,
+        op_id,
+        test_bank_id,
+    )
+
+    response = await api_client.post(f"/v1/default/banks/{test_bank_id}/operations/{op_id}/retry")
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert "batch_retain parent" in detail
+    assert "delete" in detail.lower()
+
+    # Guard must not have mutated the row.
+    row = await pool.fetchrow(
+        "SELECT status FROM async_operations WHERE operation_id = $1",
+        op_id,
+    )
+    assert row["status"] == "failed"
+
+    # But it remains deletable as the sanctioned cleanup path.
+    response = await api_client.delete(f"/v1/default/banks/{test_bank_id}/operations/{op_id}/delete")
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_cancel_rejects_non_pending_operations(api_client, memory, test_bank_id):
     """DELETE /operations/{id} should only cancel pending operations."""
     pool = memory._pool

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -1476,6 +1476,188 @@ class TestWorkerRecovery:
         )
         assert parent_row["status"] == "failed"
 
+    @pytest.mark.asyncio
+    async def test_reconcile_completes_parent_when_all_children_completed(self, pool, backend, clean_operations):
+        """A pending batch_retain parent whose children all completed is promoted.
+
+        Models the crash window where the last child committed 'completed' but the
+        parent aggregation was skipped (issue #2985). Recovery must finalize the
+        parent to 'completed' rather than leave it stranded 'pending'.
+        """
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+
+        parent_id = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+                (operation_id, bank_id, operation_type, status, task_payload, result_metadata)
+            VALUES ($1, $2, 'batch_retain', 'pending', NULL, '{}'::jsonb)
+            """,
+            parent_id,
+            bank_id,
+        )
+        for _ in range(2):
+            await pool.execute(
+                """
+                INSERT INTO async_operations
+                    (operation_id, bank_id, operation_type, status, task_payload, result_metadata)
+                VALUES ($1, $2, 'retain', 'completed', '{}'::jsonb, $3::jsonb)
+                """,
+                uuid.uuid4(),
+                bank_id,
+                json.dumps({"parent_operation_id": str(parent_id)}),
+            )
+
+        poller = WorkerPoller(backend=backend, worker_id="reconcile-worker", executor=lambda x: None)
+        reconciled = await poller._reconcile_orphaned_parents(None)
+        assert reconciled == 1
+
+        parent_row = await pool.fetchrow(
+            "SELECT status, completed_at FROM async_operations WHERE operation_id = $1",
+            parent_id,
+        )
+        assert parent_row["status"] == "completed"
+        assert parent_row["completed_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_reconcile_fails_parent_when_a_child_failed(self, pool, backend, clean_operations):
+        """A pending parent with a failed child is finalized 'failed', inheriting its reason."""
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+
+        parent_id = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+                (operation_id, bank_id, operation_type, status, task_payload, result_metadata)
+            VALUES ($1, $2, 'batch_retain', 'pending', NULL, '{}'::jsonb)
+            """,
+            parent_id,
+            bank_id,
+        )
+        meta = json.dumps({"parent_operation_id": str(parent_id)})
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+                (operation_id, bank_id, operation_type, status, task_payload, result_metadata)
+            VALUES ($1, $2, 'retain', 'completed', '{}'::jsonb, $3::jsonb)
+            """,
+            uuid.uuid4(),
+            bank_id,
+            meta,
+        )
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+                (operation_id, bank_id, operation_type, status, task_payload,
+                 result_metadata, error_message)
+            VALUES ($1, $2, 'retain', 'failed', '{}'::jsonb, $3::jsonb, 'boom: extraction failed')
+            """,
+            uuid.uuid4(),
+            bank_id,
+            meta,
+        )
+
+        poller = WorkerPoller(backend=backend, worker_id="reconcile-worker", executor=lambda x: None)
+        assert await poller._reconcile_orphaned_parents(None) == 1
+
+        parent_row = await pool.fetchrow(
+            "SELECT status, error_message FROM async_operations WHERE operation_id = $1",
+            parent_id,
+        )
+        assert parent_row["status"] == "failed"
+        # Inherits the representative child reason, not a generic string.
+        assert parent_row["error_message"] == "boom: extraction failed"
+
+    @pytest.mark.asyncio
+    async def test_reconcile_fails_orphaned_parent_with_no_children(self, pool, backend, clean_operations):
+        """A pending parent with zero children is failed with an explicit, resubmit-hint reason.
+
+        This is the exact symptom in issue #2985: task_payload IS NULL, no children,
+        invisible to failed_operations. After reconciliation it is terminal and visible.
+        """
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+
+        parent_id = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+                (operation_id, bank_id, operation_type, status, task_payload, result_metadata)
+            VALUES ($1, $2, 'batch_retain', 'pending', NULL, '{}'::jsonb)
+            """,
+            parent_id,
+            bank_id,
+        )
+
+        poller = WorkerPoller(backend=backend, worker_id="reconcile-worker", executor=lambda x: None)
+        assert await poller._reconcile_orphaned_parents(None) == 1
+
+        parent_row = await pool.fetchrow(
+            "SELECT status, error_message, completed_at FROM async_operations WHERE operation_id = $1",
+            parent_id,
+        )
+        assert parent_row["status"] == "failed"
+        assert "orphaned batch_retain parent" in parent_row["error_message"]
+        assert parent_row["completed_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_reconcile_leaves_parent_with_live_child_untouched(self, pool, backend, clean_operations):
+        """A parent with a still-pending child must not be finalized prematurely."""
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+
+        parent_id = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+                (operation_id, bank_id, operation_type, status, task_payload, result_metadata)
+            VALUES ($1, $2, 'batch_retain', 'pending', NULL, '{}'::jsonb)
+            """,
+            parent_id,
+            bank_id,
+        )
+        meta = json.dumps({"parent_operation_id": str(parent_id)})
+        # One completed, one still pending — aggregation is not done yet.
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+                (operation_id, bank_id, operation_type, status, task_payload, result_metadata)
+            VALUES ($1, $2, 'retain', 'completed', '{}'::jsonb, $3::jsonb)
+            """,
+            uuid.uuid4(),
+            bank_id,
+            meta,
+        )
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+                (operation_id, bank_id, operation_type, status, task_payload, result_metadata)
+            VALUES ($1, $2, 'retain', 'pending', '{}'::jsonb, $3::jsonb)
+            """,
+            uuid.uuid4(),
+            bank_id,
+            meta,
+        )
+
+        poller = WorkerPoller(backend=backend, worker_id="reconcile-worker", executor=lambda x: None)
+        assert await poller._reconcile_orphaned_parents(None) == 0
+
+        parent_row = await pool.fetchrow(
+            "SELECT status FROM async_operations WHERE operation_id = $1",
+            parent_id,
+        )
+        assert parent_row["status"] == "pending"
+
 
 class TestConcurrentWorkers:
     """Tests for concurrent worker task claiming (FOR UPDATE SKIP LOCKED)."""


### PR DESCRIPTION
## Summary

Fixes #2985. A hard kill during batch retain could leave the `batch_retain` **parent** operation stuck `pending` with `task_payload = NULL` forever — silently losing documents while `failed_operations` stayed at 0 and `/retry` returned 409.

### Root cause

A `batch_retain` parent is a payload-less **status aggregator**: workers never claim it, and it is promoted to a terminal state only when its last child sub-batch finishes (`_maybe_update_parent_operation`). Two crash windows strand it `pending` indefinitely:

1. **Missed aggregation** — the aggregation helper swallows and logs exceptions, so a transient error there leaves the parent behind even though every child reached a terminal state.
2. **No children committed** — an older non-atomic create path or a hard kill mid-submission leaves a parent with zero children.

Either way the parent is unclaimable (poller excludes `payload_null`), invisible to `failed_operations`, unretryable via the API, and its documents are silently absent.

## Changes

- **`worker/poller.py`** — new `WorkerPoller._reconcile_orphaned_parents(schema)`, run at the end of the per-schema `recover_own_tasks()` pass (worker startup). Every pending payload-null `batch_retain` parent is driven to a terminal state under a row lock:
  - children present, all terminal → `completed` / `failed` (inheriting a representative child error message)
  - no children at all → `failed`, with an explicit *"resubmit the source documents"* reason
  - at least one live child → left untouched (normal aggregation finishes it)
- **`engine/memory_engine.py`** — `retry_operation` now refuses a `batch_retain` parent (null payload) with a tailored 409 pointing at the supported recovery (resubmit + delete). Without this, retrying a reconciled-`failed` parent would just re-strand it `pending` (no worker claims a null-payload row, terminal children don't re-run).

This addresses all three expected behaviors in the issue: parents reach a terminal, alertable state (#1); they surface in `failed_operations` (#2, a `GROUP BY status` count); and they become actionable via the API — deletable, and no longer silently re-strandable by retry (#3). `cancel_operation` already handled the pending husk (pending → cancelled → delete).

## Testing

- `test_worker.py`: reconciliation covers completed-children promotion, failed-child roll-up, orphaned (no-children) failure, and the leave-live-child-alone case.
- `test_operation_status.py`: `test_retry_rejects_batch_retain_parent` asserts the 409 + that delete still works.
- Full `test_worker.py` + `test_operation_status.py` + `test_async_batch_retain.py` (148 tests) pass; lint + `ty` type-check clean.

The `@>` containment query mirrors the existing aggregator and is rewritten to `JSON_EXISTS` by the Oracle SQL layer, so it stays dialect-safe.

## Scope

Kept to the filed crash-recovery scenario: `batch_retain` only, startup-only reconciliation (no periodic tick, no `file_convert_retain`).
