### PR TITLE
docs(zapier): clarify private-beta availability + Webhooks-by-Zapier path

### DIFF
--- a/hindsight-docs/docs-integrations/zapier.md
+++ b/hindsight-docs/docs-integrations/zapier.md
@@ -25,7 +25,35 @@ Zapier connects everything: Gmail, Slack, Sheets, HubSpot, Notion, forms, and th
 
 1. **Sign up** at [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup) (free tier) or [self-host](/developer/installation)
 2. **Get an API key** (`hsk_...`) from the Hindsight dashboard
-3. **In Zapier**, add a Hindsight step and connect your account with the API key (the API URL defaults to Hindsight Cloud; point it at your own instance for self-hosted — leave the key blank if it runs without auth)
+
+:::note Availability
+The native Hindsight Zapier app (the **Retain / Recall / Reflect** steps and triggers) is
+currently a **private beta** — it isn't listed in Zapier's public App Directory yet, so
+searching "Hindsight" in Zapier won't find it. Use one of the two paths below.
+:::
+
+### Option A — Webhooks by Zapier (works today, no install)
+
+Every Hindsight operation is a plain REST call, so you can drive it from Zapier's built-in
+**Webhooks by Zapier** action (or **API Request**) with nothing to install:
+
+- **Method:** `POST`
+- **URL** (Hindsight Cloud):
+  - Retain — `https://api.hindsight.vectorize.io/v1/default/banks/<bank>/memories`
+  - Recall — `https://api.hindsight.vectorize.io/v1/default/banks/<bank>/memories/recall`
+  - Reflect — `https://api.hindsight.vectorize.io/v1/default/banks/<bank>/reflect`
+- **Headers:** `Authorization: Bearer hsk_...` and `Content-Type: application/json`
+- **Body:** the JSON payload for the operation — see the [API Reference](/api-reference) for the exact fields.
+
+For self-hosted, swap the host for your own instance URL; drop the `Authorization` header if it runs without auth.
+
+### Option B — Native app (private beta, invite required)
+
+Prefer the polished **Retain / Recall / Reflect** steps, the dynamic bank dropdown, and the
+memory-event triggers? Request a private-app invite link — [open an issue](https://github.com/vectorize-io/hindsight/issues)
+and we'll share one. Opening the link adds the Hindsight app to your Zapier account; then
+connect with your API key (the API URL defaults to Hindsight Cloud; point it at your own
+instance for self-hosted — leave the key blank if it runs without auth).
 
 ## Actions
 

--- a/hindsight-docs/docs-integrations/zapier.md
+++ b/hindsight-docs/docs-integrations/zapier.md
@@ -29,10 +29,10 @@ Zapier connects everything: Gmail, Slack, Sheets, HubSpot, Notion, forms, and th
 :::note Availability
 The native Hindsight Zapier app (the **Retain / Recall / Reflect** steps and triggers) is
 currently a **private beta** — it isn't listed in Zapier's public App Directory yet, so
-searching "Hindsight" in Zapier won't find it. Use one of the two paths below.
+searching "Hindsight" in Zapier won't find it. Use the **Webhooks by Zapier** path below.
 :::
 
-### Option A — Webhooks by Zapier (works today, no install)
+### Webhooks by Zapier
 
 Every Hindsight operation is a plain REST call, so you can drive it from Zapier's built-in
 **Webhooks by Zapier** action (or **API Request**) with nothing to install:
@@ -46,14 +46,6 @@ Every Hindsight operation is a plain REST call, so you can drive it from Zapier'
 - **Body:** the JSON payload for the operation — see the [API Reference](/api-reference) for the exact fields.
 
 For self-hosted, swap the host for your own instance URL; drop the `Authorization` header if it runs without auth.
-
-### Option B — Native app (private beta, invite required)
-
-Prefer the polished **Retain / Recall / Reflect** steps, the dynamic bank dropdown, and the
-memory-event triggers? Request a private-app invite link — [open an issue](https://github.com/vectorize-io/hindsight/issues)
-and we'll share one. Opening the link adds the Hindsight app to your Zapier account; then
-connect with your API key (the API URL defaults to Hindsight Cloud; point it at your own
-instance for self-hosted — leave the key blank if it runs without auth).
 
 ## Actions
 

--- a/skills/hindsight-docs/references/sdks/integrations/zapier.md
+++ b/skills/hindsight-docs/references/sdks/integrations/zapier.md
@@ -19,7 +19,34 @@ Zapier connects everything: Gmail, Slack, Sheets, HubSpot, Notion, forms, and th
 [Sign up free](https://ui.hindsight.vectorize.io/signup) and grab an API key — no self-hosting required.
 1. **Sign up** at [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup) (free tier) or [self-host](../../developer/installation.md)
 2. **Get an API key** (`hsk_...`) from the Hindsight dashboard
-3. **In Zapier**, add a Hindsight step and connect your account with the API key (the API URL defaults to Hindsight Cloud; point it at your own instance for self-hosted — leave the key blank if it runs without auth)
+
+> **📝 Availability**
+>
+The native Hindsight Zapier app (the **Retain / Recall / Reflect** steps and triggers) is
+currently a **private beta** — it isn't listed in Zapier's public App Directory yet, so
+searching "Hindsight" in Zapier won't find it. Use one of the two paths below.
+### Option A — Webhooks by Zapier (works today, no install)
+
+Every Hindsight operation is a plain REST call, so you can drive it from Zapier's built-in
+**Webhooks by Zapier** action (or **API Request**) with nothing to install:
+
+- **Method:** `POST`
+- **URL** (Hindsight Cloud):
+  - Retain — `https://api.hindsight.vectorize.io/v1/default/banks/<bank>/memories`
+  - Recall — `https://api.hindsight.vectorize.io/v1/default/banks/<bank>/memories/recall`
+  - Reflect — `https://api.hindsight.vectorize.io/v1/default/banks/<bank>/reflect`
+- **Headers:** `Authorization: Bearer hsk_...` and `Content-Type: application/json`
+- **Body:** the JSON payload for the operation — see the [API Reference](../../openapi.json) for the exact fields.
+
+For self-hosted, swap the host for your own instance URL; drop the `Authorization` header if it runs without auth.
+
+### Option B — Native app (private beta, invite required)
+
+Prefer the polished **Retain / Recall / Reflect** steps, the dynamic bank dropdown, and the
+memory-event triggers? Request a private-app invite link — [open an issue](https://github.com/vectorize-io/hindsight/issues)
+and we'll share one. Opening the link adds the Hindsight app to your Zapier account; then
+connect with your API key (the API URL defaults to Hindsight Cloud; point it at your own
+instance for self-hosted — leave the key blank if it runs without auth).
 
 ## Actions
 

--- a/skills/hindsight-docs/references/sdks/integrations/zapier.md
+++ b/skills/hindsight-docs/references/sdks/integrations/zapier.md
@@ -24,8 +24,8 @@ Zapier connects everything: Gmail, Slack, Sheets, HubSpot, Notion, forms, and th
 >
 The native Hindsight Zapier app (the **Retain / Recall / Reflect** steps and triggers) is
 currently a **private beta** — it isn't listed in Zapier's public App Directory yet, so
-searching "Hindsight" in Zapier won't find it. Use one of the two paths below.
-### Option A — Webhooks by Zapier (works today, no install)
+searching "Hindsight" in Zapier won't find it. Use the **Webhooks by Zapier** path below.
+### Webhooks by Zapier
 
 Every Hindsight operation is a plain REST call, so you can drive it from Zapier's built-in
 **Webhooks by Zapier** action (or **API Request**) with nothing to install:
@@ -39,14 +39,6 @@ Every Hindsight operation is a plain REST call, so you can drive it from Zapier'
 - **Body:** the JSON payload for the operation — see the [API Reference](../../openapi.json) for the exact fields.
 
 For self-hosted, swap the host for your own instance URL; drop the `Authorization` header if it runs without auth.
-
-### Option B — Native app (private beta, invite required)
-
-Prefer the polished **Retain / Recall / Reflect** steps, the dynamic bank dropdown, and the
-memory-event triggers? Request a private-app invite link — [open an issue](https://github.com/vectorize-io/hindsight/issues)
-and we'll share one. Opening the link adds the Hindsight app to your Zapier account; then
-connect with your API key (the API URL defaults to Hindsight Cloud; point it at your own
-instance for self-hosted — leave the key blank if it runs without auth).
 
 ## Actions
 


### PR DESCRIPTION
The Zapier doc said *"In Zapier, add a Hindsight step"* as if the app were publicly listed, but the Zapier app is still a **private/unpublished** app (`"private": true`) — it doesn't appear in Zapier's App Directory, so users search 'Hindsight' and find nothing.

This rewrites the Setup section to be accurate:
- **Availability note** — native app is private beta, not in the public directory.
- **Option A — Webhooks by Zapier** (works today, no install): POST to the Hindsight REST endpoints (retain/recall/reflect) with a `Bearer hsk_...` key. Verified paths against the OpenAPI spec.
- **Option B — Native app** via private-app invite link.

Follow-up (not in this PR): submit the app for Zapier public-beta listing so it becomes discoverable.