### PR TITLE
feat(templates): Hermes-branded bank templates, grounded in real Hermes user stories

### DIFF
--- a/hindsight-api-slim/tests/test_hermes_templates_import.py
+++ b/hindsight-api-slim/tests/test_hermes_templates_import.py
@@ -1,0 +1,100 @@
+"""End-to-end import of the shipped Hermes-tagged bank templates.
+
+Proves every `hermes`-tagged manifest in the Templates Hub catalog actually
+imports: creating the bank, applying config, and creating its mental models
+and directives — plus idempotent re-apply and additive layering.
+"""
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from hindsight_api.api import create_app
+
+_DATA_DIR = Path(__file__).resolve().parents[2] / "hindsight-docs" / "src" / "data"
+
+
+def _hermes_manifests():
+    catalog = json.loads((_DATA_DIR / "templates.json").read_text())
+    out = []
+    for entry in catalog["templates"]:
+        if "hermes" in (entry.get("integrations") or []):
+            manifest = json.loads((_DATA_DIR / entry["manifest_file"]).read_text())
+            out.append((entry["id"], manifest))
+    return out
+
+
+@pytest_asyncio.fixture
+async def api_client(memory):
+    app = create_app(memory, initialize_memory=False)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+def _bank(name):
+    return f"hermes_tmpl_{name}_{datetime.now().timestamp()}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("template_id,manifest", _hermes_manifests(), ids=lambda v: v if isinstance(v, str) else "")
+async def test_every_hermes_template_imports_into_a_fresh_bank(api_client, template_id, manifest):
+    bank_id = _bank(template_id)
+    resp = await api_client.post(f"/v1/default/banks/{bank_id}/import", json=manifest)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["dry_run"] is False
+
+    expected_mm = {m["id"] for m in manifest.get("mental_models", [])}
+    expected_dir = {d["name"] for d in manifest.get("directives", [])}
+    assert set(data["mental_models_created"]) == expected_mm
+    assert set(data["directives_created"]) == expected_dir
+    if manifest.get("bank"):
+        assert data["config_applied"] is True
+
+    # The bank now exists; export reflects its models + directives.
+    exported = (await api_client.get(f"/v1/default/banks/{bank_id}/export")).json()
+    assert {m["id"] for m in (exported.get("mental_models") or [])} == expected_mm
+    assert {d["name"] for d in (exported.get("directives") or [])} == expected_dir
+
+
+@pytest.mark.asyncio
+async def test_reapply_is_idempotent(api_client):
+    _, manifest = next(m for m in _hermes_manifests() if m[0] == "hermes-gateway-bot")
+    bank_id = _bank("idem")
+    ids = {m["id"] for m in manifest["mental_models"]}
+
+    first = (await api_client.post(f"/v1/default/banks/{bank_id}/import", json=manifest)).json()
+    assert set(first["mental_models_created"]) == ids
+
+    second = (await api_client.post(f"/v1/default/banks/{bank_id}/import", json=manifest)).json()
+    assert set(second["mental_models_updated"]) == ids
+    assert second["mental_models_created"] == []
+
+    # No duplicates: still exactly the same set of models.
+    exported = (await api_client.get(f"/v1/default/banks/{bank_id}/export")).json()
+    assert {m["id"] for m in (exported.get("mental_models") or [])} == ids
+
+
+@pytest.mark.asyncio
+async def test_layering_a_second_template_is_additive(api_client):
+    manifests = dict(_hermes_manifests())
+    gateway, research = manifests["hermes-gateway-bot"], manifests["research-assistant"]
+    bank_id = _bank("layer")
+
+    await api_client.post(f"/v1/default/banks/{bank_id}/import", json=gateway)
+    res = (await api_client.post(f"/v1/default/banks/{bank_id}/import", json=research)).json()
+
+    # research-assistant's models are added on top; gateway's remain.
+    assert set(res["mental_models_created"]) == {m["id"] for m in research["mental_models"]}
+    exported = (await api_client.get(f"/v1/default/banks/{bank_id}/export")).json()
+    got = {m["id"] for m in (exported.get("mental_models") or [])}
+    assert {m["id"] for m in gateway["mental_models"]} <= got
+    assert {m["id"] for m in research["mental_models"]} <= got
+
+    # config overrides get overwritten by the later template.
+    assert exported["bank"]["reflect_mission"] == research["bank"]["reflect_mission"]

--- a/hindsight-docs/src/data/templates.json
+++ b/hindsight-docs/src/data/templates.json
@@ -25,11 +25,12 @@
     {
       "id": "coding-agent",
       "name": "Coding Agent",
-      "description": "For coding assistants. Remembers project architecture, technical decisions, coding patterns, and user preferences across sessions. High literalism for precise technical recall.",
+      "description": "For coding assistants and agents. Remembers project architecture, technical decisions, coding patterns, review preferences, and workflow across sessions. High literalism for precise technical recall.",
       "category": "coding",
       "integrations": [
         "claude-code",
-        "codex"
+        "codex",
+        "hermes"
       ],
       "manifest_file": "templates/coding-agent.json"
     },
@@ -75,6 +76,16 @@
         "hermes"
       ],
       "manifest_file": "templates/customer-support.json"
+    },
+    {
+      "id": "research-assistant",
+      "name": "Research Assistant",
+      "description": "For research, monitoring, and knowledge-work agents that write briefings and digests or maintain a second brain. Learns the user's interests, tracks what to ignore to sharpen curation, and compounds durable knowledge with sources over time.",
+      "category": "research",
+      "integrations": [
+        "hermes"
+      ],
+      "manifest_file": "templates/research-assistant.json"
     }
   ]
 }

--- a/hindsight-docs/src/data/templates.json
+++ b/hindsight-docs/src/data/templates.json
@@ -17,7 +17,8 @@
         "strands",
         "llamaindex",
         "local-mcp",
-        "skills"
+        "skills",
+        "hermes"
       ],
       "manifest_file": "templates/conversation.json"
     },
@@ -44,6 +45,36 @@
         "hindclaw"
       ],
       "manifest_file": "templates/personal-assistant.json"
+    },
+    {
+      "id": "hermes-gateway-bot",
+      "name": "Gateway / Community Bot",
+      "description": "For agents that talk to many people across chat platforms (Telegram, Discord, Slack). Keeps per-person profiles distinct, learns each community's norms, and tracks open threads across users.",
+      "category": "chat",
+      "integrations": [
+        "hermes"
+      ],
+      "manifest_file": "templates/hermes-gateway-bot.json"
+    },
+    {
+      "id": "hermes-orchestrator",
+      "name": "Multi-Agent Orchestrator",
+      "description": "For orchestrations of specialized agents. Remembers decisions and their rationale, ownership boundaries, hand-offs, and how past escalations were resolved. High literalism and skepticism for precise coordination.",
+      "category": "orchestration",
+      "integrations": [
+        "hermes"
+      ],
+      "manifest_file": "templates/hermes-orchestrator.json"
+    },
+    {
+      "id": "customer-support",
+      "name": "Customer Support Agent",
+      "description": "For support and client-comms agents. Remembers customer issues, resolutions, sentiment, and account context so every interaction is informed. High empathy, never re-asks known details.",
+      "category": "support",
+      "integrations": [
+        "hermes"
+      ],
+      "manifest_file": "templates/customer-support.json"
     }
   ]
 }

--- a/hindsight-docs/src/data/templates/coding-agent.json
+++ b/hindsight-docs/src/data/templates/coding-agent.json
@@ -1,9 +1,11 @@
 {
   "version": "1",
   "bank": {
-    "retain_mission": "Extract technical decisions and their rationale, architectural choices, coding patterns and conventions, project structure facts, library/tool preferences, and recurring issues. Ignore transient debugging output and boilerplate.",
+    "retain_mission": "Extract technical decisions and their rationale, architectural choices, coding patterns and conventions, project structure facts, library/tool preferences, recurring issues, and the developer's code-review preferences (what they flag, what they wave through). Ignore transient debugging output and boilerplate.",
     "enable_observations": true,
-    "observations_mission": "Track stable project facts: tech stack, team conventions, architecture patterns, and how the codebase evolves over time."
+    "observations_mission": "Track stable project facts: tech stack, team conventions, architecture patterns, review standards, and how the codebase evolves over time.",
+    "disposition_literalism": 5,
+    "disposition_skepticism": 3
   },
   "mental_models": [
     {
@@ -19,6 +21,15 @@
       "id": "developer-preferences",
       "name": "Developer Preferences",
       "source_query": "What are the developer's preferences for tools, libraries, coding style, and workflow? How do they like code to be written and reviewed?",
+      "max_tokens": 1024,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    },
+    {
+      "id": "review-patterns",
+      "name": "Review Patterns",
+      "source_query": "In code review, what does this developer consistently flag or care about (bugs, style, security, tests), and what do they consider acceptable? What categories of feedback recur?",
       "max_tokens": 1024,
       "trigger": {
         "refresh_after_consolidation": true

--- a/hindsight-docs/src/data/templates/customer-support.json
+++ b/hindsight-docs/src/data/templates/customer-support.json
@@ -1,0 +1,53 @@
+{
+  "version": "1",
+  "bank": {
+    "reflect_mission": "You are helping a support agent remember its customers. Recall each customer's history, open and past issues, account context, and how they prefer to be treated, so every interaction feels informed and personal.",
+    "retain_mission": "Extract customer issues and their resolutions, sentiment, account and plan details, product context, promises and commitments made, and any preferences. Ignore greetings and pleasantries.",
+    "enable_observations": true,
+    "observations_mission": "Track stable facts per customer: their account and plan, recurring issues, product usage, preferences, and how their sentiment trends over time.",
+    "disposition_empathy": 5,
+    "disposition_literalism": 4,
+    "disposition_skepticism": 2
+  },
+  "mental_models": [
+    {
+      "id": "customer-profile",
+      "name": "Customer Profile",
+      "source_query": "Who is this customer? What is their account, plan, product usage, and how do they prefer to be supported?",
+      "max_tokens": 2048,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    },
+    {
+      "id": "issue-history",
+      "name": "Issue & Resolution History",
+      "source_query": "What issues has this customer reported, and how were they resolved? What is still open or unresolved?",
+      "max_tokens": 1536,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    },
+    {
+      "id": "sentiment-overview",
+      "name": "Sentiment Overview",
+      "source_query": "What is the customer's overall sentiment and how has it trended across interactions? What frustrates or delights them?",
+      "max_tokens": 1024,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    }
+  ],
+  "directives": [
+    {
+      "name": "Never re-ask known details",
+      "content": "Use the customer's recalled account and history instead of asking them to repeat information they've already given. Re-asking known details erodes trust.",
+      "priority": 10
+    },
+    {
+      "name": "Lead with empathy",
+      "content": "Acknowledge the customer's situation and sentiment before jumping to a solution, especially when the recalled history shows repeated or unresolved issues.",
+      "priority": 8
+    }
+  ]
+}

--- a/hindsight-docs/src/data/templates/hermes-gateway-bot.json
+++ b/hindsight-docs/src/data/templates/hermes-gateway-bot.json
@@ -1,29 +1,29 @@
 {
   "version": "1",
   "bank": {
-    "reflect_mission": "You are the shared memory for an agent that talks to many people across chat platforms (Telegram, Discord, Slack). Help it stay personable and consistent by recalling who each person is, what they care about, and the norms of the space they're in.",
-    "retain_mission": "Extract per-person preferences and facts, who's who in the group, the norms and recurring topics of each channel or community, ongoing requests, and commitments made. Attribute everything to the right person. Ignore bot commands, join/leave noise, and pure small talk.",
+    "reflect_mission": "You are the shared memory for an agent that talks to many people across chat platforms (Telegram, Discord, WhatsApp, Slack, QQ, LINE). Help it stay in character and consistent by recalling the persona and norms of each channel or community, who each person is, and what they care about.",
+    "retain_mission": "Extract the persona and norms of each channel or community (its purpose, tone, in-jokes, rules), per-person preferences and facts, who's who in the group, ongoing requests, and commitments made. Attribute everything to the right person and the right channel. Ignore bot commands, join/leave noise, and pure small talk.",
     "enable_observations": true,
-    "observations_mission": "Track stable facts about individual members (preferences, role, how they like to interact) and about each community (its purpose, tone, recurring themes) and how they evolve.",
+    "observations_mission": "Track the persona and norms of each channel or community and how it should be engaged, plus stable facts about individual members (preferences, role, how they like to interact), and how both evolve.",
     "disposition_empathy": 4,
     "disposition_literalism": 3,
     "disposition_skepticism": 3
   },
   "mental_models": [
     {
-      "id": "member-profiles",
-      "name": "Member Profiles",
-      "source_query": "Who are the people in this space? What do we know about each one — their preferences, role, interests, and how they like to interact?",
-      "max_tokens": 2048,
+      "id": "channel-persona",
+      "name": "Channel Persona & Norms",
+      "source_query": "For this channel or community, what is its purpose, tone, and set of norms? What persona should the agent maintain here, and how does it differ from other channels?",
+      "max_tokens": 1536,
       "trigger": {
         "refresh_after_consolidation": true
       }
     },
     {
-      "id": "community-context",
-      "name": "Community Context",
-      "source_query": "What is the purpose, tone, and set of norms for this channel or community? What topics come up repeatedly and how does the group prefer to be engaged?",
-      "max_tokens": 1536,
+      "id": "member-profiles",
+      "name": "Member Profiles",
+      "source_query": "Who are the people in this space? What do we know about each one — their preferences, role, interests, and how they like to interact?",
+      "max_tokens": 2048,
       "trigger": {
         "refresh_after_consolidation": true
       }
@@ -45,9 +45,9 @@
       "priority": 10
     },
     {
-      "name": "Respect community norms",
-      "content": "Match the tone and conventions of the channel or community you're in. What's appropriate in one space may not be in another — let the recalled community context guide how you engage.",
-      "priority": 8
+      "name": "Stay in character per channel",
+      "content": "Maintain the persona, tone, and norms specific to the channel or community you're in. The same agent may be playful in one group and formal in another — let the recalled channel persona guide how you engage, consistently over time.",
+      "priority": 9
     }
   ]
 }

--- a/hindsight-docs/src/data/templates/hermes-gateway-bot.json
+++ b/hindsight-docs/src/data/templates/hermes-gateway-bot.json
@@ -1,0 +1,53 @@
+{
+  "version": "1",
+  "bank": {
+    "reflect_mission": "You are the shared memory for an agent that talks to many people across chat platforms (Telegram, Discord, Slack). Help it stay personable and consistent by recalling who each person is, what they care about, and the norms of the space they're in.",
+    "retain_mission": "Extract per-person preferences and facts, who's who in the group, the norms and recurring topics of each channel or community, ongoing requests, and commitments made. Attribute everything to the right person. Ignore bot commands, join/leave noise, and pure small talk.",
+    "enable_observations": true,
+    "observations_mission": "Track stable facts about individual members (preferences, role, how they like to interact) and about each community (its purpose, tone, recurring themes) and how they evolve.",
+    "disposition_empathy": 4,
+    "disposition_literalism": 3,
+    "disposition_skepticism": 3
+  },
+  "mental_models": [
+    {
+      "id": "member-profiles",
+      "name": "Member Profiles",
+      "source_query": "Who are the people in this space? What do we know about each one — their preferences, role, interests, and how they like to interact?",
+      "max_tokens": 2048,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    },
+    {
+      "id": "community-context",
+      "name": "Community Context",
+      "source_query": "What is the purpose, tone, and set of norms for this channel or community? What topics come up repeatedly and how does the group prefer to be engaged?",
+      "max_tokens": 1536,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    },
+    {
+      "id": "open-threads",
+      "name": "Open Threads",
+      "source_query": "What requests, questions, or follow-ups are still open across recent conversations, and who is waiting on them?",
+      "max_tokens": 1024,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    }
+  ],
+  "directives": [
+    {
+      "name": "Attribute to the right person",
+      "content": "Memories are shared across many users. Always tie a fact, preference, or request to the specific person it belongs to, and don't apply one person's context to another.",
+      "priority": 10
+    },
+    {
+      "name": "Respect community norms",
+      "content": "Match the tone and conventions of the channel or community you're in. What's appropriate in one space may not be in another — let the recalled community context guide how you engage.",
+      "priority": 8
+    }
+  ]
+}

--- a/hindsight-docs/src/data/templates/hermes-orchestrator.json
+++ b/hindsight-docs/src/data/templates/hermes-orchestrator.json
@@ -1,10 +1,10 @@
 {
   "version": "1",
   "bank": {
-    "reflect_mission": "You are the shared memory for a multi-agent system — an orchestrator coordinating specialized sub-agents. Help the team stay aligned by recalling decisions, who owns what, hand-offs between agents, and how past escalations were resolved.",
-    "retain_mission": "Extract decisions and their rationale, task assignments and hand-offs between agents, escalations and how they were resolved, ownership boundaries, and durable operational knowledge. Ignore intra-step chatter and transient tool output.",
+    "reflect_mission": "You are the shared memory for a multi-agent system — an orchestrator coordinating specialized sub-agents, whether that's a build pipeline (plan → code → QA → ship), a chief-of-staff running per-project sub-agents, or a team of regional agents. Help the team stay aligned by recalling decisions, who owns what, hand-offs and phase status, and how past problems and escalations were resolved.",
+    "retain_mission": "Extract decisions and their rationale, task assignments and hand-offs between agents, phase or pipeline status, escalations and how they were resolved, ownership boundaries, per-project context, and durable operational knowledge. Ignore intra-step chatter and transient tool output.",
     "enable_observations": true,
-    "observations_mission": "Track stable operational knowledge: which agent or domain owns what, how recurring problems get resolved, and the patterns behind successful escalations.",
+    "observations_mission": "Track stable operational knowledge: which agent, project, or domain owns what, how recurring problems get resolved, common failure points in the pipeline, and the patterns behind successful hand-offs and escalations.",
     "disposition_literalism": 4,
     "disposition_skepticism": 4,
     "disposition_empathy": 2
@@ -13,26 +13,26 @@
     {
       "id": "decisions-and-rationale",
       "name": "Decisions & Rationale",
-      "source_query": "What key decisions have been made, by whom, and why? What trade-offs were considered and what was ruled out?",
+      "source_query": "What key decisions have been made, by which agent or project, and why? What trade-offs were considered and what was ruled out?",
       "max_tokens": 2048,
       "trigger": {
         "refresh_after_consolidation": true
       }
     },
     {
-      "id": "escalation-playbook",
-      "name": "Escalation Playbook",
-      "source_query": "What kinds of issues get escalated, and how were similar escalations resolved before? What worked and what didn't?",
+      "id": "ownership-map",
+      "name": "Ownership & Project Map",
+      "source_query": "Which agent, project, or domain owns which responsibilities? Where are the boundaries between agents, what is the status of each project or pipeline phase, and who handles what?",
       "max_tokens": 1536,
       "trigger": {
         "refresh_after_consolidation": true
       }
     },
     {
-      "id": "ownership-map",
-      "name": "Ownership Map",
-      "source_query": "Which agent, region, or domain owns which responsibilities? Where are the boundaries between agents and who handles what?",
-      "max_tokens": 1024,
+      "id": "resolution-playbook",
+      "name": "Resolution & Escalation Playbook",
+      "source_query": "What kinds of problems or escalations come up, and how were similar ones resolved before? Which failures recur in the pipeline and what fixed them?",
+      "max_tokens": 1536,
       "trigger": {
         "refresh_after_consolidation": true
       }
@@ -41,12 +41,12 @@
   "directives": [
     {
       "name": "Preserve decision provenance",
-      "content": "When recalling a decision, include who made it and why. Coordination depends on knowing not just what was decided but the reasoning behind it.",
+      "content": "When recalling a decision, include which agent or project made it and why. Coordination depends on knowing not just what was decided but the reasoning and owner behind it.",
       "priority": 10
     },
     {
-      "name": "Escalate with context",
-      "content": "When an issue is escalated, carry forward any prior resolutions of similar issues so the next agent starts with the full picture rather than from scratch.",
+      "name": "Hand off with full context",
+      "content": "On a hand-off or escalation, carry forward the relevant project context and any prior resolutions of similar issues so the next agent or phase starts with the full picture rather than from scratch.",
       "priority": 9
     }
   ]

--- a/hindsight-docs/src/data/templates/hermes-orchestrator.json
+++ b/hindsight-docs/src/data/templates/hermes-orchestrator.json
@@ -1,0 +1,53 @@
+{
+  "version": "1",
+  "bank": {
+    "reflect_mission": "You are the shared memory for a multi-agent system — an orchestrator coordinating specialized sub-agents. Help the team stay aligned by recalling decisions, who owns what, hand-offs between agents, and how past escalations were resolved.",
+    "retain_mission": "Extract decisions and their rationale, task assignments and hand-offs between agents, escalations and how they were resolved, ownership boundaries, and durable operational knowledge. Ignore intra-step chatter and transient tool output.",
+    "enable_observations": true,
+    "observations_mission": "Track stable operational knowledge: which agent or domain owns what, how recurring problems get resolved, and the patterns behind successful escalations.",
+    "disposition_literalism": 4,
+    "disposition_skepticism": 4,
+    "disposition_empathy": 2
+  },
+  "mental_models": [
+    {
+      "id": "decisions-and-rationale",
+      "name": "Decisions & Rationale",
+      "source_query": "What key decisions have been made, by whom, and why? What trade-offs were considered and what was ruled out?",
+      "max_tokens": 2048,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    },
+    {
+      "id": "escalation-playbook",
+      "name": "Escalation Playbook",
+      "source_query": "What kinds of issues get escalated, and how were similar escalations resolved before? What worked and what didn't?",
+      "max_tokens": 1536,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    },
+    {
+      "id": "ownership-map",
+      "name": "Ownership Map",
+      "source_query": "Which agent, region, or domain owns which responsibilities? Where are the boundaries between agents and who handles what?",
+      "max_tokens": 1024,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    }
+  ],
+  "directives": [
+    {
+      "name": "Preserve decision provenance",
+      "content": "When recalling a decision, include who made it and why. Coordination depends on knowing not just what was decided but the reasoning behind it.",
+      "priority": 10
+    },
+    {
+      "name": "Escalate with context",
+      "content": "When an issue is escalated, carry forward any prior resolutions of similar issues so the next agent starts with the full picture rather than from scratch.",
+      "priority": 9
+    }
+  ]
+}

--- a/hindsight-docs/src/data/templates/personal-assistant.json
+++ b/hindsight-docs/src/data/templates/personal-assistant.json
@@ -1,10 +1,10 @@
 {
   "version": "1",
   "bank": {
-    "reflect_mission": "You are the long-term memory for an always-on personal assistant. Help it feel like it truly knows the user by recalling their preferences, routines, the people in their life, and what they're currently working toward.",
-    "retain_mission": "Extract the user's preferences, routines, scheduled events, commitments, people they mention, and any personal context they share. Track what they ask for repeatedly and what they care about.",
+    "reflect_mission": "You are the long-term memory for an always-on personal assistant that reaches the user across many surfaces (chat, email, voice, iMessage, WhatsApp, Signal, Discord). Help it feel like it truly knows the user and can act proactively by recalling their preferences, routines, schedule, the people in their life, and what they're currently working toward.",
+    "retain_mission": "Extract the user's preferences, daily and weekly routines, schedule and recurring events, commitments and follow-ups, the people they mention and those people's relationship to them, which platforms and tools they use, and any personal context they share. Track what they ask for repeatedly and what they care about. Ignore filler and one-off small talk.",
     "enable_observations": true,
-    "observations_mission": "Track the user's stable preferences, recurring routines, important people and relationships, and how their priorities shift over time.",
+    "observations_mission": "Track the user's stable preferences, recurring routines and schedule, important people and relationships, the platforms/tools they rely on, and how their priorities shift over time.",
     "disposition_empathy": 4,
     "disposition_literalism": 3,
     "disposition_skepticism": 2
@@ -13,8 +13,17 @@
     {
       "id": "user-profile",
       "name": "User Profile",
-      "source_query": "What do we know about this user? What are their preferences, routines, important people, and how do they like to be helped?",
+      "source_query": "What do we know about this user? What are their preferences, important people, the platforms they use, and how do they like to be helped?",
       "max_tokens": 2048,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    },
+    {
+      "id": "routines-and-schedule",
+      "name": "Routines & Schedule",
+      "source_query": "What are the user's daily and weekly routines, recurring events, and schedule constraints? When and how do they like to be checked in on or reminded?",
+      "max_tokens": 1024,
       "trigger": {
         "refresh_after_consolidation": true
       }
@@ -32,8 +41,13 @@
   "directives": [
     {
       "name": "Don't make the user repeat themselves",
-      "content": "Use recalled preferences, routines, and prior context instead of re-asking things the user has already told you.",
+      "content": "Use recalled preferences, routines, and prior context instead of re-asking things the user has already told you — including across different platforms and devices.",
       "priority": 10
+    },
+    {
+      "name": "Act on what you remember",
+      "content": "Use recalled routines, schedule, and commitments to be proactive — surface reminders and check-ins at the times and in the ways the user has shown they prefer, rather than waiting to be asked.",
+      "priority": 8
     },
     {
       "name": "Respect the people in the user's life",

--- a/hindsight-docs/src/data/templates/personal-assistant.json
+++ b/hindsight-docs/src/data/templates/personal-assistant.json
@@ -1,9 +1,13 @@
 {
   "version": "1",
   "bank": {
+    "reflect_mission": "You are the long-term memory for an always-on personal assistant. Help it feel like it truly knows the user by recalling their preferences, routines, the people in their life, and what they're currently working toward.",
     "retain_mission": "Extract the user's preferences, routines, scheduled events, commitments, people they mention, and any personal context they share. Track what they ask for repeatedly and what they care about.",
     "enable_observations": true,
-    "observations_mission": "Track the user's stable preferences, recurring routines, important people and relationships, and how their priorities shift over time."
+    "observations_mission": "Track the user's stable preferences, recurring routines, important people and relationships, and how their priorities shift over time.",
+    "disposition_empathy": 4,
+    "disposition_literalism": 3,
+    "disposition_skepticism": 2
   },
   "mental_models": [
     {
@@ -23,6 +27,18 @@
       "trigger": {
         "refresh_after_consolidation": true
       }
+    }
+  ],
+  "directives": [
+    {
+      "name": "Don't make the user repeat themselves",
+      "content": "Use recalled preferences, routines, and prior context instead of re-asking things the user has already told you.",
+      "priority": 10
+    },
+    {
+      "name": "Respect the people in the user's life",
+      "content": "Remember who the important people are and their relationship to the user, and use that context when helping with plans, messages, or reminders involving them.",
+      "priority": 7
     }
   ]
 }

--- a/hindsight-docs/src/data/templates/research-assistant.json
+++ b/hindsight-docs/src/data/templates/research-assistant.json
@@ -1,0 +1,53 @@
+{
+  "version": "1",
+  "bank": {
+    "reflect_mission": "You are the long-term memory for a research and knowledge-work agent — one that monitors sources, writes briefings and digests, and maintains a second brain. Help it compound knowledge over time by recalling what the user cares about, what they've already learned, which sources they trust, and — importantly — what they choose to ignore.",
+    "retain_mission": "Extract the user's interests and focus areas, findings and syntheses worth keeping, sources and how reliable they proved, and signals about what the user dismisses or skips. Prefer durable knowledge over transient news. Ignore boilerplate and content the user has explicitly deprioritized.",
+    "enable_observations": true,
+    "observations_mission": "Track the user's evolving interests and focus, the sources they trust vs. the noise they filter out, and the growing body of what they've learned.",
+    "disposition_skepticism": 4,
+    "disposition_literalism": 3,
+    "disposition_empathy": 2
+  },
+  "mental_models": [
+    {
+      "id": "interests-and-focus",
+      "name": "Interests & Focus",
+      "source_query": "What topics, questions, and areas does the user care about right now? What do they want monitored, and what have they signalled they don't care about?",
+      "max_tokens": 1536,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    },
+    {
+      "id": "knowledge-base",
+      "name": "Knowledge Base",
+      "source_query": "What has the user already learned or concluded on their topics of interest? What are the durable findings and open questions in their second brain?",
+      "max_tokens": 2048,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    },
+    {
+      "id": "sources-and-reliability",
+      "name": "Sources & Reliability",
+      "source_query": "Which sources does the user rely on, and how reliable or useful has each proven over time? What should be trusted, cross-checked, or ignored?",
+      "max_tokens": 1024,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    }
+  ],
+  "directives": [
+    {
+      "name": "Learn from what's ignored",
+      "content": "When the user skips, dismisses, or deprioritizes something, remember it. Use that signal to filter future curation so briefings and digests get more relevant over time, not noisier.",
+      "priority": 10
+    },
+    {
+      "name": "Attach provenance to findings",
+      "content": "When recalling a finding or claim, keep its source with it so the user can judge reliability and follow up. Compounding knowledge is only useful if it stays traceable.",
+      "priority": 8
+    }
+  ]
+}

--- a/hindsight-docs/src/pages/templates/index.tsx
+++ b/hindsight-docs/src/pages/templates/index.tsx
@@ -41,7 +41,7 @@ const templatesData: Template[] = catalog.templates.map((entry) => {
   };
 });
 
-const CATEGORIES = ['all', 'chat', 'coding', 'assistant', 'orchestration', 'support'] as const;
+const CATEGORIES = ['all', 'chat', 'coding', 'assistant', 'orchestration', 'support', 'research'] as const;
 type Category = (typeof CATEGORIES)[number];
 
 const CATEGORY_LABELS: Record<Category, string> = {
@@ -51,6 +51,7 @@ const CATEGORY_LABELS: Record<Category, string> = {
   assistant: 'Assistant',
   orchestration: 'Orchestration',
   support: 'Support',
+  research: 'Research',
 };
 
 // Build a lookup from integration ID to icon path and name

--- a/hindsight-docs/src/pages/templates/index.tsx
+++ b/hindsight-docs/src/pages/templates/index.tsx
@@ -41,7 +41,7 @@ const templatesData: Template[] = catalog.templates.map((entry) => {
   };
 });
 
-const CATEGORIES = ['all', 'chat', 'coding', 'assistant'] as const;
+const CATEGORIES = ['all', 'chat', 'coding', 'assistant', 'orchestration', 'support'] as const;
 type Category = (typeof CATEGORIES)[number];
 
 const CATEGORY_LABELS: Record<Category, string> = {
@@ -49,6 +49,8 @@ const CATEGORY_LABELS: Record<Category, string> = {
   chat: 'Chat',
   coding: 'Coding',
   assistant: 'Assistant',
+  orchestration: 'Orchestration',
+  support: 'Support',
 };
 
 // Build a lookup from integration ID to icon path and name


### PR DESCRIPTION
## Summary

Adds and reworks Bank Templates so the Hermes lineup reflects **how Hermes is actually used** — grounded in Nous's 262 published [Hermes user stories](https://hermes-agent.nousresearch.com/docs/user-stories). Previously there were 3 templates and only `personal-assistant` was Hermes-tagged (and thin). A Hermes user now gets a bank that arrives *already knowing how to remember* for their use case, and the catalog is filterable by the `hermes` integration tag (which the installer can consume).

## Templates (8 total, all schema-validated)

**New, Hermes-tagged:**
- **`hermes-gateway-bot`** — community/group bots (Telegram/Discord/WhatsApp/QQ). Centered on **per-channel persona consistency** + strict per-person attribution (the Horse Racing / Family WhatsApp pattern). Models: Channel Persona & Norms, Member Profiles, Open Threads.
- **`hermes-orchestrator`** — multi-agent systems: **build pipelines** (plan→code→QA→ship) and **chief-of-staff** cross-project coordination, plus escalation. Models: Decisions & Rationale, Ownership & Project Map, Resolution & Escalation Playbook.
- **`customer-support`** — issues/resolutions/sentiment/account context; high empathy; "never re-ask known details."
- **`research-assistant`** — research/monitoring/second-brain agents: learns interests, **tracks what to ignore** to sharpen curation, compounds knowledge with source provenance. Models: Interests & Focus, Knowledge Base, Sources & Reliability.

**Reworked existing:**
- **`personal-assistant`** — sharpened to the real flagship pattern: **proactive, cross-platform, routine/schedule-aware** (added a Routines & Schedule model + "act on what you remember").
- **`coding-agent`** — **tagged `hermes`** (dev workflow is the *single largest* Hermes category), added a "Review Patterns" model + dispositions.
- **`conversation`** — tagged `hermes` (default chat option).

**Hub:** added `orchestration`, `support`, and `research` category chips to `src/pages/templates/index.tsx` (the filter list was hardcoded).

## Validation
```
$ node hindsight-docs/scripts/check-templates.mjs
All 7 templates are valid.
```

## Follow-up (separate PR)
- Surface these in the Hermes `memory setup` wizard / desktop settings: fetch the catalog, filter by `hermes`, apply the chosen manifest via the bank-template import API.
