### PR TITLE
fix(migrations): repair memory_units.chunk_id FK to ON DELETE CASCADE at current head

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/a1b2c3d4e5f7_repair_chunk_fk_cascade_at_head.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/a1b2c3d4e5f7_repair_chunk_fk_cascade_at_head.py
@@ -49,30 +49,38 @@ def _pg_schema_prefix() -> str:
 def _pg_upgrade() -> None:
     """Idempotently ensure memory_units.chunk_id FK uses ON DELETE CASCADE.
 
-    Safe to re-apply on databases where ``f6g7h8i9j0k1`` already switched
-    the constraint — the ``DROP … IF EXISTS`` followed by a guarded
-    ``ADD CONSTRAINT`` is a no-op when the CASCADE FK is already present.
+    Checks ``pg_constraint`` first and only drops/recreates the constraint
+    when it is missing or uses a non-CASCADE delete action.  This avoids
+    an unnecessary ``ACCESS EXCLUSIVE`` lock on healthy databases where the
+    FK is already correct.
     """
     schema = _pg_schema_prefix()
+    bare_schema = schema.strip(".").strip('"') if schema else ""
+    schema_clause = f"AND n.nspname = '{bare_schema}'" if bare_schema else ""
 
-    # Drop the existing FK regardless of its current ON DELETE action.
     op.execute(
-        f"ALTER TABLE {schema}memory_units DROP CONSTRAINT IF EXISTS memory_units_chunk_fkey"
-    )
-    # Use a DO block so the ADD is idempotent: if a concurrent migration
-    # already created the CASCADE FK, the duplicate_object exception is
-    # swallowed rather than failing the migration.
-    op.execute(
-        f"""
-        DO $$ BEGIN
-            ALTER TABLE {schema}memory_units
-                ADD CONSTRAINT memory_units_chunk_fkey
-                FOREIGN KEY (chunk_id)
-                REFERENCES {schema}chunks (chunk_id)
-                ON DELETE CASCADE;
-        EXCEPTION
-            WHEN duplicate_object THEN NULL;
-        END $$;
+        f"""DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint c
+                JOIN pg_class r ON r.oid = c.conrelid
+                JOIN pg_namespace n ON n.oid = r.relnamespace
+                WHERE c.conname = 'memory_units_chunk_fkey'
+                  AND r.relname = 'memory_units'
+                  AND c.contype = 'f'
+                  AND c.confdeltype = 'c'  -- 'c' = CASCADE
+                  {schema_clause}
+            ) THEN
+                ALTER TABLE {schema}memory_units
+                    DROP CONSTRAINT IF EXISTS memory_units_chunk_fkey;
+                ALTER TABLE {schema}memory_units
+                    ADD CONSTRAINT memory_units_chunk_fkey
+                    FOREIGN KEY (chunk_id)
+                    REFERENCES {schema}chunks (chunk_id)
+                    ON DELETE CASCADE;
+            END IF;
+        END$$;
         """
     )
 

--- a/hindsight-api-slim/hindsight_api/alembic/versions/a1b2c3d4e5f7_repair_chunk_fk_cascade_at_head.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/a1b2c3d4e5f7_repair_chunk_fk_cascade_at_head.py
@@ -5,8 +5,8 @@ delta retain when the orchestrator tries to delete changed/removed chunks.
 The ``memory_units.chunk_id`` FK is supposed to be ``ON DELETE CASCADE``
 (established by ``f6g7h8i9j0k1_chunk_fk_cascade_delete``) but on databases
 whose ``alembic_version`` jumped ahead via a divergent-head path that
-bypassed that migration, the FK remains ``NO ACTION`` (the original default
-from ``b7c4d8e9f1a2_add_chunks_table``).
+bypassed that migration, the FK remains without CASCADE/SET NULL semantics
+(e.g. ``NO ACTION``), causing chunk deletes to fail.
 
 The symptom is::
 
@@ -20,8 +20,8 @@ first, then ``chunks``, expecting the FK CASCADE to remove the
 
 This migration sits at the current head so every affected deployment picks
 it up on next container start.  It is fully idempotent (``DROP IF EXISTS``
-+ ``DO … WHEN duplicate_object``) so it is a no-op on databases where the
-CASCADE FK is already in place.
++ ``DO … WHEN duplicate_object``) so it is safe to re-apply on databases
+where the CASCADE FK is already in place.
 
 Revision ID: a1b2c3d4e5f7
 Revises: c7d1e9a4b3f2

--- a/hindsight-api-slim/hindsight_api/alembic/versions/a1b2c3d4e5f7_repair_chunk_fk_cascade_at_head.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/a1b2c3d4e5f7_repair_chunk_fk_cascade_at_head.py
@@ -1,0 +1,100 @@
+"""Repair memory_units.chunk_id FK to ON DELETE CASCADE
+
+Multiple production deployments report ``ForeignKeyViolationError`` during
+delta retain when the orchestrator tries to delete changed/removed chunks.
+The ``memory_units.chunk_id`` FK is supposed to be ``ON DELETE CASCADE``
+(established by ``f6g7h8i9j0k1_chunk_fk_cascade_delete``) but on databases
+whose ``alembic_version`` jumped ahead via a divergent-head path that
+bypassed that migration, the FK remains ``NO ACTION`` (the original default
+from ``b7c4d8e9f1a2_add_chunks_table``).
+
+The symptom is::
+
+    update or delete on table "chunks" violates foreign key constraint
+    "memory_units_chunk_fkey" on table "memory_units"
+    DETAIL: Key (chunk_id)=(...) is still referenced from table "memory_units".
+
+``delete_chunks_by_ids`` in ``chunk_storage.py`` deletes ``memory_links``
+first, then ``chunks``, expecting the FK CASCADE to remove the
+``memory_units`` rows — but without CASCADE the commit fails.
+
+This migration sits at the current head so every affected deployment picks
+it up on next container start.  It is fully idempotent (``DROP IF EXISTS``
++ ``DO … WHEN duplicate_object``) so it is a no-op on databases where the
+CASCADE FK is already in place.
+
+Revision ID: a1b2c3d4e5f7
+Revises: c7d1e9a4b3f2
+Create Date: 2026-07-27
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "a1b2c3d4e5f7"
+down_revision: str | Sequence[str] | None = "c7d1e9a4b3f2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _pg_schema_prefix() -> str:
+    """Schema-qualifier for raw SQL on PG (multi-tenant search_path)."""
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def _pg_upgrade() -> None:
+    """Idempotently ensure memory_units.chunk_id FK uses ON DELETE CASCADE.
+
+    Safe to re-apply on databases where ``f6g7h8i9j0k1`` already switched
+    the constraint — the ``DROP … IF EXISTS`` followed by a guarded
+    ``ADD CONSTRAINT`` is a no-op when the CASCADE FK is already present.
+    """
+    schema = _pg_schema_prefix()
+
+    # Drop the existing FK regardless of its current ON DELETE action.
+    op.execute(
+        f"ALTER TABLE {schema}memory_units DROP CONSTRAINT IF EXISTS memory_units_chunk_fkey"
+    )
+    # Use a DO block so the ADD is idempotent: if a concurrent migration
+    # already created the CASCADE FK, the duplicate_object exception is
+    # swallowed rather than failing the migration.
+    op.execute(
+        f"""
+        DO $$ BEGIN
+            ALTER TABLE {schema}memory_units
+                ADD CONSTRAINT memory_units_chunk_fkey
+                FOREIGN KEY (chunk_id)
+                REFERENCES {schema}chunks (chunk_id)
+                ON DELETE CASCADE;
+        EXCEPTION
+            WHEN duplicate_object THEN NULL;
+        END $$;
+        """
+    )
+
+
+def _pg_downgrade() -> None:
+    """Revert to NO ACTION behaviour (original default)."""
+    schema = _pg_schema_prefix()
+    op.drop_constraint(
+        "memory_units_chunk_fkey", "memory_units", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "memory_units_chunk_fkey",
+        "memory_units",
+        "chunks",
+        ["chunk_id"],
+        ["chunk_id"],
+    )
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade)

--- a/hindsight-api-slim/hindsight_api/alembic/versions/a1b2c3d4e5f7_repair_chunk_fk_cascade_at_head.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/a1b2c3d4e5f7_repair_chunk_fk_cascade_at_head.py
@@ -78,18 +78,8 @@ def _pg_upgrade() -> None:
 
 
 def _pg_downgrade() -> None:
-    """Revert to NO ACTION behaviour (original default)."""
-    schema = _pg_schema_prefix()
-    op.drop_constraint(
-        "memory_units_chunk_fkey", "memory_units", type_="foreignkey"
-    )
-    op.create_foreign_key(
-        "memory_units_chunk_fkey",
-        "memory_units",
-        "chunks",
-        ["chunk_id"],
-        ["chunk_id"],
-    )
+    """No-op: canonical schema already has ON DELETE CASCADE (see f6g7h8i9j0k1)."""
+    pass
 
 
 def upgrade() -> None:

--- a/hindsight-api-slim/hindsight_api/alembic/versions/a1b2c3d4e5f7_repair_chunk_fk_cascade_at_head.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/a1b2c3d4e5f7_repair_chunk_fk_cascade_at_head.py
@@ -19,9 +19,9 @@ first, then ``chunks``, expecting the FK CASCADE to remove the
 ``memory_units`` rows — but without CASCADE the commit fails.
 
 This migration sits at the current head so every affected deployment picks
-it up on next container start.  It is fully idempotent (``DROP IF EXISTS``
-+ ``DO … WHEN duplicate_object``) so it is safe to re-apply on databases
-where the CASCADE FK is already in place.
+it up on next container start.  It is fully idempotent — it checks
+``pg_constraint.confdeltype`` first and only drops/recreates the FK when
+it is missing or uses a non-CASCADE delete action.
 
 Revision ID: a1b2c3d4e5f7
 Revises: c7d1e9a4b3f2
@@ -55,8 +55,8 @@ def _pg_upgrade() -> None:
     FK is already correct.
     """
     schema = _pg_schema_prefix()
-    bare_schema = schema.strip(".").strip('"') if schema else ""
-    schema_clause = f"AND n.nspname = '{bare_schema}'" if bare_schema else ""
+    bare_schema = schema.strip(".").strip('"') if schema else "public"
+    schema_clause = f"AND n.nspname = '{bare_schema}'"
 
     op.execute(
         f"""DO $$


### PR DESCRIPTION
## Problem

Multiple deployments hit `ForeignKeyViolationError` during delta retain:

    update or delete on table "chunks" violates foreign key constraint
    "memory_units_chunk_fkey" on table "memory_units"

The FK `memory_units.chunk_id → chunks.chunk_id` is supposed to be `ON DELETE CASCADE` (established by `f6g7h8i9j0k1_chunk_fk_cascade_delete`, PR #580) but on databases whose `alembic_version` jumped ahead via a divergent-head path that bypassed that migration, the FK remains `NO ACTION`.

## Root Cause

`delete_chunks_by_ids()` in `chunk_storage.py` deletes `memory_links` then `chunks`, expecting FK CASCADE to remove `memory_units`. Without CASCADE, the commit fails.

Same class of bug as #1553. Fix pattern mirrors `86f7a033d372`.

## Fix

Idempotent migration at current head (`c7d1e9a4b3f2`):
1. Drops existing FK regardless of current ON DELETE action
2. Recreates with ON DELETE CASCADE using DO block for idempotency

Safe no-op on databases where `f6g7h8i9j0k1` already ran.

## Related
- Closes #572
- Related: #1553

## Testing
- Chain integrity: 89 migrations, single head
- Applied to production DB (v0.8.5), retain confirmed working
- Passes test_migration_shape.py lint