### PR TITLE
fix(claude-code): retain the whole unprocessed suffix, not just its last turn

### DIFF
--- a/hindsight-integrations/claude-code/scripts/lib/content.py
+++ b/hindsight-integrations/claude-code/scripts/lib/content.py
@@ -317,8 +317,11 @@ def prepare_retention_transcript(
     Args:
         messages: List of message dicts with 'role' and 'content'.
         retain_roles: Roles to include (default: ['user', 'assistant']).
-        retain_full_window: If True, retain all messages (chunked mode).
-            If False, retain only the last turn (last user msg + responses).
+        retain_full_window: If True, the caller has already selected the complete
+            window to retain and every message is formatted as-is. If False, only
+            the last turn (last user msg + responses) is kept — use this only when
+            the caller has NOT already narrowed the message list, since callers
+            that advance a retention cursor would otherwise skip what this drops.
         include_tool_calls: If True, output JSON format with full tool call data.
 
     Returns:

--- a/hindsight-integrations/claude-code/scripts/retain.py
+++ b/hindsight-integrations/claude-code/scripts/retain.py
@@ -130,7 +130,11 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
             debug_log(config, f"No new messages for session {session_id}, skipping retain")
             return
         messages_to_retain = all_messages[retention_progress.start_index :]
-        retain_full_window = retention_progress.start_index == 0
+        # plan_retention already selected the unprocessed suffix; do not apply
+        # last-turn slicing again. commit_retention() below advances the cursor
+        # past the whole suffix, so anything a second window dropped would be
+        # skipped permanently.
+        retain_full_window = True
         if retention_progress.compacted:
             debug_log(
                 config,

--- a/hindsight-integrations/claude-code/tests/test_retain_incremental_window.py
+++ b/hindsight-integrations/claude-code/tests/test_retain_incremental_window.py
@@ -1,0 +1,136 @@
+"""Full-session retention must send the whole unprocessed suffix, not just its last turn.
+
+`plan_retention()` selects `[start_index, len(all_messages))` as the unprocessed
+range. That range was then narrowed a second time by last-turn slicing on every
+retain after the first, while `commit_retention()` still advanced the cursor past
+the entire range — so whatever the second window dropped was skipped permanently.
+
+Claude Code makes this far worse than it looks: tool results are stored as
+`role="user"` messages, so the "last turn" scan usually lands on a tool result
+rather than the human prompt. With the resolved default `retainToolCalls: false`
+that message extracts to empty and the whole retain is skipped.
+
+Measured on a real 1,500-message transcript, formatting the same 30-message
+unprocessed suffix: last-turn 0 chars (retain skipped) vs full-window 3,697 chars
+across 6 messages.
+
+Every test here MUST drive a second retain, because the defect only appears once a
+retention cursor exists — on a fresh session `start_index == 0` and the buggy
+expression evaluates to True by accident.
+"""
+
+import json
+
+from conftest import FakeHTTPResponse, make_hook_input, make_transcript_file
+from test_hooks import _run_hook
+
+TOOL_RESULT = {"role": "user", "content": [{"type": "tool_result", "content": "exit 0"}]}
+
+SEED = [
+    {"role": "user", "content": "seed question establishing the retention cursor"},
+    {"role": "assistant", "content": "seed answer establishing the retention cursor"},
+]
+
+
+def _retain(monkeypatch, tmp_path, messages):
+    """Run the retain hook over `messages`, returning the posted body (or None)."""
+    transcript = make_transcript_file(tmp_path, messages)
+    captured = {}
+
+    def capture(req, timeout=None):
+        if "/memories" in req.full_url and "/recall" not in req.full_url:
+            captured["body"] = json.loads(req.data.decode())
+        return FakeHTTPResponse({"status": "accepted"})
+
+    _run_hook(
+        "retain",
+        make_hook_input(transcript_path=transcript),
+        monkeypatch,
+        tmp_path,
+        urlopen_side_effect=capture,
+    )
+    return captured.get("body")
+
+
+def _second_retain(monkeypatch, tmp_path, new_messages):
+    """Establish a cursor with SEED, then retain SEED + new_messages.
+
+    Returns the body posted by the SECOND retain — the incremental path.
+    """
+    first = _retain(monkeypatch, tmp_path, SEED)
+    assert first is not None, "seed retain did not fire; cursor was never established"
+    return _retain(monkeypatch, tmp_path, SEED + new_messages)
+
+
+class TestIncrementalRetainWindow:
+    def test_incremental_retain_sends_all_new_turns(self, monkeypatch, tmp_path):
+        # Intention: with several turns accumulated since the cursor, last-turn
+        # slicing keeps only the newest while the cursor advances past the rest.
+        # Expected: every new turn appears in the second payload.
+        new = []
+        for n in ("alpha", "bravo", "charlie"):
+            new.append({"role": "user", "content": f"question {n}"})
+            new.append({"role": "assistant", "content": f"answer {n}"})
+        body = _second_retain(monkeypatch, tmp_path, new)
+        assert body is not None, "incremental retain did not fire"
+        content = body["items"][0]["content"]
+        for n in ("alpha", "bravo", "charlie"):
+            assert f"question {n}" in content, f"turn {n} was dropped by re-windowing"
+            assert f"answer {n}" in content
+
+    def test_tool_result_tail_does_not_swallow_the_window(self, monkeypatch, tmp_path):
+        # Intention: THE BUG. A tool result is a role="user" message, so the last-turn
+        # scan anchors on it; with tool calls excluded it strips to empty and the whole
+        # incremental retain is skipped while the cursor still advances.
+        # Expected: the human prompt and assistant reply before it are still sent.
+        new = [
+            {"role": "user", "content": "why did the flame sensor trip"},
+            {"role": "assistant", "content": "the 74HC14 ground went marginal"},
+            TOOL_RESULT,
+        ]
+        body = _second_retain(monkeypatch, tmp_path, new)
+        assert body is not None, "retain skipped — the trailing tool result swallowed the window"
+        content = body["items"][0]["content"]
+        assert "why did the flame sensor trip" in content
+        assert "74HC14 ground went marginal" in content
+
+    def test_interleaved_tool_results_keep_all_assistant_text(self, monkeypatch, tmp_path):
+        # Intention: a realistic agent turn interleaves assistant reasoning with many
+        # tool results. Anchoring on the last tool result keeps only the tail.
+        # Expected: all assistant reasoning in the window survives.
+        new = [
+            {"role": "user", "content": "run the OTA gate"},
+            {"role": "assistant", "content": "checking the manifest signature"},
+            TOOL_RESULT,
+            {"role": "assistant", "content": "signature verified against the pinned key"},
+            TOOL_RESULT,
+            {"role": "assistant", "content": "gate passed, firmware is publishable"},
+            TOOL_RESULT,
+        ]
+        body = _second_retain(monkeypatch, tmp_path, new)
+        assert body is not None
+        content = body["items"][0]["content"]
+        assert "checking the manifest signature" in content
+        assert "signature verified against the pinned key" in content
+        assert "gate passed, firmware is publishable" in content
+
+    def test_incremental_retain_excludes_already_retained_messages(self, monkeypatch, tmp_path):
+        # Intention: don't over-correct into re-sending. The cursor, not the window,
+        # is what prevents duplicates.
+        # Expected: the second payload carries only new content, not the seed.
+        new = [
+            {"role": "user", "content": "brand new question"},
+            {"role": "assistant", "content": "brand new answer"},
+        ]
+        body = _second_retain(monkeypatch, tmp_path, new)
+        assert body is not None
+        content = body["items"][0]["content"]
+        assert "brand new question" in content
+        assert "seed question establishing the retention cursor" not in content
+
+    def test_tool_only_window_sends_nothing(self, monkeypatch, tmp_path):
+        # Intention: when the entire new window is tool results and tool calls are
+        # excluded, there is genuinely nothing retainable — don't invent a payload.
+        # Expected: no API call for the second retain.
+        body = _second_retain(monkeypatch, tmp_path, [TOOL_RESULT, TOOL_RESULT])
+        assert body is None, "expected no retain for a window with no retainable content"


### PR DESCRIPTION
**In agentic sessions the common retain path captures 0 bytes while permanently marking those messages as processed.** A second positional window re-narrows the already-correct unprocessed suffix down to its last turn — usually a tool result, which extracts to empty — while the cursor still advances past the whole suffix. The data loss is silent and unrecoverable. The fix is one line: `retain_full_window = True`.

---

## The invariant that breaks

Full-session retention selects the unprocessed transcript suffix using the persisted offset, then narrows it a second time:

```python
messages_to_retain = all_messages[retention_progress.start_index :]
retain_full_window = retention_progress.start_index == 0        # ← narrows it again
```

`retain_full_window=False` makes `prepare_retention_transcript()` keep only the last turn. But `commit_retention()` advances the cursor to the end of the **whole** suffix either way:

```python
if not transcript:
    commit_retention(session_id, len(all_messages), retention_progress.chunk_index)
    return
```

So the rule that should hold —

> once `plan_retention()` establishes `[start_index, len(all_messages))` as the unprocessed range, every message in it must be formatted, filtered by retention policy, or left uncommitted

— is violated: messages are dropped by a second positional window while the cursor records them as processed. That loss is permanent.

This holds on its own merits. Claude Code's transcript shape then makes it dramatically worse.

## Why it's severe in Claude Code specifically

**Tool results are stored as `role: "user"` messages.** So the `last_user_idx` scan usually anchors on a tool result rather than the human prompt. With the resolved default `retainToolCalls: false` (both `config.py` `DEFAULTS` and `settings.json` set `False`; the `True` fallback at `retain.py:149` is unreachable because `load_config()` always supplies the key), that message extracts to empty — `prepare_retention_transcript` returns `(None, 0)`, and the entire retain is skipped while the cursor still advances.

In an agentic session the trailing message is a tool result most of the time, so this is the common case, not an edge case.

## Measurements

Formatting the same 30-message unprocessed suffix from a real 1,500-message transcript:

| config | captured |
|---|---|
| last-turn, tools off *(current default)* | **0 chars — retain skipped** |
| last-turn, tools on | 523 chars, 1 msg |
| **full-window, tools off** | **3,697 chars, 6 msgs** |
| full-window, tools on | 17,744 chars, 24 msgs |

One session's actual retain history:

| chunk | captured |
|---|---|
| first | **54,317 chars** |
| c1 | 2,319 |
| c4 | 1,180 |
| c5 | 287 |
| c7 | 300 |

The first retain (`start_index == 0`) captures everything; every later one captures a fragment, regardless of how much work happened in between.

## Fix

```python
retain_full_window = True
```

`messages_to_retain` is already the not-yet-retained slice, so windowing it again is redundant at best and lossy at worst. There's no duplicate-send risk — the cursor, not the window, is what prevents that. Role, memory-tag and tool-content filtering are unchanged.

This also restores the behaviour the surrounding comments already describe (`retain.py:108-115`): *"each retain only sends messages not retained by a previous Stop hook."*

Note this fixes the *full-session* path by no longer reaching the narrowing branch; the `last_user_idx` scan inside `prepare_retention_transcript()` is deliberately left in place, since it remains correct for any caller that genuinely wants only the last turn. Its own tool-result confusion is a boundary-semantics problem, addressed separately in #3000.

The `commit_retention()` on an empty transcript is deliberately left alone. With this fix, "empty" can only mean the entire unprocessed suffix was filtered out by policy, so advancing is correct — and not committing would make every later Stop reprocess the same suffix forever.

## Tests

5 new tests in `tests/test_retain_incremental_window.py`. **Every one drives a second retain**, because the defect only appears once a cursor exists — on a fresh session `start_index == 0` and the old expression evaluates `True` by accident. My first draft omitted this and passed against the unfixed code; mutation testing caught it.

- multiple human turns in one window are all sent
- a trailing tool result doesn't swallow the window *(the core case)*
- interleaved tool results keep all assistant reasoning
- already-retained messages are **not** re-sent (guards against over-correcting)
- a tool-only window sends nothing

Verification:
- **206 pass** with the fix
- reverting the one-line change **fails 3 of 5**
- `ruff check` clean

## Docstring

`retain_full_window` was documented as "retain all messages (chunked mode)", which invited exactly this misuse. Reworded to say it means the caller has already selected the complete window, and to warn that callers advancing a retention cursor must not pass `False`.

## Related, not included

`slice_last_turns_by_user_boundary()` counts every `role == "user"` message as a turn boundary, so it has the same tool-result confusion. It affects chunked mode (`retain.py:120`) and recall context composition (`content.py:81`), so `recallContextTurns: N` can compose N tool results instead of N turns. That's a wider semantic change with a shared call site, so it has its own PR: **#3000**.

Same family as #2869 (SessionEnd retain cancelled at shutdown) and #2974 (retain never sent `MemoryItem.timestamp`).

