### PR TITLE
fix(claude-code): count turn boundaries by conversational content, not user-role records

### DIFF
--- a/hindsight-integrations/claude-code/scripts/lib/content.py
+++ b/hindsight-integrations/claude-code/scripts/lib/content.py
@@ -35,6 +35,19 @@ def strip_channel_envelope(content: str) -> str:
     return content
 
 
+def _conversational_text(content, role: str = "") -> str:
+    """Return the conversational text of a message, or '' if it carries none.
+
+    The single definition of "does this message say anything to the conversation":
+    extract conversational blocks, drop the channel envelope, drop injected memory
+    blocks, trim. Used both to decide turn boundaries and to compose context, so
+    the two cannot disagree about what counts as content.
+    """
+    text = _extract_text_content(content, role=role)
+    text = strip_channel_envelope(text)
+    return strip_memory_tags(text).strip()
+
+
 def strip_memory_tags(content: str) -> str:
     """Remove <hindsight_memories> and <relevant_memories> blocks.
 
@@ -86,9 +99,7 @@ def compose_recall_query(
         if role not in allowed_roles:
             continue
 
-        content = _extract_text_content(msg.get("content", ""), role=role)
-        content = strip_channel_envelope(content)
-        content = strip_memory_tags(content).strip()
+        content = _conversational_text(msg.get("content", ""), role=role)
         if not content:
             continue
 
@@ -172,8 +183,14 @@ def slice_last_turns_by_user_boundary(messages: list, turns: int) -> list:
 
     Port of: sliceLastTurnsByUserBoundary() in index.js
 
-    Walks backward counting user messages as turn boundaries. Returns
-    messages from the Nth user boundary to the end.
+    Walks backward counting user messages that carry conversational text.
+    Tool-result-only, empty, and injected-memory-only user records do NOT define
+    a boundary — they are user-role transport records that the conversation
+    extractor already discards, so counting them would exhaust the requested
+    number of turns before reaching any actual conversation. Records inside the
+    selected window are returned untouched; only boundary selection is affected.
+
+    Returns messages from the Nth qualifying user boundary to the end.
     """
     if not isinstance(messages, list) or not messages or turns <= 0:
         return []
@@ -182,7 +199,7 @@ def slice_last_turns_by_user_boundary(messages: list, turns: int) -> list:
     start_index = -1
 
     for i in range(len(messages) - 1, -1, -1):
-        if messages[i].get("role") == "user":
+        if messages[i].get("role") == "user" and _conversational_text(messages[i].get("content", ""), role="user"):
             user_turns_seen += 1
             if user_turns_seen >= turns:
                 start_index = i

--- a/hindsight-integrations/claude-code/tests/test_turn_boundary_semantics.py
+++ b/hindsight-integrations/claude-code/tests/test_turn_boundary_semantics.py
@@ -1,0 +1,145 @@
+"""Turn boundaries must agree with what the conversation extractor keeps.
+
+`slice_last_turns_by_user_boundary()` counted every `role == "user"` record as a
+turn boundary. But `_extract_text_content()` already discards tool results as
+"operational results, not conversation", and the recall composer additionally
+strips channel envelopes and injected memory blocks. So a window could be filled
+entirely by user-role records that contribute nothing, exhausting the requested
+turn count before reaching any actual conversation.
+
+In Claude Code this is the common case, not an edge case — tool results are
+stored as `role: "user"` messages. Measured on a real 1,639-message transcript,
+566 user-role records of which 514 (91%) were tool results:
+
+    recallContextTurns=3  ->  1 conversational turn,     82 chars   (before)
+    recallContextTurns=3  ->  3 conversational turns, 8,081 chars   (after)
+
+Boundary selection is the only thing that changes. Records *inside* the selected
+window are returned untouched, so retention/formatting policy still decides what
+is kept from them.
+"""
+
+from lib.content import compose_recall_query, slice_last_turns_by_user_boundary
+
+TOOL_RESULT = {"role": "user", "content": [{"type": "tool_result", "content": "exit 0"}]}
+MEMORY_ONLY = {"role": "user", "content": "<hindsight_memories>prior stuff</hindsight_memories>"}
+
+
+def _user(text):
+    return {"role": "user", "content": text}
+
+
+def _assistant(text):
+    return {"role": "assistant", "content": text}
+
+
+class TestBoundaryQualification:
+    def test_tool_result_only_record_is_not_a_boundary(self):
+        # Intention: the core defect — tool results are role="user" in Claude Code.
+        # Expected: the single real turn is found past the tool results, and the
+        # returned window still contains them.
+        msgs = [_user("the real question"), _assistant("the real answer"), TOOL_RESULT, TOOL_RESULT]
+        out = slice_last_turns_by_user_boundary(msgs, 1)
+        assert out[0] == msgs[0], "window must start at the conversational user message"
+        assert len(out) == 4, "records inside the window must be preserved, including tool results"
+
+    def test_plain_string_user_content_is_a_boundary(self):
+        # Intention: non-Claude-Code hosts and the flat test format send plain strings.
+        # Expected: unchanged behaviour.
+        msgs = [_user("first"), _assistant("a"), _user("second"), _assistant("b")]
+        assert slice_last_turns_by_user_boundary(msgs, 1)[0]["content"] == "second"
+
+    def test_text_block_user_content_is_a_boundary(self):
+        # Intention: structured text blocks are real conversation.
+        msgs = [_user("older"), {"role": "user", "content": [{"type": "text", "text": "newer"}]}]
+        out = slice_last_turns_by_user_boundary(msgs, 1)
+        assert out[0]["content"] == [{"type": "text", "text": "newer"}]
+
+    def test_empty_and_whitespace_user_records_are_not_boundaries(self):
+        # Intention: an empty record contributes nothing, so it must not consume a turn.
+        msgs = [_user("real question"), _assistant("real answer"), _user("   "), _user("")]
+        out = slice_last_turns_by_user_boundary(msgs, 1)
+        assert out[0]["content"] == "real question"
+
+    def test_memory_only_user_record_is_not_a_boundary(self):
+        # Intention: a UserPromptSubmit hook injects <hindsight_memories> into the user
+        # message. A record that is ONLY that injection is not a turn — the composer
+        # strips it and it contributes nothing.
+        msgs = [_user("real question"), _assistant("real answer"), MEMORY_ONLY]
+        out = slice_last_turns_by_user_boundary(msgs, 1)
+        assert out[0]["content"] == "real question"
+
+    def test_memory_tags_plus_real_text_is_a_boundary(self):
+        # Intention: don't over-correct — injected memory alongside a real prompt is
+        # still a real prompt.
+        mixed = _user("<hindsight_memories>prior</hindsight_memories>\nactual question")
+        msgs = [_user("older"), _assistant("a"), mixed]
+        assert slice_last_turns_by_user_boundary(msgs, 1)[0] is mixed
+
+    def test_mixed_text_and_tool_result_blocks_count_once(self):
+        # Intention: a record carrying both a tool result and genuine text is a turn.
+        mixed = {
+            "role": "user",
+            "content": [{"type": "tool_result", "content": "exit 0"}, {"type": "text", "text": "and also this"}],
+        }
+        msgs = [_user("older"), _assistant("a"), mixed]
+        assert slice_last_turns_by_user_boundary(msgs, 1)[0] is mixed
+
+    def test_counts_n_conversational_turns_across_tool_noise(self):
+        # Intention: the headline behaviour. Tool results between prompts must not
+        # consume the turn budget.
+        # Expected: N=2 reaches the second-to-last real prompt, not the last one.
+        msgs = [
+            _user("turn one"),
+            _assistant("answer one"),
+            TOOL_RESULT,
+            _user("turn two"),
+            _assistant("answer two"),
+            TOOL_RESULT,
+            TOOL_RESULT,
+            _user("turn three"),
+            _assistant("answer three"),
+        ]
+        out = slice_last_turns_by_user_boundary(msgs, 2)
+        assert out[0]["content"] == "turn two"
+        assert any(m is TOOL_RESULT for m in out), "intervening tool records must be preserved"
+
+    def test_fewer_boundaries_than_requested_returns_everything(self):
+        # Intention: preserve the existing fallback when N turns don't exist.
+        msgs = [TOOL_RESULT, _user("only one real turn"), _assistant("a")]
+        assert slice_last_turns_by_user_boundary(msgs, 5) == msgs
+
+    def test_all_tool_results_returns_everything(self):
+        # Intention: with no conversational boundary at all, fall back rather than
+        # returning an empty window.
+        msgs = [TOOL_RESULT, TOOL_RESULT]
+        assert slice_last_turns_by_user_boundary(msgs, 2) == msgs
+
+
+class TestRecallQueryComposition:
+    def test_recall_context_reaches_prior_turns_through_tool_noise(self):
+        # Intention: end-to-end — the recall query must carry real prior turns even
+        # when the transcript is dominated by tool results.
+        # Expected: earlier conversation present, tool-result text absent.
+        msgs = [
+            _user("why did the flame sensor trip"),
+            _assistant("the 74HC14 ground went marginal"),
+            TOOL_RESULT,
+            TOOL_RESULT,
+            _user("what fixed it"),
+            _assistant("resoldering VCC and GND"),
+            TOOL_RESULT,
+        ]
+        q = compose_recall_query("and what about the water sensor", msgs, 3, ["user", "assistant"])
+        assert "why did the flame sensor trip" in q
+        assert "74HC14 ground went marginal" in q
+        assert "exit 0" not in q, "tool-result content must not enter the recall query"
+        assert q.endswith("and what about the water sensor")
+
+    def test_injected_memory_blocks_stay_out_of_the_query(self):
+        # Intention: recall must not feed its own previous output back into itself.
+        msgs = [_user("real prior question"), _assistant("real prior answer"), MEMORY_ONLY]
+        q = compose_recall_query("the latest question", msgs, 3, ["user", "assistant"])
+        assert "real prior question" in q
+        assert "prior stuff" not in q
+        assert "<hindsight_memories>" not in q


### PR DESCRIPTION
**Asking for 3 turns of recall context returned 82 characters.** Turn boundaries count every `role: "user"` record, but in agentic transcripts **91% of those are tool results** (measured: 514 of 566), so the window is exhausted before reaching any real conversation. Counting boundaries by conversational content instead takes the same request from **82 → 8,081 characters**.

---

## The inconsistency

`slice_last_turns_by_user_boundary()` counts every `role == "user"` record as a turn boundary:

```python
if messages[i].get("role") == "user":
    user_turns_seen += 1
```

But the conversation extractor in the same file already treats many of those records as non-conversational. `_extract_text_content()`'s own docstring says it excludes:

> `{type: "tool_result"}` — operational results, not conversation

and `compose_recall_query()` additionally strips channel envelopes and injected `<hindsight_memories>` blocks.

So turn selection counts records that formatting then discards. A window can be exhausted by user-role transport records before reaching any actual conversation.

## Impact

Two call sites:

- `content.py` — `compose_recall_query()`, controlling `recallContextTurns` (runs on every user prompt)
- `retain.py` — the chunked-retention window

In Claude Code this is the common case rather than an edge case, because **tool results are stored as `role: "user"` messages**. Measured on a real 1,639-message transcript with 566 user-role records, **514 of them (91%) tool results**:

| setting | before | after |
|---|---|---|
| `recallContextTurns=3` | 1 conversational turn, **82 chars** | **3 turns, 8,081 chars** |
| `recallContextTurns=5` | 1 conversational turn, 3,019 chars | **5 turns, 14,152 chars** |

Asking for three turns of recall context returned 82 characters. The multi-turn feature was effectively inert on agentic transcripts.

## Fix

Rather than special-casing `tool_result` blocks, define a boundary using the same cleaned representation the composer already applies — extract conversational blocks, strip channel envelope, strip injected memory, trim — factored into one private helper:

```python
def _conversational_text(content, role: str = "") -> str:
    text = _extract_text_content(content, role=role)
    text = strip_channel_envelope(text)
    return strip_memory_tags(text).strip()
```

used by both boundary selection and recall composition, so the two cannot disagree about what counts as content.

This is preferable to structural `tool_result` detection because it handles the mixed cases correctly without duplicating knowledge that already lives in `_extract_text_content()`:

- tool-result-only record → not a boundary
- record with **both** a tool result and genuine text → still a boundary
- empty / whitespace-only record → not a boundary
- injected-memory-only record → not a boundary
- memory block **plus** a real prompt → still a boundary
- plain-string content (other hosts, flat test format) → unchanged

**Boundary selection is the only thing that changes.** Records inside the selected window are returned untouched, so retention and formatting policy still decide what is kept from them. Tool results remain excluded from output by `_extract_text_content()` exactly as before.

Both call sites want the same conversational unit, so the fix belongs in the shared helper rather than being duplicated — otherwise the two definitions would drift.

## Intentional consequences

**Recall windows traverse more records.** Finding N conversational turns may now walk across many tool records. Only extractable conversational content enters the query, and `recallMaxQueryChars` (default 800) bounds the **final** query — note it does not bound the intermediate composed string or the amount of transcript traversed. At the scale measured here that cost is negligible next to reading the transcript and making the recall request.

**Chunked retention documents get larger.** A window of N real turns now includes the tool activity between those prompts, where before it often spanned only the last few records. That is the point of a turn window, and the previously small payloads were a symptom of selecting the wrong boundaries — but it is a visible change, so calling it out.

## Not included

- Whether `recallContextTurns` should count the latest prompt as one of its N. The selector counts it and `compose_recall_query()` then drops it as a duplicate, so N can mean "latest plus N−1 prior". That predates this change and is left alone.
- Any payload capping or batching for chunked retention.
- Caching or precomputed classification — no evidence of a bottleneck.

## Tests

12 tests in `tests/test_turn_boundary_semantics.py` — 10 on boundary qualification, 2 on recall composition end-to-end. The key assertions check not just the size of the returned window but that it **starts at the Nth qualifying record and still contains the intervening tool results**.

- **213 pass** with the fix
- reverting the predicate **fails 5 of 12**
- `ruff check` and `ruff format --check` clean

## Related

Same family as #2999 (retain dropped the unprocessed suffix), #2974 (retain never sent `MemoryItem.timestamp`) and #2869 (SessionEnd retain cancelled at shutdown).

