### PR TITLE
fix(tei): retry HTTP 429 backpressure for reranking and embeddings

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -397,7 +397,7 @@ class RemoteTEICrossEncoder(CrossEncoderModel):
                         sleep_delay = tei_retry_delay(
                             e.response,
                             delay,
-                            max_delay=self.timeout,
+                            request_timeout=self.timeout,
                         )
                         logger.warning(
                             f"TEI transient error (attempt {attempt + 1}/{self.max_retries + 1}): {e}. "

--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -52,6 +52,7 @@ from .local_device import (
     resolve_model_device_type,
     select_local_device,
 )
+from .tei_retry import tei_retry_delay
 
 logger = logging.getLogger(__name__)
 
@@ -389,14 +390,20 @@ class RemoteTEICrossEncoder(CrossEncoderModel):
                         await asyncio.sleep(delay)
                         delay *= 2  # Exponential backoff
                 except httpx.HTTPStatusError as e:
-                    # Retry on 5xx server errors
-                    if e.response.status_code >= 500 and attempt < self.max_retries:
+                    # TEI uses 429 as normal overload backpressure. Retry it with
+                    # the same bounded budget as transient server errors.
+                    if (e.response.status_code == 429 or e.response.status_code >= 500) and attempt < self.max_retries:
                         last_error = e
-                        logger.warning(
-                            f"TEI server error (attempt {attempt + 1}/{self.max_retries + 1}): {e}. "
-                            f"Retrying in {delay}s..."
+                        sleep_delay = tei_retry_delay(
+                            e.response,
+                            delay,
+                            max_delay=self.timeout,
                         )
-                        await asyncio.sleep(delay)
+                        logger.warning(
+                            f"TEI transient error (attempt {attempt + 1}/{self.max_retries + 1}): {e}. "
+                            f"Retrying in {sleep_delay:.2f}s..."
+                        )
+                        await asyncio.sleep(sleep_delay)
                         delay *= 2
                     else:
                         raise

--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -522,7 +522,7 @@ class RemoteTEIEmbeddings(Embeddings):
                     sleep_delay = tei_retry_delay(
                         e.response,
                         delay,
-                        max_delay=self.timeout,
+                        request_timeout=self.timeout,
                     )
                     logger.warning(
                         f"TEI transient error (attempt {attempt + 1}/{self.max_retries + 1}): {e}. "

--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -53,6 +53,7 @@ from .local_device import (
     resolve_model_device_type,
     select_local_device,
 )
+from .tei_retry import tei_retry_delay
 
 logger = logging.getLogger(__name__)
 
@@ -514,13 +515,20 @@ class RemoteTEIEmbeddings(Embeddings):
                     time.sleep(delay)
                     delay *= 2  # Exponential backoff
             except httpx.HTTPStatusError as e:
-                # Retry on 5xx server errors
-                if e.response.status_code >= 500 and attempt < self.max_retries:
+                # TEI uses 429 as normal overload backpressure. Retry it with
+                # the same bounded budget as transient server errors.
+                if (e.response.status_code == 429 or e.response.status_code >= 500) and attempt < self.max_retries:
                     last_error = e
-                    logger.warning(
-                        f"TEI server error (attempt {attempt + 1}/{self.max_retries + 1}): {e}. Retrying in {delay}s..."
+                    sleep_delay = tei_retry_delay(
+                        e.response,
+                        delay,
+                        max_delay=self.timeout,
                     )
-                    time.sleep(delay)
+                    logger.warning(
+                        f"TEI transient error (attempt {attempt + 1}/{self.max_retries + 1}): {e}. "
+                        f"Retrying in {sleep_delay:.2f}s..."
+                    )
+                    time.sleep(sleep_delay)
                     delay *= 2
                 else:
                     raise

--- a/hindsight-api-slim/hindsight_api/engine/tei_retry.py
+++ b/hindsight-api-slim/hindsight_api/engine/tei_retry.py
@@ -1,0 +1,43 @@
+"""Shared retry timing for Text Embeddings Inference HTTP clients."""
+
+import math
+import random
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+
+import httpx
+
+
+def _retry_after_seconds(value: str | None) -> float | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError, OverflowError):
+        try:
+            retry_at = parsedate_to_datetime(value)
+            if retry_at.tzinfo is None:
+                retry_at = retry_at.replace(tzinfo=timezone.utc)
+            seconds = (retry_at - datetime.now(timezone.utc)).total_seconds()
+        except (TypeError, ValueError, OverflowError):
+            return None
+    return max(0.0, seconds) if math.isfinite(seconds) else None
+
+
+def tei_retry_delay(
+    response: httpx.Response,
+    fallback_delay: float,
+    *,
+    max_delay: float,
+) -> float:
+    """Honor Retry-After when present and de-synchronize fallback retries."""
+    retry_after = _retry_after_seconds(response.headers.get("Retry-After"))
+    limit = max_delay if math.isfinite(max_delay) and max_delay >= 0 else 60.0
+    fallback = fallback_delay if math.isfinite(fallback_delay) else 0.0
+    requested_delay = max(fallback, retry_after or 0.0, 0.0)
+    delay = min(requested_delay, limit)
+    if delay and requested_delay >= limit:
+        downward_jitter = min(delay * 0.1, 1.0)
+        return delay - random.uniform(0.0, downward_jitter)
+    jitter_limit = min(delay * 0.1, 1.0, limit - delay)
+    return delay + random.uniform(0.0, jitter_limit) if jitter_limit else delay

--- a/hindsight-api-slim/hindsight_api/engine/tei_retry.py
+++ b/hindsight-api-slim/hindsight_api/engine/tei_retry.py
@@ -7,6 +7,21 @@ from email.utils import parsedate_to_datetime
 
 import httpx
 
+# Ceiling for a single backoff sleep, independent of the client's request
+# timeout. The reranker holds its concurrency semaphore across the sleep, so a
+# large server-supplied Retry-After would stall every queued rerank behind it;
+# capping well below the request timeout keeps a slow proxy from converting a
+# transient overload into a minutes-long recall stall.
+MAX_RETRY_DELAY_SECONDS = 5.0
+
+# Fraction of the delay used as the jitter window, matching the "equal jitter"
+# policy of ``db_utils._backoff_delay``. TEI overload is self-synchronising -- a
+# burst of concurrent requests exhausts the permit pool at the same instant and
+# gets 429ed together -- so the window has to be wide enough to actually break
+# the burst apart. A token few percent would leave the callers retrying in
+# lockstep and re-colliding on the same exhausted pool.
+JITTER_RATIO = 0.5
+
 
 def _retry_after_seconds(value: str | None) -> float | None:
     if not isinstance(value, str) or not value:
@@ -19,25 +34,40 @@ def _retry_after_seconds(value: str | None) -> float | None:
             if retry_at.tzinfo is None:
                 retry_at = retry_at.replace(tzinfo=timezone.utc)
             seconds = (retry_at - datetime.now(timezone.utc)).total_seconds()
-        except (TypeError, ValueError, OverflowError):
+        except (IndexError, TypeError, ValueError, OverflowError):
             return None
     return max(0.0, seconds) if math.isfinite(seconds) else None
+
+
+def _delay_limit(request_timeout: float) -> float:
+    """Longest sleep we are willing to take between attempts."""
+    if not math.isfinite(request_timeout) or request_timeout < 0:
+        return MAX_RETRY_DELAY_SECONDS
+    return min(request_timeout, MAX_RETRY_DELAY_SECONDS)
 
 
 def tei_retry_delay(
     response: httpx.Response,
     fallback_delay: float,
     *,
-    max_delay: float,
+    request_timeout: float,
 ) -> float:
-    """Honor Retry-After when present and de-synchronize fallback retries."""
+    """Seconds to sleep before retrying a transient TEI response.
+
+    A server-supplied ``Retry-After`` wins over the caller's exponential
+    backoff, and both are bounded by :func:`_delay_limit`. The result is spread
+    over a jitter window so concurrent callers do not resume in lockstep.
+    """
     retry_after = _retry_after_seconds(response.headers.get("Retry-After"))
-    limit = max_delay if math.isfinite(max_delay) and max_delay >= 0 else 60.0
+    limit = _delay_limit(request_timeout)
     fallback = fallback_delay if math.isfinite(fallback_delay) else 0.0
     requested_delay = max(fallback, retry_after or 0.0, 0.0)
     delay = min(requested_delay, limit)
-    if delay and requested_delay >= limit:
-        downward_jitter = min(delay * 0.1, 1.0)
-        return delay - random.uniform(0.0, downward_jitter)
-    jitter_limit = min(delay * 0.1, 1.0, limit - delay)
-    return delay + random.uniform(0.0, jitter_limit) if jitter_limit else delay
+    if delay <= 0:
+        return 0.0
+    spread = delay * JITTER_RATIO
+    if requested_delay >= limit:
+        # Already at the ceiling, so the only room to de-synchronise is downward.
+        return delay - random.uniform(0.0, spread)
+    # Retry-After is a minimum, so spread upward -- but never past the ceiling.
+    return delay + random.uniform(0.0, min(spread, limit - delay))

--- a/hindsight-api-slim/tests/test_tei_cross_encoder.py
+++ b/hindsight-api-slim/tests/test_tei_cross_encoder.py
@@ -421,8 +421,12 @@ class TestRemoteTEICrossEncoderRetry:
         assert attempt_count[0] == 3  # 2 failures + 1 success
 
     @pytest.mark.asyncio
-    async def test_retry_on_server_error(self):
-        """Test that 5xx errors trigger retries."""
+    @pytest.mark.parametrize(
+        ("status_code", "error_message"),
+        [(429, "Too many requests"), (503, "Service unavailable")],
+    )
+    async def test_retry_on_transient_status(self, status_code, error_message):
+        """TEI overload and 5xx responses should trigger retries."""
         attempt_count = [0]
 
         async def mock_handler(method, url, **kwargs):
@@ -430,11 +434,11 @@ class TestRemoteTEICrossEncoderRetry:
                 attempt_count[0] += 1
                 if attempt_count[0] < 2:
                     response = MagicMock()
-                    response.status_code = 503
+                    response.status_code = status_code
 
                     def raise_for_status():
                         raise httpx.HTTPStatusError(
-                            "Service unavailable",
+                            error_message,
                             request=MagicMock(),
                             response=response,
                         )
@@ -502,6 +506,38 @@ class TestRemoteTEICrossEncoderRetry:
             await encoder.predict(pairs)
 
         assert attempt_count[0] == 1  # No retries for 4xx
+
+    @pytest.mark.asyncio
+    async def test_persistent_too_many_requests_exhausts_retry_budget(self):
+        """A persistent overload should make exactly max_retries + 1 attempts."""
+        attempt_count = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal attempt_count
+            attempt_count += 1
+            return httpx.Response(
+                429,
+                request=request,
+                headers={"Retry-After": "Infinity"},
+                json={"error": "Model is overloaded"},
+            )
+
+        encoder = RemoteTEICrossEncoder(
+            base_url="http://localhost:8080",
+            max_retries=2,
+            retry_delay=0,
+        )
+        encoder._async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        encoder._model_id = "test-model"
+
+        try:
+            with pytest.raises(RuntimeError, match="TEI rerank request failed") as exc_info:
+                await encoder.predict([("Query", "Doc 1")])
+        finally:
+            await encoder._async_client.aclose()
+
+        assert attempt_count == 3
+        assert isinstance(exc_info.value.__context__, httpx.HTTPStatusError)
 
 
 class TestRemoteTEICrossEncoderConfig:

--- a/hindsight-api-slim/tests/test_tei_embeddings.py
+++ b/hindsight-api-slim/tests/test_tei_embeddings.py
@@ -1,0 +1,78 @@
+"""Regression tests for transient HTTP handling in the remote TEI embeddings client."""
+
+import httpx
+import pytest
+
+from hindsight_api.engine.embeddings import RemoteTEIEmbeddings
+
+
+def test_retry_on_too_many_requests() -> None:
+    """TEI's 429 overload response should use the transient retry budget."""
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(429, json={"error": "Model is overloaded"})
+        return httpx.Response(200, json=[[0.1, 0.2]])
+
+    embeddings = RemoteTEIEmbeddings(
+        base_url="http://localhost:8080",
+        max_retries=3,
+        retry_delay=0,
+    )
+    embeddings._client = httpx.Client(transport=httpx.MockTransport(handler))
+
+    assert embeddings.encode(["text"]) == [[0.1, 0.2]]
+    assert attempts == 2
+
+
+def test_other_client_errors_fail_fast() -> None:
+    """Non-429 4xx responses should not consume the retry budget."""
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx.Response(400, json={"error": "invalid input"})
+
+    embeddings = RemoteTEIEmbeddings(
+        base_url="http://localhost:8080",
+        max_retries=3,
+        retry_delay=0,
+    )
+    embeddings._client = httpx.Client(transport=httpx.MockTransport(handler))
+
+    with pytest.raises(RuntimeError, match="TEI embedding request failed"):
+        embeddings.encode(["text"])
+
+    assert attempts == 1
+
+
+def test_persistent_too_many_requests_exhausts_retry_budget() -> None:
+    """A persistent overload should make exactly max_retries + 1 attempts."""
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx.Response(
+            429,
+            request=request,
+            headers={"Retry-After": "Infinity"},
+            json={"error": "Model is overloaded"},
+        )
+
+    embeddings = RemoteTEIEmbeddings(
+        base_url="http://localhost:8080",
+        max_retries=2,
+        retry_delay=0,
+    )
+    embeddings._client = httpx.Client(transport=httpx.MockTransport(handler))
+
+    with pytest.raises(RuntimeError, match="TEI embedding request failed") as exc_info:
+        embeddings.encode(["text"])
+
+    assert attempts == 3
+    assert isinstance(exc_info.value.__context__, httpx.HTTPStatusError)

--- a/hindsight-api-slim/tests/test_tei_retry.py
+++ b/hindsight-api-slim/tests/test_tei_retry.py
@@ -1,0 +1,63 @@
+"""Tests for shared TEI Retry-After and jitter handling."""
+
+from datetime import datetime, timezone
+from email.utils import format_datetime
+from unittest.mock import patch
+
+import httpx
+
+from hindsight_api.engine.tei_retry import tei_retry_delay
+
+
+def test_retry_after_takes_precedence_over_fallback() -> None:
+    response = httpx.Response(429, headers={"Retry-After": "3"})
+
+    with patch("hindsight_api.engine.tei_retry.random.uniform", return_value=0.0):
+        assert tei_retry_delay(response, 0.5, max_delay=30.0) == 3.0
+
+
+def test_http_date_retry_after_is_supported() -> None:
+    now = datetime(2026, 7, 28, tzinfo=timezone.utc)
+    response = httpx.Response(
+        429,
+        headers={"Retry-After": format_datetime(now.replace(second=3), usegmt=True)},
+    )
+
+    with (
+        patch("hindsight_api.engine.tei_retry.datetime") as mock_datetime,
+        patch("hindsight_api.engine.tei_retry.random.uniform", return_value=0.0),
+    ):
+        mock_datetime.now.return_value = now
+        assert tei_retry_delay(response, 0.5, max_delay=30.0) == 3.0
+
+
+def test_fallback_jitter_is_bounded() -> None:
+    response = httpx.Response(503)
+
+    with patch("hindsight_api.engine.tei_retry.random.uniform", return_value=0.25) as uniform:
+        assert tei_retry_delay(response, 5.0, max_delay=30.0) == 5.25
+
+    uniform.assert_called_once_with(0.0, 0.5)
+
+
+def test_non_finite_and_malformed_retry_after_use_fallback() -> None:
+    for value in ("Infinity", "NaN", "not-a-delay"):
+        response = httpx.Response(429, headers={"Retry-After": value})
+        with patch("hindsight_api.engine.tei_retry.random.uniform", return_value=0.0):
+            assert tei_retry_delay(response, 0.5, max_delay=30.0) == 0.5
+
+
+def test_oversized_retry_after_is_capped_by_client_timeout() -> None:
+    response = httpx.Response(429, headers={"Retry-After": "1000000"})
+
+    with patch("hindsight_api.engine.tei_retry.random.uniform", return_value=0.0):
+        assert tei_retry_delay(response, 0.5, max_delay=30.0) == 30.0
+
+
+def test_capped_delay_uses_downward_jitter() -> None:
+    response = httpx.Response(429, headers={"Retry-After": "1000000"})
+
+    with patch("hindsight_api.engine.tei_retry.random.uniform", return_value=0.75) as uniform:
+        assert tei_retry_delay(response, 0.5, max_delay=30.0) == 29.25
+
+    uniform.assert_called_once_with(0.0, 1.0)

--- a/hindsight-api-slim/tests/test_tei_retry.py
+++ b/hindsight-api-slim/tests/test_tei_retry.py
@@ -6,14 +6,14 @@ from unittest.mock import patch
 
 import httpx
 
-from hindsight_api.engine.tei_retry import tei_retry_delay
+from hindsight_api.engine.tei_retry import MAX_RETRY_DELAY_SECONDS, tei_retry_delay
 
 
 def test_retry_after_takes_precedence_over_fallback() -> None:
     response = httpx.Response(429, headers={"Retry-After": "3"})
 
     with patch("hindsight_api.engine.tei_retry.random.uniform", return_value=0.0):
-        assert tei_retry_delay(response, 0.5, max_delay=30.0) == 3.0
+        assert tei_retry_delay(response, 0.5, request_timeout=30.0) == 3.0
 
 
 def test_http_date_retry_after_is_supported() -> None:
@@ -28,36 +28,57 @@ def test_http_date_retry_after_is_supported() -> None:
         patch("hindsight_api.engine.tei_retry.random.uniform", return_value=0.0),
     ):
         mock_datetime.now.return_value = now
-        assert tei_retry_delay(response, 0.5, max_delay=30.0) == 3.0
+        assert tei_retry_delay(response, 0.5, request_timeout=30.0) == 3.0
 
 
-def test_fallback_jitter_is_bounded() -> None:
+def test_fallback_jitter_spans_half_the_delay() -> None:
+    """The jitter window must be wide enough to break a synchronised burst apart."""
     response = httpx.Response(503)
 
     with patch("hindsight_api.engine.tei_retry.random.uniform", return_value=0.25) as uniform:
-        assert tei_retry_delay(response, 5.0, max_delay=30.0) == 5.25
+        assert tei_retry_delay(response, 2.0, request_timeout=30.0) == 2.25
 
-    uniform.assert_called_once_with(0.0, 0.5)
+    uniform.assert_called_once_with(0.0, 1.0)
 
 
 def test_non_finite_and_malformed_retry_after_use_fallback() -> None:
     for value in ("Infinity", "NaN", "not-a-delay"):
         response = httpx.Response(429, headers={"Retry-After": value})
         with patch("hindsight_api.engine.tei_retry.random.uniform", return_value=0.0):
-            assert tei_retry_delay(response, 0.5, max_delay=30.0) == 0.5
+            assert tei_retry_delay(response, 0.5, request_timeout=30.0) == 0.5
 
 
-def test_oversized_retry_after_is_capped_by_client_timeout() -> None:
+def test_oversized_retry_after_is_capped_below_the_request_timeout() -> None:
+    """A large Retry-After must not stall the reranker for a whole request timeout."""
     response = httpx.Response(429, headers={"Retry-After": "1000000"})
 
     with patch("hindsight_api.engine.tei_retry.random.uniform", return_value=0.0):
-        assert tei_retry_delay(response, 0.5, max_delay=30.0) == 30.0
+        delay = tei_retry_delay(response, 0.5, request_timeout=30.0)
+
+    assert delay == MAX_RETRY_DELAY_SECONDS
+    assert delay < 30.0
+
+
+def test_short_request_timeout_lowers_the_cap() -> None:
+    response = httpx.Response(429, headers={"Retry-After": "1000000"})
+
+    with patch("hindsight_api.engine.tei_retry.random.uniform", return_value=0.0):
+        assert tei_retry_delay(response, 0.5, request_timeout=1.0) == 1.0
 
 
 def test_capped_delay_uses_downward_jitter() -> None:
     response = httpx.Response(429, headers={"Retry-After": "1000000"})
 
     with patch("hindsight_api.engine.tei_retry.random.uniform", return_value=0.75) as uniform:
-        assert tei_retry_delay(response, 0.5, max_delay=30.0) == 29.25
+        assert tei_retry_delay(response, 0.5, request_timeout=30.0) == MAX_RETRY_DELAY_SECONDS - 0.75
 
-    uniform.assert_called_once_with(0.0, 1.0)
+    uniform.assert_called_once_with(0.0, MAX_RETRY_DELAY_SECONDS * 0.5)
+
+
+def test_zero_delay_short_circuits_without_jitter() -> None:
+    response = httpx.Response(429)
+
+    with patch("hindsight_api.engine.tei_retry.random.uniform") as uniform:
+        assert tei_retry_delay(response, 0.0, request_timeout=30.0) == 0.0
+
+    uniform.assert_not_called()

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -901,6 +901,23 @@ ZeroEntropy's `zembed-1` supports Matryoshka dimensions: `2560`, `1280`, `640`, 
 | `HINDSIGHT_API_RERANKER_FLASHRANK_CPU_MEM_ARENA` | Enable ONNX Runtime CPU memory arena for FlashRank. When `true`, ONNX pre-allocates a memory arena that never shrinks, causing RSS to grow monotonically. `false` trades slightly slower per-call allocation for bounded RSS. | `false` |
 | `HINDSIGHT_API_RERANKER_JINA_MLX_MODEL_PATH` | Local path to downloaded `jina-reranker-v3-mlx` model (auto-downloads from HuggingFace if unset) | - |
 
+:::tip Sizing a TEI reranker
+
+TEI reserves one slot per text in a rerank request and rejects the request outright
+once its pool is full, so start it with at least
+`HINDSIGHT_API_RERANKER_TEI_MAX_CONCURRENT × HINDSIGHT_API_RERANKER_TEI_BATCH_SIZE`
+slots — 1024 for the defaults above, versus TEI's own default of 512:
+
+```bash
+text-embeddings-router --max-concurrent-requests 2048 ...
+```
+
+Below that threshold, heavy recall traffic makes the reranker reject work it has the
+capacity to do. Rejections are retried with backoff, so an undersized pool shows up as
+slower recall rather than errors.
+
+:::
+
 ```bash
 # Local (default) - uses SentenceTransformers CrossEncoder
 export HINDSIGHT_API_RERANKER_PROVIDER=local

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -901,6 +901,23 @@ ZeroEntropy's `zembed-1` supports Matryoshka dimensions: `2560`, `1280`, `640`, 
 | `HINDSIGHT_API_RERANKER_FLASHRANK_CPU_MEM_ARENA` | Enable ONNX Runtime CPU memory arena for FlashRank. When `true`, ONNX pre-allocates a memory arena that never shrinks, causing RSS to grow monotonically. `false` trades slightly slower per-call allocation for bounded RSS. | `false` |
 | `HINDSIGHT_API_RERANKER_JINA_MLX_MODEL_PATH` | Local path to downloaded `jina-reranker-v3-mlx` model (auto-downloads from HuggingFace if unset) | - |
 
+:::tip Sizing a TEI reranker
+
+TEI reserves one slot per text in a rerank request and rejects the request outright
+once its pool is full, so start it with at least
+`HINDSIGHT_API_RERANKER_TEI_MAX_CONCURRENT × HINDSIGHT_API_RERANKER_TEI_BATCH_SIZE`
+slots — 1024 for the defaults above, versus TEI's own default of 512:
+
+```bash
+text-embeddings-router --max-concurrent-requests 2048 ...
+```
+
+Below that threshold, heavy recall traffic makes the reranker reject work it has the
+capacity to do. Rejections are retried with backoff, so an undersized pool shows up as
+slower recall rather than errors.
+
+:::
+
 ```bash
 # Local (default) - uses SentenceTransformers CrossEncoder
 export HINDSIGHT_API_RERANKER_PROVIDER=local


### PR DESCRIPTION
Fixes #2991.

## Summary

- retry TEI `429 Too Many Requests` responses in both remote reranking and embeddings
- honor numeric and HTTP-date `Retry-After` values within the configured client timeout
- add bounded jitter, including when a server delay reaches the timeout cap
- preserve fail-fast behavior for every other 4xx response and the existing retry-count budget

## Testing

- `29 passed, 3 skipped` across the focused TEI cross-encoder, embeddings, and retry suites
- `ruff check` and `ruff format --check` on all changed files
- `py_compile` on all changed source and test files

The retry delay remains inside the existing request semaphore for reranking, so overload retries do not bypass its concurrency bound.
