### PR TITLE
refactor(retain): require explicit semantic link thresholds

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -7,7 +7,6 @@ import time
 from datetime import UTC, datetime, timedelta
 
 from ..._vector_index import ann_search_tuning_settings, configured_vector_extension
-from ...config import DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY
 from ..causal_links import (
     CANONICAL_CAUSAL_LINK_TYPES,
     CAUSAL_LINK_TYPES,
@@ -527,7 +526,8 @@ async def compute_semantic_links_ann(
     embeddings: list[list[float]],
     fact_types: list[str] | None = None,
     top_k: int = 50,
-    threshold: float = DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY,
+    *,
+    threshold: float,
     log_buffer: list[str] = None,
 ) -> list[tuple]:
     """
@@ -668,7 +668,8 @@ def compute_semantic_links_within_batch(
     unit_ids: list[str],
     embeddings: list[list[float]],
     top_k: int = 50,
-    threshold: float = DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY,
+    *,
+    threshold: float,
 ) -> list[tuple]:
     """
     Compute semantic links between units within the same batch (no DB needed).
@@ -728,7 +729,8 @@ async def create_semantic_links_batch(
     unit_ids: list[str],
     embeddings: list[list[float]],
     top_k: int = 50,
-    threshold: float = DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY,
+    *,
+    threshold: float,
     log_buffer: list[str] = None,
     pre_computed_ann_links: list[tuple] | None = None,
     ops=None,
@@ -763,7 +765,12 @@ async def create_semantic_links_batch(
 
         # Within-batch similarities (numpy, no DB)
         batch_start = time_mod.time()
-        within_batch_links = compute_semantic_links_within_batch(unit_ids, embeddings, top_k, threshold)
+        within_batch_links = compute_semantic_links_within_batch(
+            unit_ids,
+            embeddings,
+            top_k,
+            threshold=threshold,
+        )
         all_links.extend(within_batch_links)
         _log(
             log_buffer,

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -1124,6 +1124,7 @@ async def _run_final_semantic_ann(
     pool: Any,
     bank_id: str,
     unit_ids: list[str],
+    *,
     threshold: float,
     log_buffer: list[str],
 ) -> None:
@@ -1995,8 +1996,8 @@ async def _streaming_retain_batch(
                 pool,
                 bank_id,
                 all_unit_ids,
-                config.semantic_link_min_similarity,
-                log_buffer,
+                threshold=config.semantic_link_min_similarity,
+                log_buffer=log_buffer,
             )
         except Exception:
             # ANN pass is best-effort. FK violations can occur if a concurrent

--- a/hindsight-api-slim/tests/test_link_utils.py
+++ b/hindsight-api-slim/tests/test_link_utils.py
@@ -5,7 +5,7 @@ import pytest
 from datetime import datetime, timezone, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
-from hindsight_api.config import clear_config_cache
+from hindsight_api.config import DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY, clear_config_cache
 from hindsight_api.engine.retain.link_utils import (
     _normalize_datetime,
     _cap_links_per_unit,
@@ -321,16 +321,34 @@ class TestComputeSemanticLinksWithinBatch:
     """
 
     def test_empty_returns_empty(self):
-        assert compute_semantic_links_within_batch([], []) == []
+        assert (
+            compute_semantic_links_within_batch(
+                [],
+                [],
+                threshold=DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY,
+            )
+            == []
+        )
 
     def test_single_unit_returns_empty(self):
         emb = [np.random.randn(384).tolist()]
-        assert compute_semantic_links_within_batch(["u1"], emb) == []
+        assert (
+            compute_semantic_links_within_batch(
+                ["u1"],
+                emb,
+                threshold=DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY,
+            )
+            == []
+        )
 
     def test_identical_embeddings_produce_links(self):
         """Two identical embeddings should have similarity=1.0 (above 0.7 threshold)."""
         emb = [0.1] * 384
-        links = compute_semantic_links_within_batch(["u1", "u2"], [emb, emb])
+        links = compute_semantic_links_within_batch(
+            ["u1", "u2"],
+            [emb, emb],
+            threshold=DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY,
+        )
         assert len(links) == 2  # bidirectional: u1→u2, u2→u1
         from_ids = {lnk[0] for lnk in links}
         to_ids = {lnk[1] for lnk in links}
@@ -345,7 +363,11 @@ class TestComputeSemanticLinksWithinBatch:
         """Orthogonal embeddings should have similarity=0 (below 0.7 threshold)."""
         emb1 = [1.0] + [0.0] * 383
         emb2 = [0.0] + [1.0] + [0.0] * 382
-        links = compute_semantic_links_within_batch(["u1", "u2"], [emb1, emb2])
+        links = compute_semantic_links_within_batch(
+            ["u1", "u2"],
+            [emb1, emb2],
+            threshold=DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY,
+        )
         assert len(links) == 0
 
     def test_non_unit_embeddings_use_cosine_similarity(self):
@@ -400,7 +422,11 @@ class TestComputeSemanticLinksWithinBatch:
     def test_link_tuple_structure(self):
         """Verify the tuple format matches what _bulk_insert_links expects."""
         emb = [0.1] * 384
-        links = compute_semantic_links_within_batch(["u1", "u2"], [emb, emb])
+        links = compute_semantic_links_within_batch(
+            ["u1", "u2"],
+            [emb, emb],
+            threshold=DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY,
+        )
         for lnk in links:
             assert len(lnk) == 5
             from_id, to_id, link_type, weight, entity_id = lnk
@@ -462,6 +488,7 @@ class TestComputeSemanticLinksAnnPgBouncerSafety:
             bank_id="bank-1",
             unit_ids=[],
             embeddings=[],
+            threshold=DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY,
         )
         assert result == []
         mock_conn.transaction.assert_not_called()
@@ -478,6 +505,7 @@ class TestComputeSemanticLinksAnnPgBouncerSafety:
             unit_ids=["u1", "u2"],
             embeddings=[emb, emb],
             fact_types=["world", "world"],
+            threshold=DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY,
         )
 
         # Transaction context manager was entered.
@@ -499,6 +527,7 @@ class TestComputeSemanticLinksAnnPgBouncerSafety:
             unit_ids=["u1"],
             embeddings=[emb],
             fact_types=["world"],
+            threshold=DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY,
         )
 
         executed_sql = [call.args[0] for call in mock_conn.execute.call_args_list]
@@ -528,6 +557,7 @@ class TestComputeSemanticLinksAnnPgBouncerSafety:
             unit_ids=["u1"],
             embeddings=[emb],
             fact_types=["world"],
+            threshold=DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY,
         )
 
         executed_sql = [call.args[0] for call in mock_conn.execute.call_args_list]
@@ -555,6 +585,7 @@ class TestComputeSemanticLinksAnnPgBouncerSafety:
             unit_ids=["u1"],
             embeddings=[emb],
             fact_types=["world"],
+            threshold=DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY,
         )
 
         executed_sql = [call.args[0] for call in mock_conn.execute.call_args_list]
@@ -581,6 +612,7 @@ class TestComputeSemanticLinksAnnPgBouncerSafety:
             unit_ids=["u1"],
             embeddings=[emb],
             fact_types=["world"],
+            threshold=DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY,
         )
 
         executed_sql = [call.args[0] for call in mock_conn.execute.call_args_list]

--- a/hindsight-api-slim/tests/test_retain_orchestrator_mapping.py
+++ b/hindsight-api-slim/tests/test_retain_orchestrator_mapping.py
@@ -286,8 +286,8 @@ class TestSemanticLinkThresholdPropagation:
         assert captured_thresholds == [0.82]
 
     @pytest.mark.asyncio
-    async def test_link_creation_passes_threshold_to_within_batch_path(self, monkeypatch):
-        """The Phase 2 wrapper must not fall back to link_utils' default threshold."""
+    async def test_link_creation_forwards_threshold_to_link_utils(self, monkeypatch):
+        """The Phase 2 wrapper forwards the resolved threshold to link_utils."""
         captured_thresholds: list[float] = []
 
         async def fake_create_semantic_links_batch(*_args, **kwargs):
@@ -326,6 +326,12 @@ class TestSemanticLinkThresholdPropagation:
         monkeypatch.setattr(orchestrator, "acquire_with_retry", fake_acquire_with_retry)
         monkeypatch.setattr(link_utils, "compute_semantic_links_ann", fake_compute_semantic_links_ann)
 
-        await _run_final_semantic_ann(pool, "bank", ["unit"], 0.84, [])
+        await _run_final_semantic_ann(
+            pool,
+            "bank",
+            ["unit"],
+            threshold=0.84,
+            log_buffer=[],
+        )
 
         assert captured_thresholds == [0.84]


### PR DESCRIPTION
## Summary

This is a follow-up to #2875 and addresses the three non-blocking suggestions from its approving review:

- require the low-level semantic-link helpers to receive `threshold` explicitly as a keyword argument
- make the streaming final-ANN threshold keyword-only
- rename the forwarding test to describe what it actually verifies

## Relationship to #2875

#2875 made the embedding-dependent similarity thresholds configurable and correctly passed the resolved semantic-link threshold through every existing retain and graph-maintenance path.

The approving review noted that three low-level helpers still defaulted to `0.7`. Existing callers were correct, but a future caller could omit the argument and silently bypass the configured value. This PR removes that fallback and turns such an omission into an immediate call-site error.

This does not change the `0.7` server default, configuration behavior, or runtime behavior of existing paths. The default remains owned by `HindsightConfig`; lower-level helpers now require the resolved value.

## Validation

- `uv run pytest tests/test_link_utils.py tests/test_retain_orchestrator_mapping.py -q` (`64 passed`)
- `./scripts/hooks/lint.sh`
- `uv run ty check hindsight_api/`