### PR TITLE
fix(retain): sync metadata to unchanged memories

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -8,6 +8,7 @@ import json
 import logging
 import uuid
 from datetime import datetime
+from typing import Any
 
 from ...config import _get_raw_config, get_config
 from ..memory_engine import fq_table
@@ -444,16 +445,18 @@ async def _upsert_document_row(
     )
 
 
-async def update_memory_units_tags(
+async def update_memory_units_metadata_and_tags(
     conn,
     bank_id: str,
     document_id: str,
     tags: list[str],
+    metadata: dict[str, Any],
 ) -> int:
-    """
-    Update tags on all memory_units belonging to a document.
+    """Update document-level attributes on existing memory units.
 
-    Used during delta retain to propagate tag changes to unchanged facts.
+    Delta retain preserves unchanged chunks and their facts. Propagate the
+    current document tags and metadata so its optimized result matches a full
+    replace.
 
     Returns:
         Number of memory units updated.
@@ -461,12 +464,13 @@ async def update_memory_units_tags(
     result = await conn.execute(
         f"""
         UPDATE {fq_table("memory_units")}
-        SET tags = $3, updated_at = NOW()
+        SET tags = $3, metadata = $4, updated_at = NOW()
         WHERE bank_id = $1 AND document_id = $2
         """,
         bank_id,
         document_id,
         tags or [],
+        json.dumps(metadata or {}),
     )
     # result is a status string like "UPDATE 5"
     try:

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -2385,13 +2385,20 @@ async def _try_delta_retain(
                     f"in {time.time() - step_start:.3f}s"
                 )
 
-                # Update tags on unchanged chunks' memory units
+                # Changed/removed units were deleted above. Sync unchanged
+                # survivors; new/changed units inserted below already carry
+                # the current metadata and tags.
                 step_start = time.time()
-                updated_count = await fact_storage.update_memory_units_tags(
-                    conn, bank_id, effective_doc_id, merged_tags
+                updated_count = await fact_storage.update_memory_units_metadata_and_tags(
+                    conn,
+                    bank_id,
+                    effective_doc_id,
+                    merged_tags,
+                    retain_params.get("metadata", {}),
                 )
                 log_buffer.append(
-                    f"  Updated tags on {updated_count} existing memory units in {time.time() - step_start:.3f}s"
+                    f"  Updated tags and metadata on {updated_count} existing memory units "
+                    f"in {time.time() - step_start:.3f}s"
                 )
 
                 # Store new/changed chunks
@@ -2526,7 +2533,13 @@ async def _delta_metadata_only(
                 retain_params,
                 merged_tags,
             )
-            await fact_storage.update_memory_units_tags(conn, bank_id, document_id, merged_tags)
+            await fact_storage.update_memory_units_metadata_and_tags(
+                conn,
+                bank_id,
+                document_id,
+                merged_tags,
+                retain_params.get("metadata", {}),
+            )
             if outbox_callback is not None:
                 await outbox_callback(conn)
 

--- a/hindsight-api-slim/tests/test_delta_retain.py
+++ b/hindsight-api-slim/tests/test_delta_retain.py
@@ -2,6 +2,7 @@
 Tests for delta retain — upsert optimization that only re-processes changed chunks.
 """
 
+import json
 import logging
 from datetime import datetime, timezone
 
@@ -438,6 +439,60 @@ async def test_delta_retain_document_metadata_updated(memory, request_context):
         assert doc_v2 is not None
         assert doc_v2["updated_at"] >= doc_v1["updated_at"], "Document should have updated timestamp"
 
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_delta_retain_metadata_consistent_for_unchanged_units(memory, request_context):
+    """Metadata updates should reach facts preserved by metadata-only retain."""
+    bank_id = f"test_delta_unit_meta_{_ts()}"
+    document_id = "unit-metadata-doc"
+    content = "Alice works at Google."
+
+    try:
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {
+                    "content": content,
+                    "document_id": document_id,
+                    "metadata": {"source": "email"},
+                }
+            ],
+            request_context=request_context,
+        )
+
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {
+                    "content": content,
+                    "document_id": document_id,
+                    "metadata": {"source": "crm"},
+                }
+            ],
+            request_context=request_context,
+        )
+
+        doc = await memory.get_document(document_id, bank_id, request_context=request_context)
+        assert doc is not None
+        assert doc["document_metadata"] == {"source": "crm"}
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT metadata FROM memory_units WHERE bank_id = $1 AND document_id = $2",
+                bank_id,
+                document_id,
+            )
+
+        assert rows
+        for row in rows:
+            metadata = row["metadata"]
+            if isinstance(metadata, str):
+                metadata = json.loads(metadata)
+            assert metadata == {"source": "crm"}
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)
 

--- a/hindsight-api-slim/tests/test_retain_append_mode.py
+++ b/hindsight-api-slim/tests/test_retain_append_mode.py
@@ -86,6 +86,60 @@ async def test_append_mode_concatenates_content(memory, request_context):
 
 
 @pytest.mark.asyncio
+async def test_append_mode_metadata_consistent_for_unchanged_and_new_units(memory, request_context):
+    """Append metadata should become authoritative for old and new facts."""
+    bank_id = f"test_append_meta_{_ts()}"
+    document_id = "append-metadata"
+
+    try:
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {
+                    "content": "Alice works at Google as a software engineer.",
+                    "document_id": document_id,
+                    "metadata": {"source": "email"},
+                }
+            ],
+            request_context=request_context,
+        )
+
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {
+                    "content": "Bob works at Microsoft as a data scientist.",
+                    "document_id": document_id,
+                    "metadata": {"source": "crm"},
+                    "update_mode": "append",
+                }
+            ],
+            request_context=request_context,
+        )
+
+        doc = await memory.get_document(document_id, bank_id, request_context=request_context)
+        assert doc is not None
+        assert doc["document_metadata"] == {"source": "crm"}
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT metadata FROM memory_units WHERE bank_id = $1 AND document_id = $2",
+                bank_id,
+                document_id,
+            )
+
+        assert rows
+        for row in rows:
+            metadata = row["metadata"]
+            if isinstance(metadata, str):
+                metadata = json.loads(metadata)
+            assert metadata == {"source": "crm"}
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
 async def test_append_mode_no_existing_document(memory, request_context):
     """
     When update_mode='append' but no existing document exists,


### PR DESCRIPTION
## Summary

Keep metadata on memory units aligned with `document_metadata` when delta retain preserves unchanged chunks.

Closes #3008.

## Root cause

Delta retain already updated the document row and propagated tags to existing memory units. It did not propagate metadata, so preserved memories kept the previous value while rebuilt or newly inserted memories used the current retain metadata.

| Chunk state | Existing behavior | Result after this change |
| --- | --- | --- |
| `unchanged` | Preserve memory units with stale metadata | Preserve memory units and synchronize metadata and tags |
| `changed` | Delete and rebuild with current metadata | Unchanged |
| `new` | Insert with current metadata | Unchanged |
| `removed` | Delete chunk and memory units | Unchanged |

## Implementation

- Replace the tags-only delta helper with one focused update that synchronizes metadata and tags in a single SQL statement.
- Reuse that helper in metadata-only retain and partial-delta retain.
- Keep changed/new insertion and changed/removed deletion paths unchanged.
- Add regression coverage for metadata-only replace and append with preserved plus new chunks.

## Impact

After retain completes, every surviving direct memory unit for the document has metadata consistent with `document_metadata`, regardless of whether delta retain preserved or rebuilt its chunk.

The change adds no schema migration, JSON-specific branch, or extra database round trip.

## Validation

| Check | Result |
| --- | --- |
| Delta retain and append test files | 29 passed |
| Focused metadata and tags regressions after simplification | 3 passed |
| Ruff | Passed |
| ty | Passed |
| Repository pre-commit hooks and lint | Passed |
| `git diff --check` | Passed |