### PR TITLE
fix(oracle): skip LLM trace writes on Oracle (llm_requests is PG-only)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_trace.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_trace.py
@@ -36,6 +36,21 @@ from .db_utils import acquire_with_retry
 logger = logging.getLogger(__name__)
 
 
+def _llm_requests_persistable() -> bool:
+    """Whether the ``llm_requests`` table exists on the active backend.
+
+    ``llm_requests`` is PostgreSQL-only: its migration is ``run_for_dialect(pg=...)``
+    with the Oracle slot intentionally absent, and MaintenanceLoop skips its
+    retention sweep on Oracle for the same reason. On Oracle the table does not
+    exist, so best-effort trace writes must be skipped rather than attempted —
+    otherwise every LLM call fires an INSERT that fails with ORA-00903 and spams
+    the error log. Mirrors the ``_is_oracle()`` gate in MaintenanceLoop.start.
+    """
+    from .schema import _is_oracle
+
+    return not _is_oracle()
+
+
 # ── bank/operation attribution (carried across the async call chain) ──────────
 
 
@@ -400,6 +415,8 @@ class LLMTraceRecorder:
         """Whether tracing is active for the given call scope."""
         if not self._enabled:
             return False
+        if not _llm_requests_persistable():
+            return False
         if self._allowed_scopes is not None:
             return scope in self._allowed_scopes
         return True
@@ -566,7 +583,7 @@ class LLMTraceRecorder:
         ids are snapshotted synchronously here because the caller may reset the
         context immediately after.
         """
-        if not self._enabled or trace_ctx is None or not trace_ctx.trace_id:
+        if not self._enabled or not _llm_requests_persistable() or trace_ctx is None or not trace_ctx.trace_id:
             return
         created_ids = list(dict.fromkeys([*(created or []), *trace_ctx.created_memory_ids]))
         source_ids = list(dict.fromkeys([*(source or []), *trace_ctx.source_memory_ids]))

--- a/hindsight-api-slim/tests/test_llm_trace.py
+++ b/hindsight-api-slim/tests/test_llm_trace.py
@@ -96,6 +96,17 @@ def test_recorder_scope_allowlist():
     assert r.is_enabled("retain_extract_facts") is False
 
 
+def test_recorder_disabled_on_oracle_backend(monkeypatch):
+    # llm_requests is a PostgreSQL-only table, so on Oracle the recorder must
+    # report disabled and write nothing — otherwise every LLM call fires an
+    # INSERT that fails with ORA-00903 and spams the error log.
+    monkeypatch.setattr("hindsight_api.engine.schema._is_oracle", lambda: True)
+    rec = _CapturingRecorder()
+    assert rec.is_enabled("memory") is False
+    rec.record_llm_call(provider="mock", model="mock", scope="memory", messages=[], duration=0.1)
+    assert rec.records == []
+
+
 # ── recorder: record_llm_call builds correct records ──────────────────────────
 
 


### PR DESCRIPTION
## Summary

On Oracle, every LLM call spammed the error log with:

```
ORA-00903: invalid table name        (INSERT INTO public.llm_requests ...)
```

`LLMTraceRecorder` writes each call into `llm_requests`, but that table is **PostgreSQL-only** — its migration is `run_for_dialect(pg=_pg_upgrade)` with the Oracle slot intentionally absent, and `MaintenanceLoop.start` already skips its retention sweep on Oracle for exactly this reason (`_is_oracle()` gate). The **write path missed that gate**, so on Oracle it fired an INSERT per LLM call that failed to even parse (`public` is a reserved word on Oracle; and the table doesn't exist there regardless). The failures are caught and logged best-effort — nothing breaks functionally — but they flood the error log on every retain/consolidation.

## Fix

Add `_llm_requests_persistable()` (returns `False` on Oracle) and consult it in both write entry points — `is_enabled` (used by `record_llm_call`) and `attach_memory_ids` — so the recorder short-circuits before scheduling any work. This mirrors the existing `_is_oracle()` gate in `MaintenanceLoop.start`. **PostgreSQL behaviour is unchanged.**

## Scope note

`audit_log` *does* exist on Oracle, but `AuditLogger._safe_log` builds the same `f"{schema}.audit_log"` (→ `public.audit_log`, also ORA-00903). That's a **distinct** bug — wrong schema qualification rather than a missing table — and audit is off by default, so it wasn't in the failing logs. Left for a separate change to keep this fix tight. (The read endpoint `list_llm_requests` would likewise ORA-00942 on Oracle if the observability UI is opened; also out of scope here.)

## Test

`test_recorder_disabled_on_oracle_backend` forces the Oracle backend and asserts the recorder reports disabled and records nothing — deterministic, no live Oracle needed.