### PR TITLE
fix(oracle): audit_log write qualification + llm_requests read gating

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/audit.py
+++ b/hindsight-api-slim/hindsight_api/engine/audit.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, Field
 
 from ..engine.db_utils import acquire_with_retry
 from ..models import RequestContext
+from .schema import fq_table_explicit
 
 logger = logging.getLogger(__name__)
 
@@ -188,8 +189,12 @@ class AuditLogger:
             logger.debug("Audit log skipped: pool not available")
             return
         try:
-            schema = self._schema_getter()
-            table = f"{schema}.audit_log"
+            # fq_table_explicit qualifies per dialect: "schema".audit_log on
+            # PostgreSQL, bare audit_log on Oracle (where the schema is set at the
+            # session level). A raw f"{schema}.audit_log" produced public.audit_log
+            # on Oracle, where "public" is a reserved word — every write failed
+            # with ORA-00903 even though the table exists.
+            table = fq_table_explicit("audit_log", self._schema_getter())
             async with acquire_with_retry(pool, max_retries=1) as conn:
                 await conn.execute(
                     f"""

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8866,6 +8866,14 @@ class MemoryEngine(MemoryEngineInterface):
         if await self.get_bank_profile(bank_id, request_context=request_context, create_if_missing=False) is None:
             return None
 
+        from .schema import _is_oracle  # noqa: PLC0415
+
+        if _is_oracle():
+            # llm_requests is PostgreSQL-only (its migration omits the Oracle slot;
+            # LLMTraceRecorder skips writes on Oracle). There is nothing to read, so
+            # return an empty page rather than querying a non-existent table (ORA-00942).
+            return LLMRequestListResponse(bank_id=bank_id, total=0, limit=limit, offset=offset, items=[])
+
         where_clauses = ["bank_id = $1"]
         params: list[Any] = [bank_id]
         idx = 2
@@ -8986,6 +8994,14 @@ class MemoryEngine(MemoryEngineInterface):
             start = now - timedelta(days=30)
         else:  # 7d default
             start = now - timedelta(days=7)
+
+        from .schema import _is_oracle  # noqa: PLC0415
+
+        if _is_oracle():
+            # llm_requests is PostgreSQL-only — no rows on Oracle (see list_llm_requests).
+            return LLMRequestStatsResponse(
+                bank_id=bank_id, period=period, trunc=trunc, start=start.isoformat(), buckets=[]
+            )
 
         where_clauses = ["bank_id = $1", "started_at >= $2"]
         params: list[Any] = [bank_id, start]

--- a/hindsight-api-slim/tests/test_audit_per_bank.py
+++ b/hindsight-api-slim/tests/test_audit_per_bank.py
@@ -15,7 +15,7 @@ import pytest
 import pytest_asyncio
 
 from hindsight_api.api import create_app
-from hindsight_api.engine.audit import AuditLogger
+from hindsight_api.engine.audit import AuditEntry, AuditLogger
 from tests.conftest import enable_audit_default
 
 # Audit writes are fire-and-forget; give the background task room to land.
@@ -112,6 +112,66 @@ async def test_no_override_uses_deployment_default(client, memory):
     await client.put(f"/v1/default/banks/{bank_id}", json={})
     await _recall(client, bank_id)
     assert "recall" in await _audited_actions(client, bank_id)
+
+
+# ── AuditLogger write: dialect-aware table qualification ───────────────────
+
+
+class _CapturingConn:
+    def __init__(self, sink: list[str]) -> None:
+        self._sink = sink
+
+    async def execute(self, sql: str, *args: object) -> None:
+        self._sink.append(sql)
+
+
+class _CapturingPool:
+    """Minimal asyncpg.Pool-like stand-in that records the SQL it executes."""
+
+    def __init__(self, sink: list[str]) -> None:
+        self._sink = sink
+
+    async def acquire(self) -> _CapturingConn:
+        return _CapturingConn(self._sink)
+
+    async def release(self, conn: _CapturingConn) -> None:
+        pass
+
+    def get_size(self) -> int:
+        return 1
+
+    def get_idle_size(self) -> int:
+        return 1
+
+
+async def _capture_audit_write(monkeypatch, *, oracle: bool, schema: str) -> str:
+    monkeypatch.setattr("hindsight_api.engine.schema._is_oracle", lambda: oracle)
+    sink: list[str] = []
+    logger = AuditLogger(
+        pool_getter=lambda: _CapturingPool(sink),
+        schema_getter=lambda: schema,
+        enabled=True,
+        allowed_actions=[],
+    )
+    await logger._safe_log(AuditEntry(action="recall", transport="http", bank_id="b1"))
+    assert len(sink) == 1, "expected exactly one INSERT"
+    return sink[0]
+
+
+@pytest.mark.asyncio
+async def test_audit_write_uses_bare_table_on_oracle(monkeypatch):
+    # audit_log exists on Oracle, but a raw f"{schema}.audit_log" yields
+    # public.audit_log — "public" is a reserved word there, so every write failed
+    # with ORA-00903. The dialect-qualified (bare) name must be used instead.
+    sql = await _capture_audit_write(monkeypatch, oracle=True, schema="public")
+    assert "INSERT INTO audit_log" in sql
+    assert "public.audit_log" not in sql
+
+
+@pytest.mark.asyncio
+async def test_audit_write_qualifies_schema_on_postgres(monkeypatch):
+    sql = await _capture_audit_write(monkeypatch, oracle=False, schema="tenant_x")
+    assert '"tenant_x".audit_log' in sql
 
 
 # ── AuditLogger decision logic (no DB) ─────────────────────────────────────

--- a/hindsight-api-slim/tests/test_llm_trace.py
+++ b/hindsight-api-slim/tests/test_llm_trace.py
@@ -533,6 +533,24 @@ async def test_list_empty(trace_api_client, bank_id):
 
 
 @pytest.mark.asyncio
+async def test_llm_requests_read_returns_empty_on_oracle(trace_api_client, bank_id, monkeypatch):
+    # llm_requests is PostgreSQL-only, so the list and stats read paths must
+    # return an empty result on Oracle rather than querying a table that does
+    # not exist there (ORA-00942). The bank still resolves (no 404).
+    await trace_api_client.put(f"/v1/default/banks/{bank_id}", json={"name": "Trace Bank"})
+    monkeypatch.setattr("hindsight_api.engine.schema._is_oracle", lambda: True)
+
+    listing = await trace_api_client.get(f"/v1/default/banks/{bank_id}/llm-requests")
+    assert listing.status_code == 200
+    assert listing.json()["items"] == []
+    assert listing.json()["total"] == 0
+
+    stats = await trace_api_client.get(f"/v1/default/banks/{bank_id}/llm-requests/stats")
+    assert stats.status_code == 200
+    assert stats.json()["buckets"] == []
+
+
+@pytest.mark.asyncio
 async def test_retain_creates_trace_rows_with_tokens(trace_api_client, bank_id):
     await trace_api_client.put(f"/v1/default/banks/{bank_id}", json={"name": "Trace Bank"})
     response = await trace_api_client.post(


### PR DESCRIPTION
## Summary

The two remaining Oracle issues in the observability tables (follow-up to #3012, which gated the `llm_requests` *write* path). Both spammed ORA-errors in the Oracle CI logs. They need **different** fixes because the two tables differ on Oracle:

### 1. `audit_log` writes — wrong schema qualification (table exists on Oracle)

`AuditLogger._safe_log` built `f"{schema}.audit_log"` → `public.audit_log` on Oracle, where `public` is a **reserved word** → every write failed with `ORA-00903`, even though `audit_log` is in the Oracle baseline. Fixed by using `fq_table_explicit("audit_log", schema)`, which qualifies per dialect (`"schema".audit_log` on PostgreSQL, bare `audit_log` on Oracle where the schema is set at the session level). This makes audit writes actually work on Oracle.

### 2. `llm_requests` reads — table is PostgreSQL-only

Unlike `audit_log`, `llm_requests` is **PG-only** (its migration omits the Oracle slot; `LLMTraceRecorder` already skips *writes* on Oracle as of #3012). But `list_llm_requests` and `llm_request_stats` still issued `SELECT … FROM llm_requests` → `ORA-00942` on Oracle. Fixed by returning an empty page / empty stats on Oracle **after** the bank-auth check (so a missing bank still 404s), rather than querying a non-existent table.

## Tests (deterministic, run on the default PG backend)

- `test_audit_per_bank`: capture the emitted SQL via a fake pool; assert the audit INSERT targets **bare** `audit_log` on Oracle (no `public.`) and `"schema".audit_log` on PostgreSQL.
- `test_llm_trace`: the list and stats endpoints return empty (200, not 500) when the backend is Oracle.

## Notes

- Audit *reads* (`list_audit_logs`) already work on Oracle — they use `fq_table("audit_log")` (bare name). Only the write bypassed the helper.
- End-to-end validation of the audit write on a live Oracle isn't exercised by the default test path (audit is off by default), but the fix mirrors the `fq_table_explicit` pattern used everywhere else and the Oracle `audit_log` schema (CLOB `IS JSON` columns) is write-compatible.

Completes the Oracle observability-table cleanup started in #3012.