### PR TITLE
fix(transfer): preserve consolidation lifecycle on whole-bank import (#2965)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/transfer/export.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/export.py
@@ -193,7 +193,12 @@ async def export_documents(
         raise ValueError("include_observations is only supported when exporting the whole bank (omit document_id)")
 
     async with acquire_with_retry(backend) as conn:
-        loaded = await _load_documents(conn, bank_id, document_ids)
+        # Carry per-fact consolidation lifecycle exactly when observations are
+        # carried: with observations in the archive the target must NOT re-derive
+        # them, so imported facts keep their consolidated/failed state. Without
+        # observations (the default document export) the target re-consolidates
+        # from scratch, so lifecycle is deliberately dropped.
+        loaded = await _load_documents(conn, bank_id, document_ids, include_lifecycle=include_observations)
         documents = loaded.documents
         observations = await _load_observations(conn, bank_id, loaded.unit_index) if include_observations else []
 
@@ -293,9 +298,11 @@ async def export_bank(
     ``_current_schema`` and passes its raw connection; the engine acquires one
     after tenant auth).
     """
-    loaded = await _load_documents(conn, bank_id, None)
+    # Whole-bank export always carries observations (they're bank-level state)
+    # and, with them, the per-fact consolidation lifecycle so the target restores
+    # exact eligibility instead of re-consolidating historical facts (#2965).
+    loaded = await _load_documents(conn, bank_id, None, include_lifecycle=True)
     documents = loaded.documents
-    # Whole-bank export always carries observations (they're bank-level state).
     observations = await _load_observations(conn, bank_id, loaded.unit_index)
 
     bank_rows = {table: await _dump_bank_rows(conn, table, bank_id) for table in _BANK_ROW_TABLES}
@@ -356,6 +363,7 @@ async def _load_documents(
     conn: Any,
     bank_id: str,
     document_ids: list[str] | None,
+    include_lifecycle: bool = False,
 ) -> _LoadedExport:
     """Load and assemble TransferDocument payloads for the requested documents."""
     doc_filter = "AND id = ANY($2)" if document_ids else ""
@@ -377,7 +385,7 @@ async def _load_documents(
     selected_ids = [row["id"] for row in doc_rows]
 
     chunks_by_doc = await _load_chunks(conn, bank_id, selected_ids)
-    loaded = await _load_facts(conn, bank_id, selected_ids)
+    loaded = await _load_facts(conn, bank_id, selected_ids, include_lifecycle=include_lifecycle)
     await _attach_entities(conn, loaded)
     await _attach_causal_relations(conn, loaded)
 
@@ -472,17 +480,22 @@ async def _load_chunks(conn: Any, bank_id: str, doc_ids: list[str]) -> dict[str,
     return chunks_by_doc
 
 
-async def _load_facts(conn: Any, bank_id: str, doc_ids: list[str]) -> _LoadedFacts:
+async def _load_facts(conn: Any, bank_id: str, doc_ids: list[str], include_lifecycle: bool = False) -> _LoadedFacts:
     """Load non-observation facts grouped by document, with a unit-id location index.
 
     The ordering is fixed (created_at, id) so that
     ``causal_relations.target_fact_index`` ordinals stay consistent.
+
+    ``include_lifecycle`` carries each fact's ``created_at`` / ``consolidated_at`` /
+    ``consolidation_failed_at`` (whole-bank / with-observations export). It is left
+    off for the plain document export so the target re-consolidates from scratch.
     """
     rows = await conn.fetch(
         f"""
         SELECT id, document_id, text, fact_type, context, event_date,
                occurred_start, occurred_end, mentioned_at, metadata,
-               chunk_id, tags, observation_scopes
+               chunk_id, tags, observation_scopes,
+               created_at, consolidated_at, consolidation_failed_at
         FROM {fq_table("memory_units")}
         WHERE bank_id = $1
           AND document_id = ANY($2)
@@ -511,6 +524,9 @@ async def _load_facts(conn: Any, bank_id: str, doc_ids: list[str]) -> _LoadedFac
             tags=list(row["tags"] or []),
             observation_scopes=_as_jsonb(row["observation_scopes"]),
             chunk_index=_chunk_index_from_chunk_id(row["chunk_id"]),
+            created_at=row["created_at"] if include_lifecycle else None,
+            consolidated_at=row["consolidated_at"] if include_lifecycle else None,
+            consolidation_failed_at=row["consolidation_failed_at"] if include_lifecycle else None,
         )
         bucket.append(fact)
         loaded.unit_index[row["id"]] = _UnitLocation(document_id=doc_id, ordinal=ordinal)

--- a/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
@@ -633,6 +633,23 @@ async def _import_one_document(
                     ops=ops,
                 )
 
+            # Restore the source consolidation lifecycle. A whole-bank transfer
+            # preserves exact eligibility: a fact that was consolidated (or that
+            # failed consolidation) in the source is never re-consolidated on the
+            # target, so the maintenance reconciler sees no phantom backlog and
+            # observations are not re-derived. Archives predating these fields
+            # carry None for all three -> skipped here, leaving the
+            # observation-driven marking in _import_observations as the only
+            # (lossy) signal, exactly as before.
+            if result_unit_ids:
+                await _restore_fact_lifecycle(
+                    conn,
+                    bank_id,
+                    document.facts,
+                    retained_index_by_original,
+                    result_unit_ids[0],
+                )
+
     # Best-effort, and only after the acquire() block above has exited: this
     # takes its own connection, and on Oracle the write above is not committed
     # until that block exits, so flushing while still holding the connection
@@ -651,6 +668,51 @@ async def _import_one_document(
             original_index
             for original_index, retained_index in enumerate(retained_index_by_original)
             if retained_index is not None
+        ],
+    )
+
+
+async def _restore_fact_lifecycle(
+    conn: Any,
+    bank_id: str,
+    facts: list[TransferFact],
+    retained_index_by_original: list[int | None],
+    retained_unit_ids: list[str],
+) -> None:
+    """Apply each imported fact's source consolidation timestamps to its new row.
+
+    ``retained_unit_ids`` follows the retained fact order; ``retained_index_by_original[i]``
+    maps original fact ``i`` to its position there (or ``None`` if it was dropped
+    on insert, e.g. a duplicate). ``created_at`` restores source provenance only
+    when present (mirroring the document-row handling); ``consolidated_at`` /
+    ``consolidation_failed_at`` are set verbatim — a source-``NULL`` (unconsolidated)
+    fact stays eligible, which is correct.
+    """
+    rows: list[tuple[uuid.UUID, datetime | None, datetime | None, datetime | None]] = []
+    for original_index, fact in enumerate(facts):
+        retained_index = retained_index_by_original[original_index]
+        if retained_index is None:
+            continue
+        if fact.created_at is None and fact.consolidated_at is None and fact.consolidation_failed_at is None:
+            # Legacy archive without lifecycle fields — nothing to restore.
+            continue
+        rows.append(
+            (
+                uuid.UUID(retained_unit_ids[retained_index]),
+                fact.created_at,
+                fact.consolidated_at,
+                fact.consolidation_failed_at,
+            )
+        )
+    if not rows:
+        return
+    await conn.executemany(
+        f"UPDATE {fq_table('memory_units')} "
+        f"SET created_at = COALESCE($2, created_at), consolidated_at = $3, consolidation_failed_at = $4 "
+        f"WHERE id = $1 AND bank_id = $5",
+        [
+            (unit_id, created_at, consolidated_at, failed_at, bank_id)
+            for unit_id, created_at, consolidated_at, failed_at in rows
         ],
     )
 
@@ -736,10 +798,13 @@ async def _import_observations(
                 all_source_ids.update(source_uuids)
                 await _link_observation_sources(conn, ops, bank_id, observation_uuid, source_uuids, obs.proof_count)
 
-            # Mark source facts consolidated so the target consolidator skips them.
+            # Mark source facts consolidated so the target consolidator skips
+            # them. COALESCE keeps the exact source timestamp already restored by
+            # _restore_fact_lifecycle (new archives); now() is the fallback only
+            # for legacy archives that carry no per-fact lifecycle state.
             if all_source_ids:
                 await conn.execute(
-                    f"UPDATE {fq_table('memory_units')} SET consolidated_at = now() "
+                    f"UPDATE {fq_table('memory_units')} SET consolidated_at = COALESCE(consolidated_at, now()) "
                     f"WHERE bank_id = $1 AND id = ANY($2)",
                     bank_id,
                     list(all_source_ids),

--- a/hindsight-api-slim/hindsight_api/engine/transfer/schema.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/schema.py
@@ -68,6 +68,15 @@ class TransferFact(BaseModel):
     # Entity canonical names; re-resolved against the target bank on import.
     entities: list[str] = Field(default_factory=list)
     causal_relations: list[TransferCausalRelation] = Field(default_factory=list)
+    # Consolidation lifecycle timestamps, carried verbatim by a whole-bank
+    # transfer so imported facts keep their exact consolidation eligibility: an
+    # already-consolidated or failed fact is never re-consolidated on the target,
+    # and the maintenance reconciler sees no phantom backlog. Absent in archives
+    # produced before these were added (-> None), in which case the importer
+    # falls back to marking only observation-referenced facts consolidated.
+    created_at: datetime | None = None
+    consolidated_at: datetime | None = None
+    consolidation_failed_at: datetime | None = None
 
 
 class TransferChunk(BaseModel):

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -407,6 +407,138 @@ async def _bank_content_snapshot(memory, bank_id):
     }
 
 
+async def _fact_lifecycle(memory, bank_id):
+    """Sorted (text, created_at, consolidated_at, consolidation_failed_at) for
+    every world/experience fact — the exact per-fact consolidation lifecycle a
+    whole-bank transfer must preserve."""
+    backend = await memory._get_backend()
+    async with acquire_with_retry(backend) as conn:
+        rows = await conn.fetch(
+            f"SELECT text, created_at, consolidated_at, consolidation_failed_at "
+            f"FROM {fq_table('memory_units')} "
+            f"WHERE bank_id = $1 AND fact_type IN ('world', 'experience')",
+            bank_id,
+        )
+    return sorted((r["text"], r["created_at"], r["consolidated_at"], r["consolidation_failed_at"]) for r in rows)
+
+
+async def _eligible_fact_count(memory, bank_id):
+    """Facts the maintenance reconciler would treat as unconsolidated backlog —
+    the exact predicate of ``banks_needing_consolidation()``."""
+    backend = await memory._get_backend()
+    async with acquire_with_retry(backend) as conn:
+        return await conn.fetchval(
+            f"SELECT COUNT(*) FROM {fq_table('memory_units')} "
+            f"WHERE bank_id = $1 AND fact_type IN ('world', 'experience') "
+            f"AND consolidated_at IS NULL AND consolidation_failed_at IS NULL",
+            bank_id,
+        )
+
+
+async def _observation_count(memory, bank_id):
+    backend = await memory._get_backend()
+    async with acquire_with_retry(backend) as conn:
+        return await conn.fetchval(
+            f"SELECT COUNT(*) FROM {fq_table('memory_units')} WHERE bank_id = $1 AND fact_type = 'observation'",
+            bank_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_bank_import_preserves_consolidation_lifecycle(memory, request_context):
+    """Whole-bank import restores each fact's consolidation lifecycle verbatim, so
+    previously-consolidated and previously-failed facts are never re-consolidated
+    and the reconciler sees no phantom backlog. Regression for #2965.
+
+    Crucially the source has consolidated facts that do NOT back any surviving
+    observation, plus a ``consolidation_failed_at`` fact — state the old
+    observation-lineage reconstruction could not recover, so those facts became
+    re-eligible and the target re-derived observations."""
+    bank = _unique_bank("bank_lifecycle")
+    try:
+        await _retain(
+            memory,
+            bank,
+            "Alice works at Google. Bob works at Microsoft. Carol lives in Paris.",
+            request_context,
+            "doc-1",
+        )
+        backend = await memory._get_backend()
+
+        # Deterministic baseline: drop any auto-consolidation observations so the
+        # only observation is the one created explicitly below.
+        async with acquire_with_retry(backend) as conn:
+            await conn.execute(
+                f"DELETE FROM {fq_table('memory_units')} WHERE bank_id = $1 AND fact_type = 'observation'",
+                bank,
+            )
+
+        async with acquire_with_retry(backend) as conn:
+            wf_ids = [
+                r["id"]
+                for r in await conn.fetch(
+                    f"SELECT id FROM {fq_table('memory_units')} "
+                    f"WHERE bank_id = $1 AND fact_type IN ('world', 'experience') ORDER BY created_at, id",
+                    bank,
+                )
+            ]
+        assert len(wf_ids) >= 3, "need enough facts to exercise the lineage gap"
+
+        # One surviving observation over the first two facts.
+        obs_source_ids = [uuid.UUID(str(i)) for i in wf_ids[:2]]
+        async with acquire_with_retry(backend) as conn:
+            async with conn.transaction():
+                await _create_observation_directly(conn, memory, bank, obs_source_ids, "Alice and Bob are colleagues.")
+
+        # Fully-processed source (zero eligible): every fact is consolidated except
+        # the last — deliberately NOT an observation source — which records a
+        # consolidation failure. Most consolidated facts do not back the
+        # observation, exactly the lineage gap the fix must preserve.
+        consolidated_ts = datetime(2020, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+        failed_ts = datetime(2020, 6, 7, 8, 9, 10, tzinfo=timezone.utc)
+        failed_fact_id = wf_ids[-1]
+        assert uuid.UUID(str(failed_fact_id)) not in obs_source_ids
+        async with acquire_with_retry(backend) as conn:
+            await conn.execute(
+                f"UPDATE {fq_table('memory_units')} "
+                f"SET consolidated_at = $2, consolidation_failed_at = NULL "
+                f"WHERE bank_id = $1 AND fact_type IN ('world', 'experience') AND id != $3",
+                bank,
+                consolidated_ts,
+                failed_fact_id,
+            )
+            await conn.execute(
+                f"UPDATE {fq_table('memory_units')} "
+                f"SET consolidated_at = NULL, consolidation_failed_at = $2 "
+                f"WHERE bank_id = $1 AND id = $3",
+                bank,
+                failed_ts,
+                failed_fact_id,
+            )
+
+        source_lifecycle = await _fact_lifecycle(memory, bank)
+        source_obs_count = await _observation_count(memory, bank)
+        assert source_obs_count == 1
+        assert await _eligible_fact_count(memory, bank) == 0
+
+        from hindsight_api.engine.transfer import export_bank
+
+        async with acquire_with_retry(backend) as conn:
+            archive = await export_bank(conn, bank)
+        # Delete then restore into the same id — exact round-trip.
+        await memory.delete_bank(bank, request_context=request_context)
+        await memory.import_bank_async(archive, request_context)
+
+        # Lifecycle preserved verbatim: consolidated stays consolidated (same
+        # timestamp — not now()), the failed fact keeps consolidation_failed_at.
+        assert await _fact_lifecycle(memory, bank) == source_lifecycle
+        # No phantom backlog for the reconciler, observation not re-derived.
+        assert await _eligible_fact_count(memory, bank) == 0
+        assert await _observation_count(memory, bank) == source_obs_count
+    finally:
+        await memory.delete_bank(bank, request_context=request_context)
+
+
 @pytest.mark.asyncio
 async def test_bank_export_import_exact_roundtrip(memory, request_context):
     """A whole-bank archive restores EXACT bank content (config, docs, facts,


### PR DESCRIPTION
Fixes #2965.

## Problem

Whole-bank `export-bank`/`import-bank` did not preserve per-fact consolidation lifecycle state. Imported `world`/`experience` facts lost `created_at`, `consolidated_at`, and `consolidation_failed_at`.

Import reconstructed consolidation state **only from surviving observation lineage** — it marked `consolidated_at = now()` for facts that still backed a restored observation, and nothing else. A fact that was consolidated (or that *failed* consolidation) in the source but no longer backs a surviving observation (after an observation merge/update/delete, or a consolidation that produced no lasting observation, or any failed fact) fell through and landed with `consolidated_at IS NULL AND consolidation_failed_at IS NULL`.

`banks_needing_consolidation()` gates exactly on that predicate, so the maintenance reconciler treated those facts as fresh backlog and re-consolidated them — duplicating/rewriting observations (reported: 1,227 → 1,519 observations with no new retain; a failed-state fact re-processed). This violates the whole-bank transfer contract of restoring exact state "without firing webhooks or re-running consolidation".

## Fix

The whole-bank archive already carries observations, so the correct invariant is *restore exact state, derive nothing* — preserve the per-fact lifecycle rather than reconstruct it from lineage (which genuinely can't recover failed facts or observationless-but-consolidated facts).

- **`schema.py`** — `TransferFact` gains optional `created_at` / `consolidated_at` / `consolidation_failed_at`. Absent in pre-fix archives → `None` → legacy fallback path, so old archives still import.
- **`export.py`** — carry lifecycle **exactly when observations are carried**: always for `export_bank`, and for `export_documents` only with `include_observations=True`. The plain document export deliberately omits them so the target re-consolidates from scratch — correct there, since that path carries no observations.
- **`importer.py`** — `_restore_fact_lifecycle` writes the source timestamps verbatim after fact insert. The observation-source marking became `SET consolidated_at = COALESCE(consolidated_at, now())` so it no longer clobbers a restored timestamp (and still covers legacy archives).

`SCHEMA_VERSION` is intentionally **not** bumped — the new fields are additive-optional, and `parse_archive` rejects version mismatches, so a bump would reject pre-fix archives.

## Scope

This closes the reported bug: with lifecycle preserved, consolidated/failed facts are never re-eligible, so the dangerous duplication race (reconcile firing mid-import on phantom backlog) is gone — both reproductions in the issue had no genuine backlog. The issue also suggests an explicit `import_in_progress` reconciler guard; that only matters for a *genuine* source backlog imported over a long window, which is a separate, smaller concern. Left as a follow-up to keep this PR minimal.

## Test

`test_bank_import_preserves_consolidation_lifecycle` builds a source with consolidated facts that do **not** back any surviving observation plus a `consolidation_failed_at` fact, then asserts after export→delete→import:
- per-fact lifecycle equals the source exactly (consolidated stays consolidated with the **same** timestamp, not `now()`; failed fact keeps `consolidation_failed_at`),
- zero reconciler-eligible facts (`banks_needing_consolidation()` predicate),
- observation count unchanged.

Verified the test **fails without the importer restore** and passes with it. Full `test_document_transfer.py`: 24 passed (including the document-level `test_import_triggers_consolidation`, which confirms the plain document path still re-consolidates).
