### PR TITLE
fix(operations): re-runnable batch_retain parents (retry re-queues children)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -13128,15 +13128,73 @@ class MemoryEngine(MemoryEngineInterface):
                 )
                 if not row:
                     raise ValueError(f"Operation {operation_id} not found for bank {bank_id}")
-                # A batch_retain parent is a payload-less status aggregator. Retrying
-                # it would only re-strand it 'pending' — no worker can claim a
-                # NULL-payload row, and its already-terminal children won't re-run.
-                # Point the caller at the supported recovery instead. See issue #2985.
+                # A batch_retain parent is a payload-less status aggregator that no
+                # worker can execute directly, so the conditional UPDATE above skips
+                # it. Retrying it means re-running the batch's outstanding work:
+                # re-queue its failed/cancelled children so a worker picks them up,
+                # then revive the parent so it re-aggregates. Children that are still
+                # pending/processing are left untouched — a live worker owns a
+                # 'processing' child, and resetting it would let a second worker race
+                # it on the same document_id (#1795). The parent is revived only when
+                # at least one non-completed child remains to drive the reconcile;
+                # otherwise it would strand 'pending' with nothing to promote it (the
+                # #2985 bug). If nothing is retryable, fall through to the 409 below.
                 if row["operation_type"] == "batch_retain" and row["task_payload"] is None:
+                    child_filter = json.dumps({"parent_operation_id": operation_id})
+                    await conn.execute(
+                        f"""
+                        UPDATE {fq_table("async_operations")}
+                        SET status = 'pending',
+                            error_message = NULL,
+                            completed_at = NULL,
+                            next_retry_at = NULL,
+                            worker_id = NULL,
+                            claimed_at = NULL,
+                            retry_count = 0,
+                            updated_at = NOW()
+                        WHERE bank_id = $1
+                          AND result_metadata::jsonb @> $2::jsonb
+                          AND status IN ('failed', 'cancelled')
+                        """,
+                        bank_id,
+                        child_filter,
+                    )
+                    revived = await conn.fetchrow(
+                        f"""
+                        UPDATE {fq_table("async_operations")}
+                        SET status = 'pending',
+                            error_message = NULL,
+                            completed_at = NULL,
+                            next_retry_at = NULL,
+                            worker_id = NULL,
+                            claimed_at = NULL,
+                            retry_count = 0,
+                            updated_at = NOW()
+                        WHERE operation_id = $1
+                          AND bank_id = $2
+                          AND EXISTS (
+                              SELECT 1 FROM {fq_table("async_operations")} child
+                              WHERE child.bank_id = $2
+                                AND child.result_metadata::jsonb @> $3::jsonb
+                                AND child.status <> 'completed'
+                          )
+                        RETURNING operation_id
+                        """,
+                        op_uuid,
+                        bank_id,
+                        child_filter,
+                    )
+                    if revived is not None:
+                        return {
+                            "success": True,
+                            "message": f"Operation {operation_id} queued for retry",
+                            "operation_id": operation_id,
+                        }
                     raise OperationValidationError(
-                        f"Operation {operation_id} is a batch_retain parent (a status aggregator with no "
-                        f"payload) and cannot be retried directly. Resubmit the source documents, then "
-                        f"delete this record via DELETE /operations/{operation_id}/delete.",
+                        f"Operation {operation_id} is a batch_retain parent with no incomplete sub-batches "
+                        f"to retry (its children have all completed, or it has none). Resubmit the source "
+                        f"documents to re-ingest them, then delete this record via "
+                        f"DELETE /operations/{operation_id}/delete.",
                         409,
                     )
                 raise OperationValidationError(

--- a/hindsight-api-slim/tests/test_async_batch_retain.py
+++ b/hindsight-api-slim/tests/test_async_batch_retain.py
@@ -1432,3 +1432,110 @@ async def test_submit_async_batch_retain_rolls_back_missing_bank_on_child_failur
 
     bank = await pool.fetchrow("SELECT bank_id FROM banks WHERE bank_id = $1", bank_id)
     assert bank is None, "the lazily-created bank must roll back with the failed operation inserts"
+
+
+# ── retrying a batch_retain parent re-runs its outstanding children ─────────
+# Regression for #2985's retry guard, which rejected *every* payload-null
+# batch_retain parent — that made `retain --async` operations un-retryable
+# (their operation_id is always such a parent) and 409'd the operations doc
+# example. Retry now re-queues the parent's failed/cancelled children and
+# revives the parent, without touching in-flight children or re-stranding a
+# parent whose work is already done.
+
+
+async def _insert_parent(conn, bank_id: str, parent_id, status: str) -> None:
+    await conn.execute(
+        "INSERT INTO banks (bank_id, name) VALUES ($1, $1) ON CONFLICT DO NOTHING",
+        bank_id,
+    )
+    await conn.execute(
+        "INSERT INTO async_operations (operation_id, bank_id, operation_type, status, result_metadata) "
+        "VALUES ($1, $2, 'batch_retain', $3, $4::jsonb)",
+        parent_id,
+        bank_id,
+        status,
+        json.dumps({"is_parent": True}),
+    )
+
+
+async def _insert_child(conn, bank_id: str, child_id, parent_id, status: str) -> None:
+    await conn.execute(
+        "INSERT INTO async_operations "
+        "(operation_id, bank_id, operation_type, status, task_payload, result_metadata) "
+        "VALUES ($1, $2, 'retain', $3, $4::jsonb, $5::jsonb)",
+        child_id,
+        bank_id,
+        status,
+        json.dumps({"contents": []}),
+        json.dumps({"parent_operation_id": str(parent_id)}),
+    )
+
+
+@pytest.mark.asyncio
+async def test_retry_batch_parent_requeues_failed_child_and_revives_parent(memory, request_context):
+    from hindsight_api.engine.db_utils import acquire_with_retry
+
+    bank_id = f"retry-parent-{uuid.uuid4().hex[:8]}"
+    parent_id, child_id = uuid.uuid4(), uuid.uuid4()
+    backend = await memory._get_backend()
+    async with acquire_with_retry(backend) as conn:
+        await _insert_parent(conn, bank_id, parent_id, "cancelled")
+        await _insert_child(conn, bank_id, child_id, parent_id, "failed")
+
+    result = await memory.retry_operation(bank_id, str(parent_id), request_context=request_context)
+    assert result["success"] is True
+
+    async with acquire_with_retry(backend) as conn:
+        rows = {
+            r["operation_id"]: r["status"]
+            for r in await conn.fetch("SELECT operation_id, status FROM async_operations WHERE bank_id = $1", bank_id)
+        }
+    assert rows[child_id] == "pending", "the failed child must be re-queued"
+    assert rows[parent_id] == "pending", "the parent must be revived so it re-aggregates"
+
+
+@pytest.mark.asyncio
+async def test_retry_batch_parent_leaves_processing_child_untouched(memory, request_context):
+    # A 'processing' child is owned by a live worker; resetting it would let a
+    # second worker race it on the same document_id (#1795). Retry must revive
+    # the parent (the processing child is non-completed) but not touch the child.
+    from hindsight_api.engine.db_utils import acquire_with_retry
+
+    bank_id = f"retry-parent-{uuid.uuid4().hex[:8]}"
+    parent_id, child_id = uuid.uuid4(), uuid.uuid4()
+    backend = await memory._get_backend()
+    async with acquire_with_retry(backend) as conn:
+        await _insert_parent(conn, bank_id, parent_id, "cancelled")
+        await _insert_child(conn, bank_id, child_id, parent_id, "processing")
+
+    result = await memory.retry_operation(bank_id, str(parent_id), request_context=request_context)
+    assert result["success"] is True
+
+    async with acquire_with_retry(backend) as conn:
+        rows = {
+            r["operation_id"]: r["status"]
+            for r in await conn.fetch("SELECT operation_id, status FROM async_operations WHERE bank_id = $1", bank_id)
+        }
+    assert rows[child_id] == "processing", "an in-flight child must not be reset"
+    assert rows[parent_id] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_retry_batch_parent_all_children_completed_is_rejected(memory, request_context):
+    from hindsight_api.engine.db_utils import acquire_with_retry
+    from hindsight_api.extensions import OperationValidationError
+
+    bank_id = f"retry-parent-{uuid.uuid4().hex[:8]}"
+    parent_id, child_id = uuid.uuid4(), uuid.uuid4()
+    backend = await memory._get_backend()
+    async with acquire_with_retry(backend) as conn:
+        await _insert_parent(conn, bank_id, parent_id, "cancelled")
+        await _insert_child(conn, bank_id, child_id, parent_id, "completed")
+
+    with pytest.raises(OperationValidationError) as exc:
+        await memory.retry_operation(bank_id, str(parent_id), request_context=request_context)
+    assert exc.value.status_code == 409
+
+    async with acquire_with_retry(backend) as conn:
+        parent = await conn.fetchrow("SELECT status FROM async_operations WHERE operation_id = $1", parent_id)
+    assert parent["status"] == "cancelled", "a parent with no retryable work must not be revived (no re-strand)"

--- a/hindsight-api-slim/tests/test_operation_status.py
+++ b/hindsight-api-slim/tests/test_operation_status.py
@@ -273,11 +273,13 @@ async def test_retry_rejects_non_retriable_statuses(api_client, memory, test_ban
 
 @pytest.mark.asyncio
 async def test_retry_rejects_batch_retain_parent(api_client, memory, test_bank_id):
-    """A failed batch_retain parent (no payload) must not be retried into a re-stranded state.
+    """A failed batch_retain parent with no retryable work must not be revived into a re-stranded state.
 
-    The parent is a payload-less status aggregator: retrying it would set it back to
-    'pending' where no worker can ever claim it and its terminal children won't re-run
-    (issue #2985). The 409 should point the caller at resubmit + delete instead.
+    The parent is a payload-less status aggregator, so retrying it only makes sense
+    when it still has failed/cancelled children to re-run (see the retry tests in
+    test_async_batch_retain.py). This parent has no children at all, so there is
+    nothing to re-queue — reviving it would strand it 'pending' forever (issue #2985).
+    The 409 should point the caller at resubmit + delete instead.
     """
     pool = memory._pool
     await _ensure_bank(pool, test_bank_id)


### PR DESCRIPTION
## Summary

Fixes `test-doc-examples (cli)` — which is **red on `main`** — by fixing the regression that broke it.

## Root cause (a regression from #2985/#2986, merged the same day)

#2985 added a retry guard: `retry_operation` rejects any payload-null `batch_retain` parent (to avoid re-stranding a reconciled aggregator). But `submit_async_retain` **always** creates such a parent — even for a single item — and `retain --async` returns *that* parent's `operation_id`. So:

- Retrying any `retain --async` operation now 409s. That is a user-facing regression (you can't retry your own async retain), and it broke `operations.sh`'s retry example (`retain --async` → `cancel` → `retry` → **409**), turning `test-doc-examples (cli)` red on main.
- There's no clean CLI way to retry a *child* (the operation API exposes no parent/child linkage), so this can't be worked around in the doc example.

(My first attempt on this branch — hardening the doc example against a "worker race" — was based on a wrong root cause and has been reverted.)

## Fix

Make retrying a `batch_retain` parent **re-run the batch's outstanding work** instead of rejecting it:

- re-queue the parent's **failed/cancelled** children to `pending`;
- revive the parent to `pending` so it re-aggregates — but **only when ≥1 non-completed child remains** to drive the reconcile, else it would strand `pending` with nothing to promote it (the exact #2985 bug the guard was protecting against);
- leave **pending/processing** children untouched — a live worker owns a `processing` child, and resetting it would let a second worker race it on the same `document_id` (#1795);
- if nothing is retryable (no children, or all completed), keep the **409** pointing at resubmit + delete.

This restores the natural "retry my async retain" UX and fixes the doc example **with no change to `operations.sh`**.

## Tests (deterministic, direct `async_operations` rows — no live worker/LLM)

- failed child → re-queued + parent revived;
- processing child → untouched, parent revived;
- all children completed → 409, parent **not** revived (no re-strand).

Also updated `test_retry_rejects_batch_retain_parent`'s docstring — it now specifically covers the childless parent (still correctly 409s).
