### PR TITLE
feat(consolidation): require minimum sources for observations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -222,6 +222,9 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_TEMPORAL_SEMANTIC_MIN_SIMILARITY=0.1
 # HINDSIGHT_API_SEMANTIC_LINK_MIN_SIMILARITY=0.7
 # HINDSIGHT_API_CONSOLIDATION_DEDUP_THRESHOLD=0.97
+# Minimum distinct input facts required for a new observation (default: 1).
+# Set to 2+ when observations should only contain multi-fact synthesis.
+# HINDSIGHT_API_MIN_OBSERVATION_SOURCE_FACTS=1
 
 # Reranker Configuration (Optional - uses local by default)
 # Provider: "local" (default) or "tei" (HuggingFace Text Embeddings Inference)

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2298,6 +2298,11 @@ class BankTemplateConfig(BaseModel):
     consolidation_source_facts_max_tokens_per_observation: int | None = Field(
         default=None, description="Max tokens of source facts per observation"
     )
+    min_observation_source_facts: int | None = Field(
+        default=None,
+        ge=1,
+        description="Minimum number of distinct source facts required to create an observation",
+    )
     max_observations_per_scope: int | None = Field(
         default=None, description="Max observations to retain per consolidation scope"
     )

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -623,6 +623,7 @@ ENV_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS_PER_OBSERVATION = (
 ENV_CONSOLIDATION_RECALL_BUDGET = "HINDSIGHT_API_CONSOLIDATION_RECALL_BUDGET"
 ENV_CONSOLIDATION_MAX_ATTEMPTS = "HINDSIGHT_API_CONSOLIDATION_MAX_ATTEMPTS"
 ENV_OBSERVATIONS_MISSION = "HINDSIGHT_API_OBSERVATIONS_MISSION"
+ENV_MIN_OBSERVATION_SOURCE_FACTS = "HINDSIGHT_API_MIN_OBSERVATION_SOURCE_FACTS"
 ENV_MAX_OBSERVATIONS_PER_SCOPE = "HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE"
 ENV_OBSERVATION_SCOPE_LIMITS = "HINDSIGHT_API_OBSERVATION_SCOPE_LIMITS"
 ENV_ENABLE_OBSERVATION_HISTORY = "HINDSIGHT_API_ENABLE_OBSERVATION_HISTORY"
@@ -1125,6 +1126,7 @@ DEFAULT_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS_PER_OBSERVATION = (
     256  # Max tokens of source facts per observation in consolidation prompt (-1 = unlimited)
 )
 DEFAULT_OBSERVATIONS_MISSION = None  # Declarative spec of what observations are for this bank
+DEFAULT_MIN_OBSERVATION_SOURCE_FACTS = 1  # Minimum distinct source facts required for a new observation
 DEFAULT_MAX_OBSERVATIONS_PER_SCOPE = -1  # Max observations per tag scope (-1 = unlimited)
 # Per-scope overrides of the cap above: list of {"scope": [tag-globs], "limit": int}.
 # First rule whose pattern exact-covers a scope's tags wins; else the default above.
@@ -2030,6 +2032,7 @@ class HindsightConfig:
     consolidation_source_facts_max_tokens_per_observation: int
     consolidation_max_attempts: int
     observations_mission: str | None
+    min_observation_source_facts: int
     max_observations_per_scope: int
     # Per-scope observation caps overriding max_observations_per_scope.
     # Raw JSON shape: [{"scope": ["run_*", "shared"], "limit": 1}, ...]
@@ -2275,6 +2278,7 @@ class HindsightConfig:
         "consolidation_source_facts_max_tokens",
         "consolidation_source_facts_max_tokens_per_observation",
         "observations_mission",
+        "min_observation_source_facts",
         "max_observations_per_scope",
         "observation_scope_limits",
         # Reflect settings
@@ -2404,6 +2408,9 @@ class HindsightConfig:
 
         if self.bm25_max_query_terms < 0:
             raise ValueError(f"Invalid bm25_max_query_terms: {self.bm25_max_query_terms}. Must be >= 0")
+
+        if self.min_observation_source_facts < 1:
+            raise ValueError(f"Invalid min_observation_source_facts: {self.min_observation_source_facts}. Must be >= 1")
 
         # Validate bedrock_service_tier
         valid_bedrock_tiers = (None, "flex", "priority", "reserved")
@@ -3161,6 +3168,12 @@ class HindsightConfig:
                 os.getenv(ENV_CONSOLIDATION_MAX_ATTEMPTS, str(DEFAULT_CONSOLIDATION_MAX_ATTEMPTS))
             ),
             observations_mission=os.getenv(ENV_OBSERVATIONS_MISSION) or DEFAULT_OBSERVATIONS_MISSION,
+            min_observation_source_facts=int(
+                os.getenv(
+                    ENV_MIN_OBSERVATION_SOURCE_FACTS,
+                    str(DEFAULT_MIN_OBSERVATION_SOURCE_FACTS),
+                )
+            ),
             max_observations_per_scope=int(
                 os.getenv(ENV_MAX_OBSERVATIONS_PER_SCOPE, str(DEFAULT_MAX_OBSERVATIONS_PER_SCOPE))
             ),

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -1701,7 +1701,20 @@ async def _process_memory_batch(
     update_texts = {_norm_obs_text(u.text) for u in llm_result.updates if u.text}
 
     for create in llm_result.creates:
-        source_mems = [mem_by_id[fid] for fid in create.source_fact_ids if fid in mem_by_id]
+        # A mission can ask the LLM to synthesise only multi-fact observations,
+        # but prompt instructions are advisory. Enforce the configured minimum
+        # deterministically before any dedup or persistence side effects.
+        create_source_fact_ids = list(dict.fromkeys(fid for fid in create.source_fact_ids if fid in mem_by_id))
+        min_source_facts = max(1, getattr(config, "min_observation_source_facts", 1))
+        if len(create_source_fact_ids) < min_source_facts:
+            logger.info(
+                "[CONSOLIDATION] dropped observation CREATE with %d distinct source fact(s); minimum is %d",
+                len(create_source_fact_ids),
+                min_source_facts,
+            )
+            continue
+
+        source_mems = [mem_by_id[fid] for fid in create_source_fact_ids]
         if not source_mems:
             continue
         agg = _aggregate_source_fields(source_mems, tags=fact_tags)
@@ -2237,20 +2250,30 @@ async def _consolidate_batch_with_llm(
 
     facts_lines = "\n".join(_fact_line(m) for m in memories)
 
-    # Build capacity note for the prompt when observation limit is configured
-    observation_capacity_note: str | None = None
+    # Build hard-constraint guidance for the prompt. Runtime validation below
+    # remains authoritative because model instructions are advisory.
+    observation_constraint_notes: list[str] = []
+    min_source_facts = max(1, getattr(config, "min_observation_source_facts", 1))
+    if min_source_facts > 1:
+        observation_constraint_notes.append(
+            f"Each CREATE must reference at least {min_source_facts} distinct facts "
+            "from the current input via source_fact_ids. If there is insufficient "
+            "evidence, skip CREATE; UPDATE an existing observation only when appropriate."
+        )
+
     if remaining_observation_slots is not None and max_observations_per_scope >= 0:
         if remaining_observation_slots == 0:
-            observation_capacity_note = (
+            observation_constraint_notes.append(
                 f"OBSERVATION LIMIT REACHED ({max_observations_per_scope}/{max_observations_per_scope}). "
                 "Only UPDATE or DELETE existing observations. Do NOT create new ones — "
                 "merge new knowledge into existing observations via UPDATE."
             )
         elif remaining_observation_slots <= len(memories):
-            observation_capacity_note = (
+            observation_constraint_notes.append(
                 f"This scope has {remaining_observation_slots} observation slot(s) remaining "
                 f"(out of {max_observations_per_scope}). Prefer UPDATE over CREATE when possible."
             )
+    observation_capacity_note = " ".join(observation_constraint_notes) or None
 
     # Split the prompt: a bank-agnostic system instruction (rules + input format +
     # decision guide + output format) that is byte-identical across batches AND

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -95,6 +95,11 @@ def _duplicate_create_target(
 # semantic dedup is enabled. Small: we only need the nearest few candidates.
 _DEDUP_TOP_K = 5
 
+# Cross-batch candidates are considered only when genuinely new facts trigger a
+# consolidation call. The bounded scan/pool means a quiet bank performs no retries,
+# and an old fact naturally ages out instead of being sent to the LLM forever.
+_CROSS_BATCH_CANDIDATE_SCAN_LIMIT = 200
+
 
 class _DedupDecision(BaseModel):
     """Focused 1-by-1 verdict for whether a new observation duplicates an existing one."""
@@ -366,6 +371,78 @@ class _BatchDeltas:
     stats: dict[str, int]
     tags: set[str]
     cancelled: bool
+
+
+async def _load_cross_batch_candidates(
+    conn: "Connection",
+    memory_engine: "MemoryEngine",
+    bank_id: str,
+    primary_memories: list[dict[str, Any]],
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Return recent unsourced world facts compatible with a new LLM batch.
+
+    ``consolidated_at`` continues to mean that the fact completed a consolidation
+    attempt. Facts that did not become observation sources remain eligible here,
+    but only as bounded carry-over context for a later batch containing new facts.
+    """
+    if not primary_memories or limit <= 0:
+        return []
+
+    if memory_engine._backend.ops.uses_observation_sources_table:
+        unsourced_clause = f"""
+            AND NOT EXISTS (
+                SELECT 1
+                FROM {fq_table("observation_sources")} os
+                WHERE os.source_id = candidate.id
+            )
+        """
+    else:
+        unsourced_clause = f"""
+            AND NOT EXISTS (
+                SELECT 1
+                FROM {fq_table("memory_units")} observation
+                WHERE observation.bank_id = candidate.bank_id
+                  AND observation.fact_type = 'observation'
+                  AND observation.source_memory_ids @> ARRAY[candidate.id]
+            )
+        """
+
+    rows = await conn.fetch(
+        f"""
+        SELECT candidate.id, candidate.text, candidate.fact_type,
+               candidate.occurred_start, candidate.occurred_end,
+               candidate.event_date, candidate.tags, candidate.mentioned_at,
+               candidate.observation_scopes
+        FROM {fq_table("memory_units")} candidate
+        WHERE candidate.bank_id = $1
+          AND candidate.fact_type = 'world'
+          AND candidate.consolidated_at IS NOT NULL
+          AND candidate.consolidation_failed_at IS NULL
+          {unsourced_clause}
+        ORDER BY candidate.consolidated_at DESC, candidate.created_at DESC
+        LIMIT $2
+        """,
+        bank_id,
+        _CROSS_BATCH_CANDIDATE_SCAN_LIMIT,
+    )
+
+    primary_ids = {str(memory["id"]) for memory in primary_memories}
+    required_tags = tuple(sorted(primary_memories[0].get("tags") or []))
+    required_scopes = set(_resolve_write_scopes(primary_memories[0]))
+    candidates: list[dict[str, Any]] = []
+    for row in rows:
+        candidate = dict(row)
+        if str(candidate["id"]) in primary_ids:
+            continue
+        if tuple(sorted(candidate.get("tags") or [])) != required_tags:
+            continue
+        if set(_resolve_write_scopes(candidate)) != required_scopes:
+            continue
+        candidates.append(candidate)
+        if len(candidates) == limit:
+            break
+    return candidates
 
 
 def _parse_observation_scopes(memory: dict[str, Any]) -> Any:
@@ -1050,6 +1127,27 @@ async def _run_consolidation_job(
                 sub_batch = pending.pop(0)
 
                 async with acquire_with_retry(pool) as conn:
+                    candidate_capacity = max(llm_batch_size, config.min_observation_source_facts)
+                    candidate_limit = max(candidate_capacity - len(sub_batch), 0)
+                    carryover_memories = (
+                        await _load_cross_batch_candidates(
+                            conn=conn,
+                            memory_engine=memory_engine,
+                            bank_id=bank_id,
+                            primary_memories=sub_batch,
+                            limit=candidate_limit,
+                        )
+                        if config.min_observation_source_facts > 1
+                        else []
+                    )
+                    consolidation_memories = sub_batch + carryover_memories
+                    if carryover_memories:
+                        logger.info(
+                            "[CONSOLIDATION] bank=%s added %d bounded cross-batch world candidate(s) to %d new fact(s)",
+                            bank_id,
+                            len(carryover_memories),
+                            len(sub_batch),
+                        )
                     obs_tags_list = _resolve_obs_tags_list(sub_batch[0]) if sub_batch else None
 
                     sub_deleted: int = 0
@@ -1062,12 +1160,13 @@ async def _run_consolidation_job(
                                 memory_engine=memory_engine,
                                 llm_config=llm_config,
                                 bank_id=bank_id,
-                                memories=sub_batch,
+                                memories=consolidation_memories,
                                 request_context=request_context,
                                 perf=batch_perf,
                                 config=config,
                                 obs_tags_override=obs_tags,
                             )
+                            pass_results = pass_results[: len(sub_batch)]
                             sub_deleted += pass_deleted
                             sub_llm_failed = sub_llm_failed or pass_failed
                             if not sub_results:
@@ -1099,11 +1198,12 @@ async def _run_consolidation_job(
                             memory_engine=memory_engine,
                             llm_config=llm_config,
                             bank_id=bank_id,
-                            memories=sub_batch,
+                            memories=consolidation_memories,
                             request_context=request_context,
                             perf=batch_perf,
                             config=config,
                         )
+                        sub_results = sub_results[: len(sub_batch)]
 
                 all_deleted += sub_deleted
 
@@ -1616,6 +1716,7 @@ async def _process_memory_batch(
     # Track which memory indices participated so we can build per-memory results for stats
     per_memory_created: set[str] = set()
     per_memory_updated: set[str] = set()
+    per_memory_deferred: set[str] = set()
 
     mem_by_id = {str(m["id"]): m for m in memories}
 
@@ -1646,7 +1747,8 @@ async def _process_memory_batch(
         deleted_count += 1
 
     for update in llm_result.updates:
-        source_mems = [mem_by_id[fid] for fid in update.source_fact_ids if fid in mem_by_id]
+        update_source_fact_ids = list(dict.fromkeys(fid for fid in update.source_fact_ids if fid in mem_by_id))
+        source_mems = [mem_by_id[fid] for fid in update_source_fact_ids]
         if not source_mems:
             continue
         # Security: the observation must have been recalled for at least one of the source facts
@@ -1699,14 +1801,15 @@ async def _process_memory_batch(
     # Also collapse a CREATE that reproduces the text of an UPDATE issued in the SAME
     # response (the model occasionally UPDATEs the twin to text X and also CREATEs X).
     update_texts = {_norm_obs_text(u.text) for u in llm_result.updates if u.text}
+    min_source_facts = max(1, getattr(config, "min_observation_source_facts", 1))
 
     for create in llm_result.creates:
         # A mission can ask the LLM to synthesise only multi-fact observations,
         # but prompt instructions are advisory. Enforce the configured minimum
         # deterministically before any dedup or persistence side effects.
         create_source_fact_ids = list(dict.fromkeys(fid for fid in create.source_fact_ids if fid in mem_by_id))
-        min_source_facts = max(1, getattr(config, "min_observation_source_facts", 1))
         if len(create_source_fact_ids) < min_source_facts:
+            per_memory_deferred.update(create_source_fact_ids)
             logger.info(
                 "[CONSOLIDATION] dropped observation CREATE with %d distinct source fact(s); minimum is %d",
                 len(create_source_fact_ids),
@@ -1779,6 +1882,8 @@ async def _process_memory_batch(
             results.append({"action": "created"})
         elif updated:
             results.append({"action": "updated"})
+        elif mid in per_memory_deferred or len(memories) < min_source_facts:
+            results.append({"action": "skipped", "reason": "awaiting_additional_evidence"})
         else:
             results.append({"action": "skipped", "reason": "no_durable_knowledge"})
 
@@ -1908,7 +2013,9 @@ async def _execute_update_action(
         new_source_memory_ids=[str(mid) for mid in source_memory_ids],
     )
 
-    source_ids = list(model.source_fact_ids or []) + source_memory_ids
+    source_ids = list(
+        dict.fromkeys(uuid.UUID(str(source_id)) for source_id in list(model.source_fact_ids or []) + source_memory_ids)
+    )
 
     # SECURITY: Merge source fact's tags into existing observation tags so all contributors can see it
     existing_tags = set(model.tags or [])

--- a/hindsight-api-slim/tests/test_bank_template_configurable_fields.py
+++ b/hindsight-api-slim/tests/test_bank_template_configurable_fields.py
@@ -38,6 +38,7 @@ NEW_FIELDS: list[tuple[str, object]] = [
     ("consolidation_llm_batch_size", 11),
     ("consolidation_source_facts_max_tokens", 2048),
     ("consolidation_source_facts_max_tokens_per_observation", 256),
+    ("min_observation_source_facts", 2),
     ("max_observations_per_scope", 13),
     ("reflect_source_facts_max_tokens", 4096),
     ("llm_gemini_safety_settings", [{"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_NONE"}]),

--- a/hindsight-api-slim/tests/test_consolidation.py
+++ b/hindsight-api-slim/tests/test_consolidation.py
@@ -3211,7 +3211,11 @@ async def test_min_observation_source_facts_blocks_single_fact_creates(monkeypat
             consolidator._CreateAction(
                 text="Alice enjoys the outdoors.",
                 source_fact_ids=["fact-a", "fact-a"],
-            )
+            ),
+            consolidator._CreateAction(
+                text="Bob enjoys the outdoors.",
+                source_fact_ids=["fact-b", "not-a-live-batch-fact"],
+            ),
         ]
     )
     monkeypatch.setattr(
@@ -3244,8 +3248,8 @@ async def test_min_observation_source_facts_blocks_single_fact_creates(monkeypat
 
     create_action.assert_not_awaited()
     assert results == [
-        {"action": "skipped", "reason": "no_durable_knowledge"},
-        {"action": "skipped", "reason": "no_durable_knowledge"},
+        {"action": "skipped", "reason": "awaiting_additional_evidence"},
+        {"action": "skipped", "reason": "awaiting_additional_evidence"},
     ]
     assert deleted == 0
     assert failed is False
@@ -3301,6 +3305,306 @@ async def test_min_observation_source_facts_allows_multi_fact_create(monkeypatch
     assert results == [{"action": "created"}, {"action": "created"}]
     assert deleted == 0
     assert failed is False
+
+
+@pytest.mark.asyncio
+async def test_min_observation_source_facts_one_allows_single_fact_create(monkeypatch):
+    """The default threshold preserves single-source CREATE behavior."""
+    from hindsight_api.engine.consolidation import consolidator
+
+    memory_row = {"id": "fact-a", "text": "Alice hikes.", "tags": []}
+    monkeypatch.setattr(
+        consolidator,
+        "_find_related_observations",
+        AsyncMock(return_value=SimpleNamespace(results=[], source_facts={})),
+    )
+    monkeypatch.setattr(
+        consolidator,
+        "_consolidate_batch_with_llm",
+        AsyncMock(
+            return_value=consolidator._BatchLLMResult(
+                creates=[
+                    consolidator._CreateAction(
+                        text="Alice hikes.",
+                        source_fact_ids=["fact-a"],
+                    )
+                ]
+            )
+        ),
+    )
+    create_action = AsyncMock()
+    monkeypatch.setattr(consolidator, "_execute_create_action", create_action)
+
+    results, _, failed = await consolidator._process_memory_batch(
+        conn=MagicMock(),
+        memory_engine=MagicMock(),
+        llm_config=MagicMock(),
+        bank_id="test-bank",
+        memories=[memory_row],
+        request_context=SimpleNamespace(),
+        config=SimpleNamespace(
+            observation_scope_limits=None,
+            max_observations_per_scope=-1,
+            min_observation_source_facts=1,
+            consolidation_dedup_threshold=1.0,
+        ),
+    )
+
+    create_action.assert_awaited_once()
+    assert results == [{"action": "created"}]
+    assert failed is False
+
+
+@pytest.mark.asyncio
+async def test_min_observation_source_facts_does_not_block_single_fact_update(monkeypatch):
+    """A single new fact may evolve an existing observation when CREATE requires two."""
+    from hindsight_api.engine.consolidation import consolidator
+
+    observation = SimpleNamespace(id="observation-a", text="Alice hikes.", tags=[], source_fact_ids=["old-fact"])
+    monkeypatch.setattr(
+        consolidator,
+        "_find_related_observations",
+        AsyncMock(return_value=SimpleNamespace(results=[observation], source_facts={})),
+    )
+    monkeypatch.setattr(
+        consolidator,
+        "_consolidate_batch_with_llm",
+        AsyncMock(
+            return_value=consolidator._BatchLLMResult(
+                updates=[
+                    consolidator._UpdateAction(
+                        observation_id="observation-a",
+                        text="Alice hikes and camps.",
+                        source_fact_ids=["fact-a", "fact-a"],
+                    )
+                ]
+            )
+        ),
+    )
+    update_action = AsyncMock(return_value=None)
+    monkeypatch.setattr(consolidator, "_execute_update_action", update_action)
+
+    results, _, failed = await consolidator._process_memory_batch(
+        conn=MagicMock(),
+        memory_engine=MagicMock(),
+        llm_config=MagicMock(),
+        bank_id="test-bank",
+        memories=[{"id": "fact-a", "text": "Alice camps.", "tags": []}],
+        request_context=SimpleNamespace(),
+        config=SimpleNamespace(
+            observation_scope_limits=None,
+            max_observations_per_scope=-1,
+            min_observation_source_facts=2,
+            consolidation_dedup_threshold=1.0,
+        ),
+    )
+
+    update_action.assert_awaited_once()
+    assert update_action.await_args.kwargs["source_memory_ids"] == ["fact-a"]
+    assert results == [{"action": "updated"}]
+    assert failed is False
+
+
+@pytest.mark.asyncio
+async def test_update_accumulates_historical_sources_without_duplicates(monkeypatch):
+    """UPDATE preserves old sources and adds each live new source once."""
+    from hindsight_api.engine.consolidation import consolidator
+
+    observation_id = uuid.uuid4()
+    historical_source_id = uuid.uuid4()
+    new_source_id = uuid.uuid4()
+    observation = SimpleNamespace(
+        id=str(observation_id),
+        text="Alice hikes.",
+        tags=[],
+        source_fact_ids=[str(historical_source_id)],
+        occurred_start=None,
+        occurred_end=None,
+        mentioned_at=None,
+    )
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    monkeypatch.setattr(
+        consolidator,
+        "_filter_live_source_memories",
+        AsyncMock(return_value=[new_source_id, new_source_id]),
+    )
+    monkeypatch.setattr(
+        consolidator.embedding_utils,
+        "generate_embeddings_batch",
+        AsyncMock(return_value=[[0.1, 0.2]]),
+    )
+    monkeypatch.setattr(consolidator, "_append_observation_history", AsyncMock())
+    memory_engine = MagicMock()
+    memory_engine._backend.ops.uses_observation_sources_table = False
+
+    await consolidator._execute_update_action(
+        conn=conn,
+        memory_engine=memory_engine,
+        bank_id="test-bank",
+        source_memory_ids=[new_source_id, new_source_id],
+        observation_id=str(observation_id),
+        new_text="Alice hikes and camps.",
+        observations=[observation],
+    )
+
+    persisted_source_ids = conn.execute.await_args_list[0].args[3]
+    assert persisted_source_ids == [historical_source_id, new_source_id]
+
+
+@pytest.mark.asyncio
+async def test_min_observation_source_facts_does_not_force_unrelated_fact_create(monkeypatch):
+    """Meeting the numeric threshold never creates an observation by itself."""
+    from hindsight_api.engine.consolidation import consolidator
+
+    monkeypatch.setattr(
+        consolidator,
+        "_find_related_observations",
+        AsyncMock(return_value=SimpleNamespace(results=[], source_facts={})),
+    )
+    monkeypatch.setattr(
+        consolidator,
+        "_consolidate_batch_with_llm",
+        AsyncMock(return_value=consolidator._BatchLLMResult()),
+    )
+    create_action = AsyncMock()
+    monkeypatch.setattr(consolidator, "_execute_create_action", create_action)
+
+    results, _, failed = await consolidator._process_memory_batch(
+        conn=MagicMock(),
+        memory_engine=MagicMock(),
+        llm_config=MagicMock(),
+        bank_id="test-bank",
+        memories=[
+            {"id": "fact-a", "text": "Alice hikes.", "tags": []},
+            {"id": "fact-b", "text": "Saturn has rings.", "tags": []},
+        ],
+        request_context=SimpleNamespace(),
+        config=SimpleNamespace(
+            observation_scope_limits=None,
+            max_observations_per_scope=-1,
+            min_observation_source_facts=2,
+            consolidation_dedup_threshold=1.0,
+        ),
+    )
+
+    create_action.assert_not_awaited()
+    assert results == [
+        {"action": "skipped", "reason": "no_durable_knowledge"},
+        {"action": "skipped", "reason": "no_durable_knowledge"},
+    ]
+    assert failed is False
+
+
+@pytest.mark.asyncio
+async def test_min_observation_source_facts_combines_world_facts_across_rounds(
+    memory: MemoryEngine,
+    request_context,
+    monkeypatch,
+):
+    """A later new world fact can synthesize with an unsourced prior-round fact."""
+    from hindsight_api.engine.consolidation import consolidator
+
+    bank_id = f"test-cross-round-observation-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    raw = _get_raw_config()
+    config = type(raw)(
+        **{
+            **{field_name: getattr(raw, field_name) for field_name in raw.__dataclass_fields__},
+            "min_observation_source_facts": 2,
+            "consolidation_llm_batch_size": 8,
+        }
+    )
+    monkeypatch.setattr(memory._config_resolver, "resolve_full_config", AsyncMock(return_value=config))
+
+    async def synthesize(memories, **kwargs):
+        fact_ids = [str(memory_row["id"]) for memory_row in memories]
+        if len(fact_ids) == 1:
+            return consolidator._BatchLLMResult(
+                creates=[consolidator._CreateAction(text="Too early.", source_fact_ids=fact_ids)]
+            )
+        return consolidator._BatchLLMResult(
+            creates=[
+                consolidator._CreateAction(
+                    text="Alice regularly explores mountain environments.",
+                    source_fact_ids=fact_ids,
+                )
+            ]
+        )
+
+    monkeypatch.setattr(consolidator, "_consolidate_batch_with_llm", AsyncMock(side_effect=synthesize))
+    create_action = AsyncMock()
+    monkeypatch.setattr(consolidator, "_execute_create_action", create_action)
+
+    try:
+        async with memory._pool.acquire() as conn:
+            first_id = uuid.uuid4()
+            await conn.execute(
+                """
+                INSERT INTO memory_units (id, bank_id, text, fact_type, tags, created_at)
+                VALUES ($1, $2, $3, 'world', $4, now())
+                """,
+                first_id,
+                bank_id,
+                "Alice hikes mountain trails.",
+                ["scope:alice"],
+            )
+
+        first_result = await run_consolidation_job(
+            memory_engine=memory,
+            bank_id=bank_id,
+            request_context=request_context,
+        )
+        assert first_result["observations_created"] == 0
+
+        async with memory._pool.acquire() as conn:
+            first_state = await conn.fetchrow(
+                "SELECT consolidated_at FROM memory_units WHERE id = $1",
+                first_id,
+            )
+            assert first_state["consolidated_at"] is not None
+            assert (
+                await conn.fetchval(
+                    "SELECT COUNT(*) FROM memory_units WHERE bank_id = $1 AND fact_type = 'observation'",
+                    bank_id,
+                )
+                == 0
+            )
+
+            second_id = uuid.uuid4()
+            await conn.execute(
+                """
+                INSERT INTO memory_units (id, bank_id, text, fact_type, tags, created_at)
+                VALUES ($1, $2, $3, 'world', $4, now())
+                """,
+                second_id,
+                bank_id,
+                "Alice camped below an alpine summit.",
+                ["scope:alice"],
+            )
+
+        second_result = await run_consolidation_job(
+            memory_engine=memory,
+            bank_id=bank_id,
+            request_context=request_context,
+        )
+        assert second_result["observations_created"] == 1
+        create_action.assert_awaited_once()
+        assert set(create_action.await_args.kwargs["source_memory_ids"]) == {first_id, second_id}
+
+        third_result = await run_consolidation_job(
+            memory_engine=memory,
+            bank_id=bank_id,
+            request_context=request_context,
+        )
+        assert third_result["status"] == "no_new_memories"
+        assert consolidator._consolidate_batch_with_llm.await_count == 2
+    finally:
+        # This test inserts no documents/entities; direct cleanup keeps it isolated
+        # from optional curation tables that may not exist in an older shared pg0.
+        async with memory._pool.acquire() as conn:
+            await conn.execute("DELETE FROM memory_units WHERE bank_id = $1", bank_id)
+            await conn.execute("DELETE FROM banks WHERE bank_id = $1", bank_id)
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_consolidation.py
+++ b/hindsight-api-slim/tests/test_consolidation.py
@@ -3066,6 +3066,46 @@ def test_max_observations_per_scope_default():
     assert config.max_observations_per_scope == -1
 
 
+def test_min_observation_source_facts_config():
+    """The creation threshold is loaded from env and configurable per bank."""
+    import os
+
+    from hindsight_api.config import HindsightConfig, clear_config_cache
+
+    original = os.getenv("HINDSIGHT_API_MIN_OBSERVATION_SOURCE_FACTS")
+    try:
+        os.environ["HINDSIGHT_API_MIN_OBSERVATION_SOURCE_FACTS"] = "3"
+        clear_config_cache()
+        config = _get_raw_config()
+        assert config.min_observation_source_facts == 3
+        assert "min_observation_source_facts" in HindsightConfig.get_configurable_fields()
+    finally:
+        if original is None:
+            os.environ.pop("HINDSIGHT_API_MIN_OBSERVATION_SOURCE_FACTS", None)
+        else:
+            os.environ["HINDSIGHT_API_MIN_OBSERVATION_SOURCE_FACTS"] = original
+        clear_config_cache()
+
+
+def test_min_observation_source_facts_default():
+    """A default of one preserves existing consolidation behaviour."""
+    config = _get_raw_config()
+    assert config.min_observation_source_facts == 1
+
+
+@pytest.mark.parametrize("invalid_value", [0, -1])
+def test_min_observation_source_facts_must_be_positive(invalid_value):
+    raw = _get_raw_config()
+    config = type(raw)(
+        **{
+            **{f: getattr(raw, f) for f in raw.__dataclass_fields__},
+            "min_observation_source_facts": invalid_value,
+        }
+    )
+    with pytest.raises(ValueError, match="min_observation_source_facts"):
+        config.validate()
+
+
 @pytest.mark.asyncio
 async def test_count_observations_for_scope(memory: MemoryEngine, request_context):
     """Test _count_observations_for_scope counts observations filtered by tags."""
@@ -3155,6 +3195,112 @@ def _make_mock_llm_one_obs_per_fact():
     wrapper = MagicMock()
     wrapper.with_config.return_value = mock_llm
     return wrapper, mock_llm
+
+
+@pytest.mark.asyncio
+async def test_min_observation_source_facts_blocks_single_fact_creates(monkeypatch):
+    """The runtime gate rejects advisory LLM CREATEs below the minimum."""
+    from hindsight_api.engine.consolidation import consolidator
+
+    memories = [
+        {"id": "fact-a", "text": "Alice hikes.", "tags": ["scope:test"]},
+        {"id": "fact-b", "text": "Alice camps.", "tags": ["scope:test"]},
+    ]
+    llm_result = consolidator._BatchLLMResult(
+        creates=[
+            consolidator._CreateAction(
+                text="Alice enjoys the outdoors.",
+                source_fact_ids=["fact-a", "fact-a"],
+            )
+        ]
+    )
+    monkeypatch.setattr(
+        consolidator,
+        "_find_related_observations",
+        AsyncMock(return_value=SimpleNamespace(results=[], source_facts={})),
+    )
+    monkeypatch.setattr(
+        consolidator,
+        "_consolidate_batch_with_llm",
+        AsyncMock(return_value=llm_result),
+    )
+    create_action = AsyncMock()
+    monkeypatch.setattr(consolidator, "_execute_create_action", create_action)
+
+    results, deleted, failed = await consolidator._process_memory_batch(
+        conn=MagicMock(),
+        memory_engine=MagicMock(),
+        llm_config=MagicMock(),
+        bank_id="test-bank",
+        memories=memories,
+        request_context=SimpleNamespace(),
+        config=SimpleNamespace(
+            observation_scope_limits=None,
+            max_observations_per_scope=-1,
+            min_observation_source_facts=2,
+            consolidation_dedup_threshold=1.0,
+        ),
+    )
+
+    create_action.assert_not_awaited()
+    assert results == [
+        {"action": "skipped", "reason": "no_durable_knowledge"},
+        {"action": "skipped", "reason": "no_durable_knowledge"},
+    ]
+    assert deleted == 0
+    assert failed is False
+
+
+@pytest.mark.asyncio
+async def test_min_observation_source_facts_allows_multi_fact_create(monkeypatch):
+    """A qualifying CREATE persists each distinct source exactly once."""
+    from hindsight_api.engine.consolidation import consolidator
+
+    memories = [
+        {"id": "fact-a", "text": "Alice hikes.", "tags": ["scope:test"]},
+        {"id": "fact-b", "text": "Alice camps.", "tags": ["scope:test"]},
+    ]
+    llm_result = consolidator._BatchLLMResult(
+        creates=[
+            consolidator._CreateAction(
+                text="Alice enjoys the outdoors.",
+                source_fact_ids=["fact-a", "fact-b", "fact-a"],
+            )
+        ]
+    )
+    monkeypatch.setattr(
+        consolidator,
+        "_find_related_observations",
+        AsyncMock(return_value=SimpleNamespace(results=[], source_facts={})),
+    )
+    monkeypatch.setattr(
+        consolidator,
+        "_consolidate_batch_with_llm",
+        AsyncMock(return_value=llm_result),
+    )
+    create_action = AsyncMock()
+    monkeypatch.setattr(consolidator, "_execute_create_action", create_action)
+
+    results, deleted, failed = await consolidator._process_memory_batch(
+        conn=MagicMock(),
+        memory_engine=MagicMock(),
+        llm_config=MagicMock(),
+        bank_id="test-bank",
+        memories=memories,
+        request_context=SimpleNamespace(),
+        config=SimpleNamespace(
+            observation_scope_limits=None,
+            max_observations_per_scope=-1,
+            min_observation_source_facts=2,
+            consolidation_dedup_threshold=1.0,
+        ),
+    )
+
+    create_action.assert_awaited_once()
+    assert create_action.await_args.kwargs["source_memory_ids"] == ["fact-a", "fact-b"]
+    assert results == [{"action": "created"}, {"action": "created"}]
+    assert deleted == 0
+    assert failed is False
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_hierarchical_config.py
+++ b/hindsight-api-slim/tests/test_hierarchical_config.py
@@ -133,6 +133,7 @@ async def test_hierarchical_fields_categorization():
     # Verify other configurable fields
     assert "retain_default_strategy" in configurable
     assert "retain_strategies" in configurable
+    assert "min_observation_source_facts" in configurable
     assert "max_observations_per_scope" in configurable
     assert "observation_scope_limits" in configurable
     assert "reflect_source_facts_max_tokens" in configurable
@@ -145,7 +146,7 @@ async def test_hierarchical_fields_categorization():
     assert "store_document_text" in configurable
 
     # Verify count is correct
-    assert len(configurable) == 42
+    assert len(configurable) == 43
 
     # Verify credential fields (NEVER exposed)
     assert "llm_api_key" in credentials

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -4660,6 +4660,10 @@ components:
         consolidation_source_facts_max_tokens_per_observation:
           nullable: true
           type: integer
+        min_observation_source_facts:
+          minimum: 1.0
+          nullable: true
+          type: integer
         max_observations_per_scope:
           nullable: true
           type: integer

--- a/hindsight-clients/go/model_bank_template_config.go
+++ b/hindsight-clients/go/model_bank_template_config.go
@@ -39,6 +39,7 @@ type BankTemplateConfig struct {
 	ConsolidationLlmBatchSize NullableInt32 `json:"consolidation_llm_batch_size,omitempty"`
 	ConsolidationSourceFactsMaxTokens NullableInt32 `json:"consolidation_source_facts_max_tokens,omitempty"`
 	ConsolidationSourceFactsMaxTokensPerObservation NullableInt32 `json:"consolidation_source_facts_max_tokens_per_observation,omitempty"`
+	MinObservationSourceFacts NullableInt32 `json:"min_observation_source_facts,omitempty"`
 	MaxObservationsPerScope NullableInt32 `json:"max_observations_per_scope,omitempty"`
 	ObservationScopeLimits []map[string]interface{} `json:"observation_scope_limits,omitempty"`
 	ReflectSourceFactsMaxTokens NullableInt32 `json:"reflect_source_facts_max_tokens,omitempty"`
@@ -886,6 +887,48 @@ func (o *BankTemplateConfig) UnsetConsolidationSourceFactsMaxTokensPerObservatio
 	o.ConsolidationSourceFactsMaxTokensPerObservation.Unset()
 }
 
+// GetMinObservationSourceFacts returns the MinObservationSourceFacts field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetMinObservationSourceFacts() int32 {
+	if o == nil || IsNil(o.MinObservationSourceFacts.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.MinObservationSourceFacts.Get()
+}
+
+// GetMinObservationSourceFactsOk returns a tuple with the MinObservationSourceFacts field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetMinObservationSourceFactsOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MinObservationSourceFacts.Get(), o.MinObservationSourceFacts.IsSet()
+}
+
+// HasMinObservationSourceFacts returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasMinObservationSourceFacts() bool {
+	if o != nil && o.MinObservationSourceFacts.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetMinObservationSourceFacts gets a reference to the given NullableInt32 and assigns it to the MinObservationSourceFacts field.
+func (o *BankTemplateConfig) SetMinObservationSourceFacts(v int32) {
+	o.MinObservationSourceFacts.Set(&v)
+}
+// SetMinObservationSourceFactsNil sets the value for MinObservationSourceFacts to be an explicit nil
+func (o *BankTemplateConfig) SetMinObservationSourceFactsNil() {
+	o.MinObservationSourceFacts.Set(nil)
+}
+
+// UnsetMinObservationSourceFacts ensures that no value is present for MinObservationSourceFacts, not even an explicit nil
+func (o *BankTemplateConfig) UnsetMinObservationSourceFacts() {
+	o.MinObservationSourceFacts.Unset()
+}
+
 // GetMaxObservationsPerScope returns the MaxObservationsPerScope field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BankTemplateConfig) GetMaxObservationsPerScope() int32 {
 	if o == nil || IsNil(o.MaxObservationsPerScope.Get()) {
@@ -1567,6 +1610,9 @@ func (o BankTemplateConfig) ToMap() (map[string]interface{}, error) {
 	}
 	if o.ConsolidationSourceFactsMaxTokensPerObservation.IsSet() {
 		toSerialize["consolidation_source_facts_max_tokens_per_observation"] = o.ConsolidationSourceFactsMaxTokensPerObservation.Get()
+	}
+	if o.MinObservationSourceFacts.IsSet() {
+		toSerialize["min_observation_source_facts"] = o.MinObservationSourceFacts.Get()
 	}
 	if o.MaxObservationsPerScope.IsSet() {
 		toSerialize["max_observations_per_scope"] = o.MaxObservationsPerScope.Get()

--- a/hindsight-clients/python/hindsight_client_api/models/bank_template_config.py
+++ b/hindsight-clients/python/hindsight_client_api/models/bank_template_config.py
@@ -47,6 +47,7 @@ class BankTemplateConfig(BaseModel):
     consolidation_llm_batch_size: Optional[StrictInt] = None
     consolidation_source_facts_max_tokens: Optional[StrictInt] = None
     consolidation_source_facts_max_tokens_per_observation: Optional[StrictInt] = None
+    min_observation_source_facts: Optional[Annotated[int, Field(strict=True, ge=1)]] = None
     max_observations_per_scope: Optional[StrictInt] = None
     observation_scope_limits: Optional[List[Dict[str, Any]]] = None
     reflect_source_facts_max_tokens: Optional[StrictInt] = None
@@ -62,7 +63,7 @@ class BankTemplateConfig(BaseModel):
     recall_budget_max: Optional[StrictInt] = None
     audit_log_enabled: Optional[StrictBool] = None
     store_document_text: Optional[StrictBool] = None
-    __properties: ClassVar[List[str]] = ["reflect_mission", "retain_mission", "retain_extraction_mode", "retain_custom_instructions", "retain_chunk_size", "retain_structured_chunk_size", "enable_observations", "observations_mission", "disposition_skepticism", "disposition_literalism", "disposition_empathy", "entity_labels", "entities_allow_free_form", "retain_default_strategy", "retain_strategies", "retain_chunk_batch_size", "mcp_enabled_tools", "consolidation_llm_batch_size", "consolidation_source_facts_max_tokens", "consolidation_source_facts_max_tokens_per_observation", "max_observations_per_scope", "observation_scope_limits", "reflect_source_facts_max_tokens", "llm_gemini_safety_settings", "recall_budget_function", "recall_budget_fixed_low", "recall_budget_fixed_mid", "recall_budget_fixed_high", "recall_budget_adaptive_low", "recall_budget_adaptive_mid", "recall_budget_adaptive_high", "recall_budget_min", "recall_budget_max", "audit_log_enabled", "store_document_text"]
+    __properties: ClassVar[List[str]] = ["reflect_mission", "retain_mission", "retain_extraction_mode", "retain_custom_instructions", "retain_chunk_size", "retain_structured_chunk_size", "enable_observations", "observations_mission", "disposition_skepticism", "disposition_literalism", "disposition_empathy", "entity_labels", "entities_allow_free_form", "retain_default_strategy", "retain_strategies", "retain_chunk_batch_size", "mcp_enabled_tools", "consolidation_llm_batch_size", "consolidation_source_facts_max_tokens", "consolidation_source_facts_max_tokens_per_observation", "min_observation_source_facts", "max_observations_per_scope", "observation_scope_limits", "reflect_source_facts_max_tokens", "llm_gemini_safety_settings", "recall_budget_function", "recall_budget_fixed_low", "recall_budget_fixed_mid", "recall_budget_fixed_high", "recall_budget_adaptive_low", "recall_budget_adaptive_mid", "recall_budget_adaptive_high", "recall_budget_min", "recall_budget_max", "audit_log_enabled", "store_document_text"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -203,6 +204,11 @@ class BankTemplateConfig(BaseModel):
         if self.consolidation_source_facts_max_tokens_per_observation is None and "consolidation_source_facts_max_tokens_per_observation" in self.model_fields_set:
             _dict['consolidation_source_facts_max_tokens_per_observation'] = None
 
+        # set to None if min_observation_source_facts (nullable) is None
+        # and model_fields_set contains the field
+        if self.min_observation_source_facts is None and "min_observation_source_facts" in self.model_fields_set:
+            _dict['min_observation_source_facts'] = None
+
         # set to None if max_observations_per_scope (nullable) is None
         # and model_fields_set contains the field
         if self.max_observations_per_scope is None and "max_observations_per_scope" in self.model_fields_set:
@@ -310,6 +316,7 @@ class BankTemplateConfig(BaseModel):
             "consolidation_llm_batch_size": obj.get("consolidation_llm_batch_size"),
             "consolidation_source_facts_max_tokens": obj.get("consolidation_source_facts_max_tokens"),
             "consolidation_source_facts_max_tokens_per_observation": obj.get("consolidation_source_facts_max_tokens_per_observation"),
+            "min_observation_source_facts": obj.get("min_observation_source_facts"),
             "max_observations_per_scope": obj.get("max_observations_per_scope"),
             "observation_scope_limits": obj.get("observation_scope_limits"),
             "reflect_source_facts_max_tokens": obj.get("reflect_source_facts_max_tokens"),

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -563,6 +563,12 @@ export type BankTemplateConfig = {
    */
   consolidation_source_facts_max_tokens_per_observation?: number | null;
   /**
+   * Min Observation Source Facts
+   *
+   * Minimum number of distinct source facts required to create an observation
+   */
+  min_observation_source_facts?: number | null;
+  /**
    * Max Observations Per Scope
    *
    * Max observations to retain per consolidation scope

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1520,6 +1520,7 @@ Observations are deduplicated, evidence-grounded knowledge consolidated from mul
 | `HINDSIGHT_API_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS` | Total token budget for source facts included with observations in the consolidation prompt. `-1` = unlimited. Configurable per bank. | `4096` |
 | `HINDSIGHT_API_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS_PER_OBSERVATION` | Per-observation token cap for source facts in the consolidation prompt. Each observation independently gets at most this many tokens of source facts. `-1` = unlimited. Configurable per bank. | `256` |
 | `HINDSIGHT_API_OBSERVATIONS_MISSION` | What this bank should synthesise into durable observations. Replaces the built-in consolidation rules — leave unset to use the server default. | - |
+| `HINDSIGHT_API_MIN_OBSERVATION_SOURCE_FACTS` | Minimum number of distinct input facts that a new observation must reference. CREATE actions below this threshold are rejected deterministically; UPDATE actions remain allowed so one new fact can evolve an existing observation. Use `2` or higher to require multi-fact synthesis instead of single-fact restatement. Configurable per bank. | `1` |
 | `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE` | Maximum number of observations allowed per tag scope. When the limit is reached, consolidation will only update or delete existing observations — no new ones are created. Applies per tag scope (e.g., per-tag when using `per_tag` observation scopes). Observations with no tags are not subject to this limit. `-1` = unlimited. Configurable per bank. | `-1` |
 | `HINDSIGHT_API_OBSERVATION_SCOPE_LIMITS` | Per-scope overrides of `MAX_OBSERVATIONS_PER_SCOPE`, as a JSON array of `{"scope": [tag-globs], "limit": int}` rules. Each `scope` is a list of [fnmatch](https://docs.python.org/3/library/fnmatch.html) globs; a consolidation scope matches under *exact cover* — every tag must be matched by a glob and every glob must match a tag, so `["shared"]` matches the scope `{shared}` but not `{run_1, shared}`. The first matching rule wins; scopes that match no rule fall back to `MAX_OBSERVATIONS_PER_SCOPE`. Example: `[{"scope": ["shared"], "limit": -1}, {"scope": ["run_*", "shared"], "limit": 50}]` keeps the `{shared}` scope unlimited while capping each `{run_*, shared}` scope at 50. Configurable per bank. | - |
 
@@ -1937,7 +1938,7 @@ Configuration fields are categorized for security:
 
 1. **Configurable Fields** - Safe behavioral settings that can be customized per-bank:
    - Retention: `retain_chunk_size`, `retain_structured_chunk_size`, `retain_extraction_mode`, `retain_mission`, `retain_custom_instructions`
-   - Observations: `enable_observations`, `enable_auto_consolidation`, `observations_mission`, `max_observations_per_scope`
+   - Observations: `enable_observations`, `enable_auto_consolidation`, `observations_mission`, `min_observation_source_facts`, `max_observations_per_scope`
    - MCP access control: `mcp_enabled_tools`
 
 2. **Credential Fields** - NEVER exposed or configurable via API:

--- a/hindsight-docs/static/bank-template-schema.json
+++ b/hindsight-docs/static/bank-template-schema.json
@@ -277,6 +277,20 @@
           "description": "Max tokens of source facts per observation",
           "title": "Consolidation Source Facts Max Tokens Per Observation"
         },
+        "min_observation_source_facts": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number of distinct source facts required to create an observation",
+          "title": "Min Observation Source Facts"
+        },
         "max_observations_per_scope": {
           "anyOf": [
             {

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -6932,6 +6932,19 @@
             "title": "Consolidation Source Facts Max Tokens Per Observation",
             "description": "Max tokens of source facts per observation"
           },
+          "min_observation_source_facts": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min Observation Source Facts",
+            "description": "Minimum number of distinct source facts required to create an observation"
+          },
           "max_observations_per_scope": {
             "anyOf": [
               {

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -222,6 +222,9 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_TEMPORAL_SEMANTIC_MIN_SIMILARITY=0.1
 # HINDSIGHT_API_SEMANTIC_LINK_MIN_SIMILARITY=0.7
 # HINDSIGHT_API_CONSOLIDATION_DEDUP_THRESHOLD=0.97
+# Minimum distinct input facts required for a new observation (default: 1).
+# Set to 2+ when observations should only contain multi-fact synthesis.
+# HINDSIGHT_API_MIN_OBSERVATION_SOURCE_FACTS=1
 
 # Reranker Configuration (Optional - uses local by default)
 # Provider: "local" (default) or "tei" (HuggingFace Text Embeddings Inference)

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1520,6 +1520,7 @@ Observations are deduplicated, evidence-grounded knowledge consolidated from mul
 | `HINDSIGHT_API_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS` | Total token budget for source facts included with observations in the consolidation prompt. `-1` = unlimited. Configurable per bank. | `4096` |
 | `HINDSIGHT_API_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS_PER_OBSERVATION` | Per-observation token cap for source facts in the consolidation prompt. Each observation independently gets at most this many tokens of source facts. `-1` = unlimited. Configurable per bank. | `256` |
 | `HINDSIGHT_API_OBSERVATIONS_MISSION` | What this bank should synthesise into durable observations. Replaces the built-in consolidation rules — leave unset to use the server default. | - |
+| `HINDSIGHT_API_MIN_OBSERVATION_SOURCE_FACTS` | Minimum number of distinct input facts that a new observation must reference. CREATE actions below this threshold are rejected deterministically; UPDATE actions remain allowed so one new fact can evolve an existing observation. Use `2` or higher to require multi-fact synthesis instead of single-fact restatement. Configurable per bank. | `1` |
 | `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE` | Maximum number of observations allowed per tag scope. When the limit is reached, consolidation will only update or delete existing observations — no new ones are created. Applies per tag scope (e.g., per-tag when using `per_tag` observation scopes). Observations with no tags are not subject to this limit. `-1` = unlimited. Configurable per bank. | `-1` |
 | `HINDSIGHT_API_OBSERVATION_SCOPE_LIMITS` | Per-scope overrides of `MAX_OBSERVATIONS_PER_SCOPE`, as a JSON array of `{"scope": [tag-globs], "limit": int}` rules. Each `scope` is a list of [fnmatch](https://docs.python.org/3/library/fnmatch.html) globs; a consolidation scope matches under *exact cover* — every tag must be matched by a glob and every glob must match a tag, so `["shared"]` matches the scope `{shared}` but not `{run_1, shared}`. The first matching rule wins; scopes that match no rule fall back to `MAX_OBSERVATIONS_PER_SCOPE`. Example: `[{"scope": ["shared"], "limit": -1}, {"scope": ["run_*", "shared"], "limit": 50}]` keeps the `{shared}` scope unlimited while capping each `{run_*, shared}` scope at 50. Configurable per bank. | - |
 
@@ -1937,7 +1938,7 @@ Configuration fields are categorized for security:
 
 1. **Configurable Fields** - Safe behavioral settings that can be customized per-bank:
    - Retention: `retain_chunk_size`, `retain_structured_chunk_size`, `retain_extraction_mode`, `retain_mission`, `retain_custom_instructions`
-   - Observations: `enable_observations`, `enable_auto_consolidation`, `observations_mission`, `max_observations_per_scope`
+   - Observations: `enable_observations`, `enable_auto_consolidation`, `observations_mission`, `min_observation_source_facts`, `max_observations_per_scope`
    - MCP access control: `mcp_enabled_tools`
 
 2. **Credential Fields** - NEVER exposed or configurable via API:

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -6932,6 +6932,19 @@
             "title": "Consolidation Source Facts Max Tokens Per Observation",
             "description": "Max tokens of source facts per observation"
           },
+          "min_observation_source_facts": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min Observation Source Facts",
+            "description": "Minimum number of distinct source facts required to create an observation"
+          },
           "max_observations_per_scope": {
             "anyOf": [
               {


### PR DESCRIPTION
## Summary

- add a hierarchical `min_observation_source_facts` setting (default `1`)
- enforce the minimum as a deterministic CREATE gate using distinct valid source fact IDs
- keep UPDATE behavior unchanged so observations can evolve from one new fact
- expose the setting through bank templates, environment configuration, docs, OpenAPI, and generated clients

## Motivation

Observation missions can request multi-fact synthesis, but LLM instructions alone are advisory. A hard configurable threshold prevents one-fact observation restatements while preserving backward compatibility.

## Validation

- `uv run --frozen pytest hindsight-api-slim/tests/test_consolidation.py -k min_observation_source_facts -q` (6 passed)
- configurable-field and hierarchy tests (2 passed)
- `./scripts/hooks/lint.sh`
- `./scripts/generate-clients.sh`