### PR TITLE
fix(embeddings): honor query and document prompts locally

### DIFF
--- a/docker/docker-compose/custom-models/Dockerfile
+++ b/docker/docker-compose/custom-models/Dockerfile
@@ -17,7 +17,7 @@ FROM ghcr.io/vectorize-io/hindsight:latest-slim
 # `pip install` would fall back to user site-packages and not be visible
 # to the runtime python.
 RUN uv pip install --python /app/api/.venv/bin/python --no-cache \
-    'sentence-transformers>=3.3.0' \
+    'sentence-transformers>=5.0.0' \
     'transformers>=4.53.0' \
     'torch>=2.6.0'
 

--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -241,11 +241,28 @@ class LocalSTEmbeddings(Embeddings):
         Returns:
             List of embedding vectors
         """
+        return self._encode_local(texts)
+
+    def encode_query(self, texts: list[str]) -> list[list[float]]:
+        return self._encode_local(texts, input_type="query")
+
+    def encode_documents(self, texts: list[str]) -> list[list[float]]:
+        return self._encode_local(texts, input_type="document")
+
+    def _encode_local(
+        self, texts: list[str], input_type: Literal["query", "document"] | None = None
+    ) -> list[list[float]]:
         if self._model is None:
             raise RuntimeError("Embeddings not initialized. Call initialize() first.")
 
         try:
-            embeddings = self._model.encode(texts, convert_to_numpy=True, show_progress_bar=False)
+            if input_type == "query":
+                encode = self._model.encode_query
+            elif input_type == "document":
+                encode = self._model.encode_document
+            else:
+                encode = self._model.encode
+            embeddings = encode(texts, convert_to_numpy=True, show_progress_bar=False)
             return [emb.tolist() for emb in embeddings]
         finally:
             # Only reclaim the GPU allocator pool here, and only when actually on a

--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -256,6 +256,16 @@ class LocalSTEmbeddings(Embeddings):
             raise RuntimeError("Embeddings not initialized. Call initialize() first.")
 
         try:
+            # Delegate to SentenceTransformers' own asymmetric entry points rather than
+            # prefixing here: they apply whatever prompts the model ships with (and route
+            # the task for models exposing a Router module), so asymmetric models such as
+            # Qwen3-Embedding get their configured query prompt without Hindsight carrying
+            # per-model prefix config the way the ONNX provider has to. Models that declare
+            # no prompts are unaffected — SentenceTransformers defaults them to empty
+            # strings and skips prompt handling entirely, so this is byte-identical to
+            # encode() for e.g. the default BAAI/bge-small-en-v1.5.
+            # encode_query/encode_document exist only in sentence-transformers >= 5.0,
+            # which is why local-ml pins that floor.
             if input_type == "query":
                 encode = self._model.encode_query
             elif input_type == "document":

--- a/hindsight-api-slim/pyproject.toml
+++ b/hindsight-api-slim/pyproject.toml
@@ -93,7 +93,10 @@ dependencies = [
 [project.optional-dependencies]
 local-ml = [
     # Local ML models for embeddings/reranking
-    "sentence-transformers>=3.3.0",
+    # 5.0 is the floor: LocalSTEmbeddings calls SentenceTransformer.encode_query()
+    # and .encode_document(), which only exist from 5.0 onwards. On 4.x those are
+    # an AttributeError at first encode (recall/retain), not at startup.
+    "sentence-transformers>=5.0.0",
     "transformers>=5.5.0", # ReDoS fixes; 5.5.0 clears GHSA-fgcw-684q-jj6r (LightGlue RCE)
     # transformers enforces tokenizers<=0.23.0 with a runtime check, but has
     # shipped metadata declaring a wider range than it actually enforces. Keep

--- a/hindsight-api-slim/tests/test_local_embeddings.py
+++ b/hindsight-api-slim/tests/test_local_embeddings.py
@@ -1,0 +1,26 @@
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from hindsight_api.engine.embeddings import LocalSTEmbeddings
+
+
+def test_local_embeddings_use_sentence_transformer_input_types():
+    model = MagicMock()
+    model.encode.return_value = np.array([[1.0]])
+    model.encode_query.return_value = np.array([[2.0]])
+    model.encode_document.return_value = np.array([[3.0]])
+
+    embeddings = LocalSTEmbeddings()
+    embeddings._model = model
+    embeddings._device_type = "mps"
+
+    with patch("hindsight_api.engine.embeddings.release_local_inference_memory") as release:
+        assert embeddings.encode(["text"]) == [[1.0]]
+        assert embeddings.encode_query(["query"]) == [[2.0]]
+        assert embeddings.encode_documents(["document"]) == [[3.0]]
+
+    model.encode.assert_called_once_with(["text"], convert_to_numpy=True, show_progress_bar=False)
+    model.encode_query.assert_called_once_with(["query"], convert_to_numpy=True, show_progress_bar=False)
+    model.encode_document.assert_called_once_with(["document"], convert_to_numpy=True, show_progress_bar=False)
+    assert release.call_count == 3

--- a/hindsight-api-slim/tests/test_local_embeddings.py
+++ b/hindsight-api-slim/tests/test_local_embeddings.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+import pytest
 
 from hindsight_api.engine.embeddings import LocalSTEmbeddings
 
@@ -24,3 +25,17 @@ def test_local_embeddings_use_sentence_transformer_input_types():
     model.encode_query.assert_called_once_with(["query"], convert_to_numpy=True, show_progress_bar=False)
     model.encode_document.assert_called_once_with(["document"], convert_to_numpy=True, show_progress_bar=False)
     assert release.call_count == 3
+
+
+def test_sentence_transformer_exposes_input_type_entry_points():
+    """Guard the >=5.0 floor in local-ml.
+
+    The test above drives a MagicMock, so it passes on any sentence-transformers
+    version while the real one raises AttributeError at the first encode. These
+    entry points only exist from 5.0 onwards; assert against the real class so a
+    loosened pin fails here instead of at recall time.
+    """
+    sentence_transformers = pytest.importorskip("sentence_transformers")
+
+    assert hasattr(sentence_transformers.SentenceTransformer, "encode_query")
+    assert hasattr(sentence_transformers.SentenceTransformer, "encode_document")

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -575,7 +575,7 @@ server-level only (not overridable per tenant/bank) and a change requires a rest
 |----------|-------------|---------|
 | `HINDSIGHT_API_EMBEDDINGS_PROVIDER` | Provider: `local`, `onnx`, `tei`, `openai`, `openai-codex`, `openrouter`, `requesty`, `cohere`, `google`, `zeroentropy`, `litellm`, or `litellm-sdk` | `local` |
 | `HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS` | Applies to **every** provider. If set, truncate each text to this many tokens (tiktoken `cl100k_base`, approximate) before embedding. Set it to the model's real input limit (e.g. `8192` for Bedrock Titan V2, or a llama.cpp server's context, with a little headroom) so oversized content is truncated instead of failing the embed call permanently. Off by default. (Deprecated alias: `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS`.) | - |
-| `HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL` | Model for local provider | `BAAI/bge-small-en-v1.5` |
+| `HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL` | Model for local provider. Models that ship their own search-text and stored-text instructions (e.g. the Qwen3-Embedding family) have them applied automatically — see the note below. | `BAAI/bge-small-en-v1.5` |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_TRUST_REMOTE_CODE` | Allow loading models with custom code (security risk, disabled by default) | `false` |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU` | Force CPU mode for local embeddings (avoids MPS/XPC issues on macOS) | `false` |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_ALLOW_MPS` | Opt in to the Apple Silicon MPS GPU for local embeddings. Disabled by default because MPS caches a distinct kernel/allocator pool per input shape and never releases it, so under variable-length workloads memory grows without bound (idle instances reached ~20 GB). CUDA/XPU are unaffected and still auto-select. | `false` |
@@ -628,6 +628,14 @@ server-level only (not overridable per tenant/bank) and a change requires a rest
 | `HINDSIGHT_API_EMBEDDINGS_VERTEXAI_SERVICE_ACCOUNT_KEY` | Service account key for Vertex AI embeddings (falls back to `HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY`) | - |
 
 Embedding provider selection, credentials, base URLs, model choices, dimensions, encoding format, batch sizes, and latency modes are static server-level settings. They are not hierarchical per-bank overrides. The ONNX settings above are also static, matching the existing `embeddings_local_*` settings.
+
+:::note Models that treat searches and stored text differently
+
+Some embedding models are trained to see a short instruction in front of a search, and nothing (or a different instruction) in front of the text being stored. With the `local` provider, Hindsight applies whichever instructions the model itself ships with — you don't configure anything. The default `BAAI/bge-small-en-v1.5` ships none, so nothing changes for existing deployments; `Qwen/Qwen3-Embedding-*` ships one for searches only, which is what makes those models retrieve accurately.
+
+The rare case to watch for is a model that also instructs the **stored** side. Switching to one of those changes how new memories are indexed, so anything already stored was indexed differently and will compare poorly against it. Re-index the bank (export and re-import it) after adopting such a model. Search-side-only instructions, which covers every model listed above, need no re-indexing.
+
+:::
 
 #### Local ONNX embeddings
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -575,7 +575,7 @@ server-level only (not overridable per tenant/bank) and a change requires a rest
 |----------|-------------|---------|
 | `HINDSIGHT_API_EMBEDDINGS_PROVIDER` | Provider: `local`, `onnx`, `tei`, `openai`, `openai-codex`, `openrouter`, `requesty`, `cohere`, `google`, `zeroentropy`, `litellm`, or `litellm-sdk` | `local` |
 | `HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS` | Applies to **every** provider. If set, truncate each text to this many tokens (tiktoken `cl100k_base`, approximate) before embedding. Set it to the model's real input limit (e.g. `8192` for Bedrock Titan V2, or a llama.cpp server's context, with a little headroom) so oversized content is truncated instead of failing the embed call permanently. Off by default. (Deprecated alias: `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS`.) | - |
-| `HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL` | Model for local provider | `BAAI/bge-small-en-v1.5` |
+| `HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL` | Model for local provider. Models that ship their own search-text and stored-text instructions (e.g. the Qwen3-Embedding family) have them applied automatically — see the note below. | `BAAI/bge-small-en-v1.5` |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_TRUST_REMOTE_CODE` | Allow loading models with custom code (security risk, disabled by default) | `false` |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU` | Force CPU mode for local embeddings (avoids MPS/XPC issues on macOS) | `false` |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_ALLOW_MPS` | Opt in to the Apple Silicon MPS GPU for local embeddings. Disabled by default because MPS caches a distinct kernel/allocator pool per input shape and never releases it, so under variable-length workloads memory grows without bound (idle instances reached ~20 GB). CUDA/XPU are unaffected and still auto-select. | `false` |
@@ -628,6 +628,14 @@ server-level only (not overridable per tenant/bank) and a change requires a rest
 | `HINDSIGHT_API_EMBEDDINGS_VERTEXAI_SERVICE_ACCOUNT_KEY` | Service account key for Vertex AI embeddings (falls back to `HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY`) | - |
 
 Embedding provider selection, credentials, base URLs, model choices, dimensions, encoding format, batch sizes, and latency modes are static server-level settings. They are not hierarchical per-bank overrides. The ONNX settings above are also static, matching the existing `embeddings_local_*` settings.
+
+:::note Models that treat searches and stored text differently
+
+Some embedding models are trained to see a short instruction in front of a search, and nothing (or a different instruction) in front of the text being stored. With the `local` provider, Hindsight applies whichever instructions the model itself ships with — you don't configure anything. The default `BAAI/bge-small-en-v1.5` ships none, so nothing changes for existing deployments; `Qwen/Qwen3-Embedding-*` ships one for searches only, which is what makes those models retrieve accurately.
+
+The rare case to watch for is a model that also instructs the **stored** side. Switching to one of those changes how new memories are indexed, so anything already stored was indexed differently and will compare poorly against it. Re-index the bank (export and re-import it) after adopting such a model. Search-side-only instructions, which covers every model listed above, need no re-indexing.
+
+:::
 
 #### Local ONNX embeddings
 

--- a/uv.lock
+++ b/uv.lock
@@ -1864,7 +1864,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "safetensors", marker = "extra == 'local-ml'", specifier = ">=0.6.2" },
-    { name = "sentence-transformers", marker = "extra == 'local-ml'", specifier = ">=3.3.0" },
+    { name = "sentence-transformers", marker = "extra == 'local-ml'", specifier = ">=5.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.44,<2.1" },
     { name = "testcontainers", marker = "extra == 'test'", specifier = ">=4.0.0" },
     { name = "tiktoken", specifier = ">=0.12.0" },


### PR DESCRIPTION
## Summary

- route local query embeddings through `SentenceTransformer.encode_query()`
- route local stored content through `SentenceTransformer.encode_document()`
- preserve the existing generic `encode()` behavior
- preserve post-inference memory release for every path

## Why

Hindsight already distinguishes query and document inputs in `embedding_utils`, but `LocalSTEmbeddings` inherited the base implementations that collapse both paths into generic `encode()`. SentenceTransformer models with asymmetric prompts, including Qwen3-Embedding, therefore never receive their configured query prompt.

Using the native SentenceTransformer entry points also preserves task routing for models that provide a Router module, without adding model-specific configuration to Hindsight.

## Validation

- `uv run pytest tests/test_local_embeddings.py tests/test_local_device.py -q` — 23 passed
- `./scripts/hooks/lint.sh` — passed
- focused review: branch contains one relevant commit and two changed files; no findings