### PR TITLE
fix(tracing): serialize unvalidated provider responses

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/claude_code_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/claude_code_llm.py
@@ -324,7 +324,7 @@ class ClaudeCodeLLM(LLMInterface):
 
                 # Record trace span
                 try:
-                    from hindsight_api.tracing import get_span_recorder
+                    from hindsight_api.tracing import _serialize_for_span, get_span_recorder
 
                     span_recorder = get_span_recorder()
                     span_recorder.record_llm_call(
@@ -332,15 +332,17 @@ class ClaudeCodeLLM(LLMInterface):
                         model=self.model,
                         scope=scope,
                         messages=messages,
-                        response_content=result if isinstance(result, str) else result.model_dump_json(),
+                        response_content=_serialize_for_span(result),
                         input_tokens=estimated_input,
                         output_tokens=estimated_output,
                         duration=duration,
                         finish_reason=None,
                         error=None,
                     )
-                except Exception:
-                    pass  # logging failure must never affect the operation
+                except Exception as span_error:
+                    # Tracing must remain best-effort, but expose instrumentation
+                    # bugs that would otherwise silently erase spans (#3025).
+                    logger.debug("Claude Code span recording failed: %s", span_error, exc_info=True)
 
                 # Log slow calls
                 if duration > 10.0:

--- a/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
@@ -573,7 +573,7 @@ class CodexLLM(LLMInterface):
 
                 # Record trace span
                 try:
-                    from hindsight_api.tracing import get_span_recorder
+                    from hindsight_api.tracing import _serialize_for_span, get_span_recorder
 
                     # Estimate tokens for tracing
                     estimated_input = sum(len(m.get("content", "")) for m in messages) // 4
@@ -584,15 +584,17 @@ class CodexLLM(LLMInterface):
                         model=self.model,
                         scope=scope,
                         messages=messages,
-                        response_content=result if isinstance(result, str) else result.model_dump_json(),
+                        response_content=_serialize_for_span(result),
                         input_tokens=estimated_input,
                         output_tokens=estimated_output,
                         duration=duration,
                         finish_reason=None,
                         error=None,
                     )
-                except Exception:
-                    pass  # logging failure must never affect the operation
+                except Exception as span_error:
+                    # Tracing must remain best-effort, but expose instrumentation
+                    # bugs that would otherwise silently erase spans (#3025).
+                    logger.debug("Codex span recording failed: %s", span_error, exc_info=True)
 
                 if return_usage:
                     # Codex doesn't provide token counts, estimate based on content

--- a/hindsight-api-slim/tests/test_claude_code_llm_error_result.py
+++ b/hindsight-api-slim/tests/test_claude_code_llm_error_result.py
@@ -18,10 +18,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
+from pydantic import BaseModel
 
 QUOTA_ERROR_TEXT = "You've hit your weekly limit · resets Jul 18, 12pm (UTC)"
+
+
+class _StructuredResponse(BaseModel):
+    fact: str
 
 
 @dataclass
@@ -138,6 +144,36 @@ async def test_call_ignores_non_error_result_message(monkeypatch):
     )
 
     assert result == "ok"
+
+
+@pytest.mark.asyncio
+async def test_call_records_span_for_unvalidated_dict(monkeypatch):
+    """skip_validation returns a dict, which must still be serialized into the span."""
+    import hindsight_api.tracing as tracing
+    import claude_agent_sdk
+
+    async def fake_query(prompt: str, options: _FakeOptions):
+        yield _FakeAssistantMessage(content=[_FakeTextBlock(text='{"fact": "x"}')])
+        yield _FakeResultMessage(subtype="success", is_error=False, result='{"fact": "x"}')
+
+    span_recorder = MagicMock()
+    monkeypatch.setattr(claude_agent_sdk, "ClaudeAgentOptions", _FakeOptions)
+    monkeypatch.setattr(claude_agent_sdk, "AssistantMessage", _FakeAssistantMessage)
+    monkeypatch.setattr(claude_agent_sdk, "TextBlock", _FakeTextBlock)
+    monkeypatch.setattr(claude_agent_sdk, "ResultMessage", _FakeResultMessage)
+    monkeypatch.setattr(claude_agent_sdk, "query", fake_query)
+    monkeypatch.setattr(tracing, "get_span_recorder", lambda: span_recorder)
+
+    result = await _instantiate_provider().call(
+        messages=[{"role": "user", "content": "extract facts"}],
+        response_format=_StructuredResponse,
+        skip_validation=True,
+        max_retries=0,
+        scope="retain_extract_facts",
+    )
+
+    assert result == {"fact": "x"}
+    assert span_recorder.record_llm_call.call_args.kwargs["response_content"] == '{"fact": "x"}'
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_claude_code_llm_error_result.py
+++ b/hindsight-api-slim/tests/test_claude_code_llm_error_result.py
@@ -149,8 +149,9 @@ async def test_call_ignores_non_error_result_message(monkeypatch):
 @pytest.mark.asyncio
 async def test_call_records_span_for_unvalidated_dict(monkeypatch):
     """skip_validation returns a dict, which must still be serialized into the span."""
-    import hindsight_api.tracing as tracing
     import claude_agent_sdk
+
+    import hindsight_api.tracing as tracing
 
     async def fake_query(prompt: str, options: _FakeOptions):
         yield _FakeAssistantMessage(content=[_FakeTextBlock(text='{"fact": "x"}')])
@@ -174,6 +175,36 @@ async def test_call_records_span_for_unvalidated_dict(monkeypatch):
 
     assert result == {"fact": "x"}
     assert span_recorder.record_llm_call.call_args.kwargs["response_content"] == '{"fact": "x"}'
+
+
+@pytest.mark.asyncio
+async def test_call_survives_span_recorder_failure(monkeypatch):
+    """A raising span recorder must be logged, never break the call (best-effort, #3025)."""
+    import claude_agent_sdk
+
+    import hindsight_api.tracing as tracing
+
+    async def fake_query(prompt: str, options: _FakeOptions):
+        yield _FakeAssistantMessage(content=[_FakeTextBlock(text="ok")])
+        yield _FakeResultMessage(subtype="success", is_error=False, result="ok")
+
+    span_recorder = MagicMock()
+    span_recorder.record_llm_call.side_effect = RuntimeError("recorder exploded")
+    monkeypatch.setattr(claude_agent_sdk, "ClaudeAgentOptions", _FakeOptions)
+    monkeypatch.setattr(claude_agent_sdk, "AssistantMessage", _FakeAssistantMessage)
+    monkeypatch.setattr(claude_agent_sdk, "TextBlock", _FakeTextBlock)
+    monkeypatch.setattr(claude_agent_sdk, "ResultMessage", _FakeResultMessage)
+    monkeypatch.setattr(claude_agent_sdk, "query", fake_query)
+    monkeypatch.setattr(tracing, "get_span_recorder", lambda: span_recorder)
+
+    result = await _instantiate_provider().call(
+        messages=[{"role": "user", "content": "hi"}],
+        max_retries=0,
+        scope="test",
+    )
+
+    assert result == "ok"
+    span_recorder.record_llm_call.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_codex_strict_schema.py
+++ b/hindsight-api-slim/tests/test_codex_strict_schema.py
@@ -122,20 +122,23 @@ async def test_strict_schema_skip_validation_returns_dict():
     response = MagicMock()
     response.raise_for_status.return_value = None
     tool_call = LLMToolCall(id="c", name="structured_response", arguments={"fact": "x"})
+    span_recorder = MagicMock()
 
-    with patch.object(llm._client, "post", new_callable=AsyncMock) as mock_post:
-        mock_post.return_value = response
-        with patch.object(llm, "_parse_sse_tool_stream", new_callable=AsyncMock) as mock_parse:
-            mock_parse.return_value = (None, [tool_call])
-            result = await llm.call(
-                messages=[{"role": "user", "content": "hi"}],
-                response_format=_Fact,
-                strict_schema=True,
-                skip_validation=True,
-                max_retries=0,
-            )
+    with patch("hindsight_api.tracing.get_span_recorder", return_value=span_recorder):
+        with patch.object(llm._client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = response
+            with patch.object(llm, "_parse_sse_tool_stream", new_callable=AsyncMock) as mock_parse:
+                mock_parse.return_value = (None, [tool_call])
+                result = await llm.call(
+                    messages=[{"role": "user", "content": "hi"}],
+                    response_format=_Fact,
+                    strict_schema=True,
+                    skip_validation=True,
+                    max_retries=0,
+                )
 
     assert result == {"fact": "x"}
+    assert span_recorder.record_llm_call.call_args.kwargs["response_content"] == '{"fact": "x"}'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #3025

## Summary
- serialize raw structured-output dictionaries with the shared tracing helper
- preserve best-effort tracing while logging recorder failures at debug level
- add regression coverage for both affected CLI-backed providers

## Testing
- `uv run pytest tests/test_codex_strict_schema.py tests/test_claude_code_llm_error_result.py -v`
- `./scripts/hooks/lint.sh`
- `uv run ty check hindsight_api/engine/providers/codex_llm.py hindsight_api/engine/providers/claude_code_llm.py`