### PR TITLE
fix(config): report deleted import banks as conflicts

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -53,6 +53,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from hindsight_api import MemoryEngine
 from hindsight_api.config import RETAIN_EXTRACTION_MODES
+from hindsight_api.config_resolver import BankConfigPersistenceConflictError
 
 
 def _annotation_is_nullable(annotation: Any) -> bool:
@@ -6153,6 +6154,11 @@ def _register_routes(app: FastAPI):
                 bank_id=bank_id,
                 manifest=body,
                 request_context=request_context,
+            )
+        except BankConfigPersistenceConflictError as e:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Bank '{e.bank_id}' changed or was deleted during template import; retry the import.",
             )
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))

--- a/hindsight-api-slim/hindsight_api/config_resolver.py
+++ b/hindsight-api-slim/hindsight_api/config_resolver.py
@@ -32,6 +32,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class BankConfigPersistenceConflictError(ValueError):
+    """Raised when a validated bank config update can no longer be persisted."""
+
+    def __init__(self, bank_id: str):
+        self.bank_id = bank_id
+        super().__init__(f"Cannot update config for bank '{bank_id}': the bank does not exist")
+
+
 def _validate_retain_strategy_chunking(base_config: HindsightConfig, strategies: Any) -> None:
     """Validate retain strategy chunking with the same semantics as apply_strategy()."""
     if not isinstance(strategies, dict):
@@ -496,7 +504,7 @@ class ConfigResolver:
         # (The Oracle wrapper reshapes rowcount into the same "UPDATE <n>" form.)
         updated = int(result.split()[-1]) if isinstance(result, str) and result.startswith("UPDATE") else 0
         if updated == 0:
-            raise ValueError(f"Cannot update config for bank '{bank_id}': the bank does not exist")
+            raise BankConfigPersistenceConflictError(bank_id)
 
         logger.info(f"Updated bank config for {bank_id}: {list(normalized_updates.keys())}")
 

--- a/hindsight-api-slim/tests/test_hierarchical_config.py
+++ b/hindsight-api-slim/tests/test_hierarchical_config.py
@@ -11,7 +11,7 @@ import uuid
 import pytest
 
 from hindsight_api.config import HindsightConfig, normalize_config_dict, normalize_config_key
-from hindsight_api.config_resolver import ConfigResolver
+from hindsight_api.config_resolver import BankConfigPersistenceConflictError, ConfigResolver
 from hindsight_api.extensions.tenant import TenantExtension
 from hindsight_api.models import RequestContext
 
@@ -613,7 +613,7 @@ async def test_update_bank_config_rejects_missing_bank(memory, request_context):
     bank_id = f"test-resolver-missing-bank-{uuid.uuid4().hex[:8]}"
     resolver = ConfigResolver(backend=memory._backend)
 
-    with pytest.raises(ValueError, match="does not exist"):
+    with pytest.raises(BankConfigPersistenceConflictError, match="does not exist"):
         await resolver.update_bank_config(bank_id, {"enable_observations": False}, request_context)
 
     profile = await memory.get_bank_profile(bank_id, request_context=request_context, create_if_missing=False)

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -13,6 +13,7 @@ import pytest
 import pytest_asyncio
 
 from hindsight_api.api import create_app
+from hindsight_api.config_resolver import BankConfigPersistenceConflictError
 from hindsight_api.engine.interface import BankTemplateImportWrite
 from hindsight_api.extensions import BankReadOperation, BankWriteOperation, OperationValidationError, ValidationResult
 from hindsight_api.models import RequestContext
@@ -1697,7 +1698,7 @@ async def test_patch_returns_404_when_bank_disappears_before_config_write(api_cl
     monkeypatch.setattr(
         memory._config_resolver,
         "_persist_bank_config",
-        AsyncMock(side_effect=ValueError(f"Cannot update config for bank '{bank_id}': the bank does not exist")),
+        AsyncMock(side_effect=BankConfigPersistenceConflictError(bank_id)),
     )
 
     response = await api_client.patch(
@@ -1796,6 +1797,46 @@ async def test_config_only_import_ensures_bank_once(api_client, memory, monkeypa
     assert response.status_code == 200, response.text
     ensure_bank_exists.assert_awaited_once()
     await memory.delete_bank(bank_id, request_context=RequestContext())
+
+
+@pytest.mark.asyncio
+async def test_config_only_import_returns_409_when_bank_is_deleted_before_config_write(
+    api_client,
+    memory,
+    monkeypatch,
+):
+    """A bank deleted after import authorization is a retryable state conflict."""
+    bank_id = f"import_concurrent_delete_config_{datetime.now().timestamp()}"
+    persist_started = asyncio.Event()
+    allow_persist = asyncio.Event()
+    persist_bank_config = memory._config_resolver._persist_bank_config
+
+    async def persist_after_delete(persisted_bank_id: str, updates: dict[str, object]) -> None:
+        if persisted_bank_id == bank_id:
+            persist_started.set()
+            await allow_persist.wait()
+        await persist_bank_config(persisted_bank_id, updates)
+
+    monkeypatch.setattr(memory._config_resolver, "_persist_bank_config", persist_after_delete)
+    import_task = asyncio.create_task(
+        api_client.post(
+            f"/v1/default/banks/{bank_id}/import",
+            json={"version": "1", "bank": {"reflect_mission": "Conflict"}},
+        )
+    )
+
+    await persist_started.wait()
+    try:
+        await memory.delete_bank(bank_id, request_context=RequestContext())
+    finally:
+        allow_persist.set()
+    response = await import_task
+
+    assert response.status_code == 409, response.text
+    assert response.json()["detail"] == (
+        f"Bank '{bank_id}' changed or was deleted during template import; retry the import."
+    )
+    await _assert_bank_missing(api_client, bank_id)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add a dedicated persistence conflict for validated bank config updates that lose their bank row before the SQL write.
- Return HTTP 409 for config-only template imports when the bank is deleted after authorization.
- Preserve the existing PATCH 404 behavior and 400 responses for invalid configuration.
- Add an event-coordinated regression test for the concurrent deletion window.

## Root cause

Template import authorizes its operations and ensures the bank before persisting config, but another request can delete that bank before the config UPDATE executes. The resolver correctly detected the zero-row update, but exposed it as a generic ValueError, so the import endpoint reported a valid request as HTTP 400.

## Impact

Clients now receive HTTP 409 for this retryable state conflict, while the bank remains deleted and is not unexpectedly reprovisioned. Other configuration validation and update-only PATCH semantics remain unchanged.

## Validation

- `uv run pytest tests/test_http_api_integration.py::test_config_only_import_returns_409_when_bank_is_deleted_before_config_write tests/test_http_api_integration.py::test_patch_returns_404_when_bank_disappears_before_config_write tests/test_hierarchical_config.py::test_update_bank_config_rejects_missing_bank -q`
- `uv run pytest tests/test_http_api_integration.py::test_config_only_import_ensures_bank_once tests/test_http_api_integration.py::test_import_rejects_duplicate_items_before_bank_creation -q`
- `./scripts/hooks/lint.sh`
- `uv run ty check hindsight_api/config_resolver.py hindsight_api/api/http.py tests/test_hierarchical_config.py tests/test_http_api_integration.py`