### PR TITLE
docs(reflect): clarify tag-scoped directive behavior

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -965,17 +965,21 @@ class ReflectRequest(BaseModel):
     )
     tags: list[str] | None = Field(
         default=None,
-        description="Filter memories by tags during reflection. If not specified, all memories are considered.",
+        description="Scope raw facts, observations, mental models, and tagged directives during reflection. "
+        "With no tags, memory retrieval is unfiltered while only untagged/global directives are loaded. "
+        "Use tags=[] with tags_match='exact' to select the untagged/global scope.",
     )
     tags_match: TagsMatch = Field(
         default="any",
         description="How to match tags: 'any' (OR, includes untagged), 'all' (AND, includes untagged), "
-        "'any_strict' (OR, excludes untagged), 'all_strict' (AND, excludes untagged).",
+        "'any_strict' (OR, excludes untagged), 'all_strict' (AND, excludes untagged), or "
+        "'exact' (set equality). Untagged directives remain global in every mode.",
     )
     tag_groups: list[TagGroup] | None = Field(
         default=None,
         description="Compound tag filter using boolean groups. Groups in the list are AND-ed. "
-        "Each group is a leaf {tags, match} or compound {and: [...]}, {or: [...]}, {not: ...}.",
+        "Each group is a leaf {tags, match} or compound {and: [...]}, {or: [...]}, {not: ...}. "
+        "Mutually exclusive with tags.",
     )
     apply_all_directives: bool = Field(
         default=False,
@@ -2087,7 +2091,10 @@ class CreateDirectiveRequest(BaseModel):
     content: str = Field(description="The directive text to inject into prompts")
     priority: int = Field(default=0, description="Higher priority directives are injected first")
     is_active: bool = Field(default=True, description="Whether this directive is active")
-    tags: list[str] = FieldWithDefault(list, description="Tags for filtering")
+    tags: list[str] = FieldWithDefault(
+        list,
+        description="Directive execution scope. Empty means global; non-empty requires a matching reflect scope.",
+    )
 
 
 class UpdateDirectiveRequest(BaseModel):
@@ -5798,14 +5805,21 @@ def _register_routes(app: FastAPI):
         "/v1/default/banks/{bank_id}/directives",
         response_model=DirectiveListResponse,
         summary="List directives",
-        description="List hard rules that are injected into prompts.",
+        description="List directive definitions. Unlike reflect, an omitted tag filter returns all directives.",
         operation_id="list_directives",
         tags=["Directives"],
     )
     async def api_list_directives(
         bank_id: str,
-        tags_filter: list[str] | None = Query(None, alias="tags", description="Filter by tags"),
-        tags_match: Literal["any", "all", "exact"] = Query("any", description="How to match tags"),
+        tags_filter: list[str] | None = Query(
+            None,
+            alias="tags",
+            description="Filter directives by execution scope. Omit or pass [] to list all directives.",
+        ),
+        tags_match: Literal["any", "all", "exact"] = Query(
+            "any",
+            description="How tagged directives match the requested scope. Untagged/global directives are included.",
+        ),
         active_only: bool = Query(True, description="Only return active directives"),
         limit: int = Query(100, ge=1, le=1000),
         offset: int = Query(0, ge=0),
@@ -5872,7 +5886,7 @@ def _register_routes(app: FastAPI):
         "/v1/default/banks/{bank_id}/directives",
         response_model=DirectiveResponse,
         summary="Create directive",
-        description="Create a hard rule that will be injected into prompts.",
+        description="Create a global or tag-scoped hard rule for reflect prompts.",
         operation_id="create_directive",
         tags=["Directives"],
     )

--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
@@ -82,7 +82,7 @@ async def tool_search_mental_models(
         query_embedding: Pre-computed embedding for semantic search
         max_results: Maximum number of mental models to return
         tags: Optional tags to filter mental models
-        tags_match: How to match tags - "any" (OR), "all" (AND)
+        tags_match: How to match tags - "any", "all", "any_strict", "all_strict", or "exact"
         exclude_ids: Optional list of mental model IDs to exclude (e.g., when refreshing a mental model)
         last_memory_write_at: The bank's newest memory write, resolved once per reflect. Skips the
             per-model staleness query for any model refreshed at or after it.
@@ -199,7 +199,7 @@ async def tool_search_observations(
         request_context: Request context for authentication
         max_tokens: Maximum tokens for results (default 5000)
         tags: Optional tags to filter observations
-        tags_match: How to match tags - "any" (OR), "all" (AND)
+        tags_match: How to match tags - "any", "all", "any_strict", "all_strict", or "exact"
         last_consolidated_at: When consolidation last ran (for staleness check)
         pending_consolidation: Number of memories waiting to be consolidated
         source_facts_max_tokens: Token budget for source facts (-1 = disabled, 0+ = enabled with limit)
@@ -282,7 +282,7 @@ async def tool_recall(
         request_context: Request context for authentication
         max_tokens: Maximum tokens for results (default 2048)
         tags: Filter by tags (includes untagged memories)
-        tags_match: How to match tags - "any" (OR), "all" (AND), or "exact"
+        tags_match: How to match tags - "any", "all", "any_strict", "all_strict", or "exact"
         connection_budget: Max DB connections for this recall (default 1 for internal ops)
         max_chunk_tokens: Maximum tokens for raw source chunk text (default 1000)
         fact_types: Optional filter for fact types to retrieve. Defaults to ["experience", "world"].

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -1836,7 +1836,8 @@ paths:
       - Knowledge Base
   /v1/default/banks/{bank_id}/directives:
     get:
-      description: List hard rules that are injected into prompts.
+      description: "List directive definitions. Unlike reflect, an omitted tag filter\
+        \ returns all directives."
       operationId: list_directives
       parameters:
       - explode: false
@@ -1847,7 +1848,8 @@ paths:
           title: Bank Id
           type: string
         style: simple
-      - description: Filter by tags
+      - description: "Filter directives by execution scope. Omit or pass [] to list\
+          \ all directives."
         explode: true
         in: query
         name: tags
@@ -1858,14 +1860,16 @@ paths:
           nullable: true
           type: array
         style: form
-      - description: How to match tags
+      - description: How tagged directives match the requested scope. Untagged/global
+          directives are included.
         explode: true
         in: query
         name: tags_match
         required: false
         schema:
           default: any
-          description: How to match tags
+          description: How tagged directives match the requested scope. Untagged/global
+            directives are included.
           enum:
           - any
           - all
@@ -1930,7 +1934,7 @@ paths:
       tags:
       - Directives
     post:
-      description: Create a hard rule that will be injected into prompts.
+      description: Create a global or tag-scoped hard rule for reflect prompts.
       operationId: create_directive
       parameters:
       - explode: false
@@ -5619,7 +5623,8 @@ components:
           type: boolean
         tags:
           default: []
-          description: Tags for filtering
+          description: Directive execution scope. Empty means global; non-empty requires
+            a matching reflect scope.
           items:
             type: string
           type: array
@@ -9137,7 +9142,8 @@ components:
           default: any
           description: "How to match tags: 'any' (OR, includes untagged), 'all' (AND,\
             \ includes untagged), 'any_strict' (OR, excludes untagged), 'all_strict'\
-            \ (AND, excludes untagged)."
+            \ (AND, excludes untagged), or 'exact' (set equality). Untagged directives\
+            \ remain global in every mode."
           enum:
           - any
           - all

--- a/hindsight-clients/go/api_directives.go
+++ b/hindsight-clients/go/api_directives.go
@@ -49,7 +49,7 @@ func (r ApiCreateDirectiveRequest) Execute() (*DirectiveResponse, *http.Response
 /*
 CreateDirective Create directive
 
-Create a hard rule that will be injected into prompts.
+Create a global or tag-scoped hard rule for reflect prompts.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param bankId
@@ -421,13 +421,13 @@ type ApiListDirectivesRequest struct {
 	authorization *string
 }
 
-// Filter by tags
+// Filter directives by execution scope. Omit or pass [] to list all directives.
 func (r ApiListDirectivesRequest) Tags(tags []string) ApiListDirectivesRequest {
 	r.tags = &tags
 	return r
 }
 
-// How to match tags
+// How tagged directives match the requested scope. Untagged/global directives are included.
 func (r ApiListDirectivesRequest) TagsMatch(tagsMatch string) ApiListDirectivesRequest {
 	r.tagsMatch = &tagsMatch
 	return r
@@ -461,7 +461,7 @@ func (r ApiListDirectivesRequest) Execute() (*DirectiveListResponse, *http.Respo
 /*
 ListDirectives List directives
 
-List hard rules that are injected into prompts.
+List directive definitions. Unlike reflect, an omitted tag filter returns all directives.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param bankId

--- a/hindsight-clients/go/model_create_directive_request.go
+++ b/hindsight-clients/go/model_create_directive_request.go
@@ -29,7 +29,7 @@ type CreateDirectiveRequest struct {
 	Priority *int32 `json:"priority,omitempty"`
 	// Whether this directive is active
 	IsActive *bool `json:"is_active,omitempty"`
-	// Tags for filtering
+	// Directive execution scope. Empty means global; non-empty requires a matching reflect scope.
 	Tags []string `json:"tags,omitempty"`
 }
 

--- a/hindsight-clients/go/model_reflect_request.go
+++ b/hindsight-clients/go/model_reflect_request.go
@@ -30,7 +30,7 @@ type ReflectRequest struct {
 	Include *ReflectIncludeOptions `json:"include,omitempty"`
 	ResponseSchema map[string]interface{} `json:"response_schema,omitempty"`
 	Tags []string `json:"tags,omitempty"`
-	// How to match tags: 'any' (OR, includes untagged), 'all' (AND, includes untagged), 'any_strict' (OR, excludes untagged), 'all_strict' (AND, excludes untagged).
+	// How to match tags: 'any' (OR, includes untagged), 'all' (AND, includes untagged), 'any_strict' (OR, excludes untagged), 'all_strict' (AND, excludes untagged), or 'exact' (set equality). Untagged directives remain global in every mode.
 	TagsMatch *string `json:"tags_match,omitempty"`
 	TagGroups []MentalModelTriggerInputTagGroupsInner `json:"tag_groups,omitempty"`
 	// Apply every active directive regardless of tags. By default directives are scoped like memories: untagged directives always apply, and tagged directives apply only when the request's tags match them. Set true to apply all active directives, ignoring tag scope.

--- a/hindsight-clients/python/hindsight_client_api/api/directives_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/directives_api.py
@@ -63,7 +63,7 @@ class DirectivesApi:
     ) -> DirectiveResponse:
         """Create directive
 
-        Create a hard rule that will be injected into prompts.
+        Create a global or tag-scoped hard rule for reflect prompts.
 
         :param bank_id: (required)
         :type bank_id: str
@@ -139,7 +139,7 @@ class DirectivesApi:
     ) -> ApiResponse[DirectiveResponse]:
         """Create directive
 
-        Create a hard rule that will be injected into prompts.
+        Create a global or tag-scoped hard rule for reflect prompts.
 
         :param bank_id: (required)
         :type bank_id: str
@@ -215,7 +215,7 @@ class DirectivesApi:
     ) -> RESTResponseType:
         """Create directive
 
-        Create a hard rule that will be injected into prompts.
+        Create a global or tag-scoped hard rule for reflect prompts.
 
         :param bank_id: (required)
         :type bank_id: str
@@ -938,8 +938,8 @@ class DirectivesApi:
     async def list_directives(
         self,
         bank_id: StrictStr,
-        tags: Annotated[Optional[List[StrictStr]], Field(description="Filter by tags")] = None,
-        tags_match: Annotated[Optional[StrictStr], Field(description="How to match tags")] = None,
+        tags: Annotated[Optional[List[StrictStr]], Field(description="Filter directives by execution scope. Omit or pass [] to list all directives.")] = None,
+        tags_match: Annotated[Optional[StrictStr], Field(description="How tagged directives match the requested scope. Untagged/global directives are included.")] = None,
         active_only: Annotated[Optional[StrictBool], Field(description="Only return active directives")] = None,
         limit: Optional[Annotated[int, Field(le=1000, strict=True, ge=1)]] = None,
         offset: Optional[Annotated[int, Field(strict=True, ge=0)]] = None,
@@ -959,13 +959,13 @@ class DirectivesApi:
     ) -> DirectiveListResponse:
         """List directives
 
-        List hard rules that are injected into prompts.
+        List directive definitions. Unlike reflect, an omitted tag filter returns all directives.
 
         :param bank_id: (required)
         :type bank_id: str
-        :param tags: Filter by tags
+        :param tags: Filter directives by execution scope. Omit or pass [] to list all directives.
         :type tags: List[str]
-        :param tags_match: How to match tags
+        :param tags_match: How tagged directives match the requested scope. Untagged/global directives are included.
         :type tags_match: str
         :param active_only: Only return active directives
         :type active_only: bool
@@ -1030,8 +1030,8 @@ class DirectivesApi:
     async def list_directives_with_http_info(
         self,
         bank_id: StrictStr,
-        tags: Annotated[Optional[List[StrictStr]], Field(description="Filter by tags")] = None,
-        tags_match: Annotated[Optional[StrictStr], Field(description="How to match tags")] = None,
+        tags: Annotated[Optional[List[StrictStr]], Field(description="Filter directives by execution scope. Omit or pass [] to list all directives.")] = None,
+        tags_match: Annotated[Optional[StrictStr], Field(description="How tagged directives match the requested scope. Untagged/global directives are included.")] = None,
         active_only: Annotated[Optional[StrictBool], Field(description="Only return active directives")] = None,
         limit: Optional[Annotated[int, Field(le=1000, strict=True, ge=1)]] = None,
         offset: Optional[Annotated[int, Field(strict=True, ge=0)]] = None,
@@ -1051,13 +1051,13 @@ class DirectivesApi:
     ) -> ApiResponse[DirectiveListResponse]:
         """List directives
 
-        List hard rules that are injected into prompts.
+        List directive definitions. Unlike reflect, an omitted tag filter returns all directives.
 
         :param bank_id: (required)
         :type bank_id: str
-        :param tags: Filter by tags
+        :param tags: Filter directives by execution scope. Omit or pass [] to list all directives.
         :type tags: List[str]
-        :param tags_match: How to match tags
+        :param tags_match: How tagged directives match the requested scope. Untagged/global directives are included.
         :type tags_match: str
         :param active_only: Only return active directives
         :type active_only: bool
@@ -1122,8 +1122,8 @@ class DirectivesApi:
     async def list_directives_without_preload_content(
         self,
         bank_id: StrictStr,
-        tags: Annotated[Optional[List[StrictStr]], Field(description="Filter by tags")] = None,
-        tags_match: Annotated[Optional[StrictStr], Field(description="How to match tags")] = None,
+        tags: Annotated[Optional[List[StrictStr]], Field(description="Filter directives by execution scope. Omit or pass [] to list all directives.")] = None,
+        tags_match: Annotated[Optional[StrictStr], Field(description="How tagged directives match the requested scope. Untagged/global directives are included.")] = None,
         active_only: Annotated[Optional[StrictBool], Field(description="Only return active directives")] = None,
         limit: Optional[Annotated[int, Field(le=1000, strict=True, ge=1)]] = None,
         offset: Optional[Annotated[int, Field(strict=True, ge=0)]] = None,
@@ -1143,13 +1143,13 @@ class DirectivesApi:
     ) -> RESTResponseType:
         """List directives
 
-        List hard rules that are injected into prompts.
+        List directive definitions. Unlike reflect, an omitted tag filter returns all directives.
 
         :param bank_id: (required)
         :type bank_id: str
-        :param tags: Filter by tags
+        :param tags: Filter directives by execution scope. Omit or pass [] to list all directives.
         :type tags: List[str]
-        :param tags_match: How to match tags
+        :param tags_match: How tagged directives match the requested scope. Untagged/global directives are included.
         :type tags_match: str
         :param active_only: Only return active directives
         :type active_only: bool

--- a/hindsight-clients/python/hindsight_client_api/models/create_directive_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/create_directive_request.py
@@ -30,7 +30,7 @@ class CreateDirectiveRequest(BaseModel):
     content: StrictStr = Field(description="The directive text to inject into prompts")
     priority: Optional[StrictInt] = Field(default=0, description="Higher priority directives are injected first")
     is_active: Optional[StrictBool] = Field(default=True, description="Whether this directive is active")
-    tags: Optional[List[StrictStr]] = Field(default=None, description="Tags for filtering")
+    tags: Optional[List[StrictStr]] = Field(default=None, description="Directive execution scope. Empty means global; non-empty requires a matching reflect scope.")
     __properties: ClassVar[List[str]] = ["name", "content", "priority", "is_active", "tags"]
 
     model_config = ConfigDict(

--- a/hindsight-clients/python/hindsight_client_api/models/reflect_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/reflect_request.py
@@ -36,7 +36,7 @@ class ReflectRequest(BaseModel):
     include: Optional[ReflectIncludeOptions] = Field(default=None, description="Options for including additional data (disabled by default)")
     response_schema: Optional[Dict[str, Any]] = None
     tags: Optional[List[StrictStr]] = None
-    tags_match: Optional[StrictStr] = Field(default='any', description="How to match tags: 'any' (OR, includes untagged), 'all' (AND, includes untagged), 'any_strict' (OR, excludes untagged), 'all_strict' (AND, excludes untagged).")
+    tags_match: Optional[StrictStr] = Field(default='any', description="How to match tags: 'any' (OR, includes untagged), 'all' (AND, includes untagged), 'any_strict' (OR, excludes untagged), 'all_strict' (AND, excludes untagged), or 'exact' (set equality). Untagged directives remain global in every mode.")
     tag_groups: Optional[List[MentalModelTriggerInputTagGroupsInner]] = None
     apply_all_directives: Optional[StrictBool] = Field(default=False, description="Apply every active directive regardless of tags. By default directives are scoped like memories: untagged directives always apply, and tagged directives apply only when the request's tags match them. Set true to apply all active directives, ignoring tag scope.")
     fact_types: Optional[List[StrictStr]] = None

--- a/hindsight-clients/typescript/generated/sdk.gen.ts
+++ b/hindsight-clients/typescript/generated/sdk.gen.ts
@@ -840,7 +840,7 @@ export const updateKnowledgeNode = <ThrowOnError extends boolean = false>(
 /**
  * List directives
  *
- * List hard rules that are injected into prompts.
+ * List directive definitions. Unlike reflect, an omitted tag filter returns all directives.
  */
 export const listDirectives = <ThrowOnError extends boolean = false>(
   options: Options<ListDirectivesData, ThrowOnError>
@@ -853,7 +853,7 @@ export const listDirectives = <ThrowOnError extends boolean = false>(
 /**
  * Create directive
  *
- * Create a hard rule that will be injected into prompts.
+ * Create a global or tag-scoped hard rule for reflect prompts.
  */
 export const createDirective = <ThrowOnError extends boolean = false>(
   options: Options<CreateDirectiveData, ThrowOnError>

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -1208,7 +1208,7 @@ export type CreateDirectiveRequest = {
   /**
    * Tags
    *
-   * Tags for filtering
+   * Directive execution scope. Empty means global; non-empty requires a matching reflect scope.
    */
   tags?: Array<string>;
 };
@@ -4301,19 +4301,19 @@ export type ReflectRequest = {
   /**
    * Tags
    *
-   * Filter memories by tags during reflection. If not specified, all memories are considered.
+   * Scope raw facts, observations, mental models, and tagged directives during reflection. With no tags, memory retrieval is unfiltered while only untagged/global directives are loaded. Use tags=[] with tags_match='exact' to select the untagged/global scope.
    */
   tags?: Array<string> | null;
   /**
    * Tags Match
    *
-   * How to match tags: 'any' (OR, includes untagged), 'all' (AND, includes untagged), 'any_strict' (OR, excludes untagged), 'all_strict' (AND, excludes untagged).
+   * How to match tags: 'any' (OR, includes untagged), 'all' (AND, includes untagged), 'any_strict' (OR, excludes untagged), 'all_strict' (AND, excludes untagged), or 'exact' (set equality). Untagged directives remain global in every mode.
    */
   tags_match?: "any" | "all" | "any_strict" | "all_strict" | "exact";
   /**
    * Tag Groups
    *
-   * Compound tag filter using boolean groups. Groups in the list are AND-ed. Each group is a leaf {tags, match} or compound {and: [...]}, {or: [...]}, {not: ...}.
+   * Compound tag filter using boolean groups. Groups in the list are AND-ed. Each group is a leaf {tags, match} or compound {and: [...]}, {or: [...]}, {not: ...}. Mutually exclusive with tags.
    */
   tag_groups?: Array<TagGroupLeaf | TagGroupAndInput | TagGroupOrInput | TagGroupNotInput> | null;
   /**
@@ -6658,13 +6658,13 @@ export type ListDirectivesData = {
     /**
      * Tags
      *
-     * Filter by tags
+     * Filter directives by execution scope. Omit or pass [] to list all directives.
      */
     tags?: Array<string> | null;
     /**
      * Tags Match
      *
-     * How to match tags
+     * How tagged directives match the requested scope. Untagged/global directives are included.
      */
     tags_match?: "any" | "all" | "exact";
     /**

--- a/hindsight-docs/docs/developer/api/recall.mdx
+++ b/hindsight-docs/docs/developer/api/recall.mdx
@@ -167,7 +167,8 @@ Enabled by default. When active, each returned fact includes the canonical names
 
 ### tags
 
-Filters recall to only memories that match the specified tags. When omitted, all memories regardless of tags are eligible. Tag filtering is applied at the database level across all four retrieval strategies, not as a post-processing step.
+Filters recall to memories in the requested tag scope. `tags` defaults to `null` and
+`tags_match` defaults to `any`.
 
 The `tags_match` parameter controls the filtering logic:
 
@@ -178,6 +179,23 @@ The `tags_match` parameter controls the filtering logic:
 | `all` | Included | Memory has **all** of the specified tags |
 | `all_strict` | Excluded | Memory has **all** of the specified tags |
 | `exact` | Excluded | Memory has **exactly** the specified tag set |
+
+The defaults and empty-filter behavior are important:
+
+| `tags` | `tags_match` | Eligible memories |
+|--------|--------------|-------------------|
+| Omitted, `null`, or `[]` | Omitted (`any`) | All tagged and untagged memories |
+| Omitted, `null`, or `[]` | `any`, `all`, `any_strict`, or `all_strict` | All tagged and untagged memories; an empty tag list means no filter |
+| Omitted, `null`, or `[]` | `exact` | Only untagged/global memories |
+| Non-empty | `any` or `all` | Matching tagged memories plus untagged/global memories |
+| Non-empty | `any_strict` or `all_strict` | Matching tagged memories only |
+| Non-empty | `exact` | Memories whose complete tag set exactly equals `tags` |
+
+:::note MCP empty-scope behavior
+For the MCP `recall` tool, `tags_match` is forwarded only when `tags` is present.
+To select the untagged/global scope through MCP, pass both `tags: []` and
+`tags_match: "exact"` rather than omitting `tags`.
+:::
 
 #### Scenario setup
 
@@ -298,7 +316,13 @@ With any other `tags_match` mode, absent or empty `tags` means "no tag filter" (
 
 `tag_groups` is a list of compound boolean tag filters. The groups in the list are AND-ed together at the top level. Each group is a recursive boolean expression: a **leaf** node `{tags, match}`, or a **compound** node `{and: [...]}`, `{or: [...]}`, or `{not: ...}`.
 
-`tag_groups` and `tags` / `tags_match` can be used simultaneously — they are AND-ed together.
+`tag_groups` defaults to `null`. The public REST and MCP request models treat
+`tag_groups` and `tags` as mutually exclusive: if both are present, the request is
+rejected. Use `tag_groups` by itself for compound filtering and normally leave the
+top-level `tags_match` at its default, `any`. Each `tag_groups` leaf has its own
+`match` value. The exception is top-level `tags_match: "exact"`: because exact
+matching gives absent flat tags a meaning, it adds a global-only flat constraint
+that is AND-ed with the compound expression.
 
 #### Leaf node
 

--- a/hindsight-docs/docs/developer/api/reflect.mdx
+++ b/hindsight-docs/docs/developer/api/reflect.mdx
@@ -95,7 +95,44 @@ An optional JSON Schema **object** with a non-empty `properties` map (nested obj
 
 ### tags
 
-Filters which memories the agent can access during reflection. Works identically to [recall tags](./recall#tags) — only memories matching the specified tags are considered. The `tags_match` parameter controls the matching logic (`any`, `all`, `any_strict`, `all_strict`, `exact`) with the same semantics as recall.
+Defines the visibility scope used throughout the reflect agent. It filters raw
+facts, observations, and mental models that the agent can retrieve. The same
+`tags` and `tags_match` values also select which tagged directives are injected
+into the reflect prompt.
+
+`tags` defaults to `null`, `tags_match` defaults to `any`, and `tag_groups`
+defaults to `null`. For non-empty tags, raw facts, observations, and mental
+models use the same matching modes as [recall tags](./recall#tags). Directives
+have one additional rule: untagged directives are global and remain eligible
+whenever a tag scope is supplied, including with a strict or exact match.
+
+| Reflect configuration | Raw facts and observations | Mental models | Active directives |
+|-----------------------|----------------------------|---------------|-------------------|
+| Omit `tags`, `tags_match`, and `tag_groups` | All tagged and untagged data | All tagged and untagged models | Untagged/global directives only |
+| `tags: []`, default `tags_match: "any"` | All tagged and untagged data | All tagged and untagged models | Untagged/global directives only |
+| No tags, `tags_match: "exact"` | Untagged/global data only | Untagged/global models only | Untagged/global directives only |
+| Non-empty `tags`, `any` or `all` | Matching tagged data plus untagged/global data | Matching models plus untagged/global models | Matching tagged directives plus untagged/global directives |
+| Non-empty `tags`, `any_strict` or `all_strict` | Matching tagged data only | Matching tagged models only | Matching tagged directives plus untagged/global directives |
+| Non-empty `tags`, `exact` | Data with exactly the requested tag set | Models with exactly the requested tag set | Exactly matching tagged directives plus untagged/global directives |
+| Non-empty `tag_groups`, default top-level `tags_match` | Data matching the compound expression | Models matching the compound expression | Matching tagged directives plus untagged/global directives |
+
+The first row is intentionally asymmetric: an unscoped reflect can search all
+memories, but it does not load tagged directives. To create a directive that
+applies to every reflect call, leave its `tags` empty. To create a scoped
+directive, assign tags and pass a matching scope to `reflect`.
+
+:::note `isolation_mode`
+`isolation_mode` is an internal `list_directives` option, not a public reflect
+request parameter. Reflect always enables it. When neither `tags` nor
+`tag_groups` is supplied, it limits directive loading to untagged directives.
+There is currently no per-request switch to disable it.
+:::
+
+:::note MCP omitted tags
+The MCP `reflect` tool forwards `tags_match` only when `tags` is present. To
+request the empty exact scope through MCP, pass `tags: []` together with
+`tags_match: "exact"`.
+:::
 
 <Tabs>
 <TabItem value="python" label="Python">
@@ -111,6 +148,51 @@ Filters which memories the agent can access during reflection. Works identically
 <CodeSnippet code={reflectGo} section="reflect-with-tags" language="go" />
 </TabItem>
 </Tabs>
+
+#### Common scope examples
+
+Unscoped reflect searches all memories but applies only global directives:
+
+```json
+{
+  "query": "Summarize the current project status"
+}
+```
+
+A project scope includes global data and directives alongside matching
+`project:a` data and directives:
+
+```json
+{
+  "query": "Summarize the current project status",
+  "tags": ["project:a"]
+}
+```
+
+A strict project scope excludes untagged memories, observations, and mental
+models. Global directives still apply:
+
+```json
+{
+  "query": "Summarize the current project status",
+  "tags": ["project:a"],
+  "tags_match": "all_strict"
+}
+```
+
+### tag_groups
+
+Provides compound tag filtering with recursive `and`, `or`, and `not`
+expressions. It affects the same reflect data sources and directive selection as
+flat `tags`. `tag_groups` and `tags` are mutually exclusive in the public REST
+request. Each leaf supplies its own matching mode and defaults to
+`any_strict`; the top-level groups are AND-ed. Normally leave the top-level
+`tags_match` at its default, `any`. Setting it to `exact` while using
+`tag_groups` additionally constrains facts, observations, and mental models to
+the global flat scope before applying the compound expression.
+
+The MCP `reflect` tool currently exposes flat `tags` and `tags_match`, but not
+`tag_groups`.
 
 ### include
 

--- a/hindsight-docs/docs/developer/mcp-server.md
+++ b/hindsight-docs/docs/developer/mcp-server.md
@@ -201,8 +201,9 @@ Search memories to provide personalized responses.
 | `max_tokens` | integer | No | Maximum tokens to return (default: 4096) |
 | `budget` | string | No | Search thoroughness: `low`, `mid`, or `high` (default: `high`) |
 | `types` | list[string] | No | Filter by fact type: `world`, `experience`, `observation`. Defaults to all |
-| `tags` | list[string] | No | Filter memories by tags |
-| `tags_match` | string | No | Tag matching mode: `any` (default) or `all` |
+| `tags` | list[string] | No | Filter memories by tags. Omit for no filter |
+| `tags_match` | string | No | `any` (default), `all`, `any_strict`, `all_strict`, or `exact`. With `exact`, pass `tags: []` to select the untagged/global scope |
+| `tag_groups` | list[object] | No | Compound boolean tag filter. Mutually exclusive with `tags`; each leaf has its own `match` value |
 | `query_timestamp` | string | No | ISO 8601 timestamp — recall as if asking at this point in time; anchors relative temporal expressions and recency scoring |
 | `min_scores` | object | No | Optional per-stage score floors, e.g. `{"reranker": 0.5}`. Keys: `semantic`/`keyword` (retrieval-level cutoffs), `reranker`/`final` (post-ranking). All inclusive and AND-ed; omit for no filtering. Reranker scores aren't calibrated across queries — calibrate before use |
 
@@ -237,9 +238,14 @@ Generate thoughtful analysis by synthesizing stored memories with the bank's per
 | `budget` | string | No | Search budget: `low`, `mid`, or `high` (default: `low`) |
 | `max_tokens` | integer | No | Maximum tokens in the response (default: 4096) |
 | `response_schema` | object | No | JSON Schema for structured output. When provided, the response includes a `structured_output` field |
-| `tags` | list[string] | No | Filter memories by tags before reflecting |
-| `tags_match` | string | No | Tag matching mode: `any` (default) or `all` |
+| `tags` | list[string] | No | Scope memories, observations, mental models, and tagged directives. Omitted tags leave memory retrieval unfiltered but load only untagged directives |
+| `tags_match` | string | No | `any` (default), `all`, `any_strict`, `all_strict`, or `exact`. Untagged directives remain global in every mode |
 | `include_trace` | boolean | No | Include `tool_trace` and `llm_trace` debugging output. Defaults to `false` to keep responses small |
+
+The MCP tool forwards `tags_match` only when `tags` is present. Pass
+`tags: []` with `tags_match: "exact"` to select the empty/global scope for raw
+facts, observations, and mental models; directive loading also selects only
+untagged directives.
 
 **Example:**
 ```json
@@ -394,11 +400,13 @@ Create a new memory bank or retrieve an existing one.
 
 ### list_directives
 
-List all directives in a bank. Directives are instructions that guide how the memory system processes and responds to queries.
+List directives in a bank. This management tool does not use reflect's
+directive-isolation behavior: omitting `tags` lists every directive, including
+tagged directives.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `tags` | list[string] | No | Filter directives by tags |
+| `tags` | list[string] | No | Filter using `any` matching. When present, returns untagged/global directives plus directives sharing at least one tag. When omitted or empty, returns all directives |
 | `active_only` | boolean | No | Only return active directives (default: `true`) |
 
 ---
@@ -413,7 +421,7 @@ Create a new directive in a bank.
 | `content` | string | Yes | The directive content/instruction |
 | `priority` | integer | No | Priority level (higher = more important) |
 | `is_active` | boolean | No | Whether the directive is active (default: `true`) |
-| `tags` | list[string] | No | Tags for organizing directives |
+| `tags` | list[string] | No | Execution scope for the directive. Empty/omitted (default) means global; non-empty means reflect must use a matching tag scope |
 
 ---
 

--- a/hindsight-docs/docs/developer/reflect.mdx
+++ b/hindsight-docs/docs/developer/reflect.mdx
@@ -36,7 +36,7 @@ Unlike simple retrieval, reflect is an **agentic system** that:
 1. **Autonomously gathers evidence** — The agent decides what information it needs and calls appropriate tools
 2. **Uses hierarchical retrieval** — Checks mental models first, then observations, then raw facts
 3. **Applies disposition** — Shapes reasoning based on the bank's personality traits
-4. **Enforces directives** — Hard rules that must be followed in all responses
+4. **Enforces applicable directives** — Global rules and rules matching the reflect tag scope
 5. **Cites sources** — Returns which memories and observations were used
 
 ### The Agentic Loop
@@ -162,7 +162,11 @@ Different use cases benefit from different disposition configurations:
 
 ## Directives: Hard Rules
 
-While disposition traits *influence* reasoning style, **directives** are hard rules that the agent *must* follow. Directives are injected into the prompt and enforced in every response.
+While disposition traits *influence* reasoning style, **directives** are hard
+rules that the agent *must* follow when they apply to the current reflect scope.
+Untagged directives are global; tagged directives require matching reflect
+tags. See [Memory Banks: Directives](/developer/api/memory-banks#directives) for
+the full matching and default-behavior tables.
 
 ### When to Use Directives
 

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -2687,7 +2687,7 @@
           "Directives"
         ],
         "summary": "List directives",
-        "description": "List hard rules that are injected into prompts.",
+        "description": "List directive definitions. Unlike reflect, an omitted tag filter returns all directives.",
         "operationId": "list_directives",
         "parameters": [
           {
@@ -2715,10 +2715,10 @@
                   "type": "null"
                 }
               ],
-              "description": "Filter by tags",
+              "description": "Filter directives by execution scope. Omit or pass [] to list all directives.",
               "title": "Tags"
             },
-            "description": "Filter by tags"
+            "description": "Filter directives by execution scope. Omit or pass [] to list all directives."
           },
           {
             "name": "tags_match",
@@ -2731,11 +2731,11 @@
                 "exact"
               ],
               "type": "string",
-              "description": "How to match tags",
+              "description": "How tagged directives match the requested scope. Untagged/global directives are included.",
               "default": "any",
               "title": "Tags Match"
             },
-            "description": "How to match tags"
+            "description": "How tagged directives match the requested scope. Untagged/global directives are included."
           },
           {
             "name": "active_only",
@@ -2817,7 +2817,7 @@
           "Directives"
         ],
         "summary": "Create directive",
-        "description": "Create a hard rule that will be injected into prompts.",
+        "description": "Create a global or tag-scoped hard rule for reflect prompts.",
         "operationId": "create_directive",
         "parameters": [
           {
@@ -8593,7 +8593,7 @@
             },
             "type": "array",
             "title": "Tags",
-            "description": "Tags for filtering",
+            "description": "Directive execution scope. Empty means global; non-empty requires a matching reflect scope.",
             "default": []
           }
         },
@@ -13847,7 +13847,7 @@
               }
             ],
             "title": "Tags",
-            "description": "Filter memories by tags during reflection. If not specified, all memories are considered."
+            "description": "Scope raw facts, observations, mental models, and tagged directives during reflection. With no tags, memory retrieval is unfiltered while only untagged/global directives are loaded. Use tags=[] with tags_match='exact' to select the untagged/global scope."
           },
           "tags_match": {
             "type": "string",
@@ -13859,7 +13859,7 @@
               "exact"
             ],
             "title": "Tags Match",
-            "description": "How to match tags: 'any' (OR, includes untagged), 'all' (AND, includes untagged), 'any_strict' (OR, excludes untagged), 'all_strict' (AND, excludes untagged).",
+            "description": "How to match tags: 'any' (OR, includes untagged), 'all' (AND, includes untagged), 'any_strict' (OR, excludes untagged), 'all_strict' (AND, excludes untagged), or 'exact' (set equality). Untagged directives remain global in every mode.",
             "default": "any"
           },
           "tag_groups": {
@@ -13888,7 +13888,7 @@
               }
             ],
             "title": "Tag Groups",
-            "description": "Compound tag filter using boolean groups. Groups in the list are AND-ed. Each group is a leaf {tags, match} or compound {and: [...]}, {or: [...]}, {not: ...}."
+            "description": "Compound tag filter using boolean groups. Groups in the list are AND-ed. Each group is a leaf {tags, match} or compound {and: [...]}, {or: [...]}, {not: ...}. Mutually exclusive with tags."
           },
           "apply_all_directives": {
             "type": "boolean",

--- a/hindsight-docs/versioned_docs/version-0.8/developer/api/recall.mdx
+++ b/hindsight-docs/versioned_docs/version-0.8/developer/api/recall.mdx
@@ -167,7 +167,8 @@ Enabled by default. When active, each returned fact includes the canonical names
 
 ### tags
 
-Filters recall to only memories that match the specified tags. When omitted, all memories regardless of tags are eligible. Tag filtering is applied at the database level across all four retrieval strategies, not as a post-processing step.
+Filters recall to memories in the requested tag scope. `tags` defaults to `null` and
+`tags_match` defaults to `any`.
 
 The `tags_match` parameter controls the filtering logic:
 
@@ -178,6 +179,23 @@ The `tags_match` parameter controls the filtering logic:
 | `all` | Included | Memory has **all** of the specified tags |
 | `all_strict` | Excluded | Memory has **all** of the specified tags |
 | `exact` | Excluded | Memory has **exactly** the specified tag set |
+
+The defaults and empty-filter behavior are important:
+
+| `tags` | `tags_match` | Eligible memories |
+|--------|--------------|-------------------|
+| Omitted, `null`, or `[]` | Omitted (`any`) | All tagged and untagged memories |
+| Omitted, `null`, or `[]` | `any`, `all`, `any_strict`, or `all_strict` | All tagged and untagged memories; an empty tag list means no filter |
+| Omitted, `null`, or `[]` | `exact` | Only untagged/global memories |
+| Non-empty | `any` or `all` | Matching tagged memories plus untagged/global memories |
+| Non-empty | `any_strict` or `all_strict` | Matching tagged memories only |
+| Non-empty | `exact` | Memories whose complete tag set exactly equals `tags` |
+
+:::note MCP empty-scope behavior
+For the MCP `recall` tool, `tags_match` is forwarded only when `tags` is present.
+To select the untagged/global scope through MCP, pass both `tags: []` and
+`tags_match: "exact"` rather than omitting `tags`.
+:::
 
 #### Scenario setup
 
@@ -298,7 +316,13 @@ With any other `tags_match` mode, absent or empty `tags` means "no tag filter" (
 
 `tag_groups` is a list of compound boolean tag filters. The groups in the list are AND-ed together at the top level. Each group is a recursive boolean expression: a **leaf** node `{tags, match}`, or a **compound** node `{and: [...]}`, `{or: [...]}`, or `{not: ...}`.
 
-`tag_groups` and `tags` / `tags_match` can be used simultaneously — they are AND-ed together.
+`tag_groups` defaults to `null`. The public REST and MCP request models treat
+`tag_groups` and `tags` as mutually exclusive: if both are present, the request is
+rejected. Use `tag_groups` by itself for compound filtering and normally leave the
+top-level `tags_match` at its default, `any`. Each `tag_groups` leaf has its own
+`match` value. The exception is top-level `tags_match: "exact"`: because exact
+matching gives absent flat tags a meaning, it adds a global-only flat constraint
+that is AND-ed with the compound expression.
 
 #### Leaf node
 

--- a/hindsight-docs/versioned_docs/version-0.8/developer/api/reflect.mdx
+++ b/hindsight-docs/versioned_docs/version-0.8/developer/api/reflect.mdx
@@ -95,7 +95,44 @@ An optional JSON Schema object. When provided, the LLM generates a response that
 
 ### tags
 
-Filters which memories the agent can access during reflection. Works identically to [recall tags](./recall#tags) — only memories matching the specified tags are considered. The `tags_match` parameter controls the matching logic (`any`, `all`, `any_strict`, `all_strict`, `exact`) with the same semantics as recall.
+Defines the visibility scope used throughout the reflect agent. It filters raw
+facts, observations, and mental models that the agent can retrieve. The same
+`tags` and `tags_match` values also select which tagged directives are injected
+into the reflect prompt.
+
+`tags` defaults to `null`, `tags_match` defaults to `any`, and `tag_groups`
+defaults to `null`. For non-empty tags, raw facts, observations, and mental
+models use the same matching modes as [recall tags](./recall#tags). Directives
+have one additional rule: untagged directives are global and remain eligible
+whenever a tag scope is supplied, including with a strict or exact match.
+
+| Reflect configuration | Raw facts and observations | Mental models | Active directives |
+|-----------------------|----------------------------|---------------|-------------------|
+| Omit `tags`, `tags_match`, and `tag_groups` | All tagged and untagged data | All tagged and untagged models | Untagged/global directives only |
+| `tags: []`, default `tags_match: "any"` | All tagged and untagged data | All tagged and untagged models | Untagged/global directives only |
+| No tags, `tags_match: "exact"` | Untagged/global data only | Untagged/global models only | Untagged/global directives only |
+| Non-empty `tags`, `any` or `all` | Matching tagged data plus untagged/global data | Matching models plus untagged/global models | Matching tagged directives plus untagged/global directives |
+| Non-empty `tags`, `any_strict` or `all_strict` | Matching tagged data only | Matching tagged models only | Matching tagged directives plus untagged/global directives |
+| Non-empty `tags`, `exact` | Data with exactly the requested tag set | Models with exactly the requested tag set | Exactly matching tagged directives plus untagged/global directives |
+| Non-empty `tag_groups`, default top-level `tags_match` | Data matching the compound expression | Models matching the compound expression | Matching tagged directives plus untagged/global directives |
+
+The first row is intentionally asymmetric: an unscoped reflect can search all
+memories, but it does not load tagged directives. To create a directive that
+applies to every reflect call, leave its `tags` empty. To create a scoped
+directive, assign tags and pass a matching scope to `reflect`.
+
+:::note `isolation_mode`
+`isolation_mode` is an internal `list_directives` option, not a public reflect
+request parameter. Reflect always enables it. When neither `tags` nor
+`tag_groups` is supplied, it limits directive loading to untagged directives.
+There is currently no per-request switch to disable it.
+:::
+
+:::note MCP omitted tags
+The MCP `reflect` tool forwards `tags_match` only when `tags` is present. To
+request the empty exact scope through MCP, pass `tags: []` together with
+`tags_match: "exact"`.
+:::
 
 <Tabs>
 <TabItem value="python" label="Python">
@@ -111,6 +148,51 @@ Filters which memories the agent can access during reflection. Works identically
 <CodeSnippet code={reflectGo} section="reflect-with-tags" language="go" />
 </TabItem>
 </Tabs>
+
+#### Common scope examples
+
+Unscoped reflect searches all memories but applies only global directives:
+
+```json
+{
+  "query": "Summarize the current project status"
+}
+```
+
+A project scope includes global data and directives alongside matching
+`project:a` data and directives:
+
+```json
+{
+  "query": "Summarize the current project status",
+  "tags": ["project:a"]
+}
+```
+
+A strict project scope excludes untagged memories, observations, and mental
+models. Global directives still apply:
+
+```json
+{
+  "query": "Summarize the current project status",
+  "tags": ["project:a"],
+  "tags_match": "all_strict"
+}
+```
+
+### tag_groups
+
+Provides compound tag filtering with recursive `and`, `or`, and `not`
+expressions. It affects the same reflect data sources and directive selection as
+flat `tags`. `tag_groups` and `tags` are mutually exclusive in the public REST
+request. Each leaf supplies its own matching mode and defaults to
+`any_strict`; the top-level groups are AND-ed. Normally leave the top-level
+`tags_match` at its default, `any`. Setting it to `exact` while using
+`tag_groups` additionally constrains facts, observations, and mental models to
+the global flat scope before applying the compound expression.
+
+The MCP `reflect` tool currently exposes flat `tags` and `tags_match`, but not
+`tag_groups`.
 
 ### include
 

--- a/hindsight-docs/versioned_docs/version-0.8/developer/mcp-server.md
+++ b/hindsight-docs/versioned_docs/version-0.8/developer/mcp-server.md
@@ -201,8 +201,9 @@ Search memories to provide personalized responses.
 | `max_tokens` | integer | No | Maximum tokens to return (default: 4096) |
 | `budget` | string | No | Search thoroughness: `low`, `mid`, or `high` (default: `high`) |
 | `types` | list[string] | No | Filter by fact type: `world`, `experience`, `observation`. Defaults to all |
-| `tags` | list[string] | No | Filter memories by tags |
-| `tags_match` | string | No | Tag matching mode: `any` (default) or `all` |
+| `tags` | list[string] | No | Filter memories by tags. Omit for no filter |
+| `tags_match` | string | No | `any` (default), `all`, `any_strict`, `all_strict`, or `exact`. With `exact`, pass `tags: []` to select the untagged/global scope |
+| `tag_groups` | list[object] | No | Compound boolean tag filter. Mutually exclusive with `tags`; each leaf has its own `match` value |
 | `query_timestamp` | string | No | ISO 8601 timestamp — recall as if asking at this point in time; anchors relative temporal expressions and recency scoring |
 | `min_scores` | object | No | Optional per-stage score floors, e.g. `{"reranker": 0.5}`. Keys: `semantic`/`keyword` (retrieval-level cutoffs), `reranker`/`final` (post-ranking). All inclusive and AND-ed; omit for no filtering. Reranker scores aren't calibrated across queries — calibrate before use |
 
@@ -237,9 +238,14 @@ Generate thoughtful analysis by synthesizing stored memories with the bank's per
 | `budget` | string | No | Search budget: `low`, `mid`, or `high` (default: `low`) |
 | `max_tokens` | integer | No | Maximum tokens in the response (default: 4096) |
 | `response_schema` | object | No | JSON Schema for structured output. When provided, the response includes a `structured_output` field |
-| `tags` | list[string] | No | Filter memories by tags before reflecting |
-| `tags_match` | string | No | Tag matching mode: `any` (default) or `all` |
+| `tags` | list[string] | No | Scope memories, observations, mental models, and tagged directives. Omitted tags leave memory retrieval unfiltered but load only untagged directives |
+| `tags_match` | string | No | `any` (default), `all`, `any_strict`, `all_strict`, or `exact`. Untagged directives remain global in every mode |
 | `include_trace` | boolean | No | Include `tool_trace` and `llm_trace` debugging output. Defaults to `false` to keep responses small |
+
+The MCP tool forwards `tags_match` only when `tags` is present. Pass
+`tags: []` with `tags_match: "exact"` to select the empty/global scope for raw
+facts, observations, and mental models; directive loading also selects only
+untagged directives.
 
 **Example:**
 ```json
@@ -394,11 +400,13 @@ Create a new memory bank or retrieve an existing one.
 
 ### list_directives
 
-List all directives in a bank. Directives are instructions that guide how the memory system processes and responds to queries.
+List directives in a bank. This management tool does not use reflect's
+directive-isolation behavior: omitting `tags` lists every directive, including
+tagged directives.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `tags` | list[string] | No | Filter directives by tags |
+| `tags` | list[string] | No | Filter using `any` matching. When present, returns untagged/global directives plus directives sharing at least one tag. When omitted or empty, returns all directives |
 | `active_only` | boolean | No | Only return active directives (default: `true`) |
 
 ---
@@ -413,7 +421,7 @@ Create a new directive in a bank.
 | `content` | string | Yes | The directive content/instruction |
 | `priority` | integer | No | Priority level (higher = more important) |
 | `is_active` | boolean | No | Whether the directive is active (default: `true`) |
-| `tags` | list[string] | No | Tags for organizing directives |
+| `tags` | list[string] | No | Execution scope for the directive. Empty/omitted (default) means global; non-empty means reflect must use a matching tag scope |
 
 ---
 

--- a/hindsight-docs/versioned_docs/version-0.8/developer/reflect.mdx
+++ b/hindsight-docs/versioned_docs/version-0.8/developer/reflect.mdx
@@ -36,7 +36,7 @@ Unlike simple retrieval, reflect is an **agentic system** that:
 1. **Autonomously gathers evidence** — The agent decides what information it needs and calls appropriate tools
 2. **Uses hierarchical retrieval** — Checks mental models first, then observations, then raw facts
 3. **Applies disposition** — Shapes reasoning based on the bank's personality traits
-4. **Enforces directives** — Hard rules that must be followed in all responses
+4. **Enforces applicable directives** — Global rules and rules matching the reflect tag scope
 5. **Cites sources** — Returns which memories and observations were used
 
 ### The Agentic Loop
@@ -162,7 +162,11 @@ Different use cases benefit from different disposition configurations:
 
 ## Directives: Hard Rules
 
-While disposition traits *influence* reasoning style, **directives** are hard rules that the agent *must* follow. Directives are injected into the prompt and enforced in every response.
+While disposition traits *influence* reasoning style, **directives** are hard
+rules that the agent *must* follow when they apply to the current reflect scope.
+Untagged directives are global; tagged directives require matching reflect
+tags. See [Memory Banks: Directives](/developer/api/memory-banks#directives) for
+the full matching and default-behavior tables.
 
 ### When to Use Directives
 

--- a/skills/hindsight-architect/SKILL.md
+++ b/skills/hindsight-architect/SKILL.md
@@ -207,12 +207,12 @@ Key parameters:
 |-----------|---------|
 | `query` | Natural language search |
 | `tags` | Filter by tags |
-| `tags_match` | `any` (OR + untagged), `all` (AND + untagged), `any_strict` (OR, only tagged), `all_strict` (AND, only tagged) |
+| `tags_match` | `any` (OR + untagged), `all` (AND + untagged), `any_strict` (OR, only tagged), `all_strict` (AND, only tagged), `exact` (identical tag set) |
 | `max_tokens` | Token budget for results (not result count — Hindsight thinks in context windows) |
 | `budget` | Search depth: `low`, `mid`, `high` |
 | `types` | Filter: `world`, `experience`, `observation` |
 
-**`tags_match` modes matter.** `any` includes untagged memories — use when shared/untagged content should appear alongside tagged results. `any_strict` excludes untagged — use for strict scoping (e.g., only this user's memories).
+**`tags_match` modes matter.** `any` includes untagged memories — use when shared/untagged content should appear alongside tagged results. `any_strict` excludes untagged — use for strict scoping (e.g., only this user's memories). Omitted tags, or an empty list with any mode except `exact`, disable tag filtering. Empty tags with `exact` select only untagged/global data.
 
 ### Reflect — Agentic Reasoning
 
@@ -224,7 +224,7 @@ Retrieval priority: mental models → observations → raw facts.
 |-----------|---------|
 | `query` | Question or prompt |
 | `budget` | Research depth: `low`, `mid`, `high` |
-| `tags`, `tags_match` | Filter memories |
+| `tags`, `tags_match` | Scope raw facts, observations, mental models, and tagged directives |
 | `response_schema` | JSON Schema for structured output |
 
 **When to use reflect:** Complex reasoning that needs disposition-influenced judgment with citations — forming recommendations, making assessments, synthesizing nuanced answers where the bank's personality matters.
@@ -236,7 +236,7 @@ Retrieval priority: mental models → observations → raw facts.
 - `literalism` (1-5): flexible → literal
 - `empathy` (1-5): detached → empathetic
 
-**Directives** are hard rules enforced during reflect (vs disposition = soft influence). Use for compliance, privacy rules, style constraints.
+**Directives** are hard rules enforced during reflect (vs disposition = soft influence). Untagged directives are global. Tagged directives apply only to a matching reflect scope, while global directives still apply in strict and exact modes. An unscoped reflect loads only global directives even though its memory retrieval is otherwise unfiltered. Use directives for compliance, privacy rules, style constraints, and leave compliance rules untagged when they must apply universally.
 
 ### Memory Banks
 

--- a/skills/hindsight-docs/references/developer/api/recall.md
+++ b/skills/hindsight-docs/references/developer/api/recall.md
@@ -322,7 +322,8 @@ Enabled by default. When active, each returned fact includes the canonical names
 
 ### tags
 
-Filters recall to only memories that match the specified tags. When omitted, all memories regardless of tags are eligible. Tag filtering is applied at the database level across all four retrieval strategies, not as a post-processing step.
+Filters recall to memories in the requested tag scope. `tags` defaults to `null` and
+`tags_match` defaults to `any`.
 
 The `tags_match` parameter controls the filtering logic:
 
@@ -334,6 +335,22 @@ The `tags_match` parameter controls the filtering logic:
 | `all_strict` | Excluded | Memory has **all** of the specified tags |
 | `exact` | Excluded | Memory has **exactly** the specified tag set |
 
+The defaults and empty-filter behavior are important:
+
+| `tags` | `tags_match` | Eligible memories |
+|--------|--------------|-------------------|
+| Omitted, `null`, or `[]` | Omitted (`any`) | All tagged and untagged memories |
+| Omitted, `null`, or `[]` | `any`, `all`, `any_strict`, or `all_strict` | All tagged and untagged memories; an empty tag list means no filter |
+| Omitted, `null`, or `[]` | `exact` | Only untagged/global memories |
+| Non-empty | `any` or `all` | Matching tagged memories plus untagged/global memories |
+| Non-empty | `any_strict` or `all_strict` | Matching tagged memories only |
+| Non-empty | `exact` | Memories whose complete tag set exactly equals `tags` |
+
+> **📝 MCP empty-scope behavior**
+>
+For the MCP `recall` tool, `tags_match` is forwarded only when `tags` is present.
+To select the untagged/global scope through MCP, pass both `tags: []` and
+`tags_match: "exact"` rather than omitting `tags`.
 #### Scenario setup
 
 Consider a bank with these four memories:
@@ -543,7 +560,13 @@ With any other `tags_match` mode, absent or empty `tags` means "no tag filter" (
 
 `tag_groups` is a list of compound boolean tag filters. The groups in the list are AND-ed together at the top level. Each group is a recursive boolean expression: a **leaf** node `{tags, match}`, or a **compound** node `{and: [...]}`, `{or: [...]}`, or `{not: ...}`.
 
-`tag_groups` and `tags` / `tags_match` can be used simultaneously — they are AND-ed together.
+`tag_groups` defaults to `null`. The public REST and MCP request models treat
+`tag_groups` and `tags` as mutually exclusive: if both are present, the request is
+rejected. Use `tag_groups` by itself for compound filtering and normally leave the
+top-level `tags_match` at its default, `any`. Each `tag_groups` leaf has its own
+`match` value. The exception is top-level `tags_match: "exact"`: because exact
+matching gives absent flat tags a meaning, it adds a global-only flat constraint
+that is AND-ed with the compound expression.
 
 #### Leaf node
 

--- a/skills/hindsight-docs/references/developer/api/reflect.md
+++ b/skills/hindsight-docs/references/developer/api/reflect.md
@@ -174,8 +174,43 @@ rm -f schema.json
 
 ### tags
 
-Filters which memories the agent can access during reflection. Works identically to [recall tags](./recall#tags) — only memories matching the specified tags are considered. The `tags_match` parameter controls the matching logic (`any`, `all`, `any_strict`, `all_strict`, `exact`) with the same semantics as recall.
+Defines the visibility scope used throughout the reflect agent. It filters raw
+facts, observations, and mental models that the agent can retrieve. The same
+`tags` and `tags_match` values also select which tagged directives are injected
+into the reflect prompt.
 
+`tags` defaults to `null`, `tags_match` defaults to `any`, and `tag_groups`
+defaults to `null`. For non-empty tags, raw facts, observations, and mental
+models use the same matching modes as [recall tags](./recall#tags). Directives
+have one additional rule: untagged directives are global and remain eligible
+whenever a tag scope is supplied, including with a strict or exact match.
+
+| Reflect configuration | Raw facts and observations | Mental models | Active directives |
+|-----------------------|----------------------------|---------------|-------------------|
+| Omit `tags`, `tags_match`, and `tag_groups` | All tagged and untagged data | All tagged and untagged models | Untagged/global directives only |
+| `tags: []`, default `tags_match: "any"` | All tagged and untagged data | All tagged and untagged models | Untagged/global directives only |
+| No tags, `tags_match: "exact"` | Untagged/global data only | Untagged/global models only | Untagged/global directives only |
+| Non-empty `tags`, `any` or `all` | Matching tagged data plus untagged/global data | Matching models plus untagged/global models | Matching tagged directives plus untagged/global directives |
+| Non-empty `tags`, `any_strict` or `all_strict` | Matching tagged data only | Matching tagged models only | Matching tagged directives plus untagged/global directives |
+| Non-empty `tags`, `exact` | Data with exactly the requested tag set | Models with exactly the requested tag set | Exactly matching tagged directives plus untagged/global directives |
+| Non-empty `tag_groups`, default top-level `tags_match` | Data matching the compound expression | Models matching the compound expression | Matching tagged directives plus untagged/global directives |
+
+The first row is intentionally asymmetric: an unscoped reflect can search all
+memories, but it does not load tagged directives. To create a directive that
+applies to every reflect call, leave its `tags` empty. To create a scoped
+directive, assign tags and pass a matching scope to `reflect`.
+
+> **📝 `isolation_mode`**
+>
+`isolation_mode` is an internal `list_directives` option, not a public reflect
+request parameter. Reflect always enables it. When neither `tags` nor
+`tag_groups` is supplied, it limits directive loading to untagged directives.
+There is currently no per-request switch to disable it.
+> **📝 MCP omitted tags**
+>
+The MCP `reflect` tool forwards `tags_match` only when `tags` is present. To
+request the empty exact scope through MCP, pass `tags: []` together with
+`tags_match: "exact"`.
 ### Python
 
 ```python
@@ -210,6 +245,51 @@ hindsight memory reflect my-bank "What feedback did the user give?" \
 ```go
 # Section 'reflect-with-tags' not found in api/reflect.go
 ```
+
+#### Common scope examples
+
+Unscoped reflect searches all memories but applies only global directives:
+
+```json
+{
+  "query": "Summarize the current project status"
+}
+```
+
+A project scope includes global data and directives alongside matching
+`project:a` data and directives:
+
+```json
+{
+  "query": "Summarize the current project status",
+  "tags": ["project:a"]
+}
+```
+
+A strict project scope excludes untagged memories, observations, and mental
+models. Global directives still apply:
+
+```json
+{
+  "query": "Summarize the current project status",
+  "tags": ["project:a"],
+  "tags_match": "all_strict"
+}
+```
+
+### tag_groups
+
+Provides compound tag filtering with recursive `and`, `or`, and `not`
+expressions. It affects the same reflect data sources and directive selection as
+flat `tags`. `tag_groups` and `tags` are mutually exclusive in the public REST
+request. Each leaf supplies its own matching mode and defaults to
+`any_strict`; the top-level groups are AND-ed. Normally leave the top-level
+`tags_match` at its default, `any`. Setting it to `exact` while using
+`tag_groups` additionally constrains facts, observations, and mental models to
+the global flat scope before applying the compound expression.
+
+The MCP `reflect` tool currently exposes flat `tags` and `tags_match`, but not
+`tag_groups`.
 
 ### include
 

--- a/skills/hindsight-docs/references/developer/mcp-server.md
+++ b/skills/hindsight-docs/references/developer/mcp-server.md
@@ -201,8 +201,9 @@ Search memories to provide personalized responses.
 | `max_tokens` | integer | No | Maximum tokens to return (default: 4096) |
 | `budget` | string | No | Search thoroughness: `low`, `mid`, or `high` (default: `high`) |
 | `types` | list[string] | No | Filter by fact type: `world`, `experience`, `observation`. Defaults to all |
-| `tags` | list[string] | No | Filter memories by tags |
-| `tags_match` | string | No | Tag matching mode: `any` (default) or `all` |
+| `tags` | list[string] | No | Filter memories by tags. Omit for no filter |
+| `tags_match` | string | No | `any` (default), `all`, `any_strict`, `all_strict`, or `exact`. With `exact`, pass `tags: []` to select the untagged/global scope |
+| `tag_groups` | list[object] | No | Compound boolean tag filter. Mutually exclusive with `tags`; each leaf has its own `match` value |
 | `query_timestamp` | string | No | ISO 8601 timestamp — recall as if asking at this point in time; anchors relative temporal expressions and recency scoring |
 | `min_scores` | object | No | Optional per-stage score floors, e.g. `{"reranker": 0.5}`. Keys: `semantic`/`keyword` (retrieval-level cutoffs), `reranker`/`final` (post-ranking). All inclusive and AND-ed; omit for no filtering. Reranker scores aren't calibrated across queries — calibrate before use |
 
@@ -237,9 +238,14 @@ Generate thoughtful analysis by synthesizing stored memories with the bank's per
 | `budget` | string | No | Search budget: `low`, `mid`, or `high` (default: `low`) |
 | `max_tokens` | integer | No | Maximum tokens in the response (default: 4096) |
 | `response_schema` | object | No | JSON Schema for structured output. When provided, the response includes a `structured_output` field |
-| `tags` | list[string] | No | Filter memories by tags before reflecting |
-| `tags_match` | string | No | Tag matching mode: `any` (default) or `all` |
+| `tags` | list[string] | No | Scope memories, observations, mental models, and tagged directives. Omitted tags leave memory retrieval unfiltered but load only untagged directives |
+| `tags_match` | string | No | `any` (default), `all`, `any_strict`, `all_strict`, or `exact`. Untagged directives remain global in every mode |
 | `include_trace` | boolean | No | Include `tool_trace` and `llm_trace` debugging output. Defaults to `false` to keep responses small |
+
+The MCP tool forwards `tags_match` only when `tags` is present. Pass
+`tags: []` with `tags_match: "exact"` to select the empty/global scope for raw
+facts, observations, and mental models; directive loading also selects only
+untagged directives.
 
 **Example:**
 ```json
@@ -394,11 +400,13 @@ Create a new memory bank or retrieve an existing one.
 
 ### list_directives
 
-List all directives in a bank. Directives are instructions that guide how the memory system processes and responds to queries.
+List directives in a bank. This management tool does not use reflect's
+directive-isolation behavior: omitting `tags` lists every directive, including
+tagged directives.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `tags` | list[string] | No | Filter directives by tags |
+| `tags` | list[string] | No | Filter using `any` matching. When present, returns untagged/global directives plus directives sharing at least one tag. When omitted or empty, returns all directives |
 | `active_only` | boolean | No | Only return active directives (default: `true`) |
 
 ---
@@ -413,7 +421,7 @@ Create a new directive in a bank.
 | `content` | string | Yes | The directive content/instruction |
 | `priority` | integer | No | Priority level (higher = more important) |
 | `is_active` | boolean | No | Whether the directive is active (default: `true`) |
-| `tags` | list[string] | No | Tags for organizing directives |
+| `tags` | list[string] | No | Execution scope for the directive. Empty/omitted (default) means global; non-empty means reflect must use a matching tag scope |
 
 ---
 

--- a/skills/hindsight-docs/references/developer/reflect.md
+++ b/skills/hindsight-docs/references/developer/reflect.md
@@ -31,7 +31,7 @@ Unlike simple retrieval, reflect is an **agentic system** that:
 1. **Autonomously gathers evidence** — The agent decides what information it needs and calls appropriate tools
 2. **Uses hierarchical retrieval** — Checks mental models first, then observations, then raw facts
 3. **Applies disposition** — Shapes reasoning based on the bank's personality traits
-4. **Enforces directives** — Hard rules that must be followed in all responses
+4. **Enforces applicable directives** — Global rules and rules matching the reflect tag scope
 5. **Cites sources** — Returns which memories and observations were used
 
 ### The Agentic Loop
@@ -166,7 +166,11 @@ Different use cases benefit from different disposition configurations:
 
 ## Directives: Hard Rules
 
-While disposition traits *influence* reasoning style, **directives** are hard rules that the agent *must* follow. Directives are injected into the prompt and enforced in every response.
+While disposition traits *influence* reasoning style, **directives** are hard
+rules that the agent *must* follow when they apply to the current reflect scope.
+Untagged directives are global; tagged directives require matching reflect
+tags. See [Memory Banks: Directives](api/memory-banks.md#directives) for
+the full matching and default-behavior tables.
 
 ### When to Use Directives
 

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -2687,7 +2687,7 @@
           "Directives"
         ],
         "summary": "List directives",
-        "description": "List hard rules that are injected into prompts.",
+        "description": "List directive definitions. Unlike reflect, an omitted tag filter returns all directives.",
         "operationId": "list_directives",
         "parameters": [
           {
@@ -2715,10 +2715,10 @@
                   "type": "null"
                 }
               ],
-              "description": "Filter by tags",
+              "description": "Filter directives by execution scope. Omit or pass [] to list all directives.",
               "title": "Tags"
             },
-            "description": "Filter by tags"
+            "description": "Filter directives by execution scope. Omit or pass [] to list all directives."
           },
           {
             "name": "tags_match",
@@ -2731,11 +2731,11 @@
                 "exact"
               ],
               "type": "string",
-              "description": "How to match tags",
+              "description": "How tagged directives match the requested scope. Untagged/global directives are included.",
               "default": "any",
               "title": "Tags Match"
             },
-            "description": "How to match tags"
+            "description": "How tagged directives match the requested scope. Untagged/global directives are included."
           },
           {
             "name": "active_only",
@@ -2817,7 +2817,7 @@
           "Directives"
         ],
         "summary": "Create directive",
-        "description": "Create a hard rule that will be injected into prompts.",
+        "description": "Create a global or tag-scoped hard rule for reflect prompts.",
         "operationId": "create_directive",
         "parameters": [
           {
@@ -8593,7 +8593,7 @@
             },
             "type": "array",
             "title": "Tags",
-            "description": "Tags for filtering",
+            "description": "Directive execution scope. Empty means global; non-empty requires a matching reflect scope.",
             "default": []
           }
         },
@@ -13847,7 +13847,7 @@
               }
             ],
             "title": "Tags",
-            "description": "Filter memories by tags during reflection. If not specified, all memories are considered."
+            "description": "Scope raw facts, observations, mental models, and tagged directives during reflection. With no tags, memory retrieval is unfiltered while only untagged/global directives are loaded. Use tags=[] with tags_match='exact' to select the untagged/global scope."
           },
           "tags_match": {
             "type": "string",
@@ -13859,7 +13859,7 @@
               "exact"
             ],
             "title": "Tags Match",
-            "description": "How to match tags: 'any' (OR, includes untagged), 'all' (AND, includes untagged), 'any_strict' (OR, excludes untagged), 'all_strict' (AND, excludes untagged).",
+            "description": "How to match tags: 'any' (OR, includes untagged), 'all' (AND, includes untagged), 'any_strict' (OR, excludes untagged), 'all_strict' (AND, excludes untagged), or 'exact' (set equality). Untagged directives remain global in every mode.",
             "default": "any"
           },
           "tag_groups": {
@@ -13888,7 +13888,7 @@
               }
             ],
             "title": "Tag Groups",
-            "description": "Compound tag filter using boolean groups. Groups in the list are AND-ed. Each group is a leaf {tags, match} or compound {and: [...]}, {or: [...]}, {not: ...}."
+            "description": "Compound tag filter using boolean groups. Groups in the list are AND-ed. Each group is a leaf {tags, match} or compound {and: [...]}, {or: [...]}, {not: ...}. Mutually exclusive with tags."
           },
           "apply_all_directives": {
             "type": "boolean",


### PR DESCRIPTION
## Summary

This PR documents the tag-scoping contract used by `reflect` consistently across REST/OpenAPI descriptions, MCP tool descriptions, engine docstrings, public documentation, versioned v0.8 documentation, generated SDKs, and the bundled agent skills.

It does not change directive loading or other runtime behavior. The separate mental-model exact-empty-scope consistency fix is isolated in #3039.

## Background and root cause

Issue #3031 reports that an unscoped `reflect` call does not load tagged directives because `reflect` calls `list_directives(..., isolation_mode=True)`.

That runtime behavior is intentional: directive tags are execution scopes. Untagged directives are global, tagged directives apply only when the reflect request supplies a matching scope, and an unscoped reflect call loads only global directives. Direct directive-management calls use `isolation_mode=False`, so listing directives without a tag filter returns both global and tagged directives.

The public contract did not explain this distinction. Existing documentation described directives as always enforced, described directive tags as organizational labels, and described reflect tags as filtering memories without mentioning observations, mental models, or directives. OpenAPI, MCP, and engine docstrings also omitted supported `tags_match` modes and did not explain empty-tag behavior.

## Changes

- Document that reflect `tags` scope raw facts, observations, mental models, and tagged directives.
- Document that untagged directives are global and remain applicable with `any`, `all`, strict, exact, and compound tag scopes.
- Document that an unscoped reflect call searches all memory scopes but loads only untagged/global directives.
- Explain that `isolation_mode` is an internal directive-listing option and is not a public reflect request parameter.
- Add behavior matrices for omitted tags, empty tags, every `tags_match` mode, `tag_groups`, and directive loading.
- Clarify that public REST and MCP directive-listing behavior differs from reflect directive loading when no tag filter is supplied.
- Clarify that public `tags` and `tag_groups` inputs are mutually exclusive and that each compound tag-group leaf owns its matching mode.
- Document the exact-mode corner case: when `tag_groups` is used without flat tags, top-level `tags_match: "exact"` adds a global flat constraint to facts, observations, and mental models before the compound expression is applied. The normal compound-only configuration leaves top-level `tags_match` at its default, `any`.
- Add copyable examples for unscoped, scoped, strict, and exact-global reflect requests.
- Update current docs, v0.8 docs, MCP documentation, engine docstrings, OpenAPI, generated Python/TypeScript/Go clients, and the `hindsight-docs` and `hindsight-architect` skills.

## Documented behavior

| Reflect request | Facts, observations, and mental models | Active directives |
| --- | --- | --- |
| Tags omitted, default matching | All scopes | Global directives only |
| `tags: []`, default matching | All scopes | Global directives only |
| `tags: []`, `tags_match: "exact"` | Global scope only | Global directives only |
| Non-empty tags with `any` or `all` | Matching tagged data plus global data | Matching tagged directives plus global directives |
| Non-empty tags with `any_strict` or `all_strict` | Matching tagged data only | Matching tagged directives plus global directives |
| Non-empty tags with `exact` | Data with exactly the requested tag set | Exactly matching tagged directives plus global directives |
| Non-empty `tag_groups`, default top-level matching | Data matching the compound expression | Matching tagged directives plus global directives |

The exact-empty mental-model implementation currently differs from the consistent contract shown above; #3039 contains that focused runtime fix and regression test.

This PR does not make every tagged directive global. Deployments that need a directive to apply to every reflect call should leave that directive untagged. Existing tagged directives remain scope-specific.

## Validation

- `./scripts/hooks/lint.sh`
- OpenAPI and all supported clients regenerated successfully
- Docusaurus production build completed successfully
- Generated `hindsight-docs` skill passed link validation and deterministic regeneration checks
- `hindsight-docs` and `hindsight-architect` passed the skill validator
- Pre-commit hooks
- `git diff --check`

Related to #3031.
