### PR TITLE
fix(reflect): apply exact empty scope to mental models

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
@@ -95,8 +95,10 @@ async def tool_search_mental_models(
     params: list[Any] = [bank_id, str(query_embedding), max_results]
     next_param = 4
 
-    # Use the centralized tag filtering logic
-    if tags:
+    # Exact matching treats absent or empty tags as the global scope. Do not
+    # skip the filter, or mental models would see every scope while the other
+    # reflect retrieval tools correctly see only untagged data.
+    if tags or tags_match == "exact":
         tag_clause, tag_params, next_param = build_tags_where_clause(tags, param_offset=next_param, match=tags_match)
         filters += f" {tag_clause}"
         params.extend(tag_params)

--- a/hindsight-api-slim/tests/test_reflect_tools.py
+++ b/hindsight-api-slim/tests/test_reflect_tools.py
@@ -2,11 +2,16 @@
 
 import re
 import uuid
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from hindsight_api.engine.reflect.agent import _execute_tool, _summarize_input
-from hindsight_api.engine.reflect.tools import _document_metadata_from_retain_params, tool_expand
+from hindsight_api.engine.reflect.tools import (
+    _document_metadata_from_retain_params,
+    tool_expand,
+    tool_search_mental_models,
+)
 
 
 class _FakeReflectConnection:
@@ -90,6 +95,33 @@ class _FakeMultiMemoryConnection:
             return []
 
         raise AssertionError(f"Unexpected query: {normalized_query}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tags", [None, []], ids=["omitted", "empty"])
+async def test_tool_search_mental_models_exact_empty_scope_selects_global_models(
+    tags: list[str] | None,
+) -> None:
+    """An exact empty scope must exclude tagged mental models."""
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[])
+
+    result = await tool_search_mental_models(
+        memory_engine=MagicMock(),
+        conn=conn,
+        bank_id="test-global-mental-model-scope",
+        query="global summary",
+        query_embedding=[0.1, 0.2],
+        tags=tags,
+        tags_match="exact",
+    )
+
+    fetch_call = conn.fetch.await_args
+    assert fetch_call is not None
+    query, *args = fetch_call.args
+    assert "(tags IS NULL OR tags = '{}')" in re.sub(r"\s+", " ", query).strip()
+    assert args == ["test-global-mental-model-scope", "[0.1, 0.2]", 5]
+    assert result["mental_models"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Make mental-model retrieval honor `tags_match: "exact"` when tags are omitted or supplied as an empty list.

## Root cause

Reflect uses the same tag scope for raw facts, observations, and mental models. Facts and observations pass their filters through the central recall path, where absent or empty tags with `tags_match: "exact"` mean the untagged/global scope.

The mental-model tool conditionally built its SQL tag clause only when `tags` was truthy. Both `None` and an empty list are falsey, so the tool skipped filtering entirely even though `exact` gives the empty set a precise meaning. As a result, one reflect operation could retrieve only global facts and observations while still exposing tagged mental models from every scope.

## Change

Apply the centralized tag filter when tags are non-empty or when the matching mode is `exact`. This preserves the existing no-filter behavior for absent or empty tags with `any`, `all`, `any_strict`, and `all_strict`, while making the exact empty set select only rows whose tags are `NULL` or `{}`.

Add focused parameterized regression coverage for both omitted tags (`None`) and an explicit empty list. The test captures the generated query and verifies the global-scope predicate and parameter ordering.

## Behavior

| Request | Mental models before | Mental models after |
| --- | --- | --- |
| Tags omitted, default matching | All scopes | All scopes |
| `tags: []`, default matching | All scopes | All scopes |
| Tags omitted, `tags_match: "exact"` | All scopes | Global scope only |
| `tags: []`, `tags_match: "exact"` | All scopes | Global scope only |
| Non-empty tags | Matching behavior unchanged | Matching behavior unchanged |

## Validation

- `./scripts/hooks/lint.sh`
- `uv run pytest tests/test_reflect_tools.py -q` (`18 passed`)
- Pre-commit hooks
- `git diff --check`

Discovered while clarifying the tag-scope contract discussed in #3031. The directive-isolation behavior from that issue is not changed by this PR. The companion documentation clarification is in #3038.
