### PR TITLE
fix(clients): expose mental model query controls

### DIFF
--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -882,12 +882,26 @@ export class HindsightClient {
    */
   async listMentalModels(
     bankId: string,
-    options?: { tags?: string[]; signal?: AbortSignal }
+    options?: {
+      tags?: string[];
+      tagsMatch?: "any" | "all" | "exact";
+      /** Exclude large provenance chains with "metadata" or "content" when they are not needed. */
+      detail?: "metadata" | "content" | "full";
+      limit?: number;
+      offset?: number;
+      signal?: AbortSignal;
+    }
   ): Promise<MentalModelListResponse> {
     const response = await sdk.listMentalModels({
       client: this.client,
       path: { bank_id: bankId },
-      query: { tags: options?.tags },
+      query: {
+        tags: options?.tags,
+        ...(options?.tagsMatch !== undefined ? { tags_match: options.tagsMatch } : {}),
+        ...(options?.detail !== undefined ? { detail: options.detail } : {}),
+        ...(options?.limit !== undefined ? { limit: options.limit } : {}),
+        ...(options?.offset !== undefined ? { offset: options.offset } : {}),
+      },
       signal: options?.signal,
     });
 
@@ -900,11 +914,16 @@ export class HindsightClient {
   async getMentalModel(
     bankId: string,
     mentalModelId: string,
-    options?: { signal?: AbortSignal }
+    options?: {
+      /** Exclude large provenance chains with "metadata" or "content" when they are not needed. */
+      detail?: "metadata" | "content" | "full";
+      signal?: AbortSignal;
+    }
   ): Promise<MentalModelResponse> {
     const response = await sdk.getMentalModel({
       client: this.client,
       path: { bank_id: bankId, mental_model_id: mentalModelId },
+      ...(options?.detail ? { query: { detail: options.detail } } : {}),
       signal: options?.signal,
     });
 

--- a/hindsight-clients/typescript/tests/mental_model_query_mapping.test.ts
+++ b/hindsight-clients/typescript/tests/mental_model_query_mapping.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for mental-model query forwarding in the hand-written wrapper.
+ *
+ * These mock the generated SDK so a regression cannot silently restore its
+ * `detail=full` default or drop list pagination and tag-match controls.
+ */
+
+import { HindsightClient } from "../src";
+import * as sdk from "../generated/sdk.gen";
+
+jest.mock("../generated/sdk.gen");
+
+const mockedList = sdk.listMentalModels as jest.MockedFunction<typeof sdk.listMentalModels>;
+const mockedGet = sdk.getMentalModel as jest.MockedFunction<typeof sdk.getMentalModel>;
+
+describe("mental-model query mapping", () => {
+  let client: HindsightClient;
+
+  beforeEach(() => {
+    client = new HindsightClient({ baseUrl: "http://localhost:8888" });
+    mockedList.mockReset();
+    mockedGet.mockReset();
+    mockedList.mockResolvedValue({ data: { items: [], total: 0 } } as any);
+    mockedGet.mockResolvedValue({ data: { id: "model-1" } } as any);
+  });
+
+  test("forwards every supported list query option", async () => {
+    const signal = new AbortController().signal;
+
+    await client.listMentalModels("bank-1", {
+      tags: ["project"],
+      tagsMatch: "exact",
+      detail: "metadata",
+      limit: 25,
+      offset: 50,
+      signal,
+    });
+
+    expect(mockedList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: { bank_id: "bank-1" },
+        query: {
+          tags: ["project"],
+          tags_match: "exact",
+          detail: "metadata",
+          limit: 25,
+          offset: 50,
+        },
+        signal,
+      })
+    );
+  });
+
+  test("preserves optionless and tags-only list request shapes", async () => {
+    await client.listMentalModels("bank-1");
+    await client.listMentalModels("bank-1", { tags: ["project"] });
+
+    expect(mockedList.mock.calls[0][0].query).toEqual({ tags: undefined });
+    expect(mockedList.mock.calls[1][0].query).toEqual({ tags: ["project"] });
+  });
+
+  test("forwards detail when fetching one mental model", async () => {
+    await client.getMentalModel("bank-1", "model-1", { detail: "content" });
+
+    expect(mockedGet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: { bank_id: "bank-1", mental_model_id: "model-1" },
+        query: { detail: "content" },
+      })
+    );
+  });
+
+  test("preserves the optionless get request shape", async () => {
+    await client.getMentalModel("bank-1", "model-1");
+
+    expect(mockedGet).toHaveBeenCalledTimes(1);
+    expect(mockedGet.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        path: { bank_id: "bank-1", mental_model_id: "model-1" },
+      })
+    );
+    expect(mockedGet.mock.calls[0][0]).not.toHaveProperty("query");
+  });
+});


### PR DESCRIPTION
## Summary

- expose the generated SDK's `detail`, tag-match, limit, and offset controls through `listMentalModels`
- expose `detail` through `getMentalModel`
- preserve the existing request object shape when callers omit the new options
- add mapping and backward-compatibility regression tests

This lets TypeScript callers request metadata- or content-only responses instead of always accepting the server's full provenance payload, while also making server-side filtering and pagination available from the high-level client.

## Testing

- `npm test -- --runInBand tests/mental_model_query_mapping.test.ts tests/create_mental_model_mapping.test.ts` (8 tests)
- `npm run build`
- Prettier on the two changed TypeScript files

Closes #2975
