### PR TITLE
fix(graph): serialize graph-maintenance queue enqueue against worker drain (#3034)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -282,22 +282,29 @@ class OracleOps(DataAccessOps):
     ) -> None:
         if not unit_ids:
             return
-        # Oracle doesn't support ON CONFLICT; rely on the PK and the
-        # IGNORE_ROW_ON_DUPKEY_INDEX hint to skip duplicates server-side.
-        # The hint name must match the PK constraint exactly.
+        # Locking upsert (#3034), the Oracle analogue of the PG
+        # ``ON CONFLICT DO UPDATE``. The old IGNORE_ROW_ON_DUPKEY_INDEX insert
+        # skipped duplicates WITHOUT locking the existing row, so a mutation
+        # re-enqueueing an already-queued unit could not block a worker from
+        # concurrently claiming (deleting) that row and processing the unit's
+        # pre-mutation state — the re-enqueue signal was silently lost. MERGE
+        # WHEN MATCHED takes an exclusive row lock on the existing queue row
+        # (the SET is a deliberate no-op that preserves enqueued_at); WHEN NOT
+        # MATCHED inserts a fresh row. That serialises the mutation against the
+        # worker's claim for the same (bank_id, unit_id).
         #
-        # Sort to enforce a global lock-acquisition order on the
-        # (bank_id, unit_id) PK. Without this, two concurrent
-        # transactions inserting overlapping unit_id sets in different
-        # orders can deadlock on the unique-check row locks. Sorting
-        # gives every concurrent caller the same lock order, so
-        # conflicting inserts queue cleanly instead of cycling.
+        # Sort to enforce a global (bank_id, unit_id) lock-acquisition order,
+        # matching claim_graph_maintenance_batch's delete order, so overlapping
+        # mutation/worker sets acquire the shared row locks ascending and cannot
+        # cycle.
         sorted_unit_ids = sorted(unit_ids)
         await conn.executemany(
             f"""
-            INSERT /*+ IGNORE_ROW_ON_DUPKEY_INDEX({table}, pk_graph_maintenance_queue) */
-            INTO {table} (bank_id, unit_id)
-            VALUES ($1, $2)
+            MERGE INTO {table} q
+            USING (SELECT $1 AS bank_id, $2 AS unit_id FROM dual) s
+            ON (q.bank_id = s.bank_id AND q.unit_id = s.unit_id)
+            WHEN MATCHED THEN UPDATE SET q.enqueued_at = q.enqueued_at
+            WHEN NOT MATCHED THEN INSERT (bank_id, unit_id) VALUES (s.bank_id, s.unit_id)
             """,
             [(bank_id, uid) for uid in sorted_unit_ids],
         )
@@ -322,7 +329,15 @@ class OracleOps(DataAccessOps):
             bank_id,
             limit,
         )
-        claimed = [str(row["unit_id"]) for row in rows]
+        # Ordered locking (#3034): the per-row DELETE takes the queue rows'
+        # exclusive locks in executemany array order. Sort the claimed keys by
+        # unit_id so those locks are acquired in the same (bank_id, unit_id)
+        # order the enqueue MERGE uses — overlapping mutation/worker sets then
+        # lock the shared rows ascending and cannot cycle. (The batch is still
+        # *chosen* oldest-first by enqueued_at above; only the lock/delete order
+        # is normalised.) The Pass 1 retry wrap in run_graph_maintenance_job is
+        # the ORA-00060 backstop for any residual interleaving.
+        claimed = sorted(str(row["unit_id"]) for row in rows)
         if claimed:
             await conn.executemany(
                 f"DELETE FROM {table} WHERE bank_id = $1 AND unit_id = $2",

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -369,11 +369,24 @@ class PostgreSQLOps(DataAccessOps):
         # concurrent caller the same lock order, so conflicting inserts
         # queue cleanly instead of cycling.
         sorted_unit_ids = sorted(unit_ids)
+        # DO UPDATE (not DO NOTHING) on a duplicate enqueue — #3034. The SET is a
+        # deliberate no-op that preserves enqueued_at; its only purpose is to take
+        # the existing row's lock. DO NOTHING does NOT lock the conflicting row, so
+        # a mutation that re-enqueues an already-queued unit could not block a
+        # worker from concurrently claiming (deleting) that row and processing the
+        # unit's pre-mutation state; the re-enqueue signal was then silently lost
+        # and the unit's derived links stayed stale with an empty queue. Locking
+        # the row serialises the mutation against the worker's claim for that
+        # (bank_id, unit_id): the worker either waits for the committed post-mutation
+        # state, or (if it claimed first) this INSERT lands a fresh row after the
+        # worker's delete commits. Row locks are acquired in sorted unit_id order,
+        # matching claim_graph_maintenance_batch, so the two never cycle.
         await conn.execute(
             f"""
             INSERT INTO {table} (bank_id, unit_id)
             SELECT $1, v FROM unnest($2::uuid[]) AS t(v)
-            ON CONFLICT (bank_id, unit_id) DO NOTHING
+            ON CONFLICT (bank_id, unit_id)
+                DO UPDATE SET enqueued_at = {table}.enqueued_at
             """,
             bank_id,
             sorted_unit_ids,
@@ -386,16 +399,35 @@ class PostgreSQLOps(DataAccessOps):
         bank_id: str,
         limit: int,
     ) -> list[str]:
+        # Ordered locking (#3034). Choose the oldest batch by enqueued_at, but
+        # acquire the row locks in (bank_id, unit_id) order — the same order the
+        # enqueue upsert takes them — so a foreground mutation re-enqueueing an
+        # overlapping unit set can never cycle against a worker draining it. The
+        # `chosen` CTE is MATERIALIZED so the enqueued_at pick is fenced from the
+        # locking clause; `FOR UPDATE OF q ... ORDER BY q.unit_id` then puts
+        # LockRows above the Sort, so locks are taken ascending by unit_id (same
+        # idiom as prune_stale_cooccurrences' #2529 ordered lock). A concurrent
+        # enqueue holding one of these rows blocks this claim until it commits, at
+        # which point the worker deletes and processes the committed state.
         rows = await conn.fetch(
             f"""
-            DELETE FROM {table}
-            WHERE (bank_id, unit_id) IN (
+            WITH chosen AS MATERIALIZED (
                 SELECT bank_id, unit_id FROM {table}
                 WHERE bank_id = $1
                 ORDER BY enqueued_at
                 LIMIT $2
+            ),
+            locked AS (
+                SELECT q.bank_id, q.unit_id
+                FROM {table} q
+                JOIN chosen c ON c.bank_id = q.bank_id AND c.unit_id = q.unit_id
+                ORDER BY q.unit_id
+                FOR UPDATE OF q
             )
-            RETURNING unit_id
+            DELETE FROM {table} q
+            USING locked l
+            WHERE q.bank_id = l.bank_id AND q.unit_id = l.unit_id
+            RETURNING q.unit_id
             """,
             bank_id,
             limit,

--- a/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
@@ -83,6 +83,20 @@ class _SweepCounts:
 
 
 @dataclass
+class _BatchOutcome:
+    """Result of one relink claim+top-up batch (avoids a bare tuple return).
+
+    Returned by value from the retried batch helper so the caller only folds it
+    into ``JobResult`` after the batch's transaction has actually committed — a
+    deadlock/timeout retry rolls the batch back, so accumulating inside the
+    retried body would double-count.
+    """
+
+    units_claimed: int
+    links_added: int
+
+
+@dataclass
 class JobResult:
     """Counters surfaced to the worker dispatcher and operation result."""
 
@@ -204,10 +218,20 @@ async def run_graph_maintenance_job(
     # Per-iteration loop: claim → top up → commit. We rely on submit-time
     # dedup to keep at most one job per bank running, so no need for
     # SKIP LOCKED.
-    iterations = 0
-    while True:
-        from .memory_engine import acquire_with_retry
+    #
+    # The claim now takes the queue rows FOR UPDATE in (bank_id, unit_id) order
+    # (#3034) so it serialises against a concurrent mutation re-enqueueing the
+    # same units instead of racing it. On PG the matching enqueue/claim lock
+    # order prevents a cycle outright; on Oracle the ordered locks are a strong
+    # mitigation but the exact interleaving is harder to guarantee, so each
+    # batch runs inside retry_with_backoff — which already treats ORA-00060 and
+    # Postgres DeadlockDetectedError as retryable. The batch is idempotent: a
+    # rolled-back claim leaves its rows queued, and _relink_batch only tops up
+    # missing links, so re-running re-claims and re-tops-up cleanly.
+    from .db_utils import retry_with_backoff
+    from .memory_engine import acquire_with_retry
 
+    async def _drain_one_batch() -> _BatchOutcome:
         async with acquire_with_retry(backend) as conn:
             async with conn.transaction():
                 unit_ids = await ops.claim_graph_maintenance_batch(
@@ -217,9 +241,9 @@ async def run_graph_maintenance_job(
                     _DRAIN_BATCH_SIZE,
                 )
                 if not unit_ids:
-                    break
+                    return _BatchOutcome(units_claimed=0, links_added=0)
 
-                result.relink_links_added += await _relink_batch(
+                links_added = await _relink_batch(
                     conn,
                     bank_id,
                     unit_ids,
@@ -227,8 +251,18 @@ async def run_graph_maintenance_job(
                     backend,
                     semantic_link_min_similarity,
                 )
+                return _BatchOutcome(units_claimed=len(unit_ids), links_added=links_added)
 
-        result.relink_units_processed += len(unit_ids)
+    iterations = 0
+    while True:
+        # Fold counters in only after the batch commits — retry_with_backoff may
+        # roll back and re-run the body, and accumulating inside it would double-count.
+        outcome = await retry_with_backoff(_drain_one_batch)
+        if outcome.units_claimed == 0:
+            break
+
+        result.relink_links_added += outcome.links_added
+        result.relink_units_processed += outcome.units_claimed
         iterations += 1
 
         if iterations > 10000:
@@ -252,8 +286,7 @@ async def run_graph_maintenance_job(
     # DeadlockDetectedError. Both prunes are idempotent bank-wide sweeps —
     # rerunning only deletes what's still stale — so retrying the whole
     # transaction on deadlock is safe.
-    from .db_utils import retry_with_backoff
-    from .memory_engine import acquire_with_retry
+    # (retry_with_backoff / acquire_with_retry already imported for Pass 1 above.)
 
     async def _run_sweep() -> _SweepCounts:
         async with acquire_with_retry(backend) as conn:

--- a/hindsight-api-slim/tests/test_graph_maintenance_queue_race.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance_queue_race.py
@@ -1,0 +1,228 @@
+"""Concurrency tests for the ``graph_maintenance_queue`` re-enqueue race (#3034).
+
+Before the fix the queue used ``ON CONFLICT DO NOTHING`` (PG) /
+``IGNORE_ROW_ON_DUPKEY_INDEX`` (Oracle) on enqueue. Neither locks the existing
+row, so a mutation that re-enqueued an already-queued unit could not serialise
+against a worker that concurrently claimed (deleted) that row and processed the
+unit's *pre-mutation* state. The re-enqueue signal was silently dropped and the
+unit's derived temporal/semantic links were left stale with an empty queue.
+
+The fix makes a duplicate enqueue take the existing row's lock (PG
+``DO UPDATE`` no-op / Oracle ``MERGE ... WHEN MATCHED``) and makes the worker
+claim lock those rows ``FOR UPDATE`` in ``(bank_id, unit_id)`` order — the same
+order the enqueue takes them — so the two serialise for a given key and can
+never cycle.
+
+These run against the real Postgres test DB and drive genuinely-concurrent
+transactions (the only way to observe a *database*-level lock interleaving).
+The Oracle protocol is the same shape (MERGE + ordered per-row delete + the
+Pass-1 retry backstop); its live integration reproduction is tracked as a
+follow-up per the issue (the Python Oracle suite doesn't run in PR CI).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from hindsight_api.engine.memory_engine import MemoryEngine
+
+TABLE = "graph_maintenance_queue"
+
+# Two keys with an unambiguous sort order (low < high as UUIDs and as text).
+K_LOW = uuid.UUID("00000000-0000-4000-8000-000000000001")
+K_HIGH = uuid.UUID("ffffffff-ffff-4fff-8fff-ffffffffffff")
+
+
+async def _queue_ids(conn, bank_id: str) -> list[str]:
+    rows = await conn.fetch(
+        f"SELECT unit_id FROM {TABLE} WHERE bank_id = $1 ORDER BY unit_id",
+        bank_id,
+    )
+    return [str(r["unit_id"]) for r in rows]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_enqueue_locks_row_and_blocks_claim(memory: MemoryEngine):
+    """A duplicate enqueue holds the queue row's lock until it commits, so a
+    concurrent worker claim cannot delete-and-process the stale row underneath it.
+
+    This is the core #3034 guard. With the old ``DO NOTHING`` the duplicate
+    enqueue took no lock and the claim below would return immediately (deleting
+    the row while the mutation was still in flight) — so the ``TimeoutError``
+    assertion here would fail. ``DO UPDATE`` makes the claim wait for the commit.
+    """
+    pool = await memory._get_pool()
+    backend = await memory._get_backend()
+    bank_id = f"gmq-lock-{uuid.uuid4().hex[:8]}"
+    unit = uuid.uuid4()
+
+    # Seed a committed queue row (an earlier, not-yet-drained maintenance request).
+    async with pool.acquire() as seed:
+        await backend.ops.enqueue_graph_maintenance(seed, TABLE, bank_id, [unit])
+
+    # A mutation re-enqueues the same unit inside its (uncommitted) transaction.
+    mutation = await pool.acquire()
+    try:
+        mut_tx = mutation.transaction()
+        await mut_tx.start()
+        await backend.ops.enqueue_graph_maintenance(mutation, TABLE, bank_id, [unit])
+
+        async def claim_batch() -> list[str]:
+            async with pool.acquire() as worker:
+                async with worker.transaction():
+                    return await backend.ops.claim_graph_maintenance_batch(worker, TABLE, bank_id, 50)
+
+        claim_task = asyncio.create_task(claim_batch())
+
+        # The claim must block on the row lock the mutation holds — it cannot
+        # complete while the mutation is uncommitted.
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(claim_task), timeout=1.0)
+
+        # Mutation commits; the row is still present (the SET is a no-op), so the
+        # worker now claims it and processes the committed state.
+        await mut_tx.commit()
+        claimed = await asyncio.wait_for(claim_task, timeout=10.0)
+        assert claimed == [str(unit)]
+    finally:
+        await pool.release(mutation)
+
+    async with pool.acquire() as conn:
+        assert await _queue_ids(conn, bank_id) == []
+
+
+@pytest.mark.asyncio
+async def test_worker_claim_before_enqueue_reinserts_signal(memory: MemoryEngine):
+    """The other interleaving: the worker claims (deletes) the row first, then
+    the mutation's enqueue must land a *fresh* row rather than silently no-op'ing.
+
+    Under the old protocol the mutation's ``INSERT ... DO NOTHING`` could observe
+    the soon-to-be-deleted row and skip, losing the signal. ``DO UPDATE`` blocks
+    on the worker's delete lock and, once the delete commits, re-drives the insert
+    — so a new queue row survives and the follow-up drain will reprocess the unit.
+    """
+    pool = await memory._get_pool()
+    backend = await memory._get_backend()
+    bank_id = f"gmq-reins-{uuid.uuid4().hex[:8]}"
+    unit = uuid.uuid4()
+
+    async with pool.acquire() as seed:
+        await backend.ops.enqueue_graph_maintenance(seed, TABLE, bank_id, [unit])
+
+    # Worker claims the row inside an uncommitted transaction (holds the delete lock).
+    worker = await pool.acquire()
+    try:
+        worker_tx = worker.transaction()
+        await worker_tx.start()
+        claimed = await backend.ops.claim_graph_maintenance_batch(worker, TABLE, bank_id, 50)
+        assert claimed == [str(unit)]
+
+        async def enqueue_dup() -> None:
+            async with pool.acquire() as mutation:
+                async with mutation.transaction():
+                    await backend.ops.enqueue_graph_maintenance(mutation, TABLE, bank_id, [unit])
+
+        enqueue_task = asyncio.create_task(enqueue_dup())
+
+        # The enqueue must block on the worker's (uncommitted) delete lock.
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(enqueue_task), timeout=1.0)
+
+        # Worker commits the delete; the enqueue then inserts a fresh row.
+        await worker_tx.commit()
+        await asyncio.wait_for(enqueue_task, timeout=10.0)
+    finally:
+        await pool.release(worker)
+
+    async with pool.acquire() as conn:
+        assert await _queue_ids(conn, bank_id) == [str(unit)], (
+            "re-enqueue signal must survive the worker winning the race"
+        )
+
+
+@pytest.mark.asyncio
+async def test_claim_picks_oldest_but_drains_cleanly(memory: MemoryEngine):
+    """The ordered-lock claim still selects the oldest batch by ``enqueued_at``
+    (the CTE only normalises *lock* order, not *selection* order) and deletes
+    exactly what it returns.
+    """
+    pool = await memory._get_pool()
+    backend = await memory._get_backend()
+    bank_id = f"gmq-oldest-{uuid.uuid4().hex[:8]}"
+    # Insert three rows with explicit, distinct enqueued_at values. The two
+    # oldest have the HIGHEST unit_ids, so a claim that confused lock order with
+    # selection order would pick the wrong rows.
+    oldest = (uuid.UUID("ffffffff-ffff-4fff-8fff-fffffffffff1"), datetime(2020, 1, 1, tzinfo=UTC))
+    middle = (uuid.UUID("ffffffff-ffff-4fff-8fff-fffffffffff2"), datetime(2020, 1, 2, tzinfo=UTC))
+    newest = (uuid.UUID("00000000-0000-4000-8000-000000000009"), datetime(2020, 1, 3, tzinfo=UTC))
+    async with pool.acquire() as conn:
+        for unit, ts in (oldest, middle, newest):
+            await conn.execute(
+                f"INSERT INTO {TABLE} (bank_id, unit_id, enqueued_at) VALUES ($1, $2, $3)",
+                bank_id,
+                unit,
+                ts,
+            )
+        claimed = await backend.ops.claim_graph_maintenance_batch(conn, TABLE, bank_id, 2)
+        assert set(claimed) == {str(oldest[0]), str(middle[0])}
+        # Only the newest row is left behind.
+        assert await _queue_ids(conn, bank_id) == [str(newest[0])]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_enqueue_and_claim_never_deadlock(memory: MemoryEngine):
+    """A real re-enqueue and a real worker claim of the same two units, run
+    concurrently, must never cycle.
+
+    Both the enqueue upsert and the claim are single statements, so we can't
+    pause mid-statement to force a specific interleave (the way the row-at-a-time
+    tests in ``test_graph_maintenance_deadlock.py`` do). Instead we stress the
+    overlap across many rounds. The units are seeded with ``enqueued_at`` in the
+    REVERSE of unit_id order, so the claim's oldest-first *selection* (K_HIGH,
+    K_LOW) differs from its *lock* order (K_LOW, K_HIGH) — which is exactly the
+    order the enqueue takes them. Shared lock order ⇒ no cycle. If the worker
+    ever regressed to locking in ``enqueued_at`` order, these overlapping runs
+    would deadlock against the producer.
+    """
+    pool = await memory._get_pool()
+    backend = await memory._get_backend()
+
+    older = datetime(2020, 1, 1, tzinfo=UTC)  # earlier enqueued_at ...
+    newer = datetime(2020, 1, 2, tzinfo=UTC)  # ... but on the LOWER unit_id
+
+    for round_no in range(20):
+        bank_id = f"gmq-dl-{round_no}-{uuid.uuid4().hex[:8]}"
+        async with pool.acquire() as conn:
+            await conn.execute(
+                f"INSERT INTO {TABLE} (bank_id, unit_id, enqueued_at) VALUES ($1, $2, $3)",
+                bank_id,
+                K_HIGH,
+                older,
+            )
+            await conn.execute(
+                f"INSERT INTO {TABLE} (bank_id, unit_id, enqueued_at) VALUES ($1, $2, $3)",
+                bank_id,
+                K_LOW,
+                newer,
+            )
+
+        async def reenqueue(bid: str) -> None:
+            async with pool.acquire() as conn:
+                async with conn.transaction():
+                    await backend.ops.enqueue_graph_maintenance(conn, TABLE, bid, [K_LOW, K_HIGH])
+
+        async def claim(bid: str) -> list[str]:
+            async with pool.acquire() as conn:
+                async with conn.transaction():
+                    return await backend.ops.claim_graph_maintenance_batch(conn, TABLE, bid, 50)
+
+        results = await asyncio.wait_for(
+            asyncio.gather(reenqueue(bank_id), claim(bank_id), return_exceptions=True),
+            timeout=20,
+        )
+        errors = [r for r in results if isinstance(r, BaseException)]
+        assert not errors, f"round {round_no}: concurrent enqueue/claim must not deadlock, got {results!r}"


### PR DESCRIPTION
Fixes #3034.

## Problem

`graph_maintenance_queue` used a **lock-free** duplicate-suppression enqueue — `ON CONFLICT DO NOTHING` on PostgreSQL, `IGNORE_ROW_ON_DUPKEY_INDEX` on Oracle. Neither locks the existing row, so a mutation that re-enqueues an already-queued unit could not serialize against a worker that concurrently claimed (deleted) that row and processed the unit's **pre-mutation** state. The re-enqueue signal was then silently dropped and the unit's derived temporal/semantic links were left stale with an empty queue.

Confirmed against the code and reproduced at the DB level in the new tests.

## Fix — issue's Option 1 (schema-free, no migration)

- **PG enqueue** (`ops_postgresql.py`): `DO NOTHING` → `DO UPDATE SET enqueued_at = <table>.enqueued_at`. The SET is a deliberate no-op whose only purpose is to take the existing row's lock, serializing the mutation against the worker's claim for that `(bank_id, unit_id)`.
- **PG claim** (`ops_postgresql.py`): ordered-lock CTE — choose the oldest batch by `enqueued_at`, then lock `FOR UPDATE` in `(bank_id, unit_id)` order (LockRows above Sort — the same idiom already proven for the #2529 `prune_stale_cooccurrences` deadlock). Producer and worker now take the shared row locks in the same order and cannot cycle.
- **Oracle enqueue** (`ops_oracle.py`): `MERGE ... WHEN MATCHED THEN UPDATE` (locks the matched row) `... WHEN NOT MATCHED THEN INSERT`, replacing the lock-free hint; claim deletes claimed keys in sorted `unit_id` order.
- **Worker Pass 1** (`graph_maintenance.py`): each claim+relink batch runs inside `retry_with_backoff` (already ORA-00060 / `DeadlockDetectedError`-aware) as a backstop. A new `_BatchOutcome` dataclass folds counters into `JobResult` only **after** commit, so a retry can't double-count.

## Tests

`tests/test_graph_maintenance_queue_race.py`, driven against the real Postgres test DB:

- `test_duplicate_enqueue_locks_row_and_blocks_claim` — the core guard: a duplicate enqueue blocks a concurrent claim until commit. Deterministically fails on the old `DO NOTHING`.
- `test_worker_claim_before_enqueue_reinserts_signal` — reverse interleaving: worker deletes first → enqueue re-inserts a fresh row → signal survives.
- `test_claim_picks_oldest_but_drains_cleanly` — selection stays oldest-by-`enqueued_at` even when that's the opposite of lock order.
- `test_concurrent_enqueue_and_claim_never_deadlock` — stress overlap with `enqueued_at` reversed vs `unit_id`; no cycle.

All 4 new + 50 existing graph-maintenance/curation tests pass; `lint.sh`, `ty`, and `test_migration_shape.py` green.

## Deliberate scope

- **No new lock-wait timeout** (issue step 6). Ordered locking (no deadlock) + the retry backstop + the existing `statement_timeout` cover correctness and liveness. Adding a `lock_timeout` on the background worker is counterproductive (it should wait, not fail), and on the foreground producer it means a `SET LOCAL` inside the large mutation transaction — real blast radius for a rare contention case. The issue frames this as measure-first (step 7). Residual: a foreground edit can wait up to one relink batch if the worker holds the row — a follow-up gated on production lock-wait metrics.
- **Oracle correctness is implemented but has no live integration test** — a deliberate dialect asymmetry mirroring `prune_stale_cooccurrences`, and the issue lists the Oracle reproduction as follow-up (the Python Oracle suite doesn't run in PR CI).
