### PR TITLE
fix(clients): expose mental model query controls in python wrapper

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -159,6 +159,18 @@ If any files in `hindsight-api-slim/hindsight_api/api/` were changed:
 - Were the client SDKs regenerated? (`./scripts/generate-clients.sh`)
 - Were the control plane proxy routes updated? (`hindsight-control-plane/src/app/api/`)
 
+### 7a. Check TS/Python wrapper-client parity
+
+Two of the generated SDKs ship a **hand-written, maintained convenience wrapper** on top of the auto-generated low-level client — and *only* these two:
+- **TypeScript**: `hindsight-clients/typescript/src/index.ts` (`HindsightClient`)
+- **Python**: `hindsight-clients/python/hindsight_client/hindsight_client.py` (`Hindsight`)
+
+(The Rust/Go/etc. clients are generated-only — no wrapper to keep in sync.)
+
+These wrappers are what most third-party consumers actually call, and they must expose the same surface. **If a change touches one wrapper's method — adds/removes a parameter, changes a default, forwards a new query/body field — the equivalent method in the *other* wrapper must get the same change in the same (or an immediately-following) PR.** A parameter that exists in the generated SDK but is dropped by one wrapper silently strips it for every consumer of that language (this is exactly what #2975 / #3042 fixed for `detail`/`tags_match`/`limit`/`offset` on `listMentalModels`/`getMentalModel`). **Should fix** — flag any wrapper method that gains capabilities in one language but not the other, and add a matching mapping regression test on both sides.
+
+Note: the `client-coverage-check` CI tool only validates **request-body** fields, not GET **query** parameters — so query-param parity gaps are *not* caught automatically and must be checked by hand here.
+
 ### 7b. Check API-layer data-access boundary
 
 For each changed handler in `hindsight-api-slim/hindsight_api/api/` (e.g. `http.py`, `mcp.py`):

--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -1164,34 +1164,68 @@ class Hindsight:
             self._mental_models_api.create_mental_model(bank_id, request_obj, _request_timeout=self._timeout)
         )
 
-    def list_mental_models(self, bank_id: str, tags: list[str] | None = None):
+    def list_mental_models(
+        self,
+        bank_id: str,
+        tags: list[str] | None = None,
+        tags_match: Literal["any", "all", "exact"] | None = None,
+        detail: Literal["metadata", "content", "full"] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ):
         """
         List all mental models in a bank (sync wrapper — use ``await client.mental_models.list_mental_models(...)`` in async code).
 
         Args:
             bank_id: The memory bank ID
             tags: Optional tags to filter by
+            tags_match: How to match tags ("any", "all", or "exact")
+            detail: Detail level — "metadata" (names/tags only), "content" (adds
+                content/config), or "full" (includes the large reflect_response
+                provenance chains). Defaults server-side to "full"; pass a lighter
+                level to avoid pulling large payloads you don't need.
+            limit: Maximum number of mental models to return
+            offset: Number of mental models to skip (for pagination)
 
         Returns:
             ListMentalModelsResponse with items
         """
         return _run_async(
-            self._mental_models_api.list_mental_models(bank_id, tags=tags, _request_timeout=self._timeout)
+            self._mental_models_api.list_mental_models(
+                bank_id,
+                tags=tags,
+                tags_match=tags_match,
+                detail=detail,
+                limit=limit,
+                offset=offset,
+                _request_timeout=self._timeout,
+            )
         )
 
-    def get_mental_model(self, bank_id: str, mental_model_id: str):
+    def get_mental_model(
+        self,
+        bank_id: str,
+        mental_model_id: str,
+        detail: Literal["metadata", "content", "full"] | None = None,
+    ):
         """
         Get a specific mental model (sync wrapper — use ``await client.mental_models.get_mental_model(...)`` in async code).
 
         Args:
             bank_id: The memory bank ID
             mental_model_id: The mental model ID
+            detail: Detail level — "metadata" (names/tags only), "content" (adds
+                content/config), or "full" (includes the large reflect_response
+                provenance chains). Defaults server-side to "full"; pass a lighter
+                level to avoid pulling large payloads you don't need.
 
         Returns:
             MentalModelResponse
         """
         return _run_async(
-            self._mental_models_api.get_mental_model(bank_id, mental_model_id, _request_timeout=self._timeout)
+            self._mental_models_api.get_mental_model(
+                bank_id, mental_model_id, detail=detail, _request_timeout=self._timeout
+            )
         )
 
     def refresh_mental_model(self, bank_id: str, mental_model_id: str):

--- a/hindsight-clients/python/tests/test_mental_model_query_mapping.py
+++ b/hindsight-clients/python/tests/test_mental_model_query_mapping.py
@@ -1,0 +1,102 @@
+"""The maintained wrapper forwards mental-model query controls to the SDK.
+
+Mirrors the TypeScript wrapper's ``mental_model_query_mapping`` regression tests
+(#2975 / #3042) so a refactor cannot silently restore the server's ``detail=full``
+default or drop list pagination / tag-match controls.
+"""
+
+from unittest.mock import MagicMock
+
+from hindsight_client import Hindsight
+
+
+def _capture_list(monkeypatch, client, captured):
+    async def fake_list(bank_id, **kwargs):
+        captured["bank_id"] = bank_id
+        captured["kwargs"] = kwargs
+        return MagicMock(items=[])
+
+    monkeypatch.setattr(client._mental_models_api, "list_mental_models", fake_list)
+
+
+def _capture_get(monkeypatch, client, captured):
+    async def fake_get(bank_id, mental_model_id, **kwargs):
+        captured["bank_id"] = bank_id
+        captured["mental_model_id"] = mental_model_id
+        captured["kwargs"] = kwargs
+        return MagicMock()
+
+    monkeypatch.setattr(client._mental_models_api, "get_mental_model", fake_get)
+
+
+def test_list_forwards_every_supported_query_option(monkeypatch):
+    client = Hindsight(base_url="http://example.invalid")
+    captured: dict[str, object] = {}
+    _capture_list(monkeypatch, client, captured)
+
+    client.list_mental_models(
+        "bank-1",
+        tags=["project"],
+        tags_match="exact",
+        detail="metadata",
+        limit=25,
+        offset=50,
+    )
+
+    assert captured["bank_id"] == "bank-1"
+    kwargs = captured["kwargs"]
+    assert kwargs["tags"] == ["project"]
+    assert kwargs["tags_match"] == "exact"
+    assert kwargs["detail"] == "metadata"
+    assert kwargs["limit"] == 25
+    assert kwargs["offset"] == 50
+
+
+def test_list_defaults_leave_controls_unset(monkeypatch):
+    client = Hindsight(base_url="http://example.invalid")
+    captured: dict[str, object] = {}
+    _capture_list(monkeypatch, client, captured)
+
+    client.list_mental_models("bank-1")
+
+    kwargs = captured["kwargs"]
+    # Nothing forced on: the server keeps its own defaults for every control.
+    assert kwargs["tags"] is None
+    assert kwargs["tags_match"] is None
+    assert kwargs["detail"] is None
+    assert kwargs["limit"] is None
+    assert kwargs["offset"] is None
+
+
+def test_list_tags_only_shape_preserved(monkeypatch):
+    client = Hindsight(base_url="http://example.invalid")
+    captured: dict[str, object] = {}
+    _capture_list(monkeypatch, client, captured)
+
+    client.list_mental_models("bank-1", tags=["project"])
+
+    kwargs = captured["kwargs"]
+    assert kwargs["tags"] == ["project"]
+    assert kwargs["detail"] is None
+
+
+def test_get_forwards_detail(monkeypatch):
+    client = Hindsight(base_url="http://example.invalid")
+    captured: dict[str, object] = {}
+    _capture_get(monkeypatch, client, captured)
+
+    client.get_mental_model("bank-1", "model-1", detail="content")
+
+    assert captured["bank_id"] == "bank-1"
+    assert captured["mental_model_id"] == "model-1"
+    assert captured["kwargs"]["detail"] == "content"
+
+
+def test_get_defaults_leave_detail_unset(monkeypatch):
+    client = Hindsight(base_url="http://example.invalid")
+    captured: dict[str, object] = {}
+    _capture_get(monkeypatch, client, captured)
+
+    client.get_mental_model("bank-1", "model-1")
+
+    assert captured["kwargs"]["detail"] is None


### PR DESCRIPTION
## Summary

Python-wrapper parity follow-up to #3042 (which fixed the same gap in the TypeScript wrapper, per #2975).

The hand-written `Hindsight` wrapper in `hindsight-clients/python` was dropping supported query controls:
- `list_mental_models` forwarded **only** `tags` — silently discarding `tags_match`, `detail`, `limit`, `offset`.
- `get_mental_model` forwarded **no** query params at all — dropping `detail`.

The generated `MentalModelsApi` already accepts all of these, so Python consumers of the convenience wrapper silently inherited the server's `detail=full` default — the same 200 KB–2 MB provenance-payload problem #2975 describes for TS, and had no way to page or use tag-match.

## Changes

- `list_mental_models`: add `tags_match`, `detail`, `limit`, `offset` and forward them.
- `get_mental_model`: add `detail` and forward it.
- `detail`/`tags_match` are typed as `Literal[...]` to mirror the TS union types.
- Add `tests/test_mental_model_query_mapping.py` — a mapping regression test mirroring the TS `mental_model_query_mapping` tests, so a refactor cannot restore the dropped controls or the `detail=full` default.

## Testing

- `uv run pytest tests/test_mental_model_query_mapping.py` (5 tests, all pass)
- `./scripts/hooks/lint.sh`

## Note

The `client-coverage-check` CI tool only validates request-**body** fields, not GET **query** params, so this class of gap is not caught automatically on either client. The code-review skill has been updated (in this PR) to require TS/Python wrapper parity and to call out the query-param blind spot.

Related: #2975, #3042
