### PR TITLE
fix(control-plane): bind the `dark:` variant to the .dark class

### DIFF
--- a/hindsight-control-plane/src/app/globals.css
+++ b/hindsight-control-plane/src/app/globals.css
@@ -1,5 +1,23 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Space+Grotesk:wght@500;600;700&display=swap');
 @import "tailwindcss";
+
+/* Bind the `dark:` variant to the `.dark` class this app actually toggles.
+ *
+ * Tailwind v4 changed the default: `dark:` now compiles to
+ * `@media (prefers-color-scheme: dark)`. Themes here are switched by toggling
+ * a `.dark` class on <html> (lib/theme-context.tsx), so without this every
+ * `dark:` utility in the codebase was keyed to the OS setting instead of the
+ * in-app toggle — it fired only when the two happened to agree, and never at
+ * all for a user on a light OS.
+ *
+ * The CSS-variable half of theming always worked (the `.dark` block below
+ * overrides the tokens), which is why this was easy to miss: backgrounds and
+ * foregrounds flipped correctly while the ~145 literal `dark:` utilities —
+ * mostly `dark:text-*-400` lightened text, plus `dark:prose-invert` for
+ * rendered markdown — silently did nothing.
+ */
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
   --background: oklch(0.9911 0 0);
   --foreground: oklch(0.2046 0 0);


### PR DESCRIPTION
One line of CSS. Splitting it out from #3049 because it changes dark mode across
every view at once and deserves its own review.

## The bug

Tailwind v4 changed what `dark:` means: it compiles to
`@media (prefers-color-scheme: dark)` unless a `@custom-variant` says otherwise.

This app switches themes by toggling a `.dark` class on `<html>`
(`lib/theme-context.tsx:23`) and never declared one. So every literal `dark:`
utility has been keyed to the **OS setting** rather than the in-app toggle — it
fired only when the two happened to agree, and **never at all for a user on a
light OS who switches the app to dark**.

What made it easy to miss: the CSS-variable half of theming always worked, because
the `.dark` block overrides the tokens directly. Backgrounds and foregrounds flipped
correctly while ~145 literal `dark:` utilities silently did nothing.

## Impact

Measured on the LLM Requests table — the `success` badge is
`text-green-800 dark:text-green-300` on `bg-green-500/10`:

| | contrast |
|---|---|
| before | **1.17:1** — effectively invisible |
| after | **12.81:1** |

The affected utilities are almost entirely `dark:text-*-400` lightened text, plus
`dark:prose-invert` — without which rendered markdown (mental models, reflect
responses) draws light-theme prose on a dark surface.

## Why this is safe

I enumerated all 145 affected utilities. Every one is a dark-appropriate value:
lightened text, darker `bg-*-900/30` fills, stronger borders, `prose-invert`. None
were tuned to compensate for the variant being inert, so switching it on corrects
them rather than inverting anything.

Verification:

- **Blast radius is exactly the elements carrying a `dark:` class** — nothing else
  can change, since the fix only activates previously-inert declarations. Audited
  those elements directly: on the bank config page all 25 pass at **7.02:1 or
  better**.
- Walked the highest-density views in dark mode — mental-model detail modal (21
  utilities, incl. rendered markdown), Reflect (15), bank config / LLM requests
  (11), documents (8), Memories.
- **Production build** (`next build`), since `@custom-variant` is parsed at build
  time and a syntax error would only surface there.
- `lint.sh`, `tsc`, `check-unused`, 88 tests — all clean.

## Note on review

Screenshots in a PR won't show much: reviewers on a **dark OS** already saw the
correct rendering, because their OS agreed with the media query. To see the bug,
set your OS to **light** and toggle the app to dark on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
