### PR TITLE
docs(hermes): resolve legacy plugin tool timeout

### DIFF
--- a/hindsight-docs/docs-integrations/hermes.md
+++ b/hindsight-docs/docs-integrations/hermes.md
@@ -24,6 +24,12 @@ hermes memory setup    # select "hindsight"
 
 The wizard will prompt for your API key and API URL, and configure everything automatically.
 
+:::warning
+Do not install the deprecated `hindsight-hermes` PyPI package. Current Hermes
+releases include the maintained Hindsight provider. If the old package is
+already installed, [remove it before setup](#deprecated-plugin-tool-timeout).
+:::
+
 Or configure manually:
 
 ```bash
@@ -190,17 +196,34 @@ Re-enable later with `hermes tools enable memory`.
 
 ## Troubleshooting
 
-**Plugin not loading**: Verify the entry point is registered:
-```bash
-python -c "
-import importlib.metadata
-eps = importlib.metadata.entry_points(group='hermes_agent.plugins')
-print(list(eps))
-"
-```
-You should see `EntryPoint(name='hindsight', value='hindsight_hermes', ...)`.
+### Deprecated plugin tool timeout
 
-**Tools don't appear in `/tools`**: Check that `api_url` (or `HINDSIGHT_API_URL`) is set, or that `HINDSIGHT_API_KEY` is set for cloud mode. The plugin silently skips tool registration when unconfigured.
+If all three Hindsight tools return `Timeout context manager should be used
+inside a task`, check whether the deprecated `hindsight-hermes` package is
+still installed in Hermes's virtual environment:
+
+```bash
+$HOME/.hermes/hermes-agent/venv/bin/python -m pip show hindsight-hermes
+```
+
+Version 0.5.0 registered tools through Hermes's legacy plugin dispatch path.
+That path can invoke async tool handlers without a running asyncio task, so the
+HTTP client's timeout fails before the handler can make a request. Replacing a
+handler with a constant return value does not fix the dispatch failure.
+
+Remove the legacy package and configure Hermes's native provider instead:
+
+```bash
+$HOME/.hermes/hermes-agent/venv/bin/python -m pip uninstall -y hindsight-hermes
+hermes memory setup    # select "hindsight"
+hermes memory status
+```
+
+Use the same Hindsight API URL and `bank_id` during setup to retain access to
+existing memories. See the [migration guide](https://hindsight.vectorize.io/guides/guide-migrate-hindsight-hermes-to-native-hermes-memory)
+for the full procedure.
+
+**Tools don't appear in `/tools`**: Check that `api_url` (or `HINDSIGHT_API_URL`) is set, or that `HINDSIGHT_API_KEY` is set for cloud mode.
 
 **Connection refused**: Verify the Hindsight API is running:
 ```bash

--- a/hindsight-docs/guides/2026-04-14-guide-migrate-hindsight-hermes-to-native-hermes-memory.md
+++ b/hindsight-docs/guides/2026-04-14-guide-migrate-hindsight-hermes-to-native-hermes-memory.md
@@ -290,6 +290,27 @@ A healthy response tells you the provider has something real to talk to. If you 
 
 ## Troubleshooting common migration problems
 
+### Problem: every Hindsight tool reports an asyncio timeout context error
+
+The error `Timeout context manager should be used inside a task` is a known
+symptom of the deprecated `hindsight-hermes==0.5.0` package running through
+Hermes's legacy plugin tool dispatcher. It happens before the tool handler
+reaches Hindsight, so changing API URLs, increasing request timeouts, or
+replacing the handler body will not resolve it.
+
+Confirm and remove the old package from Hermes's own virtual environment, then
+enable the native provider:
+
+```bash
+$HOME/.hermes/hermes-agent/venv/bin/python -m pip show hindsight-hermes
+$HOME/.hermes/hermes-agent/venv/bin/python -m pip uninstall -y hindsight-hermes
+hermes memory setup    # select "hindsight"
+hermes memory status
+```
+
+Keep the same backend and `bank_id`; the migration changes the integration
+path, not the stored memory bank.
+
 ### Problem: the provider is configured, but nothing is recalled automatically
 
 Check `memory_mode`. If it is set to `tools`, auto-recall is disabled by design. The model has to call `hindsight_recall` explicitly. Switch to `hybrid` or `context` if you want automatic memory injection before every turn.

--- a/skills/hindsight-docs/references/sdks/integrations/hermes.md
+++ b/skills/hindsight-docs/references/sdks/integrations/hermes.md
@@ -18,6 +18,11 @@ hermes memory setup    # select "hindsight"
 
 The wizard will prompt for your API key and API URL, and configure everything automatically.
 
+> **⚠️ Warning**
+>
+Do not install the deprecated `hindsight-hermes` PyPI package. Current Hermes
+releases include the maintained Hindsight provider. If the old package is
+already installed, [remove it before setup](#deprecated-plugin-tool-timeout).
 Or configure manually:
 
 ```bash
@@ -182,17 +187,34 @@ Re-enable later with `hermes tools enable memory`.
 
 ## Troubleshooting
 
-**Plugin not loading**: Verify the entry point is registered:
-```bash
-python -c "
-import importlib.metadata
-eps = importlib.metadata.entry_points(group='hermes_agent.plugins')
-print(list(eps))
-"
-```
-You should see `EntryPoint(name='hindsight', value='hindsight_hermes', ...)`.
+### Deprecated plugin tool timeout
 
-**Tools don't appear in `/tools`**: Check that `api_url` (or `HINDSIGHT_API_URL`) is set, or that `HINDSIGHT_API_KEY` is set for cloud mode. The plugin silently skips tool registration when unconfigured.
+If all three Hindsight tools return `Timeout context manager should be used
+inside a task`, check whether the deprecated `hindsight-hermes` package is
+still installed in Hermes's virtual environment:
+
+```bash
+$HOME/.hermes/hermes-agent/venv/bin/python -m pip show hindsight-hermes
+```
+
+Version 0.5.0 registered tools through Hermes's legacy plugin dispatch path.
+That path can invoke async tool handlers without a running asyncio task, so the
+HTTP client's timeout fails before the handler can make a request. Replacing a
+handler with a constant return value does not fix the dispatch failure.
+
+Remove the legacy package and configure Hermes's native provider instead:
+
+```bash
+$HOME/.hermes/hermes-agent/venv/bin/python -m pip uninstall -y hindsight-hermes
+hermes memory setup    # select "hindsight"
+hermes memory status
+```
+
+Use the same Hindsight API URL and `bank_id` during setup to retain access to
+existing memories. See the [migration guide](https://hindsight.vectorize.io/guides/guide-migrate-hindsight-hermes-to-native-hermes-memory)
+for the full procedure.
+
+**Tools don't appear in `/tools`**: Check that `api_url` (or `HINDSIGHT_API_URL`) is set, or that `HINDSIGHT_API_KEY` is set for cloud mode.
 
 **Connection refused**: Verify the Hindsight API is running:
 ```bash


### PR DESCRIPTION
## Summary

- warn users not to install the deprecated `hindsight-hermes` PyPI package
- document why its legacy Hermes tool dispatch fails outside an asyncio task
- provide exact uninstall and native-provider migration commands
- preserve existing memories by reusing the same backend and bank ID
- update the generated documentation skill reference

## Validation

- `npm run build` in `hindsight-docs`
- `./scripts/hooks/lint.sh`
- generated docs skill link validation

Fixes #3057