### PR TITLE
fix: return 422 for invalid recall fact types

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -4403,9 +4403,12 @@ class MemoryEngine(MemoryEngineInterface):
         # Validate fact types
         invalid_types = set(fact_type) - VALID_RECALL_FACT_TYPES
         if invalid_types:
-            raise ValueError(
+            from hindsight_api.extensions.operation_validator import OperationValidationError
+
+            raise OperationValidationError(
                 f"Invalid fact type(s): {', '.join(sorted(invalid_types))}. "
-                f"Must be one of: {', '.join(sorted(VALID_RECALL_FACT_TYPES))}"
+                f"Must be one of: {', '.join(sorted(VALID_RECALL_FACT_TYPES))}",
+                status_code=422,
             )
 
         # Validate operation if validator is configured

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -398,6 +398,14 @@ async def test_error_handling(api_client):
     )
     assert response.status_code == 422
 
+    # Recall with an invalid fact type
+    response = await api_client.post(
+        "/v1/default/banks/error_test/memories/recall",
+        json={"query": "test", "types": ["bogus"]},
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"] == ("Invalid fact type(s): bogus. Must be one of: experience, observation, world")
+
     # Get non-existent document
     response = await api_client.get("/v1/default/banks/nonexistent_bank/documents/fake-doc-id")
     assert response.status_code == 404

--- a/hindsight-api-slim/tests/test_recall_invalid_fact_types.py
+++ b/hindsight-api-slim/tests/test_recall_invalid_fact_types.py
@@ -1,0 +1,19 @@
+"""Regression tests for invalid recall fact types."""
+
+import pytest
+
+from hindsight_api.extensions.operation_validator import OperationValidationError
+
+
+@pytest.mark.asyncio
+async def test_recall_invalid_fact_type_raises_422(memory, request_context):
+    with pytest.raises(OperationValidationError) as exc_info:
+        await memory.recall_async(
+            bank_id="invalid-fact-type-test",
+            query="test",
+            fact_type=["bogus"],
+            request_context=request_context,
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.reason == ("Invalid fact type(s): bogus. Must be one of: experience, observation, world")


### PR DESCRIPTION
## Summary

- raise `OperationValidationError(status_code=422)` for unsupported recall fact types
- preserve the existing validation detail through the HTTP exception mapping
- add engine-level and HTTP-level regression coverage

## Root cause

`MemoryEngine.recall_async` raised a plain `ValueError` for unknown fact types. The recall HTTP handler maps `OperationValidationError` to its declared status code, but the plain `ValueError` fell through to the broad exception handler and became a 500 response.

## Testing

- `python -m pytest tests/test_recall_invalid_fact_types.py tests/test_http_api_integration.py::test_error_handling tests/test_http_api_integration.py::test_full_api_workflow -v -n 0` — 3 passed
- `ruff check .` — passed
- `ruff format --check .` — 582 files already formatted
- `ty check hindsight_api/engine/memory_engine.py` — passed

Closes #3052
