### PR TITLE
feat(file-parser): support custom OCR headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -173,6 +173,8 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_BASE_URL=
 # HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_MODEL=
 # HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_PROMPT=
+# Optional JSON dict of custom headers for the OCR OpenAI client (e.g. proxies / request tracing).
+# HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_DEFAULT_HEADERS=
 
 # Embeddings Configuration (Optional - uses local by default)
 # Provider: "local" (default), "onnx", "tei", "openai", "cohere", "google", "openrouter", "zeroentropy", "litellm", or "litellm-sdk"

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -596,6 +596,7 @@ ENV_FILE_PARSER_MARKITDOWN_OCR_API_KEY = "HINDSIGHT_API_FILE_PARSER_MARKITDOWN_O
 ENV_FILE_PARSER_MARKITDOWN_OCR_BASE_URL = "HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_BASE_URL"
 ENV_FILE_PARSER_MARKITDOWN_OCR_MODEL = "HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_MODEL"
 ENV_FILE_PARSER_MARKITDOWN_OCR_PROMPT = "HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_PROMPT"
+ENV_FILE_PARSER_MARKITDOWN_OCR_DEFAULT_HEADERS = "HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_DEFAULT_HEADERS"
 ENV_FILE_PARSER_IRIS_TOKEN = "HINDSIGHT_API_FILE_PARSER_IRIS_TOKEN"
 ENV_FILE_PARSER_IRIS_ORG_ID = "HINDSIGHT_API_FILE_PARSER_IRIS_ORG_ID"
 ENV_FILE_PARSER_LLAMA_PARSE_API_KEY = "HINDSIGHT_API_FILE_PARSER_LLAMA_PARSE_API_KEY"
@@ -2233,6 +2234,7 @@ class HindsightConfig:
     file_parser_markitdown_ocr_base_url: str | None = None
     file_parser_markitdown_ocr_model: str | None = None
     file_parser_markitdown_ocr_prompt: str = DEFAULT_FILE_PARSER_MARKITDOWN_OCR_PROMPT
+    file_parser_markitdown_ocr_default_headers: dict | None = None
 
     # Multi-LLM chains (static, server-level). Index 0 of each chain is the
     # corresponding unindexed/base LLM config above; these hold the extra indexed
@@ -3128,6 +3130,9 @@ class HindsightConfig:
             file_parser_markitdown_ocr_prompt=os.getenv(
                 ENV_FILE_PARSER_MARKITDOWN_OCR_PROMPT,
                 DEFAULT_FILE_PARSER_MARKITDOWN_OCR_PROMPT,
+            ),
+            file_parser_markitdown_ocr_default_headers=json.loads(
+                os.getenv(ENV_FILE_PARSER_MARKITDOWN_OCR_DEFAULT_HEADERS, "null")
             ),
             file_parser_iris_token=os.getenv(ENV_FILE_PARSER_IRIS_TOKEN) or None,
             file_parser_iris_org_id=os.getenv(ENV_FILE_PARSER_IRIS_ORG_ID) or None,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -3230,6 +3230,7 @@ class MemoryEngine(MemoryEngineInterface):
                     ocr_base_url=config.file_parser_markitdown_ocr_base_url,
                     ocr_model=config.file_parser_markitdown_ocr_model,
                     ocr_prompt=config.file_parser_markitdown_ocr_prompt,
+                    ocr_default_headers=config.file_parser_markitdown_ocr_default_headers,
                 )
             )
             logger.debug("Registered markitdown parser")

--- a/hindsight-api-slim/hindsight_api/engine/parsers/markitdown.py
+++ b/hindsight-api-slim/hindsight_api/engine/parsers/markitdown.py
@@ -72,6 +72,7 @@ class MarkitdownParser(FileParser):
         ocr_base_url: str | None = None,
         ocr_model: str | None = None,
         ocr_prompt: str | None = None,
+        ocr_default_headers: dict[str, str] | None = None,
     ):
         """Initialize markitdown parser."""
         # Lazy import to avoid requiring markitdown for all users
@@ -89,6 +90,7 @@ class MarkitdownParser(FileParser):
                 base_url=ocr_base_url,
                 model=ocr_model,
                 prompt=ocr_prompt,
+                default_headers=ocr_default_headers,
             )
             self._markitdown = MarkItDown(
                 llm_client=ocr_options.llm_client,
@@ -105,6 +107,7 @@ class MarkitdownParser(FileParser):
         base_url: str | None,
         model: str | None,
         prompt: str | None,
+        default_headers: dict[str, str] | None,
     ) -> MarkitdownOcrOptions:
         """Build MarkItDown options for OpenAI-compatible image OCR."""
         if not model or not model.strip():
@@ -129,8 +132,15 @@ class MarkitdownParser(FileParser):
         except ImportError as e:
             raise RuntimeError("openai package is required when Markitdown OCR is enabled.") from e
 
+        client_kwargs: dict[str, object] = {
+            "api_key": api_key,
+            "base_url": base_url.strip(),
+        }
+        if default_headers:
+            client_kwargs["default_headers"] = default_headers
+
         return MarkitdownOcrOptions(
-            llm_client=OpenAI(api_key=api_key, base_url=base_url.strip()),
+            llm_client=OpenAI(**client_kwargs),
             llm_model=model.strip(),
             llm_prompt=prompt or DEFAULT_FILE_PARSER_MARKITDOWN_OCR_PROMPT,
         )

--- a/hindsight-api-slim/tests/test_config_validation.py
+++ b/hindsight-api-slim/tests/test_config_validation.py
@@ -603,6 +603,7 @@ def test_markitdown_ocr_does_not_fall_back_to_main_llm_config(monkeypatch):
     assert config.file_parser_markitdown_ocr_base_url is None
     assert config.file_parser_markitdown_ocr_model is None
     assert config.file_parser_markitdown_ocr_prompt == DEFAULT_FILE_PARSER_MARKITDOWN_OCR_PROMPT
+    assert config.file_parser_markitdown_ocr_default_headers is None
 
 
 def test_markitdown_ocr_uses_explicit_config(monkeypatch):
@@ -613,6 +614,10 @@ def test_markitdown_ocr_uses_explicit_config(monkeypatch):
     monkeypatch.setenv("HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_BASE_URL", "https://parser.example/v1")
     monkeypatch.setenv("HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_MODEL", "parser-vision-model")
     monkeypatch.setenv("HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_PROMPT", "Extract this document exactly.")
+    monkeypatch.setenv(
+        "HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_DEFAULT_HEADERS",
+        '{"X-Component-Id":"hindsight-ocr"}',
+    )
     monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "mock")
     monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "main-key")
     monkeypatch.setenv("HINDSIGHT_API_LLM_BASE_URL", "https://main.example/v1")
@@ -624,6 +629,7 @@ def test_markitdown_ocr_uses_explicit_config(monkeypatch):
     assert config.file_parser_markitdown_ocr_base_url == "https://parser.example/v1"
     assert config.file_parser_markitdown_ocr_model == "parser-vision-model"
     assert config.file_parser_markitdown_ocr_prompt == "Extract this document exactly."
+    assert config.file_parser_markitdown_ocr_default_headers == {"X-Component-Id": "hindsight-ocr"}
 
 
 def test_llm_reasoning_effort_defaults_to_low(monkeypatch):

--- a/hindsight-api-slim/tests/test_file_retain.py
+++ b/hindsight-api-slim/tests/test_file_retain.py
@@ -478,9 +478,49 @@ def test_markitdown_converter_can_enable_ocr(monkeypatch):
             "base_url": "https://vision.example/v1",
         }
     ]
+    assert "default_headers" not in openai_calls[0]
     assert markitdown_calls[0]["llm_client"].__class__ is FakeOpenAI
     assert markitdown_calls[0]["llm_model"] == "vision-model"
     assert markitdown_calls[0]["llm_prompt"] == DEFAULT_FILE_PARSER_MARKITDOWN_OCR_PROMPT
+
+
+def test_markitdown_converter_passes_default_headers_when_configured(monkeypatch):
+    """Custom OCR headers should be forwarded to the OpenAI client only when set."""
+    import markitdown
+    import openai
+
+    from hindsight_api.engine.parsers import MarkitdownParser
+
+    openai_calls = []
+
+    class FakeMarkItDown:
+        def __init__(self, **kwargs):
+            pass
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            openai_calls.append(kwargs)
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(markitdown, "MarkItDown", FakeMarkItDown)
+    monkeypatch.setattr(openai, "OpenAI", FakeOpenAI)
+
+    headers = {"X-Component-Id": "hindsight-ocr", "X-Request-Source": "markitdown"}
+    MarkitdownParser(
+        ocr_enabled=True,
+        ocr_api_key="parser-key",
+        ocr_base_url="https://vision.example/v1",
+        ocr_model="vision-model",
+        ocr_default_headers=headers,
+    )
+
+    assert openai_calls == [
+        {
+            "api_key": "parser-key",
+            "base_url": "https://vision.example/v1",
+            "default_headers": headers,
+        }
+    ]
 
 
 def test_markitdown_converter_requires_model_when_ocr_enabled(monkeypatch):

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1362,6 +1362,7 @@ This OCR path uses MarkItDown's image converter hook. It applies to image inputs
 | `HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_BASE_URL` | OpenAI-compatible Chat Completions base URL for MarkItDown OCR; required when OCR is enabled | — |
 | `HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_MODEL` | OCR/vision model with image-input support; required when OCR is enabled | — |
 | `HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_PROMPT` | OCR prompt passed to MarkItDown's image converter | Built-in OCR prompt |
+| `HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_DEFAULT_HEADERS` | Optional JSON dict passed as `default_headers` to the OCR OpenAI SDK client (proxies / request-tracing middleware) | `null` |
 
 ```bash
 # Configure a dedicated OpenAI-compatible OCR/vision endpoint for MarkItDown OCR
@@ -1370,6 +1371,8 @@ export HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_ENABLED=true
 export HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_API_KEY=your-vision-api-key
 export HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_BASE_URL=https://vision.example/v1
 export HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_MODEL=ocr-or-vision-model
+# Optional custom headers for proxies / request tracing
+# export HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_DEFAULT_HEADERS='{"X-Component-Id":"hindsight-ocr"}'
 ```
 
 #### Parser: iris

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -173,6 +173,8 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_BASE_URL=
 # HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_MODEL=
 # HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_PROMPT=
+# Optional JSON dict of custom headers for the OCR OpenAI client (e.g. proxies / request tracing).
+# HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_DEFAULT_HEADERS=
 
 # Embeddings Configuration (Optional - uses local by default)
 # Provider: "local" (default), "onnx", "tei", "openai", "cohere", "google", "openrouter", "zeroentropy", "litellm", or "litellm-sdk"

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1362,6 +1362,7 @@ This OCR path uses MarkItDown's image converter hook. It applies to image inputs
 | `HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_BASE_URL` | OpenAI-compatible Chat Completions base URL for MarkItDown OCR; required when OCR is enabled | — |
 | `HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_MODEL` | OCR/vision model with image-input support; required when OCR is enabled | — |
 | `HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_PROMPT` | OCR prompt passed to MarkItDown's image converter | Built-in OCR prompt |
+| `HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_DEFAULT_HEADERS` | Optional JSON dict passed as `default_headers` to the OCR OpenAI SDK client (proxies / request-tracing middleware) | `null` |
 
 ```bash
 # Configure a dedicated OpenAI-compatible OCR/vision endpoint for MarkItDown OCR
@@ -1370,6 +1371,8 @@ export HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_ENABLED=true
 export HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_API_KEY=your-vision-api-key
 export HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_BASE_URL=https://vision.example/v1
 export HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_MODEL=ocr-or-vision-model
+# Optional custom headers for proxies / request tracing
+# export HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_DEFAULT_HEADERS='{"X-Component-Id":"hindsight-ocr"}'
 ```
 
 #### Parser: iris


### PR DESCRIPTION
## Summary

Add `HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_DEFAULT_HEADERS` and forward its JSON object to the OpenAI client used by MarkItDown OCR. The option is documented in the developer configuration, synchronized into both environment templates, and covered for configured and unset behavior.

## Production impact

Production OCR traffic is often routed through an AI gateway, enterprise proxy, or internal model-serving layer instead of going directly to a provider. Those systems commonly require headers beyond the standard API key and base URL, including gateway authentication, tenant or workspace routing, cost attribution, and distributed tracing identifiers. Before this change, the dedicated MarkItDown OCR client could not supply those headers, so an otherwise valid OCR endpoint could reject requests or lose the routing and observability metadata required in production. This setting lets operators integrate OCR with the same infrastructure controls used elsewhere while keeping OCR credentials and routing independent from the main Hindsight LLM configuration.

The setting is optional and omitted from the OpenAI client when unset, so existing deployments retain their current behavior.

## Testing

- `./scripts/hooks/lint.sh`
- `uv run --directory hindsight-api-slim pytest tests/test_config_validation.py::test_markitdown_ocr_does_not_fall_back_to_main_llm_config tests/test_config_validation.py::test_markitdown_ocr_uses_explicit_config tests/test_file_retain.py::test_markitdown_converter_can_enable_ocr tests/test_file_retain.py::test_markitdown_converter_passes_default_headers_when_configured -q`
- `uv run --directory hindsight-embed pytest tests/test_env_template.py -q`