### PR TITLE
fix(packaging): bundle licenses in Python distributions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,20 @@ jobs:
       with:
         python-version-file: ".python-version"
 
+    # Each package is built from its own directory, so stage the repository's
+    # canonical license inside each isolated build context.
+    - name: Stage Python package licenses
+      run: |
+        for package in \
+          hindsight-clients/python \
+          hindsight-api-slim \
+          hindsight-api \
+          hindsight-all \
+          hindsight-all-slim \
+          hindsight-embed; do
+          cp LICENSE "$package/LICENSE"
+        done
+
     # Build all packages
     - name: Build hindsight-client
       working-directory: ./hindsight-clients/python
@@ -49,6 +63,24 @@ jobs:
     - name: Build hindsight-embed
       working-directory: ./hindsight-embed
       run: uv build --out-dir dist
+
+    - name: Verify Python package licenses
+      run: |
+        for package in \
+          hindsight-clients/python \
+          hindsight-api-slim \
+          hindsight-api \
+          hindsight-all \
+          hindsight-all-slim \
+          hindsight-embed; do
+          wheel=$(find "$package/dist" -maxdepth 1 -name '*.whl' -print -quit)
+          sdist=$(find "$package/dist" -maxdepth 1 -name '*.tar.gz' -print -quit)
+
+          unzip -Z1 "$wheel" | grep -Eq '\.dist-info/licenses/LICENSE$'
+          unzip -p "$wheel" '*/METADATA' | grep -Fxq 'License-Expression: MIT'
+          unzip -p "$wheel" '*/METADATA' | grep -Fxq 'License-File: LICENSE'
+          tar -tzf "$sdist" | grep -Eq '/LICENSE$'
+        done
 
     # Publish in order (client and api-slim first, then api/all wrappers which depend on them)
     - name: Publish hindsight-client to PyPI

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,13 @@ build/
 dist/
 wheels/
 *.egg-info
+# Release builds stage the canonical root license in each package context.
+/hindsight-clients/python/LICENSE
+/hindsight-api-slim/LICENSE
+/hindsight-api/LICENSE
+/hindsight-all/LICENSE
+/hindsight-all-slim/LICENSE
+/hindsight-embed/LICENSE
 .mcp.json
 .playwright-mcp/
 .osgrep

--- a/hindsight-all-slim/pyproject.toml
+++ b/hindsight-all-slim/pyproject.toml
@@ -1,11 +1,12 @@
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "hindsight-all-slim"
 version = "0.8.6"
 description = "Hindsight: Agent Memory That Works Like Human Memory - Slim All-in-One Bundle"
+license = "MIT"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [

--- a/hindsight-all/pyproject.toml
+++ b/hindsight-all/pyproject.toml
@@ -1,11 +1,12 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]
 name = "hindsight-all"
 version = "0.8.6"
 description = "Hindsight: Agent Memory That Works Like Human Memory - All-in-One Bundle"
+license = "MIT"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [

--- a/hindsight-api-slim/pyproject.toml
+++ b/hindsight-api-slim/pyproject.toml
@@ -1,11 +1,12 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]
 name = "hindsight-api-slim"
 version = "0.8.6"
 description = "Hindsight: Agent Memory That Works Like Human Memory"
+license = "MIT"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [

--- a/hindsight-api/pyproject.toml
+++ b/hindsight-api/pyproject.toml
@@ -1,11 +1,12 @@
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "hindsight-api"
 version = "0.8.6"
 description = "Hindsight: Agent Memory That Works Like Human Memory"
+license = "MIT"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [

--- a/hindsight-clients/python/pyproject.toml
+++ b/hindsight-clients/python/pyproject.toml
@@ -2,6 +2,7 @@
 name = "hindsight-client"
 version = "0.8.6"
 description = "Python client for Hindsight - Semantic memory system with personality-driven thinking"
+license = "MIT"
 authors = [
     {name = "Hindsight Team"}
 ]
@@ -24,7 +25,7 @@ test = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]

--- a/hindsight-embed/pyproject.toml
+++ b/hindsight-embed/pyproject.toml
@@ -1,11 +1,12 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]
 name = "hindsight-embed"
 version = "0.8.6"
 description = "Hindsight embedded CLI - local memory operations without a server"
+license = "MIT"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

- declare the MIT SPDX license expression for every Python distribution published by the release workflow
- stage the repository canonical LICENSE file in each isolated package build context without maintaining duplicate source copies
- verify wheel and sdist license contents and core metadata before publishing

## Production impact

Enterprise artifact repositories and supply-chain controls such as Sonatype Repository Firewall inspect both package metadata and the files shipped in the distribution. The current PyPI artifacts do not bundle the repository MIT license, so compliant environments can quarantine Hindsight packages even though the source repository is licensed correctly. That blocks automated dependency promotion and production deployments, and forces operators to open exception tickets and manually release every affected version.

This change makes the license available in both wheels and source distributions and emits the standardized License-Expression and License-File metadata consumed by compliance tooling. The release-time assertions prevent a packaging backend or workflow change from silently publishing non-compliant artifacts again. As a result, Hindsight can move through governed package repositories without one-off approvals while preserving the root LICENSE as the single source of truth.

## Verification

- built all six Python distributions from temporary isolated build contexts
- confirmed every wheel contains its dist-info/licenses/LICENSE file
- confirmed every wheel declares License-Expression: MIT and License-File: LICENSE
- confirmed every source distribution contains LICENSE
- ran ./scripts/hooks/lint.sh

Closes #3054