### PR TITLE
fix(reflect): reject serialized parameter tails in done answers

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -4440,9 +4440,8 @@ def _register_routes(app: FastAPI):
         except LLMNotAvailableError as e:
             raise HTTPException(status_code=400, detail=str(e))
         except ReflectToolCallError as e:
-            # The configured model/transport can't drive reflect's tool-calling loop.
-            # The request itself is fine, so this is a server-side (500) failure, not a
-            # 4xx -- but log at warning, not error: it's a misconfiguration, not a bug.
+            # The provider did not return a structured result that is safe to use.
+            # The request itself is fine, so this is a server-side (500) failure.
             logger.warning("Reflect tool-calling failure in bank %s: %s", bank_id, e)
             raise HTTPException(status_code=500, detail=str(e))
         except TimeoutError as e:

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -56,7 +56,7 @@ NO_ANSWER_TEXT = "No answer provided."
 
 
 class ReflectToolCallError(RuntimeError):
-    """The model never produced a tool call reflect could understand.
+    """The model did not produce a tool-call result reflect can safely use.
 
     Reflect is driven entirely by structured tool calls (``recall``, ``expand``,
     ``done`` ...). Some provider transports do not actually support function
@@ -64,8 +64,9 @@ class ReflectToolCallError(RuntimeError):
     Vertex AI gpt-oss MaaS path strips ``tools``/``tool_choice`` when the model is
     flagged as not supporting them). The model then answers in free text that may
     mimic a ``done`` payload. Rather than salvage that untooled text -- and risk
-    surfacing raw tool-call JSON as the answer -- we fail loudly so the caller can
-    switch to a tool-calling-capable model/transport.
+    surfacing raw tool-call JSON as the answer -- we fail loudly. We do the same
+    when a parsed ``done`` call contains serialized sibling parameters in its
+    answer, because that value is likewise unsafe to persist.
     """
 
 

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -101,6 +101,27 @@ def _is_done_tool(name: str) -> bool:
     return _normalize_tool_name(name) == "done"
 
 
+_DONE_SIBLING_PARAMETERS = (
+    "memory_ids",
+    "mental_model_ids",
+    "observation_ids",
+    "directive_compliance",
+)
+
+
+def _has_serialized_done_parameter_tail(answer: str) -> bool:
+    """Detect sibling done-tool parameters serialized into the answer value."""
+    _, closing_tag, tail = answer.rpartition("</answer>")
+    if not closing_tag:
+        return False
+
+    # Some providers occasionally blend XML tool serialization into an otherwise
+    # valid JSON tool call. Match only declared done() sibling parameters so prose
+    # that merely mentions </answer> is not rejected.
+    serialized_tail = tail.lstrip()
+    return any(serialized_tail.startswith(f'<parameter name="{parameter}">') for parameter in _DONE_SIBLING_PARAMETERS)
+
+
 async def _generate_structured_output(
     answer: str,
     response_schema: dict,
@@ -1262,10 +1283,13 @@ async def _process_done_tool(
     """Process the done tool call and return the result."""
     args = done_call.arguments
 
-    # ``done`` is a structured tool call: trust its ``answer`` field verbatim.
-    # Sibling id fields (memory_ids, ...) live in their own arguments and are
-    # validated separately below -- they can't bleed into a parsed answer string.
     answer = args.get("answer", "").strip()
+    if _has_serialized_done_parameter_tail(answer):
+        provider = f"{llm_config.provider}/{llm_config.model}" if llm_config else "the configured model"
+        raise ReflectToolCallError(
+            f"Reflect received a malformed done answer from {provider}: "
+            "sibling tool parameters leaked into the answer value."
+        )
     if not answer:
         answer = NO_ANSWER_TEXT
 

--- a/hindsight-api-slim/tests/test_reflect_agent.py
+++ b/hindsight-api-slim/tests/test_reflect_agent.py
@@ -353,6 +353,39 @@ class TestReflectAgentMocked:
         mock_llm.call.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_done_tool_rejects_serialized_parameter_tail(self, mock_llm, mock_functions):
+        """A parsed done call can still contain leaked tool serialization in its answer."""
+        leaked_answer = 'The user prefers concise updates.</answer>\n<parameter name="memory_ids">["mem-1"]'
+        mock_llm.provider = "litellm"
+        mock_llm.model = "anthropic/claude-haiku-4-5"
+        mock_llm.call_with_tools.side_effect = [
+            LLMToolCallResult(
+                tool_calls=[LLMToolCall(id="1", name="recall", arguments={"query": "communication preferences"})],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(
+                        id="2",
+                        name="done",
+                        arguments={"answer": leaked_answer, "memory_ids": ["mem-1"]},
+                    )
+                ],
+                finish_reason="tool_calls",
+            ),
+        ]
+
+        with pytest.raises(ReflectToolCallError, match="malformed done answer"):
+            await run_reflect_agent(
+                llm_config=mock_llm,
+                bank_id="test-bank",
+                query="How should I communicate with the user?",
+                bank_profile={"name": "Test", "mission": "Testing"},
+                max_iterations=5,
+                **mock_functions,
+            )
+
+    @pytest.mark.asyncio
     async def test_short_circuited_agent_may_still_retrieve_under_auto(self, mock_llm, mock_functions):
         """After release, the agent can still choose to retrieve deeper itself (its own query)."""
         mock_functions["search_mental_models_fn"].return_value = {


### PR DESCRIPTION
## Summary

Reject a parsed `done` tool call when its `answer` contains a serialized sibling parameter tail such as `</answer><parameter name="memory_ids">...`.

Some provider responses can return a valid tool call while blending XML tool serialization into the JSON `answer` value. Because a tool call exists, the no-tool-call guard added in #3013 does not run, and the corrupted tail gets persisted verbatim into `mental_models.content`.

This validates the exact `answer`/sibling-parameter boundary against the declared `done()` fields and raises `ReflectToolCallError` (matching the existing fail-loud contract). It does not truncate or silently clean the answer, and it does not touch #3013's no-tool-call guard.

## Tests

- Added `test_done_tool_rejects_serialized_parameter_tail`, a regression test that is red on current `main` and green with the fix (verified locally by reverting just the production fix and re-running).
- `40 passed` across the related pure unit tests in `test_reflect_agent.py` (excluding RealLLM/Integration/DirectiveLeakageOnEmptyBank, which need external providers/deps not available here).
- `ruff check` and `ruff format --check` pass for all changed Python files.

Closes #3048