### PR TITLE
fix(consolidation): trigger mental model refresh on resolved scope, not the tags column (#3053)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -1555,7 +1555,7 @@ async def _run_consolidation_job(
             processed=stats["memories_processed"],
             total=await _progress_total(stats["memories_processed"]),
         )
-        # SECURITY: Only refresh mental models with matching tags (or all if no tags were consolidated)
+        # SECURITY: Only refresh mental models whose scope covers what was consolidated
         mental_models_refreshed = await _trigger_mental_model_refreshes(
             memory_engine=memory_engine,
             bank_id=bank_id,
@@ -1570,6 +1570,23 @@ async def _run_consolidation_job(
     return {"status": "completed", "bank_id": bank_id, **stats}
 
 
+# SQL predicate: "this mental model's refresh scope can contain untagged memories".
+#
+# A model's scope is NOT its ``tags`` column — it is whatever
+# ``_resolve_refresh_tag_filtering`` resolves, and both the refresh and the staleness
+# check use that. Three cases reach untagged memories:
+#   - no tags at all             -> no tag constraint, every bank memory is in scope
+#   - tags_match "any" / "all"   -> non-strict, the clause ORs in untagged rows
+#   - trigger.tag_groups         -> overrides the tags column entirely, so the column
+#                                   says nothing about what the model can see
+# A tagged model left on the default (``all_strict``) is correctly excluded: strict
+# matching drops untagged rows, so an untagged-only consolidation cannot make it stale.
+# Gating on the tags column alone starved the first two cases (#3053).
+_MM_SCOPE_REACHES_UNTAGGED = (
+    "((tags IS NULL OR tags = '{}') OR (trigger->>'tags_match') IN ('any', 'all') OR trigger ? 'tag_groups')"
+)
+
+
 async def _trigger_mental_model_refreshes(
     memory_engine: "MemoryEngine",
     bank_id: str,
@@ -1580,14 +1597,17 @@ async def _trigger_mental_model_refreshes(
     """
     Trigger refreshes for mental models with refresh_after_consolidation=true.
 
-    SECURITY: Only triggers refresh for mental models whose tags overlap with the
-    consolidated memory tags, preventing unnecessary refreshes across security boundaries.
+    SECURITY: Only triggers refresh for mental models whose refresh scope can contain
+    what this consolidation touched, preventing unnecessary refreshes across security
+    boundaries.
 
     Args:
         memory_engine: MemoryEngine instance
         bank_id: Bank identifier
         request_context: Request context for authentication
-        consolidated_tags: Tags from memories that were consolidated (None = refresh all)
+        consolidated_tags: Tags of the memories that were consolidated. None means only
+            untagged memories were consolidated (or nothing was), so only models whose
+            scope reaches untagged memories are candidates.
         perf: Performance logging
 
     Returns:
@@ -1596,9 +1616,10 @@ async def _trigger_mental_model_refreshes(
     pool = memory_engine._backend
 
     # Find mental models with refresh_after_consolidation=true that are actually stale.
-    # The tag filter on the SELECT enforces the security boundary (never look outside the
-    # relevant tag scope); compute_mental_model_is_stale then verifies that new memories
-    # in the MM's scope really were ingested since its last refresh.
+    # The tag predicate on the SELECT is a cheap prefilter that skips models this
+    # consolidation cannot have affected; compute_mental_model_is_stale then verifies
+    # against the model's *resolved* scope that new memories really were ingested since
+    # its last refresh.
     async with acquire_with_retry(pool) as conn:
         if consolidated_tags:
             candidates = await conn.fetch(
@@ -1609,7 +1630,7 @@ async def _trigger_mental_model_refreshes(
                   AND (trigger->>'refresh_after_consolidation')::boolean = true
                   AND (
                     (tags IS NOT NULL AND tags != '{{}}' AND tags && $2::varchar[])
-                    OR (tags IS NULL OR tags = '{{}}')
+                    OR {_MM_SCOPE_REACHES_UNTAGGED}
                   )
                 """,
                 bank_id,
@@ -1622,7 +1643,7 @@ async def _trigger_mental_model_refreshes(
                 FROM {fq_table("mental_models")}
                 WHERE bank_id = $1
                   AND (trigger->>'refresh_after_consolidation')::boolean = true
-                  AND (tags IS NULL OR tags = '{{}}')
+                  AND {_MM_SCOPE_REACHES_UNTAGGED}
                 """,
                 bank_id,
             )

--- a/hindsight-api-slim/hindsight_api/engine/db/oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/oracle.py
@@ -80,7 +80,9 @@ _LIKE_ANY_RE = re.compile(r"(\w+)\s+LIKE\s+ANY\s*\(\s*:(\d+)\s*\)", re.IGNORECAS
 _NOT_LIKE_ALL_RE = re.compile(r"(\w+)\s+NOT\s+LIKE\s+ALL\s*\(\s*:(\d+)\s*\)", re.IGNORECASE)
 
 _JSON_ARROW_TEXT_RE = re.compile(r'("?\w+"?)\s*->>\s*\'(\w+)\'')  # handles both col and "col"
-_JSON_HAS_KEY_RE = re.compile(r"(\w+)\s*\?\s*'(\w+)'")
+# Reserved-word columns ("trigger") are already quoted by the time this runs, so the
+# column group must accept the quoted form too — same shape as the arrow regex above.
+_JSON_HAS_KEY_RE = re.compile(r"(\"?\w+\"?)\s*\?\s*'(\w+)'")
 _JSONB_CONTAINS_RE = re.compile(r"(\w+)\s*@>\s*:(\d+)")
 
 # ---------------------------------------------------------------------------

--- a/hindsight-api-slim/tests/test_db_abstraction.py
+++ b/hindsight-api-slim/tests/test_db_abstraction.py
@@ -532,6 +532,15 @@ class TestOracleQueryRewriter:
         query, _, _ = _rewrite_pg_to_oracle("WHERE (trigger->>'refresh_after_consolidation')::boolean = true")
         assert "JSON_VALUE" in query
         assert "'true'" in query
+
+    def test_jsonb_has_key_rewrite_on_reserved_word_column(self):
+        """`trigger ? 'key'` must become JSON_EXISTS even though the reserved-word
+        column is quoted before the JSON operators are rewritten."""
+        from hindsight_api.engine.db.oracle import _rewrite_pg_to_oracle
+
+        query, _, _ = _rewrite_pg_to_oracle("WHERE trigger ? 'tag_groups'")
+        assert """JSON_EXISTS("trigger", '$.tag_groups')""" in query
+        assert "?" not in query
         assert "->>" not in query
 
     def test_for_no_key_update_rewrite(self):

--- a/hindsight-api-slim/tests/test_mental_model_consolidation_refresh_scope.py
+++ b/hindsight-api-slim/tests/test_mental_model_consolidation_refresh_scope.py
@@ -1,0 +1,195 @@
+"""Tests for which mental models a consolidation run triggers a refresh for.
+
+``_trigger_mental_model_refreshes`` prefilters candidates in SQL and then gates each
+one on ``compute_mental_model_is_stale``. The prefilter must key off the model's
+*resolved* refresh scope (``_resolve_refresh_tag_filtering``), not its ``tags``
+column: ``tags_match`` "any"/"all" and ``trigger.tag_groups`` both let a tagged model
+see untagged memories, and gating on the column starved them (#3053).
+
+Deterministic — no LLM, no consolidation run: the trigger function is called directly
+and refresh submission is monkeypatched.
+"""
+
+import json
+import uuid
+
+import pytest
+
+from hindsight_api.engine.consolidation.consolidator import _trigger_mental_model_refreshes
+from hindsight_api.engine.memory_engine import MemoryEngine
+
+
+async def _make_bank(memory: MemoryEngine, request_context) -> str:
+    bank_id = f"mmscope-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    return bank_id
+
+
+async def _insert_mm(
+    conn,
+    bank_id: str,
+    *,
+    tags: list[str] | None = None,
+    trigger_extra: dict | None = None,
+    last_refreshed_offset: str = "1 day",
+) -> str:
+    """Insert a pinned mental model with refresh_after_consolidation=true.
+
+    ``last_refreshed_offset`` is an interval string applied as ``now() - INTERVAL <offset>``.
+    """
+    mm_id = f"mm-{uuid.uuid4().hex}"
+    trigger: dict = {"refresh_after_consolidation": True, **(trigger_extra or {})}
+    await conn.execute(
+        f"""
+        INSERT INTO mental_models
+          (id, bank_id, subtype, name, source_query, content, tags, trigger, last_refreshed_at)
+        VALUES ($1, $2, 'pinned', 'scope model', 'what changed', 'body', $3, $4::jsonb,
+                now() - INTERVAL '{last_refreshed_offset}')
+        """,
+        mm_id,
+        bank_id,
+        tags or [],
+        json.dumps(trigger),
+    )
+    return mm_id
+
+
+async def _insert_fact(conn, bank_id: str, tags: list[str] | None = None) -> None:
+    """Insert a memory newer than any model's last_refreshed_at."""
+    await conn.execute(
+        "INSERT INTO memory_units (id, bank_id, text, fact_type, tags, created_at, updated_at) "
+        "VALUES ($1, $2, 'a fresh fact', 'observation', $3, now(), now())",
+        uuid.uuid4(),
+        bank_id,
+        tags or [],
+    )
+
+
+def _patch_submit(memory: MemoryEngine, monkeypatch) -> list[str]:
+    submitted: list[str] = []
+
+    async def _record(*, bank_id, mental_model_id, request_context):
+        submitted.append(mental_model_id)
+        return {"operation_id": str(uuid.uuid4())}
+
+    monkeypatch.setattr(memory, "submit_async_refresh_mental_model", _record)
+    return submitted
+
+
+@pytest.mark.asyncio
+async def test_tagged_strict_model_skipped_when_only_untagged_consolidated(
+    memory: MemoryEngine, request_context, monkeypatch
+):
+    """A tagged model on the default all_strict scope is NOT refreshed by an
+    untagged-only consolidation — strict matching excludes untagged memories, so a
+    refresh would regenerate identical content (and risk clobbering it)."""
+    bank = await _make_bank(memory, request_context)
+    async with memory._pool.acquire() as conn:
+        mm_id = await _insert_mm(conn, bank, tags=["alpha"])
+        await _insert_fact(conn, bank)  # untagged -> outside an all_strict scope
+
+    submitted = _patch_submit(memory, monkeypatch)
+    await _trigger_mental_model_refreshes(
+        memory_engine=memory, bank_id=bank, request_context=request_context, consolidated_tags=None
+    )
+
+    assert mm_id not in submitted
+
+
+@pytest.mark.asyncio
+async def test_tagged_non_strict_model_refreshed_when_only_untagged_consolidated(
+    memory: MemoryEngine, request_context, monkeypatch
+):
+    """A tagged model with tags_match="any" IS refreshed by an untagged-only
+    consolidation: non-strict matching puts untagged memories in its scope (#3053)."""
+    bank = await _make_bank(memory, request_context)
+    async with memory._pool.acquire() as conn:
+        mm_id = await _insert_mm(conn, bank, tags=["alpha"], trigger_extra={"tags_match": "any"})
+        await _insert_fact(conn, bank)  # untagged -> inside a non-strict scope
+
+    submitted = _patch_submit(memory, monkeypatch)
+    await _trigger_mental_model_refreshes(
+        memory_engine=memory, bank_id=bank, request_context=request_context, consolidated_tags=None
+    )
+
+    assert mm_id in submitted
+
+
+@pytest.mark.asyncio
+async def test_tag_groups_model_refreshed_when_only_untagged_consolidated(
+    memory: MemoryEngine, request_context, monkeypatch
+):
+    """trigger.tag_groups overrides the tags column entirely, so a model carrying
+    tags can still have untagged memories in scope and must stay a candidate."""
+    bank = await _make_bank(memory, request_context)
+    async with memory._pool.acquire() as conn:
+        mm_id = await _insert_mm(
+            conn,
+            bank,
+            tags=["alpha"],
+            trigger_extra={"tag_groups": [{"tags": ["beta"], "match": "any"}]},
+        )
+        await _insert_fact(conn, bank)  # untagged -> matched by the group's "any"
+
+    submitted = _patch_submit(memory, monkeypatch)
+    await _trigger_mental_model_refreshes(
+        memory_engine=memory, bank_id=bank, request_context=request_context, consolidated_tags=None
+    )
+
+    assert mm_id in submitted
+
+
+@pytest.mark.asyncio
+async def test_non_strict_model_skipped_when_nothing_changed(memory: MemoryEngine, request_context, monkeypatch):
+    """Widening the prefilter must not produce spurious refreshes: with no memory
+    newer than last_refreshed_at, the staleness gate still skips the model."""
+    bank = await _make_bank(memory, request_context)
+    async with memory._pool.acquire() as conn:
+        mm_id = await _insert_mm(conn, bank, tags=["alpha"], trigger_extra={"tags_match": "any"})
+        # No facts inserted -> nothing in scope is newer than last_refreshed_at.
+
+    submitted = _patch_submit(memory, monkeypatch)
+    await _trigger_mental_model_refreshes(
+        memory_engine=memory, bank_id=bank, request_context=request_context, consolidated_tags=None
+    )
+
+    assert mm_id not in submitted
+
+
+@pytest.mark.asyncio
+async def test_tagged_model_refreshed_when_its_tag_was_consolidated(memory: MemoryEngine, request_context, monkeypatch):
+    """The overlap path is unchanged: a strict tagged model is refreshed when a memory
+    carrying its tag was consolidated."""
+    bank = await _make_bank(memory, request_context)
+    async with memory._pool.acquire() as conn:
+        mm_id = await _insert_mm(conn, bank, tags=["alpha"])
+        await _insert_fact(conn, bank, tags=["alpha"])
+
+    submitted = _patch_submit(memory, monkeypatch)
+    await _trigger_mental_model_refreshes(
+        memory_engine=memory, bank_id=bank, request_context=request_context, consolidated_tags=["alpha"]
+    )
+
+    assert mm_id in submitted
+
+
+@pytest.mark.asyncio
+async def test_non_strict_model_refreshed_on_mixed_run_with_foreign_tags(
+    memory: MemoryEngine, request_context, monkeypatch
+):
+    """A run that consolidates both untagged and foreign-tagged memories reports only
+    the foreign tags. A non-strict model whose tags do not overlap them is still
+    reached by the untagged half, so the overlap branch must widen the same way."""
+    bank = await _make_bank(memory, request_context)
+    async with memory._pool.acquire() as conn:
+        strict_mm = await _insert_mm(conn, bank, tags=["alpha"])
+        loose_mm = await _insert_mm(conn, bank, tags=["alpha"], trigger_extra={"tags_match": "any"})
+        await _insert_fact(conn, bank)  # the untagged half of the run
+
+    submitted = _patch_submit(memory, monkeypatch)
+    await _trigger_mental_model_refreshes(
+        memory_engine=memory, bank_id=bank, request_context=request_context, consolidated_tags=["beta"]
+    )
+
+    assert loose_mm in submitted
+    assert strict_mm not in submitted


### PR DESCRIPTION
Fixes #3053 — though not for the reason the issue gives (details in [this comment](https://github.com/vectorize-io/hindsight/issues/3053#issuecomment-5132138750)).

## The problem

`_trigger_mental_model_refreshes` picked candidates by matching the mental model's **`tags` column** against the tags of the memories that were just consolidated. But a model's refresh scope is not its tags column — it is whatever `_resolve_refresh_tag_filtering` resolves, and that is also what the refresh itself and `compute_mental_model_is_stale` use.

Two configurations put untagged memories inside a *tagged* model's scope:

- **`trigger.tags_match: "any"` / `"all"`** — non-strict matching ORs untagged rows into the scope
- **`trigger.tag_groups`** — overrides the flat tags entirely, so the column says nothing about what the model can see

Both were silently starved. Such a model reports stale forever, and only ever gets refreshed when some unrelated *tagged* memory happens to be consolidated. There is no workaround: `refresh_cron` — whose maintenance-loop path has no such filter — is mutually exclusive with `refresh_after_consolidation`.

## The fix

Both branches of the candidate query now prefilter on *"can this model's scope reach untagged memories?"* rather than on the column:

```sql
(tags IS NULL OR tags = '{}')
OR (trigger->>'tags_match') IN ('any', 'all')
OR trigger ? 'tag_groups'
```

A tagged model left on the default `all_strict` is still excluded, deliberately: strict matching drops untagged rows, so an untagged-only consolidation cannot make it stale, and refreshing it would burn an LLM call regenerating identical content — with the added risk of #2894 / #2959 (an empty-scope refresh overwriting healthy content). This is why the issue's proposed "refresh every model regardless of tags" is not what this PR does.

The prefilter is only a prefilter. `compute_mental_model_is_stale` still evaluates the *resolved* scope for every candidate, so widening the SELECT cannot produce spurious refreshes — it only stops discarding models before the real check runs.

The same widening is applied to the tag-overlap branch: a run that consolidates both untagged and foreign-tagged memories reports only the foreign tags, and a non-strict model is still reached by the untagged half.

## Oracle

The predicate uses `trigger ? 'tag_groups'`. The Oracle rewriter's key-exists regex only matched unquoted column names, so it missed `"trigger"` — already quoted as a reserved word earlier in the rewrite pipeline — and would have shipped the untranslated PG operator to Oracle. The regex now accepts the quoted form, matching the `->>` regex right above it.

## Tests

New `tests/test_mental_model_consolidation_refresh_scope.py` (deterministic — no LLM, refresh submission monkeypatched). Verified that the three positive tests fail on `main` and pass with the fix, and that the three guard tests hold in both directions:

| test | asserts |
|---|---|
| `test_tagged_strict_model_skipped_when_only_untagged_consolidated` | the deliberate exclusion still holds |
| `test_tagged_non_strict_model_refreshed_when_only_untagged_consolidated` | **the bug** — `tags_match: "any"` |
| `test_tag_groups_model_refreshed_when_only_untagged_consolidated` | **the bug** — `tag_groups` |
| `test_non_strict_model_skipped_when_nothing_changed` | no spurious refresh — the staleness gate still decides |
| `test_tagged_model_refreshed_when_its_tag_was_consolidated` | the overlap path is unchanged |
| `test_non_strict_model_refreshed_on_mixed_run_with_foreign_tags` | the overlap branch widens the same way |

Plus an Oracle rewriter unit test for the reserved-word column, and the existing end-to-end `TestMentalModelRefreshAfterConsolidation` suite still passes.
