### PR TITLE
fix(copilot-cli): parse Copilot CLI 1.0.76 native message transcript format

### DIFF
--- a/hindsight-integrations/copilot-cli/CHANGELOG.md
+++ b/hindsight-integrations/copilot-cli/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## [0.1.1] - 2026-07-30
+
+### Fixed
+
+- Parse GitHub Copilot CLI's native session transcript format (Copilot CLI
+  >= 1.0.76). Copilot now writes transcript events with dotted names
+  (`user.message`, `assistant.message`) and the message text under `data`,
+  which the parser did not recognize — it extracted zero messages, so
+  auto-retain silently stored nothing on newer Copilot builds. The parser now
+  reads the native envelope (using the clean `data.content`, ignoring the
+  reminder-injected `transformedContent`), with a regression test pinning the
+  1.0.76 shape.
+
+## [0.1.0]
+
+### Added
+
+- Initial release. Persistent long-term memory for GitHub Copilot CLI via
+  hooks: recall on `sessionStart` (and `subagentStart`), retain on `agentStop`
+  (every `retainEveryNTurns`) and a forced final retain on `sessionEnd`.
+  Per-repo bank scoping derived from the working directory, configurable recall
+  budget and retain frequency, and user- or repo-scoped hook registration.

--- a/hindsight-integrations/copilot-cli/hindsight_copilot_cli/hooks/scripts/lib/content.py
+++ b/hindsight-integrations/copilot-cli/hindsight_copilot_cli/hooks/scripts/lib/content.py
@@ -275,11 +275,25 @@ def _normalize_blocks_content(content):
 def _parse_transcript_entry(entry, *, text_only, include_tools=False):
     """Parse one JSONL transcript line into a message dict, or None.
 
-    Supports flat, type-nested SDK envelopes, and role-nested lines.
-    When text_only is True, content is flattened to a string; tool blocks are
-    surfaced as markers only when include_tools is True (see
-    `_normalize_blocks_to_text`).
+    Supports the Copilot CLI native envelope, flat, type-nested SDK envelopes,
+    and role-nested lines. When text_only is True, content is flattened to a
+    string; tool blocks are surfaced as markers only when include_tools is True
+    (see `_normalize_blocks_to_text`).
     """
+    # Copilot CLI native envelope: {type: "user.message"|"assistant.message",
+    # data: {content: "...", ...}}. Copilot CLI (>= 1.0.76) emits dotted event
+    # names with the message text under `data.content`. Prefer that clean text
+    # over the sibling `transformedContent`, which carries injected system
+    # reminders (datetime, sql_tables, etc.) that we don't want to retain.
+    etype = entry.get("type")
+    if etype in ("user.message", "assistant.message"):
+        role = "user" if etype == "user.message" else "assistant"
+        data = entry.get("data")
+        if not isinstance(data, dict):
+            return None
+        content = _normalize_blocks_content(data.get("content", ""))
+        return _finalize_entry(role, content, text_only=text_only, include_tools=include_tools)
+
     # Flat: {role, content}
     if entry.get("role") in ("user", "assistant") and "content" in entry:
         role = entry["role"]

--- a/hindsight-integrations/copilot-cli/pyproject.toml
+++ b/hindsight-integrations/copilot-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hindsight-copilot-cli"
-version = "0.1.0"
+version = "0.1.1"
 description = "GitHub Copilot CLI integration for Hindsight - persistent long-term memory via Copilot CLI hooks"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/hindsight-integrations/copilot-cli/tests/test_content.py
+++ b/hindsight-integrations/copilot-cli/tests/test_content.py
@@ -185,6 +185,52 @@ class TestReadTranscript:
         with_tools = read_transcript(str(f), include_tools=True)
         assert with_tools[0]["content"] == "Listing files\n[tool_use:shell]\n[tool_result]"
 
+    def test_reads_copilot_cli_native_message_envelope(self, tmp_path):
+        """Copilot CLI (>= 1.0.76) writes dotted events with text under `data`.
+
+        Regression test for the format change that silently broke retain: the
+        parser previously recognized none of these events and extracted zero
+        messages, so nothing was ever retained.
+        """
+        f = tmp_path / "events.jsonl"
+        f.write_text(
+            "\n".join(
+                [
+                    json.dumps({"type": "session.start", "data": {"sessionId": "s1"}}),
+                    json.dumps(
+                        {
+                            "type": "user.message",
+                            "data": {
+                                "content": "we use Stripe and store money as integer cents",
+                                # Injected reminders live on transformedContent — must be ignored.
+                                "transformedContent": (
+                                    "<current_datetime>2026-07-30</current_datetime>\n"
+                                    "we use Stripe and store money as integer cents\n"
+                                    "<system_reminder>noise</system_reminder>"
+                                ),
+                            },
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "type": "assistant.message",
+                            "data": {"content": "Implemented capture_payment with Stripe integer cents."},
+                        }
+                    ),
+                    json.dumps({"type": "tool.execution_start", "data": {"toolName": "view"}}),
+                    json.dumps({"type": "session.shutdown", "data": {}}),
+                ]
+            )
+        )
+        msgs = read_transcript(str(f))
+        assert msgs == [
+            {"role": "user", "content": "we use Stripe and store money as integer cents"},
+            {"role": "assistant", "content": "Implemented capture_payment with Stripe integer cents."},
+        ]
+        # The clean `content` is retained, not the reminder-laden transformedContent.
+        assert "system_reminder" not in msgs[0]["content"]
+        assert "current_datetime" not in msgs[0]["content"]
+
 
 class TestComposeRecallQuery:
     def test_single_turn_returns_latest(self):

--- a/hindsight-integrations/copilot-cli/uv.lock
+++ b/hindsight-integrations/copilot-cli/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "hindsight-copilot-cli"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

`hindsight-copilot-cli` silently stopped persisting memory on GitHub Copilot CLI **>= 1.0.76**. The hooks load and fire fine, but **nothing gets retained** to the bank.

Root cause is a **breaking change in Copilot CLI's (undocumented) session transcript format**. Copilot 1.0.76 writes events with dotted names and the message text nested under `data`:

```json
{"type":"user.message","data":{"content":"...","transformedContent":"..."}}
{"type":"assistant.message","data":{"content":"..."}}
```

Our parser (`lib/content.py :: _parse_transcript_entry`) only recognized the older `flat` / `type-nested SDK envelope` / `role-nested` shapes, so it matched **none** of these events and `read_transcript()` returned `[]`. `agent_stop.run_retain` then logs `"No messages in transcript, skipping retain"` and exits 0 — a **silent** no-op with no error surfaced.

Verified against a real Copilot 1.0.76 transcript: the parser extracted **0 messages** before this change and the target bank stayed empty; after the fix it extracts the messages and the retain posts successfully (`success: true`).

## Fix

Teach `_parse_transcript_entry` to read the native `user.message` / `assistant.message` envelope, using the clean `data.content` and deliberately **ignoring `data.transformedContent`** (which carries injected system reminders — datetime, sql_tables, etc. — that shouldn't be retained).

## Test

Adds `test_reads_copilot_cli_native_message_envelope`, a regression test built from a 1.0.76-shaped `events.jsonl`, asserting:
- user + assistant messages are extracted, and
- the reminder-laden `transformedContent` is **not** used.

Full suite: `102 passed`.

## Notes / follow-ups
- The failure class here is an upstream schema change in an **undocumented internal format**, delivered in a Copilot **patch** release. This regression test locks in the current shape; a lightweight end-to-end "teach → assert a document lands in the bank" check would catch future drift even louder.