### PR TITLE
fix(engine): don't hold pooled DB connections across embedder/LLM calls (consolidation + mental model)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -33,6 +33,7 @@ from pydantic import BaseModel, field_validator
 
 from ...config import get_config
 from ...worker.stage import set_stage
+from ..db import DatabaseBackend
 from ..db_utils import acquire_with_retry
 from ..llm_trace import (
     record_created_memory_ids,
@@ -193,10 +194,13 @@ class _DedupOutcome:
     best_id: str | None
     merged_text: str
     should_merge: bool
+    # The twin's text at probe time. Guards the fold against a concurrent survivor
+    # rewrite during the connection-free LLM window (set on the two non-None returns).
+    best_text: str = ""
 
 
 async def _dedup_adjudicate(
-    conn: "Connection",
+    pool: DatabaseBackend,
     memory_engine: "MemoryEngine",
     bank_id: str,
     config: Any,
@@ -216,6 +220,9 @@ async def _dedup_adjudicate(
     (used by the UPDATE path, where the anchor row already exists and would self-match at 1.0).
     ``anchor_emb_str`` reuses an already-computed embedding (the UPDATE path just embedded it);
     pass None to embed ``anchor_text`` here (the CREATE path).
+
+    The embedder and the LLM both run with NO connection held; only the semantic+BM25 probe
+    briefly borrows a short-lived connection.
     """
     from ..search.retrieval import retrieve_semantic_bm25_combined
 
@@ -226,9 +233,10 @@ async def _dedup_adjudicate(
             return _DedupOutcome(best_id=None, merged_text="", should_merge=False)
         anchor_emb_str = str(embs[0])
     tags_match = "all_strict" if tags else "any"
-    grouped = await retrieve_semantic_bm25_combined(
-        conn, anchor_emb_str, anchor_text, bank_id, ["observation"], _DEDUP_TOP_K, tags=tags, tags_match=tags_match
-    )
+    async with acquire_with_retry(pool) as conn:
+        grouped = await retrieve_semantic_bm25_combined(
+            conn, anchor_emb_str, anchor_text, bank_id, ["observation"], _DEDUP_TOP_K, tags=tags, tags_match=tags_match
+        )
     results = grouped["observation"].semantic
     best_id: str | None = None
     best_text = ""
@@ -253,12 +261,14 @@ async def _dedup_adjudicate(
         )
     )
     if decision.action != "merge":
-        return _DedupOutcome(best_id=best_id, merged_text="", should_merge=False)
-    return _DedupOutcome(best_id=best_id, merged_text=decision.text.strip() or best_text, should_merge=True)
+        return _DedupOutcome(best_id=best_id, merged_text="", should_merge=False, best_text=best_text)
+    return _DedupOutcome(
+        best_id=best_id, merged_text=decision.text.strip() or best_text, should_merge=True, best_text=best_text
+    )
 
 
 async def _dedup_reconcile_create(
-    conn: "Connection",
+    pool: DatabaseBackend,
     memory_engine: "MemoryEngine",
     bank_id: str,
     config: Any,
@@ -273,9 +283,12 @@ async def _dedup_reconcile_create(
     On "merge", folds the new source facts + the synthesized text into the existing
     observation and returns its id (caller skips the CREATE). Returns None when there is
     no near twin or the LLM keeps them distinct.
+
+    The probe/embed/LLM adjudication runs with no connection held; the fold takes a
+    short-lived connection and re-checks source liveness inside the fold transaction.
     """
     outcome = await _dedup_adjudicate(
-        conn, memory_engine, bank_id, config, dedup_llm_config, create_text, None, tags, exclude_id=None
+        pool, memory_engine, bank_id, config, dedup_llm_config, create_text, None, tags, exclude_id=None
     )
     if not outcome.should_merge or outcome.best_id is None:
         return None
@@ -284,32 +297,52 @@ async def _dedup_reconcile_create(
     # twin's existing embedding (the merged text is >= threshold similar, so it stays
     # representative and avoids a re-embed + a dialect-specific vector UPDATE).
     store = get_memories()
-    if store.writes_memory_rows_in_sql:
-        # Oracle-safe: _native_search_vector_update emits the to_tsvector clause only for a native
-        # PG tsvector column, "" otherwise (see #3021 — the raw ::regconfig cast breaks Oracle).
-        search_vector_clause = _native_search_vector_update(config, "$1")
-        await conn.execute(
-            f"""
-            UPDATE {fq_table("memory_units")}
-            SET text = $1,
-                source_memory_ids = (SELECT array_agg(DISTINCT e) FROM unnest(source_memory_ids || $2::uuid[]) e),
-                proof_count = (SELECT count(DISTINCT e) FROM unnest(source_memory_ids || $2::uuid[]) e),
-                updated_at = now(){search_vector_clause}
-            WHERE id = $3::uuid
-            """,
-            outcome.merged_text,
-            create_source_ids,
-            uuid.UUID(outcome.best_id),
-        )
-    else:
-        await _reconcile_merge_via_store(
-            store, conn, memory_engine, bank_id, outcome.best_id, outcome.merged_text, create_source_ids, txn=txn
-        )
+    async with acquire_with_retry(pool) as conn:
+        async with conn.transaction():
+            # Re-check liveness inside the fold transaction; CREATE performed the slow embed/LLM
+            # work off-connection, so sources may have been deleted since the decision was made.
+            live_source_ids = await _filter_live_source_memories(conn, bank_id, create_source_ids)
+            if not live_source_ids:
+                return None
+            if store.writes_memory_rows_in_sql:
+                # Oracle-safe: _native_search_vector_update emits the to_tsvector clause only for a
+                # native PG tsvector column, "" otherwise (see #3021 — the raw ::regconfig cast
+                # breaks Oracle). RETURNING-gate on the twin's probe-time text so a concurrent
+                # survivor rewrite during the connection-free LLM window can't be clobbered.
+                search_vector_clause = _native_search_vector_update(config, "$1")
+                folded = await conn.fetchval(
+                    f"""
+                    UPDATE {fq_table("memory_units")}
+                    SET text = $1,
+                        source_memory_ids = (SELECT array_agg(DISTINCT e) FROM unnest(source_memory_ids || $2::uuid[]) e),
+                        proof_count = (SELECT count(DISTINCT e) FROM unnest(source_memory_ids || $2::uuid[]) e),
+                        updated_at = now(){search_vector_clause}
+                    WHERE id = $3::uuid AND text = $4
+                    RETURNING id
+                    """,
+                    outcome.merged_text,
+                    live_source_ids,
+                    uuid.UUID(outcome.best_id),
+                    outcome.best_text,
+                )
+                if folded is None:
+                    # The twin vanished (or was rewritten) during the connection-free LLM window.
+                    # Don't skip the CREATE: returning None lets the caller insert the observation
+                    # so nothing is lost.
+                    logger.debug(
+                        "[CONSOLIDATION] dedup-merge target %s vanished before fold; proceeding with CREATE",
+                        outcome.best_id[:8],
+                    )
+                    return None
+            else:
+                await _reconcile_merge_via_store(
+                    store, conn, memory_engine, bank_id, outcome.best_id, outcome.merged_text, live_source_ids, txn=txn
+                )
     return outcome.best_id
 
 
 async def _dedup_reconcile_update(
-    conn: "Connection",
+    pool: DatabaseBackend,
     memory_engine: "MemoryEngine",
     bank_id: str,
     config: Any,
@@ -331,7 +364,7 @@ async def _dedup_reconcile_update(
     CREATE path the row already exists, so reconciliation is a fold-and-delete, not a skip.
     """
     outcome = await _dedup_adjudicate(
-        conn,
+        pool,
         memory_engine,
         bank_id,
         config,
@@ -344,39 +377,80 @@ async def _dedup_reconcile_update(
     if not outcome.should_merge or outcome.best_id is None:
         return
 
-    # Fold the updated observation's sources into the twin (keeping the twin's embedding, as in
-    # the create path) then delete the now-redundant updated row. The all_strict/any tag match
+    # Fold the updated observation's live sources into the twin (keeping the twin's embedding, as
+    # in the create path) then delete the now-redundant updated row. The all_strict/any tag match
     # guarantees twin and updated share scope, so dropping the updated row's tags loses no
     # visibility. Temporal fields follow the surviving twin (minimal scope; matches create).
+    # The fold + delete share one short transaction so the twin gains the sources exactly as the
+    # redundant row is removed; the slow adjudication above already ran connection-free.
     store = get_memories()
-    if store.writes_memory_rows_in_sql:
-        # Oracle-safe search_vector clause (#3021): "" unless a native PG tsvector column.
-        search_vector_clause = _native_search_vector_update(config, "$1")
-        await conn.execute(
-            f"""
-            UPDATE {fq_table("memory_units")} t
-            SET text = $1,
-                source_memory_ids = (
-                    SELECT array_agg(DISTINCT e) FROM unnest(t.source_memory_ids || u.source_memory_ids) e
-                ),
-                proof_count = (
-                    SELECT count(DISTINCT e) FROM unnest(t.source_memory_ids || u.source_memory_ids) e
-                ),
-                updated_at = now(){search_vector_clause}
-            FROM {fq_table("memory_units")} u
-            WHERE t.id = $2::uuid AND u.id = $3::uuid
-            """,
-            outcome.merged_text,
-            uuid.UUID(outcome.best_id),
-            uuid.UUID(updated_id),
-        )
-    else:
-        updated_obs = await store.get_memories(conn=conn, fq_table=fq_table, bank_id=bank_id, unit_ids=[updated_id])
-        updated_sources = list(updated_obs[0].source_memory_ids or []) if updated_obs else []
-        await _reconcile_merge_via_store(
-            store, conn, memory_engine, bank_id, outcome.best_id, outcome.merged_text, updated_sources, txn=txn
-        )
-    await _execute_delete_action(conn, bank_id, updated_id, txn=txn)
+    async with acquire_with_retry(pool) as conn:
+        async with conn.transaction():
+            if store.writes_memory_rows_in_sql:
+                # Snapshot the updated row's sources with a PLAIN read (no FOR UPDATE). Lock order
+                # must be sources-before-observation: _filter_live_source_memories below takes
+                # FOR SHARE on the SOURCE rows first, then the fold UPDATE locks the observation
+                # rows -- the same order as _dedup_reconcile_create and the normal write paths
+                # (_create_observation_directly / _execute_update_action). Locking the observation
+                # here (FOR UPDATE) would invert that against the invalidation path and deadlock.
+                updated_row = await conn.fetchrow(
+                    f"""
+                    SELECT source_memory_ids
+                    FROM {fq_table("memory_units")}
+                    WHERE id = $1::uuid AND text = $2
+                    """,
+                    uuid.UUID(updated_id),
+                    updated_text,
+                )
+                if updated_row is None:
+                    return
+                live_u_sources = await _filter_live_source_memories(
+                    conn, bank_id, list(updated_row["source_memory_ids"] or [])
+                )
+                if not live_u_sources:
+                    return
+                # Oracle-safe search_vector clause (#3021): "" unless a native PG tsvector column.
+                # RETURNING-gate on both rows' probe-time text so a survivor/updated rewrite during
+                # the connection-free LLM window can't be clobbered or fold a stale row.
+                search_vector_clause = _native_search_vector_update(config, "$1")
+                folded = await conn.fetchval(
+                    f"""
+                    UPDATE {fq_table("memory_units")} t
+                    SET text = $1,
+                        source_memory_ids = (
+                            SELECT array_agg(DISTINCT e) FROM unnest(t.source_memory_ids || $6::uuid[]) e
+                        ),
+                        proof_count = (
+                            SELECT count(DISTINCT e) FROM unnest(t.source_memory_ids || $6::uuid[]) e
+                        ),
+                        updated_at = now(){search_vector_clause}
+                    FROM {fq_table("memory_units")} u
+                    WHERE t.id = $2::uuid AND u.id = $3::uuid AND t.text = $4 AND u.text = $5
+                    RETURNING t.id
+                    """,
+                    outcome.merged_text,
+                    uuid.UUID(outcome.best_id),
+                    uuid.UUID(updated_id),
+                    outcome.best_text,
+                    updated_text,
+                    live_u_sources,
+                )
+                if folded is None:
+                    # Twin or updated row vanished during the LLM window — keep the updated row
+                    # as a distinct observation instead of deleting it unfolded.
+                    return
+            else:
+                updated_obs = await store.get_memories(
+                    conn=conn, fq_table=fq_table, bank_id=bank_id, unit_ids=[updated_id]
+                )
+                updated_sources = list(updated_obs[0].source_memory_ids or []) if updated_obs else []
+                live_u_sources = await _filter_live_source_memories(conn, bank_id, updated_sources)
+                if not live_u_sources:
+                    return
+                await _reconcile_merge_via_store(
+                    store, conn, memory_engine, bank_id, outcome.best_id, outcome.merged_text, live_u_sources, txn=txn
+                )
+            await _execute_delete_action(conn, bank_id, updated_id, txn=txn)
     logger.info(
         "[CONSOLIDATION] dedup-merged updated observation %s into %s (cosine>=%.2f)",
         updated_id[:8],
@@ -523,6 +597,33 @@ async def _filter_live_source_memories(
         )
         live = {str(m.unit_id) for m in present}
     return [mid for mid in source_memory_ids if str(mid) in live]
+
+
+async def _any_live_source_memory(
+    conn: "Connection",
+    bank_id: str,
+    source_memory_ids: list[uuid.UUID],
+) -> bool:
+    """Cheap, non-locking existence check used as a preflight before embedding.
+
+    Lets the create/update executors skip the (slow) embedder when every source
+    memory is already gone, restoring the pre-refactor short-circuit. The
+    authoritative, FOR SHARE liveness check still runs inside the write txn.
+    """
+    if not source_memory_ids:
+        return False
+    store = get_memories()
+    if store.writes_memory_rows_in_sql:
+        found = await conn.fetchval(
+            f"SELECT 1 FROM {fq_table('memory_units')} WHERE id = ANY($1::uuid[]) AND bank_id = $2 LIMIT 1",
+            source_memory_ids,
+            bank_id,
+        )
+        return found is not None
+    present = await store.get_memories(
+        conn=conn, fq_table=fq_table, bank_id=bank_id, unit_ids=[str(mid) for mid in source_memory_ids]
+    )
+    return bool(present)
 
 
 class _CreateAction(BaseModel):
@@ -1191,54 +1292,18 @@ async def _run_consolidation_job(
             while pending:
                 sub_batch = pending.pop(0)
 
-                async with acquire_with_retry(pool) as conn:
-                    obs_tags_list = _resolve_obs_tags_list(sub_batch[0]) if sub_batch else None
+                # No connection is held across the batch: recall, the main LLM call, the
+                # per-action embeds, and dedup all run connection-free; each helper acquires a
+                # short-lived connection only around its own SQL.
+                obs_tags_list = _resolve_obs_tags_list(sub_batch[0]) if sub_batch else None
 
-                    sub_deleted: int = 0
-                    sub_llm_failed = False
-                    if obs_tags_list:
-                        sub_results: list[dict[str, Any]] = []
-                        for obs_tags in obs_tags_list:
-                            pass_results, pass_deleted, pass_failed = await _process_memory_batch(
-                                conn=conn,
-                                memory_engine=memory_engine,
-                                llm_config=llm_config,
-                                bank_id=bank_id,
-                                memories=sub_batch,
-                                request_context=request_context,
-                                perf=batch_perf,
-                                config=config,
-                                obs_tags_override=obs_tags,
-                                txn=_batch_txn,
-                            )
-                            sub_deleted += pass_deleted
-                            sub_llm_failed = sub_llm_failed or pass_failed
-                            if not sub_results:
-                                sub_results = pass_results
-                            else:
-                                for i, (existing, new) in enumerate(zip(sub_results, pass_results)):
-                                    if existing.get("action") == "skipped" and new.get("action") != "skipped":
-                                        sub_results[i] = new
-                                    elif existing.get("action") != "skipped" and new.get("action") != "skipped":
-                                        existing_created = existing.get(
-                                            "created", 1 if existing.get("action") == "created" else 0
-                                        )
-                                        existing_updated = existing.get(
-                                            "updated", 1 if existing.get("action") == "updated" else 0
-                                        )
-                                        new_created = new.get("created", 1 if new.get("action") == "created" else 0)
-                                        new_updated = new.get("updated", 1 if new.get("action") == "updated" else 0)
-                                        total = existing_created + existing_updated + new_created + new_updated
-                                        sub_results[i] = {
-                                            "action": "multiple",
-                                            "created": existing_created + new_created,
-                                            "updated": existing_updated + new_updated,
-                                            "merged": 0,
-                                            "total_actions": total,
-                                        }
-                    else:
-                        sub_results, sub_deleted, sub_llm_failed = await _process_memory_batch(
-                            conn=conn,
+                sub_deleted: int = 0
+                sub_llm_failed = False
+                if obs_tags_list:
+                    sub_results: list[dict[str, Any]] = []
+                    for obs_tags in obs_tags_list:
+                        pass_results, pass_deleted, pass_failed = await _process_memory_batch(
+                            pool=pool,
                             memory_engine=memory_engine,
                             llm_config=llm_config,
                             bank_id=bank_id,
@@ -1246,8 +1311,46 @@ async def _run_consolidation_job(
                             request_context=request_context,
                             perf=batch_perf,
                             config=config,
+                            obs_tags_override=obs_tags,
                             txn=_batch_txn,
                         )
+                        sub_deleted += pass_deleted
+                        sub_llm_failed = sub_llm_failed or pass_failed
+                        if not sub_results:
+                            sub_results = pass_results
+                        else:
+                            for i, (existing, new) in enumerate(zip(sub_results, pass_results)):
+                                if existing.get("action") == "skipped" and new.get("action") != "skipped":
+                                    sub_results[i] = new
+                                elif existing.get("action") != "skipped" and new.get("action") != "skipped":
+                                    existing_created = existing.get(
+                                        "created", 1 if existing.get("action") == "created" else 0
+                                    )
+                                    existing_updated = existing.get(
+                                        "updated", 1 if existing.get("action") == "updated" else 0
+                                    )
+                                    new_created = new.get("created", 1 if new.get("action") == "created" else 0)
+                                    new_updated = new.get("updated", 1 if new.get("action") == "updated" else 0)
+                                    total = existing_created + existing_updated + new_created + new_updated
+                                    sub_results[i] = {
+                                        "action": "multiple",
+                                        "created": existing_created + new_created,
+                                        "updated": existing_updated + new_updated,
+                                        "merged": 0,
+                                        "total_actions": total,
+                                    }
+                else:
+                    sub_results, sub_deleted, sub_llm_failed = await _process_memory_batch(
+                        pool=pool,
+                        memory_engine=memory_engine,
+                        llm_config=llm_config,
+                        bank_id=bank_id,
+                        memories=sub_batch,
+                        request_context=request_context,
+                        perf=batch_perf,
+                        config=config,
+                        txn=_batch_txn,
+                    )
 
                 all_deleted += sub_deleted
 
@@ -1666,7 +1769,7 @@ async def _trigger_mental_model_refreshes(
 
 
 async def _process_memory_batch(
-    conn: "Connection",
+    pool: DatabaseBackend,
     memory_engine: "MemoryEngine",
     llm_config: Any,
     bank_id: str,
@@ -1754,7 +1857,10 @@ async def _process_memory_batch(
     if max_obs >= 0 and fact_tags:
         # max_obs == 0 means "no new observations": there are no slots regardless
         # of the current count, so skip the count query for that case.
-        current_count = await _count_observations_for_scope(conn, bank_id, fact_tags) if max_obs > 0 else 0
+        current_count = 0
+        if max_obs > 0:
+            async with acquire_with_retry(pool) as count_conn:
+                current_count = await _count_observations_for_scope(count_conn, bank_id, fact_tags)
         remaining_observation_slots = max(max_obs - current_count, 0)
         if remaining_observation_slots == 0:
             logger.info(
@@ -1799,17 +1905,21 @@ async def _process_memory_batch(
         else None
     )
 
-    # Execute deletes first to free observation slots before creates consume them
+    # Execute deletes first to free observation slots before creates consume them. Each delete
+    # is a single fast statement, so the whole loop shares one short-lived connection.
     deleted_count = 0
-    for delete in llm_result.deletes:
-        # Security: the observation must be present in the unioned recall
-        if not any(str(obs.id) == delete.observation_id for obs in union_observations):
-            logger.debug(
-                f"Batch consolidation: rejected delete — observation {delete.observation_id} not in unioned recall"
-            )
-            continue
-        await _execute_delete_action(conn=conn, bank_id=bank_id, observation_id=delete.observation_id, txn=txn)
-        deleted_count += 1
+    if llm_result.deletes:
+        async with acquire_with_retry(pool) as conn:
+            for delete in llm_result.deletes:
+                # Security: the observation must be present in the unioned recall
+                if not any(str(obs.id) == delete.observation_id for obs in union_observations):
+                    logger.debug(
+                        f"Batch consolidation: rejected delete — observation {delete.observation_id} "
+                        f"not in unioned recall"
+                    )
+                    continue
+                await _execute_delete_action(conn=conn, bank_id=bank_id, observation_id=delete.observation_id, txn=txn)
+                deleted_count += 1
 
     for update in llm_result.updates:
         source_mems = [mem_by_id[fid] for fid in update.source_fact_ids if fid in mem_by_id]
@@ -1824,7 +1934,7 @@ async def _process_memory_batch(
             continue
         agg = _aggregate_source_fields(source_mems, tags=fact_tags)
         updated_emb_str = await _execute_update_action(
-            conn=conn,
+            pool=pool,
             memory_engine=memory_engine,
             bank_id=bank_id,
             source_memory_ids=[m["id"] for m in source_mems],
@@ -1845,7 +1955,7 @@ async def _process_memory_batch(
         # source). updated_emb_str is None when the update was skipped — nothing to reconcile.
         if dedup_enabled and updated_emb_str is not None:
             await _dedup_reconcile_update(
-                conn,
+                pool,
                 memory_engine,
                 bank_id,
                 config,
@@ -1894,7 +2004,7 @@ async def _process_memory_batch(
         # near-identical observation (LLM-adjudicated, 1-by-1) instead of inserting a dup.
         if dedup_enabled:
             merged_into = await _dedup_reconcile_create(
-                conn,
+                pool,
                 memory_engine,
                 bank_id,
                 config,
@@ -1914,8 +2024,8 @@ async def _process_memory_batch(
                     per_memory_created.add(str(m["id"]))
                 continue
 
-        await _execute_create_action(
-            conn=conn,
+        action = await _execute_create_action(
+            pool=pool,
             memory_engine=memory_engine,
             bank_id=bank_id,
             source_memory_ids=create_source_ids,
@@ -1928,8 +2038,11 @@ async def _process_memory_batch(
             perf=perf,
             txn=txn,
         )
-        for m in source_mems:
-            per_memory_created.add(str(m["id"]))
+        # Count a memory as created only when an observation was actually written (the
+        # source-liveness recheck inside the write txn can skip it connection-free).
+        if action == "created":
+            for m in source_mems:
+                per_memory_created.add(str(m["id"]))
 
     # Build per-memory result dicts for the stats tracker in the outer loop
     results: list[dict[str, Any]] = []
@@ -2025,7 +2138,7 @@ async def _append_observation_history(
 
 
 async def _execute_update_action(
-    conn: "Connection",
+    pool: DatabaseBackend,
     memory_engine: "MemoryEngine",
     bank_id: str,
     source_memory_ids: list[uuid.UUID],
@@ -2045,41 +2158,33 @@ async def _execute_update_action(
     Extends source_memory_ids with all contributing memories, updates temporal fields
     (LEAST for occurred_start, GREATEST for occurred_end / mentioned_at), and merges tags.
 
+    The embedding is computed off-connection (a slow embedder must never pin a pooled
+    connection); the liveness check + UPDATE + history + observation_sources sync then run
+    in one short transaction so they commit atomically.
+
     Returns the observation's freshly-computed embedding (pgvector literal) so the caller can
     run UPDATE-path dedup without re-embedding, or None when the update was skipped.
     """
     model = next((m for m in observations if str(m.id) == observation_id), None)
     if not model:
         logger.debug(f"Update skipped: observation {observation_id} not found in recall results")
-        return
-
-    live_source_memory_ids = await _filter_live_source_memories(conn, bank_id, source_memory_ids)
-    if not live_source_memory_ids:
-        logger.debug(
-            f"Update skipped: all {len(source_memory_ids)} source memories for observation "
-            f"{observation_id} were deleted concurrently"
-        )
-        return
-    source_memory_ids = live_source_memory_ids
+        return None
 
     from ...config import get_config
 
-    history_entry = _ObservationHistorySnapshot(
-        previous_text=model.text,
-        previous_tags=list(model.tags or []),
-        previous_occurred_start=model.occurred_start,
-        previous_occurred_end=model.occurred_end,
-        previous_mentioned_at=model.mentioned_at,
-        new_source_memory_ids=[str(mid) for mid in source_memory_ids],
-    )
+    # Preflight (non-locking, separate short-lived conn): if every source memory is already
+    # gone, skip BEFORE the slow embed — restores the pre-refactor short-circuit so a no-op
+    # update doesn't embed and a failing embedder doesn't raise where it used to skip.
+    async with acquire_with_retry(pool) as conn:
+        if not await _any_live_source_memory(conn, bank_id, source_memory_ids):
+            logger.debug(
+                f"Update skipped: all {len(source_memory_ids)} source memories for observation "
+                f"{observation_id} were deleted before embedding"
+            )
+            return None
 
-    source_ids = list(model.source_fact_ids or []) + source_memory_ids
-
-    # SECURITY: Merge source fact's tags into existing observation tags so all contributors can see it
-    existing_tags = set(model.tags or [])
-    source_tags = set(source_fact_tags or [])
-    merged_tags = list(existing_tags | source_tags)
-
+    # Embed off-connection: the new text is known up front and does not depend on
+    # any DB state, so the (slow) embedder runs before we touch the pool.
     t0 = time.time()
     embeddings = await embedding_utils.generate_embeddings_batch(memory_engine.embeddings, [new_text])
     embedding_str = str(embeddings[0]) if embeddings else None
@@ -2087,90 +2192,120 @@ async def _execute_update_action(
         perf.record_timing("embedding", time.time() - t0)
 
     config = get_config()
-
     search_vector_clause = _native_search_vector_update(config, "$1")
-
-    t0 = time.time()
     store = get_memories()
-    if store.writes_memory_rows_in_sql:
-        await conn.execute(
-            f"""
-            UPDATE {fq_table("memory_units")}
-            SET text = $1,
-                embedding = $2::vector,
-                source_memory_ids = $3,
-                proof_count = $4,
-                tags = $9,
-                updated_at = now(),
-                occurred_start = LEAST(occurred_start, COALESCE($6, occurred_start)),
-                occurred_end = GREATEST(occurred_end, COALESCE($7, occurred_end)),
-                mentioned_at = GREATEST(mentioned_at, COALESCE($8, mentioned_at)){search_vector_clause}
-            WHERE id = $5
-            """,
-            new_text,
-            embedding_str,
-            source_ids,
-            len(source_ids),
-            uuid.UUID(observation_id),
-            source_occurred_start,
-            source_occurred_end,
-            source_mentioned_at,
-            merged_tags,
-        )
-    else:
-        # Upsert overwrites the whole observation, so start from its current state (fetched from
-        # the store) and apply the same merge the SQL does — LEAST/GREATEST on the times — while
-        # preserving fields the update never touches (event_date, created_at).
-        current = await store.get_memories(conn=conn, fq_table=fq_table, bank_id=bank_id, unit_ids=[observation_id])
-        cur = current[0] if current else None
-        await store.upsert_observation(
-            conn=conn,
-            bank_id=bank_id,
-            txn=txn,
-            record=FactRecord(
-                unit_id=observation_id,
-                text=new_text,
-                embedding=embedding_str,
-                fact_type="observation",
-                tags=merged_tags,
-                proof_count=len(source_ids),
-                source_memory_ids=[str(s) for s in source_ids],
-                event_date=cur.event_date if cur else None,
-                occurred_start=_merge_min(model.occurred_start, source_occurred_start),
-                occurred_end=_merge_max(model.occurred_end, source_occurred_end),
-                mentioned_at=_merge_max(model.mentioned_at, source_mentioned_at),
-                created_at=cur.created_at if cur else None,
-            ),
-        )
 
-    # Record the pre-update snapshot in the dedicated observation_history table
-    # (one row per change), then trim to the configured cap. History lived in a
-    # single unbounded JSONB column before; an often-reinforced observation grew
-    # it until it crossed Postgres's 256MB jsonb limit and got stuck.
-    if config.enable_observation_history:
-        await _append_observation_history(
-            conn, bank_id, observation_id, history_entry, config.observation_history_max_entries
-        )
+    async with acquire_with_retry(pool) as conn:
+        async with conn.transaction():
+            # FOR SHARE liveness + the write share one tiny transaction so a concurrent
+            # delete cannot remove a source row between the check and the UPDATE.
+            live_source_memory_ids = await _filter_live_source_memories(conn, bank_id, source_memory_ids)
+            if not live_source_memory_ids:
+                logger.debug(
+                    f"Update skipped: all {len(source_memory_ids)} source memories for observation "
+                    f"{observation_id} were deleted concurrently"
+                )
+                return None
+            live_ids = live_source_memory_ids
 
-    # Sync observation_sources junction table (Oracle only — PG uses native array ops).
-    if memory_engine._backend.ops.uses_observation_sources_table:
-        obs_uuid = uuid.UUID(observation_id)
-        await conn.execute(
-            f"DELETE FROM {fq_table('observation_sources')} WHERE observation_id = $1",
-            obs_uuid,
-        )
-        if source_ids:
-            await conn.executemany(
-                f"""
-                INSERT INTO {fq_table("observation_sources")} (observation_id, source_id)
-                VALUES ($1, $2)
-                ON CONFLICT (observation_id, source_id) DO NOTHING
-                """,
-                [(obs_uuid, sid) for sid in dict.fromkeys(source_ids)],
+            history_entry = _ObservationHistorySnapshot(
+                previous_text=model.text,
+                previous_tags=list(model.tags or []),
+                previous_occurred_start=model.occurred_start,
+                previous_occurred_end=model.occurred_end,
+                previous_mentioned_at=model.mentioned_at,
+                new_source_memory_ids=[str(mid) for mid in live_ids],
             )
 
-    if perf:
-        perf.record_timing("db_write", time.time() - t0)
+            source_ids = list(model.source_fact_ids or []) + live_ids
+
+            # SECURITY: Merge source fact's tags into existing observation tags so all contributors can see it
+            existing_tags = set(model.tags or [])
+            source_tags = set(source_fact_tags or [])
+            merged_tags = list(existing_tags | source_tags)
+
+            t0 = time.time()
+            if store.writes_memory_rows_in_sql:
+                await conn.execute(
+                    f"""
+                    UPDATE {fq_table("memory_units")}
+                    SET text = $1,
+                        embedding = $2::vector,
+                        source_memory_ids = $3,
+                        proof_count = $4,
+                        tags = $9,
+                        updated_at = now(),
+                        occurred_start = LEAST(occurred_start, COALESCE($6, occurred_start)),
+                        occurred_end = GREATEST(occurred_end, COALESCE($7, occurred_end)),
+                        mentioned_at = GREATEST(mentioned_at, COALESCE($8, mentioned_at)){search_vector_clause}
+                    WHERE id = $5
+                    """,
+                    new_text,
+                    embedding_str,
+                    source_ids,
+                    len(source_ids),
+                    uuid.UUID(observation_id),
+                    source_occurred_start,
+                    source_occurred_end,
+                    source_mentioned_at,
+                    merged_tags,
+                )
+            else:
+                # Upsert overwrites the whole observation, so start from its current state (fetched
+                # from the store) and apply the same merge the SQL does — LEAST/GREATEST on the times
+                # — while preserving fields the update never touches (event_date, created_at).
+                current = await store.get_memories(
+                    conn=conn, fq_table=fq_table, bank_id=bank_id, unit_ids=[observation_id]
+                )
+                cur = current[0] if current else None
+                await store.upsert_observation(
+                    conn=conn,
+                    bank_id=bank_id,
+                    txn=txn,
+                    record=FactRecord(
+                        unit_id=observation_id,
+                        text=new_text,
+                        embedding=embedding_str,
+                        fact_type="observation",
+                        tags=merged_tags,
+                        proof_count=len(source_ids),
+                        source_memory_ids=[str(s) for s in source_ids],
+                        event_date=cur.event_date if cur else None,
+                        occurred_start=_merge_min(model.occurred_start, source_occurred_start),
+                        occurred_end=_merge_max(model.occurred_end, source_occurred_end),
+                        mentioned_at=_merge_max(model.mentioned_at, source_mentioned_at),
+                        created_at=cur.created_at if cur else None,
+                    ),
+                )
+
+            # Record the pre-update snapshot in the dedicated observation_history table
+            # (one row per change), then trim to the configured cap. History lived in a
+            # single unbounded JSONB column before; an often-reinforced observation grew
+            # it until it crossed Postgres's 256MB jsonb limit and got stuck.
+            if config.enable_observation_history:
+                await _append_observation_history(
+                    conn, bank_id, observation_id, history_entry, config.observation_history_max_entries
+                )
+
+            # Sync observation_sources junction table (Oracle only — PG uses native array ops).
+            if memory_engine._backend.ops.uses_observation_sources_table:
+                obs_uuid = uuid.UUID(observation_id)
+                await conn.execute(
+                    f"DELETE FROM {fq_table('observation_sources')} WHERE observation_id = $1",
+                    obs_uuid,
+                )
+                if source_ids:
+                    await conn.executemany(
+                        f"""
+                        INSERT INTO {fq_table("observation_sources")} (observation_id, source_id)
+                        VALUES ($1, $2)
+                        ON CONFLICT (observation_id, source_id) DO NOTHING
+                        """,
+                        [(obs_uuid, sid) for sid in dict.fromkeys(source_ids)],
+                    )
+
+            if perf:
+                perf.record_timing("db_write", time.time() - t0)
 
     # Map the updated observation onto the consolidation trace as a produced memory.
     record_created_memory_ids([observation_id])
@@ -2179,7 +2314,7 @@ async def _execute_update_action(
 
 
 async def _execute_create_action(
-    conn: "Connection",
+    pool: DatabaseBackend,
     memory_engine: "MemoryEngine",
     bank_id: str,
     source_memory_ids: list[uuid.UUID],
@@ -2191,15 +2326,15 @@ async def _execute_create_action(
     mentioned_at: datetime | None = None,
     perf: ConsolidationPerfLog | None = None,
     txn=None,
-) -> None:
+) -> str:
     """
     Create a new observation from one or more source memories.
 
     Tags are inherited from the source facts (determined algorithmically, not by LLM)
-    to maintain visibility scope.
+    to maintain visibility scope. Returns the write action ("created" or "skipped").
     """
     created = await _create_observation_directly(
-        conn=conn,
+        pool=pool,
         memory_engine=memory_engine,
         bank_id=bank_id,
         source_memory_ids=source_memory_ids,
@@ -2217,6 +2352,7 @@ async def _execute_create_action(
     if new_id:
         record_created_memory_ids([new_id])
     logger.debug(f"Created observation from {len(source_memory_ids)} source memories")
+    return created["action"]
 
 
 async def _execute_delete_action(
@@ -2555,7 +2691,7 @@ async def _consolidate_batch_with_llm(
 
 
 async def _create_observation_directly(
-    conn: "Connection",
+    pool: DatabaseBackend,
     memory_engine: "MemoryEngine",
     bank_id: str,
     source_memory_ids: list[uuid.UUID],
@@ -2568,125 +2704,141 @@ async def _create_observation_directly(
     perf: ConsolidationPerfLog | None = None,
     txn=None,
 ) -> dict[str, Any]:
-    """Create an observation from one or more source memories with pre-processed text."""
-    live_source_memory_ids = await _filter_live_source_memories(conn, bank_id, source_memory_ids)
-    if not live_source_memory_ids:
-        logger.debug(f"Create skipped: all {len(source_memory_ids)} source memories were deleted concurrently")
-        return {"action": "skipped", "reason": "sources_deleted"}
-    source_memory_ids = live_source_memory_ids
+    """Create an observation from one or more source memories with pre-processed text.
 
-    # Generate embedding for the observation (convert to string for pgvector)
+    The embedding is computed off-connection (a slow embedder must never pin a pooled
+    connection); the liveness check + INSERT + observation_sources insert then run in one
+    short transaction so they commit atomically.
+    """
+    # Preflight (non-locking, separate short-lived conn): if every source memory is already
+    # gone, skip BEFORE the slow embed — restores the pre-refactor short-circuit so a no-op
+    # create doesn't embed and a failing embedder doesn't raise where it used to skip.
+    async with acquire_with_retry(pool) as conn:
+        if not await _any_live_source_memory(conn, bank_id, source_memory_ids):
+            logger.debug(f"Create skipped: all {len(source_memory_ids)} source memories were deleted before embedding")
+            return {"action": "skipped", "reason": "sources_deleted"}
+
+    # Generate embedding for the observation (convert to string for pgvector) BEFORE
+    # acquiring a connection so the embedder never holds a pooled connection.
     t0 = time.time()
     embeddings = await embedding_utils.generate_embeddings_batch(memory_engine.embeddings, [observation_text])
     embedding_str = str(embeddings[0]) if embeddings else None
     if perf:
         perf.record_timing("embedding", time.time() - t0)
 
-    # Create the observation as a memory_unit
     now = datetime.now(timezone.utc)
     obs_event_date = event_date or now
     obs_occurred_start = occurred_start
     obs_occurred_end = occurred_end
     obs_mentioned_at = mentioned_at or now
     obs_tags = tags or []
-
-    t0 = time.time()
     observation_id = uuid.uuid4()
 
     # Write the observation. A SQL store keeps it as a `memory_units` row (inline below, with the
     # search_vector the configured backend needs); a store that owns its rows takes it through
     # upsert_observation as a normal Observation-type memory carrying all of its own state.
     store = get_memories()
-    if store.writes_memory_rows_in_sql:
-        # Query varies based on text search backend.
-        from ..schema import _is_oracle  # noqa: PLC0415
+    async with acquire_with_retry(pool) as conn:
+        async with conn.transaction():
+            # FOR SHARE liveness + INSERT share one tiny transaction so a concurrent
+            # delete cannot orphan the new observation between the check and the insert.
+            live_source_memory_ids = await _filter_live_source_memories(conn, bank_id, source_memory_ids)
+            if not live_source_memory_ids:
+                logger.debug(f"Create skipped: all {len(source_memory_ids)} source memories were deleted concurrently")
+                return {"action": "skipped", "reason": "sources_deleted"}
+            source_memory_ids = live_source_memory_ids
 
-        config = get_config()
-        if config.text_search_extension == "vchord":
-            # VectorChord: manually tokenize and insert search_vector
-            query = f"""
-                INSERT INTO {fq_table("memory_units")} (
-                    id, bank_id, text, fact_type, embedding, proof_count, source_memory_ids,
-                    tags, event_date, occurred_start, occurred_end, mentioned_at, search_vector
+            t0 = time.time()
+            if store.writes_memory_rows_in_sql:
+                # Query varies based on text search backend.
+                from ..schema import _is_oracle  # noqa: PLC0415
+
+                config = get_config()
+                if config.text_search_extension == "vchord":
+                    # VectorChord: manually tokenize and insert search_vector
+                    query = f"""
+                        INSERT INTO {fq_table("memory_units")} (
+                            id, bank_id, text, fact_type, embedding, proof_count, source_memory_ids,
+                            tags, event_date, occurred_start, occurred_end, mentioned_at, search_vector
+                        )
+                        VALUES ($1, $2, $3, 'observation', $4::vector, 1, $5, $6, $7, $8, $9, $10,
+                                tokenize($3, 'llmlingua2')::bm25_catalog.bm25vector)
+                        RETURNING id
+                    """
+                elif config.text_search_extension == "native" and not _is_oracle():
+                    # Native (PostgreSQL): search_vector is populated with to_tsvector()
+                    # using the configured native language dictionary, matching the batch
+                    # insert path in ops_postgresql.insert_facts_batch. On Oracle this falls
+                    # through to the no-search_vector branch below (Oracle maintains its text
+                    # index separately; to_tsvector/::regconfig is PG-only — see #3021).
+                    query = f"""
+                        INSERT INTO {fq_table("memory_units")} (
+                            id, bank_id, text, fact_type, embedding, proof_count, source_memory_ids,
+                            tags, event_date, occurred_start, occurred_end, mentioned_at, search_vector
+                        )
+                        VALUES ($1, $2, $3, 'observation', $4::vector, 1, $5, $6, $7, $8, $9, $10,
+                                to_tsvector('{config.text_search_extension_native_language}'::regconfig, COALESCE($3, '')))
+                        RETURNING id
+                    """
+                else:  # pg_textsearch, pgroonga, pg_search, and Oracle: base text columns / separate index
+                    query = f"""
+                        INSERT INTO {fq_table("memory_units")} (
+                            id, bank_id, text, fact_type, embedding, proof_count, source_memory_ids,
+                            tags, event_date, occurred_start, occurred_end, mentioned_at
+                        )
+                        VALUES ($1, $2, $3, 'observation', $4::vector, 1, $5, $6, $7, $8, $9, $10)
+                        RETURNING id
+                    """
+
+                row = await conn.fetchrow(
+                    query,
+                    observation_id,
+                    bank_id,
+                    observation_text,
+                    embedding_str,
+                    source_memory_ids,
+                    obs_tags,
+                    obs_event_date,
+                    obs_occurred_start,
+                    obs_occurred_end,
+                    obs_mentioned_at,
                 )
-                VALUES ($1, $2, $3, 'observation', $4::vector, 1, $5, $6, $7, $8, $9, $10,
-                        tokenize($3, 'llmlingua2')::bm25_catalog.bm25vector)
-                RETURNING id
-            """
-        elif config.text_search_extension == "native" and not _is_oracle():
-            # Native (PostgreSQL): search_vector is populated with to_tsvector()
-            # using the configured native language dictionary, matching the batch
-            # insert path in ops_postgresql.insert_facts_batch. On Oracle this falls
-            # through to the no-search_vector branch below (Oracle maintains its text
-            # index separately; to_tsvector/::regconfig is PG-only — see #3021).
-            query = f"""
-                INSERT INTO {fq_table("memory_units")} (
-                    id, bank_id, text, fact_type, embedding, proof_count, source_memory_ids,
-                    tags, event_date, occurred_start, occurred_end, mentioned_at, search_vector
+                created_id = row["id"]
+
+                # Populate observation_sources junction table (Oracle only — PG uses native array ops).
+                if memory_engine._backend.ops.uses_observation_sources_table and source_memory_ids:
+                    await conn.executemany(
+                        f"""
+                        INSERT INTO {fq_table("observation_sources")} (observation_id, source_id)
+                        VALUES ($1, $2)
+                        ON CONFLICT (observation_id, source_id) DO NOTHING
+                        """,
+                        [(observation_id, sid) for sid in dict.fromkeys(source_memory_ids)],
+                    )
+            else:
+                await store.upsert_observation(
+                    conn=conn,
+                    bank_id=bank_id,
+                    txn=txn,
+                    record=FactRecord(
+                        unit_id=str(observation_id),
+                        text=observation_text,
+                        embedding=embedding_str,
+                        fact_type="observation",
+                        tags=list(obs_tags),
+                        proof_count=1,
+                        source_memory_ids=[str(s) for s in source_memory_ids],
+                        event_date=obs_event_date,
+                        occurred_start=obs_occurred_start,
+                        occurred_end=obs_occurred_end,
+                        mentioned_at=obs_mentioned_at,
+                        created_at=now,
+                    ),
                 )
-                VALUES ($1, $2, $3, 'observation', $4::vector, 1, $5, $6, $7, $8, $9, $10,
-                        to_tsvector('{config.text_search_extension_native_language}'::regconfig, COALESCE($3, '')))
-                RETURNING id
-            """
-        else:  # pg_textsearch, pgroonga, pg_search, and Oracle: base text columns / separate index
-            query = f"""
-                INSERT INTO {fq_table("memory_units")} (
-                    id, bank_id, text, fact_type, embedding, proof_count, source_memory_ids,
-                    tags, event_date, occurred_start, occurred_end, mentioned_at
-                )
-                VALUES ($1, $2, $3, 'observation', $4::vector, 1, $5, $6, $7, $8, $9, $10)
-                RETURNING id
-            """
+                created_id = observation_id
 
-        row = await conn.fetchrow(
-            query,
-            observation_id,
-            bank_id,
-            observation_text,
-            embedding_str,
-            source_memory_ids,
-            obs_tags,
-            obs_event_date,
-            obs_occurred_start,
-            obs_occurred_end,
-            obs_mentioned_at,
-        )
-        created_id = row["id"]
-
-        # Populate observation_sources junction table (Oracle only — PG uses native array ops).
-        if memory_engine._backend.ops.uses_observation_sources_table and source_memory_ids:
-            await conn.executemany(
-                f"""
-                INSERT INTO {fq_table("observation_sources")} (observation_id, source_id)
-                VALUES ($1, $2)
-                ON CONFLICT (observation_id, source_id) DO NOTHING
-                """,
-                [(observation_id, sid) for sid in dict.fromkeys(source_memory_ids)],
-            )
-    else:
-        await store.upsert_observation(
-            conn=conn,
-            bank_id=bank_id,
-            txn=txn,
-            record=FactRecord(
-                unit_id=str(observation_id),
-                text=observation_text,
-                embedding=embedding_str,
-                fact_type="observation",
-                tags=list(obs_tags),
-                proof_count=1,
-                source_memory_ids=[str(s) for s in source_memory_ids],
-                event_date=obs_event_date,
-                occurred_start=obs_occurred_start,
-                occurred_end=obs_occurred_end,
-                mentioned_at=obs_mentioned_at,
-                created_at=now,
-            ),
-        )
-        created_id = observation_id
-
-    if perf:
-        perf.record_timing("db_write", time.time() - t0)
+            if perf:
+                perf.record_timing("db_write", time.time() - t0)
 
     logger.debug(f"Created observation {observation_id} from {len(source_memory_ids)} memories (tags: {obs_tags})")
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -11824,6 +11824,16 @@ class MemoryEngine(MemoryEngineInterface):
                 await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
         backend = await self._get_backend()
 
+        # Compute the new embedding BEFORE acquiring a pooled connection: a slow
+        # embedder must never pin a DB connection. The embedding text depends only
+        # on the incoming name/content, never on DB state, so it can be done here.
+        new_embedding_str: str | None = None
+        if content is not None:
+            embedding_text = f"{name or ''} {content}"
+            embedding = await embedding_utils.generate_embeddings_batch(self.embeddings, [embedding_text])
+            if embedding:
+                new_embedding_str = str(embedding[0])
+
         async with acquire_with_retry(backend) as conn:
             # If content is changing, fetch current content + reflect_response to record history
             previous_content: str | None = None
@@ -11879,12 +11889,10 @@ class MemoryEngine(MemoryEngineInterface):
                         if based_on is not None:
                             slim_reflect_response = {"based_on": based_on}
                     record_mm_history = True
-                # Also update embedding (convert to string for asyncpg vector type)
-                embedding_text = f"{name or ''} {content}"
-                embedding = await embedding_utils.generate_embeddings_batch(self.embeddings, [embedding_text])
-                if embedding:
+                # Apply the embedding computed above (off-connection).
+                if new_embedding_str is not None:
                     updates.append(f"embedding = ${param_idx}")
-                    params.append(str(embedding[0]))
+                    params.append(new_embedding_str)
                     param_idx += 1
             elif refresh_watermark is not None:
                 # A successful delta refresh can find no topic-relevant facts even though

--- a/hindsight-api-slim/tests/test_consolidation_dedup.py
+++ b/hindsight-api-slim/tests/test_consolidation_dedup.py
@@ -8,8 +8,9 @@ the path stochastically.
 import logging
 import types
 import uuid
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from unittest.mock import AsyncMock, patch
+from unittest.mock import DEFAULT, AsyncMock, patch
 
 import pytest
 
@@ -82,12 +83,105 @@ def _obs(text: str, sim: float, oid: str = _TWIN_ID) -> RetrievalResult:
     return RetrievalResult(id=oid, text=text, fact_type="observation", similarity=sim)
 
 
+class _DedupConn:
+    """Backend-shaped conn for dedup-fold tests. Enforces that the live-source filter and
+    the fold UPDATE run inside the fold transaction on an acquired connection, and that the
+    fold UPDATE is RETURNING-gated."""
+
+    def __init__(self):
+        self.active = 0  # >0 while a connection is acquired (set by _DedupBackend.acquire)
+        self._in_txn = False
+        self.fetchval_result = uuid.UUID(_TWIN_ID)  # survivor id the fold "returns"
+        self.fetchrow_result = None  # update-path source snapshot
+        self.live_rows = None  # override liveness rows; None -> echo all source ids as live
+        # Modeled row text so the fold/snapshot text guards actually bite. None -> "match any"
+        # (keeps every pre-existing test, which never sets these, behaving as before).
+        self.current_twin_text = None  # survivor/twin row's current text (create + update folds)
+        self.current_updated_text = None  # updated row's current text (update snapshot + fold)
+        self.fetchval = AsyncMock(side_effect=self._fetchval)
+        self.fetch = AsyncMock(side_effect=self._fetch)
+        self.fetchrow = AsyncMock(side_effect=self._fetchrow)
+        self.execute = AsyncMock()
+
+    @asynccontextmanager
+    async def transaction(self):
+        assert self.active > 0, "fold transaction opened without an acquired connection"
+        self._in_txn = True
+        try:
+            yield
+        finally:
+            self._in_txn = False
+
+    async def _fetchval(self, query, *args):
+        assert self._in_txn, "fold UPDATE must run inside the fold transaction"
+        assert "RETURNING" in query, "fold UPDATE must be RETURNING-gated"
+        # Assert the text-guard CLAUSE is present (not just that the arg is passed) so deleting the SQL
+        # guard fails even if the param is left behind, then model the guarded row text so a stale-text
+        # fold matches no row. ``args`` excludes the bound ``query``.
+        if "u.text" in query:  # update-path fold
+            assert "t.text = $4" in query and "u.text = $5" in query, "update fold must keep both text guards"
+            if self.current_twin_text is not None and args[3] != self.current_twin_text:
+                return None
+            if self.current_updated_text is not None and args[4] != self.current_updated_text:
+                return None
+        else:  # create-path fold
+            assert "AND text = $4" in query, "create fold must keep the twin text guard (AND text = $4)"
+            if self.current_twin_text is not None and args[3] != self.current_twin_text:
+                return None
+        return self.fetchval_result
+
+    async def _fetch(self, query, source_ids, bank_id):
+        assert self._in_txn, "live-source filter must run inside the fold transaction"
+        assert "FOR SHARE" in query, "live-source filter must hold FOR SHARE on the source rows"
+        if self.live_rows is not None:
+            return self.live_rows
+        return [{"id": s} for s in source_ids]
+
+    async def _fetchrow(self, query, *args):
+        # Assert the text-guard CLAUSE is present (so deleting it fails even if the arg stays), then
+        # model the updated row's text so a row rewritten during the LLM window snapshots as gone.
+        # ``args`` excludes the bound ``query``.
+        assert "AND text = $2" in query, "update snapshot must keep the updated-text guard (AND text = $2)"
+        if self.current_updated_text is not None and args[1] != self.current_updated_text:
+            return None
+        return self.fetchrow_result
+
+
+class _DedupBackend:
+    """Backend-shaped stand-in matching acquire_with_retry's ``_wraps_backend`` path."""
+
+    _wraps_backend = True
+
+    def __init__(self, conn):
+        self._conn = conn
+
+    @asynccontextmanager
+    async def acquire(self):
+        self._conn.active += 1
+        try:
+            yield self._conn
+        finally:
+            self._conn.active -= 1
+
+
+def _make_dedup_llm(conn):
+    """An LLM stub that asserts no pooled connection is held when it is called."""
+    llm = types.SimpleNamespace(call=AsyncMock())
+
+    def _assert_released(*a, **k):
+        assert conn.active == 0, "no pooled connection may be held during the dedup LLM call"
+        return DEFAULT  # fall through to the llm.call.return_value the test sets
+
+    llm.call.side_effect = _assert_released
+    return llm
+
+
 def _ctx(threshold: float = 0.97):
     """Return (kwargs, conn_mock, llm_mock) for a _dedup_reconcile_create call."""
-    conn = AsyncMock()
-    llm = types.SimpleNamespace(call=AsyncMock())
+    conn = _DedupConn()
+    llm = _make_dedup_llm(conn)
     kwargs = dict(
-        conn=conn,
+        pool=_DedupBackend(conn),
         memory_engine=types.SimpleNamespace(embeddings=object()),
         bank_id="bank1",
         # The merge path builds a search_vector UPDATE clause from the text-search
@@ -125,7 +219,7 @@ async def test_dedup_no_twin_above_threshold_returns_none() -> None:
         result = await _dedup_reconcile_create(**kwargs)
     assert result is None
     llm.call.assert_not_called()  # below threshold → no LLM call
-    conn.execute.assert_not_called()  # no merge
+    conn.fetchval.assert_not_called()  # no merge
 
 
 async def test_dedup_llm_keep_does_not_merge() -> None:
@@ -135,7 +229,7 @@ async def test_dedup_llm_keep_does_not_merge() -> None:
         result = await _dedup_reconcile_create(**kwargs)
     assert result is None
     llm.call.assert_awaited_once()
-    conn.execute.assert_not_called()  # kept distinct → no merge
+    conn.fetchval.assert_not_called()  # kept distinct → no merge
 
 
 async def test_dedup_llm_missing_action_defaults_to_keep() -> None:
@@ -145,7 +239,7 @@ async def test_dedup_llm_missing_action_defaults_to_keep() -> None:
         result = await _dedup_reconcile_create(**kwargs)
     assert result is None
     llm.call.assert_awaited_once()
-    conn.execute.assert_not_called()  # missing action is a conservative no-merge
+    conn.fetchval.assert_not_called()  # missing action is a conservative no-merge
 
 
 def test_dedup_decision_accepts_exact_valid_actions() -> None:
@@ -236,10 +330,10 @@ async def test_dedup_llm_merge_folds_into_twin() -> None:
     with _patch_embed(), _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.99)]):
         result = await _dedup_reconcile_create(**kwargs)
     assert result == _TWIN_ID  # merged into the twin; caller skips the CREATE
-    conn.execute.assert_awaited_once()
-    args = conn.execute.await_args.args
+    conn.fetchval.assert_awaited_once()  # fold is a RETURNING-gated UPDATE
+    args = conn.fetchval.await_args.args
     assert args[1] == "Uzbek content on YouTube is very rich."  # merged text persisted
-    assert args[2] == kwargs["create_source_ids"]  # new source facts folded in
+    assert args[2] == kwargs["create_source_ids"]  # new (live) source facts folded in
     assert args[3] == uuid.UUID(_TWIN_ID)  # onto the twin row
 
 
@@ -266,10 +360,11 @@ _UPDATED_ID = "44444444-4444-4444-8444-444444444444"
 
 def _update_ctx(threshold: float = 0.97):
     """Return (kwargs, conn_mock, llm_mock) for a _dedup_reconcile_update call."""
-    conn = AsyncMock()
-    llm = types.SimpleNamespace(call=AsyncMock())
+    conn = _DedupConn()
+    conn.fetchrow_result = {"source_memory_ids": [uuid.uuid4(), uuid.uuid4()]}
+    llm = _make_dedup_llm(conn)
     kwargs = dict(
-        conn=conn,
+        pool=_DedupBackend(conn),
         memory_engine=types.SimpleNamespace(embeddings=object()),
         bank_id="bank1",
         # The merge path builds a search_vector UPDATE clause from the text-search
@@ -294,16 +389,20 @@ async def test_dedup_update_merge_folds_into_twin_and_deletes_updated() -> None:
     with _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.98)]):
         await _dedup_reconcile_update(**kwargs)
     llm.call.assert_awaited_once()
-    # Three writes: fold-into-twin UPDATE, DELETE of the updated row, and DELETE of that row's
-    # observation_history (no longer cascaded from memory_units — that FK was dropped).
-    assert conn.execute.await_count == 3
-    fold_args = conn.execute.await_args_list[0].args
+    # The fold-into-twin is a RETURNING-gated UPDATE (fetchval); it folds only the updated row's
+    # LIVE sources (snapshotted via fetchrow, filtered FOR SHARE).
+    conn.fetchval.assert_awaited_once()
+    fold_args = conn.fetchval.await_args.args
     assert fold_args[1] == "Uzbek YouTube content is very rich and growing."  # merged text on the twin
     assert fold_args[2] == uuid.UUID(_TWIN_ID)  # survivor = the twin
     assert fold_args[3] == uuid.UUID(_UPDATED_ID)  # folded-from = the updated row
-    delete_args = conn.execute.await_args_list[1].args
+    assert fold_args[6] == conn.fetchrow_result["source_memory_ids"]  # only live updated-row sources
+    # Then the updated row is deleted: DELETE of the row, and DELETE of its observation_history
+    # (no longer cascaded from memory_units — that FK was dropped).
+    assert conn.execute.await_count == 2
+    delete_args = conn.execute.await_args_list[0].args
     assert delete_args[1] == uuid.UUID(_UPDATED_ID)  # the updated row is deleted
-    history_delete_args = conn.execute.await_args_list[2].args
+    history_delete_args = conn.execute.await_args_list[1].args
     assert history_delete_args[2] == uuid.UUID(_UPDATED_ID)  # its history is reclaimed too
 
 
@@ -313,7 +412,8 @@ async def test_dedup_update_keep_does_not_merge() -> None:
     with _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.98)]):
         await _dedup_reconcile_update(**kwargs)
     llm.call.assert_awaited_once()
-    conn.execute.assert_not_called()  # kept distinct → neither fold nor delete
+    conn.fetchval.assert_not_called()  # kept distinct → no fold
+    conn.execute.assert_not_called()  # → no delete
 
 
 async def test_dedup_update_excludes_self() -> None:
@@ -323,6 +423,7 @@ async def test_dedup_update_excludes_self() -> None:
     with _patch_probe([_obs("its own current text", 1.0, oid=_UPDATED_ID)]):
         await _dedup_reconcile_update(**kwargs)
     llm.call.assert_not_called()
+    conn.fetchval.assert_not_called()
     conn.execute.assert_not_called()
 
 
@@ -331,6 +432,7 @@ async def test_dedup_update_no_twin_above_threshold() -> None:
     with _patch_probe([_obs("loosely related", 0.8)]):
         await _dedup_reconcile_update(**kwargs)
     llm.call.assert_not_called()
+    conn.fetchval.assert_not_called()
     conn.execute.assert_not_called()
 
 
@@ -369,3 +471,153 @@ def test_dedup_active_skipped_on_oracle() -> None:
 
 def test_dedup_active_none_config() -> None:
     assert _dedup_active(None) is False
+
+
+# ── connection-release fold guards (RETURNING-gated, live-source re-filter) ────
+#
+# The embed/LLM adjudication runs with no connection held; the fold then re-checks source
+# liveness inside a short transaction and is RETURNING-gated so a twin that vanished (or a
+# source deleted) during the connection-free window can't drop a CREATE or fold a dead id.
+
+
+async def test_dedup_create_twin_vanished_returns_none_so_caller_creates() -> None:
+    # If the twin is deleted during the (connection-free) LLM window, the fold UPDATE matches
+    # no row (fetchval -> None); the helper must return None so the caller still CREATEs.
+    kwargs, conn, llm = _ctx()
+    conn.fetchval_result = None
+    llm.call.return_value = _DedupDecision(action="merge", text="merged text")
+    with (
+        _patch_embed(),
+        _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.99)]),
+    ):
+        result = await _dedup_reconcile_create(**kwargs)
+    assert result is None  # twin gone → don't drop the CREATE
+    conn.fetchval.assert_awaited_once()
+
+
+async def test_dedup_create_fold_uses_only_live_new_sources() -> None:
+    kwargs, conn, llm = _ctx()
+    live_source_id = uuid.uuid4()
+    deleted_source_id = uuid.uuid4()
+    kwargs["create_source_ids"] = [deleted_source_id, live_source_id]
+    conn.live_rows = [{"id": live_source_id}]
+    llm.call.return_value = _DedupDecision(action="merge", text="merged text")
+    with (
+        _patch_embed(),
+        _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.99)]),
+    ):
+        result = await _dedup_reconcile_create(**kwargs)
+    assert result == _TWIN_ID
+    conn.fetchval.assert_awaited_once()
+    assert conn.fetchval.await_args.args[2] == [live_source_id]
+
+
+async def test_dedup_create_all_new_sources_deleted_returns_none() -> None:
+    kwargs, conn, llm = _ctx()
+    kwargs["create_source_ids"] = [uuid.uuid4(), uuid.uuid4()]
+    conn.live_rows = []
+    llm.call.return_value = _DedupDecision(action="merge", text="merged text")
+    with (
+        _patch_embed(),
+        _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.99)]),
+    ):
+        result = await _dedup_reconcile_create(**kwargs)
+    assert result is None
+    conn.fetchval.assert_not_called()
+
+
+async def test_dedup_update_twin_vanished_does_not_delete_updated() -> None:
+    # If the fold matches no row (twin vanished mid-window), the updated row must NOT be deleted.
+    kwargs, conn, llm = _update_ctx()
+    conn.fetchval_result = None
+    llm.call.return_value = _DedupDecision(action="merge", text="merged text")
+    with _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.98)]):
+        await _dedup_reconcile_update(**kwargs)
+    conn.fetchval.assert_awaited_once()  # fold attempted
+    conn.execute.assert_not_called()  # but no delete, since the fold touched nothing
+
+
+async def test_dedup_update_fold_uses_only_live_updated_sources() -> None:
+    kwargs, conn, llm = _update_ctx()
+    live_source_id = uuid.uuid4()
+    deleted_source_id = uuid.uuid4()
+    conn.fetchrow_result = {"source_memory_ids": [deleted_source_id, live_source_id]}
+    conn.live_rows = [{"id": live_source_id}]
+    llm.call.return_value = _DedupDecision(action="merge", text="merged text")
+    with _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.98)]):
+        await _dedup_reconcile_update(**kwargs)
+    conn.fetchval.assert_awaited_once()
+    assert conn.fetchval.await_args.args[6] == [live_source_id]
+    conn.execute.assert_awaited()  # fold succeeded → updated row deleted
+
+
+async def test_dedup_update_all_updated_sources_deleted_skips_fold_and_delete() -> None:
+    kwargs, conn, llm = _update_ctx()
+    conn.fetchrow_result = {"source_memory_ids": [uuid.uuid4(), uuid.uuid4()]}
+    conn.live_rows = []
+    llm.call.return_value = _DedupDecision(action="merge", text="merged text")
+    with _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.98)]):
+        await _dedup_reconcile_update(**kwargs)
+    conn.fetchval.assert_not_called()
+    conn.execute.assert_not_called()
+
+
+# ── _process_memory_batch create-contract (created vs skipped) ────────────────
+
+
+def _batch_engine():
+    return types.SimpleNamespace(_consolidation_llm_config=types.SimpleNamespace(with_config=lambda *a, **k: object()))
+
+
+async def _run_create_batch(create_action_result: str):
+    from hindsight_api.engine.consolidation import consolidator as C
+
+    mem_id = str(uuid.uuid4())
+    memories = [{"id": mem_id, "text": "Uzbek YouTube content is very rich.", "tags": []}]
+    create = C._CreateAction(text="Uzbek YouTube content is very rich.", source_fact_ids=[mem_id])
+    llm_result = C._BatchLLMResult(creates=[create])
+    with (
+        patch.object(
+            C,
+            "_find_related_observations",
+            new=AsyncMock(return_value=types.SimpleNamespace(results=[], source_facts={})),
+        ),
+        patch.object(C, "_consolidate_batch_with_llm", new=AsyncMock(return_value=llm_result)),
+        patch.object(C, "_effective_scope_limit", return_value=-1),
+        patch.object(C, "_dedup_active", return_value=True),
+        patch.object(C, "_dedup_reconcile_create", new=AsyncMock(return_value=None)),
+        patch.object(C, "_execute_create_action", new=AsyncMock(return_value=create_action_result)) as create_action,
+    ):
+        result = await C._process_memory_batch(
+            pool=object(),
+            memory_engine=_batch_engine(),
+            llm_config=object(),
+            bank_id="bank1",
+            memories=memories,
+            request_context=object(),
+            config=object(),
+        )
+    return result, create_action, mem_id
+
+
+async def test_process_batch_creates_when_dedup_target_vanished() -> None:
+    # Caller contract: when _dedup_reconcile_create returns None (twin vanished mid-window),
+    # _process_memory_batch must still CREATE the observation instead of dropping it.
+    result, create_action, mem_id = await _run_create_batch("created")
+    create_action.assert_awaited_once()
+    assert create_action.await_args.kwargs["text"] == "Uzbek YouTube content is very rich."
+    assert create_action.await_args.kwargs["source_memory_ids"] == [mem_id]
+    assert result == ([{"action": "created"}], 0, False)
+
+
+async def test_process_batch_reports_skipped_when_create_skipped() -> None:
+    # _execute_create_action returns "skipped" (all sources deleted in the write txn) ->
+    # _process_memory_batch must NOT mark the memory created; it falls through to skipped.
+    result, _create_action, _mem_id = await _run_create_batch("skipped")
+    assert result == ([{"action": "skipped", "reason": "no_durable_knowledge"}], 0, False)
+
+
+async def test_process_batch_reports_created_when_create_created() -> None:
+    # _execute_create_action returns "created" -> the memory is marked created.
+    result, _create_action, _mem_id = await _run_create_batch("created")
+    assert result == ([{"action": "created"}], 0, False)

--- a/hindsight-api-slim/tests/test_consolidation_embedding_validation.py
+++ b/hindsight-api-slim/tests/test_consolidation_embedding_validation.py
@@ -1,4 +1,17 @@
+"""Deterministic unit tests for the pre-embed guards in the consolidation executors.
+
+Both findings are exercised against the production ``_wraps_backend`` acquisition path
+(not a raw-pool sentinel):
+
+* zero-length embeddings are rejected BEFORE any write reaches the connection;
+* when every source memory is already gone, the create/update executors short-circuit
+  BEFORE running the (slow) embedder, so a no-op consolidation never embeds and a
+  failing embedder never raises where it used to skip cleanly.
+"""
+
+import types
 import uuid
+from contextlib import asynccontextmanager
 
 import pytest
 
@@ -17,25 +30,149 @@ class _FakeMemoryEngine:
     embeddings = _ZeroLengthEmbeddings()
 
 
-class _FailingConn:
+class _WriteForbiddenConn:
+    """Backend connection allowing only the pre-embed liveness probe.
+
+    The preflight (``_any_live_source_memory``) runs ``fetchval``; the write path
+    (``transaction``/``fetchrow``/``execute``/``executemany``) must never be reached,
+    because the zero-length embedding is rejected first.
+    """
+
+    async def fetchval(self, *args, **kwargs):
+        return 1  # a live source exists -> proceed to embedding
+
+    async def fetch(self, *args, **kwargs):
+        return [{"id": 1}]
+
+    def transaction(self):
+        raise AssertionError("write transaction entered before the zero-length embedding was rejected")
+
     async def fetchrow(self, *args, **kwargs):
-        raise AssertionError("zero-length embedding should be rejected before database insert")
+        raise AssertionError("INSERT reached before the zero-length embedding was rejected")
+
+    async def execute(self, *args, **kwargs):
+        raise AssertionError("write reached before the zero-length embedding was rejected")
+
+    async def executemany(self, *args, **kwargs):
+        raise AssertionError("write reached before the zero-length embedding was rejected")
+
+
+class _NoLiveConn:
+    """Backend connection whose liveness probe reports no live source.
+
+    Correct code short-circuits at the preflight (``fetchval`` -> None) and never embeds
+    or writes; every write method fails hard as a backstop.
+    """
+
+    async def fetchval(self, *args, **kwargs):
+        return None  # no live source -> skip before embedding
+
+    def transaction(self):
+        raise AssertionError("write transaction entered after all sources were dead")
+
+    async def fetchrow(self, *args, **kwargs):
+        raise AssertionError("write reached after all sources were dead")
+
+    async def execute(self, *args, **kwargs):
+        raise AssertionError("write reached after all sources were dead")
+
+
+class _Backend:
+    """Backend-shaped stand-in matching acquire_with_retry's ``_wraps_backend`` path."""
+
+    _wraps_backend = True
+
+    def __init__(self, conn):
+        self._conn = conn
+
+    @asynccontextmanager
+    async def acquire(self):
+        yield self._conn
+
+
+def _forbid_embedder(monkeypatch):
+    """Make any call to the embedder fail hard, proving it is never reached."""
+
+    async def _embedder_must_not_run(*args, **kwargs):
+        raise AssertionError("embedder must not run when all source memories are dead")
+
+    monkeypatch.setattr(
+        "hindsight_api.engine.retain.embedding_utils.generate_embeddings_batch",
+        _embedder_must_not_run,
+    )
 
 
 @pytest.mark.asyncio
-async def test_create_observation_rejects_zero_length_embedding_before_insert(monkeypatch):
-    source_id = uuid.uuid4()
-
-    async def fake_filter_live_source_memories(conn, bank_id, source_memory_ids):
-        return source_memory_ids
-
-    monkeypatch.setattr(consolidator, "_filter_live_source_memories", fake_filter_live_source_memories)
-
+async def test_create_observation_rejects_zero_length_embedding_before_insert():
+    # Preflight passes (fetchval -> live); the real embedder then yields a zero-length vector,
+    # which must be rejected before any write. _WriteForbiddenConn fails hard if a write runs.
     with pytest.raises(RuntimeError, match="embedding 0 has dimension 0; expected 384"):
         await consolidator._create_observation_directly(
-            conn=_FailingConn(),
+            pool=_Backend(_WriteForbiddenConn()),
             memory_engine=_FakeMemoryEngine(),
             bank_id="test-bank",
-            source_memory_ids=[source_id],
+            source_memory_ids=[uuid.uuid4()],
             observation_text="Consolidated observation text.",
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_observation_skips_before_embedding_when_all_sources_dead(monkeypatch):
+    # All sources gone -> the create must short-circuit at the preflight, BEFORE the embedder
+    # (patched to explode if reached). No write may run.
+    _forbid_embedder(monkeypatch)
+    result = await consolidator._create_observation_directly(
+        pool=_Backend(_NoLiveConn()),
+        memory_engine=_FakeMemoryEngine(),
+        bank_id="test-bank",
+        source_memory_ids=[uuid.uuid4()],
+        observation_text="Consolidated observation text.",
+    )
+    assert result == {"action": "skipped", "reason": "sources_deleted"}
+
+
+@pytest.mark.asyncio
+async def test_update_action_skips_before_embedding_when_all_sources_dead(monkeypatch):
+    # Same preflight contract on the UPDATE path: all sources gone -> skip (return None) BEFORE
+    # the embedder runs. The existing real-DB update test asserts only post-state, so it would
+    # pass even with the embed-first ordering this finding fixed; this pins the embed-skip directly.
+    _forbid_embedder(monkeypatch)
+    obs_id = str(uuid.uuid4())
+    result = await consolidator._execute_update_action(
+        pool=_Backend(_NoLiveConn()),
+        memory_engine=_FakeMemoryEngine(),
+        bank_id="test-bank",
+        source_memory_ids=[uuid.uuid4(), uuid.uuid4()],
+        observation_id=obs_id,
+        new_text="This update must not land.",
+        observations=[types.SimpleNamespace(id=obs_id)],
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_update_action_rejects_zero_length_embedding_before_write():
+    # Preflight passes (a live source exists -> fetchval=1); the real embedder then yields a
+    # zero-length vector, which must be rejected before any write. _WriteForbiddenConn fails
+    # hard if the write transaction is reached.
+    obs_id = str(uuid.uuid4())
+    with pytest.raises(RuntimeError, match="embedding 0 has dimension 0; expected 384"):
+        await consolidator._execute_update_action(
+            pool=_Backend(_WriteForbiddenConn()),
+            memory_engine=_FakeMemoryEngine(),
+            bank_id="test-bank",
+            source_memory_ids=[uuid.uuid4()],
+            observation_id=obs_id,
+            new_text="Consolidated observation text.",
+            observations=[
+                types.SimpleNamespace(
+                    id=obs_id,
+                    text="prior observation text",
+                    tags=[],
+                    occurred_start=None,
+                    occurred_end=None,
+                    mentioned_at=None,
+                    source_fact_ids=[],
+                )
+            ],
         )

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -484,11 +484,16 @@ async def test_bank_import_preserves_consolidation_lifecycle(memory, request_con
             ]
         assert len(wf_ids) >= 3, "need enough facts to exercise the lineage gap"
 
-        # One surviving observation over the first two facts.
+        # One surviving observation over the first two facts. The helper now self-acquires a
+        # short-lived connection (the embed runs off-connection), so pass the backend, not a conn.
         obs_source_ids = [uuid.UUID(str(i)) for i in wf_ids[:2]]
-        async with acquire_with_retry(backend) as conn:
-            async with conn.transaction():
-                await _create_observation_directly(conn, memory, bank, obs_source_ids, "Alice and Bob are colleagues.")
+        await _create_observation_directly(
+            pool=backend,
+            memory_engine=memory,
+            bank_id=bank,
+            source_memory_ids=obs_source_ids,
+            observation_text="Alice and Bob are colleagues.",
+        )
 
         # Fully-processed source (zero eligible): every fact is consolidated except
         # the last — deliberately NOT an observation source — which records a
@@ -933,19 +938,25 @@ async def test_export_import_observations(memory, request_context):
         source_ids = [uuid.UUID(str(i["id"])) for i in units["items"][:2]]
         assert len(source_ids) == 2
 
-        # Create a real observation over those source facts.
+        # Create a real observation over those source facts. The helper self-acquires a
+        # short-lived connection now (the embed runs off-connection), so pass the backend.
         backend = await memory._get_backend()
         archived_event_date = datetime(2001, 2, 3, 4, 5, 6, tzinfo=timezone.utc)
+        await _create_observation_directly(
+            pool=backend,
+            memory_engine=memory,
+            bank_id=src,
+            source_memory_ids=source_ids,
+            observation_text="Alice and Bob are colleagues.",
+        )
         async with acquire_with_retry(backend) as conn:
-            async with conn.transaction():
-                await _create_observation_directly(conn, memory, src, source_ids, "Alice and Bob are colleagues.")
-                await conn.execute(
-                    f"UPDATE {fq_table('memory_units')} SET event_date = $1 "
-                    f"WHERE bank_id = $2 AND fact_type = 'observation' AND text = $3",
-                    archived_event_date,
-                    src,
-                    "Alice and Bob are colleagues.",
-                )
+            await conn.execute(
+                f"UPDATE {fq_table('memory_units')} SET event_date = $1 "
+                f"WHERE bank_id = $2 AND fact_type = 'observation' AND text = $3",
+                archived_event_date,
+                src,
+                "Alice and Bob are colleagues.",
+            )
 
         # Export WITHOUT observations -> none in the archive (the bank may also
         # contain auto-consolidation observations; the flag is what gates them).

--- a/hindsight-api-slim/tests/test_observation_invalidation.py
+++ b/hindsight-api-slim/tests/test_observation_invalidation.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from hindsight_api import RequestContext
+from hindsight_api.engine.db_utils import acquire_with_retry
 from hindsight_api.engine.memories import FactRecord, get_memories
 from hindsight_api.engine.memory_engine import MemoryEngine, fq_table
 
@@ -871,24 +872,27 @@ class TestConsolidationSourceMemoryFiltering:
         bank_id = f"test-race-create-filter-{uuid.uuid4().hex[:8]}"
         await _ensure_bank(memory, bank_id, request_context)
 
-        pool = await memory._get_pool()
-        async with pool.acquire() as conn:
+        # The helper now self-acquires a short-lived connection (the embed runs off-connection),
+        # so we pass the backend, not a conn.
+        backend = await memory._get_backend()
+        async with acquire_with_retry(backend) as conn:
             live = await _insert_memory(memory, conn, bank_id, "Alice loves hiking.")
-            dead = uuid.uuid4()  # never existed — stands in for a concurrently deleted source
+        dead = uuid.uuid4()  # never existed — stands in for a concurrently deleted source
 
-            result = await _create_observation_directly(
-                conn=conn,
-                memory_engine=memory,
-                bank_id=bank_id,
-                source_memory_ids=[live, dead],
-                observation_text="Alice enjoys hiking regularly.",
-            )
+        result = await _create_observation_directly(
+            pool=backend,
+            memory_engine=memory,
+            bank_id=bank_id,
+            source_memory_ids=[live, dead],
+            observation_text="Alice enjoys hiking regularly.",
+        )
 
-            assert result["action"] == "created"
+        assert result["action"] == "created"
+        async with acquire_with_retry(backend) as conn:
             stored = (await _get_memory(conn, bank_id, result["observation_id"])).source_memory_ids
-            stored_set = {str(s) for s in stored}
-            assert str(live) in stored_set
-            assert str(dead) not in stored_set, "Deleted source must not appear in stored observation"
+        stored_set = {str(s) for s in stored}
+        assert str(live) in stored_set
+        assert str(dead) not in stored_set, "Deleted source must not appear in stored observation"
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
@@ -901,21 +905,21 @@ class TestConsolidationSourceMemoryFiltering:
         bank_id = f"test-race-create-skip-{uuid.uuid4().hex[:8]}"
         await _ensure_bank(memory, bank_id, request_context)
 
-        pool = await memory._get_pool()
-        async with pool.acquire() as conn:
-            result = await _create_observation_directly(
-                conn=conn,
-                memory_engine=memory,
-                bank_id=bank_id,
-                source_memory_ids=[uuid.uuid4(), uuid.uuid4()],
-                observation_text="All sources gone.",
-            )
+        backend = await memory._get_backend()
+        result = await _create_observation_directly(
+            pool=backend,
+            memory_engine=memory,
+            bank_id=bank_id,
+            source_memory_ids=[uuid.uuid4(), uuid.uuid4()],
+            observation_text="All sources gone.",
+        )
 
-            assert result["action"] == "skipped"
-            assert result["reason"] == "sources_deleted"
+        assert result["action"] == "skipped"
+        assert result["reason"] == "sources_deleted"
 
+        async with acquire_with_retry(backend) as conn:
             obs_ids = await _get_observation_ids(conn, bank_id)
-            assert obs_ids == [], "No observation row should exist"
+        assert obs_ids == [], "No observation row should exist"
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
@@ -929,33 +933,96 @@ class TestConsolidationSourceMemoryFiltering:
         bank_id = f"test-race-update-skip-{uuid.uuid4().hex[:8]}"
         await _ensure_bank(memory, bank_id, request_context)
 
-        pool = await memory._get_pool()
-        async with pool.acquire() as conn:
+        backend = await memory._get_backend()
+        async with acquire_with_retry(backend) as conn:
             original_source = await _insert_memory(memory, conn, bank_id, "Alice hikes.")
             obs_id = await _insert_observation(memory, conn, bank_id, "Alice is a hiker.", [original_source])
-            original_text = "Alice is a hiker."
+        original_text = "Alice is a hiker."
 
-            observation_model = MemoryFact(
-                id=str(obs_id),
-                text=original_text,
-                fact_type="observation",
-                source_fact_ids=[str(original_source)],
-                tags=[],
-            )
+        observation_model = MemoryFact(
+            id=str(obs_id),
+            text=original_text,
+            fact_type="observation",
+            source_fact_ids=[str(original_source)],
+            tags=[],
+        )
 
-            await _execute_update_action(
-                conn=conn,
+        result = await _execute_update_action(
+            pool=backend,
+            memory_engine=memory,
+            bank_id=bank_id,
+            source_memory_ids=[uuid.uuid4(), uuid.uuid4()],  # all dead
+            observation_id=str(obs_id),
+            new_text="This update must not land.",
+            observations=[observation_model],
+        )
+        assert result is None, "a skipped update returns None so the caller runs no follow-on dedup"
+
+        async with acquire_with_retry(backend) as conn:
+            row = await _get_memory(conn, bank_id, obs_id)
+        assert row.text == original_text, "Observation text must not change"
+        stored_sources = {str(s) for s in row.source_memory_ids}
+        assert stored_sources == {str(original_source)}, "Dead sources must not be appended"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_update_observation_skipped_when_source_deleted_after_preflight(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        # The preflight sees the source live, but it is deleted while the embedder runs
+        # off-connection. The authoritative in-txn FOR SHARE liveness guard (not the preflight) must
+        # then skip the update, so a dead source is never written back into the observation.
+        from hindsight_api.engine.consolidation.consolidator import _execute_update_action
+        from hindsight_api.engine.response_models import MemoryFact
+
+        bank_id = f"test-race-update-inflight-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        backend = await memory._get_backend()
+        async with acquire_with_retry(backend) as conn:
+            source = await _insert_memory(memory, conn, bank_id, "Alice hikes.")
+            obs_id = await _insert_observation(memory, conn, bank_id, "Alice is a hiker.", [source])
+        original_text = "Alice is a hiker."
+
+        observation_model = MemoryFact(
+            id=str(obs_id),
+            text=original_text,
+            fact_type="observation",
+            source_fact_ids=[str(source)],
+            tags=[],
+        )
+
+        deleted = {"done": False}
+
+        async def _embed_spy(_embeddings, _texts):
+            # Delete the (preflight-live) source DURING the off-connection embed, so only the in-txn
+            # FOR SHARE guard can catch it.
+            if not deleted["done"]:
+                deleted["done"] = True
+                async with acquire_with_retry(backend) as c:
+                    await c.execute("DELETE FROM memory_units WHERE id = $1", source)
+            return [[0.1, 0.2, 0.3]]
+
+        with patch(
+            "hindsight_api.engine.retain.embedding_utils.generate_embeddings_batch",
+            new=_embed_spy,
+        ):
+            result = await _execute_update_action(
+                pool=backend,
                 memory_engine=memory,
                 bank_id=bank_id,
-                source_memory_ids=[uuid.uuid4(), uuid.uuid4()],  # all dead
+                source_memory_ids=[source],
                 observation_id=str(obs_id),
                 new_text="This update must not land.",
                 observations=[observation_model],
             )
 
+        assert result is None, "the in-txn FOR SHARE liveness skip returns None (no follow-on dedup)"
+        async with acquire_with_retry(backend) as conn:
             row = await _get_memory(conn, bank_id, obs_id)
-            assert row.text == original_text, "Observation text must not change"
-            stored_sources = {str(s) for s in row.source_memory_ids}
-            assert stored_sources == {str(original_source)}, "Dead sources must not be appended"
+        assert row.text == original_text, "observation text unchanged after the skipped update"
+        stored_sources = {str(s) for s in row.source_memory_ids}
+        assert stored_sources == {str(source)}, "no dead source appended"
 
         await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## Problem

Several memory-engine paths held a pooled PostgreSQL connection checked out for the entire duration of a slow external call — an embedder or LLM round-trip. The pools are already bounded (`asyncpg`, default `max_size=20`) and per-process, so this is **not a leak** — it's **saturation**: enough concurrent operations park the pool on multi-second external calls and the poller / remaining work then block until `acquire_timeout`.

This is a reimplementation of the idea behind #2434 (which was opened before #2917 rewrote these paths around the pluggable memories store) onto current `main`.

## What this PR fixes

**`update_mental_model`** — the embedding is now computed *before* acquiring a pooled connection. Its text depends only on the incoming `name`/`content`, never on DB state.

**Consolidation** — `_process_memory_batch` and its executors / dedup helpers no longer receive a long-lived connection. Recall, the batch LLM call, every per-action embed, and dedup adjudication run with **no connection held**; each helper self-acquires a short-lived connection only around its own SQL.

Moving the slow calls off the connection widens the decision→write window, so the held-transaction serialization is replaced with explicit guards:

- Each **source-liveness check (`FOR SHARE`) is paired with its write in one short transaction**, so a concurrent delete can't orphan an observation between check and write.
- Dedup CREATE/UPDATE folds are **`RETURNING`-gated** and **re-filter live sources inside the fold transaction** (sources-before-observation lock order, matching the normal write paths). A twin deleted during the now connection-free window → the caller still CREATEs; a source deleted → it's dropped from the fold, never written back.
- A cheap non-locking **preflight** restores the pre-refactor "skip before embedding when every source is already gone" short-circuit.

The separate-store (non-SQL) branches and the Oracle-safe `search_vector` clause (#3021) are preserved throughout.

## Scope / deliberately deferred

`update_memory_unit` (and `update_mental_model`'s sibling edit path) still embed inside the acquired connection, but their fix requires a two-phase read/embed-off-connection + short write transaction with re-lock/abort/retry that must be reconciled with the pluggable store's `begin_txn`/`decide_txn` cross-store transaction coordinator — and validated against a real database. That's a **follow-up PR** (linked once opened) rather than bundling an unvalidated concurrency rewrite of the interactive-edit path here.

## Verification

- `ruff` + `ty` clean.
- **45 deterministic no-DB tests pass** — they pin the dedup fold guards (`RETURNING`-gating, live-source filtering, twin-vanished → still-CREATE, created/skipped propagation) and the pre-embed short-circuits/rejections directly.
- Live-DB consolidation / invalidation / document-transfer tests updated to the new short-acquire signatures, plus a new in-flight-delete race test (source deleted *during* the off-connection embed → the in-txn `FOR SHARE` guard skips the update). These run against live PostgreSQL in CI.

Refs #2434
