### PR TITLE
fix(retain): unwrap single-key envelope dicts in fact extraction

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1295,8 +1295,18 @@ def _build_request_body(llm_config, config, prompt: str, user_message: str, resp
 
 
 def _coerce_fact_response(response: Any) -> dict[str, Any] | None:
-    """Accept the schema wrapper, or a recoverable top-level facts array."""
+    """Accept the schema wrapper, or a recoverable top-level facts array.
+
+    Some providers (e.g. litellm + Vertex AI Claude) wrap structured output
+    in an extra envelope like ``{"parameter": {"facts": [...]}}``.  Rather than
+    hard-coding known wrapper keys, unwrap any single-key dict whose value
+    contains the expected ``facts`` list.
+    """
     if isinstance(response, dict):
+        if "facts" not in response and len(response) == 1:
+            inner = next(iter(response.values()))
+            if isinstance(inner, dict) and "facts" in inner:
+                return inner
         return response
     if isinstance(response, list) and all(isinstance(item, dict) for item in response):
         return {"facts": response}

--- a/hindsight-api-slim/tests/test_coerce_fact_response_parameter_wrapper.py
+++ b/hindsight-api-slim/tests/test_coerce_fact_response_parameter_wrapper.py
@@ -1,0 +1,78 @@
+"""
+Test that _coerce_fact_response unwraps single-key envelope dicts whose
+inner value contains the expected ``facts`` list.
+
+Vertex AI Claude (via litellm) returns ``{"parameter": {"facts": [...]}}``,
+but other providers/versions may use different wrapper keys (``"content"``,
+``"data"``, ``"json_input"``).  The fix is key-agnostic: any single-key dict
+whose sole value is a dict containing ``"facts"`` is unwrapped.
+"""
+
+from hindsight_api.engine.retain.fact_extraction import _coerce_fact_response
+
+
+def test_unwraps_parameter_envelope():
+    """Vertex AI Claude wraps tool output in {"parameter": {"facts": [...]}}."""
+    response = {
+        "parameter": {
+            "facts": [
+                {"what": "version is 1.0", "who": "user", "fact_type": "world"},
+            ]
+        }
+    }
+    result = _coerce_fact_response(response)
+    assert "facts" in result
+    assert len(result["facts"]) == 1
+    assert result["facts"][0]["what"] == "version is 1.0"
+
+
+def test_unwraps_any_single_key_envelope():
+    """Any single-key wrapper around {"facts": [...]} is unwrapped."""
+    for key in ("content", "data", "json_input", "result"):
+        response = {key: {"facts": [{"what": "a"}]}}
+        result = _coerce_fact_response(response)
+        assert "facts" in result, f"failed for wrapper key: {key}"
+        assert result["facts"][0]["what"] == "a"
+
+
+def test_no_unwrap_when_facts_at_top_level():
+    """Normal {"facts": [...]} responses pass through unchanged."""
+    response = {"facts": [{"what": "something", "fact_type": "world"}]}
+    result = _coerce_fact_response(response)
+    assert result is response
+
+
+def test_no_unwrap_multi_key_dict():
+    """Multi-key dicts are not treated as envelopes."""
+    response = {"parameter": {"facts": [{"what": "a"}]}, "extra": True}
+    result = _coerce_fact_response(response)
+    assert result is response
+    assert "parameter" in result
+
+
+def test_no_unwrap_single_key_without_facts():
+    """Single-key dict whose value lacks 'facts' is returned as-is."""
+    response = {"parameter": {"other": "stuff"}}
+    result = _coerce_fact_response(response)
+    assert result is response
+
+
+def test_passthrough_empty_facts():
+    """Empty facts list passes through."""
+    response = {"facts": []}
+    result = _coerce_fact_response(response)
+    assert result is response
+
+
+def test_coerces_bare_list():
+    """A bare list of fact dicts is wrapped into {"facts": [...]}."""
+    response = [{"what": "a"}, {"what": "b"}]
+    result = _coerce_fact_response(response)
+    assert result == {"facts": [{"what": "a"}, {"what": "b"}]}
+
+
+def test_rejects_non_dict_non_list():
+    """Non-dict, non-list values return None."""
+    assert _coerce_fact_response("bad") is None
+    assert _coerce_fact_response(42) is None
+    assert _coerce_fact_response(None) is None


### PR DESCRIPTION
## Summary

- Fixes silent 0-fact extraction when using `litellm` with `vertex_ai/claude-*` models
- Key-agnostic approach: unwraps any single-key dict whose sole value contains `"facts"` — handles `{"parameter": ...}` and any future wrapper variants without hardcoding keys
- 8 unit tests for `_coerce_fact_response()` covering envelope unwrap, passthrough, multi-key preservation, and edge cases

Supersedes #3029 (closed), rebased cleanly on current main.

## Problem

Vertex AI Claude wraps structured output in `{"parameter": {"facts": [...]}}`. Since `_coerce_fact_response()` returns the dict as-is, `extraction_response_json.get("facts", [])` returns `[]` — silently dropping all extracted facts. Every `retain_extract_facts` call produces 0 facts despite the LLM generating valid output (confirmed with 17/17 requests, full payloads in #3028).

## Approach

Per @nicoloboschi's feedback on #3029, this avoids hardcoding `"parameter"` and instead uses a structural heuristic:

```python
if "facts" not in response and len(response) == 1:
    inner = next(iter(response.values()))
    if isinstance(inner, dict) and "facts" in inner:
        return inner
```

**Constraints:**
- Only fires when the outer dict has **exactly one key** (not a normal multi-field response)
- Only fires when the inner value is a **dict containing "facts"**
- Direct `{"facts": [...]}` responses pass through unchanged

## Test plan

- [x] 8 unit tests pass: envelope unwrap (parameter, content, data, json_input, result), passthrough, multi-key preservation, single-key-without-facts, empty facts, bare list coercion, invalid types
- [x] Manual verification: retain with `litellm` + `vertex_ai/claude-opus-4-6` extracts facts correctly (was 0, now 3+ per retain)
- [x] Existing tests unaffected

Fixes #3028