### PR TITLE
feat(claude-code): coding profile, automatic file tags, and tool_use input capping

### DIFF
--- a/hindsight-integrations/claude-code/CHANGELOG.md
+++ b/hindsight-integrations/claude-code/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ### Added
 
+- `profile` setting (env: `HINDSIGHT_PROFILE`) with a `coding` preset that
+  tunes grouped defaults for coding sessions: `retainToolCalls: true`,
+  per-project dynamic banks (`dynamicBankId` + `["agent", "project"]`),
+  `recallBudget: "low"`, and engineering-focused bank/retain missions.
+  Presets override built-in and vendor-shipped defaults but never a key set
+  explicitly in user config or env, so existing configurations are
+  unaffected; without a profile, behavior is unchanged.
+- Retained documents are automatically tagged with `file:<relpath>` for each
+  file modified by `Write`/`Edit`/`MultiEdit`/`NotebookEdit` tool calls
+  (relativized against the working directory, capped at 20), and the list is
+  recorded in `metadata.files_modified`. Recall can then filter with
+  `recallTags: ["file:src/auth.py"]`.
+
 - `{user_id}` template variable for `retainTags` and `retainMetadata`, resolved
   from the `HINDSIGHT_USER_ID` env var (empty string if unset). Enables
   machine-independent per-user memory scoping without hardcoding user ids in
@@ -15,6 +28,15 @@
   10s under contention (e.g. parallel recalls) so the client doesn't surface
   `read operation timed out` on requests the server completes successfully.
   Does not affect the health check, which stays at 5s. Fixes #1575.
+
+### Fixed
+
+- `tool_use` inputs are now size-capped before retention (300 chars per
+  string field, priority-keys-only fallback above 1500 serialized chars).
+  Previously a `Write` of a large file embedded the entire file body in the
+  retain payload, bloating requests and degrading fact extraction —
+  `tool_result` blocks were already truncated at 2000 chars but inputs were
+  not.
 
 ### Changed
 

--- a/hindsight-integrations/claude-code/README.md
+++ b/hindsight-integrations/claude-code/README.md
@@ -167,6 +167,26 @@ All settings live in `~/.hindsight/claude-code.json`. Every setting can also be 
 2. Plugin `settings.json` (ships with the plugin, at `CLAUDE_PLUGIN_ROOT/settings.json`)
 3. User config (`~/.hindsight/claude-code.json` — recommended for your overrides)
 4. Environment variables
+5. Profile preset (fills in values for keys you did not set in 3 or 4)
+
+---
+
+### Profiles
+
+A profile is a named preset that tunes grouped defaults for a usage pattern, without you having to hand-pick each setting. Set it in `~/.hindsight/claude-code.json`:
+
+```json
+{ "profile": "coding" }
+```
+
+or via `HINDSIGHT_PROFILE=coding`. Any setting you configure explicitly (user config or env var) always wins over the preset.
+
+| Profile | What it changes | Why |
+|---------|-----------------|-----|
+| *(none)* | — | Conversational defaults, identical to previous plugin behavior. Right for chat/channel agents (Telegram, Discord, Slack). |
+| `coding` | `retainToolCalls: true` · `dynamicBankId: true` · `dynamicBankGranularity: ["agent", "project"]` · `recallBudget: "low"` · coding-focused `bankMission`/`retainMission` | Tool calls (edits, commands) carry the real substance of a coding session; per-project banks keep one repo's memories from polluting another's recall; the lower recall budget keeps per-prompt latency down at coding-session turn frequency. |
+
+The `coding` profile changes what gets *retained* (tool calls included, engineering-focused extraction) while conversation content is still captured — decisions and preferences discussed in chat are remembered the same as before.
 
 ---
 
@@ -248,7 +268,7 @@ Auto-retain runs after Claude responds. It extracts the conversation transcript 
 | `retainOverlapTurns` | — | `2` | When chunked retention fires, this many extra turns from the previous chunk are included for continuity. Total window size = `retainEveryNTurns + retainOverlapTurns`. |
 | `retainRoles` | — | `["user", "assistant"]` | Which message roles to include in the retained transcript. |
 | `retainToolCalls` | — | `true` | Whether to include tool calls (function invocations and results) in the retained transcript. Captures structured actions like file reads, searches, and code edits. |
-| `retainTags` | — | `["{session_id}"]` | Tags attached to the retained document. Supports template placeholders: `{session_id}`, `{bank_id}`, `{timestamp}`, and `{user_id}` (resolved from `HINDSIGHT_USER_ID` env var; empty string if unset). Tags whose resolved form ends in an empty namespace part (e.g. `"user:"` when `HINDSIGHT_USER_ID` is unset) are dropped from the outgoing request. See [Template variables](#template-variables-for-retaintags-and-retainmetadata) below. |
+| `retainTags` | — | `["{session_id}"]` | Tags attached to the retained document. Supports template placeholders: `{session_id}`, `{bank_id}`, `{timestamp}`, and `{user_id}` (resolved from `HINDSIGHT_USER_ID` env var; empty string if unset). Tags whose resolved form ends in an empty namespace part (e.g. `"user:"` when `HINDSIGHT_USER_ID` is unset) are dropped from the outgoing request. In addition to configured tags, files modified by `Write`/`Edit`/`MultiEdit`/`NotebookEdit` tool calls are automatically tagged as `file:<relpath>` (relativized against the working directory, capped at 20) and recorded in `metadata.files_modified` — recall can then filter with `recallTags: ["file:src/auth.py"]`. See [Template variables](#template-variables-for-retaintags-and-retainmetadata) below. |
 | `retainMetadata` | — | `{}` | Arbitrary key-value metadata attached to the retained document. Same template placeholders as `retainTags`. |
 | `retainContext` | — | `"claude-code"` | A label attached to retained memories identifying their source. Useful when multiple integrations write to the same bank. |
 

--- a/hindsight-integrations/claude-code/scripts/lib/config.py
+++ b/hindsight-integrations/claude-code/scripts/lib/config.py
@@ -61,8 +61,40 @@ DEFAULTS = {
     "llmModel": None,
     "llmApiKeyEnv": None,
     # Misc
+    "profile": None,
     "enableKnowledgeTools": True,
     "debug": False,
+}
+
+# Named presets that tune grouped defaults for a usage pattern. A preset
+# overrides built-in defaults and the plugin's shipped settings.json
+# (vendor defaults), but never a key the user set explicitly in
+# ~/.hindsight/claude-code.json or via environment variable.
+PROFILE_PRESETS = {
+    # Coding sessions (Claude Code's primary use). Tool calls carry the
+    # session's real substance, so they are retained; banks isolate per
+    # project so recall from one repo doesn't surface another repo's
+    # context; recall budget is lowered because coding turns are far more
+    # frequent than chat turns and recall latency is paid on every prompt.
+    "coding": {
+        "retainToolCalls": True,
+        "dynamicBankId": True,
+        "dynamicBankGranularity": ["agent", "project"],
+        "recallBudget": "low",
+        "bankMission": (
+            "You are a coding assistant with long-term memory of this "
+            "project's engineering history: decisions, bug fixes, "
+            "conventions, and workflows."
+        ),
+        "retainMission": (
+            "Extract durable engineering knowledge: technical decisions and "
+            "their rationale, bug root causes and their fixes, architecture "
+            "and API constraints, commands that worked for building/testing/"
+            "running, code style and workflow preferences, and file- or "
+            "module-specific gotchas. Ignore greetings, routine tool output, "
+            "and transient operational chatter."
+        ),
+    },
 }
 
 # Map env var names to config keys and their types
@@ -91,6 +123,7 @@ ENV_OVERRIDES = {
     "HINDSIGHT_BANK_MISSION": ("bankMission", str),
     "HINDSIGHT_LLM_PROVIDER": ("llmProvider", str),
     "HINDSIGHT_LLM_MODEL": ("llmModel", str),
+    "HINDSIGHT_PROFILE": ("profile", str),
     "HINDSIGHT_DEBUG": ("debug", bool),
 }
 
@@ -154,15 +187,37 @@ def load_config() -> dict:
 
     # 2. User config — stable, version-independent, matches openclaw convention
     user_config_path = os.path.join(os.path.expanduser("~"), ".hindsight", "claude-code.json")
-    _load_settings_file(user_config_path, config)
+    user_config = {}
+    _load_settings_file(user_config_path, user_config)
+    config.update(user_config)
 
-    # Apply environment variable overrides
+    # 3. Environment variable overrides
+    env_set_keys = set()
     for env_name, (key, typ) in ENV_OVERRIDES.items():
         val = os.environ.get(env_name)
         if val is not None:
             cast_val = _cast_env(val, typ)
             if cast_val is not None:
                 config[key] = cast_val
+                env_set_keys.add(key)
+
+    # 4. Profile preset — applies profile-tuned values for keys the user did
+    #    not set explicitly (user config file or env var). The plugin's
+    #    shipped settings.json counts as vendor defaults, which a profile
+    #    intentionally overrides.
+    profile = config.get("profile")
+    if profile:
+        preset = PROFILE_PRESETS.get(profile)
+        if preset is None:
+            print(
+                f"[Hindsight] Unknown profile '{profile}' — valid: {', '.join(sorted(PROFILE_PRESETS))}",
+                file=sys.stderr,
+            )
+        else:
+            explicit_keys = set(user_config) | env_set_keys
+            for key, value in preset.items():
+                if key not in explicit_keys:
+                    config[key] = value
 
     return config
 

--- a/hindsight-integrations/claude-code/scripts/lib/content.py
+++ b/hindsight-integrations/claude-code/scripts/lib/content.py
@@ -8,6 +8,7 @@ truncateRecallQuery, sliceLastTurnsByUserBoundary, prepareRetentionTranscript,
 formatMemories.
 """
 
+import json
 import re
 from datetime import datetime, timezone
 
@@ -276,7 +277,7 @@ def _extract_message_blocks(content, role: str = "") -> list:
                 # Skip Hindsight MCP tools to avoid feedback loops
                 if name.startswith("mcp__") and _OPERATIONAL_TOOL_PATTERN.search(name.split("__")[-1]):
                     continue
-                blocks.append({"type": "tool_use", "name": name, "input": inp})
+                blocks.append({"type": "tool_use", "name": name, "input": _compact_tool_input(inp)})
 
         elif block_type == "tool_result":
             # Include tool results for context.
@@ -399,6 +400,117 @@ def _prepare_text_transcript(messages: list, allowed_roles: set) -> tuple:
         return None, 0
 
     return transcript, len(parts)
+
+
+# ---------------------------------------------------------------------------
+# Tool input compaction
+# ---------------------------------------------------------------------------
+
+# Per-string-field cap. Long enough to preserve the semantic signal of a code
+# edit (what changed, roughly how) without retaining entire file bodies —
+# a single Write of a large file would otherwise dominate the retain payload
+# and degrade fact extraction.
+_TOOL_INPUT_FIELD_MAX = 300
+
+# Total serialized budget per tool_use input. Second-level guard for inputs
+# that are large through many fields or nested structures (e.g. MultiEdit).
+_TOOL_INPUT_TOTAL_MAX = 1500
+
+# Keys that carry the most durable signal about a tool call. When the total
+# budget is exceeded, only these survive.
+_PRIORITY_INPUT_KEYS = (
+    "file_path",
+    "notebook_path",
+    "path",
+    "command",
+    "description",
+    "pattern",
+    "query",
+    "url",
+)
+
+
+def _compact_tool_input(tool_input) -> dict:
+    """Cap tool_use input size for retention.
+
+    tool_result blocks are already truncated at 2000 chars; tool_use inputs
+    previously went through untouched, so a Write of a whole file was retained
+    verbatim. Two-level cap: per-string-field truncation first, then a
+    priority-keys-only fallback if the serialized whole is still too large.
+    """
+    if not isinstance(tool_input, dict):
+        return {}
+
+    compact = {}
+    for key, value in tool_input.items():
+        if isinstance(value, str) and len(value) > _TOOL_INPUT_FIELD_MAX:
+            value = value[:_TOOL_INPUT_FIELD_MAX] + f"... (+{len(value) - _TOOL_INPUT_FIELD_MAX} chars)"
+        compact[key] = value
+
+    try:
+        serialized_len = len(json.dumps(compact, ensure_ascii=False, default=str))
+    except (TypeError, ValueError):
+        serialized_len = _TOOL_INPUT_TOTAL_MAX + 1
+
+    if serialized_len > _TOOL_INPUT_TOTAL_MAX:
+        kept = {k: compact[k] for k in _PRIORITY_INPUT_KEYS if k in compact}
+        dropped = [k for k in compact if k not in kept]
+        if dropped:
+            kept["_truncated_fields"] = dropped
+        compact = kept
+
+    return compact
+
+
+# ---------------------------------------------------------------------------
+# Touched-file extraction (coding sessions)
+# ---------------------------------------------------------------------------
+
+# Tool base names whose calls modify a file. Read-only tools (Read, Glob,
+# Grep) are deliberately excluded — tagging every file a session merely
+# looked at would drown the signal of what it changed.
+_FILE_MUTATING_TOOLS = {"Write", "Edit", "MultiEdit", "NotebookEdit"}
+
+
+def extract_touched_files(messages: list, cwd: str = "") -> list:
+    """Collect unique file paths modified by tool calls, in first-touch order.
+
+    Looks at assistant tool_use blocks for file-mutating tools and pulls
+    file_path/notebook_path from their inputs. Paths under cwd are
+    relativized so tags stay stable across machines/checkout locations.
+    """
+    files = []
+    seen = set()
+    cwd_prefix = cwd.rstrip("/") + "/" if cwd else ""
+
+    for msg in messages or []:
+        if msg.get("role") != "assistant":
+            continue
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict) or block.get("type") != "tool_use":
+                continue
+            # Base name handles both plain tools ("Edit") and namespaced
+            # variants ("mcp__someserver__Edit").
+            base_name = block.get("name", "").split("__")[-1]
+            if base_name not in _FILE_MUTATING_TOOLS:
+                continue
+            tool_input = block.get("input")
+            if not isinstance(tool_input, dict):
+                continue
+            file_path = tool_input.get("file_path") or tool_input.get("notebook_path")
+            if not isinstance(file_path, str) or not file_path.strip():
+                continue
+            file_path = file_path.strip()
+            if cwd_prefix and file_path.startswith(cwd_prefix):
+                file_path = file_path[len(cwd_prefix) :]
+            if file_path not in seen:
+                seen.add(file_path)
+                files.append(file_path)
+
+    return files
 
 
 # ---------------------------------------------------------------------------

--- a/hindsight-integrations/claude-code/scripts/retain.py
+++ b/hindsight-integrations/claude-code/scripts/retain.py
@@ -28,6 +28,7 @@ from lib.bank import derive_bank_id, ensure_bank_mission
 from lib.client import HindsightClient
 from lib.config import debug_log, load_config
 from lib.content import (
+    extract_touched_files,
     prepare_retention_transcript,
     slice_last_turns_by_user_boundary,
 )
@@ -199,19 +200,13 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
     # Tags from config with template resolution.
     # Drop tags whose resolved form ends in an empty namespace part (e.g. "user:"
     # when HINDSIGHT_USER_ID is unset). Tags without ':' are preserved as-is.
-    raw_tags = config.get("retainTags", [])
-    if raw_tags:
-        tags = []
-        for original in raw_tags:
-            resolved = _resolve_template(original)
-            if ":" in resolved and resolved.split(":", 1)[1] == "":
-                debug_log(config, f"Dropping tag '{original}' -> '{resolved}' (empty content after ':')")
-                continue
-            tags.append(resolved)
-        if not tags:
-            tags = None
-    else:
-        tags = None
+    tags = []
+    for original in config.get("retainTags", []):
+        resolved = _resolve_template(original)
+        if ":" in resolved and resolved.split(":", 1)[1] == "":
+            debug_log(config, f"Dropping tag '{original}' -> '{resolved}' (empty content after ':')")
+            continue
+        tags.append(resolved)
 
     # Metadata: merge built-in defaults with user-configured extras
     metadata = {
@@ -221,6 +216,18 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
     }
     for k, v in config.get("retainMetadata", {}).items():
         metadata[k] = _resolve_template(str(v))
+
+    # Tag files modified in this window so recall can filter by file
+    # (e.g. tags=["file:src/auth.py"]). Only file-mutating tools count;
+    # reads are ignored. Capped so sweeping refactors don't explode the
+    # tag list. No-op for conversational sessions with no file tools.
+    touched_files = extract_touched_files(messages_to_retain, cwd=hook_input.get("cwd", ""))
+    if touched_files:
+        tags.extend(f"file:{p}" for p in touched_files[:20])
+        metadata["files_modified"] = ",".join(touched_files[:20])
+        debug_log(config, f"Touched files: {touched_files[:20]}")
+
+    tags = tags or None
 
     debug_log(
         config, f"Retaining to bank '{bank_id}', doc '{document_id}', {message_count} messages, {len(transcript)} chars"

--- a/hindsight-integrations/claude-code/tests/test_config.py
+++ b/hindsight-integrations/claude-code/tests/test_config.py
@@ -162,3 +162,76 @@ class TestLoadConfig:
         monkeypatch.setenv("HINDSIGHT_RECALL_BUDGET", "high")
         cfg = load_config()
         assert cfg["recallBudget"] == "high"
+
+
+class TestProfilePresets:
+    @pytest.fixture(autouse=True)
+    def _isolate_config(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        for k in list(os.environ):
+            if k.startswith("HINDSIGHT_"):
+                monkeypatch.delenv(k, raising=False)
+
+    def _write_user_config(self, tmp_path, data):
+        user_cfg_dir = tmp_path / ".hindsight"
+        user_cfg_dir.mkdir(exist_ok=True)
+        (user_cfg_dir / "claude-code.json").write_text(json.dumps(data))
+
+    def test_no_profile_keeps_chat_defaults(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+        cfg = load_config()
+        assert cfg["profile"] is None
+        assert cfg["retainToolCalls"] is False
+        assert cfg["dynamicBankId"] is False
+        assert cfg["recallBudget"] == "mid"
+
+    def test_coding_profile_applies_preset(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+        self._write_user_config(tmp_path, {"profile": "coding"})
+        cfg = load_config()
+        assert cfg["retainToolCalls"] is True
+        assert cfg["dynamicBankId"] is True
+        assert cfg["dynamicBankGranularity"] == ["agent", "project"]
+        assert cfg["recallBudget"] == "low"
+        assert "engineering" in cfg["retainMission"]
+
+    def test_coding_profile_overrides_plugin_settings_json(self, tmp_path, monkeypatch):
+        # The shipped settings.json (vendor defaults) says retainToolCalls
+        # false — a profile must override vendor defaults.
+        plugin_root = tmp_path / "plugin"
+        plugin_root.mkdir()
+        (plugin_root / "settings.json").write_text(json.dumps({"retainToolCalls": False, "recallBudget": "mid"}))
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        self._write_user_config(tmp_path, {"profile": "coding"})
+        cfg = load_config()
+        assert cfg["retainToolCalls"] is True
+        assert cfg["recallBudget"] == "low"
+
+    def test_explicit_user_config_beats_preset(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+        self._write_user_config(tmp_path, {"profile": "coding", "recallBudget": "high"})
+        cfg = load_config()
+        assert cfg["recallBudget"] == "high"  # user's explicit choice wins
+        assert cfg["retainToolCalls"] is True  # rest of preset still applies
+
+    def test_env_var_beats_preset(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+        self._write_user_config(tmp_path, {"profile": "coding"})
+        monkeypatch.setenv("HINDSIGHT_RECALL_BUDGET", "high")
+        cfg = load_config()
+        assert cfg["recallBudget"] == "high"
+        assert cfg["dynamicBankId"] is True
+
+    def test_profile_via_env_var(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+        monkeypatch.setenv("HINDSIGHT_PROFILE", "coding")
+        cfg = load_config()
+        assert cfg["retainToolCalls"] is True
+        assert cfg["dynamicBankId"] is True
+
+    def test_unknown_profile_warns_and_keeps_defaults(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+        self._write_user_config(tmp_path, {"profile": "gardening"})
+        cfg = load_config()
+        assert cfg["retainToolCalls"] is False  # untouched defaults
+        assert "Unknown profile" in capsys.readouterr().err

--- a/hindsight-integrations/claude-code/tests/test_content.py
+++ b/hindsight-integrations/claude-code/tests/test_content.py
@@ -5,9 +5,11 @@ import re
 import pytest
 
 from lib.content import (
+    _compact_tool_input,
     _extract_text_content,
     _is_channel_message_tool,
     compose_recall_query,
+    extract_touched_files,
     format_current_time,
     format_memories,
     prepare_retention_transcript,
@@ -487,3 +489,120 @@ class TestFormatCurrentTime:
 
     def test_format_shape(self):
         assert re.fullmatch(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC", format_current_time())
+
+
+# ---------------------------------------------------------------------------
+# _compact_tool_input
+# ---------------------------------------------------------------------------
+
+
+class TestCompactToolInput:
+    def test_short_input_passthrough(self):
+        inp = {"file_path": "/tmp/a.py", "content": "print('hi')"}
+        assert _compact_tool_input(inp) == inp
+
+    def test_long_string_field_truncated(self):
+        big = "x" * 5000
+        result = _compact_tool_input({"file_path": "/tmp/a.py", "content": big})
+        assert result["file_path"] == "/tmp/a.py"
+        assert len(result["content"]) < 400
+        assert "+4700 chars" in result["content"]
+
+    def test_total_budget_falls_back_to_priority_keys(self):
+        # Many medium fields that each fit but together blow the budget
+        inp = {f"field_{i}": "y" * 250 for i in range(10)}
+        inp["file_path"] = "/tmp/big.py"
+        inp["command"] = "make build"
+        result = _compact_tool_input(inp)
+        assert result["file_path"] == "/tmp/big.py"
+        assert result["command"] == "make build"
+        assert "field_0" not in result
+        assert "field_0" in result["_truncated_fields"]
+
+    def test_non_dict_input_returns_empty(self):
+        assert _compact_tool_input(None) == {}
+        assert _compact_tool_input("oops") == {}
+
+    def test_non_string_values_preserved(self):
+        inp = {"count": 42, "flags": ["a", "b"], "enabled": True}
+        assert _compact_tool_input(inp) == inp
+
+    def test_write_of_whole_file_in_transcript_is_capped(self):
+        # End-to-end through prepare_retention_transcript: retaining a Write
+        # tool call must not embed the entire file body.
+        big_file = "def f():\n    pass\n" * 2000
+        msgs = [
+            {"role": "user", "content": "write the module"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "name": "Write", "input": {"file_path": "/tmp/mod.py", "content": big_file}},
+                ],
+            },
+        ]
+        transcript, _ = prepare_retention_transcript(msgs, retain_full_window=True, include_tool_calls=True)
+        assert len(transcript) < 2000
+        assert "/tmp/mod.py" in transcript
+
+
+# ---------------------------------------------------------------------------
+# extract_touched_files
+# ---------------------------------------------------------------------------
+
+
+def _tool_msg(*calls):
+    return {
+        "role": "assistant",
+        "content": [{"type": "tool_use", "name": name, "input": inp} for name, inp in calls],
+    }
+
+
+class TestExtractTouchedFiles:
+    def test_collects_write_and_edit_paths(self):
+        msgs = [
+            _tool_msg(("Write", {"file_path": "/repo/a.py", "content": "x"})),
+            _tool_msg(("Edit", {"file_path": "/repo/b.py", "old_string": "1", "new_string": "2"})),
+        ]
+        assert extract_touched_files(msgs) == ["/repo/a.py", "/repo/b.py"]
+
+    def test_ignores_read_only_tools(self):
+        msgs = [
+            _tool_msg(
+                ("Read", {"file_path": "/repo/a.py"}),
+                ("Grep", {"pattern": "foo", "path": "/repo"}),
+                ("Bash", {"command": "ls"}),
+            )
+        ]
+        assert extract_touched_files(msgs) == []
+
+    def test_dedupes_preserving_first_touch_order(self):
+        msgs = [
+            _tool_msg(("Edit", {"file_path": "/repo/a.py"})),
+            _tool_msg(("Write", {"file_path": "/repo/b.py"})),
+            _tool_msg(("Edit", {"file_path": "/repo/a.py"})),
+        ]
+        assert extract_touched_files(msgs) == ["/repo/a.py", "/repo/b.py"]
+
+    def test_relativizes_against_cwd(self):
+        msgs = [_tool_msg(("Write", {"file_path": "/home/user/proj/src/main.py"}))]
+        assert extract_touched_files(msgs, cwd="/home/user/proj") == ["src/main.py"]
+        # Paths outside cwd stay absolute
+        msgs2 = [_tool_msg(("Write", {"file_path": "/etc/config.yaml"}))]
+        assert extract_touched_files(msgs2, cwd="/home/user/proj") == ["/etc/config.yaml"]
+
+    def test_notebook_path_supported(self):
+        msgs = [_tool_msg(("NotebookEdit", {"notebook_path": "/repo/nb.ipynb", "new_source": "x"}))]
+        assert extract_touched_files(msgs) == ["/repo/nb.ipynb"]
+
+    def test_namespaced_tool_names(self):
+        msgs = [_tool_msg(("mcp__someserver__Edit", {"file_path": "/repo/c.py"}))]
+        assert extract_touched_files(msgs) == ["/repo/c.py"]
+
+    def test_user_messages_and_plain_content_ignored(self):
+        msgs = [
+            {"role": "user", "content": "please edit /repo/a.py"},
+            {"role": "assistant", "content": "done"},
+        ]
+        assert extract_touched_files(msgs) == []
+        assert extract_touched_files([]) == []
+        assert extract_touched_files(None) == []

--- a/hindsight-integrations/claude-code/tests/test_hooks.py
+++ b/hindsight-integrations/claude-code/tests/test_hooks.py
@@ -411,6 +411,73 @@ class TestRetainHook:
         item = captured["body"]["items"][0]
         assert item["tags"] == ["sess-tag-test", "claude-code", "custom-tag"]
 
+    def test_retain_tags_modified_files(self, monkeypatch, tmp_path):
+        """Files touched by Write/Edit tool calls become file:<relpath> tags."""
+        messages = [
+            {"role": "user", "content": "fix the auth bug"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "fixing"},
+                    {
+                        "type": "tool_use",
+                        "name": "Edit",
+                        "input": {"file_path": "/home/user/myproject/src/auth.py", "old_string": "a", "new_string": "b"},
+                    },
+                    {"type": "tool_use", "name": "Read", "input": {"file_path": "/home/user/myproject/src/other.py"}},
+                ],
+            },
+        ]
+        transcript = make_transcript_file(tmp_path, messages)
+        # make_hook_input defaults cwd to /home/user/myproject → path relativized
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-file-tags")
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=capture,
+            extra_settings={"retainTags": ["{session_id}"]},
+        )
+
+        assert "body" in captured, "retain API was not called"
+        item = captured["body"]["items"][0]
+        assert item["tags"] == ["sess-file-tags", "file:src/auth.py"]
+        assert item["metadata"]["files_modified"] == "src/auth.py"
+
+    def test_retain_no_file_tags_for_conversational_session(self, monkeypatch, tmp_path):
+        """Sessions without file-mutating tool calls get no file: tags."""
+        messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-chat")
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=capture,
+            extra_settings={"retainTags": ["{session_id}"]},
+        )
+
+        assert "body" in captured
+        item = captured["body"]["items"][0]
+        assert item["tags"] == ["sess-chat"]
+        assert "files_modified" not in item["metadata"]
+
     def test_retain_tag_resolves_user_id_when_env_set(self, monkeypatch, tmp_path):
         """retainTags with {user_id} resolves from HINDSIGHT_USER_ID env var."""
         messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]


### PR DESCRIPTION
## Motivation

The Claude Code plugin is a faithful port of the Openclaw chat plugin, so its defaults are tuned for conversational agents: tool calls are not retained, every session shares one bank, and recall pacing assumes chat-frequency turns. For Claude Code's primary use — coding sessions — those defaults remember the small talk and forget the actual work: the substance of a coding session lives in Edit/Write/Bash tool calls, sessions span many repositories, and prompts fire far more frequently than in chat.

This PR makes the plugin coding-capable while leaving existing behavior untouched: without a profile configured, nothing changes.

## Changes

**Fix: cap `tool_use` input size in retained transcripts** (`_compact_tool_input`)
`tool_result` blocks were truncated at 2000 chars, but `tool_use` inputs went through verbatim — a `Write` of a large file embedded the entire file body in the retain payload, bloating requests and degrading fact extraction. Two-level cap: 300 chars per string field, then a priority-keys-only fallback (`file_path`, `command`, ...) when the serialized input still exceeds 1500 chars.

**Feature: automatic `file:<relpath>` tags** (`extract_touched_files`)
Each retained document is tagged with the files modified by `Write`/`Edit`/`MultiEdit`/`NotebookEdit` tool calls (relativized against cwd, capped at 20, read-only tools excluded) and gets `metadata.files_modified`. Recall can then answer "what happened to this file" via `recallTags: ["file:src/auth.py"]`. No-op for conversational sessions.

**Feature: `profile` setting with a `coding` preset**
`{"profile": "coding"}` in user config (or `HINDSIGHT_PROFILE=coding`) applies: `retainToolCalls: true`, `dynamicBankId: true` with `["agent", "project"]` granularity, `recallBudget: "low"`, and engineering-focused bank/retain missions. Precedence is deliberate: a preset overrides built-in defaults and the vendor-shipped `settings.json`, but never a key the user set explicitly in `~/.hindsight/claude-code.json` or via env — so existing configurations are unaffected and the preset stays fully overridable.

## Backward compatibility

- No profile configured → identical behavior to before (verified by the existing test suite passing unchanged).
- File tags only appear when file-mutating tool calls exist in the window; chat sessions see no new tags.
- The input cap changes retained payloads for sessions that already had `retainToolCalls: true`, but only by truncating fields that were previously retained verbatim at unbounded size.

## Testing

- Test suite: 197 → 219 (22 new unit/e2e tests across `test_content.py`, `test_hooks.py`, `test_config.py`), all passing with stdlib-only hooks as before.
- Live end-to-end: wired the hooks into a real Claude Code project against `hindsight-embed` on :9077 with Ollama (`qwen3-14b`) as the extraction LLM. A coding transcript (bug-fix session with Edit/Write/Bash calls) produced: per-project bank `claude-code::<project>`, both modified files tagged, 4 accurate extracted observations including facts that existed only in tool_use inputs (which stock defaults would have dropped), correct recall injection, and correct tag-filtered recall (`file:` tag returns the document's memories; a nonexistent file tag with `any_strict` returns none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)