### PR TITLE
blog(github-copilot): redate to 2026-07-30

### DIFF
--- a/hindsight-docs/blog/2026-07-30-github-copilot-persistent-memory.md
+++ b/hindsight-docs/blog/2026-07-30-github-copilot-persistent-memory.md
@@ -1,8 +1,8 @@
 ---
 title: "Give GitHub Copilot CLI a Memory of Your Codebase"
 authors: [benfrank241]
-slug: "2026/07/29/github-copilot-persistent-memory"
-date: 2026-07-29T12:00
+slug: "2026/07/30/github-copilot-persistent-memory"
+date: 2026-07-30T12:00
 tags: [hindsight, github-copilot, copilot-cli, agent-memory, persistent-memory, coding-agent]
 description: "GitHub Copilot CLI forgets your project between sessions. Add Hindsight so it recalls past decisions and retains what it learns, automatically via hooks."
 image: /img/blog/github-copilot-persistent-memory.png


### PR DESCRIPTION
Redates the GitHub Copilot CLI persistent-memory post to **today (2026-07-30)** to align with the `hindsight-copilot-cli` 0.1.1 release and the social video launch.

Changes:
- Rename `2026-07-29-…` → `2026-07-30-github-copilot-persistent-memory.md`
- `slug`: `2026/07/29/...` → `2026/07/30/...`
- `date`: `2026-07-29T12:00` → `2026-07-30T12:00`

⚠️ **URL changes** from `/blog/2026/07/29/github-copilot-persistent-memory` to `/blog/2026/07/30/github-copilot-persistent-memory`. The old dated URL will 404 (post is one day old; no internal links reference it besides the file itself).