### PR TITLE
fix(llm): explicit per-operation thinking control for Qwen/vLLM providers

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -453,13 +453,49 @@ class _LLMCallDefaults:
         }
 
 
+# Providers that speak the OpenAI completions wire format and therefore
+# accept ``extra_body.chat_template_kwargs.enable_thinking`` (the Qwen/vLLM
+# thinking-mode flag). Other providers (Gemini/Vertex, Anthropic, LiteLLM,
+# Bedrock) have their own generation-config spaces and would reject or ignore
+# the field — so we gate the per-operation injection on this set.
+_OPENAI_COMPATIBLE_PROVIDERS = frozenset(
+    {
+        "openai",
+        "groq",
+        "ollama",
+        "ollama-cloud",
+        "lmstudio",
+        "minimax",
+        "deepseek",
+        "volcano",
+        "openrouter",
+        "requesty",
+        "zai",
+        "opencode-go",
+        "atlas",
+        "nous",
+        "fireworks",
+        "llamacpp",
+    }
+)
+
+
 def _operation_extra_body(
     configured: dict[str, Any] | None,
     *,
     enable_thinking: bool,
+    provider: str | None,
 ) -> dict[str, Any]:
-    """Apply the explicit per-operation Qwen/vLLM thinking contract."""
+    """Apply the explicit per-operation Qwen/vLLM thinking contract.
+
+    Only OpenAI-compatible providers receive ``chat_template_kwargs``; other
+    providers (Gemini/Vertex, Anthropic, LiteLLM, Bedrock) keep the configured
+    extra body untouched, avoiding a provider-specific field being forwarded
+    where it is not understood.
+    """
     body = copy.deepcopy(configured or {})
+    if not provider or provider.lower() not in _OPENAI_COMPATIBLE_PROVIDERS:
+        return body
     template = body.get("chat_template_kwargs")
     if not isinstance(template, dict):
         template = {}
@@ -496,7 +532,7 @@ def _member_to_llm(
         base_url=member.base_url,
         model=member.model,
         reasoning_effort=member.reasoning_effort or config.llm_reasoning_effort,
-        extra_body=_operation_extra_body(member.extra_body, enable_thinking=enable_thinking),
+        extra_body=_operation_extra_body(member.extra_body, enable_thinking=enable_thinking, provider=member.provider),
         default_headers=member.default_headers or config.llm_default_headers,
         ollama_num_ctx=config.llm_ollama_num_ctx,
         bedrock_service_tier=member.bedrock_service_tier,
@@ -1161,7 +1197,7 @@ class MemoryEngine(MemoryEngineInterface):
             base_url=memory_llm_base_url,
             model=memory_llm_model,
             reasoning_effort=config.llm_reasoning_effort,
-            extra_body=_operation_extra_body(config.llm_extra_body, enable_thinking=False),
+            extra_body=_operation_extra_body(config.llm_extra_body, enable_thinking=False, provider=memory_llm_provider),
             default_headers=config.llm_default_headers,
             ollama_num_ctx=config.llm_ollama_num_ctx,
             litellmrouter_config=config.llm_litellmrouter_config,
@@ -1206,7 +1242,7 @@ class MemoryEngine(MemoryEngineInterface):
             base_url=retain_base_url,
             model=retain_model,
             reasoning_effort=config.retain_llm_reasoning_effort or config.llm_reasoning_effort,
-            extra_body=_operation_extra_body(config.llm_extra_body, enable_thinking=False),
+            extra_body=_operation_extra_body(config.llm_extra_body, enable_thinking=False, provider=retain_provider),
             default_headers=config.llm_default_headers,
             ollama_num_ctx=config.llm_ollama_num_ctx,
             litellmrouter_config=config.retain_llm_litellmrouter_config or config.llm_litellmrouter_config,
@@ -1245,7 +1281,7 @@ class MemoryEngine(MemoryEngineInterface):
             base_url=reflect_base_url,
             model=reflect_model,
             reasoning_effort=config.reflect_llm_reasoning_effort or config.llm_reasoning_effort,
-            extra_body=_operation_extra_body(config.llm_extra_body, enable_thinking=True),
+            extra_body=_operation_extra_body(config.llm_extra_body, enable_thinking=True, provider=reflect_provider),
             default_headers=config.llm_default_headers,
             ollama_num_ctx=config.llm_ollama_num_ctx,
             litellmrouter_config=config.reflect_llm_litellmrouter_config or config.llm_litellmrouter_config,
@@ -1284,7 +1320,7 @@ class MemoryEngine(MemoryEngineInterface):
             base_url=consolidation_base_url,
             model=consolidation_model,
             reasoning_effort=config.consolidation_llm_reasoning_effort or config.llm_reasoning_effort,
-            extra_body=_operation_extra_body(config.llm_extra_body, enable_thinking=False),
+            extra_body=_operation_extra_body(config.llm_extra_body, enable_thinking=False, provider=consolidation_provider),
             default_headers=config.llm_default_headers,
             ollama_num_ctx=config.llm_ollama_num_ctx,
             litellmrouter_config=config.consolidation_llm_litellmrouter_config or config.llm_litellmrouter_config,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -453,7 +453,28 @@ class _LLMCallDefaults:
         }
 
 
-def _member_to_llm(member: "LLMMemberConfig", config: HindsightConfig, defaults: _LLMCallDefaults) -> LLMConfig:
+def _operation_extra_body(
+    configured: dict[str, Any] | None,
+    *,
+    enable_thinking: bool,
+) -> dict[str, Any]:
+    """Apply the explicit per-operation Qwen/vLLM thinking contract."""
+    body = copy.deepcopy(configured or {})
+    template = body.get("chat_template_kwargs")
+    if not isinstance(template, dict):
+        template = {}
+    template["enable_thinking"] = enable_thinking
+    body["chat_template_kwargs"] = template
+    return body
+
+
+def _member_to_llm(
+    member: "LLMMemberConfig",
+    config: HindsightConfig,
+    defaults: _LLMCallDefaults,
+    *,
+    enable_thinking: bool = False,
+) -> LLMConfig:
     """Build an LLMProvider from one indexed multi-LLM member.
 
     ``LLMProvider`` uses its arguments verbatim (it no longer reads global config),
@@ -475,7 +496,7 @@ def _member_to_llm(member: "LLMMemberConfig", config: HindsightConfig, defaults:
         base_url=member.base_url,
         model=member.model,
         reasoning_effort=member.reasoning_effort or config.llm_reasoning_effort,
-        extra_body=member.extra_body,
+        extra_body=_operation_extra_body(member.extra_body, enable_thinking=enable_thinking),
         default_headers=member.default_headers or config.llm_default_headers,
         ollama_num_ctx=config.llm_ollama_num_ctx,
         bedrock_service_tier=member.bedrock_service_tier,
@@ -495,6 +516,8 @@ def _build_llm(
     config: HindsightConfig,
     prefix: str,
     defaults: _LLMCallDefaults,
+    *,
+    enable_thinking: bool = False,
 ) -> "LLMConfig | MultiLLMProvider":
     """Resolve an operation's multi-LLM chain and wrap ``base`` (member 0) in it.
 
@@ -517,7 +540,7 @@ def _build_llm(
 
     if not strategy or not members:
         return base
-    extra = [_member_to_llm(m, config, defaults) for m in members]
+    extra = [_member_to_llm(m, config, defaults, enable_thinking=enable_thinking) for m in members]
     return MultiLLMProvider([base, *extra], strategy)
 
 
@@ -1138,7 +1161,7 @@ class MemoryEngine(MemoryEngineInterface):
             base_url=memory_llm_base_url,
             model=memory_llm_model,
             reasoning_effort=config.llm_reasoning_effort,
-            extra_body=config.llm_extra_body,
+            extra_body=_operation_extra_body(config.llm_extra_body, enable_thinking=False),
             default_headers=config.llm_default_headers,
             ollama_num_ctx=config.llm_ollama_num_ctx,
             litellmrouter_config=config.llm_litellmrouter_config,
@@ -1153,7 +1176,7 @@ class MemoryEngine(MemoryEngineInterface):
             vertexai_service_account_key=config.llm_vertexai_service_account_key,
             **default_call_defaults.as_kwargs(),
         )
-        self._llm_config = _build_llm(_default_base_llm, config, "", default_call_defaults)
+        self._llm_config = _build_llm(_default_base_llm, config, "", default_call_defaults, enable_thinking=False)
 
         # Store client and model for convenience (deprecated: use _llm_config.call() instead).
         # Read from the primary member so a multi-LLM chain behaves like the base config here.
@@ -1183,7 +1206,7 @@ class MemoryEngine(MemoryEngineInterface):
             base_url=retain_base_url,
             model=retain_model,
             reasoning_effort=config.retain_llm_reasoning_effort or config.llm_reasoning_effort,
-            extra_body=config.llm_extra_body,
+            extra_body=_operation_extra_body(config.llm_extra_body, enable_thinking=False),
             default_headers=config.llm_default_headers,
             ollama_num_ctx=config.llm_ollama_num_ctx,
             litellmrouter_config=config.retain_llm_litellmrouter_config or config.llm_litellmrouter_config,
@@ -1198,7 +1221,7 @@ class MemoryEngine(MemoryEngineInterface):
             vertexai_service_account_key=config.llm_vertexai_service_account_key,
             **retain_call_defaults.as_kwargs(),
         )
-        self._retain_llm_config = _build_llm(_retain_base_llm, config, "retain_", retain_call_defaults)
+        self._retain_llm_config = _build_llm(_retain_base_llm, config, "retain_", retain_call_defaults, enable_thinking=False)
 
         # Reflect LLM config - for think/observe operations (can use lighter models)
         reflect_provider = reflect_llm_provider or config.reflect_llm_provider or memory_llm_provider
@@ -1222,7 +1245,7 @@ class MemoryEngine(MemoryEngineInterface):
             base_url=reflect_base_url,
             model=reflect_model,
             reasoning_effort=config.reflect_llm_reasoning_effort or config.llm_reasoning_effort,
-            extra_body=config.llm_extra_body,
+            extra_body=_operation_extra_body(config.llm_extra_body, enable_thinking=True),
             default_headers=config.llm_default_headers,
             ollama_num_ctx=config.llm_ollama_num_ctx,
             litellmrouter_config=config.reflect_llm_litellmrouter_config or config.llm_litellmrouter_config,
@@ -1237,7 +1260,7 @@ class MemoryEngine(MemoryEngineInterface):
             vertexai_service_account_key=config.llm_vertexai_service_account_key,
             **reflect_call_defaults.as_kwargs(),
         )
-        self._reflect_llm_config = _build_llm(_reflect_base_llm, config, "reflect_", reflect_call_defaults)
+        self._reflect_llm_config = _build_llm(_reflect_base_llm, config, "reflect_", reflect_call_defaults, enable_thinking=True)
 
         # Consolidation LLM config - for mental model consolidation (can use efficient models)
         consolidation_provider = consolidation_llm_provider or config.consolidation_llm_provider or memory_llm_provider
@@ -1261,7 +1284,7 @@ class MemoryEngine(MemoryEngineInterface):
             base_url=consolidation_base_url,
             model=consolidation_model,
             reasoning_effort=config.consolidation_llm_reasoning_effort or config.llm_reasoning_effort,
-            extra_body=config.llm_extra_body,
+            extra_body=_operation_extra_body(config.llm_extra_body, enable_thinking=False),
             default_headers=config.llm_default_headers,
             ollama_num_ctx=config.llm_ollama_num_ctx,
             litellmrouter_config=config.consolidation_llm_litellmrouter_config or config.llm_litellmrouter_config,
@@ -1277,7 +1300,7 @@ class MemoryEngine(MemoryEngineInterface):
             **consolidation_call_defaults.as_kwargs(),
         )
         self._consolidation_llm_config = _build_llm(
-            _consolidation_base_llm, config, "consolidation_", consolidation_call_defaults
+            _consolidation_base_llm, config, "consolidation_", consolidation_call_defaults, enable_thinking=False
         )
 
         # Initialize cross-encoder reranker (cached for performance)

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -475,7 +475,6 @@ _OPENAI_COMPATIBLE_PROVIDERS = frozenset(
         "atlas",
         "nous",
         "fireworks",
-        "llamacpp",
     }
 )
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -1196,7 +1196,9 @@ class MemoryEngine(MemoryEngineInterface):
             base_url=memory_llm_base_url,
             model=memory_llm_model,
             reasoning_effort=config.llm_reasoning_effort,
-            extra_body=_operation_extra_body(config.llm_extra_body, enable_thinking=False, provider=memory_llm_provider),
+            extra_body=_operation_extra_body(
+                config.llm_extra_body, enable_thinking=False, provider=memory_llm_provider
+            ),
             default_headers=config.llm_default_headers,
             ollama_num_ctx=config.llm_ollama_num_ctx,
             litellmrouter_config=config.llm_litellmrouter_config,
@@ -1256,7 +1258,9 @@ class MemoryEngine(MemoryEngineInterface):
             vertexai_service_account_key=config.llm_vertexai_service_account_key,
             **retain_call_defaults.as_kwargs(),
         )
-        self._retain_llm_config = _build_llm(_retain_base_llm, config, "retain_", retain_call_defaults, enable_thinking=False)
+        self._retain_llm_config = _build_llm(
+            _retain_base_llm, config, "retain_", retain_call_defaults, enable_thinking=False
+        )
 
         # Reflect LLM config - for think/observe operations (can use lighter models)
         reflect_provider = reflect_llm_provider or config.reflect_llm_provider or memory_llm_provider
@@ -1295,7 +1299,9 @@ class MemoryEngine(MemoryEngineInterface):
             vertexai_service_account_key=config.llm_vertexai_service_account_key,
             **reflect_call_defaults.as_kwargs(),
         )
-        self._reflect_llm_config = _build_llm(_reflect_base_llm, config, "reflect_", reflect_call_defaults, enable_thinking=True)
+        self._reflect_llm_config = _build_llm(
+            _reflect_base_llm, config, "reflect_", reflect_call_defaults, enable_thinking=True
+        )
 
         # Consolidation LLM config - for mental model consolidation (can use efficient models)
         consolidation_provider = consolidation_llm_provider or config.consolidation_llm_provider or memory_llm_provider
@@ -1319,7 +1325,9 @@ class MemoryEngine(MemoryEngineInterface):
             base_url=consolidation_base_url,
             model=consolidation_model,
             reasoning_effort=config.consolidation_llm_reasoning_effort or config.llm_reasoning_effort,
-            extra_body=_operation_extra_body(config.llm_extra_body, enable_thinking=False, provider=consolidation_provider),
+            extra_body=_operation_extra_body(
+                config.llm_extra_body, enable_thinking=False, provider=consolidation_provider
+            ),
             default_headers=config.llm_default_headers,
             ollama_num_ctx=config.llm_ollama_num_ctx,
             litellmrouter_config=config.consolidation_llm_litellmrouter_config or config.llm_litellmrouter_config,

--- a/hindsight-api-slim/tests/test_operation_thinking_contract.py
+++ b/hindsight-api-slim/tests/test_operation_thinking_contract.py
@@ -5,16 +5,13 @@ from dataclasses import replace
 from hindsight_api.config import HindsightConfig, LLMMemberConfig, LLMStrategyConfig
 from hindsight_api.engine.llm_wrapper import LLMProvider
 from hindsight_api.engine.memory_engine import (
-    _LLMCallDefaults,
     _build_llm,
+    _LLMCallDefaults,
     _operation_extra_body,
 )
 from hindsight_api.engine.multi_llm import MultiLLMProvider
 
-
-_NO_CALL_DEFAULTS = _LLMCallDefaults(
-    timeout=None, max_retries=None, initial_backoff=None, max_backoff=None
-)
+_NO_CALL_DEFAULTS = _LLMCallDefaults(timeout=None, max_retries=None, initial_backoff=None, max_backoff=None)
 
 
 # ── _operation_extra_body unit tests ───────────────────────────────────────────
@@ -42,24 +39,20 @@ def test_operation_extra_body_sets_thinking_for_openai_compatible_provider():
 def test_operation_extra_body_skips_non_openai_compatible_provider():
     """Gemini/Vertex/Anthropic/LiteLLM must not receive chat_template_kwargs."""
     for non_oai in ("gemini", "vertexai", "anthropic", "litellm", "litellmrouter", "bedrock"):
-        result = _operation_extra_body(
-            {"temperature": 0.2}, enable_thinking=True, provider=non_oai
-        )
+        result = _operation_extra_body({"temperature": 0.2}, enable_thinking=True, provider=non_oai)
         assert result == {"temperature": 0.2}, f"provider={non_oai}"
         assert "chat_template_kwargs" not in result, f"provider={non_oai}"
 
 
 def test_operation_extra_body_none_provider_is_safe_noop():
-    result = _operation_extra_body(
-        {"temperature": 0.2}, enable_thinking=True, provider=None
-    )
+    result = _operation_extra_body({"temperature": 0.2}, enable_thinking=True, provider=None)
     assert result == {"temperature": 0.2}
 
 
 def test_operation_extra_body_replaces_malformed_template_kwargs():
-    assert _operation_extra_body(
-        {"chat_template_kwargs": "invalid"}, enable_thinking=False, provider="ollama"
-    ) == {"chat_template_kwargs": {"enable_thinking": False}}
+    assert _operation_extra_body({"chat_template_kwargs": "invalid"}, enable_thinking=False, provider="ollama") == {
+        "chat_template_kwargs": {"enable_thinking": False}
+    }
 
 
 # ── _build_llm integration tests ───────────────────────────────────────────────
@@ -109,6 +102,4 @@ def test_build_llm_applies_enabled_thinking_to_reflect_members():
     result = _build_llm(base, config, "", _NO_CALL_DEFAULTS, enable_thinking=True)
 
     assert isinstance(result, MultiLLMProvider)
-    assert result.members[1].extra_body == {
-        "chat_template_kwargs": {"enable_thinking": True}
-    }
+    assert result.members[1].extra_body == {"chat_template_kwargs": {"enable_thinking": True}}

--- a/hindsight-api-slim/tests/test_operation_thinking_contract.py
+++ b/hindsight-api-slim/tests/test_operation_thinking_contract.py
@@ -17,42 +17,70 @@ _NO_CALL_DEFAULTS = _LLMCallDefaults(
 )
 
 
-def test_operation_extra_body_sets_thinking_without_mutating_configured_body():
+# ── _operation_extra_body unit tests ───────────────────────────────────────────
+
+
+def test_operation_extra_body_sets_thinking_for_openai_compatible_provider():
     configured = {
         "temperature": 0.2,
         "chat_template_kwargs": {"foo": "bar"},
     }
 
-    result = _operation_extra_body(configured, enable_thinking=True)
+    result = _operation_extra_body(configured, enable_thinking=True, provider="openai")
 
     assert result == {
         "temperature": 0.2,
         "chat_template_kwargs": {"foo": "bar", "enable_thinking": True},
     }
+    # Original is not mutated.
     assert configured == {
         "temperature": 0.2,
         "chat_template_kwargs": {"foo": "bar"},
     }
 
 
+def test_operation_extra_body_skips_non_openai_compatible_provider():
+    """Gemini/Vertex/Anthropic/LiteLLM must not receive chat_template_kwargs."""
+    for non_oai in ("gemini", "vertexai", "anthropic", "litellm", "litellmrouter", "bedrock"):
+        result = _operation_extra_body(
+            {"temperature": 0.2}, enable_thinking=True, provider=non_oai
+        )
+        assert result == {"temperature": 0.2}, f"provider={non_oai}"
+        assert "chat_template_kwargs" not in result, f"provider={non_oai}"
+
+
+def test_operation_extra_body_none_provider_is_safe_noop():
+    result = _operation_extra_body(
+        {"temperature": 0.2}, enable_thinking=True, provider=None
+    )
+    assert result == {"temperature": 0.2}
+
+
 def test_operation_extra_body_replaces_malformed_template_kwargs():
     assert _operation_extra_body(
-        {"chat_template_kwargs": "invalid"}, enable_thinking=False
+        {"chat_template_kwargs": "invalid"}, enable_thinking=False, provider="ollama"
     ) == {"chat_template_kwargs": {"enable_thinking": False}}
 
 
-def test_build_llm_applies_disabled_thinking_to_failover_members():
-    member = LLMMemberConfig(
-        provider="mock",
-        api_key="",
-        model="fallback",
-        base_url="",
+# ── _build_llm integration tests ───────────────────────────────────────────────
+
+
+def _member(provider="ollama", extra_body=None):
+    return LLMMemberConfig(
+        provider=provider,
+        api_key=None,
+        model="m",
+        base_url=None,
         reasoning_effort=None,
-        extra_body={"temperature": 0.1},
+        extra_body=extra_body,
         default_headers=None,
         bedrock_service_tier=None,
         gemini_service_tier=None,
     )
+
+
+def test_build_llm_applies_disabled_thinking_to_failover_members():
+    member = _member(provider="ollama", extra_body={"temperature": 0.1})
     config = replace(
         HindsightConfig.from_env(),
         llm_members=[member],
@@ -70,17 +98,7 @@ def test_build_llm_applies_disabled_thinking_to_failover_members():
 
 
 def test_build_llm_applies_enabled_thinking_to_reflect_members():
-    member = LLMMemberConfig(
-        provider="mock",
-        api_key="",
-        model="reflect-fallback",
-        base_url="",
-        reasoning_effort=None,
-        extra_body=None,
-        default_headers=None,
-        bedrock_service_tier=None,
-        gemini_service_tier=None,
-    )
+    member = _member(provider="ollama", extra_body=None)
     config = replace(
         HindsightConfig.from_env(),
         llm_members=[member],

--- a/hindsight-api-slim/tests/test_operation_thinking_contract.py
+++ b/hindsight-api-slim/tests/test_operation_thinking_contract.py
@@ -1,0 +1,96 @@
+"""Contract tests for explicit per-operation thinking controls."""
+
+from dataclasses import replace
+
+from hindsight_api.config import HindsightConfig, LLMMemberConfig, LLMStrategyConfig
+from hindsight_api.engine.llm_wrapper import LLMProvider
+from hindsight_api.engine.memory_engine import (
+    _LLMCallDefaults,
+    _build_llm,
+    _operation_extra_body,
+)
+from hindsight_api.engine.multi_llm import MultiLLMProvider
+
+
+_NO_CALL_DEFAULTS = _LLMCallDefaults(
+    timeout=None, max_retries=None, initial_backoff=None, max_backoff=None
+)
+
+
+def test_operation_extra_body_sets_thinking_without_mutating_configured_body():
+    configured = {
+        "temperature": 0.2,
+        "chat_template_kwargs": {"foo": "bar"},
+    }
+
+    result = _operation_extra_body(configured, enable_thinking=True)
+
+    assert result == {
+        "temperature": 0.2,
+        "chat_template_kwargs": {"foo": "bar", "enable_thinking": True},
+    }
+    assert configured == {
+        "temperature": 0.2,
+        "chat_template_kwargs": {"foo": "bar"},
+    }
+
+
+def test_operation_extra_body_replaces_malformed_template_kwargs():
+    assert _operation_extra_body(
+        {"chat_template_kwargs": "invalid"}, enable_thinking=False
+    ) == {"chat_template_kwargs": {"enable_thinking": False}}
+
+
+def test_build_llm_applies_disabled_thinking_to_failover_members():
+    member = LLMMemberConfig(
+        provider="mock",
+        api_key="",
+        model="fallback",
+        base_url="",
+        reasoning_effort=None,
+        extra_body={"temperature": 0.1},
+        default_headers=None,
+        bedrock_service_tier=None,
+        gemini_service_tier=None,
+    )
+    config = replace(
+        HindsightConfig.from_env(),
+        llm_members=[member],
+        llm_strategy=LLMStrategyConfig(mode="failover"),
+    )
+    base = LLMProvider(provider="mock", api_key="", base_url="", model="primary")
+
+    result = _build_llm(base, config, "", _NO_CALL_DEFAULTS, enable_thinking=False)
+
+    assert isinstance(result, MultiLLMProvider)
+    assert result.members[1].extra_body == {
+        "temperature": 0.1,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+
+
+def test_build_llm_applies_enabled_thinking_to_reflect_members():
+    member = LLMMemberConfig(
+        provider="mock",
+        api_key="",
+        model="reflect-fallback",
+        base_url="",
+        reasoning_effort=None,
+        extra_body=None,
+        default_headers=None,
+        bedrock_service_tier=None,
+        gemini_service_tier=None,
+    )
+    config = replace(
+        HindsightConfig.from_env(),
+        llm_members=[member],
+        llm_strategy=LLMStrategyConfig(mode="failover"),
+    )
+    base = LLMProvider(provider="mock", api_key="", base_url="", model="reflect")
+
+    result = _build_llm(base, config, "", _NO_CALL_DEFAULTS, enable_thinking=True)
+
+    assert isinstance(result, MultiLLMProvider)
+    assert result.members[1].extra_body == {
+        "chat_template_kwargs": {"enable_thinking": True}
+    }


### PR DESCRIPTION
## Related issues

- **Fixes #2630** — OpenAI-compatible verification fails on reasoning models because `max_tokens=100` is exhausted by reasoning. That issue raised the verification token cap, but the deeper fix is explicit per-operation thinking control: disable thinking for utility operations (retain, consolidation, verification) so the token budget goes to visible output.
- **Relates to #2431** — Structured reflect with `response_schema` times out with empty content and `finish_reason=length`. Same failure class: reasoning tokens consuming the budget before visible output.

## Problem

Qwen/vLLM-compatible servers with server-side `reasoning: auto` can consume the entire completion token budget on hidden reasoning. When callers omit an explicit thinking flag, short utility requests return **empty `content`** with `finish_reason: length` — the response is entirely hidden reasoning with no visible output.

This affects all Hindsight operations (retain, reflect, consolidation, default) when pointed at a Qwen/vLLM-compatible endpoint.

## Root cause

Hindsight threaded `config.llm_extra_body` verbatim into every provider without explicit per-operation thinking control. The server-side `reasoning: auto` default then consumed the whole budget on reasoning tokens before producing any visible output.

## Solution

Add `_operation_extra_body()`, which injects `chat_template_kwargs.enable_thinking` into the configured `extra_body` with an explicit per-operation value:

- **retain, consolidation, default operations**: `enable_thinking=False`
- **reflect operations**: `enable_thinking=True`

Only OpenAI-compatible providers receive the injection — the field is Qwen/vLLM-specific and would be rejected or ignored by Gemini/Vertex, Anthropic, LiteLLM, Bedrock, and llama.cpp. Non-eligible providers keep the configured `extra_body` untouched.

### Provider gating

`_OPENAI_COMPATIBLE_PROVIDERS` is an explicit allowlist matched against the actual provider factory paths in `llm_wrapper.create_llm_provider()`:
- `openai`, `groq`, `ollama`, `ollama-cloud`, `lmstudio`, `minimax`, `deepseek`, `volcano`, `openrouter`, `requesty`, `zai`, `opencode-go`, `atlas` → `OpenAICompatibleLLM` (accepts `extra_body`)
- `fireworks`, `nous` → dedicated factory branches that forward `extra_body`
- Excluded: `llamacpp` (factory drops `extra_body`), `gemini`, `vertexai`, `anthropic`, `litellm`, `litellmrouter`, `bedrock`

### Semantics

- Configured `extra_body` is deep-copied — never mutated
- Malformed `chat_template_kwargs` (string, None, etc.) is safely replaced
- `None` provider is a safe no-op (returns body unchanged)
- Multi-LLM chain members inherit the same operation flag

## Files changed

- `hindsight-api-slim/hindsight_api/engine/memory_engine.py` — `_operation_extra_body()` helper, `_OPENAI_COMPATIBLE_PROVIDERS` allowlist, all 6 call sites updated
- `hindsight-api-slim/tests/test_operation_thinking_contract.py` — new contract tests

## Tests

```
cd hindsight-api-slim && uv run pytest tests/test_operation_thinking_contract.py tests/test_multi_llm_config.py tests/test_llm_extra_body.py tests/test_minimax_thinking_body.py -q
```

67 passed in 4.79s (only expected missing `.env`/local-ML dependency warnings).

## Validation scope

- Transport-level `chat_template_kwargs.enable_thinking` forwarding was validated against a Qwen-compatible llama.cpp/Lemonade server (OpenAI-compatible wire format).
- No live Qwen Portal API request was tested; the implementation uses Qwen's documented `enable_thinking` request field.
