### PR TITLE
fix(embeddings): bounded retry/backoff + timeout for litellm/litellm-sdk providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -326,6 +326,14 @@ HINDSIGHT_API_LOG_LEVEL=info
 # DeepSeek note: DeepSeek is supported for LLM calls, but not for embeddings.
 # If using DeepSeek as LLM provider, keep embeddings on local/openai/cohere/google/etc.
 
+# Retry policy for remote embedding calls (litellm / litellm-sdk providers).
+# Transient upstream failures (5xx, timeouts, connection errors) are retried with
+# jittered exponential backoff; 4xx auth/validation errors are never retried.
+# HINDSIGHT_API_EMBEDDINGS_MAX_RETRIES=4        # retries after the first attempt; 0 disables
+# HINDSIGHT_API_EMBEDDINGS_INITIAL_BACKOFF=0.5  # seconds; doubles per attempt, with jitter
+# HINDSIGHT_API_EMBEDDINGS_MAX_BACKOFF=4.0      # cap on per-retry backoff, seconds
+# HINDSIGHT_API_EMBEDDINGS_RETRY_BUDGET=15.0    # wall-clock ceiling per encode() spent retrying
+
 # Embedding similarity thresholds. These defaults preserve the behavior calibrated
 # for BAAI/bge-small-en-v1.5. Recalibrate each threshold independently when changing
 # embedding models because cosine-similarity distributions are model-dependent.

--- a/.env.example
+++ b/.env.example
@@ -222,6 +222,14 @@ HINDSIGHT_API_LOG_LEVEL=info
 # DeepSeek note: DeepSeek is supported for LLM calls, but not for embeddings.
 # If using DeepSeek as LLM provider, keep embeddings on local/openai/cohere/google/etc.
 
+# Retry policy for remote embedding calls (litellm / litellm-sdk providers).
+# Transient upstream failures (5xx, timeouts, connection errors) are retried with
+# jittered exponential backoff; 4xx auth/validation errors are never retried.
+# HINDSIGHT_API_EMBEDDINGS_MAX_RETRIES=4        # retries after the first attempt; 0 disables
+# HINDSIGHT_API_EMBEDDINGS_INITIAL_BACKOFF=0.5  # seconds; doubles per attempt, with jitter
+# HINDSIGHT_API_EMBEDDINGS_MAX_BACKOFF=4.0      # cap on per-retry backoff, seconds
+# HINDSIGHT_API_EMBEDDINGS_RETRY_BUDGET=15.0    # wall-clock ceiling per encode() spent retrying
+
 # Embedding similarity thresholds. These defaults preserve the behavior calibrated
 # for BAAI/bge-small-en-v1.5. Recalibrate each threshold independently when changing
 # embedding models because cosine-similarity distributions are model-dependent.

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -406,6 +406,13 @@ ENV_EMBEDDINGS_OPENAI_BASE_URL = "HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL"
 ENV_EMBEDDINGS_OPENAI_BATCH_SIZE = "HINDSIGHT_API_EMBEDDINGS_OPENAI_BATCH_SIZE"
 ENV_EMBEDDINGS_OPENAI_DIMENSIONS = "HINDSIGHT_API_EMBEDDINGS_OPENAI_DIMENSIONS"
 
+# Retry/backoff for remote embedding APIs. Recall embeds its query inline on the
+# request path, so a single upstream 5xx must not surface as a user-visible 500.
+ENV_EMBEDDINGS_MAX_RETRIES = "HINDSIGHT_API_EMBEDDINGS_MAX_RETRIES"
+ENV_EMBEDDINGS_INITIAL_BACKOFF = "HINDSIGHT_API_EMBEDDINGS_INITIAL_BACKOFF"
+ENV_EMBEDDINGS_MAX_BACKOFF = "HINDSIGHT_API_EMBEDDINGS_MAX_BACKOFF"
+ENV_EMBEDDINGS_RETRY_BUDGET = "HINDSIGHT_API_EMBEDDINGS_RETRY_BUDGET"
+
 # Gemini/Vertex AI embeddings configuration
 ENV_EMBEDDINGS_GEMINI_API_KEY = "HINDSIGHT_API_EMBEDDINGS_GEMINI_API_KEY"
 ENV_EMBEDDINGS_GEMINI_MODEL = "HINDSIGHT_API_EMBEDDINGS_GEMINI_MODEL"
@@ -997,6 +1004,13 @@ DEFAULT_EMBEDDINGS_OPENAI_BATCH_SIZE = 100
 # coalesces its per-chunk embedding calls up to (see embedding_coalescer), so raising
 # it is how a TEI deployment with headroom trades requests for larger ones.
 DEFAULT_EMBEDDINGS_TEI_BATCH_SIZE = 32
+# Embedding retry defaults: 4 retries (5 attempts total) with 0.5s -> 4s exponential
+# backoff, plus a 15s ceiling on the time any single encode() call may spend retrying
+# so a synchronous recall degrades to a slow response instead of a long stall.
+DEFAULT_EMBEDDINGS_MAX_RETRIES = 4
+DEFAULT_EMBEDDINGS_INITIAL_BACKOFF = 0.5
+DEFAULT_EMBEDDINGS_MAX_BACKOFF = 4.0
+DEFAULT_EMBEDDINGS_RETRY_BUDGET = 15.0
 DEFAULT_EMBEDDINGS_GEMINI_MODEL = "gemini-embedding-001"
 DEFAULT_EMBEDDINGS_GEMINI_OUTPUT_DIMENSIONALITY = 768
 DEFAULT_EMBEDDINGS_GEMINI_FORCE_IPV4 = False
@@ -1729,6 +1743,19 @@ def _parse_optional_non_negative_int(name: str, raw: str | None) -> int | None:
         parsed = int(raw)
     except ValueError as e:
         raise ValueError(f"{name} must be an integer, got {raw!r}") from e
+    if parsed < 0:
+        raise ValueError(f"{name} must be >= 0, got {parsed}")
+    return parsed
+
+
+def _parse_non_negative_float(name: str, raw: str | None, default: float) -> float:
+    """Parse an env var that must be a non-negative number of seconds (>= 0)."""
+    if raw is None or raw == "":
+        return default
+    try:
+        parsed = float(raw)
+    except ValueError as e:
+        raise ValueError(f"{name} must be a number, got {raw!r}") from e
     if parsed < 0:
         raise ValueError(f"{name} must be >= 0, got {parsed}")
     return parsed
@@ -2853,6 +2880,12 @@ class HindsightConfig:
     operation_cleanup_interval_seconds: int = DEFAULT_OPERATION_CLEANUP_INTERVAL_SECONDS
     maintenance_start_jitter_seconds: int = DEFAULT_MAINTENANCE_START_JITTER_SECONDS
 
+    # Retry/backoff applied to remote embedding API calls (see EmbeddingRetryPolicy).
+    embeddings_max_retries: int = DEFAULT_EMBEDDINGS_MAX_RETRIES
+    embeddings_initial_backoff: float = DEFAULT_EMBEDDINGS_INITIAL_BACKOFF
+    embeddings_max_backoff: float = DEFAULT_EMBEDDINGS_MAX_BACKOFF
+    embeddings_retry_budget: float = DEFAULT_EMBEDDINGS_RETRY_BUDGET
+
     # Class-level sets for configuration categorization
 
     # CREDENTIAL_FIELDS: Never exposed via API, never configurable per-tenant/bank
@@ -3548,6 +3581,26 @@ class HindsightConfig:
             ),
             embeddings_query_prefix=os.getenv(ENV_EMBEDDINGS_QUERY_PREFIX, DEFAULT_EMBEDDINGS_QUERY_PREFIX),
             embeddings_passage_prefix=os.getenv(ENV_EMBEDDINGS_PASSAGE_PREFIX, DEFAULT_EMBEDDINGS_PASSAGE_PREFIX),
+            embeddings_max_retries=_parse_non_negative_int(
+                ENV_EMBEDDINGS_MAX_RETRIES,
+                os.getenv(ENV_EMBEDDINGS_MAX_RETRIES),
+                DEFAULT_EMBEDDINGS_MAX_RETRIES,
+            ),
+            embeddings_initial_backoff=_parse_non_negative_float(
+                ENV_EMBEDDINGS_INITIAL_BACKOFF,
+                os.getenv(ENV_EMBEDDINGS_INITIAL_BACKOFF),
+                DEFAULT_EMBEDDINGS_INITIAL_BACKOFF,
+            ),
+            embeddings_max_backoff=_parse_non_negative_float(
+                ENV_EMBEDDINGS_MAX_BACKOFF,
+                os.getenv(ENV_EMBEDDINGS_MAX_BACKOFF),
+                DEFAULT_EMBEDDINGS_MAX_BACKOFF,
+            ),
+            embeddings_retry_budget=_parse_non_negative_float(
+                ENV_EMBEDDINGS_RETRY_BUDGET,
+                os.getenv(ENV_EMBEDDINGS_RETRY_BUDGET),
+                DEFAULT_EMBEDDINGS_RETRY_BUDGET,
+            ),
             # Cohere embeddings (with backward-compatible fallback to shared API key)
             embeddings_cohere_api_key=os.getenv(ENV_EMBEDDINGS_COHERE_API_KEY) or os.getenv(ENV_COHERE_API_KEY),
             embeddings_cohere_model=os.getenv(ENV_EMBEDDINGS_COHERE_MODEL, DEFAULT_EMBEDDINGS_COHERE_MODEL),

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -374,6 +374,13 @@ ENV_EMBEDDINGS_OPENAI_BASE_URL = "HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL"
 ENV_EMBEDDINGS_OPENAI_BATCH_SIZE = "HINDSIGHT_API_EMBEDDINGS_OPENAI_BATCH_SIZE"
 ENV_EMBEDDINGS_OPENAI_DIMENSIONS = "HINDSIGHT_API_EMBEDDINGS_OPENAI_DIMENSIONS"
 
+# Retry/backoff for remote embedding APIs. Recall embeds its query inline on the
+# request path, so a single upstream 5xx must not surface as a user-visible 500.
+ENV_EMBEDDINGS_MAX_RETRIES = "HINDSIGHT_API_EMBEDDINGS_MAX_RETRIES"
+ENV_EMBEDDINGS_INITIAL_BACKOFF = "HINDSIGHT_API_EMBEDDINGS_INITIAL_BACKOFF"
+ENV_EMBEDDINGS_MAX_BACKOFF = "HINDSIGHT_API_EMBEDDINGS_MAX_BACKOFF"
+ENV_EMBEDDINGS_RETRY_BUDGET = "HINDSIGHT_API_EMBEDDINGS_RETRY_BUDGET"
+
 # Gemini/Vertex AI embeddings configuration
 ENV_EMBEDDINGS_GEMINI_API_KEY = "HINDSIGHT_API_EMBEDDINGS_GEMINI_API_KEY"
 ENV_EMBEDDINGS_GEMINI_MODEL = "HINDSIGHT_API_EMBEDDINGS_GEMINI_MODEL"
@@ -890,6 +897,13 @@ DEFAULT_EMBEDDINGS_ONNX_QUERY_PREFIX = "query: "
 DEFAULT_EMBEDDINGS_ONNX_PASSAGE_PREFIX = "passage: "
 DEFAULT_EMBEDDINGS_OPENAI_MODEL = "text-embedding-3-small"
 DEFAULT_EMBEDDINGS_OPENAI_BATCH_SIZE = 100
+# Embedding retry defaults: 4 retries (5 attempts total) with 0.5s -> 4s exponential
+# backoff, plus a 15s ceiling on the time any single encode() call may spend retrying
+# so a synchronous recall degrades to a slow response instead of a long stall.
+DEFAULT_EMBEDDINGS_MAX_RETRIES = 4
+DEFAULT_EMBEDDINGS_INITIAL_BACKOFF = 0.5
+DEFAULT_EMBEDDINGS_MAX_BACKOFF = 4.0
+DEFAULT_EMBEDDINGS_RETRY_BUDGET = 15.0
 DEFAULT_EMBEDDINGS_GEMINI_MODEL = "gemini-embedding-001"
 DEFAULT_EMBEDDINGS_GEMINI_OUTPUT_DIMENSIONALITY = 768
 DEFAULT_EMBEDDINGS_GEMINI_FORCE_IPV4 = False
@@ -1434,6 +1448,19 @@ def _parse_optional_non_negative_int(name: str, raw: str | None) -> int | None:
         parsed = int(raw)
     except ValueError as e:
         raise ValueError(f"{name} must be an integer, got {raw!r}") from e
+    if parsed < 0:
+        raise ValueError(f"{name} must be >= 0, got {parsed}")
+    return parsed
+
+
+def _parse_non_negative_float(name: str, raw: str | None, default: float) -> float:
+    """Parse an env var that must be a non-negative number of seconds (>= 0)."""
+    if raw is None or raw == "":
+        return default
+    try:
+        parsed = float(raw)
+    except ValueError as e:
+        raise ValueError(f"{name} must be a number, got {raw!r}") from e
     if parsed < 0:
         raise ValueError(f"{name} must be >= 0, got {parsed}")
     return parsed
@@ -2251,6 +2278,12 @@ class HindsightConfig:
     consolidation_llm_strategy: LLMStrategyConfig | None = None
     bm25_max_query_terms: int = DEFAULT_BM25_MAX_QUERY_TERMS
 
+    # Retry/backoff applied to remote embedding API calls (see EmbeddingRetryPolicy).
+    embeddings_max_retries: int = DEFAULT_EMBEDDINGS_MAX_RETRIES
+    embeddings_initial_backoff: float = DEFAULT_EMBEDDINGS_INITIAL_BACKOFF
+    embeddings_max_backoff: float = DEFAULT_EMBEDDINGS_MAX_BACKOFF
+    embeddings_retry_budget: float = DEFAULT_EMBEDDINGS_RETRY_BUDGET
+
     # Class-level sets for configuration categorization
 
     # CREDENTIAL_FIELDS: Never exposed via API, never configurable per-tenant/bank
@@ -2806,6 +2839,26 @@ class HindsightConfig:
             embeddings_openai_dimensions=_parse_optional_positive_int(
                 ENV_EMBEDDINGS_OPENAI_DIMENSIONS,
                 os.getenv(ENV_EMBEDDINGS_OPENAI_DIMENSIONS),
+            ),
+            embeddings_max_retries=_parse_non_negative_int(
+                ENV_EMBEDDINGS_MAX_RETRIES,
+                os.getenv(ENV_EMBEDDINGS_MAX_RETRIES),
+                DEFAULT_EMBEDDINGS_MAX_RETRIES,
+            ),
+            embeddings_initial_backoff=_parse_non_negative_float(
+                ENV_EMBEDDINGS_INITIAL_BACKOFF,
+                os.getenv(ENV_EMBEDDINGS_INITIAL_BACKOFF),
+                DEFAULT_EMBEDDINGS_INITIAL_BACKOFF,
+            ),
+            embeddings_max_backoff=_parse_non_negative_float(
+                ENV_EMBEDDINGS_MAX_BACKOFF,
+                os.getenv(ENV_EMBEDDINGS_MAX_BACKOFF),
+                DEFAULT_EMBEDDINGS_MAX_BACKOFF,
+            ),
+            embeddings_retry_budget=_parse_non_negative_float(
+                ENV_EMBEDDINGS_RETRY_BUDGET,
+                os.getenv(ENV_EMBEDDINGS_RETRY_BUDGET),
+                DEFAULT_EMBEDDINGS_RETRY_BUDGET,
             ),
             # Cohere embeddings (with backward-compatible fallback to shared API key)
             embeddings_cohere_api_key=os.getenv(ENV_EMBEDDINGS_COHERE_API_KEY) or os.getenv(ENV_COHERE_API_KEY),

--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -9,13 +9,17 @@ The database schema is automatically adjusted to match the model's dimension.
 Configuration via environment variables - see hindsight_api.config for all env var names.
 """
 
+import asyncio
 import base64
 import logging
 import os
 import struct
+import time
 import warnings
 from abc import ABC, abstractmethod
-from typing import Literal, cast
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, TypeVar, cast
 from urllib.parse import parse_qs, urlparse, urlunparse
 
 import httpx
@@ -24,10 +28,14 @@ from pydantic import BaseModel
 from ..config import (
     DEFAULT_EMBEDDINGS_COHERE_MODEL,
     DEFAULT_EMBEDDINGS_GEMINI_MODEL,
+    DEFAULT_EMBEDDINGS_INITIAL_BACKOFF,
     DEFAULT_EMBEDDINGS_LITELLM_MODEL,
     DEFAULT_EMBEDDINGS_LITELLM_SDK_MODEL,
     DEFAULT_EMBEDDINGS_LOCAL_MODEL,
+    DEFAULT_EMBEDDINGS_MAX_BACKOFF,
+    DEFAULT_EMBEDDINGS_MAX_RETRIES,
     DEFAULT_EMBEDDINGS_OPENAI_MODEL,
+    DEFAULT_EMBEDDINGS_RETRY_BUDGET,
     DEFAULT_EMBEDDINGS_ZEROENTROPY_BATCH_SIZE,
     DEFAULT_EMBEDDINGS_ZEROENTROPY_DIMENSIONS,
     DEFAULT_EMBEDDINGS_ZEROENTROPY_ENCODING_FORMAT,
@@ -55,7 +63,209 @@ from .local_device import (
 )
 from .tei_retry import TEI_KEEPALIVE_EXPIRY_SECONDS, is_retryable_tei_transport_error, tei_retry_delay
 
+if TYPE_CHECKING:
+    from ..config import HindsightConfig
+
 logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# 4xx codes that describe a transient condition rather than a bad request.
+# Everything else in the 4xx range (auth, validation, not-found) is a client-side
+# problem that retrying cannot fix.
+_TRANSIENT_STATUS_CODES = frozenset({408, 409, 425, 429})
+
+# Exception class names treated as transient when the exception carries no HTTP
+# status code. Matching by name keeps this module free of a hard litellm/openai
+# import (litellm is imported lazily, and only by the providers that need it).
+_TRANSIENT_EXCEPTION_NAMES = frozenset(
+    {
+        "APIConnectionError",
+        "APIError",
+        "APITimeoutError",
+        "ConnectionError",
+        "InternalServerError",
+        "RateLimitError",
+        "ServiceUnavailableError",
+        "Timeout",
+        "TimeoutError",
+    }
+)
+
+
+@dataclass(frozen=True)
+class EmbeddingRetryPolicy:
+    """
+    Bounded retry policy for remote embedding APIs.
+
+    Recall embeds the query inline on the request path, so a single upstream 5xx
+    would otherwise become a user-visible recall failure. Retries are bounded two
+    ways at once:
+
+    * ``max_retries`` caps the number of extra attempts (0 disables retrying).
+    * ``budget_seconds`` caps the wall-clock time a single ``encode()`` call may
+      *waste* on retries — failed attempts plus backoff sleeps. Successful work
+      never counts against it, so a large multi-batch encode is not penalised for
+      the batches that worked, while the worst-case added latency stays bounded.
+
+    The pairing matters: attempts alone cannot bound latency (an upstream that
+    fails slowly turns 5 attempts into minutes), and a budget alone cannot stop a
+    fast-failing upstream from being hammered.
+    """
+
+    max_retries: int = DEFAULT_EMBEDDINGS_MAX_RETRIES
+    initial_backoff: float = DEFAULT_EMBEDDINGS_INITIAL_BACKOFF
+    max_backoff: float = DEFAULT_EMBEDDINGS_MAX_BACKOFF
+    budget_seconds: float = DEFAULT_EMBEDDINGS_RETRY_BUDGET
+
+    def new_budget(self) -> "_RetryBudget":
+        """Start a fresh retry budget, scoped to one logical embedding call."""
+        return _RetryBudget(self.budget_seconds)
+
+
+class _RetryBudget:
+    """Mutable remaining-retry-time counter shared across the batches of one call."""
+
+    __slots__ = ("remaining",)
+
+    def __init__(self, seconds: float):
+        self.remaining = max(0.0, seconds)
+
+    @property
+    def exhausted(self) -> bool:
+        return self.remaining <= 0.0
+
+    def spend(self, seconds: float) -> None:
+        self.remaining = max(0.0, self.remaining - max(0.0, seconds))
+
+
+def _status_code_of(exc: BaseException) -> int | None:
+    """Best-effort HTTP status extraction across httpx, openai and litellm errors."""
+    candidates = (
+        getattr(exc, "status_code", None),
+        getattr(getattr(exc, "response", None), "status_code", None),
+    )
+    for candidate in candidates:
+        if isinstance(candidate, bool):
+            continue
+        if isinstance(candidate, int):
+            return candidate
+        if isinstance(candidate, str) and candidate.isdigit():
+            return int(candidate)
+    return None
+
+
+def _is_transient_embedding_error(exc: BaseException) -> bool:
+    """
+    Return True when ``exc`` is worth retrying.
+
+    A status code, when present, is authoritative: 5xx and the transient 4xx set
+    are retryable, every other 4xx (401/403 auth, 400/422 validation, 404) is
+    permanent and must fail fast. Without a status code we fall back to
+    transport-level exception types and known SDK exception names.
+    """
+    status = _status_code_of(exc)
+    if status is not None:
+        return status >= 500 or status in _TRANSIENT_STATUS_CODES
+    if isinstance(exc, (httpx.TimeoutException, httpx.NetworkError, httpx.RemoteProtocolError)):
+        return True
+    if isinstance(exc, (TimeoutError, ConnectionError)):
+        return True
+    return type(exc).__name__ in _TRANSIENT_EXCEPTION_NAMES
+
+
+def _retry_delay_for(
+    exc: BaseException,
+    *,
+    attempt: int,
+    attempts: int,
+    policy: EmbeddingRetryPolicy,
+    budget: _RetryBudget,
+    provider: str,
+) -> float | None:
+    """
+    Decide whether ``exc`` should be retried and how long to wait first.
+
+    Returns the sleep duration, or None when the exception must propagate. Logs
+    the decision and charges the sleep to ``budget``. Upstream error text is
+    truncated (matching the LLM providers) so a verbose provider payload cannot
+    flood the log.
+    """
+    if not _is_transient_embedding_error(exc):
+        return None
+
+    status = _status_code_of(exc)
+    status_label = f"HTTP {status}" if status is not None else type(exc).__name__
+    detail = str(exc)[:200]
+
+    if attempt >= attempts - 1:
+        logger.error(f"{provider} embedding call failed after {attempts} attempt(s) ({status_label}): {detail}")
+        return None
+
+    if budget.exhausted:
+        logger.error(
+            f"{provider} embedding call failed on attempt {attempt + 1}/{attempts} ({status_label}) and the "
+            f"{policy.budget_seconds:.1f}s retry budget is exhausted, giving up: {detail}"
+        )
+        return None
+
+    backoff = min(policy.initial_backoff * (2**attempt), policy.max_backoff)
+    jitter = backoff * 0.2 * (2 * (time.time() % 1) - 1)
+    sleep_for = min(max(0.0, backoff + jitter), budget.remaining)
+    budget.spend(sleep_for)
+    logger.warning(
+        f"{provider} embedding call failed (attempt {attempt + 1}/{attempts}, {status_label}), "
+        f"retrying in {sleep_for:.2f}s ({budget.remaining:.1f}s of retry budget left): {detail}"
+    )
+    return sleep_for
+
+
+def _call_with_retry(
+    call: Callable[[], T],
+    *,
+    policy: EmbeddingRetryPolicy,
+    budget: _RetryBudget,
+    provider: str,
+) -> T:
+    """Run a blocking embedding call, retrying transient upstream failures."""
+    attempts = policy.max_retries + 1
+    for attempt in range(attempts):
+        started = time.monotonic()
+        try:
+            return call()
+        except Exception as exc:
+            budget.spend(time.monotonic() - started)
+            delay = _retry_delay_for(
+                exc, attempt=attempt, attempts=attempts, policy=policy, budget=budget, provider=provider
+            )
+            if delay is None:
+                raise
+            time.sleep(delay)
+    raise RuntimeError("unreachable: retry loop exited without returning or raising")
+
+
+async def _acall_with_retry(
+    call: Callable[[], Awaitable[T]],
+    *,
+    policy: EmbeddingRetryPolicy,
+    budget: _RetryBudget,
+    provider: str,
+) -> T:
+    """Async twin of :func:`_call_with_retry`, sharing its policy and classification."""
+    attempts = policy.max_retries + 1
+    for attempt in range(attempts):
+        started = time.monotonic()
+        try:
+            return await call()
+        except Exception as exc:
+            budget.spend(time.monotonic() - started)
+            delay = _retry_delay_for(
+                exc, attempt=attempt, attempts=attempts, policy=policy, budget=budget, provider=provider
+            )
+            if delay is None:
+                raise
+            await asyncio.sleep(delay)
+    raise RuntimeError("unreachable: retry loop exited without returning or raising")
 
 
 ZeroEntropyInputType = Literal["document", "query"]
@@ -1179,6 +1389,7 @@ class LiteLLMEmbeddings(Embeddings):
         timeout: float = 60.0,
         query_prefix: str = "",
         passage_prefix: str = "",
+        retry_policy: EmbeddingRetryPolicy | None = None,
     ):
         """
         Initialize LiteLLM embeddings client.
@@ -1192,6 +1403,8 @@ class LiteLLMEmbeddings(Embeddings):
             timeout: Request timeout in seconds (default: 60.0)
             query_prefix: Prefix prepended to recall/search queries (default: none)
             passage_prefix: Prefix prepended to retained document text (default: none)
+            retry_policy: Bounded retry policy for transient upstream failures
+                (default: EmbeddingRetryPolicy() built-in defaults)
         """
         self.api_base = api_base.rstrip("/")
         self.api_key = api_key
@@ -1200,6 +1413,7 @@ class LiteLLMEmbeddings(Embeddings):
         self.timeout = timeout
         self.query_prefix = query_prefix
         self.passage_prefix = passage_prefix
+        self.retry_policy = retry_policy or EmbeddingRetryPolicy()
         self._client: httpx.Client | None = None
         self._dimension: int | None = None
 
@@ -1258,16 +1472,30 @@ class LiteLLMEmbeddings(Embeddings):
 
         all_embeddings = []
 
+        # One retry budget for the whole call: batching must not multiply the
+        # worst-case added latency of a single encode().
+        budget = self.retry_policy.new_budget()
+
         # Process in batches
         for i in range(0, len(texts), self.batch_size):
             batch = texts[i : i + self.batch_size]
 
-            response = self._client.post(
-                f"{self.api_base}/embeddings",
-                json={"model": self.model, "input": batch},
+            def post_batch(payload_batch=batch):
+                response = self._client.post(
+                    f"{self.api_base}/embeddings",
+                    json={"model": self.model, "input": payload_batch},
+                )
+                # Inside the retried closure so a 5xx from the proxy is retried
+                # rather than raised straight through to the caller.
+                response.raise_for_status()
+                return response.json()
+
+            result = _call_with_retry(
+                post_batch,
+                policy=self.retry_policy,
+                budget=budget,
+                provider=self.provider_name,
             )
-            response.raise_for_status()
-            result = response.json()
 
             # Sort by index to ensure correct order
             batch_embeddings = sorted(result["data"], key=lambda x: x["index"])
@@ -1301,6 +1529,7 @@ class LiteLLMSDKEmbeddings(Embeddings):
         encoding_format: str | None = "float",
         query_prefix: str = "",
         passage_prefix: str = "",
+        retry_policy: EmbeddingRetryPolicy | None = None,
     ):
         """
         Initialize LiteLLM SDK embeddings client.
@@ -1317,6 +1546,8 @@ class LiteLLMSDKEmbeddings(Embeddings):
                 Set to None or empty string to omit (needed for Voyage AI, Gemini).
             query_prefix: Prefix prepended to recall/search queries (default: none)
             passage_prefix: Prefix prepended to retained document text (default: none)
+            retry_policy: Bounded retry policy for transient upstream failures
+                (default: EmbeddingRetryPolicy() built-in defaults)
         """
         self.api_key = api_key
         self.model = model
@@ -1327,6 +1558,7 @@ class LiteLLMSDKEmbeddings(Embeddings):
         self.encoding_format = encoding_format or None
         self.query_prefix = query_prefix
         self.passage_prefix = passage_prefix
+        self.retry_policy = retry_policy or EmbeddingRetryPolicy()
         self._litellm = None  # Will be set during initialization
         self._dimension: int | None = None
 
@@ -1361,6 +1593,9 @@ class LiteLLMSDKEmbeddings(Embeddings):
             embed_kwargs = {
                 "model": self.model,
                 "input": ["test"],
+                # Without this litellm falls back to its own (much larger) default
+                # timeout, so a stalled provider would hang startup for minutes.
+                "timeout": self.timeout,
             }
             if self.api_key:
                 embed_kwargs["api_key"] = self.api_key
@@ -1375,8 +1610,15 @@ class LiteLLMSDKEmbeddings(Embeddings):
             if self.model.startswith("voyage/"):
                 embed_kwargs["input_type"] = "document"
 
-            # Use async embedding method (standard in litellm)
-            response = await self._litellm.aembedding(**embed_kwargs)
+            # Use async embedding method (standard in litellm). Retried on transient
+            # upstream errors: a flaky provider must not take the whole API down at
+            # startup, since dimension detection gates initialization.
+            response = await _acall_with_retry(
+                lambda: self._litellm.aembedding(**embed_kwargs),
+                policy=self.retry_policy,
+                budget=self.retry_policy.new_budget(),
+                provider=self.provider_name,
+            )
 
             # Extract dimension from response
             if response.data and len(response.data) > 0:
@@ -1423,6 +1665,10 @@ class LiteLLMSDKEmbeddings(Embeddings):
 
         all_embeddings = []
 
+        # One retry budget for the whole call: batching must not multiply the
+        # worst-case added latency of a single encode().
+        budget = self.retry_policy.new_budget()
+
         # Process in batches
         for i in range(0, len(texts), self.batch_size):
             batch = texts[i : i + self.batch_size]
@@ -1432,6 +1678,10 @@ class LiteLLMSDKEmbeddings(Embeddings):
                 embed_kwargs = {
                     "model": self.model,
                     "input": batch,
+                    # Without this litellm falls back to its own (much larger)
+                    # default timeout, which would let one stalled request hang a
+                    # synchronous recall far past the retry budget.
+                    "timeout": self.timeout,
                 }
                 if self.api_key:
                     embed_kwargs["api_key"] = self.api_key
@@ -1446,8 +1696,15 @@ class LiteLLMSDKEmbeddings(Embeddings):
                 if input_type is not None:
                     embed_kwargs["input_type"] = input_type
 
-                # Use sync embedding (litellm doesn't have async in thread-safe way)
-                response = self._litellm.embedding(**embed_kwargs)
+                # Use sync embedding (litellm doesn't have async in thread-safe way).
+                # Recall runs this inline, so transient upstream failures are retried
+                # here rather than surfacing as a failed recall.
+                response = _call_with_retry(
+                    lambda kwargs=embed_kwargs: self._litellm.embedding(**kwargs),
+                    policy=self.retry_policy,
+                    budget=budget,
+                    provider=self.provider_name,
+                )
 
                 # Extract embeddings from response
                 # Sort by index to ensure correct order
@@ -1684,6 +1941,16 @@ class GeminiEmbeddings(Embeddings):
         return all_embeddings
 
 
+def _retry_policy_from_config(config: "HindsightConfig") -> EmbeddingRetryPolicy:
+    """Build the embedding retry policy from resolved configuration."""
+    return EmbeddingRetryPolicy(
+        max_retries=config.embeddings_max_retries,
+        initial_backoff=config.embeddings_initial_backoff,
+        max_backoff=config.embeddings_max_backoff,
+        budget_seconds=config.embeddings_retry_budget,
+    )
+
+
 def create_embeddings_from_env() -> Embeddings:
     """
     Create an Embeddings instance based on configuration.
@@ -1835,6 +2102,7 @@ def create_embeddings_from_env() -> Embeddings:
             model=config.embeddings_litellm_model,
             query_prefix=query_prefix,
             passage_prefix=passage_prefix,
+            retry_policy=_retry_policy_from_config(config),
         )
     elif provider == "litellm-sdk":
         return LiteLLMSDKEmbeddings(
@@ -1845,6 +2113,7 @@ def create_embeddings_from_env() -> Embeddings:
             encoding_format=config.embeddings_litellm_sdk_encoding_format,
             query_prefix=query_prefix,
             passage_prefix=passage_prefix,
+            retry_policy=_retry_policy_from_config(config),
         )
     elif provider == "google":
         vertexai_project_id = config.embeddings_vertexai_project_id

--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -9,13 +9,17 @@ The database schema is automatically adjusted to match the model's dimension.
 Configuration via environment variables - see hindsight_api.config for all env var names.
 """
 
+import asyncio
 import base64
 import logging
 import os
 import struct
+import time
 import warnings
 from abc import ABC, abstractmethod
-from typing import Literal, cast
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, TypeVar, cast
 from urllib.parse import parse_qs, urlparse, urlunparse
 
 import httpx
@@ -24,10 +28,14 @@ from pydantic import BaseModel
 from ..config import (
     DEFAULT_EMBEDDINGS_COHERE_MODEL,
     DEFAULT_EMBEDDINGS_GEMINI_MODEL,
+    DEFAULT_EMBEDDINGS_INITIAL_BACKOFF,
     DEFAULT_EMBEDDINGS_LITELLM_MODEL,
     DEFAULT_EMBEDDINGS_LITELLM_SDK_MODEL,
     DEFAULT_EMBEDDINGS_LOCAL_MODEL,
+    DEFAULT_EMBEDDINGS_MAX_BACKOFF,
+    DEFAULT_EMBEDDINGS_MAX_RETRIES,
     DEFAULT_EMBEDDINGS_OPENAI_MODEL,
+    DEFAULT_EMBEDDINGS_RETRY_BUDGET,
     DEFAULT_EMBEDDINGS_ZEROENTROPY_BATCH_SIZE,
     DEFAULT_EMBEDDINGS_ZEROENTROPY_DIMENSIONS,
     DEFAULT_EMBEDDINGS_ZEROENTROPY_ENCODING_FORMAT,
@@ -55,7 +63,209 @@ from .local_device import (
 )
 from .tei_retry import tei_retry_delay
 
+if TYPE_CHECKING:
+    from ..config import HindsightConfig
+
 logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# 4xx codes that describe a transient condition rather than a bad request.
+# Everything else in the 4xx range (auth, validation, not-found) is a client-side
+# problem that retrying cannot fix.
+_TRANSIENT_STATUS_CODES = frozenset({408, 409, 425, 429})
+
+# Exception class names treated as transient when the exception carries no HTTP
+# status code. Matching by name keeps this module free of a hard litellm/openai
+# import (litellm is imported lazily, and only by the providers that need it).
+_TRANSIENT_EXCEPTION_NAMES = frozenset(
+    {
+        "APIConnectionError",
+        "APIError",
+        "APITimeoutError",
+        "ConnectionError",
+        "InternalServerError",
+        "RateLimitError",
+        "ServiceUnavailableError",
+        "Timeout",
+        "TimeoutError",
+    }
+)
+
+
+@dataclass(frozen=True)
+class EmbeddingRetryPolicy:
+    """
+    Bounded retry policy for remote embedding APIs.
+
+    Recall embeds the query inline on the request path, so a single upstream 5xx
+    would otherwise become a user-visible recall failure. Retries are bounded two
+    ways at once:
+
+    * ``max_retries`` caps the number of extra attempts (0 disables retrying).
+    * ``budget_seconds`` caps the wall-clock time a single ``encode()`` call may
+      *waste* on retries — failed attempts plus backoff sleeps. Successful work
+      never counts against it, so a large multi-batch encode is not penalised for
+      the batches that worked, while the worst-case added latency stays bounded.
+
+    The pairing matters: attempts alone cannot bound latency (an upstream that
+    fails slowly turns 5 attempts into minutes), and a budget alone cannot stop a
+    fast-failing upstream from being hammered.
+    """
+
+    max_retries: int = DEFAULT_EMBEDDINGS_MAX_RETRIES
+    initial_backoff: float = DEFAULT_EMBEDDINGS_INITIAL_BACKOFF
+    max_backoff: float = DEFAULT_EMBEDDINGS_MAX_BACKOFF
+    budget_seconds: float = DEFAULT_EMBEDDINGS_RETRY_BUDGET
+
+    def new_budget(self) -> "_RetryBudget":
+        """Start a fresh retry budget, scoped to one logical embedding call."""
+        return _RetryBudget(self.budget_seconds)
+
+
+class _RetryBudget:
+    """Mutable remaining-retry-time counter shared across the batches of one call."""
+
+    __slots__ = ("remaining",)
+
+    def __init__(self, seconds: float):
+        self.remaining = max(0.0, seconds)
+
+    @property
+    def exhausted(self) -> bool:
+        return self.remaining <= 0.0
+
+    def spend(self, seconds: float) -> None:
+        self.remaining = max(0.0, self.remaining - max(0.0, seconds))
+
+
+def _status_code_of(exc: BaseException) -> int | None:
+    """Best-effort HTTP status extraction across httpx, openai and litellm errors."""
+    candidates = (
+        getattr(exc, "status_code", None),
+        getattr(getattr(exc, "response", None), "status_code", None),
+    )
+    for candidate in candidates:
+        if isinstance(candidate, bool):
+            continue
+        if isinstance(candidate, int):
+            return candidate
+        if isinstance(candidate, str) and candidate.isdigit():
+            return int(candidate)
+    return None
+
+
+def _is_transient_embedding_error(exc: BaseException) -> bool:
+    """
+    Return True when ``exc`` is worth retrying.
+
+    A status code, when present, is authoritative: 5xx and the transient 4xx set
+    are retryable, every other 4xx (401/403 auth, 400/422 validation, 404) is
+    permanent and must fail fast. Without a status code we fall back to
+    transport-level exception types and known SDK exception names.
+    """
+    status = _status_code_of(exc)
+    if status is not None:
+        return status >= 500 or status in _TRANSIENT_STATUS_CODES
+    if isinstance(exc, (httpx.TimeoutException, httpx.NetworkError, httpx.RemoteProtocolError)):
+        return True
+    if isinstance(exc, (TimeoutError, ConnectionError)):
+        return True
+    return type(exc).__name__ in _TRANSIENT_EXCEPTION_NAMES
+
+
+def _retry_delay_for(
+    exc: BaseException,
+    *,
+    attempt: int,
+    attempts: int,
+    policy: EmbeddingRetryPolicy,
+    budget: _RetryBudget,
+    provider: str,
+) -> float | None:
+    """
+    Decide whether ``exc`` should be retried and how long to wait first.
+
+    Returns the sleep duration, or None when the exception must propagate. Logs
+    the decision and charges the sleep to ``budget``. Upstream error text is
+    truncated (matching the LLM providers) so a verbose provider payload cannot
+    flood the log.
+    """
+    if not _is_transient_embedding_error(exc):
+        return None
+
+    status = _status_code_of(exc)
+    status_label = f"HTTP {status}" if status is not None else type(exc).__name__
+    detail = str(exc)[:200]
+
+    if attempt >= attempts - 1:
+        logger.error(f"{provider} embedding call failed after {attempts} attempt(s) ({status_label}): {detail}")
+        return None
+
+    if budget.exhausted:
+        logger.error(
+            f"{provider} embedding call failed on attempt {attempt + 1}/{attempts} ({status_label}) and the "
+            f"{policy.budget_seconds:.1f}s retry budget is exhausted, giving up: {detail}"
+        )
+        return None
+
+    backoff = min(policy.initial_backoff * (2**attempt), policy.max_backoff)
+    jitter = backoff * 0.2 * (2 * (time.time() % 1) - 1)
+    sleep_for = min(max(0.0, backoff + jitter), budget.remaining)
+    budget.spend(sleep_for)
+    logger.warning(
+        f"{provider} embedding call failed (attempt {attempt + 1}/{attempts}, {status_label}), "
+        f"retrying in {sleep_for:.2f}s ({budget.remaining:.1f}s of retry budget left): {detail}"
+    )
+    return sleep_for
+
+
+def _call_with_retry(
+    call: Callable[[], T],
+    *,
+    policy: EmbeddingRetryPolicy,
+    budget: _RetryBudget,
+    provider: str,
+) -> T:
+    """Run a blocking embedding call, retrying transient upstream failures."""
+    attempts = policy.max_retries + 1
+    for attempt in range(attempts):
+        started = time.monotonic()
+        try:
+            return call()
+        except Exception as exc:
+            budget.spend(time.monotonic() - started)
+            delay = _retry_delay_for(
+                exc, attempt=attempt, attempts=attempts, policy=policy, budget=budget, provider=provider
+            )
+            if delay is None:
+                raise
+            time.sleep(delay)
+    raise RuntimeError("unreachable: retry loop exited without returning or raising")
+
+
+async def _acall_with_retry(
+    call: Callable[[], Awaitable[T]],
+    *,
+    policy: EmbeddingRetryPolicy,
+    budget: _RetryBudget,
+    provider: str,
+) -> T:
+    """Async twin of :func:`_call_with_retry`, sharing its policy and classification."""
+    attempts = policy.max_retries + 1
+    for attempt in range(attempts):
+        started = time.monotonic()
+        try:
+            return await call()
+        except Exception as exc:
+            budget.spend(time.monotonic() - started)
+            delay = _retry_delay_for(
+                exc, attempt=attempt, attempts=attempts, policy=policy, budget=budget, provider=provider
+            )
+            if delay is None:
+                raise
+            await asyncio.sleep(delay)
+    raise RuntimeError("unreachable: retry loop exited without returning or raising")
 
 
 ZeroEntropyInputType = Literal["document", "query"]
@@ -1121,6 +1331,7 @@ class LiteLLMEmbeddings(Embeddings):
         model: str = DEFAULT_EMBEDDINGS_LITELLM_MODEL,
         batch_size: int = 100,
         timeout: float = 60.0,
+        retry_policy: EmbeddingRetryPolicy | None = None,
     ):
         """
         Initialize LiteLLM embeddings client.
@@ -1132,12 +1343,15 @@ class LiteLLMEmbeddings(Embeddings):
                    Use provider prefix for non-OpenAI models (e.g., cohere/embed-english-v3.0)
             batch_size: Maximum batch size for embedding requests (default: 100)
             timeout: Request timeout in seconds (default: 60.0)
+            retry_policy: Bounded retry policy for transient upstream failures
+                (default: EmbeddingRetryPolicy() built-in defaults)
         """
         self.api_base = api_base.rstrip("/")
         self.api_key = api_key
         self.model = model
         self.batch_size = batch_size
         self.timeout = timeout
+        self.retry_policy = retry_policy or EmbeddingRetryPolicy()
         self._client: httpx.Client | None = None
         self._dimension: int | None = None
 
@@ -1196,16 +1410,30 @@ class LiteLLMEmbeddings(Embeddings):
 
         all_embeddings = []
 
+        # One retry budget for the whole call: batching must not multiply the
+        # worst-case added latency of a single encode().
+        budget = self.retry_policy.new_budget()
+
         # Process in batches
         for i in range(0, len(texts), self.batch_size):
             batch = texts[i : i + self.batch_size]
 
-            response = self._client.post(
-                f"{self.api_base}/embeddings",
-                json={"model": self.model, "input": batch},
+            def post_batch(payload_batch=batch):
+                response = self._client.post(
+                    f"{self.api_base}/embeddings",
+                    json={"model": self.model, "input": payload_batch},
+                )
+                # Inside the retried closure so a 5xx from the proxy is retried
+                # rather than raised straight through to the caller.
+                response.raise_for_status()
+                return response.json()
+
+            result = _call_with_retry(
+                post_batch,
+                policy=self.retry_policy,
+                budget=budget,
+                provider=self.provider_name,
             )
-            response.raise_for_status()
-            result = response.json()
 
             # Sort by index to ensure correct order
             batch_embeddings = sorted(result["data"], key=lambda x: x["index"])
@@ -1238,6 +1466,7 @@ class LiteLLMSDKEmbeddings(Embeddings):
         timeout: float = 60.0,
         encoding_format: str | None = "float",
         max_input_tokens: int | None = None,
+        retry_policy: EmbeddingRetryPolicy | None = None,
     ):
         """
         Initialize LiteLLM SDK embeddings client.
@@ -1256,6 +1485,8 @@ class LiteLLMSDKEmbeddings(Embeddings):
                 (tiktoken cl100k_base) before embedding. Needed for models with a
                 fixed input-token limit (e.g. Bedrock Titan V2's hard 8192 cap),
                 where an oversized text would otherwise fail permanently (#2501).
+            retry_policy: Bounded retry policy for transient upstream failures
+                (default: EmbeddingRetryPolicy() built-in defaults)
         """
         self.api_key = api_key
         self.model = model
@@ -1265,6 +1496,7 @@ class LiteLLMSDKEmbeddings(Embeddings):
         self.timeout = timeout
         self.encoding_format = encoding_format or None
         self.max_input_tokens = max_input_tokens
+        self.retry_policy = retry_policy or EmbeddingRetryPolicy()
         self._litellm = None  # Will be set during initialization
         self._dimension: int | None = None
 
@@ -1299,6 +1531,9 @@ class LiteLLMSDKEmbeddings(Embeddings):
             embed_kwargs = {
                 "model": self.model,
                 "input": ["test"],
+                # Without this litellm falls back to its own (much larger) default
+                # timeout, so a stalled provider would hang startup for minutes.
+                "timeout": self.timeout,
             }
             if self.api_key:
                 embed_kwargs["api_key"] = self.api_key
@@ -1311,8 +1546,15 @@ class LiteLLMSDKEmbeddings(Embeddings):
                 if self.model.startswith("openai/"):
                     embed_kwargs["allowed_openai_params"] = ["dimensions"]
 
-            # Use async embedding method (standard in litellm)
-            response = await self._litellm.aembedding(**embed_kwargs)
+            # Use async embedding method (standard in litellm). Retried on transient
+            # upstream errors: a flaky provider must not take the whole API down at
+            # startup, since dimension detection gates initialization.
+            response = await _acall_with_retry(
+                lambda: self._litellm.aembedding(**embed_kwargs),
+                policy=self.retry_policy,
+                budget=self.retry_policy.new_budget(),
+                provider=self.provider_name,
+            )
 
             # Extract dimension from response
             if response.data and len(response.data) > 0:
@@ -1370,6 +1612,10 @@ class LiteLLMSDKEmbeddings(Embeddings):
 
         all_embeddings = []
 
+        # One retry budget for the whole call: batching must not multiply the
+        # worst-case added latency of a single encode().
+        budget = self.retry_policy.new_budget()
+
         # Process in batches
         for i in range(0, len(texts), self.batch_size):
             batch = texts[i : i + self.batch_size]
@@ -1379,6 +1625,10 @@ class LiteLLMSDKEmbeddings(Embeddings):
                 embed_kwargs = {
                     "model": self.model,
                     "input": batch,
+                    # Without this litellm falls back to its own (much larger)
+                    # default timeout, which would let one stalled request hang a
+                    # synchronous recall far past the retry budget.
+                    "timeout": self.timeout,
                 }
                 if self.api_key:
                     embed_kwargs["api_key"] = self.api_key
@@ -1391,8 +1641,15 @@ class LiteLLMSDKEmbeddings(Embeddings):
                     if self.model.startswith("openai/"):
                         embed_kwargs["allowed_openai_params"] = ["dimensions"]
 
-                # Use sync embedding (litellm doesn't have async in thread-safe way)
-                response = self._litellm.embedding(**embed_kwargs)
+                # Use sync embedding (litellm doesn't have async in thread-safe way).
+                # Recall runs this inline, so transient upstream failures are retried
+                # here rather than surfacing as a failed recall.
+                response = _call_with_retry(
+                    lambda kwargs=embed_kwargs: self._litellm.embedding(**kwargs),
+                    policy=self.retry_policy,
+                    budget=budget,
+                    provider=self.provider_name,
+                )
 
                 # Extract embeddings from response
                 # Sort by index to ensure correct order
@@ -1629,6 +1886,16 @@ class GeminiEmbeddings(Embeddings):
         return all_embeddings
 
 
+def _retry_policy_from_config(config: "HindsightConfig") -> EmbeddingRetryPolicy:
+    """Build the embedding retry policy from resolved configuration."""
+    return EmbeddingRetryPolicy(
+        max_retries=config.embeddings_max_retries,
+        initial_backoff=config.embeddings_initial_backoff,
+        max_backoff=config.embeddings_max_backoff,
+        budget_seconds=config.embeddings_retry_budget,
+    )
+
+
 def create_embeddings_from_env() -> Embeddings:
     """
     Create an Embeddings instance based on configuration.
@@ -1752,6 +2019,7 @@ def create_embeddings_from_env() -> Embeddings:
             api_base=config.embeddings_litellm_api_base,
             api_key=config.embeddings_litellm_api_key,
             model=config.embeddings_litellm_model,
+            retry_policy=_retry_policy_from_config(config),
         )
     elif provider == "litellm-sdk":
         return LiteLLMSDKEmbeddings(
@@ -1761,6 +2029,7 @@ def create_embeddings_from_env() -> Embeddings:
             output_dimensions=config.embeddings_litellm_sdk_output_dimensions,
             encoding_format=config.embeddings_litellm_sdk_encoding_format,
             max_input_tokens=config.embeddings_litellm_sdk_max_input_tokens,
+            retry_policy=_retry_policy_from_config(config),
         )
     elif provider == "google":
         vertexai_project_id = config.embeddings_vertexai_project_id

--- a/hindsight-api-slim/tests/test_embedding_retry.py
+++ b/hindsight-api-slim/tests/test_embedding_retry.py
@@ -16,10 +16,12 @@ contract of the retry wrapper:
 import time
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
 
 from hindsight_api.engine.embeddings import (
     EmbeddingRetryPolicy,
+    LiteLLMEmbeddings,
     LiteLLMSDKEmbeddings,
     _is_transient_embedding_error,
 )
@@ -308,3 +310,64 @@ class TestPolicyFromConfig:
 
         assert 3 <= policy.max_retries + 1 <= 5
         assert policy.budget_seconds <= 15.0
+
+
+class TestLiteLLMProxyEncodeRetries:
+    """
+    The `litellm` proxy provider is the sibling of `litellm-sdk` and shares the
+    retry wrapper. It needs its own coverage because it fails differently: the
+    proxy returns an ordinary HTTP response, so the 5xx only becomes an exception
+    when `raise_for_status()` runs — and that call had to move *inside* the
+    retried closure for a proxy 5xx to be retried rather than raised straight
+    through to the caller.
+    """
+
+    def _make_proxy(self, policy: EmbeddingRetryPolicy, batch_size: int = 100) -> LiteLLMEmbeddings:
+        emb = LiteLLMEmbeddings(
+            api_base="https://proxy.invalid",
+            api_key="test_key",
+            model="text-embedding-3-small",
+            batch_size=batch_size,
+            retry_policy=policy,
+        )
+        emb._client = MagicMock()
+        emb._dimension = 768
+        return emb
+
+    def _http_response(self, status_code: int, texts: list[str] | None = None) -> MagicMock:
+        response = MagicMock()
+        response.status_code = status_code
+        if status_code >= 400:
+            request = httpx.Request("POST", "https://proxy.invalid/embeddings")
+            error = httpx.HTTPStatusError(
+                f"{status_code} error", request=request, response=httpx.Response(status_code, request=request)
+            )
+            response.raise_for_status.side_effect = error
+        else:
+            response.json.return_value = {
+                "data": [{"embedding": [0.1] * 768, "index": i} for i in range(len(texts or []))]
+            }
+        return response
+
+    def test_proxy_5xx_is_retried_then_succeeds(self):
+        emb = self._make_proxy(FAST_POLICY)
+        texts = ["what did we decide about embeddings?"]
+        emb._client.post.side_effect = [
+            self._http_response(503),
+            self._http_response(200, texts),
+        ]
+
+        result = emb.encode(texts)
+
+        assert len(result) == 1
+        assert len(result[0]) == 768
+        assert emb._client.post.call_count == 2
+
+    def test_proxy_4xx_raises_immediately_without_retrying(self):
+        emb = self._make_proxy(FAST_POLICY)
+        emb._client.post.return_value = self._http_response(401)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            emb.encode(["query"])
+
+        assert emb._client.post.call_count == 1

--- a/hindsight-api-slim/tests/test_embedding_retry.py
+++ b/hindsight-api-slim/tests/test_embedding_retry.py
@@ -1,0 +1,310 @@
+"""
+Tests for bounded retry/backoff on remote embedding calls.
+
+Recall generates its query embedding synchronously on the request path, so a
+single upstream 5xx used to surface as a failed recall. These tests pin the
+contract of the retry wrapper:
+
+1. Transient failures (5xx, timeouts, connection errors) are retried and a later
+   success is returned.
+2. Persistent transient failures still raise, after a bounded number of attempts.
+3. Non-transient failures (4xx auth/validation) raise immediately, with no retry.
+4. The wall-clock retry budget caps how long a single encode() call can spend
+   retrying, and batching does not multiply it.
+"""
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from hindsight_api.engine.embeddings import (
+    EmbeddingRetryPolicy,
+    LiteLLMSDKEmbeddings,
+    _is_transient_embedding_error,
+)
+
+
+class _StatusError(Exception):
+    """Stand-in for litellm/openai errors, which expose `status_code`."""
+
+    def __init__(self, status_code: int, message: str = "upstream error"):
+        super().__init__(f"{message} (status {status_code})")
+        self.status_code = status_code
+
+
+class _InternalServerError(_StatusError):
+    """Matches litellm.InternalServerError closely enough for classification."""
+
+    def __init__(self, message: str = "Venice AI returned 500"):
+        super().__init__(500, message)
+
+
+class _AuthenticationError(_StatusError):
+    def __init__(self, message: str = "invalid api key"):
+        super().__init__(401, message)
+
+
+def _response_for(texts):
+    response = MagicMock()
+    response.data = [{"embedding": [0.1] * 768, "index": i} for i in range(len(texts))]
+    return response
+
+
+def _make_embeddings(policy: EmbeddingRetryPolicy, batch_size: int = 100) -> LiteLLMSDKEmbeddings:
+    emb = LiteLLMSDKEmbeddings(
+        api_key="test_key",
+        model="openai/text-embedding-qwen3-8b",
+        api_base="https://example.invalid/api/v1",
+        batch_size=batch_size,
+        timeout=60.0,
+        retry_policy=policy,
+    )
+    emb._litellm = MagicMock()
+    emb._dimension = 768
+    return emb
+
+
+# Fast policy so the tests exercise the logic, not the sleeps.
+FAST_POLICY = EmbeddingRetryPolicy(max_retries=4, initial_backoff=0.01, max_backoff=0.04, budget_seconds=5.0)
+
+
+class TestTransientClassification:
+    """Only genuinely transient failures should be retried."""
+
+    @pytest.mark.parametrize("status", [500, 502, 503, 504, 408, 429])
+    def test_transient_status_codes(self, status):
+        assert _is_transient_embedding_error(_StatusError(status)) is True
+
+    @pytest.mark.parametrize("status", [400, 401, 403, 404, 422])
+    def test_client_error_status_codes_are_not_transient(self, status):
+        assert _is_transient_embedding_error(_StatusError(status)) is False
+
+    def test_transport_errors_are_transient(self):
+        import httpx
+
+        assert _is_transient_embedding_error(httpx.ConnectError("connection refused")) is True
+        assert _is_transient_embedding_error(httpx.ReadTimeout("read timed out")) is True
+        assert _is_transient_embedding_error(TimeoutError("timed out")) is True
+        assert _is_transient_embedding_error(ConnectionError("reset by peer")) is True
+
+    def test_named_sdk_errors_are_transient_without_status(self):
+        class APITimeoutError(Exception):
+            pass
+
+        assert _is_transient_embedding_error(APITimeoutError("no status attribute")) is True
+
+    def test_unknown_errors_are_not_transient(self):
+        assert _is_transient_embedding_error(ValueError("bad input")) is False
+        assert _is_transient_embedding_error(Exception("API Error")) is False
+
+
+class TestEncodeRetries:
+    """encode() is the synchronous path recall runs inline."""
+
+    def test_transient_then_success(self):
+        emb = _make_embeddings(FAST_POLICY)
+        calls = {"n": 0}
+
+        def side_effect(**kwargs):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise _InternalServerError()
+            return _response_for(kwargs["input"])
+
+        emb._litellm.embedding.side_effect = side_effect
+
+        result = emb.encode(["what did we decide about embeddings?"])
+
+        assert len(result) == 1
+        assert len(result[0]) == 768
+        assert emb._litellm.embedding.call_count == 3
+
+    def test_persistent_transient_failure_raises_after_attempt_cap(self):
+        emb = _make_embeddings(FAST_POLICY)
+        emb._litellm.embedding.side_effect = _InternalServerError()
+
+        with pytest.raises(_InternalServerError):
+            emb.encode(["query"])
+
+        # max_retries=4 -> 5 attempts total, then the original error propagates.
+        assert emb._litellm.embedding.call_count == FAST_POLICY.max_retries + 1
+
+    def test_auth_error_raises_immediately_with_no_retries(self):
+        emb = _make_embeddings(FAST_POLICY)
+        emb._litellm.embedding.side_effect = _AuthenticationError()
+
+        with pytest.raises(_AuthenticationError):
+            emb.encode(["query"])
+
+        assert emb._litellm.embedding.call_count == 1
+
+    @pytest.mark.parametrize("status", [400, 403, 404, 422])
+    def test_other_client_errors_raise_immediately(self, status):
+        emb = _make_embeddings(FAST_POLICY)
+        emb._litellm.embedding.side_effect = _StatusError(status)
+
+        with pytest.raises(_StatusError):
+            emb.encode(["query"])
+
+        assert emb._litellm.embedding.call_count == 1
+
+    def test_retries_disabled_by_zero_max_retries(self):
+        emb = _make_embeddings(EmbeddingRetryPolicy(max_retries=0, budget_seconds=5.0))
+        emb._litellm.embedding.side_effect = _InternalServerError()
+
+        with pytest.raises(_InternalServerError):
+            emb.encode(["query"])
+
+        assert emb._litellm.embedding.call_count == 1
+
+
+class TestRetryBudget:
+    """The budget is what keeps a degraded upstream from stalling a recall."""
+
+    def test_budget_cuts_retries_short_and_bounds_wall_clock(self):
+        # Each failed attempt burns ~0.2s, so a 0.5s budget cannot fund the full
+        # 5 attempts even though max_retries would allow them.
+        policy = EmbeddingRetryPolicy(max_retries=4, initial_backoff=0.05, max_backoff=0.2, budget_seconds=0.5)
+        emb = _make_embeddings(policy)
+
+        def slow_failure(**kwargs):
+            time.sleep(0.2)
+            raise _InternalServerError()
+
+        emb._litellm.embedding.side_effect = slow_failure
+
+        started = time.monotonic()
+        with pytest.raises(_InternalServerError):
+            emb.encode(["query"])
+        elapsed = time.monotonic() - started
+
+        assert emb._litellm.embedding.call_count < policy.max_retries + 1
+        # Budget + one in-flight attempt is the ceiling; the point is that it is
+        # bounded and small, not the exact figure.
+        assert elapsed < policy.budget_seconds + 0.5
+
+    def test_budget_is_shared_across_batches(self):
+        # 6 texts at batch_size=2 -> 3 batches. A per-batch budget would let the
+        # call spend 3x the configured ceiling.
+        policy = EmbeddingRetryPolicy(max_retries=4, initial_backoff=0.05, max_backoff=0.2, budget_seconds=0.4)
+        emb = _make_embeddings(policy, batch_size=2)
+
+        def slow_failure(**kwargs):
+            time.sleep(0.15)
+            raise _InternalServerError()
+
+        emb._litellm.embedding.side_effect = slow_failure
+
+        started = time.monotonic()
+        with pytest.raises(_InternalServerError):
+            emb.encode([f"text {i}" for i in range(6)])
+        elapsed = time.monotonic() - started
+
+        # The first batch never succeeds, so the call aborts there.
+        assert elapsed < policy.budget_seconds + 0.5
+
+    def test_budget_not_consumed_by_successful_batches(self):
+        # A long run of successful batches must not starve a later batch of its
+        # retries — only failures and backoff sleeps count against the budget.
+        policy = EmbeddingRetryPolicy(max_retries=4, initial_backoff=0.01, max_backoff=0.04, budget_seconds=0.5)
+        emb = _make_embeddings(policy, batch_size=1)
+        calls = {"n": 0}
+
+        def side_effect(**kwargs):
+            calls["n"] += 1
+            time.sleep(0.1)  # successful but slow
+            if calls["n"] == 4:
+                raise _InternalServerError()
+            return _response_for(kwargs["input"])
+
+        emb._litellm.embedding.side_effect = side_effect
+
+        result = emb.encode([f"text {i}" for i in range(5)])
+
+        assert len(result) == 5
+        # 5 batches + 1 retry of the batch that failed.
+        assert emb._litellm.embedding.call_count == 6
+
+
+class TestInitializeRetries:
+    """Dimension detection gates startup; a flaky provider must not blow it up."""
+
+    async def test_initialize_retries_transient_failure(self, monkeypatch):
+        import litellm
+
+        calls = {"n": 0}
+
+        async def flaky_aembedding(**kwargs):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise _InternalServerError()
+            return _response_for(["test"])
+
+        monkeypatch.setattr(litellm, "aembedding", flaky_aembedding, raising=False)
+
+        emb = LiteLLMSDKEmbeddings(
+            api_key="test_key",
+            model="openai/text-embedding-qwen3-8b",
+            api_base="https://example.invalid/api/v1",
+            retry_policy=FAST_POLICY,
+        )
+        await emb.initialize()
+
+        assert emb.dimension == 768
+        assert calls["n"] == 3
+
+    async def test_initialize_does_not_retry_auth_failure(self, monkeypatch):
+        import litellm
+
+        calls = {"n": 0}
+
+        async def failing_aembedding(**kwargs):
+            calls["n"] += 1
+            raise _AuthenticationError()
+
+        monkeypatch.setattr(litellm, "aembedding", failing_aembedding, raising=False)
+
+        emb = LiteLLMSDKEmbeddings(
+            api_key="bad_key",
+            model="openai/text-embedding-qwen3-8b",
+            api_base="https://example.invalid/api/v1",
+            retry_policy=FAST_POLICY,
+        )
+        with pytest.raises(RuntimeError, match="Failed to initialize LiteLLM SDK embeddings"):
+            await emb.initialize()
+
+        assert calls["n"] == 1
+
+
+class TestPolicyFromConfig:
+    """Attempts and budget must be tunable without a code change."""
+
+    def test_env_overrides_are_picked_up(self, monkeypatch):
+        from hindsight_api.config import (
+            ENV_EMBEDDINGS_INITIAL_BACKOFF,
+            ENV_EMBEDDINGS_MAX_BACKOFF,
+            ENV_EMBEDDINGS_MAX_RETRIES,
+            ENV_EMBEDDINGS_RETRY_BUDGET,
+            HindsightConfig,
+        )
+        from hindsight_api.engine.embeddings import _retry_policy_from_config
+
+        monkeypatch.setenv(ENV_EMBEDDINGS_MAX_RETRIES, "2")
+        monkeypatch.setenv(ENV_EMBEDDINGS_INITIAL_BACKOFF, "0.25")
+        monkeypatch.setenv(ENV_EMBEDDINGS_MAX_BACKOFF, "2.5")
+        monkeypatch.setenv(ENV_EMBEDDINGS_RETRY_BUDGET, "7.5")
+
+        config = HindsightConfig.from_env()
+        policy = _retry_policy_from_config(config)
+
+        assert policy.max_retries == 2
+        assert policy.initial_backoff == 0.25
+        assert policy.max_backoff == 2.5
+        assert policy.budget_seconds == 7.5
+
+    def test_defaults_are_bounded(self):
+        policy = EmbeddingRetryPolicy()
+
+        assert 3 <= policy.max_retries + 1 <= 5
+        assert policy.budget_seconds <= 15.0

--- a/hindsight-api-slim/tests/test_litellm_sdk_embeddings.py
+++ b/hindsight-api-slim/tests/test_litellm_sdk_embeddings.py
@@ -82,6 +82,7 @@ class TestLiteLLMSDKEmbeddings:
                 model="cohere/embed-english-v3.0",
                 input=["test"],
                 api_key="test_key",
+                timeout=60.0,
                 encoding_format="float",
             )
 
@@ -218,6 +219,7 @@ class TestLiteLLMSDKEmbeddings:
             model="cohere/embed-english-v3.0",
             input=["Hello world"],
             api_key="test_key",
+            timeout=60.0,
             encoding_format="float",
         )
 

--- a/hindsight-api-slim/tests/test_litellm_sdk_embeddings.py
+++ b/hindsight-api-slim/tests/test_litellm_sdk_embeddings.py
@@ -82,6 +82,7 @@ class TestLiteLLMSDKEmbeddings:
                 model="cohere/embed-english-v3.0",
                 input=["test"],
                 api_key="test_key",
+                timeout=60.0,
                 encoding_format="float",
             )
 
@@ -174,6 +175,7 @@ class TestLiteLLMSDKEmbeddings:
             model="cohere/embed-english-v3.0",
             input=["Hello world"],
             api_key="test_key",
+            timeout=60.0,
             encoding_format="float",
         )
 

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -728,6 +728,10 @@ server-level only (not overridable per tenant/bank) and a change requires a rest
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL` | Custom base URL for OpenAI-compatible API (e.g., Azure OpenAI) | - |
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_BATCH_SIZE` | Max inputs per `embeddings.create` call for `openai`/`openrouter` providers — lower this when the upstream endpoint enforces stricter limits (e.g. DashScope caps at 10) | `100` |
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_DIMENSIONS` | Optional requested output dimensions for OpenAI `text-embedding-3` models (e.g., `384` to match an existing pgvector schema) | - |
+| `HINDSIGHT_API_EMBEDDINGS_MAX_RETRIES` | Retries after the first attempt when a remote embedding call fails transiently (5xx, timeout, connection error). `0` disables retrying. Applies to the `litellm` and `litellm-sdk` providers; 4xx auth/validation errors are never retried. | `4` |
+| `HINDSIGHT_API_EMBEDDINGS_INITIAL_BACKOFF` | Initial backoff in seconds between embedding retries (doubles per attempt, with jitter) | `0.5` |
+| `HINDSIGHT_API_EMBEDDINGS_MAX_BACKOFF` | Cap on the backoff between embedding retries, in seconds | `4.0` |
+| `HINDSIGHT_API_EMBEDDINGS_RETRY_BUDGET` | Wall-clock ceiling, in seconds, on the time one `encode()` call may spend retrying (failed attempts plus backoff). Keeps a degraded provider from stalling a synchronous recall. | `15.0` |
 | `HINDSIGHT_API_EMBEDDINGS_OPENROUTER_API_KEY` | OpenRouter API key for embeddings (falls back to `HINDSIGHT_API_OPENROUTER_API_KEY`, then `HINDSIGHT_API_LLM_API_KEY`) | - |
 | `HINDSIGHT_API_EMBEDDINGS_REQUESTY_API_KEY` | Requesty API key for embeddings (falls back to `HINDSIGHT_API_REQUESTY_API_KEY`, then `HINDSIGHT_API_LLM_API_KEY`) | - |
 | `HINDSIGHT_API_EMBEDDINGS_REQUESTY_MODEL` | Requesty embedding model | `openai/text-embedding-3-small` |

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -574,6 +574,10 @@ server-level only (not overridable per tenant/bank) and a change requires a rest
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL` | Custom base URL for OpenAI-compatible API (e.g., Azure OpenAI) | - |
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_BATCH_SIZE` | Max inputs per `embeddings.create` call for `openai`/`openrouter` providers — lower this when the upstream endpoint enforces stricter limits (e.g. DashScope caps at 10) | `100` |
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_DIMENSIONS` | Optional requested output dimensions for OpenAI `text-embedding-3` models (e.g., `384` to match an existing pgvector schema) | - |
+| `HINDSIGHT_API_EMBEDDINGS_MAX_RETRIES` | Retries after the first attempt when a remote embedding call fails transiently (5xx, timeout, connection error). `0` disables retrying. Applies to the `litellm` and `litellm-sdk` providers; 4xx auth/validation errors are never retried. | `4` |
+| `HINDSIGHT_API_EMBEDDINGS_INITIAL_BACKOFF` | Initial backoff in seconds between embedding retries (doubles per attempt, with jitter) | `0.5` |
+| `HINDSIGHT_API_EMBEDDINGS_MAX_BACKOFF` | Cap on the backoff between embedding retries, in seconds | `4.0` |
+| `HINDSIGHT_API_EMBEDDINGS_RETRY_BUDGET` | Wall-clock ceiling, in seconds, on the time one `encode()` call may spend retrying (failed attempts plus backoff). Keeps a degraded provider from stalling a synchronous recall. | `15.0` |
 | `HINDSIGHT_API_EMBEDDINGS_OPENROUTER_API_KEY` | OpenRouter API key for embeddings (falls back to `HINDSIGHT_API_OPENROUTER_API_KEY`, then `HINDSIGHT_API_LLM_API_KEY`) | - |
 | `HINDSIGHT_API_EMBEDDINGS_REQUESTY_API_KEY` | Requesty API key for embeddings (falls back to `HINDSIGHT_API_REQUESTY_API_KEY`, then `HINDSIGHT_API_LLM_API_KEY`) | - |
 | `HINDSIGHT_API_EMBEDDINGS_REQUESTY_MODEL` | Requesty embedding model | `openai/text-embedding-3-small` |

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -326,6 +326,14 @@ HINDSIGHT_API_LOG_LEVEL=info
 # DeepSeek note: DeepSeek is supported for LLM calls, but not for embeddings.
 # If using DeepSeek as LLM provider, keep embeddings on local/openai/cohere/google/etc.
 
+# Retry policy for remote embedding calls (litellm / litellm-sdk providers).
+# Transient upstream failures (5xx, timeouts, connection errors) are retried with
+# jittered exponential backoff; 4xx auth/validation errors are never retried.
+# HINDSIGHT_API_EMBEDDINGS_MAX_RETRIES=4        # retries after the first attempt; 0 disables
+# HINDSIGHT_API_EMBEDDINGS_INITIAL_BACKOFF=0.5  # seconds; doubles per attempt, with jitter
+# HINDSIGHT_API_EMBEDDINGS_MAX_BACKOFF=4.0      # cap on per-retry backoff, seconds
+# HINDSIGHT_API_EMBEDDINGS_RETRY_BUDGET=15.0    # wall-clock ceiling per encode() spent retrying
+
 # Embedding similarity thresholds. These defaults preserve the behavior calibrated
 # for BAAI/bge-small-en-v1.5. Recalibrate each threshold independently when changing
 # embedding models because cosine-similarity distributions are model-dependent.

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -222,6 +222,14 @@ HINDSIGHT_API_LOG_LEVEL=info
 # DeepSeek note: DeepSeek is supported for LLM calls, but not for embeddings.
 # If using DeepSeek as LLM provider, keep embeddings on local/openai/cohere/google/etc.
 
+# Retry policy for remote embedding calls (litellm / litellm-sdk providers).
+# Transient upstream failures (5xx, timeouts, connection errors) are retried with
+# jittered exponential backoff; 4xx auth/validation errors are never retried.
+# HINDSIGHT_API_EMBEDDINGS_MAX_RETRIES=4        # retries after the first attempt; 0 disables
+# HINDSIGHT_API_EMBEDDINGS_INITIAL_BACKOFF=0.5  # seconds; doubles per attempt, with jitter
+# HINDSIGHT_API_EMBEDDINGS_MAX_BACKOFF=4.0      # cap on per-retry backoff, seconds
+# HINDSIGHT_API_EMBEDDINGS_RETRY_BUDGET=15.0    # wall-clock ceiling per encode() spent retrying
+
 # Embedding similarity thresholds. These defaults preserve the behavior calibrated
 # for BAAI/bge-small-en-v1.5. Recalibrate each threshold independently when changing
 # embedding models because cosine-similarity distributions are model-dependent.

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -728,6 +728,10 @@ server-level only (not overridable per tenant/bank) and a change requires a rest
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL` | Custom base URL for OpenAI-compatible API (e.g., Azure OpenAI) | - |
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_BATCH_SIZE` | Max inputs per `embeddings.create` call for `openai`/`openrouter` providers — lower this when the upstream endpoint enforces stricter limits (e.g. DashScope caps at 10) | `100` |
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_DIMENSIONS` | Optional requested output dimensions for OpenAI `text-embedding-3` models (e.g., `384` to match an existing pgvector schema) | - |
+| `HINDSIGHT_API_EMBEDDINGS_MAX_RETRIES` | Retries after the first attempt when a remote embedding call fails transiently (5xx, timeout, connection error). `0` disables retrying. Applies to the `litellm` and `litellm-sdk` providers; 4xx auth/validation errors are never retried. | `4` |
+| `HINDSIGHT_API_EMBEDDINGS_INITIAL_BACKOFF` | Initial backoff in seconds between embedding retries (doubles per attempt, with jitter) | `0.5` |
+| `HINDSIGHT_API_EMBEDDINGS_MAX_BACKOFF` | Cap on the backoff between embedding retries, in seconds | `4.0` |
+| `HINDSIGHT_API_EMBEDDINGS_RETRY_BUDGET` | Wall-clock ceiling, in seconds, on the time one `encode()` call may spend retrying (failed attempts plus backoff). Keeps a degraded provider from stalling a synchronous recall. | `15.0` |
 | `HINDSIGHT_API_EMBEDDINGS_OPENROUTER_API_KEY` | OpenRouter API key for embeddings (falls back to `HINDSIGHT_API_OPENROUTER_API_KEY`, then `HINDSIGHT_API_LLM_API_KEY`) | - |
 | `HINDSIGHT_API_EMBEDDINGS_REQUESTY_API_KEY` | Requesty API key for embeddings (falls back to `HINDSIGHT_API_REQUESTY_API_KEY`, then `HINDSIGHT_API_LLM_API_KEY`) | - |
 | `HINDSIGHT_API_EMBEDDINGS_REQUESTY_MODEL` | Requesty embedding model | `openai/text-embedding-3-small` |


### PR DESCRIPTION
## Problem

The `litellm-sdk` and `litellm` embedding providers have no retry handling: one transient upstream failure becomes a user-visible error. We hit this in production when a hosted embedding model started returning intermittent 500s
(`Inference processing failed`), with the model failing ~80% of requests:

- **Recall** (synchronous) returned HTTP 500 to callers on the first upstream  failure.
- **Startup** was gated on the same call: `LiteLLMSDKEmbeddings.initialize()` does dimension detection through the provider, so the API failed to boot most attempts.
- Separately, `LiteLLMSDKEmbeddings` built a `timeout` value but never passed it to litellm, so litellm's much larger default applied, leaving potential for a stalled provider to hang a synchronous recall for minutes.

This is the same failure class [#3001](https://github.com/vectorize-io/hindsight/pull/3001) addressed for the TEI provider (429 backpressure retries); this PR is the litellm-side sibling.

## Change

- `EmbeddingRetryPolicy` (dataclass) + `_call_with_retry` / `_acall_with_retry` in `embeddings.py`:
  - 5 attempts by default (`max_retries=4`), backoff `min(0.5 · 2^n, 4.0)` with ±20% jitter, using the same formula as `openai_compatible_llm.py`.
  - **15s retry budget** counting only *wasted* time (failed attempts + sleeps), shared across all batches of one `encode()` call, so batching can't multiply the worst case and a long successful multi-batch  call isn't starved of retries on a late batch.
  - **Transient-only**: status code is authoritative when present (5xx and 408/409/425/429 retry; other 4xx raise immediately on first attempt). Without a status: transport errors, timeouts, and known SDK exception names (`InternalServerError`, `APITimeoutError`, …), matched by name to avoid importing litellm at module scope.
  - Each retry logs at `warning` with attempt count, status label, and remaining budget.
- Applied to all three litellm call sites: `LiteLLMSDKEmbeddings.encode`, `LiteLLMSDKEmbeddings.initialize` (so a flaky provider can't block boot), and `LiteLLMEmbeddings.encode` (proxy sibling). TEI keeps its existing retry to avoid double-stacking wrappers; OpenAI/Cohere/Gemini delegate to SDKs that already retry internally.
- `timeout` now actually passed to litellm in both `LiteLLMSDKEmbeddings` call sites.
- Config: `HINDSIGHT_API_EMBEDDINGS_{MAX_RETRIES,INITIAL_BACKOFF,MAX_BACKOFF,RETRY_BUDGET}` (env-only, static), documented in `configuration.md` and `.env.example` (embed template synced).

## Tests

`tests/test_embedding_retry.py` (29 tests): transient-then-success; persistent 5xx raises after the attempt cap; 400/401/403/404/422 raise with exactly one call; `max_retries=0` disables; timeout budget is shared across batches but not consumed by successful batches; async `initialize` retries transient and fails fast on auth; env plumbing. Existing `test_litellm_sdk_embeddings.py` updated for the now-passed `timeout` kwarg. `ruff check` / `ruff format` clean; env-template sync test passes