### PR TITLE
feat(embeddings): optional client-side char cap for OpenAI-compatible backends

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -207,6 +207,7 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY=sk-xxxx
 # HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL=text-embedding-3-small
 # HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL=https://api.openai.com/v1
+# HINDSIGHT_API_EMBEDDINGS_OPENAI_TRUNCATE_CHARS=0  # Optional per-input char cap (0 = off). OpenAI-compatible local backends (llama.cpp) hard-reject inputs beyond the model context; capping client-side keeps the batch alive.
 # For ZeroEntropy zembed-1:
 # HINDSIGHT_API_EMBEDDINGS_PROVIDER=zeroentropy
 # HINDSIGHT_API_EMBEDDINGS_ZEROENTROPY_API_KEY=ze-xxxx

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -372,6 +372,7 @@ ENV_EMBEDDINGS_OPENAI_API_KEY = "HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY"
 ENV_EMBEDDINGS_OPENAI_MODEL = "HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL"
 ENV_EMBEDDINGS_OPENAI_BASE_URL = "HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL"
 ENV_EMBEDDINGS_OPENAI_BATCH_SIZE = "HINDSIGHT_API_EMBEDDINGS_OPENAI_BATCH_SIZE"
+ENV_EMBEDDINGS_OPENAI_TRUNCATE_CHARS = "HINDSIGHT_API_EMBEDDINGS_OPENAI_TRUNCATE_CHARS"
 ENV_EMBEDDINGS_OPENAI_DIMENSIONS = "HINDSIGHT_API_EMBEDDINGS_OPENAI_DIMENSIONS"
 
 # Gemini/Vertex AI embeddings configuration
@@ -890,6 +891,8 @@ DEFAULT_EMBEDDINGS_ONNX_QUERY_PREFIX = "query: "
 DEFAULT_EMBEDDINGS_ONNX_PASSAGE_PREFIX = "passage: "
 DEFAULT_EMBEDDINGS_OPENAI_MODEL = "text-embedding-3-small"
 DEFAULT_EMBEDDINGS_OPENAI_BATCH_SIZE = 100
+# 0 = disabled: no client-side truncation of embedding inputs.
+DEFAULT_EMBEDDINGS_OPENAI_TRUNCATE_CHARS = 0
 DEFAULT_EMBEDDINGS_GEMINI_MODEL = "gemini-embedding-001"
 DEFAULT_EMBEDDINGS_GEMINI_OUTPUT_DIMENSIONALITY = 768
 DEFAULT_EMBEDDINGS_GEMINI_FORCE_IPV4 = False
@@ -2221,6 +2224,7 @@ class HindsightConfig:
     # Defaulted fields (source-compatible additions — existing direct constructor callers keep working).
     # Keep at the end of the dataclass; Python forbids non-default fields after default fields.
     embeddings_openai_batch_size: int = DEFAULT_EMBEDDINGS_OPENAI_BATCH_SIZE
+    embeddings_openai_truncate_chars: int = DEFAULT_EMBEDDINGS_OPENAI_TRUNCATE_CHARS
     embeddings_openai_dimensions: int | None = None
     embeddings_zeroentropy_api_key: str | None = None
     embeddings_zeroentropy_model: str = DEFAULT_EMBEDDINGS_ZEROENTROPY_MODEL
@@ -2806,6 +2810,11 @@ class HindsightConfig:
             embeddings_openai_dimensions=_parse_optional_positive_int(
                 ENV_EMBEDDINGS_OPENAI_DIMENSIONS,
                 os.getenv(ENV_EMBEDDINGS_OPENAI_DIMENSIONS),
+            ),
+            embeddings_openai_truncate_chars=_parse_positive_int(
+                ENV_EMBEDDINGS_OPENAI_TRUNCATE_CHARS,
+                os.getenv(ENV_EMBEDDINGS_OPENAI_TRUNCATE_CHARS),
+                DEFAULT_EMBEDDINGS_OPENAI_TRUNCATE_CHARS,
             ),
             # Cohere embeddings (with backward-compatible fallback to shared API key)
             embeddings_cohere_api_key=os.getenv(ENV_EMBEDDINGS_COHERE_API_KEY) or os.getenv(ENV_COHERE_API_KEY),

--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -630,6 +630,7 @@ class OpenAIEmbeddings(Embeddings):
         batch_size: int = 100,
         dimensions: int | None = None,
         max_retries: int = 3,
+        truncate_chars: int = 0,
     ):
         """
         Initialize OpenAI embeddings client.
@@ -641,11 +642,16 @@ class OpenAIEmbeddings(Embeddings):
             batch_size: Maximum batch size for embedding requests (default: 100)
             dimensions: Optional requested output dimensions for OpenAI text-embedding-3 models
             max_retries: Maximum number of retries for failed requests (default: 3)
+            truncate_chars: Optional per-input character cap (0 = disabled).
+                OpenAI-compatible local backends (e.g. llama.cpp) hard-reject
+                inputs beyond the model context instead of truncating
+                server-side; capping client-side keeps the batch alive.
         """
         self.api_key = api_key
         self.model = model
         self.base_url = base_url
         self.batch_size = batch_size
+        self.truncate_chars = truncate_chars
         self.dimensions = dimensions
         self.max_retries = max_retries
         self._client = None
@@ -722,6 +728,16 @@ class OpenAIEmbeddings(Embeddings):
         if not texts:
             return []
 
+        if self.truncate_chars > 0:
+            oversized = sum(1 for t in texts if len(t) > self.truncate_chars)
+            if oversized:
+                logger.warning(
+                    f"Embeddings: truncating {oversized} input(s) above "
+                    f"{self.truncate_chars} chars "
+                    f"(HINDSIGHT_API_EMBEDDINGS_OPENAI_TRUNCATE_CHARS)"
+                )
+                texts = [t[: self.truncate_chars] for t in texts]
+
         all_embeddings = []
 
         # Process in batches
@@ -766,6 +782,7 @@ class CodexOAuthEmbeddings(OpenAIEmbeddings):
         batch_size: int = 100,
         dimensions: int | None = None,
         max_retries: int = 3,
+        truncate_chars: int = 0,
     ):
         from .providers.codex_auth import CodexAuthManager
 
@@ -777,6 +794,7 @@ class CodexOAuthEmbeddings(OpenAIEmbeddings):
             batch_size=batch_size,
             dimensions=dimensions,
             max_retries=max_retries,
+            truncate_chars=truncate_chars,
         )
 
     @property
@@ -1684,6 +1702,7 @@ def create_embeddings_from_env() -> Embeddings:
             model=model,
             base_url=base_url,
             batch_size=config.embeddings_openai_batch_size,
+            truncate_chars=config.embeddings_openai_truncate_chars,
             dimensions=config.embeddings_openai_dimensions,
         )
     elif provider == "openai-codex":
@@ -1691,6 +1710,7 @@ def create_embeddings_from_env() -> Embeddings:
         return CodexOAuthEmbeddings(
             model=model,
             batch_size=config.embeddings_openai_batch_size,
+            truncate_chars=config.embeddings_openai_truncate_chars,
             dimensions=config.embeddings_openai_dimensions,
         )
     elif provider == "openrouter":
@@ -1705,6 +1725,7 @@ def create_embeddings_from_env() -> Embeddings:
             model=config.embeddings_openrouter_model,
             base_url="https://openrouter.ai/api/v1",
             batch_size=config.embeddings_openai_batch_size,
+            truncate_chars=config.embeddings_openai_truncate_chars,
             dimensions=config.embeddings_openai_dimensions,
         )
     elif provider == "requesty":
@@ -1719,6 +1740,7 @@ def create_embeddings_from_env() -> Embeddings:
             model=config.embeddings_requesty_model,
             base_url="https://router.requesty.ai/v1",
             batch_size=config.embeddings_openai_batch_size,
+            truncate_chars=config.embeddings_openai_truncate_chars,
             dimensions=config.embeddings_openai_dimensions,
         )
     elif provider == "zeroentropy":

--- a/hindsight-api-slim/tests/test_embeddings_openai_truncate_chars.py
+++ b/hindsight-api-slim/tests/test_embeddings_openai_truncate_chars.py
@@ -1,0 +1,100 @@
+"""HINDSIGHT_API_EMBEDDINGS_OPENAI_TRUNCATE_CHARS config wiring + behaviour.
+
+OpenAI-compatible local backends (e.g. llama.cpp ``/v1/embeddings``) hard-
+reject inputs beyond the model context instead of truncating server-side the
+way the SentenceTransformers provider does — one oversized memory then fails
+the whole retain/recall batch. The optional client-side cap keeps the batch
+alive; 0 (the default) preserves current behaviour exactly.
+"""
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def setup_test_env():
+    """Save/restore env vars touched by these tests."""
+    from hindsight_api.config import clear_config_cache
+
+    env_vars_to_save = [
+        "HINDSIGHT_API_LLM_PROVIDER",
+        "HINDSIGHT_API_EMBEDDINGS_OPENAI_TRUNCATE_CHARS",
+    ]
+    original_values = {key: os.environ.get(key) for key in env_vars_to_save}
+    clear_config_cache()
+    yield
+    for key, original_value in original_values.items():
+        if original_value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = original_value
+    clear_config_cache()
+
+
+def test_default_truncate_chars_is_disabled():
+    """Default is 0 (no truncation) — current behaviour is preserved."""
+    from hindsight_api.config import HindsightConfig
+
+    os.environ["HINDSIGHT_API_LLM_PROVIDER"] = "mock"
+    os.environ.pop("HINDSIGHT_API_EMBEDDINGS_OPENAI_TRUNCATE_CHARS", None)
+
+    config = HindsightConfig.from_env()
+    assert config.embeddings_openai_truncate_chars == 0
+
+
+def test_truncate_chars_env_var_is_read():
+    from hindsight_api.config import HindsightConfig
+
+    os.environ["HINDSIGHT_API_LLM_PROVIDER"] = "mock"
+    os.environ["HINDSIGHT_API_EMBEDDINGS_OPENAI_TRUNCATE_CHARS"] = "3500"
+
+    config = HindsightConfig.from_env()
+    assert config.embeddings_openai_truncate_chars == 3500
+
+
+def _fake_client(sent):
+    class _FakeEmbeddings:
+        def create(self, *, model, input, **kw):
+            sent["input"] = list(input)
+
+            class _Item:
+                def __init__(self, i):
+                    self.index = i
+                    self.embedding = [0.0]
+
+            class _Resp:
+                data = [_Item(i) for i, _ in enumerate(input)]
+
+            return _Resp()
+
+    class _FakeClient:
+        embeddings = _FakeEmbeddings()
+
+    return _FakeClient()
+
+
+def test_encode_truncates_oversized_inputs_only():
+    """Inputs above the cap are cut to it; shorter inputs pass unchanged."""
+    from hindsight_api.engine.embeddings import OpenAIEmbeddings
+
+    emb = OpenAIEmbeddings(api_key="k", truncate_chars=10)
+    sent = {}
+    emb._client = _fake_client(sent)
+    emb._dimension = 1
+
+    emb.encode(["short", "x" * 25])
+    assert sent["input"] == ["short", "x" * 10]
+
+
+def test_encode_cap_disabled_leaves_inputs_untouched():
+    from hindsight_api.engine.embeddings import OpenAIEmbeddings
+
+    emb = OpenAIEmbeddings(api_key="k", truncate_chars=0)
+    sent = {}
+    emb._client = _fake_client(sent)
+    emb._dimension = 1
+
+    long = "x" * 25
+    emb.encode([long])
+    assert sent["input"] == [long]


### PR DESCRIPTION
## Summary

OpenAI-compatible **local** embedding backends (llama.cpp `/v1/embeddings`
and friends) hard-reject inputs beyond the model context with an HTTP 4xx
instead of truncating server-side the way the SentenceTransformers provider
does. One oversized memory then fails the whole retain/recall batch.

This adds an optional client-side per-input character cap,
`HINDSIGHT_API_EMBEDDINGS_OPENAI_TRUNCATE_CHARS`. Default `0` = disabled —
current behaviour is unchanged unless the operator opts in. When set,
oversized inputs are cut to the cap before the request, with a warning
naming the affected count and the env var.

## Why

We run Hindsight against a llama.cpp embedder (bge-m3, 8192-token context)
in production. Before the cap, a single long memory (pasted log, big
document chunk) poisoned entire retain batches with 400s; with
`TRUNCATE_CHARS=3500` the batch survives and only the tail of the oversized
input is lost — for embedding purposes a far better trade than losing the
whole operation. Running this in production since 2026-07-16.

## Changes

Wired exactly like the existing `EMBEDDINGS_OPENAI_BATCH_SIZE` knob:
config constant + `HindsightConfig` field + `from_env` parsing,
`OpenAIEmbeddings` constructor parameter, all construction sites in
`create_embeddings_from_env()` (incl. the `CodexOAuthEmbeddings`
subclass pass-through), `.env.example`.

## Validation

`tests/test_embeddings_openai_truncate_chars.py` (new, in the pattern of
`test_embeddings_openai_batch_size.py`): default-is-disabled, env parsing,
and two behaviour tests against a fake client — oversized inputs are cut,
shorter ones untouched; `0` leaves everything untouched. Verified both
directions: the truncation test fails without the encode-side logic and
passes with it (15 passed together with the batch-size file).
