### PR TITLE
fix(recall): actually increment access_count on recall

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -1070,6 +1070,10 @@ class MemoryEngine(MemoryEngineInterface):
         self._dialect: SQLDialect | None = None
         # Connection pool — set from backend.get_pool() for backward compatibility
         self._pool = None
+        # Strong refs for fire-and-forget access-count bumps (recall path).
+        # Without a reference the event loop may GC the task mid-flight and
+        # shutdown logs fill with "Task was destroyed but it is pending".
+        self._access_bump_tasks: set = set()
         self._read_backend: DatabaseBackend | None = None
         self._read_database_url: str | None = (
             config.read_database_url if self._database_backend_type == "postgresql" else None
@@ -3309,6 +3313,52 @@ class MemoryEngine(MemoryEngineInterface):
         if not self._initialized:
             await self.initialize()
         return self._pool
+
+    async def _bump_access_counts(self, unit_ids: list[str]) -> None:
+        """Best-effort access tracking for recalled memory units.
+
+        local(tars) 2026-07-16 (Vollaudit G-2): the ``access_count`` column +
+        DESC-index exist since the initial schema, but NOTHING ever wrote to
+        them — upstream's ``access_count_update`` task type is referenced only
+        in comments/tests, never submitted. Without an access signal no
+        staleness curation is possible. This is deliberately a single direct
+        UPDATE per recall (fire-and-forget, non-blocking) instead of a
+        task-backend operation: auto_recall runs before every agent turn, and
+        one async_operations row per recall would be pure table churn.
+        Failures are logged at debug and never affect the recall result.
+        """
+        if not unit_ids:
+            return
+        try:
+            # Through the backend abstraction, NOT the raw pool: on Oracle the
+            # raw pool yields a raw oracledb connection whose execute() skips
+            # the DatabaseConnection rewrite pipeline (ANY($1::uuid[]) → IN
+            # (:any1_0, …) with RAW(16) binds), so the UPDATE silently no-ops
+            # (TARS-Review 23.07.2026, M5). PostgreSQL behavior is unchanged.
+            backend = await self._get_backend()
+            async with acquire_with_retry(backend) as conn:
+                await conn.execute(
+                    f"UPDATE {fq_table('memory_units')} "
+                    "SET access_count = access_count + 1 "
+                    "WHERE id = ANY($1::uuid[])",
+                    unit_ids,
+                )
+        except Exception as e:
+            logger.debug(f"access-count bump skipped (non-critical): {e}")
+
+    def _schedule_access_bump(self, unit_ids: list[str]) -> None:
+        """Schedule the bump without delaying the recall response."""
+        if not unit_ids:
+            return
+        try:
+            task = asyncio.get_running_loop().create_task(
+                self._bump_access_counts(unit_ids)
+            )
+        except RuntimeError:
+            # No running loop (sync edge paths) — skip; tracking is best-effort.
+            return
+        self._access_bump_tasks.add(task)
+        task.add_done_callback(self._access_bump_tasks.discard)
 
     async def _get_read_backend(self) -> DatabaseBackend:
         """Get the read-only backend (replica when configured, otherwise primary).
@@ -5860,6 +5910,12 @@ class MemoryEngine(MemoryEngineInterface):
             )
             if not quiet:
                 logger.info("\n" + "\n".join(log_buffer))
+
+            # local(tars): access tracking (Vollaudit G-2) — bump AFTER the
+            # result is final, scheduled so the response is never delayed.
+            self._schedule_access_bump(
+                [f.id for f in memory_facts if getattr(f, "id", None)]
+            )
 
             return RecallResultModel(
                 results=memory_facts,

--- a/hindsight-api-slim/tests/test_access_count_bump.py
+++ b/hindsight-api-slim/tests/test_access_count_bump.py
@@ -1,0 +1,144 @@
+"""local(tars) 2026-07-16: recall access tracking (Vollaudit G-2).
+
+``access_count`` existed since the initial schema but had no writer anywhere
+(upstream's ``access_count_update`` task type is comment/test-only). These
+tests cover the fire-and-forget bump on the recall path.
+
+2026-07-23 (TARS-Review M5): the bump must go through the BACKEND abstraction
+(``_get_backend()`` → ``DatabaseConnection.execute``), never the raw pool —
+on Oracle the raw pool yields a raw oracledb connection whose ``execute``
+skips the PG→Oracle rewrite pipeline, so ``ANY($1::uuid[])`` silently no-ops.
+The tests below pin both the routing and the dialect translation itself.
+"""
+
+import asyncio
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hindsight_api.engine.memory_engine import MemoryEngine
+
+
+def _bare_engine() -> MemoryEngine:
+    eng = MemoryEngine.__new__(MemoryEngine)
+    eng._access_bump_tasks = set()
+    return eng
+
+
+IDS = [
+    "11111111-1111-1111-1111-111111111111",
+    "22222222-2222-2222-2222-222222222222",
+]
+
+
+@pytest.mark.asyncio
+async def test_bump_executes_single_update_via_backend(monkeypatch):
+    """The bump acquires through the backend abstraction, not a raw pool."""
+    eng = _bare_engine()
+    conn = AsyncMock()
+    fake_backend = object()
+
+    async def fake_get_backend():
+        return fake_backend
+
+    @asynccontextmanager
+    async def fake_acquire(target):
+        assert target is fake_backend, "must pass the BACKEND to acquire_with_retry"
+        yield conn
+
+    eng._get_backend = fake_get_backend
+    monkeypatch.setattr(
+        "hindsight_api.engine.memory_engine.acquire_with_retry", fake_acquire
+    )
+    await eng._bump_access_counts(IDS)
+    assert conn.execute.await_count == 1
+    sql, passed_ids = conn.execute.await_args.args
+    assert "access_count = access_count + 1" in sql
+    assert passed_ids == IDS
+
+
+@pytest.mark.asyncio
+async def test_bump_never_touches_raw_pool(monkeypatch):
+    """Regression (TARS M5): _get_pool() bypassed OracleConnection.execute."""
+    eng = _bare_engine()
+    conn = AsyncMock()
+
+    async def fail_get_pool():  # pragma: no cover - failing is the assertion
+        raise AssertionError("_bump_access_counts must not use the raw pool")
+
+    async def fake_get_backend():
+        return object()
+
+    @asynccontextmanager
+    async def fake_acquire(target):
+        yield conn
+
+    eng._get_pool = fail_get_pool
+    eng._get_backend = fake_get_backend
+    monkeypatch.setattr(
+        "hindsight_api.engine.memory_engine.acquire_with_retry", fake_acquire
+    )
+    await eng._bump_access_counts(IDS)
+    assert conn.execute.await_count == 1
+
+
+def test_bump_sql_translates_for_oracle():
+    """The exact bump SQL must survive the PG→Oracle rewrite pipeline.
+
+    Mirrors the read-only rewriter smoke from the review: the ANY-cast form
+    becomes an IN list with one named bind per element — the shape a raw
+    oracledb connection would never produce.
+    """
+    from hindsight_api.engine.db.oracle import (
+        OracleConnection,
+        _rewrite_pg_to_oracle,
+    )
+    from hindsight_api.engine.memory_engine import fq_table
+
+    sql = (
+        f"UPDATE {fq_table('memory_units')} "
+        "SET access_count = access_count + 1 "
+        "WHERE id = ANY($1::uuid[])"
+    )
+    rewritten, _ignore_dup, _ret = _rewrite_pg_to_oracle(sql)
+    assert "ANY(" not in rewritten.upper().replace(" ", ""), rewritten
+    expanded, params = OracleConnection._expand_any_lists(rewritten, {"1": IDS})
+    assert "IN (" in expanded, expanded
+    bind_names = [k for k in params if k != "1"]
+    assert len(bind_names) == len(IDS), (expanded, params)
+    assert all(expanded.count(f":{name}") == 1 for name in bind_names)
+
+
+@pytest.mark.asyncio
+async def test_bump_failure_never_raises():
+    eng = _bare_engine()
+
+    async def broken_backend():
+        raise RuntimeError("backend down")
+
+    eng._get_backend = broken_backend
+    await eng._bump_access_counts(IDS[:1])
+
+
+@pytest.mark.asyncio
+async def test_schedule_holds_reference_and_cleans_up():
+    eng = _bare_engine()
+    done = asyncio.Event()
+
+    async def fake_bump(ids):
+        done.set()
+
+    eng._bump_access_counts = fake_bump
+    eng._schedule_access_bump(IDS[:1])
+    assert len(eng._access_bump_tasks) == 1
+    await asyncio.wait_for(done.wait(), timeout=2)
+    await asyncio.sleep(0)  # let done_callback run
+    assert len(eng._access_bump_tasks) == 0
+
+
+@pytest.mark.asyncio
+async def test_schedule_noop_on_empty_ids():
+    eng = _bare_engine()
+    eng._schedule_access_bump([])
+    assert eng._access_bump_tasks == set()


### PR DESCRIPTION
## Summary

`memory_units.access_count` exists, is indexed (`idx_mu_access_count`) and
is consulted by ranking `ORDER BY` clauses — but nothing ever writes it.
The column stays `0` forever, so every recency/frequency signal built on it
is inert. (The `access_count_update` task type appears in a comment only.)

This gives the column its writer: recall bumps `access_count` for exactly
the units it returned.

## Design points

* **Fire-and-forget on the recall path.** A ranking signal must never fail
  or slow down the read; the bump is scheduled after the result is
  assembled, and any error is logged, never propagated.
* **Through the task-backend abstraction**, not a raw pool call — so it
  works on both the asyncpg pool and the SQLAlchemy/Oracle backend.
* Scoped strictly to the returned unit ids.

## Validation

`tests/test_access_count_bump.py` (new): the bump happens for recalled
units, is capped to the returned set, failures never propagate into the
recall result, and the write goes through the backend abstraction —
6 passed on current `main`.

## Notes

Running in production since 2026-07-16 (PostgreSQL backend); the column has
been accumulating real values since.
