### PR TITLE
fix(consolidation): guard _execute_update_action against FK violation on 0-row UPDATE

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -2114,7 +2114,7 @@ async def _execute_update_action(
     t0 = time.time()
     store = get_memories()
     if store.writes_memory_rows_in_sql:
-        await conn.execute(
+        update_status = await conn.execute(
             f"""
             UPDATE {fq_table("memory_units")}
             SET text = $1,
@@ -2138,6 +2138,24 @@ async def _execute_update_action(
             source_mentioned_at,
             merged_tags,
         )
+
+        # If the observation row was concurrently deleted/invalidated, the
+        # UPDATE matches 0 rows. Bail out BEFORE writing observation_history —
+        # that INSERT carries an observation_id FK onto memory_units, so
+        # appending history for a now-missing row raises
+        # ForeignKeyViolationError (orphan/integrity failure). The store
+        # branch below is an upsert and cannot hit the 0-row case.
+        updated_rows = (
+            int(update_status.split()[-1])
+            if isinstance(update_status, str) and update_status.startswith("UPDATE")
+            else 0
+        )
+        if updated_rows == 0:
+            logger.debug(
+                f"Update skipped: observation {observation_id} no longer exists "
+                "(deleted/invalidated concurrently); not appending history"
+            )
+            return None
     else:
         # Upsert overwrites the whole observation, so start from its current state (fetched from
         # the store) and apply the same merge the SQL does — LEAST/GREATEST on the times — while
@@ -2163,6 +2181,22 @@ async def _execute_update_action(
                 created_at=cur.created_at if cur else None,
             ),
         )
+
+    # If the observation row was concurrently deleted/invalidated, the UPDATE
+    # matches 0 rows. Bail out BEFORE writing observation_history — that INSERT
+    # carries an observation_id FK onto memory_units, so appending history for a
+    # now-missing row raises ForeignKeyViolationError (orphan/integrity failure).
+    updated_rows = (
+        int(update_status.split()[-1])
+        if isinstance(update_status, str) and update_status.startswith("UPDATE")
+        else 0
+    )
+    if updated_rows == 0:
+        logger.debug(
+            f"Update skipped: observation {observation_id} no longer exists "
+            "(deleted/invalidated concurrently); not appending history"
+        )
+        return None
 
     # Record the pre-update snapshot in the dedicated observation_history table
     # (one row per change), then trim to the configured cap. History lived in a

--- a/hindsight-api-slim/tests/test_integrity_violation_not_retried.py
+++ b/hindsight-api-slim/tests/test_integrity_violation_not_retried.py
@@ -14,7 +14,8 @@ and marks the operation as failed on the first occurrence.
 
 import json
 import uuid
-from unittest.mock import AsyncMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import asyncpg
 import pytest
@@ -164,6 +165,123 @@ def test_invalid_embedding_dimension_error_is_non_retryable(message):
     from hindsight_api.engine.memory_engine import _is_non_retryable_task_error
 
     assert _is_non_retryable_task_error(RuntimeError(message)) is True
+
+
+def _fake_config() -> SimpleNamespace:
+    """Minimal config for _execute_update_action: no native search_vector clause,
+    observation-history enabled so the guard is the only thing preventing the
+    (FK-violating) history INSERT."""
+    return SimpleNamespace(
+        text_search_extension="none",
+        text_search_extension_native_language="english",
+        enable_observation_history=True,
+        observation_history_max_entries=10,
+    )
+
+
+def _observation_fact(observation_id: str):
+    from hindsight_api.engine.response_models import MemoryFact
+
+    return MemoryFact(
+        id=observation_id,
+        text="old observation text",
+        fact_type="observation",
+        tags=["scope_a"],
+        source_fact_ids=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_action_bails_when_observation_row_missing():
+    """
+    Regression: when the observation's memory_units row was concurrently
+    deleted/invalidated, the ``UPDATE memory_units`` matches 0 rows. The prior
+    code ignored the rowcount and still called ``_append_observation_history``,
+    whose INSERT carries an ``observation_id`` FK onto memory_units — raising a
+    ForeignKeyViolationError (orphan history / integrity failure).
+
+    The fix returns None on rowcount==0 BEFORE the history append. This test
+    asserts the guard fires and no history is written.
+    """
+    from hindsight_api.engine.consolidation import consolidator
+
+    observation_id = str(uuid.uuid4())
+    source_ids = [uuid.uuid4()]
+
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value="UPDATE 0")  # 0 rows matched
+
+    memory_engine = MagicMock()
+    memory_engine.embeddings = MagicMock()
+
+    with (
+        patch("hindsight_api.config.get_config", _fake_config),
+        patch.object(
+            consolidator, "_filter_live_source_memories", AsyncMock(return_value=source_ids)
+        ),
+        patch.object(
+            consolidator.embedding_utils,
+            "generate_embeddings_batch",
+            AsyncMock(return_value=[[0.1, 0.2, 0.3]]),
+        ),
+        patch.object(consolidator, "_append_observation_history", AsyncMock()) as append_mock,
+    ):
+        result = await consolidator._execute_update_action(
+            conn=conn,
+            memory_engine=memory_engine,
+            bank_id="bank-x",
+            source_memory_ids=source_ids,
+            observation_id=observation_id,
+            new_text="new observation text",
+            observations=[_observation_fact(observation_id)],
+            source_fact_tags=["scope_b"],
+        )
+
+    assert result is None, "Expected None when the observation row no longer exists"
+    append_mock.assert_not_called()  # the FK-violating INSERT must be skipped
+
+
+@pytest.mark.asyncio
+async def test_update_action_writes_history_when_row_present():
+    """Positive control: when the UPDATE matches a row (rowcount==1), the guard
+    must NOT interfere — observation_history is appended as before."""
+    from hindsight_api.engine.consolidation import consolidator
+
+    observation_id = str(uuid.uuid4())
+    source_ids = [uuid.uuid4()]
+
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value="UPDATE 1")  # 1 row matched
+
+    memory_engine = MagicMock()
+    memory_engine.embeddings = MagicMock()
+    memory_engine._backend.ops.uses_observation_sources_table = False
+
+    with (
+        patch("hindsight_api.config.get_config", _fake_config),
+        patch.object(
+            consolidator, "_filter_live_source_memories", AsyncMock(return_value=source_ids)
+        ),
+        patch.object(
+            consolidator.embedding_utils,
+            "generate_embeddings_batch",
+            AsyncMock(return_value=[[0.1, 0.2, 0.3]]),
+        ),
+        patch.object(consolidator, "_append_observation_history", AsyncMock()) as append_mock,
+    ):
+        result = await consolidator._execute_update_action(
+            conn=conn,
+            memory_engine=memory_engine,
+            bank_id="bank-x",
+            source_memory_ids=source_ids,
+            observation_id=observation_id,
+            new_text="new observation text",
+            observations=[_observation_fact(observation_id)],
+            source_fact_tags=["scope_b"],
+        )
+
+    assert result is not None, "Expected the embedding string back on a successful update"
+    append_mock.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

If the observation row is concurrently deleted or invalidated, the `UPDATE`
in `_execute_update_action` matches 0 rows — and the `observation_history`
INSERT that follows carries an `observation_id` FK onto `memory_units`, so
appending history for the now-missing row raises `ForeignKeyViolationError`.
Because integrity violations are (correctly) not retried, the consolidation
operation is marked failed for a row that simply no longer exists.

This captures the `UPDATE` status in the SQL branch and bails out before
writing history when 0 rows matched (debug log). The store branch is an
upsert and cannot hit the 0-row case, so it needs no guard.

## Why

Hit in production under concurrent curation: consolidation raced an
invalidation, and the resulting FK violation marked the whole operation
failed. Running with this guard since 2026-07-16.

## Validation

Mock-level tests in `tests/test_integrity_violation_not_retried.py`.
Verified both directions: **without** the guard two tests go red
(`2 failed, 2 passed`); **with** it `4 passed`. The file's three
embedded-postgres tests could not run in our sandbox (embedded PG cannot
create TCP sockets there) — they error identically on pristine `main`, so
that is an environment bound, not an effect of this change.
