### PR TITLE
fix(auth): authorize legacy bank writes before provisioning

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -6432,13 +6432,14 @@ def _register_routes(app: FastAPI):
     ):
         """Update bank disposition traits."""
         try:
-            # Update disposition
-            await app.state.memory.update_bank_disposition(
-                bank_id, request.disposition.model_dump(), request_context=request_context
+            # Authorize the response read before mutating and reuse the profile
+            # returned by the same engine call instead of validating a second
+            # GET_BANK_PROFILE after the disposition has already changed.
+            profile = await app.state.memory.update_bank_disposition_and_get_profile(
+                bank_id,
+                request.disposition.model_dump(),
+                request_context=request_context,
             )
-
-            # Get updated profile
-            profile = await app.state.memory.get_bank_profile(bank_id, request_context=request_context)
             disposition_dict = (
                 profile["disposition"].model_dump()
                 if hasattr(profile["disposition"], "model_dump")

--- a/hindsight-api-slim/hindsight_api/engine/interface.py
+++ b/hindsight-api-slim/hindsight_api/engine/interface.py
@@ -247,6 +247,46 @@ class MemoryEngineInterface(ABC):
         """
         ...
 
+    async def update_bank_disposition_and_get_profile(
+        self,
+        bank_id: str,
+        disposition: dict[str, int],
+        *,
+        request_context: "RequestContext",
+    ) -> dict[str, Any]:
+        """Update disposition and return its profile.
+
+        Implementations should override this to authorize the response read
+        before mutating. This fallback preserves compatibility for existing
+        interface implementations that only provide update_bank_disposition.
+        """
+        # Resolve the read path once so implementations that enforce read
+        # authorization in get_bank_profile reject before the legacy write.
+        # Project the known disposition change locally afterward: a second
+        # authorized read could fail after the mutation has already committed.
+        profile = await self.get_bank_profile(
+            bank_id,
+            request_context=request_context,
+            create_if_missing=False,
+        )
+        await self.update_bank_disposition(
+            bank_id,
+            disposition,
+            request_context=request_context,
+        )
+        if profile is None:
+            return {
+                "bank_id": bank_id,
+                "name": bank_id,
+                "disposition": disposition,
+                "mission": "",
+            }
+        return {
+            **profile,
+            "bank_id": profile.get("bank_id", bank_id),
+            "disposition": disposition,
+        }
+
     @abstractmethod
     async def merge_bank_mission(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -9259,7 +9259,12 @@ class MemoryEngine(MemoryEngineInterface):
         backend = await self._get_backend()
         if self._operation_validator:
             if conn is not None:
-                exists = await conn.fetchval(f"SELECT 1 FROM {fq_table('banks')} WHERE bank_id = $1", bank_id)
+                # Lock an existing row until the caller's transaction commits,
+                # preventing delete/recreate races between authorization and write.
+                exists = await conn.fetchval(
+                    f"SELECT 1 FROM {fq_table('banks')} WHERE bank_id = $1 FOR UPDATE",
+                    bank_id,
+                )
             else:
                 exists = await bank_utils.get_bank_profile_if_exists(backend, bank_id)
             if not exists:
@@ -9660,6 +9665,90 @@ class MemoryEngine(MemoryEngineInterface):
         except Exception as e:
             logger.error(f"Failed to apply HINDSIGHT_API_DEFAULT_BANK_TEMPLATE to bank '{bank_id}': {e}")
 
+    async def _update_bank_disposition_impl(
+        self,
+        bank_id: str,
+        disposition: dict[str, int],
+        *,
+        request_context: "RequestContext",
+        return_profile: bool = False,
+    ) -> dict[str, Any] | None:
+        """Shared implementation for the legacy write and response-returning path."""
+        await self._authenticate_tenant(request_context)
+        if self._operation_validator:
+            from hindsight_api.extensions import (
+                BankReadContext,
+                BankReadOperation,
+                BankWriteContext,
+                BankWriteOperation,
+            )
+
+            if return_profile:
+                read_ctx = BankReadContext(
+                    bank_id=bank_id,
+                    operation=BankReadOperation.GET_BANK_PROFILE,
+                    request_context=request_context,
+                )
+                await self._validate_operation(self._operation_validator.validate_bank_read(read_ctx))
+            write_ctx = BankWriteContext(
+                bank_id=bank_id, operation=BankWriteOperation.UPDATE_BANK_DISPOSITION, request_context=request_context
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_write(write_ctx))
+        backend = await self._get_backend()
+        profile_snapshot = None
+        # Keep lazy creation and the legacy write in one transaction so a
+        # failed disposition update cannot leave an otherwise empty bank.
+        async with acquire_with_retry(backend) as conn:
+            async with conn.transaction():
+                created = await self._ensure_bank_exists(
+                    bank_id,
+                    request_context,
+                    conn=conn,
+                )
+                await bank_utils.update_bank_disposition_on_conn(conn, bank_id, disposition)
+                if return_profile:
+                    # Capture the row while this transaction still owns its
+                    # write lock. A post-commit legacy writer must not change
+                    # the response for the disposition written above.
+                    profile_snapshot = await bank_utils.get_bank_profile_on_conn(conn, bank_id)
+                    if profile_snapshot is None:
+                        raise RuntimeError(f"Bank '{bank_id}' was not found after updating its disposition")
+
+        # Follow the established connection-bound ensure contract: server-owned
+        # defaults are best-effort and run only after the write transaction commits.
+        if created:
+            await self._apply_default_bank_template(bank_id, request_context)
+
+        if return_profile:
+            if profile_snapshot is None:
+                raise RuntimeError(f"Bank '{bank_id}' was not found after updating its disposition")
+
+            # Default templates may add resolved config after the legacy-row
+            # transaction commits. Overlay that config onto the locked
+            # snapshot instead of rereading mutable legacy columns.
+            try:
+                config_dict = await self._config_resolver.get_bank_config(bank_id, request_context)
+            except Exception as e:
+                # The disposition write already committed. Preserve the
+                # endpoint's success response from the locked snapshot rather
+                # than turning a config-resolution outage into a false failure.
+                logger.warning(f"Failed to resolve bank config for disposition response on bank '{bank_id}': {e}")
+                config_dict = {}
+            db_disp = profile_snapshot["disposition"]
+            db_disp_dict = db_disp.model_dump() if hasattr(db_disp, "model_dump") else dict(db_disp)
+            resolved = _overlay_bank_config_disposition_mission(
+                db_disp_dict,
+                profile_snapshot["mission"],
+                config_dict,
+            )
+            return {
+                "bank_id": bank_id,
+                "name": profile_snapshot["name"],
+                "disposition": resolved.disposition,
+                "mission": resolved.mission,
+            }
+        return None
+
     async def update_bank_disposition(
         self,
         bank_id: str,
@@ -9667,24 +9756,30 @@ class MemoryEngine(MemoryEngineInterface):
         *,
         request_context: "RequestContext",
     ) -> None:
-        """
-        Update bank disposition traits.
+        """Update bank disposition traits."""
+        await self._update_bank_disposition_impl(
+            bank_id,
+            disposition,
+            request_context=request_context,
+        )
 
-        Args:
-            bank_id: bank IDentifier
-            disposition: Dict with skepticism, literalism, empathy (all 1-5)
-            request_context: Request context for authentication.
-        """
-        await self._authenticate_tenant(request_context)
-        if self._operation_validator:
-            from hindsight_api.extensions import BankWriteContext, BankWriteOperation
-
-            ctx = BankWriteContext(
-                bank_id=bank_id, operation=BankWriteOperation.UPDATE_BANK_DISPOSITION, request_context=request_context
-            )
-            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
-        await self._get_backend()
-        await bank_utils.update_bank_disposition(self._backend, bank_id, disposition)
+    async def update_bank_disposition_and_get_profile(
+        self,
+        bank_id: str,
+        disposition: dict[str, int],
+        *,
+        request_context: "RequestContext",
+    ) -> dict[str, Any]:
+        """Authorize the deprecated endpoint's response read before updating."""
+        profile = await self._update_bank_disposition_impl(
+            bank_id,
+            disposition,
+            request_context=request_context,
+            return_profile=True,
+        )
+        if profile is None:
+            raise RuntimeError(f"Bank '{bank_id}' was not found after updating its disposition")
+        return profile
 
     async def set_bank_mission(
         self,
@@ -9712,8 +9807,23 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id, operation=BankWriteOperation.SET_BANK_MISSION, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
-        await self._get_backend()
-        await bank_utils.set_bank_mission(self._backend, bank_id, mission)
+        backend = await self._get_backend()
+        # Keep lazy creation and the legacy write in one transaction so a
+        # failed mission update cannot leave an otherwise empty bank.
+        async with acquire_with_retry(backend) as conn:
+            async with conn.transaction():
+                created = await self._ensure_bank_exists(
+                    bank_id,
+                    request_context,
+                    conn=conn,
+                )
+                await bank_utils.set_bank_mission_on_conn(conn, bank_id, mission)
+
+        # Follow the established connection-bound ensure contract: server-owned
+        # defaults are best-effort and run only after the write transaction commits.
+        if created:
+            await self._apply_default_bank_template(bank_id, request_context)
+
         return {"bank_id": bank_id, "mission": mission}
 
     async def merge_bank_mission(
@@ -9737,14 +9847,65 @@ class MemoryEngine(MemoryEngineInterface):
         """
         await self._authenticate_tenant(request_context)
         if self._operation_validator:
-            from hindsight_api.extensions import BankWriteContext, BankWriteOperation
+            from hindsight_api.extensions import (
+                BankReadContext,
+                BankReadOperation,
+                BankWriteContext,
+                BankWriteOperation,
+            )
 
-            ctx = BankWriteContext(
+            read_ctx = BankReadContext(
+                bank_id=bank_id,
+                operation=BankReadOperation.GET_BANK_PROFILE,
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_read(read_ctx))
+            write_ctx = BankWriteContext(
                 bank_id=bank_id, operation=BankWriteOperation.MERGE_BANK_MISSION, request_context=request_context
             )
-            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
-        await self._get_backend()
-        return await bank_utils.merge_bank_mission(self._backend, self._reflect_llm_config, bank_id, new_info)
+            await self._validate_operation(self._operation_validator.validate_bank_write(write_ctx))
+        backend = await self._get_backend()
+        mission_snapshot = None
+        # Commit provisioning before the model call. Fresh-bank provisioning
+        # can build vector indexes, and holding those transaction locks across
+        # an external LLM request would block unrelated bank writes.
+        async with acquire_with_retry(backend) as conn:
+            async with conn.transaction():
+                created = await self._ensure_bank_exists(
+                    bank_id,
+                    request_context,
+                    conn=conn,
+                )
+                mission_snapshot = await bank_utils.get_bank_mission_snapshot_on_conn(conn, bank_id)
+                if mission_snapshot is None:
+                    raise RuntimeError(f"Bank '{bank_id}' was not found after ensuring it exists")
+
+        # The connection-bound ensure contract applies defaults after commit.
+        # Reload the lifecycle token afterward so a delete/recreate during the
+        # best-effort hook cannot redirect the eventual mission update.
+        if created:
+            await self._apply_default_bank_template(bank_id, request_context)
+            async with acquire_with_retry(backend) as conn:
+                provisioned_snapshot = await bank_utils.get_bank_mission_snapshot_on_conn(conn, bank_id)
+            if (
+                provisioned_snapshot is None
+                or mission_snapshot is None
+                or provisioned_snapshot.internal_id != mission_snapshot.internal_id
+            ):
+                raise RuntimeError(f"Bank '{bank_id}' changed while its default template was being applied")
+            mission_snapshot = provisioned_snapshot
+
+        if mission_snapshot is None:
+            raise RuntimeError(f"Bank '{bank_id}' was not found after ensuring it exists")
+
+        return await bank_utils.merge_bank_mission_from_snapshot(
+            backend,
+            self._reflect_llm_config,
+            bank_id,
+            mission_snapshot,
+            mission_snapshot.mission or "",
+            new_info,
+        )
 
     async def list_banks(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
@@ -6,15 +6,20 @@ import json
 import logging
 import uuid
 from dataclasses import dataclass
-from typing import TypedDict
+from datetime import datetime
+from typing import TYPE_CHECKING, TypedDict
 
 from pydantic import BaseModel, Field
 
 from ..._vector_index import index_using_clause, uses_per_bank_vector_indexes
 from ...config import get_config
+from ..db.base import DatabaseBackend, DatabaseConnection
 from ..db_utils import acquire_with_retry, retry_with_backoff
 from ..memory_engine import fq_table, get_current_schema
 from ..response_models import DispositionTraits
+
+if TYPE_CHECKING:
+    from ..llm_wrapper import LLMProvider
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +122,15 @@ class BankProfileResult:
     created: bool
 
 
+@dataclass(frozen=True)
+class BankMissionSnapshot:
+    """Immutable identity and legacy mission used for a conditional merge."""
+
+    internal_id: uuid.UUID | str
+    mission: str | None
+    updated_at: datetime
+
+
 class MissionMergeResponse(BaseModel):
     """LLM response for mission merge."""
 
@@ -155,23 +169,58 @@ async def get_bank_profile_if_exists(pool, bank_id: str) -> BankProfile | None:
         BankProfile if the bank exists, otherwise None.
     """
     async with acquire_with_retry(pool) as conn:
-        row = await conn.fetchrow(
-            f"""
-            SELECT name, disposition, mission
-            FROM {fq_table("banks")} WHERE bank_id = $1
-            """,
-            bank_id,
-        )
-        if not row:
-            return None
-        disposition_data = row["disposition"]
-        if isinstance(disposition_data, str):
-            disposition_data = json.loads(disposition_data)
-        return BankProfile(
-            name=row["name"],
-            disposition=DispositionTraits(**disposition_data),
-            mission=row["mission"] or "",
-        )
+        return await get_bank_profile_on_conn(conn, bank_id)
+
+
+async def get_bank_profile_on_conn(
+    conn: DatabaseConnection,
+    bank_id: str,
+    *,
+    for_update: bool = False,
+) -> BankProfile | None:
+    """Connection-bound read of an existing bank profile."""
+    lock_clause = " FOR UPDATE" if for_update else ""
+    row = await conn.fetchrow(
+        f"""
+        SELECT name, disposition, mission
+        FROM {fq_table("banks")} WHERE bank_id = $1{lock_clause}
+        """,
+        bank_id,
+    )
+    if not row:
+        return None
+    disposition_data = row["disposition"]
+    if isinstance(disposition_data, str):
+        disposition_data = json.loads(disposition_data)
+    return BankProfile(
+        name=row["name"],
+        disposition=DispositionTraits(**disposition_data),
+        mission=row["mission"] or "",
+    )
+
+
+async def get_bank_mission_snapshot_on_conn(
+    conn: DatabaseConnection,
+    bank_id: str,
+    *,
+    for_update: bool = False,
+) -> BankMissionSnapshot | None:
+    """Load the immutable bank identity and legacy mission on one connection."""
+    lock_clause = " FOR UPDATE" if for_update else ""
+    row = await conn.fetchrow(
+        f"""
+        SELECT internal_id, mission, updated_at
+        FROM {fq_table("banks")} WHERE bank_id = $1{lock_clause}
+        """,
+        bank_id,
+    )
+    if not row:
+        return None
+    return BankMissionSnapshot(
+        internal_id=row["internal_id"],
+        mission=row["mission"],
+        updated_at=row["updated_at"],
+    )
 
 
 async def get_or_create_bank_profile(pool, bank_id: str) -> BankProfileResult:
@@ -217,29 +266,11 @@ async def get_or_create_bank_profile_on_conn(conn, bank_id: str, *, ops) -> Bank
     ``ops`` is the backend's dialect ops object (``backend.ops``), needed for
     per-bank vector index DDL.
     """
-    # Try to get existing bank
-    row = await conn.fetchrow(
-        f"""
-        SELECT name, disposition, mission
-        FROM {fq_table("banks")} WHERE bank_id = $1
-        """,
-        bank_id,
-    )
-
-    if row:
-        # asyncpg returns JSONB as a string, so parse it
-        disposition_data = row["disposition"]
-        if isinstance(disposition_data, str):
-            disposition_data = json.loads(disposition_data)
-
-        return BankProfileResult(
-            profile=BankProfile(
-                name=row["name"],
-                disposition=DispositionTraits(**disposition_data),
-                mission=row["mission"] or "",
-            ),
-            created=False,
-        )
+    # Lock an existing row so a concurrent delete cannot slip between this
+    # lifecycle check and the caller's bank-scoped write.
+    profile = await get_bank_profile_on_conn(conn, bank_id, for_update=True)
+    if profile:
+        return BankProfileResult(profile=profile, created=False)
 
     # Bank doesn't exist, create with defaults.
     # Generate internal_id here so we control the value and can use it
@@ -270,57 +301,86 @@ async def get_or_create_bank_profile_on_conn(conn, bank_id: str, *, ops) -> Bank
     )
 
 
-async def update_bank_disposition(pool, bank_id: str, disposition: dict[str, int]) -> None:
+def _require_bank_row_updated(result: str, bank_id: str) -> None:
+    """Fail rather than reporting success when a concurrent delete won."""
+    updated = int(result.split()[-1]) if result.startswith("UPDATE") else 0
+    if updated == 0:
+        raise RuntimeError(f"Bank '{bank_id}' disappeared before the legacy profile write")
+
+
+async def update_bank_disposition_on_conn(
+    conn: DatabaseConnection,
+    bank_id: str,
+    disposition: dict[str, int],
+) -> None:
     """
-    Update bank disposition traits.
+    Update bank disposition traits on a caller-supplied connection.
 
     Args:
-        pool: Database connection pool
+        conn: Database connection
         bank_id: bank IDentifier
         disposition: Dict with skepticism, literalism, empathy (all 1-5)
     """
-    # Ensure bank exists first
+    result = await conn.execute(
+        f"""
+        UPDATE {fq_table("banks")}
+        SET disposition = $2::jsonb,
+            updated_at = NOW()
+        WHERE bank_id = $1
+        """,
+        bank_id,
+        json.dumps(disposition),
+    )
+    _require_bank_row_updated(result, bank_id)
+
+
+async def update_bank_disposition(
+    pool: DatabaseBackend,
+    bank_id: str,
+    disposition: dict[str, int],
+) -> None:
+    """Compatibility wrapper that preserves the legacy lazy-create contract."""
     await get_bank_profile(pool, bank_id)
-
     async with acquire_with_retry(pool) as conn:
-        await conn.execute(
-            f"""
-            UPDATE {fq_table("banks")}
-            SET disposition = $2::jsonb,
-                updated_at = NOW()
-            WHERE bank_id = $1
-            """,
-            bank_id,
-            json.dumps(disposition),
-        )
+        await update_bank_disposition_on_conn(conn, bank_id, disposition)
 
 
-async def set_bank_mission(pool, bank_id: str, mission: str) -> None:
+async def set_bank_mission_on_conn(conn: DatabaseConnection, bank_id: str, mission: str) -> None:
     """
-    Set bank mission (replacing any existing mission).
+    Set bank mission on a caller-supplied connection.
 
     Args:
-        pool: Database connection pool
+        conn: Database connection
         bank_id: bank IDentifier
         mission: The mission text
     """
-    # Ensure bank exists first
+    result = await conn.execute(
+        f"""
+        UPDATE {fq_table("banks")}
+        SET mission = $2,
+            updated_at = NOW()
+        WHERE bank_id = $1
+        """,
+        bank_id,
+        mission,
+    )
+    _require_bank_row_updated(result, bank_id)
+
+
+async def set_bank_mission(pool: DatabaseBackend, bank_id: str, mission: str) -> None:
+    """Compatibility wrapper that preserves the legacy lazy-create contract."""
     await get_bank_profile(pool, bank_id)
-
     async with acquire_with_retry(pool) as conn:
-        await conn.execute(
-            f"""
-            UPDATE {fq_table("banks")}
-            SET mission = $2,
-                updated_at = NOW()
-            WHERE bank_id = $1
-            """,
-            bank_id,
-            mission,
-        )
+        await set_bank_mission_on_conn(conn, bank_id, mission)
 
 
-async def merge_bank_mission(pool, llm_config, bank_id: str, new_info: str) -> dict:
+async def merge_bank_mission_from_profile(
+    pool: DatabaseBackend,
+    llm_config: "LLMProvider",
+    bank_id: str,
+    current_mission: str,
+    new_info: str,
+) -> dict[str, str]:
     """
     Merge new mission information with existing mission using LLM.
     Normalizes to first person ("I") and resolves conflicts.
@@ -329,15 +389,12 @@ async def merge_bank_mission(pool, llm_config, bank_id: str, new_info: str) -> d
         pool: Database connection pool
         llm_config: LLM configuration for mission merging
         bank_id: bank IDentifier
+        current_mission: Existing mission loaded by the authorized caller
         new_info: New mission information to add/merge
 
     Returns:
         Dict with 'mission' (str) key
     """
-    # Get current profile
-    profile = await get_bank_profile(pool, bank_id)
-    current_mission = profile["mission"]
-
     # Use LLM to merge missions
     result = await _llm_merge_mission(llm_config, current_mission, new_info)
 
@@ -357,6 +414,57 @@ async def merge_bank_mission(pool, llm_config, bank_id: str, new_info: str) -> d
         )
 
     return {"mission": merged_mission}
+
+
+async def merge_bank_mission_from_snapshot(
+    pool: DatabaseBackend,
+    llm_config: "LLMProvider",
+    bank_id: str,
+    snapshot: BankMissionSnapshot,
+    current_mission: str,
+    new_info: str,
+) -> dict[str, str]:
+    """Merge a mission without overwriting another bank lifecycle or writer."""
+    result = await _llm_merge_mission(llm_config, current_mission, new_info)
+    merged_mission = result["mission"]
+
+    async with acquire_with_retry(pool) as conn:
+        update_result = await conn.execute(
+            f"""
+            UPDATE {fq_table("banks")}
+            SET mission = $2,
+                updated_at = NOW()
+            WHERE bank_id = $1
+              AND internal_id = $3
+              AND updated_at = $4
+            """,
+            bank_id,
+            merged_mission,
+            snapshot.internal_id,
+            snapshot.updated_at,
+        )
+    updated = int(update_result.split()[-1]) if update_result.startswith("UPDATE") else 0
+    if updated == 0:
+        raise RuntimeError(f"Bank '{bank_id}' changed while its mission was being merged")
+
+    return {"mission": merged_mission}
+
+
+async def merge_bank_mission(
+    pool: DatabaseBackend,
+    llm_config: "LLMProvider",
+    bank_id: str,
+    new_info: str,
+) -> dict[str, str]:
+    """Compatibility wrapper that preserves the legacy lazy-create contract."""
+    profile = await get_bank_profile(pool, bank_id)
+    return await merge_bank_mission_from_profile(
+        pool,
+        llm_config,
+        bank_id,
+        profile["mission"],
+        new_info,
+    )
 
 
 async def _llm_merge_mission(llm_config, current: str, new_info: str) -> dict:

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -13,7 +13,8 @@ import pytest
 import pytest_asyncio
 
 from hindsight_api.api import create_app
-from hindsight_api.engine.interface import BankTemplateImportWrite
+from hindsight_api.engine.interface import BankTemplateImportWrite, MemoryEngineInterface
+from hindsight_api.engine.retain import bank_utils
 from hindsight_api.extensions import BankReadOperation, BankWriteOperation, OperationValidationError, ValidationResult
 from hindsight_api.models import RequestContext
 from tests.llm_judge import assert_meets_criteria
@@ -75,6 +76,636 @@ async def api_client_real_llm(memory_real_llm):
 def test_bank_id():
     """Provide a unique bank ID for this test run."""
     return f"integration_test_{datetime.now().timestamp()}"
+
+
+async def _call_legacy_bank_write(
+    memory,
+    method: str,
+    bank_id: str,
+    request_context: RequestContext,
+) -> object:
+    if method == "disposition":
+        return await memory.update_bank_disposition(
+            bank_id,
+            {"skepticism": 5, "literalism": 4, "empathy": 2},
+            request_context=request_context,
+        )
+    if method == "set_mission":
+        return await memory.set_bank_mission(
+            bank_id,
+            "Keep the customer informed.",
+            request_context=request_context,
+        )
+    if method == "merge_mission":
+        return await memory.merge_bank_mission(
+            bank_id,
+            "Also flag urgent risks.",
+            request_context=request_context,
+        )
+    raise AssertionError(f"Unknown legacy bank write: {method}")
+
+
+@pytest.mark.asyncio
+async def test_disposition_profile_interface_fallback_preserves_legacy_implementations():
+    """Old interface implementations inherit a working response-returning fallback."""
+    engine = MagicMock()
+    engine.update_bank_disposition = AsyncMock()
+    expected_profile = {
+        "bank_id": "legacy-interface",
+        "name": "legacy-interface",
+        "disposition": {"skepticism": 4, "literalism": 3, "empathy": 2},
+        "mission": "",
+    }
+    engine.get_bank_profile = AsyncMock(return_value=expected_profile)
+    request_context = RequestContext()
+
+    profile = await MemoryEngineInterface.update_bank_disposition_and_get_profile(
+        engine,
+        "legacy-interface",
+        {"skepticism": 4, "literalism": 3, "empathy": 2},
+        request_context=request_context,
+    )
+
+    assert profile == expected_profile
+    engine.update_bank_disposition.assert_awaited_once()
+    engine.get_bank_profile.assert_awaited_once_with(
+        "legacy-interface",
+        request_context=request_context,
+        create_if_missing=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_disposition_profile_interface_fallback_read_denial_prevents_update():
+    """A legacy implementation's read rejection must happen before mutation."""
+    engine = MagicMock()
+    engine.update_bank_disposition = AsyncMock()
+    engine.get_bank_profile = AsyncMock(side_effect=OperationValidationError("profile reads are forbidden"))
+
+    with pytest.raises(OperationValidationError, match="profile reads are forbidden"):
+        await MemoryEngineInterface.update_bank_disposition_and_get_profile(
+            engine,
+            "legacy-interface",
+            {"skepticism": 4, "literalism": 3, "empathy": 2},
+            request_context=RequestContext(),
+        )
+
+    engine.get_bank_profile.assert_awaited_once()
+    engine.update_bank_disposition.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_disposition_profile_interface_fallback_projects_new_bank_response():
+    """The fallback does not need a failure-prone read after creating a bank."""
+    engine = MagicMock()
+    engine.update_bank_disposition = AsyncMock()
+    engine.get_bank_profile = AsyncMock(return_value=None)
+    disposition = {"skepticism": 4, "literalism": 3, "empathy": 2}
+    request_context = RequestContext()
+
+    profile = await MemoryEngineInterface.update_bank_disposition_and_get_profile(
+        engine,
+        "legacy-interface",
+        disposition,
+        request_context=request_context,
+    )
+
+    assert profile == {
+        "bank_id": "legacy-interface",
+        "name": "legacy-interface",
+        "disposition": disposition,
+        "mission": "",
+    }
+    engine.get_bank_profile.assert_awaited_once()
+    engine.update_bank_disposition.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_bank_profile_locks_existing_row():
+    """Connection-bound provisioning locks the row before a legacy write."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = {
+        "name": "locked-bank",
+        "disposition": {"skepticism": 3, "literalism": 3, "empathy": 3},
+        "mission": "",
+    }
+
+    result = await bank_utils.get_or_create_bank_profile_on_conn(
+        conn,
+        "locked-bank",
+        ops=MagicMock(),
+    )
+
+    assert result.created is False
+    assert "FOR UPDATE" in conn.fetchrow.await_args.args[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["disposition", "mission"])
+async def test_connection_bound_legacy_write_rejects_zero_rows(method):
+    """A delete race must fail instead of returning success for UPDATE 0."""
+    conn = AsyncMock()
+    conn.execute.return_value = "UPDATE 0"
+
+    with pytest.raises(RuntimeError, match="disappeared before the legacy profile write"):
+        if method == "disposition":
+            await bank_utils.update_bank_disposition_on_conn(
+                conn,
+                "deleted-bank",
+                {"skepticism": 5, "literalism": 4, "empathy": 2},
+            )
+        else:
+            await bank_utils.set_bank_mission_on_conn(
+                conn,
+                "deleted-bank",
+                "Mission",
+            )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("existing", [False, True])
+async def test_legacy_profile_put_read_denial_has_no_side_effects(
+    api_client,
+    memory,
+    monkeypatch,
+    existing,
+):
+    """The deprecated response read must be authorized before create or update."""
+    bank_id = f"legacy_profile_read_denied_{existing}_{datetime.now().timestamp()}"
+    original = {"skepticism": 2, "literalism": 3, "empathy": 4}
+    if existing:
+        await memory.update_bank_disposition(bank_id, original, request_context=RequestContext())
+
+    validator = _make_operation_validator(
+        reject_bank_read=BankReadOperation.GET_BANK_PROFILE,
+        reason="profile reads are forbidden",
+    )
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+
+    response = await api_client.put(
+        f"/v1/default/banks/{bank_id}/profile",
+        json={"disposition": {"skepticism": 5, "literalism": 5, "empathy": 1}},
+    )
+
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "profile reads are forbidden"
+    validator.validate_bank_read.assert_awaited_once()
+    validator.validate_bank_write.assert_not_awaited()
+    validator.validate_create_bank.assert_not_awaited()
+
+    monkeypatch.setattr(memory, "_operation_validator", None)
+    profile = await memory.get_bank_profile(
+        bank_id,
+        request_context=RequestContext(),
+        create_if_missing=False,
+    )
+    if existing:
+        assert profile is not None
+        assert dict(profile["disposition"]) == original
+        await memory.delete_bank(bank_id, request_context=RequestContext())
+    else:
+        assert profile is None
+
+
+@pytest.mark.asyncio
+async def test_legacy_profile_put_authorizes_once_and_reuses_profile(
+    api_client,
+    memory,
+    monkeypatch,
+):
+    """A successful deprecated PUT uses one auth pass and provisions once."""
+    bank_id = f"legacy_profile_single_auth_{datetime.now().timestamp()}"
+    validator = _make_operation_validator()
+    authenticate = AsyncMock(wraps=memory._authenticate_tenant)
+    apply_template = AsyncMock()
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+    monkeypatch.setattr(memory, "_authenticate_tenant", authenticate)
+    monkeypatch.setattr(memory, "_apply_default_bank_template", apply_template)
+
+    response = await api_client.put(
+        f"/v1/default/banks/{bank_id}/profile",
+        json={"disposition": {"skepticism": 4, "literalism": 2, "empathy": 5}},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["disposition"] == {"skepticism": 4, "literalism": 2, "empathy": 5}
+    authenticate.assert_awaited_once()
+    assert [call.args[0].operation for call in validator.validate_bank_read.await_args_list] == [
+        BankReadOperation.GET_BANK_PROFILE
+    ]
+    assert [call.args[0].operation for call in validator.validate_bank_write.await_args_list] == [
+        BankWriteOperation.UPDATE_BANK_DISPOSITION
+    ]
+    validator.validate_create_bank.assert_awaited_once()
+    apply_template.assert_awaited_once()
+
+    authenticate.reset_mock()
+    validator.validate_bank_read.reset_mock()
+    validator.validate_bank_write.reset_mock()
+    validator.validate_create_bank.reset_mock()
+    apply_template.reset_mock()
+
+    response = await api_client.put(
+        f"/v1/default/banks/{bank_id}/profile",
+        json={"disposition": {"skepticism": 1, "literalism": 3, "empathy": 2}},
+    )
+
+    assert response.status_code == 200, response.text
+    authenticate.assert_awaited_once()
+    validator.validate_bank_read.assert_awaited_once()
+    validator.validate_bank_write.assert_awaited_once()
+    validator.validate_create_bank.assert_not_awaited()
+    apply_template.assert_not_awaited()
+
+    monkeypatch.setattr(memory, "_operation_validator", None)
+    await memory.delete_bank(bank_id, request_context=RequestContext())
+
+
+@pytest.mark.asyncio
+async def test_legacy_profile_put_returns_locked_snapshot_with_post_commit_config(
+    memory,
+    monkeypatch,
+):
+    """The response keeps this write's legacy values while applying template config."""
+    bank_id = f"legacy_profile_locked_snapshot_{datetime.now().timestamp()}"
+    request_context = RequestContext()
+    backend = await memory._get_backend()
+    concurrent_disposition = {"skepticism": 1, "literalism": 1, "empathy": 1}
+
+    async def apply_template_with_concurrent_legacy_write(_bank_id, _request_context):
+        await bank_utils.update_bank_disposition(
+            backend,
+            bank_id,
+            concurrent_disposition,
+        )
+
+    monkeypatch.setattr(memory, "_apply_default_bank_template", apply_template_with_concurrent_legacy_write)
+    monkeypatch.setattr(
+        memory._config_resolver,
+        "get_bank_config",
+        AsyncMock(
+            return_value={
+                "disposition_skepticism": 2,
+                "reflect_mission": "Configured mission.",
+            }
+        ),
+    )
+
+    profile = await memory.update_bank_disposition_and_get_profile(
+        bank_id,
+        {"skepticism": 5, "literalism": 4, "empathy": 3},
+        request_context=request_context,
+    )
+
+    assert profile == {
+        "bank_id": bank_id,
+        "name": bank_id,
+        "disposition": {"skepticism": 2, "literalism": 4, "empathy": 3},
+        "mission": "Configured mission.",
+    }
+    stored = await bank_utils.get_bank_profile_if_exists(backend, bank_id)
+    assert stored is not None
+    assert dict(stored["disposition"]) == concurrent_disposition
+    await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_legacy_profile_put_config_failure_returns_locked_snapshot(
+    api_client,
+    memory,
+    monkeypatch,
+):
+    """A post-commit config outage must not turn a successful write into a 500."""
+    bank_id = f"legacy_profile_config_failure_{datetime.now().timestamp()}"
+    request_context = RequestContext()
+    await memory.update_bank_disposition(
+        bank_id,
+        {"skepticism": 2, "literalism": 2, "empathy": 2},
+        request_context=request_context,
+    )
+    monkeypatch.setattr(
+        memory._config_resolver,
+        "get_bank_config",
+        AsyncMock(side_effect=RuntimeError("config backend unavailable")),
+    )
+
+    response = await api_client.put(
+        f"/v1/default/banks/{bank_id}/profile",
+        json={"disposition": {"skepticism": 5, "literalism": 4, "empathy": 3}},
+    )
+
+    assert response.status_code == 200, response.text
+    response_profile = response.json()
+    assert response_profile["bank_id"] == bank_id
+    assert response_profile["name"] == bank_id
+    assert response_profile["disposition"] == {"skepticism": 5, "literalism": 4, "empathy": 3}
+    assert response_profile["mission"] == ""
+    await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "operation"),
+    [
+        ("disposition", BankWriteOperation.UPDATE_BANK_DISPOSITION),
+        ("set_mission", BankWriteOperation.SET_BANK_MISSION),
+    ],
+)
+async def test_legacy_bank_writes_use_authorized_provisioning(
+    memory,
+    monkeypatch,
+    method,
+    operation,
+):
+    """Legacy writes create transactionally, apply defaults once, and skip read auth."""
+    bank_id = f"legacy_authorized_provision_{method}_{datetime.now().timestamp()}"
+    request_context = RequestContext()
+    validator = _make_operation_validator()
+    apply_template = AsyncMock()
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+    monkeypatch.setattr(memory, "_apply_default_bank_template", apply_template)
+
+    await _call_legacy_bank_write(memory, method, bank_id, request_context)
+
+    assert [call.args[0].operation for call in validator.validate_bank_write.await_args_list] == [operation]
+    validator.validate_bank_read.assert_not_awaited()
+    validator.validate_create_bank.assert_awaited_once()
+    apply_template.assert_awaited_once()
+
+    validator.validate_bank_write.reset_mock()
+    validator.validate_create_bank.reset_mock()
+    apply_template.reset_mock()
+    await _call_legacy_bank_write(memory, method, bank_id, request_context)
+
+    assert [call.args[0].operation for call in validator.validate_bank_write.await_args_list] == [operation]
+    validator.validate_bank_read.assert_not_awaited()
+    validator.validate_create_bank.assert_not_awaited()
+    apply_template.assert_not_awaited()
+
+    monkeypatch.setattr(memory, "_operation_validator", None)
+    profile = await memory.get_bank_profile(
+        bank_id,
+        request_context=request_context,
+        create_if_missing=False,
+    )
+    assert profile is not None
+    if method == "disposition":
+        assert dict(profile["disposition"]) == {"skepticism": 5, "literalism": 4, "empathy": 2}
+    else:
+        assert profile["mission"] == "Keep the customer informed."
+    await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "operation", "read_operation"),
+    [
+        ("disposition", BankWriteOperation.UPDATE_BANK_DISPOSITION, None),
+        ("set_mission", BankWriteOperation.SET_BANK_MISSION, None),
+        ("merge_mission", BankWriteOperation.MERGE_BANK_MISSION, BankReadOperation.GET_BANK_PROFILE),
+    ],
+)
+async def test_legacy_bank_write_create_denial_has_no_side_effects_or_llm(
+    memory,
+    monkeypatch,
+    method,
+    operation,
+    read_operation,
+):
+    """A rejected create hook leaves no row and stops before mission model work."""
+    bank_id = f"legacy_create_denied_{method}_{datetime.now().timestamp()}"
+    request_context = RequestContext()
+    validator = _make_operation_validator()
+    validator.validate_create_bank = AsyncMock(return_value=ValidationResult.reject("bank creation is forbidden"))
+    apply_template = AsyncMock()
+    merge_llm = AsyncMock(return_value={"mission": "should not run"})
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+    monkeypatch.setattr(memory, "_apply_default_bank_template", apply_template)
+    monkeypatch.setattr(bank_utils, "_llm_merge_mission", merge_llm)
+
+    with pytest.raises(OperationValidationError, match="bank creation is forbidden"):
+        await _call_legacy_bank_write(memory, method, bank_id, request_context)
+
+    assert [call.args[0].operation for call in validator.validate_bank_write.await_args_list] == [operation]
+    if read_operation is None:
+        validator.validate_bank_read.assert_not_awaited()
+    else:
+        assert [call.args[0].operation for call in validator.validate_bank_read.await_args_list] == [read_operation]
+    validator.validate_create_bank.assert_awaited_once()
+    apply_template.assert_not_awaited()
+    merge_llm.assert_not_awaited()
+
+    monkeypatch.setattr(memory, "_operation_validator", None)
+    profile = await memory.get_bank_profile(
+        bank_id,
+        request_context=request_context,
+        create_if_missing=False,
+    )
+    assert profile is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reject_read", "reject_write"),
+    [
+        (BankReadOperation.GET_BANK_PROFILE, None),
+        (None, BankWriteOperation.MERGE_BANK_MISSION),
+    ],
+)
+async def test_merge_bank_mission_denied_authorization_does_not_call_llm_or_mutate(
+    memory,
+    monkeypatch,
+    reject_read,
+    reject_write,
+):
+    """Both required merge permissions are resolved before the model call."""
+    bank_id = f"legacy_merge_denied_{reject_read}_{reject_write}_{datetime.now().timestamp()}"
+    request_context = RequestContext()
+    await memory.set_bank_mission(bank_id, "Original mission.", request_context=request_context)
+    validator = _make_operation_validator(
+        reject_bank_read=reject_read,
+        reject_bank_write=reject_write,
+        reason="mission merge is forbidden",
+    )
+    merge_llm = AsyncMock(return_value={"mission": "should not run"})
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+    monkeypatch.setattr(bank_utils, "_llm_merge_mission", merge_llm)
+
+    with pytest.raises(OperationValidationError, match="mission merge is forbidden"):
+        await memory.merge_bank_mission(
+            bank_id,
+            "New mission details.",
+            request_context=request_context,
+        )
+
+    validator.validate_bank_read.assert_awaited_once()
+    if reject_read is None:
+        validator.validate_bank_write.assert_awaited_once()
+    else:
+        validator.validate_bank_write.assert_not_awaited()
+    validator.validate_create_bank.assert_not_awaited()
+    merge_llm.assert_not_awaited()
+
+    monkeypatch.setattr(memory, "_operation_validator", None)
+    profile = await memory.get_bank_profile(
+        bank_id,
+        request_context=request_context,
+        create_if_missing=False,
+    )
+    assert profile is not None
+    assert profile["mission"] == "Original mission."
+    await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_merge_bank_mission_authorizes_and_provisions_once(
+    memory,
+    monkeypatch,
+):
+    """Successful mission merges run each hook once and never re-provision."""
+    bank_id = f"legacy_merge_authorized_{datetime.now().timestamp()}"
+    request_context = RequestContext()
+    validator = _make_operation_validator()
+    apply_template = AsyncMock()
+    merge_llm = AsyncMock(return_value={"mission": "I track customers and urgent risks."})
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+    monkeypatch.setattr(memory, "_apply_default_bank_template", apply_template)
+    monkeypatch.setattr(bank_utils, "_llm_merge_mission", merge_llm)
+
+    result = await memory.merge_bank_mission(
+        bank_id,
+        "Track customers and urgent risks.",
+        request_context=request_context,
+    )
+
+    assert result == {"mission": "I track customers and urgent risks."}
+    assert [call.args[0].operation for call in validator.validate_bank_read.await_args_list] == [
+        BankReadOperation.GET_BANK_PROFILE
+    ]
+    assert [call.args[0].operation for call in validator.validate_bank_write.await_args_list] == [
+        BankWriteOperation.MERGE_BANK_MISSION
+    ]
+    validator.validate_create_bank.assert_awaited_once()
+    apply_template.assert_awaited_once()
+    merge_llm.assert_awaited_once_with(
+        memory._reflect_llm_config,
+        "",
+        "Track customers and urgent risks.",
+    )
+
+    validator.validate_bank_read.reset_mock()
+    validator.validate_bank_write.reset_mock()
+    validator.validate_create_bank.reset_mock()
+    apply_template.reset_mock()
+    merge_llm.reset_mock()
+    merge_llm.return_value = {"mission": "I track customers, urgent risks, and renewals."}
+
+    result = await memory.merge_bank_mission(
+        bank_id,
+        "Also track renewals.",
+        request_context=request_context,
+    )
+
+    assert result == {"mission": "I track customers, urgent risks, and renewals."}
+    validator.validate_bank_read.assert_awaited_once()
+    validator.validate_bank_write.assert_awaited_once()
+    validator.validate_create_bank.assert_not_awaited()
+    apply_template.assert_not_awaited()
+    merge_llm.assert_awaited_once_with(
+        memory._reflect_llm_config,
+        "I track customers and urgent risks.",
+        "Also track renewals.",
+    )
+
+    monkeypatch.setattr(memory, "_operation_validator", None)
+    await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("concurrent_change", ["mission_update", "delete_recreate"])
+async def test_merge_bank_mission_rejects_concurrent_lifecycle_change(
+    memory,
+    monkeypatch,
+    concurrent_change,
+):
+    """A stale model result must not overwrite another writer or replacement bank."""
+    bank_id = f"legacy_merge_concurrent_{concurrent_change}_{datetime.now().timestamp()}"
+    request_context = RequestContext()
+    original_mission = "Original mission."
+    await memory.set_bank_mission(bank_id, original_mission, request_context=request_context)
+
+    async def merge_with_concurrent_change(_llm_config, _current, _new_info):
+        if concurrent_change == "mission_update":
+            await memory.set_bank_mission(
+                bank_id,
+                "Concurrent mission.",
+                request_context=request_context,
+            )
+        else:
+            await memory.delete_bank(bank_id, request_context=request_context)
+            await memory.set_bank_mission(
+                bank_id,
+                original_mission,
+                request_context=request_context,
+            )
+        return {"mission": "Stale merged mission."}
+
+    monkeypatch.setattr(bank_utils, "_llm_merge_mission", merge_with_concurrent_change)
+
+    with pytest.raises(RuntimeError, match="changed while its mission was being merged"):
+        await memory.merge_bank_mission(
+            bank_id,
+            "New mission details.",
+            request_context=request_context,
+        )
+
+    profile = await memory.get_bank_profile(
+        bank_id,
+        request_context=request_context,
+        create_if_missing=False,
+    )
+    assert profile is not None
+    expected_mission = "Concurrent mission." if concurrent_change == "mission_update" else original_mission
+    assert profile["mission"] == expected_mission
+    await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_bank_utils_legacy_write_wrappers_preserve_call_contracts(
+    memory,
+    monkeypatch,
+):
+    """Retain-level callers can keep using the original pool-based signatures."""
+    bank_id = f"legacy_bank_utils_contract_{datetime.now().timestamp()}"
+    request_context = RequestContext()
+    backend = await memory._get_backend()
+    merge_llm = AsyncMock(return_value={"mission": "Merged mission."})
+    monkeypatch.setattr(bank_utils, "_llm_merge_mission", merge_llm)
+
+    await bank_utils.update_bank_disposition(
+        backend,
+        bank_id,
+        {"skepticism": 5, "literalism": 4, "empathy": 2},
+    )
+    await bank_utils.set_bank_mission(backend, bank_id, "Original mission.")
+    result = await bank_utils.merge_bank_mission(
+        backend,
+        memory._reflect_llm_config,
+        bank_id,
+        "New detail.",
+    )
+
+    assert result == {"mission": "Merged mission."}
+    profile = await bank_utils.get_bank_profile_if_exists(backend, bank_id)
+    assert profile is not None
+    assert dict(profile["disposition"]) == {"skepticism": 5, "literalism": 4, "empathy": 2}
+    assert profile["mission"] == "Merged mission."
+    merge_llm.assert_awaited_once_with(
+        memory._reflect_llm_config,
+        "Original mission.",
+        "New detail.",
+    )
+    await memory.delete_bank(bank_id, request_context=request_context)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- authorize the deprecated profile response read before any disposition mutation
- route legacy disposition and mission writes through the unified create-bank lifecycle
- validate read, write, and create hooks exactly once before writes or mission-merge LLM work
- keep lazy creation and legacy writes atomic on one connection, then apply defaults once after commit
- return disposition responses from a transaction-locked snapshot and reject stale mission merges with an `internal_id` + `updated_at` compare-and-set

Fixes #3036.

## Tests

- 22 focused authorization, provisioning, compatibility, rollback, and concurrency regressions
- 8 existing agent-profile, mission, and full API workflow tests
- targeted Ruff check and format check
- `git diff --check`

## Review note

Adversarial review was reworked across several rounds: the final patch adds compatibility-safe preauthorization, row locking, zero-row detection, a locked response snapshot, post-commit config fallback, and portable stale-write protection for PostgreSQL and Oracle.

The remaining review concern is the repository's existing connection-bound provisioning contract: `HINDSIGHT_API_DEFAULT_BANK_TEMPLATE` is best-effort, opens separate connections, and therefore runs after the caller transaction commits using `bank_id`. Fully lifecycle-binding every template resource write would require a broader provisioning-state design; this PR preserves the explicit contract described in `_ensure_bank_exists()` and issue #3036 rather than expanding that architecture.
