### PR TITLE
fix(tei): retry embedding connect timeouts

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -506,7 +506,7 @@ class RemoteTEIEmbeddings(Embeddings):
                     response = self._client.post(url, **kwargs)
                 response.raise_for_status()
                 return response
-            except (httpx.ConnectError, httpx.ReadTimeout, httpx.WriteTimeout) as e:
+            except (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadTimeout, httpx.WriteTimeout) as e:
                 last_error = e
                 if attempt < self.max_retries:
                     logger.warning(

--- a/hindsight-api-slim/tests/test_tei_embeddings.py
+++ b/hindsight-api-slim/tests/test_tei_embeddings.py
@@ -6,6 +6,49 @@ import pytest
 from hindsight_api.engine.embeddings import RemoteTEIEmbeddings
 
 
+def test_connect_timeout_retries_then_succeeds() -> None:
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise httpx.ConnectTimeout("connection timed out")
+        return httpx.Response(200, json=[[0.1, 0.2]])
+
+    embeddings = RemoteTEIEmbeddings(
+        base_url="http://localhost:8080",
+        max_retries=3,
+        retry_delay=0,
+    )
+    embeddings._client = httpx.Client(transport=httpx.MockTransport(handler))
+
+    assert embeddings.encode(["text"]) == [[0.1, 0.2]]
+    assert attempts == 2
+
+
+def test_persistent_connect_timeout_exhausts_retry_budget() -> None:
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        raise httpx.ConnectTimeout("connection timed out")
+
+    embeddings = RemoteTEIEmbeddings(
+        base_url="http://localhost:8080",
+        max_retries=2,
+        retry_delay=0,
+    )
+    embeddings._client = httpx.Client(transport=httpx.MockTransport(handler))
+
+    with pytest.raises(RuntimeError, match="TEI embedding request failed") as exc_info:
+        embeddings.encode(["text"])
+
+    assert attempts == 3
+    assert isinstance(exc_info.value.__context__, httpx.ConnectTimeout)
+
+
 def test_retry_on_too_many_requests() -> None:
     """TEI's 429 overload response should use the transient retry budget."""
     attempts = 0


### PR DESCRIPTION
## Summary
- retry `httpx.ConnectTimeout` in `RemoteTEIEmbeddings` using the existing bounded retry budget
- add focused coverage for transient recovery and persistent timeout exhaustion

## Test plan
- [x] RED: both new ConnectTimeout regressions failed before the production change
- [x] `cd hindsight-api-slim && uv run pytest tests/test_tei_embeddings.py -q` (5 passed)
- [x] `./scripts/hooks/lint.sh`
- [x] independent read-only code review (no findings)

No schema, auth, public API, or deployment changes.
