### PR TITLE
fix(integrations-claude-code): resolve deleted subagent worktree cwd to parent repo bank

### DIFF
--- a/hindsight-integrations/claude-code/scripts/lib/bank.py
+++ b/hindsight-integrations/claude-code/scripts/lib/bank.py
@@ -29,25 +29,18 @@ DEFAULT_BANK_NAME = "claude-code"
 VALID_FIELDS = {"agent", "project", "session", "channel", "user"}
 
 
-def _resolve_project_name(cwd: str, config: dict) -> str:
-    """Resolve the project name from the working directory.
+def _project_name_from_git(cwd: str):
+    """Ask git for the repository name at ``cwd``.
 
-    When resolveWorktrees is enabled (default), detects git worktrees and
-    resolves to the main repository basename so that all worktrees of the
-    same repo share the same bank.
+    Returns the repository basename, or None when ``cwd`` cannot be
+    resolved (not inside a repo, directory missing, git unavailable).
 
-    For a regular repo at /home/user/myproject:
-        git-common-dir → /home/user/myproject/.git → basename "myproject"
-
-    For a worktree at /home/user/myproject-wt1 linked to /home/user/myproject:
-        git-common-dir → /home/user/myproject/.git → basename "myproject"
+    The name is derived from --git-common-dir so that all worktrees of
+    the same repo share one name:
+      - regular repo / linked worktree: <repo>/.git            → "repo"
+      - bare repo:                      <path>/repo.git        → "repo"
+      - submodule:                      <super>/.git/modules/<name> → "<name>"
     """
-    if not cwd:
-        return "unknown"
-
-    if not config.get("resolveWorktrees", True):
-        return os.path.basename(cwd)
-
     try:
         result = subprocess.run(
             ["git", "-C", cwd, "rev-parse", "--path-format=absolute", "--git-common-dir"],
@@ -55,14 +48,58 @@ def _resolve_project_name(cwd: str, config: dict) -> str:
             text=True,
             timeout=5,
         )
-        if result.returncode == 0:
-            git_common_dir = result.stdout.strip()
-            # git-common-dir returns the .git directory of the main repo
-            # e.g. /home/user/myproject/.git → parent is /home/user/myproject
-            main_repo_path = os.path.dirname(git_common_dir)
-            return os.path.basename(main_repo_path)
     except (OSError, subprocess.TimeoutExpired):
-        pass
+        return None
+    if result.returncode != 0:
+        return None
+
+    git_common_dir = result.stdout.strip()
+    name = os.path.basename(git_common_dir)
+    if name == ".git":
+        # e.g. /home/user/myproject/.git → parent is /home/user/myproject
+        return os.path.basename(os.path.dirname(git_common_dir))
+    if name.endswith(".git"):
+        # bare repo gitdir, e.g. /srv/git/myproject.git
+        return name[: -len(".git")]
+    # submodule gitdir lives under <super>/.git/modules/<name>, so the
+    # common dir's own basename is the submodule name
+    return name
+
+
+def _resolve_project_name(cwd: str, config: dict) -> str:
+    """Resolve the project name from the working directory.
+
+    When resolveWorktrees is enabled (default), detects git worktrees and
+    resolves to the main repository basename so that all worktrees of the
+    same repo share the same bank.
+
+    If ``cwd`` no longer exists on disk — e.g. an ephemeral subagent
+    worktree under <repo>/.claude/worktrees/ that was cleaned up before an
+    async hook ran — resolution is retried from the nearest existing
+    ancestor so the project still maps to the containing repository
+    instead of the generated leaf basename.
+    """
+    if not cwd:
+        return "unknown"
+
+    if not config.get("resolveWorktrees", True):
+        return os.path.basename(cwd)
+
+    name = _project_name_from_git(cwd)
+    if name is not None:
+        return name
+
+    if not os.path.exists(cwd):
+        ancestor = os.path.dirname(cwd)
+        while ancestor and not os.path.isdir(ancestor):
+            parent = os.path.dirname(ancestor)
+            if parent == ancestor:
+                break
+            ancestor = parent
+        if ancestor and os.path.isdir(ancestor):
+            name = _project_name_from_git(ancestor)
+            if name is not None:
+                return name
 
     # Fallback: not a git repo or git not available
     return os.path.basename(cwd)

--- a/hindsight-integrations/claude-code/tests/test_bank.py
+++ b/hindsight-integrations/claude-code/tests/test_bank.py
@@ -163,6 +163,64 @@ class TestResolveProjectName:
     def test_empty_cwd(self):
         assert _resolve_project_name("", _cfg()) == "unknown"
 
+    @patch("lib.bank.subprocess.run")
+    def test_submodule_resolves_to_submodule_name(self, mock_run):
+        # Submodule gitdir lives under <super>/.git/modules/<name>; the old
+        # dirname+basename parse returned the meaningless "modules"
+        mock_run.return_value = self._mock_git("/home/user/super/.git/modules/libfoo\n")
+        assert _resolve_project_name("/home/user/super/libfoo", _cfg()) == "libfoo"
+
+    @patch("lib.bank.subprocess.run")
+    def test_nested_submodule_resolves_to_leaf_name(self, mock_run):
+        mock_run.return_value = self._mock_git("/home/user/super/.git/modules/libfoo/modules/inner\n")
+        assert _resolve_project_name("/home/user/super/libfoo/inner", _cfg()) == "inner"
+
+    @patch("lib.bank.subprocess.run")
+    def test_bare_repo_gitdir_strips_suffix(self, mock_run):
+        mock_run.return_value = self._mock_git("/srv/git/myproject.git\n")
+        assert _resolve_project_name("/srv/checkouts/wt1", _cfg()) == "myproject"
+
+
+class TestDeletedCwdResolution:
+    """Regression tests for cwds that no longer exist on disk (#3096).
+
+    The async Stop retain hook can fire after an isolated Claude Code
+    subagent worktree under <repo>/.claude/worktrees/ has been cleaned up.
+    The resolver must still map the deleted path to the containing
+    repository, not to the generated leaf basename (e.g. "agent-deadbeef").
+
+    These tests run real git against tmp_path instead of mocking, so the
+    upward-discovery semantics of `git -C <ancestor>` are exercised.
+    """
+
+    def _init_repo(self, path):
+        path.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["git", "init", "-q", str(path)], check=True)
+
+    def test_deleted_worktree_resolves_to_parent_repo(self, tmp_path):
+        repo = tmp_path / "myproject"
+        self._init_repo(repo)
+        dead = repo / ".claude" / "worktrees" / "agent-deadbeef"
+        assert _resolve_project_name(str(dead), _cfg()) == "myproject"
+
+    def test_deleted_path_outside_any_repo_falls_back_to_basename(self, tmp_path):
+        dead = tmp_path / "plaindir" / "gone"
+        assert _resolve_project_name(str(dead), _cfg()) == "gone"
+
+    def test_existing_non_git_dir_keeps_basename(self, tmp_path):
+        # Ancestor retry is gated on the cwd being deleted; a live non-git
+        # directory keeps the current basename behavior
+        plain = tmp_path / "plaindir"
+        plain.mkdir()
+        assert _resolve_project_name(str(plain), _cfg()) == "plaindir"
+
+    def test_derive_bank_id_deleted_worktree(self, tmp_path):
+        repo = tmp_path / "myproject"
+        self._init_repo(repo)
+        cfg = _cfg(dynamicBankId=True, dynamicBankGranularity=["project"])
+        dead = repo / ".claude" / "worktrees" / "agent-deadbeef"
+        assert derive_bank_id({"cwd": str(dead), "session_id": "s"}, cfg) == "myproject"
+
 
 class TestDirectoryBankMap:
     """Tests for explicit directory-to-bank mapping."""
@@ -245,10 +303,12 @@ class TestDirectoryBankMap:
         assert result == "fallback"
 
     def test_multiple_entries(self):
-        cfg = _cfg(directoryBankMap={
-            "/home/user/project-a": "bank-a",
-            "/home/user/project-b": "bank-b",
-        })
+        cfg = _cfg(
+            directoryBankMap={
+                "/home/user/project-a": "bank-a",
+                "/home/user/project-b": "bank-b",
+            }
+        )
         assert derive_bank_id(_hook(cwd="/home/user/project-a"), cfg) == "bank-a"
         assert derive_bank_id(_hook(cwd="/home/user/project-b"), cfg) == "bank-b"
 
@@ -300,6 +360,7 @@ class TestEnsureBankMission:
     @pytest.mark.skipif(not hasattr(__import__("os"), "symlink"), reason="symlinks not supported")
     def test_directorybankmap_matches_symlinked_cwd(self, tmp_path):
         import os
+
         real = os.path.realpath(tmp_path / "proj")
         os.makedirs(real)
         link = str(tmp_path / "proj-link")


### PR DESCRIPTION
Fixes #3096

## Problem

With project-scoped dynamic banks (`dynamicBankId: true`, `dynamicBankGranularity: ["project"]`, `resolveWorktrees: true`), the async `Stop` retain hook can fire after an isolated Claude Code subagent worktree under `<repo>/.claude/worktrees/agent-*` has already been cleaned up. `git -C <cwd> rev-parse --git-common-dir` fails for the deleted path and `_resolve_project_name()` falls back directly to `os.path.basename(cwd)`, silently creating orphan banks named after the generated worktree directory (e.g. `agent-a33c4d636c3472e69`) and fragmenting project memory away from the intended bank. Observed in production: one parent session produced 5 orphan `agent-*` banks, one of which accumulated 598 memory units (details in #3096).

## Fix

Two changes to `scripts/lib/bank.py`:

1. **Extract git resolution into `_project_name_from_git()` and fix the common-dir parse.** The old `basename(dirname(git_common_dir))` assumed the common dir always ends in `.git`. For a submodule the common dir is `<super>/.git/modules/<name>`, so the resolver returned the meaningless name `modules` even for a *live* submodule cwd. The parse now handles:
   - regular repo / linked worktree: `<repo>/.git` → `repo` (unchanged)
   - bare repo gitdir: `<path>/repo.git` → `repo` (was: parent directory name)
   - submodule: `<super>/.git/modules/<name>` → `<name>` (was: `modules`)

2. **Retry from the nearest existing ancestor when the cwd is deleted.** If (and only if) the supplied cwd no longer exists on disk, git resolution is retried once from the nearest existing ancestor, so a removed ephemeral workspace still resolves to its containing repository. This is generic — no hard-coding of `.claude/worktrees`. Live directories (including live non-git directories) keep the existing behavior unchanged; the basename fallback remains for deleted paths with no repository ancestor.

The submodule parse fix also makes the ancestor retry consistent: a deleted path under a live submodule now resolves to the same name a live cwd would produce.

## Behavior note

Users who work inside git submodules will see their bank resolve to the submodule name instead of the previous (buggy) `modules`. This is a bug fix but technically a bank-id change for that configuration.

## Tests

- Mocked regression tests for the common-dir parse: submodule, nested submodule, bare repo gitdir.
- Real-git regression tests (`git init` against `tmp_path`, no mocks) for the deleted-cwd path: deleted worktree under an existing repo resolves to the repo basename (also asserted end-to-end through `derive_bank_id()`), deleted path outside any repo keeps the basename fallback, and a live non-git directory is unaffected.

All 204 tests in `hindsight-integrations/claude-code` pass; `ruff format --check` clean with the shared `ruff.toml`.
