### PR TITLE
feat(control-plane): badge documents an in-flight retain op is updating

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -14226,11 +14226,15 @@ class MemoryEngine(MemoryEngineInterface):
         parent_operation_id = client_operation_id if client_operation_id is not None else uuid.uuid4()
         backend = await self._get_backend()
 
-        # Create typed metadata for parent operation
+        # Create typed metadata for parent operation. `doc_ids` was validated
+        # above to be duplicate-free, so a length of 1 means the batch targets a
+        # single document (e.g. a reprocess) — surface it so the documents UI can
+        # badge that row as "updating" while the op is in flight.
         parent_metadata = BatchRetainParentMetadata(
             items_count=len(contents),
             total_tokens=total_tokens,
             num_sub_batches=len(sub_batches),
+            document_id=doc_ids[0] if len(doc_ids) == 1 else None,
         )
 
         # Persist the parent row and all child rows in a single transaction.
@@ -14299,11 +14303,16 @@ class MemoryEngine(MemoryEngineInterface):
                         if request_context.api_key_id:
                             task_payload["_api_key_id"] = request_context.api_key_id
 
+                        # Per-child single-document surfacing (see parent note):
+                        # in a multi-document batch, each single-document child
+                        # still lets the UI badge its row.
+                        child_doc_ids = [item.get("document_id") for item in sub_batch if item.get("document_id")]
                         child_metadata = BatchRetainChildMetadata(
                             items_count=len(sub_batch),
                             parent_operation_id=str(parent_operation_id),
                             sub_batch_index=i,
                             total_sub_batches=len(sub_batches),
+                            document_id=child_doc_ids[0] if len(child_doc_ids) == 1 else None,
                         )
 
                         child_operation_id = uuid.uuid4()

--- a/hindsight-api-slim/hindsight_api/engine/operation_metadata.py
+++ b/hindsight-api-slim/hindsight_api/engine/operation_metadata.py
@@ -19,10 +19,18 @@ class BatchRetainParentMetadata:
     total_tokens: int
     num_sub_batches: int
     is_parent: bool = True
+    # Set only when the whole batch targets a single document, so the operations
+    # list surfaces which document an in-flight retain is (re)writing. The
+    # documents UI cross-checks this to badge rows as "updating". Multi-document
+    # batches leave it None and are matched per single-document child instead.
+    document_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        """Convert to dict for JSON serialization."""
-        return asdict(self)
+        """Convert to dict for JSON serialization, omitting document_id when unset."""
+        data = asdict(self)
+        if data.get("document_id") is None:
+            data.pop("document_id", None)
+        return data
 
 
 @dataclass
@@ -33,10 +41,15 @@ class BatchRetainChildMetadata:
     parent_operation_id: str
     sub_batch_index: int
     total_sub_batches: int
+    # Set only when this child processes a single document (see the parent's note).
+    document_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        """Convert to dict for JSON serialization."""
-        return asdict(self)
+        """Convert to dict for JSON serialization, omitting document_id when unset."""
+        data = asdict(self)
+        if data.get("document_id") is None:
+            data.pop("document_id", None)
+        return data
 
 
 @dataclass

--- a/hindsight-api-slim/tests/test_async_batch_retain.py
+++ b/hindsight-api-slim/tests/test_async_batch_retain.py
@@ -1539,3 +1539,46 @@ async def test_retry_batch_parent_all_children_completed_is_rejected(memory, req
     async with acquire_with_retry(backend) as conn:
         parent = await conn.fetchrow("SELECT status FROM async_operations WHERE operation_id = $1", parent_id)
     assert parent["status"] == "cancelled", "a parent with no retryable work must not be revived (no re-strand)"
+
+
+@pytest.mark.asyncio
+async def test_single_document_retain_surfaces_document_id(memory, request_context):
+    """A single-document async retain (e.g. a document reprocess) surfaces its
+    target document_id in the operations list, so the documents UI can cross-check
+    pending/processing ops and badge that row as "updating" while it's in flight.
+    """
+    bank_id = "test_single_doc_update"
+    await memory.submit_async_retain(
+        bank_id=bank_id,
+        contents=[{"content": "Alice works at Google", "document_id": "report_2024"}],
+        request_context=request_context,
+    )
+
+    ops = (await memory.list_operations(bank_id, request_context=request_context))["operations"]
+    parents = [op for op in ops if op["task_type"] == "batch_retain"]
+    assert parents, "expected a batch_retain parent operation"
+    # Both the parent and its single child should carry the document_id.
+    assert all(op["document_id"] == "report_2024" for op in ops if op["task_type"] == "batch_retain")
+
+
+@pytest.mark.asyncio
+async def test_multi_document_batch_does_not_misattribute_document_id(memory, request_context):
+    """A batch that packs several documents into one child must NOT claim a single
+    document_id — that would badge the wrong row. The document_id is surfaced only
+    when an operation genuinely targets exactly one document.
+    """
+    bank_id = "test_multi_doc_update"
+    await memory.submit_async_retain(
+        bank_id=bank_id,
+        contents=[
+            {"content": "Alice works at Google", "document_id": "doc_a"},
+            {"content": "Bob loves Python", "document_id": "doc_b"},
+        ],
+        request_context=request_context,
+    )
+
+    ops = (await memory.list_operations(bank_id, request_context=request_context))["operations"]
+    # These two small items pack into one multi-document child, so neither the
+    # parent nor the child resolves to a single document_id.
+    assert ops, "expected operations for the batch"
+    assert all(op["document_id"] is None for op in ops)

--- a/hindsight-control-plane/src/components/documents-view.tsx
+++ b/hindsight-control-plane/src/components/documents-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo } from "react";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import { toast } from "sonner";
 import { client, LLMRequestEntry } from "@/lib/api";
 import { useBank } from "@/lib/bank-context";
@@ -125,6 +125,35 @@ function formatRelativeTime(dateStr: string): string {
   const months = Math.floor(days / 30);
   if (months < 12) return `${months}mo ago`;
   return `${Math.floor(months / 12)}y ago`;
+}
+
+// Live "Refreshed N seconds ago" label next to the documents count. It owns a
+// 1s ticker so only this label re-renders each second (not the whole table), and
+// uses Intl.RelativeTimeFormat with the active locale — no per-unit translation
+// keys needed. The list's own formatRelativeTime floors anything under a minute
+// to "just now", which is useless for an ~8s auto-refresh, so we format seconds
+// here directly.
+function LastRefreshedLabel({ at }: { at: number }) {
+  const t = useTranslations("documentsView");
+  const locale = useLocale();
+  const [, tick] = useState(0);
+  useEffect(() => {
+    const id = window.setInterval(() => tick((n) => n + 1), 1000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const sec = Math.max(0, Math.round((Date.now() - at) / 1000));
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+  const rel =
+    sec < 60
+      ? rtf.format(-sec, "second")
+      : sec < 3600
+        ? rtf.format(-Math.round(sec / 60), "minute")
+        : rtf.format(-Math.round(sec / 3600), "hour");
+
+  return (
+    <span className="text-xs text-muted-foreground/70">· {t("lastRefreshed", { time: rel })}</span>
+  );
 }
 
 function formatBytes(bytes: number): string {
@@ -1442,17 +1471,13 @@ export function DocumentsView() {
       {/* Hide the count during the very first load so it doesn't read
           "0 total documents" above the loading spinner. */}
       {(loaded || documents.length > 0 || pendingRows.length > 0) && (
-        <div className="mb-4 flex items-center gap-2 text-sm text-muted-foreground">
+        <div className="mb-4 flex items-baseline gap-2 text-sm text-muted-foreground">
           <span>
             {hasActiveFilters
               ? t("matchingDocuments", { total: displayTotal })
               : t("totalDocuments", { total: displayTotal })}
           </span>
-          {lastRefreshedAt !== null && (
-            <span className="text-xs text-muted-foreground/70">
-              · {t("lastRefreshed", { time: new Date(lastRefreshedAt).toLocaleTimeString() })}
-            </span>
-          )}
+          {lastRefreshedAt !== null && <LastRefreshedLabel at={lastRefreshedAt} />}
         </div>
       )}
 

--- a/hindsight-control-plane/src/components/documents-view.tsx
+++ b/hindsight-control-plane/src/components/documents-view.tsx
@@ -970,6 +970,9 @@ export function DocumentsView() {
         success: true,
         message: `Reprocessing started (operation: ${result.operation_id})`,
       });
+      // Surface the "Updating" badge immediately instead of waiting for the next
+      // poll tick; the poll then keeps it live and clears it when the op finishes.
+      loadUpdatingOps();
     } catch (error) {
       setReprocessResult({
         success: false,
@@ -1124,17 +1127,21 @@ export function DocumentsView() {
     }
   }, [currentBank, loadPendingUploads, loadUpdatingOps]);
 
-  // While any upload is converting OR any visible document is being rewritten,
-  // poll the operations endpoint and refresh the document list — so finished
-  // uploads flip from "Processing" to a real row, and an updated document's
-  // "Updating" badge clears (and its content refreshes) once the op completes.
+  // Poll so the "Updating" badge appears (and clears) on its own — you don't have
+  // to catch the moment or reload. Detection (loadUpdatingOps) is a light
+  // operations fetch and runs on every tick while the view is open; the heavier
+  // document/upload refresh only runs while something is actually in flight, so
+  // an idle table isn't constantly re-fetching documents. Once an op completes,
+  // one more refresh drops the badge and pulls in the rewritten content.
   useEffect(() => {
-    if (!currentBank || (!hasActiveUploads && !hasUpdatingDocs)) return;
+    if (!currentBank) return;
 
     const interval = window.setInterval(() => {
-      loadPendingUploads();
       loadUpdatingOps();
-      loadDocuments(currentPage);
+      if (hasActiveUploads || hasUpdatingDocs) {
+        loadPendingUploads();
+        loadDocuments(currentPage);
+      }
     }, PENDING_POLL_INTERVAL_MS);
 
     return () => window.clearInterval(interval);

--- a/hindsight-control-plane/src/components/documents-view.tsx
+++ b/hindsight-control-plane/src/components/documents-view.tsx
@@ -90,6 +90,10 @@ const ITEMS_PER_PAGE = 50;
 // client-side store — so the status survives reloads, tabs and devices.
 const PENDING_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const PENDING_POLL_INTERVAL_MS = 4000;
+// Idle cadence for auto-refreshing the whole table (new/updated docs, counts,
+// "Updating" badges) so it stays live without a manual reload. Gentler than the
+// active poll above — a quiet table shouldn't hammer the API.
+const DOCUMENTS_AUTO_REFRESH_MS = 8000;
 // A file_convert_retain operation flips to "completed" a couple of seconds
 // before the document becomes visible in listDocuments. Keep showing the
 // pending row for recently-completed operations so it stays on screen until
@@ -1127,22 +1131,20 @@ export function DocumentsView() {
     }
   }, [currentBank, loadPendingUploads, loadUpdatingOps]);
 
-  // Poll so the "Updating" badge appears (and clears) on its own — you don't have
-  // to catch the moment or reload. Detection (loadUpdatingOps) is a light
-  // operations fetch and runs on every tick while the view is open; the heavier
-  // document/upload refresh only runs while something is actually in flight, so
-  // an idle table isn't constantly re-fetching documents. Once an op completes,
-  // one more refresh drops the badge and pulls in the rewritten content.
+  // Auto-refresh the whole table on a timer so new/updated documents, counts,
+  // pending uploads, and "Updating" badges all appear without a manual reload.
+  // Refresh faster while something is actively in flight (uploads converting or a
+  // document being rewritten), and on the gentler idle cadence otherwise.
   useEffect(() => {
     if (!currentBank) return;
 
+    const period =
+      hasActiveUploads || hasUpdatingDocs ? PENDING_POLL_INTERVAL_MS : DOCUMENTS_AUTO_REFRESH_MS;
     const interval = window.setInterval(() => {
       loadUpdatingOps();
-      if (hasActiveUploads || hasUpdatingDocs) {
-        loadPendingUploads();
-        loadDocuments(currentPage);
-      }
-    }, PENDING_POLL_INTERVAL_MS);
+      loadPendingUploads();
+      loadDocuments(currentPage);
+    }, period);
 
     return () => window.clearInterval(interval);
   }, [
@@ -1566,10 +1568,10 @@ export function DocumentsView() {
                                 />
                                 {updatingDocIds.has(doc.id) && (
                                   <span
-                                    className="inline-flex items-center gap-1 rounded-full border border-blue-500/20 bg-blue-500/10 px-1.5 py-0.5 text-[11px] font-medium text-blue-600 dark:text-blue-400"
+                                    className="inline-flex items-center gap-1.5 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground"
                                     title={t("documentUpdating")}
                                   >
-                                    <RefreshCw className="w-3 h-3 animate-spin" />
+                                    <span className="h-1.5 w-1.5 rounded-full bg-blue-500/70 animate-pulse" />
                                     {t("documentUpdating")}
                                   </span>
                                 )}

--- a/hindsight-control-plane/src/components/documents-view.tsx
+++ b/hindsight-control-plane/src/components/documents-view.tsx
@@ -702,6 +702,9 @@ export function DocumentsView() {
   // flashes for the initial paint + debounce window before `loading` ever flips.
   // Gate the empty state on this so we show the loader until we actually know.
   const [loaded, setLoaded] = useState(false);
+  // Wall-clock time of the last list refresh, shown next to the count so the
+  // auto-refresh is visible ("Refreshed 14:41:32").
+  const [lastRefreshedAt, setLastRefreshedAt] = useState<number | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   // The UI exposes the two useful modes; both map to their *_strict variant so
@@ -782,6 +785,7 @@ export function DocumentsView() {
       } finally {
         setLoading(false);
         setLoaded(true);
+        setLastRefreshedAt(Date.now());
       }
     },
     [currentBank, searchQuery, selectedTags, tagsMatch]
@@ -1438,10 +1442,17 @@ export function DocumentsView() {
       {/* Hide the count during the very first load so it doesn't read
           "0 total documents" above the loading spinner. */}
       {(loaded || documents.length > 0 || pendingRows.length > 0) && (
-        <div className="mb-4 text-sm text-muted-foreground">
-          {hasActiveFilters
-            ? t("matchingDocuments", { total: displayTotal })
-            : t("totalDocuments", { total: displayTotal })}
+        <div className="mb-4 flex items-center gap-2 text-sm text-muted-foreground">
+          <span>
+            {hasActiveFilters
+              ? t("matchingDocuments", { total: displayTotal })
+              : t("totalDocuments", { total: displayTotal })}
+          </span>
+          {lastRefreshedAt !== null && (
+            <span className="text-xs text-muted-foreground/70">
+              · {t("lastRefreshed", { time: new Date(lastRefreshedAt).toLocaleTimeString() })}
+            </span>
+          )}
         </div>
       )}
 

--- a/hindsight-control-plane/src/components/documents-view.tsx
+++ b/hindsight-control-plane/src/components/documents-view.tsx
@@ -690,6 +690,8 @@ export function DocumentsView() {
   const { features } = useFeatures();
   const [documents, setDocuments] = useState<any[]>([]);
   const [pendingUploads, setPendingUploads] = useState<PendingUpload[]>([]);
+  // Document IDs targeted by a pending/processing retain op → badged as "updating".
+  const [inFlightDocIds, setInFlightDocIds] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(false);
   // Whether the first document fetch has completed. The mount fetch is debounced
   // (see the load effect), so without this the empty state ("No documents found")
@@ -825,6 +827,38 @@ export function DocumentsView() {
       // Keep whatever we had; the Operations tab remains the detailed source of truth.
     }
   }, [currentBank]);
+
+  // Cross-check in-flight retain operations against the visible documents: a
+  // pending/processing op that targets an existing document_id means that
+  // document is being rewritten. Fetched broadly (not just file uploads) so text
+  // re-retains and reprocesses are caught too — the API surfaces the target
+  // document_id for single-document retains (batch/file), which is the case here.
+  const loadUpdatingOps = useCallback(async () => {
+    if (!currentBank) {
+      setInFlightDocIds(new Set());
+      return;
+    }
+    try {
+      const data = await client.listOperations(currentBank, { limit: 100 });
+      const ids = new Set<string>();
+      for (const op of data.operations || []) {
+        if ((op.status === "pending" || op.status === "processing") && op.document_id) {
+          ids.add(op.document_id);
+        }
+      }
+      setInFlightDocIds(ids);
+    } catch {
+      // Keep the previous set; the Operations tab is the detailed source of truth.
+    }
+  }, [currentBank]);
+
+  // Only badge documents that are actually visible in the table.
+  const updatingDocIds = useMemo(() => {
+    if (inFlightDocIds.size === 0) return new Set<string>();
+    const realIds = new Set(documents.map((doc) => doc.id));
+    return new Set([...inFlightDocIds].filter((id) => realIds.has(id)));
+  }, [inFlightDocIds, documents]);
+  const hasUpdatingDocs = updatingDocIds.size > 0;
 
   // Pending rows: in-flight/failed uploads that aren't yet in the real list.
   // A tag filter hides them entirely — their tags only exist on the document
@@ -1083,23 +1117,36 @@ export function DocumentsView() {
   useEffect(() => {
     if (currentBank) {
       loadPendingUploads();
+      loadUpdatingOps();
     } else {
       setPendingUploads([]);
+      setInFlightDocIds(new Set());
     }
-  }, [currentBank, loadPendingUploads]);
+  }, [currentBank, loadPendingUploads, loadUpdatingOps]);
 
-  // While any upload is converting, poll the operations endpoint and refresh
-  // the document list so finished uploads flip from "Processing" to a real row.
+  // While any upload is converting OR any visible document is being rewritten,
+  // poll the operations endpoint and refresh the document list — so finished
+  // uploads flip from "Processing" to a real row, and an updated document's
+  // "Updating" badge clears (and its content refreshes) once the op completes.
   useEffect(() => {
-    if (!currentBank || !hasActiveUploads) return;
+    if (!currentBank || (!hasActiveUploads && !hasUpdatingDocs)) return;
 
     const interval = window.setInterval(() => {
       loadPendingUploads();
+      loadUpdatingOps();
       loadDocuments(currentPage);
     }, PENDING_POLL_INTERVAL_MS);
 
     return () => window.clearInterval(interval);
-  }, [currentBank, hasActiveUploads, currentPage, loadDocuments, loadPendingUploads]);
+  }, [
+    currentBank,
+    hasActiveUploads,
+    hasUpdatingDocs,
+    currentPage,
+    loadDocuments,
+    loadPendingUploads,
+    loadUpdatingOps,
+  ]);
 
   // Refresh immediately after an upload is submitted elsewhere (bank selector).
   useEffect(() => {
@@ -1107,11 +1154,12 @@ export function DocumentsView() {
 
     const onRefresh = () => {
       loadPendingUploads();
+      loadUpdatingOps();
       loadDocuments(currentPage);
     };
     window.addEventListener(DOCUMENTS_REFRESH_EVENT, onRefresh);
     return () => window.removeEventListener(DOCUMENTS_REFRESH_EVENT, onRefresh);
-  }, [currentBank, currentPage, loadDocuments, loadPendingUploads]);
+  }, [currentBank, currentPage, loadDocuments, loadPendingUploads, loadUpdatingOps]);
 
   const triggerDownload = (blob: Blob, filename: string) => {
     const url = URL.createObjectURL(blob);
@@ -1509,6 +1557,15 @@ export function DocumentsView() {
                                   size={14}
                                   titlePrefix={tCommon("harness")}
                                 />
+                                {updatingDocIds.has(doc.id) && (
+                                  <span
+                                    className="inline-flex items-center gap-1 rounded-full border border-blue-500/20 bg-blue-500/10 px-1.5 py-0.5 text-[11px] font-medium text-blue-600 dark:text-blue-400"
+                                    title={t("documentUpdating")}
+                                  >
+                                    <RefreshCw className="w-3 h-3 animate-spin" />
+                                    {t("documentUpdating")}
+                                  </span>
+                                )}
                               </div>
                             </div>
                           </TableCell>

--- a/hindsight-control-plane/src/messages/de.json
+++ b/hindsight-control-plane/src/messages/de.json
@@ -704,7 +704,8 @@
     "importConflictNewId": "Beide behalten — unter neuer id importieren",
     "textNotStoredWarning": "Der Quelltext wird auf diesem Server nicht gespeichert – nur die extrahierten Erinnerungen werden behalten.",
     "labelObservationScopes": "Beobachtungsbereiche",
-    "invalidatedFactsTitle": "Ungültige Fakten"
+    "invalidatedFactsTitle": "Ungültige Fakten",
+    "documentUpdating": "Wird aktualisiert"
   },
   "entitiesView": {
     "viewRelations": "Beziehungen",

--- a/hindsight-control-plane/src/messages/de.json
+++ b/hindsight-control-plane/src/messages/de.json
@@ -705,7 +705,8 @@
     "textNotStoredWarning": "Der Quelltext wird auf diesem Server nicht gespeichert – nur die extrahierten Erinnerungen werden behalten.",
     "labelObservationScopes": "Beobachtungsbereiche",
     "invalidatedFactsTitle": "Ungültige Fakten",
-    "documentUpdating": "Wird aktualisiert"
+    "documentUpdating": "Wird aktualisiert",
+    "lastRefreshed": "Aktualisiert {time}"
   },
   "entitiesView": {
     "viewRelations": "Beziehungen",

--- a/hindsight-control-plane/src/messages/en.json
+++ b/hindsight-control-plane/src/messages/en.json
@@ -705,7 +705,8 @@
     "textNotStoredWarning": "Source text isn't stored on this server — only the extracted memories are kept.",
     "labelObservationScopes": "Observation scopes",
     "invalidatedFactsTitle": "Invalidated facts",
-    "documentUpdating": "Updating"
+    "documentUpdating": "Updating",
+    "lastRefreshed": "Refreshed {time}"
   },
   "entitiesView": {
     "viewRelations": "Relations",

--- a/hindsight-control-plane/src/messages/en.json
+++ b/hindsight-control-plane/src/messages/en.json
@@ -704,7 +704,8 @@
     "importConflictNewId": "Keep both — import under a new id",
     "textNotStoredWarning": "Source text isn't stored on this server — only the extracted memories are kept.",
     "labelObservationScopes": "Observation scopes",
-    "invalidatedFactsTitle": "Invalidated facts"
+    "invalidatedFactsTitle": "Invalidated facts",
+    "documentUpdating": "Updating"
   },
   "entitiesView": {
     "viewRelations": "Relations",

--- a/hindsight-control-plane/src/messages/es.json
+++ b/hindsight-control-plane/src/messages/es.json
@@ -705,7 +705,8 @@
     "textNotStoredWarning": "El texto original no se almacena en este servidor: solo se conservan las memorias extraídas.",
     "labelObservationScopes": "Ámbitos de observación",
     "invalidatedFactsTitle": "Hechos invalidados",
-    "documentUpdating": "Actualizando"
+    "documentUpdating": "Actualizando",
+    "lastRefreshed": "Actualizado {time}"
   },
   "entitiesView": {
     "viewRelations": "Relaciones",

--- a/hindsight-control-plane/src/messages/es.json
+++ b/hindsight-control-plane/src/messages/es.json
@@ -704,7 +704,8 @@
     "importConflictNewId": "Conservar ambos — importar con un nuevo id",
     "textNotStoredWarning": "El texto original no se almacena en este servidor: solo se conservan las memorias extraídas.",
     "labelObservationScopes": "Ámbitos de observación",
-    "invalidatedFactsTitle": "Hechos invalidados"
+    "invalidatedFactsTitle": "Hechos invalidados",
+    "documentUpdating": "Actualizando"
   },
   "entitiesView": {
     "viewRelations": "Relaciones",

--- a/hindsight-control-plane/src/messages/fr.json
+++ b/hindsight-control-plane/src/messages/fr.json
@@ -705,7 +705,8 @@
     "textNotStoredWarning": "Le texte source n'est pas conservé sur ce serveur — seules les mémoires extraites sont conservées.",
     "labelObservationScopes": "Portées d'observation",
     "invalidatedFactsTitle": "Faits invalidés",
-    "documentUpdating": "Mise à jour…"
+    "documentUpdating": "Mise à jour…",
+    "lastRefreshed": "Actualisé {time}"
   },
   "entitiesView": {
     "viewRelations": "Relations",

--- a/hindsight-control-plane/src/messages/fr.json
+++ b/hindsight-control-plane/src/messages/fr.json
@@ -704,7 +704,8 @@
     "importConflictNewId": "Conserver les deux — importer sous un nouvel id",
     "textNotStoredWarning": "Le texte source n'est pas conservé sur ce serveur — seules les mémoires extraites sont conservées.",
     "labelObservationScopes": "Portées d'observation",
-    "invalidatedFactsTitle": "Faits invalidés"
+    "invalidatedFactsTitle": "Faits invalidés",
+    "documentUpdating": "Mise à jour…"
   },
   "entitiesView": {
     "viewRelations": "Relations",

--- a/hindsight-control-plane/src/messages/ja.json
+++ b/hindsight-control-plane/src/messages/ja.json
@@ -705,7 +705,8 @@
     "textNotStoredWarning": "このサーバーでは元のテキストは保存されません。抽出されたメモリのみが保持されます。",
     "labelObservationScopes": "観測スコープ",
     "invalidatedFactsTitle": "無効化されたファクト",
-    "documentUpdating": "更新中"
+    "documentUpdating": "更新中",
+    "lastRefreshed": "更新 {time}"
   },
   "entitiesView": {
     "viewRelations": "関係",

--- a/hindsight-control-plane/src/messages/ja.json
+++ b/hindsight-control-plane/src/messages/ja.json
@@ -704,7 +704,8 @@
     "importConflictNewId": "両方保持 — 新しい id でインポート",
     "textNotStoredWarning": "このサーバーでは元のテキストは保存されません。抽出されたメモリのみが保持されます。",
     "labelObservationScopes": "観測スコープ",
-    "invalidatedFactsTitle": "無効化されたファクト"
+    "invalidatedFactsTitle": "無効化されたファクト",
+    "documentUpdating": "更新中"
   },
   "entitiesView": {
     "viewRelations": "関係",

--- a/hindsight-control-plane/src/messages/ko.json
+++ b/hindsight-control-plane/src/messages/ko.json
@@ -705,7 +705,8 @@
     "textNotStoredWarning": "이 서버에는 원본 텍스트가 저장되지 않습니다. 추출된 메모리만 보관됩니다.",
     "labelObservationScopes": "관찰 범위",
     "invalidatedFactsTitle": "무효화된 사실",
-    "documentUpdating": "업데이트 중"
+    "documentUpdating": "업데이트 중",
+    "lastRefreshed": "새로고침 {time}"
   },
   "entitiesView": {
     "viewRelations": "관계",

--- a/hindsight-control-plane/src/messages/ko.json
+++ b/hindsight-control-plane/src/messages/ko.json
@@ -704,7 +704,8 @@
     "importConflictNewId": "둘 다 유지 — 새 id로 가져오기",
     "textNotStoredWarning": "이 서버에는 원본 텍스트가 저장되지 않습니다. 추출된 메모리만 보관됩니다.",
     "labelObservationScopes": "관찰 범위",
-    "invalidatedFactsTitle": "무효화된 사실"
+    "invalidatedFactsTitle": "무효화된 사실",
+    "documentUpdating": "업데이트 중"
   },
   "entitiesView": {
     "viewRelations": "관계",

--- a/hindsight-control-plane/src/messages/pt.json
+++ b/hindsight-control-plane/src/messages/pt.json
@@ -704,7 +704,8 @@
     "importConflictNewId": "Manter ambos — importar com novo id",
     "textNotStoredWarning": "O texto de origem não é armazenado neste servidor — apenas as memórias extraídas são mantidas.",
     "labelObservationScopes": "Escopos de observação",
-    "invalidatedFactsTitle": "Fatos invalidados"
+    "invalidatedFactsTitle": "Fatos invalidados",
+    "documentUpdating": "Atualizando"
   },
   "entitiesView": {
     "viewRelations": "Relações",

--- a/hindsight-control-plane/src/messages/pt.json
+++ b/hindsight-control-plane/src/messages/pt.json
@@ -705,7 +705,8 @@
     "textNotStoredWarning": "O texto de origem não é armazenado neste servidor — apenas as memórias extraídas são mantidas.",
     "labelObservationScopes": "Escopos de observação",
     "invalidatedFactsTitle": "Fatos invalidados",
-    "documentUpdating": "Atualizando"
+    "documentUpdating": "Atualizando",
+    "lastRefreshed": "Atualizado {time}"
   },
   "entitiesView": {
     "viewRelations": "Relações",

--- a/hindsight-control-plane/src/messages/yue-Hant.json
+++ b/hindsight-control-plane/src/messages/yue-Hant.json
@@ -705,7 +705,8 @@
     "textNotStoredWarning": "呢個伺服器唔會儲存原始文字，淨係保留擷取到嘅記憶。",
     "labelObservationScopes": "觀測範圍",
     "invalidatedFactsTitle": "已失效嘅事實",
-    "documentUpdating": "更新緊"
+    "documentUpdating": "更新緊",
+    "lastRefreshed": "已更新 {time}"
   },
   "entitiesView": {
     "viewRelations": "關係",

--- a/hindsight-control-plane/src/messages/yue-Hant.json
+++ b/hindsight-control-plane/src/messages/yue-Hant.json
@@ -704,7 +704,8 @@
     "importConflictNewId": "兩者都保留 — 以新 id 匯入",
     "textNotStoredWarning": "呢個伺服器唔會儲存原始文字，淨係保留擷取到嘅記憶。",
     "labelObservationScopes": "觀測範圍",
-    "invalidatedFactsTitle": "已失效嘅事實"
+    "invalidatedFactsTitle": "已失效嘅事實",
+    "documentUpdating": "更新緊"
   },
   "entitiesView": {
     "viewRelations": "關係",

--- a/hindsight-control-plane/src/messages/zh-CN.json
+++ b/hindsight-control-plane/src/messages/zh-CN.json
@@ -704,7 +704,8 @@
     "importConflictNewId": "两者都保留 — 以新 id 导入",
     "textNotStoredWarning": "此服务器不存储原始文本，仅保留提取的记忆。",
     "labelObservationScopes": "观测范围",
-    "invalidatedFactsTitle": "已失效的事实"
+    "invalidatedFactsTitle": "已失效的事实",
+    "documentUpdating": "更新中"
   },
   "entitiesView": {
     "viewRelations": "关系",

--- a/hindsight-control-plane/src/messages/zh-CN.json
+++ b/hindsight-control-plane/src/messages/zh-CN.json
@@ -705,7 +705,8 @@
     "textNotStoredWarning": "此服务器不存储原始文本，仅保留提取的记忆。",
     "labelObservationScopes": "观测范围",
     "invalidatedFactsTitle": "已失效的事实",
-    "documentUpdating": "更新中"
+    "documentUpdating": "更新中",
+    "lastRefreshed": "已刷新 {time}"
   },
   "entitiesView": {
     "viewRelations": "关系",

--- a/hindsight-control-plane/src/messages/zh-TW.json
+++ b/hindsight-control-plane/src/messages/zh-TW.json
@@ -704,7 +704,8 @@
     "importConflictNewId": "兩者都保留 — 以新 id 匯入",
     "textNotStoredWarning": "此伺服器不會儲存原始文字，僅保留擷取的記憶。",
     "labelObservationScopes": "觀測範圍",
-    "invalidatedFactsTitle": "已失效的事實"
+    "invalidatedFactsTitle": "已失效的事實",
+    "documentUpdating": "更新中"
   },
   "entitiesView": {
     "viewRelations": "關係",

--- a/hindsight-control-plane/src/messages/zh-TW.json
+++ b/hindsight-control-plane/src/messages/zh-TW.json
@@ -705,7 +705,8 @@
     "textNotStoredWarning": "此伺服器不會儲存原始文字，僅保留擷取的記憶。",
     "labelObservationScopes": "觀測範圍",
     "invalidatedFactsTitle": "已失效的事實",
-    "documentUpdating": "更新中"
+    "documentUpdating": "更新中",
+    "lastRefreshed": "已重新整理 {time}"
   },
   "entitiesView": {
     "viewRelations": "關係",


### PR DESCRIPTION
## What

Show in the Documents table which documents are **being rewritten by an in-flight retain operation**, and keep the table live.

- **"Updating" badge** on any row whose `document_id` has a pending/processing retain op (a soft pill with a gently pulsing dot).
- **Auto-refresh** the table on a timer (8s idle / 4s while something's in flight) so new/updated documents, counts, and badges appear without a manual reload.
- **Last-refresh indicator** next to the count — a live relative label (`Refreshed 3 seconds ago`, localized via `Intl.RelativeTimeFormat`) so you can see the auto-refresh working.

## How

Operations already expose `document_id`, but only **file** ops populated it — plain retains/reprocesses left it `null` while pending. The engine now stamps `result_metadata.document_id` for **single-document** retains (`submit_async_retain`, via new `document_id` fields on `BatchRetainParent/ChildMetadata`), so reprocesses and single-document async retains surface their target. Multi-document batches leave it unset (matched per single-document child) so no row is misattributed.

No endpoint/response-shape change (the `document_id` field already existed on the operations list) → **no OpenAPI/client regen**. No new migration (extra content inside the existing `result_metadata` JSON).

## Tests

- Two engine regression tests: single-document retain surfaces `document_id`; a multi-document batch does not misattribute one.
- `documentUpdating` + `lastRefreshed` added to all 10 locales (message-parity tests pass).

## Verified

- `lint.sh`, `tsc`, eslint, message-parity tests all pass.
- End-to-end against a live API: reprocessing a document makes its `batch_retain`/`retain` ops report the `document_id`, while `consolidation`/`refresh_mental_model` correctly stay `null`.
