### PR TITLE
fix(embed): increase health-check timeouts from 2s to 10s

### DIFF
--- a/hindsight-embed/hindsight_embed/control_center/lifecycle.py
+++ b/hindsight-embed/hindsight_embed/control_center/lifecycle.py
@@ -107,7 +107,7 @@ class ControlStartResult:
 
 def _health_ok(port: int) -> bool:
     try:
-        with httpx.Client(timeout=2.0) as client:
+        with httpx.Client(timeout=10.0) as client:
             resp = client.get(f"http://127.0.0.1:{port}/api/health")
             return resp.status_code == 200 and resp.json().get("status") == "ok"
     except Exception:

--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -154,7 +154,7 @@ class DaemonEmbedManager(EmbedManager):
         """Check if daemon is running and responsive."""
         daemon_url = self.get_url(profile)
         try:
-            with httpx.Client(timeout=2) as client:
+            with httpx.Client(timeout=10) as client:
                 response = client.get(f"{daemon_url}/health")
                 return response.status_code == 200
         except Exception:
@@ -338,7 +338,7 @@ class DaemonEmbedManager(EmbedManager):
     def _port_health_ok(port: int) -> bool:
         """Return True when the listener on port responds like initialized Hindsight."""
         try:
-            with httpx.Client(timeout=2) as client:
+            with httpx.Client(timeout=10) as client:
                 response = client.get(f"http://127.0.0.1:{port}/health")
                 if response.status_code != 200:
                     return False
@@ -732,7 +732,7 @@ class DaemonEmbedManager(EmbedManager):
         # Always health-check on 127.0.0.1 regardless of bind hostname
         ui_url = self.get_ui_url(profile, ui_port, hostname="127.0.0.1")
         try:
-            with httpx.Client(timeout=2) as client:
+            with httpx.Client(timeout=10) as client:
                 response = client.get(f"{ui_url}/api/health")
                 return response.status_code == 200
         except Exception:


### PR DESCRIPTION
Slow LLM extraction (e.g. 12.5s for retain_extract_facts) blocks the event loop, causing 2-second /health timeouts to falsely kill the daemon. Issue #1992 fixed this in scripts/lib/ but missed the embed path.

Changes:
- lifecycle.py: _health_ok() 2.0s -> 10.0s
- daemon_embed_manager.py: is_running(), _port_health_ok(), control_center health check: 2s -> 10s

Closes #3099