### PR TITLE
fix(api): report the real last-write time on banks and documents

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1223,7 +1223,20 @@ class BankListItem(BaseModel):
     created_at: str | None = None
     updated_at: str | None = None
     fact_count: int = 0
-    last_document_at: str | None = None
+    last_document_at: str | None = Field(
+        default=None,
+        description=(
+            "When a document was last *ingested* into this bank. Appending to an existing "
+            "document does not move this — use `last_write_at` for write activity."
+        ),
+    )
+    last_write_at: str | None = Field(
+        default=None,
+        description=(
+            "When anything was last written to this bank: a document retained (including "
+            "appends to an existing document) or a fact stored. Null if the bank is empty."
+        ),
+    )
 
 
 class BankListResponse(BaseModel):
@@ -1242,6 +1255,7 @@ class BankListResponse(BaseModel):
                         "updated_at": "2024-01-16T14:20:00Z",
                         "fact_count": 156,
                         "last_document_at": "2024-01-16T14:20:00Z",
+                        "last_write_at": "2024-01-17T09:05:00Z",
                     }
                 ]
             }
@@ -5799,7 +5813,7 @@ def _register_routes(app: FastAPI):
         "/v1/default/banks/{bank_id}/documents",
         response_model=ListDocumentsResponse,
         summary="List documents",
-        description="List documents with pagination and optional search. Documents are the source content from which memory units are extracted.",
+        description="List documents with pagination and optional search, most recently written first (`updated_at` descending). Documents are the source content from which memory units are extracted.",
         operation_id="list_documents",
         tags=["Documents"],
     )

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8203,6 +8203,9 @@ class MemoryEngine(MemoryEngineInterface):
         """
         List documents with optional search and pagination.
 
+        Ordered by ``updated_at`` DESC so a long-lived document that keeps receiving
+        appends stays on the first page instead of sinking to its creation position.
+
         Args:
             bank_id: bank ID (required)
             search_query: Search in document ID
@@ -8282,7 +8285,7 @@ class MemoryEngine(MemoryEngineInterface):
                     tags
                 FROM {fq_table("documents")}
                 {where_clause}
-                ORDER BY created_at DESC
+                ORDER BY updated_at DESC, created_at DESC, id
                 LIMIT {limit_param} OFFSET {offset_param}
             """,
                 *query_params,

--- a/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
@@ -6,6 +6,7 @@ import json
 import logging
 import uuid
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import TypedDict
 
 from pydantic import BaseModel, Field
@@ -412,15 +413,33 @@ Merged mission:"""
         return {"mission": merged}
 
 
+# Sort floor for banks that have never been written to and carry no created_at.
+_UNIX_EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+
+
+def _as_utc(ts: datetime | None) -> datetime | None:
+    """Normalize a DB timestamp to an aware UTC datetime so values stay comparable."""
+    if ts is None:
+        return None
+    return ts if ts.tzinfo is not None else ts.replace(tzinfo=UTC)
+
+
 async def list_banks(pool) -> list:
     """
     List all banks in the system with summary stats.
+
+    ``last_document_at`` is document *ingestion* time (when a document first
+    landed), while ``last_write_at`` is the last time anything was written to
+    the bank — a document re-retained/appended to, or a fact stored. Appending
+    to a long-lived document does not move ``last_document_at``, which is why
+    the two differ and why UIs showing "last write" must use ``last_write_at``.
 
     Args:
         pool: Database connection pool
 
     Returns:
-        List of dicts with bank info and stats (document_count, fact_count, last_event_at)
+        List of dicts with bank info and stats (fact_count, last_document_at, last_write_at),
+        most recently written bank first.
     """
     banks_table = fq_table("banks")
     docs_table = fq_table("documents")
@@ -433,23 +452,32 @@ async def list_banks(pool) -> list:
                 b.bank_id, b.name, b.disposition, b.mission,
                 b.created_at, b.updated_at,
                 COALESCE(m.fact_count, 0) AS fact_count,
-                d.last_document_at
+                d.last_document_at,
+                d.last_document_write_at,
+                m.last_fact_at
             FROM {banks_table} b
             LEFT JOIN (
-                SELECT bank_id, MAX(created_at) AS last_document_at
+                SELECT bank_id,
+                       MAX(created_at) AS last_document_at,
+                       MAX(updated_at) AS last_document_write_at
                 FROM {docs_table}
                 GROUP BY bank_id
             ) d ON d.bank_id = b.bank_id
             LEFT JOIN (
-                SELECT bank_id, COUNT(*) AS fact_count
+                SELECT bank_id,
+                       COUNT(*) AS fact_count,
+                       MAX(created_at) AS last_fact_at
                 FROM {mu_table}
                 GROUP BY bank_id
             ) m ON m.bank_id = b.bank_id
-            ORDER BY d.last_document_at DESC NULLS LAST, b.updated_at DESC
+            ORDER BY b.bank_id
             """
         )
 
         result = []
+        # Banks are ordered by last write in Python rather than SQL: GREATEST() has
+        # different NULL semantics on PostgreSQL vs Oracle, and the bank list is small.
+        sort_keys: dict[str, datetime] = {}
         # A store that keeps memories outside SQL leaves the memory_units join empty, so its
         # per-bank fact_count comes from the store instead (one live count per bank).
         from ..memories import get_memories
@@ -461,7 +489,14 @@ async def list_banks(pool) -> list:
             if isinstance(disposition_data, str):
                 disposition_data = json.loads(disposition_data)
 
-            last_doc = row["last_document_at"]
+            last_doc = _as_utc(row["last_document_at"])
+            created_at = _as_utc(row["created_at"])
+            updated_at = _as_utc(row["updated_at"])
+            # Last write = newest of "a document was (re-)retained" and "a fact was stored".
+            # Appending to an existing document only bumps documents.updated_at, and facts
+            # written outside a retain (consolidation, curation, import) only bump memory_units.
+            write_times = [t for t in (_as_utc(row["last_document_write_at"]), _as_utc(row["last_fact_at"])) if t]
+            last_write = max(write_times) if write_times else None
 
             fact_count = row["fact_count"]
             if not _store.writes_memory_rows_in_sql:
@@ -469,17 +504,20 @@ async def list_banks(pool) -> list:
                     (await _store.count_memories(conn=conn, fq_table=fq_table, bank_id=row["bank_id"])).values()
                 )
 
+            sort_keys[row["bank_id"]] = last_write or created_at or _UNIX_EPOCH
             result.append(
                 {
                     "bank_id": row["bank_id"],
                     "name": row["name"],
                     "disposition": disposition_data,
                     "mission": row["mission"] or "",
-                    "created_at": row["created_at"].isoformat() if row["created_at"] else None,
-                    "updated_at": row["updated_at"].isoformat() if row["updated_at"] else None,
+                    "created_at": created_at.isoformat() if created_at else None,
+                    "updated_at": updated_at.isoformat() if updated_at else None,
                     "fact_count": fact_count,
                     "last_document_at": last_doc.isoformat() if last_doc else None,
+                    "last_write_at": last_write.isoformat() if last_write else None,
                 }
             )
 
+        result.sort(key=lambda bank: sort_keys[bank["bank_id"]], reverse=True)
         return result

--- a/hindsight-api-slim/tests/test_bank_last_write_at.py
+++ b/hindsight-api-slim/tests/test_bank_last_write_at.py
@@ -1,0 +1,93 @@
+"""
+Tests for the bank-level `last_write_at` timestamp returned by list_banks.
+
+`last_document_at` is document ingestion time, so appending to (or re-retaining)
+a long-lived document leaves it frozen while the bank is still being written to.
+`last_write_at` must track the actual write.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+
+async def _retain(memory, bank_id, document_id, content, request_context):
+    """Retain content into a document. Gibberish avoids LLM fact extraction noise."""
+    await memory.retain_batch_async(
+        bank_id=bank_id,
+        contents=[{"content": content}],
+        document_id=document_id,
+        request_context=request_context,
+    )
+
+
+async def _bank_entry(memory, bank_id, request_context):
+    banks = await memory.list_banks(request_context=request_context)
+    return next(b for b in banks if b["bank_id"] == bank_id)
+
+
+def _ts(value: str | None) -> datetime:
+    assert value is not None
+    return datetime.fromisoformat(value)
+
+
+@pytest.mark.asyncio
+async def test_last_write_at_advances_when_existing_document_is_rewritten(memory, request_context):
+    """Re-retaining an existing document moves last_write_at but not last_document_at."""
+    bank_id = f"test_last_write_{datetime.now(timezone.utc).timestamp()}"
+
+    try:
+        await _retain(memory, bank_id, "session-1", "xyzabc123 !@# first slice", request_context)
+        after_first = await _bank_entry(memory, bank_id, request_context)
+        # First ingestion: the document was created and written at the same time.
+        assert _ts(after_first["last_write_at"]) >= _ts(after_first["last_document_at"])
+
+        await _retain(memory, bank_id, "session-1", "xyzabc123 !@# second slice", request_context)
+        after_second = await _bank_entry(memory, bank_id, request_context)
+
+        # Ingestion time is frozen — no new document appeared.
+        assert after_second["last_document_at"] == after_first["last_document_at"]
+        # ...but the bank was written to, and last_write_at says so.
+        assert _ts(after_second["last_write_at"]) > _ts(after_first["last_write_at"])
+        assert _ts(after_second["last_write_at"]) > _ts(after_second["last_document_at"])
+
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_last_write_at_is_null_for_empty_bank(memory, request_context):
+    """A bank with no documents and no facts has never been written to."""
+    bank_id = f"test_last_write_empty_{datetime.now(timezone.utc).timestamp()}"
+
+    try:
+        await memory._ensure_bank_exists(bank_id, request_context)
+        entry = await _bank_entry(memory, bank_id, request_context)
+        assert entry["last_write_at"] is None
+        assert entry["last_document_at"] is None
+
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_banks_are_ordered_by_last_write(memory, request_context):
+    """The bank written to most recently sorts first, even if its document is older."""
+    stamp = datetime.now(timezone.utc).timestamp()
+    older_bank = f"test_last_write_order_a_{stamp}"
+    newer_bank = f"test_last_write_order_b_{stamp}"
+
+    try:
+        await _retain(memory, older_bank, "doc-a", "xyzabc123 !@# alpha", request_context)
+        await _retain(memory, newer_bank, "doc-b", "xyzabc123 !@# beta", request_context)
+        # Rewrite the older bank's existing document: no new document, but it is now
+        # the most recently written bank.
+        await _retain(memory, older_bank, "doc-a", "xyzabc123 !@# alpha revised", request_context)
+
+        banks = await memory.list_banks(request_context=request_context)
+        ordered = [b["bank_id"] for b in banks if b["bank_id"] in (older_bank, newer_bank)]
+        assert ordered == [older_bank, newer_bank]
+
+    finally:
+        await memory.delete_bank(older_bank, request_context=request_context)
+        await memory.delete_bank(newer_bank, request_context=request_context)

--- a/hindsight-api-slim/tests/test_list_documents.py
+++ b/hindsight-api-slim/tests/test_list_documents.py
@@ -28,7 +28,7 @@ async def test_list_documents_offset_pagination(memory, request_context):
         for i in range(4):
             await _retain_doc(memory, bank_id, f"doc-{i:02d}", [], request_context)
 
-        # All documents, ordered by created_at DESC → doc-03, doc-02, doc-01, doc-00
+        # All documents, most recently written first → doc-03, doc-02, doc-01, doc-00
         all_docs = await memory.list_documents(bank_id=bank_id, limit=10, offset=0, request_context=request_context)
         assert all_docs["total"] == 4
         assert len(all_docs["items"]) == 4
@@ -164,6 +164,39 @@ async def test_list_documents_tags_and_search_query_combined(memory, request_con
         )
         ids = {d["id"] for d in result["items"]}
         assert ids == {"report-2024"}
+
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_list_documents_orders_by_last_write(memory, request_context):
+    """A re-retained old document sorts ahead of newer, untouched documents.
+
+    Ordering by created_at would bury a long-lived document that keeps receiving
+    appends behind every document created after it.
+    """
+    bank_id = f"test_list_docs_order_{datetime.now(timezone.utc).timestamp()}"
+
+    try:
+        await _retain_doc(memory, bank_id, "doc-old", [], request_context)
+        await _retain_doc(memory, bank_id, "doc-new", [], request_context)
+
+        # Baseline: newest-created first.
+        result = await memory.list_documents(bank_id=bank_id, request_context=request_context)
+        assert [d["id"] for d in result["items"]] == ["doc-new", "doc-old"]
+
+        # Write to the older document again — no new document, but it is now the
+        # most recently written one.
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": "xyzabc123 !@# $$$ doc-old revised"}],
+            document_id="doc-old",
+            request_context=request_context,
+        )
+
+        result = await memory.list_documents(bank_id=bank_id, request_context=request_context)
+        assert [d["id"] for d in result["items"]] == ["doc-old", "doc-new"]
 
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -2061,8 +2061,9 @@ paths:
       - Directives
   /v1/default/banks/{bank_id}/documents:
     get:
-      description: List documents with pagination and optional search. Documents are
-        the source content from which memory units are extracted.
+      description: "List documents with pagination and optional search, most recently\
+        \ written first (`updated_at` descending). Documents are the source content\
+        \ from which memory units are extracted."
       operationId: list_documents
       parameters:
       - explode: false
@@ -4754,6 +4755,9 @@ components:
         last_document_at:
           nullable: true
           type: string
+        last_write_at:
+          nullable: true
+          type: string
       required:
       - bank_id
       - disposition
@@ -4770,6 +4774,7 @@ components:
             skepticism: 3
           fact_count: 156
           last_document_at: 2024-01-16T14:20:00Z
+          last_write_at: 2024-01-17T09:05:00Z
           mission: I am a software engineer helping my team ship quality code
           name: Alice
           updated_at: 2024-01-16T14:20:00Z

--- a/hindsight-clients/go/api_documents.go
+++ b/hindsight-clients/go/api_documents.go
@@ -609,7 +609,7 @@ func (r ApiListDocumentsRequest) Execute() (*ListDocumentsResponse, *http.Respon
 /*
 ListDocuments List documents
 
-List documents with pagination and optional search. Documents are the source content from which memory units are extracted.
+List documents with pagination and optional search, most recently written first (`updated_at` descending). Documents are the source content from which memory units are extracted.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param bankId

--- a/hindsight-clients/go/model_bank_list_item.go
+++ b/hindsight-clients/go/model_bank_list_item.go
@@ -29,6 +29,7 @@ type BankListItem struct {
 	UpdatedAt NullableString `json:"updated_at,omitempty"`
 	FactCount *int32 `json:"fact_count,omitempty"`
 	LastDocumentAt NullableString `json:"last_document_at,omitempty"`
+	LastWriteAt NullableString `json:"last_write_at,omitempty"`
 }
 
 type _BankListItem BankListItem
@@ -346,6 +347,48 @@ func (o *BankListItem) UnsetLastDocumentAt() {
 	o.LastDocumentAt.Unset()
 }
 
+// GetLastWriteAt returns the LastWriteAt field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankListItem) GetLastWriteAt() string {
+	if o == nil || IsNil(o.LastWriteAt.Get()) {
+		var ret string
+		return ret
+	}
+	return *o.LastWriteAt.Get()
+}
+
+// GetLastWriteAtOk returns a tuple with the LastWriteAt field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankListItem) GetLastWriteAtOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.LastWriteAt.Get(), o.LastWriteAt.IsSet()
+}
+
+// HasLastWriteAt returns a boolean if a field has been set.
+func (o *BankListItem) HasLastWriteAt() bool {
+	if o != nil && o.LastWriteAt.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetLastWriteAt gets a reference to the given NullableString and assigns it to the LastWriteAt field.
+func (o *BankListItem) SetLastWriteAt(v string) {
+	o.LastWriteAt.Set(&v)
+}
+// SetLastWriteAtNil sets the value for LastWriteAt to be an explicit nil
+func (o *BankListItem) SetLastWriteAtNil() {
+	o.LastWriteAt.Set(nil)
+}
+
+// UnsetLastWriteAt ensures that no value is present for LastWriteAt, not even an explicit nil
+func (o *BankListItem) UnsetLastWriteAt() {
+	o.LastWriteAt.Unset()
+}
+
 func (o BankListItem) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -375,6 +418,9 @@ func (o BankListItem) ToMap() (map[string]interface{}, error) {
 	}
 	if o.LastDocumentAt.IsSet() {
 		toSerialize["last_document_at"] = o.LastDocumentAt.Get()
+	}
+	if o.LastWriteAt.IsSet() {
+		toSerialize["last_write_at"] = o.LastWriteAt.Get()
 	}
 	return toSerialize, nil
 }

--- a/hindsight-clients/python/hindsight_client_api/api/documents_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/documents_api.py
@@ -1262,7 +1262,7 @@ class DocumentsApi:
     ) -> ListDocumentsResponse:
         """List documents
 
-        List documents with pagination and optional search. Documents are the source content from which memory units are extracted.
+        List documents with pagination and optional search, most recently written first (`updated_at` descending). Documents are the source content from which memory units are extracted.
 
         :param bank_id: (required)
         :type bank_id: str
@@ -1354,7 +1354,7 @@ class DocumentsApi:
     ) -> ApiResponse[ListDocumentsResponse]:
         """List documents
 
-        List documents with pagination and optional search. Documents are the source content from which memory units are extracted.
+        List documents with pagination and optional search, most recently written first (`updated_at` descending). Documents are the source content from which memory units are extracted.
 
         :param bank_id: (required)
         :type bank_id: str
@@ -1446,7 +1446,7 @@ class DocumentsApi:
     ) -> RESTResponseType:
         """List documents
 
-        List documents with pagination and optional search. Documents are the source content from which memory units are extracted.
+        List documents with pagination and optional search, most recently written first (`updated_at` descending). Documents are the source content from which memory units are extracted.
 
         :param bank_id: (required)
         :type bank_id: str

--- a/hindsight-clients/python/hindsight_client_api/models/bank_list_item.py
+++ b/hindsight-clients/python/hindsight_client_api/models/bank_list_item.py
@@ -35,7 +35,8 @@ class BankListItem(BaseModel):
     updated_at: Optional[StrictStr] = None
     fact_count: Optional[StrictInt] = 0
     last_document_at: Optional[StrictStr] = None
-    __properties: ClassVar[List[str]] = ["bank_id", "name", "disposition", "mission", "created_at", "updated_at", "fact_count", "last_document_at"]
+    last_write_at: Optional[StrictStr] = None
+    __properties: ClassVar[List[str]] = ["bank_id", "name", "disposition", "mission", "created_at", "updated_at", "fact_count", "last_document_at", "last_write_at"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -104,6 +105,11 @@ class BankListItem(BaseModel):
         if self.last_document_at is None and "last_document_at" in self.model_fields_set:
             _dict['last_document_at'] = None
 
+        # set to None if last_write_at (nullable) is None
+        # and model_fields_set contains the field
+        if self.last_write_at is None and "last_write_at" in self.model_fields_set:
+            _dict['last_write_at'] = None
+
         return _dict
 
     @classmethod
@@ -123,7 +129,8 @@ class BankListItem(BaseModel):
             "created_at": obj.get("created_at"),
             "updated_at": obj.get("updated_at"),
             "fact_count": obj.get("fact_count") if obj.get("fact_count") is not None else 0,
-            "last_document_at": obj.get("last_document_at")
+            "last_document_at": obj.get("last_document_at"),
+            "last_write_at": obj.get("last_write_at")
         })
         return _obj
 

--- a/hindsight-clients/typescript/generated/sdk.gen.ts
+++ b/hindsight-clients/typescript/generated/sdk.gen.ts
@@ -889,7 +889,7 @@ export const updateDirective = <ThrowOnError extends boolean = false>(
 /**
  * List documents
  *
- * List documents with pagination and optional search. Documents are the source content from which memory units are extracted.
+ * List documents with pagination and optional search, most recently written first (`updated_at` descending). Documents are the source content from which memory units are extracted.
  */
 export const listDocuments = <ThrowOnError extends boolean = false>(
   options: Options<ListDocumentsData, ThrowOnError>

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -272,8 +272,16 @@ export type BankListItem = {
   fact_count?: number;
   /**
    * Last Document At
+   *
+   * When a document was last *ingested* into this bank. Appending to an existing document does not move this — use `last_write_at` for write activity.
    */
   last_document_at?: string | null;
+  /**
+   * Last Write At
+   *
+   * When anything was last written to this bank: a document retained (including appends to an existing document) or a fact stored. Null if the bank is empty.
+   */
+  last_write_at?: string | null;
 };
 
 /**

--- a/hindsight-control-plane/src/components/bank-selector.tsx
+++ b/hindsight-control-plane/src/components/bank-selector.tsx
@@ -189,10 +189,11 @@ function BankSelectorInner() {
   }, []);
 
   const sortedBanks = React.useMemo(() => {
-    // Sort by last document inserted descending, then by created_at
+    // Sort by last write descending, then by created_at. last_write_at covers appends to
+    // an existing document, which leave last_document_at (ingestion time) untouched.
     return [...bankInfos].sort((a, b) => {
-      const aTime = a.last_document_at || a.created_at || "";
-      const bTime = b.last_document_at || b.created_at || "";
+      const aTime = a.last_write_at || a.last_document_at || a.created_at || "";
+      const bTime = b.last_write_at || b.last_document_at || b.created_at || "";
       return bTime.localeCompare(aTime);
     });
   }, [bankInfos]);
@@ -560,6 +561,9 @@ function BankSelectorInner() {
                   {sortedBanks.map((bank) => {
                     const barPct = (bank.fact_count / maxFactCount) * 100;
                     const isSelected = currentBank === bank.bank_id;
+                    // Last write, not last ingestion: appends to an existing document
+                    // bump last_write_at only.
+                    const lastWriteAt = bank.last_write_at || bank.last_document_at;
                     return (
                       <CommandItem
                         key={bank.bank_id}
@@ -619,9 +623,7 @@ function BankSelectorInner() {
                               <>
                                 {formatCompact(bank.fact_count)}
                                 <span className="ml-1.5 text-muted-foreground/40">
-                                  {bank.last_document_at
-                                    ? formatTimeAgo(bank.last_document_at)
-                                    : ""}
+                                  {lastWriteAt ? formatTimeAgo(lastWriteAt) : ""}
                                 </span>
                               </>
                             ) : (

--- a/hindsight-control-plane/src/lib/bank-context.tsx
+++ b/hindsight-control-plane/src/lib/bank-context.tsx
@@ -12,6 +12,7 @@ export interface BankInfo {
   updated_at: string | null;
   fact_count: number;
   last_document_at: string | null;
+  last_write_at: string | null;
 }
 
 interface BankContextType {
@@ -44,6 +45,7 @@ export function BankProvider({ children }: { children: React.ReactNode }) {
           updated_at: bank.updated_at ?? null,
           fact_count: bank.fact_count ?? 0,
           last_document_at: bank.last_document_at ?? null,
+          last_write_at: bank.last_write_at ?? null,
         })) || [];
       setBankInfos(infos);
     } catch (error) {

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -3026,7 +3026,7 @@
           "Documents"
         ],
         "summary": "List documents",
-        "description": "List documents with pagination and optional search. Documents are the source content from which memory units are extracted.",
+        "description": "List documents with pagination and optional search, most recently written first (`updated_at` descending). Documents are the source content from which memory units are extracted.",
         "operationId": "list_documents",
         "parameters": [
           {
@@ -6938,7 +6938,20 @@
                 "type": "null"
               }
             ],
-            "title": "Last Document At"
+            "title": "Last Document At",
+            "description": "When a document was last *ingested* into this bank. Appending to an existing document does not move this \u2014 use `last_write_at` for write activity."
+          },
+          "last_write_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Write At",
+            "description": "When anything was last written to this bank: a document retained (including appends to an existing document) or a fact stored. Null if the bank is empty."
           }
         },
         "type": "object",
@@ -6977,6 +6990,7 @@
               },
               "fact_count": 156,
               "last_document_at": "2024-01-16T14:20:00Z",
+              "last_write_at": "2024-01-17T09:05:00Z",
               "mission": "I am a software engineer helping my team ship quality code",
               "name": "Alice",
               "updated_at": "2024-01-16T14:20:00Z"


### PR DESCRIPTION
Fixes #2944.

## The bug

`/v1/default/banks` had no field that tracks writes:

- `last_document_at` = `MAX(documents.created_at)` — **ingestion** time. Appending to (or re-retaining) an existing document never moves it.
- `updated_at` = `banks.updated_at`, bumped only by name/mission/config edits — not by retain at all.

So a bank being actively written to through one long-lived document (the reporter's `hermes-s0`) reported activity from 12h ago while `memories/list` kept returning fresh facts.

## The fix

**`last_write_at` on the bank list** — the newest of:

- `MAX(documents.updated_at)` — a document was retained, including appends to an existing one, and
- `MAX(memory_units.created_at)` — a fact was stored (covers writes with no document upsert: consolidation, curation, import).

Both come from aggregates the query already computed, so there is no extra scan. The list is now ordered by `last_write_at`. `last_document_at` keeps its meaning and is documented as ingestion time, per the issue's "label it as document activity" alternative.

The combining is done in Python, not `GREATEST()`, because `GREATEST` ignores NULLs on PostgreSQL but returns NULL on Oracle.

**Documents list ordering** (@ttomiczek's follow-up): `ORDER BY created_at DESC` → `ORDER BY updated_at DESC, created_at DESC, id`. A document created in June and appended to daily now sits on page 1 instead of at the end of the pagination.

**Control plane**: the bank selector's time-ago and its sort order now use `last_write_at` (falling back to `last_document_at`).

## Tests

- `tests/test_bank_last_write_at.py` — re-retaining an existing document advances `last_write_at` while `last_document_at` stays frozen; `last_write_at` is null for an untouched bank; banks sort by last write, not by document age.
- `tests/test_list_documents.py::test_list_documents_orders_by_last_write` — a re-retained older document sorts ahead of a newer untouched one.

## Note for API consumers

`last_write_at` is a new response field (bank list only); nothing was removed or renamed. The documents-list default ordering changed — clients that paginated assuming creation order will see a different sequence.
