### PR TITLE
fix(claude-code): keep project resolution stable when the worktree is gone

### DIFF
--- a/hindsight-integrations/claude-code/CHANGELOG.md
+++ b/hindsight-integrations/claude-code/CHANGELOG.md
@@ -16,6 +16,17 @@
   `read operation timed out` on requests the server completes successfully.
   Does not affect the health check, which stays at 5s. Fixes #1575.
 
+### Fixed
+
+- Project resolution no longer degrades to the leaf directory name when the
+  working directory has been deleted before the hook runs. The `Stop` retain
+  hook is asynchronous, so an ephemeral subagent worktree could already be gone,
+  producing throwaway `agent-<hash>` banks that fragment project memory
+  (#3096). `CLAUDE_PROJECT_DIR`, which Claude Code exports into the hook process
+  and which does not follow the agent into a worktree, is probed before that
+  fallback; a working directory git can still resolve keeps its previous
+  answer, so existing banks do not move.
+
 ### Changed
 
 - Tags that resolve to an empty namespace content (e.g. `"user:"` when

--- a/hindsight-integrations/claude-code/scripts/lib/bank.py
+++ b/hindsight-integrations/claude-code/scripts/lib/bank.py
@@ -29,28 +29,13 @@ DEFAULT_BANK_NAME = "claude-code"
 VALID_FIELDS = {"agent", "project", "session", "channel", "user"}
 
 
-def _resolve_project_name(cwd: str, config: dict) -> str:
-    """Resolve the project name from the working directory.
-
-    When resolveWorktrees is enabled (default), detects git worktrees and
-    resolves to the main repository basename so that all worktrees of the
-    same repo share the same bank.
-
-    For a regular repo at /home/user/myproject:
-        git-common-dir → /home/user/myproject/.git → basename "myproject"
-
-    For a worktree at /home/user/myproject-wt1 linked to /home/user/myproject:
-        git-common-dir → /home/user/myproject/.git → basename "myproject"
-    """
-    if not cwd:
-        return "unknown"
-
-    if not config.get("resolveWorktrees", True):
-        return os.path.basename(cwd)
-
+def _probe_git_root(path: str) -> str:
+    """Return the main repository basename for path, or "" if git can't resolve it."""
+    if not path:
+        return ""
     try:
         result = subprocess.run(
-            ["git", "-C", cwd, "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            ["git", "-C", path, "rev-parse", "--path-format=absolute", "--git-common-dir"],
             capture_output=True,
             text=True,
             timeout=5,
@@ -63,6 +48,42 @@ def _resolve_project_name(cwd: str, config: dict) -> str:
             return os.path.basename(main_repo_path)
     except (OSError, subprocess.TimeoutExpired):
         pass
+    return ""
+
+
+def _resolve_project_name(cwd: str, config: dict) -> str:
+    """Resolve the project name from the working directory.
+
+    When resolveWorktrees is enabled (default), detects git worktrees and
+    resolves to the main repository basename so that all worktrees of the
+    same repo share the same bank.
+
+    For a regular repo at /home/user/myproject:
+        git-common-dir → /home/user/myproject/.git → basename "myproject"
+
+    For a worktree at /home/user/myproject-wt1 linked to /home/user/myproject:
+        git-common-dir → /home/user/myproject/.git → basename "myproject"
+
+    The retain hook runs on Stop, asynchronously, so an ephemeral subagent
+    worktree can already be deleted by the time git is probed. Probing the
+    deleted leaf fails and the basename fallback then yields a throwaway name
+    like "agent-a33c4d63", scattering memory across orphan banks.
+    CLAUDE_PROJECT_DIR is the rescue: Claude Code exports the project root into
+    the hook process, and unlike the cwd arriving on stdin it does not follow
+    the agent into a worktree, so it still names the repository after that
+    worktree is gone. It is probed only once the cwd probe has failed, so a
+    resolvable cwd keeps its historical answer and existing banks never move.
+    """
+    if not cwd:
+        return "unknown"
+
+    if not config.get("resolveWorktrees", True):
+        return os.path.basename(cwd)
+
+    for candidate in (cwd, os.environ.get("CLAUDE_PROJECT_DIR", "")):
+        name = _probe_git_root(candidate)
+        if name:
+            return name
 
     # Fallback: not a git repo or git not available
     return os.path.basename(cwd)

--- a/hindsight-integrations/claude-code/tests/test_bank.py
+++ b/hindsight-integrations/claude-code/tests/test_bank.py
@@ -164,6 +164,48 @@ class TestResolveProjectName:
         assert _resolve_project_name("", _cfg()) == "unknown"
 
 
+class TestResolveProjectNameDeletedWorktree:
+    """The Stop hook is async: an ephemeral subagent worktree can be gone by then."""
+
+    @staticmethod
+    def _git_resolving_only(repo_path, git_dir):
+        """subprocess.run stub where only repo_path resolves as a git repository."""
+
+        def fake_run(cmd, **kwargs):
+            result = MagicMock()
+            if cmd[2] == repo_path:
+                result.returncode = 0
+                result.stdout = f"{git_dir}\n"
+            else:
+                result.returncode = 128
+                result.stdout = ""
+            return result
+
+        return fake_run
+
+    @patch("lib.bank.subprocess.run")
+    def test_deleted_worktree_uses_claude_project_dir(self, mock_run, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/home/user/myproject")
+        mock_run.side_effect = self._git_resolving_only("/home/user/myproject", "/home/user/myproject/.git")
+        gone = "/home/user/myproject/.claude/worktrees/agent-deadbeef"
+        assert _resolve_project_name(gone, _cfg()) == "myproject"
+
+    @patch("lib.bank.subprocess.run")
+    def test_resolvable_cwd_never_consults_the_fallbacks(self, mock_run, monkeypatch):
+        # Guards existing banks: a cwd git can resolve must keep its historical
+        # answer even when CLAUDE_PROJECT_DIR points somewhere else entirely.
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/home/user/otherproject")
+        mock_run.side_effect = self._git_resolving_only("/home/user/myproject-wt1", "/home/user/myproject/.git")
+        assert _resolve_project_name("/home/user/myproject-wt1", _cfg()) == "myproject"
+        assert mock_run.call_count == 1
+
+    @patch("lib.bank.subprocess.run")
+    def test_no_candidate_resolves_keeps_basename(self, mock_run, monkeypatch):
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        mock_run.side_effect = self._git_resolving_only("/nowhere", "/nowhere/.git")
+        assert _resolve_project_name("/home/user/plaindir", _cfg()) == "plaindir"
+
+
 class TestDirectoryBankMap:
     """Tests for explicit directory-to-bank mapping."""
 


### PR DESCRIPTION
Fixes #3096.

## The failure

`_resolve_project_name()` probes `cwd` with `git rev-parse --git-common-dir`. The `Stop` retain hook is asynchronous, so an ephemeral subagent worktree can already have been removed by the time it runs. The probe fails, the basename fallback takes over, and the leaf directory becomes the project identity — the reported session produced five orphan `agent-<hash>` banks, one of them holding 598 memory units that belonged to the repository.

## The fix

`CLAUDE_PROJECT_DIR` is probed before falling back to the basename. Claude Code exports the project root into the hook process, and unlike the `cwd` carried on the hook's stdin — [documented](https://code.claude.com/docs/en/hooks) as *"the current working directory when the hook is invoked"* — it does not follow the agent.

Measured on Claude Code 2.1.220, with a hook logging both values across an `EnterWorktree` call:

```
event              = PostToolUse
CLAUDE_PROJECT_DIR = /tmp/myproject
stdin cwd          = /tmp/myproject/.claude/worktrees/test3
```

So the value that survives the worktree's deletion is exactly the one that still names the repository.

## Why no second fallback

The issue suggests retrying from the nearest existing ancestor of `cwd`. That works too, but it is redundant here: `CLAUDE_PROJECT_DIR` has been exported to hook commands since Claude Code **1.0.58** (*"Hooks: Added CLAUDE_PROJECT_DIR env var for hook commands"*), long before this plugin existed. Should it ever be missing, the empty candidate is skipped without spawning git and resolution degrades to today's behaviour.

## Existing banks do not move

The new candidate runs **only after** the `cwd` probe has failed. Any working directory git can still resolve keeps its historical answer, so no one's memory is silently re-homed by upgrading. `test_resolvable_cwd_never_consults_the_fallbacks` pins that: with a resolvable `cwd` and `CLAUDE_PROJECT_DIR` deliberately pointing at a different repository, the result is unchanged and `git` is invoked exactly once.

## Tests

Three cases added to `TestResolveProjectNameDeletedWorktree`, covering the deleted worktree, the no-regression guarantee above, and the basename fallback when nothing resolves. The existing git probe moved into `_probe_git_root()` unchanged. Full suite: 200 passed.
