### PR TITLE
feat(claude-code): expose the granularity fields to retainTags and recallTags

### DIFF
--- a/hindsight-integrations/claude-code/CHANGELOG.md
+++ b/hindsight-integrations/claude-code/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- The five `dynamicBankGranularity` fields (`{agent}`, `{project}`, `{session}`,
+  `{channel}`, `{user}`) are available as template variables, and `recallTags`
+  now resolves templates like `retainTags` already did. Scoping memory per
+  project no longer needs a `settings.json` per repository — the same
+  `"project:{project}"` on both sides writes and reads the tag.
 - `{user_id}` template variable for `retainTags` and `retainMetadata`, resolved
   from the `HINDSIGHT_USER_ID` env var (empty string if unset). Enables
   machine-independent per-user memory scoping without hardcoding user ids in

--- a/hindsight-integrations/claude-code/README.md
+++ b/hindsight-integrations/claude-code/README.md
@@ -228,7 +228,7 @@ Auto-recall runs on every user prompt. It queries Hindsight for relevant memorie
 | `recallContextTurns` | `HINDSIGHT_RECALL_CONTEXT_TURNS` | `1` | How many prior conversation turns to include when composing the recall query. `1` = only the latest user message; higher values give more context but may dilute the query. |
 | `recallMaxQueryChars` | `HINDSIGHT_RECALL_MAX_QUERY_CHARS` | `800` | Maximum character length of the query sent to Hindsight. Longer queries are truncated. |
 | `recallRoles` | — | `["user", "assistant"]` | Which message roles to include when building the recall query from prior turns. |
-| `recallTags` | `HINDSIGHT_RECALL_TAGS` | `[]` | Optional tags to pass to the recall API, such as `["memory_type:rule"]`. The env var accepts JSON or a comma-separated list. |
+| `recallTags` | `HINDSIGHT_RECALL_TAGS` | `[]` | Optional tags to pass to the recall API, such as `["memory_type:rule"]`. Supports the same [template placeholders](#template-variables-for-retaintags-recalltags-and-retainmetadata) as `retainTags`. The env var accepts JSON or a comma-separated list. |
 | `recallTagsMatch` | `HINDSIGHT_RECALL_TAGS_MATCH` | `"any"` | Tag matching mode used with `recallTags` or `recallTagGroups`: `"any"`, `"all"`, `"any_strict"`, or `"all_strict"`. |
 | `recallTagGroups` | `HINDSIGHT_RECALL_TAG_GROUPS` | `null` | Optional compound tag filter passed through to the recall API. The env var must be JSON. |
 | `recallAdditionalBankFilters` | `HINDSIGHT_RECALL_ADDITIONAL_BANK_FILTERS` | `{}` | Optional per-bank tag filter overrides for banks listed in `recallAdditionalBanks`, keyed by bank ID. Each value may set `recallTags`, `recallTagsMatch`, and `recallTagGroups`. The env var must be JSON. |
@@ -248,18 +248,53 @@ Auto-retain runs after Claude responds. It extracts the conversation transcript 
 | `retainOverlapTurns` | — | `2` | When chunked retention fires, this many extra turns from the previous chunk are included for continuity. Total window size = `retainEveryNTurns + retainOverlapTurns`. |
 | `retainRoles` | — | `["user", "assistant"]` | Which message roles to include in the retained transcript. |
 | `retainToolCalls` | — | `true` | Whether to include tool calls (function invocations and results) in the retained transcript. Captures structured actions like file reads, searches, and code edits. |
-| `retainTags` | — | `["{session_id}"]` | Tags attached to the retained document. Supports template placeholders: `{session_id}`, `{bank_id}`, `{timestamp}`, and `{user_id}` (resolved from `HINDSIGHT_USER_ID` env var; empty string if unset). Tags whose resolved form ends in an empty namespace part (e.g. `"user:"` when `HINDSIGHT_USER_ID` is unset) are dropped from the outgoing request. See [Template variables](#template-variables-for-retaintags-and-retainmetadata) below. |
+| `retainTags` | — | `["{session_id}"]` | Tags attached to the retained document. Supports template placeholders: the `dynamicBankGranularity` fields (`{agent}`, `{project}`, `{session}`, `{channel}`, `{user}`) plus `{session_id}`, `{user_id}`, `{bank_id}` and `{timestamp}`. Tags whose resolved form ends in an empty namespace part (e.g. `"user:"` when `HINDSIGHT_USER_ID` is unset) are dropped from the outgoing request. See [Template variables](#template-variables-for-retaintags-recalltags-and-retainmetadata) below. |
 | `retainMetadata` | — | `{}` | Arbitrary key-value metadata attached to the retained document. Same template placeholders as `retainTags`. |
 | `retainContext` | — | `"claude-code"` | A label attached to retained memories identifying their source. Useful when multiple integrations write to the same bank. |
 
-#### Template variables for `retainTags` and `retainMetadata`
+#### Template variables for `retainTags`, `recallTags` and `retainMetadata`
+
+The five `dynamicBankGranularity` fields are available as template variables, so
+the dimension you scope banks by is the dimension you can tag by:
 
 | Variable | Source |
 |----------|--------|
-| `{session_id}` | Current Claude Code session ID |
+| `{agent}` | `agentName` (`HINDSIGHT_AGENT_NAME`), default `claude-code` |
+| `{project}` | Repository name for the current working directory, worktrees resolved to the main repo |
+| `{session}` | Current Claude Code session ID, `unknown` if absent |
+| `{channel}` | Value of `HINDSIGHT_CHANNEL_ID`, `default` if unset |
+| `{user}` | Value of `HINDSIGHT_USER_ID`, `anonymous` if unset |
+
+Plus three that are not granularity fields:
+
+| Variable | Source |
+|----------|--------|
 | `{bank_id}` | Resolved bank ID (per `bankGranularity`) |
 | `{timestamp}` | ISO 8601 UTC at retain time |
-| `{user_id}` | Value of `HINDSIGHT_USER_ID` env var (empty string if unset) |
+| `{session_id}` | Raw session ID — like `{session}` but empty rather than `unknown` |
+| `{user_id}` | Raw `HINDSIGHT_USER_ID` — like `{user}` but empty rather than `anonymous` |
+
+Prefer `{session_id}` / `{user_id}` when the tag should disappear on an
+unconfigured host: a tag whose value half resolves to nothing (`user:`) is
+dropped instead of being sent, where `user:anonymous` would be a real tag
+matching every unconfigured session.
+
+##### Example: per-project memory scoping
+
+One repository's memories stay out of another's, with no per-project config
+file — the same two lines work everywhere:
+
+```json
+{
+  "retainTags": ["project:{project}", "session:{session_id}"],
+  "recallTags": ["project:{project}"],
+  "recallTagsMatch": "any"
+}
+```
+
+`"any"` keeps untagged memories visible alongside the current project's, so
+memories retained before tagging was enabled are not orphaned. Use
+`"any_strict"` for hard isolation.
 
 ##### Example: per-user memory scoping
 

--- a/hindsight-integrations/claude-code/scripts/lib/bank.py
+++ b/hindsight-integrations/claude-code/scripts/lib/bank.py
@@ -20,6 +20,7 @@ their environment to achieve equivalent behavior.
 import os
 import subprocess
 import sys
+import time
 
 from .state import read_state, write_state
 
@@ -66,6 +67,79 @@ def _resolve_project_name(cwd: str, config: dict) -> str:
 
     # Fallback: not a git repo or git not available
     return os.path.basename(cwd)
+
+
+def build_field_map(hook_input: dict, config: dict) -> dict:
+    """Resolve every context dimension Claude Code can scope memory by.
+
+    The same five values feed two consumers: dynamicBankGranularity, which
+    composes them into a bank ID, and the tag templates in retain/recall, which
+    interpolate them by name. Keeping one resolver means a bank and the tags
+    written into it can never disagree about which project they belong to.
+
+    Args:
+        hook_input: The hook's stdin JSON (has session_id, cwd).
+        config: Plugin configuration dict.
+    """
+    # Channel and user come from environment variables, set by the host agent
+    # (e.g. Telegram bot sets HINDSIGHT_CHANNEL_ID=telegram-group-12345)
+    return {
+        "agent": config.get("agentName", "claude-code"),
+        "project": _resolve_project_name(hook_input.get("cwd", ""), config),
+        "session": hook_input.get("session_id", "") or "unknown",
+        "channel": os.environ.get("HINDSIGHT_CHANNEL_ID", "") or "default",
+        "user": os.environ.get("HINDSIGHT_USER_ID", "") or "anonymous",
+    }
+
+
+def build_template_vars(hook_input: dict, config: dict, bank_id: str) -> dict:
+    """Variables available to retainTags / recallTags / retainMetadata templates.
+
+    Carries the VALID_FIELDS names plus {bank_id} and {timestamp}. {session_id}
+    and {user_id} predate the field map and are kept as-is — they expose the raw
+    values, empty when unset, which is what the empty-namespace tag drop relies
+    on to discard "user:" for an unconfigured host. Their field-map counterparts
+    {session} and {user} substitute "unknown"/"anonymous" instead.
+    """
+    template_vars = build_field_map(hook_input, config)
+    template_vars.update(
+        {
+            "session_id": hook_input.get("session_id", ""),
+            "user_id": os.environ.get("HINDSIGHT_USER_ID", ""),
+            "bank_id": bank_id,
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        }
+    )
+    return template_vars
+
+
+def resolve_template(value: str, template_vars: dict) -> str:
+    """Substitute {name} placeholders in a single string."""
+    for key, replacement in template_vars.items():
+        value = value.replace(f"{{{key}}}", replacement)
+    return value
+
+
+def resolve_tags(raw_tags, template_vars: dict, debug_fn=None):
+    """Resolve templates in a tag list, dropping tags left with an empty namespace.
+
+    A tag whose value half resolves to nothing (e.g. "user:" when the host set no
+    HINDSIGHT_USER_ID) would match every memory that shares the namespace, so it
+    is dropped rather than sent. Tags without ':' are passed through untouched.
+    Returns None when nothing survives, which is what the API expects for "no
+    tag filter".
+    """
+    if not raw_tags:
+        return None
+    tags = []
+    for original in raw_tags:
+        resolved = resolve_template(original, template_vars)
+        if ":" in resolved and resolved.split(":", 1)[1] == "":
+            if debug_fn:
+                debug_fn(f"Dropping tag '{original}' -> '{resolved}' (empty content after ':')")
+            continue
+        tags.append(resolved)
+    return tags or None
 
 
 def derive_bank_id(hook_input: dict, config: dict) -> str:
@@ -119,22 +193,7 @@ def derive_bank_id(hook_input: dict, config: dict) -> str:
                 file=sys.stderr,
             )
 
-    # Build field values from hook context + env vars
-    session_id = hook_input.get("session_id", "")
-    agent_name = config.get("agentName", "claude-code")
-
-    # Channel and user come from environment variables, set by the host agent
-    # (e.g. Telegram bot sets HINDSIGHT_CHANNEL_ID=telegram-group-12345)
-    channel_id = os.environ.get("HINDSIGHT_CHANNEL_ID", "")
-    user_id = os.environ.get("HINDSIGHT_USER_ID", "")
-
-    field_map = {
-        "agent": agent_name,
-        "project": _resolve_project_name(cwd, config),
-        "session": session_id or "unknown",
-        "channel": channel_id or "default",
-        "user": user_id or "anonymous",
-    }
+    field_map = build_field_map(hook_input, config)
 
     # bank_id is stored as-is server-side; HTTP path encoding is the client layer's job.
     segments = [field_map.get(f, "unknown") for f in fields]

--- a/hindsight-integrations/claude-code/scripts/recall.py
+++ b/hindsight-integrations/claude-code/scripts/recall.py
@@ -26,7 +26,7 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from lib.bank import derive_bank_id, ensure_bank_mission
+from lib.bank import build_template_vars, derive_bank_id, ensure_bank_mission, resolve_tags
 from lib.client import HindsightClient
 from lib.config import debug_log, load_config
 from lib.content import (
@@ -177,7 +177,10 @@ def main():
 
     debug_log(config, f"Recalling from bank '{bank_id}', query length: {len(query)}")
 
-    recall_tags = config.get("recallTags") or None
+    # Same template variables as retainTags, so a tag can be written and read back
+    # with one identical line of config.
+    template_vars = build_template_vars(hook_input, config, bank_id)
+    recall_tags = resolve_tags(config.get("recallTags"), template_vars, debug_fn=_dbg)
     tag_groups = config.get("recallTagGroups") or None
     tags_match = config.get("recallTagsMatch") if recall_tags or tag_groups else None
     additional_bank_filters = config.get("recallAdditionalBankFilters") or {}
@@ -211,7 +214,7 @@ def main():
             continue
         seen_banks.add(extra_bank_id)
         extra_filter = additional_bank_filters.get(extra_bank_id, {})
-        extra_tags = extra_filter.get("recallTags", recall_tags) or None
+        extra_tags = resolve_tags(extra_filter.get("recallTags", recall_tags), template_vars, debug_fn=_dbg)
         extra_tag_groups = extra_filter.get("recallTagGroups", tag_groups) or None
         extra_tags_match = extra_filter.get(
             "recallTagsMatch",

--- a/hindsight-integrations/claude-code/scripts/retain.py
+++ b/hindsight-integrations/claude-code/scripts/retain.py
@@ -24,7 +24,7 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from lib.bank import derive_bank_id, ensure_bank_mission
+from lib.bank import build_template_vars, derive_bank_id, ensure_bank_mission, resolve_tags, resolve_template
 from lib.client import HindsightClient
 from lib.config import debug_log, load_config
 from lib.content import (
@@ -182,36 +182,12 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
     bank_id = derive_bank_id(hook_input, config)
     ensure_bank_mission(client, bank_id, config, debug_fn=_dbg)
 
-    # Resolve template variables in tags and metadata.
-    # Supported variables: {session_id}, {bank_id}, {timestamp}, {user_id}
-    template_vars = {
-        "session_id": session_id,
-        "bank_id": bank_id,
-        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        "user_id": os.environ.get("HINDSIGHT_USER_ID", ""),
-    }
+    # Resolve template variables in tags and metadata. Supported variables:
+    # {agent}, {project}, {session}, {channel}, {user} — the dynamicBankGranularity
+    # fields — plus {session_id}, {user_id}, {bank_id}, {timestamp}.
+    template_vars = build_template_vars(hook_input, config, bank_id)
 
-    def _resolve_template(value: str) -> str:
-        for k, v in template_vars.items():
-            value = value.replace(f"{{{k}}}", v)
-        return value
-
-    # Tags from config with template resolution.
-    # Drop tags whose resolved form ends in an empty namespace part (e.g. "user:"
-    # when HINDSIGHT_USER_ID is unset). Tags without ':' are preserved as-is.
-    raw_tags = config.get("retainTags", [])
-    if raw_tags:
-        tags = []
-        for original in raw_tags:
-            resolved = _resolve_template(original)
-            if ":" in resolved and resolved.split(":", 1)[1] == "":
-                debug_log(config, f"Dropping tag '{original}' -> '{resolved}' (empty content after ':')")
-                continue
-            tags.append(resolved)
-        if not tags:
-            tags = None
-    else:
-        tags = None
+    tags = resolve_tags(config.get("retainTags", []), template_vars, debug_fn=_dbg)
 
     # Metadata: merge built-in defaults with user-configured extras
     metadata = {
@@ -220,7 +196,7 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
         "session_id": session_id,
     }
     for k, v in config.get("retainMetadata", {}).items():
-        metadata[k] = _resolve_template(str(v))
+        metadata[k] = resolve_template(str(v), template_vars)
 
     debug_log(
         config, f"Retaining to bank '{bank_id}', doc '{document_id}', {message_count} messages, {len(transcript)} chars"

--- a/hindsight-integrations/claude-code/tests/test_bank.py
+++ b/hindsight-integrations/claude-code/tests/test_bank.py
@@ -6,7 +6,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from lib.bank import _resolve_project_name, derive_bank_id, ensure_bank_mission
+from lib.bank import (
+    VALID_FIELDS,
+    _resolve_project_name,
+    build_field_map,
+    build_template_vars,
+    derive_bank_id,
+    ensure_bank_mission,
+    resolve_tags,
+)
 
 
 def _cfg(**overrides):
@@ -162,6 +170,64 @@ class TestResolveProjectName:
 
     def test_empty_cwd(self):
         assert _resolve_project_name("", _cfg()) == "unknown"
+
+
+class TestBuildFieldMap:
+    @patch("lib.bank._resolve_project_name", return_value="myproject")
+    def test_exposes_every_granularity_field(self, _mock, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_CHANNEL_ID", "telegram-123")
+        monkeypatch.setenv("HINDSIGHT_USER_ID", "user-456")
+        field_map = build_field_map(_hook(), _cfg())
+        assert field_map == {
+            "agent": "claude-code",
+            "project": "myproject",
+            "session": "sess-1",
+            "channel": "telegram-123",
+            "user": "user-456",
+        }
+        assert set(field_map) == VALID_FIELDS
+
+    @patch("lib.bank._resolve_project_name", return_value="myproject")
+    def test_defaults_when_env_unset(self, _mock, monkeypatch):
+        monkeypatch.delenv("HINDSIGHT_CHANNEL_ID", raising=False)
+        monkeypatch.delenv("HINDSIGHT_USER_ID", raising=False)
+        field_map = build_field_map(_hook(session_id=""), _cfg())
+        assert field_map["session"] == "unknown"
+        assert field_map["channel"] == "default"
+        assert field_map["user"] == "anonymous"
+
+
+class TestBuildTemplateVars:
+    @patch("lib.bank._resolve_project_name", return_value="myproject")
+    def test_legacy_names_keep_raw_values(self, _mock, monkeypatch):
+        monkeypatch.delenv("HINDSIGHT_USER_ID", raising=False)
+        template_vars = build_template_vars(_hook(session_id=""), _cfg(), "bank-1")
+        # {user}/{session} substitute, {user_id}/{session_id} stay raw so the
+        # empty-namespace drop still fires for an unconfigured host.
+        assert template_vars["user_id"] == ""
+        assert template_vars["session_id"] == ""
+        assert template_vars["user"] == "anonymous"
+        assert template_vars["session"] == "unknown"
+        assert template_vars["bank_id"] == "bank-1"
+
+
+class TestResolveTags:
+    def test_substitutes_field_map_names(self):
+        template_vars = {"project": "myproject", "session": "sess-1"}
+        assert resolve_tags(["project:{project}", "session:{session}"], template_vars) == [
+            "project:myproject",
+            "session:sess-1",
+        ]
+
+    def test_drops_tag_left_with_empty_namespace(self):
+        assert resolve_tags(["user:{user_id}"], {"user_id": ""}) is None
+
+    def test_keeps_tags_without_namespace(self):
+        assert resolve_tags(["standalone"], {}) == ["standalone"]
+
+    def test_empty_input_returns_none(self):
+        assert resolve_tags([], {}) is None
+        assert resolve_tags(None, {}) is None
 
 
 class TestDirectoryBankMap:


### PR DESCRIPTION
> Independent of #3110, but best merged after it — see *Ordering* below.

## The gap

`dynamicBankGranularity` already resolves five context dimensions — `agent`, `project`, `session`, `channel`, `user` — but they stopped at bank composition. `retainTags` only ever saw `{session_id}` and `{user_id}`; `recallTags` resolved no templates at all (`recall.py` read `config.get("recallTags")` raw, so `"project:{project}"` would have been sent with the braces intact).

Scoping memory per project therefore meant either a `settings.json` per repository with the name hardcoded on both sides, or `dynamicBankId`, which silos each project into its own bank and gives up cross-project recall entirely.

## The change

`build_field_map()` moves out of `derive_bank_id()` — it was computed *after* the static-mode early return, so nothing outside that function could reach it — and both consumers now share it. A bank and the tags written into it can no longer disagree about which project they belong to, and one global config line covers every repository:

```json
{
  "retainTags": ["project:{project}", "session:{session_id}"],
  "recallTags": ["project:{project}"],
  "recallTagsMatch": "any"
}
```

`"any"` keeps untagged memories visible alongside the current project's, so memories retained before tagging was enabled are not orphaned.

## Backward compatibility

`{session}` and `{user}` join the namespace next to the existing `{session_id}` and `{user_id}`, which keep their raw semantics — empty rather than `unknown`/`anonymous`. That distinction is load-bearing: the empty-namespace drop relies on it to discard `user:` on a host that set no `HINDSIGHT_USER_ID`, where `user:anonymous` would be a real tag matching every unconfigured session. `TestBuildTemplateVars` pins it.

The tag-resolution loop that was inline in `retain.py` moved to `resolve_tags()` unchanged, and `recall.py` now calls it too — including for the per-bank overrides in `recallAdditionalBankFilters`.

## Ordering

`{project}` resolves through `_resolve_project_name()`, which #3110 fixes. Merged alone, this PR hands worktree-isolated subagents tags like `project:agent-a33c4d63` — the same fragmentation as #3096, moved from bank ids into tags. The two touch different functions and do not conflict outside a trivial CHANGELOG hunk.

## Tests

7 cases added across `TestBuildFieldMap`, `TestBuildTemplateVars` and `TestResolveTags`. No existing test modified. Full suite: 204 passed.
