### PR TITLE
docs(embed): document uvx cache growth and how to reclaim it (#2915)

### DIFF
--- a/hindsight-docs/docs/sdks/embed.md
+++ b/hindsight-docs/docs/sdks/embed.md
@@ -170,6 +170,16 @@ hindsight-embed daemon logs -f
 hindsight-embed daemon stop
 ```
 
+### Reclaiming Disk Space
+
+When the daemon is launched with `uvx` (the default for the npm package and the editor plugins), every Hindsight version it has run keeps its own cached Python environment — around 1.5 GB each — and these are not removed automatically. If disk space gets tight, stop the daemon before clearing the cache: unused entries can only be reclaimed while no daemon is running.
+
+```bash
+hindsight-embed daemon stop
+uv cache prune
+hindsight-embed daemon status   # starts fresh on the current version
+```
+
 ### Control Center Commands
 
 ```bash

--- a/skills/hindsight-docs/references/sdks/embed.md
+++ b/skills/hindsight-docs/references/sdks/embed.md
@@ -170,6 +170,16 @@ hindsight-embed daemon logs -f
 hindsight-embed daemon stop
 ```
 
+### Reclaiming Disk Space
+
+When the daemon is launched with `uvx` (the default for the npm package and the editor plugins), every Hindsight version it has run keeps its own cached Python environment — around 1.5 GB each — and these are not removed automatically. If disk space gets tight, stop the daemon before clearing the cache: unused entries can only be reclaimed while no daemon is running.
+
+```bash
+hindsight-embed daemon stop
+uv cache prune
+hindsight-embed daemon status   # starts fresh on the current version
+```
+
 ### Control Center Commands
 
 ```bash


### PR DESCRIPTION
Closes #2915.

The `uvx`-launched embedded daemon keeps a cached Python environment for every Hindsight version it has run (~1.5 GB each) and nothing retires them — one reporter accumulated 35 generations / 55.5 GiB.

We're resolving this as a documentation fix rather than adding cleanup logic. Reasoning, from checking the behaviour directly:

- `uv tool run` (uvx) holds an open handle on `~/.cache/uv/.lock` for the **entire life** of the daemon, and the embedded daemon runs with `--idle-timeout 0`. So `uv cache prune` invoked from the integration while a daemon is up blocks and then fails — it can only work once the daemon is stopped, which is exactly the manual sequence now documented.
- `uv cache prune` is also machine-wide: it evicts cached environments for every other uvx-run tool on the host, not just Hindsight's.

So this adds a short "Reclaiming Disk Space" section to the daemon docs with the stop / prune / restart sequence and a note on why the daemon must be stopped first.

Docs source only (`hindsight-docs/docs/`) plus the regenerated `skills/` mirror — the release script syncs it into `version-0.8/` at the next patch cut.