### PR TITLE
feat(llm): add `openai-responses` provider (OpenAI Responses API)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Copy this file to .env and fill in your values
 
 # LLM Configuration (Required)
-# Supported providers: openai, groq, ollama, gemini, anthropic, lmstudio, vertexai, minimax, deepseek, zai, atlas, volcano
+# Supported providers: openai, openai-responses, groq, ollama, gemini, anthropic, lmstudio, vertexai, minimax, deepseek, zai, atlas, volcano
 HINDSIGHT_API_LLM_PROVIDER=openai
 HINDSIGHT_API_LLM_API_KEY=your-api-key-here
 HINDSIGHT_API_LLM_MODEL=gpt-4o-mini
@@ -56,6 +56,12 @@ HINDSIGHT_API_LLM_BASE_URL=https://api.openai.com/v1
 # HINDSIGHT_API_LLM_PROVIDER=minimax
 # HINDSIGHT_API_LLM_API_KEY=your-minimax-api-key
 # HINDSIGHT_API_LLM_MODEL=MiniMax-M3  # or MiniMax-M2.7 for the previous generation
+
+# Example: OpenAI Responses API (/v1/responses) — reasoning + function tools together
+# HINDSIGHT_API_LLM_PROVIDER=openai-responses
+# HINDSIGHT_API_LLM_API_KEY=your-openai-api-key
+# HINDSIGHT_API_LLM_MODEL=gpt-5.6  # reasoning model (gpt-5.x / o-series); e.g. gpt-5.6-terra
+# HINDSIGHT_API_LLM_REASONING_EFFORT=high  # sent alongside tools, unlike chat/completions
 
 # Example: DeepSeek configuration (https://api.deepseek.com)
 # HINDSIGHT_API_LLM_PROVIDER=deepseek

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -816,6 +816,7 @@ DEFAULT_LLM_PROVIDER = "openai"
 # Provider-specific default models
 PROVIDER_DEFAULT_MODELS = {
     "openai": "gpt-4o-mini",
+    "openai-responses": "gpt-5.6",
     "anthropic": "claude-haiku-4-5",
     "gemini": "gemini-3.5-flash",
     "groq": "openai/gpt-oss-120b",

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -340,6 +340,7 @@ def create_llm_provider(
         MockLLM,
         NoneLLM,
         OpenAICompatibleLLM,
+        OpenAIResponsesLLM,
     )
 
     provider_lower = provider.lower()
@@ -507,6 +508,22 @@ def create_llm_provider(
             timeout=timeout,
         )
 
+    elif provider_lower == "openai-responses":
+        # OpenAI Responses API (/v1/responses). Unlike chat/completions, it
+        # supports reasoning + function tools together, so reflect's tool loop
+        # can run with a real reasoning_effort. See OpenAIResponsesLLM.
+        return OpenAIResponsesLLM(
+            provider=provider,
+            api_key=api_key,
+            base_url=base_url,
+            model=model,
+            reasoning_effort=reasoning_effort,
+            openai_service_tier=openai_service_tier,
+            extra_body=extra_body,
+            default_headers=default_headers,
+            timeout=timeout,
+        )
+
     elif provider_lower in (
         "openai",
         "groq",
@@ -657,6 +674,7 @@ class LLMProvider:
         # Validate provider
         valid_providers = [
             "openai",
+            "openai-responses",
             "groq",
             "ollama",
             "ollama-cloud",

--- a/hindsight-api-slim/hindsight_api/engine/providers/__init__.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/__init__.py
@@ -15,6 +15,7 @@ from .llamacpp_llm import LlamaCppLLM
 from .mock_llm import MockLLM
 from .none_llm import NoneLLM
 from .openai_compatible_llm import OpenAICompatibleLLM
+from .openai_responses_llm import OpenAIResponsesLLM
 
 __all__ = [
     "AnthropicLLM",
@@ -28,4 +29,5 @@ __all__ = [
     "MockLLM",
     "NoneLLM",
     "OpenAICompatibleLLM",
+    "OpenAIResponsesLLM",
 ]

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_responses_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_responses_llm.py
@@ -1,0 +1,629 @@
+"""OpenAI Responses API provider (``client.responses.create`` → ``/v1/responses``).
+
+This provider **always** uses the Responses API — never chat/completions. The
+chat/completions path rejects ``reasoning_effort`` combined with function tools on
+some reasoning models — gpt-5.6-terra returns HTTP 400 unless ``reasoning_effort``
+is exactly ``"none"`` (see #2983). Reflect is a tool-calling search loop, so that
+constraint forces the whole reflect operation, including the final synthesis, to
+run with reasoning disabled.
+
+The Responses API models the chain-of-thought as a first-class reasoning item, so
+reasoning and function tools coexist. This provider issues requests against
+``responses.create``, translating the engine's chat-shaped inputs:
+
+- chat messages → Responses ``input`` items (assistant ``tool_calls`` →
+  ``function_call`` items, ``role="tool"`` results → ``function_call_output``),
+- nested ``{"type":"function","function":{...}}`` tools → flattened
+  ``{"type":"function","name":...,"parameters":...}``,
+- the flat ``reasoning_effort`` scalar → a ``reasoning={"effort": ...}`` object,
+- ``response_format`` → ``text={"format": {...}}``,
+
+and reads ``response.output_text`` plus ``function_call`` items out of
+``response.output``.
+
+It is OpenAI-only (unlike the multi-vendor ``OpenAICompatibleLLM``, it carries no
+groq/ollama/deepseek special-casing) and stands alone on ``LLMInterface`` so the
+"always Responses, never completions" guarantee is structural.
+
+The conversation is replayed statelessly on every turn (``store=False``, no
+``previous_response_id``); the model re-derives reasoning each turn rather than
+resuming a server-side chain. Server-side reasoning reuse across turns is a
+possible future optimization.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import time
+from typing import Any
+from urllib.parse import parse_qs, urlparse, urlunparse
+
+from openai import APIConnectionError, APIStatusError, AsyncOpenAI
+
+from hindsight_api.config import DEFAULT_LLM_TIMEOUT, ENV_LLM_TIMEOUT
+from hindsight_api.engine.bank_attribution import apply_bank_attribution
+from hindsight_api.engine.llm_interface import (
+    LLM_TOOL_CHOICE_AUTO,
+    LLMInterface,
+    LLMToolChoice,
+    LLMToolChoiceMode,
+    OutputTooLongError,
+)
+from hindsight_api.engine.llm_trace import LLMResponseUsage, stash_response_usage
+from hindsight_api.engine.providers.llm_debug import dump_request_on_4xx
+
+# Provider-agnostic pure helpers (text cleanup, quota-defer parsing, json-mode
+# hint). These are module-level utilities, not chat/completions behavior.
+from hindsight_api.engine.providers.openai_compatible_llm import (
+    _ensure_json_word_in_user_message,
+    _raise_provider_quota_defer,
+    _strip_code_fences,
+    _strip_reasoning_tags,
+)
+from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
+from hindsight_api.engine.structured_output import strict_json_schema
+from hindsight_api.metrics import get_metrics_collector
+from hindsight_api.worker.stage import set_stage
+
+logger = logging.getLogger(__name__)
+
+
+def _tools_to_responses(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert chat/completions tool schemas to the flattened Responses shape.
+
+    Chat nests the function under a ``function`` key; Responses lifts ``name`` /
+    ``description`` / ``parameters`` to the top level. Anything already flattened
+    (or a built-in tool) is passed through unchanged.
+    """
+    converted: list[dict[str, Any]] = []
+    for tool in tools:
+        function = tool.get("function") if isinstance(tool, dict) else None
+        if tool.get("type") == "function" and isinstance(function, dict):
+            item: dict[str, Any] = {
+                "type": "function",
+                "name": function.get("name"),
+                "parameters": function.get("parameters", {}),
+            }
+            if function.get("description") is not None:
+                item["description"] = function["description"]
+            if "strict" in function:
+                item["strict"] = function["strict"]
+            converted.append(item)
+        else:
+            converted.append(tool)
+    return converted
+
+
+def _messages_to_responses_input(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert chat/completions messages to Responses ``input`` items.
+
+    - ``role="tool"`` result → ``function_call_output`` keyed by ``call_id``,
+    - assistant ``tool_calls`` → ``function_call`` items (plus a message item when
+      the assistant turn also carried text),
+    - every other message → a role/content message item.
+    """
+    items: list[dict[str, Any]] = []
+    for message in messages:
+        role = message.get("role")
+
+        if role == "tool":
+            content = message.get("content")
+            items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": message.get("tool_call_id"),
+                    "output": content if isinstance(content, str) else json.dumps(content, ensure_ascii=False),
+                }
+            )
+            continue
+
+        if role == "assistant" and message.get("tool_calls"):
+            text = message.get("content")
+            if isinstance(text, str) and text:
+                items.append({"role": "assistant", "content": text})
+            for tool_call in message["tool_calls"]:
+                function = tool_call.get("function", {})
+                arguments = function.get("arguments")
+                items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": tool_call.get("id"),
+                        "name": function.get("name"),
+                        "arguments": arguments if isinstance(arguments, str) else json.dumps(arguments or {}),
+                    }
+                )
+            continue
+
+        content = message.get("content")
+        items.append({"role": role, "content": content if content is not None else ""})
+    return items
+
+
+def _inject_schema_into_input(input_items: list[dict[str, Any]], schema: dict[str, Any]) -> list[dict[str, Any]]:
+    """Soft structured-output path: append the JSON schema to the first message.
+
+    A leading ``system`` message gets the schema appended, otherwise it is
+    prepended to the first message. Only string-content message items are touched.
+    """
+    schema_msg = (
+        f"\n\nYou must respond with valid JSON matching this schema:\n"
+        f"{json.dumps(schema, indent=2, ensure_ascii=False)}"
+    )
+    items = [dict(item) for item in input_items]
+    for item in items:
+        if not isinstance(item.get("content"), str):
+            continue
+        if item.get("role") == "system":
+            item["content"] += schema_msg
+        else:
+            item["content"] = schema_msg + "\n\n" + item["content"]
+        return items
+    return items
+
+
+class OpenAIResponsesLLM(LLMInterface):
+    """OpenAI provider that talks exclusively to the Responses API.
+
+    OpenAI-only and standalone (does not inherit the multi-vendor
+    chat/completions provider), so it never routes through ``chat.completions``.
+    """
+
+    def __init__(
+        self,
+        provider: str,
+        api_key: str,
+        base_url: str,
+        model: str,
+        reasoning_effort: str = "low",
+        timeout: float | None = None,
+        extra_body: dict[str, Any] | None = None,
+        default_headers: dict[str, str] | None = None,
+        **kwargs: Any,
+    ):
+        """Initialize the Responses provider.
+
+        Args:
+            provider: Provider name (``"openai-responses"``).
+            api_key: OpenAI API key (required).
+            base_url: Optional custom endpoint; empty uses the OpenAI default.
+            model: Model name (reasoning models — gpt-5.x, o-series — benefit most).
+            reasoning_effort: Effort forwarded as ``reasoning={"effort": ...}`` for
+                reasoning models. Unlike chat/completions, this is sent alongside
+                function tools.
+            timeout: Request timeout in seconds (env var or 120s default).
+            extra_body: Extra body params merged into every request.
+            default_headers: Custom headers passed to the OpenAI SDK client (for
+                operators routing through proxies / request-tracing middleware).
+            **kwargs: Additional provider-specific parameters (e.g. ``openai_service_tier``).
+        """
+        super().__init__(provider, api_key, base_url, model, reasoning_effort, **kwargs)
+
+        if not self.api_key:
+            raise ValueError(f"API key is required for {self.provider}")
+
+        # OpenAI service tier ("flex" = 50% cheaper / variable latency, "priority",
+        # "default"). Applied as the native Responses ``service_tier`` param.
+        self.openai_service_tier = kwargs.get("openai_service_tier")
+        self._config_extra_body = extra_body or {}
+        self.default_headers = default_headers
+        self.timeout = timeout or float(os.getenv(ENV_LLM_TIMEOUT, str(DEFAULT_LLM_TIMEOUT)))
+
+        # Manual retries (max_retries=0). Extract query params from base_url so an
+        # Azure-style ``?api-version=`` is forwarded as a default query param.
+        client_kwargs: dict[str, Any] = {"api_key": self.api_key, "max_retries": 0}
+        if self.default_headers:
+            client_kwargs["default_headers"] = self.default_headers
+        if self.base_url:
+            parsed = urlparse(self.base_url)
+            if parsed.query:
+                clean_url = urlunparse(parsed._replace(query=""))
+                client_kwargs["base_url"] = clean_url
+                client_kwargs["default_query"] = {k: v[0] for k, v in parse_qs(parsed.query).items()}
+                self.base_url = clean_url
+            else:
+                client_kwargs["base_url"] = self.base_url
+        if self.timeout:
+            client_kwargs["timeout"] = self.timeout
+
+        self._client = AsyncOpenAI(**client_kwargs)
+        logger.info(
+            f"OpenAI Responses client initialized: provider={self.provider}, model={self.model}, "
+            f"base_url={self.base_url or 'default'}"
+        )
+
+    def _supports_reasoning_model(self) -> bool:
+        """Whether the model is an OpenAI reasoning model (gpt-5.x, o1, o3)."""
+        model_lower = self.model.lower()
+        return any(x in model_lower for x in ["gpt-5", "o1", "o3"])
+
+    async def verify_connection(self) -> None:
+        """Verify configuration with a minimal Responses call."""
+        try:
+            logger.info(f"Verifying connection: {self.provider}/{self.model}")
+            await self.call(
+                messages=[{"role": "user", "content": "Say 'ok'"}],
+                max_completion_tokens=512,
+                max_retries=2,
+                initial_backoff=0.5,
+                max_backoff=2.0,
+                scope="verification",
+            )
+            logger.info(f"Connection verified: {self.provider}/{self.model}")
+        except Exception as e:
+            raise RuntimeError(f"Connection verification failed for {self.provider}/{self.model}: {e}") from e
+
+    async def cleanup(self) -> None:
+        """Close the OpenAI client connections."""
+        if hasattr(self, "_client") and self._client:
+            await self._client.close()
+
+    @staticmethod
+    def _extract_usage(response: Any) -> TokenUsage:
+        """Read Responses token usage, splitting reasoning out of visible output.
+
+        The provider folds reasoning tokens into ``output_tokens``; the
+        ``TokenUsage`` contract treats output as visible-only and surfaces
+        reasoning separately, so subtract to avoid double-counting.
+        """
+        usage = getattr(response, "usage", None)
+        input_tokens = int(getattr(usage, "input_tokens", 0) or 0)
+        raw_output = int(getattr(usage, "output_tokens", 0) or 0)
+        cached = int(getattr(getattr(usage, "input_tokens_details", None), "cached_tokens", 0) or 0)
+        reasoning = int(getattr(getattr(usage, "output_tokens_details", None), "reasoning_tokens", 0) or 0)
+        visible_output = max(0, raw_output - reasoning)
+        return TokenUsage(
+            input_tokens=input_tokens,
+            output_tokens=visible_output,
+            total_tokens=input_tokens + visible_output,
+            cached_tokens=cached,
+            thoughts_tokens=reasoning,
+        )
+
+    @staticmethod
+    def _raise_if_truncated(response: Any) -> None:
+        """Map a ``max_output_tokens`` truncation to ``OutputTooLongError``."""
+        if getattr(response, "status", None) != "incomplete":
+            return
+        details = getattr(response, "incomplete_details", None)
+        if getattr(details, "reason", None) == "max_output_tokens":
+            raise OutputTooLongError(
+                "LLM output exceeded token limits. Input may need to be split into smaller chunks."
+            )
+
+    def _record_success(
+        self,
+        *,
+        scope: str,
+        usage: TokenUsage,
+        duration: float,
+        span_messages: list[dict[str, Any]],
+        response_content: Any,
+        finish_reason: str,
+        tool_calls_dict: list[dict[str, Any]] | None = None,
+    ) -> None:
+        """Record metrics + a trace span for a successful call (shared by both paths)."""
+        get_metrics_collector().record_llm_call(
+            provider=self.provider,
+            model=self.model,
+            scope=scope,
+            duration=duration,
+            input_tokens=usage.input_tokens,
+            output_tokens=usage.output_tokens,
+            success=True,
+            cached_input_tokens=usage.cached_tokens,
+            thoughts_tokens=usage.thoughts_tokens,
+        )
+
+        from hindsight_api.tracing import _serialize_for_span, get_span_recorder
+
+        get_span_recorder().record_llm_call(
+            provider=self.provider,
+            model=self.model,
+            scope=scope,
+            messages=span_messages,
+            response_content=_serialize_for_span(response_content),
+            input_tokens=usage.input_tokens,
+            output_tokens=usage.output_tokens,
+            duration=duration,
+            finish_reason=finish_reason,
+            error=None,
+            cached_tokens=usage.cached_tokens,
+            tool_calls=tool_calls_dict,
+        )
+
+    async def _run_with_retries(
+        self,
+        params: dict[str, Any],
+        *,
+        scope: str,
+        parse: Any,
+        max_retries: int,
+        initial_backoff: float,
+        max_backoff: float,
+    ) -> Any:
+        """Call ``responses.create`` with retries and hand the response to ``parse``.
+
+        ``parse(response)`` extracts the result; raising ``json.JSONDecodeError``
+        signals a bad structured reply and triggers a retry. Connection and
+        non-auth 4xx/5xx errors back off and retry; 401/403 fail fast. Provider
+        usage is stashed before ``parse`` runs so an error trace can still attach
+        real token counts (see #2387).
+        """
+        last_exception: Exception | None = None
+        for attempt in range(max_retries + 1):
+            set_stage(f"llm.{self.provider}.{scope}.attempt={attempt + 1}/{max_retries + 1}")
+            try:
+                response = await self._client.responses.create(**params)
+                usage = self._extract_usage(response)
+                stash_response_usage(
+                    LLMResponseUsage(
+                        input_tokens=usage.input_tokens,
+                        output_tokens=usage.output_tokens,
+                        cached_tokens=usage.cached_tokens,
+                    )
+                )
+                return parse(response)
+
+            except json.JSONDecodeError as e:
+                last_exception = e
+                logger.warning(
+                    f"JSON parse error from Responses reply "
+                    f"({self.provider}/{self.model}, scope={scope}, attempt {attempt + 1}/{max_retries + 1}): "
+                    f"{str(e)[:200]}"
+                )
+                if attempt < max_retries:
+                    await asyncio.sleep(min(initial_backoff * (2**attempt), max_backoff))
+                    continue
+                raise
+
+            except APIConnectionError as e:
+                last_exception = e
+                status_code = getattr(e, "status_code", None) or getattr(
+                    getattr(e, "response", None), "status_code", None
+                )
+                logger.warning(
+                    f"APIConnectionError ({self.provider}/{self.model}, scope={scope}, HTTP {status_code}, "
+                    f"attempt {attempt + 1}/{max_retries + 1}): {str(e)[:200]}"
+                )
+                if attempt < max_retries:
+                    await asyncio.sleep(min(initial_backoff * (2**attempt), max_backoff))
+                    continue
+                raise
+
+            except APIStatusError as e:
+                if e.status_code in (401, 403):
+                    logger.error(f"Auth error (HTTP {e.status_code}, {self.provider}/{self.model}), not retrying")
+                    raise
+
+                dump_request_on_4xx(scope=scope, provider=self.provider, model=self.model, err=e, request=params)
+                _raise_provider_quota_defer(
+                    e, provider=self.provider, model=self.model, scope=scope, max_backoff=max_backoff
+                )
+
+                last_exception = e
+                if attempt < max_retries:
+                    logger.warning(
+                        f"APIStatusError ({self.provider}/{self.model}, scope={scope}, "
+                        f"attempt {attempt + 1}/{max_retries + 1}): HTTP {e.status_code}"
+                    )
+                    backoff = min(initial_backoff * (2**attempt), max_backoff)
+                    jitter = backoff * 0.2 * (2 * (time.time() % 1) - 1)
+                    await asyncio.sleep(backoff + jitter)
+                    continue
+                logger.error(
+                    f"API error after {max_retries + 1} attempts "
+                    f"({self.provider}/{self.model}, scope={scope}): HTTP {e.status_code}"
+                )
+                raise
+
+        if last_exception:
+            raise last_exception
+        raise RuntimeError("LLM call failed after all retries with no exception captured")
+
+    async def call(
+        self,
+        messages: list[dict[str, str]],
+        response_format: Any | None = None,
+        max_completion_tokens: int | None = None,
+        temperature: float | None = None,
+        scope: str = "memory",
+        max_retries: int = 10,
+        initial_backoff: float = 1.0,
+        max_backoff: float = 60.0,
+        skip_validation: bool = False,
+        strict_schema: bool = False,
+        return_usage: bool = False,
+        cached_prefix: str | None = None,
+    ) -> Any:
+        """Make a Responses API call with retry logic (see ``LLMInterface.call``)."""
+        start_time = time.time()
+        is_reasoning_model = self._supports_reasoning_model()
+
+        input_items = _messages_to_responses_input(messages)
+        params: dict[str, Any] = {"model": self.model, "input": input_items, "store": False}
+
+        if max_completion_tokens is not None:
+            # Reasoning models spend part of the budget on hidden reasoning; keep
+            # headroom so the visible answer isn't truncated.
+            if is_reasoning_model and max_completion_tokens < 16000:
+                max_completion_tokens = 16000
+            params["max_output_tokens"] = max_completion_tokens
+        if temperature is not None and not is_reasoning_model:
+            params["temperature"] = temperature
+        if is_reasoning_model:
+            params["reasoning"] = {"effort": self.reasoning_effort}
+        if self.openai_service_tier:
+            params["service_tier"] = self.openai_service_tier
+        if self._config_extra_body:
+            params["extra_body"] = {**self._config_extra_body}
+
+        # Structured output: strict grammar-enforced schema, or the soft
+        # schema-in-prompt + json_object fallback.
+        if response_format is not None and hasattr(response_format, "model_json_schema"):
+            if strict_schema:
+                params["text"] = {
+                    "format": {
+                        "type": "json_schema",
+                        "name": "response",
+                        "strict": True,
+                        "schema": strict_json_schema(response_format),
+                    }
+                }
+            else:
+                schema = response_format.model_json_schema()
+                params["input"] = _ensure_json_word_in_user_message(_inject_schema_into_input(input_items, schema))
+                params["text"] = {"format": {"type": "json_object"}}
+
+        apply_bank_attribution(params)
+
+        def parse(response: Any) -> Any:
+            self._raise_if_truncated(response)
+            usage = self._extract_usage(response)
+            duration = time.time() - start_time
+            content = _strip_reasoning_tags(response.output_text or "")
+
+            if response_format is not None:
+                json_data = json.loads(_strip_code_fences(content))
+                result: Any = json_data if skip_validation else response_format.model_validate(json_data)
+            else:
+                result = content
+
+            self._record_success(
+                scope=scope,
+                usage=usage,
+                duration=duration,
+                span_messages=params["input"],
+                response_content=result,
+                finish_reason=getattr(response, "status", "completed"),
+            )
+            if duration > 10.0:
+                logger.info(
+                    f"slow llm call: scope={scope}, model={self.provider}/{self.model}, "
+                    f"input_tokens={usage.input_tokens}, output_tokens={usage.output_tokens}, time={duration:.3f}s"
+                )
+            return (result, usage) if return_usage else result
+
+        return await self._run_with_retries(
+            params,
+            scope=scope,
+            parse=parse,
+            max_retries=max_retries,
+            initial_backoff=initial_backoff,
+            max_backoff=max_backoff,
+        )
+
+    async def call_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        max_completion_tokens: int | None = None,
+        temperature: float | None = None,
+        scope: str = "tools",
+        max_retries: int = 5,
+        initial_backoff: float = 1.0,
+        max_backoff: float = 30.0,
+        tool_choice: LLMToolChoice = LLM_TOOL_CHOICE_AUTO,
+        cached_prefix: str | None = None,
+        cached_prefix_message_count: int = 0,
+    ) -> LLMToolCallResult:
+        """Make a Responses API call with tools (see ``LLMInterface.call_with_tools``).
+
+        Unlike chat/completions, ``reasoning`` and ``tools`` are sent together —
+        the reason this provider exists.
+        """
+        start_time = time.time()
+        is_reasoning_model = self._supports_reasoning_model()
+
+        responses_tools = _tools_to_responses(tools)
+
+        request_tool_choice: str | dict[str, Any] | None
+        if tool_choice.mode is LLMToolChoiceMode.NAMED:
+            forced_name = tool_choice.selected_function_name
+            filtered = [tool for tool in responses_tools if tool.get("name") == forced_name]
+            if len(filtered) != 1:
+                raise ValueError(
+                    f"Named tool_choice must reference exactly one declared tool; "
+                    f"found {len(filtered)} definitions for {forced_name!r}"
+                )
+            responses_tools = filtered
+            request_tool_choice = {"type": "function", "name": forced_name}
+        elif tool_choice.mode is LLMToolChoiceMode.AUTO:
+            request_tool_choice = None
+        else:
+            request_tool_choice = tool_choice.mode.value
+
+        params: dict[str, Any] = {
+            "model": self.model,
+            "input": _messages_to_responses_input(messages),
+            "tools": responses_tools,
+            "store": False,
+        }
+        if request_tool_choice is not None:
+            params["tool_choice"] = request_tool_choice
+        if max_completion_tokens is not None:
+            params["max_output_tokens"] = max_completion_tokens
+        if temperature is not None and not is_reasoning_model:
+            params["temperature"] = temperature
+        if is_reasoning_model:
+            params["reasoning"] = {"effort": self.reasoning_effort}
+        if self.openai_service_tier:
+            params["service_tier"] = self.openai_service_tier
+        if self._config_extra_body:
+            params["extra_body"] = {**self._config_extra_body}
+
+        apply_bank_attribution(params)
+
+        def parse(response: Any) -> LLMToolCallResult:
+            self._raise_if_truncated(response)
+            usage = self._extract_usage(response)
+            duration = time.time() - start_time
+
+            tool_calls: list[LLMToolCall] = []
+            for item in getattr(response, "output", None) or []:
+                if getattr(item, "type", None) != "function_call":
+                    continue
+                raw_args = getattr(item, "arguments", "") or ""
+                try:
+                    arguments = json.loads(raw_args) if raw_args else {}
+                except json.JSONDecodeError:
+                    arguments = {"_raw": raw_args}
+                tool_calls.append(
+                    LLMToolCall(id=getattr(item, "call_id", None), name=getattr(item, "name", ""), arguments=arguments)
+                )
+
+            content = response.output_text or None
+            finish_reason = "tool_calls" if tool_calls else getattr(response, "status", "completed")
+
+            self._record_success(
+                scope=scope,
+                usage=usage,
+                duration=duration,
+                span_messages=params["input"],
+                response_content=content,
+                finish_reason=finish_reason,
+                tool_calls_dict=(
+                    [{"id": tc.id, "name": tc.name, "arguments": tc.arguments} for tc in tool_calls]
+                    if tool_calls
+                    else None
+                ),
+            )
+
+            return LLMToolCallResult(
+                content=content,
+                tool_calls=tool_calls,
+                finish_reason=finish_reason,
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
+                cached_tokens=usage.cached_tokens,
+                thoughts_tokens=usage.thoughts_tokens,
+            )
+
+        return await self._run_with_retries(
+            params,
+            scope=scope,
+            parse=parse,
+            max_retries=max_retries,
+            initial_backoff=initial_backoff,
+            max_backoff=max_backoff,
+        )

--- a/hindsight-api-slim/pyproject.toml
+++ b/hindsight-api-slim/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.11"
 dependencies = [
     "asyncpg>=0.29.0",
     "python-dotenv>=1.0.0",
-    "openai>=1.0.0",
+    "openai>=1.66.0",  # Responses API (client.responses.create, reasoning=, text.format) for the openai-responses provider
     "pydantic>=2.0.0",
     "rich>=13.0.0",
     "langchain-text-splitters>=0.3.0",

--- a/hindsight-api-slim/tests/test_openai_responses_provider.py
+++ b/hindsight-api-slim/tests/test_openai_responses_provider.py
@@ -1,0 +1,387 @@
+"""Tests for the ``openai-responses`` provider (OpenAI Responses API).
+
+Two surfaces are covered:
+- registration/wiring (default model, factory routing, API-key requirement), and
+- request shaping + response parsing, mocking ``_client.responses.create``.
+
+The load-bearing assertion is that ``reasoning`` and ``tools`` are sent together
+on the tool path — the exact combination chat/completions rejects for gpt-5.6-terra
+(#2983), and the reason this provider exists.
+"""
+
+import json
+import types
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from hindsight_api.engine.llm_interface import LLMToolChoice, OutputTooLongError
+from hindsight_api.engine.providers.openai_responses_llm import OpenAIResponsesLLM
+
+
+def _fake_response(
+    *, output_text="", output=None, input_tokens=100, output_tokens=20, reasoning_tokens=5, status="completed"
+):
+    """Build a duck-typed OpenAI Responses reply for mocking ``responses.create``."""
+    usage = types.SimpleNamespace(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        input_tokens_details=types.SimpleNamespace(cached_tokens=0),
+        output_tokens_details=types.SimpleNamespace(reasoning_tokens=reasoning_tokens),
+    )
+    return types.SimpleNamespace(output_text=output_text, output=output or [], usage=usage, status=status)
+
+
+def _function_call(*, call_id, name, arguments):
+    return types.SimpleNamespace(type="function_call", call_id=call_id, name=name, arguments=arguments)
+
+
+def _make_llm(model="gpt-5.6", reasoning_effort="high"):
+    return OpenAIResponsesLLM(
+        provider="openai-responses",
+        api_key="sk-test",
+        base_url="",
+        model=model,
+        reasoning_effort=reasoning_effort,
+    )
+
+
+def _mock_create(llm, response):
+    create = AsyncMock(return_value=response)
+    llm._client.responses.create = create
+    return create
+
+
+# --------------------------------------------------------------------------- #
+# Registration / wiring
+# --------------------------------------------------------------------------- #
+
+
+def test_default_model_is_a_reasoning_model():
+    from hindsight_api.config import PROVIDER_DEFAULT_MODELS
+
+    assert PROVIDER_DEFAULT_MODELS["openai-responses"] == "gpt-5.6"
+
+
+def test_from_env_routes_to_openai_responses_llm(monkeypatch):
+    from hindsight_api.config import clear_config_cache
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "openai-responses")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "sk-test")
+    monkeypatch.delenv("HINDSIGHT_API_LLM_MODEL", raising=False)
+    monkeypatch.delenv("HINDSIGHT_API_LLM_BASE_URL", raising=False)
+    clear_config_cache()
+
+    try:
+        llm = LLMProvider.from_env()
+        assert llm.provider == "openai-responses"
+        assert llm.model == "gpt-5.6"
+        assert isinstance(llm._provider_impl, OpenAIResponsesLLM)
+    finally:
+        clear_config_cache()
+
+
+def test_openai_responses_requires_api_key():
+    from hindsight_api.engine.llm_wrapper import requires_api_key
+
+    assert requires_api_key("openai-responses") is True
+
+
+def test_rejects_missing_api_key():
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+
+    with pytest.raises(ValueError, match="API key is required for openai-responses"):
+        LLMProvider(provider="openai-responses", api_key="", base_url="", model="gpt-5.6")
+
+
+# --------------------------------------------------------------------------- #
+# call()
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_call_sends_reasoning_object_and_omits_temperature_for_reasoning_model():
+    llm = _make_llm()
+    create = _mock_create(llm, _fake_response(output_text="hello"))
+    with patch("hindsight_api.engine.providers.openai_responses_llm.get_metrics_collector"):
+        result = await llm.call(
+            messages=[{"role": "user", "content": "hi"}], temperature=0.7, max_completion_tokens=1000
+        )
+
+    kwargs = create.call_args.kwargs
+    assert result == "hello"
+    assert kwargs["reasoning"] == {"effort": "high"}
+    assert "temperature" not in kwargs  # reasoning models reject temperature
+    assert kwargs["max_output_tokens"] == 16000  # reasoning floor enforced
+    assert kwargs["store"] is False
+    assert kwargs["input"] == [{"role": "user", "content": "hi"}]
+
+
+@pytest.mark.asyncio
+async def test_call_non_reasoning_model_keeps_temperature_and_sends_no_reasoning():
+    llm = _make_llm(model="gpt-4o-mini", reasoning_effort="low")
+    create = _mock_create(llm, _fake_response(output_text="ok", reasoning_tokens=0))
+    with patch("hindsight_api.engine.providers.openai_responses_llm.get_metrics_collector"):
+        await llm.call(messages=[{"role": "user", "content": "hi"}], temperature=0.5, max_completion_tokens=500)
+
+    kwargs = create.call_args.kwargs
+    assert "reasoning" not in kwargs
+    assert kwargs["temperature"] == 0.5
+    assert kwargs["max_output_tokens"] == 500
+
+
+@pytest.mark.asyncio
+async def test_call_splits_reasoning_tokens_out_of_visible_output():
+    llm = _make_llm()
+    _mock_create(llm, _fake_response(output_text="hi", input_tokens=100, output_tokens=30, reasoning_tokens=12))
+    with patch("hindsight_api.engine.providers.openai_responses_llm.get_metrics_collector"):
+        _, usage = await llm.call(messages=[{"role": "user", "content": "hi"}], return_usage=True)
+
+    assert usage.input_tokens == 100
+    assert usage.output_tokens == 18  # 30 - 12 reasoning
+    assert usage.thoughts_tokens == 12
+    assert usage.total_tokens == 118
+
+
+class _Answer(BaseModel):
+    answer: str
+
+
+@pytest.mark.asyncio
+async def test_call_strict_schema_uses_text_format_json_schema():
+    llm = _make_llm()
+    create = _mock_create(llm, _fake_response(output_text=json.dumps({"answer": "42"})))
+    with patch("hindsight_api.engine.providers.openai_responses_llm.get_metrics_collector"):
+        result = await llm.call(
+            messages=[{"role": "user", "content": "q"}],
+            response_format=_Answer,
+            strict_schema=True,
+        )
+
+    text_format = create.call_args.kwargs["text"]["format"]
+    assert text_format["type"] == "json_schema"
+    assert text_format["strict"] is True
+    assert "schema" in text_format
+    assert isinstance(result, _Answer) and result.answer == "42"
+
+
+@pytest.mark.asyncio
+async def test_call_soft_schema_injects_schema_and_uses_json_object():
+    llm = _make_llm()
+    create = _mock_create(llm, _fake_response(output_text=json.dumps({"answer": "x"})))
+    with patch("hindsight_api.engine.providers.openai_responses_llm.get_metrics_collector"):
+        await llm.call(
+            messages=[{"role": "system", "content": "be terse"}, {"role": "user", "content": "q"}],
+            response_format=_Answer,
+            strict_schema=False,
+        )
+
+    kwargs = create.call_args.kwargs
+    assert kwargs["text"]["format"] == {"type": "json_object"}
+    # schema text is appended to the system message
+    assert "valid JSON matching this schema" in kwargs["input"][0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_call_raises_output_too_long_on_truncation():
+    llm = _make_llm()
+    truncated = _fake_response(output_text="", status="incomplete")
+    truncated.incomplete_details = types.SimpleNamespace(reason="max_output_tokens")
+    _mock_create(llm, truncated)
+    with patch("hindsight_api.engine.providers.openai_responses_llm.get_metrics_collector"):
+        with pytest.raises(OutputTooLongError):
+            await llm.call(messages=[{"role": "user", "content": "hi"}])
+
+
+# --------------------------------------------------------------------------- #
+# call_with_tools()
+# --------------------------------------------------------------------------- #
+
+_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "recall",
+            "description": "search memory",
+            "parameters": {"type": "object", "properties": {"query": {"type": "string"}}},
+        },
+    }
+]
+
+
+@pytest.mark.asyncio
+async def test_tool_path_sends_reasoning_and_tools_together():
+    """The regression pin: reasoning + function tools in one request.
+
+    This is exactly what chat/completions rejects for gpt-5.6-terra (#2983);
+    the Responses API accepts it, which is the whole point of this provider.
+    """
+    llm = _make_llm()
+    create = _mock_create(
+        llm,
+        _fake_response(output_text="", output=[_function_call(call_id="c1", name="recall", arguments='{"query":"x"}')]),
+    )
+    with patch("hindsight_api.engine.providers.openai_responses_llm.get_metrics_collector"):
+        result = await llm.call_with_tools(messages=[{"role": "user", "content": "q"}], tools=_TOOLS)
+
+    kwargs = create.call_args.kwargs
+    assert kwargs["reasoning"] == {"effort": "high"}
+    assert kwargs["tools"] == [
+        {
+            "type": "function",
+            "name": "recall",
+            "description": "search memory",
+            "parameters": {"type": "object", "properties": {"query": {"type": "string"}}},
+        }
+    ]
+    assert result.tool_calls[0].name == "recall"
+    assert result.tool_calls[0].arguments == {"query": "x"}
+    assert result.tool_calls[0].id == "c1"
+    assert result.finish_reason == "tool_calls"
+
+
+@pytest.mark.asyncio
+async def test_named_tool_choice_flattens_and_filters():
+    llm = _make_llm()
+    create = _mock_create(
+        llm, _fake_response(output_text="", output=[_function_call(call_id="c1", name="recall", arguments="{}")])
+    )
+    with patch("hindsight_api.engine.providers.openai_responses_llm.get_metrics_collector"):
+        await llm.call_with_tools(
+            messages=[{"role": "user", "content": "q"}],
+            tools=_TOOLS,
+            tool_choice=LLMToolChoice.named("recall"),
+        )
+
+    kwargs = create.call_args.kwargs
+    assert kwargs["tool_choice"] == {"type": "function", "name": "recall"}
+    assert len(kwargs["tools"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_auto_tool_choice_omits_tool_choice():
+    llm = _make_llm()
+    create = _mock_create(llm, _fake_response(output_text="done"))
+    with patch("hindsight_api.engine.providers.openai_responses_llm.get_metrics_collector"):
+        await llm.call_with_tools(messages=[{"role": "user", "content": "q"}], tools=_TOOLS)
+
+    assert "tool_choice" not in create.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_message_history_translation():
+    """Assistant tool_calls -> function_call items; role=tool -> function_call_output."""
+    llm = _make_llm()
+    create = _mock_create(llm, _fake_response(output_text="done"))
+    history = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"id": "c1", "type": "function", "function": {"name": "recall", "arguments": '{"query":"x"}'}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": '{"memories":[]}'},
+    ]
+    with patch("hindsight_api.engine.providers.openai_responses_llm.get_metrics_collector"):
+        await llm.call_with_tools(messages=history, tools=_TOOLS)
+
+    items = create.call_args.kwargs["input"]
+    assert items[0] == {"role": "user", "content": "q"}
+    assert items[1] == {"type": "function_call", "call_id": "c1", "name": "recall", "arguments": '{"query":"x"}'}
+    assert items[2] == {"type": "function_call_output", "call_id": "c1", "output": '{"memories":[]}'}
+
+
+@pytest.mark.asyncio
+async def test_tool_path_returns_content_when_no_tool_calls():
+    llm = _make_llm()
+    _mock_create(llm, _fake_response(output_text="final answer"))
+    with patch("hindsight_api.engine.providers.openai_responses_llm.get_metrics_collector"):
+        result = await llm.call_with_tools(messages=[{"role": "user", "content": "q"}], tools=_TOOLS)
+
+    assert result.content == "final answer"
+    assert result.tool_calls == []
+
+
+# --------------------------------------------------------------------------- #
+# Generic LLM config flags (extra_body, service_tier, default_headers)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_extra_body_is_merged_into_requests():
+    llm = OpenAIResponsesLLM(
+        provider="openai-responses",
+        api_key="sk-test",
+        base_url="",
+        model="gpt-5.6",
+        extra_body={"foo": "bar"},
+    )
+    create = _mock_create(llm, _fake_response(output_text="ok"))
+    with patch("hindsight_api.engine.providers.openai_responses_llm.get_metrics_collector"):
+        await llm.call(messages=[{"role": "user", "content": "hi"}])
+
+    assert create.call_args.kwargs["extra_body"] == {"foo": "bar"}
+
+
+@pytest.mark.asyncio
+async def test_service_tier_applied_on_both_paths():
+    llm = OpenAIResponsesLLM(
+        provider="openai-responses",
+        api_key="sk-test",
+        base_url="",
+        model="gpt-5.6",
+        openai_service_tier="flex",
+    )
+    with patch("hindsight_api.engine.providers.openai_responses_llm.get_metrics_collector"):
+        create = _mock_create(llm, _fake_response(output_text="ok"))
+        await llm.call(messages=[{"role": "user", "content": "hi"}])
+        assert create.call_args.kwargs["service_tier"] == "flex"
+
+        create_tools = _mock_create(llm, _fake_response(output_text="ok"))
+        await llm.call_with_tools(messages=[{"role": "user", "content": "hi"}], tools=_TOOLS)
+        assert create_tools.call_args.kwargs["service_tier"] == "flex"
+
+
+def test_default_headers_passed_to_client():
+    llm = OpenAIResponsesLLM(
+        provider="openai-responses",
+        api_key="sk-test",
+        base_url="",
+        model="gpt-5.6",
+        default_headers={"X-Trace-Id": "abc123"},
+    )
+    # AsyncOpenAI merges custom headers into its default_headers.
+    assert llm._client.default_headers.get("X-Trace-Id") == "abc123"
+
+
+def test_custom_base_url_targets_compatible_responses_endpoint():
+    """A custom base_url routes the OpenAI SDK at an OpenAI-compatible /v1/responses endpoint."""
+    llm = OpenAIResponsesLLM(
+        provider="openai-responses",
+        api_key="sk-test",
+        base_url="https://gateway.example.com/v1",
+        model="gpt-5.6",
+    )
+    assert llm.base_url == "https://gateway.example.com/v1"
+    assert str(llm._client.base_url).rstrip("/") == "https://gateway.example.com/v1"
+
+
+def test_factory_threads_service_tier_and_headers():
+    """The factory forwards the generic flags to the standalone provider."""
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+
+    llm = LLMProvider(
+        provider="openai-responses",
+        api_key="sk-test",
+        base_url="",
+        model="gpt-5.6",
+        openai_service_tier="flex",
+        default_headers={"X-Trace-Id": "abc123"},
+    )
+    impl = llm._provider_impl
+    assert isinstance(impl, OpenAIResponsesLLM)
+    assert impl.openai_service_tier == "flex"
+    assert impl.default_headers == {"X-Trace-Id": "abc123"}

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -168,7 +168,7 @@ For non-English banks (especially CJK) and the language/extraction-language trad
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `opencode-go`, `nous`, `fireworks`, `ollama`, `ollama-cloud`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `requesty`, `none` | `openai` |
+| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-responses`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `opencode-go`, `nous`, `fireworks`, `ollama`, `ollama-cloud`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `requesty`, `none` | `openai` |
 | `HINDSIGHT_API_LLM_API_KEY` | API key for LLM provider | - |
 | `HINDSIGHT_API_LLM_MODEL` | Model name | `gpt-5-mini` |
 | `HINDSIGHT_API_LLM_BASE_URL` | Custom LLM endpoint | Provider default |
@@ -220,6 +220,17 @@ export HINDSIGHT_API_LLM_MODEL=gpt-4o
 # Optional: Use Flex Processing for 50% cost savings (with variable latency)
 # export HINDSIGHT_API_LLM_OPENAI_SERVICE_TIER=flex
 
+# OpenAI Responses API (/v1/responses)
+export HINDSIGHT_API_LLM_PROVIDER=openai-responses
+export HINDSIGHT_API_LLM_API_KEY=sk-xxxxxxxxxxxx
+export HINDSIGHT_API_LLM_MODEL=gpt-5.6
+# Uses the OpenAI Responses API instead of chat/completions. Unlike
+# chat/completions, it supports reasoning together with function tools, so
+# reflect's tool-calling search loop can run with a real reasoning effort.
+# Recommended for reasoning models (gpt-5.x, o-series) that reject
+# `reasoning_effort` alongside tools on chat/completions (e.g. gpt-5.6-terra).
+# export HINDSIGHT_API_LLM_REASONING_EFFORT=high
+
 # Gemini
 export HINDSIGHT_API_LLM_PROVIDER=gemini
 export HINDSIGHT_API_LLM_API_KEY=xxxxxxxxxxxx
@@ -261,8 +272,15 @@ export HINDSIGHT_API_LLM_PROVIDER=llamacpp
 # Auto-downloads Gemma 4 E2B (~3.5 GB GGUF) on first run.
 # See "Built-in llama.cpp" section below for all configuration options.
 
-# OpenAI-compatible endpoint
+# OpenAI-compatible endpoint (Chat Completions API, /v1/chat/completions)
 export HINDSIGHT_API_LLM_PROVIDER=openai
+export HINDSIGHT_API_LLM_BASE_URL=https://your-endpoint.com/v1
+export HINDSIGHT_API_LLM_API_KEY=your-api-key
+export HINDSIGHT_API_LLM_MODEL=your-model-name
+
+# OpenAI-compatible endpoint (Responses API, /v1/responses)
+# Same as above but targets /v1/responses instead of /v1/chat/completions.
+export HINDSIGHT_API_LLM_PROVIDER=openai-responses
 export HINDSIGHT_API_LLM_BASE_URL=https://your-endpoint.com/v1
 export HINDSIGHT_API_LLM_API_KEY=your-api-key
 export HINDSIGHT_API_LLM_MODEL=your-model-name

--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -29,6 +29,18 @@ Also supports **any OpenAI-compatible API** (e.g., Azure OpenAI, Together AI, Fi
 :::tip OpenAI-Compatible Providers
 Hindsight works with any provider that exposes an OpenAI-compatible API (e.g., Azure OpenAI). Simply set `HINDSIGHT_API_LLM_PROVIDER=openai` and configure `HINDSIGHT_API_LLM_BASE_URL` to point to your provider's endpoint.
 
+The `openai` provider talks to the **Chat Completions API** (`/v1/chat/completions`). For the newer **Responses API** (`/v1/responses`), use `HINDSIGHT_API_LLM_PROVIDER=openai-responses` — see the tip below. Both accept a custom `HINDSIGHT_API_LLM_BASE_URL`, so an OpenAI-compatible endpoint that exposes `/v1/responses` works the same way as a Chat Completions one.
+
+See [Configuration](./configuration#llm-provider) for setup examples.
+:::
+
+:::tip OpenAI Responses API (reasoning + tools together)
+Set `HINDSIGHT_API_LLM_PROVIDER=openai-responses` to call OpenAI's **Responses API** (`/v1/responses`) instead of Chat Completions.
+
+Why it exists: some reasoning models — e.g. `gpt-5.6-terra` — **reject `reasoning_effort` when function tools are present** on Chat Completions (HTTP 400 unless `reasoning_effort="none"`). Reflect is a tool-calling loop, so on the `openai` (Completions) provider that forces the whole operation — including the final synthesis — to run with reasoning disabled. The Responses API keeps the model's chain-of-thought as a first-class reasoning item, so **reasoning and tools coexist**: reflect's search loop runs with a real `HINDSIGHT_API_LLM_REASONING_EFFORT` (e.g. `high`).
+
+Recommended for reasoning models (gpt-5.x, o-series) that use tools. It also honors a custom `HINDSIGHT_API_LLM_BASE_URL`, so any OpenAI-compatible endpoint exposing `/v1/responses` (gateways, Azure-style deployments) can be used just like the Chat Completions path.
+
 See [Configuration](./configuration#llm-provider) for setup examples.
 :::
 
@@ -158,10 +170,18 @@ export HINDSIGHT_API_LLM_PROVIDER=groq
 export HINDSIGHT_API_LLM_API_KEY=gsk_xxxxxxxxxxxx
 export HINDSIGHT_API_LLM_MODEL=openai/gpt-oss-20b
 
-# OpenAI
+# OpenAI (Chat Completions API, /v1/chat/completions)
 export HINDSIGHT_API_LLM_PROVIDER=openai
 export HINDSIGHT_API_LLM_API_KEY=sk-xxxxxxxxxxxx
 export HINDSIGHT_API_LLM_MODEL=gpt-4o
+
+# OpenAI Responses API (/v1/responses) — reasoning + tools together
+export HINDSIGHT_API_LLM_PROVIDER=openai-responses
+export HINDSIGHT_API_LLM_API_KEY=sk-xxxxxxxxxxxx
+export HINDSIGHT_API_LLM_MODEL=gpt-5.6           # reasoning model; e.g. gpt-5.6-terra
+export HINDSIGHT_API_LLM_REASONING_EFFORT=high   # sent alongside tools, unlike Completions
+# Optional: point at any OpenAI-compatible endpoint exposing /v1/responses
+# export HINDSIGHT_API_LLM_BASE_URL=https://your-gateway.example.com/v1
 
 # Gemini
 export HINDSIGHT_API_LLM_PROVIDER=gemini

--- a/hindsight-docs/src/data/llmProviders.json
+++ b/hindsight-docs/src/data/llmProviders.json
@@ -1,5 +1,6 @@
 [
   {"id": "openai",        "label": "OpenAI",            "iconKey": "openai",             "defaultModel": "gpt-4o-mini", "batchApi": true},
+  {"id": "openai-responses", "label": "OpenAI Responses", "iconKey": "openai",          "defaultModel": "gpt-5.6"},
   {"id": "anthropic",     "label": "Anthropic",         "iconKey": "anthropic",          "defaultModel": "claude-haiku-4-5"},
   {"id": "gemini",        "label": "Google Gemini",     "iconKey": "gemini",             "defaultModel": "gemini-3.5-flash", "batchApi": true, "promptCaching": true},
   {"id": "vertexai",      "label": "Vertex AI",         "iconKey": "gemini",             "defaultModel": "google/gemini-3.1-flash-lite", "promptCaching": true},

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -2,7 +2,7 @@
 # Copy this file to .env and fill in your values
 
 # LLM Configuration (Required)
-# Supported providers: openai, groq, ollama, gemini, anthropic, lmstudio, vertexai, minimax, deepseek, zai, atlas, volcano
+# Supported providers: openai, openai-responses, groq, ollama, gemini, anthropic, lmstudio, vertexai, minimax, deepseek, zai, atlas, volcano
 HINDSIGHT_API_LLM_PROVIDER=openai
 HINDSIGHT_API_LLM_API_KEY=your-api-key-here
 HINDSIGHT_API_LLM_MODEL=gpt-4o-mini
@@ -56,6 +56,12 @@ HINDSIGHT_API_LLM_BASE_URL=https://api.openai.com/v1
 # HINDSIGHT_API_LLM_PROVIDER=minimax
 # HINDSIGHT_API_LLM_API_KEY=your-minimax-api-key
 # HINDSIGHT_API_LLM_MODEL=MiniMax-M3  # or MiniMax-M2.7 for the previous generation
+
+# Example: OpenAI Responses API (/v1/responses) — reasoning + function tools together
+# HINDSIGHT_API_LLM_PROVIDER=openai-responses
+# HINDSIGHT_API_LLM_API_KEY=your-openai-api-key
+# HINDSIGHT_API_LLM_MODEL=gpt-5.6  # reasoning model (gpt-5.x / o-series); e.g. gpt-5.6-terra
+# HINDSIGHT_API_LLM_REASONING_EFFORT=high  # sent alongside tools, unlike chat/completions
 
 # Example: DeepSeek configuration (https://api.deepseek.com)
 # HINDSIGHT_API_LLM_PROVIDER=deepseek

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -168,7 +168,7 @@ For non-English banks (especially CJK) and the language/extraction-language trad
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `opencode-go`, `nous`, `fireworks`, `ollama`, `ollama-cloud`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `requesty`, `none` | `openai` |
+| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-responses`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `opencode-go`, `nous`, `fireworks`, `ollama`, `ollama-cloud`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `requesty`, `none` | `openai` |
 | `HINDSIGHT_API_LLM_API_KEY` | API key for LLM provider | - |
 | `HINDSIGHT_API_LLM_MODEL` | Model name | `gpt-5-mini` |
 | `HINDSIGHT_API_LLM_BASE_URL` | Custom LLM endpoint | Provider default |
@@ -220,6 +220,17 @@ export HINDSIGHT_API_LLM_MODEL=gpt-4o
 # Optional: Use Flex Processing for 50% cost savings (with variable latency)
 # export HINDSIGHT_API_LLM_OPENAI_SERVICE_TIER=flex
 
+# OpenAI Responses API (/v1/responses)
+export HINDSIGHT_API_LLM_PROVIDER=openai-responses
+export HINDSIGHT_API_LLM_API_KEY=sk-xxxxxxxxxxxx
+export HINDSIGHT_API_LLM_MODEL=gpt-5.6
+# Uses the OpenAI Responses API instead of chat/completions. Unlike
+# chat/completions, it supports reasoning together with function tools, so
+# reflect's tool-calling search loop can run with a real reasoning effort.
+# Recommended for reasoning models (gpt-5.x, o-series) that reject
+# `reasoning_effort` alongside tools on chat/completions (e.g. gpt-5.6-terra).
+# export HINDSIGHT_API_LLM_REASONING_EFFORT=high
+
 # Gemini
 export HINDSIGHT_API_LLM_PROVIDER=gemini
 export HINDSIGHT_API_LLM_API_KEY=xxxxxxxxxxxx
@@ -261,8 +272,15 @@ export HINDSIGHT_API_LLM_PROVIDER=llamacpp
 # Auto-downloads Gemma 4 E2B (~3.5 GB GGUF) on first run.
 # See "Built-in llama.cpp" section below for all configuration options.
 
-# OpenAI-compatible endpoint
+# OpenAI-compatible endpoint (Chat Completions API, /v1/chat/completions)
 export HINDSIGHT_API_LLM_PROVIDER=openai
+export HINDSIGHT_API_LLM_BASE_URL=https://your-endpoint.com/v1
+export HINDSIGHT_API_LLM_API_KEY=your-api-key
+export HINDSIGHT_API_LLM_MODEL=your-model-name
+
+# OpenAI-compatible endpoint (Responses API, /v1/responses)
+# Same as above but targets /v1/responses instead of /v1/chat/completions.
+export HINDSIGHT_API_LLM_PROVIDER=openai-responses
 export HINDSIGHT_API_LLM_BASE_URL=https://your-endpoint.com/v1
 export HINDSIGHT_API_LLM_API_KEY=your-api-key
 export HINDSIGHT_API_LLM_MODEL=your-model-name

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -20,6 +20,7 @@ Used for fact extraction, entity resolution, mental model consolidation, and ans
 **Supported providers:**
 
 - OpenAI
+- OpenAI Responses
 - Anthropic
 - Google Gemini
 - Vertex AI
@@ -49,6 +50,17 @@ Also supports **any OpenAI-compatible API** (e.g., Azure OpenAI, Together AI, Fi
 > **💡 OpenAI-Compatible Providers**
 >
 Hindsight works with any provider that exposes an OpenAI-compatible API (e.g., Azure OpenAI). Simply set `HINDSIGHT_API_LLM_PROVIDER=openai` and configure `HINDSIGHT_API_LLM_BASE_URL` to point to your provider's endpoint.
+
+The `openai` provider talks to the **Chat Completions API** (`/v1/chat/completions`). For the newer **Responses API** (`/v1/responses`), use `HINDSIGHT_API_LLM_PROVIDER=openai-responses` — see the tip below. Both accept a custom `HINDSIGHT_API_LLM_BASE_URL`, so an OpenAI-compatible endpoint that exposes `/v1/responses` works the same way as a Chat Completions one.
+
+See [Configuration](./configuration#llm-provider) for setup examples.
+> **💡 OpenAI Responses API (reasoning + tools together)**
+>
+Set `HINDSIGHT_API_LLM_PROVIDER=openai-responses` to call OpenAI's **Responses API** (`/v1/responses`) instead of Chat Completions.
+
+Why it exists: some reasoning models — e.g. `gpt-5.6-terra` — **reject `reasoning_effort` when function tools are present** on Chat Completions (HTTP 400 unless `reasoning_effort="none"`). Reflect is a tool-calling loop, so on the `openai` (Completions) provider that forces the whole operation — including the final synthesis — to run with reasoning disabled. The Responses API keeps the model's chain-of-thought as a first-class reasoning item, so **reasoning and tools coexist**: reflect's search loop runs with a real `HINDSIGHT_API_LLM_REASONING_EFFORT` (e.g. `high`).
+
+Recommended for reasoning models (gpt-5.x, o-series) that use tools. It also honors a custom `HINDSIGHT_API_LLM_BASE_URL`, so any OpenAI-compatible endpoint exposing `/v1/responses` (gateways, Azure-style deployments) can be used just like the Chat Completions path.
 
 See [Configuration](./configuration#llm-provider) for setup examples.
 > **💡 AWS Bedrock**
@@ -80,6 +92,7 @@ Beyond basic generation, some providers support optional features that lower cos
 | Provider | Batch API | Explicit prompt caching |
 |----------|:---------:|:-----------------------:|
 | OpenAI (`openai`) | ✅ | — |
+| OpenAI Responses (`openai-responses`) | — | — |
 | Anthropic (`anthropic`) | — | — |
 | Google Gemini (`gemini`) | ✅ | ✅ |
 | Vertex AI (`vertexai`) | — | ✅ |
@@ -143,6 +156,7 @@ Each provider has a recommended default model that's used when `HINDSIGHT_API_LL
 | Provider | Default Model |
 |----------|--------------|
 | `openai` | `gpt-4o-mini` |
+| `openai-responses` | `gpt-5.6` |
 | `anthropic` | `claude-haiku-4-5` |
 | `gemini` | `gemini-3.5-flash` |
 | `vertexai` | `google/gemini-3.1-flash-lite` |
@@ -218,10 +232,18 @@ export HINDSIGHT_API_LLM_PROVIDER=groq
 export HINDSIGHT_API_LLM_API_KEY=gsk_xxxxxxxxxxxx
 export HINDSIGHT_API_LLM_MODEL=openai/gpt-oss-20b
 
-# OpenAI
+# OpenAI (Chat Completions API, /v1/chat/completions)
 export HINDSIGHT_API_LLM_PROVIDER=openai
 export HINDSIGHT_API_LLM_API_KEY=sk-xxxxxxxxxxxx
 export HINDSIGHT_API_LLM_MODEL=gpt-4o
+
+# OpenAI Responses API (/v1/responses) — reasoning + tools together
+export HINDSIGHT_API_LLM_PROVIDER=openai-responses
+export HINDSIGHT_API_LLM_API_KEY=sk-xxxxxxxxxxxx
+export HINDSIGHT_API_LLM_MODEL=gpt-5.6           # reasoning model; e.g. gpt-5.6-terra
+export HINDSIGHT_API_LLM_REASONING_EFFORT=high   # sent alongside tools, unlike Completions
+# Optional: point at any OpenAI-compatible endpoint exposing /v1/responses
+# export HINDSIGHT_API_LLM_BASE_URL=https://your-gateway.example.com/v1
 
 # Gemini
 export HINDSIGHT_API_LLM_PROVIDER=gemini

--- a/skills/hindsight-docs/references/faq.md
+++ b/skills/hindsight-docs/references/faq.md
@@ -69,6 +69,7 @@ Browse all supported integrations in the Integrations Hub.
 ### Which LLM providers are supported?
 
 - OpenAI
+- OpenAI Responses
 - Anthropic
 - Google Gemini
 - Vertex AI

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -3026,7 +3026,7 @@
           "Documents"
         ],
         "summary": "List documents",
-        "description": "List documents with pagination and optional search. Documents are the source content from which memory units are extracted.",
+        "description": "List documents with pagination and optional search, most recently written first (`updated_at` descending). Documents are the source content from which memory units are extracted.",
         "operationId": "list_documents",
         "parameters": [
           {
@@ -6938,7 +6938,20 @@
                 "type": "null"
               }
             ],
-            "title": "Last Document At"
+            "title": "Last Document At",
+            "description": "When a document was last *ingested* into this bank. Appending to an existing document does not move this \u2014 use `last_write_at` for write activity."
+          },
+          "last_write_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Write At",
+            "description": "When anything was last written to this bank: a document retained (including appends to an existing document) or a fact stored. Null if the bank is empty."
           }
         },
         "type": "object",
@@ -6977,6 +6990,7 @@
               },
               "fact_count": 156,
               "last_document_at": "2024-01-16T14:20:00Z",
+              "last_write_at": "2024-01-17T09:05:00Z",
               "mission": "I am a software engineer helping my team ship quality code",
               "name": "Alice",
               "updated_at": "2024-01-16T14:20:00Z"

--- a/uv.lock
+++ b/uv.lock
@@ -1836,7 +1836,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'local-onnx'", specifier = ">=1.26.0" },
     { name = "obstore", specifier = ">=0.4.0" },
     { name = "onnxruntime", marker = "extra == 'local-onnx'", specifier = ">=1.17.0" },
-    { name = "openai", specifier = ">=1.0.0" },
+    { name = "openai", specifier = ">=1.66.0" },
     { name = "opentelemetry-api", specifier = ">=1.44.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.44.0" },
     { name = "opentelemetry-exporter-prometheus", specifier = ">=0.65b0" },


### PR DESCRIPTION
## What

Adds a new LLM provider **`openai-responses`** that calls the OpenAI **Responses API** (`client.responses.create` → `/v1/responses`) instead of chat/completions.

## Why

Reasoning models such as `gpt-5.6-terra` reject `reasoning_effort` combined with function tools on `/v1/chat/completions`:

```
reasoning_effort="low"   -> HTTP 400
reasoning_effort absent  -> HTTP 400
reasoning_effort="none"  -> succeeds
```

Reflect is a tool-calling search loop, so on chat/completions the only non-400 setting (`"none"`) also strips reasoning from reflect's **final synthesis** (single effort knob per op). The Responses API models the chain-of-thought as a first-class reasoning item, so **reasoning and function tools coexist** — reflect's search loop runs with a real `reasoning_effort` and still calls tools.

## Design

`OpenAIResponsesLLM` is a **standalone `LLMInterface`** implementation. It is OpenAI-only and deliberately **does not subclass** the multi-vendor `OpenAICompatibleLLM` (chat/completions) class — so it can never route through `chat.completions` and carries none of the groq/ollama/deepseek special-casing. It reuses only a few provider-agnostic pure helpers (text-tag stripping, quota-defer parsing). The shared chat retry loop is untouched (no regression risk to the ~13 existing OpenAI-compatible providers).

Translations:
- chat messages → Responses `input` items (assistant `tool_calls` → `function_call`; `role="tool"` → `function_call_output` keyed by `call_id`)
- nested `{"type":"function","function":{…}}` tools → flattened `{"type":"function","name":…,"parameters":…}`
- flat `reasoning_effort` → `reasoning={"effort": …}`
- `response_format` → `text={"format": {…}}` (strict `json_schema`, or the soft schema-in-prompt + `json_object` fallback)
- reads `response.output_text` + `function_call` items from `response.output`; usage from `usage.input_tokens`/`output_tokens` (reasoning split out of visible output)

Conversation is replayed **statelessly** each turn (`store=False`, no `previous_response_id`); server-side reasoning reuse across turns is a future optimization.

## Generic LLM config flags

Honors `extra_body`, `timeout`, and per-call `temperature` / `max_completion_tokens` / `max_retries`. It additionally wires two generic flags the chat/completions path drops:
- **`openai_service_tier`** → the native Responses `service_tier` param (e.g. `flex`)
- **`default_headers`** → the OpenAI SDK client (proxy / request-tracing)

## OpenAI-compatible endpoints
Like the `openai` (Chat Completions) provider, `openai-responses` honors a custom `HINDSIGHT_API_LLM_BASE_URL`, so any OpenAI-compatible endpoint that exposes `/v1/responses` (gateways, Azure-style deployments) works the same way as a Chat Completions one.

## Docs
- **Models page** (`developer/models.mdx`): new provider in the grid, a dedicated "OpenAI Responses API" tip, and the OpenAI-Compatible tip now states explicitly that the **`openai` provider uses Chat Completions** while `openai-responses` uses the Responses API — both usable against compatible custom endpoints.
- `configuration.md` provider list + Chat-Completions/Responses compatible-endpoint examples.
- `.env.example` (+ embed template sync); docs skill mirror regenerated.

## Wiring
- Provider registration + factory dispatch (`llm_wrapper.py`).
- `PROVIDER_DEFAULT_MODELS["openai-responses"] = "gpt-5.6"`.
- `openai` floor bumped to `>=1.66.0` for the Responses API surface.

## Tests
`tests/test_openai_responses_provider.py` (19 tests) mock `responses.create` and cover registration/wiring, request shaping (reasoning object, temperature omission for reasoning models, `max_output_tokens`, strict/soft structured output, truncation → `OutputTooLongError`), message-history translation, tool-choice mapping, response parsing, and the generic-flag wiring (`extra_body`, `service_tier`, `default_headers`). The load-bearing test pins that **`reasoning` and `tools` are sent together** on the tool path.

## Live validation (real `gpt-5.6-terra`)
- plain + reasoning, strict structured output ✅
- **reasoning + tools together** (`reasoning_tokens` > 0 in the same request as a function call) ✅
- **stateless `function_call` / `function_call_output` replay → final answer** ✅
- full `run_reflect_agent` end-to-end (stubbed retrieval, no DB): the agent drove the Responses tool loop through `recall` to a correct synthesized answer ✅

## Usage
```bash
export HINDSIGHT_API_LLM_PROVIDER=openai-responses
export HINDSIGHT_API_LLM_MODEL=gpt-5.6            # or gpt-5.6-terra
export HINDSIGHT_API_LLM_REASONING_EFFORT=high    # now rides alongside tools
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
