### PR TITLE
fix(reflect): stop evidence starvation — budget the LLM-facing rendering, truncate instead of drop, surface evidence_truncated

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -318,6 +318,13 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_LOOP_WATCHDOG_POLL_INTERVAL_MS=250
 # HINDSIGHT_API_DB_ACQUIRE_WARN_THRESHOLD_MS=1000
 
+# Opt-in: render reflect tool results for the LLM as a slim projection (id, text,
+# type, temporal fields) and budget entry selection by that rendered cost instead
+# of fact-text tokens. Cuts reflect context usage ~5x on observation-heavy banks;
+# based_on citations and traces keep full objects either way. Hierarchical — can
+# be overridden per bank via the config API.
+# HINDSIGHT_API_REFLECT_SLIM_TOOL_RESULTS=true
+
 # -----------------------------------------------------------------------------
 # Webhooks (Optional)
 # -----------------------------------------------------------------------------

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2620,6 +2620,10 @@ class BankTemplateConfig(BaseModel):
     reflect_source_facts_max_tokens: int | None = Field(
         default=None, description="Max tokens of source facts per reflect call"
     )
+    reflect_slim_tool_results: bool | None = Field(
+        default=None,
+        description="Show the reflect LLM a slim rendering of tool results and budget entry selection by its cost",
+    )
     llm_gemini_safety_settings: list | None = Field(
         default=None, description="Per-bank Gemini/VertexAI safety filter settings"
     )

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1148,6 +1148,14 @@ class ReflectResponse(BaseModel):
         default=None,
         description="Execution trace of tool and LLM calls. Only present when include.tool_calls is set.",
     )
+    evidence_truncated: bool = Field(
+        default=False,
+        description=(
+            "True when the answer was synthesized without the model having seen all retrieved evidence "
+            "(forced synthesis under the context budget, or retrieved data truncated to fit the final prompt). "
+            "A 'no information' answer with this flag set reflects evidence starvation, not a grounded conclusion."
+        ),
+    )
 
 
 class DispositionTraits(BaseModel):
@@ -4788,6 +4796,7 @@ def _register_routes(app: FastAPI):
                 structured_output=core_result.structured_output,
                 usage=core_result.usage,
                 trace=trace_result,
+                evidence_truncated=core_result.evidence_truncated,
             )
 
         except OperationValidationError as e:

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -769,6 +769,7 @@ ENV_REFLECT_MAX_CONTEXT_TOKENS = "HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS"
 ENV_REFLECT_WALL_TIMEOUT = "HINDSIGHT_API_REFLECT_WALL_TIMEOUT"
 ENV_REFLECT_MISSION = "HINDSIGHT_API_REFLECT_MISSION"
 ENV_REFLECT_SOURCE_FACTS_MAX_TOKENS = "HINDSIGHT_API_REFLECT_SOURCE_FACTS_MAX_TOKENS"
+ENV_REFLECT_SLIM_TOOL_RESULTS = "HINDSIGHT_API_REFLECT_SLIM_TOOL_RESULTS"
 ENV_RECALL_INCLUDE_CHUNKS = "HINDSIGHT_API_RECALL_INCLUDE_CHUNKS"
 ENV_RECALL_MAX_TOKENS = "HINDSIGHT_API_RECALL_MAX_TOKENS"
 ENV_RECALL_CHUNKS_MAX_TOKENS = "HINDSIGHT_API_RECALL_CHUNKS_MAX_TOKENS"
@@ -1289,6 +1290,10 @@ DEFAULT_REFLECT_PROMPT_CACHE_ENABLED = True
 DEFAULT_REFLECT_MAX_CONTEXT_TOKENS = 100_000  # Max accumulated context tokens before forcing final prompt
 DEFAULT_REFLECT_WALL_TIMEOUT = 300  # Wall-clock timeout in seconds for the entire reflect operation (5 minutes)
 DEFAULT_REFLECT_SOURCE_FACTS_MAX_TOKENS = -1  # Token budget for source facts in search_observations (-1 = disabled)
+# Opt-in: render reflect tool results for the LLM as a slim projection (id/text/type/temporal
+# fields only) and budget entry selection by that rendered cost instead of fact-text tokens.
+# Off by default so model inputs are unchanged unless a deployment or bank enables it.
+DEFAULT_REFLECT_SLIM_TOOL_RESULTS = False
 DEFAULT_RECALL_INCLUDE_CHUNKS = True  # Whether internal recall (e.g. mental model refresh) returns raw chunks
 DEFAULT_RECALL_MAX_TOKENS = 2048  # Token budget for facts returned by internal recall
 DEFAULT_RECALL_CHUNKS_MAX_TOKENS = 1000  # Token budget for raw chunks returned by internal recall
@@ -2403,6 +2408,7 @@ class HindsightConfig:
     # Reflect agent settings
     reflect_mission: str | None
     reflect_source_facts_max_tokens: int
+    reflect_slim_tool_results: bool
 
     # Recall pipeline stages (per-bank; all default True)
     enable_temporal_retrieval: bool
@@ -2660,6 +2666,7 @@ class HindsightConfig:
         # Reflect settings
         "reflect_mission",
         "reflect_source_facts_max_tokens",
+        "reflect_slim_tool_results",
         # Recall settings (used by internal recall, e.g. mental model refresh)
         "recall_include_chunks",
         "recall_max_tokens",
@@ -3728,6 +3735,10 @@ class HindsightConfig:
             reflect_source_facts_max_tokens=int(
                 os.getenv(ENV_REFLECT_SOURCE_FACTS_MAX_TOKENS, str(DEFAULT_REFLECT_SOURCE_FACTS_MAX_TOKENS))
             ),
+            reflect_slim_tool_results=os.getenv(
+                ENV_REFLECT_SLIM_TOOL_RESULTS, str(DEFAULT_REFLECT_SLIM_TOOL_RESULTS)
+            ).lower()
+            in ("true", "1", "yes"),
             enable_temporal_retrieval=os.getenv(
                 ENV_ENABLE_TEMPORAL_RETRIEVAL, str(DEFAULT_ENABLE_TEMPORAL_RETRIEVAL)
             ).lower()

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -10866,6 +10866,7 @@ class MemoryEngine(MemoryEngineInterface):
                 tool_trace=tool_trace_result,
                 llm_trace=llm_trace_result,
                 directives_applied=directives_applied_result,
+                evidence_truncated=agent_result.evidence_truncated,
             )
 
             # Call post-operation hook if validator is configured

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -36,6 +36,7 @@ from ..config import (
     DEFAULT_RECALL_CHUNKS_MAX_TOKENS,
     DEFAULT_RECALL_INCLUDE_CHUNKS,
     DEFAULT_RECALL_MAX_TOKENS,
+    DEFAULT_REFLECT_SLIM_TOOL_RESULTS,
     DEFAULT_REFLECT_SOURCE_FACTS_MAX_TOKENS,
     DEFAULT_STORE_DOCUMENT_TEXT,
     ENV_MODEL_INIT_TIMEOUT,
@@ -10536,6 +10537,7 @@ class MemoryEngine(MemoryEngineInterface):
         reflect_source_facts_max_tokens = config_dict.get(
             "reflect_source_facts_max_tokens", DEFAULT_REFLECT_SOURCE_FACTS_MAX_TOKENS
         )
+        reflect_slim_tool_results = config_dict.get("reflect_slim_tool_results", DEFAULT_REFLECT_SLIM_TOOL_RESULTS)
 
         # Resolve recall overrides: caller arg (e.g. mental model trigger) → bank config → env default
         effective_recall_include_chunks = (
@@ -10574,6 +10576,7 @@ class MemoryEngine(MemoryEngineInterface):
                 source_facts_max_tokens=reflect_source_facts_max_tokens,
                 created_after=created_after,
                 created_before=created_before,
+                slim_tool_results=reflect_slim_tool_results,
             )
 
         # Determine which tools to enable based on fact_types and exclude_mental_models
@@ -10603,6 +10606,7 @@ class MemoryEngine(MemoryEngineInterface):
                 include_chunks=effective_recall_include_chunks,
                 created_after=created_after,
                 created_before=created_before,
+                slim_tool_results=reflect_slim_tool_results,
             )
 
         async def expand_fn(memory_ids: list[str], depth: str) -> dict[str, Any]:
@@ -10684,6 +10688,7 @@ class MemoryEngine(MemoryEngineInterface):
                         llm_output_language=getattr(resolved_reflect_config, "llm_output_language", None),
                         cancel_check=request_context.raise_if_cancelled,
                         store_document_text=config_dict.get("store_document_text", DEFAULT_STORE_DOCUMENT_TEXT),
+                        slim_tool_results=reflect_slim_tool_results,
                     ),
                     timeout=wall_timeout,
                 )

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -685,9 +685,10 @@ async def _run_reflect_agent_inner(
 
         if is_last:
             # Force text response on last iteration - no tools
-            prompt = build_final_prompt(
+            final = build_final_prompt(
                 query, context_history, bank_profile, context, max_context_tokens=max_context_tokens
-            ).prompt
+            )
+            prompt = final.prompt
             llm_start = time.time()
             response, usage = await llm_config.call(
                 messages=[
@@ -738,6 +739,7 @@ async def _run_reflect_agent_inner(
                 llm_trace=_get_llm_trace(),
                 usage=_get_usage(),
                 directives_applied=directives_applied,
+                evidence_truncated=final.evidence_truncated,
             )
 
         # Proactive context-window guard: if accumulated messages would exceed the
@@ -750,9 +752,10 @@ async def _run_reflect_agent_inner(
                 f"[REFLECT {reflect_id}] Context budget exceeded on iteration {iteration + 1}: "
                 f"~{estimated_tokens} tokens >= {max_context_tokens} limit. Forcing final synthesis."
             )
-            prompt = build_final_prompt(
+            final = build_final_prompt(
                 query, context_history, bank_profile, context, max_context_tokens=max_context_tokens
-            ).prompt
+            )
+            prompt = final.prompt
             llm_start = time.time()
             response, usage = await llm_config.call(
                 messages=[
@@ -802,6 +805,9 @@ async def _run_reflect_agent_inner(
                 llm_trace=_get_llm_trace(),
                 usage=_get_usage(),
                 directives_applied=directives_applied,
+                # The guard cut retrieval short: the model answered from whatever
+                # had been gathered, not from everything it might have retrieved.
+                evidence_truncated=True,
             )
 
         # Call LLM with tools
@@ -893,9 +899,10 @@ async def _run_reflect_agent_inner(
             # For other errors: retry if no evidence yet (but cap consecutive errors to avoid long hangs)
             elif not has_gathered_evidence and iteration < max_iterations - 1 and consecutive_errors < 2:
                 continue
-            prompt = build_final_prompt(
+            final = build_final_prompt(
                 query, context_history, bank_profile, context, max_context_tokens=max_context_tokens
-            ).prompt
+            )
+            prompt = final.prompt
             llm_start = time.time()
             response, usage = await llm_config.call(
                 messages=[
@@ -946,6 +953,7 @@ async def _run_reflect_agent_inner(
                 llm_trace=_get_llm_trace(),
                 usage=_get_usage(),
                 directives_applied=directives_applied,
+                evidence_truncated=final.evidence_truncated,
             )
 
         # No tool calls this turn.
@@ -971,9 +979,10 @@ async def _run_reflect_agent_inner(
                 )
             # Model tool-called earlier and is now stopping: fall through to a clean
             # forced final synthesis (tools disabled, prose expected).
-            prompt = build_final_prompt(
+            final = build_final_prompt(
                 query, context_history, bank_profile, context, max_context_tokens=max_context_tokens
-            ).prompt
+            )
+            prompt = final.prompt
             llm_start = time.time()
             response, usage = await llm_config.call(
                 messages=[
@@ -1024,6 +1033,7 @@ async def _run_reflect_agent_inner(
                 llm_trace=_get_llm_trace(),
                 usage=_get_usage(),
                 directives_applied=directives_applied,
+                evidence_truncated=final.evidence_truncated,
             )
 
         # The model produced at least one tool call reflect could parse: it can

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -27,7 +27,7 @@ from .models import (
 
 
 def _slim_tool_output_for_llm(output: Any) -> Any:
-    """Return the LLM-facing rendering of a tool output (issue #3122).
+    """Return the LLM-facing rendering of a tool output.
 
     Result lists (``observations``/``memories``) are projected to
     ``SlimMemoryFact`` fields; every other key — ``chunks``, ``source_facts``,
@@ -45,6 +45,8 @@ def _slim_tool_output_for_llm(output: Any) -> Any:
         if isinstance(items, list):
             slimmed[key] = [SlimMemoryFact.project(item) if isinstance(item, dict) else item for item in items]
     return slimmed
+
+
 from .prompts import (
     _extract_directive_rules,
     build_final_prompt,
@@ -1214,7 +1216,7 @@ async def _run_reflect_agent_inner(
                             available_memory_ids.add(memory["id"])
 
                 # Add tool result message — slim rendering only; the full output
-                # object continues to tool_trace/context consumers below (#3122).
+                # object continues to tool_trace/context consumers below.
                 messages.append(
                     {
                         "role": "tool",

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -471,6 +471,7 @@ async def _run_reflect_agent_inner(
     incremental_caching: bool,
     cache_session_id: str,
     cache_tasks: list[asyncio.Task],
+    slim_tool_results: bool = False,
 ) -> ReflectAgentResult:
     """
     Execute the reflect agent loop using native tool calling.
@@ -1223,13 +1224,15 @@ async def _run_reflect_agent_inner(
                         if "id" in memory:
                             available_memory_ids.add(memory["id"])
 
-                # Add tool result message — slim rendering only; the full output
-                # object continues to tool_trace/context consumers below.
+                # Add tool result message — when slimming is enabled, only the
+                # LLM-facing rendering is reduced; the full output object
+                # continues to tool_trace/context consumers below.
+                llm_output = _slim_tool_output_for_llm(output) if slim_tool_results else output
                 messages.append(
                     {
                         "role": "tool",
                         "tool_call_id": tc.id,
-                        "content": json.dumps(_slim_tool_output_for_llm(output), default=str, ensure_ascii=False),
+                        "content": json.dumps(llm_output, default=str, ensure_ascii=False),
                     }
                 )
 
@@ -1265,11 +1268,10 @@ async def _run_reflect_agent_inner(
                     }
                 )
 
-                # Keep context history for fallback final prompt — slim rendering,
-                # so forced synthesis budgets the same payload the agent loop saw.
-                context_history.append(
-                    {"tool": tc.name, "input": input_dict, "output": _slim_tool_output_for_llm(output)}
-                )
+                # Keep context history for fallback final prompt — the same
+                # rendering the agent loop saw, so forced synthesis budgets the
+                # payload the model was actually shown.
+                context_history.append({"tool": tc.name, "input": input_dict, "output": llm_output})
 
     # Should not reach here
     answer = "I was unable to formulate a complete answer within the iteration limit."

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -15,7 +15,36 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from ...config import get_config
 from ..llm_interface import LLM_TOOL_CHOICE_AUTO, LLMToolChoice
-from .models import DirectiveInfo, LLMCall, ReflectAgentResult, StructuredOutputResult, TokenUsageSummary, ToolCall
+from .models import (
+    DirectiveInfo,
+    LLMCall,
+    ReflectAgentResult,
+    SlimMemoryFact,
+    StructuredOutputResult,
+    TokenUsageSummary,
+    ToolCall,
+)
+
+
+def _slim_tool_output_for_llm(output: Any) -> Any:
+    """Return the LLM-facing rendering of a tool output (issue #3122).
+
+    Result lists (``observations``/``memories``) are projected to
+    ``SlimMemoryFact`` fields; every other key — ``chunks``, ``source_facts``,
+    ``mental_models``, error payloads — passes through unchanged. Returns a new
+    top-level dict and never mutates ``output``: the same object also feeds
+    ``tool_trace`` (based_on/trace/persistence), which must keep the full
+    envelope, and already-appended messages are never rewritten (the step-wise
+    prompt cache snapshots message prefixes).
+    """
+    if not isinstance(output, dict):
+        return output
+    slimmed = dict(output)
+    for key in ("observations", "memories"):
+        items = slimmed.get(key)
+        if isinstance(items, list):
+            slimmed[key] = [SlimMemoryFact.project(item) if isinstance(item, dict) else item for item in items]
+    return slimmed
 from .prompts import (
     _extract_directive_rules,
     build_final_prompt,
@@ -1184,12 +1213,13 @@ async def _run_reflect_agent_inner(
                         if "id" in memory:
                             available_memory_ids.add(memory["id"])
 
-                # Add tool result message
+                # Add tool result message — slim rendering only; the full output
+                # object continues to tool_trace/context consumers below (#3122).
                 messages.append(
                     {
                         "role": "tool",
                         "tool_call_id": tc.id,
-                        "content": json.dumps(output, default=str, ensure_ascii=False),
+                        "content": json.dumps(_slim_tool_output_for_llm(output), default=str, ensure_ascii=False),
                     }
                 )
 

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -24,29 +24,6 @@ from .models import (
     TokenUsageSummary,
     ToolCall,
 )
-
-
-def _slim_tool_output_for_llm(output: Any) -> Any:
-    """Return the LLM-facing rendering of a tool output.
-
-    Result lists (``observations``/``memories``) are projected to
-    ``SlimMemoryFact`` fields; every other key — ``chunks``, ``source_facts``,
-    ``mental_models``, error payloads — passes through unchanged. Returns a new
-    top-level dict and never mutates ``output``: the same object also feeds
-    ``tool_trace`` (based_on/trace/persistence), which must keep the full
-    envelope, and already-appended messages are never rewritten (the step-wise
-    prompt cache snapshots message prefixes).
-    """
-    if not isinstance(output, dict):
-        return output
-    slimmed = dict(output)
-    for key in ("observations", "memories"):
-        items = slimmed.get(key)
-        if isinstance(items, list):
-            slimmed[key] = [SlimMemoryFact.project(item) if isinstance(item, dict) else item for item in items]
-    return slimmed
-
-
 from .prompts import (
     _extract_directive_rules,
     build_final_prompt,
@@ -98,6 +75,27 @@ class ReflectToolCallError(RuntimeError):
     surfacing raw tool-call JSON as the answer -- we fail loudly so the caller can
     switch to a tool-calling-capable model/transport.
     """
+
+
+def _slim_tool_output_for_llm(output: Any) -> Any:
+    """Return the LLM-facing rendering of a tool output.
+
+    Result lists (``observations``/``memories``) are projected to
+    ``SlimMemoryFact`` fields; every other key — ``chunks``, ``source_facts``,
+    ``mental_models``, error payloads — passes through unchanged. Returns a new
+    top-level dict and never mutates ``output``: the same object also feeds
+    ``tool_trace`` (based_on/trace/persistence), which must keep the full
+    envelope, and already-appended messages are never rewritten (the step-wise
+    prompt cache snapshots message prefixes).
+    """
+    if not isinstance(output, dict):
+        return output
+    slimmed = dict(output)
+    for key in ("observations", "memories"):
+        items = slimmed.get(key)
+        if isinstance(items, list):
+            slimmed[key] = [SlimMemoryFact.project(item) if isinstance(item, dict) else item for item in items]
+    return slimmed
 
 
 def _normalize_tool_name(name: str) -> str:
@@ -1257,8 +1255,11 @@ async def _run_reflect_agent_inner(
                     }
                 )
 
-                # Keep context history for fallback final prompt
-                context_history.append({"tool": tc.name, "input": input_dict, "output": output})
+                # Keep context history for fallback final prompt — slim rendering,
+                # so forced synthesis budgets the same payload the agent loop saw.
+                context_history.append(
+                    {"tool": tc.name, "input": input_dict, "output": _slim_tool_output_for_llm(output)}
+                )
 
     # Should not reach here
     answer = "I was unable to formulate a complete answer within the iteration limit."

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -687,7 +687,7 @@ async def _run_reflect_agent_inner(
             # Force text response on last iteration - no tools
             prompt = build_final_prompt(
                 query, context_history, bank_profile, context, max_context_tokens=max_context_tokens
-            )
+            ).prompt
             llm_start = time.time()
             response, usage = await llm_config.call(
                 messages=[
@@ -752,7 +752,7 @@ async def _run_reflect_agent_inner(
             )
             prompt = build_final_prompt(
                 query, context_history, bank_profile, context, max_context_tokens=max_context_tokens
-            )
+            ).prompt
             llm_start = time.time()
             response, usage = await llm_config.call(
                 messages=[
@@ -895,7 +895,7 @@ async def _run_reflect_agent_inner(
                 continue
             prompt = build_final_prompt(
                 query, context_history, bank_profile, context, max_context_tokens=max_context_tokens
-            )
+            ).prompt
             llm_start = time.time()
             response, usage = await llm_config.call(
                 messages=[
@@ -973,7 +973,7 @@ async def _run_reflect_agent_inner(
             # forced final synthesis (tools disabled, prose expected).
             prompt = build_final_prompt(
                 query, context_history, bank_profile, context, max_context_tokens=max_context_tokens
-            )
+            ).prompt
             llm_start = time.time()
             response, usage = await llm_config.call(
                 messages=[

--- a/hindsight-api-slim/hindsight_api/engine/reflect/models.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/models.py
@@ -163,3 +163,15 @@ class SlimMemoryFact(BaseModel):
         """Project a full fact dict to its slim dict form, keeping only present fields."""
         slim = cls(**{k: item[k] for k in cls.model_fields if k in item})
         return slim.model_dump(exclude_none=True)
+
+
+class FinalPromptResult(BaseModel):
+    """Result of building the forced final-synthesis prompt.
+
+    Carries whether any retrieved evidence had to be truncated or omitted to
+    fit the prompt's token budget, so callers can surface that the answer was
+    synthesized from partial evidence.
+    """
+
+    prompt: str
+    evidence_truncated: bool = False

--- a/hindsight-api-slim/hindsight_api/engine/reflect/models.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/models.py
@@ -130,6 +130,13 @@ class ReflectAgentResult(BaseModel):
     directives_applied: list[DirectiveInfo] = Field(
         default_factory=list, description="Directive mental models that affected this reflection"
     )
+    evidence_truncated: bool = Field(
+        default=False,
+        description=(
+            "True when the final answer was synthesized without the model having seen all retrieved "
+            "evidence (context-guard forced synthesis, or retrieved data truncated to fit the prompt budget)"
+        ),
+    )
 
 
 class SlimMemoryFact(BaseModel):

--- a/hindsight-api-slim/hindsight_api/engine/reflect/models.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/models.py
@@ -133,7 +133,7 @@ class ReflectAgentResult(BaseModel):
 
 
 class SlimMemoryFact(BaseModel):
-    """LLM-facing rendering of a retrieved fact/observation (issue #3122).
+    """LLM-facing rendering of a retrieved fact/observation.
 
     Tool results serialize full ``MemoryFact`` dumps — entities, scores,
     metadata, chunk/document ids — measured at ~6x the token cost of the fact

--- a/hindsight-api-slim/hindsight_api/engine/reflect/models.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/models.py
@@ -142,15 +142,18 @@ class ReflectAgentResult(BaseModel):
 class SlimMemoryFact(BaseModel):
     """LLM-facing rendering of a retrieved fact/observation.
 
-    Tool results serialize full ``MemoryFact`` dumps — entities, scores,
-    metadata, chunk/document ids — measured at ~6x the token cost of the fact
+    Tool results serialize full ``MemoryFact`` dumps — scores, metadata,
+    chunk/document ids — measured at ~6x the token cost of the fact
     text the recall budgeter actually counted, so one or two tool calls could
     consume the whole reflect context budget. The agent loop and prompts only
     use the fields kept here: ``id`` for citation validation, ``text`` and
     ``fact_type`` for reasoning, the temporal fields for supersession (the
     agent system prompt instructs the model to read per-entry ``mentioned_at``),
-    and ``source_fact_ids`` for ``expand`` drill-down. Full objects still flow
-    to ``tool_trace`` for based_on construction, the API trace, and persistence.
+    ``entities`` for the resolved canonical names the surface text may lack
+    ("Bob" in the text vs canonical "Robert Smith" — semantic signal, not
+    plumbing), and ``source_fact_ids`` for ``expand`` drill-down. Full objects
+    still flow to ``tool_trace`` for based_on construction, the API trace, and
+    persistence.
 
     Field types are ``Any`` on purpose: values are passed through verbatim from
     the already-serialized tool output (datetimes may arrive as objects or ISO
@@ -163,6 +166,7 @@ class SlimMemoryFact(BaseModel):
     occurred_start: Any = None
     occurred_end: Any = None
     mentioned_at: Any = None
+    entities: Any = None
     source_fact_ids: Any = None
 
     @classmethod

--- a/hindsight-api-slim/hindsight_api/engine/reflect/models.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/models.py
@@ -130,3 +130,36 @@ class ReflectAgentResult(BaseModel):
     directives_applied: list[DirectiveInfo] = Field(
         default_factory=list, description="Directive mental models that affected this reflection"
     )
+
+
+class SlimMemoryFact(BaseModel):
+    """LLM-facing rendering of a retrieved fact/observation (issue #3122).
+
+    Tool results serialize full ``MemoryFact`` dumps — entities, scores,
+    metadata, chunk/document ids — measured at ~6x the token cost of the fact
+    text the recall budgeter actually counted, so one or two tool calls could
+    consume the whole reflect context budget. The agent loop and prompts only
+    use the fields kept here: ``id`` for citation validation, ``text`` and
+    ``fact_type`` for reasoning, the temporal fields for supersession (the
+    agent system prompt instructs the model to read per-entry ``mentioned_at``),
+    and ``source_fact_ids`` for ``expand`` drill-down. Full objects still flow
+    to ``tool_trace`` for based_on construction, the API trace, and persistence.
+
+    Field types are ``Any`` on purpose: values are passed through verbatim from
+    the already-serialized tool output (datetimes may arrive as objects or ISO
+    strings depending on the caller) and are never interpreted here.
+    """
+
+    id: Any = None
+    text: Any = None
+    fact_type: Any = None
+    occurred_start: Any = None
+    occurred_end: Any = None
+    mentioned_at: Any = None
+    source_fact_ids: Any = None
+
+    @classmethod
+    def project(cls, item: dict[str, Any]) -> dict[str, Any]:
+        """Project a full fact dict to its slim dict form, keeping only present fields."""
+        slim = cls(**{k: item[k] for k in cls.model_fields if k in item})
+        return slim.model_dump(exclude_none=True)

--- a/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
@@ -11,6 +11,7 @@ import json
 from datetime import datetime, timezone
 from typing import Any
 
+from .models import FinalPromptResult
 from .tokenization import count_cl100k_tokens
 
 # Fraction of max_context_tokens reserved for tool results in the final synthesis prompt.
@@ -449,7 +450,7 @@ def build_final_prompt(
     bank_profile: dict,
     additional_context: str | None = None,
     max_context_tokens: int = 100_000,
-) -> str:
+) -> FinalPromptResult:
     """Build the final prompt when forcing a text response (no tools)."""
     parts = []
 
@@ -480,12 +481,12 @@ def build_final_prompt(
 
     # Tool call history — include as many entries as fit within the token budget,
     # preferring the most recent calls (they tend to be the most targeted).
+    truncated = False
     if context_history:
         parts.append("\n## Retrieved Data (synthesize and reason from this data)")
         token_budget = int(max_context_tokens * _FINAL_PROMPT_CONTEXT_FRACTION)
         # Render entries newest-first, then reverse so the prompt reads chronologically.
         rendered: list[str] = []
-        truncated = False
         for entry in reversed(context_history):
             tool = entry["tool"]
             output = entry["output"]
@@ -522,7 +523,7 @@ def build_final_prompt(
         "Just provide the direct synthesized answer."
     )
 
-    return "\n".join(parts)
+    return FinalPromptResult(prompt="\n".join(parts), evidence_truncated=truncated)
 
 
 _FINAL_SYSTEM_PROMPT_BASE = """CRITICAL: You MUST ONLY use information from retrieved tool results. NEVER make up names, people, events, or entities.

--- a/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
@@ -444,6 +444,74 @@ def build_system_prompt_for_tools(
     return "\n".join(parts)
 
 
+def _render_history_block(entry: dict) -> str:
+    """Render one context-history entry as a fenced JSON block."""
+    tool = entry["tool"]
+    output = entry["output"]
+    try:
+        output_str = json.dumps(output, indent=2, default=str, ensure_ascii=False)
+    except (TypeError, ValueError):
+        output_str = str(output)
+    return f"\n### From {tool}:\n```json\n{output_str}\n```"
+
+
+def _cut_text_to_tokens(text: str, budget: int) -> str:
+    """Cut ``text`` so its token count fits ``budget`` (empty when budget <= 0)."""
+    if budget <= 0:
+        return ""
+    tokens = count_cl100k_tokens(text)
+    while text and tokens > budget:
+        # Proportional shrink with a safety margin; loop guards against the
+        # estimate landing high, and always makes progress.
+        keep = min(len(text) - 1, max(1, int(len(text) * budget / tokens * 0.95)))
+        text = text[:keep]
+        tokens = count_cl100k_tokens(text)
+    return text
+
+
+def _truncate_history_block(entry: dict, token_budget: int) -> str | None:
+    """Render an oversized history entry to fit ``token_budget``, or None.
+
+    Prefers keeping whole leading result entries (results are relevance-ordered,
+    so the head is the best evidence): binary-search the largest prefix of the
+    ``observations``/``memories`` list whose rendered block fits. When not even
+    one entry fits — or the output has no result list — fall back to a
+    token-bounded cut of the serialized output.
+    """
+    output = entry["output"]
+    if isinstance(output, dict):
+        for key in ("observations", "memories"):
+            items = output.get(key)
+            if isinstance(items, list) and items:
+                best: str | None = None
+                lo, hi = 1, len(items)
+                while lo <= hi:
+                    mid = (lo + hi) // 2
+                    candidate = _render_history_block({**entry, "output": {**output, key: items[:mid]}})
+                    if count_cl100k_tokens(candidate) <= token_budget:
+                        best = candidate
+                        lo = mid + 1
+                    else:
+                        hi = mid - 1
+                if best is not None:
+                    return best
+                break
+
+    # Not even one whole entry fits (or there is no result list): cut the raw
+    # serialized text. The fence stays intact so the prompt still parses.
+    tool = entry["tool"]
+    try:
+        output_str = json.dumps(output, indent=2, default=str, ensure_ascii=False)
+    except (TypeError, ValueError):
+        output_str = str(output)
+    header = f"\n### From {tool} (truncated):\n```text\n"
+    footer = "\n```"
+    body = _cut_text_to_tokens(output_str, token_budget - count_cl100k_tokens(header + footer))
+    if not body:
+        return None
+    return header + body + footer
+
+
 def build_final_prompt(
     query: str,
     context_history: list[dict],
@@ -481,6 +549,10 @@ def build_final_prompt(
 
     # Tool call history — include as many entries as fit within the token budget,
     # preferring the most recent calls (they tend to be the most targeted).
+    # An oversized block is truncated to its leading result entries rather than
+    # dropped whole: dropping it (and every older block with it) used to leave
+    # forced synthesis with an empty Retrieved Data section, and the model then
+    # answered "I don't have information" while evidence existed.
     truncated = False
     if context_history:
         parts.append("\n## Retrieved Data (synthesize and reason from this data)")
@@ -488,17 +560,18 @@ def build_final_prompt(
         # Render entries newest-first, then reverse so the prompt reads chronologically.
         rendered: list[str] = []
         for entry in reversed(context_history):
-            tool = entry["tool"]
-            output = entry["output"]
-            try:
-                output_str = json.dumps(output, indent=2, default=str, ensure_ascii=False)
-            except (TypeError, ValueError):
-                output_str = str(output)
-            block = f"\n### From {tool}:\n```json\n{output_str}\n```"
+            if token_budget <= 0:
+                truncated = True
+                break
+            block = _render_history_block(entry)
             block_tokens = count_cl100k_tokens(block)
             if block_tokens > token_budget:
                 truncated = True
-                break
+                fitted = _truncate_history_block(entry, token_budget)
+                if fitted is None:
+                    break
+                block = fitted
+                block_tokens = count_cl100k_tokens(block)
             rendered.append(block)
             token_budget -= block_tokens
         for block in reversed(rendered):

--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
@@ -239,6 +239,7 @@ async def tool_search_observations(
     source_facts_max_tokens: int = -1,
     created_after: datetime | None = None,
     created_before: datetime | None = None,
+    slim_tool_results: bool = False,
 ) -> dict[str, Any]:
     """
     Search consolidated observations using recall.
@@ -302,21 +303,23 @@ async def tool_search_observations(
     else:
         freshness = "stale"
 
-    observations = _fit_results_to_llm_budget([_prune_nulls(m.model_dump()) for m in result.results], max_tokens)
-    # Source facts are keyed by fact id; keep only those the surviving
-    # observations reference, or trimmed-away observations would leak their
-    # tokens back in. The plumbing trim runs last: it strips fields the
-    # budget pruning matches on.
-    kept_source_ids = {sid for o in observations for sid in o.get("source_fact_ids", [])}
+    observations = [_prune_nulls(m.model_dump()) for m in result.results]
+    source_facts = {k: _prune_nulls(v.model_dump()) for k, v in (result.source_facts or {}).items()}
+    if slim_tool_results:
+        # Budget entry selection by the rendered cost the loop actually pays,
+        # and keep only source facts the surviving observations reference —
+        # trimmed-away observations would leak their tokens back in.
+        observations = _fit_results_to_llm_budget(observations, max_tokens)
+        kept_source_ids = {sid for o in observations for sid in o.get("source_fact_ids", [])}
+        source_facts = {k: v for k, v in source_facts.items() if k in kept_source_ids}
+    # Plumbing trim runs last: budget pruning above matches on fields it removes.
+    observations = [_drop_unread_fields(o) for o in observations]
+    source_facts = {k: _drop_unread_fields(v) for k, v in source_facts.items()}
     return {
         "query": query,
         "count": len(observations),
-        "observations": [_drop_unread_fields(o) for o in observations],
-        "source_facts": {
-            k: _drop_unread_fields(_prune_nulls(v.model_dump()))
-            for k, v in (result.source_facts or {}).items()
-            if k in kept_source_ids
-        },
+        "observations": observations,
+        "source_facts": source_facts,
         "is_stale": is_stale,
         "freshness": freshness,
     }
@@ -337,6 +340,7 @@ async def tool_recall(
     include_chunks: bool = True,
     created_after: datetime | None = None,
     created_before: datetime | None = None,
+    slim_tool_results: bool = False,
 ) -> dict[str, Any]:
     """
     Search memories using TEMPR retrieval.
@@ -384,19 +388,25 @@ async def tool_recall(
         max_chunk_tokens=max_chunk_tokens,
     )
 
-    memories = _fit_results_to_llm_budget([_prune_nulls(m.model_dump()) for m in result.results], max_tokens)
-    # Chunks are keyed by chunk_id; keep only those the surviving memories
-    # reference, or trimmed-away memories would leak their tokens back in.
-    # The plumbing trim runs last: it strips the chunk_id this match needs.
-    # ``chunks`` itself is deliberately not trimmed: ChunkInfo carries only
-    # chunk_text / chunk_index / truncated, so it holds none of the trimmed
-    # fields and the call would be a no-op. Pinned by
+    memories = [_prune_nulls(m.model_dump()) for m in result.results]
+    chunks = {k: _prune_nulls(v.model_dump()) for k, v in (result.chunks or {}).items()}
+    if slim_tool_results:
+        # Budget entry selection by the rendered cost the loop actually pays,
+        # and keep only chunks the surviving memories reference — trimmed-away
+        # memories would leak their tokens back in.
+        memories = _fit_results_to_llm_budget(memories, max_tokens)
+        kept_chunk_ids = {m.get("chunk_id") for m in memories}
+        chunks = {k: v for k, v in chunks.items() if k in kept_chunk_ids}
+    # Plumbing trim runs last: the chunk pruning above matches on chunk_id,
+    # which the trim removes. ``chunks`` is deliberately not trimmed: ChunkInfo
+    # carries only chunk_text / chunk_index / truncated, so it holds none of
+    # the trimmed fields and the call would be a no-op. Pinned by
     # test_chunk_info_carries_no_unread_fields.
-    kept_chunk_ids = {m.get("chunk_id") for m in memories}
+    memories = [_drop_unread_fields(m) for m in memories]
     return {
         "query": query,
-        "memories": [_drop_unread_fields(m) for m in memories],
-        "chunks": {k: _prune_nulls(v.model_dump()) for k, v in (result.chunks or {}).items() if k in kept_chunk_ids},
+        "memories": memories,
+        "chunks": chunks,
     }
 
 

--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
@@ -396,9 +396,7 @@ async def tool_recall(
     return {
         "query": query,
         "memories": [_drop_unread_fields(m) for m in memories],
-        "chunks": {
-            k: _prune_nulls(v.model_dump()) for k, v in (result.chunks or {}).items() if k in kept_chunk_ids
-        },
+        "chunks": {k: _prune_nulls(v.model_dump()) for k, v in (result.chunks or {}).items() if k in kept_chunk_ids},
     }
 
 

--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
@@ -14,6 +14,9 @@ from dataclasses import replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
+from .models import SlimMemoryFact
+from .tokenization import count_cl100k_tokens
+
 if TYPE_CHECKING:
     from asyncpg import Connection
 
@@ -35,9 +38,7 @@ logger = logging.getLogger(__name__)
 #: Identity, text, dates, tags and ``source_fact_ids`` are deliberately kept.
 #: So is ``entities``: it carries canonical entity *names* (not ids), which are
 #: semantically useful retrieval handles -- the canonical name can differ from
-#: the surface text ("Bob" in the text vs canonical "Robert Smith"). Reflect's
-#: recalls don't populate it today (``include_entities`` defaults to False), but
-#: trimming it would bake in dropping the names if that ever flips on.
+#: the surface text ("Bob" in the text vs canonical "Robert Smith").
 _UNREAD_RESULT_FIELDS = ("scores", "metadata", "chunk_id", "document_id")
 
 
@@ -45,11 +46,35 @@ def _drop_unread_fields(d: dict[str, Any]) -> dict[str, Any]:
     """Strip retrieval plumbing from one serialized tool result.
 
     Mutates and returns ``d``, which is always a fresh ``model_dump()`` by the
-    time it gets here -- never a caller's dict.
+    time it gets here -- never a caller's dict. Callers that match on a trimmed
+    field (e.g. ``chunk_id`` for chunk pruning) must do so BEFORE this runs.
     """
     for k in _UNREAD_RESULT_FIELDS:
         d.pop(k, None)
     return d
+
+
+def _fit_results_to_llm_budget(items: list[dict[str, Any]], max_tokens: int) -> list[dict[str, Any]]:
+    """Keep the leading results whose LLM-facing rendering fits ``max_tokens``.
+
+    ``recall_async`` budgets result selection by fact-*text* tokens, but what
+    the reflect loop actually pays for is the serialized ``SlimMemoryFact``
+    rendering the model sees: ids and timestamps are token-dense, so for short
+    facts the envelope dominates and a text-token budget under-counts by an
+    order of magnitude. Measure the real cost and cut where it exceeds the
+    requested budget. At least one result is always kept so a single oversized
+    fact still gives the agent something to reason from. Results arrive
+    relevance-ordered, so cutting the tail keeps the best evidence.
+    """
+    kept: list[dict[str, Any]] = []
+    used = 0
+    for item in items:
+        cost = count_cl100k_tokens(json.dumps(SlimMemoryFact.project(item), default=str, ensure_ascii=False))
+        if kept and used + cost > max_tokens:
+            break
+        kept.append(item)
+        used += cost
+    return kept
 
 
 def _prune_nulls(d: dict[str, Any]) -> dict[str, Any]:
@@ -277,12 +302,20 @@ async def tool_search_observations(
     else:
         freshness = "stale"
 
+    observations = _fit_results_to_llm_budget([_prune_nulls(m.model_dump()) for m in result.results], max_tokens)
+    # Source facts are keyed by fact id; keep only those the surviving
+    # observations reference, or trimmed-away observations would leak their
+    # tokens back in. The plumbing trim runs last: it strips fields the
+    # budget pruning matches on.
+    kept_source_ids = {sid for o in observations for sid in o.get("source_fact_ids", [])}
     return {
         "query": query,
-        "count": len(result.results),
-        "observations": [_drop_unread_fields(_prune_nulls(m.model_dump())) for m in result.results],
+        "count": len(observations),
+        "observations": [_drop_unread_fields(o) for o in observations],
         "source_facts": {
-            k: _drop_unread_fields(_prune_nulls(v.model_dump())) for k, v in (result.source_facts or {}).items()
+            k: _drop_unread_fields(_prune_nulls(v.model_dump()))
+            for k, v in (result.source_facts or {}).items()
+            if k in kept_source_ids
         },
         "is_stale": is_stale,
         "freshness": freshness,
@@ -351,14 +384,21 @@ async def tool_recall(
         max_chunk_tokens=max_chunk_tokens,
     )
 
+    memories = _fit_results_to_llm_budget([_prune_nulls(m.model_dump()) for m in result.results], max_tokens)
+    # Chunks are keyed by chunk_id; keep only those the surviving memories
+    # reference, or trimmed-away memories would leak their tokens back in.
+    # The plumbing trim runs last: it strips the chunk_id this match needs.
+    # ``chunks`` itself is deliberately not trimmed: ChunkInfo carries only
+    # chunk_text / chunk_index / truncated, so it holds none of the trimmed
+    # fields and the call would be a no-op. Pinned by
+    # test_chunk_info_carries_no_unread_fields.
+    kept_chunk_ids = {m.get("chunk_id") for m in memories}
     return {
         "query": query,
-        "memories": [_drop_unread_fields(_prune_nulls(m.model_dump())) for m in result.results],
-        # ``chunks`` is deliberately not trimmed: ChunkInfo carries only
-        # chunk_text / chunk_index / truncated, so it holds none of the fields
-        # above and the call would be a no-op. Pinned by
-        # test_chunk_info_carries_no_unread_fields.
-        "chunks": {k: _prune_nulls(v.model_dump()) for k, v in (result.chunks or {}).items()},
+        "memories": [_drop_unread_fields(m) for m in memories],
+        "chunks": {
+            k: _prune_nulls(v.model_dump()) for k, v in (result.chunks or {}).items() if k in kept_chunk_ids
+        },
     }
 
 

--- a/hindsight-api-slim/hindsight_api/engine/response_models.py
+++ b/hindsight-api-slim/hindsight_api/engine/response_models.py
@@ -421,6 +421,14 @@ class ReflectResult(BaseModel):
         default_factory=list,
         description="Directive mental models that were applied during this reflection.",
     )
+    evidence_truncated: bool = Field(
+        default=False,
+        description=(
+            "True when the answer was synthesized without the model having seen all retrieved evidence "
+            "(forced synthesis under the context budget, or retrieved data truncated to fit the final prompt). "
+            "A 'no information' answer with this flag set reflects evidence starvation, not a grounded conclusion."
+        ),
+    )
 
 
 class EntityObservation(BaseModel):

--- a/hindsight-api-slim/tests/test_bank_template_full_roundtrip.py
+++ b/hindsight-api-slim/tests/test_bank_template_full_roundtrip.py
@@ -97,6 +97,7 @@ _SAMPLE_VALUES: dict[str, Any] = {
     "max_observations_per_scope": 13,
     "observation_scope_limits": [{"scope": ["run_*"], "limit": 2}],
     "reflect_source_facts_max_tokens": 4096,
+    "reflect_slim_tool_results": True,
     "llm_gemini_safety_settings": [{"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_NONE"}],
     "recall_budget_function": "adaptive",
     "recall_budget_fixed_low": 50,

--- a/hindsight-api-slim/tests/test_hierarchical_config.py
+++ b/hindsight-api-slim/tests/test_hierarchical_config.py
@@ -148,7 +148,7 @@ async def test_hierarchical_fields_categorization():
     assert "enable_reranking" in configurable
 
     # Verify count is correct
-    assert len(configurable) == 45
+    assert len(configurable) == 46
 
     # Verify credential fields (NEVER exposed)
     assert "llm_api_key" in credentials

--- a/hindsight-api-slim/tests/test_reflect_agent.py
+++ b/hindsight-api-slim/tests/test_reflect_agent.py
@@ -1017,6 +1017,7 @@ class TestSlimToolResultRendering:
             query="What are the user's preferences?",
             bank_profile={"name": "Test", "mission": "Testing"},
             max_iterations=5,
+            slim_tool_results=True,
             **mock_functions,
         )
 
@@ -1042,6 +1043,41 @@ class TestSlimToolResultRendering:
         assert result.used_memory_ids == ["mem-2"]
 
     @pytest.mark.asyncio
+    async def test_slim_rendering_is_off_by_default(self, mock_llm):
+        """Without opting in, the model sees the full tool-result envelope —
+        the pre-existing behavior existing deployments rely on."""
+        mock_functions = {
+            "search_mental_models_fn": AsyncMock(return_value={"mental_models": []}),
+            "search_observations_fn": AsyncMock(return_value={"observations": []}),
+            "recall_fn": AsyncMock(return_value={"memories": [self._full_envelope_item(1, "mem")]}),
+            "expand_fn": AsyncMock(return_value={"memories": []}),
+        }
+        mock_llm.call_with_tools.side_effect = [
+            LLMToolCallResult(
+                tool_calls=[LLMToolCall(id="1", name="recall", arguments={"query": "prefs"})],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(
+                tool_calls=[LLMToolCall(id="2", name="done", arguments={"answer": "Done.", "memory_ids": ["mem-1"]})],
+                finish_reason="tool_calls",
+            ),
+        ]
+
+        await run_reflect_agent(
+            llm_config=mock_llm,
+            bank_id="test-bank",
+            query="What are the user's preferences?",
+            bank_profile={"name": "Test", "mission": "Testing"},
+            max_iterations=5,
+            **mock_functions,
+        )
+
+        messages = mock_llm.call_with_tools.await_args_list[1].kwargs["messages"]
+        tool_message = next(json.loads(m["content"]) for m in messages if m.get("role") == "tool")
+        assert tool_message["memories"][0]["entities"] == [{"id": "ent-1", "name": "User"}]
+        assert "scores" in tool_message["memories"][0]
+
+    @pytest.mark.asyncio
     async def test_forced_synthesis_prompt_renders_slim_evidence(self, mock_llm):
         """When the context guard forces final synthesis, the Retrieved Data the
         synthesis model sees is the slim rendering — the fact text is present,
@@ -1065,6 +1101,7 @@ class TestSlimToolResultRendering:
             query="What are the user's preferences?",
             bank_profile={"name": "Test", "mission": "Testing"},
             max_context_tokens=1000,
+            slim_tool_results=True,
             **mock_functions,
         )
 

--- a/hindsight-api-slim/tests/test_reflect_agent.py
+++ b/hindsight-api-slim/tests/test_reflect_agent.py
@@ -937,7 +937,7 @@ class TestContextOverflowBehavior:
 
 class TestSlimToolResultRendering:
     """The agent loop must show the LLM a slim rendering of retrieved facts while
-    keeping the full objects in tool_trace for citations and tracing (issue #3122).
+    keeping the full objects in tool_trace for citations and tracing.
 
     Before this fix, the full serialized envelope (entities, scores, metadata, ...)
     reached the model — ~6x the budgeted text — so one or two tool calls could blow
@@ -1006,9 +1006,7 @@ class TestSlimToolResultRendering:
                 finish_reason="tool_calls",
             ),
             LLMToolCallResult(
-                tool_calls=[
-                    LLMToolCall(id="3", name="done", arguments={"answer": "Done.", "memory_ids": ["mem-2"]})
-                ],
+                tool_calls=[LLMToolCall(id="3", name="done", arguments={"answer": "Done.", "memory_ids": ["mem-2"]})],
                 finish_reason="tool_calls",
             ),
         ]

--- a/hindsight-api-slim/tests/test_reflect_agent.py
+++ b/hindsight-api-slim/tests/test_reflect_agent.py
@@ -1041,6 +1041,41 @@ class TestSlimToolResultRendering:
         # Citation validation still saw the retrieved ids.
         assert result.used_memory_ids == ["mem-2"]
 
+    @pytest.mark.asyncio
+    async def test_forced_synthesis_prompt_renders_slim_evidence(self, mock_llm):
+        """When the context guard forces final synthesis, the Retrieved Data the
+        synthesis model sees is the slim rendering — the fact text is present,
+        the envelope fields are not."""
+        mock_functions = {
+            "search_mental_models_fn": AsyncMock(return_value={"mental_models": []}),
+            "search_observations_fn": AsyncMock(return_value={"observations": []}),
+            "recall_fn": AsyncMock(return_value={"memories": [self._full_envelope_item(1, "mem")]}),
+            "expand_fn": AsyncMock(return_value={"memories": []}),
+        }
+        mock_llm.call_with_tools.return_value = LLMToolCallResult(
+            tool_calls=[LLMToolCall(id="1", name="recall", arguments={"query": "prefs"})],
+            finish_reason="tool_calls",
+        )
+
+        # Budget low enough that the (large) agent system prompt alone trips the
+        # guard, but high enough that the one slim memory fits the final prompt.
+        result = await run_reflect_agent(
+            llm_config=mock_llm,
+            bank_id="test-bank",
+            query="What are the user's preferences?",
+            bank_profile={"name": "Test", "mission": "Testing"},
+            max_context_tokens=1000,
+            **mock_functions,
+        )
+
+        assert result.text == "Synthesized answer."
+        mock_llm.call.assert_called_once()
+        final_prompt = mock_llm.call.await_args.kwargs["messages"][1]["content"]
+        assert "User prefers option 1." in final_prompt
+        assert "mentioned_at" in final_prompt
+        for key in self.DROPPED_KEYS:
+            assert f'"{key}"' not in final_prompt, f"final synthesis prompt still carries {key!r}"
+
 
 class TestDirectiveLeakageOnEmptyBank:
     """Test that directives don't leak into the answer when the bank has no data.

--- a/hindsight-api-slim/tests/test_reflect_agent.py
+++ b/hindsight-api-slim/tests/test_reflect_agent.py
@@ -9,6 +9,7 @@ These tests verify:
 """
 
 import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -932,6 +933,115 @@ class TestContextOverflowBehavior:
         assert mock_llm.call_with_tools.call_count == 1
         # Final synthesis was called
         mock_llm.call.assert_called_once()
+
+
+class TestSlimToolResultRendering:
+    """The agent loop must show the LLM a slim rendering of retrieved facts while
+    keeping the full objects in tool_trace for citations and tracing (issue #3122).
+
+    Before this fix, the full serialized envelope (entities, scores, metadata, ...)
+    reached the model — ~6x the budgeted text — so one or two tool calls could blow
+    the whole reflect context budget.
+    """
+
+    @staticmethod
+    def _full_envelope_item(i: int, id_prefix: str = "fact") -> dict:
+        return {
+            "id": f"{id_prefix}-{i}",
+            "text": f"User prefers option {i}.",
+            "fact_type": "world",
+            "entities": [{"id": "ent-1", "name": "User"}],
+            "context": "conversation about preferences",
+            "occurred_start": "2026-07-01T00:00:00Z",
+            "occurred_end": "2026-07-02T00:00:00Z",
+            "mentioned_at": "2026-07-03T00:00:00Z",
+            "document_id": "doc-1",
+            "metadata": {"source": "chat"},
+            "chunk_id": "chunk-1",
+            "tags": ["pref"],
+            "source_fact_ids": ["src-1", "src-2"],
+            "scores": {"semantic": 0.9, "recency": 0.5},
+        }
+
+    DROPPED_KEYS = ("entities", "scores", "metadata", "chunk_id", "document_id", "tags", "context")
+    KEPT_KEYS = ("id", "text", "fact_type", "occurred_start", "occurred_end", "mentioned_at", "source_fact_ids")
+
+    @pytest.fixture
+    def mock_llm(self):
+        llm = MagicMock()
+        llm.call_with_tools = AsyncMock()
+        llm.call = AsyncMock(
+            return_value=(
+                "Synthesized answer.",
+                TokenUsage(input_tokens=50, output_tokens=20, total_tokens=70),
+            )
+        )
+        return llm
+
+    @pytest.mark.asyncio
+    async def test_llm_sees_slim_items_while_tool_trace_keeps_full_envelope(self, mock_llm):
+        """Tool-result messages sent to the LLM carry only the fields the model
+        uses (id, text, type, temporal fields, source_fact_ids); sibling keys like
+        chunks/source_facts pass through; tool_trace keeps the full objects."""
+        observations_output = {
+            "observations": [self._full_envelope_item(1, "obs")],
+            "source_facts": {"src-1": {"id": "src-1", "text": "source fact text"}},
+        }
+        recall_output = {
+            "memories": [self._full_envelope_item(2, "mem")],
+            "chunks": {"chunk-1": {"chunk_id": "chunk-1", "text": "raw chunk text"}},
+        }
+        mock_functions = {
+            "search_mental_models_fn": AsyncMock(return_value={"mental_models": []}),
+            "search_observations_fn": AsyncMock(return_value=observations_output),
+            "recall_fn": AsyncMock(return_value=recall_output),
+            "expand_fn": AsyncMock(return_value={"memories": []}),
+        }
+        mock_llm.call_with_tools.side_effect = [
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(id="1", name="search_observations", arguments={"query": "prefs"}),
+                    LLMToolCall(id="2", name="recall", arguments={"query": "prefs"}),
+                ],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(id="3", name="done", arguments={"answer": "Done.", "memory_ids": ["mem-2"]})
+                ],
+                finish_reason="tool_calls",
+            ),
+        ]
+
+        result = await run_reflect_agent(
+            llm_config=mock_llm,
+            bank_id="test-bank",
+            query="What are the user's preferences?",
+            bank_profile={"name": "Test", "mission": "Testing"},
+            max_iterations=5,
+            **mock_functions,
+        )
+
+        # What the model saw on the second turn: the two tool-result messages.
+        messages = mock_llm.call_with_tools.await_args_list[1].kwargs["messages"]
+        tool_messages = {m["tool_call_id"]: json.loads(m["content"]) for m in messages if m.get("role") == "tool"}
+        slim_obs = tool_messages["1"]["observations"][0]
+        slim_mem = tool_messages["2"]["memories"][0]
+        for item in (slim_obs, slim_mem):
+            for key in self.DROPPED_KEYS:
+                assert key not in item, f"LLM-facing item still carries dropped field {key!r}"
+            for key in self.KEPT_KEYS:
+                assert key in item, f"LLM-facing item lost kept field {key!r}"
+        # Sibling keys pass through unmodified.
+        assert tool_messages["1"]["source_facts"] == observations_output["source_facts"]
+        assert tool_messages["2"]["chunks"] == recall_output["chunks"]
+
+        # tool_trace keeps the full envelope: based_on / trace consumers are unchanged.
+        trace_by_tool = {tc.tool: tc.output for tc in result.tool_trace}
+        assert trace_by_tool["search_observations"]["observations"][0]["entities"] == [{"id": "ent-1", "name": "User"}]
+        assert trace_by_tool["recall"]["memories"][0]["scores"] == {"semantic": 0.9, "recency": 0.5}
+        # Citation validation still saw the retrieved ids.
+        assert result.used_memory_ids == ["mem-2"]
 
 
 class TestDirectiveLeakageOnEmptyBank:

--- a/hindsight-api-slim/tests/test_reflect_agent.py
+++ b/hindsight-api-slim/tests/test_reflect_agent.py
@@ -1185,6 +1185,9 @@ class TestContextOverflowIntegration:
 
             assert result.text, "reflect must return a non-empty answer"
             assert result.usage.total_tokens > 0
+            # The guard forced synthesis under a 1-token budget: the caller must
+            # be able to tell this answer was cut short of the full evidence.
+            assert result.evidence_truncated is True
 
         finally:
             await memory.delete_bank(bank_id, request_context=request_context)
@@ -1471,3 +1474,120 @@ class TestReflectIncrementalCache:
         assert len(provider.deleted_sessions) == 1
         assert provider.deleted_sessions[0].startswith("reflect:")
         assert provider.deleted_sessions[0] == provider.created[0][0]
+
+
+class TestEvidenceTruncatedFlag:
+    """The agent result reports when the answer was synthesized without the
+    model having seen all retrieved evidence, so callers can tell a grounded
+    'no information' from an evidence-starved one."""
+
+    @pytest.fixture
+    def mock_llm(self):
+        llm = MagicMock()
+        llm.call_with_tools = AsyncMock()
+        llm.call = AsyncMock(
+            return_value=(
+                "Synthesized answer.",
+                TokenUsage(input_tokens=50, output_tokens=20, total_tokens=70),
+            )
+        )
+        return llm
+
+    @pytest.fixture
+    def mock_functions_with_large_output(self):
+        large_memories = [{"id": f"mem-{i}", "text": f"Memory fact number {i}: " + "A" * 200} for i in range(20)]
+        return {
+            "search_mental_models_fn": AsyncMock(return_value={"mental_models": []}),
+            "search_observations_fn": AsyncMock(return_value={"observations": []}),
+            "recall_fn": AsyncMock(return_value={"memories": large_memories}),
+            "expand_fn": AsyncMock(return_value={"memories": []}),
+        }
+
+    @pytest.mark.asyncio
+    async def test_context_guard_forced_synthesis_sets_flag(self, mock_llm, mock_functions_with_large_output):
+        """When the proactive context guard forces final synthesis, the caller
+        must be told the evidence was cut short."""
+        mock_llm.call_with_tools.return_value = LLMToolCallResult(
+            tool_calls=[LLMToolCall(id="1", name="recall", arguments={"query": "test"})],
+            finish_reason="tool_calls",
+        )
+
+        result = await run_reflect_agent(
+            llm_config=mock_llm,
+            bank_id="test-bank",
+            query="What do you know?",
+            bank_profile={"name": "Test", "mission": "Testing"},
+            max_context_tokens=100,
+            **mock_functions_with_large_output,
+        )
+
+        assert result.text == "Synthesized answer."
+        assert result.evidence_truncated is True
+
+    @pytest.mark.asyncio
+    async def test_normal_done_completion_reports_untruncated(self, mock_llm):
+        """A run that gathers evidence and completes via done saw everything —
+        the flag stays false."""
+        mock_functions = {
+            "search_mental_models_fn": AsyncMock(return_value={"mental_models": []}),
+            "search_observations_fn": AsyncMock(return_value={"observations": []}),
+            "recall_fn": AsyncMock(return_value={"memories": [{"id": "mem-1", "text": "small fact"}]}),
+            "expand_fn": AsyncMock(return_value={"memories": []}),
+        }
+        mock_llm.call_with_tools.side_effect = [
+            LLMToolCallResult(
+                tool_calls=[LLMToolCall(id="1", name="recall", arguments={"query": "q"})],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(
+                tool_calls=[LLMToolCall(id="2", name="done", arguments={"answer": "All good.", "memory_ids": ["mem-1"]})],
+                finish_reason="tool_calls",
+            ),
+        ]
+
+        result = await run_reflect_agent(
+            llm_config=mock_llm,
+            bank_id="test-bank",
+            query="q",
+            bank_profile={"name": "Test", "mission": "Testing"},
+            max_iterations=5,
+            **mock_functions,
+        )
+
+        assert result.text == "All good."
+        assert result.evidence_truncated is False
+
+    @pytest.mark.asyncio
+    async def test_last_iteration_truncated_prompt_sets_flag(self, mock_llm):
+        """When the iteration limit forces synthesis and the final prompt had to
+        truncate retrieved data, the flag must reflect it — the guard is not the
+        only path that loses evidence."""
+        big_memories = [{"id": f"mem-{i}", "text": f"Long memory {i}: " + "detail " * 60} for i in range(50)]
+        mock_functions = {
+            "search_mental_models_fn": AsyncMock(return_value={"mental_models": []}),
+            "search_observations_fn": AsyncMock(return_value={"observations": []}),
+            "recall_fn": AsyncMock(return_value={"memories": big_memories}),
+            "expand_fn": AsyncMock(return_value={"memories": []}),
+        }
+        mock_llm.call_with_tools.return_value = LLMToolCallResult(
+            tool_calls=[LLMToolCall(id="1", name="recall", arguments={"query": "q"})],
+            finish_reason="tool_calls",
+        )
+
+        # max_iterations=2: iteration 0 recalls (the guard is skipped there —
+        # no evidence gathered yet), iteration 1 takes the is_last branch, which
+        # runs before the guard. The budget is small enough that the final
+        # prompt cannot hold all fifty long memories (~3500+ tokens rendered vs
+        # a 0.8 * 2000 = 1600-token retrieved-data budget).
+        result = await run_reflect_agent(
+            llm_config=mock_llm,
+            bank_id="test-bank",
+            query="q",
+            bank_profile={"name": "Test", "mission": "Testing"},
+            max_iterations=2,
+            max_context_tokens=2000,
+            **mock_functions,
+        )
+
+        assert result.text == "Synthesized answer."
+        assert result.evidence_truncated is True

--- a/hindsight-api-slim/tests/test_reflect_agent.py
+++ b/hindsight-api-slim/tests/test_reflect_agent.py
@@ -939,9 +939,11 @@ class TestSlimToolResultRendering:
     """The agent loop must show the LLM a slim rendering of retrieved facts while
     keeping the full objects in tool_trace for citations and tracing.
 
-    Before this fix, the full serialized envelope (entities, scores, metadata, ...)
-    reached the model — ~6x the budgeted text — so one or two tool calls could blow
-    the whole reflect context budget.
+    Before this fix, the full serialized envelope (scores, metadata, chunk and
+    document ids, ...) reached the model — ~6x the budgeted text — so one or two
+    tool calls could blow the whole reflect context budget. ``entities`` is
+    deliberately NOT dropped: it carries canonical entity names (semantic
+    signal, not plumbing — see #3334).
     """
 
     @staticmethod
@@ -963,8 +965,17 @@ class TestSlimToolResultRendering:
             "scores": {"semantic": 0.9, "recency": 0.5},
         }
 
-    DROPPED_KEYS = ("entities", "scores", "metadata", "chunk_id", "document_id", "tags", "context")
-    KEPT_KEYS = ("id", "text", "fact_type", "occurred_start", "occurred_end", "mentioned_at", "source_fact_ids")
+    DROPPED_KEYS = ("scores", "metadata", "chunk_id", "document_id", "tags", "context")
+    KEPT_KEYS = (
+        "id",
+        "text",
+        "fact_type",
+        "occurred_start",
+        "occurred_end",
+        "mentioned_at",
+        "entities",
+        "source_fact_ids",
+    )
 
     @pytest.fixture
     def mock_llm(self):

--- a/hindsight-api-slim/tests/test_reflect_agent.py
+++ b/hindsight-api-slim/tests/test_reflect_agent.py
@@ -1540,7 +1540,9 @@ class TestEvidenceTruncatedFlag:
                 finish_reason="tool_calls",
             ),
             LLMToolCallResult(
-                tool_calls=[LLMToolCall(id="2", name="done", arguments={"answer": "All good.", "memory_ids": ["mem-1"]})],
+                tool_calls=[
+                    LLMToolCall(id="2", name="done", arguments={"answer": "All good.", "memory_ids": ["mem-1"]})
+                ],
                 finish_reason="tool_calls",
             ),
         ]

--- a/hindsight-api-slim/tests/test_reflect_empty_based_on.py
+++ b/hindsight-api-slim/tests/test_reflect_empty_based_on.py
@@ -102,3 +102,18 @@ async def test_reflect_without_include_facts(api_client):
 
     # Verify structure
     assert isinstance(data["text"], str)
+
+
+@pytest.mark.asyncio
+async def test_reflect_response_reports_evidence_truncated(api_client):
+    """The reflect response carries the evidence_truncated indicator so callers
+    can tell a grounded answer from one synthesized after evidence was cut."""
+    response = await api_client.post(
+        "/v1/default/banks/test_evidence_truncated_bank/reflect",
+        json={"query": "What do you know?", "budget": "low"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "evidence_truncated" in data
+    assert data["evidence_truncated"] is False

--- a/hindsight-api-slim/tests/test_reflect_prompt_builder.py
+++ b/hindsight-api-slim/tests/test_reflect_prompt_builder.py
@@ -22,7 +22,11 @@ mechanical join, not a re-implementation of the builder.
 import pytest
 
 from hindsight_api.engine.reflect import prompts
-from hindsight_api.engine.reflect.prompts import build_final_system_prompt, build_system_prompt_for_tools
+from hindsight_api.engine.reflect.prompts import (
+    build_final_prompt,
+    build_final_system_prompt,
+    build_system_prompt_for_tools,
+)
 
 BANK = {"name": "TestBank", "mission": ""}
 
@@ -602,3 +606,26 @@ def test_final_prompt_output_language_override_is_appended_last():
     assert "Respond exclusively in Spanish" in prompt
     # The config override is appended after the default LANGUAGE rule so it wins.
     assert prompt.index("Respond exclusively in Spanish") > prompt.index("## LANGUAGE")
+
+
+class TestBuildFinalPromptTruncation:
+    """build_final_prompt degrades gracefully under the token budget.
+
+    Historically an oversized tool-result block was dropped whole together
+    with every older block, leaving forced synthesis with an empty Retrieved
+    Data section — the model then correctly answered "I don't have
+    information" while the endpoint still attached every citation.
+    """
+
+    @staticmethod
+    def _entry(items: list[dict], tool: str = "recall", key: str = "memories") -> dict:
+        return {"tool": tool, "input": {"tool": tool}, "output": {key: items}}
+
+    def test_all_blocks_fit_returns_untruncated_result(self):
+        history = [self._entry([{"id": "m1", "text": "User prefers dark mode."}])]
+
+        result = build_final_prompt("What are the prefs?", history, BANK, max_context_tokens=100_000)
+
+        assert "User prefers dark mode." in result.prompt
+        assert result.evidence_truncated is False
+        assert "omitted" not in result.prompt

--- a/hindsight-api-slim/tests/test_reflect_prompt_builder.py
+++ b/hindsight-api-slim/tests/test_reflect_prompt_builder.py
@@ -634,7 +634,9 @@ class TestBuildFinalPromptTruncation:
         """A block that exceeds the budget keeps its leading entries instead of
         vanishing wholesale — forced synthesis must never see an empty Retrieved
         Data section while evidence exists."""
-        items = [{"id": f"m-{i}", "text": f"Team decision number {i} about the deployment pipeline."} for i in range(200)]
+        items = [
+            {"id": f"m-{i}", "text": f"Team decision number {i} about the deployment pipeline."} for i in range(200)
+        ]
         history = [self._entry(items)]
 
         result = build_final_prompt("What was decided?", history, BANK, max_context_tokens=2000)

--- a/hindsight-api-slim/tests/test_reflect_prompt_builder.py
+++ b/hindsight-api-slim/tests/test_reflect_prompt_builder.py
@@ -629,3 +629,67 @@ class TestBuildFinalPromptTruncation:
         assert "User prefers dark mode." in result.prompt
         assert result.evidence_truncated is False
         assert "omitted" not in result.prompt
+
+    def test_oversized_newest_block_is_truncated_not_dropped(self):
+        """A block that exceeds the budget keeps its leading entries instead of
+        vanishing wholesale — forced synthesis must never see an empty Retrieved
+        Data section while evidence exists."""
+        items = [{"id": f"m-{i}", "text": f"Team decision number {i} about the deployment pipeline."} for i in range(200)]
+        history = [self._entry(items)]
+
+        result = build_final_prompt("What was decided?", history, BANK, max_context_tokens=2000)
+
+        assert result.evidence_truncated is True
+        assert "Team decision number 0" in result.prompt, "leading entries must survive truncation"
+        assert "Team decision number 199" not in result.prompt, "trailing entries beyond the budget are cut"
+        assert "No data was retrieved" not in result.prompt
+        assert "omitted" in result.prompt
+
+    def test_newest_block_kept_whole_older_block_truncated_in_order(self):
+        """The newest call renders fully; an older oversized call is truncated to
+        the remaining budget; chronological order is preserved in the prompt."""
+        older_items = [{"id": f"old-{i}", "text": f"Old observation {i} about infrastructure."} for i in range(200)]
+        newest_items = [{"id": "new-1", "text": "Newest finding about the deploy freeze."}]
+        history = [
+            self._entry(older_items, tool="search_observations", key="observations"),
+            self._entry(newest_items),
+        ]
+
+        result = build_final_prompt("What is known?", history, BANK, max_context_tokens=2500)
+
+        assert result.evidence_truncated is True
+        assert "Newest finding about the deploy freeze." in result.prompt
+        assert "Old observation 0" in result.prompt, "older block must be truncated, not dropped"
+        assert "Old observation 199" not in result.prompt
+        assert result.prompt.index("Old observation 0") < result.prompt.index("Newest finding"), (
+            "blocks must read chronologically"
+        )
+
+    def test_listless_oversized_output_gets_token_bounded_cut(self):
+        """An oversized output with no result list (nothing to trim entry-wise)
+        is cut to the budget rather than dropped."""
+        history = [{"tool": "expand", "input": {"tool": "expand"}, "output": {"answer": "word " * 5000}}]
+
+        result = build_final_prompt("What happened?", history, BANK, max_context_tokens=1000)
+
+        assert result.evidence_truncated is True
+        assert "word word word" in result.prompt, "a bounded cut of the oversized output must survive"
+        assert "No data was retrieved" not in result.prompt
+
+    def test_empty_history_reports_no_data_untruncated(self):
+        result = build_final_prompt("Anything?", [], BANK, max_context_tokens=1000)
+
+        assert "No data was retrieved" in result.prompt
+        assert result.evidence_truncated is False
+
+    def test_unserializable_output_falls_back_to_str_within_budget(self):
+        """A circular structure can't be JSON-serialized; the block falls back to
+        str() rendering and still respects the budget."""
+        circular: dict = {"tool_note": "circular payload"}
+        circular["self"] = circular
+        history = [{"tool": "recall", "input": {"tool": "recall"}, "output": circular}]
+
+        result = build_final_prompt("What happened?", history, BANK, max_context_tokens=100_000)
+
+        assert "circular payload" in result.prompt
+        assert result.evidence_truncated is False

--- a/hindsight-api-slim/tests/test_reflect_slim_config.py
+++ b/hindsight-api-slim/tests/test_reflect_slim_config.py
@@ -1,0 +1,22 @@
+"""
+Tests for the reflect_slim_tool_results configuration flag.
+
+The slim LLM-facing rendering of reflect tool results (and the serialized-cost
+entry budgeting that depends on it) is opt-in: default-off keeps the exact
+pre-existing model-input behavior, and a bank or tenant can enable it via the
+hierarchical config API.
+"""
+
+from hindsight_api.config import DEFAULT_REFLECT_SLIM_TOOL_RESULTS, HindsightConfig
+
+
+class TestReflectSlimToolResultsConfig:
+    def test_default_is_disabled(self):
+        """The slim rendering must be opt-in: default-off preserves the exact
+        model-input behavior existing deployments have today."""
+        assert DEFAULT_REFLECT_SLIM_TOOL_RESULTS is False
+
+    def test_config_is_configurable_per_bank(self):
+        """The flag is hierarchical so a single bank can opt in (or out) without
+        a server-wide change."""
+        assert "reflect_slim_tool_results" in HindsightConfig.get_configurable_fields()

--- a/hindsight-api-slim/tests/test_reflect_tiktoken_lazy_load.py
+++ b/hindsight-api-slim/tests/test_reflect_tiktoken_lazy_load.py
@@ -41,5 +41,5 @@ def test_reflect_token_counting_loads_tiktoken_encoding_when_used():
         )
 
     assert count == 2
-    assert "three four" in final_prompt
+    assert "three four" in final_prompt.prompt
     get_encoding.assert_called_once_with("cl100k_base")

--- a/hindsight-api-slim/tests/test_reflect_tools.py
+++ b/hindsight-api-slim/tests/test_reflect_tools.py
@@ -478,7 +478,7 @@ class TestToolResultLlmBudget:
         engine = MagicMock()
         engine.recall_async = AsyncMock(return_value=RecallResult(results=facts, source_facts={}))
 
-        out = await tool_recall(engine, "bank-1", "prefs", RequestContext(), max_tokens=1000)
+        out = await tool_recall(engine, "bank-1", "prefs", RequestContext(), max_tokens=1000, slim_tool_results=True)
 
         assert len(out["memories"]) >= 1
         assert len(out["memories"]) < 300, "no trimming happened: every short fact was returned"
@@ -494,7 +494,7 @@ class TestToolResultLlmBudget:
         engine = MagicMock()
         engine.recall_async = AsyncMock(return_value=RecallResult(results=facts, source_facts={}, chunks=chunks))
 
-        out = await tool_recall(engine, "bank-1", "prefs", RequestContext(), max_tokens=1000)
+        out = await tool_recall(engine, "bank-1", "prefs", RequestContext(), max_tokens=1000, slim_tool_results=True)
 
         kept_chunk_ids = {m["chunk_id"] for m in out["memories"]}
         assert set(out["chunks"]) == kept_chunk_ids
@@ -516,7 +516,13 @@ class TestToolResultLlmBudget:
         engine.recall_async = AsyncMock(return_value=RecallResult(results=observations, source_facts=source_facts))
 
         out = await tool_search_observations(
-            engine, "bank-1", "prefs", RequestContext(), max_tokens=1000, source_facts_max_tokens=0
+            engine,
+            "bank-1",
+            "prefs",
+            RequestContext(),
+            max_tokens=1000,
+            source_facts_max_tokens=0,
+            slim_tool_results=True,
         )
 
         assert 1 <= len(out["observations"]) < 300
@@ -524,3 +530,15 @@ class TestToolResultLlmBudget:
         assert out["count"] == len(out["observations"])
         kept_source_ids = {sid for o in out["observations"] for sid in o.get("source_fact_ids", [])}
         assert set(out["source_facts"]) == kept_source_ids
+
+    @pytest.mark.asyncio
+    async def test_entry_budgeting_is_off_by_default(self):
+        """Without opting in, tool_recall keeps the pre-existing behavior:
+        every recall result is returned regardless of its rendered cost."""
+        facts = [self._short_fact(i) for i in range(300)]
+        engine = MagicMock()
+        engine.recall_async = AsyncMock(return_value=RecallResult(results=facts, source_facts={}))
+
+        out = await tool_recall(engine, "bank-1", "prefs", RequestContext(), max_tokens=1000)
+
+        assert len(out["memories"]) == 300

--- a/hindsight-api-slim/tests/test_reflect_tools.py
+++ b/hindsight-api-slim/tests/test_reflect_tools.py
@@ -1,5 +1,6 @@
 """Regression tests for reflect tool helpers."""
 
+import json
 import re
 import uuid
 from unittest.mock import AsyncMock, MagicMock
@@ -7,11 +8,17 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from hindsight_api.engine.reflect.agent import _execute_tool, _summarize_input
+from hindsight_api.engine.reflect.models import SlimMemoryFact
+from hindsight_api.engine.reflect.tokenization import count_cl100k_tokens
 from hindsight_api.engine.reflect.tools import (
     _document_metadata_from_retain_params,
     tool_expand,
+    tool_recall,
     tool_search_mental_models,
+    tool_search_observations,
 )
+from hindsight_api.engine.response_models import ChunkInfo, MemoryFact, RecallResult
+from hindsight_api.models import RequestContext
 
 
 class _FakeReflectConnection:
@@ -429,3 +436,93 @@ def test_summarize_input_never_raises_for_invalid_tool_limit_strings() -> None:
         )
         == "(query='', max_tokens=5000)"
     )
+
+
+class TestToolResultLlmBudget:
+    """Reflect tool results are budgeted by what their LLM-facing rendering
+    actually costs.
+
+    recall_async budgets result selection by fact-text tokens only, but for
+    short facts the serialized rendering the model sees is dominated by ids and
+    timestamps, so a text-token budget under-counts by an order of magnitude
+    and a single tool call can consume most of the reflect context window.
+    """
+
+    @staticmethod
+    def _short_fact(i: int, fact_type: str = "world") -> MemoryFact:
+        return MemoryFact(
+            id=str(uuid.uuid4()),
+            text=f"User prefers option {i}.",
+            fact_type=fact_type,
+            entities=["User"],
+            context="preference chat",
+            occurred_start="2026-07-01T00:00:00+00:00",
+            occurred_end="2026-07-01T00:00:00+00:00",
+            mentioned_at="2026-07-02T00:00:00+00:00",
+            document_id=str(uuid.uuid4()),
+            metadata={"source": "chat"},
+            chunk_id=f"chunk-{i}",
+            tags=["pref"],
+        )
+
+    @staticmethod
+    def _llm_rendering_tokens(items: list[dict]) -> int:
+        rendered = json.dumps([SlimMemoryFact.project(m) for m in items], default=str, ensure_ascii=False)
+        return count_cl100k_tokens(rendered)
+
+    @pytest.mark.asyncio
+    async def test_recall_results_fit_llm_rendering_budget(self):
+        """With hundreds of short facts, tool_recall returns only as many as fit
+        max_tokens when measured on the slim rendering the model actually sees."""
+        facts = [self._short_fact(i) for i in range(300)]
+        engine = MagicMock()
+        engine.recall_async = AsyncMock(return_value=RecallResult(results=facts, source_facts={}))
+
+        out = await tool_recall(engine, "bank-1", "prefs", RequestContext(), max_tokens=1000)
+
+        assert len(out["memories"]) >= 1
+        assert len(out["memories"]) < 300, "no trimming happened: every short fact was returned"
+        assert self._llm_rendering_tokens(out["memories"]) <= 1000
+
+    @pytest.mark.asyncio
+    async def test_recall_chunks_pruned_to_kept_memories(self):
+        """When trimming cuts memories, the chunks map keeps only entries the
+        surviving memories reference — dropped memories' chunks would otherwise
+        leak the very tokens the trim removed."""
+        facts = [self._short_fact(i) for i in range(300)]
+        chunks = {f"chunk-{i}": ChunkInfo(chunk_text=f"chunk text {i}", chunk_index=i) for i in range(300)}
+        engine = MagicMock()
+        engine.recall_async = AsyncMock(return_value=RecallResult(results=facts, source_facts={}, chunks=chunks))
+
+        out = await tool_recall(engine, "bank-1", "prefs", RequestContext(), max_tokens=1000)
+
+        kept_chunk_ids = {m["chunk_id"] for m in out["memories"]}
+        assert set(out["chunks"]) == kept_chunk_ids
+        assert 0 < len(out["chunks"]) < 300
+
+    @pytest.mark.asyncio
+    async def test_search_observations_fit_budget_with_pruned_source_facts_and_count(self):
+        """Observation results are budget-fitted the same way; count reports what
+        is actually returned, and source_facts keeps only facts the surviving
+        observations reference."""
+        observations = []
+        source_facts = {}
+        for i in range(300):
+            obs = self._short_fact(i, fact_type="observation")
+            obs.source_fact_ids = [f"src-{i}"]
+            observations.append(obs)
+            source_facts[f"src-{i}"] = MemoryFact(id=f"src-{i}", text=f"source fact {i}", fact_type="world")
+        engine = MagicMock()
+        engine.recall_async = AsyncMock(
+            return_value=RecallResult(results=observations, source_facts=source_facts)
+        )
+
+        out = await tool_search_observations(
+            engine, "bank-1", "prefs", RequestContext(), max_tokens=1000, source_facts_max_tokens=0
+        )
+
+        assert 1 <= len(out["observations"]) < 300
+        assert self._llm_rendering_tokens(out["observations"]) <= 1000
+        assert out["count"] == len(out["observations"])
+        kept_source_ids = {sid for o in out["observations"] for sid in o.get("source_fact_ids", [])}
+        assert set(out["source_facts"]) == kept_source_ids

--- a/hindsight-api-slim/tests/test_reflect_tools.py
+++ b/hindsight-api-slim/tests/test_reflect_tools.py
@@ -496,7 +496,10 @@ class TestToolResultLlmBudget:
 
         out = await tool_recall(engine, "bank-1", "prefs", RequestContext(), max_tokens=1000, slim_tool_results=True)
 
-        kept_chunk_ids = {m["chunk_id"] for m in out["memories"]}
+        # The returned memories no longer carry chunk_id (plumbing trim), but
+        # budget fitting keeps a leading prefix of the relevance-ordered input,
+        # so the surviving chunks must be exactly the first N memories'.
+        kept_chunk_ids = {f"chunk-{i}" for i in range(len(out["memories"]))}
         assert set(out["chunks"]) == kept_chunk_ids
         assert 0 < len(out["chunks"]) < 300
 

--- a/hindsight-api-slim/tests/test_reflect_tools.py
+++ b/hindsight-api-slim/tests/test_reflect_tools.py
@@ -513,9 +513,7 @@ class TestToolResultLlmBudget:
             observations.append(obs)
             source_facts[f"src-{i}"] = MemoryFact(id=f"src-{i}", text=f"source fact {i}", fact_type="world")
         engine = MagicMock()
-        engine.recall_async = AsyncMock(
-            return_value=RecallResult(results=observations, source_facts=source_facts)
-        )
+        engine.recall_async = AsyncMock(return_value=RecallResult(results=observations, source_facts=source_facts))
 
         out = await tool_search_observations(
             engine, "bank-1", "prefs", RequestContext(), max_tokens=1000, source_facts_max_tokens=0

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -5141,6 +5141,9 @@ components:
         reflect_source_facts_max_tokens:
           nullable: true
           type: integer
+        reflect_slim_tool_results:
+          nullable: true
+          type: boolean
         llm_gemini_safety_settings:
           items: {}
           nullable: true

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -9319,6 +9319,15 @@ components:
           $ref: '#/components/schemas/TokenUsage'
         trace:
           $ref: '#/components/schemas/ReflectTrace'
+        evidence_truncated:
+          default: false
+          description: "True when the answer was synthesized without the model having\
+            \ seen all retrieved evidence (forced synthesis under the context budget,\
+            \ or retrieved data truncated to fit the final prompt). A 'no information'\
+            \ answer with this flag set reflects evidence starvation, not a grounded\
+            \ conclusion."
+          title: Evidence Truncated
+          type: boolean
       required:
       - text
       title: ReflectResponse

--- a/hindsight-clients/go/model_bank_template_config.go
+++ b/hindsight-clients/go/model_bank_template_config.go
@@ -45,6 +45,7 @@ type BankTemplateConfig struct {
 	MaxObservationsPerScope NullableInt32 `json:"max_observations_per_scope,omitempty"`
 	ObservationScopeLimits []map[string]interface{} `json:"observation_scope_limits,omitempty"`
 	ReflectSourceFactsMaxTokens NullableInt32 `json:"reflect_source_facts_max_tokens,omitempty"`
+	ReflectSlimToolResults NullableBool `json:"reflect_slim_tool_results,omitempty"`
 	LlmGeminiSafetySettings []interface{} `json:"llm_gemini_safety_settings,omitempty"`
 	RecallBudgetFunction NullableString `json:"recall_budget_function,omitempty"`
 	RecallBudgetFixedLow NullableInt32 `json:"recall_budget_fixed_low,omitempty"`
@@ -1139,6 +1140,48 @@ func (o *BankTemplateConfig) UnsetReflectSourceFactsMaxTokens() {
 	o.ReflectSourceFactsMaxTokens.Unset()
 }
 
+// GetReflectSlimToolResults returns the ReflectSlimToolResults field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetReflectSlimToolResults() bool {
+	if o == nil || IsNil(o.ReflectSlimToolResults.Get()) {
+		var ret bool
+		return ret
+	}
+	return *o.ReflectSlimToolResults.Get()
+}
+
+// GetReflectSlimToolResultsOk returns a tuple with the ReflectSlimToolResults field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetReflectSlimToolResultsOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.ReflectSlimToolResults.Get(), o.ReflectSlimToolResults.IsSet()
+}
+
+// HasReflectSlimToolResults returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasReflectSlimToolResults() bool {
+	if o != nil && o.ReflectSlimToolResults.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetReflectSlimToolResults gets a reference to the given NullableBool and assigns it to the ReflectSlimToolResults field.
+func (o *BankTemplateConfig) SetReflectSlimToolResults(v bool) {
+	o.ReflectSlimToolResults.Set(&v)
+}
+// SetReflectSlimToolResultsNil sets the value for ReflectSlimToolResults to be an explicit nil
+func (o *BankTemplateConfig) SetReflectSlimToolResultsNil() {
+	o.ReflectSlimToolResults.Set(nil)
+}
+
+// UnsetReflectSlimToolResults ensures that no value is present for ReflectSlimToolResults, not even an explicit nil
+func (o *BankTemplateConfig) UnsetReflectSlimToolResults() {
+	o.ReflectSlimToolResults.Unset()
+}
+
 // GetLlmGeminiSafetySettings returns the LlmGeminiSafetySettings field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BankTemplateConfig) GetLlmGeminiSafetySettings() []interface{} {
 	if o == nil {
@@ -2006,6 +2049,9 @@ func (o BankTemplateConfig) ToMap() (map[string]interface{}, error) {
 	}
 	if o.ReflectSourceFactsMaxTokens.IsSet() {
 		toSerialize["reflect_source_facts_max_tokens"] = o.ReflectSourceFactsMaxTokens.Get()
+	}
+	if o.ReflectSlimToolResults.IsSet() {
+		toSerialize["reflect_slim_tool_results"] = o.ReflectSlimToolResults.Get()
 	}
 	if o.LlmGeminiSafetySettings != nil {
 		toSerialize["llm_gemini_safety_settings"] = o.LlmGeminiSafetySettings

--- a/hindsight-clients/go/model_reflect_response.go
+++ b/hindsight-clients/go/model_reflect_response.go
@@ -27,6 +27,8 @@ type ReflectResponse struct {
 	StructuredOutput map[string]interface{} `json:"structured_output,omitempty"`
 	Usage NullableTokenUsage `json:"usage,omitempty"`
 	Trace NullableReflectTrace `json:"trace,omitempty"`
+	// True when the answer was synthesized without the model having seen all retrieved evidence (forced synthesis under the context budget, or retrieved data truncated to fit the final prompt). A 'no information' answer with this flag set reflects evidence starvation, not a grounded conclusion.
+	EvidenceTruncated *bool `json:"evidence_truncated,omitempty"`
 }
 
 type _ReflectResponse ReflectResponse
@@ -38,6 +40,8 @@ type _ReflectResponse ReflectResponse
 func NewReflectResponse(text string) *ReflectResponse {
 	this := ReflectResponse{}
 	this.Text = text
+	var evidenceTruncated bool = false
+	this.EvidenceTruncated = &evidenceTruncated
 	return &this
 }
 
@@ -46,6 +50,8 @@ func NewReflectResponse(text string) *ReflectResponse {
 // but it doesn't guarantee that properties required by API are set
 func NewReflectResponseWithDefaults() *ReflectResponse {
 	this := ReflectResponse{}
+	var evidenceTruncated bool = false
+	this.EvidenceTruncated = &evidenceTruncated
 	return &this
 }
 
@@ -232,6 +238,38 @@ func (o *ReflectResponse) UnsetTrace() {
 	o.Trace.Unset()
 }
 
+// GetEvidenceTruncated returns the EvidenceTruncated field value if set, zero value otherwise.
+func (o *ReflectResponse) GetEvidenceTruncated() bool {
+	if o == nil || IsNil(o.EvidenceTruncated) {
+		var ret bool
+		return ret
+	}
+	return *o.EvidenceTruncated
+}
+
+// GetEvidenceTruncatedOk returns a tuple with the EvidenceTruncated field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ReflectResponse) GetEvidenceTruncatedOk() (*bool, bool) {
+	if o == nil || IsNil(o.EvidenceTruncated) {
+		return nil, false
+	}
+	return o.EvidenceTruncated, true
+}
+
+// HasEvidenceTruncated returns a boolean if a field has been set.
+func (o *ReflectResponse) HasEvidenceTruncated() bool {
+	if o != nil && !IsNil(o.EvidenceTruncated) {
+		return true
+	}
+
+	return false
+}
+
+// SetEvidenceTruncated gets a reference to the given bool and assigns it to the EvidenceTruncated field.
+func (o *ReflectResponse) SetEvidenceTruncated(v bool) {
+	o.EvidenceTruncated = &v
+}
+
 func (o ReflectResponse) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -254,6 +292,9 @@ func (o ReflectResponse) ToMap() (map[string]interface{}, error) {
 	}
 	if o.Trace.IsSet() {
 		toSerialize["trace"] = o.Trace.Get()
+	}
+	if !IsNil(o.EvidenceTruncated) {
+		toSerialize["evidence_truncated"] = o.EvidenceTruncated
 	}
 	return toSerialize, nil
 }

--- a/hindsight-clients/python/hindsight_client_api/models/bank_template_config.py
+++ b/hindsight-clients/python/hindsight_client_api/models/bank_template_config.py
@@ -54,6 +54,7 @@ class BankTemplateConfig(BaseModel):
     max_observations_per_scope: Optional[StrictInt] = None
     observation_scope_limits: Optional[List[Dict[str, Any]]] = None
     reflect_source_facts_max_tokens: Optional[StrictInt] = None
+    reflect_slim_tool_results: Optional[StrictBool] = None
     llm_gemini_safety_settings: Optional[List[Any]] = None
     recall_budget_function: Optional[StrictStr] = None
     recall_budget_fixed_low: Optional[StrictInt] = None
@@ -73,7 +74,7 @@ class BankTemplateConfig(BaseModel):
     recall_max_tokens: Optional[StrictInt] = None
     recall_chunks_max_tokens: Optional[StrictInt] = None
     memory_defense: Optional[Dict[str, Any]] = None
-    __properties: ClassVar[List[str]] = ["reflect_mission", "retain_mission", "retain_extraction_mode", "retain_custom_instructions", "retain_chunk_size", "retain_structured_chunk_size", "enable_observations", "observations_mission", "enable_temporal_retrieval", "enable_graph_retrieval", "enable_reranking", "disposition_skepticism", "disposition_literalism", "disposition_empathy", "entity_labels", "entities_allow_free_form", "retain_default_strategy", "retain_strategies", "retain_chunk_batch_size", "mcp_enabled_tools", "consolidation_llm_batch_size", "consolidation_source_facts_max_tokens", "consolidation_source_facts_max_tokens_per_observation", "max_observations_per_scope", "observation_scope_limits", "reflect_source_facts_max_tokens", "llm_gemini_safety_settings", "recall_budget_function", "recall_budget_fixed_low", "recall_budget_fixed_mid", "recall_budget_fixed_high", "recall_budget_adaptive_low", "recall_budget_adaptive_mid", "recall_budget_adaptive_high", "recall_budget_min", "recall_budget_max", "audit_log_enabled", "store_document_text", "enable_auto_consolidation", "consolidation_max_memories_per_round", "consolidation_llm_parallelism", "recall_include_chunks", "recall_max_tokens", "recall_chunks_max_tokens", "memory_defense"]
+    __properties: ClassVar[List[str]] = ["reflect_mission", "retain_mission", "retain_extraction_mode", "retain_custom_instructions", "retain_chunk_size", "retain_structured_chunk_size", "enable_observations", "observations_mission", "enable_temporal_retrieval", "enable_graph_retrieval", "enable_reranking", "disposition_skepticism", "disposition_literalism", "disposition_empathy", "entity_labels", "entities_allow_free_form", "retain_default_strategy", "retain_strategies", "retain_chunk_batch_size", "mcp_enabled_tools", "consolidation_llm_batch_size", "consolidation_source_facts_max_tokens", "consolidation_source_facts_max_tokens_per_observation", "max_observations_per_scope", "observation_scope_limits", "reflect_source_facts_max_tokens", "reflect_slim_tool_results", "llm_gemini_safety_settings", "recall_budget_function", "recall_budget_fixed_low", "recall_budget_fixed_mid", "recall_budget_fixed_high", "recall_budget_adaptive_low", "recall_budget_adaptive_mid", "recall_budget_adaptive_high", "recall_budget_min", "recall_budget_max", "audit_log_enabled", "store_document_text", "enable_auto_consolidation", "consolidation_max_memories_per_round", "consolidation_llm_parallelism", "recall_include_chunks", "recall_max_tokens", "recall_chunks_max_tokens", "memory_defense"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -251,6 +252,11 @@ class BankTemplateConfig(BaseModel):
         if self.reflect_source_facts_max_tokens is None and "reflect_source_facts_max_tokens" in self.model_fields_set:
             _dict['reflect_source_facts_max_tokens'] = None
 
+        # set to None if reflect_slim_tool_results (nullable) is None
+        # and model_fields_set contains the field
+        if self.reflect_slim_tool_results is None and "reflect_slim_tool_results" in self.model_fields_set:
+            _dict['reflect_slim_tool_results'] = None
+
         # set to None if llm_gemini_safety_settings (nullable) is None
         # and model_fields_set contains the field
         if self.llm_gemini_safety_settings is None and "llm_gemini_safety_settings" in self.model_fields_set:
@@ -384,6 +390,7 @@ class BankTemplateConfig(BaseModel):
             "max_observations_per_scope": obj.get("max_observations_per_scope"),
             "observation_scope_limits": obj.get("observation_scope_limits"),
             "reflect_source_facts_max_tokens": obj.get("reflect_source_facts_max_tokens"),
+            "reflect_slim_tool_results": obj.get("reflect_slim_tool_results"),
             "llm_gemini_safety_settings": obj.get("llm_gemini_safety_settings"),
             "recall_budget_function": obj.get("recall_budget_function"),
             "recall_budget_fixed_low": obj.get("recall_budget_fixed_low"),

--- a/hindsight-clients/python/hindsight_client_api/models/reflect_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/reflect_response.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field, StrictStr
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from hindsight_client_api.models.reflect_based_on import ReflectBasedOn
 from hindsight_client_api.models.reflect_trace import ReflectTrace
@@ -34,7 +34,8 @@ class ReflectResponse(BaseModel):
     structured_output: Optional[Dict[str, Any]] = None
     usage: Optional[TokenUsage] = None
     trace: Optional[ReflectTrace] = None
-    __properties: ClassVar[List[str]] = ["text", "based_on", "structured_output", "usage", "trace"]
+    evidence_truncated: Optional[StrictBool] = Field(default=False, description="True when the answer was synthesized without the model having seen all retrieved evidence (forced synthesis under the context budget, or retrieved data truncated to fit the final prompt). A 'no information' answer with this flag set reflects evidence starvation, not a grounded conclusion.")
+    __properties: ClassVar[List[str]] = ["text", "based_on", "structured_output", "usage", "trace", "evidence_truncated"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -120,7 +121,8 @@ class ReflectResponse(BaseModel):
             "based_on": ReflectBasedOn.from_dict(obj["based_on"]) if obj.get("based_on") is not None else None,
             "structured_output": obj.get("structured_output"),
             "usage": TokenUsage.from_dict(obj["usage"]) if obj.get("usage") is not None else None,
-            "trace": ReflectTrace.from_dict(obj["trace"]) if obj.get("trace") is not None else None
+            "trace": ReflectTrace.from_dict(obj["trace"]) if obj.get("trace") is not None else None,
+            "evidence_truncated": obj.get("evidence_truncated") if obj.get("evidence_truncated") is not None else False
         })
         return _obj
 

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -613,6 +613,12 @@ export type BankTemplateConfig = {
    */
   reflect_source_facts_max_tokens?: number | null;
   /**
+   * Reflect Slim Tool Results
+   *
+   * Show the reflect LLM a slim rendering of tool results and budget entry selection by its cost
+   */
+  reflect_slim_tool_results?: boolean | null;
+  /**
    * Llm Gemini Safety Settings
    *
    * Per-bank Gemini/VertexAI safety filter settings

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -4444,6 +4444,12 @@ export type ReflectResponse = {
    * Execution trace of tool and LLM calls. Only present when include.tool_calls is set.
    */
   trace?: ReflectTrace | null;
+  /**
+   * Evidence Truncated
+   *
+   * True when the answer was synthesized without the model having seen all retrieved evidence (forced synthesis under the context budget, or retrieved data truncated to fit the final prompt). A 'no information' answer with this flag set reflects evidence starvation, not a grounded conclusion.
+   */
+  evidence_truncated?: boolean;
 };
 
 /**

--- a/hindsight-docs/docs/developer/api/reflect.mdx
+++ b/hindsight-docs/docs/developer/api/reflect.mdx
@@ -169,3 +169,9 @@ The full execution log of the agentic loop. Only present when `include.tool_call
 
 - `tool_calls` — each tool invocation with `tool` name (`lookup`, `recall`, `learn`, `expand`), `input`, `output` (if `output: true`), `duration_ms`, and `iteration` number.
 - `llm_calls` — each LLM call with `scope` (e.g., `"agent_1"`, `"final"`) and `duration_ms`.
+
+### evidence_truncated
+
+`true` when the answer was synthesized without the model having seen all retrieved evidence — either the context budget forced an early synthesis, or retrieved data had to be truncated to fit the final prompt. Defaults to `false`.
+
+When this flag is set, treat an "I don't have information" answer as evidence starvation rather than a grounded conclusion: the citations in `based_on` reflect what was retrieved, not necessarily what the answering model saw in full. Callers can retry with a narrower question or a higher `HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS` budget.

--- a/hindsight-docs/docs/developer/api/reflect.mdx
+++ b/hindsight-docs/docs/developer/api/reflect.mdx
@@ -175,3 +175,5 @@ The full execution log of the agentic loop. Only present when `include.tool_call
 `true` when the answer was synthesized without the model having seen all retrieved evidence — either the context budget forced an early synthesis, or retrieved data had to be truncated to fit the final prompt. Defaults to `false`.
 
 When this flag is set, treat an "I don't have information" answer as evidence starvation rather than a grounded conclusion: the citations in `based_on` reflect what was retrieved, not necessarily what the answering model saw in full. Callers can retry with a narrower question or a higher `HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS` budget.
+
+The slim tool-result rendering and rendered-cost entry budgeting that keep the reflect loop inside its context budget on observation-heavy banks are opt-in via `HINDSIGHT_API_REFLECT_SLIM_TOOL_RESULTS` (default `false`, per-bank overridable — see [Configuration](/developer/configuration)). `evidence_truncated` is reported regardless of that setting.

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1755,6 +1755,7 @@ export HINDSIGHT_API_OBSERVATIONS_MISSION="Observations are recurring patterns i
 | `HINDSIGHT_API_REFLECT_WALL_TIMEOUT` | Wall-clock timeout in seconds for the entire reflect operation. If exceeded, the request returns HTTP 504. | `300` |
 | `HINDSIGHT_API_REFLECT_MISSION` | Global reflect mission (identity and reasoning framing). Overridden per bank via config API. | - |
 | `HINDSIGHT_API_REFLECT_SOURCE_FACTS_MAX_TOKENS` | Token budget for source facts in `search_observations` during reflect. `-1` disables source facts (default), `0` enables with no limit, `>0` enables with a token budget. Hierarchical — can be overridden per bank via config API. | `-1` |
+| `HINDSIGHT_API_REFLECT_SLIM_TOOL_RESULTS` | Opt-in: render reflect tool results for the LLM as a slim projection (`id`, `text`, `fact_type`, temporal fields, `source_fact_ids`) and budget tool entry selection by that rendered cost instead of fact-text tokens. On observation-heavy banks this cuts the reflect loop's context usage ~5x and stops a single tool call from consuming most of `HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS`. `based_on` citations, traces, and persisted reflect responses keep full objects regardless of this setting. Hierarchical — can be overridden per bank via config API. | `false` |
 
 #### Internal recall (used by mental model refresh)
 

--- a/hindsight-docs/static/bank-template-schema.json
+++ b/hindsight-docs/static/bank-template-schema.json
@@ -358,6 +358,19 @@
           "description": "Max tokens of source facts per reflect call",
           "title": "Reflect Source Facts Max Tokens"
         },
+        "reflect_slim_tool_results": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Show the reflect LLM a slim rendering of tool results and budget entry selection by its cost",
+          "title": "Reflect Slim Tool Results"
+        },
         "llm_gemini_safety_settings": {
           "anyOf": [
             {

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -7695,6 +7695,18 @@
             "title": "Reflect Source Facts Max Tokens",
             "description": "Max tokens of source facts per reflect call"
           },
+          "reflect_slim_tool_results": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reflect Slim Tool Results",
+            "description": "Show the reflect LLM a slim rendering of tool results and budget entry selection by its cost"
+          },
           "llm_gemini_safety_settings": {
             "anyOf": [
               {

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -14187,6 +14187,12 @@
               }
             ],
             "description": "Execution trace of tool and LLM calls. Only present when include.tool_calls is set."
+          },
+          "evidence_truncated": {
+            "type": "boolean",
+            "title": "Evidence Truncated",
+            "description": "True when the answer was synthesized without the model having seen all retrieved evidence (forced synthesis under the context budget, or retrieved data truncated to fit the final prompt). A 'no information' answer with this flag set reflects evidence starvation, not a grounded conclusion.",
+            "default": false
           }
         },
         "type": "object",

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -318,6 +318,13 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_LOOP_WATCHDOG_POLL_INTERVAL_MS=250
 # HINDSIGHT_API_DB_ACQUIRE_WARN_THRESHOLD_MS=1000
 
+# Opt-in: render reflect tool results for the LLM as a slim projection (id, text,
+# type, temporal fields) and budget entry selection by that rendered cost instead
+# of fact-text tokens. Cuts reflect context usage ~5x on observation-heavy banks;
+# based_on citations and traces keep full objects either way. Hierarchical — can
+# be overridden per bank via the config API.
+# HINDSIGHT_API_REFLECT_SLIM_TOOL_RESULTS=true
+
 # -----------------------------------------------------------------------------
 # Webhooks (Optional)
 # -----------------------------------------------------------------------------

--- a/skills/hindsight-docs/references/developer/api/reflect.md
+++ b/skills/hindsight-docs/references/developer/api/reflect.md
@@ -301,3 +301,5 @@ The full execution log of the agentic loop. Only present when `include.tool_call
 `true` when the answer was synthesized without the model having seen all retrieved evidence — either the context budget forced an early synthesis, or retrieved data had to be truncated to fit the final prompt. Defaults to `false`.
 
 When this flag is set, treat an "I don't have information" answer as evidence starvation rather than a grounded conclusion: the citations in `based_on` reflect what was retrieved, not necessarily what the answering model saw in full. Callers can retry with a narrower question or a higher `HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS` budget.
+
+The slim tool-result rendering and rendered-cost entry budgeting that keep the reflect loop inside its context budget on observation-heavy banks are opt-in via `HINDSIGHT_API_REFLECT_SLIM_TOOL_RESULTS` (default `false`, per-bank overridable — see [Configuration](../configuration.md)). `evidence_truncated` is reported regardless of that setting.

--- a/skills/hindsight-docs/references/developer/api/reflect.md
+++ b/skills/hindsight-docs/references/developer/api/reflect.md
@@ -295,3 +295,9 @@ The full execution log of the agentic loop. Only present when `include.tool_call
 
 - `tool_calls` — each tool invocation with `tool` name (`lookup`, `recall`, `learn`, `expand`), `input`, `output` (if `output: true`), `duration_ms`, and `iteration` number.
 - `llm_calls` — each LLM call with `scope` (e.g., `"agent_1"`, `"final"`) and `duration_ms`.
+
+### evidence_truncated
+
+`true` when the answer was synthesized without the model having seen all retrieved evidence — either the context budget forced an early synthesis, or retrieved data had to be truncated to fit the final prompt. Defaults to `false`.
+
+When this flag is set, treat an "I don't have information" answer as evidence starvation rather than a grounded conclusion: the citations in `based_on` reflect what was retrieved, not necessarily what the answering model saw in full. Callers can retry with a narrower question or a higher `HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS` budget.

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1755,6 +1755,7 @@ export HINDSIGHT_API_OBSERVATIONS_MISSION="Observations are recurring patterns i
 | `HINDSIGHT_API_REFLECT_WALL_TIMEOUT` | Wall-clock timeout in seconds for the entire reflect operation. If exceeded, the request returns HTTP 504. | `300` |
 | `HINDSIGHT_API_REFLECT_MISSION` | Global reflect mission (identity and reasoning framing). Overridden per bank via config API. | - |
 | `HINDSIGHT_API_REFLECT_SOURCE_FACTS_MAX_TOKENS` | Token budget for source facts in `search_observations` during reflect. `-1` disables source facts (default), `0` enables with no limit, `>0` enables with a token budget. Hierarchical — can be overridden per bank via config API. | `-1` |
+| `HINDSIGHT_API_REFLECT_SLIM_TOOL_RESULTS` | Opt-in: render reflect tool results for the LLM as a slim projection (`id`, `text`, `fact_type`, temporal fields, `source_fact_ids`) and budget tool entry selection by that rendered cost instead of fact-text tokens. On observation-heavy banks this cuts the reflect loop's context usage ~5x and stops a single tool call from consuming most of `HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS`. `based_on` citations, traces, and persisted reflect responses keep full objects regardless of this setting. Hierarchical — can be overridden per bank via config API. | `false` |
 
 #### Internal recall (used by mental model refresh)
 

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -7695,6 +7695,18 @@
             "title": "Reflect Source Facts Max Tokens",
             "description": "Max tokens of source facts per reflect call"
           },
+          "reflect_slim_tool_results": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reflect Slim Tool Results",
+            "description": "Show the reflect LLM a slim rendering of tool results and budget entry selection by its cost"
+          },
           "llm_gemini_safety_settings": {
             "anyOf": [
               {

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -14187,6 +14187,12 @@
               }
             ],
             "description": "Execution trace of tool and LLM calls. Only present when include.tool_calls is set."
+          },
+          "evidence_truncated": {
+            "type": "boolean",
+            "title": "Evidence Truncated",
+            "description": "True when the answer was synthesized without the model having seen all retrieved evidence (forced synthesis under the context budget, or retrieved data truncated to fit the final prompt). A 'no information' answer with this flag set reflects evidence starvation, not a grounded conclusion.",
+            "default": false
           }
         },
         "type": "object",


### PR DESCRIPTION
Closes #3122.

On banks with a few hundred small observations, broad reflect questions deterministically returned a confident "I don't have information" while attaching hundreds of citations in `based_on` — the synthesis call in the captured transcript saw 730 input tokens alongside 503 citations. Two defects compounded, and this PR fixes both plus adds the caller-facing signal the issue proposed.

## What changed

**1. Opt-in: the LLM sees a slim rendering of tool results; `tool_trace` keeps full objects.**
Tool results serialized full `MemoryFact` dumps (`entities`, `scores`, `metadata`, chunk/document ids, …) into the agent loop — ~6× the token cost of the text the recall budgeter counted. When `reflect_slim_tool_results` is enabled, the agent projects `observations`/`memories` items to `SlimMemoryFact` (`id`, `text`, `fact_type`, `occurred_start/end`, `mentioned_at`, `source_fact_ids`) at the tool-message and `context_history` sites. `mentioned_at` is deliberately kept — the agent system prompt makes it the temporal-supersession signal. `based_on`, the API trace, and persisted reflect responses are unchanged in both modes (full objects still flow through `tool_trace`; regression-tested).

**2. Opt-in: tool entry selection budgeted by what the rendering actually costs.**
For short facts, ids and timestamps dominate the serialized payload (measured 10–18× the text tokens), so text-token budgeting under-counts by an order of magnitude. With the flag enabled, `tool_recall` / `tool_search_observations` keep the leading results whose slim rendering fits `max_tokens` (always at least one), prune `chunks`/`source_facts` to surviving entries, and report the returned count. Trimming happens before `tool_trace`, so citations stay consistent with what the loop actually retrieved.

Both are gated behind **`HINDSIGHT_API_REFLECT_SLIM_TOOL_RESULTS` / `reflect_slim_tool_results` — hierarchical, default `false`, per-bank overridable** — so model inputs are byte-identical to today unless a deployment or bank opts in (default-off is pinned by regression tests). Documented in `configuration.md`, the reflect API reference, and `.env.example` (embed copy synced). Flipping the default later is a one-line change if benchmarks support it.

**3. Always on: forced synthesis truncates oversized blocks instead of dropping them.**
`build_final_prompt` used to drop any over-budget tool-result block *and every older one* (`break`), leaving an empty Retrieved Data section. It now keeps the largest leading prefix of a block's result entries (binary search on rendered size; results are relevance-ordered), with a token-bounded cut fallback for list-less outputs, and returns a typed `FinalPromptResult`. Not gated: dropping all evidence is never desirable behavior.

**4. Always on: the response carries `evidence_truncated`.**
True when the context guard forces synthesis or the final prompt had to truncate retrieved data; false on a normal `done` completion. Threaded `ReflectAgentResult` → `ReflectResult` → `ReflectResponse`; MCP picks it up via `model_dump()`. Callers can now tell an evidence-starved "no information" from a grounded one. Additive and non-breaking. OpenAPI spec, generated clients (Go/Python/TS), and the API reference are regenerated/updated in this PR; the hand-written wrappers return generated types so they need no change; the Rust client regenerates at `hindsight-cli` build time; the control plane passes the reflect response through verbatim.

## How it was built and verified

Strict test-first: every behavior landed as a failing test watched red before the implementation (slim/full split, context-history rendering, budget fitting with chunk/source-fact pruning, per-block truncation shapes, flag threading at agent and HTTP levels, config gating with default-off regression coverage). Highlights:

- `TestSlimToolResultRendering` — slim message + full trace + `based_on` byte-compatibility (opt-in), full envelope by default
- `TestToolResultLlmBudget` — rendering-cost budget fitting, ≤ `max_tokens` asserted on cl100k counts (opt-in), no trimming by default
- `TestBuildFinalPromptTruncation` — oversized-newest, multi-block ordering, token-cut fallback, empty history, unserializable output
- `TestEvidenceTruncatedFlag` + endpoint test — flag semantics on guard/last-iteration/normal paths and HTTP serialization
- `TestReflectSlimToolResultsConfig` — default off, hierarchical/per-bank configurable
- `TestContextOverflowIntegration` (`hs_llm_core`) now asserts `evidence_truncated is True` instead of tolerating the failure mode

Verification: full API suite green (remaining failures are credential-gated real-LLM tests and known parallel-load flakes, all verified passing in isolation), `lint.sh`, `ty check`, generated-file drift clean. Real-LLM runs via `openai-codex` (the provider class from the original report): **6 passes across `gpt-5.6-sol`/`luna`/`terra` (low+medium efforts) and `gpt-5.4-mini`** — the context guard trips at a model-independent ~2.3k tokens with slimming enabled where the full envelope previously blew six-figure budgets, and `evidence_truncated` surfaces end-to-end every time.

## Independent validation on a second bank

Measured on one bank of 781 memories / 315 observations / 411 documents built
from a synthetic corpus, `gpt-5.6-luna`, same bank and same question across all
builds. Reproduced on two independent auth paths (a subscription provider and a
metered API key); the numbered table below is the subscription path.

**The reported symptom, on the released build:**

```
question: "Summarize all operational decisions and team conventions across every project."

answer:    "I don't have information about operational decisions or team
            conventions across the projects in the retrieved memories."
            (119 characters)
citations attached: 246
latency:   6.2s
```

246 memories asserted as provenance for an answer containing nothing.

**How bad this is depends on how the agent chunks retrieval, which is worth
stating plainly.** On the path above the agent made a *single* ~304k-char
`search_observations` call. It exceeds the budget, `break` fires on the first
(newest) block, and nothing at all reaches the model. On a second provider the
same released build made a large call *plus* a smaller follow-up `recall`
(~262k + ~37k chars): the newest block fit, survived, and the model answered
with 30 claims, all grounded. Same build, same bug, same bank — the outcome
turned on whether a small enough block happened to be last.

That is the sharper argument for change 3. `break` does not merely fail when
there is nothing to show; in the second case it silently discarded a 262k-char
block that was almost certainly richer than the 37k one it kept. Truncating
means the large block contributes what fits instead of nothing, in both cases.

**Across builds:**

| | released 0.8.6 | this PR, flag off | this PR, flag on |
|---|---|---|---|
| answer length | 119 chars | 14,179 | 7,135 |
| distinct claims made | **0** (single-sweep retrieval; 30 on a provider that split the retrieval) | **53** | 25 |
| claims grounded in attached evidence | n/a (no claims) | 52/53 (98%) | 24/25 (96%) |
| citations attached | 246 | 300 | 36 |
| largest single tool result | 304,876 chars | 304,982 | 89,531 |
| tool result vs its own `max_tokens` | 7.6–9.5× | 9.5× | **1.8–2.2×** |
| forced synthesis | 40 / 42 calls | 21 / 22 | **2 / 20** |
| context budget exceeded | — | 21 | **0** |
| latency | 6.2s | 78.8s | 61.1s |

"Grounded" = for each claim bullet, at least two distinctive content words also
appear in one of the memories the response attached as `based_on`. It screens
for claims asserted without support, which is the failure mode truncation could
plausibly have introduced.

**Three things this establishes:**

1. **The always-on truncation fix carries the result.** With both opt-in flags
   off — the shipped default — the same question goes from 0 claims to 53.
2. **Truncating rather than dropping does not induce fabrication.** 96–98% of
   claims are grounded in attached evidence in both fixed configurations. The
   concern that synthesising over a truncated prefix would produce confident
   invention did not materialise.
3. **The opt-in path fixes the root cause.** Slim rendering takes the largest
   tool result from ~305k to ~89k chars, and context-budget exhaustion from 21
   occurrences to 0. The agent then completes its own loop instead of being
   forced (2/20 vs 21/22).

**The default-off gating looks right on this corpus.** Flag-off produced ~2×
the distinct claims at equal grounding rate and equal claim density (268 vs 285
chars per claim), so the extra length is additional content rather than padding.
On a separate graded check with five fixed must-contain facts, flag-off scored
4/5 on all five runs with zero variance; flag-on averaged 2.8/5 across five.

**Side effect worth noting:** the response-level `max_tokens` is only enforced
on the `done` path, where `_handle_done_call` runs its rewrite-to-budget pass.
Forced synthesis bypasses it. On the released build, which forces 40 of 42
calls, a request for 200 tokens returned ~1,500. With the loop completing
normally under this PR, a `final_rewrite` scope appears in the trace and a
2,000-token request returned 1,942. Reducing forcing restores that budget as a
consequence.

**Caveats:** one bank, one corpus, one model; two providers. Grades are n=5 per
arm; grounding rates are single runs. Latency is heavily model-dependent.


## Behavioural note for adopters

Broad questions that previously returned an instant refusal now perform real
synthesis, and that costs wall-clock time.

On the measured bank, a broad sweep question went from **~6s to ~60–98s**.
Decomposed from the trace, **94–98% of that is LLM time** — the final synthesis
call alone was 53–83s — against **1–2% engine and database work**. This is not
overhead the change introduces; it is the cost of answering rather than
declining to.

Two practical consequences:

- **Check client and RPC timeouts before adopting.** Callers whose deadline sits
  under ~100s will begin seeing timeouts where they previously saw fast
  refusals. A tool-call or RPC budget in the 60–90s range is likely to be too
  tight for broad questions on a bank of a few hundred observations.
- **Responses get larger.** Answers grew from ~100 characters to 7k–14k on
  broad questions. Anything embedding a reflect response in a bounded context
  window should re-check its budget.

Both effects scale with how badly a deployment was affected by the original
defect: the more evidence was being dropped, the more work now happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

