### PR TITLE
fix(coding-agents): surface missing sqlite3 instead of silently disabling Devin retain

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/retain-hook.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -7,13 +7,21 @@ import { buildRetain, runRetainHook } from "./retain-hook";
 
 let root: string;
 let file: string;
+const ORIGINAL_DIAG_FILE = process.env.HINDSIGHT_DIAG_FILE;
+const ORIGINAL_LOG_FILE = process.env.HINDSIGHT_LOG_FILE;
 
 beforeEach(() => {
   root = mkdtempSync(join(tmpdir(), "hs-retain-hook-"));
   file = join(root, "session.jsonl");
+  process.env.HINDSIGHT_DIAG_FILE = join(root, "diag.jsonl");
+  process.env.HINDSIGHT_LOG_FILE = join(root, "plugin.log");
 });
 
 afterEach(() => {
+  if (ORIGINAL_DIAG_FILE === undefined) delete process.env.HINDSIGHT_DIAG_FILE;
+  else process.env.HINDSIGHT_DIAG_FILE = ORIGINAL_DIAG_FILE;
+  if (ORIGINAL_LOG_FILE === undefined) delete process.env.HINDSIGHT_LOG_FILE;
+  else process.env.HINDSIGHT_LOG_FILE = ORIGINAL_LOG_FILE;
   rmSync(root, { recursive: true, force: true });
 });
 
@@ -109,6 +117,62 @@ describe("buildRetain", () => {
         client,
       })
     ).resolves.toBeUndefined();
+  });
+
+  it("fails open and records a diagnostic when the transcript reader throws", async () => {
+    const retainSpy = vi.fn().mockResolvedValue(undefined);
+    const client = { retain: retainSpy } as unknown as HindsightClient;
+    const readTranscript = vi.fn(() => {
+      throw new Error("spawnSync sqlite3 ENOENT");
+    });
+
+    await expect(
+      buildRetain({
+        harness: "devin-cli",
+        sessionId: "session-unreadable",
+        transcriptPath: "session-unreadable",
+        client,
+        readTranscript,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(retainSpy).not.toHaveBeenCalled();
+    expect(JSON.parse(readFileSync(process.env.HINDSIGHT_DIAG_FILE!, "utf8"))).toMatchObject({
+      harness: "devin-cli",
+      event: "retain_transcript_failed",
+      error: "spawnSync sqlite3 ENOENT",
+      session: "session-unreadable",
+    });
+    expect(readFileSync(process.env.HINDSIGHT_LOG_FILE!, "utf8")).toContain(
+      "session transcript read failed"
+    );
+  });
+
+  it("keeps sqlite stderr when a long child-process message would hide it", async () => {
+    const client = { retain: vi.fn() } as unknown as HindsightClient;
+    const readTranscript = vi.fn(() => {
+      throw Object.assign(new Error(`Command failed: ${"x".repeat(400)}`), {
+        stderr: Buffer.from(
+          "\u001b[31mError: in prepare, database disk image is malformed\u001b[0m\nnext line"
+        ),
+      });
+    });
+
+    await buildRetain({
+      harness: "devin-cli",
+      sessionId: "session-malformed",
+      transcriptPath: "session-malformed",
+      client,
+      readTranscript,
+    });
+
+    const diagnostic = JSON.parse(readFileSync(process.env.HINDSIGHT_DIAG_FILE!, "utf8"));
+    expect(diagnostic).toMatchObject({ event: "retain_transcript_failed" });
+    expect(diagnostic.error).toContain(
+      "stderr: Error: in prepare, database disk image is malformed next line"
+    );
+    expect(diagnostic.error).toContain("message: Command failed:");
+    expect(diagnostic.error).not.toContain("\u001b");
   });
 });
 

--- a/hindsight-integrations/coding-agents/src/core/retain-hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.ts
@@ -49,7 +49,8 @@ interface RetainClient {
 /**
  * Pure retain logic: read the transcript, and if it has any usable turns, upsert the full
  * conversation under `conversation:<sessionId>`. A transcript with no usable turns (e.g. only
- * tool calls / meta lines) is a no-op — nothing worth remembering. Fail-open: never throws.
+ * tool calls / meta lines) is a no-op — nothing worth remembering. Fail-open: never throws; reader
+ * failures are diagnosed separately so an integration dependency cannot break the host hook.
  */
 export async function buildRetain(args: {
   harness: string;
@@ -61,7 +62,22 @@ export async function buildRetain(args: {
   const { harness, sessionId, transcriptPath, client } = args;
   const readTranscript = args.readTranscript ?? readClaudeTranscript;
 
-  const turns = readTranscript(transcriptPath);
+  let turns: TransportTurn[];
+  const readT0 = Date.now();
+  try {
+    turns = readTranscript(transcriptPath);
+  } catch (e) {
+    // Transcript readers bridge host-owned files/CLI databases. A dependency or schema failure is
+    // expected to be recoverable at this boundary for every harness, so never break Stop hooks.
+    const error = describeError(e);
+    log.warn(harness, "session transcript read failed", { error });
+    diag(harness, "retain_transcript_failed", {
+      ms: Date.now() - readT0,
+      error,
+      session: sessionId,
+    });
+    return;
+  }
   if (turns.length === 0) return;
 
   const startTs = turns[0]?.timestamp ?? new Date().toISOString();
@@ -70,15 +86,45 @@ export async function buildRetain(args: {
     await retainLiveSession(client as HindsightClient, sessionId, turns, startTs, harness);
     diag(harness, "retain_ok", { ms: Date.now() - t0, turns: turns.length, session: sessionId });
   } catch (e) {
-    log.warn(harness, "session write-back failed", {
-      error: String((e as Error)?.message || e).slice(0, 200),
-    });
+    const error = describeError(e);
+    log.warn(harness, "session write-back failed", { error });
     diag(harness, "retain_failed", {
       ms: Date.now() - t0,
-      error: String((e as Error)?.message || e).slice(0, 200),
+      error,
       session: sessionId,
     });
   }
+}
+
+/** Prefer a child-process stderr diagnostic over its often-long command prefix. */
+function describeError(e: unknown): string {
+  if (e && typeof e === "object") {
+    const error = e as {
+      message?: unknown;
+      stderr?: unknown;
+      code?: unknown;
+      signal?: unknown;
+    };
+    const clean = (value: unknown): string =>
+      String(value ?? "")
+        .replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, "")
+        .replace(/[\u0000-\u001f\u007f]+/g, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+    const stderr = Buffer.isBuffer(error.stderr) ? error.stderr.toString("utf8") : error.stderr;
+    const parts = [
+      clean(stderr) ? `stderr: ${clean(stderr)}` : "",
+      clean(error.message)
+        ? clean(stderr)
+          ? `message: ${clean(error.message)}`
+          : clean(error.message)
+        : "",
+      error.code !== undefined ? `code: ${clean(error.code)}` : "",
+      error.signal !== undefined ? `signal: ${clean(error.signal)}` : "",
+    ].filter(Boolean);
+    if (parts.length) return parts.join(" | ").slice(0, 200);
+  }
+  return String((e as Error)?.message || e).slice(0, 200);
 }
 
 /** Run one Stop-hook invocation: stdin event in, no stdout output (a Stop hook injects nothing). */

--- a/hindsight-integrations/coding-agents/src/core/transcript-devin.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript-devin.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from "vitest";
-import { parseDevinMessages } from "./transcript-devin";
+import { execFileSync } from "node:child_process";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { parseDevinMessages, readDevinTranscript } from "./transcript-devin";
+
+vi.mock("node:child_process", () => ({ execFileSync: vi.fn() }));
+
+const execFile = vi.mocked(execFileSync);
+
+beforeEach(() => {
+  execFile.mockReset();
+});
 
 describe("parseDevinMessages", () => {
   it("uses the final streamed assistant update", () => {
@@ -30,5 +39,48 @@ describe("parseDevinMessages", () => {
       { role: "user", content: "Explain this repo" },
       { role: "assistant", content: "Complete answer" },
     ]);
+  });
+});
+
+describe("readDevinTranscript", () => {
+  it("returns an empty transcript when sqlite3 successfully finds no rows", () => {
+    execFile.mockReturnValue("");
+
+    expect(readDevinTranscript("session-empty")).toEqual([]);
+  });
+
+  it("parses a successful sqlite3 query", () => {
+    execFile.mockReturnValue(
+      JSON.stringify([
+        {
+          node_id: 1,
+          chat_message: JSON.stringify({
+            message_id: "u",
+            role: "user",
+            content: "Remember the release process",
+          }),
+        },
+      ])
+    );
+
+    expect(readDevinTranscript("session-ok")).toEqual([
+      { role: "user", content: "Remember the release process" },
+    ]);
+    expect(execFile).toHaveBeenCalledWith(
+      "sqlite3",
+      expect.arrayContaining(["-json", expect.stringContaining("sessions.db")]),
+      expect.objectContaining({ stdio: ["ignore", "pipe", "pipe"] })
+    );
+  });
+
+  it.each([
+    new Error("spawnSync sqlite3 ENOENT"),
+    new Error("Error: database disk image is malformed"),
+  ])("propagates sqlite3 failures for the retain diagnostic boundary", (error) => {
+    execFile.mockImplementation(() => {
+      throw error;
+    });
+
+    expect(() => readDevinTranscript("session-broken")).toThrow(error.message);
   });
 });

--- a/hindsight-integrations/coding-agents/src/core/transcript-devin.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript-devin.ts
@@ -44,22 +44,24 @@ export function parseDevinMessages(nodes: DevinMessageNode[]): TransportTurn[] {
 }
 
 /** Devin hooks provide no transcript path, but the local CLI persists its full conversation in
- * sessions.db. Use sqlite3 as a read-only bridge to avoid a native Node dependency in hook bundles. */
+ * sessions.db. Use sqlite3 as a read-only bridge to avoid a native Node dependency in hook bundles.
+ * Command/database failures deliberately propagate to buildRetain's fail-open diagnostic boundary;
+ * only a missing session id or a successful query with no rows is a legitimate empty transcript. */
 export function readDevinTranscript(sessionId: string | undefined): TransportTurn[] {
   if (!sessionId) return [];
-  try {
-    const quotedId = sessionId.replace(/'/g, "''");
-    const raw = execFileSync(
-      "sqlite3",
-      [
-        "-json",
-        sessionDb,
-        `SELECT node_id, chat_message FROM message_nodes WHERE session_id = '${quotedId}' ORDER BY node_id`,
-      ],
-      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 2000 }
-    );
-    return parseDevinMessages(JSON.parse(raw) as DevinMessageNode[]);
-  } catch {
-    return [];
-  }
+  const quotedId = sessionId.replace(/'/g, "''");
+  const raw = execFileSync(
+    "sqlite3",
+    [
+      "-json",
+      sessionDb,
+      `SELECT node_id, chat_message FROM message_nodes WHERE session_id = '${quotedId}' ORDER BY node_id`,
+    ],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], timeout: 2000 }
+  );
+  // sqlite3 emits an empty string, rather than `[]`, when a SELECT returns no rows.
+  if (!raw.trim()) return [];
+  const nodes: unknown = JSON.parse(raw);
+  if (!Array.isArray(nodes)) throw new Error("sqlite3 returned unexpected Devin transcript data");
+  return parseDevinMessages(nodes as DevinMessageNode[]);
 }

--- a/hindsight-integrations/coding-agents/src/installer.test.ts
+++ b/hindsight-integrations/coding-agents/src/installer.test.ts
@@ -1,9 +1,14 @@
+import { execFileSync } from "node:child_process";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
-import { INSTALLERS, MARKER, run, type InstallCtx } from "./installer";
+import { canUseSqlite3, INSTALLERS, MARKER, run, type InstallCtx } from "./installer";
+
+vi.mock("node:child_process", () => ({ execFileSync: vi.fn() }));
+
+const execFile = vi.mocked(execFileSync);
 
 // Every test gets a FRESH temp dir as ctx.home (never the real $HOME) and a stubbed
 // claudeMcp so the real `claude` CLI is never executed. run() is always called with
@@ -289,6 +294,37 @@ describe("antigravity-cli installer", () => {
     expect(mcp.mcpServers.other).toEqual({ command: "other-tool" });
     expect(JSON.stringify(mcp)).not.toContain(MARKER);
     expect(readJson(settingsPath(ctx)).statusLine).toBeUndefined();
+  });
+});
+
+describe("devin-cli installer", () => {
+  it.each(["", "1", "not-json", '[{"wrong":1}]'])(
+    "rejects sqlite3 output that does not prove JSON query compatibility: %s",
+    (output) => {
+      execFile.mockReturnValue(output);
+      expect(canUseSqlite3()).toBe(false);
+    }
+  );
+
+  it("accepts the expected JSON probe row", () => {
+    execFile.mockReturnValue('[{"probe":1}]\n');
+    expect(canUseSqlite3()).toBe(true);
+  });
+
+  it("warns about an unusable sqlite3 prerequisite without blocking installation", () => {
+    const ctx = makeCtx();
+    const logs: string[] = [];
+    ctx.sqlite3Probe = vi.fn(() => false);
+    ctx.log = (message) => logs.push(message);
+
+    expect(run(["install", "devin-cli"], ctx)).toBe(0);
+    expect(logs.join("\n")).toContain(
+      "sqlite3 was not found or cannot run the required -json query"
+    );
+    expect(logs.join("\n")).toContain("session retain requires a compatible sqlite3");
+
+    const config = readJson(join(ctx.home, ".config", "devin", "config.json"));
+    expect(Object.keys(config.hooks).sort()).toEqual(["SessionStart", "Stop", "UserPromptSubmit"]);
   });
 });
 

--- a/hindsight-integrations/coding-agents/src/installer.ts
+++ b/hindsight-integrations/coding-agents/src/installer.ts
@@ -56,6 +56,8 @@ export interface InstallCtx {
   claudeMcp?: (args: string[]) => boolean;
   /** Runs `cline plugin ...`; injectable for tests. Returns false when the CLI isn't usable. */
   clinePlugin?: (args: string[]) => boolean;
+  /** Probes sqlite3's required JSON query mode; injectable so installs stay deterministic in tests. */
+  sqlite3Probe?: () => boolean;
   log?: (m: string) => void;
 }
 
@@ -177,6 +179,23 @@ function onPath(bin: string): boolean {
   try {
     execFileSync("which", [bin], { stdio: "pipe" });
     return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Check the exact sqlite3 mode used by the Devin transcript reader, not just binary presence. */
+export function canUseSqlite3(): boolean {
+  try {
+    const raw = execFileSync("sqlite3", ["-json", ":memory:", "SELECT 1 AS probe;"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 2000,
+    });
+    const parsed: unknown = JSON.parse(raw.trim());
+    if (!Array.isArray(parsed) || parsed.length !== 1) return false;
+    const row = parsed[0];
+    return typeof row === "object" && row !== null && (row as { probe?: unknown }).probe === 1;
   } catch {
     return false;
   }
@@ -493,6 +512,12 @@ const devin: HarnessInstaller = {
   name: "devin-cli",
   detect: (c) => onPath("devin") || existsSync(join(c.home, ".config", "devin")),
   install(c) {
+    if (!(c.sqlite3Probe ?? canUseSqlite3)()) {
+      c.log?.(
+        "devin-cli: warning: sqlite3 was not found or cannot run the required -json query; hooks " +
+          "will be installed, but session retain requires a compatible sqlite3"
+      );
+    }
     const configPath = join(c.home, ".config", "devin", "config.json");
     const config = readJson(configPath);
     config.hooks = config.hooks ?? {};

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -3026,7 +3026,7 @@
           "Documents"
         ],
         "summary": "List documents",
-        "description": "List documents with pagination and optional search. Documents are the source content from which memory units are extracted.",
+        "description": "List documents with pagination and optional search, most recently written first (`updated_at` descending). Documents are the source content from which memory units are extracted.",
         "operationId": "list_documents",
         "parameters": [
           {
@@ -6938,7 +6938,20 @@
                 "type": "null"
               }
             ],
-            "title": "Last Document At"
+            "title": "Last Document At",
+            "description": "When a document was last *ingested* into this bank. Appending to an existing document does not move this \u2014 use `last_write_at` for write activity."
+          },
+          "last_write_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Write At",
+            "description": "When anything was last written to this bank: a document retained (including appends to an existing document) or a fact stored. Null if the bank is empty."
           }
         },
         "type": "object",
@@ -6977,6 +6990,7 @@
               },
               "fact_count": 156,
               "last_document_at": "2024-01-16T14:20:00Z",
+              "last_write_at": "2024-01-17T09:05:00Z",
               "mission": "I am a software engineer helping my team ship quality code",
               "name": "Alice",
               "updated_at": "2024-01-16T14:20:00Z"


### PR DESCRIPTION
## Summary

- distinguish a successful empty Devin transcript query from sqlite execution, schema, and parse failures
- keep Stop hooks fail-open while logging and recording `retain_transcript_failed` diagnostics
- probe sqlite3's required JSON query mode during Devin installation and warn without blocking hook setup

The sqlite CLI bridge remains dependency-free for Node; users now get an actionable signal when its external prerequisite cannot read transcripts. Thanks @ichoosetoaccept for isolating the failure mode in #3125.

## Testing

- `npm test` (267 tests)
- `npx tsc --noEmit`
- `npm run build`
- Prettier check on all changed files

## CI note

Current `main` contains #3109's canonical OpenAPI update but not its generated `skills/hindsight-docs/references/openapi.json` mirror. The required generated-file check reproduced that base drift on this PR, so a separate commit synchronizes the mirror byte-for-byte with `hindsight-docs/static/openapi.json`; no API source or schema is changed here.

Fixes #3125
