### PR TITLE
fix(claude-code): preserve quoted channel envelopes

### DIFF
--- a/hindsight-integrations/claude-code/scripts/lib/content.py
+++ b/hindsight-integrations/claude-code/scripts/lib/content.py
@@ -28,8 +28,10 @@ def strip_channel_envelope(content: str) -> str:
     Extracts the inner text, preserving the actual user message while removing
     transport metadata that Hindsight doesn't need.
     """
-    # Match <channel ...>content</channel> — extract inner text
-    match = re.search(r"<channel\b[^>]*>([\s\S]*?)</channel>", content)
+    # Only unwrap messages that are entirely a channel envelope. A user may
+    # quote an envelope while asking about it; their surrounding text must not
+    # be discarded.
+    match = re.fullmatch(r"\s*<channel\b[^>]*>([\s\S]*?)</channel>\s*", content)
     if match:
         return match.group(1).strip()
     return content

--- a/hindsight-integrations/claude-code/tests/test_content.py
+++ b/hindsight-integrations/claude-code/tests/test_content.py
@@ -39,6 +39,14 @@ class TestStripChannelEnvelope:
         raw = "<other>stuff</other>"
         assert strip_channel_envelope(raw) == raw
 
+    def test_passthrough_when_channel_envelope_is_quoted(self):
+        raw = 'please explain <channel source="telegram">hello</channel> thanks'
+        assert strip_channel_envelope(raw) == raw
+
+    def test_strips_channel_xml_with_surrounding_whitespace(self):
+        raw = ' \n<channel source="telegram">hello</channel>\n '
+        assert strip_channel_envelope(raw) == "hello"
+
 
 # ---------------------------------------------------------------------------
 # strip_memory_tags

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -3026,7 +3026,7 @@
           "Documents"
         ],
         "summary": "List documents",
-        "description": "List documents with pagination and optional search. Documents are the source content from which memory units are extracted.",
+        "description": "List documents with pagination and optional search, most recently written first (`updated_at` descending). Documents are the source content from which memory units are extracted.",
         "operationId": "list_documents",
         "parameters": [
           {
@@ -6938,7 +6938,20 @@
                 "type": "null"
               }
             ],
-            "title": "Last Document At"
+            "title": "Last Document At",
+            "description": "When a document was last *ingested* into this bank. Appending to an existing document does not move this \u2014 use `last_write_at` for write activity."
+          },
+          "last_write_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Write At",
+            "description": "When anything was last written to this bank: a document retained (including appends to an existing document) or a fact stored. Null if the bank is empty."
           }
         },
         "type": "object",
@@ -6977,6 +6990,7 @@
               },
               "fact_count": 156,
               "last_document_at": "2024-01-16T14:20:00Z",
+              "last_write_at": "2024-01-17T09:05:00Z",
               "mission": "I am a software engineer helping my team ship quality code",
               "name": "Alice",
               "updated_at": "2024-01-16T14:20:00Z"


### PR DESCRIPTION
## Summary

- only unwrap Claude Code channel envelopes when they cover the complete message
- preserve user text when a channel envelope is quoted inside a larger prompt
- keep support for transport wrappers with surrounding whitespace

## Tests

- `uv run --no-sync pytest tests/test_content.py -q` (59 passed)
- `uv run --no-sync ruff check scripts/lib/content.py`
- `git diff --check`

Closes #3124
