### PR TITLE
fix(mental-models): don't overwrite content when reflect retrieved nothing

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -12974,6 +12974,18 @@ class MemoryEngine(MemoryEngineInterface):
         for _facts in based_on_serialized_payload.values():
             delta_supporting_facts.extend(_facts)
 
+        # Grounding = memories reflect actually retrieved. Directives are bank-config
+        # injection (see based_on["directives"] above), not retrieval evidence, so they
+        # never count. ``fresh`` must be computed BEFORE the delta merge below folds the
+        # previous based_on into the payload.
+        def _grounding_count(based_on: dict[str, Any]) -> int:
+            return sum(
+                len(facts) for ftype, facts in based_on.items() if ftype != "directives" and isinstance(facts, list)
+            )
+
+        fresh_grounding_count = _grounding_count(based_on_serialized_payload)
+        prior_grounding_count = _grounding_count((mental_model.get("reflect_response") or {}).get("based_on") or {})
+
         # In delta mode, based_on must accumulate: the mental model is
         # grounded on ALL facts ever used, not just the latest delta's new
         # ones. Merge previous based_on with current, deduplicating by id.
@@ -13101,8 +13113,10 @@ class MemoryEngine(MemoryEngineInterface):
                 supporting_facts = delta_supporting_facts
 
                 # No new facts since last refresh — skip the delta LLM call
-                # and preserve existing content unchanged.
-                if not supporting_facts:
+                # and preserve existing content unchanged. Counted on non-directive
+                # grounding only: directives are bank-config injection and must not
+                # pass as retrieved evidence (#2894).
+                if fresh_grounding_count == 0:
                     reflect_response_payload["delta_applied"] = False
                     reflect_response_payload["delta_skipped_reason"] = "no_new_facts"
                     return _finish(
@@ -13250,6 +13264,31 @@ class MemoryEngine(MemoryEngineInterface):
                 final_structured=None,
                 delta_operations=delta_operations,
                 outcome="refresh_failed_empty_candidate",
+            )
+
+        # Refuse to overwrite a grounded document when this run retrieved nothing
+        # (#2894). An empty recall does not produce an empty answer: the agent falls
+        # back to the prompt alone and returns a non-empty generic refusal ("I don't
+        # have information about…") that sails past the check above and replaces a good
+        # document with garbage — and in delta mode that refusal becomes the baseline
+        # the next refresh builds on.
+        #
+        # Retrieval going N facts -> 0 is the regression signal. A model that has never
+        # been grounded (fresh seed content, no prior reflect_response) has nothing to
+        # lose, so its first refresh still writes normally.
+        if fresh_grounding_count == 0 and prior_grounding_count > 0 and has_delta_baseline:
+            warnings.append(
+                "Reflect retrieved no memories for a model that was grounded in "
+                f"{prior_grounding_count} before. A real refresh would preserve the existing "
+                "content and fail rather than store an ungrounded answer."
+            )
+            return _finish(
+                effective_mode=effective_mode,
+                mode_fallback_reason=mode_fallback_reason,
+                final_content=final_content,
+                final_structured=None,
+                delta_operations=delta_operations,
+                outcome="refresh_failed_no_memories_found",
             )
 
         # Refuse to write a delta-window candidate as the whole document (#3112).
@@ -13401,6 +13440,18 @@ class MemoryEngine(MemoryEngineInterface):
                 """
                 logger.warning(f"[MENTAL_MODELS] Refresh for {mental_model_id} failed ({reason}); {detail}")
                 reflect_response_payload["refresh_skipped"] = reason
+                # Keep the STORED based_on rather than this run's. Content is preserved
+                # on every path through here, so the stored grounding is what actually
+                # describes the stored document — and the ``no_memories_found`` guard
+                # reads it back as ``prior_grounding_count``. Overwriting it with a run
+                # that retrieved nothing would zero out the guard's own precondition, so
+                # it would hold for exactly one refresh (cycle N preserves the document
+                # but persists an empty based_on; cycle N+1 sees a prior count of 0 and
+                # writes the refusal). Everything else on the payload — trace, delta
+                # operations — describes the failed run and is kept for the audit.
+                prior_based_on = (mental_model.get("reflect_response") or {}).get("based_on")
+                if prior_based_on is not None:
+                    reflect_response_payload["based_on"] = prior_based_on
                 await self.update_mental_model(
                     bank_id,
                     mental_model_id,
@@ -13417,6 +13468,13 @@ class MemoryEngine(MemoryEngineInterface):
                 await _preserve_and_fail(
                     "empty_candidate",
                     "the refresh produced empty content (likely an upstream LLM failure).",
+                )
+
+            if run.outcome == "refresh_failed_no_memories_found":
+                await _preserve_and_fail(
+                    "no_memories_found",
+                    "reflect retrieved no memories for a model that was grounded in them before, so the "
+                    "answer is ungrounded and writing it would replace a good document with a refusal.",
                 )
 
             if run.outcome == "refresh_failed_delta_not_applied":

--- a/hindsight-api-slim/hindsight_api/engine/mental_model_refresh.py
+++ b/hindsight-api-slim/hindsight_api/engine/mental_model_refresh.py
@@ -38,6 +38,7 @@ RefreshOutcome = Literal[
     "content_written",
     "content_preserved_no_new_facts",
     "refresh_failed_empty_candidate",
+    "refresh_failed_no_memories_found",
     "refresh_failed_delta_not_applied",
 ]
 

--- a/hindsight-api-slim/tests/test_mental_model_delta.py
+++ b/hindsight-api-slim/tests/test_mental_model_delta.py
@@ -33,20 +33,21 @@ from hindsight_api.engine.response_models import ReflectResult
 from hindsight_api.engine.retain import embedding_utils
 
 
-def _canned_reflect_result(text: str, facts: list[dict] | None = None) -> ReflectResult:
+def _canned_reflect_result(
+    text: str,
+    facts: list[dict] | None = None,
+    based_on: dict[str, list[dict]] | None = None,
+) -> ReflectResult:
     """Build a minimal ReflectResult for monkey-patching reflect_async."""
-    return ReflectResult.model_validate(
-        {
-            "text": text,
-            "based_on": {
-                "observation": facts or [],
-                "world": [],
-                "experience": [],
-                "mental-models": [],
-                "directives": [],
-            },
+    if based_on is None:
+        based_on = {
+            "observation": facts or [],
+            "world": [],
+            "experience": [],
+            "mental-models": [],
+            "directives": [],
         }
-    )
+    return ReflectResult.model_validate({"text": text, "based_on": based_on})
 
 
 @pytest.fixture
@@ -59,12 +60,18 @@ def patch_reflect(monkeypatch):
         assert len(calls) == 1
     """
 
-    def _install(memory: MemoryEngine, *, text: str, facts: list[dict] | None = None):
+    def _install(
+        memory: MemoryEngine,
+        *,
+        text: str,
+        facts: list[dict] | None = None,
+        based_on: dict[str, list[dict]] | None = None,
+    ):
         calls: list[dict] = []
 
         async def fake_reflect_async(**kwargs):
             calls.append(kwargs)
-            return _canned_reflect_result(text, facts)
+            return _canned_reflect_result(text, facts, based_on)
 
         monkeypatch.setattr(memory, "reflect_async", fake_reflect_async)
         return calls
@@ -1297,6 +1304,276 @@ class TestDeltaRefreshPlumbing:
         )
         rr = preserved.get("reflect_response") or {}
         assert rr.get("refresh_skipped") == "empty_candidate"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    # ------------------------------------------------------------------
+    # #2894 — empty based_on must not overwrite existing content with a
+    # non-empty generic LLM refusal ("I don't have information…").
+    # ------------------------------------------------------------------
+
+    _GENERIC_NO_INFO = "I don't have information about this topic."
+    _DIRECTIVES_ONLY: dict[str, list[dict]] = {
+        "observation": [],
+        "world": [],
+        "experience": [],
+        "mental-models": [],
+        "directives": [
+            {
+                "id": "dir-1",
+                "text": "Always be concise",
+                "type": "directives",
+                "context": None,
+            }
+        ],
+    }
+    _MENTAL_MODELS_ONLY: dict[str, list[dict]] = {
+        "observation": [],
+        "world": [],
+        "experience": [],
+        "mental-models": [
+            {
+                "id": "mm-1",
+                "text": "Related model content about the team",
+                "type": "mental-models",
+                "context": None,
+            }
+        ],
+        "directives": [],
+    }
+
+    _GROUNDED_FACT = {"id": "obs-1", "text": "Alice is the lead", "type": "observation", "context": None}
+    _GROUNDED_CONTENT = "# Team\n\nAlice is the lead.\n"
+
+    @pytest.mark.parametrize(
+        "case,based_on,facts,prior_grounded,expect_skip",
+        [
+            ("no_facts", None, [], True, True),
+            ("directives_only", _DIRECTIVES_ONLY, None, True, True),
+            ("mental_models_only", _MENTAL_MODELS_ONLY, None, True, False),
+            ("never_grounded", None, [], False, False),
+        ],
+        ids=["no_facts", "directives_only", "mental_models_only", "never_grounded"],
+    )
+    async def test_full_refresh_empty_based_on_preserves_content(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+        case: str,
+        based_on: dict[str, list[dict]] | None,
+        facts: list[dict] | None,
+        prior_grounded: bool,
+        expect_skip: bool,
+    ):
+        """#2894: once a model's content came from retrieval, a later refresh that
+        retrieves nothing must not replace it with the agent's generic refusal.
+
+        Directives are bank-config injection, not retrieval evidence, so they don't
+        count as grounding; mental-models do. A model that was never grounded (seed
+        content only) is still freely replaceable — that is what the first refresh
+        is for.
+        """
+        from hindsight_api.engine.memory_engine import MentalModelRefreshError
+
+        bank_id = f"test-empty-based-on-{case}-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        seed = "# Team\n\nSeed content.\n"
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Team Info",
+            source_query="Tell me about the team",
+            content=seed,
+            # no trigger.mode → full mode (default)
+            request_context=request_context,
+        )
+
+        expected_preserved = seed
+        if prior_grounded:
+            # Refresh #1 is grounded in a real memory: this is what makes the
+            # content worth protecting when retrieval later returns nothing.
+            patch_reflect(memory, text=self._GROUNDED_CONTENT, facts=[self._GROUNDED_FACT])
+            first = await memory.refresh_mental_model(
+                bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+            )
+            assert first is not None
+            assert first["content"] == self._GROUNDED_CONTENT
+            expected_preserved = self._GROUNDED_CONTENT
+
+        # Refresh #2: retrieval comes back empty and the agent answers from the
+        # prompt alone with a non-empty refusal.
+        patch_reflect(memory, text=self._GENERIC_NO_INFO, facts=facts, based_on=based_on)
+
+        if expect_skip:
+            with pytest.raises(MentalModelRefreshError):
+                await memory.refresh_mental_model(
+                    bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+                )
+            preserved = await memory.get_mental_model(
+                bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+            )
+            assert preserved is not None
+            assert preserved["content"] == expected_preserved, (
+                f"case={case}: ungrounded refresh overwrote grounded content with a generic refusal"
+            )
+            rr = preserved.get("reflect_response") or {}
+            assert rr.get("refresh_skipped") == "no_memories_found"
+        else:
+            refreshed = await memory.refresh_mental_model(
+                bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+            )
+            assert refreshed is not None
+            assert refreshed["content"] == self._GENERIC_NO_INFO, f"case={case}: refresh should have written"
+            assert (refreshed.get("reflect_response") or {}).get("refresh_skipped") != "no_memories_found"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_full_refresh_guard_survives_consecutive_skips(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+    ):
+        """#2894: the guard must hold on every repeat, not just the first one.
+
+        The skip path persists reflect_response, so a guard keyed on the previously
+        stored grounding count zeroes out its own precondition: skip #1 writes an
+        empty based_on, and skip #2 reads a prior count of 0 and lets the refusal
+        through. Worker-driven refreshes retry, so the window between the two is
+        just the retry interval. Full mode only — delta re-accumulates based_on and
+        never showed the bug, which is exactly why one cycle looked correct.
+        """
+        from hindsight_api.engine.memory_engine import MentalModelRefreshError
+
+        bank_id = f"test-guard-repeat-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Team Info",
+            source_query="Tell me about the team",
+            content="# Team\n\nSeed content.\n",
+            # no trigger.mode → full mode (default)
+            request_context=request_context,
+        )
+
+        patch_reflect(memory, text=self._GROUNDED_CONTENT, facts=[self._GROUNDED_FACT])
+        first = await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        assert first is not None
+        assert first["content"] == self._GROUNDED_CONTENT
+
+        patch_reflect(memory, text=self._GENERIC_NO_INFO, facts=[])
+
+        for cycle in (1, 2, 3):
+            with pytest.raises(MentalModelRefreshError):
+                await memory.refresh_mental_model(
+                    bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+                )
+            preserved = await memory.get_mental_model(
+                bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+            )
+            assert preserved is not None
+            assert preserved["content"] == self._GROUNDED_CONTENT, (
+                f"cycle {cycle}: guard stopped holding and the refusal overwrote the document"
+            )
+            rr = preserved.get("reflect_response") or {}
+            assert rr.get("refresh_skipped") == "no_memories_found", (
+                f"cycle {cycle}: the skip was not recorded, so the failure is unauditable"
+            )
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_full_refresh_empty_based_on_pending_baseline_still_writes(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+    ):
+        """#2894: a previously-grounded model whose content was reset to the pending
+        placeholder has nothing to protect — the guard must not strand it as an
+        un-refreshable model forever.
+        """
+        from hindsight_api.engine.memory_engine import MENTAL_MODEL_PENDING_CONTENT
+
+        bank_id = f"test-empty-based-on-pending-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Team Info",
+            source_query="Tell me about the team",
+            content="# Team\n\nSeed content.\n",
+            request_context=request_context,
+        )
+
+        # Grounded refresh, then content reset to the placeholder: what makes the
+        # model refreshable again is the placeholder in the content column.
+        patch_reflect(memory, text=self._GROUNDED_CONTENT, facts=[self._GROUNDED_FACT])
+        await memory.refresh_mental_model(bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context)
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            content=MENTAL_MODEL_PENDING_CONTENT,
+            request_context=request_context,
+        )
+
+        patch_reflect(memory, text=self._GENERIC_NO_INFO, facts=[])
+
+        refreshed = await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        assert refreshed is not None
+        assert refreshed["content"] == self._GENERIC_NO_INFO
+        assert (refreshed.get("reflect_response") or {}).get("refresh_skipped") != "no_memories_found"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_delta_directives_only_skips_as_no_new_facts(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+        monkeypatch,
+    ):
+        """#2894 Test D: delta mode with directives-only based_on must treat
+        grounding as empty (directives are not retrieval) → no_new_facts early
+        return; content preserved; delta LLM never called.
+        """
+        bank_id = f"test-empty-based-on-delta-dir-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        existing = "# Team\n\nAlice is the lead.\n\n## Members\n\n- Alice\n"
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Team Info",
+            source_query="Tell me about the team",
+            content=existing,
+            trigger={"mode": "delta"},
+            request_context=request_context,
+        )
+
+        patch_reflect(
+            memory,
+            text=self._GENERIC_NO_INFO,
+            based_on=self._DIRECTIVES_ONLY,
+        )
+
+        async def boom(*, messages, **kwargs):
+            raise RuntimeError("delta LLM must not be called for directives-only based_on")
+
+        monkeypatch.setattr(memory._reflect_llm_config, "call", boom)
+
+        refreshed = await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        assert refreshed is not None
+        assert refreshed["content"] == existing
+        rr = refreshed.get("reflect_response") or {}
+        assert rr.get("delta_skipped_reason") == "no_new_facts"
+        assert rr.get("delta_applied") is False
 
         await memory.delete_bank(bank_id, request_context=request_context)
 

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -2231,6 +2231,71 @@ class TestMentalModelRefreshMaxTokens:
             f"to reflect_async, but got max_tokens={kwargs.get('max_tokens')!r}"
         )
 
+    async def test_refresh_real_baseline_empty_based_on_never_writes_content(self, request_context):
+        """#2894: with a real baseline and zero retrieved facts, refresh must raise
+        and must not pass ``content`` to update_mental_model.
+
+        This is the negative case of the test above: that one uses the pending
+        placeholder precisely because a *real* baseline is protected here. Asserting
+        on the update_mental_model kwargs pins the "audit but don't overwrite"
+        contract directly, which the DB-backed tests can only observe indirectly.
+        """
+        from datetime import datetime, timezone
+        from unittest.mock import AsyncMock
+
+        from hindsight_api.engine.memory_engine import MemoryEngine, MentalModelRefreshError
+        from hindsight_api.engine.response_models import ReflectResult
+
+        existing = "Alice is a frontend engineer specializing in React"
+        mental_model = {
+            "id": "mm-1",
+            "bank_id": "bank-1",
+            "name": "Real Baseline Model",
+            "source_query": "Summarize the facts",
+            "content": existing,
+            "tags": None,
+            "max_tokens": None,
+            "trigger": {"refresh_after_consolidation": False},
+            # The previous refresh WAS grounded — that is what makes the retrieval
+            # dropping to zero a regression rather than a never-grounded model.
+            "reflect_response": {
+                "based_on": {
+                    "observation": [{"id": "f-1", "text": "Alice works in React", "type": "observation"}],
+                    "directives": [],
+                }
+            },
+        }
+
+        engine = MemoryEngine.__new__(MemoryEngine)
+        engine._authenticate_tenant = AsyncMock(return_value=None)  # type: ignore[method-assign]
+        engine.get_mental_model = AsyncMock(return_value=mental_model)  # type: ignore[method-assign]
+        # Non-empty generic refusal + empty based_on: exactly the #2894 shape that
+        # slipped past the empty-candidate check and clobbered good content.
+        engine.reflect_async = AsyncMock(  # type: ignore[method-assign]
+            return_value=ReflectResult(text="I don't have information about this topic.", based_on={})
+        )
+        engine.update_mental_model = AsyncMock(return_value=mental_model)  # type: ignore[method-assign]
+        engine._mental_model_refresh_cutoff = AsyncMock(  # type: ignore[method-assign]
+            return_value=datetime(2026, 1, 1, tzinfo=timezone.utc)
+        )
+        engine._mental_model_processed_watermark = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+        with pytest.raises(MentalModelRefreshError):
+            await engine.refresh_mental_model(
+                bank_id="bank-1",
+                mental_model_id="mm-1",
+                request_context=request_context,
+            )
+
+        assert engine.update_mental_model.await_count == 1
+        update_kwargs = engine.update_mental_model.await_args.kwargs
+        assert "content" not in update_kwargs, (
+            "refresh must not write content when reflect retrieved no memories; "
+            f"got content={update_kwargs.get('content')!r}"
+        )
+        assert "structured_content" not in update_kwargs
+        assert update_kwargs["reflect_response"]["refresh_skipped"] == "no_memories_found"
+
     async def test_refresh_content_respects_max_tokens(self, memory: MemoryEngine, request_context):
         """End-to-end: refreshed content must stay within the model's max_tokens cap.
 

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -7992,6 +7992,7 @@ components:
           - content_written
           - content_preserved_no_new_facts
           - refresh_failed_empty_candidate
+          - refresh_failed_no_memories_found
           - refresh_failed_delta_not_applied
           title: Outcome
           type: string
@@ -8264,6 +8265,7 @@ components:
           - content_written
           - content_preserved_no_new_facts
           - refresh_failed_empty_candidate
+          - refresh_failed_no_memories_found
           - refresh_failed_delta_not_applied
           title: Outcome
           type: string

--- a/hindsight-clients/python/hindsight_client_api/models/mental_model_dry_run_refresh_result.py
+++ b/hindsight-clients/python/hindsight_client_api/models/mental_model_dry_run_refresh_result.py
@@ -81,8 +81,8 @@ class MentalModelDryRunRefreshResult(BaseModel):
     @field_validator('outcome')
     def outcome_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['content_written', 'content_preserved_no_new_facts', 'refresh_failed_empty_candidate', 'refresh_failed_delta_not_applied']):
-            raise ValueError("must be one of enum values ('content_written', 'content_preserved_no_new_facts', 'refresh_failed_empty_candidate', 'refresh_failed_delta_not_applied')")
+        if value not in set(['content_written', 'content_preserved_no_new_facts', 'refresh_failed_empty_candidate', 'refresh_failed_no_memories_found', 'refresh_failed_delta_not_applied']):
+            raise ValueError("must be one of enum values ('content_written', 'content_preserved_no_new_facts', 'refresh_failed_empty_candidate', 'refresh_failed_no_memories_found', 'refresh_failed_delta_not_applied')")
         return value
 
     model_config = ConfigDict(

--- a/hindsight-clients/python/hindsight_client_api/models/mental_model_refresh_trace.py
+++ b/hindsight-clients/python/hindsight_client_api/models/mental_model_refresh_trace.py
@@ -63,8 +63,8 @@ class MentalModelRefreshTrace(BaseModel):
     @field_validator('outcome')
     def outcome_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['content_written', 'content_preserved_no_new_facts', 'refresh_failed_empty_candidate', 'refresh_failed_delta_not_applied']):
-            raise ValueError("must be one of enum values ('content_written', 'content_preserved_no_new_facts', 'refresh_failed_empty_candidate', 'refresh_failed_delta_not_applied')")
+        if value not in set(['content_written', 'content_preserved_no_new_facts', 'refresh_failed_empty_candidate', 'refresh_failed_no_memories_found', 'refresh_failed_delta_not_applied']):
+            raise ValueError("must be one of enum values ('content_written', 'content_preserved_no_new_facts', 'refresh_failed_empty_candidate', 'refresh_failed_no_memories_found', 'refresh_failed_delta_not_applied')")
         return value
 
     model_config = ConfigDict(

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -3119,6 +3119,7 @@ export type MentalModelDryRunRefreshResult = {
     | "content_written"
     | "content_preserved_no_new_facts"
     | "refresh_failed_empty_candidate"
+    | "refresh_failed_no_memories_found"
     | "refresh_failed_delta_not_applied";
   /**
    * Would Persist
@@ -3333,6 +3334,7 @@ export type MentalModelRefreshTrace = {
     | "content_written"
     | "content_preserved_no_new_facts"
     | "refresh_failed_empty_candidate"
+    | "refresh_failed_no_memories_found"
     | "refresh_failed_delta_not_applied";
   /**
    * Tool Calls

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -11841,6 +11841,7 @@
               "content_written",
               "content_preserved_no_new_facts",
               "refresh_failed_empty_candidate",
+              "refresh_failed_no_memories_found",
               "refresh_failed_delta_not_applied"
             ],
             "title": "Outcome",
@@ -12150,6 +12151,7 @@
               "content_written",
               "content_preserved_no_new_facts",
               "refresh_failed_empty_candidate",
+              "refresh_failed_no_memories_found",
               "refresh_failed_delta_not_applied"
             ],
             "title": "Outcome",

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -11841,6 +11841,7 @@
               "content_written",
               "content_preserved_no_new_facts",
               "refresh_failed_empty_candidate",
+              "refresh_failed_no_memories_found",
               "refresh_failed_delta_not_applied"
             ],
             "title": "Outcome",
@@ -12150,6 +12151,7 @@
               "content_written",
               "content_preserved_no_new_facts",
               "refresh_failed_empty_candidate",
+              "refresh_failed_no_memories_found",
               "refresh_failed_delta_not_applied"
             ],
             "title": "Outcome",


### PR DESCRIPTION
## Problem

`refresh_mental_model` refuses to write only when the rendered content is empty:

```python
if not final_content.strip():
```

A reflect run that retrieves nothing does not produce an empty answer. The agent
answers from the prompt alone, with a non-empty generic refusal along the lines of
"I don't have information about that", which passes that check and replaces a good
mental model with garbage. In delta mode it is worse than a one-off: the refusal
text becomes the baseline the next refresh builds on.

The existing `no_new_facts` skip does not cover this. It is gated on
`use_delta and current_doc is not None`, so full mode has no protection at all,
and full is the default.

Fixes vectorize-io/hindsight#2894

## Fix

Count the grounding reflect actually retrieved, from `based_on`, before the delta
merge folds the previous `based_on` into the payload. Directives are excluded from
that count: they are bank-config injection, not retrieval evidence, so a
`based_on` carrying only directives is not grounding.

The guard fires only when retrieval regressed:

```python
fresh_grounding_count == 0 and prior_grounding_count > 0 and has_delta_baseline
```

`prior_grounding_count > 0` matters. A model that has never been grounded (fresh
seed content, no prior `reflect_response`) has nothing to lose, so its first
refresh still writes normally. Only a model that had grounding and now has none is
protected.

On that path the previous content and structured payload are left untouched, the
failure is recorded as `reflect_response.refresh_skipped = 'no_memories_found'`
alongside the source-query tracking, and `MentalModelRefreshError` is raised.

The same counter also replaces `not supporting_facts` in the delta no-new-facts
skip, which until now let directives alone count as new evidence.

## What this is and is not

This is defense in depth against an empty recall from any cause. It is not a fix
for the consolidation or embedding-index race the reporter suspected. Sanderhoff-alt
could not reproduce that race: he dropped all three bank HNSW indexes and held
ACCESS EXCLUSIVE on `memory_units`, and the overwrite never happened. He did
confirm the defensive gap itself, via a mismatched strict tag scope. PR #2997 was
closed as not reproducible for claiming the former, so this claims only the latter.

#2959 covers a sibling case, the `"No answer provided."` placeholder taking the
same path. That is deliberately not touched here; PR #2960 owns it, and keeping
the two apart keeps both diffs composable.

## Behaviour change worth flagging

Refreshes that previously "succeeded" while writing a refusal will now raise and
surface as failed operations. That is the point, but it is visible: bank operators
who were silently accumulating garbage documents will start seeing failures
instead. The alternative, returning the previous content quietly, would hide
upstream retrieval failures from workers and tests.

Only one internal caller is affected, `_handle_refresh_mental_model` via
`execute_task`. The HTTP route enqueues and returns an operation id, so the new
raise cannot become a user-facing 500.

Merged PR #3078 named this issue as a blocker on widening auto-refresh to
strict-tagged models.

## Test evidence

| Check | Result |
|---|---|
| mental-model suite, `-n0 -m "not hs_llm_core"` | 95 passed, 12 deselected, 111s |

The 12 deselected are `hs_llm_core` tests, which CI runs in its own core-LLM job.

New cases are deterministic (MockLLM and monkeypatch, no judge), parametrized over
empty `based_on` with existing content, `based_on` carrying only directives, a
never-grounded model whose first refresh must still write, and delta versus full
mode.
