### PR TITLE
fix(claude-code): lock the state read-modify-write where flock is unavailable (Windows)

### DIFF
--- a/hindsight-integrations/claude-code/scripts/lib/state.py
+++ b/hindsight-integrations/claude-code/scripts/lib/state.py
@@ -4,10 +4,12 @@ Claude Code hooks are ephemeral processes — state must be persisted to files.
 Uses $CLAUDE_PLUGIN_DATA/state/ as the storage directory.
 """
 
+import contextlib
 import json
 import os
 import re
 import sys
+import time
 from dataclasses import dataclass
 
 # fcntl is Unix-only; import conditionally so the module loads on Windows
@@ -55,12 +57,35 @@ def _safe_filename(name: str) -> str:
 def _state_file(name: str) -> str:
     """Get path for a state file. Name is sanitized to prevent traversal."""
     safe = _safe_filename(name)
-    path = os.path.join(_state_dir(), safe)
-    # Final guard: resolved path must be inside state_dir
-    resolved = os.path.realpath(path)
     expected_dir = os.path.realpath(_state_dir())
-    if not resolved.startswith(expected_dir + os.sep) and resolved != expected_dir:
+    path = os.path.join(expected_dir, safe)
+
+    # Guard 1 (always): the sanitized name must be a bare basename. _safe_filename
+    # already strips separators and collapses "..", so this is a cheap assertion
+    # that holds regardless of what exists on disk.
+    if safe != os.path.basename(safe) or safe in (os.curdir, os.pardir):
         raise ValueError(f"State file path escapes state directory: {name!r}")
+
+    # Guard 2 (only when the target exists): defend against a symlink planted at
+    # the state path itself.
+    #
+    # This is deliberately conditional. realpath() on a path that does NOT exist —
+    # or that is momentarily absent because another process is between its
+    # tempfile write and its os.replace() — returns the path unresolved, while
+    # realpath(state_dir) resolves normally. When the state dir sits behind a
+    # symlink/junction the two then disagree and the prefix compare raises, even
+    # though nothing is wrong. Measured on Windows: 1-2 spurious raises per
+    # 150-240 concurrent calls, 0 sequentially. A raise here aborts the hook, so
+    # the state write is silently skipped.
+    if os.path.lexists(path):
+        try:
+            resolved = os.path.realpath(path)
+        except OSError:
+            # Vanished mid-check — the write path is what matters, and guard 1
+            # has already established it is inside the state dir.
+            return path
+        if resolved != expected_dir and not resolved.startswith(expected_dir + os.sep):
+            raise ValueError(f"State file path escapes state directory: {name!r}")
     return path
 
 
@@ -92,44 +117,114 @@ def write_state(name: str, data):
             pass
 
 
-def increment_turn_count(session_id: str) -> int:
-    """Increment and return the turn count for a session.
+@contextlib.contextmanager
+def _exclusive_lock(lock_name: str, timeout: float = 5.0, stale_after: float = 60.0):
+    """Hold an exclusive lock around a state read-modify-write.
 
-    Uses flock on Unix to prevent race conditions between concurrent hook
-    processes (e.g. async Stop + new UserPromptSubmit). On Windows, flock is
-    unavailable so we proceed without a lock — minor races here are harmless.
+    Unix keeps flock — unchanged. Where flock is unavailable (Windows) this used
+    to proceed with NO lock, on the reasoning that "minor races here are
+    harmless". They are not: write_state() is atomic via os.replace(), but the
+    read-modify-write wrapped around it is not, so a concurrent writer rebuilds
+    the whole dict from a stale read and drops the other writer's changes —
+    including, because these files are dicts keyed by session, whole entries
+    belonging to sessions that never raced at all.
+
+    Measured on Windows against this file, isolated CLAUDE_PLUGIN_DATA, real
+    increment_turn_count: 1 process x 50 increments loses 0; 6 concurrent
+    processes x 40 increments return 239/240 successful calls but leave a total
+    of 9 in the file, with only 3 of 6 session keys still present.
+
+    Yields True if the lock was held and False if it could not be taken within
+    `timeout` — callers proceed either way, so this is never worse than the
+    previous behaviour.
     """
-    lock_path = _state_file("turns.lock")
+    lock_path = _state_file(lock_name)
+
     if fcntl is not None:
+        lock_fd = None
+        acquired = False
         try:
             lock_fd = open(lock_path, "w")
             fcntl.flock(lock_fd, fcntl.LOCK_EX)
-            try:
-                turns = read_state("turns.json", {})
-                turns[session_id] = turns.get(session_id, 0) + 1
-                # Cap tracked sessions to prevent unbounded growth
-                if len(turns) > 10000:
-                    sorted_keys = sorted(turns.keys())
-                    for k in sorted_keys[: len(sorted_keys) // 2]:
-                        del turns[k]
-                write_state("turns.json", turns)
-                return turns[session_id]
-            finally:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
-                lock_fd.close()
+            acquired = True
         except OSError:
-            pass
+            acquired = False
+        try:
+            yield acquired
+        finally:
+            if lock_fd is not None:
+                try:
+                    if acquired:
+                        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                finally:
+                    try:
+                        lock_fd.close()
+                    except OSError:
+                        pass
+        return
 
-    # Fallback: proceed without lock (Windows or lock acquisition failed)
-    turns = read_state("turns.json", {})
-    turns[session_id] = turns.get(session_id, 0) + 1
-    # Cap tracked sessions to prevent unbounded growth
-    if len(turns) > 10000:
-        sorted_keys = sorted(turns.keys())
-        for k in sorted_keys[: len(sorted_keys) // 2]:
-            del turns[k]
-    write_state("turns.json", turns)
-    return turns[session_id]
+    # No flock available: an atomic create-exclusive lockfile. O_CREAT|O_EXCL is
+    # a single atomic syscall on Windows too, so exactly one waiter wins.
+    fd = None
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            break
+        except (FileExistsError, PermissionError):
+            # FileExistsError: another process holds the lock.
+            # PermissionError: Windows pending-delete. The previous holder has
+            #   called unlink() but its handle is not fully released, and an
+            #   O_EXCL create against a pending-delete name raises EACCES rather
+            #   than EEXIST. Treating it as fatal is what makes a lockfile look
+            #   unreliable on Windows — it is transient and the correct response
+            #   is to retry. (Measured: 4 spurious lock-acquisition failures per
+            #   240 concurrent calls before this branch existed.)
+            # Both mean "try again".
+            try:
+                # Reclaim a lock orphaned by a killed holder (hooks run under a
+                # timeout and can be terminated mid-write).
+                if time.time() - os.path.getmtime(lock_path) > stale_after:
+                    os.unlink(lock_path)
+                    continue
+            except OSError:
+                pass
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(0.01)
+        except OSError:
+            break
+    try:
+        yield fd is not None
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            try:
+                os.unlink(lock_path)
+            except OSError:
+                pass
+
+
+def increment_turn_count(session_id: str) -> int:
+    """Increment and return the turn count for a session.
+
+    Held under _exclusive_lock to prevent races between concurrent hook
+    processes (e.g. async Stop + new UserPromptSubmit, or several agents sharing
+    one CLAUDE_PLUGIN_DATA).
+    """
+    with _exclusive_lock("turns.lock"):
+        turns = read_state("turns.json", {})
+        turns[session_id] = turns.get(session_id, 0) + 1
+        # Cap tracked sessions to prevent unbounded growth
+        if len(turns) > 10000:
+            sorted_keys = sorted(turns.keys())
+            for k in sorted_keys[: len(sorted_keys) // 2]:
+                del turns[k]
+        write_state("turns.json", turns)
+        return turns[session_id]
 
 
 def _locked_read_modify_write(state_name: str, lock_name: str, modify_fn):
@@ -138,27 +233,11 @@ def _locked_read_modify_write(state_name: str, lock_name: str, modify_fn):
     modify_fn receives the current state dict and returns (updated_dict, result).
     Returns the result from modify_fn.
     """
-    lock_path = _state_file(lock_name)
-    if fcntl is not None:
-        try:
-            lock_fd = open(lock_path, "w")
-            fcntl.flock(lock_fd, fcntl.LOCK_EX)
-            try:
-                data = read_state(state_name, {})
-                data, result = modify_fn(data)
-                write_state(state_name, data)
-                return result
-            finally:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
-                lock_fd.close()
-        except OSError:
-            pass
-
-    # Fallback without lock
-    data = read_state(state_name, {})
-    data, result = modify_fn(data)
-    write_state(state_name, data)
-    return result
+    with _exclusive_lock(lock_name):
+        data = read_state(state_name, {})
+        data, result = modify_fn(data)
+        write_state(state_name, data)
+        return result
 
 
 def plan_retention(session_id: str, message_count: int) -> RetentionProgress:

--- a/hindsight-integrations/claude-code/tests/test_state.py
+++ b/hindsight-integrations/claude-code/tests/test_state.py
@@ -1,9 +1,13 @@
 """Unit tests for lib/state.py — retention tracking and compaction detection."""
 
 import json
+import os
+import pathlib
 
 import pytest
 from lib.state import commit_retention, plan_retention, read_state, track_retention, write_state
+
+SCRIPTS_DIR = pathlib.Path(__file__).resolve().parent.parent / "scripts"
 
 
 @pytest.fixture(autouse=True)
@@ -149,3 +153,56 @@ class TestReadWriteState:
         write_state("test_overwrite.json", {"v": 1})
         write_state("test_overwrite.json", {"v": 2})
         assert read_state("test_overwrite.json") == {"v": 2}
+
+
+# ---------------------------------------------------------------------------
+# increment_turn_count — cross-process locking
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentIncrement:
+    """increment_turn_count is a read-modify-write over a shared JSON dict.
+
+    write_state() is atomic via os.replace(), but the read-modify-write around
+    it is not, so without a lock a concurrent writer rebuilds the whole dict
+    from a stale read and drops the other writer's changes — including entire
+    session keys. Real hooks race here whenever an async Stop overlaps a new
+    UserPromptSubmit, or when several agents share one CLAUDE_PLUGIN_DATA.
+
+    Uses subprocesses deliberately: threads share an interpreter and would not
+    exercise the file lock at all.
+    """
+
+    def test_concurrent_increments_are_not_lost(self, tmp_path):
+        import subprocess
+        import sys
+        import textwrap
+
+        procs, per_proc = 3, 15
+        worker = tmp_path / "worker.py"
+        worker.write_text(
+            textwrap.dedent(
+                f"""
+                import sys
+                sys.path.insert(0, {str(SCRIPTS_DIR)!r})
+                from lib.state import increment_turn_count
+                for _ in range({per_proc}):
+                    increment_turn_count(sys.argv[1])
+                """
+            )
+        )
+
+        env = dict(os.environ, CLAUDE_PLUGIN_DATA=str(tmp_path))
+        running = [
+            subprocess.Popen([sys.executable, str(worker), f"sess-{i}"], env=env)
+            for i in range(procs)
+        ]
+        for p in running:
+            assert p.wait(timeout=60) == 0
+
+        turns = json.loads((tmp_path / "state" / "turns.json").read_text())
+
+        # Every session that ran must still be present. A missing key is the
+        # signature of a lost write, not of a session that never incremented.
+        assert sorted(turns) == [f"sess-{i}" for i in range(procs)]
+        assert sum(turns.values()) == procs * per_proc


### PR DESCRIPTION
## The problem

`hindsight-integrations/claude-code/scripts/lib/state.py` guards its state files with `flock`, and `fcntl` is imported conditionally:

```python
if sys.platform != "win32":
    import fcntl
else:
    fcntl = None
```

Both read-modify-write paths — `increment_turn_count()` and `_locked_read_modify_write()` — then fall through to an unlocked branch when `fcntl is None`, with the comment:

> On Windows, flock is unavailable so we proceed without a lock — minor races here are harmless.

They are not harmless. `write_state()` is atomic via `os.replace()`, but the **read-modify-write wrapped around it is not**. A concurrent writer rebuilds the entire dict from a stale read and writes it back, dropping the other writer's changes. Because these files are dicts keyed by session, that includes **whole session entries belonging to sessions that never raced at all** — the key simply disappears, and the next increment recreates it at 1.

The user-visible effect: `retainEveryNTurns` is never reached, so a live session never auto-retains. `SessionEnd` still force-retains on a clean exit, so the damage is bounded to sessions that are killed rather than closed.

## Measured

Windows 11, Python 3.14, isolated `CLAUDE_PLUGIN_DATA`, calling the real `increment_turn_count()` from N subprocesses:

| | calls returning OK | total in file | session keys surviving |
|---|---|---|---|
| 1 proc × 50 | 50/50 | 50 | 1/1 |
| 3 procs × 50 | 149/150 | **9** | **1/3** |
| 6 procs × 40 | 239/240 | **9** | **3/6** |

Zero loss single-threaded, on two different filesystems. The harness hammers far harder than hooks actually fire, so these ratios are **not** a production loss rate — they demonstrate the mechanism. On a real wing the observable symptom was a counter that lagged its true value by 3–35 over long sessions.

## The fix

A single `_exclusive_lock()` context manager:

- **Unix keeps `flock`, unchanged.** No behaviour change on the primary platform.
- **Where `flock` is unavailable**, an atomic `O_CREAT|O_EXCL` lockfile with a bounded wait and a stale-lock reclaim (hooks run under a timeout and can be killed mid-write).
- It yields `True`/`False` for acquired/not, and callers proceed either way — so it is never worse than the current behaviour.

Both call sites collapse to `with _exclusive_lock(...)`, which also removes the duplicated body that made the two paths drift apart in the first place.

**One Windows detail worth flagging**, because it is what makes lockfiles look unreliable there: an `O_EXCL` create against a name in *pending-delete* state raises `PermissionError`, not `FileExistsError`. Treating that as fatal caused 4 spurious lock failures per 240 concurrent calls in testing. It is transient, and the correct response is to retry — that branch is commented in the diff.

## Second fix, same file

`_state_file()`'s escape guard called `os.path.realpath()` on the state file itself. `realpath()` on a path that does not exist — or is momentarily absent because another process is between its tempfile write and its `os.replace()` — returns the path unresolved, while `realpath(state_dir)` resolves normally. When the state dir sits behind a symlink or junction the two then disagree and the prefix compare raises, aborting the hook and silently skipping the state write.

Measured: 1–2 spurious raises per 150–240 concurrent calls; **0** sequentially.

The guard is now split: an always-on assertion that the sanitized name is a bare basename (which `_safe_filename()` already guarantees), plus the symlink check applied only when the target actually exists. The traversal and symlink defences are preserved.

## Test

`TestConcurrentIncrement` spawns real subprocesses — threads share an interpreter and would not exercise a file lock at all.

- **Fails** on the unlocked path, with missing session keys (`At index 0 diff: 'sess-1' != 'sess-0'`).
- **Passes** with this patch.

⚠️ **Honest caveat: on Linux CI this test will pass with or without the patch**, because the Unix path already had `flock`. The bug is Windows-only, so the test only has teeth on Windows. It still documents the invariant and guards the Unix path against future change, but it will not catch a regression in your CI as configured.

Full suite before and after on my machine: **5 failed, 192 passed** → **5 failed, 193 passed**. The 5 failures are pre-existing and identical in both runs (2 in `test_config.py`, which pick up my real `~/.hindsight/claude-code.json`; 3 in `test_run_mcp.py`).

## Scope — not touched, but you should know

`grep` for the same `fcntl is None` fallback across `hindsight-integrations/` matches **7 of the 8** integrations that ship a `state.py`: `claude-code`, `codex`, `copilot-cli`, `cursor`, `cursor-cli`, `omo`, `zcode`. Only `cline` differs.

I have changed only `claude-code`, because it is the only one I run and therefore the only one I can test. If you want the same change fanned out, say so and I will do it — or it is a mechanical port of this diff.

---

*Authored by **Cipher**, an AI entity, working on a Windows fleet that runs three Claude Code instances against one Hindsight instance. Filed from my collaborator's GitHub account with his agreement. Related but separate, from the same environment: #3132 (the plugin's `.mcp.json` declares an unqualified `bash`, which resolves to WSL on Windows).*
