### PR TITLE
fix(consolidation): drop invalid batch items instead of failing the whole batch

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -22,14 +22,15 @@ import time
 import uuid
 from collections import defaultdict
 from contextlib import AsyncExitStack
+from contextvars import ContextVar
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from fnmatch import fnmatchcase
 from itertools import combinations
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, get_args
 
 import asyncpg
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ValidationInfo, field_validator
 
 from ...config import get_config
 from ...worker.stage import set_stage
@@ -670,10 +671,61 @@ class _DeleteAction(BaseModel):
     reason: str = ""  # LLM's one-sentence justification (diagnostic only)
 
 
+# Label of the batch being consolidated, so the per-item drop warning below can name it.
+# That warning fires deep inside the provider's response parsing (llm_config.call ->
+# response_format.model_validate), where batch_label is not in scope.
+# ponytail: set, never reset. Each batch overwrites it before its own call and
+# concurrent batches get their own context copy (asyncio wraps them in Tasks), so the
+# worst case is a leaked label mislabelling a warning line.
+_batch_label_var: ContextVar[str] = ContextVar("consolidation_batch_label", default="unlabelled batch")
+
+
 class _ConsolidationBatchResponse(BaseModel):
     creates: list[_CreateAction] = []
     updates: list[_UpdateAction] = []
     deletes: list[_DeleteAction] = []
+
+    @field_validator("creates", "updates", "deletes", mode="before")
+    @classmethod
+    def drop_invalid_items(cls, v: Any, info: ValidationInfo) -> Any:
+        """Drop individual malformed actions instead of failing the whole batch (#3003).
+
+        One update missing `observation_id` used to raise ValidationError inside the
+        provider's response parsing, discarding every valid action in the same response
+        and spending the remaining attempts re-asking a model that answers the same way.
+
+        Dropping an update the LLM meant to make is real (bounded) loss — the observation
+        is not rewritten while its source facts are already marked consolidated — so each
+        drop warns rather than passing silently.
+
+        Non-list input passes through so a genuinely malformed response shape still
+        raises instead of becoming a silently empty list.
+        """
+        if not isinstance(v, list):
+            return v
+        # The item model comes off the field's own annotation, so the three declarations
+        # above stay the single source of truth instead of a name->model map that has to
+        # be kept in sync — and a subclass that redeclares one of them (see
+        # _build_response_model) filters against whatever it declares.
+        (item_model,) = get_args(cls.model_fields[info.field_name].annotation)
+        kept: list[BaseModel] = []
+        for item in v:
+            try:
+                kept.append(item_model.model_validate(item))
+            except Exception as exc:
+                # Not just ValidationError: the item models' own `sanitize_text`
+                # validator raises TypeError on a non-string `text` (e.g. `"text": 42`),
+                # and *any* exception escaping here is the same whole-batch failure
+                # this validator exists to prevent. If the item can't be built, it's
+                # unusable — drop it and say so.
+                logger.warning(
+                    "[CONSOLIDATION] %s: dropped malformed %s entry from the LLM response (entry: %.300r): %s",
+                    _batch_label_var.get(),
+                    info.field_name,
+                    item,
+                    exc,
+                )
+        return kept
 
 
 @dataclass
@@ -2653,6 +2705,9 @@ async def _consolidate_batch_with_llm(
     else:
         ids_label = f"{', '.join(memory_ids[:3])}, ... +{len(memory_ids) - 3} more"
     batch_label = f"{len(memory_ids)} memories [{ids_label}]"
+    # Read by _ConsolidationBatchResponse.drop_invalid_items, which runs inside the
+    # provider's response parsing where this label is otherwise unreachable.
+    _batch_label_var.set(batch_label)
     for attempt in range(1, max_attempts + 1):
         try:
             call_kwargs: dict[str, Any] = {

--- a/hindsight-api-slim/tests/test_consolidation.py
+++ b/hindsight-api-slim/tests/test_consolidation.py
@@ -2547,6 +2547,220 @@ class TestBuildResponseModel:
         assert len(result.creates) == expected_creates
 
 
+def _issue_3003_payload(**overrides) -> dict:
+    """The response shape from #3003: an UPDATE carrying only `text`.
+
+    `observation_id` and `source_fact_ids` are absent, which used to raise a
+    ValidationError for the whole response inside the provider's parsing.
+    """
+    payload = {
+        "creates": [{"text": "User is training for a marathon.", "source_fact_ids": ["fact-1"]}],
+        "updates": [{"text": "User moved from Lisbon to Berlin in March."}],
+        "deletes": [{"observation_id": "obs-stale"}],
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestDropInvalidBatchItems:
+    """#3003: one malformed action must not throw away the rest of the batch.
+
+    The validator runs inside the provider's `response_format.model_validate`, so a
+    ValidationError there escapes as an opaque batch failure — every valid create,
+    update and delete in the same response is lost and the retry budget is spent
+    re-asking a model that deterministically answers the same way.
+    """
+
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            pytest.param(_issue_3003_payload(), (1, 0, 1), id="bad-update-keeps-create-and-delete"),
+            pytest.param(
+                _issue_3003_payload(
+                    creates=[
+                        {"text": "obs one", "source_fact_ids": ["f1"]},
+                        {"text": "obs two", "source_fact_ids": ["f2"]},
+                    ]
+                ),
+                (2, 0, 1),
+                id="bad-update-plus-several-valid-creates",
+            ),
+            pytest.param(
+                _issue_3003_payload(updates=[{"text": "a"}, {"text": "b"}, {"observation_id": "o"}]),
+                (1, 0, 1),
+                id="all-updates-bad",
+            ),
+            pytest.param(
+                _issue_3003_payload(
+                    creates=[{"text": "no source ids"}],
+                    updates=[{"text": "t", "observation_id": "o1", "source_fact_ids": ["f1"]}],
+                ),
+                (0, 1, 1),
+                id="bad-create",
+            ),
+            pytest.param(
+                _issue_3003_payload(
+                    updates=[{"text": "t", "observation_id": "o1", "source_fact_ids": ["f1"]}],
+                    deletes=[{"reason": "forgot the id"}, {"observation_id": "obs-stale"}],
+                ),
+                (1, 1, 1),
+                id="bad-delete",
+            ),
+            pytest.param(
+                _issue_3003_payload(updates=[{"text": "t", "observation_id": "o1", "source_fact_ids": ["f1"]}]),
+                (1, 1, 1),
+                id="fully-valid-payload-untouched",
+            ),
+        ],
+    )
+    def test_malformed_items_dropped_valid_items_kept(self, payload: dict, expected: tuple[int, int, int]):
+        from hindsight_api.engine.consolidation.consolidator import _ConsolidationBatchResponse
+
+        result = _ConsolidationBatchResponse.model_validate(payload)
+        assert (len(result.creates), len(result.updates), len(result.deletes)) == expected
+
+    @pytest.mark.parametrize("bad_text", [42, ["a", "b"], {"value": "text"}, True], ids=["int", "list", "dict", "bool"])
+    def test_non_string_text_is_dropped_not_raised(self, bad_text):
+        """A wrong-typed `text` must be dropped like any other malformed entry.
+
+        `_CreateAction.sanitize_text` runs `re.sub` on the raw value, so a non-string
+        `text` raises TypeError — not ValidationError — and a filter that only caught
+        ValidationError would still let the whole batch die exactly as in #3003.
+        """
+        from hindsight_api.engine.consolidation.consolidator import _ConsolidationBatchResponse
+
+        result = _ConsolidationBatchResponse.model_validate(
+            _issue_3003_payload(
+                creates=[
+                    {"text": bad_text, "source_fact_ids": ["fact-1"]},
+                    {"text": "User is training for a marathon.", "source_fact_ids": ["fact-2"]},
+                ],
+                updates=[{"text": bad_text, "observation_id": "obs-1", "source_fact_ids": ["fact-3"]}],
+            )
+        )
+        assert [c.text for c in result.creates] == ["User is training for a marathon."]
+        assert result.updates == []
+        assert len(result.deletes) == 1
+
+    def test_valid_payload_round_trips_unchanged(self):
+        """No drop, no mutation: a clean response survives byte-identical."""
+        from hindsight_api.engine.consolidation.consolidator import _ConsolidationBatchResponse
+
+        payload = _issue_3003_payload(
+            updates=[
+                {
+                    "text": "User moved from Lisbon to Berlin in March.",
+                    "observation_id": "obs-1",
+                    "source_fact_ids": ["fact-2"],
+                    "reason": "new evidence",
+                }
+            ]
+        )
+        result = _ConsolidationBatchResponse.model_validate(payload)
+        assert result.creates[0].text == "User is training for a marathon."
+        assert result.creates[0].source_fact_ids == ["fact-1"]
+        assert result.updates[0].observation_id == "obs-1"
+        assert result.updates[0].source_fact_ids == ["fact-2"]
+        assert result.updates[0].reason == "new evidence"
+        assert result.deletes[0].observation_id == "obs-stale"
+
+    def test_drop_warns_with_batch_label_and_entry(self, caplog):
+        """The loss is visible: dropping an update the LLM intended is real (bounded)
+        semantic loss, so each drop must name the batch and the rejected entry."""
+        import logging
+
+        from hindsight_api.engine.consolidation.consolidator import (
+            _batch_label_var,
+            _ConsolidationBatchResponse,
+        )
+
+        token = _batch_label_var.set("2 memories [mem-a, mem-b]")
+        try:
+            with caplog.at_level(logging.WARNING, logger="hindsight_api.engine.consolidation.consolidator"):
+                _ConsolidationBatchResponse.model_validate(_issue_3003_payload())
+        finally:
+            _batch_label_var.reset(token)
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "2 memories [mem-a, mem-b]" in warnings[0].message
+        assert "Lisbon to Berlin" in warnings[0].message
+
+    def test_drop_outside_a_consolidation_batch_uses_the_default_label(self, caplog):
+        """Direct callers (tests, future call sites) must not blow up on an unset var.
+
+        Read in a pristine `Context()` so a label leaked by an earlier test cannot
+        make this pass by accident.
+        """
+        import contextvars
+        import logging
+
+        from hindsight_api.engine.consolidation.consolidator import (
+            _batch_label_var,
+            _ConsolidationBatchResponse,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="hindsight_api.engine.consolidation.consolidator"):
+            result = contextvars.Context().run(_ConsolidationBatchResponse.model_validate, _issue_3003_payload())
+
+        assert result.updates == []
+        assert contextvars.Context().run(_batch_label_var.get) in caplog.records[0].message
+
+    def test_constrained_subclass_filters_too(self):
+        """The Bedrock-constrained variant subclasses the base, so it inherits filtering."""
+        model = _build_response_model(5)
+        result = model.model_validate(_issue_3003_payload())
+        assert len(result.creates) == 1
+        assert result.updates == []
+
+    def test_emitted_schema_still_requires_all_action_fields(self):
+        """A before-validator must not relax the JSON schema — strict-schema and
+        response_schema providers grammar-enforce exactly these required fields."""
+        from hindsight_api.engine.consolidation.consolidator import _ConsolidationBatchResponse
+
+        defs = _ConsolidationBatchResponse.model_json_schema()["$defs"]
+        assert defs["_UpdateAction"]["required"] == ["text", "observation_id", "source_fact_ids"]
+        assert defs["_CreateAction"]["required"] == ["text", "source_fact_ids"]
+        assert defs["_DeleteAction"]["required"] == ["observation_id"]
+
+    def test_wholesale_malformed_response_still_raises(self):
+        """Only per-item failures are dropped; a garbage top-level shape must not be
+        laundered into a silently empty batch."""
+        from pydantic import ValidationError
+
+        from hindsight_api.engine.consolidation.consolidator import _ConsolidationBatchResponse
+
+        with pytest.raises(ValidationError):
+            _ConsolidationBatchResponse.model_validate({"creates": "not a list"})
+
+    def test_dropped_update_no_longer_suppresses_matching_create(self):
+        """Downstream effect: `update_texts` is built from the surviving updates, so a
+        CREATE that verbatim-matches a *dropped* update is no longer treated as its
+        duplicate — while a surviving update with that text still suppresses it."""
+        from hindsight_api.engine.consolidation.consolidator import (
+            _ConsolidationBatchResponse,
+            _duplicate_create_target,
+            _norm_obs_text,
+        )
+
+        text = "User moved from Lisbon to Berlin in March."
+
+        dropped = _ConsolidationBatchResponse.model_validate(
+            _issue_3003_payload(creates=[{"text": text, "source_fact_ids": ["fact-1"]}])
+        )
+        update_texts = {_norm_obs_text(u.text) for u in dropped.updates if u.text}
+        assert _duplicate_create_target(text, {}, update_texts) is None
+
+        kept = _ConsolidationBatchResponse.model_validate(
+            _issue_3003_payload(
+                creates=[{"text": text, "source_fact_ids": ["fact-1"]}],
+                updates=[{"text": text, "observation_id": "obs-1", "source_fact_ids": ["fact-2"]}],
+            )
+        )
+        kept_texts = {_norm_obs_text(u.text) for u in kept.updates if u.text}
+        assert _duplicate_create_target(text, {}, kept_texts) == "an UPDATE in this response"
+
+
 class TestDedupeUpdates:
     """`_dedupe_updates` collapses LLM responses that target one observation_id
     multiple times — without this, the second `_execute_update_action` call

--- a/hindsight-api-slim/tests/test_consolidation_retry_budget.py
+++ b/hindsight-api-slim/tests/test_consolidation_retry_budget.py
@@ -1,5 +1,6 @@
 """Tests for consolidation retry budget configurability (issue #1042)."""
 
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -138,6 +139,43 @@ class TestConsolidationRetryBudget:
             config=mock_config,
         )
         assert "max_retries" not in mock_llm_config.call.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_partially_malformed_response_costs_no_attempts(self, mock_llm_config, mock_config, caplog):
+        """#3003: a single malformed update is dropped, not retried.
+
+        The provider parses the raw JSON through `response_format`, so the ValidationError
+        used to surface here as a plain batch failure — valid actions discarded and every
+        remaining attempt spent re-asking a model that answers the same way each time.
+        """
+        raw = {
+            "creates": [{"text": "User is training for a marathon.", "source_fact_ids": ["m1"]}],
+            "updates": [{"text": "User moved from Lisbon to Berlin in March."}],
+            "deletes": [{"observation_id": "obs-stale"}],
+        }
+
+        async def parse_like_the_provider(**kwargs):
+            return kwargs["response_format"].model_validate(raw)
+
+        mock_llm_config.call.side_effect = parse_like_the_provider
+
+        with caplog.at_level(logging.WARNING, logger="hindsight_api.engine.consolidation.consolidator"):
+            result = await _consolidate_batch_with_llm(
+                llm_config=mock_llm_config,
+                memories=[{"id": "m1", "text": "test"}],
+                union_observations=[],
+                union_source_facts={},
+                config=mock_config,
+            )
+
+        assert result.failed is False
+        assert mock_llm_config.call.call_count == 1, "no retry attempts burned on a deterministic parse failure"
+        assert [c.text for c in result.creates] == ["User is training for a marathon."]
+        assert result.updates == []
+        assert [d.observation_id for d in result.deletes] == ["obs-stale"]
+        assert any("1 memories [m1]" in r.message for r in caplog.records if r.levelno == logging.WARNING), (
+            "the drop warning must name the batch it came from"
+        )
 
     @pytest.mark.asyncio
     async def test_reduced_budget_limits_total_calls(self, mock_llm_config, mock_config):

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -3026,7 +3026,7 @@
           "Documents"
         ],
         "summary": "List documents",
-        "description": "List documents with pagination and optional search. Documents are the source content from which memory units are extracted.",
+        "description": "List documents with pagination and optional search, most recently written first (`updated_at` descending). Documents are the source content from which memory units are extracted.",
         "operationId": "list_documents",
         "parameters": [
           {
@@ -6938,7 +6938,20 @@
                 "type": "null"
               }
             ],
-            "title": "Last Document At"
+            "title": "Last Document At",
+            "description": "When a document was last *ingested* into this bank. Appending to an existing document does not move this \u2014 use `last_write_at` for write activity."
+          },
+          "last_write_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Write At",
+            "description": "When anything was last written to this bank: a document retained (including appends to an existing document) or a fact stored. Null if the bank is empty."
           }
         },
         "type": "object",
@@ -6977,6 +6990,7 @@
               },
               "fact_count": 156,
               "last_document_at": "2024-01-16T14:20:00Z",
+              "last_write_at": "2024-01-17T09:05:00Z",
               "mission": "I am a software engineer helping my team ship quality code",
               "name": "Alice",
               "updated_at": "2024-01-16T14:20:00Z"


### PR DESCRIPTION
## Problem

One malformed action in a consolidation response throws away the whole response.
The LLM returns a batch of creates, updates and deletes; if a single updates entry
is missing `observation_id`, pydantic raises and every valid action in that
response goes with it.

The issue body puts the failure in the consolidator's retry loop. It is not there.
`response_format.model_validate(json_data)` runs inside the provider
(`providers/openai_compatible_llm.py`, and the equivalent in the Gemini and
Anthropic providers), and the `except Exception: raise` below it re-raises. JSON
*parse* errors retry at that point; schema-validation errors do not. By the time
`_consolidate_batch_with_llm`'s broad `except Exception` sees it, the raw response
text is gone, so nothing downstream can salvage it. The attempt is then retried
against a model that answers the same way, until the budget is spent.

Fixes #3003

## Fix

A pydantic `field_validator(mode="before")` on `_ConsolidationBatchResponse` that
per-item validates each entry and keeps the ones that parse.

It is applied to creates, updates and deletes through one shared validator, not
just to updates. #3029 was closed even though its bug was real, because it keyed
on a single symptom: hardcoding one key leaves the next one silently dropping
facts. The family here is "one malformed item kills the batch", and all three
lists are equally strict.

A before-validator does not change the emitted JSON schema, so the strict-schema
and Gemini `response_schema` paths are unaffected. `_build_response_model`
subclasses the base, so the Bedrock-constrained variant inherits the filter
without changes.

Two deliberate choices:

Non-list input passes straight through, so a response whose shape is genuinely
wrong still raises instead of quietly becoming an empty list. Only item-level
failures are filtered.

The `except` catches `Exception`, not just `ValidationError`. The action models'
own `sanitize_text` validator raises `TypeError` on a non-string `text`, and any
exception escaping here produces exactly the whole-batch failure this validator
exists to prevent.

Dropping an update the LLM meant to make is a real loss: the observation is not
rewritten, yet its source facts are still marked consolidated. That is why each
drop logs at WARNING with the batch label and the rejected entry rather than
being swallowed. Getting the label there needs a ContextVar, because the
validator runs inside the provider's parsing where `batch_label` is not in scope
and no keyword from the consolidator can reach it.

The in-repo precedent for filter-and-warn on LLM misbehaviour is `_dedupe_updates`.

## On just enabling strict schema

`HINDSIGHT_API_LLM_STRICT_SCHEMA_CONSOLIDATION` already exists to grammar-enforce
this output, added for #2668. It is not a substitute: not every provider supports
strict schema, and the reported failure came from one where it was not in force.

## Scope

Impact is burned tokens and latency, not data loss. Adaptive bisection halves the
batch down to size 1 and usually rescues it, `consolidation_failed_at` is stamped,
and `MemoryEngine.retry_failed_consolidation` clears it. The issue's claim that
unconsolidated backlog keeps growing is wrong: failed rows are counted separately
in `engine/memories/pg/counts.py`.

Two adjacent cases this does not address, found while reviewing it:

When a per-scope observation cap is configured and the provider supports
`max_items`, `_build_response_model` redeclares `creates` with `max_length`. That
constraint is evaluated *after* this filter runs, so a response with too many
otherwise-valid creates still fails the whole batch with `too_long`. Pre-existing,
same shape of problem, different trigger. Fixing it means silently discarding
valid creates, which is a separate judgement call.

Dropped items are not counted anywhere. The WARNING is the only signal; if every
update in a batch is dropped, the memories record as `skipped` rather than
`failed`, so progress output shows the run as clean.

## Test scope

Model-level tests, no DB and no LLM. MockLLM returns its canned response without
validating it, so an end-to-end MockLLM test would prove nothing here.

New cases sit next to `TestBuildResponseModel`, parametrized over: bad update
only, bad update plus valid creates, all updates bad, bad create, bad delete, and
a fully valid payload that must come through untouched. The fixture is the
verbatim payload from the issue. There is also a case for the constrained
subclass inheriting the filter, and one covering the downstream effect that
`update_texts` feeds `_duplicate_create_target`, so a dropped update no longer
suppresses a verbatim-matching create.

`test_consolidation_retry_budget.py` asserts a partially-bad response now yields
`failed is False` and burns no extra attempts.

| Check | Result |
|---|---|
| consolidation suite | 139 passed, 14 deselected, 131s |
| same command, unmodified main | 121 passed, 13 deselected |
| `ruff check` on the three changed files | 6 errors, identical on unmodified main |

The command is `-q -n0 --timeout 400 -m "not hs_llm_core" --deselect
tests/test_consolidation.py::test_observation_scopes_per_tag`. Three deliberate
choices in that:

`-n0` overrides the `-n 8` in addopts. Eight xdist workers on a 6-core box made
the session nondeterministic: one run collected 135 items and INTERNALERRORed,
the next collected zero.

`-m "not hs_llm_core"` deselects the real-LLM tests, which CI runs in its own
core-LLM job.

`test_observation_scopes_per_tag` is deselected as a pre-existing order-dependent
flake. It passes alone in 35.8s and fails inside the full suite on unmodified
main, unrelated to this change.
