### PR TITLE
fix(control-plane): report mental model staleness accurately

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -4946,6 +4946,10 @@ def _register_routes(app: FastAPI):
         ),
         limit: int = Query(100, ge=1, le=1000),
         offset: int = Query(0, ge=0),
+        include_stale: bool = Query(
+            False,
+            description="Compute scope-aware staleness for each model. Expensive and disabled by default.",
+        ),
         request_context: RequestContext = Depends(get_request_context),
     ):
         """List mental models for a bank."""
@@ -4957,6 +4961,7 @@ def _register_routes(app: FastAPI):
                 detail=detail,
                 limit=limit,
                 offset=offset,
+                include_stale=include_stale,
                 request_context=request_context,
             )
             return MentalModelListResponse(items=[MentalModelResponse(**m) for m in mental_models])

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -11208,6 +11208,7 @@ class MemoryEngine(MemoryEngineInterface):
         detail: str = "full",
         limit: int = 100,
         offset: int = 0,
+        include_stale: bool = False,
         request_context: "RequestContext",
     ) -> list[dict[str, Any]]:
         """List pinned mental models for a bank.
@@ -11219,6 +11220,7 @@ class MemoryEngine(MemoryEngineInterface):
             detail: Detail level - 'metadata', 'content', or 'full'
             limit: Maximum number of results
             offset: Offset for pagination
+            include_stale: Compute scope-aware staleness for each model (expensive; opt-in)
             request_context: Request context for authentication
 
         Returns:
@@ -11260,7 +11262,13 @@ class MemoryEngine(MemoryEngineInterface):
                 *params,
             )
 
-            return [self._row_to_mental_model(row, detail=detail) for row in rows]
+            results = [self._row_to_mental_model(row, detail=detail) for row in rows]
+            if include_stale:
+                # Each check queries the model's own tag/fact scope. Keep this
+                # opt-in so ordinary list calls do not incur an N+1 workload.
+                for result, row in zip(results, rows, strict=True):
+                    result["is_stale"] = await self.compute_mental_model_is_stale(conn, bank_id, row)
+            return results
 
     async def get_mental_model(
         self,

--- a/hindsight-api-slim/tests/test_reflections.py
+++ b/hindsight-api-slim/tests/test_reflections.py
@@ -356,7 +356,18 @@ class TestMentalModelsAPI:
         # Find our mental model
         mental_model = next((m for m in mental_models if m["name"] == "API Test Mental Model"), None)
         assert mental_model is not None, f"Mental model not found. Items: {mental_models}"
+        assert "is_stale" not in mental_model
         mental_model_id = mental_model["id"]
+
+        # Staleness is scope-aware and requires an extra query per model, so
+        # list callers must explicitly opt in when they need an exact summary.
+        response = await api_client.get(
+            f"/v1/default/banks/{test_bank_id}/mental-models",
+            params={"include_stale": "true", "detail": "metadata"},
+        )
+        assert response.status_code == 200
+        with_staleness = next(m for m in response.json()["items"] if m["id"] == mental_model_id)
+        assert isinstance(with_staleness["is_stale"], bool)
 
         # Get the mental model
         response = await api_client.get(f"/v1/default/banks/{test_bank_id}/mental-models/{mental_model_id}")

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -1052,6 +1052,19 @@ paths:
           title: Offset
           type: integer
         style: form
+      - description: Compute scope-aware staleness for each model. Expensive and disabled
+          by default.
+        explode: true
+        in: query
+        name: include_stale
+        required: false
+        schema:
+          default: false
+          description: Compute scope-aware staleness for each model. Expensive and
+            disabled by default.
+          title: Include Stale
+          type: boolean
+        style: form
       - explode: false
         in: header
         name: authorization

--- a/hindsight-clients/go/api_mental_models.go
+++ b/hindsight-clients/go/api_mental_models.go
@@ -683,6 +683,7 @@ type ApiListMentalModelsRequest struct {
 	detail *string
 	limit *int32
 	offset *int32
+	includeStale *bool
 	authorization *string
 }
 
@@ -711,6 +712,12 @@ func (r ApiListMentalModelsRequest) Limit(limit int32) ApiListMentalModelsReques
 
 func (r ApiListMentalModelsRequest) Offset(offset int32) ApiListMentalModelsRequest {
 	r.offset = &offset
+	return r
+}
+
+// Compute scope-aware staleness for each model. Expensive and disabled by default.
+func (r ApiListMentalModelsRequest) IncludeStale(includeStale bool) ApiListMentalModelsRequest {
+	r.includeStale = &includeStale
 	return r
 }
 
@@ -796,6 +803,12 @@ func (a *MentalModelsAPIService) ListMentalModelsExecute(r ApiListMentalModelsRe
 	} else {
 		var defaultValue int32 = 0
 		r.offset = &defaultValue
+	}
+	if r.includeStale != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "include_stale", r.includeStale, "form", "")
+	} else {
+		var defaultValue bool = false
+		r.includeStale = &defaultValue
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}

--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -1172,6 +1172,7 @@ class Hindsight:
         detail: Literal["metadata", "content", "full"] | None = None,
         limit: int | None = None,
         offset: int | None = None,
+        include_stale: bool | None = None,
     ):
         """
         List all mental models in a bank (sync wrapper — use ``await client.mental_models.list_mental_models(...)`` in async code).
@@ -1186,6 +1187,7 @@ class Hindsight:
                 level to avoid pulling large payloads you don't need.
             limit: Maximum number of mental models to return
             offset: Number of mental models to skip (for pagination)
+            include_stale: Whether to compute scope-aware staleness for each model
 
         Returns:
             ListMentalModelsResponse with items
@@ -1198,6 +1200,7 @@ class Hindsight:
                 detail=detail,
                 limit=limit,
                 offset=offset,
+                include_stale=include_stale,
                 _request_timeout=self._timeout,
             )
         )

--- a/hindsight-clients/python/hindsight_client_api/api/mental_models_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/mental_models_api.py
@@ -1879,9 +1879,9 @@ class MentalModelsApi:
             _query_params.append(('offset', offset))
             
         if include_stale is not None:
-
+            
             _query_params.append(('include_stale', include_stale))
-
+            
         # process the header parameters
         if authorization is not None:
             _header_params['authorization'] = authorization
@@ -2530,4 +2530,5 @@ class MentalModelsApi:
             _host=_host,
             _request_auth=_request_auth
         )
+
 

--- a/hindsight-clients/python/hindsight_client_api/api/mental_models_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/mental_models_api.py
@@ -16,7 +16,7 @@ from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictStr, field_validator
+from pydantic import Field, StrictBool, StrictStr, field_validator
 from typing import Any, List, Optional
 from typing_extensions import Annotated
 from hindsight_client_api.models.async_operation_submit_response import AsyncOperationSubmitResponse
@@ -1548,6 +1548,7 @@ class MentalModelsApi:
         detail: Annotated[Optional[StrictStr], Field(description="Detail level: 'metadata' (names/tags only), 'content' (adds content/config), 'full' (includes reflect_response)")] = None,
         limit: Optional[Annotated[int, Field(le=1000, strict=True, ge=1)]] = None,
         offset: Optional[Annotated[int, Field(strict=True, ge=0)]] = None,
+        include_stale: Annotated[Optional[StrictBool], Field(description="Compute scope-aware staleness for each model. Expensive and disabled by default.")] = None,
         authorization: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
@@ -1578,6 +1579,8 @@ class MentalModelsApi:
         :type limit: int
         :param offset:
         :type offset: int
+        :param include_stale: Compute scope-aware staleness for each model. Expensive and disabled by default.
+        :type include_stale: bool
         :param authorization:
         :type authorization: str
         :param _request_timeout: timeout setting for this request. If one
@@ -1609,6 +1612,7 @@ class MentalModelsApi:
             detail=detail,
             limit=limit,
             offset=offset,
+            include_stale=include_stale,
             authorization=authorization,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -1640,6 +1644,7 @@ class MentalModelsApi:
         detail: Annotated[Optional[StrictStr], Field(description="Detail level: 'metadata' (names/tags only), 'content' (adds content/config), 'full' (includes reflect_response)")] = None,
         limit: Optional[Annotated[int, Field(le=1000, strict=True, ge=1)]] = None,
         offset: Optional[Annotated[int, Field(strict=True, ge=0)]] = None,
+        include_stale: Annotated[Optional[StrictBool], Field(description="Compute scope-aware staleness for each model. Expensive and disabled by default.")] = None,
         authorization: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
@@ -1670,6 +1675,8 @@ class MentalModelsApi:
         :type limit: int
         :param offset:
         :type offset: int
+        :param include_stale: Compute scope-aware staleness for each model. Expensive and disabled by default.
+        :type include_stale: bool
         :param authorization:
         :type authorization: str
         :param _request_timeout: timeout setting for this request. If one
@@ -1701,6 +1708,7 @@ class MentalModelsApi:
             detail=detail,
             limit=limit,
             offset=offset,
+            include_stale=include_stale,
             authorization=authorization,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -1732,6 +1740,7 @@ class MentalModelsApi:
         detail: Annotated[Optional[StrictStr], Field(description="Detail level: 'metadata' (names/tags only), 'content' (adds content/config), 'full' (includes reflect_response)")] = None,
         limit: Optional[Annotated[int, Field(le=1000, strict=True, ge=1)]] = None,
         offset: Optional[Annotated[int, Field(strict=True, ge=0)]] = None,
+        include_stale: Annotated[Optional[StrictBool], Field(description="Compute scope-aware staleness for each model. Expensive and disabled by default.")] = None,
         authorization: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
@@ -1762,6 +1771,8 @@ class MentalModelsApi:
         :type limit: int
         :param offset:
         :type offset: int
+        :param include_stale: Compute scope-aware staleness for each model. Expensive and disabled by default.
+        :type include_stale: bool
         :param authorization:
         :type authorization: str
         :param _request_timeout: timeout setting for this request. If one
@@ -1793,6 +1804,7 @@ class MentalModelsApi:
             detail=detail,
             limit=limit,
             offset=offset,
+            include_stale=include_stale,
             authorization=authorization,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -1819,6 +1831,7 @@ class MentalModelsApi:
         detail,
         limit,
         offset,
+        include_stale,
         authorization,
         _request_auth,
         _content_type,
@@ -1865,6 +1878,10 @@ class MentalModelsApi:
             
             _query_params.append(('offset', offset))
             
+        if include_stale is not None:
+
+            _query_params.append(('include_stale', include_stale))
+
         # process the header parameters
         if authorization is not None:
             _header_params['authorization'] = authorization
@@ -2513,5 +2530,4 @@ class MentalModelsApi:
             _host=_host,
             _request_auth=_request_auth
         )
-
 

--- a/hindsight-clients/python/tests/test_mental_model_query_mapping.py
+++ b/hindsight-clients/python/tests/test_mental_model_query_mapping.py
@@ -41,6 +41,7 @@ def test_list_forwards_every_supported_query_option(monkeypatch):
         detail="metadata",
         limit=25,
         offset=50,
+        include_stale=True,
     )
 
     assert captured["bank_id"] == "bank-1"
@@ -50,6 +51,7 @@ def test_list_forwards_every_supported_query_option(monkeypatch):
     assert kwargs["detail"] == "metadata"
     assert kwargs["limit"] == 25
     assert kwargs["offset"] == 50
+    assert kwargs["include_stale"] is True
 
 
 def test_list_defaults_leave_controls_unset(monkeypatch):
@@ -66,6 +68,7 @@ def test_list_defaults_leave_controls_unset(monkeypatch):
     assert kwargs["detail"] is None
     assert kwargs["limit"] is None
     assert kwargs["offset"] is None
+    assert kwargs["include_stale"] is None
 
 
 def test_list_tags_only_shape_preserved(monkeypatch):

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -5328,6 +5328,12 @@ export type ListMentalModelsData = {
      * Offset
      */
     offset?: number;
+    /**
+     * Include Stale
+     *
+     * Compute scope-aware staleness for each model. Expensive and disabled by default.
+     */
+    include_stale?: boolean;
   };
   url: "/v1/default/banks/{bank_id}/mental-models";
 };

--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -889,6 +889,7 @@ export class HindsightClient {
       detail?: "metadata" | "content" | "full";
       limit?: number;
       offset?: number;
+      includeStale?: boolean;
       signal?: AbortSignal;
     }
   ): Promise<MentalModelListResponse> {
@@ -901,6 +902,7 @@ export class HindsightClient {
         ...(options?.detail !== undefined ? { detail: options.detail } : {}),
         ...(options?.limit !== undefined ? { limit: options.limit } : {}),
         ...(options?.offset !== undefined ? { offset: options.offset } : {}),
+        ...(options?.includeStale !== undefined ? { include_stale: options.includeStale } : {}),
       },
       signal: options?.signal,
     });

--- a/hindsight-clients/typescript/tests/mental_model_query_mapping.test.ts
+++ b/hindsight-clients/typescript/tests/mental_model_query_mapping.test.ts
@@ -33,6 +33,7 @@ describe("mental-model query mapping", () => {
       detail: "metadata",
       limit: 25,
       offset: 50,
+      includeStale: true,
       signal,
     });
 
@@ -45,6 +46,7 @@ describe("mental-model query mapping", () => {
           detail: "metadata",
           limit: 25,
           offset: 50,
+          include_stale: true,
         },
         signal,
       })

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/route.ts
@@ -8,8 +8,10 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
     const { searchParams } = new URL(request.url);
     const tags = searchParams.getAll("tags");
     const tagsMatch = searchParams.get("tags_match");
+    const detail = searchParams.get("detail");
     const limit = searchParams.get("limit");
     const offset = searchParams.get("offset");
+    const includeStale = searchParams.get("include_stale");
 
     if (!bankId) {
       return NextResponse.json(
@@ -28,11 +30,17 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
     if (tagsMatch) {
       queryParams.append("tags_match", tagsMatch);
     }
+    if (detail) {
+      queryParams.append("detail", detail);
+    }
     if (limit) {
       queryParams.append("limit", limit);
     }
     if (offset) {
       queryParams.append("offset", offset);
+    }
+    if (includeStale) {
+      queryParams.append("include_stale", includeStale);
     }
 
     const url = dataplaneBankUrl(

--- a/hindsight-control-plane/src/components/bank-stats-view.tsx
+++ b/hindsight-control-plane/src/components/bank-stats-view.tsx
@@ -701,22 +701,13 @@ function FailedConsolidationsDialog({
   );
 }
 
-function MentalModelsCard({
-  models,
-  lastConsolidatedAt,
-}: {
-  models: MentalModel[];
-  lastConsolidatedAt: string | null;
-}) {
+function MentalModelsCard({ models }: { models: MentalModel[] }) {
   const t = useTranslations("bankStats");
   const total = models.length;
-  const consolidatedTime = lastConsolidatedAt ? new Date(lastConsolidatedAt).getTime() : 0;
-  const upToDate = models.filter((m) => {
-    if (!consolidatedTime) return true;
-    if (!m.last_refreshed_at) return false;
-    return new Date(m.last_refreshed_at).getTime() >= consolidatedTime;
-  }).length;
-  const stale = total - upToDate;
+  const knownModels = models.filter((m) => m.is_stale !== null && m.is_stale !== undefined);
+  const upToDate = knownModels.filter((m) => m.is_stale === false).length;
+  const stale = knownModels.filter((m) => m.is_stale === true).length;
+  const hasStaleness = knownModels.length > 0;
 
   return (
     <Card>
@@ -731,7 +722,15 @@ function MentalModelsCard({
           <div className="text-sm text-muted-foreground py-4">{t("noMentalModels")}</div>
         ) : (
           <>
-            <ProgressRow done={upToDate} total={total} doneColor={CHART_COLORS.success} />
+            {hasStaleness ? (
+              <ProgressRow
+                done={upToDate}
+                total={knownModels.length}
+                doneColor={CHART_COLORS.success}
+              />
+            ) : (
+              <div className="text-sm text-muted-foreground py-1">—</div>
+            )}
             <div className="grid grid-cols-3 gap-3 pt-1">
               <div className="space-y-0.5">
                 <div className="flex items-center gap-1.5">
@@ -741,7 +740,7 @@ function MentalModelsCard({
                   </span>
                 </div>
                 <span className="text-base font-semibold tabular-nums text-foreground block">
-                  {upToDate}
+                  {hasStaleness ? upToDate : "—"}
                 </span>
               </div>
               <div className="space-y-0.5">
@@ -752,7 +751,7 @@ function MentalModelsCard({
                   </span>
                 </div>
                 <span className="text-base font-semibold tabular-nums text-foreground block">
-                  {stale}
+                  {hasStaleness ? stale : "—"}
                 </span>
               </div>
               <div className="space-y-0.5">
@@ -1074,7 +1073,11 @@ export function BankStatsView() {
     try {
       const [statsData, mentalModelsData] = await Promise.all([
         client.getBankStats(currentBank),
-        client.listMentalModels(currentBank),
+        client.listMentalModels(currentBank, {
+          detail: "metadata",
+          limit: 1000,
+          includeStale: true,
+        }),
       ]);
       setStats(statsData as BankStats);
       setMentalModels(mentalModelsData.items || []);
@@ -1124,7 +1127,7 @@ export function BankStatsView() {
             total={stats.total_nodes}
             lastConsolidatedAt={stats.last_consolidated_at}
           />
-          <MentalModelsCard models={mentalModels} lastConsolidatedAt={stats.last_consolidated_at} />
+          <MentalModelsCard models={mentalModels} />
         </div>
       </section>
 

--- a/hindsight-control-plane/src/components/mental-models-view.tsx
+++ b/hindsight-control-plane/src/components/mental-models-view.tsx
@@ -160,13 +160,12 @@ export function MentalModelsView() {
       const PAGE_SIZE = 100;
       const all: MentalModel[] = [];
       for (let offset = 0; ; offset += PAGE_SIZE) {
-        const page = await client.listMentalModels(
-          currentBank,
-          selectedTags.length > 0 ? selectedTags : undefined,
-          selectedTags.length > 0 ? tagsMatch : undefined,
-          PAGE_SIZE,
-          offset
-        );
+        const page = await client.listMentalModels(currentBank, {
+          tags: selectedTags.length > 0 ? selectedTags : undefined,
+          tagsMatch: selectedTags.length > 0 ? tagsMatch : undefined,
+          limit: PAGE_SIZE,
+          offset,
+        });
         const items = page.items || [];
         all.push(...items);
         if (items.length < PAGE_SIZE) break;

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -1288,23 +1288,33 @@ export class ControlPlaneClient {
    */
   async listMentalModels(
     bankId: string,
-    tags?: string[],
-    tagsMatch?: string,
-    limit?: number,
-    offset?: number
+    options: {
+      tags?: string[];
+      tagsMatch?: string;
+      detail?: "metadata" | "content" | "full";
+      limit?: number;
+      offset?: number;
+      includeStale?: boolean;
+    } = {}
   ) {
     const params = new URLSearchParams();
-    if (tags && tags.length > 0) {
-      tags.forEach((t) => params.append("tags", t));
+    if (options.tags && options.tags.length > 0) {
+      options.tags.forEach((t) => params.append("tags", t));
     }
-    if (tagsMatch) {
-      params.append("tags_match", tagsMatch);
+    if (options.tagsMatch) {
+      params.append("tags_match", options.tagsMatch);
     }
-    if (limit !== undefined) {
-      params.append("limit", String(limit));
+    if (options.detail) {
+      params.append("detail", options.detail);
     }
-    if (offset !== undefined) {
-      params.append("offset", String(offset));
+    if (options.limit !== undefined) {
+      params.append("limit", String(options.limit));
+    }
+    if (options.offset !== undefined) {
+      params.append("offset", String(options.offset));
+    }
+    if (options.includeStale !== undefined) {
+      params.append("include_stale", String(options.includeStale));
     }
     const query = params.toString();
     return this.fetchApi<{
@@ -1335,6 +1345,7 @@ export class ControlPlaneClient {
           text: string;
           based_on: Record<string, Array<{ id: string; text: string; type: string }>>;
         };
+        is_stale?: boolean | null;
       }>;
     }>(bankApi(bankId, `/mental-models${query ? `?${query}` : ""}`));
   }

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -1528,6 +1528,18 @@
             }
           },
           {
+            "name": "include_stale",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Compute scope-aware staleness for each model. Expensive and disabled by default.",
+              "default": false,
+              "title": "Include Stale"
+            },
+            "description": "Compute scope-aware staleness for each model. Expensive and disabled by default."
+          },
+          {
             "name": "authorization",
             "in": "header",
             "required": false,

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -1528,6 +1528,18 @@
             }
           },
           {
+            "name": "include_stale",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Compute scope-aware staleness for each model. Expensive and disabled by default.",
+              "default": false,
+              "title": "Include Stale"
+            },
+            "description": "Compute scope-aware staleness for each model. Expensive and disabled by default."
+          },
+          {
             "name": "authorization",
             "in": "header",
             "required": false,
@@ -3026,7 +3038,7 @@
           "Documents"
         ],
         "summary": "List documents",
-        "description": "List documents with pagination and optional search. Documents are the source content from which memory units are extracted.",
+        "description": "List documents with pagination and optional search, most recently written first (`updated_at` descending). Documents are the source content from which memory units are extracted.",
         "operationId": "list_documents",
         "parameters": [
           {
@@ -6938,7 +6950,20 @@
                 "type": "null"
               }
             ],
-            "title": "Last Document At"
+            "title": "Last Document At",
+            "description": "When a document was last *ingested* into this bank. Appending to an existing document does not move this \u2014 use `last_write_at` for write activity."
+          },
+          "last_write_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Write At",
+            "description": "When anything was last written to this bank: a document retained (including appends to an existing document) or a fact stored. Null if the bank is empty."
           }
         },
         "type": "object",
@@ -6977,6 +7002,7 @@
               },
               "fact_count": 156,
               "last_document_at": "2024-01-16T14:20:00Z",
+              "last_write_at": "2024-01-17T09:05:00Z",
               "mission": "I am a software engineer helping my team ship quality code",
               "name": "Alice",
               "updated_at": "2024-01-16T14:20:00Z"


### PR DESCRIPTION
## Summary

- add an opt-in `include_stale` query parameter that computes scope-aware staleness for listed mental models
- use exact per-model staleness in the control-plane summary instead of comparing against the global consolidation timestamp
- request metadata-only results for the stats view and keep unknown staleness from being reported as stale
- regenerate OpenAPI and generated clients, and expose the option through maintained Python and TypeScript wrappers

## Testing

- `./scripts/hooks/lint.sh`
- `uv run ty check hindsight_api/`
- `uv run pytest tests/test_reflections.py::TestMentalModelsAPI::test_mental_models_api_crud -v`
- Python mental-model query mapping tests
- TypeScript mental-model query mapping tests
- `go build ./...`

Fixes #3139