### PR TITLE
fix(reranker): foreground-priority lane for the local cross-encoder pool

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -7,11 +7,14 @@ Configuration via environment variables - see hindsight_api.config for all env v
 """
 
 import asyncio
+import itertools
 import logging
 import os
+import queue
+import threading
 import warnings
 from abc import ABC, abstractmethod
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any
 
 import httpx
@@ -57,6 +60,94 @@ from .tei_retry import tei_retry_delay
 logger = logging.getLogger(__name__)
 
 
+class _PriorityRerankExecutor:
+    """Fixed-size thread pool that dispatches foreground work ahead of queued background work.
+
+    Reranking is CPU-bound and runs in worker threads. A plain
+    ``ThreadPoolExecutor`` drains a single FIFO queue, so an interactive
+    (foreground) rerank submitted while a large fan-out of background reranks is
+    already queued must wait behind every one of them. Consolidation/reflect
+    issue exactly that background fan-out (each internal sub-recall runs a
+    rerank), which spikes foreground recall latency.
+
+    This pool keeps foreground reranks responsive by ordering the shared work
+    queue foreground-first. A foreground job jumps ahead of any *queued*
+    background jobs, but it does not preempt a background job already running in
+    a worker — so background always keeps making progress between foreground
+    arrivals. This is foreground *priority*, not background exclusion.
+
+    Note on starvation: a sustained, saturating stream of foreground jobs could
+    in principle keep background jobs queued indefinitely. In this system that
+    cannot happen in practice — foreground reranks are driven by per-user recall
+    turns (bounded, bursty), while background reranks are the bulk fan-out.
+    Foreground volume cannot saturate the pool, so background continues to drain.
+    """
+
+    # Lower number == higher priority in the PriorityQueue.
+    _FOREGROUND = 0
+    _BACKGROUND = 1
+    _SHUTDOWN_PRIORITY = -1
+
+    _SHUTDOWN = object()
+
+    def __init__(self, max_workers: int, thread_name_prefix: str = "reranker"):
+        if max_workers < 1:
+            raise ValueError("max_workers must be >= 1")
+        self._max_workers = max_workers
+        # Items are (priority, seq, fn, args, future). ``seq`` is a strictly
+        # increasing tie-breaker so the payload (fn/future) is never compared —
+        # PriorityQueue only ever orders by (priority, seq), both integers.
+        self._queue: "queue.PriorityQueue" = queue.PriorityQueue()
+        self._seq = itertools.count()
+        self._seq_lock = threading.Lock()
+        self._threads: list[threading.Thread] = []
+        for i in range(max_workers):
+            t = threading.Thread(
+                target=self._worker,
+                name=f"{thread_name_prefix}-{i}",
+                daemon=True,
+            )
+            t.start()
+            self._threads.append(t)
+
+    def _next_seq(self) -> int:
+        # itertools.count() is not documented thread-safe under free-threading;
+        # guard it so ties never collide (a collision would compare payloads).
+        with self._seq_lock:
+            return next(self._seq)
+
+    def submit(self, fn, /, *args, background: bool = False) -> Future:
+        """Schedule ``fn(*args)``; foreground jobs jump ahead of queued background jobs."""
+        fut: Future = Future()
+        priority = self._BACKGROUND if background else self._FOREGROUND
+        self._queue.put((priority, self._next_seq(), fn, args, fut))
+        return fut
+
+    def _worker(self) -> None:
+        while True:
+            _priority, _seq, fn, args, fut = self._queue.get()
+            try:
+                if fn is self._SHUTDOWN:
+                    return
+                if not fut.set_running_or_notify_cancel():
+                    # Caller cancelled before we started — skip.
+                    continue
+                try:
+                    fut.set_result(fn(*args))
+                except BaseException as exc:  # noqa: BLE001 — propagate to the awaiting caller
+                    fut.set_exception(exc)
+            finally:
+                self._queue.task_done()
+
+    def shutdown(self, wait: bool = True) -> None:
+        """Stop all workers. Sentinels preempt queued work so shutdown is prompt."""
+        for _ in self._threads:
+            self._queue.put((self._SHUTDOWN_PRIORITY, self._next_seq(), self._SHUTDOWN, (), Future()))
+        if wait:
+            for t in self._threads:
+                t.join()
+
+
 class CrossEncoderModel(ABC):
     """
     Abstract base class for cross-encoder reranking.
@@ -81,12 +172,17 @@ class CrossEncoderModel(ABC):
         pass
 
     @abstractmethod
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def predict(self, pairs: list[tuple[str, str]], *, background: bool = False) -> list[float]:
         """
         Score query-document pairs for relevance.
 
         Args:
             pairs: List of (query, document) tuples to score
+            background: True for internal/background reranks (e.g. consolidation
+                and reflect sub-recalls). Providers with a local worker pool use
+                this to give interactive (foreground) reranks queue priority so
+                they are not starved behind a background fan-out. Remote providers
+                have their own concurrency controls and may ignore it.
 
         Returns:
             List of relevance scores (higher = more relevant)
@@ -108,8 +204,12 @@ class LocalSTCrossEncoder(CrossEncoderModel):
     Uses a dedicated thread pool to limit concurrent CPU-bound work.
     """
 
-    # Shared executor across all instances (one model loaded anyway)
-    _executor: ThreadPoolExecutor | None = None
+    # Shared executor across all instances (one model loaded anyway).
+    # Priority-aware: foreground reranks are dispatched ahead of queued
+    # background ones so interactive recall latency is not starved by the
+    # consolidation/reflect background fan-out.
+    _executor: "_PriorityRerankExecutor | None" = None
+    _executor_lock: threading.Lock = threading.Lock()
     _max_concurrent: int = 4  # Limit concurrent CPU-bound reranking calls
 
     def __init__(
@@ -235,15 +335,34 @@ class LocalSTCrossEncoder(CrossEncoderModel):
             self._model.model.half()
             logger.info("Reranker: FP16 inference enabled")
 
-        # Initialize shared executor (limited workers naturally limits concurrency)
-        if LocalSTCrossEncoder._executor is None:
-            LocalSTCrossEncoder._executor = ThreadPoolExecutor(
-                max_workers=LocalSTCrossEncoder._max_concurrent,
-                thread_name_prefix="reranker",
-            )
+        # Initialize the shared priority-aware executor (limited workers naturally
+        # limits concurrency; foreground reranks jump ahead of queued background ones).
+        created = LocalSTCrossEncoder._executor is None
+        LocalSTCrossEncoder._get_executor()
+        if created:
             logger.info(f"Reranker: local provider initialized (max_concurrent={LocalSTCrossEncoder._max_concurrent})")
         else:
             logger.info("Reranker: local provider initialized (using existing executor)")
+
+    @classmethod
+    def _get_executor(cls) -> "_PriorityRerankExecutor":
+        """Return the shared priority executor, creating it on first use.
+
+        Lazy creation keeps predict() usable when a caller skips initialize()
+        (the model is injected directly), mirroring the previous
+        ``run_in_executor(None, ...)`` fallback while now routing through the
+        foreground-priority pool.
+        """
+        ex = cls._executor
+        if ex is None:
+            with cls._executor_lock:
+                if cls._executor is None:
+                    cls._executor = _PriorityRerankExecutor(
+                        max_workers=cls._max_concurrent,
+                        thread_name_prefix="reranker",
+                    )
+                ex = cls._executor
+        return ex
 
     def _predict_sync(self, pairs: list[tuple[str, str]]) -> list[float]:
         """Synchronous prediction wrapper for thread pool execution.
@@ -276,14 +395,18 @@ class LocalSTCrossEncoder(CrossEncoderModel):
         finally:
             release_local_inference_memory(self._device_type)
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def predict(self, pairs: list[tuple[str, str]], *, background: bool = False) -> list[float]:
         """
         Score query-document pairs for relevance.
 
-        Uses a dedicated thread pool with limited workers to prevent CPU thrashing.
+        Uses a dedicated priority-aware thread pool with limited workers to
+        prevent CPU thrashing. Foreground reranks (``background=False``) are
+        dispatched ahead of queued background reranks so interactive recall is
+        not starved behind a consolidation/reflect background fan-out.
 
         Args:
             pairs: List of (query, document) tuples to score
+            background: True for internal/background reranks (lower queue priority)
 
         Returns:
             List of relevance scores (raw logits from the model)
@@ -291,13 +414,10 @@ class LocalSTCrossEncoder(CrossEncoderModel):
         if self._model is None:
             raise RuntimeError("Reranker not initialized. Call initialize() first.")
 
-        # Use dedicated executor - limited workers naturally limits concurrency
-        loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(
-            LocalSTCrossEncoder._executor,
-            self._predict_sync,
-            pairs,
-        )
+        # Priority-aware executor: limited workers limit concurrency, and
+        # foreground work jumps ahead of queued background work.
+        fut = LocalSTCrossEncoder._get_executor().submit(self._predict_sync, pairs, background=background)
+        return await asyncio.wrap_future(fut)
 
 
 class RemoteTEICrossEncoder(CrossEncoderModel):
@@ -504,7 +624,7 @@ class RemoteTEICrossEncoder(CrossEncoderModel):
 
         return all_scores
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def predict(self, pairs: list[tuple[str, str]], *, background: bool = False) -> list[float]:
         """
         Score query-document pairs using the remote TEI reranker.
 
@@ -564,7 +684,7 @@ class _CohereCompatibleRerankClient:
             },
         )
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def predict(self, pairs: list[tuple[str, str]], *, background: bool = False) -> list[float]:
         if self._async_client is None:
             raise RuntimeError("Reranker not initialized. Call initialize() first.")
 
@@ -674,7 +794,7 @@ class CohereCrossEncoder(CrossEncoderModel):
             self._client = cohere.Client(api_key=self.api_key, timeout=self.timeout)
             logger.info("Reranker: Cohere provider initialized")
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def predict(self, pairs: list[tuple[str, str]], *, background: bool = False) -> list[float]:
         """
         Score query-document pairs using the Cohere Rerank API.
 
@@ -762,7 +882,7 @@ class ZeroEntropyCrossEncoder(CrossEncoderModel):
         await self._client.initialize()
         logger.info("Reranker: ZeroEntropy provider initialized")
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def predict(self, pairs: list[tuple[str, str]], *, background: bool = False) -> list[float]:
         return await self._client.predict(pairs)
 
 
@@ -804,7 +924,7 @@ class SiliconFlowCrossEncoder(CrossEncoderModel):
         await self._client.initialize()
         logger.info("Reranker: SiliconFlow provider initialized")
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def predict(self, pairs: list[tuple[str, str]], *, background: bool = False) -> list[float]:
         return await self._client.predict(pairs)
 
 
@@ -830,7 +950,7 @@ class RRFPassthroughCrossEncoder(CrossEncoderModel):
         """No initialization needed."""
         logger.info("Reranker: RRF passthrough provider initialized (neural reranking disabled)")
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def predict(self, pairs: list[tuple[str, str]], *, background: bool = False) -> list[float]:
         """
         Return neutral scores - actual ranking uses RRF scores from retrieval.
 
@@ -996,7 +1116,7 @@ class FlashRankCrossEncoder(CrossEncoderModel):
         finally:
             release_local_inference_memory(self._device_type)
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def predict(self, pairs: list[tuple[str, str]], *, background: bool = False) -> list[float]:
         """
         Score query-document pairs using FlashRank.
 
@@ -1088,7 +1208,7 @@ class LiteLLMCrossEncoder(CrossEncoderModel):
         self._async_client = httpx.AsyncClient(timeout=self.timeout, headers=headers)
         logger.info("Reranker: LiteLLM provider initialized")
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def predict(self, pairs: list[tuple[str, str]], *, background: bool = False) -> list[float]:
         """
         Score query-document pairs using the LiteLLM proxy's /rerank endpoint.
 
@@ -1208,7 +1328,7 @@ class LiteLLMSDKCrossEncoder(CrossEncoderModel):
         self._initialized = True
         logger.info("Reranker: LiteLLM SDK provider initialized")
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def predict(self, pairs: list[tuple[str, str]], *, background: bool = False) -> list[float]:
         """
         Score query-document pairs using the LiteLLM SDK.
 
@@ -1367,7 +1487,7 @@ class JinaMLXCrossEncoder(CrossEncoderModel):
 
         return all_scores
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def predict(self, pairs: list[tuple[str, str]], *, background: bool = False) -> list[float]:
         if self._reranker is None:
             raise RuntimeError("Reranker not initialized. Call initialize() first.")
 
@@ -1513,7 +1633,7 @@ class GoogleCrossEncoder(CrossEncoderModel):
 
         return all_scores
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def predict(self, pairs: list[tuple[str, str]], *, background: bool = False) -> list[float]:
         """
         Score query-document pairs using Google Discovery Engine Ranking API.
 
@@ -1571,7 +1691,7 @@ class AlibabaCloudCrossEncoder(CrossEncoderModel):
         await self._client.initialize()
         logger.info("Reranker: Alibaba Cloud provider initialized")
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def predict(self, pairs: list[tuple[str, str]], *, background: bool = False) -> list[float]:
         return await self._client.predict(pairs)
 
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -5119,7 +5119,16 @@ class MemoryEngine(MemoryEngineInterface):
 
                     # Ensure reranker is initialized (for lazy initialization mode)
                     await reranker_instance.ensure_initialized()
-                    scored_results = await reranker_instance.rerank(query, merged_candidates)
+                    # Foreground vs background priority for the reranker pool.
+                    # Internal/background operations — consolidation and reflect
+                    # sub-recalls (RequestContext.internal=True) — fan out a wall of
+                    # reranks; marking them background lets a local reranker keep
+                    # interactive (foreground) recall reranks from being starved
+                    # behind that queue.
+                    background_rerank = bool(request_context is not None and request_context.internal)
+                    scored_results = await reranker_instance.rerank(
+                        query, merged_candidates, background=background_rerank
+                    )
                 else:
                     # "rrf" / "interleave": skip the cross-encoder and keep the fusion order
                     # (rrf_score is descending by fusion position for both). The cross-encoder

--- a/hindsight-api-slim/hindsight_api/engine/search/reranking.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/reranking.py
@@ -247,13 +247,18 @@ class CrossEncoderReranker:
             ) from e
         self._initialized = True
 
-    async def rerank(self, query: str, candidates: list[MergedCandidate]) -> list[ScoredResult]:
+    async def rerank(
+        self, query: str, candidates: list[MergedCandidate], *, background: bool = False
+    ) -> list[ScoredResult]:
         """
         Rerank candidates using cross-encoder scores.
 
         Args:
             query: Search query
             candidates: Merged candidates from RRF
+            background: True for internal/background recalls (consolidation, reflect
+                sub-recalls). Forwarded to the cross-encoder so a local reranker can
+                give foreground (interactive) reranks queue priority.
 
         Returns:
             List of ScoredResult objects sorted by cross-encoder score
@@ -288,7 +293,7 @@ class CrossEncoderReranker:
             pairs.append([query, doc_text])
 
         # Get cross-encoder scores
-        scores = await self.cross_encoder.predict(pairs)
+        scores = await self.cross_encoder.predict(pairs, background=background)
 
         # Normalize scores to [0, 1] range.
         # External API rerankers (Cohere, Jina, llama.cpp/Qwen, etc.) return

--- a/hindsight-api-slim/tests/test_reranker_foreground_priority.py
+++ b/hindsight-api-slim/tests/test_reranker_foreground_priority.py
@@ -1,0 +1,203 @@
+"""
+Deterministic tests for the local reranker's foreground-priority lane.
+
+The local cross-encoder runs CPU-bound reranks in a shared worker pool. A plain
+FIFO ``ThreadPoolExecutor`` lets an interactive (foreground) rerank queue behind
+a large fan-out of background reranks (issued by consolidation/reflect
+sub-recalls), spiking foreground recall latency. ``_PriorityRerankExecutor``
+fixes this by dispatching foreground work ahead of *queued* background work.
+
+These tests assert **ordering / reservation semantics**, not wall-clock timing:
+there are no sleeps. ``threading.Event`` barriers and short ``result()`` timeouts
+are used only as correctness bounds (correct code completes instantly; only a
+regression to a plain FIFO pool would hit them).
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import Future
+from unittest.mock import AsyncMock
+
+from hindsight_api.engine.cross_encoder import (
+    LocalSTCrossEncoder,
+    _PriorityRerankExecutor,
+)
+from hindsight_api.engine.search.reranking import CrossEncoderReranker
+from hindsight_api.engine.search.types import MergedCandidate, RetrievalResult
+
+
+# ---------------------------------------------------------------------------
+# _PriorityRerankExecutor — the core ordering guarantee
+# ---------------------------------------------------------------------------
+
+
+def test_foreground_dispatched_before_queued_background():
+    """A foreground job submitted AFTER background jobs is dispatched first.
+
+    With a single worker held busy, every subsequent submission queues. The
+    priority queue must drain the foreground job ahead of the earlier-queued
+    background jobs. A plain FIFO pool would run them in submission order
+    (bg1, bg2, fg, bg3) and fail this assertion.
+    """
+    ex = _PriorityRerankExecutor(max_workers=1)
+    try:
+        gate = threading.Event()
+        worker_busy = threading.Event()
+        order: list[str] = []
+        order_lock = threading.Lock()
+
+        def occupy():
+            worker_busy.set()
+            # Hold the only worker until we have queued everything behind it.
+            # This is a synchronization barrier, not a timing sleep.
+            gate.wait(timeout=5)
+            return "occupy"
+
+        def record(tag: str):
+            with order_lock:
+                order.append(tag)
+            return tag
+
+        f_occupy = ex.submit(occupy)
+        assert worker_busy.wait(timeout=5), "worker never picked up the occupying job"
+
+        # Queue background jobs, then a foreground job, then more background.
+        f_bg1 = ex.submit(record, "bg1", background=True)
+        f_bg2 = ex.submit(record, "bg2", background=True)
+        f_fg = ex.submit(record, "fg", background=False)
+        f_bg3 = ex.submit(record, "bg3", background=True)
+
+        # Release the worker; the queue now drains in priority order.
+        gate.set()
+        for f in (f_occupy, f_bg1, f_bg2, f_fg, f_bg3):
+            f.result(timeout=5)
+
+        # Foreground jumped the queue; background preserved FIFO among itself.
+        assert order == ["fg", "bg1", "bg2", "bg3"], order
+    finally:
+        ex.shutdown()
+
+
+def test_same_priority_preserves_fifo():
+    """Within a priority class, submission order (FIFO) is preserved."""
+    ex = _PriorityRerankExecutor(max_workers=1)
+    try:
+        gate = threading.Event()
+        worker_busy = threading.Event()
+        order: list[str] = []
+        order_lock = threading.Lock()
+
+        def occupy():
+            worker_busy.set()
+            gate.wait(timeout=5)
+
+        def record(tag: str):
+            with order_lock:
+                order.append(tag)
+
+        f_occupy = ex.submit(occupy)
+        assert worker_busy.wait(timeout=5)
+
+        futures = [f_occupy]
+        for tag in ("fg1", "fg2", "fg3"):
+            futures.append(ex.submit(record, tag, background=False))
+
+        gate.set()
+        for f in futures:
+            f.result(timeout=5)
+
+        assert order == ["fg1", "fg2", "fg3"], order
+    finally:
+        ex.shutdown()
+
+
+def test_submitted_callable_exception_propagates_to_future():
+    """A raising job surfaces its exception via the future, not the worker thread."""
+    ex = _PriorityRerankExecutor(max_workers=1)
+    try:
+
+        def boom():
+            raise ValueError("kaboom")
+
+        fut = ex.submit(boom)
+        try:
+            fut.result(timeout=5)
+            raise AssertionError("expected ValueError")
+        except ValueError as e:
+            assert str(e) == "kaboom"
+    finally:
+        ex.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# LocalSTCrossEncoder.predict — plumbing the background flag to the pool
+# ---------------------------------------------------------------------------
+
+
+class _SpyExecutor:
+    """Records the ``background`` flag each submit was called with."""
+
+    def __init__(self):
+        self.calls: list[bool] = []
+
+    def submit(self, fn, /, *args, background: bool = False) -> Future:
+        self.calls.append(background)
+        fut: Future = Future()
+        # Return a shaped result without running the (mocked) model.
+        fut.set_result([0.5] * len(args[0]))
+        return fut
+
+
+async def test_predict_forwards_background_flag_to_executor():
+    """predict(background=...) must reach the priority executor unchanged."""
+    encoder = LocalSTCrossEncoder(model_name="test-model")
+    encoder._model = object()  # non-None so predict() does not raise
+
+    spy = _SpyExecutor()
+    saved = LocalSTCrossEncoder._executor
+    LocalSTCrossEncoder._executor = spy  # _get_executor() returns this when set
+    try:
+        await encoder.predict([("q", "d")], background=True)
+        await encoder.predict([("q", "d")], background=False)
+        await encoder.predict([("q", "d")])  # default is foreground
+        assert spy.calls == [True, False, False]
+    finally:
+        LocalSTCrossEncoder._executor = saved
+
+
+# ---------------------------------------------------------------------------
+# CrossEncoderReranker.rerank — plumbing background to predict
+# ---------------------------------------------------------------------------
+
+
+def _make_candidates(n: int) -> list[MergedCandidate]:
+    candidates = []
+    for i in range(n):
+        retrieval = RetrievalResult(
+            id=f"id-{i}",
+            text=f"Document {i}",
+            fact_type="world",
+            occurred_start=None,
+            occurred_end=None,
+        )
+        candidates.append(MergedCandidate(retrieval=retrieval, rrf_score=1.0 / (i + 1)))
+    return candidates
+
+
+async def test_reranker_forwards_background_to_predict():
+    """CrossEncoderReranker.rerank forwards its background flag to predict."""
+    ce = AsyncMock()
+    ce.predict = AsyncMock(return_value=[0.1, 0.2])
+    ce.provider_name = "local"
+    ce.initialize = AsyncMock()
+
+    reranker = CrossEncoderReranker(cross_encoder=ce)
+    reranker._initialized = True
+
+    candidates = _make_candidates(2)
+    await reranker.rerank("q", candidates, background=True)
+    assert ce.predict.await_args.kwargs.get("background") is True
+
+    await reranker.rerank("q", candidates)  # default
+    assert ce.predict.await_args.kwargs.get("background") is False


### PR DESCRIPTION
## Problem

The local cross-encoder (`LocalSTCrossEncoder`) runs **every** rerank through a single shared FIFO `ThreadPoolExecutor(max_workers=RERANKER_LOCAL_MAX_CONCURRENT)`. There is no notion of priority.

Under consolidation/reflect load — a large fan-out of **internal (background)** recalls, each doing a cross-encoder rerank — an **interactive (foreground)** recall's rerank job queues *behind that entire wall* of background jobs. Foreground recall latency spikes as a result (observed on a busy deployment: foreground recalls 5-8s while background reranks wait 20-37s).

## Fix

Introduce `_PriorityRerankExecutor` — a fixed-size worker-thread pool backed by a `queue.PriorityQueue` — that dispatches **foreground reranks ahead of *queued* background ones**. A foreground job jumps the queue; it never preempts a background job already running in a worker, so background continues to make progress between foreground arrivals. This is foreground **priority**, not background exclusion.

`LocalSTCrossEncoder` now submits through this pool (with a lazy getter so `predict()` still works when a caller injects the model without calling `initialize()`, preserving the previous `run_in_executor(None, ...)` fallback behaviour).

### Signal plumbing

The foreground/background signal already exists at the recall call site: **`RequestContext.internal`** (set `True` by reflect sub-recalls and maintenance; `False` for user-facing recalls). It is threaded down:

- `MemoryEngine._search_with_retries` derives `background = request_context.internal` at the rerank call.
- `CrossEncoderReranker.rerank(..., *, background=False)` forwards it.
- `CrossEncoderModel.predict(..., *, background=False)` receives it; `LocalSTCrossEncoder` uses it for queue priority. Remote providers accept and ignore it (they have their own concurrency controls).

## Design choice

Two options were weighed (priority queue vs. reserved-slot semaphore). The **priority queue** was chosen: it is the simplest change that keeps worker-thread semantics, it yields a fully deterministic, timing-free ordering test, and it directly expresses "foreground PRIORITY." Background starvation is not a practical risk here — foreground reranks are driven by bounded, bursty per-user recall turns and cannot saturate the pool, while background is the bulk fan-out.

> Note: the codebase currently has a single `_search_semaphore` at the recall-admission layer (no separate background-reservation semaphore at `HEAD`), so this change introduces the foreground/background distinction at the reranker layer rather than mirroring an existing two-semaphore pattern.

## Tests

`tests/test_reranker_foreground_priority.py` — deterministic, no sleeps, asserts ordering/semantics not wall-clock timing:

- **`test_foreground_dispatched_before_queued_background`** — with one worker held busy, a foreground job submitted *after* three background jobs drains **first** (`["fg","bg1","bg2","bg3"]`). A plain FIFO pool yields submission order `["bg1","bg2","fg","bg3"]` and fails this assertion (verified).
- FIFO tie-breaking within a priority class, exception propagation, `predict(background=...)` → executor plumbing, and `CrossEncoderReranker.rerank` → `predict` forwarding.

Scoped `ruff check` / `ruff format` clean; `ty` adds no new diagnostics; existing reranker tests pass unchanged.

## Scope

Single concern: the local cross-encoder pool. `FlashRankCrossEncoder` has the identical FIFO pattern and could adopt the same `_PriorityRerankExecutor` as a follow-up; it accepts and ignores `background` for now.