### PR TITLE
fix(consolidation): apply sanitize_text to the _DedupDecision merge write path

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -262,9 +262,8 @@ async def _dedup_adjudicate(
     )
     if decision.action != "merge":
         return _DedupOutcome(best_id=best_id, merged_text="", should_merge=False, best_text=best_text)
-    return _DedupOutcome(
-        best_id=best_id, merged_text=decision.text.strip() or best_text, should_merge=True, best_text=best_text
-    )
+    merged_text = (sanitize_llm_output(decision.text) or "").strip() or best_text
+    return _DedupOutcome(best_id=best_id, merged_text=merged_text, should_merge=True, best_text=best_text)
 
 
 async def _dedup_reconcile_create(

--- a/hindsight-api-slim/tests/test_consolidation_dedup.py
+++ b/hindsight-api-slim/tests/test_consolidation_dedup.py
@@ -337,6 +337,24 @@ async def test_dedup_llm_merge_folds_into_twin() -> None:
     assert args[3] == uuid.UUID(_TWIN_ID)  # onto the twin row
 
 
+async def test_dedup_llm_merge_sanitizes_text_before_write() -> None:
+    # The merge path writes the LLM's synthesized text straight to the fold UPDATE, so it needs
+    # the same character-safety scrub _CreateAction/_UpdateAction already apply via field_validator.
+    # A raw NUL reaching the driver breaks the Postgres UTF-8 encode.
+    kwargs, conn, llm = _ctx()
+    kwargs["create_source_ids"] = [uuid.uuid4(), uuid.uuid4()]
+    llm.call.return_value = _DedupDecision(
+        action="merge", text="Uzbek content\x00 on YouTube is very rich.", reason="same fact"
+    )
+    with _patch_embed(), _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.99)]):
+        result = await _dedup_reconcile_create(**kwargs)
+    assert result == _TWIN_ID  # still folds into the twin
+    conn.fetchval.assert_awaited_once()
+    args = conn.fetchval.await_args.args
+    assert "\x00" not in args[1]  # the control character never reaches SQL
+    assert args[1] == "Uzbek content on YouTube is very rich."  # scrubbed, not mangled
+
+
 async def test_dedup_picks_highest_above_threshold_skips_below() -> None:
     # Only the >=threshold candidate is considered; a 0.95 result is ignored at threshold 0.97.
     kwargs, conn, llm = _ctx(threshold=0.97)


### PR DESCRIPTION
Follows up #2544.

@nicoloboschi on that issue:

> the `_DedupDecision` merge path has no output-side scrub at all (`merged_text = decision.text` → straight to SQL). That's a real asymmetry worth a small dedicated fix (apply the existing character-safety `sanitize_text` to all three consolidation write paths)... a clean standalone issue I'd support.

This is that fix, scoped to the merge path.

### Character-safety only

`sanitize_llm_output` is an alias of `sanitize_text` (`llm_wrapper.py`), which strips ASCII control characters and lone UTF-16 surrogates — the things that break `json.loads` and the Postgres UTF-8 encode. This is **not** the declined content sanitizer; no content filtering is added here.

### The asymmetry

`_CreateAction` and `_UpdateAction` each scrub `text` through a `sanitize_llm_output` field validator. `_DedupDecision` has only `_normalize_action`, so the merge path handed the LLM's synthesized text to the fold `UPDATE` with just `.strip()` applied.

```diff
-        best_id=best_id, merged_text=decision.text.strip() or best_text, should_merge=True, best_text=best_text
+    merged_text = (sanitize_llm_output(decision.text) or "").strip() or best_text
```

The `best_text` fallback is preserved: a decision whose text sanitizes away to empty still folds into the twin's existing text rather than blanking the row.

### Test

Adds `test_dedup_llm_merge_sanitizes_text_before_write` next to the existing `test_dedup_llm_merge_folds_into_twin`, which is left untouched. It injects a NUL into the merge decision and asserts the fold `UPDATE` argument is clean.

### Verification

- The new test is **red without** the production line and **green with** it. The failure is on `assert "\x00" not in args[1]`, and the other 41 tests in the file pass either way — so it detects this gap and nothing else.
- `tests/test_consolidation_dedup.py` — 42 passed.
- `tests/test_consolidation*.py` — 114 passed, vs 113 on unmodified `main`; the delta is exactly this test. Both runs report the same 83 setup errors, which are environmental: this checkout lacks the optional `sentence-transformers` extra.
- `tests/test_llm_wrapper.py` — 47 passed.
- `ruff check` clean, `ruff format --check` clean, `ty check hindsight_api/` reports no diagnostics in `consolidator.py`.
