### PR TITLE
fix: render disallowed fields in config permission error message

### DIFF
--- a/hindsight-api-slim/hindsight_api/config_resolver.py
+++ b/hindsight-api-slim/hindsight_api/config_resolver.py
@@ -401,7 +401,7 @@ class ConfigResolver:
                             f"Not allowed to modify fields: {sorted(disallowed)}. "
                             f"Your permissions allow: {sorted(list(allowed_fields)[:10])}..."
                             if allowed_fields
-                            else "Not allowed to modify fields: {sorted(disallowed)}. "
+                            else f"Not allowed to modify fields: {sorted(disallowed)}. "
                             "Your permissions do not allow any config modifications."
                         )
             except ValueError:


### PR DESCRIPTION
## Summary

The `ConfigResolver` permission check builds its error message with a ternary. The branch used when the caller has **no** allowed config fields is missing its `f` prefix, so the API returns the literal placeholder instead of the offending field names:

```
Not allowed to modify fields: {sorted(disallowed)}. Your permissions do not allow any config modifications.
```

One-character fix: add the `f` prefix so both branches render.

## Testing

- Existing tests in `tests/test_hierarchical_config.py` match on the `"Not allowed to modify fields"` prefix and still pass.
- Verified both ternary branches now interpolate the field list correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)