### PR TITLE
feat(control-plane): refresh the UI design system

### DIFF
--- a/hindsight-control-plane/src/app/[locale]/banks/[bankId]/page.tsx
+++ b/hindsight-control-plane/src/app/[locale]/banks/[bankId]/page.tsx
@@ -251,482 +251,490 @@ export default function BankPage() {
 
         <main className="flex-1 min-w-0 overflow-y-auto">
           <div className="p-6">
-            {/* Bank Configuration Tab */}
-            {view === "profile" && (
-              <div>
-                <div className="flex justify-between items-start mb-6">
-                  <div>
-                    <h1 className="text-3xl font-bold mb-2 text-foreground">
-                      {t("bankConfiguration")}
-                    </h1>
-                    <p className="text-muted-foreground">{t("bankConfigurationDescription")}</p>
-                  </div>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant="outline" size="sm">
-                        {t("actions")}
-                        <MoreVertical className="w-4 h-4 ml-2" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" className="w-48">
-                      <DropdownMenuItem
-                        onClick={async () => {
-                          if (!bankId) return;
-                          try {
-                            const manifest = await client.exportBankTemplate(bankId);
-                            const json = JSON.stringify(manifest, null, 2);
-                            await navigator.clipboard.writeText(json);
-                            toast.success(t("templateCopied"));
-                          } catch {
-                            toast.error(t("failedToExportTemplate"));
-                          }
-                        }}
-                      >
-                        <Download className="w-4 h-4 mr-2" />
-                        {t("exportTemplate")}
-                      </DropdownMenuItem>
-                      <DropdownMenuItem onClick={() => setShowExtractDialog(true)}>
-                        <FlaskConical className="w-4 h-4 mr-2" />
-                        {t("dryRunExtraction")}
-                      </DropdownMenuItem>
-                      {llmHealthEnabled && (
-                        <DropdownMenuItem onClick={() => setShowLlmHealthDialog(true)}>
-                          <Activity className="w-4 h-4 mr-2" />
-                          {t("health")}
+            {/* Content width staircase. Without a cap the views ran the full
+                width of the window, which on a 16" display left body text and
+                table rows spanning ~1700px. The Kit specifies a flat 1024px;
+                the steps at xl/2xl are a Hindsight extension so large displays
+                don't pay ~350px gutters for that cap. One wrapper covers
+                every view because they all sit under this container. */}
+            <div className="max-w-[1024px] xl:max-w-[1280px] 2xl:max-w-[1440px] mx-auto w-full">
+              {/* Bank Configuration Tab */}
+              {view === "profile" && (
+                <div>
+                  <div className="flex justify-between items-start mb-6">
+                    <div>
+                      <h1 className="text-3xl font-bold mb-2 text-foreground">
+                        {t("bankConfiguration")}
+                      </h1>
+                      <p className="text-muted-foreground">{t("bankConfigurationDescription")}</p>
+                    </div>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="outline" size="sm">
+                          {t("actions")}
+                          <MoreVertical className="w-4 h-4 ml-2" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end" className="w-48">
+                        <DropdownMenuItem
+                          onClick={async () => {
+                            if (!bankId) return;
+                            try {
+                              const manifest = await client.exportBankTemplate(bankId);
+                              const json = JSON.stringify(manifest, null, 2);
+                              await navigator.clipboard.writeText(json);
+                              toast.success(t("templateCopied"));
+                            } catch {
+                              toast.error(t("failedToExportTemplate"));
+                            }
+                          }}
+                        >
+                          <Download className="w-4 h-4 mr-2" />
+                          {t("exportTemplate")}
                         </DropdownMenuItem>
-                      )}
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        onClick={handleTriggerConsolidation}
-                        disabled={isConsolidating || !observationsEnabled}
-                        title={
-                          !observationsEnabled ? "Observations feature is not enabled" : undefined
-                        }
-                      >
-                        {isConsolidating ? (
-                          <Spinner size="sm" className="mr-2" />
-                        ) : (
-                          <Brain className="w-4 h-4 mr-2" />
+                        <DropdownMenuItem onClick={() => setShowExtractDialog(true)}>
+                          <FlaskConical className="w-4 h-4 mr-2" />
+                          {t("dryRunExtraction")}
+                        </DropdownMenuItem>
+                        {llmHealthEnabled && (
+                          <DropdownMenuItem onClick={() => setShowLlmHealthDialog(true)}>
+                            <Activity className="w-4 h-4 mr-2" />
+                            {t("health")}
+                          </DropdownMenuItem>
                         )}
-                        {isConsolidating ? t("consolidating") : t("runConsolidation")}
-                        {!observationsEnabled && (
-                          <span className="ml-auto text-xs text-muted-foreground">Off</span>
-                        )}
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={handleRecoverConsolidation}
-                        disabled={isRecoveringConsolidation || !observationsEnabled}
-                        title={
-                          !observationsEnabled ? "Observations feature is not enabled" : undefined
-                        }
-                      >
-                        {isRecoveringConsolidation ? (
-                          <Spinner size="sm" className="mr-2" />
-                        ) : (
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          onClick={handleTriggerConsolidation}
+                          disabled={isConsolidating || !observationsEnabled}
+                          title={
+                            !observationsEnabled ? "Observations feature is not enabled" : undefined
+                          }
+                        >
+                          {isConsolidating ? (
+                            <Spinner size="sm" className="mr-2" />
+                          ) : (
+                            <Brain className="w-4 h-4 mr-2" />
+                          )}
+                          {isConsolidating ? t("consolidating") : t("runConsolidation")}
+                          {!observationsEnabled && (
+                            <span className="ml-auto text-xs text-muted-foreground">Off</span>
+                          )}
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={handleRecoverConsolidation}
+                          disabled={isRecoveringConsolidation || !observationsEnabled}
+                          title={
+                            !observationsEnabled ? "Observations feature is not enabled" : undefined
+                          }
+                        >
+                          {isRecoveringConsolidation ? (
+                            <Spinner size="sm" className="mr-2" />
+                          ) : (
+                            <RotateCcw className="w-4 h-4 mr-2" />
+                          )}
+                          {isRecoveringConsolidation ? t("recovering") : t("recoverConsolidation")}
+                          {!observationsEnabled && (
+                            <span className="ml-auto text-xs text-muted-foreground">Off</span>
+                          )}
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() => setShowClearObservationsDialog(true)}
+                          disabled={!observationsEnabled}
+                          className="text-amber-600 dark:text-amber-400 focus:text-amber-700 dark:focus:text-amber-300"
+                          title={
+                            !observationsEnabled ? "Observations feature is not enabled" : undefined
+                          }
+                        >
+                          <Trash2 className="w-4 h-4 mr-2" />
+                          {t("clearObservations")}
+                          {!observationsEnabled && (
+                            <span className="ml-auto text-xs text-muted-foreground">Off</span>
+                          )}
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          onClick={() => setShowResetConfigDialog(true)}
+                          disabled={!bankConfigEnabled}
+                          className="text-amber-600 dark:text-amber-400 focus:text-amber-700 dark:focus:text-amber-300"
+                          title={!bankConfigEnabled ? "Bank Config API is disabled" : undefined}
+                        >
                           <RotateCcw className="w-4 h-4 mr-2" />
-                        )}
-                        {isRecoveringConsolidation ? t("recovering") : t("recoverConsolidation")}
-                        {!observationsEnabled && (
-                          <span className="ml-auto text-xs text-muted-foreground">Off</span>
-                        )}
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={() => setShowClearObservationsDialog(true)}
-                        disabled={!observationsEnabled}
-                        className="text-amber-600 dark:text-amber-400 focus:text-amber-700 dark:focus:text-amber-300"
-                        title={
-                          !observationsEnabled ? "Observations feature is not enabled" : undefined
-                        }
-                      >
-                        <Trash2 className="w-4 h-4 mr-2" />
-                        {t("clearObservations")}
-                        {!observationsEnabled && (
-                          <span className="ml-auto text-xs text-muted-foreground">Off</span>
-                        )}
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        onClick={() => setShowResetConfigDialog(true)}
-                        disabled={!bankConfigEnabled}
-                        className="text-amber-600 dark:text-amber-400 focus:text-amber-700 dark:focus:text-amber-300"
-                        title={!bankConfigEnabled ? "Bank Config API is disabled" : undefined}
-                      >
-                        <RotateCcw className="w-4 h-4 mr-2" />
-                        {t("resetConfiguration")}
-                        {!bankConfigEnabled && (
-                          <span className="ml-auto text-xs text-muted-foreground">Off</span>
-                        )}
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        onClick={() => setShowDeleteDialog(true)}
-                        className="text-red-600 dark:text-red-400 focus:text-red-700 dark:focus:text-red-300"
-                      >
-                        <Trash2 className="w-4 h-4 mr-2" />
-                        {t("deleteBank")}
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
+                          {t("resetConfiguration")}
+                          {!bankConfigEnabled && (
+                            <span className="ml-auto text-xs text-muted-foreground">Off</span>
+                          )}
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          onClick={() => setShowDeleteDialog(true)}
+                          className="text-red-600 dark:text-red-400 focus:text-red-700 dark:focus:text-red-300"
+                        >
+                          <Trash2 className="w-4 h-4 mr-2" />
+                          {t("deleteBank")}
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
 
-                {/* Sub-tabs */}
-                <div className="mb-6 border-b border-border">
-                  <div className="flex gap-1">
-                    <button
-                      onClick={() => handleBankConfigTabChange("general")}
-                      className={`px-6 py-3 font-semibold text-sm transition-all relative ${
-                        bankConfigTab === "general"
-                          ? "text-primary"
-                          : "text-muted-foreground hover:text-foreground"
-                      }`}
-                    >
-                      {t("general")}
-                      {bankConfigTab === "general" && (
-                        <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
-                      )}
-                    </button>
-                    {bankConfigEnabled && (
+                  {/* Sub-tabs */}
+                  <div className="mb-6 border-b border-border">
+                    <div className="flex gap-1">
                       <button
-                        onClick={() => handleBankConfigTabChange("memory-defense")}
+                        onClick={() => handleBankConfigTabChange("general")}
                         className={`px-6 py-3 font-semibold text-sm transition-all relative ${
-                          bankConfigTab === "memory-defense"
+                          bankConfigTab === "general"
                             ? "text-primary"
                             : "text-muted-foreground hover:text-foreground"
                         }`}
                       >
-                        {t("memoryDefense")}
-                        {bankConfigTab === "memory-defense" && (
-                          <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
+                        {t("general")}
+                        {bankConfigTab === "general" && (
+                          <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary-gradient" />
                         )}
                       </button>
-                    )}
-                    {bankConfigEnabled && (
+                      {bankConfigEnabled && (
+                        <button
+                          onClick={() => handleBankConfigTabChange("memory-defense")}
+                          className={`px-6 py-3 font-semibold text-sm transition-all relative ${
+                            bankConfigTab === "memory-defense"
+                              ? "text-primary"
+                              : "text-muted-foreground hover:text-foreground"
+                          }`}
+                        >
+                          {t("memoryDefense")}
+                          {bankConfigTab === "memory-defense" && (
+                            <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary-gradient" />
+                          )}
+                        </button>
+                      )}
+                      {bankConfigEnabled && (
+                        <button
+                          onClick={() => handleBankConfigTabChange("configuration")}
+                          className={`px-6 py-3 font-semibold text-sm transition-all relative ${
+                            bankConfigTab === "configuration"
+                              ? "text-primary"
+                              : "text-muted-foreground hover:text-foreground"
+                          }`}
+                        >
+                          {t("configuration")}
+                          {bankConfigTab === "configuration" && (
+                            <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary-gradient" />
+                          )}
+                        </button>
+                      )}
                       <button
-                        onClick={() => handleBankConfigTabChange("configuration")}
+                        onClick={() => handleBankConfigTabChange("webhooks")}
                         className={`px-6 py-3 font-semibold text-sm transition-all relative ${
-                          bankConfigTab === "configuration"
+                          bankConfigTab === "webhooks"
                             ? "text-primary"
                             : "text-muted-foreground hover:text-foreground"
                         }`}
                       >
-                        {t("configuration")}
-                        {bankConfigTab === "configuration" && (
-                          <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
+                        {t("webhooks")}
+                        {bankConfigTab === "webhooks" && (
+                          <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary-gradient" />
                         )}
                       </button>
-                    )}
-                    <button
-                      onClick={() => handleBankConfigTabChange("webhooks")}
-                      className={`px-6 py-3 font-semibold text-sm transition-all relative ${
-                        bankConfigTab === "webhooks"
-                          ? "text-primary"
-                          : "text-muted-foreground hover:text-foreground"
-                      }`}
-                    >
-                      {t("webhooks")}
-                      {bankConfigTab === "webhooks" && (
-                        <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
-                      )}
-                    </button>
-                    <button
-                      onClick={() => handleBankConfigTabChange("audit-logs")}
-                      className={`px-6 py-3 font-semibold text-sm transition-all relative ${
-                        bankConfigTab === "audit-logs"
-                          ? "text-primary"
-                          : "text-muted-foreground hover:text-foreground"
-                      }`}
-                    >
-                      {t("auditLogs")}
-                      {!auditLogEnabled && (
-                        <span className="ml-2 text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
-                          Off
-                        </span>
-                      )}
-                      {bankConfigTab === "audit-logs" && (
-                        <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
-                      )}
-                    </button>
-                    <button
-                      onClick={() => handleBankConfigTabChange("llm-requests")}
-                      className={`px-6 py-3 font-semibold text-sm transition-all relative ${
-                        bankConfigTab === "llm-requests"
-                          ? "text-primary"
-                          : "text-muted-foreground hover:text-foreground"
-                      }`}
-                    >
-                      {t("llmRequests")}
-                      {!llmTraceEnabled && (
-                        <span className="ml-2 text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
-                          Off
-                        </span>
-                      )}
-                      {bankConfigTab === "llm-requests" && (
-                        <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
-                      )}
-                    </button>
+                      <button
+                        onClick={() => handleBankConfigTabChange("audit-logs")}
+                        className={`px-6 py-3 font-semibold text-sm transition-all relative ${
+                          bankConfigTab === "audit-logs"
+                            ? "text-primary"
+                            : "text-muted-foreground hover:text-foreground"
+                        }`}
+                      >
+                        {t("auditLogs")}
+                        {!auditLogEnabled && (
+                          <span className="ml-2 text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+                            Off
+                          </span>
+                        )}
+                        {bankConfigTab === "audit-logs" && (
+                          <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary-gradient" />
+                        )}
+                      </button>
+                      <button
+                        onClick={() => handleBankConfigTabChange("llm-requests")}
+                        className={`px-6 py-3 font-semibold text-sm transition-all relative ${
+                          bankConfigTab === "llm-requests"
+                            ? "text-primary"
+                            : "text-muted-foreground hover:text-foreground"
+                        }`}
+                      >
+                        {t("llmRequests")}
+                        {!llmTraceEnabled && (
+                          <span className="ml-2 text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+                            Off
+                          </span>
+                        )}
+                        {bankConfigTab === "llm-requests" && (
+                          <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary-gradient" />
+                        )}
+                      </button>
+                    </div>
                   </div>
-                </div>
 
-                {/* Tab content */}
-                <div>
-                  {bankConfigTab === "general" && (
-                    <div>
-                      <p className="text-sm text-muted-foreground mb-4">
-                        {t("overviewAndOperations")}
-                      </p>
-                      <div className="space-y-6">
-                        <BankStatsView />
-                        <BankOperationsView />
-                        <BankProfileView hideReflectFields />
-                      </div>
-                    </div>
-                  )}
-                  {bankConfigTab === "memory-defense" && bankConfigEnabled && bankId && (
-                    <div className="space-y-6">
-                      <MemoryDefenseSection bankId={bankId} />
-                    </div>
-                  )}
-                  {bankConfigTab === "configuration" && bankConfigEnabled && (
-                    <div className="space-y-6">
-                      <BankConfigView />
-                    </div>
-                  )}
-                  {bankConfigTab === "webhooks" && (
-                    <div>
-                      <p className="text-sm text-muted-foreground mb-4">
-                        {t("webhooksDescription")}
-                      </p>
-                      <WebhooksView />
-                    </div>
-                  )}
-                  {bankConfigTab === "audit-logs" &&
-                    (auditLogEnabled ? (
-                      <div>
-                        <p className="text-sm text-muted-foreground mb-4">
-                          {t("auditLogsDescription")}
-                        </p>
-                        <AuditLogsView />
-                      </div>
-                    ) : (
-                      <FeatureNotEnabled
-                        title={t("auditLogsNotEnabled")}
-                        description={t.rich("auditLogsDisabledMessage", {
-                          envVar: () => (
-                            <code className="px-1 py-0.5 bg-muted rounded text-xs">
-                              HINDSIGHT_API_AUDIT_LOG_ENABLED=true
-                            </code>
-                          ),
-                        })}
-                      />
-                    ))}
-                  {bankConfigTab === "llm-requests" &&
-                    (llmTraceEnabled ? (
-                      <div>
-                        <p className="text-sm text-muted-foreground mb-4">
-                          {t("llmRequestsDescription")}
-                        </p>
-                        <LLMRequestsView />
-                      </div>
-                    ) : (
-                      <FeatureNotEnabled
-                        title={t("llmRequestsNotEnabled")}
-                        description={t.rich("llmRequestsDisabledMessage", {
-                          envVar: () => (
-                            <code className="px-1 py-0.5 bg-muted rounded text-xs">
-                              HINDSIGHT_API_LLM_TRACE_ENABLED=true
-                            </code>
-                          ),
-                        })}
-                      />
-                    ))}
-                </div>
-              </div>
-            )}
-
-            {/* Recall Tab */}
-            {view === "recall" && (
-              <div>
-                <h1 className="text-3xl font-bold mb-2 text-foreground">{t("recallAnalyzer")}</h1>
-                <p className="text-muted-foreground mb-6">{t("recallAnalyzerDescription")}</p>
-                <SearchDebugView />
-              </div>
-            )}
-
-            {/* Reflect Tab */}
-            {view === "reflect" && (
-              <div>
-                <h1 className="text-3xl font-bold mb-2 text-foreground">{t("reflect")}</h1>
-                <p className="text-muted-foreground mb-6">{t("reflectDescription")}</p>
-                <ThinkView />
-              </div>
-            )}
-
-            {/* Data/Memories Tab */}
-            {view === "data" && (
-              <div>
-                <h1 className="text-3xl font-bold mb-2 text-foreground">{t("memories")}</h1>
-                <p className="text-muted-foreground mb-6">{t("memoriesDescription")}</p>
-
-                <div className="mb-6 border-b border-border">
-                  <div className="flex gap-1">
-                    <button
-                      onClick={() => handleDataSubTabChange("world")}
-                      className={`px-6 py-3 font-semibold text-sm transition-all relative ${
-                        subTab === "world"
-                          ? "text-primary"
-                          : "text-muted-foreground hover:text-foreground"
-                      }`}
-                    >
-                      {t("worldFacts")}
-                      {subTab === "world" && (
-                        <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
-                      )}
-                    </button>
-                    <button
-                      onClick={() => handleDataSubTabChange("experience")}
-                      className={`px-6 py-3 font-semibold text-sm transition-all relative ${
-                        subTab === "experience"
-                          ? "text-primary"
-                          : "text-muted-foreground hover:text-foreground"
-                      }`}
-                    >
-                      {t("experience")}
-                      {subTab === "experience" && (
-                        <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
-                      )}
-                    </button>
-                    <button
-                      onClick={() => handleDataSubTabChange("observations")}
-                      className={`px-6 py-3 font-semibold text-sm transition-all relative ${
-                        subTab === "observations"
-                          ? "text-primary"
-                          : "text-muted-foreground hover:text-foreground"
-                      }`}
-                    >
-                      {t("observations")}
-                      {!observationsEnabled && (
-                        <span className="ml-2 text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
-                          Off
-                        </span>
-                      )}
-                      {subTab === "observations" && (
-                        <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
-                      )}
-                    </button>
-                  </div>
-                </div>
-
-                <div>
-                  {subTab === "world" && (
-                    <div>
-                      <p className="text-sm text-muted-foreground mb-4">
-                        {t("worldFactsDescription")}
-                      </p>
-                      <DataView key="world" factType="world" />
-                    </div>
-                  )}
-                  {subTab === "experience" && (
-                    <div>
-                      <p className="text-sm text-muted-foreground mb-4">
-                        {t("experienceDescription")}
-                      </p>
-                      <DataView key="experience" factType="experience" />
-                    </div>
-                  )}
-                  {subTab === "observations" &&
-                    (observationsEnabled ? (
-                      <div>
-                        <p className="text-sm text-muted-foreground mb-4">
-                          {t("observationsDescription")}
-                        </p>
-                        <DataView key="observations" factType="observation" />
-                      </div>
-                    ) : (
-                      <FeatureNotEnabled
-                        title={t("observationsNotEnabled")}
-                        description={t.rich("observationsDisabledMessage", {
-                          envVar: () => (
-                            <code className="px-1 py-0.5 bg-muted rounded text-xs">
-                              HINDSIGHT_API_ENABLE_OBSERVATIONS=true
-                            </code>
-                          ),
-                        })}
-                      />
-                    ))}
-                </div>
-              </div>
-            )}
-
-            {/* Documents Tab — DocumentsView renders its own title row so the
-                Export/Import Actions menu can sit beside the heading. */}
-            {view === "documents" && (
-              <div>
-                <DocumentsView />
-              </div>
-            )}
-
-            {/* Entities Tab */}
-            {view === "entities" && (
-              <div>
-                <h1 className="text-3xl font-bold mb-2 text-foreground">{t("entities")}</h1>
-                <p className="text-muted-foreground mb-6">{t("entitiesDescription")}</p>
-                <EntitiesView />
-              </div>
-            )}
-
-            {/* Knowledge Tab — Pages (knowledge base) + Mental Models sub-tabs. */}
-            {view === "knowledge" && (
-              <div>
-                <h1 className="text-3xl font-bold mb-2 text-foreground">{t("knowledge")}</h1>
-                <p className="text-muted-foreground mb-4">{t("knowledgeDescription")}</p>
-
-                <div className="mb-4 border-b border-border">
-                  <div className="flex gap-1">
-                    <button
-                      onClick={() => handleKnowledgeTabChange("pages")}
-                      className={`px-6 py-3 font-semibold text-sm transition-all relative ${
-                        knowledgeTab === "pages"
-                          ? "text-primary"
-                          : "text-muted-foreground hover:text-foreground"
-                      }`}
-                    >
-                      {t("pages")}
-                      {knowledgeTab === "pages" && (
-                        <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
-                      )}
-                    </button>
-                    <button
-                      onClick={() => handleKnowledgeTabChange("models")}
-                      className={`px-6 py-3 font-semibold text-sm transition-all relative ${
-                        knowledgeTab === "models"
-                          ? "text-primary"
-                          : "text-muted-foreground hover:text-foreground"
-                      }`}
-                    >
-                      {t("mentalModels")}
-                      {knowledgeTab === "models" && (
-                        <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
-                      )}
-                    </button>
-                  </div>
-                </div>
-
-                {knowledgeTab === "pages" && <KnowledgeBaseView />}
-                {knowledgeTab === "models" && (
+                  {/* Tab content */}
                   <div>
-                    <p className="text-sm text-muted-foreground mb-4">
-                      {t("mentalModelsDescription")}
-                    </p>
-                    <MentalModelsView key="mental-models" />
+                    {bankConfigTab === "general" && (
+                      <div>
+                        <p className="text-sm text-muted-foreground mb-4">
+                          {t("overviewAndOperations")}
+                        </p>
+                        <div className="space-y-6">
+                          <BankStatsView />
+                          <BankOperationsView />
+                          <BankProfileView hideReflectFields />
+                        </div>
+                      </div>
+                    )}
+                    {bankConfigTab === "memory-defense" && bankConfigEnabled && bankId && (
+                      <div className="space-y-6">
+                        <MemoryDefenseSection bankId={bankId} />
+                      </div>
+                    )}
+                    {bankConfigTab === "configuration" && bankConfigEnabled && (
+                      <div className="space-y-6">
+                        <BankConfigView />
+                      </div>
+                    )}
+                    {bankConfigTab === "webhooks" && (
+                      <div>
+                        <p className="text-sm text-muted-foreground mb-4">
+                          {t("webhooksDescription")}
+                        </p>
+                        <WebhooksView />
+                      </div>
+                    )}
+                    {bankConfigTab === "audit-logs" &&
+                      (auditLogEnabled ? (
+                        <div>
+                          <p className="text-sm text-muted-foreground mb-4">
+                            {t("auditLogsDescription")}
+                          </p>
+                          <AuditLogsView />
+                        </div>
+                      ) : (
+                        <FeatureNotEnabled
+                          title={t("auditLogsNotEnabled")}
+                          description={t.rich("auditLogsDisabledMessage", {
+                            envVar: () => (
+                              <code className="px-1 py-0.5 bg-muted rounded text-xs">
+                                HINDSIGHT_API_AUDIT_LOG_ENABLED=true
+                              </code>
+                            ),
+                          })}
+                        />
+                      ))}
+                    {bankConfigTab === "llm-requests" &&
+                      (llmTraceEnabled ? (
+                        <div>
+                          <p className="text-sm text-muted-foreground mb-4">
+                            {t("llmRequestsDescription")}
+                          </p>
+                          <LLMRequestsView />
+                        </div>
+                      ) : (
+                        <FeatureNotEnabled
+                          title={t("llmRequestsNotEnabled")}
+                          description={t.rich("llmRequestsDisabledMessage", {
+                            envVar: () => (
+                              <code className="px-1 py-0.5 bg-muted rounded text-xs">
+                                HINDSIGHT_API_LLM_TRACE_ENABLED=true
+                              </code>
+                            ),
+                          })}
+                        />
+                      ))}
                   </div>
-                )}
-              </div>
-            )}
+                </div>
+              )}
 
-            {/* Home Tab — bank dashboard. */}
-            {view === "home" && bankId && (
-              <HomeView bankId={bankId} onNavigate={(tab) => handleTabChange(tab as NavItem)} />
-            )}
+              {/* Recall Tab */}
+              {view === "recall" && (
+                <div>
+                  <h1 className="text-3xl font-bold mb-2 text-foreground">{t("recallAnalyzer")}</h1>
+                  <p className="text-muted-foreground mb-6">{t("recallAnalyzerDescription")}</p>
+                  <SearchDebugView />
+                </div>
+              )}
+
+              {/* Reflect Tab */}
+              {view === "reflect" && (
+                <div>
+                  <h1 className="text-3xl font-bold mb-2 text-foreground">{t("reflect")}</h1>
+                  <p className="text-muted-foreground mb-6">{t("reflectDescription")}</p>
+                  <ThinkView />
+                </div>
+              )}
+
+              {/* Data/Memories Tab */}
+              {view === "data" && (
+                <div>
+                  <h1 className="text-3xl font-bold mb-2 text-foreground">{t("memories")}</h1>
+                  <p className="text-muted-foreground mb-6">{t("memoriesDescription")}</p>
+
+                  <div className="mb-6 border-b border-border">
+                    <div className="flex gap-1">
+                      <button
+                        onClick={() => handleDataSubTabChange("world")}
+                        className={`px-6 py-3 font-semibold text-sm transition-all relative ${
+                          subTab === "world"
+                            ? "text-primary"
+                            : "text-muted-foreground hover:text-foreground"
+                        }`}
+                      >
+                        {t("worldFacts")}
+                        {subTab === "world" && (
+                          <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary-gradient" />
+                        )}
+                      </button>
+                      <button
+                        onClick={() => handleDataSubTabChange("experience")}
+                        className={`px-6 py-3 font-semibold text-sm transition-all relative ${
+                          subTab === "experience"
+                            ? "text-primary"
+                            : "text-muted-foreground hover:text-foreground"
+                        }`}
+                      >
+                        {t("experience")}
+                        {subTab === "experience" && (
+                          <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary-gradient" />
+                        )}
+                      </button>
+                      <button
+                        onClick={() => handleDataSubTabChange("observations")}
+                        className={`px-6 py-3 font-semibold text-sm transition-all relative ${
+                          subTab === "observations"
+                            ? "text-primary"
+                            : "text-muted-foreground hover:text-foreground"
+                        }`}
+                      >
+                        {t("observations")}
+                        {!observationsEnabled && (
+                          <span className="ml-2 text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+                            Off
+                          </span>
+                        )}
+                        {subTab === "observations" && (
+                          <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary-gradient" />
+                        )}
+                      </button>
+                    </div>
+                  </div>
+
+                  <div>
+                    {subTab === "world" && (
+                      <div>
+                        <p className="text-sm text-muted-foreground mb-4">
+                          {t("worldFactsDescription")}
+                        </p>
+                        <DataView key="world" factType="world" />
+                      </div>
+                    )}
+                    {subTab === "experience" && (
+                      <div>
+                        <p className="text-sm text-muted-foreground mb-4">
+                          {t("experienceDescription")}
+                        </p>
+                        <DataView key="experience" factType="experience" />
+                      </div>
+                    )}
+                    {subTab === "observations" &&
+                      (observationsEnabled ? (
+                        <div>
+                          <p className="text-sm text-muted-foreground mb-4">
+                            {t("observationsDescription")}
+                          </p>
+                          <DataView key="observations" factType="observation" />
+                        </div>
+                      ) : (
+                        <FeatureNotEnabled
+                          title={t("observationsNotEnabled")}
+                          description={t.rich("observationsDisabledMessage", {
+                            envVar: () => (
+                              <code className="px-1 py-0.5 bg-muted rounded text-xs">
+                                HINDSIGHT_API_ENABLE_OBSERVATIONS=true
+                              </code>
+                            ),
+                          })}
+                        />
+                      ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Documents Tab — DocumentsView renders its own title row so the
+                Export/Import Actions menu can sit beside the heading. */}
+              {view === "documents" && (
+                <div>
+                  <DocumentsView />
+                </div>
+              )}
+
+              {/* Entities Tab */}
+              {view === "entities" && (
+                <div>
+                  <h1 className="text-3xl font-bold mb-2 text-foreground">{t("entities")}</h1>
+                  <p className="text-muted-foreground mb-6">{t("entitiesDescription")}</p>
+                  <EntitiesView />
+                </div>
+              )}
+
+              {/* Knowledge Tab — Pages (knowledge base) + Mental Models sub-tabs. */}
+              {view === "knowledge" && (
+                <div>
+                  <h1 className="text-3xl font-bold mb-2 text-foreground">{t("knowledge")}</h1>
+                  <p className="text-muted-foreground mb-4">{t("knowledgeDescription")}</p>
+
+                  <div className="mb-4 border-b border-border">
+                    <div className="flex gap-1">
+                      <button
+                        onClick={() => handleKnowledgeTabChange("pages")}
+                        className={`px-6 py-3 font-semibold text-sm transition-all relative ${
+                          knowledgeTab === "pages"
+                            ? "text-primary"
+                            : "text-muted-foreground hover:text-foreground"
+                        }`}
+                      >
+                        {t("pages")}
+                        {knowledgeTab === "pages" && (
+                          <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary-gradient" />
+                        )}
+                      </button>
+                      <button
+                        onClick={() => handleKnowledgeTabChange("models")}
+                        className={`px-6 py-3 font-semibold text-sm transition-all relative ${
+                          knowledgeTab === "models"
+                            ? "text-primary"
+                            : "text-muted-foreground hover:text-foreground"
+                        }`}
+                      >
+                        {t("mentalModels")}
+                        {knowledgeTab === "models" && (
+                          <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary-gradient" />
+                        )}
+                      </button>
+                    </div>
+                  </div>
+
+                  {knowledgeTab === "pages" && <KnowledgeBaseView />}
+                  {knowledgeTab === "models" && (
+                    <div>
+                      <p className="text-sm text-muted-foreground mb-4">
+                        {t("mentalModelsDescription")}
+                      </p>
+                      <MentalModelsView key="mental-models" />
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Home Tab — bank dashboard. */}
+              {view === "home" && bankId && (
+                <HomeView bankId={bankId} onNavigate={(tab) => handleTabChange(tab as NavItem)} />
+              )}
+            </div>
           </div>
         </main>
       </div>

--- a/hindsight-control-plane/src/app/[locale]/layout.tsx
+++ b/hindsight-control-plane/src/app/[locale]/layout.tsx
@@ -1,3 +1,4 @@
+import { Inter, JetBrains_Mono } from "next/font/google";
 import { NextIntlClientProvider, hasLocale } from "next-intl";
 import { setRequestLocale } from "next-intl/server";
 import { notFound } from "next/navigation";
@@ -6,6 +7,24 @@ import { BankProvider } from "@/lib/bank-context";
 import { FeaturesProvider } from "@/lib/features-context";
 import { ThemeProvider } from "@/lib/theme-context";
 import { Toaster } from "@/components/ui/sonner";
+
+// Inter preloaded server-side so every weight (400/500/600/700) is ready
+// before paint. The Google Fonts @import this replaces loaded weights lazily,
+// which made semibold headings render in the system fallback until the weight
+// arrived. --font-sans / --font-mono are consumed by globals.css.
+const inter = Inter({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-sans",
+  display: "swap",
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500"],
+  variable: "--font-mono",
+  display: "swap",
+});
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
@@ -41,7 +60,11 @@ export default async function LocaleLayout({
   setRequestLocale(locale);
 
   return (
-    <html lang={locale} suppressHydrationWarning>
+    <html
+      lang={locale}
+      className={`${inter.variable} ${jetbrainsMono.variable}`}
+      suppressHydrationWarning
+    >
       <body className="bg-background text-foreground">
         <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <ThemeProvider>

--- a/hindsight-control-plane/src/app/globals.css
+++ b/hindsight-control-plane/src/app/globals.css
@@ -1,4 +1,6 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Space+Grotesk:wght@500;600;700&display=swap');
+/* Inter and JetBrains Mono are loaded via next/font/google in
+   src/app/[locale]/layout.tsx. The CSS variables --font-sans and
+   --font-mono are set on <html> and consumed below in :root. */
 @import "tailwindcss";
 
 /* Bind the `dark:` variant to the `.dark` class this app actually toggles.
@@ -19,31 +21,38 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 :root {
-  --background: oklch(0.9911 0 0);
-  --foreground: oklch(0.2046 0 0);
-  --card: oklch(0.9911 0 0);
-  --card-foreground: oklch(0.2046 0 0);
-  --popover: oklch(0.9911 0 0);
-  --popover-foreground: oklch(0.4386 0 0);
-  --primary: oklch(0.55 0.19 250);
-  --primary-foreground: oklch(0.98 0.01 250);
+  /* Hindsight design system palette — light mode. Replaces the shadcn oklch
+     defaults so every bg-card / text-foreground / border-border utility across
+     the whole site picks up the design system without per-component edits. */
+  --background: #F3F5F9;
+  --foreground: #0D1117;
+  --card: #FFFFFF;
+  --card-foreground: #0D1117;
+  --popover: #FFFFFF;
+  --popover-foreground: #0D1117;
+  --primary: #0074D9;
+  --primary-foreground: #FFFFFF;
   --primary-gradient: linear-gradient(135deg, #0074d9 0%, #009296 100%);
-  --secondary: oklch(0.9940 0 0);
-  --secondary-foreground: oklch(0.2046 0 0);
-  --muted: oklch(0.9461 0 0);
-  --muted-foreground: oklch(0.2435 0 0);
-  --accent: oklch(0.9461 0 0);
-  --accent-foreground: oklch(0.2435 0 0);
-  --destructive: oklch(0.5523 0.1927 32.7272);
-  --destructive-foreground: oklch(0.9934 0.0032 17.2118);
-  --border: oklch(0.9037 0 0);
-  --input: oklch(0.9731 0 0);
-  --ring: oklch(0.55 0.19 250);
-  --chart-1: oklch(0.55 0.19 250);
-  --chart-2: oklch(0.6231 0.1880 259.8145);
-  --chart-3: oklch(0.6056 0.2189 292.7172);
-  --chart-4: oklch(0.7686 0.1647 70.0804);
-  --chart-5: oklch(0.6959 0.1491 162.4796);
+  --secondary: #EDF0F6;
+  --secondary-foreground: #0D1117;
+  --muted: #EDF0F6;
+  /* #525866 is 5.3:1 against the page bg and 7.1:1 against card white, which
+     hits WCAG AA for body text at every size we use. The lighter #6C7586 used
+     elsewhere in the palette is only 4.4:1 against the page and fails AA, so
+     light mode keeps this darker value for body copy. */
+  --muted-foreground: #525866;
+  --accent: #EDF0F6;
+  --accent-foreground: #0D1117;
+  --destructive: #D4183D;
+  --destructive-foreground: #FFFFFF;
+  --border: rgba(0, 0, 0, 0.08);
+  --input: rgba(0, 0, 0, 0.08);
+  --ring: #0074D9;
+  --chart-1: #2C82F5;
+  --chart-2: #10B981;
+  --chart-3: #8B5CF6;
+  --chart-4: #F59E0B;
+  --chart-5: #EC4899;
 
   /* Chip treatment — used by components/ui/facet-chip.tsx, the only place tags,
      entities and metadata are rendered.
@@ -76,17 +85,19 @@
   --chip-meta-border: #e7ebef;
   --chip-fg: #55677d;
   --chip-accent: #0e7f8c; /* brand cyan, darkened for the light surface */
-  --sidebar: oklch(0.9911 0 0);
-  --sidebar-foreground: oklch(0.5452 0 0);
-  --sidebar-primary: oklch(0.55 0.19 250);
-  --sidebar-primary-foreground: oklch(0.98 0.01 250);
-  --sidebar-accent: oklch(0.9461 0 0);
-  --sidebar-accent-foreground: oklch(0.2435 0 0);
-  --sidebar-border: oklch(0.9037 0 0);
-  --sidebar-ring: oklch(0.55 0.19 250);
-  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  --font-heading: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  --font-mono: 'JetBrains Mono', monospace;
+  --sidebar: #FFFFFF;
+  --sidebar-foreground: #6C7586;
+  --sidebar-primary: #0074D9;
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: #EDF0F6;
+  --sidebar-accent-foreground: #0D1117;
+  --sidebar-border: rgba(0, 0, 0, 0.05);
+  --sidebar-ring: #0074D9;
+  /* --font-sans and --font-mono are set on <html> by next/font/google in
+     [locale]/layout.tsx. :root inherits them; we intentionally do NOT
+     redeclare them here so the next/font value is what utilities resolve to.
+     A separate --font-fallback chain is provided for any future use. */
+  --font-fallback: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   --radius: 0.5rem;
   --shadow-x: 0px;
   --shadow-y: 1px;
@@ -102,36 +113,76 @@
   --shadow-lg: 0px 1px 3px 0px hsl(0 0% 0% / 0.17), 0px 4px 6px -1px hsl(0 0% 0% / 0.17);
   --shadow-xl: 0px 1px 3px 0px hsl(0 0% 0% / 0.17), 0px 8px 10px -1px hsl(0 0% 0% / 0.17);
   --shadow-2xl: 0px 1px 3px 0px hsl(0 0% 0% / 0.43);
-  --tracking-normal: 0.025em;
+  /* Inter renders best at 0 tracking for body text, negative at heading sizes.
+     Was 0.025em (positive), which made all body/label text feel spaced-out and
+     wrong at the sizes the design system actually uses. */
+  --tracking-normal: 0em;
   --spacing: 0.25rem;
+
+  /* Hindsight design tokens (light) — semantic surface/text/border/status/chart
+     palette. The brand gradient stays as the pre-existing --primary-gradient
+     above. These are namespaced with --hs- to avoid colliding with the shadcn
+     token set. */
+  --hs-surface-page: #F3F5F9;
+  --hs-surface-card: #FFFFFF;
+  --hs-surface-sidebar: #FFFFFF;
+  --hs-surface-hover: #EDF0F6;
+  --hs-surface-muted: #EDF0F6;
+
+  --hs-fg-primary: #0D1117;
+  --hs-fg-muted: #6C7586;
+  --hs-fg-on-accent: #FFFFFF;
+
+  --hs-border-default: rgba(0, 0, 0, 0.08);
+  --hs-border-subtle: rgba(0, 0, 0, 0.05);
+
+  /* #00BC7D is the success accent across light mode (progress %, "done"
+     values, operation dots). Distinct from #10B981, which is the Experience
+     chart series — different token, don't conflate them. */
+  --hs-success: #00BC7D;
+  --hs-warning: #F59E0B;
+  --hs-danger: #D4183D;
+  --hs-info: #0074D9;
+  --hs-neutral: #6C7586;
+
+  --hs-brand-blue: #0074D9;
+  --hs-brand-teal: #009296;
+
+  --hs-chart-world: #2C82F5;
+  --hs-chart-experience: #10B981;
+  --hs-chart-observations: #8B5CF6;
+  --hs-chart-temporal: #F59E0B;
+  --hs-chart-semantic: #009296;
+  --hs-chart-entity: #EC4899;
 }
 
 .dark {
-  --background: oklch(0.1822 0 0);
-  --foreground: oklch(0.9288 0.0126 255.5078);
-  --card: oklch(0.2046 0 0);
-  --card-foreground: oklch(0.9288 0.0126 255.5078);
-  --popover: oklch(0.2603 0 0);
-  --popover-foreground: oklch(0.7348 0 0);
-  --primary: oklch(0.60 0.17 250);
-  --primary-foreground: oklch(0.98 0.01 250);
+  /* Hindsight design system palette — dark mode. */
+  --background: #080C17;
+  --foreground: #DCE8FF;
+  --card: #0F1724;
+  --card-foreground: #DCE8FF;
+  --popover: #0F1724;
+  --popover-foreground: #DCE8FF;
+  --primary: #5BB0FF;
+  --primary-foreground: #080C17;
   --primary-gradient: linear-gradient(135deg, #0074d9 0%, #009296 100%);
-  --secondary: oklch(0.2603 0 0);
-  --secondary-foreground: oklch(0.9851 0 0);
-  --muted: oklch(0.2393 0 0);
-  --muted-foreground: oklch(0.7122 0 0);
-  --accent: oklch(0.3132 0 0);
-  --accent-foreground: oklch(0.9851 0 0);
-  --destructive: oklch(0.3123 0.0852 29.7877);
-  --destructive-foreground: oklch(0.9368 0.0045 34.3092);
-  --border: oklch(0.2809 0 0);
-  --input: oklch(0.2603 0 0);
-  --ring: oklch(0.60 0.17 250);
-  --chart-1: oklch(0.60 0.17 250);
-  --chart-2: oklch(0.7137 0.1434 254.6240);
-  --chart-3: oklch(0.7090 0.1592 293.5412);
-  --chart-4: oklch(0.8369 0.1644 84.4286);
-  --chart-5: oklch(0.7845 0.1325 181.9120);
+  --secondary: #172036;
+  --secondary-foreground: #DCE8FF;
+  --muted: #172036;
+  --muted-foreground: #94A8C9;
+  --accent: #172036;
+  --accent-foreground: #DCE8FF;
+  --destructive: #C0183A;
+  --destructive-foreground: #FFFFFF;
+  --border: rgba(100, 160, 255, 0.10);
+  --input: rgba(100, 160, 255, 0.10);
+  --ring: #5BB0FF;
+  --chart-1: #2C82F5;
+  --chart-2: #10B981;
+  --chart-3: #8B5CF6;
+  --chart-4: #F59E0B;
+  --chart-5: #EC4899;
 
   /* Chip treatment on the dark surface (see :root for rationale). */
   --chip-tag: #1c2836; /* slate */
@@ -142,14 +193,38 @@
   --chip-meta-border: #232d3a;
   --chip-fg: #94a8bc;
   --chip-accent: #4dd8e6; /* logo cyan */
-  --sidebar: oklch(0.1822 0 0);
-  --sidebar-foreground: oklch(0.6301 0 0);
-  --sidebar-primary: oklch(0.60 0.17 250);
-  --sidebar-primary-foreground: oklch(0.98 0.01 250);
-  --sidebar-accent: oklch(0.3132 0 0);
-  --sidebar-accent-foreground: oklch(0.9851 0 0);
-  --sidebar-border: oklch(0.2809 0 0);
-  --sidebar-ring: oklch(0.60 0.17 250);
+  --sidebar: #0A1020;
+  --sidebar-foreground: #6E8AAF;
+  --sidebar-primary: #5BB0FF;
+  --sidebar-primary-foreground: #080C17;
+  --sidebar-accent: #172036;
+  --sidebar-accent-foreground: #DCE8FF;
+  --sidebar-border: rgba(100, 160, 255, 0.07);
+  --sidebar-ring: #5BB0FF;
+
+  /* Hindsight design tokens (dark) — see the :root block above for rationale. */
+  --hs-surface-page: #080C17;
+  --hs-surface-card: #0F1724;
+  --hs-surface-sidebar: #0A1020;
+  --hs-surface-hover: #172036;
+  --hs-surface-muted: #172036;
+
+  --hs-fg-primary: #DCE8FF;
+  --hs-fg-muted: #94A8C9;
+  --hs-fg-on-accent: #FFFFFF;
+
+  --hs-border-default: rgba(100, 160, 255, 0.10);
+  --hs-border-subtle: rgba(100, 160, 255, 0.07);
+
+  /* Dark mode uses the more vivid #00D492 as the primary success — it reads
+     better against the deep navy page than the light-mode #00BC7D. */
+  --hs-success: #00D492;
+  --hs-warning: #FBB040;
+  --hs-danger: #C0183A;
+  --hs-info: #5BB0FF;
+  --hs-neutral: #6E8AAF;
+
+  /* Brand stops are mode-invariant; the gradient stays as --primary-gradient. */
 }
 
 @theme inline {
@@ -196,7 +271,9 @@
 
   --font-sans: var(--font-sans);
   --font-mono: var(--font-mono);
-  --font-heading: var(--font-heading);
+  /* Headings use Inter like the rest of the UI — alias --font-heading to
+     --font-sans so any legacy `font-heading` utility falls through to Inter. */
+  --font-heading: var(--font-sans);
 
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
@@ -218,15 +295,58 @@
   --tracking-wide: calc(var(--tracking-normal) + 0.025em);
   --tracking-wider: calc(var(--tracking-normal) + 0.05em);
   --tracking-widest: calc(var(--tracking-normal) + 0.1em);
+
+  /* Hindsight semantic utilities — generate bg-surface-*, text-fg-*, bg-success,
+     border-border-*, text-chart-* etc. from the --hs-* tokens above. */
+  --color-surface-page: var(--hs-surface-page);
+  --color-surface-card: var(--hs-surface-card);
+  --color-surface-sidebar: var(--hs-surface-sidebar);
+  --color-surface-hover: var(--hs-surface-hover);
+  --color-surface-muted: var(--hs-surface-muted);
+
+  --color-fg-primary: var(--hs-fg-primary);
+  --color-fg-muted: var(--hs-fg-muted);
+  --color-fg-on-accent: var(--hs-fg-on-accent);
+
+  --color-border-default: var(--hs-border-default);
+  --color-border-subtle: var(--hs-border-subtle);
+
+  --color-success: var(--hs-success);
+  --color-warning: var(--hs-warning);
+  --color-danger: var(--hs-danger);
+  --color-info: var(--hs-info);
+  --color-neutral: var(--hs-neutral);
+
+  --color-brand-blue: var(--hs-brand-blue);
+  --color-brand-teal: var(--hs-brand-teal);
+
+  --color-chart-world: var(--hs-chart-world);
+  --color-chart-experience: var(--hs-chart-experience);
+  --color-chart-observations: var(--hs-chart-observations);
+  --color-chart-temporal: var(--hs-chart-temporal);
+  --color-chart-semantic: var(--hs-chart-semantic);
+  --color-chart-entity: var(--hs-chart-entity);
+}
+
+/* Force the Inter chain on the document AND on form elements, which don't
+   inherit font-family from body. Without this they fall back to the browser
+   default and render visibly off against the rest of the page. */
+html, body, button, input, select, textarea, optgroup {
+  font-family: var(--font-sans), 'Inter', -apple-system, BlinkMacSystemFont,
+    system-ui, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
 }
 
 body {
-  font-family: var(--font-sans);
-  letter-spacing: var(--tracking-normal);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
+/* Tailwind preflight resets headings to `font-weight: inherit`, and unlike the
+   every heading in this app carries an explicit weight utility yet. Keep the
+   600 default so those headings stay headings; the font-family override is
+   gone because everything is Inter now. 600 is the ceiling for UI text. */
 h1, h2, h3, h4, h5, h6 {
-  font-family: var(--font-heading);
   font-weight: 600;
 }
 
@@ -237,6 +357,20 @@ code, pre {
 /* Gradient utilities */
 .bg-primary-gradient {
   background: var(--primary-gradient);
+}
+
+/* Switch primitive states. Tailwind `data-[state=...]` variants don't reach
+   the custom `.bg-primary-gradient` class (it's not a generated utility), so
+   we wire the visible track colors here. Targets Radix's `data-state` on
+   the Switch root rendered by `src/components/ui/switch.tsx`. */
+[data-slot="hs-switch"][data-state="checked"] {
+  background: var(--primary-gradient) !important;
+}
+[data-slot="hs-switch"][data-state="unchecked"] {
+  background-color: #c3cad6; /* between slate-300 and slate-400 — visible on white without feeling heavy */
+}
+.dark [data-slot="hs-switch"][data-state="unchecked"] {
+  background-color: #475569; /* slate-600 — visible on navy card without being loud */
 }
 
 .border-primary-gradient {
@@ -439,7 +573,7 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator {
 }
 
 /* Themed scrollbars — match the app surface instead of the default white track.
-   Theme tokens are oklch, so wrap with color-mix to apply opacity. */
+   color-mix is what applies the opacity to the theme token. */
 * {
   scrollbar-width: thin;
   scrollbar-color: color-mix(in oklab, var(--muted-foreground) 35%, transparent) transparent;

--- a/hindsight-control-plane/src/components/bank-config-view.tsx
+++ b/hindsight-control-plane/src/components/bank-config-view.tsx
@@ -1138,29 +1138,39 @@ function RetainStrategiesPanel({
       {/* Tab bar */}
       <div className="border-b border-border px-6 flex items-stretch gap-1 flex-wrap">
         {/* Default tab */}
+        {/* Active tab is marked with the brand gradient, which can't be
+            expressed as a border colour — so the active underline is an
+            absolutely-positioned bar and the border-b-2 is kept transparent
+            purely to carry the subtle hover underline on inactive tabs. */}
         <button
           type="button"
           onClick={() => setSelectedTab("default")}
-          className={`relative py-3 px-4 text-sm font-semibold transition-colors border-b-2 -mb-px ${
+          className={`relative py-3 px-4 text-sm font-semibold transition-colors border-b-2 border-transparent -mb-px ${
             selectedTab === "default"
-              ? "border-primary text-foreground"
-              : "border-transparent text-muted-foreground hover:text-foreground hover:border-border"
+              ? "text-foreground"
+              : "text-muted-foreground hover:text-foreground hover:border-border"
           }`}
         >
           {t("default")}
+          {selectedTab === "default" && (
+            <div className="absolute bottom-[-2px] left-0 right-0 h-0.5 bg-primary-gradient" />
+          )}
         </button>
 
         {/* Named strategy tabs */}
         {local.map((s) => (
           <div
             key={s.id}
-            className={`relative flex items-center gap-2 py-3 px-4 text-sm font-semibold transition-colors border-b-2 -mb-px cursor-pointer ${
+            className={`relative flex items-center gap-2 py-3 px-4 text-sm font-semibold transition-colors border-b-2 border-transparent -mb-px cursor-pointer ${
               selectedTab === s.id
-                ? "border-primary text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground hover:border-border"
+                ? "text-foreground"
+                : "text-muted-foreground hover:text-foreground hover:border-border"
             }`}
             onClick={() => setSelectedTab(s.id)}
           >
+            {selectedTab === s.id && (
+              <div className="absolute bottom-[-2px] left-0 right-0 h-0.5 bg-primary-gradient" />
+            )}
             <span className="font-mono">
               {s.name || <span className="italic font-normal opacity-50">{t("unnamed")}</span>}
             </span>

--- a/hindsight-control-plane/src/components/entities-view.tsx
+++ b/hindsight-control-plane/src/components/entities-view.tsx
@@ -272,7 +272,7 @@ export function EntitiesView() {
       </div>
 
       {viewMode === "relations" && (
-        <div className="border border-border rounded-lg overflow-hidden">
+        <div className="bg-card border border-border border-solid rounded-[16px] overflow-hidden">
           {graphLoading ? (
             <div className="flex items-center justify-center py-20">
               <div className="text-center">

--- a/hindsight-control-plane/src/components/home-view.tsx
+++ b/hindsight-control-plane/src/components/home-view.tsx
@@ -189,7 +189,7 @@ export function HomeView({
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 lg:h-[520px]">
         {/* Memory constellation — fills the row height so it never leaves a gap. */}
-        <div className="lg:col-span-2 rounded-lg border border-border overflow-hidden flex flex-col lg:h-full">
+        <div className="lg:col-span-2 bg-card border border-border border-solid rounded-[16px] overflow-hidden flex flex-col lg:h-full">
           <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
             <div className="flex items-center gap-2">
               <Network className="w-4 h-4 text-muted-foreground" />
@@ -225,7 +225,7 @@ export function HomeView({
 
         {/* Right column: knowledge pages + recent documents (share the row height). */}
         <div className="flex flex-col gap-4 lg:h-full min-h-0">
-          <div className="rounded-lg border border-border flex-1 min-h-0 flex flex-col overflow-hidden">
+          <div className="bg-card border border-border border-solid rounded-[16px] flex-1 min-h-0 flex flex-col overflow-hidden">
             <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
               <h2 className="text-sm font-semibold text-foreground">{t("pagesTitle")}</h2>
               {pages.length > 0 && (
@@ -271,7 +271,7 @@ export function HomeView({
             )}
           </div>
 
-          <div className="rounded-lg border border-border flex-1 min-h-0 flex flex-col overflow-hidden">
+          <div className="bg-card border border-border border-solid rounded-[16px] flex-1 min-h-0 flex flex-col overflow-hidden">
             <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
               <h2 className="text-sm font-semibold text-foreground">{t("recentDocsTitle")}</h2>
               {docs.length > 0 && (

--- a/hindsight-control-plane/src/components/sidebar.tsx
+++ b/hindsight-control-plane/src/components/sidebar.tsx
@@ -64,10 +64,30 @@ export function Sidebar({ currentTab, onTabChange }: SidebarProps) {
     { id: "profile" as NavItem, label: tBank("bankConfiguration"), icon: Settings },
   ];
 
+  // Toggle when the user clicks the aside chrome itself — nav links and the
+  // collapse button stop propagation so clicking an item navigates without
+  // also flipping the collapsed state.
+  const toggleCollapsed = () => setIsCollapsed((v) => !v);
+
   return (
     <aside
+      onClick={toggleCollapsed}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        // Only when the aside itself has focus. Without this guard, pressing
+        // Enter on a focused nav link bubbles up here and collapses the rail
+        // on every keyboard navigation.
+        if (e.target !== e.currentTarget) return;
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          toggleCollapsed();
+        }
+      }}
+      aria-label={isCollapsed ? t("expandSidebar") : t("collapseSidebar")}
+      aria-expanded={!isCollapsed}
       className={cn(
-        "bg-card border-r border-border flex flex-col transition-all duration-300",
+        "bg-card border-r border-border flex flex-col h-full transition-all duration-300 cursor-pointer select-none",
         isCollapsed ? "w-16" : "w-64"
       )}
     >
@@ -83,6 +103,9 @@ export function Sidebar({ currentTab, onTabChange }: SidebarProps) {
                 <Link
                   href={href}
                   onClick={(e) => {
+                    // Don't bubble — clicking an item navigates, it doesn't
+                    // toggle the sidebar.
+                    e.stopPropagation();
                     // For left-click, prevent default and use the callback
                     // This allows the parent to handle navigation without full page reload
                     if (e.button === 0 && !e.ctrlKey && !e.metaKey) {
@@ -94,7 +117,7 @@ export function Sidebar({ currentTab, onTabChange }: SidebarProps) {
                     // Middle-click or Ctrl/Cmd+click will naturally open in new tab
                   }}
                   className={cn(
-                    "w-full flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium transition-all",
+                    "w-full flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium transition-all cursor-pointer",
                     isActive
                       ? "bg-primary-gradient text-white shadow-sm"
                       : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
@@ -111,7 +134,8 @@ export function Sidebar({ currentTab, onTabChange }: SidebarProps) {
         </ul>
       </nav>
 
-      {/* Collapse/Expand button at bottom */}
+      {/* Collapse/Expand button at bottom — kept as an explicit affordance
+          alongside the ambient click-to-toggle on the aside chrome. */}
       <div className="p-3 border-t border-border">
         {apiVersion && (
           <div
@@ -125,9 +149,13 @@ export function Sidebar({ currentTab, onTabChange }: SidebarProps) {
           </div>
         )}
         <button
-          onClick={() => setIsCollapsed(!isCollapsed)}
+          onClick={(e) => {
+            // Don't double-toggle when the aside's onClick also fires.
+            e.stopPropagation();
+            toggleCollapsed();
+          }}
           className={cn(
-            "w-full flex items-center gap-3 px-4 py-2 rounded-lg text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors",
+            "w-full flex items-center gap-3 px-4 py-2 rounded-lg text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors cursor-pointer",
             isCollapsed && "justify-center px-0"
           )}
           title={isCollapsed ? t("expandSidebar") : t("collapseSidebar")}

--- a/hindsight-control-plane/src/components/ui/alert-dialog.tsx
+++ b/hindsight-control-plane/src/components/ui/alert-dialog.tsx
@@ -18,7 +18,7 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -36,7 +36,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-5 bg-card text-card-foreground p-6 rounded-[16px] border border-border shadow-[0_24px_64px_rgba(0,0,0,0.18)] dark:shadow-[0_24px_80px_rgba(0,0,0,0.8),0_0_0_1px_rgba(100,160,255,0.08)] duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
         className
       )}
       {...props}
@@ -46,13 +46,13 @@ const AlertDialogContent = React.forwardRef<
 AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
 
 const AlertDialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...props} />
+  <div className={cn("flex flex-col gap-1 text-left", className)} {...props} />
 );
 AlertDialogHeader.displayName = "AlertDialogHeader";
 
 const AlertDialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+    className={cn("flex flex-col-reverse sm:flex-row sm:justify-end gap-2 pt-2", className)}
     {...props}
   />
 );
@@ -64,7 +64,10 @@ const AlertDialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Title
     ref={ref}
-    className={cn("text-lg font-semibold", className)}
+    className={cn(
+      "text-[16px] font-semibold leading-[22px] tracking-tight text-foreground",
+      className
+    )}
     {...props}
   />
 ));
@@ -76,7 +79,7 @@ const AlertDialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-[13px] text-muted-foreground leading-[19px]", className)}
     {...props}
   />
 ));
@@ -96,7 +99,7 @@ const AlertDialogCancel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Cancel
     ref={ref}
-    className={cn(buttonVariants({ variant: "outline" }), "mt-2 sm:mt-0", className)}
+    className={cn(buttonVariants({ variant: "outline" }), className)}
     {...props}
   />
 ));

--- a/hindsight-control-plane/src/components/ui/button.tsx
+++ b/hindsight-control-plane/src/components/ui/button.tsx
@@ -5,22 +5,24 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[10px] text-[13px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-pointer",
   {
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        outline: "border border-border bg-card hover:bg-accent hover:text-accent-foreground",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
+        // The brand IS the gradient — this is the one primary CTA per view.
+        gradient: "bg-primary-gradient text-fg-on-accent font-semibold shadow-sm hover:opacity-90",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        default: "h-9 px-4",
+        sm: "h-8 px-3.5",
+        lg: "h-10 px-6",
+        icon: "h-9 w-9",
       },
     },
     defaultVariants: {

--- a/hindsight-control-plane/src/components/ui/card.tsx
+++ b/hindsight-control-plane/src/components/ui/card.tsx
@@ -2,12 +2,18 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
+// Standard panel chrome — a flat 16px card with a hairline border and no drop
+// shadow. The border token already carries the mode-appropriate tint
+// (rgba(0,0,0,0.08) light / rgba(100,160,255,0.10) dark), so the ring + shadow
+// stack this replaces is redundant: it made Card read one layer higher than
+// the raw `bg-card border border-border rounded-[16px]` divs used across the
+// rest of the app. Keep the two identical.
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
       className={cn(
-        "rounded-xl bg-card text-card-foreground ring-1 ring-border/60 shadow-[0_1px_2px_rgba(0,0,0,0.04),0_2px_8px_-2px_rgba(0,0,0,0.06)] dark:ring-border/40 dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_4px_16px_-4px_rgba(0,0,0,0.5)]",
+        "bg-card text-card-foreground border border-border border-solid rounded-[16px]",
         className
       )}
       {...props}

--- a/hindsight-control-plane/src/components/ui/checkbox.tsx
+++ b/hindsight-control-plane/src/components/ui/checkbox.tsx
@@ -6,6 +6,12 @@ import { Check } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
+// The unchecked-rest border is intentionally stronger than the generic
+// `border-border` token (0.08 light / 0.10 dark) — an unchecked checkbox has no
+// interior content, so it relies entirely on the border to define its shape
+// against the card surface it usually sits on. 3:1 against `bg-card` in both
+// modes, which is WCAG AA for non-text borders. Hover keeps the brand-blue
+// accent the primitive already used.
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
@@ -13,7 +19,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      "grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border border-[rgba(0,0,0,0.32)] dark:border-[rgba(100,160,255,0.40)] bg-card ring-offset-background hover:border-primary/60 dark:hover:border-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:border-primary data-[state=checked]:text-primary-foreground",
       className
     )}
     {...props}

--- a/hindsight-control-plane/src/components/ui/command.tsx
+++ b/hindsight-control-plane/src/components/ui/command.tsx
@@ -15,7 +15,7 @@ const Command = React.forwardRef<
   <CommandPrimitive
     ref={ref}
     className={cn(
-      "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+      "flex h-full w-full flex-col overflow-hidden rounded-[10px] bg-popover text-popover-foreground",
       className
     )}
     {...props}
@@ -39,12 +39,12 @@ const CommandInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
-  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
-    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+  <div className="flex items-center border-b border-border px-3" cmdk-input-wrapper="">
+    <Search className="mr-2 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-10 w-full rounded-[10px] bg-transparent py-3 text-[13px] outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}
@@ -71,7 +71,11 @@ const CommandEmpty = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Empty>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
 >((props, ref) => (
-  <CommandPrimitive.Empty ref={ref} className="py-6 text-center text-sm" {...props} />
+  <CommandPrimitive.Empty
+    ref={ref}
+    className="py-6 text-center text-[13px] text-muted-foreground"
+    {...props}
+  />
 ));
 
 CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
@@ -83,7 +87,7 @@ const CommandGroup = React.forwardRef<
   <CommandPrimitive.Group
     ref={ref}
     className={cn(
-      "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+      "overflow-hidden p-1.5 text-foreground [&_[cmdk-group-heading]]:px-2.5 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-[11px] [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-[1.045px] [&_[cmdk-group-heading]]:text-muted-foreground",
       className
     )}
     {...props}
@@ -111,7 +115,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-default gap-2 select-none items-center rounded-[6px] px-2.5 py-1.5 text-[13px] outline-none transition-colors hover:bg-accent hover:text-accent-foreground data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       className
     )}
     {...props}

--- a/hindsight-control-plane/src/components/ui/dialog.tsx
+++ b/hindsight-control-plane/src/components/ui/dialog.tsx
@@ -21,7 +21,9 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      // bg-black/60 + backdrop-blur-sm so the dialog reads as a surface above a
+      // softened page, not a stamp on a black sheet.
+      "fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -38,13 +40,23 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        // Card chrome: bg-card, rounded-[16px], hairline border, heavier
+        // dark-mode shadow so the panel separates from the very dark page. p-6
+        // is fine for dialogs (vs cards' p-[21px]) — it gives the header /
+        // form / footer enough breathing room.
+        //
+        // Tall dialogs overflow the viewport otherwise, putting the footer —
+        // and therefore the primary action — below the bottom edge. Cap the
+        // height to the viewport minus a gutter and let the content scroll
+        // inside. Callers that need a different cap can override, since their
+        // className is merged last.
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-5 bg-card text-card-foreground p-6 rounded-[16px] border border-border shadow-[0_24px_64px_rgba(0,0,0,0.18)] dark:shadow-[0_24px_80px_rgba(0,0,0,0.8),0_0_0_1px_rgba(100,160,255,0.08)] duration-200 max-h-[calc(100vh-4rem)] overflow-y-auto data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
         className
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm ring-offset-background transition-opacity hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground text-foreground">
+      <DialogPrimitive.Close className="absolute right-4 top-4 size-7 inline-flex items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus:outline-none focus:ring-1 focus:ring-primary/40 disabled:pointer-events-none">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
@@ -54,13 +66,13 @@ const DialogContent = React.forwardRef<
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+  <div className={cn("flex flex-col gap-1 text-left", className)} {...props} />
 );
 DialogHeader.displayName = "DialogHeader";
 
 const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+    className={cn("flex flex-col-reverse sm:flex-row sm:justify-end gap-2 pt-2", className)}
     {...props}
   />
 );
@@ -72,7 +84,11 @@ const DialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
-    className={cn("text-lg font-semibold leading-none tracking-tight text-foreground", className)}
+    // "Card heading" scale: 16/600.
+    className={cn(
+      "text-[16px] font-semibold leading-[22px] tracking-tight text-foreground",
+      className
+    )}
     {...props}
   />
 ));
@@ -84,7 +100,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-[13px] text-muted-foreground leading-[19px]", className)}
     {...props}
   />
 ));

--- a/hindsight-control-plane/src/components/ui/dropdown-menu.tsx
+++ b/hindsight-control-plane/src/components/ui/dropdown-menu.tsx
@@ -27,7 +27,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "flex cursor-default select-none items-center gap-2 rounded-[6px] px-2.5 py-1.5 text-[13px] outline-none transition-colors hover:bg-accent focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className
     )}
@@ -46,7 +46,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+      "z-50 min-w-[10rem] overflow-hidden rounded-[10px] border border-border bg-popover p-1.5 text-popover-foreground shadow-[0_8px_24px_rgba(0,0,0,0.12)] dark:shadow-[0_0_0_1px_rgba(100,160,255,0.07),0_8px_24px_rgba(0,0,0,0.5)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
       className
     )}
     {...props}
@@ -63,7 +63,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[10rem] overflow-y-auto overflow-x-hidden rounded-[10px] border border-border bg-popover p-1.5 text-popover-foreground shadow-[0_8px_24px_rgba(0,0,0,0.12)] dark:shadow-[0_0_0_1px_rgba(100,160,255,0.07),0_8px_24px_rgba(0,0,0,0.5)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
         className
       )}
       {...props}
@@ -81,7 +81,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-default select-none items-center gap-2 rounded-[6px] px-2.5 py-1.5 text-[13px] outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className
     )}
@@ -97,7 +97,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-[6px] py-1.5 pl-8 pr-2.5 text-[13px] outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}
@@ -120,7 +120,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-[6px] py-1.5 pl-8 pr-2.5 text-[13px] outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}
@@ -143,7 +143,11 @@ const DropdownMenuLabel = React.forwardRef<
 >(({ className, inset, ...props }, ref) => (
   <DropdownMenuPrimitive.Label
     ref={ref}
-    className={cn("px-2 py-1.5 text-sm font-semibold", inset && "pl-8", className)}
+    className={cn(
+      "px-2.5 py-1.5 text-[11px] font-semibold uppercase tracking-[1.045px] text-muted-foreground",
+      inset && "pl-8",
+      className
+    )}
     {...props}
   />
 ));
@@ -155,7 +159,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
     {...props}
   />
 ));

--- a/hindsight-control-plane/src/components/ui/input.tsx
+++ b/hindsight-control-plane/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-9 w-full rounded-[10px] border border-border bg-card px-3 text-[13px] file:border-0 file:bg-transparent file:text-[13px] file:font-medium file:text-foreground placeholder:text-muted-foreground transition-colors hover:border-[rgba(0,0,0,0.18)] dark:hover:border-[rgba(100,160,255,0.22)] focus-visible:outline-none focus-visible:border-primary focus-visible:ring-1 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/hindsight-control-plane/src/components/ui/popover.tsx
+++ b/hindsight-control-plane/src/components/ui/popover.tsx
@@ -19,7 +19,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border border-border/50 bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]",
+        "z-50 w-72 rounded-[10px] border border-border bg-popover p-4 text-popover-foreground shadow-[0_8px_24px_rgba(0,0,0,0.12)] dark:shadow-[0_0_0_1px_rgba(100,160,255,0.07),0_8px_24px_rgba(0,0,0,0.5)] outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]",
         className
       )}
       {...props}

--- a/hindsight-control-plane/src/components/ui/select.tsx
+++ b/hindsight-control-plane/src/components/ui/select.tsx
@@ -19,14 +19,14 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-9 w-full items-center justify-between rounded-[10px] border border-border bg-card px-3 text-[13px] data-[placeholder]:text-muted-foreground transition-colors hover:border-[rgba(0,0,0,0.18)] dark:hover:border-[rgba(100,160,255,0.22)] focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 opacity-50" />
+      <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ));
@@ -68,7 +68,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[10rem] overflow-y-auto overflow-x-hidden rounded-[10px] border border-border bg-popover text-popover-foreground shadow-[0_8px_24px_rgba(0,0,0,0.12)] dark:shadow-[0_0_0_1px_rgba(100,160,255,0.07),0_8px_24px_rgba(0,0,0,0.5)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className
@@ -79,7 +79,7 @@ const SelectContent = React.forwardRef<
       <SelectScrollUpButton />
       <SelectPrimitive.Viewport
         className={cn(
-          "p-1",
+          "p-1.5",
           position === "popper" &&
             "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
         )}
@@ -98,7 +98,10 @@ const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    className={cn(
+      "py-1.5 pl-8 pr-2.5 text-[11px] font-semibold uppercase tracking-[1.045px] text-muted-foreground",
+      className
+    )}
     {...props}
   />
 ));
@@ -115,7 +118,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex w-full cursor-default select-none items-center rounded-[6px] py-1.5 pl-8 pr-2.5 text-[13px] outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[state=checked]:bg-accent/60 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}
@@ -144,7 +147,7 @@ const SelectSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
     {...props}
   />
 ));

--- a/hindsight-control-plane/src/components/ui/switch.tsx
+++ b/hindsight-control-plane/src/components/ui/switch.tsx
@@ -9,9 +9,14 @@ const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,
   React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
 >(({ className, ...props }, ref) => (
+  // The checked track is the brand gradient, which is a plain CSS class rather
+  // than a generated utility, so `data-[state=...]` variants can't reach it.
+  // The track colors for both states are wired in globals.css off this
+  // data-slot; don't set them here.
   <SwitchPrimitives.Root
+    data-slot="hs-switch"
     className={cn(
-      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      "peer inline-flex h-[22px] w-[40px] shrink-0 cursor-pointer items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-50",
       className
     )}
     {...props}
@@ -19,7 +24,7 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+        "pointer-events-none block h-[18px] w-[18px] rounded-full bg-white shadow-[0_1px_3px_rgba(0,0,0,0.35)] ring-0 transition-transform data-[state=checked]:translate-x-[20px] data-[state=unchecked]:translate-x-[2px]"
       )}
     />
   </SwitchPrimitives.Root>

--- a/hindsight-control-plane/src/components/ui/textarea.tsx
+++ b/hindsight-control-plane/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"tex
     return (
       <textarea
         className={cn(
-          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex min-h-[80px] w-full rounded-[10px] border border-border bg-card px-3 py-2 text-[13px] leading-[19px] placeholder:text-muted-foreground transition-colors hover:border-[rgba(0,0,0,0.18)] dark:hover:border-[rgba(100,160,255,0.22)] focus-visible:outline-none focus-visible:border-primary focus-visible:ring-1 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}


### PR DESCRIPTION
Refreshes the control plane's design system. The stock shadcn oklch greys are replaced with the Hindsight palette and the shared primitives move onto the design system's density, so the whole app picks up the new look from tokens rather than per-component edits.

## Tokens (`globals.css`)

- Blue-shifted neutral palette in both modes: page `#F3F5F9`/`#080C17`, card `#FFFFFF`/`#0F1724`, sidebar `#FFFFFF`/`#0A1020`, hairline borders (`rgba(0,0,0,0.08)` / `rgba(100,160,255,0.10)`).
  In light mode `--card` was previously the *same value* as `--background`, so cards were indistinguishable from the page behind them.
- Adds the `--hs-*` semantic layer (surface / foreground / border / status / chart) plus its `@theme inline` mappings, so pages can reach for `bg-success`, `text-chart-world` etc. instead of raw hex.
- `--tracking-normal` `0.025em` → `0`. Inter reads wrong with positive tracking at body sizes.
- Light `--muted-foreground` is `#525866` — 5.3:1 against the page and 7.1:1 against card white, so body copy clears WCAG AA in both modes.

## Fonts

Inter and JetBrains Mono move to `next/font/google`. The Google Fonts `@import` they replace loaded weights lazily, which left semibold headings rendering in the system fallback until the weight arrived. Space Grotesk is dropped — it was only reachable through a `font-heading` utility that no component used.

## Primitives

`card`, `button` (plus a `gradient` variant for the primary CTA), `input`, `textarea`, `select`, `switch`, `checkbox`, `dialog`, `alert-dialog`, `popover`, `dropdown-menu` and `command` move to 13px / `h-9` / `rounded-[10px]`, with `rounded-[16px]` cards and dialogs and blurred overlays.

## Layout

- Bank page content is capped by a responsive staircase (`1024` / `xl:1280` / `2xl:1440`, centered). It was previously uncapped, so on a 16" display body text and table rows spanned the full ~1700px window.
- Active tab underlines use the brand gradient rather than flat `--primary`. The bank-config strategy tabs needed converting from `border-b-2 border-primary` to an absolutely-positioned bar, since a border can't carry a gradient; the transparent `border-b-2` stays so inactive tabs keep their hover underline.
- The sidebar toggles from anywhere on its chrome, not just the collapse button. The keydown handler is scoped to the aside itself so pressing Enter on a focused nav link navigates without also collapsing the rail.
- The three dashboard panels and the entities graph panel were bordered but transparent, which showed page-grey inside a card-looking box under the new palette; they now carry a card surface.

## Deliberately preserved

- The `h1`–`h6` weight default. Tailwind preflight resets headings to `font-weight: inherit`, and not every heading in this app carries an explicit weight utility, so dropping the rule would flatten them.
- The chip tokens (`facet-chip`), logo keyframes, themed scrollbars and `.prose` table rules, which a wholesale token rewrite would have dropped.
- Nested `bg-muted` boxes (code blocks, tool-call rows, chunk lists) stay at `rounded-lg`. The 16px radius is for card surfaces; promoting nested content boxes to it makes sub-content read as cards.

## Review notes

- **`page.tsx` is mostly re-indentation** from wrapping the views in the width container — `git diff -w` shows the actual change.
- No new primitives were added even where the design system defines them (`badge`, `skeleton`, `tooltip`): nothing imports them yet and knip's orphaned-file check is blocking in CI.

## Verification

- `./scripts/hooks/lint.sh` passes; `check-unused.sh` reports no blocking findings.
- 101/101 control-plane tests pass.
- `npm run build` compiles clean (54/54 static pages).
- Exercised manually against a live API in both themes: sidebar collapse/expand, bank config tabs, the configuration form (selects, inputs, textarea, switch, checkbox) and the Add Document dialog.
