### PR TITLE
chore: replace broken star-history chart with self-hosted gh-stars

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,29 @@
+name: Update star history
+
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    concurrency:
+      group: star-history
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nicoloboschi/gh-stars@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          line-color: '#14b8a6'
+      - name: Commit chart
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add .github/star-history/data.json .github/star-history/chart.svg
+          git diff --cached --quiet || git commit -m 'chore: update star history'
+          git push

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ client.reflect(bank_id="my-bank", query="What should I know about Alice?")
 ---
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=vectorize-io/hindsight&type=date&legend=top-left)](https://www.star-history.com/#vectorize-io/hindsight&type=date&legend=top-left)
+[![Star history](https://raw.githubusercontent.com/vectorize-io/hindsight/main/.github/star-history/chart.svg)](https://github.com/vectorize-io/hindsight/stargazers)
 ---
 
 ## Supported Platforms


### PR DESCRIPTION
## What

The **Star History** chart in the README embedded `api.star-history.com`, which was broken. This replaces it with [`nicoloboschi/gh-stars`](https://github.com/nicoloboschi/gh-stars): a scheduled GitHub Action that backfills stargazer data and commits a self-hosted SVG chart into the repo. No more dependency on a flaky third-party image service.

## Changes

- **`.github/workflows/star-history.yml`** — new workflow (daily cron + `workflow_dispatch`) that runs `nicoloboschi/gh-stars@v1` and commits `.github/star-history/{data.json,chart.svg}`. Uses the built-in `GITHUB_TOKEN` and a teal line color (`#14b8a6`).
- **`README.md`** — Star History now embeds `.github/star-history/chart.svg` from the repo, linking to the stargazers page.

## Follow-up required after merge

The chart SVG doesn't exist until the action runs once, so the README image will 404 until then. After merge, trigger it manually: **Actions → Update star history → Run workflow**. This generates the initial backfill + SVG, after which the daily cron keeps it fresh.