### PR TITLE
docs(knowledge-pages): document Knowledge Pages and Mental Models, and manage them from the CLI

### DIFF
--- a/hindsight-cli/.openapi-coverage.toml
+++ b/hindsight-cli/.openapi-coverage.toml
@@ -66,19 +66,6 @@ llm_request_stats = "UI-only endpoint for the control plane LLM Requests stats c
 export_documents = "Admin/ops operation, used via the API and control plane, not the end-user CLI"
 import_documents = "Admin/ops operation, used via the API and control plane, not the end-user CLI"
 
-# Knowledge base (folders + pages over mental models) is authored and managed in
-# the control plane UI. `hindsight fs` mirrors it read-only to disk over its own
-# raw HTTP client, so these CRUD/read/search endpoints have no dedicated CLI
-# subcommand.
-get_knowledge_base_tree = "Knowledge base is managed in the control plane UI; mirrored read-only by `hindsight fs`"
-create_knowledge_folder = "Knowledge base is managed in the control plane UI, not the end-user CLI"
-create_knowledge_page = "Knowledge base is managed in the control plane UI, not the end-user CLI"
-update_knowledge_node = "Knowledge base is managed in the control plane UI, not the end-user CLI"
-delete_knowledge_node = "Knowledge base is managed in the control plane UI, not the end-user CLI"
-get_knowledge_page = "Knowledge base is managed in the control plane UI; mirrored read-only by `hindsight fs`"
-export_knowledge_base = "Knowledge base export is consumed by `hindsight fs` over raw HTTP, not a CLI subcommand"
-search_knowledge_base = "Knowledge page search is a control plane UI feature, not the end-user CLI"
-
 # ---------------------------------------------------------------------------
 # Per-operation parameter skips
 # ---------------------------------------------------------------------------
@@ -140,6 +127,9 @@ apply_all_directives = "Directive tag-scope override; exposed via the API, SDKs,
 
 [fields.retain_memories]
 items = "Constructed from the single positional content argument on `memory retain`."
+
+[fields.create_knowledge_page]
+trigger = "Exposed as --mode / --fact-types on `knowledge-base create-page`; the remaining nested trigger fields (tag_groups, refresh_cron, recall_* budgets) are page-level tuning best done via the API."
 
 [fields.create_mental_model]
 trigger = "Exposed as --trigger-refresh-after-consolidation on `mental-model create` (other nested trigger fields like fact_types/tag_groups are not exposed yet)."

--- a/hindsight-cli/src/api.rs
+++ b/hindsight-cli/src/api.rs
@@ -921,6 +921,122 @@ impl ApiClient {
         })
     }
 
+    // --- Knowledge Base Methods ---
+
+    pub fn get_knowledge_base_tree(
+        &self,
+        bank_id: &str,
+        _verbose: bool,
+    ) -> Result<types::KnowledgeTreeResponse> {
+        self.runtime.block_on(async {
+            let response = self.client.get_knowledge_base_tree(bank_id, None).await?;
+            Ok(response.into_inner())
+        })
+    }
+
+    pub fn create_knowledge_folder(
+        &self,
+        bank_id: &str,
+        request: &types::CreateFolderRequest,
+        _verbose: bool,
+    ) -> Result<types::KnowledgeNode> {
+        self.runtime.block_on(async {
+            let response = self
+                .client
+                .create_knowledge_folder(bank_id, None, request)
+                .await?;
+            Ok(response.into_inner())
+        })
+    }
+
+    pub fn create_knowledge_page(
+        &self,
+        bank_id: &str,
+        request: &types::CreatePageRequest,
+        _verbose: bool,
+    ) -> Result<types::CreateKnowledgePageResponse> {
+        self.runtime.block_on(async {
+            let response = self
+                .client
+                .create_knowledge_page(bank_id, None, request)
+                .await?;
+            Ok(response.into_inner())
+        })
+    }
+
+    pub fn get_knowledge_page(
+        &self,
+        bank_id: &str,
+        page_id: &str,
+        _verbose: bool,
+    ) -> Result<types::KnowledgePageResponse> {
+        self.runtime.block_on(async {
+            let response = self
+                .client
+                .get_knowledge_page(bank_id, page_id, None)
+                .await?;
+            Ok(response.into_inner())
+        })
+    }
+
+    pub fn search_knowledge_base(
+        &self,
+        bank_id: &str,
+        query: &types::Q,
+        limit: Option<std::num::NonZeroU64>,
+        _verbose: bool,
+    ) -> Result<types::KnowledgePageSearchResponse> {
+        self.runtime.block_on(async {
+            let response = self
+                .client
+                .search_knowledge_base(bank_id, limit, query, None)
+                .await?;
+            Ok(response.into_inner())
+        })
+    }
+
+    pub fn update_knowledge_node(
+        &self,
+        bank_id: &str,
+        node_id: &str,
+        request: &types::UpdateNodeRequest,
+        _verbose: bool,
+    ) -> Result<types::KnowledgeNode> {
+        self.runtime.block_on(async {
+            let response = self
+                .client
+                .update_knowledge_node(bank_id, node_id, None, request)
+                .await?;
+            Ok(response.into_inner())
+        })
+    }
+
+    pub fn delete_knowledge_node(
+        &self,
+        bank_id: &str,
+        node_id: &str,
+        _verbose: bool,
+    ) -> Result<serde_json::Value> {
+        self.runtime.block_on(async {
+            let response = self
+                .client
+                .delete_knowledge_node(bank_id, node_id, None)
+                .await?;
+            Ok(response.into_inner())
+        })
+    }
+
+    pub fn export_knowledge_base(
+        &self,
+        bank_id: &str,
+        _verbose: bool,
+    ) -> Result<types::KnowledgePageBundleResponse> {
+        self.runtime.block_on(async {
+            let response = self.client.export_knowledge_base(bank_id, None).await?;
+            Ok(response.into_inner())
+        })
+    }
+
     // --- Directive Methods ---
 
     pub fn list_directives(

--- a/hindsight-cli/src/commands/knowledge_base.rs
+++ b/hindsight-cli/src/commands/knowledge_base.rs
@@ -1,0 +1,537 @@
+//! Knowledge base commands for managing a bank's folder/page tree.
+//!
+//! A page is a mental model with document-shaped defaults plus a place in the
+//! tree, so these commands mirror `hindsight mental-model` where the operations
+//! overlap. `hindsight fs` mirrors the same knowledge base read-only onto disk;
+//! these commands are the read/write side.
+
+use anyhow::Result;
+
+use crate::api::ApiClient;
+use crate::output::{self, OutputFormat};
+use crate::ui;
+
+use hindsight_client::types;
+
+/// Parse a --fact-types value into the generated enum, rejecting unknown values
+/// so a typo fails loudly instead of silently widening what a page reads.
+fn parse_fact_type(value: &str) -> Result<types::FactTypesItem> {
+    Ok(match value.to_lowercase().as_str() {
+        "world" => types::FactTypesItem::World,
+        "experience" => types::FactTypesItem::Experience,
+        "observation" => types::FactTypesItem::Observation,
+        other => anyhow::bail!(
+            "invalid --fact-types value '{other}': expected one of world, experience, observation"
+        ),
+    })
+}
+
+/// Parse a --mode value into the generated refresh-mode enum.
+fn parse_mode(value: &str) -> Result<types::Mode> {
+    Ok(match value.to_lowercase().as_str() {
+        "full" => types::Mode::Full,
+        "delta" => types::Mode::Delta,
+        other => anyhow::bail!("invalid --mode '{other}': expected one of full, delta"),
+    })
+}
+
+/// Show the folder/page tree for a bank
+pub fn tree(
+    client: &ApiClient,
+    bank_id: &str,
+    verbose: bool,
+    output_format: OutputFormat,
+) -> Result<()> {
+    let spinner = if output_format == OutputFormat::Pretty {
+        Some(ui::create_spinner("Fetching knowledge base..."))
+    } else {
+        None
+    };
+
+    let response = client.get_knowledge_base_tree(bank_id, verbose);
+
+    if let Some(mut sp) = spinner {
+        sp.finish();
+    }
+
+    match response {
+        Ok(result) => {
+            if output_format == OutputFormat::Pretty {
+                ui::print_section_header(&format!("Knowledge Base: {}", bank_id));
+
+                if result.roots.is_empty() {
+                    println!("  {}", ui::dim("No folders or pages found."));
+                } else {
+                    for root in &result.roots {
+                        print_node(root, 1);
+                    }
+                }
+            } else {
+                output::print_output(&result, output_format)?;
+            }
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Create a folder
+pub fn create_folder(
+    client: &ApiClient,
+    bank_id: &str,
+    name: &str,
+    parent_id: Option<&str>,
+    verbose: bool,
+    output_format: OutputFormat,
+) -> Result<()> {
+    let spinner = if output_format == OutputFormat::Pretty {
+        Some(ui::create_spinner("Creating folder..."))
+    } else {
+        None
+    };
+
+    let request = types::CreateFolderRequest {
+        name: name.to_string(),
+        parent_id: parent_id.map(|s| s.to_string()),
+    };
+
+    let response = client.create_knowledge_folder(bank_id, &request, verbose);
+
+    if let Some(mut sp) = spinner {
+        sp.finish();
+    }
+
+    match response {
+        Ok(node) => {
+            if output_format == OutputFormat::Pretty {
+                ui::print_success(&format!("Folder created: {}", node.id));
+            } else {
+                output::print_output(&node, output_format)?;
+            }
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Create a page
+#[allow(clippy::too_many_arguments)]
+pub fn create_page(
+    client: &ApiClient,
+    bank_id: &str,
+    name: &str,
+    source_query: &str,
+    parent_id: Option<&str>,
+    tags: Vec<String>,
+    max_tokens: Option<i64>,
+    mode: Option<&str>,
+    fact_types: Vec<String>,
+    verbose: bool,
+    output_format: OutputFormat,
+) -> Result<()> {
+    // Only send a trigger when the user overrode part of it. Omitting it keeps
+    // the server's page defaults (observation-only, delta, refresh after
+    // consolidation) — and because a supplied trigger REPLACES those defaults
+    // rather than merging, a partial override has to restate them.
+    let trigger = if mode.is_some() || !fact_types.is_empty() {
+        let parsed_fact_types = if fact_types.is_empty() {
+            vec![types::FactTypesItem::Observation]
+        } else {
+            fact_types
+                .iter()
+                .map(|ft| parse_fact_type(ft))
+                .collect::<Result<Vec<_>>>()?
+        };
+        Some(types::MentalModelTriggerInput {
+            mode: mode
+                .map(parse_mode)
+                .transpose()?
+                .unwrap_or(types::Mode::Delta),
+            refresh_after_consolidation: true,
+            refresh_cron: None,
+            exclude_mental_models: true,
+            exclude_mental_model_ids: None,
+            fact_types: Some(parsed_fact_types),
+            tag_groups: None,
+            tags_match: None,
+            include_chunks: None,
+            recall_max_tokens: None,
+            recall_chunks_max_tokens: None,
+        })
+    } else {
+        None
+    };
+
+    let spinner = if output_format == OutputFormat::Pretty {
+        Some(ui::create_spinner("Creating page..."))
+    } else {
+        None
+    };
+
+    let request = types::CreatePageRequest {
+        name: name.to_string(),
+        source_query: source_query.to_string(),
+        parent_id: parent_id.map(|s| s.to_string()),
+        tags: if tags.is_empty() { None } else { Some(tags) },
+        max_tokens,
+        trigger,
+    };
+
+    let response = client.create_knowledge_page(bank_id, &request, verbose);
+
+    if let Some(mut sp) = spinner {
+        sp.finish();
+    }
+
+    match response {
+        Ok(result) => {
+            if output_format == OutputFormat::Pretty {
+                ui::print_success(&format!("Page created: {}", result.page_id));
+                if let Some(ref operation_id) = result.operation_id {
+                    println!("  {} {}", ui::dim("Operation:"), operation_id);
+                    println!();
+                    println!(
+                        "{}",
+                        ui::dim("Content is generated in the background. Use 'hindsight operation get' to track it.")
+                    );
+                }
+            } else {
+                output::print_output(&result, output_format)?;
+            }
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Read a page as a markdown document
+pub fn get_page(
+    client: &ApiClient,
+    bank_id: &str,
+    page_id: &str,
+    verbose: bool,
+    output_format: OutputFormat,
+) -> Result<()> {
+    let spinner = if output_format == OutputFormat::Pretty {
+        Some(ui::create_spinner("Fetching page..."))
+    } else {
+        None
+    };
+
+    let response = client.get_knowledge_page(bank_id, page_id, verbose);
+
+    if let Some(mut sp) = spinner {
+        sp.finish();
+    }
+
+    match response {
+        Ok(page) => {
+            if output_format == OutputFormat::Pretty {
+                ui::print_section_header(&page.name);
+                println!("  {} {}", ui::dim("ID:"), ui::gradient_start(&page.id));
+                println!("  {} {}", ui::dim("Type:"), page.type_);
+                if let Some(ref description) = page.description {
+                    println!("  {} {}", ui::dim("Question:"), description);
+                }
+                if let Some(ref timestamp) = page.timestamp {
+                    println!("  {} {}", ui::dim("Last refresh:"), timestamp);
+                }
+                if !page.tags.is_empty() {
+                    println!("  {} {}", ui::dim("Tags:"), page.tags.join(", "));
+                }
+                if let Some(ref body) = page.body {
+                    println!();
+                    println!("{}", body);
+                    println!();
+                }
+            } else {
+                output::print_output(&page, output_format)?;
+            }
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Search pages (hybrid full-text + vector)
+pub fn search(
+    client: &ApiClient,
+    bank_id: &str,
+    query: &str,
+    limit: Option<u64>,
+    verbose: bool,
+    output_format: OutputFormat,
+) -> Result<()> {
+    // The generated query type rejects an empty string, which is also what the
+    // server enforces (min_length 1); surface it as a normal CLI error.
+    let query: types::Q = query
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid search query: {e}"))?;
+    let limit = limit
+        .map(|l| {
+            std::num::NonZeroU64::new(l).ok_or_else(|| {
+                anyhow::anyhow!("invalid --limit 0: expected a value between 1 and 50")
+            })
+        })
+        .transpose()?;
+
+    let spinner = if output_format == OutputFormat::Pretty {
+        Some(ui::create_spinner("Searching knowledge base..."))
+    } else {
+        None
+    };
+
+    let response = client.search_knowledge_base(bank_id, &query, limit, verbose);
+
+    if let Some(mut sp) = spinner {
+        sp.finish();
+    }
+
+    match response {
+        Ok(result) => {
+            if output_format == OutputFormat::Pretty {
+                ui::print_section_header(&format!("Search Results: {}", bank_id));
+
+                if result.results.is_empty() {
+                    println!("  {}", ui::dim("No pages matched."));
+                } else {
+                    for hit in &result.results {
+                        println!(
+                            "  {} {} {}",
+                            ui::gradient_start(&hit.id),
+                            hit.name,
+                            ui::dim(&format!("({:.3})", hit.score))
+                        );
+                        let preview: String = hit.snippet.chars().take(100).collect();
+                        let ellipsis = if hit.snippet.len() > 100 { "..." } else { "" };
+                        println!("    {}{}", ui::dim(&preview), ellipsis);
+                        println!();
+                    }
+                }
+            } else {
+                output::print_output(&result, output_format)?;
+            }
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Rename/move a node and/or update a page's options
+#[allow(clippy::too_many_arguments)]
+pub fn update(
+    client: &ApiClient,
+    bank_id: &str,
+    node_id: &str,
+    name: Option<String>,
+    parent_id: Option<String>,
+    source_query: Option<String>,
+    tags: Option<Vec<String>>,
+    max_tokens: Option<i64>,
+    verbose: bool,
+    output_format: OutputFormat,
+) -> Result<()> {
+    if name.is_none()
+        && parent_id.is_none()
+        && source_query.is_none()
+        && tags.is_none()
+        && max_tokens.is_none()
+    {
+        anyhow::bail!(
+            "At least one of --name, --parent-id, --source-query, --tags, or --max-tokens must be provided"
+        );
+    }
+
+    let spinner = if output_format == OutputFormat::Pretty {
+        Some(ui::create_spinner("Updating node..."))
+    } else {
+        None
+    };
+
+    let request = types::UpdateNodeRequest {
+        name,
+        parent_id,
+        source_query,
+        tags,
+        max_tokens,
+    };
+
+    let response = client.update_knowledge_node(bank_id, node_id, &request, verbose);
+
+    if let Some(mut sp) = spinner {
+        sp.finish();
+    }
+
+    match response {
+        Ok(node) => {
+            if output_format == OutputFormat::Pretty {
+                ui::print_success(&format!("Node '{}' updated successfully", node_id));
+                print_node(&node, 1);
+            } else {
+                output::print_output(&node, output_format)?;
+            }
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Delete a folder or page (and its whole subtree)
+pub fn delete(
+    client: &ApiClient,
+    bank_id: &str,
+    node_id: &str,
+    yes: bool,
+    verbose: bool,
+    output_format: OutputFormat,
+) -> Result<()> {
+    // Deleting a folder takes its whole subtree (and the pages' mental models)
+    // with it, so confirm unless the caller opted out.
+    if !yes && output_format == OutputFormat::Pretty {
+        let message = format!(
+            "Are you sure you want to delete '{}' and everything under it? This cannot be undone.",
+            node_id
+        );
+
+        if !ui::prompt_confirmation(&message)? {
+            ui::print_info("Operation cancelled");
+            return Ok(());
+        }
+    }
+
+    let spinner = if output_format == OutputFormat::Pretty {
+        Some(ui::create_spinner("Deleting node..."))
+    } else {
+        None
+    };
+
+    let response = client.delete_knowledge_node(bank_id, node_id, verbose);
+
+    if let Some(mut sp) = spinner {
+        sp.finish();
+    }
+
+    match response {
+        Ok(_) => {
+            if output_format == OutputFormat::Pretty {
+                ui::print_success(&format!("Node '{}' deleted successfully", node_id));
+            } else {
+                println!("{{\"success\": true}}");
+            }
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Export the knowledge base as a markdown bundle
+pub fn export(
+    client: &ApiClient,
+    bank_id: &str,
+    verbose: bool,
+    output_format: OutputFormat,
+) -> Result<()> {
+    let spinner = if output_format == OutputFormat::Pretty {
+        Some(ui::create_spinner("Exporting knowledge base..."))
+    } else {
+        None
+    };
+
+    let response = client.export_knowledge_base(bank_id, verbose);
+
+    if let Some(mut sp) = spinner {
+        sp.finish();
+    }
+
+    match response {
+        Ok(bundle) => {
+            if output_format == OutputFormat::Pretty {
+                ui::print_section_header(&format!("Knowledge Base Bundle: {}", bank_id));
+                for file in &bundle.files {
+                    println!("  {}", ui::gradient_start(&file.path));
+                }
+                println!();
+                println!(
+                    "{}",
+                    ui::dim("Use --output json to get the file contents, or 'hindsight fs mount' to mirror them to disk.")
+                );
+            } else {
+                output::print_output(&bundle, output_format)?;
+            }
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Print one tree node and its children, indented by depth.
+fn print_node(node: &types::KnowledgeNode, depth: usize) {
+    let indent = "  ".repeat(depth);
+    let marker = if node.kind == types::Kind::Folder {
+        "/"
+    } else {
+        ""
+    };
+    // Staleness only means something for pages; folders always report None.
+    let stale = if node.is_stale == Some(true) {
+        format!(" {}", ui::dim("(stale)"))
+    } else {
+        String::new()
+    };
+    println!(
+        "{}{} {}{}{}",
+        indent,
+        ui::gradient_start(&node.id),
+        node.name,
+        marker,
+        stale
+    );
+    for child in &node.children {
+        print_node(child, depth + 1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_fact_type_accepts_every_type() {
+        assert_eq!(
+            parse_fact_type("world").unwrap(),
+            types::FactTypesItem::World
+        );
+        assert_eq!(
+            parse_fact_type("experience").unwrap(),
+            types::FactTypesItem::Experience
+        );
+        assert_eq!(
+            parse_fact_type("OBSERVATION").unwrap(),
+            types::FactTypesItem::Observation
+        );
+    }
+
+    #[test]
+    fn parse_fact_type_rejects_unknown() {
+        let err = parse_fact_type("belief").unwrap_err().to_string();
+        assert!(
+            err.contains("invalid --fact-types value 'belief'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_mode_accepts_both_modes() {
+        assert_eq!(parse_mode("full").unwrap(), types::Mode::Full);
+        assert_eq!(parse_mode("DELTA").unwrap(), types::Mode::Delta);
+    }
+
+    #[test]
+    fn parse_mode_rejects_unknown() {
+        let err = parse_mode("incremental").unwrap_err().to_string();
+        assert!(
+            err.contains("invalid --mode 'incremental'"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/hindsight-cli/src/commands/mod.rs
+++ b/hindsight-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod entity;
 pub mod explore;
 pub mod fs;
 pub mod health;
+pub mod knowledge_base;
 pub mod memory;
 pub mod mental_model;
 pub mod operation;

--- a/hindsight-cli/src/main.rs
+++ b/hindsight-cli/src/main.rs
@@ -104,6 +104,10 @@ enum Commands {
     #[command(subcommand)]
     MentalModel(MentalModelCommands),
 
+    /// Manage the knowledge base (folder/page tree, search, export)
+    #[command(subcommand)]
+    KnowledgeBase(KnowledgeBaseCommands),
+
     /// Manage directives (behavioral rules)
     #[command(subcommand)]
     Directive(DirectiveCommands),
@@ -1104,6 +1108,132 @@ enum MentalModelCommands {
 }
 
 #[derive(Subcommand)]
+enum KnowledgeBaseCommands {
+    /// Show the folder/page tree for a bank
+    Tree {
+        /// Bank ID
+        bank_id: String,
+    },
+
+    /// Create a folder
+    CreateFolder {
+        /// Bank ID
+        bank_id: String,
+
+        /// Folder name
+        name: String,
+
+        /// Parent folder ID (omit to create at the root)
+        #[arg(long)]
+        parent_id: Option<String>,
+    },
+
+    /// Create a page (content is generated in the background)
+    CreatePage {
+        /// Bank ID
+        bank_id: String,
+
+        /// Page name (must be unique within its folder)
+        name: String,
+
+        /// The question the page answers, re-asked on every refresh
+        source_query: String,
+
+        /// Parent folder ID (omit to create at the root)
+        #[arg(long)]
+        parent_id: Option<String>,
+
+        /// Tags scoping which memories the page is built from (comma-separated).
+        /// A `type:<x>` tag also sets the page's rendered type.
+        #[arg(long, value_delimiter = ',')]
+        tags: Vec<String>,
+
+        /// Maximum tokens for generated content (server default: 4096)
+        #[arg(long)]
+        max_tokens: Option<i64>,
+
+        /// Refresh mode: full or delta. Omit to keep the page default (delta).
+        #[arg(long)]
+        mode: Option<String>,
+
+        /// Fact types the page is built from (comma-separated): world,
+        /// experience, observation. Omit to keep the page default (observation).
+        #[arg(long, value_delimiter = ',')]
+        fact_types: Vec<String>,
+    },
+
+    /// Read a page as a markdown document
+    GetPage {
+        /// Bank ID
+        bank_id: String,
+
+        /// Page ID
+        page_id: String,
+    },
+
+    /// Search pages (hybrid full-text + vector)
+    Search {
+        /// Bank ID
+        bank_id: String,
+
+        /// Search query
+        query: String,
+
+        /// Maximum results to return (1-50)
+        #[arg(long)]
+        limit: Option<u64>,
+    },
+
+    /// Rename/move a node, or update a page's options
+    Update {
+        /// Bank ID
+        bank_id: String,
+
+        /// Folder or page ID
+        node_id: String,
+
+        /// New name
+        #[arg(long)]
+        name: Option<String>,
+
+        /// New parent folder ID
+        #[arg(long)]
+        parent_id: Option<String>,
+
+        /// Pages only: new question. Changing it rebuilds the page.
+        #[arg(long)]
+        source_query: Option<String>,
+
+        /// Pages only: replace tags (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        tags: Option<Vec<String>>,
+
+        /// Pages only: new maximum tokens for generated content
+        #[arg(long)]
+        max_tokens: Option<i64>,
+    },
+
+    /// Delete a folder or page and its whole subtree
+    Delete {
+        /// Bank ID
+        bank_id: String,
+
+        /// Folder or page ID
+        node_id: String,
+
+        /// Skip the confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+
+    /// Export the knowledge base as a markdown bundle
+    Export {
+        /// Bank ID
+        bank_id: String,
+    },
+}
+
+#[derive(Subcommand)]
 enum DirectiveCommands {
     /// List directives for a bank
     List {
@@ -1756,6 +1886,97 @@ fn run() -> Result<()> {
                 verbose,
                 output_format,
             ),
+        },
+
+        // Knowledge base commands
+        Commands::KnowledgeBase(kb_cmd) => match kb_cmd {
+            KnowledgeBaseCommands::Tree { bank_id } => {
+                commands::knowledge_base::tree(&client, &bank_id, verbose, output_format)
+            }
+            KnowledgeBaseCommands::CreateFolder {
+                bank_id,
+                name,
+                parent_id,
+            } => commands::knowledge_base::create_folder(
+                &client,
+                &bank_id,
+                &name,
+                parent_id.as_deref(),
+                verbose,
+                output_format,
+            ),
+            KnowledgeBaseCommands::CreatePage {
+                bank_id,
+                name,
+                source_query,
+                parent_id,
+                tags,
+                max_tokens,
+                mode,
+                fact_types,
+            } => commands::knowledge_base::create_page(
+                &client,
+                &bank_id,
+                &name,
+                &source_query,
+                parent_id.as_deref(),
+                tags,
+                max_tokens,
+                mode.as_deref(),
+                fact_types,
+                verbose,
+                output_format,
+            ),
+            KnowledgeBaseCommands::GetPage { bank_id, page_id } => {
+                commands::knowledge_base::get_page(&client, &bank_id, &page_id, verbose, output_format)
+            }
+            KnowledgeBaseCommands::Search {
+                bank_id,
+                query,
+                limit,
+            } => commands::knowledge_base::search(
+                &client,
+                &bank_id,
+                &query,
+                limit,
+                verbose,
+                output_format,
+            ),
+            KnowledgeBaseCommands::Update {
+                bank_id,
+                node_id,
+                name,
+                parent_id,
+                source_query,
+                tags,
+                max_tokens,
+            } => commands::knowledge_base::update(
+                &client,
+                &bank_id,
+                &node_id,
+                name,
+                parent_id,
+                source_query,
+                tags,
+                max_tokens,
+                verbose,
+                output_format,
+            ),
+            KnowledgeBaseCommands::Delete {
+                bank_id,
+                node_id,
+                yes,
+            } => commands::knowledge_base::delete(
+                &client,
+                &bank_id,
+                &node_id,
+                yes,
+                verbose,
+                output_format,
+            ),
+            KnowledgeBaseCommands::Export { bank_id } => {
+                commands::knowledge_base::export(&client, &bank_id, verbose, output_format)
+            }
         },
 
         // Directive commands

--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -27,6 +27,7 @@ from hindsight_client_api.api import (
     documents_api,
     entities_api,
     files_api,
+    knowledge_base_api,
     memory_api,
     mental_models_api,
     monitoring_api,
@@ -48,6 +49,11 @@ from hindsight_client_api.models.recall_response import RecallResponse
 from hindsight_client_api.models.reflect_response import ReflectResponse
 from hindsight_client_api.models.retain_response import RetainResponse
 from hindsight_client_api.models.version_response import VersionResponse
+
+
+# Sentinel for "argument not provided", where None is itself a meaningful value
+# the server distinguishes from absence (e.g. parent_id=None means "the root").
+_UNSET: Any = object()
 
 
 def _run_async(coro):
@@ -173,6 +179,7 @@ class Hindsight:
         self._memory_api = memory_api.MemoryApi(self._api_client)
         self._banks_api = banks_api.BanksApi(self._api_client)
         self._mental_models_api = mental_models_api.MentalModelsApi(self._api_client)
+        self._knowledge_base_api = knowledge_base_api.KnowledgeBaseApi(self._api_client)
         self._directives_api = directives_api.DirectivesApi(self._api_client)
         self._files_api = files_api.FilesApi(self._api_client)
         self._documents_api = documents_api.DocumentsApi(self._api_client)
@@ -210,6 +217,11 @@ class Hindsight:
     def mental_models(self) -> mental_models_api.MentalModelsApi:
         """Low-level Mental Models API — create, list, get, update, refresh, delete, history."""
         return self._mental_models_api
+
+    @property
+    def knowledge_base(self) -> knowledge_base_api.KnowledgeBaseApi:
+        """Low-level Knowledge Base API — folder/page tree, page CRUD, search, export."""
+        return self._knowledge_base_api
 
     @property
     def directives(self) -> directives_api.DirectivesApi:
@@ -1329,6 +1341,209 @@ class Hindsight:
         return _run_async(
             self._mental_models_api.get_mental_model_history(bank_id, mental_model_id, _request_timeout=self._timeout)
         )
+
+    # Knowledge base methods
+
+    def get_knowledge_base_tree(self, bank_id: str):
+        """
+        Get the knowledge base as a nested folder/page tree (sync wrapper — use
+        ``await client.knowledge_base.get_knowledge_base_tree(...)`` in async code).
+
+        Page bodies are not included; fetch a page with :meth:`get_knowledge_page`.
+
+        Args:
+            bank_id: The memory bank ID
+
+        Returns:
+            KnowledgeTreeResponse with roots
+        """
+        return _run_async(self._knowledge_base_api.get_knowledge_base_tree(bank_id, _request_timeout=self._timeout))
+
+    def create_knowledge_folder(self, bank_id: str, name: str, parent_id: str | None = None):
+        """
+        Create a knowledge-base folder (sync wrapper — use
+        ``await client.knowledge_base.create_knowledge_folder(...)`` in async code).
+
+        Args:
+            bank_id: The memory bank ID
+            name: Folder name
+            parent_id: Optional parent folder ID (None creates it at the root)
+
+        Returns:
+            KnowledgeNode
+        """
+        from hindsight_client_api.models import create_folder_request
+
+        request_obj = create_folder_request.CreateFolderRequest(name=name, parent_id=parent_id)
+
+        return _run_async(
+            self._knowledge_base_api.create_knowledge_folder(bank_id, request_obj, _request_timeout=self._timeout)
+        )
+
+    def create_knowledge_page(
+        self,
+        bank_id: str,
+        name: str,
+        source_query: str,
+        parent_id: str | None = None,
+        tags: list[str] | None = None,
+        max_tokens: int | None = None,
+        trigger: dict[str, Any] | None = None,
+    ):
+        """
+        Create a knowledge-base page (sync wrapper — use
+        ``await client.knowledge_base.create_knowledge_page(...)`` in async code).
+
+        Content is generated asynchronously; poll the returned ``operation_id``
+        to know when the first build has finished.
+
+        Args:
+            bank_id: The memory bank ID
+            name: Page name (must be unique within its folder)
+            source_query: The question the page answers, re-asked on every refresh
+            parent_id: Optional parent folder ID (None creates it at the root)
+            tags: Optional tags scoping which memories the page is built from. A
+                ``type:<x>`` tag also sets the page's rendered type.
+            max_tokens: Optional content budget (defaults to 4096 server-side)
+            trigger: Optional trigger settings. Omit to use the page defaults
+                (observation-only, delta mode, refresh after consolidation); a
+                supplied trigger replaces those defaults rather than merging.
+
+        Returns:
+            CreateKnowledgePageResponse with page_id, mental_model_id and operation_id
+        """
+        from hindsight_client_api.models import create_page_request, mental_model_trigger_input
+
+        trigger_obj = None
+        if trigger:
+            trigger_obj = mental_model_trigger_input.MentalModelTriggerInput(**trigger)
+
+        request_obj = create_page_request.CreatePageRequest(
+            name=name,
+            source_query=source_query,
+            parent_id=parent_id,
+            tags=tags,
+            max_tokens=max_tokens,
+            trigger=trigger_obj,
+        )
+
+        return _run_async(
+            self._knowledge_base_api.create_knowledge_page(bank_id, request_obj, _request_timeout=self._timeout)
+        )
+
+    def get_knowledge_page(self, bank_id: str, page_id: str):
+        """
+        Get a knowledge page rendered as a markdown document (sync wrapper — use
+        ``await client.knowledge_base.get_knowledge_page(...)`` in async code).
+
+        Args:
+            bank_id: The memory bank ID
+            page_id: The page ID
+
+        Returns:
+            KnowledgePageResponse with body and full markdown (frontmatter + body)
+        """
+        return _run_async(
+            self._knowledge_base_api.get_knowledge_page(bank_id, page_id, _request_timeout=self._timeout)
+        )
+
+    def search_knowledge_base(self, bank_id: str, q: str, limit: int | None = None):
+        """
+        Hybrid search over knowledge pages (sync wrapper — use
+        ``await client.knowledge_base.search_knowledge_base(...)`` in async code).
+
+        Args:
+            bank_id: The memory bank ID
+            q: Search query
+            limit: Maximum results to return (1-50, defaults to 10 server-side)
+
+        Returns:
+            KnowledgePageSearchResponse with ranked results
+        """
+        return _run_async(
+            self._knowledge_base_api.search_knowledge_base(bank_id, q, limit=limit, _request_timeout=self._timeout)
+        )
+
+    def update_knowledge_node(
+        self,
+        bank_id: str,
+        node_id: str,
+        name: str | None = None,
+        parent_id: str | None = _UNSET,
+        source_query: str | None = None,
+        tags: list[str] | None = None,
+        max_tokens: int | None = None,
+    ):
+        """
+        Rename/move a knowledge node and/or update a page's options (sync wrapper —
+        use ``await client.knowledge_base.update_knowledge_node(...)`` in async code).
+
+        Only the fields you pass are applied. ``parent_id`` is only sent when
+        provided, so passing ``None`` explicitly moves the node to the root.
+
+        Args:
+            bank_id: The memory bank ID
+            node_id: The folder or page ID
+            name: Optional new name
+            parent_id: Optional new parent folder (pass None to move to the root)
+            source_query: Pages only — new question. Changing it rebuilds the page.
+            tags: Pages only — replaces the page's tags (pass [] to clear)
+            max_tokens: Pages only — new content budget
+
+        Returns:
+            KnowledgeNode
+        """
+        from hindsight_client_api.models import update_node_request
+
+        # Build the request from only the arguments the caller supplied: the server
+        # treats an absent field as "leave alone" but an explicit null parent_id as
+        # "move to the root", so passing every field through (as the other update
+        # wrappers do) would make those two cases indistinguishable.
+        fields: dict[str, Any] = {}
+        if name is not None:
+            fields["name"] = name
+        if parent_id is not _UNSET:
+            fields["parent_id"] = parent_id
+        if source_query is not None:
+            fields["source_query"] = source_query
+        if tags is not None:
+            fields["tags"] = tags
+        if max_tokens is not None:
+            fields["max_tokens"] = max_tokens
+
+        request_obj = update_node_request.UpdateNodeRequest(**fields)
+
+        return _run_async(
+            self._knowledge_base_api.update_knowledge_node(
+                bank_id, node_id, request_obj, _request_timeout=self._timeout
+            )
+        )
+
+    def delete_knowledge_node(self, bank_id: str, node_id: str):
+        """
+        Delete a knowledge folder or page and its whole subtree (sync wrapper — use
+        ``await client.knowledge_base.delete_knowledge_node(...)`` in async code).
+
+        Args:
+            bank_id: The memory bank ID
+            node_id: The folder or page ID
+        """
+        return _run_async(
+            self._knowledge_base_api.delete_knowledge_node(bank_id, node_id, _request_timeout=self._timeout)
+        )
+
+    def export_knowledge_base(self, bank_id: str):
+        """
+        Export the knowledge base as a portable markdown bundle (sync wrapper — use
+        ``await client.knowledge_base.export_knowledge_base(...)`` in async code).
+
+        Args:
+            bank_id: The memory bank ID
+
+        Returns:
+            KnowledgePageBundleResponse with files (index.md, one file per page, history logs)
+        """
+        return _run_async(self._knowledge_base_api.export_knowledge_base(bank_id, _request_timeout=self._timeout))
 
     # Directives methods
 

--- a/hindsight-clients/python/tests/test_knowledge_base_mapping.py
+++ b/hindsight-clients/python/tests/test_knowledge_base_mapping.py
@@ -1,0 +1,134 @@
+"""The maintained wrapper builds correct knowledge-base requests.
+
+Mirrors the TypeScript wrapper's ``knowledge_base_mapping`` tests so the two
+hand-written clients stay at parity. The interesting case is
+``update_knowledge_node``: the server distinguishes "field not provided" from
+``parent_id: null`` (which means "move to the root"), so an omitted argument
+must not be serialized at all.
+"""
+
+from unittest.mock import MagicMock
+
+from hindsight_client import Hindsight
+
+
+def _capture(monkeypatch, client, method, captured):
+    async def fake(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return MagicMock()
+
+    monkeypatch.setattr(client._knowledge_base_api, method, fake)
+
+
+def test_create_page_maps_every_option(monkeypatch):
+    client = Hindsight(base_url="http://example.invalid")
+    captured: dict[str, object] = {}
+    _capture(monkeypatch, client, "create_knowledge_page", captured)
+
+    client.create_knowledge_page(
+        "bank-1",
+        name="Deploying the API",
+        source_query="How is the API deployed?",
+        parent_id="kf-1",
+        tags=["ops", "type:runbook"],
+        max_tokens=8192,
+    )
+
+    bank_id, request = captured["args"]
+    assert bank_id == "bank-1"
+    assert request.name == "Deploying the API"
+    assert request.source_query == "How is the API deployed?"
+    assert request.parent_id == "kf-1"
+    assert request.tags == ["ops", "type:runbook"]
+    assert request.max_tokens == 8192
+    # Omitting trigger must leave the server-side page defaults in place.
+    assert request.trigger is None
+
+
+def test_create_page_threads_trigger_fields(monkeypatch):
+    client = Hindsight(base_url="http://example.invalid")
+    captured: dict[str, object] = {}
+    _capture(monkeypatch, client, "create_knowledge_page", captured)
+
+    client.create_knowledge_page(
+        "bank-1",
+        name="Page",
+        source_query="q",
+        trigger={
+            "mode": "delta",
+            "refresh_after_consolidation": True,
+            "fact_types": ["observation"],
+            "exclude_mental_models": True,
+        },
+    )
+
+    _, request = captured["args"]
+    assert request.trigger.mode == "delta"
+    assert request.trigger.refresh_after_consolidation is True
+    assert request.trigger.fact_types == ["observation"]
+    assert request.trigger.exclude_mental_models is True
+
+
+def test_update_node_sends_only_provided_fields(monkeypatch):
+    client = Hindsight(base_url="http://example.invalid")
+    captured: dict[str, object] = {}
+    _capture(monkeypatch, client, "update_knowledge_node", captured)
+
+    client.update_knowledge_node("bank-1", "kp-1", name="Renamed")
+
+    _, node_id, request = captured["args"]
+    assert node_id == "kp-1"
+    assert request.name == "Renamed"
+    assert "parent_id" not in request.model_fields_set
+
+
+def test_update_node_sends_explicit_null_parent(monkeypatch):
+    client = Hindsight(base_url="http://example.invalid")
+    captured: dict[str, object] = {}
+    _capture(monkeypatch, client, "update_knowledge_node", captured)
+
+    client.update_knowledge_node("bank-1", "kp-1", parent_id=None)
+
+    _, _, request = captured["args"]
+    assert "parent_id" in request.model_fields_set
+    assert request.parent_id is None
+
+
+def test_update_node_maps_page_options(monkeypatch):
+    client = Hindsight(base_url="http://example.invalid")
+    captured: dict[str, object] = {}
+    _capture(monkeypatch, client, "update_knowledge_node", captured)
+
+    client.update_knowledge_node("bank-1", "kp-1", source_query="New question?", tags=[], max_tokens=2048)
+
+    _, _, request = captured["args"]
+    assert request.source_query == "New question?"
+    assert request.tags == []
+    assert request.max_tokens == 2048
+
+
+def test_search_forwards_query_and_limit(monkeypatch):
+    client = Hindsight(base_url="http://example.invalid")
+    captured: dict[str, object] = {}
+    _capture(monkeypatch, client, "search_knowledge_base", captured)
+
+    client.search_knowledge_base("bank-1", "how do we deploy", limit=5)
+
+    bank_id, query = captured["args"]
+    assert bank_id == "bank-1"
+    assert query == "how do we deploy"
+    assert captured["kwargs"]["limit"] == 5
+
+
+def test_create_folder_maps_parent(monkeypatch):
+    client = Hindsight(base_url="http://example.invalid")
+    captured: dict[str, object] = {}
+    _capture(monkeypatch, client, "create_knowledge_folder", captured)
+
+    client.create_knowledge_folder("bank-1", "Operations", parent_id=None)
+
+    bank_id, request = captured["args"]
+    assert bank_id == "bank-1"
+    assert request.name == "Operations"
+    assert request.parent_id is None

--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -53,10 +53,16 @@ import type {
   TagGroupNotInput,
   MinScores,
   AsyncOperationSubmitResponse,
+  CreateKnowledgePageResponse,
   CreateMentalModelResponse,
   DirectiveListResponse,
   DirectiveResponse,
   DocumentResponse,
+  KnowledgeNode,
+  KnowledgePageBundleResponse,
+  KnowledgePageResponse,
+  KnowledgePageSearchResponse,
+  KnowledgeTreeResponse,
   ListDocumentsResponse,
   MentalModelListResponse,
   MentalModelResponse,
@@ -1033,6 +1039,213 @@ export class HindsightClient {
   }
 
   /**
+   * Get the knowledge base as a nested folder/page tree.
+   *
+   * Page bodies are not included — fetch one with `getKnowledgePage`.
+   */
+  async getKnowledgeBaseTree(
+    bankId: string,
+    options?: { signal?: AbortSignal }
+  ): Promise<KnowledgeTreeResponse> {
+    const response = await sdk.getKnowledgeBaseTree({
+      client: this.client,
+      path: { bank_id: bankId },
+      signal: options?.signal,
+    });
+
+    return this.validateResponse(response, "getKnowledgeBaseTree");
+  }
+
+  /**
+   * Create a knowledge-base folder.
+   */
+  async createKnowledgeFolder(
+    bankId: string,
+    name: string,
+    options?: { parentId?: string | null; signal?: AbortSignal }
+  ): Promise<KnowledgeNode> {
+    const response = await sdk.createKnowledgeFolder({
+      client: this.client,
+      path: { bank_id: bankId },
+      body: { name, parent_id: options?.parentId },
+      signal: options?.signal,
+    });
+
+    return this.validateResponse(response, "createKnowledgeFolder");
+  }
+
+  /**
+   * Create a knowledge-base page. Content is generated asynchronously — poll the
+   * returned `operation_id` to know when the first build has finished.
+   *
+   * Omit `trigger` to use the page defaults (observation-only, delta mode,
+   * refresh after consolidation); a supplied trigger replaces those defaults
+   * rather than merging with them.
+   */
+  async createKnowledgePage(
+    bankId: string,
+    name: string,
+    sourceQuery: string,
+    options?: {
+      parentId?: string | null;
+      /** Scopes which memories the page is built from. A `type:<x>` tag also sets the page's rendered type. */
+      tags?: string[];
+      maxTokens?: number;
+      trigger?: {
+        mode?: "full" | "delta";
+        refreshAfterConsolidation?: boolean;
+        refreshCron?: string | null;
+        factTypes?: Array<"world" | "experience" | "observation">;
+        excludeMentalModels?: boolean;
+        excludeMentalModelIds?: string[];
+        tagsMatch?: "any" | "all" | "any_strict" | "all_strict" | "exact";
+        tagGroups?: Array<TagGroupLeaf | TagGroupAndInput | TagGroupOrInput | TagGroupNotInput>;
+        includeChunks?: boolean;
+        recallMaxTokens?: number;
+        recallChunksMaxTokens?: number;
+      };
+      signal?: AbortSignal;
+    }
+  ): Promise<CreateKnowledgePageResponse> {
+    const response = await sdk.createKnowledgePage({
+      client: this.client,
+      path: { bank_id: bankId },
+      body: {
+        name,
+        source_query: sourceQuery,
+        parent_id: options?.parentId,
+        tags: options?.tags,
+        max_tokens: options?.maxTokens,
+        trigger: options?.trigger
+          ? {
+              mode: options.trigger.mode,
+              refresh_after_consolidation: options.trigger.refreshAfterConsolidation,
+              refresh_cron: options.trigger.refreshCron,
+              fact_types: options.trigger.factTypes,
+              exclude_mental_models: options.trigger.excludeMentalModels,
+              exclude_mental_model_ids: options.trigger.excludeMentalModelIds,
+              tags_match: options.trigger.tagsMatch,
+              tag_groups: options.trigger.tagGroups,
+              include_chunks: options.trigger.includeChunks,
+              recall_max_tokens: options.trigger.recallMaxTokens,
+              recall_chunks_max_tokens: options.trigger.recallChunksMaxTokens,
+            }
+          : undefined,
+      },
+      signal: options?.signal,
+    });
+
+    return this.validateResponse(response, "createKnowledgePage");
+  }
+
+  /**
+   * Get a knowledge page rendered as a markdown document (frontmatter + body).
+   */
+  async getKnowledgePage(
+    bankId: string,
+    pageId: string,
+    options?: { signal?: AbortSignal }
+  ): Promise<KnowledgePageResponse> {
+    const response = await sdk.getKnowledgePage({
+      client: this.client,
+      path: { bank_id: bankId, page_id: pageId },
+      signal: options?.signal,
+    });
+
+    return this.validateResponse(response, "getKnowledgePage");
+  }
+
+  /**
+   * Hybrid search (full-text + vector) over the bank's knowledge pages.
+   */
+  async searchKnowledgeBase(
+    bankId: string,
+    query: string,
+    options?: { limit?: number; signal?: AbortSignal }
+  ): Promise<KnowledgePageSearchResponse> {
+    const response = await sdk.searchKnowledgeBase({
+      client: this.client,
+      path: { bank_id: bankId },
+      query: {
+        q: query,
+        ...(options?.limit !== undefined ? { limit: options.limit } : {}),
+      },
+      signal: options?.signal,
+    });
+
+    return this.validateResponse(response, "searchKnowledgeBase");
+  }
+
+  /**
+   * Rename/move a knowledge node and/or update a page's options.
+   *
+   * Only the fields present in `options` are sent, so passing `parentId: null`
+   * explicitly moves the node to the root.
+   */
+  async updateKnowledgeNode(
+    bankId: string,
+    nodeId: string,
+    options: {
+      name?: string;
+      parentId?: string | null;
+      /** Pages only — changing it rebuilds the page against the new question. */
+      sourceQuery?: string;
+      /** Pages only — replaces the page's tags (pass [] to clear). */
+      tags?: string[];
+      maxTokens?: number;
+      signal?: AbortSignal;
+    }
+  ): Promise<KnowledgeNode> {
+    const response = await sdk.updateKnowledgeNode({
+      client: this.client,
+      path: { bank_id: bankId, node_id: nodeId },
+      body: {
+        ...(options.name !== undefined ? { name: options.name } : {}),
+        ...("parentId" in options ? { parent_id: options.parentId } : {}),
+        ...(options.sourceQuery !== undefined ? { source_query: options.sourceQuery } : {}),
+        ...(options.tags !== undefined ? { tags: options.tags } : {}),
+        ...(options.maxTokens !== undefined ? { max_tokens: options.maxTokens } : {}),
+      },
+      signal: options.signal,
+    });
+
+    return this.validateResponse(response, "updateKnowledgeNode");
+  }
+
+  /**
+   * Delete a knowledge folder or page and its whole subtree.
+   */
+  async deleteKnowledgeNode(
+    bankId: string,
+    nodeId: string,
+    options?: { signal?: AbortSignal }
+  ): Promise<unknown> {
+    const response = await sdk.deleteKnowledgeNode({
+      client: this.client,
+      path: { bank_id: bankId, node_id: nodeId },
+      signal: options?.signal,
+    });
+
+    return this.validateResponse(response, "deleteKnowledgeNode");
+  }
+
+  /**
+   * Export the knowledge base as a portable markdown bundle.
+   */
+  async exportKnowledgeBase(
+    bankId: string,
+    options?: { signal?: AbortSignal }
+  ): Promise<KnowledgePageBundleResponse> {
+    const response = await sdk.exportKnowledgeBase({
+      client: this.client,
+      path: { bank_id: bankId },
+      signal: options?.signal,
+    });
+
+    return this.validateResponse(response, "exportKnowledgeBase");
+  }
+
+  /**
    * Get a document by ID. Returns null if not found.
    */
   async getDocument(
@@ -1178,10 +1391,16 @@ export type {
   TagGroupNotInput,
   MinScores,
   AsyncOperationSubmitResponse,
+  CreateKnowledgePageResponse,
   CreateMentalModelResponse,
   DirectiveListResponse,
   DirectiveResponse,
   DocumentResponse,
+  KnowledgeNode,
+  KnowledgePageBundleResponse,
+  KnowledgePageResponse,
+  KnowledgePageSearchResponse,
+  KnowledgeTreeResponse,
   ListDocumentsResponse,
   MentalModelListResponse,
   MentalModelResponse,

--- a/hindsight-clients/typescript/tests/knowledge_base_mapping.test.ts
+++ b/hindsight-clients/typescript/tests/knowledge_base_mapping.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for the knowledge-base wrappers' request mapping.
+ *
+ * Like create_mental_model_mapping, these do NOT require a running server: the
+ * generated sdk layer is mocked so we can assert the ergonomic camelCase
+ * options land on the snake_case request body — and, for updateKnowledgeNode,
+ * that an omitted field is genuinely absent rather than sent as undefined
+ * (the server distinguishes "not provided" from `parent_id: null`, which means
+ * "move to the root").
+ */
+
+import { HindsightClient } from "../src";
+import * as sdk from "../generated/sdk.gen";
+
+jest.mock("../generated/sdk.gen");
+
+const mockedCreatePage = sdk.createKnowledgePage as jest.MockedFunction<
+  typeof sdk.createKnowledgePage
+>;
+const mockedUpdateNode = sdk.updateKnowledgeNode as jest.MockedFunction<
+  typeof sdk.updateKnowledgeNode
+>;
+const mockedSearch = sdk.searchKnowledgeBase as jest.MockedFunction<typeof sdk.searchKnowledgeBase>;
+
+describe("createKnowledgePage mapping", () => {
+  let client: HindsightClient;
+
+  beforeEach(() => {
+    client = new HindsightClient({ baseUrl: "http://localhost:8888" });
+    mockedCreatePage.mockReset();
+    mockedCreatePage.mockResolvedValue({
+      data: { page_id: "kp-1", mental_model_id: "mm-1", operation_id: "op-1" },
+    } as any);
+  });
+
+  test("maps name, source query, parent and tags", async () => {
+    await client.createKnowledgePage("bank", "Deploying the API", "How is the API deployed?", {
+      parentId: "kf-1",
+      tags: ["ops", "type:runbook"],
+      maxTokens: 8192,
+    });
+
+    const body = mockedCreatePage.mock.calls[0][0].body as any;
+    expect(body.name).toBe("Deploying the API");
+    expect(body.source_query).toBe("How is the API deployed?");
+    expect(body.parent_id).toBe("kf-1");
+    expect(body.tags).toEqual(["ops", "type:runbook"]);
+    expect(body.max_tokens).toBe(8192);
+  });
+
+  test("omitting trigger sends no trigger (preserves the page defaults)", async () => {
+    await client.createKnowledgePage("bank", "Page", "q");
+
+    expect((mockedCreatePage.mock.calls[0][0].body as any).trigger).toBeUndefined();
+  });
+
+  test("threads every trigger field through, snake_cased", async () => {
+    await client.createKnowledgePage("bank", "Page", "q", {
+      trigger: {
+        mode: "delta",
+        refreshAfterConsolidation: true,
+        factTypes: ["observation"],
+        excludeMentalModels: true,
+        excludeMentalModelIds: ["mm-9"],
+        tagsMatch: "any",
+        includeChunks: false,
+        recallMaxTokens: 4096,
+        recallChunksMaxTokens: 1024,
+      },
+    });
+
+    const trigger = (mockedCreatePage.mock.calls[0][0].body as any).trigger;
+    expect(trigger.mode).toBe("delta");
+    expect(trigger.refresh_after_consolidation).toBe(true);
+    expect(trigger.fact_types).toEqual(["observation"]);
+    expect(trigger.exclude_mental_models).toBe(true);
+    expect(trigger.exclude_mental_model_ids).toEqual(["mm-9"]);
+    expect(trigger.tags_match).toBe("any");
+    expect(trigger.include_chunks).toBe(false);
+    expect(trigger.recall_max_tokens).toBe(4096);
+    expect(trigger.recall_chunks_max_tokens).toBe(1024);
+  });
+});
+
+describe("updateKnowledgeNode mapping", () => {
+  let client: HindsightClient;
+
+  beforeEach(() => {
+    client = new HindsightClient({ baseUrl: "http://localhost:8888" });
+    mockedUpdateNode.mockReset();
+    mockedUpdateNode.mockResolvedValue({ data: { id: "kp-1", kind: "page", name: "Page" } } as any);
+  });
+
+  test("sends only the fields provided", async () => {
+    await client.updateKnowledgeNode("bank", "kp-1", { name: "Renamed" });
+
+    const body = mockedUpdateNode.mock.calls[0][0].body as any;
+    expect(body).toEqual({ name: "Renamed" });
+    expect("parent_id" in body).toBe(false);
+  });
+
+  test("an explicit null parentId is sent (move to the root)", async () => {
+    await client.updateKnowledgeNode("bank", "kp-1", { parentId: null });
+
+    const body = mockedUpdateNode.mock.calls[0][0].body as any;
+    expect("parent_id" in body).toBe(true);
+    expect(body.parent_id).toBeNull();
+  });
+
+  test("maps page options to snake_case", async () => {
+    await client.updateKnowledgeNode("bank", "kp-1", {
+      sourceQuery: "New question?",
+      tags: [],
+      maxTokens: 2048,
+    });
+
+    const body = mockedUpdateNode.mock.calls[0][0].body as any;
+    expect(body.source_query).toBe("New question?");
+    expect(body.tags).toEqual([]);
+    expect(body.max_tokens).toBe(2048);
+  });
+});
+
+describe("searchKnowledgeBase mapping", () => {
+  let client: HindsightClient;
+
+  beforeEach(() => {
+    client = new HindsightClient({ baseUrl: "http://localhost:8888" });
+    mockedSearch.mockReset();
+    mockedSearch.mockResolvedValue({ data: { results: [], total: 0 } } as any);
+  });
+
+  test("sends the query as q and omits limit when unset", async () => {
+    await client.searchKnowledgeBase("bank", "how do we deploy");
+
+    const query = mockedSearch.mock.calls[0][0].query as any;
+    expect(query.q).toBe("how do we deploy");
+    expect("limit" in query).toBe(false);
+  });
+
+  test("passes limit through when set", async () => {
+    await client.searchKnowledgeBase("bank", "deploy", { limit: 5 });
+
+    expect((mockedSearch.mock.calls[0][0].query as any).limit).toBe(5);
+  });
+});

--- a/hindsight-docs/docs/developer/api/knowledge-pages.mdx
+++ b/hindsight-docs/docs/developer/api/knowledge-pages.mdx
@@ -1,0 +1,367 @@
+---
+sidebar_position: 5
+---
+
+# Knowledge Pages
+
+Living markdown documents, organized in a folder tree, that rewrite themselves as the bank learns.
+
+A page is backed by a [mental model](./mental-models) but is configured as a document: it is built from the bank's [observations](../observations) only, it never reads other pages, and it refreshes incrementally after each consolidation. See [Knowledge Pages](../knowledge-pages) for the concepts behind the API.
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeSnippet from '@site/src/components/CodeSnippet';
+
+{/* Import raw source files */}
+import knowledgePagesPy from '!!raw-loader!@site/examples/api/knowledge-pages.py';
+import knowledgePagesMjs from '!!raw-loader!@site/examples/api/knowledge-pages.mjs';
+import knowledgePagesGo from '!!raw-loader!@site/examples/api/knowledge-pages.go';
+
+All endpoints below are relative to a bank:
+
+```
+/v1/default/banks/{bank_id}/knowledge-base
+```
+
+---
+
+## Get the Tree
+
+Returns the whole knowledge base as a nested tree of folders and pages. Page bodies are **not** included — fetch a page to read its content.
+
+<Tabs>
+<TabItem value="python" label="Python">
+<CodeSnippet code={knowledgePagesPy} section="get-tree" language="python" />
+</TabItem>
+<TabItem value="node" label="Node.js">
+<CodeSnippet code={knowledgePagesMjs} section="get-tree" language="javascript" />
+</TabItem>
+<TabItem value="go" label="Go">
+<CodeSnippet code={knowledgePagesGo} section="get-tree" language="go" />
+</TabItem>
+</Tabs>
+
+```json
+{
+  "roots": [
+    {
+      "id": "kf-9f2c...",
+      "kind": "folder",
+      "name": "Operations",
+      "parent_id": null,
+      "mental_model_id": null,
+      "managed": false,
+      "description": null,
+      "tags": [],
+      "timestamp": "2026-08-01T11:04:02+00:00",
+      "is_stale": null,
+      "children": [
+        {
+          "id": "kp-2e85...",
+          "kind": "page",
+          "name": "Deploying the API",
+          "parent_id": "kf-9f2c...",
+          "mental_model_id": "mm-77ab...",
+          "managed": false,
+          "description": "How is the API deployed?",
+          "tags": ["ops"],
+          "timestamp": "2026-08-03T09:12:44+00:00",
+          "is_stale": true,
+          "children": []
+        }
+      ]
+    }
+  ]
+}
+```
+
+| Field | Description |
+|---|---|
+| `kind` | `folder` or `page` |
+| `mental_model_id` | The backing mental model (pages only) |
+| `description` | The page's source query — the question that rebuilds it |
+| `timestamp` | Last refresh for a page, last update for a folder |
+| `is_stale` | Pages only: `true` when memories in the page's scope are newer than its last refresh |
+| `managed` | `true` when the node is flagged as system-owned rather than hand-authored |
+
+---
+
+## Create a Page
+
+Creating a page stores it with placeholder content and schedules the first build in the background. Poll the returned `operation_id` via the [operations API](./operations) to know when the content is ready.
+
+<Tabs>
+<TabItem value="python" label="Python">
+<CodeSnippet code={knowledgePagesPy} section="create-page" language="python" />
+</TabItem>
+<TabItem value="node" label="Node.js">
+<CodeSnippet code={knowledgePagesMjs} section="create-page" language="javascript" />
+</TabItem>
+<TabItem value="go" label="Go">
+<CodeSnippet code={knowledgePagesGo} section="create-page" language="go" />
+</TabItem>
+</Tabs>
+
+```json
+{
+  "page_id": "kp-2e85...",
+  "mental_model_id": "mm-77ab...",
+  "operation_id": "op-1d0f..."
+}
+```
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Page name. Must be unique within its folder, case-insensitively — a duplicate returns `409`. (Enforced on PostgreSQL only.) |
+| `source_query` | string | Yes | The question the page answers, re-asked on every refresh. |
+| `parent_id` | string | No | Folder to create the page in. `null` (or omitted) creates it at the root. |
+| `tags` | list | No | Tags that scope which memories the page is built from. A `type:<x>` tag also sets the page's rendered type. |
+| `max_tokens` | int | No | Content budget. Defaults to `4096` (a plain mental model defaults to `2048`). |
+| `trigger` | object | No | Refresh configuration — see below. |
+
+### Default Trigger
+
+When `trigger` is omitted, the page is created with a document-oriented configuration:
+
+```json
+{
+  "mode": "delta",
+  "fact_types": ["observation"],
+  "exclude_mental_models": true,
+  "refresh_after_consolidation": true
+}
+```
+
+This makes the page a living document built from consolidated observations only, refreshed incrementally whenever consolidation produces new knowledge in its scope, and never influenced by other pages.
+
+| Setting | Why |
+|---|---|
+| `fact_types: ["observation"]` | The page reads consolidated beliefs, not the raw conversational noise underneath them. Observations are already deduplicated and evidence-backed, so a page reads as a settled document instead of a transcript. Enforced structurally — with only `observation` in scope, the refresh agent isn't given the raw-memory recall tool at all. |
+| `exclude_mental_models: true` | A page never reflects on sibling pages. Without this, pages would cite each other and drift into a feedback loop where one wrong claim propagates across the knowledge base. |
+| `mode: "delta"` | Each refresh edits the existing document with what is new since the last refresh instead of regenerating it, so hand-tuned structure and wording survive. See [Refresh Mode](./mental-models#refresh-mode). |
+| `refresh_after_consolidation: true` | The page rewrites itself whenever consolidation produces new knowledge in its scope — gated by the same [staleness check](./mental-models#staleness-gating) as any mental model, so unrelated bank activity doesn't trigger rebuilds. |
+
+### Page Lifecycle
+
+1. **Create** — the page is stored with placeholder content and a background refresh is submitted; the call returns immediately with an `operation_id`.
+2. **First build** — a full generation, since there is no prior document to edit.
+3. **Consolidation** — new memories are retained and consolidated into observations.
+4. **Staleness check** — pages whose trigger asks for it are checked against their own scope (tags and `fact_types` both apply).
+5. **Delta refresh** — stale pages are rewritten by editing the existing document with the new observations only.
+
+Observations are what a page is *built from*, but it can still inspect the evidence underneath them: the refresh agent can expand a memory to its original chunk or document (unless `store_document_text` is disabled for the bank), and if `HINDSIGHT_API_REFLECT_SOURCE_FACTS_MAX_TOKENS` is enabled — off by default — observation search also returns each observation's grounding facts.
+
+:::caution
+A supplied `trigger` **replaces** these defaults, it does not merge with them. Sending `{"trigger": {"mode": "full"}}` also resets `fact_types` to all types, `exclude_mental_models` to `false`, and `refresh_after_consolidation` to `false`. Repeat the fields you want to keep.
+:::
+
+Every [mental model trigger setting](./mental-models#trigger-settings) is accepted here — including `refresh_cron` for scheduled rebuilds instead of consolidation-driven ones, and `tag_groups` for compound tag scoping.
+
+---
+
+## Create a Folder
+
+<Tabs>
+<TabItem value="python" label="Python">
+<CodeSnippet code={knowledgePagesPy} section="create-folder" language="python" />
+</TabItem>
+<TabItem value="node" label="Node.js">
+<CodeSnippet code={knowledgePagesMjs} section="create-folder" language="javascript" />
+</TabItem>
+<TabItem value="go" label="Go">
+<CodeSnippet code={knowledgePagesGo} section="create-folder" language="go" />
+</TabItem>
+</Tabs>
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Folder name |
+| `parent_id` | string | No | Parent folder. Omit or pass `null` for the root. |
+
+A `parent_id` that does not exist, or that points at a page rather than a folder, returns `400`.
+
+---
+
+## Read a Page
+
+Returns the page rendered as a markdown document.
+
+<Tabs>
+<TabItem value="python" label="Python">
+<CodeSnippet code={knowledgePagesPy} section="get-page" language="python" />
+</TabItem>
+<TabItem value="node" label="Node.js">
+<CodeSnippet code={knowledgePagesMjs} section="get-page" language="javascript" />
+</TabItem>
+<TabItem value="go" label="Go">
+<CodeSnippet code={knowledgePagesGo} section="get-page" language="go" />
+</TabItem>
+</Tabs>
+
+```json
+{
+  "id": "kp-2e85...",
+  "name": "Deploying the API",
+  "type": "runbook",
+  "description": "How is the API deployed?",
+  "tags": ["ops"],
+  "timestamp": "2026-08-03T09:12:44+00:00",
+  "body": "# Deploying the API\n\n...",
+  "markdown": "---\nid: \"kp-2e85...\"\ntype: \"runbook\"\n...\n---\n\n# Deploying the API\n\n..."
+}
+```
+
+- `body` is the synthesized markdown body on its own.
+- `markdown` is the full document: a YAML frontmatter block (`id`, `type`, `title`, `description`, `tags`, `timestamp`) followed by the body.
+- `type` comes from a `type:<x>` tag and defaults to `knowledge-page`. The `type:` tag is removed from the returned `tags`.
+
+---
+
+## Search Pages
+
+Document-level hybrid search: a full-text (BM25) match and a vector-similarity match, fused with Reciprocal Rank Fusion. There is no reranking step, which keeps it fast enough to be an agent's first call.
+
+<Tabs>
+<TabItem value="python" label="Python">
+<CodeSnippet code={knowledgePagesPy} section="search-pages" language="python" />
+</TabItem>
+<TabItem value="node" label="Node.js">
+<CodeSnippet code={knowledgePagesMjs} section="search-pages" language="javascript" />
+</TabItem>
+<TabItem value="go" label="Go">
+<CodeSnippet code={knowledgePagesGo} section="search-pages" language="go" />
+</TabItem>
+</Tabs>
+
+```json
+{
+  "results": [
+    {
+      "id": "kp-2e85...",
+      "name": "Deploying the API",
+      "mental_model_id": "mm-77ab...",
+      "snippet": "The API is deployed via ...",
+      "score": 0.032,
+      "updated_at": "2026-08-03T09:12:44+00:00"
+    }
+  ],
+  "total": 1
+}
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `q` | string | — | Required. Search query (min length 1). |
+| `limit` | int | `10` | Maximum results, 1–50. |
+
+This searches whole pages. To search individual memories, use [recall](./recall).
+
+---
+
+## Update or Move a Node
+
+One `PATCH` renames a node, moves it, and/or updates a page's options. Each field applies only when present in the body.
+
+<Tabs>
+<TabItem value="python" label="Python">
+<CodeSnippet code={knowledgePagesPy} section="update-node" language="python" />
+</TabItem>
+<TabItem value="node" label="Node.js">
+<CodeSnippet code={knowledgePagesMjs} section="update-node" language="javascript" />
+</TabItem>
+<TabItem value="go" label="Go">
+<CodeSnippet code={knowledgePagesGo} section="update-node" language="go" />
+</TabItem>
+</Tabs>
+
+| Parameter | Type | Applies to | Description |
+|---|---|---|---|
+| `name` | string | Both | New name |
+| `parent_id` | string \| null | Both | New parent folder. Pass `null` explicitly to move to the root. |
+| `source_query` | string | Pages | New question. Changing it schedules an async refresh so the page rebuilds against the new question. |
+| `tags` | list | Pages | Replaces the page's tags. Pass `[]` to clear them. |
+| `max_tokens` | int | Pages | New content budget |
+
+Sending an empty body returns `400`; an unknown node returns `404`.
+
+---
+
+## Delete a Node
+
+Deletes a folder or page **and its entire subtree**. The mental models backing the deleted pages are removed too.
+
+<Tabs>
+<TabItem value="python" label="Python">
+<CodeSnippet code={knowledgePagesPy} section="delete-node" language="python" />
+</TabItem>
+<TabItem value="node" label="Node.js">
+<CodeSnippet code={knowledgePagesMjs} section="delete-node" language="javascript" />
+</TabItem>
+<TabItem value="go" label="Go">
+<CodeSnippet code={knowledgePagesGo} section="delete-node" language="go" />
+</TabItem>
+</Tabs>
+
+```json
+{"status": "deleted"}
+```
+
+---
+
+## Export as a Markdown Bundle
+
+Returns the whole knowledge base as a flat set of portable markdown files: a nested `index.md`, one `<page-id>.md` per page, and a `<page-id>.log.md` refresh history for pages that have been rebuilt.
+
+<Tabs>
+<TabItem value="python" label="Python">
+<CodeSnippet code={knowledgePagesPy} section="export" language="python" />
+</TabItem>
+<TabItem value="node" label="Node.js">
+<CodeSnippet code={knowledgePagesMjs} section="export" language="javascript" />
+</TabItem>
+<TabItem value="go" label="Go">
+<CodeSnippet code={knowledgePagesGo} section="export" language="go" />
+</TabItem>
+</Tabs>
+
+```json
+{
+  "files": [
+    {"path": "index.md", "content": "---\ntype: \"index\"\n..."},
+    {"path": "kp-2e85....md", "content": "---\nid: \"kp-2e85...\"\n..."},
+    {"path": "kp-2e85....log.md", "content": "---\ntype: \"log\"\n..."}
+  ]
+}
+```
+
+:::tip Mirror it to disk
+`hindsight fs mount --bank my-bank` keeps a local folder in sync with this bundle via a background refresh loop, so `ls`, `grep`, `rg`, and your editor work against real files.
+:::
+
+---
+
+## Storage
+
+| Table | Holds |
+|---|---|
+| `knowledge_pages` | The tree: folders and pages, their names, parents, and ordering. A page row references its backing mental model; a folder row has none. |
+| `mental_models` | The content: the document body, its source query, tags, token budget, trigger, and refresh history. |
+
+The page layer owns only tree structure — everything about the content lives on the backing mental model, which is why every [mental model](./mental-models) capability applies to pages unchanged.
+
+---
+
+## Endpoint Summary
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/knowledge-base/tree` | Nested folder/page tree with staleness |
+| `POST` | `/knowledge-base/folders` | Create a folder |
+| `POST` | `/knowledge-base/pages` | Create a page (async first build) |
+| `GET` | `/knowledge-base/pages/{page_id}` | Read a page as markdown |
+| `GET` | `/knowledge-base/search` | Hybrid search over pages |
+| `PATCH` | `/knowledge-base/nodes/{node_id}` | Rename, move, or reconfigure a node |
+| `DELETE` | `/knowledge-base/nodes/{node_id}` | Delete a node and its subtree |
+| `GET` | `/knowledge-base/export` | Export the whole base as markdown files |

--- a/hindsight-docs/docs/developer/api/knowledge-pages.mdx
+++ b/hindsight-docs/docs/developer/api/knowledge-pages.mdx
@@ -15,6 +15,7 @@ import CodeSnippet from '@site/src/components/CodeSnippet';
 {/* Import raw source files */}
 import knowledgePagesPy from '!!raw-loader!@site/examples/api/knowledge-pages.py';
 import knowledgePagesMjs from '!!raw-loader!@site/examples/api/knowledge-pages.mjs';
+import knowledgePagesSh from '!!raw-loader!@site/examples/api/knowledge-pages.sh';
 import knowledgePagesGo from '!!raw-loader!@site/examples/api/knowledge-pages.go';
 
 All endpoints below are relative to a bank:
@@ -35,6 +36,9 @@ Returns the whole knowledge base as a nested tree of folders and pages. Page bod
 </TabItem>
 <TabItem value="node" label="Node.js">
 <CodeSnippet code={knowledgePagesMjs} section="get-tree" language="javascript" />
+</TabItem>
+<TabItem value="cli" label="CLI">
+<CodeSnippet code={knowledgePagesSh} section="get-tree" language="bash" />
 </TabItem>
 <TabItem value="go" label="Go">
 <CodeSnippet code={knowledgePagesGo} section="get-tree" language="go" />
@@ -96,6 +100,9 @@ Creating a page stores it with placeholder content and schedules the first build
 </TabItem>
 <TabItem value="node" label="Node.js">
 <CodeSnippet code={knowledgePagesMjs} section="create-page" language="javascript" />
+</TabItem>
+<TabItem value="cli" label="CLI">
+<CodeSnippet code={knowledgePagesSh} section="create-page" language="bash" />
 </TabItem>
 <TabItem value="go" label="Go">
 <CodeSnippet code={knowledgePagesGo} section="create-page" language="go" />
@@ -170,6 +177,9 @@ Every [mental model trigger setting](./mental-models#trigger-settings) is accept
 <TabItem value="node" label="Node.js">
 <CodeSnippet code={knowledgePagesMjs} section="create-folder" language="javascript" />
 </TabItem>
+<TabItem value="cli" label="CLI">
+<CodeSnippet code={knowledgePagesSh} section="create-folder" language="bash" />
+</TabItem>
 <TabItem value="go" label="Go">
 <CodeSnippet code={knowledgePagesGo} section="create-folder" language="go" />
 </TabItem>
@@ -194,6 +204,9 @@ Returns the page rendered as a markdown document.
 </TabItem>
 <TabItem value="node" label="Node.js">
 <CodeSnippet code={knowledgePagesMjs} section="get-page" language="javascript" />
+</TabItem>
+<TabItem value="cli" label="CLI">
+<CodeSnippet code={knowledgePagesSh} section="get-page" language="bash" />
 </TabItem>
 <TabItem value="go" label="Go">
 <CodeSnippet code={knowledgePagesGo} section="get-page" language="go" />
@@ -229,6 +242,9 @@ Document-level hybrid search: a full-text (BM25) match and a vector-similarity m
 </TabItem>
 <TabItem value="node" label="Node.js">
 <CodeSnippet code={knowledgePagesMjs} section="search-pages" language="javascript" />
+</TabItem>
+<TabItem value="cli" label="CLI">
+<CodeSnippet code={knowledgePagesSh} section="search-pages" language="bash" />
 </TabItem>
 <TabItem value="go" label="Go">
 <CodeSnippet code={knowledgePagesGo} section="search-pages" language="go" />
@@ -271,6 +287,9 @@ One `PATCH` renames a node, moves it, and/or updates a page's options. Each fiel
 <TabItem value="node" label="Node.js">
 <CodeSnippet code={knowledgePagesMjs} section="update-node" language="javascript" />
 </TabItem>
+<TabItem value="cli" label="CLI">
+<CodeSnippet code={knowledgePagesSh} section="update-node" language="bash" />
+</TabItem>
 <TabItem value="go" label="Go">
 <CodeSnippet code={knowledgePagesGo} section="update-node" language="go" />
 </TabItem>
@@ -299,6 +318,9 @@ Deletes a folder or page **and its entire subtree**. The mental models backing t
 <TabItem value="node" label="Node.js">
 <CodeSnippet code={knowledgePagesMjs} section="delete-node" language="javascript" />
 </TabItem>
+<TabItem value="cli" label="CLI">
+<CodeSnippet code={knowledgePagesSh} section="delete-node" language="bash" />
+</TabItem>
 <TabItem value="go" label="Go">
 <CodeSnippet code={knowledgePagesGo} section="delete-node" language="go" />
 </TabItem>
@@ -320,6 +342,9 @@ Returns the whole knowledge base as a flat set of portable markdown files: a nes
 </TabItem>
 <TabItem value="node" label="Node.js">
 <CodeSnippet code={knowledgePagesMjs} section="export" language="javascript" />
+</TabItem>
+<TabItem value="cli" label="CLI">
+<CodeSnippet code={knowledgePagesSh} section="export" language="bash" />
 </TabItem>
 <TabItem value="go" label="Go">
 <CodeSnippet code={knowledgePagesGo} section="export" language="go" />

--- a/hindsight-docs/docs/developer/api/mental-models.mdx
+++ b/hindsight-docs/docs/developer/api/mental-models.mdx
@@ -6,6 +6,8 @@ sidebar_position: 4
 
 User-curated summaries that provide high-quality, pre-computed answers for common queries.
 
+See [Mental Models](../mental-models) for the concepts behind this API.
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeSnippet from '@site/src/components/CodeSnippet';
@@ -121,10 +123,29 @@ Mental models can be configured to **automatically refresh** when observations a
 | `refresh_cron` | string \| null | null | UTC 5-field cron expression for scheduled refreshes, such as `"0 3 * * *"` for daily at 03:00 UTC |
 | `tags_match` | string \| null | null | How the model's `tags` filter source memories during refresh: `any`, `all`, `any_strict`, `all_strict`, or `exact`. When `null`, a **tagged** model defaults to `all_strict` (a memory must carry every one of the model's tags). Set `"any"` to match memories carrying *any* of the tags — see [Tags and Visibility](#tags-and-visibility). |
 | `tag_groups` | list \| null | null | Advanced boolean tag expressions that override flat `tags`/`tags_match` entirely. See the [Recall tags reference](./recall#tags). |
+| `fact_types` | list \| null | null | Restrict which fact types the refresh reads: any of `world`, `experience`, `observation`. `null` means all three. Must not be an empty list. |
+| `exclude_mental_models` | bool | false | Hide *all* other mental models from the refresh, so the model never synthesises from sibling models. |
+| `exclude_mental_model_ids` | list \| null | null | Hide specific mental models by ID from the refresh. The model being refreshed is always excluded from itself. |
+| `include_chunks` | bool \| null | null | Override whether the refresh's internal recall returns raw chunk text. `null` uses the bank/global `recall_include_chunks` default. |
+| `recall_max_tokens` | int \| null | null | Override the token budget for facts retrieved during refresh. `null` uses the bank/global default. |
+| `recall_chunks_max_tokens` | int \| null | null | Override the token budget for raw chunks retrieved during refresh. `null` uses the bank/global default. |
 
 When `refresh_after_consolidation` is enabled, the mental model will be re-generated every time the bank's observations are consolidated — ensuring it always reflects the latest synthesized knowledge.
 
 When `refresh_cron` is set, Hindsight checks the schedule on the server's mental-model refresh tick and refreshes the model only if memories in its scope have changed since the last refresh. `refresh_cron` and `refresh_after_consolidation` are mutually exclusive, so a model refreshes either after consolidation or on a fixed UTC schedule, not both.
+
+### Staleness Gating
+
+Both automatic triggers run the same check before spending an LLM call: **is there a memory in this model's resolved scope newer than its last refresh?** The model's `tags`/`tags_match`, `tag_groups`, and `fact_types` all apply to that check, so activity elsewhere in the bank does not trigger a rebuild, and a cron tick over an unchanged scope is skipped entirely. Memories still waiting to be consolidated count — they are already stored, so a model whose scope reaches them is considered stale.
+
+The `is_stale` flag surfaced to the reflect agent (and in the knowledge-base tree) is computed by the same rule.
+
+### What a Refresh Reads
+
+- **A point-in-time snapshot.** Each refresh is bounded by a database-time cutoff and only reads memories committed at or before it, so a write landing mid-refresh is never half-included. The watermark recorded afterwards is the newest in-scope memory the refresh actually saw — not `now()` — so a write that commits just after the snapshot stays "newer" and is picked up on the next round instead of being skipped.
+- **Only what's new, in `delta` mode.** A delta refresh scopes its retrieval to memories created since the last refresh, so the LLM reads genuinely new information rather than re-reading the whole bank.
+- **Cumulative grounding.** Even in delta mode, `reflect_response.based_on` accumulates: the facts from this refresh are merged with everything previous refreshes relied on, deduplicated by id. The document rests on all of them, not just the latest slice.
+- **Nothing, if nothing is relevant.** A refresh that finds no topic-relevant memories leaves the content alone and only advances the watermark, so the same empty window stops re-triggering.
 
 ### Refresh Mode
 
@@ -133,6 +154,22 @@ Two strategies are available for how a refresh produces the new content:
 - **`full`** *(default)* — every refresh regenerates the entire content from scratch. Simple and predictable: the LLM synthesises a fresh document from the retrieved memories. Best when the document is short, when you want every refresh to potentially restructure the output, or when you're not yet sure what the final shape should be.
 
 - **`delta`** — refresh emits a list of typed *operations* (add a section, append a bullet, replace a block, remove a stale paragraph) against the document's existing structure, then renders the result. Sections that aren't targeted by any operation are copied through **byte-identical** — no paraphrasing, no whitespace drift, no list-style normalisation. Best for long-lived "playbook"–style mental models where you want stability across refreshes and only the genuinely changed parts to move.
+
+#### How delta mode works
+
+Hindsight keeps an authoritative **structured** representation of the document — an ordered list of sections, each holding typed blocks (paragraph, bullet list, ordered list, code) — and the markdown you read is a deterministic render of that structure. A delta refresh never asks the LLM to rewrite the document; it asks for operations against that structure:
+
+| Operation | Effect |
+|---|---|
+| `add_section` / `remove_section` | Add or drop a whole section |
+| `rename_section` | Change a section's heading |
+| `replace_section_blocks` | Replace a section's contents wholesale |
+| `append_block` / `insert_block` | Add a block at the end of, or at a position in, a section |
+| `replace_block` / `remove_block` | Change or drop one block |
+
+Anything no operation mentions is copied through untouched, so unchanged prose is preserved rather than regenerated and checked. This matters because "preserve the unchanged content" is only a soft constraint on an LLM — generating the next token from a gestalt of the input is what it intrinsically does, so instructed-to-preserve prose drifts over many refreshes.
+
+Failure modes are conservative by design: an operation list that fails to parse, or operations referencing sections and blocks that don't exist, are **dropped** rather than guessed at. Zero valid operations means an identical document — a refresh can improve the content or leave it alone, never corrupt it.
 
 Delta mode falls back to a full regeneration automatically in two cases:
 1. The mental model has no existing content yet (nothing to anchor edits on).
@@ -452,7 +489,7 @@ The endpoint returns a list of history entries, most recent first:
 Each entry captures the **content before the change** and when it happened. The current content is returned by the standard [Get a Mental Model](#get-a-mental-model) endpoint.
 
 :::note
-History tracking is enabled by default. Set `HINDSIGHT_API_ENABLE_MENTAL_MODEL_HISTORY=false` to disable it.
+History tracking is enabled by default. Set `HINDSIGHT_API_ENABLE_MENTAL_MODEL_HISTORY=false` to disable it, and `HINDSIGHT_API_MENTAL_MODEL_HISTORY_MAX_ENTRIES` to change how many versions are kept per model (default `50`).
 :::
 
 ---

--- a/hindsight-docs/docs/developer/knowledge-pages.mdx
+++ b/hindsight-docs/docs/developer/knowledge-pages.mdx
@@ -1,0 +1,79 @@
+---
+sidebar_position: 7
+---
+
+# Knowledge Pages
+
+**Knowledge pages** are living documents a bank writes about itself. Each page answers one question — "What are the components here?", "What's our error-handling convention?" — and rewrites itself as the bank learns more. They're organized in folders, browsable, searchable, and can be projected onto disk as ordinary markdown files.
+
+The shape is a wiki. The engine underneath is memory.
+
+---
+
+## Mental Models, Simplified
+
+A knowledge page *is* a [mental model](./mental-models). Same synthesis, same background refresh, same provenance.
+
+What's different is how much you have to know to use one. A mental model exposes its mechanics — what it reads, when it rebuilds, how it edits itself. Nobody should have to think about synthesis scope and refresh triggers to keep a wiki. So a page comes with those decisions already made:
+
+- It's built from the bank's [observations](./observations) — consolidated, deduplicated beliefs — rather than raw conversational detail.
+- It refreshes incrementally whenever consolidation produces new knowledge in its scope, editing the document rather than regenerating it.
+- It never reads other pages, so pages can't cite each other into a feedback loop.
+- It gets a larger content budget, because it's a document rather than an answer.
+
+You supply a name and a question. Everything else is a default you can override if you need to — every mental model setting still applies. See the [Knowledge Pages API](./api/knowledge-pages) for the exact defaults and how to change them.
+
+---
+
+## Organized Like a Wiki
+
+Pages live in a tree of folders. Nesting is arbitrary, page names are unique within their folder, and deleting a folder deletes its subtree. That's the whole structural model — a hierarchy, the way anyone would organize documents by hand.
+
+The tree is what makes a knowledge base navigable rather than a flat list of synthesized blobs: `Architecture/`, `Runbooks/`, `Decisions/`, each holding pages that stay current on their own.
+
+---
+
+## Projected as Real Files
+
+Agents already know how to work with a filesystem. So the CLI can mirror a bank's knowledge base onto disk:
+
+```bash
+hindsight fs mount --bank my-bank
+```
+
+The folder tree becomes real directories, each page a real markdown file with YAML frontmatter, kept current by a background refresh loop. From there, everything ordinary works — `ls`, `cat`, `grep`, `rg`, `fzf`, your editor, an agent's file tools. No SDK, no API client, no new vocabulary.
+
+The same content is available as a portable markdown bundle over the API, for exporting or committing elsewhere.
+
+---
+
+## Searchable
+
+Pages are searchable at the **document level**: a query returns whole pages, ranked, with snippets. It combines full-text and semantic matching, fused server-side, with no reranking step — fast enough to be the first thing an agent reaches for.
+
+That last part matters. Search is a tool an agent *chooses* to call, visible in the transcript, rather than content pushed into its context on every turn. Retrieval the agent asked for informs what it's doing; retrieval it didn't ask for tends to derail it.
+
+This is a different path from [recall](./retrieval), which searches individual memories. Use page search to pick a document; use recall for a specific fact.
+
+---
+
+## Why Not Just Raw Files?
+
+If the answer is documents in a tree, haven't we reinvented files — the thing a memory system exists to replace?
+
+The difference is what sits underneath. A file is where information goes to age. Whoever wrote it last wins, contradictions accumulate quietly, and nothing ever reconciles them. Left alone, a hand-maintained wiki becomes a beautifully formatted lie — not because anyone lied, but because keeping it true is a chore, and chores lose.
+
+A knowledge page is a **projected view** over processed memory, the way a database view is not a table. Before a page is written, Hindsight has already done the work files can't do for themselves: extracted facts from the raw sessions, commits, and documents; deduplicated them; and reconciled their contradictions through consolidation. So when a team decided X and later amended it to Y, the page says Y — and can say why — instead of preserving both a paragraph apart.
+
+Your raw documents remain the source of truth about *what was said*. The pages are the reconciled truth about *what holds*.
+
+This is also why pages heal themselves rather than rot: they aren't the storage, they're the rendering. Delete a page and nothing is lost — it re-projects from memory. Try deleting a wiki and getting it back.
+
+---
+
+## Working With Pages
+
+- **Control plane** — the Knowledge Base view renders the tree, page contents, and which pages have fallen behind.
+- **HTTP API** — see [Knowledge Pages API](./api/knowledge-pages) for the full endpoint surface.
+- **CLI** — `hindsight fs` mirrors a bank to a local folder of markdown files.
+- **Agent tools** — the agent SDK exposes `agent_knowledge_*` tools so an agent can list, read, create, and update its own pages during a session.

--- a/hindsight-docs/docs/developer/mental-models.mdx
+++ b/hindsight-docs/docs/developer/mental-models.mdx
@@ -1,0 +1,71 @@
+---
+sidebar_position: 6
+---
+
+# Mental Models
+
+A **mental model** is a standing answer to a question about a bank. You define the question once; Hindsight writes the answer, keeps it stored, and rewrites it in the background as the bank learns more.
+
+Where [observations](./observations) are produced automatically and are atomic — one belief at a time — a mental model is deliberately curated: you decide which questions deserve a permanent, always-current answer.
+
+```mermaid
+graph LR
+    A[Raw facts] --> B[Observations]
+    B --> C[Mental model]
+    A --> C
+    C --> D[Your application]
+```
+
+---
+
+## The Answer Is Already Written
+
+The reason to use a mental model is speed. Reasoning over a bank's memory is expensive — retrieval, synthesis, an LLM writing an answer. A mental model moves all of that off the request path: the work happens in the background, ahead of time, and your application simply **reads the current version**.
+
+Fetching a mental model is a database read. No retrieval, no synthesis, no LLM call, no waiting. An agent that boots by loading its mental models starts with a page of settled knowledge instead of spending its first few seconds rediscovering it.
+
+This also makes answers **consistent**. Two users asking the same question get the same document, because there is only one document — not two independently generated answers that happen to disagree on the details.
+
+Mental models are also the first thing [reflect](./reflect) reaches for. Its retrieval ladder goes:
+
+| Layer | Produced by | Granularity |
+|---|---|---|
+| **Mental models** | You, explicitly | A whole document per question |
+| **Observations** | Consolidation, automatically | One belief per fact cluster |
+| **Raw facts** | Retain, automatically | One fact per statement |
+
+Each layer is a cheaper, more settled version of the one below it. If the first step turns up a mental model that is fresh and covers the question, reflect can answer from it instead of descending through observations and raw facts — the same saving, applied inside the agentic loop.
+
+---
+
+## Always Current, Without Asking
+
+A mental model is not a cached answer that goes stale silently. Hindsight tracks whether new memories have arrived that the model is supposed to cover, and rebuilds it when they have — either as soon as new knowledge is consolidated, or on a schedule you set.
+
+The check comes first, and it is scoped: a rebuild only happens when something *within this model's own scope* actually changed. A busy bank does not cause unrelated models to churn, and a scheduled rebuild over an unchanged bank costs nothing.
+
+When a model is handed to the reflect agent, it comes with a freshness signal — whether memories in its scope have landed since it was last written. A model that has fallen behind is still shown, but it no longer short-circuits retrieval, and the agent is expected to check it against the layers below rather than trust it blindly.
+
+---
+
+## Stable Across Rewrites
+
+A document that is rewritten hundreds of times has a problem an LLM cannot solve by being asked nicely: told to "preserve the unchanged parts", it will still drift. Bullets become numbers, casing shifts, sentences get quietly paraphrased. Generating text is what the model does; copying it verbatim is not.
+
+Hindsight can instead refresh a model **incrementally** — applying only the changes the new knowledge implies, and leaving everything else physically untouched rather than regenerating and hoping. A long-lived playbook stays the document you wrote, with the new parts added, instead of slowly becoming a different document that says roughly the same thing.
+
+---
+
+## Scope and Isolation
+
+A mental model's tags decide two things: which memories it is allowed to read, and which callers are allowed to see it. A model scoped to one customer, team, or user is built only from that scope's memories and surfaces only for requests in that scope — the same isolation rules that govern the rest of the bank, applied to synthesized knowledge.
+
+---
+
+## Provenance
+
+A mental model is not free-floating prose. It records the facts and observations it was built from, and it keeps the previous version of its content every time it changes. You can see what the model said last month and what evidence it was standing on — which matters when a model states something surprising and someone needs to know where it came from.
+
+---
+
+**See also:** [Mental Models API](./api/mental-models) — creating, refreshing, and configuring them, including refresh triggers, scoping options, and history.

--- a/hindsight-docs/docs/sdks/cli.md
+++ b/hindsight-docs/docs/sdks/cli.md
@@ -308,6 +308,53 @@ hindsight webhook delete <bank_id> <webhook_id>
 hindsight webhook deliveries <bank_id> <webhook_id>
 ```
 
+## Knowledge Base
+
+Manage a bank's knowledge pages — living documents organized in a folder tree. See [Knowledge Pages](../developer/api/knowledge-pages) for what they are and how they refresh.
+
+```bash
+# Show the folder/page tree (pages that have fallen behind are marked stale)
+hindsight knowledge-base tree <bank_id>
+
+# Create a folder, optionally nested under another
+hindsight knowledge-base create-folder <bank_id> "Operations"
+hindsight knowledge-base create-folder <bank_id> "Runbooks" --parent-id <folder_id>
+
+# Create a page — content is generated in the background
+hindsight knowledge-base create-page <bank_id> \
+  "Deploying the API" \
+  "How is the API deployed?" \
+  --parent-id <folder_id> \
+  --tags ops,type:runbook
+
+# Build a page from raw facts instead of the observation-only default
+hindsight knowledge-base create-page <bank_id> "Recent Incidents" \
+  "What incidents happened recently?" \
+  --fact-types experience,world --mode full
+
+# Read a page as a markdown document
+hindsight knowledge-base get-page <bank_id> <page_id>
+
+# Hybrid search (full-text + vector) over whole pages
+hindsight knowledge-base search <bank_id> "how do we deploy" --limit 5
+
+# Rename, move, or reconfigure a node
+hindsight knowledge-base update <bank_id> <node_id> --name "New name"
+hindsight knowledge-base update <bank_id> <page_id> --source-query "New question?"
+
+# Export the whole knowledge base as a markdown bundle
+hindsight knowledge-base export <bank_id>
+
+# Delete a folder or page and everything under it
+hindsight knowledge-base delete <bank_id> <node_id> -y
+```
+
+:::tip
+`hindsight fs mount --bank <bank_id>` mirrors the same knowledge base onto disk as
+real markdown files, kept current by a background refresh loop — handy when you'd
+rather use `grep`, `rg`, or your editor than the commands above.
+:::
+
 ## Audit Logs
 
 Inspect the audit trail for a bank:

--- a/hindsight-docs/examples/api/knowledge-pages.go
+++ b/hindsight-docs/examples/api/knowledge-pages.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	hindsight "github.com/vectorize-io/hindsight/hindsight-clients/go"
+)
+
+const kpBankID = "knowledge-pages-demo-bank-go"
+
+func main() {
+	apiURL := os.Getenv("HINDSIGHT_API_URL")
+	if apiURL == "" {
+		apiURL = "http://localhost:8888"
+	}
+
+	cfg := hindsight.NewConfiguration()
+	cfg.Servers = hindsight.ServerConfigurations{{URL: apiURL}}
+	client := hindsight.NewAPIClient(cfg)
+	ctx := context.Background()
+
+	// =============================================================================
+	// Setup (not shown in docs)
+	// =============================================================================
+	client.BanksAPI.CreateOrUpdateBank(ctx, kpBankID).
+		CreateBankRequest(hindsight.CreateBankRequest{
+			Name: *hindsight.NewNullableString(hindsight.PtrString("Knowledge Pages Demo")),
+		}).Execute()
+	for _, content := range []string{
+		"The API is deployed to Kubernetes with a rolling update",
+		"Deploys run from the main branch after CI passes",
+		"A failed deploy is rolled back by redeploying the previous tag",
+	} {
+		client.MemoryAPI.RetainMemories(ctx, kpBankID).
+			RetainRequest(hindsight.RetainRequest{
+				Items: []hindsight.MemoryItem{{Content: content}},
+			}).Execute()
+	}
+	time.Sleep(2 * time.Second)
+
+	// [docs:create-folder]
+	// Create a folder (leave ParentId unset to create it at the root)
+	folder, _, _ := client.KnowledgeBaseAPI.CreateKnowledgeFolder(ctx, kpBankID).
+		CreateFolderRequest(hindsight.CreateFolderRequest{Name: "Operations"}).
+		Execute()
+
+	fmt.Printf("Folder ID: %s\n", folder.Id)
+	// [/docs:create-folder]
+
+	// [docs:create-page]
+	// Create a page — content is generated in the background
+	page, _, _ := client.KnowledgeBaseAPI.CreateKnowledgePage(ctx, kpBankID).
+		CreatePageRequest(hindsight.CreatePageRequest{
+			Name:        "Deploying the API",
+			SourceQuery: "How is the API deployed?",
+			ParentId:    *hindsight.NewNullableString(&folder.Id),
+			Tags:        []string{"ops", "type:runbook"},
+		}).Execute()
+
+	// Poll the operation to know when the first build has finished
+	fmt.Printf("Page ID: %s, operation: %s\n", page.PageId, page.GetOperationId())
+	// [/docs:create-page]
+
+	// Wait for the page's first build
+	time.Sleep(20 * time.Second)
+
+	// [docs:get-tree]
+	// Fetch the whole knowledge base as a nested folder/page tree (no page bodies)
+	tree, _, _ := client.KnowledgeBaseAPI.GetKnowledgeBaseTree(ctx, kpBankID).Execute()
+
+	for _, root := range tree.Roots {
+		fmt.Printf("%s: %s\n", root.Kind, root.Name)
+		for _, child := range root.Children {
+			fmt.Printf("  %s: %s (stale: %v)\n", child.Kind, child.Name, child.GetIsStale())
+		}
+	}
+	// [/docs:get-tree]
+
+	// [docs:get-page]
+	// Read a page as a markdown document
+	document, _, _ := client.KnowledgeBaseAPI.GetKnowledgePage(ctx, kpBankID, page.PageId).Execute()
+
+	fmt.Println(document.Type)      // "runbook" — from the type:runbook tag
+	fmt.Println(document.GetBody()) // the synthesized markdown body
+	fmt.Println(document.Markdown)  // YAML frontmatter + body
+	// [/docs:get-page]
+
+	// [docs:search-pages]
+	// Hybrid search (full-text + vector) over whole pages
+	results, _, _ := client.KnowledgeBaseAPI.SearchKnowledgeBase(ctx, kpBankID).
+		Q("how do we deploy").Limit(5).Execute()
+
+	for _, hit := range results.Results {
+		fmt.Printf("%.3f  %s: %s\n", hit.Score, hit.Name, hit.Snippet)
+	}
+	// [/docs:search-pages]
+
+	// [docs:update-node]
+	// Rename a node, move it, and/or update a page's options.
+	// Changing SourceQuery rebuilds the page against the new question.
+	client.KnowledgeBaseAPI.UpdateKnowledgeNode(ctx, kpBankID, page.PageId).
+		UpdateNodeRequest(hindsight.UpdateNodeRequest{
+			Name: *hindsight.NewNullableString(hindsight.PtrString("Deploying the API (v2)")),
+			Tags: []string{"ops", "type:runbook", "reviewed"},
+		}).Execute()
+	// [/docs:update-node]
+
+	// [docs:export]
+	// Export the knowledge base as a portable markdown bundle
+	bundle, _, _ := client.KnowledgeBaseAPI.ExportKnowledgeBase(ctx, kpBankID).Execute()
+
+	for _, file := range bundle.Files {
+		fmt.Println(file.Path) // index.md, <page-id>.md, <page-id>.log.md
+	}
+	// [/docs:export]
+
+	// [docs:delete-node]
+	// Delete a folder or page — deleting a folder removes its whole subtree
+	client.KnowledgeBaseAPI.DeleteKnowledgeNode(ctx, kpBankID, folder.Id).Execute()
+	// [/docs:delete-node]
+
+	// =============================================================================
+	// Cleanup (not shown in docs)
+	// =============================================================================
+	cleanupKnowledgePages(apiURL)
+
+	fmt.Println("knowledge-pages.go: All examples passed")
+}
+
+func cleanupKnowledgePages(apiURL string) {
+	req, _ := http.NewRequest("DELETE", fmt.Sprintf("%s/v1/default/banks/%s", apiURL, kpBankID), nil)
+	http.DefaultClient.Do(req)
+}

--- a/hindsight-docs/examples/api/knowledge-pages.mjs
+++ b/hindsight-docs/examples/api/knowledge-pages.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Knowledge Pages API examples for Hindsight (Node.js)
+ * Run: node examples/api/knowledge-pages.mjs
+ */
+import { HindsightClient } from '@vectorize-io/hindsight-client';
+
+const HINDSIGHT_URL = process.env.HINDSIGHT_API_URL || 'http://localhost:8888';
+const BANK_ID = 'knowledge-pages-demo-bank-node';
+
+// =============================================================================
+// Setup (not shown in docs)
+// =============================================================================
+const client = new HindsightClient({ baseUrl: HINDSIGHT_URL });
+await client.createBank(BANK_ID, { name: 'Knowledge Pages Demo' });
+await client.retain(BANK_ID, 'The API is deployed to Kubernetes with a rolling update');
+await client.retain(BANK_ID, 'Deploys run from the main branch after CI passes');
+await client.retain(BANK_ID, 'A failed deploy is rolled back by redeploying the previous tag');
+await new Promise(r => setTimeout(r, 2000));
+
+// =============================================================================
+// Doc Examples
+// =============================================================================
+
+// [docs:create-folder]
+// Create a folder (omit parentId, or pass null, to create it at the root)
+const folder = await client.createKnowledgeFolder(BANK_ID, 'Operations');
+
+console.log(`Folder ID: ${folder.id}`);
+// [/docs:create-folder]
+
+// [docs:create-page]
+// Create a page — content is generated in the background
+const page = await client.createKnowledgePage(
+    BANK_ID,
+    'Deploying the API',
+    'How is the API deployed?',
+    { parentId: folder.id, tags: ['ops', 'type:runbook'] },
+);
+
+// Poll the operation to know when the first build has finished
+console.log(`Page ID: ${page.page_id}, operation: ${page.operation_id}`);
+// [/docs:create-page]
+
+// Wait for the page's first build
+await new Promise(r => setTimeout(r, 20000));
+
+// [docs:get-tree]
+// Fetch the whole knowledge base as a nested folder/page tree (no page bodies)
+const tree = await client.getKnowledgeBaseTree(BANK_ID);
+
+for (const root of tree.roots) {
+    console.log(`${root.kind}: ${root.name}`);
+    for (const child of root.children ?? []) {
+        console.log(`  ${child.kind}: ${child.name} (stale: ${child.is_stale})`);
+    }
+}
+// [/docs:get-tree]
+
+// [docs:get-page]
+// Read a page as a markdown document
+const document = await client.getKnowledgePage(BANK_ID, page.page_id);
+
+console.log(document.type);      // "runbook" — from the type:runbook tag
+console.log(document.body);      // the synthesized markdown body
+console.log(document.markdown);  // YAML frontmatter + body
+// [/docs:get-page]
+
+// [docs:search-pages]
+// Hybrid search (full-text + vector) over whole pages
+const results = await client.searchKnowledgeBase(BANK_ID, 'how do we deploy', { limit: 5 });
+
+for (const hit of results.results) {
+    console.log(`${hit.score.toFixed(3)}  ${hit.name}: ${hit.snippet}`);
+}
+// [/docs:search-pages]
+
+// [docs:update-node]
+// Rename a node, move it, and/or update a page's options.
+// Changing sourceQuery rebuilds the page against the new question.
+await client.updateKnowledgeNode(BANK_ID, page.page_id, {
+    name: 'Deploying the API (v2)',
+    tags: ['ops', 'type:runbook', 'reviewed'],
+});
+// [/docs:update-node]
+
+// [docs:export]
+// Export the knowledge base as a portable markdown bundle
+const bundle = await client.exportKnowledgeBase(BANK_ID);
+
+for (const file of bundle.files) {
+    console.log(file.path);  // index.md, <page-id>.md, <page-id>.log.md
+}
+// [/docs:export]
+
+// [docs:delete-node]
+// Delete a folder or page — deleting a folder removes its whole subtree
+await client.deleteKnowledgeNode(BANK_ID, folder.id);
+// [/docs:delete-node]
+
+// =============================================================================
+// Cleanup (not shown in docs)
+// =============================================================================
+await client.deleteBank(BANK_ID);
+
+console.log('knowledge-pages.mjs: All examples passed');

--- a/hindsight-docs/examples/api/knowledge-pages.py
+++ b/hindsight-docs/examples/api/knowledge-pages.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+Knowledge Pages API examples for Hindsight.
+Run: python examples/api/knowledge-pages.py
+"""
+import os
+import time
+
+HINDSIGHT_URL = os.getenv("HINDSIGHT_API_URL", "http://localhost:8888")
+BANK_ID = "knowledge-pages-demo-bank"
+
+# =============================================================================
+# Setup (not shown in docs)
+# =============================================================================
+from hindsight_client import Hindsight
+
+client = Hindsight(base_url=HINDSIGHT_URL)
+
+client.create_bank(bank_id=BANK_ID, name="Knowledge Pages Demo")
+client.retain(bank_id=BANK_ID, content="The API is deployed to Kubernetes with a rolling update")
+client.retain(bank_id=BANK_ID, content="Deploys run from the main branch after CI passes")
+client.retain(bank_id=BANK_ID, content="A failed deploy is rolled back by redeploying the previous tag")
+
+time.sleep(2)
+
+# =============================================================================
+# Doc Examples
+# =============================================================================
+
+# [docs:create-folder]
+# Create a folder (omit parent_id, or pass None, to create it at the root)
+folder = client.create_knowledge_folder(BANK_ID, name="Operations")
+
+print(f"Folder ID: {folder.id}")
+# [/docs:create-folder]
+
+# [docs:create-page]
+# Create a page — content is generated in the background
+page = client.create_knowledge_page(
+    BANK_ID,
+    name="Deploying the API",
+    source_query="How is the API deployed?",
+    parent_id=folder.id,
+    tags=["ops", "type:runbook"],
+)
+
+# Poll the operation to know when the first build has finished
+print(f"Page ID: {page.page_id}, operation: {page.operation_id}")
+# [/docs:create-page]
+
+# Wait for the page's first build
+time.sleep(20)
+
+# [docs:get-tree]
+# Fetch the whole knowledge base as a nested folder/page tree (no page bodies)
+tree = client.get_knowledge_base_tree(BANK_ID)
+
+for root in tree.roots:
+    print(f"{root.kind}: {root.name}")
+    for child in root.children:
+        print(f"  {child.kind}: {child.name} (stale: {child.is_stale})")
+# [/docs:get-tree]
+
+# [docs:get-page]
+# Read a page as a markdown document
+document = client.get_knowledge_page(BANK_ID, page.page_id)
+
+print(document.type)      # "runbook" — from the type:runbook tag
+print(document.body)      # the synthesized markdown body
+print(document.markdown)  # YAML frontmatter + body
+# [/docs:get-page]
+
+# [docs:search-pages]
+# Hybrid search (full-text + vector) over whole pages
+results = client.search_knowledge_base(BANK_ID, q="how do we deploy", limit=5)
+
+for hit in results.results:
+    print(f"{hit.score:.3f}  {hit.name}: {hit.snippet}")
+# [/docs:search-pages]
+
+# [docs:update-node]
+# Rename a node, move it, and/or update a page's options.
+# Changing source_query rebuilds the page against the new question.
+client.update_knowledge_node(
+    BANK_ID,
+    page.page_id,
+    name="Deploying the API (v2)",
+    tags=["ops", "type:runbook", "reviewed"],
+)
+# [/docs:update-node]
+
+# [docs:export]
+# Export the knowledge base as a portable markdown bundle
+bundle = client.export_knowledge_base(BANK_ID)
+
+for file in bundle.files:
+    print(file.path)  # index.md, <page-id>.md, <page-id>.log.md
+# [/docs:export]
+
+# [docs:delete-node]
+# Delete a folder or page — deleting a folder removes its whole subtree
+client.delete_knowledge_node(BANK_ID, folder.id)
+# [/docs:delete-node]
+
+# =============================================================================
+# Cleanup (not shown in docs)
+# =============================================================================
+client.delete_bank(bank_id=BANK_ID)
+
+print("knowledge-pages.py: All examples passed")

--- a/hindsight-docs/examples/api/knowledge-pages.sh
+++ b/hindsight-docs/examples/api/knowledge-pages.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Knowledge Pages API examples for Hindsight CLI
+# Run: bash examples/api/knowledge-pages.sh
+
+set -e
+
+HINDSIGHT_URL="${HINDSIGHT_API_URL:-http://localhost:8888}"
+BANK_ID="knowledge-pages-demo-bank-cli"
+
+# =============================================================================
+# Setup (not shown in docs)
+# =============================================================================
+hindsight bank create "$BANK_ID" --name "Knowledge Pages Demo"
+hindsight memory retain "$BANK_ID" "The API is deployed to Kubernetes with a rolling update"
+hindsight memory retain "$BANK_ID" "Deploys run from the main branch after CI passes"
+hindsight memory retain "$BANK_ID" "A failed deploy is rolled back by redeploying the previous tag"
+sleep 2
+
+# =============================================================================
+# Doc Examples
+# =============================================================================
+
+# [docs:create-folder]
+# Create a folder (omit --parent-id to create it at the root)
+hindsight knowledge-base create-folder "$BANK_ID" "Operations"
+# [/docs:create-folder]
+
+FOLDER_ID=$(hindsight knowledge-base tree "$BANK_ID" -o json | jq -r '.roots[0].id')
+
+# [docs:create-page]
+# Create a page — content is generated in the background
+hindsight knowledge-base create-page "$BANK_ID" \
+  "Deploying the API" \
+  "How is the API deployed?" \
+  --parent-id "$FOLDER_ID" \
+  --tags ops,type:runbook
+# [/docs:create-page]
+
+# Wait for the page's first build
+sleep 20
+
+# [docs:get-tree]
+# Show the folder/page tree (no page bodies)
+hindsight knowledge-base tree "$BANK_ID"
+# [/docs:get-tree]
+
+PAGE_ID=$(hindsight knowledge-base tree "$BANK_ID" -o json | jq -r '.roots[0].children[0].id')
+
+# [docs:get-page]
+# Read a page as a markdown document
+hindsight knowledge-base get-page "$BANK_ID" "$PAGE_ID"
+# [/docs:get-page]
+
+# [docs:search-pages]
+# Hybrid search (full-text + vector) over whole pages
+hindsight knowledge-base search "$BANK_ID" "how do we deploy" --limit 5
+# [/docs:search-pages]
+
+# [docs:update-node]
+# Rename a node, move it, and/or update a page's options.
+# Changing --source-query rebuilds the page against the new question.
+hindsight knowledge-base update "$BANK_ID" "$PAGE_ID" \
+  --name "Deploying the API (v2)" \
+  --tags ops,type:runbook,reviewed
+# [/docs:update-node]
+
+# [docs:export]
+# Export the knowledge base as a portable markdown bundle
+hindsight knowledge-base export "$BANK_ID"
+# [/docs:export]
+
+# [docs:delete-node]
+# Delete a folder or page — deleting a folder removes its whole subtree
+hindsight knowledge-base delete "$BANK_ID" "$FOLDER_ID" -y
+# [/docs:delete-node]
+
+# =============================================================================
+# Cleanup (not shown in docs)
+# =============================================================================
+curl -s -X DELETE "${HINDSIGHT_URL}/v1/default/banks/${BANK_ID}" > /dev/null
+
+echo "knowledge-pages.sh: All examples passed"

--- a/hindsight-docs/sidebars.ts
+++ b/hindsight-docs/sidebars.ts
@@ -39,6 +39,18 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'doc',
+          id: 'developer/mental-models',
+          label: 'Mental Models',
+          customProps: { icon: 'lu-layers' },
+        },
+        {
+          type: 'doc',
+          id: 'developer/knowledge-pages',
+          label: 'Knowledge Pages',
+          customProps: { icon: 'lu-book-text' },
+        },
+        {
+          type: 'doc',
           id: 'developer/multilingual',
           label: 'Multilingual',
           customProps: { icon: 'lu-languages' },
@@ -97,6 +109,12 @@ const sidebars: SidebarsConfig = {
           id: 'developer/api/mental-models',
           label: 'Mental Models',
           customProps: { icon: 'lu-layers' },
+        },
+        {
+          type: 'doc',
+          id: 'developer/api/knowledge-pages',
+          label: 'Knowledge Pages',
+          customProps: { icon: 'lu-book-text' },
         },
         {
           type: 'doc',

--- a/hindsight-docs/src/pages/faq.mdx
+++ b/hindsight-docs/src/pages/faq.mdx
@@ -20,6 +20,7 @@ import PageHero from '@site/src/components/PageHero';
 - [Retain, recall, and reflect — what's the difference?](#whats-the-difference-between-retain-recall-and-reflect)
 - [When should I use recall vs reflect?](#when-should-i-use-recall-vs-reflect)
 - [When should I use mental models?](#when-should-i-use-mental-models)
+- [Mental model vs. knowledge page](#whats-the-difference-between-a-mental-model-and-a-knowledge-page)
 - [Latency expectations](#whats-the-typical-latency-for-recall-operations)
 - [Tags, metadata, and entity labels](#does-hindsight-support-metadata-filtering)
 - [Controlling which memory types are recalled](#how-do-i-control-which-types-of-memories-are-recalled)
@@ -201,13 +202,32 @@ See [Recall](/developer/api/recall) and [Reflect](/developer/reflect) for full A
 
 ### When should I use mental models?
 
-**Mental models** are consolidated knowledge patterns synthesized from individual facts over time. Use them when you need:
+**Mental models** are standing answers to questions you define — synthesized from the bank's knowledge and rewritten in the background as it changes. Use them when you need:
 
 - Higher-level understanding beyond raw facts (e.g., "User prefers functional programming patterns")
 - Long-term behavioral patterns (e.g., "Customer is price-sensitive but values quality")
+- An answer available instantly, with no reasoning on the request path
 - Context for AI agent reasoning during **reflect** operations
 
-Mental models are automatically built during retain and used by reflect to provide richer, more contextual responses. See [Mental Models](/developer/api/mental-models).
+You create a mental model with the question that defines it; Hindsight builds the content and keeps it current. Reflect checks mental models first, so a fresh one can answer without descending into observations and raw facts. See [Mental Models](/developer/api/mental-models).
+
+---
+
+### What's the difference between a mental model and a knowledge page?
+
+A **knowledge page is a mental model** — the same engine, the same refresh behaviour — with two additions: a place in a folder tree, and a set of defaults tuned for documents rather than answers (built from observations only, refreshed incrementally after each consolidation, never influenced by other pages, and a larger content budget).
+
+| | Mental model | Knowledge page |
+|---|---|---|
+| Shape | A standing answer to a question | A markdown document with frontmatter |
+| Organization | Flat list, scoped by tags | Nested folders and pages |
+| Sources | All fact types by default | Observations only by default |
+| Refresh | Off by default | Delta refresh after each consolidation |
+| Typical consumer | Your application or an agent, by lookup | A person or agent browsing and reading |
+
+Use a plain mental model when something in your system looks up the answer. Use a knowledge page when the result is meant to be browsed and read directly, like a wiki. Anything you can configure on a mental model can be configured on a page.
+
+See [Mental Models](/developer/api/mental-models) and the Knowledge Pages section of the developer docs.
 
 ---
 

--- a/hindsight-docs/src/theme/DocSidebarItem/Link/index.tsx
+++ b/hindsight-docs/src/theme/DocSidebarItem/Link/index.tsx
@@ -12,7 +12,7 @@ import {
   LuNetwork, LuCode, LuLayers, LuCpu, LuHardDrive,
   LuArrowUpRight, LuBookOpen, LuRss, LuCloud, LuMessageCircle,
   LuChartBar, LuChartColumn, LuStar, LuCircleHelp,
-  LuLayoutTemplate, LuFileJson, LuEraser,
+  LuLayoutTemplate, LuFileJson, LuEraser, LuBookText,
 } from 'react-icons/lu';
 import {SiGo, SiPython, SiGithub, SiSlack, SiDocker, SiKubernetes, SiNodedotjs} from 'react-icons/si';
 
@@ -62,6 +62,7 @@ const ICON_MAP: Record<string, IconType> = {
   'lu-layout-template': LuLayoutTemplate,
   'lu-file-json':   LuFileJson,
   'lu-eraser':      LuEraser,
+  'lu-book-text':   LuBookText,
 };
 
 type Props = WrapperProps<typeof LinkType>;

--- a/skills/hindsight-docs/references/developer/api/knowledge-pages.md
+++ b/skills/hindsight-docs/references/developer/api/knowledge-pages.md
@@ -45,6 +45,13 @@ for (const root of tree.roots) {
 }
 ```
 
+### CLI
+
+```bash
+# Show the folder/page tree (no page bodies)
+hindsight knowledge-base tree "$BANK_ID"
+```
+
 ### Go
 
 ```go
@@ -131,6 +138,17 @@ const page = await client.createKnowledgePage(
 console.log(`Page ID: ${page.page_id}, operation: ${page.operation_id}`);
 ```
 
+### CLI
+
+```bash
+# Create a page — content is generated in the background
+hindsight knowledge-base create-page "$BANK_ID" \
+  "Deploying the API" \
+  "How is the API deployed?" \
+  --parent-id "$FOLDER_ID" \
+  --tags ops,type:runbook
+```
+
 ### Go
 
 ```go
@@ -215,6 +233,13 @@ const folder = await client.createKnowledgeFolder(BANK_ID, 'Operations');
 console.log(`Folder ID: ${folder.id}`);
 ```
 
+### CLI
+
+```bash
+# Create a folder (omit --parent-id to create it at the root)
+hindsight knowledge-base create-folder "$BANK_ID" "Operations"
+```
+
 ### Go
 
 ```go
@@ -254,6 +279,13 @@ const document = await client.getKnowledgePage(BANK_ID, page.page_id);
 console.log(document.type);      // "runbook" — from the type:runbook tag
 console.log(document.body);      // the synthesized markdown body
 console.log(document.markdown);  // YAML frontmatter + body
+```
+
+### CLI
+
+```bash
+# Read a page as a markdown document
+hindsight knowledge-base get-page "$BANK_ID" "$PAGE_ID"
 ```
 
 ### Go
@@ -304,6 +336,13 @@ const results = await client.searchKnowledgeBase(BANK_ID, 'how do we deploy', { 
 for (const hit of results.results) {
     console.log(`${hit.score.toFixed(3)}  ${hit.name}: ${hit.snippet}`);
 }
+```
+
+### CLI
+
+```bash
+# Hybrid search (full-text + vector) over whole pages
+hindsight knowledge-base search "$BANK_ID" "how do we deploy" --limit 5
 ```
 
 ### Go
@@ -365,6 +404,16 @@ await client.updateKnowledgeNode(BANK_ID, page.page_id, {
 });
 ```
 
+### CLI
+
+```bash
+# Rename a node, move it, and/or update a page's options.
+# Changing --source-query rebuilds the page against the new question.
+hindsight knowledge-base update "$BANK_ID" "$PAGE_ID" \
+  --name "Deploying the API (v2)" \
+  --tags ops,type:runbook,reviewed
+```
+
 ### Go
 
 ```go
@@ -399,6 +448,13 @@ client.delete_knowledge_node(BANK_ID, folder.id)
 ```javascript
 // Delete a folder or page — deleting a folder removes its whole subtree
 await client.deleteKnowledgeNode(BANK_ID, folder.id);
+```
+
+### CLI
+
+```bash
+# Delete a folder or page — deleting a folder removes its whole subtree
+hindsight knowledge-base delete "$BANK_ID" "$FOLDER_ID" -y
 ```
 
 ### Go
@@ -436,6 +492,13 @@ const bundle = await client.exportKnowledgeBase(BANK_ID);
 for (const file of bundle.files) {
     console.log(file.path);  // index.md, <page-id>.md, <page-id>.log.md
 }
+```
+
+### CLI
+
+```bash
+# Export the knowledge base as a portable markdown bundle
+hindsight knowledge-base export "$BANK_ID"
 ```
 
 ### Go

--- a/skills/hindsight-docs/references/developer/api/knowledge-pages.md
+++ b/skills/hindsight-docs/references/developer/api/knowledge-pages.md
@@ -1,0 +1,484 @@
+
+# Knowledge Pages
+
+Living markdown documents, organized in a folder tree, that rewrite themselves as the bank learns.
+
+A page is backed by a [mental model](./mental-models) but is configured as a document: it is built from the bank's [observations](../observations) only, it never reads other pages, and it refreshes incrementally after each consolidation. See [Knowledge Pages](../knowledge-pages) for the concepts behind the API.
+
+{/* Import raw source files */}
+
+All endpoints below are relative to a bank:
+
+```
+/v1/default/banks/{bank_id}/knowledge-base
+```
+
+---
+
+## Get the Tree
+
+Returns the whole knowledge base as a nested tree of folders and pages. Page bodies are **not** included — fetch a page to read its content.
+
+### Python
+
+```python
+# Fetch the whole knowledge base as a nested folder/page tree (no page bodies)
+tree = client.get_knowledge_base_tree(BANK_ID)
+
+for root in tree.roots:
+    print(f"{root.kind}: {root.name}")
+    for child in root.children:
+        print(f"  {child.kind}: {child.name} (stale: {child.is_stale})")
+```
+
+### Node.js
+
+```javascript
+// Fetch the whole knowledge base as a nested folder/page tree (no page bodies)
+const tree = await client.getKnowledgeBaseTree(BANK_ID);
+
+for (const root of tree.roots) {
+    console.log(`${root.kind}: ${root.name}`);
+    for (const child of root.children ?? []) {
+        console.log(`  ${child.kind}: ${child.name} (stale: ${child.is_stale})`);
+    }
+}
+```
+
+### Go
+
+```go
+# Section 'get-tree' not found in api/knowledge-pages.go
+```
+
+```json
+{
+  "roots": [
+    {
+      "id": "kf-9f2c...",
+      "kind": "folder",
+      "name": "Operations",
+      "parent_id": null,
+      "mental_model_id": null,
+      "managed": false,
+      "description": null,
+      "tags": [],
+      "timestamp": "2026-08-01T11:04:02+00:00",
+      "is_stale": null,
+      "children": [
+        {
+          "id": "kp-2e85...",
+          "kind": "page",
+          "name": "Deploying the API",
+          "parent_id": "kf-9f2c...",
+          "mental_model_id": "mm-77ab...",
+          "managed": false,
+          "description": "How is the API deployed?",
+          "tags": ["ops"],
+          "timestamp": "2026-08-03T09:12:44+00:00",
+          "is_stale": true,
+          "children": []
+        }
+      ]
+    }
+  ]
+}
+```
+
+| Field | Description |
+|---|---|
+| `kind` | `folder` or `page` |
+| `mental_model_id` | The backing mental model (pages only) |
+| `description` | The page's source query — the question that rebuilds it |
+| `timestamp` | Last refresh for a page, last update for a folder |
+| `is_stale` | Pages only: `true` when memories in the page's scope are newer than its last refresh |
+| `managed` | `true` when the node is flagged as system-owned rather than hand-authored |
+
+---
+
+## Create a Page
+
+Creating a page stores it with placeholder content and schedules the first build in the background. Poll the returned `operation_id` via the [operations API](./operations) to know when the content is ready.
+
+### Python
+
+```python
+# Create a page — content is generated in the background
+page = client.create_knowledge_page(
+    BANK_ID,
+    name="Deploying the API",
+    source_query="How is the API deployed?",
+    parent_id=folder.id,
+    tags=["ops", "type:runbook"],
+)
+
+# Poll the operation to know when the first build has finished
+print(f"Page ID: {page.page_id}, operation: {page.operation_id}")
+```
+
+### Node.js
+
+```javascript
+// Create a page — content is generated in the background
+const page = await client.createKnowledgePage(
+    BANK_ID,
+    'Deploying the API',
+    'How is the API deployed?',
+    { parentId: folder.id, tags: ['ops', 'type:runbook'] },
+);
+
+// Poll the operation to know when the first build has finished
+console.log(`Page ID: ${page.page_id}, operation: ${page.operation_id}`);
+```
+
+### Go
+
+```go
+# Section 'create-page' not found in api/knowledge-pages.go
+```
+
+```json
+{
+  "page_id": "kp-2e85...",
+  "mental_model_id": "mm-77ab...",
+  "operation_id": "op-1d0f..."
+}
+```
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Page name. Must be unique within its folder, case-insensitively — a duplicate returns `409`. (Enforced on PostgreSQL only.) |
+| `source_query` | string | Yes | The question the page answers, re-asked on every refresh. |
+| `parent_id` | string | No | Folder to create the page in. `null` (or omitted) creates it at the root. |
+| `tags` | list | No | Tags that scope which memories the page is built from. A `type:<x>` tag also sets the page's rendered type. |
+| `max_tokens` | int | No | Content budget. Defaults to `4096` (a plain mental model defaults to `2048`). |
+| `trigger` | object | No | Refresh configuration — see below. |
+
+### Default Trigger
+
+When `trigger` is omitted, the page is created with a document-oriented configuration:
+
+```json
+{
+  "mode": "delta",
+  "fact_types": ["observation"],
+  "exclude_mental_models": true,
+  "refresh_after_consolidation": true
+}
+```
+
+This makes the page a living document built from consolidated observations only, refreshed incrementally whenever consolidation produces new knowledge in its scope, and never influenced by other pages.
+
+| Setting | Why |
+|---|---|
+| `fact_types: ["observation"]` | The page reads consolidated beliefs, not the raw conversational noise underneath them. Observations are already deduplicated and evidence-backed, so a page reads as a settled document instead of a transcript. Enforced structurally — with only `observation` in scope, the refresh agent isn't given the raw-memory recall tool at all. |
+| `exclude_mental_models: true` | A page never reflects on sibling pages. Without this, pages would cite each other and drift into a feedback loop where one wrong claim propagates across the knowledge base. |
+| `mode: "delta"` | Each refresh edits the existing document with what is new since the last refresh instead of regenerating it, so hand-tuned structure and wording survive. See [Refresh Mode](./mental-models#refresh-mode). |
+| `refresh_after_consolidation: true` | The page rewrites itself whenever consolidation produces new knowledge in its scope — gated by the same [staleness check](./mental-models#staleness-gating) as any mental model, so unrelated bank activity doesn't trigger rebuilds. |
+
+### Page Lifecycle
+
+1. **Create** — the page is stored with placeholder content and a background refresh is submitted; the call returns immediately with an `operation_id`.
+2. **First build** — a full generation, since there is no prior document to edit.
+3. **Consolidation** — new memories are retained and consolidated into observations.
+4. **Staleness check** — pages whose trigger asks for it are checked against their own scope (tags and `fact_types` both apply).
+5. **Delta refresh** — stale pages are rewritten by editing the existing document with the new observations only.
+
+Observations are what a page is *built from*, but it can still inspect the evidence underneath them: the refresh agent can expand a memory to its original chunk or document (unless `store_document_text` is disabled for the bank), and if `HINDSIGHT_API_REFLECT_SOURCE_FACTS_MAX_TOKENS` is enabled — off by default — observation search also returns each observation's grounding facts.
+
+> **🚨 Caution**
+>
+A supplied `trigger` **replaces** these defaults, it does not merge with them. Sending `{"trigger": {"mode": "full"}}` also resets `fact_types` to all types, `exclude_mental_models` to `false`, and `refresh_after_consolidation` to `false`. Repeat the fields you want to keep.
+Every [mental model trigger setting](./mental-models#trigger-settings) is accepted here — including `refresh_cron` for scheduled rebuilds instead of consolidation-driven ones, and `tag_groups` for compound tag scoping.
+
+---
+
+## Create a Folder
+
+### Python
+
+```python
+# Create a folder (omit parent_id, or pass None, to create it at the root)
+folder = client.create_knowledge_folder(BANK_ID, name="Operations")
+
+print(f"Folder ID: {folder.id}")
+```
+
+### Node.js
+
+```javascript
+// Create a folder (omit parentId, or pass null, to create it at the root)
+const folder = await client.createKnowledgeFolder(BANK_ID, 'Operations');
+
+console.log(`Folder ID: ${folder.id}`);
+```
+
+### Go
+
+```go
+# Section 'create-folder' not found in api/knowledge-pages.go
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Folder name |
+| `parent_id` | string | No | Parent folder. Omit or pass `null` for the root. |
+
+A `parent_id` that does not exist, or that points at a page rather than a folder, returns `400`.
+
+---
+
+## Read a Page
+
+Returns the page rendered as a markdown document.
+
+### Python
+
+```python
+# Read a page as a markdown document
+document = client.get_knowledge_page(BANK_ID, page.page_id)
+
+print(document.type)      # "runbook" — from the type:runbook tag
+print(document.body)      # the synthesized markdown body
+print(document.markdown)  # YAML frontmatter + body
+```
+
+### Node.js
+
+```javascript
+// Read a page as a markdown document
+const document = await client.getKnowledgePage(BANK_ID, page.page_id);
+
+console.log(document.type);      // "runbook" — from the type:runbook tag
+console.log(document.body);      // the synthesized markdown body
+console.log(document.markdown);  // YAML frontmatter + body
+```
+
+### Go
+
+```go
+# Section 'get-page' not found in api/knowledge-pages.go
+```
+
+```json
+{
+  "id": "kp-2e85...",
+  "name": "Deploying the API",
+  "type": "runbook",
+  "description": "How is the API deployed?",
+  "tags": ["ops"],
+  "timestamp": "2026-08-03T09:12:44+00:00",
+  "body": "# Deploying the API\n\n...",
+  "markdown": "---\nid: \"kp-2e85...\"\ntype: \"runbook\"\n...\n---\n\n# Deploying the API\n\n..."
+}
+```
+
+- `body` is the synthesized markdown body on its own.
+- `markdown` is the full document: a YAML frontmatter block (`id`, `type`, `title`, `description`, `tags`, `timestamp`) followed by the body.
+- `type` comes from a `type:<x>` tag and defaults to `knowledge-page`. The `type:` tag is removed from the returned `tags`.
+
+---
+
+## Search Pages
+
+Document-level hybrid search: a full-text (BM25) match and a vector-similarity match, fused with Reciprocal Rank Fusion. There is no reranking step, which keeps it fast enough to be an agent's first call.
+
+### Python
+
+```python
+# Hybrid search (full-text + vector) over whole pages
+results = client.search_knowledge_base(BANK_ID, q="how do we deploy", limit=5)
+
+for hit in results.results:
+    print(f"{hit.score:.3f}  {hit.name}: {hit.snippet}")
+```
+
+### Node.js
+
+```javascript
+// Hybrid search (full-text + vector) over whole pages
+const results = await client.searchKnowledgeBase(BANK_ID, 'how do we deploy', { limit: 5 });
+
+for (const hit of results.results) {
+    console.log(`${hit.score.toFixed(3)}  ${hit.name}: ${hit.snippet}`);
+}
+```
+
+### Go
+
+```go
+# Section 'search-pages' not found in api/knowledge-pages.go
+```
+
+```json
+{
+  "results": [
+    {
+      "id": "kp-2e85...",
+      "name": "Deploying the API",
+      "mental_model_id": "mm-77ab...",
+      "snippet": "The API is deployed via ...",
+      "score": 0.032,
+      "updated_at": "2026-08-03T09:12:44+00:00"
+    }
+  ],
+  "total": 1
+}
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `q` | string | — | Required. Search query (min length 1). |
+| `limit` | int | `10` | Maximum results, 1–50. |
+
+This searches whole pages. To search individual memories, use [recall](./recall).
+
+---
+
+## Update or Move a Node
+
+One `PATCH` renames a node, moves it, and/or updates a page's options. Each field applies only when present in the body.
+
+### Python
+
+```python
+# Rename a node, move it, and/or update a page's options.
+# Changing source_query rebuilds the page against the new question.
+client.update_knowledge_node(
+    BANK_ID,
+    page.page_id,
+    name="Deploying the API (v2)",
+    tags=["ops", "type:runbook", "reviewed"],
+)
+```
+
+### Node.js
+
+```javascript
+// Rename a node, move it, and/or update a page's options.
+// Changing sourceQuery rebuilds the page against the new question.
+await client.updateKnowledgeNode(BANK_ID, page.page_id, {
+    name: 'Deploying the API (v2)',
+    tags: ['ops', 'type:runbook', 'reviewed'],
+});
+```
+
+### Go
+
+```go
+# Section 'update-node' not found in api/knowledge-pages.go
+```
+
+| Parameter | Type | Applies to | Description |
+|---|---|---|---|
+| `name` | string | Both | New name |
+| `parent_id` | string \| null | Both | New parent folder. Pass `null` explicitly to move to the root. |
+| `source_query` | string | Pages | New question. Changing it schedules an async refresh so the page rebuilds against the new question. |
+| `tags` | list | Pages | Replaces the page's tags. Pass `[]` to clear them. |
+| `max_tokens` | int | Pages | New content budget |
+
+Sending an empty body returns `400`; an unknown node returns `404`.
+
+---
+
+## Delete a Node
+
+Deletes a folder or page **and its entire subtree**. The mental models backing the deleted pages are removed too.
+
+### Python
+
+```python
+# Delete a folder or page — deleting a folder removes its whole subtree
+client.delete_knowledge_node(BANK_ID, folder.id)
+```
+
+### Node.js
+
+```javascript
+// Delete a folder or page — deleting a folder removes its whole subtree
+await client.deleteKnowledgeNode(BANK_ID, folder.id);
+```
+
+### Go
+
+```go
+# Section 'delete-node' not found in api/knowledge-pages.go
+```
+
+```json
+{"status": "deleted"}
+```
+
+---
+
+## Export as a Markdown Bundle
+
+Returns the whole knowledge base as a flat set of portable markdown files: a nested `index.md`, one `<page-id>.md` per page, and a `<page-id>.log.md` refresh history for pages that have been rebuilt.
+
+### Python
+
+```python
+# Export the knowledge base as a portable markdown bundle
+bundle = client.export_knowledge_base(BANK_ID)
+
+for file in bundle.files:
+    print(file.path)  # index.md, <page-id>.md, <page-id>.log.md
+```
+
+### Node.js
+
+```javascript
+// Export the knowledge base as a portable markdown bundle
+const bundle = await client.exportKnowledgeBase(BANK_ID);
+
+for (const file of bundle.files) {
+    console.log(file.path);  // index.md, <page-id>.md, <page-id>.log.md
+}
+```
+
+### Go
+
+```go
+# Section 'export' not found in api/knowledge-pages.go
+```
+
+```json
+{
+  "files": [
+    {"path": "index.md", "content": "---\ntype: \"index\"\n..."},
+    {"path": "kp-2e85....md", "content": "---\nid: \"kp-2e85...\"\n..."},
+    {"path": "kp-2e85....log.md", "content": "---\ntype: \"log\"\n..."}
+  ]
+}
+```
+
+> **💡 Mirror it to disk**
+>
+`hindsight fs mount --bank my-bank` keeps a local folder in sync with this bundle via a background refresh loop, so `ls`, `grep`, `rg`, and your editor work against real files.
+---
+
+## Storage
+
+| Table | Holds |
+|---|---|
+| `knowledge_pages` | The tree: folders and pages, their names, parents, and ordering. A page row references its backing mental model; a folder row has none. |
+| `mental_models` | The content: the document body, its source query, tags, token budget, trigger, and refresh history. |
+
+The page layer owns only tree structure — everything about the content lives on the backing mental model, which is why every [mental model](./mental-models) capability applies to pages unchanged.
+
+---
+
+## Endpoint Summary
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/knowledge-base/tree` | Nested folder/page tree with staleness |
+| `POST` | `/knowledge-base/folders` | Create a folder |
+| `POST` | `/knowledge-base/pages` | Create a page (async first build) |
+| `GET` | `/knowledge-base/pages/{page_id}` | Read a page as markdown |
+| `GET` | `/knowledge-base/search` | Hybrid search over pages |
+| `PATCH` | `/knowledge-base/nodes/{node_id}` | Rename, move, or reconfigure a node |
+| `DELETE` | `/knowledge-base/nodes/{node_id}` | Delete a node and its subtree |
+| `GET` | `/knowledge-base/export` | Export the whole base as markdown files |

--- a/skills/hindsight-docs/references/developer/api/mental-models.md
+++ b/skills/hindsight-docs/references/developer/api/mental-models.md
@@ -3,6 +3,8 @@
 
 User-curated summaries that provide high-quality, pre-computed answers for common queries.
 
+See [Mental Models](../mental-models) for the concepts behind this API.
+
 {/* Import raw source files */}
 
 ## What Are Mental Models?
@@ -168,10 +170,29 @@ Mental models can be configured to **automatically refresh** when observations a
 | `refresh_cron` | string \| null | null | UTC 5-field cron expression for scheduled refreshes, such as `"0 3 * * *"` for daily at 03:00 UTC |
 | `tags_match` | string \| null | null | How the model's `tags` filter source memories during refresh: `any`, `all`, `any_strict`, `all_strict`, or `exact`. When `null`, a **tagged** model defaults to `all_strict` (a memory must carry every one of the model's tags). Set `"any"` to match memories carrying *any* of the tags — see [Tags and Visibility](#tags-and-visibility). |
 | `tag_groups` | list \| null | null | Advanced boolean tag expressions that override flat `tags`/`tags_match` entirely. See the [Recall tags reference](./recall#tags). |
+| `fact_types` | list \| null | null | Restrict which fact types the refresh reads: any of `world`, `experience`, `observation`. `null` means all three. Must not be an empty list. |
+| `exclude_mental_models` | bool | false | Hide *all* other mental models from the refresh, so the model never synthesises from sibling models. |
+| `exclude_mental_model_ids` | list \| null | null | Hide specific mental models by ID from the refresh. The model being refreshed is always excluded from itself. |
+| `include_chunks` | bool \| null | null | Override whether the refresh's internal recall returns raw chunk text. `null` uses the bank/global `recall_include_chunks` default. |
+| `recall_max_tokens` | int \| null | null | Override the token budget for facts retrieved during refresh. `null` uses the bank/global default. |
+| `recall_chunks_max_tokens` | int \| null | null | Override the token budget for raw chunks retrieved during refresh. `null` uses the bank/global default. |
 
 When `refresh_after_consolidation` is enabled, the mental model will be re-generated every time the bank's observations are consolidated — ensuring it always reflects the latest synthesized knowledge.
 
 When `refresh_cron` is set, Hindsight checks the schedule on the server's mental-model refresh tick and refreshes the model only if memories in its scope have changed since the last refresh. `refresh_cron` and `refresh_after_consolidation` are mutually exclusive, so a model refreshes either after consolidation or on a fixed UTC schedule, not both.
+
+### Staleness Gating
+
+Both automatic triggers run the same check before spending an LLM call: **is there a memory in this model's resolved scope newer than its last refresh?** The model's `tags`/`tags_match`, `tag_groups`, and `fact_types` all apply to that check, so activity elsewhere in the bank does not trigger a rebuild, and a cron tick over an unchanged scope is skipped entirely. Memories still waiting to be consolidated count — they are already stored, so a model whose scope reaches them is considered stale.
+
+The `is_stale` flag surfaced to the reflect agent (and in the knowledge-base tree) is computed by the same rule.
+
+### What a Refresh Reads
+
+- **A point-in-time snapshot.** Each refresh is bounded by a database-time cutoff and only reads memories committed at or before it, so a write landing mid-refresh is never half-included. The watermark recorded afterwards is the newest in-scope memory the refresh actually saw — not `now()` — so a write that commits just after the snapshot stays "newer" and is picked up on the next round instead of being skipped.
+- **Only what's new, in `delta` mode.** A delta refresh scopes its retrieval to memories created since the last refresh, so the LLM reads genuinely new information rather than re-reading the whole bank.
+- **Cumulative grounding.** Even in delta mode, `reflect_response.based_on` accumulates: the facts from this refresh are merged with everything previous refreshes relied on, deduplicated by id. The document rests on all of them, not just the latest slice.
+- **Nothing, if nothing is relevant.** A refresh that finds no topic-relevant memories leaves the content alone and only advances the watermark, so the same empty window stops re-triggering.
 
 ### Refresh Mode
 
@@ -180,6 +201,22 @@ Two strategies are available for how a refresh produces the new content:
 - **`full`** *(default)* — every refresh regenerates the entire content from scratch. Simple and predictable: the LLM synthesises a fresh document from the retrieved memories. Best when the document is short, when you want every refresh to potentially restructure the output, or when you're not yet sure what the final shape should be.
 
 - **`delta`** — refresh emits a list of typed *operations* (add a section, append a bullet, replace a block, remove a stale paragraph) against the document's existing structure, then renders the result. Sections that aren't targeted by any operation are copied through **byte-identical** — no paraphrasing, no whitespace drift, no list-style normalisation. Best for long-lived "playbook"–style mental models where you want stability across refreshes and only the genuinely changed parts to move.
+
+#### How delta mode works
+
+Hindsight keeps an authoritative **structured** representation of the document — an ordered list of sections, each holding typed blocks (paragraph, bullet list, ordered list, code) — and the markdown you read is a deterministic render of that structure. A delta refresh never asks the LLM to rewrite the document; it asks for operations against that structure:
+
+| Operation | Effect |
+|---|---|
+| `add_section` / `remove_section` | Add or drop a whole section |
+| `rename_section` | Change a section's heading |
+| `replace_section_blocks` | Replace a section's contents wholesale |
+| `append_block` / `insert_block` | Add a block at the end of, or at a position in, a section |
+| `replace_block` / `remove_block` | Change or drop one block |
+
+Anything no operation mentions is copied through untouched, so unchanged prose is preserved rather than regenerated and checked. This matters because "preserve the unchanged content" is only a soft constraint on an LLM — generating the next token from a gestalt of the input is what it intrinsically does, so instructed-to-preserve prose drifts over many refreshes.
+
+Failure modes are conservative by design: an operation list that fails to parse, or operations referencing sections and blocks that don't exist, are **dropped** rather than guessed at. Zero valid operations means an identical document — a refresh can improve the content or leave it alone, never corrupt it.
 
 Delta mode falls back to a full regeneration automatically in two cases:
 1. The mental model has no existing content yet (nothing to anchor edits on).
@@ -669,7 +706,7 @@ Each entry captures the **content before the change** and when it happened. The 
 
 > **📝 Note**
 >
-History tracking is enabled by default. Set `HINDSIGHT_API_ENABLE_MENTAL_MODEL_HISTORY=false` to disable it.
+History tracking is enabled by default. Set `HINDSIGHT_API_ENABLE_MENTAL_MODEL_HISTORY=false` to disable it, and `HINDSIGHT_API_MENTAL_MODEL_HISTORY_MAX_ENTRIES` to change how many versions are kept per model (default `50`).
 ---
 
 ## Use Cases

--- a/skills/hindsight-docs/references/developer/knowledge-pages.md
+++ b/skills/hindsight-docs/references/developer/knowledge-pages.md
@@ -1,0 +1,76 @@
+
+# Knowledge Pages
+
+**Knowledge pages** are living documents a bank writes about itself. Each page answers one question — "What are the components here?", "What's our error-handling convention?" — and rewrites itself as the bank learns more. They're organized in folders, browsable, searchable, and can be projected onto disk as ordinary markdown files.
+
+The shape is a wiki. The engine underneath is memory.
+
+---
+
+## Mental Models, Simplified
+
+A knowledge page *is* a [mental model](./mental-models). Same synthesis, same background refresh, same provenance.
+
+What's different is how much you have to know to use one. A mental model exposes its mechanics — what it reads, when it rebuilds, how it edits itself. Nobody should have to think about synthesis scope and refresh triggers to keep a wiki. So a page comes with those decisions already made:
+
+- It's built from the bank's [observations](./observations) — consolidated, deduplicated beliefs — rather than raw conversational detail.
+- It refreshes incrementally whenever consolidation produces new knowledge in its scope, editing the document rather than regenerating it.
+- It never reads other pages, so pages can't cite each other into a feedback loop.
+- It gets a larger content budget, because it's a document rather than an answer.
+
+You supply a name and a question. Everything else is a default you can override if you need to — every mental model setting still applies. See the [Knowledge Pages API](./api/knowledge-pages) for the exact defaults and how to change them.
+
+---
+
+## Organized Like a Wiki
+
+Pages live in a tree of folders. Nesting is arbitrary, page names are unique within their folder, and deleting a folder deletes its subtree. That's the whole structural model — a hierarchy, the way anyone would organize documents by hand.
+
+The tree is what makes a knowledge base navigable rather than a flat list of synthesized blobs: `Architecture/`, `Runbooks/`, `Decisions/`, each holding pages that stay current on their own.
+
+---
+
+## Projected as Real Files
+
+Agents already know how to work with a filesystem. So the CLI can mirror a bank's knowledge base onto disk:
+
+```bash
+hindsight fs mount --bank my-bank
+```
+
+The folder tree becomes real directories, each page a real markdown file with YAML frontmatter, kept current by a background refresh loop. From there, everything ordinary works — `ls`, `cat`, `grep`, `rg`, `fzf`, your editor, an agent's file tools. No SDK, no API client, no new vocabulary.
+
+The same content is available as a portable markdown bundle over the API, for exporting or committing elsewhere.
+
+---
+
+## Searchable
+
+Pages are searchable at the **document level**: a query returns whole pages, ranked, with snippets. It combines full-text and semantic matching, fused server-side, with no reranking step — fast enough to be the first thing an agent reaches for.
+
+That last part matters. Search is a tool an agent *chooses* to call, visible in the transcript, rather than content pushed into its context on every turn. Retrieval the agent asked for informs what it's doing; retrieval it didn't ask for tends to derail it.
+
+This is a different path from [recall](./retrieval), which searches individual memories. Use page search to pick a document; use recall for a specific fact.
+
+---
+
+## Why Not Just Raw Files?
+
+If the answer is documents in a tree, haven't we reinvented files — the thing a memory system exists to replace?
+
+The difference is what sits underneath. A file is where information goes to age. Whoever wrote it last wins, contradictions accumulate quietly, and nothing ever reconciles them. Left alone, a hand-maintained wiki becomes a beautifully formatted lie — not because anyone lied, but because keeping it true is a chore, and chores lose.
+
+A knowledge page is a **projected view** over processed memory, the way a database view is not a table. Before a page is written, Hindsight has already done the work files can't do for themselves: extracted facts from the raw sessions, commits, and documents; deduplicated them; and reconciled their contradictions through consolidation. So when a team decided X and later amended it to Y, the page says Y — and can say why — instead of preserving both a paragraph apart.
+
+Your raw documents remain the source of truth about *what was said*. The pages are the reconciled truth about *what holds*.
+
+This is also why pages heal themselves rather than rot: they aren't the storage, they're the rendering. Delete a page and nothing is lost — it re-projects from memory. Try deleting a wiki and getting it back.
+
+---
+
+## Working With Pages
+
+- **Control plane** — the Knowledge Base view renders the tree, page contents, and which pages have fallen behind.
+- **HTTP API** — see [Knowledge Pages API](./api/knowledge-pages) for the full endpoint surface.
+- **CLI** — `hindsight fs` mirrors a bank to a local folder of markdown files.
+- **Agent tools** — the agent SDK exposes `agent_knowledge_*` tools so an agent can list, read, create, and update its own pages during a session.

--- a/skills/hindsight-docs/references/developer/mental-models.md
+++ b/skills/hindsight-docs/references/developer/mental-models.md
@@ -1,0 +1,68 @@
+
+# Mental Models
+
+A **mental model** is a standing answer to a question about a bank. You define the question once; Hindsight writes the answer, keeps it stored, and rewrites it in the background as the bank learns more.
+
+Where [observations](./observations) are produced automatically and are atomic — one belief at a time — a mental model is deliberately curated: you decide which questions deserve a permanent, always-current answer.
+
+```mermaid
+graph LR
+    A[Raw facts] --> B[Observations]
+    B --> C[Mental model]
+    A --> C
+    C --> D[Your application]
+```
+
+---
+
+## The Answer Is Already Written
+
+The reason to use a mental model is speed. Reasoning over a bank's memory is expensive — retrieval, synthesis, an LLM writing an answer. A mental model moves all of that off the request path: the work happens in the background, ahead of time, and your application simply **reads the current version**.
+
+Fetching a mental model is a database read. No retrieval, no synthesis, no LLM call, no waiting. An agent that boots by loading its mental models starts with a page of settled knowledge instead of spending its first few seconds rediscovering it.
+
+This also makes answers **consistent**. Two users asking the same question get the same document, because there is only one document — not two independently generated answers that happen to disagree on the details.
+
+Mental models are also the first thing [reflect](./reflect) reaches for. Its retrieval ladder goes:
+
+| Layer | Produced by | Granularity |
+|---|---|---|
+| **Mental models** | You, explicitly | A whole document per question |
+| **Observations** | Consolidation, automatically | One belief per fact cluster |
+| **Raw facts** | Retain, automatically | One fact per statement |
+
+Each layer is a cheaper, more settled version of the one below it. If the first step turns up a mental model that is fresh and covers the question, reflect can answer from it instead of descending through observations and raw facts — the same saving, applied inside the agentic loop.
+
+---
+
+## Always Current, Without Asking
+
+A mental model is not a cached answer that goes stale silently. Hindsight tracks whether new memories have arrived that the model is supposed to cover, and rebuilds it when they have — either as soon as new knowledge is consolidated, or on a schedule you set.
+
+The check comes first, and it is scoped: a rebuild only happens when something *within this model's own scope* actually changed. A busy bank does not cause unrelated models to churn, and a scheduled rebuild over an unchanged bank costs nothing.
+
+When a model is handed to the reflect agent, it comes with a freshness signal — whether memories in its scope have landed since it was last written. A model that has fallen behind is still shown, but it no longer short-circuits retrieval, and the agent is expected to check it against the layers below rather than trust it blindly.
+
+---
+
+## Stable Across Rewrites
+
+A document that is rewritten hundreds of times has a problem an LLM cannot solve by being asked nicely: told to "preserve the unchanged parts", it will still drift. Bullets become numbers, casing shifts, sentences get quietly paraphrased. Generating text is what the model does; copying it verbatim is not.
+
+Hindsight can instead refresh a model **incrementally** — applying only the changes the new knowledge implies, and leaving everything else physically untouched rather than regenerating and hoping. A long-lived playbook stays the document you wrote, with the new parts added, instead of slowly becoming a different document that says roughly the same thing.
+
+---
+
+## Scope and Isolation
+
+A mental model's tags decide two things: which memories it is allowed to read, and which callers are allowed to see it. A model scoped to one customer, team, or user is built only from that scope's memories and surfaces only for requests in that scope — the same isolation rules that govern the rest of the bank, applied to synthesized knowledge.
+
+---
+
+## Provenance
+
+A mental model is not free-floating prose. It records the facts and observations it was built from, and it keeps the previous version of its content every time it changes. You can see what the model said last month and what evidence it was standing on — which matters when a model states something surprising and someone needs to know where it came from.
+
+---
+
+**See also:** [Mental Models API](./api/mental-models) — creating, refreshing, and configuring them, including refresh triggers, scoping options, and history.

--- a/skills/hindsight-docs/references/faq.md
+++ b/skills/hindsight-docs/references/faq.md
@@ -15,6 +15,7 @@ Common questions and answers about Hindsight.
 - [Retain, recall, and reflect — what's the difference?](#whats-the-difference-between-retain-recall-and-reflect)
 - [When should I use recall vs reflect?](#when-should-i-use-recall-vs-reflect)
 - [When should I use mental models?](#when-should-i-use-mental-models)
+- [Mental model vs. knowledge page](#whats-the-difference-between-a-mental-model-and-a-knowledge-page)
 - [Latency expectations](#whats-the-typical-latency-for-recall-operations)
 - [Tags, metadata, and entity labels](#does-hindsight-support-metadata-filtering)
 - [Controlling which memory types are recalled](#how-do-i-control-which-types-of-memories-are-recalled)
@@ -218,13 +219,32 @@ See [Recall](developer/api/recall.md) and [Reflect](developer/reflect.md) for fu
 
 ### When should I use mental models?
 
-**Mental models** are consolidated knowledge patterns synthesized from individual facts over time. Use them when you need:
+**Mental models** are standing answers to questions you define — synthesized from the bank's knowledge and rewritten in the background as it changes. Use them when you need:
 
 - Higher-level understanding beyond raw facts (e.g., "User prefers functional programming patterns")
 - Long-term behavioral patterns (e.g., "Customer is price-sensitive but values quality")
+- An answer available instantly, with no reasoning on the request path
 - Context for AI agent reasoning during **reflect** operations
 
-Mental models are automatically built during retain and used by reflect to provide richer, more contextual responses. See [Mental Models](developer/api/mental-models.md).
+You create a mental model with the question that defines it; Hindsight builds the content and keeps it current. Reflect checks mental models first, so a fresh one can answer without descending into observations and raw facts. See [Mental Models](developer/api/mental-models.md).
+
+---
+
+### What's the difference between a mental model and a knowledge page?
+
+A **knowledge page is a mental model** — the same engine, the same refresh behaviour — with two additions: a place in a folder tree, and a set of defaults tuned for documents rather than answers (built from observations only, refreshed incrementally after each consolidation, never influenced by other pages, and a larger content budget).
+
+| | Mental model | Knowledge page |
+|---|---|---|
+| Shape | A standing answer to a question | A markdown document with frontmatter |
+| Organization | Flat list, scoped by tags | Nested folders and pages |
+| Sources | All fact types by default | Observations only by default |
+| Refresh | Off by default | Delta refresh after each consolidation |
+| Typical consumer | Your application or an agent, by lookup | A person or agent browsing and reading |
+
+Use a plain mental model when something in your system looks up the answer. Use a knowledge page when the result is meant to be browsed and read directly, like a wiki. Anything you can configure on a mental model can be configured on a page.
+
+See [Mental Models](developer/api/mental-models.md) and the Knowledge Pages section of the developer docs.
 
 ---
 

--- a/skills/hindsight-docs/references/sdks/cli.md
+++ b/skills/hindsight-docs/references/sdks/cli.md
@@ -308,6 +308,53 @@ hindsight webhook delete <bank_id> <webhook_id>
 hindsight webhook deliveries <bank_id> <webhook_id>
 ```
 
+## Knowledge Base
+
+Manage a bank's knowledge pages — living documents organized in a folder tree. See [Knowledge Pages](../developer/api/knowledge-pages) for what they are and how they refresh.
+
+```bash
+# Show the folder/page tree (pages that have fallen behind are marked stale)
+hindsight knowledge-base tree <bank_id>
+
+# Create a folder, optionally nested under another
+hindsight knowledge-base create-folder <bank_id> "Operations"
+hindsight knowledge-base create-folder <bank_id> "Runbooks" --parent-id <folder_id>
+
+# Create a page — content is generated in the background
+hindsight knowledge-base create-page <bank_id> \
+  "Deploying the API" \
+  "How is the API deployed?" \
+  --parent-id <folder_id> \
+  --tags ops,type:runbook
+
+# Build a page from raw facts instead of the observation-only default
+hindsight knowledge-base create-page <bank_id> "Recent Incidents" \
+  "What incidents happened recently?" \
+  --fact-types experience,world --mode full
+
+# Read a page as a markdown document
+hindsight knowledge-base get-page <bank_id> <page_id>
+
+# Hybrid search (full-text + vector) over whole pages
+hindsight knowledge-base search <bank_id> "how do we deploy" --limit 5
+
+# Rename, move, or reconfigure a node
+hindsight knowledge-base update <bank_id> <node_id> --name "New name"
+hindsight knowledge-base update <bank_id> <page_id> --source-query "New question?"
+
+# Export the whole knowledge base as a markdown bundle
+hindsight knowledge-base export <bank_id>
+
+# Delete a folder or page and everything under it
+hindsight knowledge-base delete <bank_id> <node_id> -y
+```
+
+:::tip
+`hindsight fs mount --bank <bank_id>` mirrors the same knowledge base onto disk as
+real markdown files, kept current by a background refresh loop — handy when you'd
+rather use `grep`, `rg`, or your editor than the commands above.
+:::
+
 ## Audit Logs
 
 Inspect the audit trail for a bank:


### PR DESCRIPTION
Knowledge Pages shipped in #2455 with no documentation at all — no architecture page, no API page, not even a sidebar entry. Mental models had an API page but nothing explaining what they are or why an application would reach for one. This adds both, as top-level entries under **Architecture** and **API**, and closes the CLI gap the docs exposed.

## Docs

**Architecture → Mental Models** (new) — a standing answer to a question you define, built in the background so the application reads the current version instead of paying for retrieval and synthesis on the request path. Covers the mental model / observation / raw fact ladder that reflect walks, freshness, scope isolation, and provenance. Deliberately conceptual — the flags live in the API page.

**Architecture → Knowledge Pages** (new) — pages are mental models with the mechanics pre-decided, so nobody has to think about synthesis scope to keep a wiki. Covers the folder hierarchy, the `hindsight fs` filesystem projection, page-level search, and a "why not just raw files?" section: a page is a projected view over memory that has already deduplicated and reconciled contradictions, so an amended decision reads as the current one instead of two paragraphs disagreeing.

**API → Knowledge Pages** (new) — the full endpoint surface with Python / Node.js / CLI / Go examples, the page defaults and what each one buys, staleness gating, what a refresh actually reads, and the storage split.

**API → Mental Models** — the trigger settings table gained the seven options it was missing (`fact_types`, `exclude_mental_models`, `exclude_mental_model_ids`, `include_chunks`, `recall_max_tokens`, `recall_chunks_max_tokens`), plus new sections on staleness gating, what a refresh reads, and how delta mode edits a structured document rather than regenerating prose.

**FAQ** — new entry on mental model vs knowledge page. Also corrects the neighbouring answer, which described mental models as "automatically built during retain" — that describes observations.

## Clients

The API examples use the maintained clients like every other API page, which meant the knowledge-base surface had to exist in each of them.

**Python + TypeScript wrappers**, kept at parity: `get_knowledge_base_tree` · `create_knowledge_folder` · `create_knowledge_page` · `get_knowledge_page` · `search_knowledge_base` · `update_knowledge_node` · `delete_knowledge_node` · `export_knowledge_base`. `update_knowledge_node` only serializes the arguments the caller passed — the server treats an absent field as "leave alone" but an explicit null `parent_id` as "move to the root", and passing every field through would make those indistinguishable. Request-mapping regression tests cover this on both sides.

**Rust CLI** — `hindsight knowledge-base` with `tree`, `create-folder`, `create-page`, `get-page`, `search`, `update`, `delete`, `export`. All eight endpoints were previously listed as deliberate skips in `.openapi-coverage.toml` ("managed in the control plane UI, not the end-user CLI"); those are removed, so `cli-coverage-check` now enforces the surface. `create-page` sends no trigger unless `--mode` or `--fact-types` is given, so the server's page defaults stand — and when either is given the whole trigger is restated, because a supplied trigger replaces the defaults rather than merging.

Runnable Python / Node / CLI / Go examples added under `hindsight-docs/examples/api/`, and a Knowledge Base section added to the CLI reference.

## Verification

- All eight CLI commands exercised end-to-end against a running API (create folder → create page → tree → get-page → search → update → export → delete), on a scratch bank that was removed afterwards
- `cli-coverage-check` passes: all 84 operations and 108 request params covered
- `cargo test` 118 passed; new unit tests for the `--fact-types` / `--mode` parsers
- `docusaurus build` passes; no broken links or anchors from the new pages (the two reported are pre-existing in a 0.5.5 blog post)
- `./scripts/hooks/lint.sh` clean; `check-unused.sh` clean
- Python wrapper suite 96 passed; TypeScript wrapper suites pass
- `skills/hindsight-docs` mirror regenerated, link validation passes

## Notes, not addressed here

- `client-coverage-check` reports `reflect.apply_all_directives` missing from both wrappers — introduced by #3046 and unrelated to this change. That check is not wired into CI.
- New pages exist only in the unreleased docs version, so links to them from non-versioned pages (the FAQ) point at the released API page instead. Worth revisiting when the next version is cut.
