### PR TITLE
fix(retain): reject batches with mixed document IDs

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -19,6 +19,7 @@ import logging
 import sys
 import time
 import uuid
+from collections import Counter
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
@@ -425,6 +426,28 @@ from .token_encoding import get_token_encoding
 
 RetainOutboxCallback = Callable[[asyncpg.Connection], Awaitable[None]]
 RetainOutboxCallbackFactory = Callable[[list[RetainContentDict]], RetainOutboxCallback | None]
+
+
+def _validate_batch_document_ids(contents: list[RetainContentDict]) -> list[str]:
+    """Return explicit document IDs after validating batch routing semantics."""
+    document_ids = [document_id for item in contents if (document_id := item.get("document_id"))]
+
+    duplicates = [document_id for document_id, count in Counter(document_ids).items() if count > 1]
+    if duplicates:
+        raise ValueError(
+            f"Batch contains duplicate document_ids: {duplicates}. "
+            f"Each content item in a batch must have a unique document_id to avoid race conditions."
+        )
+
+    # A single explicit ID currently becomes the effective ID for every implicit
+    # item, silently combining otherwise independent content into one document.
+    if document_ids and len(document_ids) != len(contents):
+        raise ValueError(
+            "Batch cannot mix content items with and without document_ids. "
+            "Provide a unique document_id for every content item, or omit document_id from all items."
+        )
+
+    return document_ids
 
 
 @dataclass(frozen=True)
@@ -3706,17 +3729,7 @@ class MemoryEngine(MemoryEngineInterface):
         if outbox_callback is None and outbox_callback_factory is not None:
             outbox_callback = outbox_callback_factory(contents)
 
-        # Validate no duplicate document_ids in the batch
-        # Having duplicate document_ids causes race conditions in document upserts during parallel processing
-        doc_ids = [item.get("document_id") for item in contents if item.get("document_id")]
-        if len(doc_ids) != len(set(doc_ids)):
-            from collections import Counter
-
-            duplicates = [doc_id for doc_id, count in Counter(doc_ids).items() if count > 1]
-            raise ValueError(
-                f"Batch contains duplicate document_ids: {duplicates}. "
-                f"Each content item in a batch must have a unique document_id to avoid race conditions."
-            )
+        _validate_batch_document_ids(contents)
 
         # Validate update_mode=append requires document_id
         for item in contents:
@@ -14365,17 +14378,7 @@ class MemoryEngine(MemoryEngineInterface):
             if replay is not None:
                 return replay
 
-        # Validate no duplicate document_ids in the batch
-        # Having duplicate document_ids causes race conditions in document upserts during parallel processing
-        doc_ids = [item.get("document_id") for item in contents if item.get("document_id")]
-        if len(doc_ids) != len(set(doc_ids)):
-            from collections import Counter
-
-            duplicates = [doc_id for doc_id, count in Counter(doc_ids).items() if count > 1]
-            raise ValueError(
-                f"Batch contains duplicate document_ids: {duplicates}. "
-                f"Each content item in a batch must have a unique document_id to avoid race conditions."
-            )
+        doc_ids = _validate_batch_document_ids(cast(list[RetainContentDict], contents))
 
         # Calculate total token count and determine if we need to split
         total_tokens = sum(count_tokens(item.get("content", "")) for item in contents)

--- a/hindsight-api-slim/tests/test_async_batch_retain.py
+++ b/hindsight-api-slim/tests/test_async_batch_retain.py
@@ -17,6 +17,22 @@ from hindsight_api.extensions import RequestContext
 pytestmark = pytest.mark.xdist_group("worker_tests")
 
 
+MIXED_DOCUMENT_ID_BATCHES = [
+    [
+        {"content": "Explicit item", "document_id": "doc1"},
+        {"content": "Implicit item"},
+    ],
+    [
+        {"content": "Implicit item"},
+        {"content": "Explicit item", "document_id": "doc1"},
+    ],
+    [
+        {"content": "Explicit item", "document_id": "doc1"},
+        {"content": "Empty ID item", "document_id": ""},
+    ],
+]
+
+
 async def _ensure_bank(pool, bank_id: str) -> None:
     """Upsert a minimal bank row so FK on async_operations passes."""
     await pool.execute(
@@ -24,6 +40,46 @@ async def _ensure_bank(pool, bank_id: str) -> None:
         bank_id,
         bank_id,
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "contents",
+    MIXED_DOCUMENT_ID_BATCHES,
+    ids=["explicit-then-missing", "missing-then-explicit", "explicit-then-empty"],
+)
+async def test_mixed_document_ids_rejected_async(memory, request_context, contents):
+    """Async retain rejects mixed IDs before creating operation rows."""
+    bank_id = f"test_mixed_document_ids_async_{uuid.uuid4().hex[:8]}"
+
+    with pytest.raises(ValueError, match="cannot mix content items with and without document_ids"):
+        await memory.submit_async_retain(
+            bank_id=bank_id,
+            contents=contents,
+            request_context=request_context,
+        )
+
+    pool = await memory._get_pool()
+    operation_count = await pool.fetchval("SELECT COUNT(*) FROM async_operations WHERE bank_id = $1", bank_id)
+    assert operation_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "contents",
+    MIXED_DOCUMENT_ID_BATCHES,
+    ids=["explicit-then-missing", "missing-then-explicit", "explicit-then-empty"],
+)
+async def test_mixed_document_ids_rejected_sync(memory, request_context, contents):
+    """Sync retain applies the same document ID validation as async retain."""
+    bank_id = f"test_mixed_document_ids_sync_{uuid.uuid4().hex[:8]}"
+
+    with pytest.raises(ValueError, match="cannot mix content items with and without document_ids"):
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=contents,
+            request_context=request_context,
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- reject retain batches that mix explicit document IDs with omitted or empty IDs, preventing an explicit ID from absorbing unrelated items
- share the validation between synchronous and asynchronous retain while preserving all-implicit and all-explicit unique batches
- reject invalid asynchronous batches before creating parent or child operation rows

Fixes #3010.

## Tests

- `uv run pytest tests/test_async_batch_retain.py -n 0` (39 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check hindsight_api/`
