### PR TITLE
fix(recall): apply the created_after/created_before window to graph expansion

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops.py
@@ -35,6 +35,57 @@ class TagListingParts:
     bank_prefix: str
 
 
+@dataclass(frozen=True)
+class UpdatedWindow:
+    """Recall's ``created_after``/``created_before`` bounds, as SQL for graph expansion.
+
+    Recall applies the window to ``updated_at`` — a consolidation touch makes a
+    fact current again — so link expansion has to bound the same column its seed
+    query does.  Filtering only the seeds is not enough: a single in-window seed
+    would otherwise drag its whole neighbourhood (shared entities, semantic kNN
+    links, causal links) into the results no matter how old those neighbours are.
+
+    ``first_param_index`` is where the bounds land in the owning query's param
+    list, so each call site keeps the placeholder numbering next to the params it
+    binds.  Rendering is per-alias because the same window is applied to several
+    correlation names within one query.
+    """
+
+    after: datetime | None
+    before: datetime | None
+    first_param_index: int
+
+    def clause(self, alias: str) -> str:
+        """``AND <alias>.updated_at > $n ...`` — empty when the window is unbounded."""
+        parts: list[str] = []
+        index = self.first_param_index
+        if self.after is not None:
+            parts.append(f" AND {alias}.updated_at > ${index}")
+            index += 1
+        if self.before is not None:
+            parts.append(f" AND {alias}.updated_at < ${index}")
+        return "".join(parts)
+
+    @property
+    def params(self) -> list[datetime]:
+        """The bound values, in placeholder order. Append to the owning param list."""
+        return [bound for bound in (self.after, self.before) if bound is not None]
+
+
+@dataclass(frozen=True)
+class LinkExpansionRows:
+    """The three link-expansion signals, kept apart until they are scored.
+
+    They cannot be concatenated at the SQL layer: each carries a different score
+    scale (shared-entity count, kNN weight, causal weight) and the caller applies
+    a different transformation to each before summing them.
+    """
+
+    entity: list[ResultRow]
+    semantic: list[ResultRow]
+    causal: list[ResultRow]
+
+
 class DataAccessOps(ABC):
     """Backend-specific multi-statement data access operations.
 
@@ -250,12 +301,16 @@ class DataAccessOps(ABC):
         mu_table: str,
         ue_table: str,
         per_entity_limit: int,
+        window: UpdatedWindow,
     ) -> str:
         """Build entity expansion CTE for link expansion retrieval.
 
         PG uses DISTINCT ON with CROSS JOIN LATERAL and GROUP BY.
         Non-PG splits into entity_scores subquery then JOINs for full columns
         (can't GROUP BY CLOB).
+
+        ``window`` narrows candidates *before* the per-entity cap, so out-of-window
+        neighbours don't consume an entity's bounded fan-out.
         """
         ...
 
@@ -264,6 +319,7 @@ class DataAccessOps(ABC):
         self,
         ml_table: str,
         mu_table: str,
+        window: UpdatedWindow,
     ) -> str:
         """Build semantic + causal expansion CTEs.
 
@@ -282,7 +338,8 @@ class DataAccessOps(ABC):
         seed_ids: list,
         budget: int,
         per_entity_limit: int,
-    ) -> tuple[list[ResultRow], list[ResultRow], list[ResultRow]]:
+        window: UpdatedWindow,
+    ) -> LinkExpansionRows:
         """Observation-specific graph expansion.
 
         PG uses native array ops (source_memory_ids column) for performance.

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -10,7 +10,7 @@ import uuid as uuid_mod
 from datetime import UTC, datetime
 
 from .base import DatabaseConnection
-from .ops import DataAccessOps, TagListingParts
+from .ops import DataAccessOps, LinkExpansionRows, TagListingParts, UpdatedWindow
 from .result import DictResultRow as ResultRow
 
 ORACLE_IN_LIST_LIMIT = 1000
@@ -480,6 +480,7 @@ class OracleOps(DataAccessOps):
         mu_table: str,
         ue_table: str,
         per_entity_limit: int,
+        window: UpdatedWindow,
     ) -> str:
         # Oracle: can't GROUP BY CLOB columns (text, context).
         # Restructure: count entities per unit_id in a subquery, then join to get full columns.
@@ -498,12 +499,14 @@ class OracleOps(DataAccessOps):
                     WHERE ue_target.entity_id = se.entity_id
                       AND ue_target.unit_id != ALL($1::uuid[])
                       -- Filter before applying the cap: candidates from other fact
-                      -- types must not consume this entity's bounded fan-out.
+                      -- types, or outside the recall window, must not consume this
+                      -- entity's bounded fan-out.
                       AND EXISTS (
                           SELECT 1
                           FROM {mu_table} mu_target
                           WHERE mu_target.id = ue_target.unit_id
                             AND mu_target.fact_type = $2
+                            {window.clause("mu_target")}
                       )
                     ORDER BY ue_target.unit_id DESC
                     FETCH FIRST {per_entity_limit} ROWS ONLY
@@ -525,6 +528,7 @@ class OracleOps(DataAccessOps):
         self,
         ml_table: str,
         mu_table: str,
+        window: UpdatedWindow,
     ) -> str:
         # Non-PG: can't GROUP BY CLOB columns, no DISTINCT ON.
         # Restructure semantic: compute max weight per id, then join for full columns.
@@ -539,6 +543,7 @@ class OracleOps(DataAccessOps):
                       AND ml.link_type = 'semantic'
                       AND mu.fact_type = $2
                       AND mu.id != ALL($1::uuid[])
+                      {window.clause("mu")}
                     UNION ALL
                     SELECT mu.id, ml.weight
                     FROM {ml_table} ml
@@ -547,6 +552,7 @@ class OracleOps(DataAccessOps):
                       AND ml.link_type = 'semantic'
                       AND mu.fact_type = $2
                       AND mu.id != ALL($1::uuid[])
+                      {window.clause("mu")}
                 ) sem_raw
                 GROUP BY id
             ),
@@ -573,6 +579,7 @@ class OracleOps(DataAccessOps):
                 WHERE ml.from_unit_id = ANY($1::uuid[])
                   AND ml.link_type IN ('causes', 'caused_by', 'enables', 'prevents')
                   AND mu.fact_type = $2
+                  {window.clause("mu")}
             ),
             causal_expanded AS (
                 SELECT id, text, context, event_date, occurred_start, occurred_end, mentioned_at,
@@ -591,7 +598,8 @@ class OracleOps(DataAccessOps):
         seed_ids: list,
         budget: int,
         per_entity_limit: int,
-    ) -> tuple[list[ResultRow], list[ResultRow], list[ResultRow]]:
+        window: UpdatedWindow,
+    ) -> LinkExpansionRows:
         import logging
 
         logger = logging.getLogger(__name__)
@@ -645,11 +653,13 @@ class OracleOps(DataAccessOps):
                   WHERE os3.observation_id = mu.id
                     AND os3.source_id IN (SELECT source_id FROM connected_sources)
               )
+              {window.clause("mu")}
             ORDER BY score DESC
             FETCH FIRST $2 ROWS ONLY
             """,
             seed_ids,
             budget,
+            *window.params,
         )
         logger.debug(f"[LinkExpansion] observation graph (Oracle): found {len(entity_rows)} connected observations")
 
@@ -665,12 +675,14 @@ class OracleOps(DataAccessOps):
                     WHERE ml.from_unit_id = ANY($1::uuid[])
                       AND ml.link_type = 'semantic' AND mu.fact_type = 'observation'
                       AND mu.id != ALL($1::uuid[])
+                      {window.clause("mu")}
                     UNION ALL
                     SELECT mu.id, ml.weight
                     FROM {ml_table} ml JOIN {mu_table} mu ON mu.id = ml.from_unit_id
                     WHERE ml.to_unit_id = ANY($1::uuid[])
                       AND ml.link_type = 'semantic' AND mu.fact_type = 'observation'
                       AND mu.id != ALL($1::uuid[])
+                      {window.clause("mu")}
                 ) sem_raw
                 GROUP BY id
             ),
@@ -696,6 +708,7 @@ class OracleOps(DataAccessOps):
                 WHERE ml.from_unit_id = ANY($1::uuid[])
                   AND ml.link_type IN ('causes', 'caused_by', 'enables', 'prevents')
                   AND mu.fact_type = 'observation'
+                  {window.clause("mu")}
             ),
             causal_expanded AS (
                 SELECT id, text, context, event_date, occurred_start, occurred_end, mentioned_at,
@@ -710,11 +723,12 @@ class OracleOps(DataAccessOps):
             """,
             seed_ids,
             budget,
+            *window.params,
         )
 
         semantic_rows = [r for r in sem_causal_rows if r["source"] == "semantic"]
         causal_rows = [r for r in sem_causal_rows if r["source"] == "causal"]
-        return list(entity_rows), semantic_rows, causal_rows
+        return LinkExpansionRows(entity=list(entity_rows), semantic=semantic_rows, causal=causal_rows)
 
     def build_tag_listing_parts(self, mu_table: str) -> TagListingParts:
         return TagListingParts(

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -7,7 +7,7 @@ efficient batch operations.
 from datetime import datetime
 
 from .base import DatabaseConnection
-from .ops import DataAccessOps, TagListingParts
+from .ops import DataAccessOps, LinkExpansionRows, TagListingParts, UpdatedWindow
 from .result import ResultRow
 
 
@@ -605,6 +605,7 @@ class PostgreSQLOps(DataAccessOps):
         mu_table: str,
         ue_table: str,
         per_entity_limit: int,
+        window: UpdatedWindow,
     ) -> str:
         return f"""
             seed_entities AS (
@@ -625,12 +626,14 @@ class PostgreSQLOps(DataAccessOps):
                     WHERE ue_target.entity_id = se.entity_id
                       AND ue_target.unit_id != ALL($1::uuid[])
                       -- Filter before applying the cap: candidates from other fact
-                      -- types must not consume this entity's bounded fan-out.
+                      -- types, or outside the recall window, must not consume this
+                      -- entity's bounded fan-out.
                       AND EXISTS (
                           SELECT 1
                           FROM {mu_table} mu_target
                           WHERE mu_target.id = ue_target.unit_id
                             AND mu_target.fact_type = $2
+                            {window.clause("mu_target")}
                       )
                     ORDER BY ue_target.unit_id DESC
                     LIMIT {per_entity_limit}
@@ -645,6 +648,7 @@ class PostgreSQLOps(DataAccessOps):
         self,
         ml_table: str,
         mu_table: str,
+        window: UpdatedWindow,
     ) -> str:
         # Exact v0.5.6 query shape: GROUP BY + MAX(weight) for semantic,
         # DISTINCT ON for causal.
@@ -668,6 +672,7 @@ class PostgreSQLOps(DataAccessOps):
                       AND ml.link_type = 'semantic'
                       AND mu.fact_type = $2
                       AND mu.id != ALL($1::uuid[])
+                      {window.clause("mu")}
                     UNION ALL
                     SELECT
                         mu.id, mu.text, mu.context, mu.event_date, mu.occurred_start,
@@ -680,6 +685,7 @@ class PostgreSQLOps(DataAccessOps):
                       AND ml.link_type = 'semantic'
                       AND mu.fact_type = $2
                       AND mu.id != ALL($1::uuid[])
+                      {window.clause("mu")}
                 ) sem_raw
                 GROUP BY id, text, context, event_date, occurred_start,
                          occurred_end, mentioned_at,
@@ -699,6 +705,7 @@ class PostgreSQLOps(DataAccessOps):
                 WHERE ml.from_unit_id = ANY($1::uuid[])
                   AND ml.link_type IN ('causes', 'caused_by', 'enables', 'prevents')
                   AND mu.fact_type = $2
+                  {window.clause("mu")}
                 ORDER BY mu.id, ml.weight DESC
                 LIMIT $3
             )"""
@@ -712,8 +719,13 @@ class PostgreSQLOps(DataAccessOps):
         seed_ids: list,
         budget: int,
         per_entity_limit: int,
-    ) -> tuple[list[ResultRow], list[ResultRow], list[ResultRow]]:
+        window: UpdatedWindow,
+    ) -> LinkExpansionRows:
         # v0.5.6 array ops: unnest, &&, COUNT(DISTINCT) on source_memory_ids.
+        #
+        # The window bounds the observations that come *back*, not the source facts
+        # traversed to reach them: an observation is in the window when it was itself
+        # written or refreshed there, regardless of how old the facts underneath it are.
 
         entity_rows = await conn.fetch(
             f"""
@@ -755,11 +767,13 @@ class PostgreSQLOps(DataAccessOps):
               AND mu.id != ALL($1::uuid[])
               AND ca.source_ids IS NOT NULL
               AND mu.source_memory_ids && ca.source_ids
+              {window.clause("mu")}
             ORDER BY score DESC
             LIMIT $2
             """,
             seed_ids,
             budget,
+            *window.params,
         )
 
         # Exact v0.5.6 query shape: GROUP BY + MAX(weight) for semantic,
@@ -781,6 +795,7 @@ class PostgreSQLOps(DataAccessOps):
                     WHERE ml.from_unit_id = ANY($1::uuid[])
                       AND ml.link_type = 'semantic' AND mu.fact_type = 'observation'
                       AND mu.id != ALL($1::uuid[])
+                      {window.clause("mu")}
                     UNION ALL
                     SELECT mu.id, mu.text, mu.context, mu.event_date, mu.occurred_start,
                            mu.occurred_end, mu.mentioned_at, mu.fact_type, mu.document_id,
@@ -789,6 +804,7 @@ class PostgreSQLOps(DataAccessOps):
                     WHERE ml.to_unit_id = ANY($1::uuid[])
                       AND ml.link_type = 'semantic' AND mu.fact_type = 'observation'
                       AND mu.id != ALL($1::uuid[])
+                      {window.clause("mu")}
                 ) sem_raw
                 GROUP BY id, text, context, event_date, occurred_start, occurred_end,
                          mentioned_at, fact_type, document_id, chunk_id, tags, proof_count
@@ -803,6 +819,7 @@ class PostgreSQLOps(DataAccessOps):
                 WHERE ml.from_unit_id = ANY($1::uuid[])
                   AND ml.link_type IN ('causes', 'caused_by', 'enables', 'prevents')
                   AND mu.fact_type = 'observation'
+                  {window.clause("mu")}
                 ORDER BY mu.id, ml.weight DESC LIMIT $2
             )
             SELECT * FROM semantic_expanded
@@ -811,11 +828,12 @@ class PostgreSQLOps(DataAccessOps):
             """,
             seed_ids,
             budget,
+            *window.params,
         )
 
         semantic_rows = [r for r in sem_causal_rows if r["source"] == "semantic"]
         causal_rows = [r for r in sem_causal_rows if r["source"] == "causal"]
-        return list(entity_rows), semantic_rows, causal_rows
+        return LinkExpansionRows(entity=list(entity_rows), semantic=semantic_rows, causal=causal_rows)
 
     def build_tag_listing_parts(self, mu_table: str) -> TagListingParts:
         return TagListingParts(

--- a/hindsight-api-slim/hindsight_api/engine/search/link_expansion_retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/link_expansion_retrieval.py
@@ -32,6 +32,7 @@ from datetime import datetime
 from typing import Any
 
 from ...config import DEFAULT_GRAPH_SEED_MIN_SIMILARITY, get_config
+from ..db.ops import LinkExpansionRows, UpdatedWindow
 from ..db_utils import acquire_with_retry
 from ..memory_engine import fq_table
 from .graph_retrieval import GraphRetriever
@@ -198,17 +199,28 @@ class LinkExpansionRetriever(GraphRetriever):
 
             ops = pool.ops
             if fact_type == "observation":
-                entity_rows, semantic_rows, causal_rows = await self._expand_observations(
-                    conn, seed_ids, budget, ops=ops
+                expanded = await self._expand_observations(
+                    conn,
+                    seed_ids,
+                    budget,
+                    ops=ops,
+                    created_after=created_after,
+                    created_before=created_before,
                 )
             else:
-                entity_rows, semantic_rows, causal_rows = await self._expand_combined(
-                    conn, seed_ids, fact_type, budget, ops=ops
+                expanded = await self._expand_combined(
+                    conn,
+                    seed_ids,
+                    fact_type,
+                    budget,
+                    ops=ops,
+                    created_after=created_after,
+                    created_before=created_before,
                 )
 
             timings.edge_load_time = time.time() - query_start
             timings.db_queries = 1
-            timings.edge_count = len(entity_rows) + len(semantic_rows) + len(causal_rows)
+            timings.edge_count = len(expanded.entity) + len(expanded.semantic) + len(expanded.causal)
 
         # Merge results with additive intra-score: entity + semantic + causal ∈ [0, 3].
         #
@@ -224,17 +236,17 @@ class LinkExpansionRetriever(GraphRetriever):
         causal_scores: dict[str, float] = {}
         row_map: dict[str, dict] = {}
 
-        for row in entity_rows:
+        for row in expanded.entity:
             fact_id = str(row["id"])
             entity_scores[fact_id] = math.tanh(row["score"] * 0.5)
             row_map[fact_id] = dict(row)
 
-        for row in semantic_rows:
+        for row in expanded.semantic:
             fact_id = str(row["id"])
             semantic_scores[fact_id] = max(semantic_scores.get(fact_id, 0.0), row["score"])
             row_map.setdefault(fact_id, dict(row))
 
-        for row in causal_rows:
+        for row in expanded.causal:
             fact_id = str(row["id"])
             causal_scores[fact_id] = max(causal_scores.get(fact_id, 0.0), row["score"])
             row_map.setdefault(fact_id, dict(row))
@@ -284,7 +296,9 @@ class LinkExpansionRetriever(GraphRetriever):
         budget: int,
         *,
         ops,
-    ) -> tuple[list, list, list]:
+        created_after: datetime | None = None,
+        created_before: datetime | None = None,
+    ) -> LinkExpansionRows:
         """
         Single-roundtrip CTE query combining entity, semantic, and causal expansions.
 
@@ -306,8 +320,10 @@ class LinkExpansionRetriever(GraphRetriever):
 
         per_entity_limit = config.link_expansion_per_entity_limit
 
-        entity_cte = ops.build_entity_expansion_cte(mu, ue, per_entity_limit)
-        semantic_causal_cte = ops.build_semantic_causal_cte(ml, mu)
+        # $1 seeds, $2 fact_type, $3 budget — the window binds after them.
+        window = UpdatedWindow(after=created_after, before=created_before, first_param_index=4)
+        entity_cte = ops.build_entity_expansion_cte(mu, ue, per_entity_limit, window)
+        semantic_causal_cte = ops.build_semantic_causal_cte(ml, mu, window)
 
         full_query = f"""
             WITH {entity_cte},
@@ -319,7 +335,7 @@ class LinkExpansionRetriever(GraphRetriever):
             SELECT * FROM causal_expanded
             """
 
-        params = [seed_ids, fact_type, budget]
+        params = [seed_ids, fact_type, budget, *window.params]
 
         try:
             all_rows = await asyncio.wait_for(
@@ -340,10 +356,11 @@ class LinkExpansionRetriever(GraphRetriever):
                 """
             all_rows = await conn.fetch(fallback_query, *params)
 
-        entity_rows = [r for r in all_rows if r["source"] == "entity"]
-        semantic_rows = [r for r in all_rows if r["source"] == "semantic"]
-        causal_rows = [r for r in all_rows if r["source"] == "causal"]
-        return entity_rows, semantic_rows, causal_rows
+        return LinkExpansionRows(
+            entity=[r for r in all_rows if r["source"] == "entity"],
+            semantic=[r for r in all_rows if r["source"] == "semantic"],
+            causal=[r for r in all_rows if r["source"] == "causal"],
+        )
 
     async def _expand_observations(
         self,
@@ -352,7 +369,9 @@ class LinkExpansionRetriever(GraphRetriever):
         budget: int,
         *,
         ops,
-    ) -> tuple[list, list, list]:
+        created_after: datetime | None = None,
+        created_before: datetime | None = None,
+    ) -> LinkExpansionRows:
         """
         Observation-specific expansion.
 
@@ -389,6 +408,7 @@ class LinkExpansionRetriever(GraphRetriever):
         # Delegate to DataAccessOps. Both backends now use the observation_sources
         # junction table with standard SQL joins (previously PG used native array
         # ops and Oracle used JSON_TABLE).
+        # $1 seeds, $2 budget — the window binds after them.
         return await ops.expand_observations(
             conn,
             mu,
@@ -397,4 +417,5 @@ class LinkExpansionRetriever(GraphRetriever):
             seed_ids,
             budget,
             per_entity_limit,
+            UpdatedWindow(after=created_after, before=created_before, first_param_index=3),
         )

--- a/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
@@ -16,6 +16,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Optional
 
 from ...config import DEFAULT_BM25_MAX_QUERY_TERMS, DEFAULT_TEMPORAL_SEMANTIC_MIN_SIMILARITY, get_config
+from ..db.ops import UpdatedWindow
 from ..db_utils import acquire_with_retry
 from ..memory_engine import fq_table
 from ..sql import create_sql_dialect
@@ -724,6 +725,14 @@ async def retrieve_temporal_combined_sql(
         spreading_groups_clause, spreading_groups_params, _ = build_tag_groups_where_clause(
             tag_groups, spreading_groups_param_start, table_alias="mu."
         )
+        # The window has to be repeated here, not just on the entry-point query
+        # above: spreading walks temporal/causal links outward, so an in-window
+        # entry point would otherwise pull out-of-window neighbours into results.
+        spreading_window = UpdatedWindow(
+            after=created_after,
+            before=created_before,
+            first_param_index=spreading_groups_param_start + len(spreading_groups_params),
+        )
 
         # Multi-hop temporal spreading expands a batch of seed ids with
         # ``FROM unnest($2::uuid[])``, which has no Oracle equivalent. On backends
@@ -741,6 +750,7 @@ async def retrieve_temporal_combined_sql(
             if tags:
                 spreading_params.append(tags)
             spreading_params.extend(spreading_groups_params)
+            spreading_params.extend(spreading_window.params)
 
             # LATERAL join: for each source node, fetch top-K neighbors by weight using
             # the existing idx_memory_links_from_type_weight index with early-exit semantics.
@@ -768,6 +778,7 @@ async def retrieve_temporal_combined_sql(
                   AND (1 - (mu.embedding <=> $1::vector)) >= $4
                   {spreading_tags_clause}
                   {spreading_groups_clause}
+                  {spreading_window.clause("mu")}
                 """,
                 *spreading_params,
             )

--- a/hindsight-api-slim/tests/test_db_abstraction.py
+++ b/hindsight-api-slim/tests/test_db_abstraction.py
@@ -5,15 +5,21 @@ without requiring a live database connection.
 """
 
 import asyncio
+from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from hindsight_api.engine.db import DatabaseBackend, DatabaseConnection, create_database_backend
+from hindsight_api.engine.db.ops import UpdatedWindow
 from hindsight_api.engine.db.postgresql import PostgreSQLBackend
 from hindsight_api.engine.db.result import DictResultRow as ResultRow
 from hindsight_api.engine.sql import SQLDialect, create_sql_dialect
 from hindsight_api.engine.sql.postgresql import PostgreSQLDialect
+
+# A recall with no created_after/created_before — the graph-expansion CTEs must
+# then render exactly as they did before the window existed.
+_UNBOUNDED_WINDOW = UpdatedWindow(after=None, before=None, first_param_index=4)
 
 # ---------------------------------------------------------------------------
 # ResultRow tests
@@ -661,7 +667,7 @@ def test_entity_expansion_filters_fact_type_before_per_entity_cap(
     from importlib import import_module
 
     ops = getattr(import_module(ops_module), ops_class)()
-    cte = ops.build_entity_expansion_cte("memory_units", "unit_entities", 7)
+    cte = ops.build_entity_expansion_cte("memory_units", "unit_entities", 7, _UNBOUNDED_WINDOW)
 
     lateral_start = cte.index("CROSS JOIN LATERAL")
     lateral_end = cte.index(") t", lateral_start)
@@ -669,6 +675,83 @@ def test_entity_expansion_filters_fact_type_before_per_entity_cap(
 
     assert "mu_target.fact_type = $2" in lateral_query
     assert lateral_query.index("mu_target.fact_type = $2") < lateral_query.index(limit_clause)
+
+
+@pytest.mark.parametrize(
+    "ops_module,ops_class,limit_clause",
+    [
+        ("hindsight_api.engine.db.ops_postgresql", "PostgreSQLOps", "LIMIT 7"),
+        ("hindsight_api.engine.db.ops_oracle", "OracleOps", "FETCH FIRST 7 ROWS ONLY"),
+    ],
+)
+def test_entity_expansion_applies_updated_window_before_per_entity_cap(
+    ops_module: str, ops_class: str, limit_clause: str
+) -> None:
+    """Recall's time window bounds the entity fan-out, not just the graph seeds.
+
+    Placement matters as much as presence: filtering after the cap would let
+    out-of-window neighbours eat an entity's bounded budget and starve the
+    in-window ones.
+    """
+    from importlib import import_module
+
+    from hindsight_api.engine.db.ops import UpdatedWindow
+
+    ops = getattr(import_module(ops_module), ops_class)()
+    window = UpdatedWindow(after=datetime(2026, 1, 1), before=datetime(2026, 2, 1), first_param_index=4)
+    cte = ops.build_entity_expansion_cte("memory_units", "unit_entities", 7, window)
+
+    lateral_start = cte.index("CROSS JOIN LATERAL")
+    lateral_query = cte[lateral_start : cte.index(") t", lateral_start)]
+
+    assert "mu_target.updated_at > $4" in lateral_query
+    assert "mu_target.updated_at < $5" in lateral_query
+    assert lateral_query.index("mu_target.updated_at > $4") < lateral_query.index(limit_clause)
+
+
+@pytest.mark.parametrize(
+    "ops_module,ops_class",
+    [
+        ("hindsight_api.engine.db.ops_postgresql", "PostgreSQLOps"),
+        ("hindsight_api.engine.db.ops_oracle", "OracleOps"),
+    ],
+)
+def test_semantic_causal_expansion_applies_updated_window(ops_module: str, ops_class: str) -> None:
+    """All three link-expansion arms honour the window — both semantic directions
+    (the kNN graph is not symmetric, so each is a separate scan) and causal."""
+    from importlib import import_module
+
+    from hindsight_api.engine.db.ops import UpdatedWindow
+
+    ops = getattr(import_module(ops_module), ops_class)()
+    window = UpdatedWindow(after=datetime(2026, 1, 1), before=None, first_param_index=4)
+    cte = ops.build_semantic_causal_cte("memory_links", "memory_units", window)
+
+    assert cte.count("mu.updated_at > $4") == 3
+    assert "updated_at <" not in cte
+
+
+@pytest.mark.parametrize(
+    "ops_module,ops_class",
+    [
+        ("hindsight_api.engine.db.ops_postgresql", "PostgreSQLOps"),
+        ("hindsight_api.engine.db.ops_oracle", "OracleOps"),
+    ],
+)
+def test_expansion_ctes_omit_window_when_unbounded(ops_module: str, ops_class: str) -> None:
+    """An unbounded recall must emit the pre-existing SQL verbatim — no dangling
+    placeholders, since every backend binds params positionally and Oracle rejects
+    a query that references a bind it was not given."""
+    from importlib import import_module
+
+    ops = getattr(import_module(ops_module), ops_class)()
+
+    entity_cte = ops.build_entity_expansion_cte("memory_units", "unit_entities", 7, _UNBOUNDED_WINDOW)
+    sem_causal_cte = ops.build_semantic_causal_cte("memory_links", "memory_units", _UNBOUNDED_WINDOW)
+
+    assert "updated_at" not in entity_cte
+    assert "updated_at" not in sem_causal_cte
+    assert "$4" not in entity_cte + sem_causal_cte
 
 
 # ---------------------------------------------------------------------------

--- a/hindsight-api-slim/tests/test_link_expansion_config.py
+++ b/hindsight-api-slim/tests/test_link_expansion_config.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from hindsight_api.engine.db.ops import LinkExpansionRows
 from hindsight_api.engine.search import link_expansion_retrieval
 from hindsight_api.engine.search.link_expansion_retrieval import LinkExpansionRetriever
 from hindsight_api.engine.search.types import RetrievalResult
@@ -24,8 +25,8 @@ async def test_retrieve_passes_configured_graph_seed_threshold(monkeypatch):
         seed_thresholds.append(kwargs["threshold"])
         return [RetrievalResult(id="seed", text="seed", fact_type=fact_type)]
 
-    async def fake_expand_combined(_conn, _seed_ids, _fact_type, _budget, *, ops):
-        return [], [], []
+    async def fake_expand_combined(_conn, _seed_ids, _fact_type, _budget, *, ops, created_after, created_before):
+        return LinkExpansionRows(entity=[], semantic=[], causal=[])
 
     monkeypatch.setattr(link_expansion_retrieval, "acquire_with_retry", fake_acquire_with_retry)
     monkeypatch.setattr(link_expansion_retrieval, "_find_semantic_seeds", fake_find_semantic_seeds)

--- a/hindsight-api-slim/tests/test_link_expansion_scoring.py
+++ b/hindsight-api-slim/tests/test_link_expansion_scoring.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from hindsight_api.engine.db.ops import LinkExpansionRows
 from hindsight_api.engine.search import link_expansion_retrieval
 from hindsight_api.engine.search.link_expansion_retrieval import LinkExpansionRetriever
 from hindsight_api.engine.search.types import RetrievalResult
@@ -25,12 +26,16 @@ async def test_activation_preserves_additive_score_across_fact_types(monkeypatch
     async def fake_acquire_with_retry(_pool):
         yield object()
 
-    async def fake_expand_combined(_conn, _seed_ids, fact_type, _budget, *, ops):
+    async def fake_expand_combined(_conn, _seed_ids, fact_type, _budget, *, ops, created_after, created_before):
         if fact_type == "world":
             # Convergent semantic and causal signals make this fact's total
             # score higher, despite its raw entity count being only 1.
-            return [_row("a", 1.0, fact_type)], [_row("a", 0.9, fact_type)], [_row("a", 0.3, fact_type)]
-        return [_row("b", 2.0, fact_type)], [_row("b", 0.7, fact_type)], []
+            return LinkExpansionRows(
+                entity=[_row("a", 1.0, fact_type)],
+                semantic=[_row("a", 0.9, fact_type)],
+                causal=[_row("a", 0.3, fact_type)],
+            )
+        return LinkExpansionRows(entity=[_row("b", 2.0, fact_type)], semantic=[_row("b", 0.7, fact_type)], causal=[])
 
     async def fake_find_semantic_seeds(_conn, _embedding, _bank_id, fact_type, **_kwargs):
         # Link Expansion chooses its own seeds internally (#2683), so stub the
@@ -76,9 +81,9 @@ async def test_preselected_semantic_seeds_skip_seed_query(monkeypatch):
     async def fail_find_semantic_seeds(*args, **kwargs):
         raise AssertionError("preselected seeds must bypass the graph seed query")
 
-    async def fake_expand_combined(_conn, seed_ids, fact_type, _budget, *, ops):
+    async def fake_expand_combined(_conn, seed_ids, fact_type, _budget, *, ops, created_after, created_before):
         assert set(seed_ids) == {"seed-a", "seed-b"}
-        return [_row("result", 1.0, fact_type)], [], []
+        return LinkExpansionRows(entity=[_row("result", 1.0, fact_type)], semantic=[], causal=[])
 
     monkeypatch.setattr(link_expansion_retrieval, "acquire_with_retry", fake_acquire_with_retry)
     monkeypatch.setattr(link_expansion_retrieval, "_find_semantic_seeds", fail_find_semantic_seeds)

--- a/hindsight-api-slim/tests/test_recall_time_range_graph.py
+++ b/hindsight-api-slim/tests/test_recall_time_range_graph.py
@@ -1,0 +1,356 @@
+"""created_after / created_before must also bound the graph-expansion arm.
+
+The semantic, BM25 and temporal arms filter on ``updated_at`` in SQL, but graph
+retrieval only filtered its *seeds*: once a fresh fact was picked as a seed, link
+expansion pulled in its whole neighbourhood — entity co-occurrence, semantic kNN
+links and causal links — regardless of how old those neighbours were.  Mental-model
+delta refresh recalls with ``created_after=<last refresh>`` expecting only what
+changed since, so stale neighbours silently re-entered every refresh.
+
+Each test seeds one in-window fact (the seed the query matches) plus one
+out-of-window neighbour reachable only through the graph, and asserts recall never
+returns the neighbour.
+
+No LLM required — uses the mock provider.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+
+from hindsight_api import MemoryEngine, RequestContext
+from hindsight_api.engine.retain import embedding_utils
+
+pytestmark = pytest.mark.xdist_group("recall_time_range_graph")
+
+T_OLD = datetime(2026, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+T_CUTOFF = datetime(2026, 1, 1, 11, 0, 0, tzinfo=timezone.utc)
+T_NEW = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+RC = RequestContext(tenant_id="default")
+
+# The seed and its neighbours are deliberately about unrelated subjects so the
+# neighbours cannot be retrieved by the semantic or BM25 arms — the only path to
+# them is graph expansion.
+SEED_TEXT = "the tabby cat sat on the woven mat"
+QUERY = "tabby cat on a mat"
+NEIGHBOUR_TEXTS = {
+    "entity": "quarterly logistics invoices were reconciled in the ledger",
+    "semantic": "the harbour crane was repainted before the monsoon season",
+    "causal": "shipping container seals are audited by the port authority",
+}
+
+# The temporal arm needs a parseable date in the query and dated facts to match it.
+TEMPORAL_QUERY = "what did the tabby cat do in March 2025?"
+TEMPORAL_SEED_TEXT = "the tabby cat sat on the woven mat"
+TEMPORAL_NEIGHBOUR_TEXT = "the tabby cat knocked over the milk jug"
+IN_WINDOW_DATE = datetime(2025, 3, 15, tzinfo=timezone.utc)
+OUT_OF_WINDOW_DATE = datetime(2024, 1, 10, tzinfo=timezone.utc)
+
+
+def _to_str(emb: list[float]) -> str:
+    return "[" + ",".join(str(v) for v in emb) + "]"
+
+
+async def _insert_fact(
+    conn,
+    *,
+    fact_id: uuid.UUID,
+    bank_id: str,
+    text: str,
+    embedding_str: str,
+    updated_at: datetime,
+    fact_type: str = "world",
+    source_memory_ids: list[uuid.UUID] | None = None,
+) -> None:
+    await conn.execute(
+        """
+        INSERT INTO memory_units (
+            id, bank_id, text, fact_type, embedding, created_at, updated_at,
+            source_memory_ids, proof_count
+        )
+        VALUES ($1, $2, $3, $4, $5::vector, $6, $6, $7::uuid[], 1)
+        """,
+        fact_id,
+        bank_id,
+        text,
+        fact_type,
+        embedding_str,
+        updated_at,
+        source_memory_ids,
+    )
+
+
+async def _insert_entity(conn, bank_id: str, name: str) -> uuid.UUID:
+    entity_id = uuid.uuid4()
+    await conn.execute(
+        """
+        INSERT INTO entities (id, bank_id, canonical_name, first_seen, last_seen, mention_count)
+        VALUES ($1, $2, $3, NOW(), NOW(), 1)
+        """,
+        entity_id,
+        bank_id,
+        name,
+    )
+    return entity_id
+
+
+async def _link_unit_entity(conn, unit_id: uuid.UUID, entity_id: uuid.UUID) -> None:
+    await conn.execute(
+        "INSERT INTO unit_entities (unit_id, entity_id) VALUES ($1, $2)",
+        unit_id,
+        entity_id,
+    )
+
+
+async def _insert_link(conn, bank_id: str, from_id: uuid.UUID, to_id: uuid.UUID, link_type: str) -> None:
+    await conn.execute(
+        """
+        INSERT INTO memory_links (from_unit_id, to_unit_id, link_type, weight, bank_id)
+        VALUES ($1, $2, $3, 0.9, $4)
+        """,
+        from_id,
+        to_id,
+        link_type,
+        bank_id,
+    )
+
+
+async def _seed_neighbourhood(conn, engine, bank_id: str, *, fact_type: str) -> dict[str, uuid.UUID]:
+    """Seed one in-window fact plus three out-of-window neighbours.
+
+    The neighbours hang off the seed by each of link expansion's three signals
+    (shared entity, semantic kNN link, causal link) so a single recall exercises
+    all of them.  For observations the entity signal runs through
+    ``source_memory_ids`` rather than the observation's own entity rows, so the
+    shared entity is attached to the sources.
+    """
+    texts = [SEED_TEXT, *NEIGHBOUR_TEXTS.values()]
+    embeddings = await embedding_utils.generate_embeddings_batch(engine.embeddings, texts)
+
+    ids = {"seed": uuid.uuid4(), **{k: uuid.uuid4() for k in NEIGHBOUR_TEXTS}}
+
+    sources: dict[str, uuid.UUID] = {}
+    if fact_type == "observation":
+        # Observations reach entities through their sources; give the seed and the
+        # entity-neighbour one source each, both carrying the shared entity.
+        for key in ("seed", "entity"):
+            source_id = uuid.uuid4()
+            sources[key] = source_id
+            await _insert_fact(
+                conn,
+                fact_id=source_id,
+                bank_id=bank_id,
+                text=f"source fact for {key}",
+                embedding_str=_to_str(embeddings[0]),
+                updated_at=T_NEW if key == "seed" else T_OLD,
+            )
+
+    for key, text in [("seed", SEED_TEXT), *NEIGHBOUR_TEXTS.items()]:
+        await _insert_fact(
+            conn,
+            fact_id=ids[key],
+            bank_id=bank_id,
+            text=text,
+            embedding_str=_to_str(embeddings[texts.index(text)]),
+            updated_at=T_NEW if key == "seed" else T_OLD,
+            fact_type=fact_type,
+            source_memory_ids=[sources[key]] if key in sources else None,
+        )
+
+    shared_entity = await _insert_entity(conn, bank_id, "Harbour Logistics")
+    for key in ("seed", "entity"):
+        await _link_unit_entity(conn, sources.get(key, ids[key]), shared_entity)
+
+    await _insert_link(conn, bank_id, ids["seed"], ids["semantic"], "semantic")
+    await _insert_link(conn, bank_id, ids["seed"], ids["causal"], "causes")
+
+    return ids
+
+
+@pytest_asyncio.fixture
+async def world_graph(memory_no_llm_verify: MemoryEngine):
+    engine = memory_no_llm_verify
+    bank_id = f"test-tr-graph-world-{uuid.uuid4().hex[:8]}"
+    await engine.get_bank_profile(bank_id, request_context=RC)
+    pool = await engine._get_pool()
+    async with pool.acquire() as conn:
+        ids = await _seed_neighbourhood(conn, engine, bank_id, fact_type="world")
+    yield engine, bank_id, ids
+    await engine.delete_bank(bank_id, request_context=RC)
+
+
+@pytest_asyncio.fixture
+async def observation_graph(memory_no_llm_verify: MemoryEngine):
+    engine = memory_no_llm_verify
+    bank_id = f"test-tr-graph-obs-{uuid.uuid4().hex[:8]}"
+    await engine.get_bank_profile(bank_id, request_context=RC)
+    pool = await engine._get_pool()
+    async with pool.acquire() as conn:
+        ids = await _seed_neighbourhood(conn, engine, bank_id, fact_type="observation")
+    yield engine, bank_id, ids
+    await engine.delete_bank(bank_id, request_context=RC)
+
+
+@pytest_asyncio.fixture
+async def temporal_graph(memory_no_llm_verify: MemoryEngine):
+    """A dated seed inside the query's month, plus a temporally-linked older fact.
+
+    The neighbour sits outside the query's date window, so the temporal arm's
+    entry-point query can never return it — only the multi-hop spread that walks
+    ``memory_links`` from the entry points can.
+    """
+    engine = memory_no_llm_verify
+    bank_id = f"test-tr-graph-temporal-{uuid.uuid4().hex[:8]}"
+    await engine.get_bank_profile(bank_id, request_context=RC)
+
+    embeddings = await embedding_utils.generate_embeddings_batch(
+        engine.embeddings, [TEMPORAL_SEED_TEXT, TEMPORAL_NEIGHBOUR_TEXT]
+    )
+    seed_id, neighbour_id = uuid.uuid4(), uuid.uuid4()
+
+    pool = await engine._get_pool()
+    async with pool.acquire() as conn:
+        for fact_id, text, embedding, mentioned_at, updated_at in (
+            (seed_id, TEMPORAL_SEED_TEXT, embeddings[0], IN_WINDOW_DATE, T_NEW),
+            (neighbour_id, TEMPORAL_NEIGHBOUR_TEXT, embeddings[1], OUT_OF_WINDOW_DATE, T_OLD),
+        ):
+            await conn.execute(
+                """
+                INSERT INTO memory_units (
+                    id, bank_id, text, fact_type, embedding, mentioned_at,
+                    created_at, updated_at, proof_count
+                )
+                VALUES ($1, $2, $3, 'world', $4::vector, $5, $6, $6, 1)
+                """,
+                fact_id,
+                bank_id,
+                text,
+                _to_str(embedding),
+                mentioned_at,
+                updated_at,
+            )
+        await _insert_link(conn, bank_id, seed_id, neighbour_id, "temporal")
+
+    yield engine, bank_id, seed_id, neighbour_id
+    await engine.delete_bank(bank_id, request_context=RC)
+
+
+def _result_ids(result) -> set[str]:
+    return {str(r.id) for r in result.results}
+
+
+class TestGraphExpansionTimeRange:
+    async def test_unfiltered_recall_reaches_neighbours(self, world_graph):
+        """Without a window, graph expansion does surface all three neighbours.
+
+        This is the control: it proves the fixture's links are live, so the
+        filtered assertions below can only fail because of the window.
+        """
+        engine, bank_id, ids = world_graph
+        result = await engine.recall_async(
+            bank_id=bank_id,
+            query=QUERY,
+            request_context=RC,
+            max_tokens=10000,
+        )
+        found = _result_ids(result)
+        assert str(ids["seed"]) in found
+        for key in NEIGHBOUR_TEXTS:
+            assert str(ids[key]) in found, f"{key} neighbour unreachable — fixture links are not wired"
+
+    async def test_created_after_excludes_graph_neighbours(self, world_graph):
+        engine, bank_id, ids = world_graph
+        result = await engine.recall_async(
+            bank_id=bank_id,
+            query=QUERY,
+            request_context=RC,
+            max_tokens=10000,
+            created_after=T_CUTOFF,
+        )
+        found = _result_ids(result)
+        assert str(ids["seed"]) in found, "the in-window seed must still be returned"
+        for key in NEIGHBOUR_TEXTS:
+            assert str(ids[key]) not in found, (
+                f"{key}-linked neighbour (updated_at={T_OLD}) leaked past created_after={T_CUTOFF}"
+            )
+
+    async def test_created_before_excludes_graph_neighbours(self, world_graph):
+        """The mirror bound: an old seed must not drag in newer neighbours."""
+        engine, bank_id, ids = world_graph
+        pool = await engine._get_pool()
+        async with pool.acquire() as conn:
+            # Flip the timestamps so the seed is the old one and its neighbours new.
+            await conn.execute(
+                "UPDATE memory_units SET updated_at = $1 WHERE bank_id = $2",
+                T_NEW,
+                bank_id,
+            )
+            await conn.execute(
+                "UPDATE memory_units SET updated_at = $1 WHERE id = $2",
+                T_OLD,
+                ids["seed"],
+            )
+
+        result = await engine.recall_async(
+            bank_id=bank_id,
+            query=QUERY,
+            request_context=RC,
+            max_tokens=10000,
+            created_before=T_CUTOFF,
+        )
+        found = _result_ids(result)
+        assert str(ids["seed"]) in found
+        for key in NEIGHBOUR_TEXTS:
+            assert str(ids[key]) not in found, (
+                f"{key}-linked neighbour (updated_at={T_NEW}) leaked past created_before={T_CUTOFF}"
+            )
+
+    async def test_created_after_excludes_temporal_spreading_neighbours(self, temporal_graph):
+        """The temporal arm spreads outward too, and had the same hole.
+
+        Its entry-point query filtered on the window, but the multi-hop spread that
+        walks temporal/causal links from those entry points did not.
+        """
+        engine, bank_id, seed_id, neighbour_id = temporal_graph
+
+        unfiltered = await engine.recall_async(
+            bank_id=bank_id,
+            query=TEMPORAL_QUERY,
+            request_context=RC,
+            max_tokens=10000,
+        )
+        assert str(neighbour_id) in _result_ids(unfiltered), (
+            "control: the out-of-window-by-date neighbour is reachable only by temporal "
+            "spreading — if it is absent here the test proves nothing"
+        )
+
+        result = await engine.recall_async(
+            bank_id=bank_id,
+            query=TEMPORAL_QUERY,
+            request_context=RC,
+            max_tokens=10000,
+            created_after=T_CUTOFF,
+        )
+        found = _result_ids(result)
+        assert str(seed_id) in found
+        assert str(neighbour_id) not in found, (
+            f"temporally-linked neighbour (updated_at={T_OLD}) leaked past created_after={T_CUTOFF}"
+        )
+
+    async def test_created_after_excludes_observation_neighbours(self, observation_graph):
+        engine, bank_id, ids = observation_graph
+        result = await engine.recall_async(
+            bank_id=bank_id,
+            query=QUERY,
+            request_context=RC,
+            max_tokens=10000,
+            created_after=T_CUTOFF,
+        )
+        found = _result_ids(result)
+        for key in NEIGHBOUR_TEXTS:
+            assert str(ids[key]) not in found, (
+                f"{key}-linked observation (updated_at={T_OLD}) leaked past created_after={T_CUTOFF}"
+            )


### PR DESCRIPTION
## The bug

Recall's `created_after` / `created_before` window is applied to `updated_at`. Two retrieval arms filtered only their **entry points** and then expanded outward with no window at all:

1. **Link expansion (graph arm)** — filtered its semantic *seeds*, then pulled each seed's entire neighbourhood: shared entities, semantic kNN links, causal links.
2. **Temporal spreading** — the entry-point query applied the window, but the multi-hop spread that walks temporal/causal links from those entry points did not.

Either way, one in-window seed dragged arbitrarily old facts back into the results.

This bites **mental-model delta refresh**, which recalls with `created_after=<last refresh>` *and* `created_before=<cutoff>` precisely so the agentic loop sees only what changed. Every refresh was silently re-ingesting stale neighbourhoods.

## The fix

The window is pushed into the expansion SQL on both Postgres and Oracle via a shared `UpdatedWindow`, which renders `AND <alias>.updated_at > $n` plus its bind params. Rendering is per-alias because a single query applies the window to several correlation names.

Covered: entity expansion, both semantic directions (the kNN graph isn't symmetric, so each is a separate scan), causal expansion, observation expansion (both the source-traversal and the semantic/causal query), and temporal spreading.

**Placement matters as much as presence.** For entity expansion the predicate goes *inside* the `EXISTS` that already filters `fact_type` — i.e. **before** the per-entity `LIMIT`. Filtering after the cap would let out-of-window neighbours consume an entity's bounded fan-out and starve the in-window ones.

Deliberately left unwindowed: `include_source_facts` returns an observation's sources in a separate `source_facts` field, not in `results`. An observation refreshed inside the window has older sources by construction, so filtering there would gut the feature.

## Drive-by

The three expansion methods returned a bare `tuple[list, list, list]`, which the project standards forbid. Since every one of those signatures was changing anyway, they now return `LinkExpansionRows`. The signals stay separate rather than concatenated — each carries a different score scale (shared-entity count, kNN weight, causal weight) and the caller transforms each before summing.

## Tests

`tests/test_recall_time_range_graph.py` — each test seeds one in-window fact plus neighbours reachable **only** through the graph, then asserts recall never returns them:

- all three link signals (entity / semantic / causal) under `created_after`
- the mirror bound: an old seed must not drag in newer neighbours (`created_before`)
- observations, whose entity path runs through `source_memory_ids`
- temporal spreading, with a neighbour outside the query's *date* window so the temporal entry-point query can never reach it

Every test carries a control assertion proving its links are live, so a pass can't be vacuous. I verified each regression test fails without its corresponding fix.

Fast backend-parametrized unit tests in `test_db_abstraction.py` cover clause placement relative to the per-entity cap and assert that an unbounded recall emits the SQL verbatim with no dangling placeholders — Oracle rejects a query referencing a bind it wasn't given.

## Verification

- `./scripts/hooks/lint.sh` passes; `check-unused.sh` reports nothing new.
- 135 passed across the recall / graph / temporal / db-abstraction surface.

⚠️ Unrelated to this PR: the repo's `GEMINI_API_KEY` is revoked (`403 PERMISSION_DENIED — Your API key was reported as leaked`), so every LLM-dependent test fails locally. Confirmed pre-existing by re-running the same tests on a clean tree.
