### PR TITLE
docs(retain): deprecate bank name as narrator; steer speaker via context (#3138)

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1532,7 +1532,14 @@ class DryRunExtractRequest(BaseModel):
     timestamp: datetime | None = Field(
         default=None, description="Reference timestamp for resolving relative times (ISO 8601)."
     )
-    agent_name: str | None = Field(default=None, description="Narrator override (memory owner) primed in the prompt.")
+    agent_name: str | None = Field(
+        default=None,
+        deprecated=True,
+        description=(
+            "Deprecated: describe the speaker in `context` instead. Narrator override (memory owner) "
+            "primed in the prompt; still honored for backwards compatibility."
+        ),
+    )
     # --- prompt-affecting config overrides (null = use the bank's value) ---
     retain_mission: str | None = None
     retain_extraction_mode: str | None = None

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8332,7 +8332,8 @@ class MemoryEngine(MemoryEngineInterface):
         Returns candidate facts (a subset of the ``list_memory_units`` item shape) plus the LLM token
         usage, so callers can diff a mission's extraction output against stored memories without
         mutating the bank. Every prompt-affecting setting is overridable per call via ``overrides``
-        (e.g. to test a candidate retain mission); ``agent_name`` overrides the narrator.
+        (e.g. to test a candidate retain mission). ``agent_name`` is deprecated (describe the speaker
+        in ``context`` instead) but still overrides the narrator when supplied, for backwards compatibility.
         Side-effect-free and idempotent.
         """
         from .response_models import ExtractedFact

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -1605,7 +1605,9 @@ export type DryRunExtractRequest = {
   /**
    * Agent Name
    *
-   * Narrator override (memory owner) primed in the prompt.
+   * Deprecated: describe the speaker in `context` instead. Narrator override (memory owner) primed in the prompt; still honored for backwards compatibility.
+   *
+   * @deprecated
    */
   agent_name?: string | null;
   /**

--- a/hindsight-docs/docs/developer/retain.md
+++ b/hindsight-docs/docs/developer/retain.md
@@ -67,10 +67,7 @@ The split is decided by **who is speaking**, not by grammar. A first-person stat
 - Agent's own log — "I patched the auth bug" → **experience** (the agent did it).
 - A user talking to the agent — "I bought a Tesla" → **world** (a fact about the *user*, not the agent).
 
-Two things steer this correctly:
-
-- **Set a human-readable bank `name`** (the agent's name). It identifies who "the agent" is. If left unset it defaults to the `bank_id`; a `bank_id` that is a routing key (e.g. `my-agent::channel-456::user-789`) is not a usable speaker name, so give the bank a real name.
-- **Describe the speaker in each item's `context`** when retaining transcripts or third-party content. For a chat log, a context like *"Customer Maria is speaking"* ensures her first-person statements are stored as `world` facts about Maria rather than mistaken for the agent's own experiences. The `context` takes precedence over the bank name when the two disagree.
+**Describe the speaker in each item's `context`** to steer this correctly. When retaining transcripts or third-party content, a context like *"Customer Maria is speaking"* ensures her first-person statements are stored as `world` facts about Maria rather than mistaken for the agent's own experiences. For the agent's own logs, a context like *"The assistant is speaking"* attributes its first-person statements to the agent as `experience` facts.
 
 **Note:** Observations are consolidated automatically in the background after `retain()` operations complete. This consolidation process synthesizes patterns from new facts into the bank's knowledge base.
 

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -9217,7 +9217,8 @@
               }
             ],
             "title": "Agent Name",
-            "description": "Narrator override (memory owner) primed in the prompt."
+            "description": "Deprecated: describe the speaker in `context` instead. Narrator override (memory owner) primed in the prompt; still honored for backwards compatibility.",
+            "deprecated": true
           },
           "retain_mission": {
             "anyOf": [


### PR DESCRIPTION
## What

Closes #3138.

The bank profile `name` field is documented as *"Deprecated: display label only, not advertised"*, but at retain time `_resolve_narrator(profile["name"], bank_id)` silently uses it as the **narrator** (memory owner) whenever `name != bank_id` — priming a `Narrator: <name>` line in fact extraction and stamping it into the who-dimension of every first-person fact. That undocumented coupling is what #3138 reports: a "deprecated, display-only" field quietly steering (or, when `name == bank_id`, suppressing) speaker attribution.

## Approach — deprecate for real, keep 100% backward compatible

We stop *advertising* the `name`-as-narrator path and point users at the `context` field instead, **without changing any runtime behavior**:

- **`retain.md`** now steers speaker attribution solely through each item's `context` (which already takes precedence), and drops the advice to set a bank `name` as the agent's name.
- **Dry-run extract `agent_name` override** (`DryRunExtractRequest`) is marked `deprecated` in the OpenAPI schema and repointed to `context`. It is still accepted and still primes the narrator when supplied.

`_resolve_narrator` and the extraction prompt injection are **untouched**, so every existing bank behaves exactly as before — this is purely documentation + schema-metadata.

## Not done (deliberately)

Fully removing the `name`→narrator coupling in the engine would be a breaking behavior change; left for a future major. This PR only removes the docs that lead people into it and flags the explicit knob.

## Changes
- `hindsight-api-slim/hindsight_api/api/http.py` — `agent_name` field `deprecated=True` + description
- `hindsight-api-slim/hindsight_api/engine/memory_engine.py` — dry-run docstring note
- `hindsight-docs/docs/developer/retain.md` — `context`-only speaker guidance
- `hindsight-docs/static/openapi.json`, `hindsight-clients/typescript/generated/types.gen.ts` — regenerated

## Testing
No behavior change to test (deprecation is schema metadata + prose). Lint passes; OpenAPI and client SDKs regenerated.
