### PR TITLE
chore(api): drop the never-written memory_units.access_count column

### DIFF
--- a/hindsight-api-slim/hindsight_api/admin/cli.py
+++ b/hindsight-api-slim/hindsight_api/admin/cli.py
@@ -8,6 +8,7 @@ import asyncio
 import io
 import json
 import logging
+import struct
 import zipfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -80,6 +81,76 @@ class BackupColumn:
     type_name: str
 
 
+@dataclass(frozen=True)
+class TableRestorePlan:
+    """How one table's backed-up binary COPY stream is replayed onto the target.
+
+    ``columns`` is the target column list handed to ``copy_to_table``, in stream
+    order. When the target no longer has a backed-up column, its field is stripped
+    from every tuple (``dropped_field_indices``) before the stream is replayed —
+    binary COPY is positional, so the column list and the tuple fields must agree.
+    """
+
+    columns: list[str]
+    dropped_field_indices: tuple[int, ...]
+    source_field_count: int
+
+
+# Header of a PostgreSQL binary COPY stream: an 11-byte signature, an int32 flags
+# field, and an int32 header-extension length followed by that many bytes.
+_COPY_BINARY_SIGNATURE = b"PGCOPY\n\xff\r\n\x00"
+_COPY_BINARY_HEADER_LEN = len(_COPY_BINARY_SIGNATURE) + 8
+
+
+def _strip_binary_copy_fields(data: bytes, plan: TableRestorePlan) -> bytes:
+    """Drop `plan.dropped_field_indices` from every tuple of a binary COPY stream.
+
+    Restore used to reject a backup whose columns the target no longer had — the
+    preflight raised "target is missing backup columns …", which made any backup
+    taken before a column-dropping migration unrestorable afterwards. Those columns
+    are now ignored instead, but they cannot simply be left out of the
+    ``copy_to_table`` column list: binary COPY carries no column identities, so each
+    tuple's fields are matched to the column list purely by position and an unedited
+    stream would desynchronise (or, worse, land values in the wrong columns). So the
+    stream itself is rewritten here.
+
+    Tuple format: int16 field count, then per field an int32 length (-1 for NULL)
+    followed by that many bytes. An int16 of -1 is the end-of-data trailer.
+    """
+    if not plan.dropped_field_indices:
+        return data
+    if not data.startswith(_COPY_BINARY_SIGNATURE):
+        raise ValueError("Backup stream is not in PostgreSQL binary COPY format")
+
+    (extension_len,) = struct.unpack_from("!i", data, len(_COPY_BINARY_SIGNATURE) + 4)
+    pos = _COPY_BINARY_HEADER_LEN + extension_len
+    out = bytearray(data[:pos])
+
+    dropped = set(plan.dropped_field_indices)
+    kept_count = plan.source_field_count - len(dropped)
+    while True:
+        (field_count,) = struct.unpack_from("!h", data, pos)
+        pos += 2
+        if field_count == -1:  # end-of-data trailer
+            out += struct.pack("!h", -1)
+            break
+        if field_count != plan.source_field_count:
+            raise ValueError(
+                f"Backup stream tuple has {field_count} fields, manifest declares {plan.source_field_count}"
+            )
+        out += struct.pack("!h", kept_count)
+        for index in range(field_count):
+            (length,) = struct.unpack_from("!i", data, pos)
+            pos += 4
+            payload = b"" if length == -1 else data[pos : pos + length]
+            pos += max(length, 0)
+            if index in dropped:
+                continue
+            out += struct.pack("!i", length)
+            out += payload
+    return bytes(out)
+
+
 async def _table_columns(conn: asyncpg.Connection, schema: str, table: str) -> list[BackupColumn]:
     rows = await conn.fetch(
         """
@@ -99,37 +170,52 @@ async def _table_columns(conn: asyncpg.Connection, schema: str, table: str) -> l
 
 async def _validate_restore_schema(
     conn: asyncpg.Connection, manifest: dict[str, Any], schema: str
-) -> dict[str, list[str]]:
+) -> dict[str, TableRestorePlan]:
     """Validate every COPY stream against the target before destructive work starts.
 
-    Type equality is an exact ``format_type`` string match. This is deliberately
-    stricter than binary-COPY wire compatibility (e.g. ``varchar`` and ``text``
-    share a binary format yet compare unequal here): we would rather fail a
-    genuinely-restorable backup with a clear, actionable error than silently risk
-    a subtle binary mismatch. Restores blocked this way can be recovered by
-    aligning the target schema.
+    A column the target no longer has is **not** an error: a migration that drops a
+    column would otherwise make every backup taken before it permanently
+    unrestorable. Such columns are skipped (their fields are stripped from the
+    stream by ``_strip_binary_copy_fields``) and reported, so the operator sees what
+    was discarded instead of the restore failing outright.
+
+    Type mismatches remain fatal. Type equality is an exact ``format_type`` string
+    match. This is deliberately stricter than binary-COPY wire compatibility (e.g.
+    ``varchar`` and ``text`` share a binary format yet compare unequal here): we
+    would rather fail a genuinely-restorable backup with a clear, actionable error
+    than silently risk a subtle binary mismatch. Restores blocked this way can be
+    recovered by aligning the target schema.
     """
-    restore_columns: dict[str, list[str]] = {}
+    plans: dict[str, TableRestorePlan] = {}
     errors: list[str] = []
     for table, table_manifest in manifest["tables"].items():
         source_columns = [BackupColumn(**column) for column in table_manifest["columns"]]
         target_by_name = {column.name: column for column in await _table_columns(conn, schema, table)}
-        missing = [column.name for column in source_columns if column.name not in target_by_name]
+        unknown = [
+            (index, column.name) for index, column in enumerate(source_columns) if column.name not in target_by_name
+        ]
         mismatched = [
             f"{column.name} ({column.type_name} in backup, {target_by_name[column.name].type_name} in target)"
             for column in source_columns
             if column.name in target_by_name and target_by_name[column.name].type_name != column.type_name
         ]
-        if missing:
-            errors.append(f"{table}: target is missing backup columns {', '.join(missing)}")
         if mismatched:
             errors.append(f"{table}: incompatible column types: {', '.join(mismatched)}")
-        restore_columns[table] = [column.name for column in source_columns]
+        if unknown:
+            typer.echo(
+                f"  {table}: ignoring {len(unknown)} backup column(s) absent from the target schema: "
+                f"{', '.join(name for _, name in unknown)}"
+            )
+        plans[table] = TableRestorePlan(
+            columns=[column.name for column in source_columns if column.name in target_by_name],
+            dropped_field_indices=tuple(index for index, _ in unknown),
+            source_field_count=len(source_columns),
+        )
 
     if errors:
         details = "; ".join(errors)
         raise ValueError(f"Backup schema is incompatible with target schema '{schema}': {details}")
-    return restore_columns
+    return plans
 
 
 def _effective_backup_tables() -> list[str]:
@@ -264,7 +350,7 @@ async def _restore(
             # Complete the compatibility check before entering the transaction
             # that truncates tables. This turns historical schema drift into an
             # actionable error without risking the target's existing data.
-            restore_columns = await _validate_restore_schema(conn, manifest, schema)
+            restore_plans = await _validate_restore_schema(conn, manifest, schema)
 
             # Use a transaction for atomic restore - either all tables are
             # restored or none are, preventing partial/inconsistent state.
@@ -285,13 +371,15 @@ async def _restore(
                     expected_rows = manifest["tables"].get(table, {}).get("rows", "?")
                     typer.echo(f"  [{i}/{len(backup_tables)}] Restoring {table}... {expected_rows} rows")
 
-                    data = zf.read(filename)
-                    buffer = io.BytesIO(data)
+                    plan = restore_plans[table]
+                    # Strips the fields of any column the target no longer has;
+                    # a no-op when the schemas still line up.
+                    buffer = io.BytesIO(_strip_binary_copy_fields(zf.read(filename), plan))
                     # asyncpg requires schema_name as separate parameter
                     await conn.copy_to_table(
                         table,
                         schema_name=schema,
-                        columns=restore_columns[table],
+                        columns=plan.columns,
                         source=buffer,
                         format="binary",
                     )

--- a/hindsight-api-slim/hindsight_api/alembic/versions/e4a7c1b9d2f6_drop_memory_units_access_count.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/e4a7c1b9d2f6_drop_memory_units_access_count.py
@@ -1,0 +1,114 @@
+"""Drop the never-written `access_count` column from memory_units (and its archive).
+
+``memory_units.access_count`` has been dead since the initial schema
+(5a366d414dce): no code path anywhere in the repo ever writes it, and — despite
+the ``access_count DESC`` index created alongside it — no query ever reads or
+orders by it either. It is 0 on every row of every install. The lone remaining
+mentions were an index, a stale comment naming an ``access_count_update`` task
+type that was never implemented, and the column's name in the Oracle backend's
+numeric-RETURNING list; all three go away with this change.
+
+The column is dropped from the curation archive too. ``invalidated_memory_units``
+was cloned ``LIKE memory_units`` (c9a1b2d3e4f5), so it inherited the column, and
+curation's INSERT…SELECT round-trip builds its column list from the catalog
+(``writes.py::_memory_unit_columns``) — the two tables must stay in lockstep or
+the round-trip breaks on a column-count mismatch.
+
+Dropping the column implicitly drops its index on both dialects
+(``idx_memory_units_access_count`` on PG, ``idx_mu_access_count`` on Oracle), so
+PostgreSQL also stops maintaining a btree that nothing ever probed.
+
+Cost: on PostgreSQL ``DROP COLUMN`` is metadata-only (the attribute is marked
+dropped, no table rewrite). On Oracle it does delete the column data row by row,
+so on a large ``memory_units`` this migration is not free — it is still bounded
+work on a single small integer column, and Oracle installs of that size can run
+it during a maintenance window ahead of the upgrade if they prefer.
+
+Revision ID: e4a7c1b9d2f6
+Revises: a9b8c7d6e5f4
+Create Date: 2026-08-03
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "e4a7c1b9d2f6"
+down_revision: str | Sequence[str] | None = "a9b8c7d6e5f4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLES = ("memory_units", "invalidated_memory_units")
+
+
+def _pg_schema_prefix() -> str:
+    """Schema-qualifier for raw SQL on PG (multi-tenant search_path)."""
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def _pg_upgrade() -> None:
+    schema = _pg_schema_prefix()
+    for table in _TABLES:
+        # Drops idx_memory_units_access_count along with the column.
+        op.execute(f"ALTER TABLE {schema}{table} DROP COLUMN IF EXISTS access_count")
+
+
+def _pg_downgrade() -> None:
+    schema = _pg_schema_prefix()
+    for table in _TABLES:
+        op.execute(f"ALTER TABLE {schema}{table} ADD COLUMN IF NOT EXISTS access_count integer NOT NULL DEFAULT 0")
+    # The archive was cloned without indexes; only the live table carried one.
+    op.execute(f"CREATE INDEX IF NOT EXISTS idx_memory_units_access_count ON {schema}memory_units (access_count DESC)")
+
+
+def _oracle_upgrade() -> None:
+    # Oracle has no `DROP COLUMN IF EXISTS`; swallow ORA-00904 (column does not
+    # exist) so the migration is idempotent and safe on a schema that already
+    # lacks the column. Dropping the column also drops idx_mu_access_count.
+    for table in _TABLES:
+        op.execute(
+            f"""
+            BEGIN
+                EXECUTE IMMEDIATE 'ALTER TABLE {table} DROP COLUMN access_count';
+            EXCEPTION WHEN OTHERS THEN
+                IF SQLCODE != -904 THEN RAISE; END IF;
+            END;
+            """
+        )
+
+
+def _oracle_downgrade() -> None:
+    # Swallow ORA-01430 (column already exists) for idempotency. Matches the
+    # Oracle baseline's declaration: NUMBER(10) DEFAULT 0 NOT NULL.
+    for table in _TABLES:
+        op.execute(
+            f"""
+            BEGIN
+                EXECUTE IMMEDIATE
+                    'ALTER TABLE {table} ADD (access_count NUMBER(10) DEFAULT 0 NOT NULL)';
+            EXCEPTION WHEN OTHERS THEN
+                IF SQLCODE != -1430 THEN RAISE; END IF;
+            END;
+            """
+        )
+    # ORA-00955: index name already in use.
+    op.execute(
+        """
+        BEGIN
+            EXECUTE IMMEDIATE 'CREATE INDEX idx_mu_access_count ON memory_units(access_count DESC)';
+        EXCEPTION WHEN OTHERS THEN
+            IF SQLCODE != -955 THEN RAISE; END IF;
+        END;
+        """
+    )
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade, oracle=_oracle_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade, oracle=_oracle_downgrade)

--- a/hindsight-api-slim/hindsight_api/engine/db/oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/oracle.py
@@ -689,7 +689,6 @@ class OracleConnection(DatabaseConnection):
                 "max_tokens",
                 "priority",
                 "proof_count",
-                "access_count",
                 "importance_score",
                 "decay_factor",
                 "chunk_index",

--- a/hindsight-api-slim/hindsight_api/engine/task_backend.py
+++ b/hindsight-api-slim/hindsight_api/engine/task_backend.py
@@ -238,7 +238,6 @@ class BrokerTaskBackend(TaskBackend):
             logger.debug(f"submit_task UPDATE for operation {operation_id} (no-op if payload already set)")
         else:
             # Insert new operation (for tasks without pre-created records)
-            # e.g., access_count_update tasks
             import uuid
 
             new_id = uuid.uuid4()

--- a/hindsight-api-slim/tests/test_admin_backup_restore.py
+++ b/hindsight-api-slim/tests/test_admin_backup_restore.py
@@ -359,13 +359,42 @@ async def test_backup_restore_preserves_all_column_types(backup_test_schema):
 
 
 @pytest.mark.asyncio
-async def test_restore_rejects_legacy_extra_column_before_truncating(backup_test_schema):
-    """Schema drift must fail preflight without deleting existing target data."""
+async def test_restore_ignores_backup_columns_the_target_dropped(backup_test_schema):
+    """A column dropped by a migration must not make older backups unrestorable.
+
+    Restore used to reject the backup outright ("target is missing backup
+    columns …"). It now strips those fields from the binary COPY stream instead.
+    Two legacy columns are backed up and only the *first* is dropped, so a stream
+    rewrite that got the positions wrong would shift the survivor's value (or the
+    trailing real columns) and fail the assertions below rather than silently
+    landing data in the wrong column.
+    """
     db_url, schema_name, _fq, _embeddings = backup_test_schema
+    bank_id = f"drop-col-{uuid.uuid4().hex[:8]}"
+    doc_id = f"doc-{uuid.uuid4().hex[:8]}"
     conn = await asyncpg.connect(db_url)
     try:
-        await conn.execute(f"ALTER TABLE {_fq('documents')} ADD COLUMN legacy_metadata JSONB")
-        await conn.execute(f"INSERT INTO {_fq('banks')} (bank_id) VALUES ('source-bank')")
+        await conn.execute(f"ALTER TABLE {_fq('documents')} ADD COLUMN legacy_dropped TEXT")
+        await conn.execute(f"ALTER TABLE {_fq('documents')} ADD COLUMN legacy_kept TEXT")
+        await conn.execute(f"INSERT INTO {_fq('banks')} (bank_id) VALUES ($1)", bank_id)
+        await conn.execute(
+            f"""INSERT INTO {_fq("documents")} (id, bank_id, original_text, legacy_dropped, legacy_kept)
+                VALUES ($1, $2, $3, $4, $5)""",
+            doc_id,
+            bank_id,
+            "the surviving document body",
+            "value that goes away",
+            "value that must survive",
+        )
+        # A NULL in a dropped-adjacent column exercises the -1 field-length path
+        # of the stream rewrite.
+        await conn.execute(
+            f"""INSERT INTO {_fq("documents")} (id, bank_id, original_text, legacy_dropped, legacy_kept)
+                VALUES ($1, $2, $3, NULL, NULL)""",
+            f"{doc_id}-null",
+            bank_id,
+            "second document",
+        )
     finally:
         await conn.close()
 
@@ -376,20 +405,26 @@ async def test_restore_rejects_legacy_extra_column_before_truncating(backup_test
         await _backup(db_url, backup_path, schema=schema_name)
         conn = await asyncpg.connect(db_url)
         try:
-            await conn.execute(f"ALTER TABLE {_fq('documents')} DROP COLUMN legacy_metadata")
-            await conn.execute(f"INSERT INTO {_fq('banks')} (bank_id) VALUES ('target-bank')")
+            await conn.execute(f"ALTER TABLE {_fq('documents')} DROP COLUMN legacy_dropped")
         finally:
             await conn.close()
 
-        with pytest.raises(ValueError, match=r"documents: target is missing backup columns legacy_metadata"):
-            await _restore(db_url, backup_path, schema=schema_name)
+        await _restore(db_url, backup_path, schema=schema_name)
 
         conn = await asyncpg.connect(db_url)
         try:
-            banks = await conn.fetch(f"SELECT bank_id FROM {_fq('banks')} ORDER BY bank_id")
+            rows = await conn.fetch(
+                f"SELECT id, bank_id, original_text, legacy_kept FROM {_fq('documents')} ORDER BY id",
+            )
         finally:
             await conn.close()
-        assert [row["bank_id"] for row in banks] == ["source-bank", "target-bank"]
+
+        assert [row["id"] for row in rows] == [doc_id, f"{doc_id}-null"]
+        assert rows[0]["bank_id"] == bank_id
+        assert rows[0]["original_text"] == "the surviving document body"
+        assert rows[0]["legacy_kept"] == "value that must survive"
+        assert rows[1]["original_text"] == "second document"
+        assert rows[1]["legacy_kept"] is None
     finally:
         if backup_path.exists():
             backup_path.unlink()

--- a/hindsight-api-slim/tests/test_migration_drop_access_count.py
+++ b/hindsight-api-slim/tests/test_migration_drop_access_count.py
@@ -1,0 +1,144 @@
+"""Regression for the ``access_count`` drop (``e4a7c1b9d2f6``).
+
+``memory_units.access_count`` was created by the initial schema together with an
+``access_count DESC`` index, but nothing ever wrote it and nothing ever read it —
+it was 0 on every row of every install, and PostgreSQL maintained a btree over it
+for nothing. The migration drops it from the live table *and* from the curation
+archive.
+
+Dropping it from both tables is not cosmetic symmetry: curation moves a row with
+an ``INSERT INTO invalidated_memory_units … SELECT … FROM memory_units`` whose
+column list is read from the catalog at runtime
+(``memories/pg/writes.py::_memory_unit_columns``), minus ``embedding`` and
+``search_vector``. If the drop hit only one of the two tables the round-trip
+would break on a column mismatch, so this test pins the lockstep invariant as
+well as the drop itself.
+
+Uses a dedicated pg0 instance (mirrors test_migration_observation_search_vector_backfill)
+so it controls exactly which migrations have run and never stamps the shared test
+instance.
+"""
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+# All three tests share one module-scoped pg0 instance. CI runs with
+# `--dist loadgroup`, which, absent an xdist_group, scatters them across workers
+# that then each instantiate the module fixture and race to provision the SAME
+# named instance. Pinning the module to a single worker serialises that — and
+# keeps the downgrade test from re-migrating a DB another worker is reading.
+pytestmark = pytest.mark.xdist_group("migration-drop-access-count-pg0")
+
+_SCRIPT_LOCATION = str(Path(__file__).parent.parent / "hindsight_api" / "alembic")
+
+_DROP_REVISION = "e4a7c1b9d2f6"
+# Revision immediately before the drop.
+_PRE_DROP_REVISION = "a9b8c7d6e5f4"
+
+_TABLES = ("memory_units", "invalidated_memory_units")
+# The archive is cold storage and carries neither recall-surface column; both are
+# recomputed on revert (d4f6a8c2e1b3, e7c3a9f1b2d5).
+_ARCHIVE_OMITTED = {"embedding", "search_vector"}
+
+
+def _alembic_cfg(db_url: str) -> Config:
+    cfg = Config()
+    cfg.set_main_option("script_location", _SCRIPT_LOCATION)
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    cfg.set_main_option("prepend_sys_path", ".")
+    cfg.set_main_option("path_separator", "os")
+    return cfg
+
+
+def _columns(conn, table: str) -> set[str]:
+    return {
+        r[0]
+        for r in conn.execute(
+            text("SELECT column_name FROM information_schema.columns WHERE table_name = :t"),
+            {"t": table},
+        )
+    }
+
+
+def _index_exists(conn, name: str) -> bool:
+    return bool(
+        conn.execute(
+            text("SELECT 1 FROM pg_indexes WHERE indexname = :n"),
+            {"n": name},
+        ).scalar()
+    )
+
+
+@pytest.fixture(scope="module")
+def head_db_url():
+    """pg0 instance migrated to head (includes the drop migration)."""
+    from hindsight_api.pg0 import EmbeddedPostgres
+
+    # port=None lets pg0 auto-assign a free port; a hardcoded port is not xdist-safe.
+    pg0 = EmbeddedPostgres(name="hindsight-drop-access-count-test", port=None)
+    loop = asyncio.new_event_loop()
+    try:
+        url = loop.run_until_complete(pg0.ensure_running())
+    finally:
+        loop.close()
+
+    command.upgrade(_alembic_cfg(url), "heads")
+    return url
+
+
+def test_access_count_is_gone_from_both_tables(head_db_url):
+    engine = create_engine(head_db_url)
+    try:
+        with engine.connect() as conn:
+            for table in _TABLES:
+                assert "access_count" not in _columns(conn, table), (
+                    f"{table}.access_count still exists at head — nothing writes or reads it"
+                )
+            assert not _index_exists(conn, "idx_memory_units_access_count"), (
+                "dropping the column should have dropped its index with it"
+            )
+    finally:
+        engine.dispose()
+
+
+def test_archive_stays_in_lockstep_with_memory_units(head_db_url):
+    """The curation INSERT…SELECT builds its column list from the live table, so
+    the archive must still carry every ``memory_units`` column but the two
+    recall-surface ones."""
+    engine = create_engine(head_db_url)
+    try:
+        with engine.connect() as conn:
+            live = _columns(conn, "memory_units")
+            archive = _columns(conn, "invalidated_memory_units")
+            missing = (live - _ARCHIVE_OMITTED) - archive
+            assert not missing, f"invalidated_memory_units is missing {sorted(missing)} — curation would break"
+    finally:
+        engine.dispose()
+
+
+def test_downgrade_restores_the_column_and_index(head_db_url):
+    """The downgrade re-adds an (empty) column and its index, and re-upgrading
+    drops them again — so the migration is not a one-way door on a live DB."""
+    cfg = _alembic_cfg(head_db_url)
+    engine = create_engine(head_db_url)
+    try:
+        command.downgrade(cfg, _PRE_DROP_REVISION)
+        with engine.connect() as conn:
+            for table in _TABLES:
+                assert "access_count" in _columns(conn, table), f"downgrade did not restore {table}.access_count"
+            assert _index_exists(conn, "idx_memory_units_access_count")
+
+        command.upgrade(cfg, _DROP_REVISION)
+        with engine.connect() as conn:
+            for table in _TABLES:
+                assert "access_count" not in _columns(conn, table)
+            assert not _index_exists(conn, "idx_memory_units_access_count")
+    finally:
+        # Leave the module fixture's instance at head for any later user.
+        command.upgrade(cfg, "heads")
+        engine.dispose()

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -317,7 +317,7 @@ class TestBrokerTaskBackend:
         bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
         await _ensure_bank(pool, bank_id)
         task_dict = {
-            "type": "access_count_update",
+            "type": "graph_maintenance",
             "bank_id": bank_id,
             "node_ids": ["node1", "node2"],
         }
@@ -329,7 +329,7 @@ class TestBrokerTaskBackend:
             bank_id,
         )
         assert row is not None
-        assert row["operation_type"] == "access_count_update"
+        assert row["operation_type"] == "graph_maintenance"
         assert row["status"] == "pending"
         payload = json.loads(row["task_payload"])
         assert payload["node_ids"] == ["node1", "node2"]


### PR DESCRIPTION
## What

Drops `memory_units.access_count` (and its index) from both PostgreSQL and Oracle.

The column has existed since the initial schema (`5a366d414dce`), created together with an `access_count DESC` index — but **nothing ever wrote it and nothing ever read it**. It is `0` on every row of every install, and PostgreSQL has been maintaining a btree over it on every insert for no reader.

Repo-wide, the only references were:

| Location | What it was |
|---|---|
| `alembic/versions/5a366d414dce` | PG column + `idx_memory_units_access_count` |
| `alembic/versions/o1a2b3c4d5e6` | Oracle column on both tables + `idx_mu_access_count` |
| `engine/db/oracle.py` | the name in `_NUMERIC_COLS` (RETURNING out-bind typing) — never actually returned |
| `engine/task_backend.py` | a comment citing an `access_count_update` task type that was never implemented |
| `tests/test_worker.py` | that same never-implemented task type, used as a placeholder string |

There is no `ORDER BY access_count` anywhere, and no SDK / OpenAPI / control-plane / CLI surface exposes it.

## Why both tables

The column is dropped from the curation archive `invalidated_memory_units` too, and that is not cosmetic symmetry. Curation moves a row with an `INSERT INTO invalidated_memory_units … SELECT … FROM memory_units` whose column list is read from the catalog at runtime (`memories/pg/writes.py::_memory_unit_columns`), minus `embedding` and `search_vector`. Dropping the column from only one of the two would break the round-trip on a column mismatch. A test pins that lockstep invariant.

Dropping the column implicitly drops its index on both dialects.

## Tests

New `tests/test_migration_drop_access_count.py` (dedicated pg0 instance, mirrors `test_migration_observation_search_vector_backfill`):

- the column is gone from both tables at head, and `idx_memory_units_access_count` with it
- `invalidated_memory_units` still carries every `memory_units` column but the two recall-surface ones (the curation lockstep invariant)
- downgrade restores the column + index, and re-upgrading drops them again — the migration is not a one-way door

Also ran `tests/test_memory_curation.py` (23 passed) against an isolated pg0 to confirm the invalidate/revert round-trip still works with the column gone.

## Restore compatibility (second commit)

Restore's preflight rejected any backup carrying a column the target lacks (`admin/cli.py::_validate_restore_schema`), so dropping `access_count` would have made every backup taken before this migration permanently unrestorable. That is fixed here rather than documented as a caveat: unknown columns are now **skipped and reported** instead of failing the restore.

They cannot simply be omitted from the `copy_to_table` column list — binary COPY carries no column identities, so each tuple's fields are matched to the column list purely by position, and an unedited stream desynchronises (PostgreSQL rejects it with `row field count is N, expected M`; a subtler mismatch could land values in the wrong columns). `_strip_binary_copy_fields` therefore rewrites the stream, dropping each ignored column's field from every tuple.

Type mismatches on columns present in both schemas stay fatal — that is a genuine binary-wire risk, not recoverable drift.

The former rejection test becomes a round-trip test: two legacy columns are backed up and only the *first* is dropped, so a rewrite that got the positions wrong shifts the survivor's value rather than silently passing. Confirmed it fails without the strip.

## Cost

`DROP COLUMN` is metadata-only on PostgreSQL (no table rewrite). On Oracle it does delete the column data row by row, so on a large `memory_units` it is bounded but not free; noted in the migration docstring.
