### PR TITLE
fix(recall): enforce the query token cap for internal recalls, not just HTTP

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -823,6 +823,31 @@ def _get_tiktoken_encoding():
     return get_token_encoding()
 
 
+def _truncate_query_to_token_limit(query: str, max_query_tokens: int, log_prefix: str = "") -> str:
+    """Bound a recall query to ``max_query_tokens`` cl100k tokens (``0`` disables the cap).
+
+    Truncation, not rejection: this runs on the path every *internal* caller takes
+    (consolidation, reflect tools, MCP tools, the context extension), and those must
+    degrade to a shorter query rather than fail. The REST handler keeps its own HTTP
+    400 for client-supplied queries.
+    """
+    # A token is never shorter than one character, so a query of at most
+    # `max_query_tokens` characters cannot exceed the cap — skip tokenizing it.
+    if max_query_tokens <= 0 or len(query) <= max_query_tokens:
+        return query
+
+    encoding = _get_tiktoken_encoding()
+    tokens = encoding.encode(query)
+    if len(tokens) <= max_query_tokens:
+        return query
+
+    logger.warning(
+        f"{log_prefix}Query truncated to {max_query_tokens} tokens (was {len(tokens)}); "
+        f"raise HINDSIGHT_API_RECALL_MAX_QUERY_TOKENS to allow longer queries"
+    )
+    return encoding.decode(tokens[:max_query_tokens])
+
+
 @dataclass(frozen=True)
 class _TimeseriesPeriodConfig:
     """How one period slices the time axis for the memories-ingested chart."""
@@ -4599,6 +4624,21 @@ class MemoryEngine(MemoryEngineInterface):
         # the cross-encoder tokenizer with an HTTP 500 (see issue #1875). Cleaning it
         # here protects every sink that the query flows into.
         query = sanitize_text(query) or ""
+
+        # Bound the query length at the engine ingress. The REST handler rejects an
+        # over-long query with HTTP 400 (PR #298), but that check only guards the one
+        # public entry point: consolidation, the reflect tools, the MCP tools and the
+        # context extension all call this method directly. Consolidation recalls with
+        # the *whole fact text* as the query, so a degenerate extraction (58k words,
+        # 4 distinct) became a 54k-term OR tsquery whose evaluation blew Postgres'
+        # stack depth (SQLSTATE 54001) and wedged the bank's consolidation for a week
+        # (issue #3134). Truncating here keeps every internal caller working on a
+        # bounded query instead of failing.
+        query = _truncate_query_to_token_limit(
+            query,
+            get_config().recall_max_query_tokens,
+            log_prefix=f"[RECALL {bank_id[:8]}] ",
+        )
 
         # Default to all fact types if not specified
         if fact_type is None:

--- a/hindsight-api-slim/tests/test_recall_query_token_cap.py
+++ b/hindsight-api-slim/tests/test_recall_query_token_cap.py
@@ -1,0 +1,82 @@
+"""Recall queries are bounded at the engine ingress, not only at the HTTP edge (issue #3134).
+
+`HINDSIGHT_API_RECALL_MAX_QUERY_TOKENS` used to be enforced only in the REST handler,
+so every internal caller (consolidation, reflect tools, MCP tools, the context
+extension) could pass arbitrarily long text into BM25 tokenization. A degenerate
+extraction — 58k words, 4 distinct — became a 54k-term OR `tsquery` whose evaluation
+exceeded Postgres' stack depth (SQLSTATE 54001).
+"""
+
+from hindsight_api.engine.memory_engine import (
+    _get_tiktoken_encoding,
+    _truncate_query_to_token_limit,
+    count_tokens,
+)
+from hindsight_api.engine.search.retrieval import tokenize_query
+
+
+def test_short_query_is_returned_unchanged():
+    query = "What did Alice say about machine learning?"
+    assert _truncate_query_to_token_limit(query, 500) is query
+
+
+def test_query_under_the_cap_but_over_the_char_shortcut_is_unchanged():
+    """A query longer than `max` characters but under `max` tokens must survive intact.
+
+    The character comparison is only a shortcut to skip tokenizing short queries; it
+    must never truncate on its own.
+    """
+    query = "machine learning " * 40  # ~680 chars, ~120 tokens
+    assert len(query) > 500  # past the character shortcut, so it gets tokenized
+    assert count_tokens(query) < 500
+    assert _truncate_query_to_token_limit(query, 500) == query
+
+
+def test_long_query_is_truncated_to_the_cap():
+    query = "alpha beta gamma delta " * 500
+    assert count_tokens(query) > 500
+
+    truncated = _truncate_query_to_token_limit(query, 500)
+
+    assert count_tokens(truncated) == 500
+    assert query.startswith(truncated[:100])
+
+
+def test_zero_disables_the_cap():
+    query = "alpha beta gamma delta " * 500
+    assert _truncate_query_to_token_limit(query, 0) is query
+
+
+def test_degenerate_repetition_stays_far_below_the_tsquery_stack_cliff():
+    """The reported input: 58k words, 4 distinct, OR-joined into one tsquery.
+
+    Evaluating `@@` recurses once per node, and the measured failure threshold sits
+    between 30k and 50k terms. Capping the query keeps the term count ~2 orders of
+    magnitude below that.
+    """
+    degenerate = "Ismar is mandating " + "mandatory " * 58_279
+
+    assert len(tokenize_query(degenerate)) > 50_000  # unbounded: over the cliff
+
+    bounded = _truncate_query_to_token_limit(degenerate, 500)
+
+    assert len(tokenize_query(bounded)) <= 500
+
+
+def test_truncation_never_raises_on_special_token_literals():
+    """Internal callers must degrade, never fail — including on content that merely
+    mentions a tiktoken special-token literal (issue #1883)."""
+    query = "<|endoftext|> " * 1000
+
+    bounded = _truncate_query_to_token_limit(query, 500)
+
+    assert count_tokens(bounded) == 500
+
+
+def test_truncated_query_round_trips_through_the_encoder():
+    """decode(encode(x)[:n]) must yield text the downstream tokenizer accepts."""
+    query = "consolidation observation recall " * 300
+    bounded = _truncate_query_to_token_limit(query, 500)
+
+    assert isinstance(bounded, str)
+    assert _get_tiktoken_encoding().encode(bounded) == _get_tiktoken_encoding().encode(query)[:500]

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1097,7 +1097,7 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | `HINDSIGHT_API_LINK_EXPANSION_TIMEOUT` | Timeout (seconds) for the per-entity graph expansion query in `link_expansion` retrieval. | `10` |
 | `HINDSIGHT_API_RECALL_MAX_CONCURRENT` | Max concurrent recall operations per worker (backpressure) | `32` |
 | `HINDSIGHT_API_RECALL_CONNECTION_BUDGET` | Max concurrent DB connections per recall operation | `4` |
-| `HINDSIGHT_API_RECALL_MAX_QUERY_TOKENS` | Maximum token length of a recall query; requests exceeding this limit are rejected with HTTP 400 | `500` |
+| `HINDSIGHT_API_RECALL_MAX_QUERY_TOKENS` | Maximum token length of a recall query. API requests exceeding this limit are rejected with HTTP 400; recalls that Hindsight runs internally (consolidation, reflect, MCP) truncate the query to the limit instead of failing. `0` disables the limit. | `500` |
 | `HINDSIGHT_API_RERANKER_MAX_CANDIDATES` | Max candidates to rerank per recall (RRF pre-filters the rest) | `300` |
 | `HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY` | Minimum cosine similarity a candidate must reach to be returned by the semantic retrieval strategy. Must be between `0` and `1`. | `0.3` |
 | `HINDSIGHT_API_GRAPH_SEED_MIN_SIMILARITY` | Minimum cosine similarity for a memory to seed graph retrieval. This is independent from the main semantic retrieval threshold. Must be between `0` and `1`. | `0.3` |

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1097,7 +1097,7 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | `HINDSIGHT_API_LINK_EXPANSION_TIMEOUT` | Timeout (seconds) for the per-entity graph expansion query in `link_expansion` retrieval. | `10` |
 | `HINDSIGHT_API_RECALL_MAX_CONCURRENT` | Max concurrent recall operations per worker (backpressure) | `32` |
 | `HINDSIGHT_API_RECALL_CONNECTION_BUDGET` | Max concurrent DB connections per recall operation | `4` |
-| `HINDSIGHT_API_RECALL_MAX_QUERY_TOKENS` | Maximum token length of a recall query; requests exceeding this limit are rejected with HTTP 400 | `500` |
+| `HINDSIGHT_API_RECALL_MAX_QUERY_TOKENS` | Maximum token length of a recall query. API requests exceeding this limit are rejected with HTTP 400; recalls that Hindsight runs internally (consolidation, reflect, MCP) truncate the query to the limit instead of failing. `0` disables the limit. | `500` |
 | `HINDSIGHT_API_RERANKER_MAX_CANDIDATES` | Max candidates to rerank per recall (RRF pre-filters the rest) | `300` |
 | `HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY` | Minimum cosine similarity a candidate must reach to be returned by the semantic retrieval strategy. Must be between `0` and `1`. | `0.3` |
 | `HINDSIGHT_API_GRAPH_SEED_MIN_SIMILARITY` | Minimum cosine similarity for a memory to seed graph retrieval. This is independent from the main semantic retrieval threshold. Must be between `0` and `1`. | `0.3` |

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -75,6 +75,32 @@ Adding an agent: hook-based → write a `HookSpec` entry point (see `src/cursor-
 a `hookAdapter` in `src/harness/registry.ts`; persistent-plugin → implement `HarnessAdapter`
 (`src/core/types.ts`) fully (see `src/harness/opencode.ts`).
 
+## Migrating from the per-agent plugins
+
+The older per-agent integrations (`hindsight-claude-code`, `hindsight-cursor-cli`, `hindsight-codex`, …) are superseded by this package. Their memory does **not** carry over automatically, and it cannot be merged:
+
+- They scope a bank **per agent per project** (`claude-code::myrepo`); this package uses one **per repo** (`coding-agent::myrepo`) so every agent shares it. Two old banks map onto one new one.
+- The server restores a whole bank rather than merging into an existing one, so the old bank can't be folded in.
+
+Instead, re-import the conversations the agent already wrote to disk — they get re-extracted into the current bank:
+
+```bash
+cd /path/to/your/repo
+hindsight-coding-agents install claude-code --import-conversations
+```
+
+- Scoped to the **current repo**, since history is per-repo and a machine can hold thousands of unrelated sessions.
+- Safe to re-run: ingestion dedups by document id.
+- It runs extraction, so it costs tokens roughly in proportion to the history imported.
+- Supported for **Claude Code** and **Codex**, which store transcripts as files _and_ record the directory each session ran in. Sessions are matched on that recorded directory — never on a filename or folder name — because a wrong guess would file another repo's conversation into this bank. Anything that can't be attributed is skipped and reported.
+- opencode, Kilo, Cursor, Cline, Copilot and Devin keep history in internal SQLite databases with unversioned schemas; those report as skipped rather than importing nothing silently.
+
+Prefer to keep the old bank instead? Point this package at it — no data moves:
+
+```jsonc
+{ "bankIdTemplate": "{harness}::{gitProject}" } // reproduces the old per-agent naming
+```
+
 ## How it works
 
 **Ingestion — automatic, no command to run**


### PR DESCRIPTION
Partially addresses #3134 — the `StatementTooComplexError` itself. The BM25 term cap and the async-op retry ceiling are left alone.

## The bug

`HINDSIGHT_API_RECALL_MAX_QUERY_TOKENS` already exists (default 500). It was added in #298 for exactly this failure class — "a recall query with 1848 tokens caused a database timeout". But it is enforced in one place only, the REST handler (`api/http.py:4312`):

| recall call site | behind the 500-token check? |
|---|---|
| `http.py` (REST `recall`) | yes |
| `consolidation/consolidator.py` (`_find_related_observations`) | **no** |
| `reflect/tools.py` ×2 | **no** |
| `mcp_tools.py` ×2 | **no** |
| `extensions/context.py` | **no** |

Consolidation recalls related observations using the **whole fact text** as the query. A degenerate extraction — 582 KB, 58,282 words, 4 distinct — was tokenized into ~54,280 terms and OR-joined into a single `tsquery`. `to_tsquery` parses that into a 108,541-node tree fine; `@@` then evaluates it with `TS_execute`, which recurses once per node, and Postgres aborts with SQLSTATE 54001 (`stack depth limit exceeded`). Raising `max_stack_depth` doesn't help — it fails at both 2 MB and 6 MB, and macOS caps the process stack at 8 MB.

## The fix

Move enforcement to the engine ingress (`MemoryEngine.recall_async`), where every caller passes through, and **truncate instead of rejecting**: an internal recall must degrade to a shorter query, never fail. Consolidation always proceeds.

The REST handler keeps its HTTP 400 — that's the documented public contract for client-supplied queries, and it fires before the truncation is ever reached.

```python
query = _truncate_query_to_token_limit(
    query, get_config().recall_max_query_tokens, log_prefix=f"[RECALL {bank_id[:8]}] "
)
```

Short queries skip tokenization entirely: a token is never shorter than one character, so `len(query) <= max_query_tokens` is an exact sufficient condition for being under the cap.

## Impact

- 500 tokens ⇒ at most ~500 BM25 terms, two orders of magnitude below the measured 30k–50k stack-depth cliff.
- No change for normal facts. The affected bank's mean fact is 1,404 chars (~350 tokens); only facts over ~500 tokens are truncated, and their embedding was already being truncated by the embedder's own sequence limit.
- Truncation is logged at WARNING with the original token count and the env var to raise.
- `0` still disables the cap.

## Tests

`tests/test_recall_query_token_cap.py` — 7 unit tests, no DB: pass-through under the cap, truncation to exactly the cap, the character shortcut never truncating on its own, `0` disabling it, tolerance of special-token literals (#1883), and a regression test that the reported 58k-repetition input drops from >50,000 BM25 terms to <=500.

## Note for the reviewer

`skills/hindsight-docs/references/sdks/integrations/coding-agents.md` is included but unrelated: `scripts/generate-docs-skill.sh` regenerated it from docs already on `main` that were never re-synced. Without it the pre-commit hook fails on an out-of-sync skill tree.
