### PR TITLE
feat(embeddings): generic per-input token cap across all providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -207,6 +207,11 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_EMBEDDINGS_ONNX_TOKENIZER_NAME_OR_PATH=/models/multilingual-e5-small
 # Optional for China network / restricted HF access:
 # HF_ENDPOINT=https://hf-mirror.com
+# Applies to any provider: cap each input at this many tiktoken tokens before
+# embedding, so oversized content is truncated instead of failing the embed call
+# permanently (e.g. Bedrock Titan V2's 8192, or a llama.cpp server's context). Off
+# by default. (Deprecated alias: HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS)
+# HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS=8192
 # For TEI provider:
 # HINDSIGHT_API_EMBEDDINGS_TEI_URL=http://localhost:8080
 # For OpenAI-compatible embeddings:

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -432,6 +432,10 @@ ENV_EMBEDDINGS_LITELLM_SDK_MODEL = "HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MODEL"
 ENV_EMBEDDINGS_LITELLM_SDK_API_BASE = "HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_API_BASE"
 ENV_EMBEDDINGS_LITELLM_SDK_OUTPUT_DIMENSIONS = "HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_OUTPUT_DIMENSIONS"
 ENV_EMBEDDINGS_LITELLM_SDK_ENCODING_FORMAT = "HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_ENCODING_FORMAT"
+# Provider-agnostic per-input truncation cap (tiktoken cl100k_base tokens).
+ENV_EMBEDDINGS_MAX_INPUT_TOKENS = "HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS"
+# Deprecated alias kept so existing deployments keep working; folded into
+# ENV_EMBEDDINGS_MAX_INPUT_TOKENS (the generic name) at load time.
 ENV_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS = "HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS"
 ENV_RERANKER_LITELLM_SDK_API_KEY = "HINDSIGHT_API_RERANKER_LITELLM_SDK_API_KEY"
 ENV_RERANKER_LITELLM_SDK_MODEL = "HINDSIGHT_API_RERANKER_LITELLM_SDK_MODEL"
@@ -1056,9 +1060,10 @@ DEFAULT_RERANKER_LITELLM_MAX_TOKENS_PER_DOC: int | None = None
 DEFAULT_EMBEDDINGS_LITELLM_SDK_MODEL = "cohere/embed-english-v3.0"
 DEFAULT_EMBEDDINGS_LITELLM_SDK_ENCODING_FORMAT = "float"
 # Opt-in per-text input truncation (tiktoken cl100k_base tokens). Off by default;
-# set to the embedding model's real input limit (e.g. 8192 for Bedrock Titan V2)
-# to keep oversized content from permanently failing the embed call. See #2501.
-DEFAULT_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS: int | None = None
+# set to the embedding model's real input limit (e.g. 8192 for Bedrock Titan V2, or a
+# llama.cpp server's context) to keep oversized content from permanently failing the
+# embed call. Applies to every embeddings provider. See #2501.
+DEFAULT_EMBEDDINGS_MAX_INPUT_TOKENS: int | None = None
 DEFAULT_RERANKER_LITELLM_SDK_MODEL = "cohere/rerank-english-v3.0"
 
 DEFAULT_HOST = "0.0.0.0"
@@ -1897,6 +1902,8 @@ class HindsightConfig:
 
     # Embeddings
     embeddings_provider: str
+    # Provider-agnostic per-input token cap; None disables truncation.
+    embeddings_max_input_tokens: int | None
     embeddings_local_model: str
     embeddings_local_force_cpu: bool
     embeddings_local_allow_mps: bool
@@ -1930,7 +1937,6 @@ class HindsightConfig:
     embeddings_litellm_sdk_api_base: str | None
     embeddings_litellm_sdk_output_dimensions: int | None
     embeddings_litellm_sdk_encoding_format: str | None
-    embeddings_litellm_sdk_max_input_tokens: int | None
     # Gemini/Vertex AI embeddings
     embeddings_gemini_api_key: str | None
     embeddings_gemini_model: str
@@ -2754,6 +2760,13 @@ class HindsightConfig:
             consolidation_llm_strategy=_parse_llm_strategy(os.getenv(ENV_CONSOLIDATION_LLM_STRATEGY)),
             # Embeddings
             embeddings_provider=os.getenv(ENV_EMBEDDINGS_PROVIDER, DEFAULT_EMBEDDINGS_PROVIDER),
+            # Generic name, falling back to the deprecated LiteLLM-SDK-specific alias.
+            embeddings_max_input_tokens=int(v)
+            if (
+                v := os.getenv(ENV_EMBEDDINGS_MAX_INPUT_TOKENS)
+                or os.getenv(ENV_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS)
+            )
+            else DEFAULT_EMBEDDINGS_MAX_INPUT_TOKENS,
             embeddings_local_model=os.getenv(ENV_EMBEDDINGS_LOCAL_MODEL, DEFAULT_EMBEDDINGS_LOCAL_MODEL),
             embeddings_local_force_cpu=os.getenv(
                 ENV_EMBEDDINGS_LOCAL_FORCE_CPU, str(DEFAULT_EMBEDDINGS_LOCAL_FORCE_CPU)
@@ -2872,9 +2885,6 @@ class HindsightConfig:
             embeddings_litellm_sdk_encoding_format=os.getenv(
                 ENV_EMBEDDINGS_LITELLM_SDK_ENCODING_FORMAT, DEFAULT_EMBEDDINGS_LITELLM_SDK_ENCODING_FORMAT
             ),
-            embeddings_litellm_sdk_max_input_tokens=int(v)
-            if (v := os.getenv(ENV_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS))
-            else DEFAULT_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS,
             # Gemini/Vertex AI embeddings (with fallback to LLM keys)
             embeddings_gemini_api_key=os.getenv(ENV_EMBEDDINGS_GEMINI_API_KEY) or os.getenv(ENV_LLM_API_KEY),
             embeddings_gemini_model=os.getenv(ENV_EMBEDDINGS_GEMINI_MODEL, DEFAULT_EMBEDDINGS_GEMINI_MODEL),

--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -82,25 +82,6 @@ class _ZeroEntropyEmbedResponse(BaseModel):
     results: list[_ZeroEntropyEmbedResult]
 
 
-def _truncate_to_tokens(text: str, max_tokens: int) -> tuple[str, int]:
-    """Truncate ``text`` to at most ``max_tokens`` cl100k_base tokens.
-
-    tiktoken is an approximation of any given provider's tokenizer, so set
-    ``max_tokens`` with a little headroom below the model's real limit.
-
-    Returns the (possibly truncated) text and the original token count (so the
-    caller can report how much was dropped); the count equals ``len(tokens)``
-    whether or not truncation occurred.
-    """
-    from .token_encoding import get_token_encoding
-
-    enc = get_token_encoding()
-    tokens = enc.encode(text)
-    if len(tokens) <= max_tokens:
-        return text, len(tokens)
-    return enc.decode(tokens[:max_tokens]), len(tokens)
-
-
 class Embeddings(ABC):
     """
     Abstract base class for embedding generation.
@@ -1237,7 +1218,6 @@ class LiteLLMSDKEmbeddings(Embeddings):
         batch_size: int = 100,
         timeout: float = 60.0,
         encoding_format: str | None = "float",
-        max_input_tokens: int | None = None,
     ):
         """
         Initialize LiteLLM SDK embeddings client.
@@ -1252,10 +1232,6 @@ class LiteLLMSDKEmbeddings(Embeddings):
             timeout: Request timeout in seconds (default: 60.0)
             encoding_format: Encoding format for embeddings (default: "float").
                 Set to None or empty string to omit (needed for Voyage AI, Gemini).
-            max_input_tokens: If set, truncate each input text to this many tokens
-                (tiktoken cl100k_base) before embedding. Needed for models with a
-                fixed input-token limit (e.g. Bedrock Titan V2's hard 8192 cap),
-                where an oversized text would otherwise fail permanently (#2501).
         """
         self.api_key = api_key
         self.model = model
@@ -1264,7 +1240,6 @@ class LiteLLMSDKEmbeddings(Embeddings):
         self.batch_size = batch_size
         self.timeout = timeout
         self.encoding_format = encoding_format or None
-        self.max_input_tokens = max_input_tokens
         self._litellm = None  # Will be set during initialization
         self._dimension: int | None = None
 
@@ -1340,33 +1315,6 @@ class LiteLLMSDKEmbeddings(Embeddings):
 
         if not texts:
             return []
-
-        # Truncate oversized inputs before hitting the provider. Models with a
-        # fixed input-token limit (e.g. Bedrock Titan V2, 8192) reject an
-        # oversized text with a permanent error rather than truncating it
-        # server-side, which strands the caller (e.g. a delta mental model whose
-        # content grew past the cap) with no recovery path. See #2501.
-        if self.max_input_tokens is not None:
-            truncated_texts = []
-            original_token_counts = []
-            for t in texts:
-                new_text, original_tokens = _truncate_to_tokens(t, self.max_input_tokens)
-                truncated_texts.append(new_text)
-                if original_tokens > self.max_input_tokens:
-                    original_token_counts.append(original_tokens)
-            texts = truncated_texts
-            if original_token_counts:
-                logger.warning(
-                    "Embeddings: truncated %d of %d input(s) to %d tokens for model %s "
-                    "(largest was ~%d tokens); embedded content is incomplete. "
-                    "This usually means a mental model's content has grown past the model's "
-                    "input limit — see issue #2501.",
-                    len(original_token_counts),
-                    len(texts),
-                    self.max_input_tokens,
-                    self.model,
-                    max(original_token_counts),
-                )
 
         all_embeddings = []
 
@@ -1760,7 +1708,6 @@ def create_embeddings_from_env() -> Embeddings:
             api_base=config.embeddings_litellm_sdk_api_base,
             output_dimensions=config.embeddings_litellm_sdk_output_dimensions,
             encoding_format=config.embeddings_litellm_sdk_encoding_format,
-            max_input_tokens=config.embeddings_litellm_sdk_max_input_tokens,
         )
     elif provider == "google":
         vertexai_project_id = config.embeddings_vertexai_project_id

--- a/hindsight-api-slim/hindsight_api/engine/retain/embedding_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/embedding_utils.py
@@ -7,6 +7,9 @@ import contextvars
 import logging
 from typing import Literal, Protocol
 
+from ...config import ENV_EMBEDDINGS_MAX_INPUT_TOKENS, get_config
+from ..token_encoding import truncate_to_tokens
+
 logger = logging.getLogger(__name__)
 
 EmbeddingInputType = Literal["document", "query"]
@@ -22,6 +25,37 @@ class EmbeddingsBackend(Protocol):
     def encode_query(self, texts: list[str]) -> list[list[float]]: ...
 
     def encode_documents(self, texts: list[str]) -> list[list[float]]: ...
+
+
+def _truncate_inputs(texts: list[str], max_input_tokens: int, backend: EmbeddingsBackend) -> list[str]:
+    """Cap each input at ``max_input_tokens`` tiktoken tokens before it reaches the provider.
+
+    Remote providers with a fixed input-token limit (e.g. Bedrock Titan V2's hard 8192
+    cap, or a llama.cpp ``/v1/embeddings`` server) reject an oversized text with a
+    permanent 4xx rather than truncating server-side the way SentenceTransformers does.
+    One oversized memory then fails the whole retain/recall batch. This is provider-
+    agnostic on purpose: the cap is applied here, once, before any backend's `encode()`.
+    """
+    truncated: list[str] = []
+    original_token_counts: list[int] = []
+    for text in texts:
+        result = truncate_to_tokens(text, max_input_tokens)
+        truncated.append(result.text)
+        if result.original_tokens > max_input_tokens:
+            original_token_counts.append(result.original_tokens)
+    if original_token_counts:
+        logger.warning(
+            "Embeddings: truncated %d of %d input(s) to %d tokens for provider %s "
+            "(largest was ~%d tokens); embedded content is incomplete. Raise or unset "
+            "%s if this is unexpected.",
+            len(original_token_counts),
+            len(texts),
+            max_input_tokens,
+            getattr(backend, "provider_name", "?"),
+            max(original_token_counts),
+            ENV_EMBEDDINGS_MAX_INPUT_TOKENS,
+        )
+    return truncated
 
 
 def _validate_embedding_vector(vector: list[float], *, index: int, expected_dimension: int) -> list[float]:
@@ -58,6 +92,13 @@ async def generate_embeddings_batch(
     Returns:
         List of embeddings in same order as input texts
     """
+    # Cap oversized inputs once, here, before they reach any provider's encode(). Kept
+    # out of the individual backends so every provider (and every call path — retain,
+    # recall queries, consolidation, import) gets identical, model-agnostic truncation.
+    max_input_tokens = get_config().embeddings_max_input_tokens
+    if max_input_tokens is not None and texts:
+        texts = _truncate_inputs(texts, max_input_tokens, embeddings_backend)
+
     try:
         loop = asyncio.get_event_loop()
         # run_in_executor runs the encode in a worker thread, which does NOT inherit

--- a/hindsight-api-slim/hindsight_api/engine/token_encoding.py
+++ b/hindsight-api-slim/hindsight_api/engine/token_encoding.py
@@ -11,6 +11,7 @@ counts are unaffected; this only stops the encoder from rejecting valid input. E
 call site in the engine routes through ``get_token_encoding()``, so the fix is global.
 """
 
+from dataclasses import dataclass
 from functools import lru_cache
 
 import tiktoken
@@ -44,3 +45,27 @@ def get_token_encoding() -> _SafeEncoding:
 def count_tokens(text: str) -> int:
     """Count cl100k_base tokens in ``text`` (tolerant of special-token literals)."""
     return len(get_token_encoding().encode(text))
+
+
+@dataclass(frozen=True)
+class TokenTruncation:
+    """Result of :func:`truncate_to_tokens`."""
+
+    text: str  # the (possibly truncated) text
+    original_tokens: int  # token count of the input before any truncation
+
+
+def truncate_to_tokens(text: str, max_tokens: int) -> TokenTruncation:
+    """Truncate ``text`` to at most ``max_tokens`` cl100k_base tokens.
+
+    tiktoken is an approximation of any given provider's tokenizer, so set
+    ``max_tokens`` with a little headroom below the model's real limit.
+
+    ``original_tokens`` is the input's token count (so the caller can report how
+    much was dropped) whether or not truncation occurred.
+    """
+    enc = get_token_encoding()
+    tokens = enc.encode(text)
+    if len(tokens) <= max_tokens:
+        return TokenTruncation(text=text, original_tokens=len(tokens))
+    return TokenTruncation(text=enc.decode(tokens[:max_tokens]), original_tokens=len(tokens))

--- a/hindsight-api-slim/tests/test_embeddings_max_input_tokens.py
+++ b/hindsight-api-slim/tests/test_embeddings_max_input_tokens.py
@@ -1,0 +1,121 @@
+"""Provider-agnostic embedding input truncation.
+
+The cap lives at the single choke point (`generate_embeddings_batch`) so every
+provider and every call path (retain, recall queries, consolidation, import) gets
+identical, model-agnostic truncation before any backend's `encode()` runs.
+
+Config is exposed as the generic `HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS`, with the
+old LiteLLM-SDK-specific `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS` kept as
+a deprecated alias for backward compatibility.
+"""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from hindsight_api.config import (
+    ENV_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS,
+    ENV_EMBEDDINGS_MAX_INPUT_TOKENS,
+    HindsightConfig,
+)
+from hindsight_api.engine.retain import embedding_utils
+from hindsight_api.engine.token_encoding import get_token_encoding
+
+
+class _FakeBackend:
+    """Records the texts each `encode_*` call actually receives."""
+
+    provider_name = "fake"
+
+    def __init__(self, dimension: int = 3) -> None:
+        self._dimension = dimension
+        self.received: list[str] = []
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+
+    def encode_documents(self, texts: list[str]) -> list[list[float]]:
+        self.received = list(texts)
+        return [[0.1] * self._dimension for _ in texts]
+
+    def encode_query(self, texts: list[str]) -> list[list[float]]:
+        return self.encode_documents(texts)
+
+
+def _patch_cap(value: int | None):
+    return patch.object(
+        embedding_utils,
+        "get_config",
+        return_value=SimpleNamespace(embeddings_max_input_tokens=value),
+    )
+
+
+class TestTruncateInputs:
+    def test_truncates_oversized_and_warns(self, caplog):
+        backend = _FakeBackend()
+        long_text = "word " * 500  # far more than 50 tokens
+        with caplog.at_level(logging.WARNING):
+            result = embedding_utils._truncate_inputs([long_text], 50, backend)
+
+        assert len(get_token_encoding().encode(result[0])) <= 50
+        assert result[0] != long_text
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING and "truncated" in r.message]
+        assert warnings, "expected a truncation warning"
+        # The warning names the generic env var (so operators know which knob to turn)
+        # and the provider, not a model-specific message.
+        assert ENV_EMBEDDINGS_MAX_INPUT_TOKENS in warnings[0].getMessage()
+        assert "fake" in warnings[0].getMessage()
+
+    def test_short_input_untouched_no_warning(self, caplog):
+        backend = _FakeBackend()
+        with caplog.at_level(logging.WARNING):
+            result = embedding_utils._truncate_inputs(["short text"], 50, backend)
+
+        assert result == ["short text"]
+        assert not any("truncated" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+class TestGenerateEmbeddingsBatch:
+    async def test_cap_applied_before_backend(self):
+        backend = _FakeBackend()
+        long_text = "word " * 500
+        with _patch_cap(50):
+            await embedding_utils.generate_embeddings_batch(backend, [long_text])
+
+        assert backend.received, "backend was never called"
+        assert len(get_token_encoding().encode(backend.received[0])) <= 50
+        assert backend.received[0] != long_text
+
+    async def test_no_cap_passes_verbatim(self):
+        backend = _FakeBackend()
+        long_text = "word " * 500
+        with _patch_cap(None):
+            await embedding_utils.generate_embeddings_batch(backend, [long_text])
+
+        assert backend.received == [long_text]
+
+
+class TestConfigWiring:
+    def test_generic_env_parsed(self, monkeypatch):
+        monkeypatch.setenv(ENV_EMBEDDINGS_MAX_INPUT_TOKENS, "8192")
+        monkeypatch.delenv(ENV_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS, raising=False)
+        assert HindsightConfig.from_env().embeddings_max_input_tokens == 8192
+
+    def test_deprecated_litellm_alias_still_works(self, monkeypatch):
+        monkeypatch.delenv(ENV_EMBEDDINGS_MAX_INPUT_TOKENS, raising=False)
+        monkeypatch.setenv(ENV_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS, "4096")
+        assert HindsightConfig.from_env().embeddings_max_input_tokens == 4096
+
+    def test_generic_takes_precedence_over_alias(self, monkeypatch):
+        monkeypatch.setenv(ENV_EMBEDDINGS_MAX_INPUT_TOKENS, "8192")
+        monkeypatch.setenv(ENV_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS, "4096")
+        assert HindsightConfig.from_env().embeddings_max_input_tokens == 8192
+
+    def test_default_is_disabled(self, monkeypatch):
+        monkeypatch.delenv(ENV_EMBEDDINGS_MAX_INPUT_TOKENS, raising=False)
+        monkeypatch.delenv(ENV_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS, raising=False)
+        assert HindsightConfig.from_env().embeddings_max_input_tokens is None

--- a/hindsight-api-slim/tests/test_litellm_sdk_embeddings.py
+++ b/hindsight-api-slim/tests/test_litellm_sdk_embeddings.py
@@ -244,65 +244,6 @@ class TestLiteLLMSDKEmbeddings:
         assert isinstance(result, list)
         assert len(result) == 0
 
-    async def test_encode_truncates_oversized_input_when_max_tokens_set(self, mock_litellm, caplog):
-        """Oversized inputs are truncated to max_input_tokens before embedding, with a warning (#2501)."""
-        import logging
-
-        from hindsight_api.engine.token_encoding import get_token_encoding
-
-        emb = LiteLLMSDKEmbeddings(
-            api_key="test_key",
-            model="bedrock/amazon.titan-embed-text-v2:0",
-            api_base=None,
-            batch_size=100,
-            timeout=60.0,
-            max_input_tokens=50,
-        )
-        emb._litellm = mock_litellm
-        emb._dimension = 768
-        mock_litellm.embedding.return_value.data = [{"embedding": [0.1] * 768, "index": 0}]
-
-        long_text = "word " * 500  # far more than 50 tokens
-        with caplog.at_level(logging.WARNING):
-            emb.encode([long_text])
-
-        sent = mock_litellm.embedding.call_args.kwargs["input"][0]
-        enc = get_token_encoding()
-        assert len(enc.encode(sent)) <= 50
-        assert sent != long_text  # actually truncated
-        assert any("truncated" in r.message and r.levelno == logging.WARNING for r in caplog.records)
-
-    async def test_encode_no_warning_when_input_within_limit(self, mock_litellm, caplog):
-        """No truncation warning when every input already fits under max_input_tokens."""
-        import logging
-
-        emb = LiteLLMSDKEmbeddings(
-            api_key="test_key",
-            model="bedrock/amazon.titan-embed-text-v2:0",
-            api_base=None,
-            batch_size=100,
-            timeout=60.0,
-            max_input_tokens=50,
-        )
-        emb._litellm = mock_litellm
-        emb._dimension = 768
-        mock_litellm.embedding.return_value.data = [{"embedding": [0.1] * 768, "index": 0}]
-
-        with caplog.at_level(logging.WARNING):
-            emb.encode(["short text well under the limit"])
-
-        assert not any("truncated" in r.message for r in caplog.records)
-
-    async def test_encode_does_not_truncate_when_max_tokens_unset(self, embeddings, mock_litellm):
-        """Without max_input_tokens the text is passed through verbatim (default behavior)."""
-        assert embeddings.max_input_tokens is None
-        mock_litellm.embedding.return_value.data = [{"embedding": [0.1] * 768, "index": 0}]
-
-        long_text = "word " * 500
-        embeddings.encode([long_text])
-
-        assert mock_litellm.embedding.call_args.kwargs["input"] == [long_text]
-
     async def test_encode_before_initialization(self, mock_litellm):
         """Test that encode raises error if not initialized."""
         emb = LiteLLMSDKEmbeddings(

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -571,6 +571,7 @@ server-level only (not overridable per tenant/bank) and a change requires a rest
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_API_EMBEDDINGS_PROVIDER` | Provider: `local`, `onnx`, `tei`, `openai`, `openai-codex`, `openrouter`, `requesty`, `cohere`, `google`, `zeroentropy`, `litellm`, or `litellm-sdk` | `local` |
+| `HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS` | Applies to **every** provider. If set, truncate each text to this many tokens (tiktoken `cl100k_base`, approximate) before embedding. Set it to the model's real input limit (e.g. `8192` for Bedrock Titan V2, or a llama.cpp server's context, with a little headroom) so oversized content is truncated instead of failing the embed call permanently. Off by default. (Deprecated alias: `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS`.) | - |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL` | Model for local provider | `BAAI/bge-small-en-v1.5` |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_TRUST_REMOTE_CODE` | Allow loading models with custom code (security risk, disabled by default) | `false` |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU` | Force CPU mode for local embeddings (avoids MPS/XPC issues on macOS) | `false` |
@@ -615,7 +616,6 @@ server-level only (not overridable per tenant/bank) and a change requires a rest
 | `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_API_BASE` | Custom base URL for LiteLLM SDK embeddings (optional) | - |
 | `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_OUTPUT_DIMENSIONS` | Optional output embedding dimensions (provider-dependent, e.g., `768` for Gemini embedding models) | - |
 | `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_ENCODING_FORMAT` | Encoding format for embedding responses. Set to empty string to omit the parameter (needed for Voyage AI, Gemini). | `float` |
-| `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS` | If set, truncate each text to this many tokens (tiktoken `cl100k_base`, approximate) before embedding. Set it to the model's real input limit (e.g. `8192` for Bedrock Titan V2, with a little headroom) so oversized content is truncated instead of failing the embed call permanently. Off by default. | - |
 | `HINDSIGHT_API_EMBEDDINGS_GEMINI_API_KEY` | Gemini API key for embeddings (falls back to `HINDSIGHT_API_LLM_API_KEY`) | - |
 | `HINDSIGHT_API_EMBEDDINGS_GEMINI_MODEL` | Gemini embedding model. The `gemini-embedding-2` family (e.g. `gemini-embedding-2-preview`) is supported on both the Gemini API and Vertex AI — because these multimodal models aggregate a multi-input request into one embedding, Hindsight automatically embeds one input per call to keep per-fact vectors. | `gemini-embedding-001` |
 | `HINDSIGHT_API_EMBEDDINGS_GEMINI_OUTPUT_DIMENSIONALITY` | Output embedding dimensions (Gemini supports configurable dimensionality) | `768` |
@@ -832,8 +832,9 @@ export HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_API_KEY=your-provider-api-key
 export HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MODEL=cohere/embed-english-v3.0
 # Optional: request a specific output dimension when the provider supports it
 # export HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_OUTPUT_DIMENSIONS=768
-# Optional: truncate oversized inputs to the model's input-token limit (e.g. Bedrock Titan V2)
-# export HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS=8192
+# Optional (any provider): truncate oversized inputs to the model's input-token limit
+# (e.g. Bedrock Titan V2, or a llama.cpp server's context)
+# export HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS=8192
 
 # Supported LiteLLM SDK embedding providers:
 # - cohere/embed-english-v3.0 (1024 dimensions)

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -207,6 +207,11 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_EMBEDDINGS_ONNX_TOKENIZER_NAME_OR_PATH=/models/multilingual-e5-small
 # Optional for China network / restricted HF access:
 # HF_ENDPOINT=https://hf-mirror.com
+# Applies to any provider: cap each input at this many tiktoken tokens before
+# embedding, so oversized content is truncated instead of failing the embed call
+# permanently (e.g. Bedrock Titan V2's 8192, or a llama.cpp server's context). Off
+# by default. (Deprecated alias: HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS)
+# HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS=8192
 # For TEI provider:
 # HINDSIGHT_API_EMBEDDINGS_TEI_URL=http://localhost:8080
 # For OpenAI-compatible embeddings:


### PR DESCRIPTION
## Summary

There were two separate embedding-truncation knobs — a token-based
`HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS` wired only into the
LiteLLM SDK provider (Bedrock Titan, #2501), and a proposed char-based
OpenAI-only cap (#3091). This unifies them into **one generic,
provider-agnostic flag** and moves the truncation to the single choke point
that every embedding path flows through.

## What changed

- **New flag `HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS`** (config
  `embeddings_max_input_tokens`), off by default, **applies to every provider**
  (local, OpenAI-compatible/llama.cpp, LiteLLM SDK/Bedrock, Cohere, Gemini…).
  Token-based (tiktoken `cl100k_base`, approximate — set with headroom).
- **Backward compatible:** the old
  `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS` is kept as a
  deprecated alias and folded into the generic name at load time (generic wins
  when both are set).
- **Truncation moved before the provider:** it now runs once in
  `generate_embeddings_batch` (the universal boundary for retain, recall
  queries, consolidation, and import) instead of inside a single provider's
  `encode()`. Removed the per-provider `max_input_tokens` from
  `LiteLLMSDKEmbeddings`.
- `truncate_to_tokens` moved to `token_encoding.py` and now returns a
  `TokenTruncation` dataclass (no tuple return).

## Why

Remote providers with a fixed input-token limit (Bedrock Titan V2's hard 8192
cap, or a self-hosted llama.cpp `/v1/embeddings` server) reject an oversized
input with a permanent 4xx rather than truncating server-side the way local
SentenceTransformers does. One oversized memory then fails the whole
retain/recall batch. The cap is the escape hatch — and it belongs to every
provider, not just LiteLLM SDK.

## Validation

- `tests/test_embeddings_max_input_tokens.py` (new): central truncation +
  warning, cap-applied-before-backend, no-cap-passes-verbatim, and config
  parsing (generic env, deprecated alias, precedence, default-disabled).
- LiteLLM-SDK truncation tests migrated out of
  `test_litellm_sdk_embeddings.py` into the central path.
- `lint.sh` ✓, `ty check` ✓, targeted tests green.

## Docs

`configuration.md` moves the row into the general Embeddings section, notes it
applies to all providers, and records the deprecated alias. `.env.example`
(and the bundled `hindsight-embed` copy) updated.
