### PR TITLE
fix(embed): bound daemon log growth

### DIFF
--- a/hindsight-docs/docs/sdks/embed.md
+++ b/hindsight-docs/docs/sdks/embed.md
@@ -123,8 +123,11 @@ The control center runs as a separate process from the memory daemon. Stopping o
 | `HINDSIGHT_EMBED_DAEMON_LOG_BACKUP_COUNT` | Retained backups; `0` truncates a full log at startup | `3` |
 | `HINDSIGHT_EMBED_CONTROL_PORT` | Default port for `hindsight-embed control start` | `7878` |
 
-Peak retained log size is approximately `MAX_BYTES × (BACKUP_COUNT + 1)`, or 40 MiB by default. Rotation
-occurs only when a daemon starts; it does not bound an uninterrupted daemon run.
+The size is checked only when a daemon starts, so a single uninterrupted run is never truncated and can
+grow past `MAX_BYTES` — and at the next start that whole file is kept as the first backup. Retained size
+is therefore around `MAX_BYTES × (BACKUP_COUNT + 1)` (40 MiB by default) only for daemons that restart
+regularly; a daemon left running for weeks (the default, since it never auto-exits) keeps whatever it
+wrote. Restart it, or lower `HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT`, to keep the bound meaningful.
 
 **Provider Examples:**
 

--- a/hindsight-docs/docs/sdks/embed.md
+++ b/hindsight-docs/docs/sdks/embed.md
@@ -119,7 +119,12 @@ The control center runs as a separate process from the memory daemon. Stopping o
 | `HINDSIGHT_API_LLM_PROVIDER` | LLM provider: `openai`, `anthropic`, `gemini`, `groq`, `minimax`, `ollama` | `openai` |
 | `HINDSIGHT_API_LLM_MODEL` | Model name | `gpt-4o-mini` |
 | `HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT` | Seconds before daemon auto-exits when idle (0 = never) | `0` |
+| `HINDSIGHT_EMBED_DAEMON_LOG_MAX_BYTES` | Rotate the daemon log at startup when it reaches this size; `0` disables rotation | `10485760` (10 MiB) |
+| `HINDSIGHT_EMBED_DAEMON_LOG_BACKUP_COUNT` | Retained backups; `0` truncates a full log at startup | `3` |
 | `HINDSIGHT_EMBED_CONTROL_PORT` | Default port for `hindsight-embed control start` | `7878` |
+
+Peak retained log size is approximately `MAX_BYTES × (BACKUP_COUNT + 1)`, or 40 MiB by default. Rotation
+occurs only when a daemon starts; it does not bound an uninterrupted daemon run.
 
 **Provider Examples:**
 

--- a/hindsight-embed/README.md
+++ b/hindsight-embed/README.md
@@ -157,6 +157,11 @@ Run `hindsight-embed configure` for a guided setup that saves to `~/.hindsight/e
 | `HINDSIGHT_EMBED_API_TOKEN` | Authentication token for external API (sent as Bearer token) | None |
 | `HINDSIGHT_EMBED_API_DATABASE_URL` | Database URL for daemon | `pg0://hindsight-embed` |
 | `HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT` | Seconds before daemon auto-exits when idle | `300` |
+| `HINDSIGHT_EMBED_DAEMON_LOG_MAX_BYTES` | Rotate the daemon log at startup at this size; `0` disables rotation | `10485760` (10 MiB) |
+| `HINDSIGHT_EMBED_DAEMON_LOG_BACKUP_COUNT` | Retained backups; `0` truncates a full log at startup | `3` |
+
+Peak retained log size is approximately `MAX_BYTES × (BACKUP_COUNT + 1)`, or 40 MiB by default. Rotation
+occurs only when a daemon starts; it does not bound an uninterrupted daemon run.
 
 **Using an External API Server:**
 

--- a/hindsight-embed/README.md
+++ b/hindsight-embed/README.md
@@ -160,8 +160,11 @@ Run `hindsight-embed configure` for a guided setup that saves to `~/.hindsight/e
 | `HINDSIGHT_EMBED_DAEMON_LOG_MAX_BYTES` | Rotate the daemon log at startup at this size; `0` disables rotation | `10485760` (10 MiB) |
 | `HINDSIGHT_EMBED_DAEMON_LOG_BACKUP_COUNT` | Retained backups; `0` truncates a full log at startup | `3` |
 
-Peak retained log size is approximately `MAX_BYTES × (BACKUP_COUNT + 1)`, or 40 MiB by default. Rotation
-occurs only when a daemon starts; it does not bound an uninterrupted daemon run.
+The size is checked only when a daemon starts, so a single uninterrupted run is never truncated and can
+grow past `MAX_BYTES` — and at the next start that whole file is kept as the first backup. Retained size
+is therefore around `MAX_BYTES × (BACKUP_COUNT + 1)` (40 MiB by default) only for daemons that restart
+regularly; a daemon left running for weeks keeps whatever it wrote. Restart it, or lower
+`HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT`, to keep the bound meaningful.
 
 **Using an External API Server:**
 

--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -72,18 +72,10 @@ def _parse_non_negative_int(value: str | None, default: int, name: str) -> int:
 # runners than POSIX.
 DAEMON_STARTUP_TIMEOUT = int(os.getenv("HINDSIGHT_EMBED_DAEMON_STARTUP_TIMEOUT", "180"))
 DEFAULT_DAEMON_IDLE_TIMEOUT = 0  # 0 = disabled (no auto-exit)
+ENV_DAEMON_LOG_MAX_BYTES = "HINDSIGHT_EMBED_DAEMON_LOG_MAX_BYTES"
+ENV_DAEMON_LOG_BACKUP_COUNT = "HINDSIGHT_EMBED_DAEMON_LOG_BACKUP_COUNT"
 DEFAULT_DAEMON_LOG_MAX_BYTES = 10 * 1024 * 1024
 DEFAULT_DAEMON_LOG_BACKUP_COUNT = 3
-DAEMON_LOG_MAX_BYTES = _parse_non_negative_int(
-    os.getenv("HINDSIGHT_EMBED_DAEMON_LOG_MAX_BYTES"),
-    DEFAULT_DAEMON_LOG_MAX_BYTES,
-    "HINDSIGHT_EMBED_DAEMON_LOG_MAX_BYTES",
-)
-DAEMON_LOG_BACKUP_COUNT = _parse_non_negative_int(
-    os.getenv("HINDSIGHT_EMBED_DAEMON_LOG_BACKUP_COUNT"),
-    DEFAULT_DAEMON_LOG_BACKUP_COUNT,
-    "HINDSIGHT_EMBED_DAEMON_LOG_BACKUP_COUNT",
-)
 # When another process is concurrently starting the daemon, the TCP port can be
 # bound before /health returns 200. Give that warming daemon a short grace window
 # before treating the listener as stale/foreign and attempting to reclaim it.
@@ -138,11 +130,7 @@ class DaemonEmbedManager(EmbedManager):
         self._profile_manager = ProfileManager()
 
     @staticmethod
-    def _rotate_daemon_log(
-        log_path: Path,
-        max_bytes: int = DAEMON_LOG_MAX_BYTES,
-        backup_count: int = DAEMON_LOG_BACKUP_COUNT,
-    ) -> None:
+    def _rotate_daemon_log(log_path: Path, max_bytes: int, backup_count: int) -> None:
         """Rotate a full daemon log before a new daemon opens it.
 
         Startup is serialized by the profile lock, and this runs only after
@@ -581,14 +569,14 @@ class DaemonEmbedManager(EmbedManager):
         # Create log directory
         daemon_log.parent.mkdir(parents=True, exist_ok=True)
         max_bytes = _parse_non_negative_int(
-            env.get("HINDSIGHT_EMBED_DAEMON_LOG_MAX_BYTES"),
-            DAEMON_LOG_MAX_BYTES,
-            "HINDSIGHT_EMBED_DAEMON_LOG_MAX_BYTES",
+            env.get(ENV_DAEMON_LOG_MAX_BYTES),
+            DEFAULT_DAEMON_LOG_MAX_BYTES,
+            ENV_DAEMON_LOG_MAX_BYTES,
         )
         backup_count = _parse_non_negative_int(
-            env.get("HINDSIGHT_EMBED_DAEMON_LOG_BACKUP_COUNT"),
-            DAEMON_LOG_BACKUP_COUNT,
-            "HINDSIGHT_EMBED_DAEMON_LOG_BACKUP_COUNT",
+            env.get(ENV_DAEMON_LOG_BACKUP_COUNT),
+            DEFAULT_DAEMON_LOG_BACKUP_COUNT,
+            ENV_DAEMON_LOG_BACKUP_COUNT,
         )
         try:
             self._rotate_daemon_log(daemon_log, max_bytes=max_bytes, backup_count=backup_count)

--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -53,12 +53,27 @@ def _safe_positive_float(value: float, fallback: float) -> float:
     return value if math.isfinite(value) and value > 0 else fallback
 
 
+def _parse_non_negative_int_env(name: str, default: int) -> int:
+    """Parse a non-negative integer environment variable."""
+    try:
+        value = int(os.getenv(name, str(default)))
+    except ValueError:
+        return default
+    return value if value >= 0 else default
+
+
 # Constants
 # Allow CI/Windows to extend the startup budget — pg0-embedded's Windows wheel
 # unpacks and runs initdb on first boot, which takes noticeably longer on cold
 # runners than POSIX.
 DAEMON_STARTUP_TIMEOUT = int(os.getenv("HINDSIGHT_EMBED_DAEMON_STARTUP_TIMEOUT", "180"))
 DEFAULT_DAEMON_IDLE_TIMEOUT = 0  # 0 = disabled (no auto-exit)
+DEFAULT_DAEMON_LOG_MAX_BYTES = 10 * 1024 * 1024
+DEFAULT_DAEMON_LOG_BACKUP_COUNT = 3
+DAEMON_LOG_MAX_BYTES = _parse_non_negative_int_env("HINDSIGHT_EMBED_DAEMON_LOG_MAX_BYTES", DEFAULT_DAEMON_LOG_MAX_BYTES)
+DAEMON_LOG_BACKUP_COUNT = _parse_non_negative_int_env(
+    "HINDSIGHT_EMBED_DAEMON_LOG_BACKUP_COUNT", DEFAULT_DAEMON_LOG_BACKUP_COUNT
+)
 # When another process is concurrently starting the daemon, the TCP port can be
 # bound before /health returns 200. Give that warming daemon a short grace window
 # before treating the listener as stale/foreign and attempting to reclaim it.
@@ -111,6 +126,33 @@ class DaemonEmbedManager(EmbedManager):
     def __init__(self):
         """Initialize the daemon embed manager."""
         self._profile_manager = ProfileManager()
+
+    @staticmethod
+    def _rotate_daemon_log(
+        log_path: Path,
+        max_bytes: int = DAEMON_LOG_MAX_BYTES,
+        backup_count: int = DAEMON_LOG_BACKUP_COUNT,
+    ) -> None:
+        """Rotate a full daemon log before a new daemon opens it.
+
+        Startup is serialized by the profile lock, and this runs only after
+        any stale daemon has been stopped. That keeps child processes from
+        writing to a renamed inode during rotation.
+        """
+        if max_bytes == 0 or not log_path.exists() or log_path.stat().st_size < max_bytes:
+            return
+
+        if backup_count == 0:
+            log_path.unlink()
+            return
+
+        oldest = log_path.with_name(f"{log_path.name}.{backup_count}")
+        oldest.unlink(missing_ok=True)
+        for index in range(backup_count - 1, 0, -1):
+            source = log_path.with_name(f"{log_path.name}.{index}")
+            if source.exists():
+                source.replace(log_path.with_name(f"{log_path.name}.{index + 1}"))
+        log_path.replace(log_path.with_name(f"{log_path.name}.1"))
 
     def _sanitize_profile_name(self, profile: str | None) -> str:
         """Sanitize profile name for use in database names and file paths."""
@@ -527,6 +569,7 @@ class DaemonEmbedManager(EmbedManager):
 
         # Create log directory
         daemon_log.parent.mkdir(parents=True, exist_ok=True)
+        self._rotate_daemon_log(daemon_log)
         env["HINDSIGHT_API_DAEMON_LOG"] = str(daemon_log)
 
         # Build command

--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -53,13 +53,17 @@ def _safe_positive_float(value: float, fallback: float) -> float:
     return value if math.isfinite(value) and value > 0 else fallback
 
 
-def _parse_non_negative_int_env(name: str, default: int) -> int:
-    """Parse a non-negative integer environment variable."""
+def _parse_non_negative_int(value: str | None, default: int, name: str) -> int:
+    """Parse a non-negative integer, falling back for invalid or negative values."""
     try:
-        value = int(os.getenv(name, str(default)))
+        parsed = int(value) if value is not None else default
     except ValueError:
+        logger.warning("Invalid %s=%r; using %d", name, value, default)
         return default
-    return value if value >= 0 else default
+    if parsed < 0:
+        logger.warning("Invalid %s=%r; using %d", name, value, default)
+        return default
+    return parsed
 
 
 # Constants
@@ -70,9 +74,15 @@ DAEMON_STARTUP_TIMEOUT = int(os.getenv("HINDSIGHT_EMBED_DAEMON_STARTUP_TIMEOUT",
 DEFAULT_DAEMON_IDLE_TIMEOUT = 0  # 0 = disabled (no auto-exit)
 DEFAULT_DAEMON_LOG_MAX_BYTES = 10 * 1024 * 1024
 DEFAULT_DAEMON_LOG_BACKUP_COUNT = 3
-DAEMON_LOG_MAX_BYTES = _parse_non_negative_int_env("HINDSIGHT_EMBED_DAEMON_LOG_MAX_BYTES", DEFAULT_DAEMON_LOG_MAX_BYTES)
-DAEMON_LOG_BACKUP_COUNT = _parse_non_negative_int_env(
-    "HINDSIGHT_EMBED_DAEMON_LOG_BACKUP_COUNT", DEFAULT_DAEMON_LOG_BACKUP_COUNT
+DAEMON_LOG_MAX_BYTES = _parse_non_negative_int(
+    os.getenv("HINDSIGHT_EMBED_DAEMON_LOG_MAX_BYTES"),
+    DEFAULT_DAEMON_LOG_MAX_BYTES,
+    "HINDSIGHT_EMBED_DAEMON_LOG_MAX_BYTES",
+)
+DAEMON_LOG_BACKUP_COUNT = _parse_non_negative_int(
+    os.getenv("HINDSIGHT_EMBED_DAEMON_LOG_BACKUP_COUNT"),
+    DEFAULT_DAEMON_LOG_BACKUP_COUNT,
+    "HINDSIGHT_EMBED_DAEMON_LOG_BACKUP_COUNT",
 )
 # When another process is concurrently starting the daemon, the TCP port can be
 # bound before /health returns 200. Give that warming daemon a short grace window
@@ -137,13 +147,14 @@ class DaemonEmbedManager(EmbedManager):
 
         Startup is serialized by the profile lock, and this runs only after
         any stale daemon has been stopped. That keeps child processes from
-        writing to a renamed inode during rotation.
+        writing to a renamed inode during rotation. Rotation only occurs at
+        startup; an already-running daemon is left untouched.
         """
         if max_bytes == 0 or not log_path.exists() or log_path.stat().st_size < max_bytes:
             return
 
         if backup_count == 0:
-            log_path.unlink()
+            log_path.write_bytes(b"")
             return
 
         oldest = log_path.with_name(f"{log_path.name}.{backup_count}")
@@ -569,7 +580,20 @@ class DaemonEmbedManager(EmbedManager):
 
         # Create log directory
         daemon_log.parent.mkdir(parents=True, exist_ok=True)
-        self._rotate_daemon_log(daemon_log)
+        max_bytes = _parse_non_negative_int(
+            env.get("HINDSIGHT_EMBED_DAEMON_LOG_MAX_BYTES"),
+            DAEMON_LOG_MAX_BYTES,
+            "HINDSIGHT_EMBED_DAEMON_LOG_MAX_BYTES",
+        )
+        backup_count = _parse_non_negative_int(
+            env.get("HINDSIGHT_EMBED_DAEMON_LOG_BACKUP_COUNT"),
+            DAEMON_LOG_BACKUP_COUNT,
+            "HINDSIGHT_EMBED_DAEMON_LOG_BACKUP_COUNT",
+        )
+        try:
+            self._rotate_daemon_log(daemon_log, max_bytes=max_bytes, backup_count=backup_count)
+        except OSError as exc:
+            logger.warning("Could not rotate daemon log %s: %s", daemon_log, exc)
         env["HINDSIGHT_API_DAEMON_LOG"] = str(daemon_log)
 
         # Build command

--- a/hindsight-embed/hindsight_embed/profile_manager.py
+++ b/hindsight-embed/hindsight_embed/profile_manager.py
@@ -6,12 +6,15 @@ Each profile has its own config, daemon lock, log file, and port.
 
 import hashlib
 import json
+import logging
 import os
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 # ==============================================================================
 # Cross-platform file locking implementation
@@ -337,11 +340,15 @@ class ProfileManager:
         if lock_path.exists():
             lock_path.unlink()
 
-        # Remove the active log and any retained rotation backups.
+        # Remove the active log and any retained rotation backups. A log that
+        # cannot be removed (still held open on Windows, say) must not abort the
+        # delete and leave the profile half-registered in metadata below.
         log_path = self._get_profiles_dir() / f"{name}.log"
-        for retained_log in log_path.parent.glob(f"{log_path.name}.*"):
-            retained_log.unlink()
-        log_path.unlink(missing_ok=True)
+        for stale_log in [log_path, *log_path.parent.glob(f"{log_path.name}.*")]:
+            try:
+                stale_log.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning("Could not remove log %s while deleting profile '%s': %s", stale_log, name, exc)
 
         # Update metadata
         metadata = self._load_metadata()

--- a/hindsight-embed/hindsight_embed/profile_manager.py
+++ b/hindsight-embed/hindsight_embed/profile_manager.py
@@ -337,10 +337,11 @@ class ProfileManager:
         if lock_path.exists():
             lock_path.unlink()
 
-        # Remove log file
+        # Remove the active log and any retained rotation backups.
         log_path = self._get_profiles_dir() / f"{name}.log"
-        if log_path.exists():
-            log_path.unlink()
+        for retained_log in log_path.parent.glob(f"{log_path.name}.*"):
+            retained_log.unlink()
+        log_path.unlink(missing_ok=True)
 
         # Update metadata
         metadata = self._load_metadata()

--- a/hindsight-embed/tests/test_daemon_client.py
+++ b/hindsight-embed/tests/test_daemon_client.py
@@ -1,15 +1,12 @@
 """Tests for daemon_client module."""
 
-import os
-import subprocess
-from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
 import httpx
 import pytest
 
 from hindsight_embed import daemon_client
-from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
+from hindsight_embed.daemon_embed_manager import DaemonEmbedManager, _parse_non_negative_int
 
 
 @pytest.fixture
@@ -439,10 +436,40 @@ class TestStartDaemonSerialization:
             patch.object(DaemonEmbedManager, "_clear_port", return_value=True),
             patch.object(DaemonEmbedManager, "is_running", return_value=True),
             patch.object(DaemonEmbedManager, "_register_profile"),
+            patch.object(DaemonEmbedManager, "_rotate_daemon_log") as mock_rotate,
             patch("subprocess.Popen") as mock_popen,
         ):
             assert manager._start_daemon_locked({}, "codex", paths) is True
             mock_popen.assert_not_called()
+            mock_rotate.assert_not_called()
+
+    def test_rotation_runs_after_port_clear_and_before_spawn(self, tmp_path, monkeypatch):
+        from hindsight_embed.profile_manager import ProfilePaths
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        manager = DaemonEmbedManager()
+        paths = ProfilePaths(
+            config=tmp_path / "embed", lock=tmp_path / "daemon.lock", log=tmp_path / "daemon.log", port=9600
+        )
+        calls = []
+
+        with (
+            patch.object(DaemonEmbedManager, "_clear_port", side_effect=lambda _: calls.append("clear") or True),
+            patch.object(DaemonEmbedManager, "is_running", side_effect=[False, True, True]),
+            patch.object(
+                DaemonEmbedManager, "_rotate_daemon_log", side_effect=lambda *_args, **_kwargs: calls.append("rotate")
+            ),
+            patch.object(DaemonEmbedManager, "_find_api_command", return_value=["hindsight-api"]),
+            patch.object(DaemonEmbedManager, "_component_version", return_value=None),
+            patch.object(DaemonEmbedManager, "_register_profile"),
+            patch("subprocess.Popen", side_effect=lambda *_args, **_kwargs: calls.append("spawn")),
+            patch("hindsight_embed.daemon_embed_manager.Live"),
+        ):
+            assert manager._start_daemon_locked({}, "codex", paths) is True
+
+        assert calls == ["clear", "rotate", "spawn"]
 
 
 class TestDaemonLogRotation:
@@ -475,4 +502,18 @@ class TestDaemonLogRotation:
 
         DaemonEmbedManager._rotate_daemon_log(log_path, max_bytes=1, backup_count=0)
 
-        assert not log_path.exists()
+        assert log_path.exists()
+        assert log_path.read_bytes() == b""
+
+    def test_zero_max_bytes_disables_rotation(self, tmp_path):
+        log_path = tmp_path / "daemon.log"
+        log_path.write_bytes(b"current")
+
+        DaemonEmbedManager._rotate_daemon_log(log_path, max_bytes=0, backup_count=2)
+
+        assert log_path.read_bytes() == b"current"
+
+    def test_non_negative_int_falls_back_for_invalid_values(self, caplog):
+        assert _parse_non_negative_int("10MB", 42, "LIMIT") == 42
+        assert _parse_non_negative_int("-1", 42, "LIMIT") == 42
+        assert "Invalid LIMIT" in caplog.text

--- a/hindsight-embed/tests/test_daemon_client.py
+++ b/hindsight-embed/tests/test_daemon_client.py
@@ -443,3 +443,36 @@ class TestStartDaemonSerialization:
         ):
             assert manager._start_daemon_locked({}, "codex", paths) is True
             mock_popen.assert_not_called()
+
+
+class TestDaemonLogRotation:
+    """Tests for restart-boundary daemon log rotation."""
+
+    def test_small_log_is_left_in_place(self, tmp_path):
+        log_path = tmp_path / "daemon.log"
+        log_path.write_bytes(b"1234")
+
+        DaemonEmbedManager._rotate_daemon_log(log_path, max_bytes=5, backup_count=2)
+
+        assert log_path.read_bytes() == b"1234"
+        assert not (tmp_path / "daemon.log.1").exists()
+
+    def test_full_log_rotates_and_retention_is_bounded(self, tmp_path):
+        log_path = tmp_path / "daemon.log"
+        log_path.write_bytes(b"current")
+        (tmp_path / "daemon.log.1").write_bytes(b"previous")
+        (tmp_path / "daemon.log.2").write_bytes(b"oldest")
+
+        DaemonEmbedManager._rotate_daemon_log(log_path, max_bytes=7, backup_count=2)
+
+        assert not log_path.exists()
+        assert (tmp_path / "daemon.log.1").read_bytes() == b"current"
+        assert (tmp_path / "daemon.log.2").read_bytes() == b"previous"
+
+    def test_zero_backups_truncates_full_log(self, tmp_path):
+        log_path = tmp_path / "daemon.log"
+        log_path.write_bytes(b"current")
+
+        DaemonEmbedManager._rotate_daemon_log(log_path, max_bytes=1, backup_count=0)
+
+        assert not log_path.exists()

--- a/hindsight-embed/tests/test_profile_manager.py
+++ b/hindsight-embed/tests/test_profile_manager.py
@@ -1,16 +1,12 @@
 """Tests for profile_manager module."""
 
 import json
-import os
-from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
 
 from hindsight_embed.profile_manager import (
-    ProfileInfo,
     ProfileManager,
-    ProfilePaths,
     resolve_active_profile,
     validate_profile_exists,
 )
@@ -119,16 +115,19 @@ class TestProfileManager:
         # Create profile
         profile_manager.create_profile("test-profile", {"KEY": "value"})
         assert profile_manager.profile_exists("test-profile")
+        profiles_dir = temp_hindsight_dir / "profiles"
+        (profiles_dir / "test-profile.log").write_text("current")
+        (profiles_dir / "test-profile.log.1").write_text("retained")
 
         # Delete profile
         profile_manager.delete_profile("test-profile")
         assert not profile_manager.profile_exists("test-profile")
 
         # Verify all files are removed
-        profiles_dir = temp_hindsight_dir / "profiles"
         assert not (profiles_dir / "test-profile.env").exists()
         assert not (profiles_dir / "test-profile.lock").exists()
         assert not (profiles_dir / "test-profile.log").exists()
+        assert not (profiles_dir / "test-profile.log.1").exists()
 
         # Verify metadata no longer contains profile
         metadata_path = profiles_dir / "metadata.json"

--- a/hindsight-embed/tests/test_profile_manager.py
+++ b/hindsight-embed/tests/test_profile_manager.py
@@ -1,6 +1,7 @@
 """Tests for profile_manager module."""
 
 import json
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
@@ -134,6 +135,31 @@ class TestProfileManager:
         if metadata_path.exists():
             metadata = json.loads(metadata_path.read_text())
             assert "test-profile" not in metadata.get("profiles", {})
+
+    def test_delete_profile_survives_undeletable_log(self, profile_manager, temp_hindsight_dir):
+        """An unremovable log (e.g. still open on Windows) must not strand the profile."""
+        profile_manager.create_profile("test-profile", {"KEY": "value"})
+        profiles_dir = temp_hindsight_dir / "profiles"
+        (profiles_dir / "test-profile.log").write_text("current")
+        (profiles_dir / "test-profile.log.1").write_text("retained")
+
+        real_unlink = Path.unlink
+
+        def refuse_active_log(self, **kwargs):
+            if self.name == "test-profile.log":
+                raise PermissionError(32, "The process cannot access the file")
+            return real_unlink(self, **kwargs)
+
+        with patch.object(Path, "unlink", refuse_active_log):
+            profile_manager.delete_profile("test-profile")
+
+        # The locked log stays behind, but everything else is cleaned up and the
+        # profile is fully deregistered rather than left half-deleted.
+        assert (profiles_dir / "test-profile.log").exists()
+        assert not (profiles_dir / "test-profile.log.1").exists()
+        assert not profile_manager.profile_exists("test-profile")
+        metadata = json.loads((profiles_dir / "metadata.json").read_text())
+        assert "test-profile" not in metadata.get("profiles", {})
 
     def test_delete_nonexistent_profile(self, profile_manager):
         """Test deleting a non-existent profile fails."""

--- a/skills/hindsight-docs/references/sdks/embed.md
+++ b/skills/hindsight-docs/references/sdks/embed.md
@@ -123,8 +123,11 @@ The control center runs as a separate process from the memory daemon. Stopping o
 | `HINDSIGHT_EMBED_DAEMON_LOG_BACKUP_COUNT` | Retained backups; `0` truncates a full log at startup | `3` |
 | `HINDSIGHT_EMBED_CONTROL_PORT` | Default port for `hindsight-embed control start` | `7878` |
 
-Peak retained log size is approximately `MAX_BYTES × (BACKUP_COUNT + 1)`, or 40 MiB by default. Rotation
-occurs only when a daemon starts; it does not bound an uninterrupted daemon run.
+The size is checked only when a daemon starts, so a single uninterrupted run is never truncated and can
+grow past `MAX_BYTES` — and at the next start that whole file is kept as the first backup. Retained size
+is therefore around `MAX_BYTES × (BACKUP_COUNT + 1)` (40 MiB by default) only for daemons that restart
+regularly; a daemon left running for weeks (the default, since it never auto-exits) keeps whatever it
+wrote. Restart it, or lower `HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT`, to keep the bound meaningful.
 
 **Provider Examples:**
 

--- a/skills/hindsight-docs/references/sdks/embed.md
+++ b/skills/hindsight-docs/references/sdks/embed.md
@@ -119,7 +119,12 @@ The control center runs as a separate process from the memory daemon. Stopping o
 | `HINDSIGHT_API_LLM_PROVIDER` | LLM provider: `openai`, `anthropic`, `gemini`, `groq`, `minimax`, `ollama` | `openai` |
 | `HINDSIGHT_API_LLM_MODEL` | Model name | `gpt-4o-mini` |
 | `HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT` | Seconds before daemon auto-exits when idle (0 = never) | `0` |
+| `HINDSIGHT_EMBED_DAEMON_LOG_MAX_BYTES` | Rotate the daemon log at startup when it reaches this size; `0` disables rotation | `10485760` (10 MiB) |
+| `HINDSIGHT_EMBED_DAEMON_LOG_BACKUP_COUNT` | Retained backups; `0` truncates a full log at startup | `3` |
 | `HINDSIGHT_EMBED_CONTROL_PORT` | Default port for `hindsight-embed control start` | `7878` |
+
+Peak retained log size is approximately `MAX_BYTES × (BACKUP_COUNT + 1)`, or 40 MiB by default. Rotation
+occurs only when a daemon starts; it does not bound an uninterrupted daemon run.
 
 **Provider Examples:**
 


### PR DESCRIPTION
## Summary

- rotate a full embedded-daemon log before starting a replacement daemon
- keep three 10 MiB backups by default
- allow operators to tune or disable the limit with `HINDSIGHT_EMBED_DAEMON_LOG_MAX_BYTES` and `HINDSIGHT_EMBED_DAEMON_LOG_BACKUP_COUNT`

## Why

The embedded daemon currently reopens the same profile log in append mode across restarts. Long-running profiles can therefore accumulate multi-gigabyte logs. Rotation happens inside the existing per-profile startup lock, after stale-port cleanup and before the new child opens the file, so no live daemon keeps writing to a renamed inode.

## Tests

- `uv run pytest tests/test_daemon_client.py -q` (21 passed)
- `uv run ruff check hindsight_embed/daemon_embed_manager.py`
- `uv run ruff format --check hindsight_embed/daemon_embed_manager.py tests/test_daemon_client.py`
- `uv run ty check hindsight_embed`
- `git diff --check`

The full embed suite reached 148 passed with three pre-existing environment-sensitive command-selection failures: this slim checkout does not install `sentence-transformers`, while those tests expect the sibling binary path. The focused daemon suite and type/style gates are green.

Closes #3164
