### PR TITLE
docs(retain): suggest a distinct document_id per source document

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -620,7 +620,11 @@ class MemoryItem(BaseModel):
     )
     context: str | None = None
     metadata: dict[str, str] | None = None
-    document_id: str | None = Field(default=None, description="Optional document ID for this memory item.")
+    document_id: str | None = Field(
+        default=None,
+        description="Optional document ID for this memory item. Provide a distinct document_id per source "
+        "document — items sharing a document_id are grouped into the same document. Auto-generated when omitted.",
+    )
     entities: list[EntityInput] | None = Field(
         default=None,
         description="Optional entities to combine with auto-extracted entities.",

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -2688,7 +2688,7 @@ export type MemoryItem = {
   /**
    * Document Id
    *
-   * Optional document ID for this memory item.
+   * Optional document ID for this memory item. Provide a distinct document_id per source document — items sharing a document_id are grouped into the same document. Auto-generated when omitted.
    */
   document_id?: string | null;
   /**

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -11021,7 +11021,7 @@
               }
             ],
             "title": "Document Id",
-            "description": "Optional document ID for this memory item."
+            "description": "Optional document ID for this memory item. Provide a distinct document_id per source document \u2014 items sharing a document_id are grouped into the same document. Auto-generated when omitted."
           },
           "entities": {
             "anyOf": [

--- a/skills/hindsight-docs/references/developer/retain.md
+++ b/skills/hindsight-docs/references/developer/retain.md
@@ -67,10 +67,7 @@ The split is decided by **who is speaking**, not by grammar. A first-person stat
 - Agent's own log — "I patched the auth bug" → **experience** (the agent did it).
 - A user talking to the agent — "I bought a Tesla" → **world** (a fact about the *user*, not the agent).
 
-Two things steer this correctly:
-
-- **Set a human-readable bank `name`** (the agent's name). It identifies who "the agent" is. If left unset it defaults to the `bank_id`; a `bank_id` that is a routing key (e.g. `my-agent::channel-456::user-789`) is not a usable speaker name, so give the bank a real name.
-- **Describe the speaker in each item's `context`** when retaining transcripts or third-party content. For a chat log, a context like *"Customer Maria is speaking"* ensures her first-person statements are stored as `world` facts about Maria rather than mistaken for the agent's own experiences. The `context` takes precedence over the bank name when the two disagree.
+**Describe the speaker in each item's `context`** to steer this correctly. When retaining transcripts or third-party content, a context like *"Customer Maria is speaking"* ensures her first-person statements are stored as `world` facts about Maria rather than mistaken for the agent's own experiences. For the agent's own logs, a context like *"The assistant is speaking"* attributes its first-person statements to the agent as `experience` facts.
 
 **Note:** Observations are consolidated automatically in the background after `retain()` operations complete. This consolidation process synthesizes patterns from new facts into the bank's knowledge base.
 

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -9217,7 +9217,8 @@
               }
             ],
             "title": "Agent Name",
-            "description": "Narrator override (memory owner) primed in the prompt."
+            "description": "Deprecated: describe the speaker in `context` instead. Narrator override (memory owner) primed in the prompt; still honored for backwards compatibility.",
+            "deprecated": true
           },
           "retain_mission": {
             "anyOf": [
@@ -11020,7 +11021,7 @@
               }
             ],
             "title": "Document Id",
-            "description": "Optional document ID for this memory item."
+            "description": "Optional document ID for this memory item. Provide a distinct document_id per source document \u2014 items sharing a document_id are grouped into the same document. Auto-generated when omitted."
           },
           "entities": {
             "anyOf": [

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -75,6 +75,39 @@ Adding an agent: hook-based → write a `HookSpec` entry point (see `src/cursor-
 a `hookAdapter` in `src/harness/registry.ts`; persistent-plugin → implement `HarnessAdapter`
 (`src/core/types.ts`) fully (see `src/harness/opencode.ts`).
 
+## Migrating from the per-agent plugins
+
+The older per-agent integrations (`hindsight-claude-code`, `hindsight-cursor-cli`, `hindsight-codex`, …) are superseded by this package. Their memory does **not** carry over automatically, and it cannot be merged:
+
+- They scope a bank **per agent per project** (`claude-code::myrepo`); this package uses one **per repo** (`coding-agent::myrepo`) so every agent shares it. Two old banks map onto one new one.
+- The server restores a whole bank rather than merging into an existing one, so the old bank can't be folded in.
+
+Instead, re-import the conversations the agent already wrote to disk — they get re-extracted into the current bank:
+
+```bash
+cd /path/to/your/repo
+hindsight-coding-agents install claude-code --import-conversations
+```
+
+**How sessions are matched.** A conversation is imported only when the session itself records the
+directory it ran in — never inferred from a file or folder name. Claude Code writes that directory
+on its entries and Codex in its `session_meta` header, so both can be attributed exactly, including
+sessions started in a subdirectory of the repo. Guessing was tempting (Claude names its history
+folders after the project path) but unsafe: `/` and `.` both encode to `-`, so `repo-sub` is either
+the subdirectory `repo/sub` or an unrelated sibling repo — and a wrong guess files someone else's
+conversation into your bank. Sessions that record nothing are skipped and the count is reported.
+The other harnesses (opencode, Kilo, Cursor, Cline, Copilot, Devin) keep history in internal SQLite
+databases with unversioned schemas and are skipped with a reason.
+
+The import is scoped to the **current repo**, safe to re-run (ingestion dedups by document id), and
+runs extraction — so it costs tokens roughly in proportion to the history imported.
+
+Prefer to keep the old bank instead? Point this package at it — no data moves:
+
+```jsonc
+{ "bankIdTemplate": "{harness}::{gitProject}" } // reproduces the old per-agent naming
+```
+
 ## How it works
 
 **Ingestion — automatic, no command to run**


### PR DESCRIPTION
## Summary

Addresses #3010 by **documenting** the item-level `document_id` semantics rather than changing behavior.

- Clarifies the `MemoryItem.document_id` field description: items sharing a `document_id` are grouped into the same document, so callers should provide a distinct id per source document (auto-generated when omitted).
- Regenerates the OpenAPI spec so the guidance surfaces in the API reference and generated clients.

No behavior change. Mixed explicit/implicit `document_id` batches remain accepted for backwards compatibility.

## Why not reject mixed batches?

#3010 proposed enforcing a one-item/one-document invariant (and #3152 implemented rejecting mixed batches). That's a breaking change for existing callers who rely on grouping. Instead, this PR keeps the current behavior and just steers callers toward a distinct id per document via a short note in the field docs.

Closes #3010