### PR TITLE
fix(retain): unify OutputTooLongError so #2579 output auto-split actually runs

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -29,7 +29,14 @@ from ..config import (
     ENV_REFLECT_LLM_MAX_CONCURRENT,
     ENV_RETAIN_LLM_MAX_CONCURRENT,
 )
-from .llm_interface import LLM_TOOL_CHOICE_AUTO, LLMToolChoice, LLMToolChoiceMode
+from .llm_interface import (
+    LLM_TOOL_CHOICE_AUTO,
+    LLMToolChoice,
+    LLMToolChoiceMode,
+)
+from .llm_interface import (
+    OutputTooLongError as OutputTooLongError,
+)
 
 if TYPE_CHECKING:
     from .response_models import LLMToolCallResult
@@ -164,16 +171,11 @@ def sanitize_text(text: str | None) -> str | None:
 sanitize_llm_output = sanitize_text
 
 
-class OutputTooLongError(Exception):
-    """
-    Bridge exception raised when LLM output exceeds token limits.
-
-    This wraps provider-specific errors (e.g., OpenAI's LengthFinishReasonError)
-    to allow callers to handle output length issues without depending on
-    provider-specific implementations.
-    """
-
-    pass
+# ``OutputTooLongError`` is re-exported from ``llm_interface`` (the canonical
+# definition the providers raise) so that ``fact_extraction`` and ``multi_llm``,
+# which import it from here, catch/inspect the very same class. Do NOT redefine
+# it locally: a shadow class silently breaks ``except OutputTooLongError`` on the
+# real provider path (see issue #3172).
 
 
 def parse_llm_json(raw: str) -> Any:

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -236,10 +236,20 @@ class FactExtractionResponse(BaseModel):
     facts: list[ExtractedFact] = Field(description="List of extracted factual statements")
 
 
+# Below this size, splitting an over-long chunk further cannot help: if a chunk
+# this small still overflows the model's output cap, the cause is degenerate or
+# looping model output rather than genuinely dense input, and halving it just
+# recurses toward a single character. A few-hundred-character floor bounds that
+# runaway (an all-sizes-overflow 3000-char chunk drops in ~17 extraction calls
+# instead of ~5000) while staying well under any chunk that legitimately holds
+# enough facts to exceed the cap.
+_MIN_SPLIT_CHUNK_CHARS = 500
+
+
 def _split_chunk_for_output_retry(chunk: str) -> tuple[str, str] | None:
     """Split an oversized extraction chunk without corrupting structured input."""
     stripped = chunk.strip()
-    if len(stripped) <= 1:
+    if len(stripped) <= _MIN_SPLIT_CHUNK_CHARS:
         return None
 
     try:

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -20,11 +20,13 @@ def test_output_retry_split_preserves_conversation_array_boundaries():
     """OutputTooLong retry splitting must keep conversation chunks valid JSON arrays."""
     from hindsight_api.engine.retain.fact_extraction import _split_chunk_for_output_retry
 
+    # Contents are padded so the array clears the minimum-split floor and the
+    # boundary-preserving branch (not the drop-when-too-small guard) is exercised.
     turns = [
-        {"role": "user", "content": "alpha"},
-        {"role": "assistant", "content": "bravo"},
-        {"role": "user", "content": "charlie"},
-        {"role": "assistant", "content": "delta"},
+        {"role": "user", "content": "alpha " * 40},
+        {"role": "assistant", "content": "bravo " * 40},
+        {"role": "user", "content": "charlie " * 40},
+        {"role": "assistant", "content": "delta " * 40},
     ]
 
     split = _split_chunk_for_output_retry(json.dumps(turns))
@@ -39,7 +41,9 @@ def test_output_retry_split_divides_single_oversized_turn_content():
     """A lone oversized conversation turn is split inside content and rewrapped."""
     from hindsight_api.engine.retain.fact_extraction import _split_chunk_for_output_retry
 
-    turn = {"role": "user", "content": "abcdefghijklmnopqrstuvwxyz", "name": "casey"}
+    # Content must exceed the minimum-split floor for the single-turn branch to
+    # divide it rather than drop the sub-chunk outright.
+    turn = {"role": "user", "content": "abcdefghijklmnopqrstuvwxyz" * 40, "name": "casey"}
 
     split = _split_chunk_for_output_retry(json.dumps([turn]))
 
@@ -60,6 +64,44 @@ def test_output_retry_split_returns_none_when_no_progress_possible():
 
     assert _split_chunk_for_output_retry("x") is None
     assert _split_chunk_for_output_retry(json.dumps([{"role": "user", "content": ""}])) is None
+
+
+def test_output_too_long_error_is_a_single_class_across_modules():
+    """Regression for #3172.
+
+    ``OutputTooLongError`` must be one class everywhere: the providers raise the
+    ``llm_interface`` definition, and ``fact_extraction`` / ``multi_llm`` catch
+    the name they import from ``llm_wrapper``. If ``llm_wrapper`` shadows it with
+    a second definition, ``except OutputTooLongError`` silently stops matching
+    what the providers raise and the #2579 auto-split becomes dead code.
+    """
+    from hindsight_api.engine import llm_interface, llm_wrapper, multi_llm
+    from hindsight_api.engine.providers import litellm_llm, openai_compatible_llm
+    from hindsight_api.engine.retain import fact_extraction
+
+    canonical = llm_interface.OutputTooLongError
+    assert llm_wrapper.OutputTooLongError is canonical
+    assert fact_extraction.OutputTooLongError is canonical
+    assert multi_llm.OutputTooLongError is canonical
+    assert litellm_llm.OutputTooLongError is canonical
+    assert openai_compatible_llm.OutputTooLongError is canonical
+
+
+def test_output_retry_split_drops_subchunk_below_minimum_floor():
+    """A chunk at/under the minimum-split floor is dropped, not recursively halved.
+
+    Without this floor a chunk that overflows the output cap at *every* size
+    (degenerate/looping model output) would recurse until it is a single
+    character, burning thousands of extraction calls (#3172).
+    """
+    from hindsight_api.engine.retain.fact_extraction import (
+        _MIN_SPLIT_CHUNK_CHARS,
+        _split_chunk_for_output_retry,
+    )
+
+    assert _split_chunk_for_output_retry("a" * _MIN_SPLIT_CHUNK_CHARS) is None
+    # Just over the floor still splits.
+    assert _split_chunk_for_output_retry("a. " * ((_MIN_SPLIT_CHUNK_CHARS // 3) + 5)) is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`OutputTooLongError` was defined **twice** as unrelated classes:

| Definition | Who uses it |
|---|---|
| `engine/llm_interface.py` (canonical) | **raised** by `litellm_llm`, `openai_compatible_llm`, `openai_responses_llm` |
| `engine/llm_wrapper.py` (shadow) | **caught/inspected** by `retain/fact_extraction.py` and `multi_llm.py` |

Since `llm_wrapper` shadowed the name instead of importing it, `except OutputTooLongError` in `_extract_facts_with_auto_split` could never match what the providers actually raise. Consequences (per #3172):

1. **PR #2579's output-too-long auto-split was dead code on the real path.** An over-long chunk propagated out, landed in `failed_chunks`, and triggered the all-or-nothing failure — every successfully-extracted chunk in that retain was discarded, and the poller retried the whole task (which fails the same way deterministically).
2. **`multi_llm._should_failover`** did `isinstance(exc, OutputTooLongError)` against the shadow class → returned `False` → inverted its documented intent, so the cascade *did* fail over and burned an extra provider call that can't fit an over-length output either.

## Fix

- **Re-export the canonical class** from `llm_wrapper` (`from .llm_interface import OutputTooLongError as OutputTooLongError`) and delete the shadow definition. All catch/inspect sites now bind to the exact object providers raise. This is the issue's preferred fix and adds no new import edge (`llm_wrapper` already imports from `llm_interface`).
- **Bound the now-reachable recursion.** With the split path live, `_split_chunk_for_output_retry`'s `len(stripped) <= 1` floor became load-bearing: content that overflows the output cap at *every* size (degenerate/looping model output) recursed toward a single character (~5000 extraction calls). A `_MIN_SPLIT_CHUNK_CHARS = 500` floor drops such a sub-chunk in ~17 calls instead, while staying well under any chunk that legitimately holds enough facts to exceed the cap.

## Tests

- `test_output_too_long_error_is_a_single_class_across_modules` — locks the identity across `llm_interface`/`llm_wrapper`/`fact_extraction`/`multi_llm`/providers so this can't regress.
- `test_output_retry_split_drops_subchunk_below_minimum_floor` — verifies the floor drops rather than recurses.
- Existing splitter mechanics tests padded above the floor; the existing `_should_failover` tests now genuinely exercise the real class (they were previously self-consistent against the shadow).

Fixes #3172
