### PR TITLE
fix(coding-agents): read Devin's transcript with node:sqlite, and refuse to install without it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
       integrations-composio: ${{ steps.filter.outputs.integrations-composio }}
       integrations-chat: ${{ steps.filter.outputs.integrations-chat }}
       integrations-claude-code: ${{ steps.filter.outputs.integrations-claude-code }}
+      integrations-coding-agents: ${{ steps.filter.outputs.integrations-coding-agents }}
       integrations-cline: ${{ steps.filter.outputs.integrations-cline }}
       integrations-codex: ${{ steps.filter.outputs.integrations-codex }}
       integrations-github-copilot: ${{ steps.filter.outputs.integrations-github-copilot }}

--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -47,10 +47,15 @@ Same command, only the harness name changes. Run after installing the package gl
 | GitHub Copilot CLI | `hindsight-coding-agents install copilot-cli` | `~/.copilot/hooks/` + `mcp-config.json` + skill                                                  |
 | Grok Build         | `hindsight-coding-agents install grok-build`  | native hooks + MCP in `~/.grok/config.toml` + skill                                              |
 | Antigravity CLI    | `hindsight-coding-agents install agy`         | lifecycle hooks + MCP + the `Hindsight · <bank>` status line                                     |
-| Devin CLI          | `hindsight-coding-agents install devin-cli`   | hooks in `~/.config/devin/config.json` + MCP                                                     |
+| Devin CLI          | `hindsight-coding-agents install devin-cli`   | hooks in `~/.config/devin/config.json` + MCP (needs Node 22.5+, see below)                       |
 | Cline CLI          | `hindsight-coding-agents install cline-cli`   | native plugin via `cline plugin install` + MCP + skill                                           |
 
 Uninstall the same way: `hindsight-coding-agents uninstall claude-code` (or `uninstall all`).
+
+**Devin CLI needs Node 22.5 or newer.** Its hooks pass only a session id — the conversation itself
+lives in `~/.local/share/devin/cli/sessions.db` — so reading it depends on Node's built-in
+`node:sqlite`. Installing `devin-cli` checks for this first and refuses (with the reason) rather
+than wiring hooks that could never retain anything. Every other agent works on any supported Node.
 
 Install globally (not `npx`): the wiring points at this package's files, so it must live at a
 stable path — the installer refuses to run from an npx cache. **Updating** is just

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -39,10 +39,15 @@ Same command, only the harness name changes. Run after installing the package gl
 | GitHub Copilot CLI | `hindsight-coding-agents install copilot-cli` | `~/.copilot/hooks/` + `mcp-config.json` + skill                                                  |
 | Grok Build         | `hindsight-coding-agents install grok-build`  | native hooks + MCP in `~/.grok/config.toml` + skill                                              |
 | Antigravity CLI    | `hindsight-coding-agents install agy`         | lifecycle hooks + MCP + the `Hindsight · <bank>` status line                                     |
-| Devin CLI          | `hindsight-coding-agents install devin-cli`   | hooks in `~/.config/devin/config.json` + MCP                                                     |
+| Devin CLI          | `hindsight-coding-agents install devin-cli`   | hooks in `~/.config/devin/config.json` + MCP (needs Node 22.5+, see below)                       |
 | Cline CLI          | `hindsight-coding-agents install cline-cli`   | native plugin via `cline plugin install` + MCP + skill                                           |
 
 Uninstall the same way: `hindsight-coding-agents uninstall claude-code` (or `uninstall all`).
+
+**Devin CLI needs Node 22.5 or newer.** Its hooks pass only a session id — the conversation itself
+lives in `~/.local/share/devin/cli/sessions.db` — so reading it depends on Node's built-in
+`node:sqlite`. Installing `devin-cli` checks for this first and refuses (with the reason) rather
+than wiring hooks that could never retain anything. Every other agent works on any supported Node.
 
 Install globally (not `npx`): the wiring points at this package's files, so it must live at a
 stable path — the installer refuses to run from an npx cache. **Updating** is just

--- a/hindsight-integrations/coding-agents/src/core/transcript-devin.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript-devin.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { parseDevinMessages } from "./transcript-devin";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { devinSessionDb, parseDevinMessages, readDevinTranscript } from "./transcript-devin";
 
 describe("parseDevinMessages", () => {
   it("uses the final streamed assistant update", () => {
@@ -30,5 +34,110 @@ describe("parseDevinMessages", () => {
       { role: "user", content: "Explain this repo" },
       { role: "assistant", content: "Complete answer" },
     ]);
+  });
+});
+
+/**
+ * The SQLite read path itself, which used to shell out to an undeclared `sqlite3` binary and return
+ * an empty transcript on every failure (#3125). Skipped rather than failed on a Node without
+ * `node:sqlite` — that is precisely the environment the installer preflight now refuses.
+ */
+const sqlite = (() => {
+  try {
+    return createRequire(import.meta.url)("node:sqlite") as {
+      DatabaseSync: new (path: string) => {
+        exec(sql: string): void;
+        prepare(sql: string): { run(...params: unknown[]): void };
+        close(): void;
+      };
+    };
+  } catch {
+    return undefined;
+  }
+})();
+
+describe.skipIf(!sqlite)("readDevinTranscript", () => {
+  let dir: string;
+  let dbPath: string;
+  let diagFile: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "hindsight-devin-"));
+    dbPath = join(dir, "sessions.db");
+    diagFile = join(dir, "diag.log");
+    process.env.HINDSIGHT_DIAG_FILE = diagFile;
+  });
+
+  afterEach(() => {
+    delete process.env.HINDSIGHT_DIAG_FILE;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function seed(rows: Array<{ node_id: number; session_id: string; chat_message: string }>): void {
+    const db = new sqlite!.DatabaseSync(dbPath);
+    db.exec("CREATE TABLE message_nodes (node_id INTEGER, session_id TEXT, chat_message TEXT)");
+    const insert = db.prepare("INSERT INTO message_nodes VALUES (?, ?, ?)");
+    for (const row of rows) {
+      insert.run(row.node_id, row.session_id, row.chat_message);
+    }
+    db.close();
+  }
+
+  it("reads the conversation for one session", () => {
+    seed([
+      {
+        node_id: 1,
+        session_id: "s1",
+        chat_message: JSON.stringify({ message_id: "u", role: "user", content: "hi" }),
+      },
+      {
+        node_id: 2,
+        session_id: "s1",
+        chat_message: JSON.stringify({ message_id: "a", role: "assistant", content: "hello" }),
+      },
+      {
+        node_id: 3,
+        session_id: "other",
+        chat_message: JSON.stringify({ message_id: "x", role: "user", content: "not mine" }),
+      },
+    ]);
+    expect(readDevinTranscript("s1", dbPath)).toEqual([
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello" },
+    ]);
+  });
+
+  // The session id reaches SQLite as a bound parameter, so a quote in it can't terminate the
+  // string literal the way the previous hand-escaped `sqlite3` command line could.
+  it("binds the session id instead of interpolating it", () => {
+    seed([
+      {
+        node_id: 1,
+        session_id: "s'1",
+        chat_message: JSON.stringify({ message_id: "u", role: "user", content: "quoted" }),
+      },
+    ]);
+    expect(readDevinTranscript("s'1", dbPath)).toEqual([{ role: "user", content: "quoted" }]);
+  });
+
+  // Regression for #3125: an unreadable database must be DISTINGUISHABLE from an idle session,
+  // both returning [] but only one leaving a trace.
+  it("reports a missing database rather than looking idle", () => {
+    expect(readDevinTranscript("s1", join(dir, "absent.db"))).toEqual([]);
+    expect(readFileSync(diagFile, "utf8")).toContain("session_db_missing");
+  });
+
+  it("reports a schema change rather than looking idle", () => {
+    const db = new sqlite!.DatabaseSync(dbPath);
+    db.exec("CREATE TABLE renamed_in_a_future_release (node_id INTEGER)");
+    db.close();
+    expect(readDevinTranscript("s1", dbPath)).toEqual([]);
+    expect(readFileSync(diagFile, "utf8")).toContain("session_db_read_failed");
+  });
+});
+
+describe("devinSessionDb", () => {
+  it("resolves under the given home", () => {
+    expect(devinSessionDb("/home/x")).toBe("/home/x/.local/share/devin/cli/sessions.db");
   });
 });

--- a/hindsight-integrations/coding-agents/src/core/transcript-devin.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript-devin.ts
@@ -1,10 +1,15 @@
-import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { TransportTurn } from "./chat";
+import { diag } from "./diag";
 import { stripInjectedMemory } from "./transcript-util";
 
-const sessionDb = join(homedir(), ".local", "share", "devin", "cli", "sessions.db");
+/** Where the Devin CLI persists its conversations. Resolved per call so tests can point elsewhere. */
+export function devinSessionDb(home = homedir()): string {
+  return join(home, ".local", "share", "devin", "cli", "sessions.db");
+}
 
 interface DevinMessageNode {
   node_id: number;
@@ -43,23 +48,79 @@ export function parseDevinMessages(nodes: DevinMessageNode[]): TransportTurn[] {
     .map(({ role, content }) => ({ role, content }));
 }
 
-/** Devin hooks provide no transcript path, but the local CLI persists its full conversation in
- * sessions.db. Use sqlite3 as a read-only bridge to avoid a native Node dependency in hook bundles. */
-export function readDevinTranscript(sessionId: string | undefined): TransportTurn[] {
-  if (!sessionId) return [];
+interface SqliteStatement {
+  all(...params: unknown[]): DevinMessageNode[];
+}
+interface SqliteDatabase {
+  prepare(sql: string): SqliteStatement;
+  close(): void;
+}
+type DatabaseCtor = new (path: string, options?: { readOnly?: boolean }) => SqliteDatabase;
+
+const requireBuiltin = createRequire(import.meta.url);
+
+/**
+ * Resolve Node's built-in SQLite, lazily and on the Devin path only.
+ *
+ * `node:sqlite` ships with Node — nothing to install, nothing to bundle — but it does not exist
+ * before 22.5 and is flag-gated in early 22.x. A static import would therefore throw at MODULE
+ * LOAD, and this module is pulled in by hook-lifecycle, which every harness shares: an old Node
+ * would take Claude Code and Codex down with it. Resolving inside the call keeps the blast radius
+ * to Devin, where the failure is real.
+ *
+ * This previously shelled out to the `sqlite3` BINARY to avoid a native npm dependency
+ * (better-sqlite3). The builtin removes both — and the binary was an undeclared prerequisite whose
+ * absence silently produced an empty transcript (#3125).
+ */
+function loadSqlite(): DatabaseCtor | undefined {
   try {
-    const quotedId = sessionId.replace(/'/g, "''");
-    const raw = execFileSync(
-      "sqlite3",
-      [
-        "-json",
-        sessionDb,
-        `SELECT node_id, chat_message FROM message_nodes WHERE session_id = '${quotedId}' ORDER BY node_id`,
-      ],
-      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 2000 }
-    );
-    return parseDevinMessages(JSON.parse(raw) as DevinMessageNode[]);
+    return (requireBuiltin("node:sqlite") as { DatabaseSync: DatabaseCtor }).DatabaseSync;
   } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Devin hooks provide no transcript path — only a session id — so the conversation has to come from
+ * the CLI's own sessions.db.
+ *
+ * Every failure below is reported through `diag`. An empty array used to be returned for a missing
+ * reader, an absent database and a genuinely idle session alike, which made a permanently
+ * memory-less install indistinguishable from one that simply had nothing to retain yet (#3125).
+ */
+export function readDevinTranscript(
+  sessionId: string | undefined,
+  dbPath = devinSessionDb()
+): TransportTurn[] {
+  if (!sessionId) return [];
+  const Database = loadSqlite();
+  if (!Database) {
+    diag("devin-cli", "sqlite_unavailable", { node: process.version, dbPath });
     return [];
+  }
+  if (!existsSync(dbPath)) {
+    diag("devin-cli", "session_db_missing", { dbPath });
+    return [];
+  }
+  let db: SqliteDatabase | undefined;
+  try {
+    db = new Database(dbPath, { readOnly: true });
+    const rows = db
+      .prepare(
+        "SELECT node_id, chat_message FROM message_nodes WHERE session_id = ? ORDER BY node_id"
+      )
+      .all(sessionId);
+    return parseDevinMessages(rows);
+  } catch (error) {
+    // A corrupt file or a Devin storage-schema change surfaces here instead of masquerading as an
+    // empty conversation.
+    diag("devin-cli", "session_db_read_failed", { dbPath, error: String(error) });
+    return [];
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      /* the read already succeeded or was reported; a close failure adds nothing */
+    }
   }
 }

--- a/hindsight-integrations/coding-agents/src/installer.test.ts
+++ b/hindsight-integrations/coding-agents/src/installer.test.ts
@@ -14,6 +14,7 @@ const homes: string[] = [];
 function makeCtx(): InstallCtx & {
   claudeMcp: ReturnType<typeof vi.fn>;
   clinePlugin: ReturnType<typeof vi.fn>;
+  nodeSqlite: ReturnType<typeof vi.fn>;
 } {
   const home = mkdtempSync(join(tmpdir(), "hindsight-installer-test-"));
   homes.push(home);
@@ -24,6 +25,8 @@ function makeCtx(): InstallCtx & {
     dist: join(pkgRoot, "dist"),
     claudeMcp: vi.fn(() => true),
     clinePlugin: vi.fn(() => true),
+    // Stubbed like the CLI seams above, so the suite never depends on the Node running it.
+    nodeSqlite: vi.fn(() => true),
   };
 }
 
@@ -668,5 +671,54 @@ describe("skill install across skills-capable hosts", () => {
     }
     rmSync(home, { recursive: true, force: true });
     rmSync(pkgRoot, { recursive: true, force: true });
+  });
+});
+
+/**
+ * Devin is the only harness that cannot fall back to a transcript file: its hooks pass a session id
+ * and the conversation lives in a SQLite database. Without `node:sqlite` the install used to
+ * succeed and then retain nothing, forever (#3125).
+ */
+describe("devin-cli preflight", () => {
+  it("refuses to install when the hook node can't read SQLite", () => {
+    const ctx = makeCtx();
+    ctx.nodeSqlite = vi.fn(() => false);
+    const logs: string[] = [];
+    ctx.log = (m) => logs.push(m);
+
+    expect(run(["install", "devin-cli"], ctx)).toBe(1);
+    // Nothing written: a blocked harness must leave the machine untouched.
+    expect(existsSync(join(ctx.home, ".config", "devin", "config.json"))).toBe(false);
+    const output = logs.join("\n");
+    expect(output).toContain("node:sqlite");
+    expect(output).toContain("Node 22.5");
+    expect(output).not.toContain("✅ installed");
+  });
+
+  it("installs normally when SQLite is available", () => {
+    const ctx = makeCtx();
+    expect(run(["install", "devin-cli"], ctx)).toBe(0);
+    expect(existsSync(join(ctx.home, ".config", "devin", "config.json"))).toBe(true);
+    expect(ctx.nodeSqlite).toHaveBeenCalled();
+  });
+
+  it("blocks only the failing harness, still wiring the rest", () => {
+    const ctx = makeCtx();
+    ctx.nodeSqlite = vi.fn(() => false);
+    const logs: string[] = [];
+    ctx.log = (m) => logs.push(m);
+
+    // Non-zero exit so a script notices, but Claude Code is still set up.
+    expect(run(["install", "claude-code", "devin-cli"], ctx)).toBe(1);
+    expect(existsSync(join(ctx.home, ".claude", "settings.json"))).toBe(true);
+    expect(existsSync(join(ctx.home, ".config", "devin", "config.json"))).toBe(false);
+    expect(logs.join("\n")).toContain("not installed: devin-cli");
+  });
+
+  it("does not block uninstall", () => {
+    const ctx = makeCtx();
+    run(["install", "devin-cli"], ctx);
+    ctx.nodeSqlite = vi.fn(() => false);
+    expect(run(["uninstall", "devin-cli"], ctx)).toBe(0);
   });
 });

--- a/hindsight-integrations/coding-agents/src/installer.ts
+++ b/hindsight-integrations/coding-agents/src/installer.ts
@@ -58,6 +58,8 @@ export interface InstallCtx {
   claudeMcp?: (args: string[]) => boolean;
   /** Runs `cline plugin ...`; injectable for tests. Returns false when the CLI isn't usable. */
   clinePlugin?: (args: string[]) => boolean;
+  /** Reports whether `node:sqlite` works in the node that runs hooks; injectable for tests. */
+  nodeSqlite?: () => boolean;
   log?: (m: string) => void;
 }
 
@@ -171,6 +173,12 @@ function uninstallSkill(c: InstallCtx, skillsBase: string): void {
 export interface HarnessInstaller {
   name: string;
   detect(ctx: InstallCtx): boolean;
+  /**
+   * Blocking environment check, run before anything is written. Returns the reason when this
+   * machine cannot support the harness, so a doomed setup fails at install time instead of
+   * reporting success and then never retaining anything.
+   */
+  preflight?(ctx: InstallCtx): string | undefined;
   install(ctx: InstallCtx): void;
   uninstall(ctx: InstallCtx): void;
 }
@@ -506,9 +514,46 @@ const antigravity: HarnessInstaller = {
   },
 };
 
+/**
+ * Probe the `node` on PATH — not this process — because that is the interpreter the installed hook
+ * command (`node "<dist>/devin-stop-hook.js"`) will actually run under. An installer started through
+ * npx, a version manager or a wrapper script is easily a different build than the one the agent
+ * later uses. `-e` runs as CommonJS regardless of the surrounding package type, so `require` here
+ * is safe.
+ */
+function pathNodeHasSqlite(): boolean {
+  try {
+    execFileSync("node", ["-e", "require('node:sqlite')"], { stdio: "pipe", timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pathNodeVersion(): string {
+  try {
+    return execFileSync("node", ["-v"], { encoding: "utf8", stdio: "pipe" }).trim();
+  } catch {
+    return "not found";
+  }
+}
+
 const devin: HarnessInstaller = {
   name: "devin-cli",
   detect: (c) => onPath("devin") || existsSync(join(c.home, ".config", "devin")),
+  // Devin is the ONLY harness whose hooks never hand over a transcript: they carry a session id and
+  // nothing else, so retain can only work by reading the CLI's own sessions.db. That makes SQLite
+  // support a hard prerequisite here — and one worth checking now, because the alternative is an
+  // install that looks perfectly healthy and stores nothing, forever (#3125).
+  preflight(c) {
+    if ((c.nodeSqlite ?? pathNodeHasSqlite)()) return undefined;
+    return (
+      `\`node:sqlite\` is unavailable in the \`node\` on PATH (${pathNodeVersion()}).\n` +
+      `   Devin keeps its conversations in ~/.local/share/devin/cli/sessions.db and its hooks pass\n` +
+      `   only a session id, so without SQLite nothing could ever be retained.\n` +
+      `   Upgrade to Node 22.5 or newer (24 LTS recommended) and re-run this command.`
+    );
+  },
   install(c) {
     const configPath = join(c.home, ".config", "devin", "config.json");
     const config = readJson(configPath);
@@ -856,9 +901,28 @@ export function run(argv: string[], ctx: InstallCtx): number {
     );
     return 1;
   }
-  for (const t of targets) t[command](ctx);
+  // Preflight runs BEFORE any config is written, and only blocks the harness that failed: on
+  // `install all` the other agents are still worth wiring. The non-zero exit keeps the failure
+  // visible to whatever script invoked this.
+  const blocked = new Set<string>();
+  if (command === "install") {
+    for (const t of targets) {
+      const problem = t.preflight?.(ctx);
+      if (!problem) continue;
+      ctx.log?.(`\n❌ ${t.name}: ${problem}`);
+      blocked.add(t.name);
+    }
+  }
+  const runnable = targets.filter((t) => !blocked.has(t.name));
+  for (const t of runnable) t[command](ctx);
   if (command === "install" && importHistory) {
-    for (const t of targets) importConversations(t.name, ctx);
+    for (const t of runnable) importConversations(t.name, ctx);
+  }
+  if (blocked.size) {
+    ctx.log?.(
+      `\n❌ not installed: ${[...blocked].join(", ")} — this machine can't run ${blocked.size > 1 ? "them" : "it"} (see above).`
+    );
+    return 1;
   }
   ctx.log?.(
     command === "install"

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -574,6 +574,7 @@ server-level only (not overridable per tenant/bank) and a change requires a rest
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_API_EMBEDDINGS_PROVIDER` | Provider: `local`, `onnx`, `tei`, `openai`, `openai-codex`, `openrouter`, `requesty`, `cohere`, `google`, `zeroentropy`, `litellm`, or `litellm-sdk` | `local` |
+| `HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS` | Applies to **every** provider. If set, truncate each text to this many tokens (tiktoken `cl100k_base`, approximate) before embedding. Set it to the model's real input limit (e.g. `8192` for Bedrock Titan V2, or a llama.cpp server's context, with a little headroom) so oversized content is truncated instead of failing the embed call permanently. Off by default. (Deprecated alias: `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS`.) | - |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL` | Model for local provider | `BAAI/bge-small-en-v1.5` |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_TRUST_REMOTE_CODE` | Allow loading models with custom code (security risk, disabled by default) | `false` |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU` | Force CPU mode for local embeddings (avoids MPS/XPC issues on macOS) | `false` |
@@ -618,7 +619,6 @@ server-level only (not overridable per tenant/bank) and a change requires a rest
 | `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_API_BASE` | Custom base URL for LiteLLM SDK embeddings (optional) | - |
 | `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_OUTPUT_DIMENSIONS` | Optional output embedding dimensions (provider-dependent, e.g., `768` for Gemini embedding models) | - |
 | `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_ENCODING_FORMAT` | Encoding format for embedding responses. Set to empty string to omit the parameter (needed for Voyage AI, Gemini). | `float` |
-| `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS` | If set, truncate each text to this many tokens (tiktoken `cl100k_base`, approximate) before embedding. Set it to the model's real input limit (e.g. `8192` for Bedrock Titan V2, with a little headroom) so oversized content is truncated instead of failing the embed call permanently. Off by default. | - |
 | `HINDSIGHT_API_EMBEDDINGS_GEMINI_API_KEY` | Gemini API key for embeddings (falls back to `HINDSIGHT_API_LLM_API_KEY`) | - |
 | `HINDSIGHT_API_EMBEDDINGS_GEMINI_MODEL` | Gemini embedding model. The `gemini-embedding-2` family (e.g. `gemini-embedding-2-preview`) is supported on both the Gemini API and Vertex AI — because these multimodal models aggregate a multi-input request into one embedding, Hindsight automatically embeds one input per call to keep per-fact vectors. | `gemini-embedding-001` |
 | `HINDSIGHT_API_EMBEDDINGS_GEMINI_OUTPUT_DIMENSIONALITY` | Output embedding dimensions (Gemini supports configurable dimensionality) | `768` |
@@ -835,8 +835,9 @@ export HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_API_KEY=your-provider-api-key
 export HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MODEL=cohere/embed-english-v3.0
 # Optional: request a specific output dimension when the provider supports it
 # export HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_OUTPUT_DIMENSIONS=768
-# Optional: truncate oversized inputs to the model's input-token limit (e.g. Bedrock Titan V2)
-# export HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS=8192
+# Optional (any provider): truncate oversized inputs to the model's input-token limit
+# (e.g. Bedrock Titan V2, or a llama.cpp server's context)
+# export HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS=8192
 
 # Supported LiteLLM SDK embedding providers:
 # - cohere/embed-english-v3.0 (1024 dimensions)

--- a/skills/hindsight-docs/references/developer/retain.md
+++ b/skills/hindsight-docs/references/developer/retain.md
@@ -67,10 +67,7 @@ The split is decided by **who is speaking**, not by grammar. A first-person stat
 - Agent's own log — "I patched the auth bug" → **experience** (the agent did it).
 - A user talking to the agent — "I bought a Tesla" → **world** (a fact about the *user*, not the agent).
 
-Two things steer this correctly:
-
-- **Set a human-readable bank `name`** (the agent's name). It identifies who "the agent" is. If left unset it defaults to the `bank_id`; a `bank_id` that is a routing key (e.g. `my-agent::channel-456::user-789`) is not a usable speaker name, so give the bank a real name.
-- **Describe the speaker in each item's `context`** when retaining transcripts or third-party content. For a chat log, a context like *"Customer Maria is speaking"* ensures her first-person statements are stored as `world` facts about Maria rather than mistaken for the agent's own experiences. The `context` takes precedence over the bank name when the two disagree.
+**Describe the speaker in each item's `context`** to steer this correctly. When retaining transcripts or third-party content, a context like *"Customer Maria is speaking"* ensures her first-person statements are stored as `world` facts about Maria rather than mistaken for the agent's own experiences. For the agent's own logs, a context like *"The assistant is speaking"* attributes its first-person statements to the agent as `experience` facts.
 
 **Note:** Observations are consolidated automatically in the background after `retain()` operations complete. This consolidation process synthesizes patterns from new facts into the bank's knowledge base.
 

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -9217,7 +9217,8 @@
               }
             ],
             "title": "Agent Name",
-            "description": "Narrator override (memory owner) primed in the prompt."
+            "description": "Deprecated: describe the speaker in `context` instead. Narrator override (memory owner) primed in the prompt; still honored for backwards compatibility.",
+            "deprecated": true
           },
           "retain_mission": {
             "anyOf": [

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -41,10 +41,15 @@ Same command, only the harness name changes. Run after installing the package gl
 | GitHub Copilot CLI | `hindsight-coding-agents install copilot-cli` | `~/.copilot/hooks/` + `mcp-config.json` + skill                                                  |
 | Grok Build         | `hindsight-coding-agents install grok-build`  | native hooks + MCP in `~/.grok/config.toml` + skill                                              |
 | Antigravity CLI    | `hindsight-coding-agents install agy`         | lifecycle hooks + MCP + the `Hindsight · <bank>` status line                                     |
-| Devin CLI          | `hindsight-coding-agents install devin-cli`   | hooks in `~/.config/devin/config.json` + MCP                                                     |
+| Devin CLI          | `hindsight-coding-agents install devin-cli`   | hooks in `~/.config/devin/config.json` + MCP (needs Node 22.5+, see below)                       |
 | Cline CLI          | `hindsight-coding-agents install cline-cli`   | native plugin via `cline plugin install` + MCP + skill                                           |
 
 Uninstall the same way: `hindsight-coding-agents uninstall claude-code` (or `uninstall all`).
+
+**Devin CLI needs Node 22.5 or newer.** Its hooks pass only a session id — the conversation itself
+lives in `~/.local/share/devin/cli/sessions.db` — so reading it depends on Node's built-in
+`node:sqlite`. Installing `devin-cli` checks for this first and refuses (with the reason) rather
+than wiring hooks that could never retain anything. Every other agent works on any supported Node.
 
 Install globally (not `npx`): the wiring points at this package's files, so it must live at a
 stable path — the installer refuses to run from an npx cache. **Updating** is just
@@ -89,11 +94,18 @@ cd /path/to/your/repo
 hindsight-coding-agents install claude-code --import-conversations
 ```
 
-- Scoped to the **current repo**, since history is per-repo and a machine can hold thousands of unrelated sessions.
-- Safe to re-run: ingestion dedups by document id.
-- It runs extraction, so it costs tokens roughly in proportion to the history imported.
-- Supported for **Claude Code** and **Codex**, which store transcripts as files _and_ record the directory each session ran in. Sessions are matched on that recorded directory — never on a filename or folder name — because a wrong guess would file another repo's conversation into this bank. Anything that can't be attributed is skipped and reported.
-- opencode, Kilo, Cursor, Cline, Copilot and Devin keep history in internal SQLite databases with unversioned schemas; those report as skipped rather than importing nothing silently.
+**How sessions are matched.** A conversation is imported only when the session itself records the
+directory it ran in — never inferred from a file or folder name. Claude Code writes that directory
+on its entries and Codex in its `session_meta` header, so both can be attributed exactly, including
+sessions started in a subdirectory of the repo. Guessing was tempting (Claude names its history
+folders after the project path) but unsafe: `/` and `.` both encode to `-`, so `repo-sub` is either
+the subdirectory `repo/sub` or an unrelated sibling repo — and a wrong guess files someone else's
+conversation into your bank. Sessions that record nothing are skipped and the count is reported.
+The other harnesses (opencode, Kilo, Cursor, Cline, Copilot, Devin) keep history in internal SQLite
+databases with unversioned schemas and are skipped with a reason.
+
+The import is scoped to the **current repo**, safe to re-run (ingestion dedups by document id), and
+runs extraction — so it costs tokens roughly in proportion to the history imported.
 
 Prefer to keep the old bank instead? Point this package at it — no data moves:
 


### PR DESCRIPTION
Fixes #3125.

## Why Devin needs SQLite at all

Devin is the only harness whose hooks never hand over a transcript — they carry a session id and nothing else (`hook-lifecycle.ts` passes the session id where every other harness passes a path). The conversation exists only in `~/.local/share/devin/cli/sessions.db`. Claude Code, Codex and Grok give us a JSONL path; opencode and Kilo hand us the messages directly. So *some* SQLite reader is unavoidable here.

What was avoidable was the `sqlite3` **binary**: undeclared in `package.json`, unchecked at install time, and its absence swallowed by a bare `catch { return []; }` — indistinguishable from "this session has no messages yet". Retain no-opped forever while the installer reported success.

## What changed

**`node:sqlite` instead of the subprocess.** It's a Node builtin, so nothing is added to the package and nothing is bundled — esbuild leaves `node:` imports external, and the Devin hook bundle is unchanged at 59K. It's resolved via `createRequire` *inside* the read function, not at module scope: `transcript-devin.ts` is imported by `hook-lifecycle.ts`, which every harness shares, so a static import would take Claude Code and Codex down on a Node that lacks it. The session id is now a bound parameter rather than hand-escaped into SQL.

**Failures are distinguishable.** Missing reader, absent database, and read failure each emit their own `diag` event. A future Devin storage-schema change surfaces the same way instead of masquerading as an idle session.

**Install refuses when it can't work.** `install devin-cli` probes the `node` on PATH — the interpreter the installed hook command actually runs under, which an npx- or version-manager-launched installer may not be — and blocks with the reason plus a non-zero exit:

```
❌ devin-cli: `node:sqlite` is unavailable in the `node` on PATH (v20.11.0).
   Devin keeps its conversations in ~/.local/share/devin/cli/sessions.db and its hooks pass
   only a session id, so without SQLite nothing could ever be retained.
   Upgrade to Node 22.5 or newer (24 LTS recommended) and re-run this command.

❌ not installed: devin-cli — this machine can't run it (see above).
```

On `install all` only Devin is blocked; the other agents are still wired, and nothing is written for the blocked one. Preflight is a new optional `HarnessInstaller` hook, so other harnesses can declare hard prerequisites the same way.

## Tests

The SQLite read path had no coverage at all. Added: reading one session's turns, binding a session id containing a quote, and both failure diagnostics — all against a real database. Skipped (not failed) on a Node without `node:sqlite`, which is exactly the environment the preflight now refuses. The installer tests cover the blocked install, the mixed `claude-code + devin-cli` case, and that uninstall is never blocked.

Full suite: 284 passed, 19 skipped. `LINT_ALL_INTEGRATIONS=1 ./scripts/hooks/lint.sh` clean.

## Note

Requires Node 22.5+ **for Devin only**; every other harness is unaffected. Documented in the README and the synced docs page.
