### PR TITLE
feat(reranker): failover chain via indexed HINDSIGHT_API_RERANKER_<n>_* members

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -258,6 +258,16 @@ HINDSIGHT_API_LOG_LEVEL=info
 # For TEI provider:
 # HINDSIGHT_API_RERANKER_TEI_URL=http://localhost:8081
 
+# Reranker failover chain: extra rerankers tried, in order, when the one above
+# fails. Members are numbered from 1 (indices must be contiguous) and every
+# setting of member n carries the same index. A member inherits nothing from the
+# primary, so spell out everything it needs. Unset = no fallback (default): a
+# failing reranker fails the recall. End the chain with "rrf" to fail open and
+# keep the retrieval order instead.
+# HINDSIGHT_API_RERANKER_1_PROVIDER=cohere
+# HINDSIGHT_API_RERANKER_1_COHERE_API_KEY=your-cohere-api-key
+# HINDSIGHT_API_RERANKER_2_PROVIDER=rrf
+
 # Observability & Tracing (Optional - disabled by default)
 # Enable OpenTelemetry tracing for LLM calls (GenAI semantic conventions)
 # HINDSIGHT_API_OTEL_TRACES_ENABLED=true

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -1733,6 +1733,222 @@ def _parse_llm_members(prefix: str) -> list[LLMMemberConfig]:
     return members
 
 
+@dataclass
+class RerankerMemberConfig:
+    """One reranker in the failover chain.
+
+    Member 0 is the **primary**: the unindexed ``HINDSIGHT_API_RERANKER_*``
+    settings, built by :meth:`HindsightConfig.reranker_chain`. Members 1..N come
+    from ``HINDSIGHT_API_RERANKER_<n>_*`` and are read in isolation — an indexed
+    member inherits nothing from the primary and nothing from the shared provider
+    keys (``HINDSIGHT_API_COHERE_API_KEY`` and friends), so every setting it needs
+    must be spelled out with its own index. Settings left unset fall back to the
+    same built-in defaults the primary uses.
+
+    The fields mirror the ``reranker_*`` fields of :class:`HindsightConfig`, minus
+    the chain-level ones (``max_candidates``, ``send_bank_as_header``) which stay
+    global.
+    """
+
+    index: int
+    provider: str
+    # local
+    local_model: str
+    local_force_cpu: bool
+    local_allow_mps: bool
+    local_max_concurrent: int
+    local_trust_remote_code: bool
+    local_fp16: bool
+    local_bucket_batching: bool
+    local_batch_size: int
+    # tei
+    tei_url: str | None
+    tei_batch_size: int
+    tei_max_concurrent: int
+    tei_http_timeout: float
+    # cohere
+    cohere_api_key: str | None
+    cohere_model: str
+    cohere_base_url: str | None
+    cohere_timeout: float
+    # openrouter
+    openrouter_api_key: str | None
+    openrouter_model: str
+    openrouter_base_url: str
+    openrouter_timeout: float
+    # flashrank
+    flashrank_model: str
+    flashrank_cache_dir: str | None
+    flashrank_cpu_mem_arena: bool
+    # litellm (proxy)
+    litellm_api_base: str
+    litellm_api_key: str | None
+    litellm_model: str
+    litellm_max_tokens_per_doc: int | None
+    litellm_timeout: float
+    # litellm-sdk
+    litellm_sdk_api_key: str | None
+    litellm_sdk_model: str
+    litellm_sdk_api_base: str | None
+    litellm_sdk_timeout: float
+    # zeroentropy
+    zeroentropy_api_key: str | None
+    zeroentropy_model: str
+    zeroentropy_base_url: str | None
+    zeroentropy_timeout: float
+    # siliconflow
+    siliconflow_api_key: str | None
+    siliconflow_model: str
+    siliconflow_base_url: str
+    siliconflow_timeout: float
+    # alibaba
+    alibaba_api_key: str | None
+    alibaba_model: str
+    alibaba_timeout: float
+    # google
+    google_model: str
+    google_project_id: str | None
+    google_service_account_key: str | None
+    google_timeout: float
+
+    def env_name(self, suffix: str) -> str:
+        """The env var this member reads ``suffix`` from, for error messages.
+
+        ``"TEI_URL"`` → ``HINDSIGHT_API_RERANKER_TEI_URL`` for the primary and
+        ``HINDSIGHT_API_RERANKER_1_TEI_URL`` for member 1.
+        """
+        infix = "" if self.index == 0 else f"{self.index}_"
+        return f"HINDSIGHT_API_RERANKER_{infix}{suffix}"
+
+
+def _member_str(base: str, suffix: str, default: str) -> str:
+    """Read an indexed reranker setting as a string, falling back to ``default``."""
+    return os.getenv(base + suffix) or default
+
+
+def _member_opt_str(base: str, suffix: str) -> str | None:
+    """Read an optional indexed reranker setting (empty string reads as unset)."""
+    return os.getenv(base + suffix) or None
+
+
+def _member_bool(base: str, suffix: str, default: bool) -> bool:
+    raw = os.getenv(base + suffix)
+    return default if raw is None else raw.strip().lower() in ("true", "1", "yes")
+
+
+def _member_int(base: str, suffix: str, default: int) -> int:
+    raw = os.getenv(base + suffix)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw)
+    except ValueError as e:
+        raise ValueError(f"Invalid {base}{suffix}: expected an integer, got {raw!r}") from e
+
+
+def _member_opt_int(base: str, suffix: str, default: int | None) -> int | None:
+    raw = os.getenv(base + suffix)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw)
+    except ValueError as e:
+        raise ValueError(f"Invalid {base}{suffix}: expected an integer, got {raw!r}") from e
+
+
+def _member_float(base: str, suffix: str, default: float) -> float:
+    raw = os.getenv(base + suffix)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return float(raw)
+    except ValueError as e:
+        raise ValueError(f"Invalid {base}{suffix}: expected a number, got {raw!r}") from e
+
+
+def _parse_reranker_members() -> list[RerankerMemberConfig]:
+    """Parse the indexed reranker fallback members.
+
+    Members are read from ``HINDSIGHT_API_RERANKER_{n}_PROVIDER`` for n = 1, 2, ...
+    and scanning stops at the first index whose ``_PROVIDER`` is unset (so indices
+    must be contiguous from 1), mirroring :func:`_parse_llm_members`. Every other
+    setting of member ``n`` carries the same index. Provider-specific requirements
+    (a TEI URL, an API key, ...) are validated when the chain is built, so the
+    error names the exact indexed variable that is missing.
+    """
+    members: list[RerankerMemberConfig] = []
+    index = 1
+    while True:
+        base = f"HINDSIGHT_API_RERANKER_{index}_"
+        provider = os.getenv(base + "PROVIDER")
+        if not provider:
+            break
+        members.append(
+            RerankerMemberConfig(
+                index=index,
+                provider=provider,
+                local_model=_member_str(base, "LOCAL_MODEL", DEFAULT_RERANKER_LOCAL_MODEL),
+                local_force_cpu=_member_bool(base, "LOCAL_FORCE_CPU", DEFAULT_RERANKER_LOCAL_FORCE_CPU),
+                local_allow_mps=_member_bool(base, "LOCAL_ALLOW_MPS", DEFAULT_RERANKER_LOCAL_ALLOW_MPS),
+                local_max_concurrent=_member_int(base, "LOCAL_MAX_CONCURRENT", DEFAULT_RERANKER_LOCAL_MAX_CONCURRENT),
+                local_trust_remote_code=_member_bool(
+                    base, "LOCAL_TRUST_REMOTE_CODE", DEFAULT_RERANKER_LOCAL_TRUST_REMOTE_CODE
+                ),
+                local_fp16=_member_bool(base, "LOCAL_FP16", DEFAULT_RERANKER_LOCAL_FP16),
+                local_bucket_batching=_member_bool(
+                    base, "LOCAL_BUCKET_BATCHING", DEFAULT_RERANKER_LOCAL_BUCKET_BATCHING
+                ),
+                local_batch_size=_member_int(base, "LOCAL_BATCH_SIZE", DEFAULT_RERANKER_LOCAL_BATCH_SIZE),
+                tei_url=_member_opt_str(base, "TEI_URL"),
+                tei_batch_size=_member_int(base, "TEI_BATCH_SIZE", DEFAULT_RERANKER_TEI_BATCH_SIZE),
+                tei_max_concurrent=_member_int(base, "TEI_MAX_CONCURRENT", DEFAULT_RERANKER_TEI_MAX_CONCURRENT),
+                tei_http_timeout=_member_float(base, "TEI_HTTP_TIMEOUT", DEFAULT_RERANKER_TEI_HTTP_TIMEOUT),
+                cohere_api_key=_member_opt_str(base, "COHERE_API_KEY"),
+                cohere_model=_member_str(base, "COHERE_MODEL", DEFAULT_RERANKER_COHERE_MODEL),
+                cohere_base_url=_member_opt_str(base, "COHERE_BASE_URL"),
+                cohere_timeout=_member_float(base, "COHERE_TIMEOUT", DEFAULT_RERANKER_COHERE_TIMEOUT),
+                openrouter_api_key=_member_opt_str(base, "OPENROUTER_API_KEY"),
+                openrouter_model=_member_str(base, "OPENROUTER_MODEL", DEFAULT_RERANKER_OPENROUTER_MODEL),
+                openrouter_base_url=_member_str(base, "OPENROUTER_BASE_URL", DEFAULT_RERANKER_OPENROUTER_BASE_URL),
+                openrouter_timeout=_member_float(base, "OPENROUTER_TIMEOUT", DEFAULT_RERANKER_OPENROUTER_TIMEOUT),
+                flashrank_model=_member_str(base, "FLASHRANK_MODEL", DEFAULT_RERANKER_FLASHRANK_MODEL),
+                flashrank_cache_dir=_member_opt_str(base, "FLASHRANK_CACHE_DIR"),
+                flashrank_cpu_mem_arena=_member_bool(
+                    base, "FLASHRANK_CPU_MEM_ARENA", DEFAULT_RERANKER_FLASHRANK_CPU_MEM_ARENA
+                ),
+                litellm_api_base=_member_str(base, "LITELLM_API_BASE", DEFAULT_LITELLM_API_BASE),
+                litellm_api_key=_member_opt_str(base, "LITELLM_API_KEY"),
+                litellm_model=_member_str(base, "LITELLM_MODEL", DEFAULT_RERANKER_LITELLM_MODEL),
+                litellm_max_tokens_per_doc=_member_opt_int(
+                    base, "LITELLM_MAX_TOKENS_PER_DOC", DEFAULT_RERANKER_LITELLM_MAX_TOKENS_PER_DOC
+                ),
+                litellm_timeout=_member_float(base, "LITELLM_TIMEOUT", DEFAULT_RERANKER_LITELLM_TIMEOUT),
+                litellm_sdk_api_key=_member_opt_str(base, "LITELLM_SDK_API_KEY"),
+                litellm_sdk_model=_member_str(base, "LITELLM_SDK_MODEL", DEFAULT_RERANKER_LITELLM_SDK_MODEL),
+                litellm_sdk_api_base=_member_opt_str(base, "LITELLM_SDK_API_BASE"),
+                litellm_sdk_timeout=_member_float(base, "LITELLM_SDK_TIMEOUT", DEFAULT_RERANKER_LITELLM_SDK_TIMEOUT),
+                zeroentropy_api_key=_member_opt_str(base, "ZEROENTROPY_API_KEY"),
+                zeroentropy_model=_member_str(base, "ZEROENTROPY_MODEL", DEFAULT_RERANKER_ZEROENTROPY_MODEL),
+                zeroentropy_base_url=_member_opt_str(base, "ZEROENTROPY_BASE_URL"),
+                zeroentropy_timeout=_member_float(base, "ZEROENTROPY_TIMEOUT", DEFAULT_RERANKER_ZEROENTROPY_TIMEOUT),
+                siliconflow_api_key=_member_opt_str(base, "SILICONFLOW_API_KEY"),
+                siliconflow_model=_member_str(base, "SILICONFLOW_MODEL", DEFAULT_RERANKER_SILICONFLOW_MODEL),
+                siliconflow_base_url=_member_str(base, "SILICONFLOW_BASE_URL", DEFAULT_RERANKER_SILICONFLOW_BASE_URL),
+                siliconflow_timeout=_member_float(base, "SILICONFLOW_TIMEOUT", DEFAULT_RERANKER_SILICONFLOW_TIMEOUT),
+                alibaba_api_key=_member_opt_str(base, "ALIBABA_API_KEY"),
+                alibaba_model=_member_str(base, "ALIBABA_MODEL", DEFAULT_RERANKER_ALIBABA_MODEL),
+                alibaba_timeout=_member_float(base, "ALIBABA_TIMEOUT", DEFAULT_RERANKER_ALIBABA_TIMEOUT),
+                google_model=_member_str(base, "GOOGLE_MODEL", DEFAULT_RERANKER_GOOGLE_MODEL),
+                google_project_id=_member_opt_str(base, "GOOGLE_PROJECT_ID"),
+                google_service_account_key=_member_opt_str(base, "GOOGLE_SERVICE_ACCOUNT_KEY"),
+                google_timeout=_member_float(base, "GOOGLE_TIMEOUT", DEFAULT_RERANKER_GOOGLE_TIMEOUT),
+            )
+        )
+        index += 1
+
+    return members
+
+
 def _parse_default_bank_template(raw: str | None) -> dict | None:
     """
     Parse HINDSIGHT_API_DEFAULT_BANK_TEMPLATE as JSON.
@@ -2262,6 +2478,12 @@ class HindsightConfig:
     reflect_llm_strategy: LLMStrategyConfig | None = None
     consolidation_llm_members: list[LLMMemberConfig] = field(default_factory=list)
     consolidation_llm_strategy: LLMStrategyConfig | None = None
+
+    # Reranker failover chain (static, server-level). Index 0 is the unindexed
+    # reranker config above; these are the extra HINDSIGHT_API_RERANKER_<n>_*
+    # members tried, in order, when a member fails. Credential field (members
+    # embed api_keys/base_urls).
+    reranker_members: list[RerankerMemberConfig] = field(default_factory=list)
     bm25_max_query_terms: int = DEFAULT_BM25_MAX_QUERY_TERMS
 
     # Class-level sets for configuration categorization
@@ -2283,6 +2505,8 @@ class HindsightConfig:
         "retain_llm_members",
         "reflect_llm_members",
         "consolidation_llm_members",
+        # Reranker failover chain — members embed api_keys and base_urls
+        "reranker_members",
         # Base URLs (could expose infrastructure)
         "llm_base_url",
         "retain_llm_base_url",
@@ -2381,6 +2605,72 @@ class HindsightConfig:
     def file_conversion_max_batch_size_bytes(self) -> int:
         """Get maximum total batch size in bytes."""
         return self.file_conversion_max_batch_size_mb * 1024 * 1024
+
+    def reranker_chain(self) -> list[RerankerMemberConfig]:
+        """The reranker failover chain: the primary (index 0) plus indexed members.
+
+        The primary mirrors the unindexed ``reranker_*`` fields, so it keeps their
+        shared-key fallbacks (``HINDSIGHT_API_COHERE_API_KEY``,
+        ``HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID``, ...). Indexed members do not —
+        see :class:`RerankerMemberConfig`. A chain of length 1 means no fallback is
+        configured, which is the default.
+        """
+        primary = RerankerMemberConfig(
+            index=0,
+            provider=self.reranker_provider,
+            local_model=self.reranker_local_model,
+            local_force_cpu=self.reranker_local_force_cpu,
+            local_allow_mps=self.reranker_local_allow_mps,
+            local_max_concurrent=self.reranker_local_max_concurrent,
+            local_trust_remote_code=self.reranker_local_trust_remote_code,
+            local_fp16=self.reranker_local_fp16,
+            local_bucket_batching=self.reranker_local_bucket_batching,
+            local_batch_size=self.reranker_local_batch_size,
+            tei_url=self.reranker_tei_url,
+            tei_batch_size=self.reranker_tei_batch_size,
+            tei_max_concurrent=self.reranker_tei_max_concurrent,
+            tei_http_timeout=self.reranker_tei_http_timeout,
+            cohere_api_key=self.reranker_cohere_api_key,
+            cohere_model=self.reranker_cohere_model,
+            cohere_base_url=self.reranker_cohere_base_url,
+            cohere_timeout=self.reranker_cohere_timeout,
+            openrouter_api_key=self.reranker_openrouter_api_key,
+            openrouter_model=self.reranker_openrouter_model,
+            openrouter_base_url=self.reranker_openrouter_base_url,
+            openrouter_timeout=self.reranker_openrouter_timeout,
+            # flashrank has no HindsightConfig fields — it is read from the env directly
+            flashrank_model=os.environ.get(ENV_RERANKER_FLASHRANK_MODEL, DEFAULT_RERANKER_FLASHRANK_MODEL),
+            flashrank_cache_dir=os.environ.get(ENV_RERANKER_FLASHRANK_CACHE_DIR, DEFAULT_RERANKER_FLASHRANK_CACHE_DIR),
+            flashrank_cpu_mem_arena=os.environ.get(
+                ENV_RERANKER_FLASHRANK_CPU_MEM_ARENA, str(DEFAULT_RERANKER_FLASHRANK_CPU_MEM_ARENA)
+            ).lower()
+            in ("true", "1", "yes"),
+            litellm_api_base=self.reranker_litellm_api_base,
+            litellm_api_key=self.reranker_litellm_api_key,
+            litellm_model=self.reranker_litellm_model,
+            litellm_max_tokens_per_doc=self.reranker_litellm_max_tokens_per_doc,
+            litellm_timeout=self.reranker_litellm_timeout,
+            litellm_sdk_api_key=self.reranker_litellm_sdk_api_key,
+            litellm_sdk_model=self.reranker_litellm_sdk_model,
+            litellm_sdk_api_base=self.reranker_litellm_sdk_api_base,
+            litellm_sdk_timeout=self.reranker_litellm_sdk_timeout,
+            zeroentropy_api_key=self.reranker_zeroentropy_api_key,
+            zeroentropy_model=self.reranker_zeroentropy_model,
+            zeroentropy_base_url=self.reranker_zeroentropy_base_url,
+            zeroentropy_timeout=self.reranker_zeroentropy_timeout,
+            siliconflow_api_key=self.reranker_siliconflow_api_key,
+            siliconflow_model=self.reranker_siliconflow_model,
+            siliconflow_base_url=self.reranker_siliconflow_base_url,
+            siliconflow_timeout=self.reranker_siliconflow_timeout,
+            alibaba_api_key=self.reranker_alibaba_api_key,
+            alibaba_model=self.reranker_alibaba_model,
+            alibaba_timeout=self.reranker_alibaba_timeout,
+            google_model=self.reranker_google_model,
+            google_project_id=self.reranker_google_project_id,
+            google_service_account_key=self.reranker_google_service_account_key,
+            google_timeout=self.reranker_google_timeout,
+        )
+        return [primary, *self.reranker_members]
 
     @classmethod
     def get_configurable_fields(cls) -> set[str]:
@@ -3048,6 +3338,7 @@ class HindsightConfig:
             reranker_google_service_account_key=os.getenv(ENV_RERANKER_GOOGLE_SERVICE_ACCOUNT_KEY)
             or os.getenv(ENV_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY),
             reranker_google_timeout=float(os.getenv(ENV_RERANKER_GOOGLE_TIMEOUT, str(DEFAULT_RERANKER_GOOGLE_TIMEOUT))),
+            reranker_members=_parse_reranker_members(),
             # Server
             host=os.getenv(ENV_HOST, DEFAULT_HOST),
             port=int(os.getenv(ENV_PORT, DEFAULT_PORT)),

--- a/hindsight-api-slim/hindsight_api/config_resolver.py
+++ b/hindsight-api-slim/hindsight_api/config_resolver.py
@@ -128,12 +128,13 @@ class ConfigResolver:
         # Return full config object (dataclass doesn't have __init__ that accepts kwargs, so we update the object)
         # Create a new config instance by copying the global config and updating fields
         resolved_config = HindsightConfig(**config_dict)
-        # Multi-LLM chains are static credential fields (never tenant/bank-overridable),
-        # but asdict() above flattened their member dataclasses into plain dicts. Restore
-        # the original typed objects from the global config so the resolved object stays
-        # well-typed for any consumer that reads them.
+        # Multi-LLM chains and the reranker failover chain are static credential fields
+        # (never tenant/bank-overridable), but asdict() above flattened their member
+        # dataclasses into plain dicts. Restore the original typed objects from the global
+        # config so the resolved object stays well-typed for any consumer that reads them.
         resolved_config = replace(
             resolved_config,
+            reranker_members=self._global_config.reranker_members,
             llm_members=self._global_config.llm_members,
             llm_strategy=self._global_config.llm_strategy,
             retain_llm_members=self._global_config.retain_llm_members,

--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -8,7 +8,6 @@ Configuration via environment variables - see hindsight_api.config for all env v
 
 import asyncio
 import logging
-import os
 import warnings
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
@@ -21,7 +20,6 @@ from ..config import (
     DEFAULT_RERANKER_ALIBABA_MODEL,
     DEFAULT_RERANKER_COHERE_MODEL,
     DEFAULT_RERANKER_FLASHRANK_CACHE_DIR,
-    DEFAULT_RERANKER_FLASHRANK_CPU_MEM_ARENA,
     DEFAULT_RERANKER_FLASHRANK_MODEL,
     DEFAULT_RERANKER_GOOGLE_MODEL,
     DEFAULT_RERANKER_LITELLM_MAX_TOKENS_PER_DOC,
@@ -35,16 +33,7 @@ from ..config import (
     DEFAULT_RERANKER_TEI_MAX_CONCURRENT,
     DEFAULT_RERANKER_ZEROENTROPY_MODEL,
     DEFAULT_ZEROENTROPY_BASE_URL,
-    ENV_RERANKER_ALIBABA_API_KEY,
-    ENV_RERANKER_COHERE_API_KEY,
-    ENV_RERANKER_FLASHRANK_CACHE_DIR,
-    ENV_RERANKER_FLASHRANK_CPU_MEM_ARENA,
-    ENV_RERANKER_FLASHRANK_MODEL,
-    ENV_RERANKER_GOOGLE_PROJECT_ID,
-    ENV_RERANKER_PROVIDER,
-    ENV_RERANKER_SILICONFLOW_API_KEY,
-    ENV_RERANKER_TEI_URL,
-    ENV_RERANKER_ZEROENTROPY_API_KEY,
+    RerankerMemberConfig,
 )
 from .bank_attribution import reranker_bank_attribution_headers
 from .local_device import (
@@ -69,6 +58,15 @@ class CrossEncoderModel(ABC):
     def provider_name(self) -> str:
         """Return a human-readable name for this provider (e.g., 'local', 'tei')."""
         pass
+
+    @property
+    def blocking_init(self) -> bool:
+        """Whether ``initialize()`` blocks the event loop (loads a model in-process).
+
+        Callers run those in a thread pool. Remote providers leave this False, and
+        so does :class:`MultiCrossEncoder` — it offloads its own members.
+        """
+        return False
 
     @abstractmethod
     async def initialize(self) -> None:
@@ -161,6 +159,10 @@ class LocalSTCrossEncoder(CrossEncoderModel):
     @property
     def provider_name(self) -> str:
         return "local"
+
+    @property
+    def blocking_init(self) -> bool:
+        return True
 
     async def initialize(self) -> None:
         """Load the cross-encoder model and initialize the executor."""
@@ -1575,132 +1577,246 @@ class AlibabaCloudCrossEncoder(CrossEncoderModel):
         return await self._client.predict(pairs)
 
 
-def create_cross_encoder_from_env() -> CrossEncoderModel:
-    """
-    Create a CrossEncoderModel instance based on configuration.
+class MultiCrossEncoder(CrossEncoderModel):
+    """Failover across an ordered chain of cross-encoders.
 
-    Reads configuration via get_config() to ensure consistency across the codebase.
+    Member 0 is the primary (the unindexed ``HINDSIGHT_API_RERANKER_*`` config);
+    members 1..N are the indexed fallbacks. Each ``predict`` tries members in order
+    and returns the first usable set of scores, so an unreachable reranker costs
+    ranking quality (whatever the next member gives) instead of the whole recall.
+    Put ``rrf`` last to degrade to the fusion order rather than failing.
+
+    Each member keeps its own retry budget, so we only advance after a member has
+    exhausted its retries and raised. A member that fails to initialize is not
+    fatal — that is the point of the chain — it is retried lazily on the next
+    request that reaches it.
+    """
+
+    def __init__(self, members: list[CrossEncoderModel]) -> None:
+        if len(members) < 2:
+            raise ValueError("MultiCrossEncoder requires at least two members")
+        self._members = members
+        self._ready = [False] * len(members)
+        self._locks = [asyncio.Lock() for _ in members]
+        self._active = 0
+
+    @property
+    def provider_name(self) -> str:
+        """The provider of the member that last served a request (primary before any).
+
+        Callers use this to detect a passthrough reranker, so it has to track the
+        member actually serving rather than name the chain: a chain that has
+        degraded to its ``rrf`` member is passthrough. Concurrent requests share it,
+        so a request that fails over can briefly mislabel a neighbour — this only
+        tunes downstream scoring, never correctness.
+        """
+        return self._members[self._active].provider_name
+
+    async def _initialize_member(self, index: int) -> None:
+        """Initialize one member, off the event loop when it loads a model in-process."""
+        member = self._members[index]
+        if member.blocking_init:
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, lambda: asyncio.run(member.initialize()))
+        else:
+            await member.initialize()
+        self._ready[index] = True
+
+    async def _ensure_member_ready(self, index: int) -> None:
+        async with self._locks[index]:
+            if not self._ready[index]:
+                await self._initialize_member(index)
+
+    async def initialize(self) -> None:
+        """Initialize every member, tolerating members that are down.
+
+        Members initialize concurrently so one unreachable member cannot eat the
+        startup budget the others need. Failures are logged and retried on use.
+        """
+        results = await asyncio.gather(
+            *(self._ensure_member_ready(i) for i in range(len(self._members))),
+            return_exceptions=True,
+        )
+        for index, result in enumerate(results):
+            if isinstance(result, BaseException):
+                logger.warning(
+                    "Reranker member %d (%s) failed to initialize: %s; it will be retried on use",
+                    index,
+                    self._members[index].provider_name,
+                    result,
+                )
+        if not any(self._ready):
+            logger.error("Reranker: no member of the failover chain initialized; recall will retry them per request")
+
+    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+        """Score ``pairs`` with the first member that answers usably."""
+        last_exc: BaseException | None = None
+        for index, member in enumerate(self._members):
+            try:
+                if not self._ready[index]:
+                    await self._ensure_member_ready(index)
+                scores = await member.predict(pairs)
+                if len(scores) != len(pairs):
+                    raise RuntimeError(f"returned {len(scores)} scores for {len(pairs)} pairs")
+            except Exception as e:  # noqa: BLE001 - re-raised below if no member answers
+                last_exc = e
+                remaining = len(self._members) - index - 1
+                logger.warning(
+                    "Reranker member %d (%s) failed: %s%s",
+                    index,
+                    member.provider_name,
+                    e,
+                    f"; trying next member ({remaining} left)" if remaining else "; no members left",
+                )
+                continue
+            if index != self._active:
+                logger.info(
+                    "Reranker: now serving from member %d (%s)",
+                    index,
+                    member.provider_name,
+                )
+            self._active = index
+            return scores
+        # All members failed; surface the last error (loop ran at least once).
+        assert last_exc is not None
+        raise last_exc
+
+
+def create_cross_encoder(member: RerankerMemberConfig) -> CrossEncoderModel:
+    """
+    Create a CrossEncoderModel for one member of the reranker chain.
+
+    ``member`` is the primary (index 0, the unindexed ``HINDSIGHT_API_RERANKER_*``
+    config) or an indexed fallback. Missing-setting errors name the member's own
+    env var, so a chain misconfiguration points at the exact indexed variable.
+
+    Args:
+        member: Resolved settings for this member
 
     Returns:
         Configured CrossEncoderModel instance
     """
-    from ..config import get_config
-
-    config = get_config()
-    provider = config.reranker_provider.lower()
+    provider = member.provider.lower()
 
     if provider == "tei":
-        url = config.reranker_tei_url
+        url = member.tei_url
         if not url:
-            raise ValueError(f"{ENV_RERANKER_TEI_URL} is required when {ENV_RERANKER_PROVIDER} is 'tei'")
+            raise ValueError(f"{member.env_name('TEI_URL')} is required when {member.env_name('PROVIDER')} is 'tei'")
         return RemoteTEICrossEncoder(
             base_url=url,
-            timeout=config.reranker_tei_http_timeout,
-            batch_size=config.reranker_tei_batch_size,
-            max_concurrent=config.reranker_tei_max_concurrent,
+            timeout=member.tei_http_timeout,
+            batch_size=member.tei_batch_size,
+            max_concurrent=member.tei_max_concurrent,
         )
     elif provider == "local":
         return LocalSTCrossEncoder(
-            model_name=config.reranker_local_model,
-            max_concurrent=config.reranker_local_max_concurrent,
-            force_cpu=config.reranker_local_force_cpu,
-            trust_remote_code=config.reranker_local_trust_remote_code,
-            fp16=config.reranker_local_fp16,
-            bucket_batching=config.reranker_local_bucket_batching,
-            batch_size=config.reranker_local_batch_size,
-            allow_mps=config.reranker_local_allow_mps,
+            model_name=member.local_model,
+            max_concurrent=member.local_max_concurrent,
+            force_cpu=member.local_force_cpu,
+            trust_remote_code=member.local_trust_remote_code,
+            fp16=member.local_fp16,
+            bucket_batching=member.local_bucket_batching,
+            batch_size=member.local_batch_size,
+            allow_mps=member.local_allow_mps,
         )
     elif provider == "cohere":
-        api_key = config.reranker_cohere_api_key
-        if not api_key:
-            raise ValueError(f"{ENV_RERANKER_COHERE_API_KEY} is required when {ENV_RERANKER_PROVIDER} is 'cohere'")
-        return CohereCrossEncoder(
-            api_key=api_key,
-            model=config.reranker_cohere_model,
-            base_url=config.reranker_cohere_base_url,
-            timeout=config.reranker_cohere_timeout,
-        )
-    elif provider == "openrouter":
-        api_key = config.reranker_openrouter_api_key
+        api_key = member.cohere_api_key
         if not api_key:
             raise ValueError(
-                "HINDSIGHT_API_RERANKER_OPENROUTER_API_KEY, HINDSIGHT_API_OPENROUTER_API_KEY, "
-                f"or HINDSIGHT_API_LLM_API_KEY is required when {ENV_RERANKER_PROVIDER} is 'openrouter'"
+                f"{member.env_name('COHERE_API_KEY')} is required when {member.env_name('PROVIDER')} is 'cohere'"
             )
         return CohereCrossEncoder(
             api_key=api_key,
-            model=config.reranker_openrouter_model,
-            base_url=config.reranker_openrouter_base_url,
-            timeout=config.reranker_openrouter_timeout,
+            model=member.cohere_model,
+            base_url=member.cohere_base_url,
+            timeout=member.cohere_timeout,
+        )
+    elif provider == "openrouter":
+        api_key = member.openrouter_api_key
+        if not api_key:
+            shared = ", HINDSIGHT_API_OPENROUTER_API_KEY, or HINDSIGHT_API_LLM_API_KEY" if member.index == 0 else ""
+            raise ValueError(
+                f"{member.env_name('OPENROUTER_API_KEY')}{shared} is required "
+                f"when {member.env_name('PROVIDER')} is 'openrouter'"
+            )
+        return CohereCrossEncoder(
+            api_key=api_key,
+            model=member.openrouter_model,
+            base_url=member.openrouter_base_url,
+            timeout=member.openrouter_timeout,
         )
     elif provider == "flashrank":
-        model = os.environ.get(ENV_RERANKER_FLASHRANK_MODEL, DEFAULT_RERANKER_FLASHRANK_MODEL)
-        cache_dir = os.environ.get(ENV_RERANKER_FLASHRANK_CACHE_DIR, DEFAULT_RERANKER_FLASHRANK_CACHE_DIR)
-        cpu_mem_arena = os.environ.get(
-            ENV_RERANKER_FLASHRANK_CPU_MEM_ARENA, str(DEFAULT_RERANKER_FLASHRANK_CPU_MEM_ARENA)
-        ).lower() in ("true", "1", "yes")
-        return FlashRankCrossEncoder(model_name=model, cache_dir=cache_dir, cpu_mem_arena=cpu_mem_arena)
+        return FlashRankCrossEncoder(
+            model_name=member.flashrank_model,
+            cache_dir=member.flashrank_cache_dir,
+            cpu_mem_arena=member.flashrank_cpu_mem_arena,
+        )
     elif provider == "litellm":
         return LiteLLMCrossEncoder(
-            api_base=config.reranker_litellm_api_base,
-            api_key=config.reranker_litellm_api_key,
-            model=config.reranker_litellm_model,
-            max_tokens_per_doc=config.reranker_litellm_max_tokens_per_doc,
-            timeout=config.reranker_litellm_timeout,
+            api_base=member.litellm_api_base,
+            api_key=member.litellm_api_key,
+            model=member.litellm_model,
+            max_tokens_per_doc=member.litellm_max_tokens_per_doc,
+            timeout=member.litellm_timeout,
         )
     elif provider == "litellm-sdk":
         return LiteLLMSDKCrossEncoder(
-            api_key=config.reranker_litellm_sdk_api_key or None,
-            model=config.reranker_litellm_sdk_model,
-            api_base=config.reranker_litellm_sdk_api_base,
-            max_tokens_per_doc=config.reranker_litellm_max_tokens_per_doc,
-            timeout=config.reranker_litellm_sdk_timeout,
+            api_key=member.litellm_sdk_api_key or None,
+            model=member.litellm_sdk_model,
+            api_base=member.litellm_sdk_api_base,
+            max_tokens_per_doc=member.litellm_max_tokens_per_doc,
+            timeout=member.litellm_sdk_timeout,
         )
     elif provider == "zeroentropy":
-        api_key = config.reranker_zeroentropy_api_key
+        api_key = member.zeroentropy_api_key
         if not api_key:
             raise ValueError(
-                f"{ENV_RERANKER_ZEROENTROPY_API_KEY} is required when {ENV_RERANKER_PROVIDER} is 'zeroentropy'"
+                f"{member.env_name('ZEROENTROPY_API_KEY')} is required "
+                f"when {member.env_name('PROVIDER')} is 'zeroentropy'"
             )
         return ZeroEntropyCrossEncoder(
             api_key=api_key,
-            model=config.reranker_zeroentropy_model,
-            base_url=config.reranker_zeroentropy_base_url,
-            timeout=config.reranker_zeroentropy_timeout,
+            model=member.zeroentropy_model,
+            base_url=member.zeroentropy_base_url,
+            timeout=member.zeroentropy_timeout,
         )
     elif provider == "siliconflow":
-        api_key = config.reranker_siliconflow_api_key
+        api_key = member.siliconflow_api_key
         if not api_key:
             raise ValueError(
-                f"{ENV_RERANKER_SILICONFLOW_API_KEY} is required when {ENV_RERANKER_PROVIDER} is 'siliconflow'"
+                f"{member.env_name('SILICONFLOW_API_KEY')} is required "
+                f"when {member.env_name('PROVIDER')} is 'siliconflow'"
             )
         return SiliconFlowCrossEncoder(
             api_key=api_key,
-            model=config.reranker_siliconflow_model,
-            base_url=config.reranker_siliconflow_base_url,
-            timeout=config.reranker_siliconflow_timeout,
+            model=member.siliconflow_model,
+            base_url=member.siliconflow_base_url,
+            timeout=member.siliconflow_timeout,
         )
     elif provider == "google":
-        project_id = config.reranker_google_project_id
+        project_id = member.google_project_id
         if not project_id:
+            shared = " (or HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID)" if member.index == 0 else ""
             raise ValueError(
-                f"{ENV_RERANKER_GOOGLE_PROJECT_ID} (or HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID) "
-                f"is required when {ENV_RERANKER_PROVIDER} is 'google'"
+                f"{member.env_name('GOOGLE_PROJECT_ID')}{shared} "
+                f"is required when {member.env_name('PROVIDER')} is 'google'"
             )
         return GoogleCrossEncoder(
             project_id=project_id,
-            model=config.reranker_google_model,
-            service_account_key=config.reranker_google_service_account_key,
-            timeout=config.reranker_google_timeout,
+            model=member.google_model,
+            service_account_key=member.google_service_account_key,
+            timeout=member.google_timeout,
         )
     elif provider == "alibaba":
-        api_key = config.reranker_alibaba_api_key
+        api_key = member.alibaba_api_key
         if not api_key:
-            raise ValueError(f"{ENV_RERANKER_ALIBABA_API_KEY} is required when {ENV_RERANKER_PROVIDER} is 'alibaba'")
+            raise ValueError(
+                f"{member.env_name('ALIBABA_API_KEY')} is required when {member.env_name('PROVIDER')} is 'alibaba'"
+            )
         return AlibabaCloudCrossEncoder(
             api_key=api_key,
-            model=config.reranker_alibaba_model,
-            timeout=config.reranker_alibaba_timeout,
+            model=member.alibaba_model,
+            timeout=member.alibaba_timeout,
         )
     elif provider == "rrf":
         return RRFPassthroughCrossEncoder()
@@ -1710,3 +1826,23 @@ def create_cross_encoder_from_env() -> CrossEncoderModel:
         raise ValueError(
             f"Unknown reranker provider: {provider}. Supported: 'local', 'tei', 'cohere', 'zeroentropy', 'siliconflow', 'alibaba', 'google', 'flashrank', 'litellm', 'litellm-sdk', 'rrf', 'jina-mlx'"
         )
+
+
+def create_cross_encoder_from_env() -> CrossEncoderModel:
+    """
+    Create the configured reranker, based on configuration.
+
+    Reads configuration via get_config() to ensure consistency across the codebase.
+    With no ``HINDSIGHT_API_RERANKER_<n>_*`` members configured (the default) this
+    is the single configured reranker; otherwise the chain is wrapped in a
+    :class:`MultiCrossEncoder` that fails over across members in order.
+
+    Returns:
+        Configured CrossEncoderModel instance
+    """
+    from ..config import get_config
+
+    chain = get_config().reranker_chain()
+    if len(chain) == 1:
+        return create_cross_encoder(chain[0])
+    return MultiCrossEncoder([create_cross_encoder(member) for member in chain])

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -3146,8 +3146,8 @@ class MemoryEngine(MemoryEngineInterface):
         async def init_cross_encoder():
             """Initialize cross-encoder model."""
             cross_encoder = self._cross_encoder_reranker.cross_encoder
-            # For local providers, run in thread pool to avoid blocking event loop
-            if cross_encoder.provider_name == "local":
+            # For in-process models, run in thread pool to avoid blocking event loop
+            if cross_encoder.blocking_init:
                 await loop.run_in_executor(None, lambda: asyncio.run(cross_encoder.initialize()))
             else:
                 await cross_encoder.initialize()

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -3146,8 +3146,10 @@ class MemoryEngine(MemoryEngineInterface):
         async def init_cross_encoder():
             """Initialize cross-encoder model."""
             cross_encoder = self._cross_encoder_reranker.cross_encoder
-            # For in-process models, run in thread pool to avoid blocking event loop
-            if cross_encoder.blocking_init:
+            # For in-process models, run in thread pool to avoid blocking event loop.
+            # getattr: tests inject duck-typed cross encoders that don't subclass
+            # CrossEncoderModel (same reason as the provider_name read in _recall).
+            if getattr(cross_encoder, "blocking_init", False):
                 await loop.run_in_executor(None, lambda: asyncio.run(cross_encoder.initialize()))
             else:
                 await cross_encoder.initialize()

--- a/hindsight-api-slim/hindsight_api/engine/search/reranking.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/reranking.py
@@ -225,8 +225,8 @@ class CrossEncoderReranker:
         from hindsight_api.config import ENV_MODEL_INIT_TIMEOUT, get_config
 
         cross_encoder = self.cross_encoder
-        # For local providers, run in thread pool to avoid blocking event loop
-        if cross_encoder.provider_name == "local":
+        # For in-process models, run in thread pool to avoid blocking event loop
+        if cross_encoder.blocking_init:
             loop = asyncio.get_event_loop()
             init = loop.run_in_executor(None, lambda: asyncio.run(cross_encoder.initialize()))
         else:

--- a/hindsight-api-slim/hindsight_api/engine/search/reranking.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/reranking.py
@@ -225,8 +225,10 @@ class CrossEncoderReranker:
         from hindsight_api.config import ENV_MODEL_INIT_TIMEOUT, get_config
 
         cross_encoder = self.cross_encoder
-        # For in-process models, run in thread pool to avoid blocking event loop
-        if cross_encoder.blocking_init:
+        # For in-process models, run in thread pool to avoid blocking event loop.
+        # getattr: tests inject duck-typed cross encoders that don't subclass
+        # CrossEncoderModel and so don't carry the property.
+        if getattr(cross_encoder, "blocking_init", False):
             loop = asyncio.get_event_loop()
             init = loop.run_in_executor(None, lambda: asyncio.run(cross_encoder.initialize()))
         else:

--- a/hindsight-api-slim/tests/test_bank_attribution_config.py
+++ b/hindsight-api-slim/tests/test_bank_attribution_config.py
@@ -51,6 +51,8 @@ def _make_full_config(**overrides):
             defaults[f.name] = None
         elif f.type == "bool":
             defaults[f.name] = False
+        elif str(f.type).startswith("list["):
+            defaults[f.name] = []
         else:
             defaults[f.name] = None
     defaults.update(overrides)

--- a/hindsight-api-slim/tests/test_google_cross_encoder.py
+++ b/hindsight-api-slim/tests/test_google_cross_encoder.py
@@ -247,6 +247,8 @@ class TestGoogleCrossEncoderFactory:
                 defaults[f.name] = False
             elif f.type == "list | None":
                 defaults[f.name] = None
+            elif str(f.type).startswith("list["):
+                defaults[f.name] = []
             else:
                 defaults[f.name] = None
 

--- a/hindsight-api-slim/tests/test_model_init_timeout.py
+++ b/hindsight-api-slim/tests/test_model_init_timeout.py
@@ -46,6 +46,7 @@ class _HangingCrossEncoder:
     """Cross-encoder whose initialize() never returns (simulates a stuck download)."""
 
     provider_name = "remote"  # non-local: stays on the event loop, no executor thread
+    blocking_init = False
 
     async def initialize(self) -> None:
         await asyncio.Event().wait()  # hangs forever
@@ -53,6 +54,7 @@ class _HangingCrossEncoder:
 
 class _FastCrossEncoder:
     provider_name = "remote"
+    blocking_init = False
 
     def __init__(self) -> None:
         self.initialized = False

--- a/hindsight-api-slim/tests/test_reranker_failover_chain.py
+++ b/hindsight-api-slim/tests/test_reranker_failover_chain.py
@@ -1,0 +1,289 @@
+"""
+Reranker failover chain: HINDSIGHT_API_RERANKER_<n>_* members.
+
+Covers issue #3168: an unreachable reranker took the whole recall down with a 500
+because the stage was a hard dependency. A chain of indexed members lets the
+refinement degrade — typically to a trailing `rrf` member, which is the same
+neutral-score ordering you get with no reranker configured at all.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from hindsight_api.config import HindsightConfig
+from hindsight_api.engine.cross_encoder import (
+    CohereCrossEncoder,
+    CrossEncoderModel,
+    MultiCrossEncoder,
+    RemoteTEICrossEncoder,
+    RRFPassthroughCrossEncoder,
+    create_cross_encoder,
+    create_cross_encoder_from_env,
+)
+
+PAIRS = [("q", "doc a"), ("q", "doc b")]
+
+
+class _FakeCrossEncoder(CrossEncoderModel):
+    """Scriptable member: records calls, optionally fails init and/or predict."""
+
+    def __init__(
+        self,
+        name: str,
+        scores: list[float] | None = None,
+        init_error: Exception | None = None,
+        predict_error: Exception | None = None,
+    ) -> None:
+        self._name = name
+        self._scores = scores
+        self._init_error = init_error
+        self._predict_error = predict_error
+        self.init_calls = 0
+        self.predict_calls = 0
+
+    @property
+    def provider_name(self) -> str:
+        return self._name
+
+    async def initialize(self) -> None:
+        self.init_calls += 1
+        if self._init_error is not None:
+            raise self._init_error
+
+    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+        self.predict_calls += 1
+        if self._predict_error is not None:
+            raise self._predict_error
+        assert self._scores is not None
+        return self._scores
+
+
+# ── env parsing ────────────────────────────────────────────────────────────────
+
+
+def test_no_indexed_members_by_default():
+    """The default config has no fallback members — behaviour is unchanged."""
+    with patch.dict(os.environ, {}, clear=False):
+        config = HindsightConfig.from_env()
+    assert config.reranker_members == []
+    assert len(config.reranker_chain()) == 1
+
+
+def test_indexed_members_are_parsed_in_order_and_stop_at_a_gap():
+    """Members must be contiguous from 1; scanning stops at the first missing index."""
+    env = {
+        "HINDSIGHT_API_RERANKER_1_PROVIDER": "tei",
+        "HINDSIGHT_API_RERANKER_1_TEI_URL": "http://backup:8080",
+        "HINDSIGHT_API_RERANKER_2_PROVIDER": "rrf",
+        # index 3 missing on purpose
+        "HINDSIGHT_API_RERANKER_4_PROVIDER": "cohere",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        config = HindsightConfig.from_env()
+
+    assert [m.provider for m in config.reranker_members] == ["tei", "rrf"]
+    assert [m.index for m in config.reranker_members] == [1, 2]
+
+
+def test_indexed_member_reads_its_own_provider_settings():
+    """Every setting of member n carries the same index."""
+    env = {
+        "HINDSIGHT_API_RERANKER_1_PROVIDER": "tei",
+        "HINDSIGHT_API_RERANKER_1_TEI_URL": "http://backup:8080",
+        "HINDSIGHT_API_RERANKER_1_TEI_BATCH_SIZE": "7",
+        "HINDSIGHT_API_RERANKER_1_TEI_HTTP_TIMEOUT": "2.5",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        member = HindsightConfig.from_env().reranker_members[0]
+
+    assert member.tei_url == "http://backup:8080"
+    assert member.tei_batch_size == 7
+    assert member.tei_http_timeout == 2.5
+
+
+def test_indexed_member_inherits_nothing_from_the_primary():
+    """An indexed member is read in isolation — no inheritance, only built-in defaults."""
+    env = {
+        "HINDSIGHT_API_RERANKER_PROVIDER": "cohere",
+        "HINDSIGHT_API_RERANKER_COHERE_API_KEY": "primary-key",
+        "HINDSIGHT_API_RERANKER_COHERE_MODEL": "rerank-multilingual-v3.0",
+        "HINDSIGHT_API_RERANKER_COHERE_BASE_URL": "http://primary/rerank",
+        "HINDSIGHT_API_COHERE_API_KEY": "shared-key",
+        "HINDSIGHT_API_RERANKER_1_PROVIDER": "cohere",
+        "HINDSIGHT_API_RERANKER_1_COHERE_API_KEY": "member-key",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        member = HindsightConfig.from_env().reranker_members[0]
+
+    assert member.cohere_api_key == "member-key"
+    assert member.cohere_base_url is None
+    assert member.cohere_model == "rerank-english-v3.0"  # built-in default, not the primary's
+
+
+def test_member_with_a_bad_numeric_setting_fails_fast():
+    env = {
+        "HINDSIGHT_API_RERANKER_1_PROVIDER": "tei",
+        "HINDSIGHT_API_RERANKER_1_TEI_BATCH_SIZE": "lots",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        with pytest.raises(ValueError, match="HINDSIGHT_API_RERANKER_1_TEI_BATCH_SIZE"):
+            HindsightConfig.from_env()
+
+
+# ── chain construction ─────────────────────────────────────────────────────────
+
+
+def test_factory_returns_a_single_encoder_without_members():
+    env = {
+        "HINDSIGHT_API_RERANKER_PROVIDER": "cohere",
+        "HINDSIGHT_API_RERANKER_COHERE_API_KEY": "k",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        config = HindsightConfig.from_env()
+        with patch("hindsight_api.config.get_config", return_value=config):
+            encoder = create_cross_encoder_from_env()
+
+    assert isinstance(encoder, CohereCrossEncoder)
+
+
+def test_factory_builds_the_chain_when_members_are_configured():
+    env = {
+        "HINDSIGHT_API_RERANKER_PROVIDER": "cohere",
+        "HINDSIGHT_API_RERANKER_COHERE_API_KEY": "k",
+        "HINDSIGHT_API_RERANKER_1_PROVIDER": "tei",
+        "HINDSIGHT_API_RERANKER_1_TEI_URL": "http://backup:8080",
+        "HINDSIGHT_API_RERANKER_2_PROVIDER": "rrf",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        config = HindsightConfig.from_env()
+        with patch("hindsight_api.config.get_config", return_value=config):
+            encoder = create_cross_encoder_from_env()
+
+    assert isinstance(encoder, MultiCrossEncoder)
+    members = encoder._members
+    assert isinstance(members[0], CohereCrossEncoder)
+    assert isinstance(members[1], RemoteTEICrossEncoder)
+    assert isinstance(members[2], RRFPassthroughCrossEncoder)
+
+
+def test_factory_builds_the_chain_through_the_real_config_proxy():
+    """The production path reads the chain via get_config()'s static proxy."""
+    from hindsight_api.config import clear_config_cache
+
+    env = {
+        "HINDSIGHT_API_RERANKER_PROVIDER": "rrf",
+        "HINDSIGHT_API_RERANKER_1_PROVIDER": "rrf",
+    }
+    try:
+        with patch.dict(os.environ, env, clear=False):
+            clear_config_cache()
+            encoder = create_cross_encoder_from_env()
+    finally:
+        clear_config_cache()
+
+    assert isinstance(encoder, MultiCrossEncoder)
+
+
+def test_missing_member_setting_names_the_indexed_env_var():
+    """A chain misconfiguration points at the exact indexed variable."""
+    env = {
+        "HINDSIGHT_API_RERANKER_1_PROVIDER": "tei",  # no _1_TEI_URL
+    }
+    with patch.dict(os.environ, env, clear=False):
+        member = HindsightConfig.from_env().reranker_members[0]
+
+    with pytest.raises(ValueError, match="HINDSIGHT_API_RERANKER_1_TEI_URL"):
+        create_cross_encoder(member)
+
+
+def test_multi_requires_at_least_two_members():
+    with pytest.raises(ValueError, match="at least two members"):
+        MultiCrossEncoder([RRFPassthroughCrossEncoder()])
+
+
+# ── failover ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_healthy_primary_serves_and_no_fallback_is_touched():
+    primary = _FakeCrossEncoder("primary", scores=[0.9, 0.1])
+    fallback = _FakeCrossEncoder("fallback", scores=[0.5, 0.5])
+    chain = MultiCrossEncoder([primary, fallback])
+    await chain.initialize()
+
+    assert await chain.predict(PAIRS) == [0.9, 0.1]
+    assert fallback.predict_calls == 0
+    assert chain.provider_name == "primary"
+
+
+@pytest.mark.asyncio
+async def test_unreachable_primary_falls_over_to_the_next_member():
+    """The issue's case: recall keeps its answer instead of raising."""
+    primary = _FakeCrossEncoder("primary", predict_error=TimeoutError("connect timeout"))
+    fallback = RRFPassthroughCrossEncoder()
+    chain = MultiCrossEncoder([primary, fallback])
+    await chain.initialize()
+
+    scores = await chain.predict(PAIRS)
+
+    assert scores == [0.5, 0.5]  # neutral — the fusion order survives
+    assert chain.provider_name == "rrf"  # reported as passthrough for downstream scoring
+
+
+@pytest.mark.asyncio
+async def test_wrong_length_scores_fail_over():
+    """A member that answers with the wrong number of scores is unusable, not fatal."""
+    primary = _FakeCrossEncoder("primary", scores=[0.9])  # one score for two pairs
+    fallback = _FakeCrossEncoder("fallback", scores=[0.4, 0.6])
+    chain = MultiCrossEncoder([primary, fallback])
+    await chain.initialize()
+
+    assert await chain.predict(PAIRS) == [0.4, 0.6]
+
+
+@pytest.mark.asyncio
+async def test_all_members_failing_raises_the_last_error():
+    primary = _FakeCrossEncoder("primary", predict_error=TimeoutError("connect timeout"))
+    fallback = _FakeCrossEncoder("fallback", predict_error=RuntimeError("404 Not Found"))
+    chain = MultiCrossEncoder([primary, fallback])
+    await chain.initialize()
+
+    with pytest.raises(RuntimeError, match="404 Not Found"):
+        await chain.predict(PAIRS)
+
+
+@pytest.mark.asyncio
+async def test_a_member_that_fails_to_initialize_is_not_fatal():
+    """Startup tolerates a member that is down, and retries it when it is used."""
+    primary = _FakeCrossEncoder("primary", scores=[0.9, 0.1], init_error=ConnectionError("refused"))
+    fallback = _FakeCrossEncoder("fallback", scores=[0.4, 0.6])
+    chain = MultiCrossEncoder([primary, fallback])
+
+    await chain.initialize()  # must not raise
+
+    assert primary.init_calls == 1
+    assert await chain.predict(PAIRS) == [0.4, 0.6]
+    assert primary.init_calls == 2  # retried on use, then failed over again
+
+
+@pytest.mark.asyncio
+async def test_members_initialize_once_when_healthy():
+    primary = _FakeCrossEncoder("primary", scores=[0.9, 0.1])
+    fallback = _FakeCrossEncoder("fallback", scores=[0.4, 0.6])
+    chain = MultiCrossEncoder([primary, fallback])
+
+    await chain.initialize()
+    await chain.predict(PAIRS)
+    await chain.predict(PAIRS)
+
+    assert primary.init_calls == 1
+    assert fallback.init_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_chain_handles_its_own_blocking_member_init():
+    """MultiCrossEncoder offloads local members itself, so callers never thread it."""
+    chain = MultiCrossEncoder([RRFPassthroughCrossEncoder(), RRFPassthroughCrossEncoder()])
+    assert chain.blocking_init is False

--- a/hindsight-api-slim/tests/test_reranker_timeouts.py
+++ b/hindsight-api-slim/tests/test_reranker_timeouts.py
@@ -33,6 +33,8 @@ def _make_config(**overrides) -> HindsightConfig:
             defaults[f.name] = None
         elif f.type == "bool":
             defaults[f.name] = False
+        elif str(f.type).startswith("list["):
+            defaults[f.name] = []
         else:
             defaults[f.name] = None
     defaults.update(overrides)

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -926,6 +926,61 @@ ZeroEntropy's `zembed-1` supports Matryoshka dimensions: `2560`, `1280`, `640`, 
 | `HINDSIGHT_API_RERANKER_FLASHRANK_CPU_MEM_ARENA` | Enable ONNX Runtime CPU memory arena for FlashRank. When `true`, ONNX pre-allocates a memory arena that never shrinks, causing RSS to grow monotonically. `false` trades slightly slower per-call allocation for bounded RSS. | `false` |
 | `HINDSIGHT_API_RERANKER_JINA_MLX_MODEL_PATH` | Local path to downloaded `jina-reranker-v3-mlx` model (auto-downloads from HuggingFace if unset) | - |
 
+#### Reranker failover chain
+
+Reranking is a refinement stage, but by default a reranker that is unreachable takes
+recall down with it. Configure extra rerankers **by index** and Hindsight tries them
+in order: if a member fails (timeout, connection error, HTTP error, or an unusable
+response), the next one serves the request.
+
+The unindexed `HINDSIGHT_API_RERANKER_*` config is the **primary** (member 0). Extra
+members are numbered from 1, and every setting of member `n` carries the same index —
+`HINDSIGHT_API_RERANKER_<n>_<SETTING>` for any `<SETTING>` in the table above:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HINDSIGHT_API_RERANKER_<n>_PROVIDER` | Provider for fallback member `n` (`n` = 1, 2, ...). Presence of this var defines the member; indices must be contiguous from 1. Unset = no fallback (default). | - |
+| `HINDSIGHT_API_RERANKER_<n>_<SETTING>` | Any other reranker setting, for member `n` — e.g. `HINDSIGHT_API_RERANKER_1_TEI_URL`, `HINDSIGHT_API_RERANKER_1_COHERE_API_KEY`, `HINDSIGHT_API_RERANKER_1_TEI_HTTP_TIMEOUT`. | Same built-in default as the primary |
+
+An indexed member is read **in isolation**: it inherits nothing from the primary and
+nothing from the shared provider keys (`HINDSIGHT_API_COHERE_API_KEY` and friends), so
+spell out every setting it needs with its own index. Unset settings fall back to the
+same built-in defaults the primary uses. Chain-level settings
+(`HINDSIGHT_API_RERANKER_MAX_CANDIDATES`, `HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER`)
+stay global and are not indexed.
+
+```bash
+# Primary: a self-hosted reranker that is not always up.
+export HINDSIGHT_API_RERANKER_PROVIDER=tei
+export HINDSIGHT_API_RERANKER_TEI_URL=http://workstation:8081
+
+# Member 1: a hosted reranker to fall back on.
+export HINDSIGHT_API_RERANKER_1_PROVIDER=cohere
+export HINDSIGHT_API_RERANKER_1_COHERE_API_KEY=...
+
+# Member 2: last resort — no reranking, keep the fusion order rather than fail.
+export HINDSIGHT_API_RERANKER_2_PROVIDER=rrf
+```
+
+Ending the chain with `rrf` makes recall **fail open**: results come back in the order
+the retrieval stages produced, exactly as if no reranker were configured, instead of
+the request failing. Without an `rrf` member (or with every member down) the error still
+surfaces, which is the default behaviour.
+
+Notes:
+
+- Members are tried in order on every request; there is no circuit breaker, so a member
+  that is down costs its own timeout on each request before the next one is tried. Keep
+  the timeouts of an unreliable primary short (`HINDSIGHT_API_RERANKER_TEI_HTTP_TIMEOUT`
+  and the per-provider `*_TIMEOUT` settings).
+- A member that fails to initialize at startup is logged, not fatal — it is retried on
+  the next request that reaches it.
+- Scores are not comparable across providers (some return calibrated `[0, 1]` relevance,
+  others logits), so a request served by a fallback member can score differently from one
+  served by the primary. Failovers are logged at `WARNING`.
+- The indexed members are credential fields — never returned by the bank-config API, and
+  server-level only (not per-bank configurable).
+
 :::tip Sizing a TEI reranker
 
 TEI reserves one slot per text in a rerank request and rejects the request outright

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -258,6 +258,16 @@ HINDSIGHT_API_LOG_LEVEL=info
 # For TEI provider:
 # HINDSIGHT_API_RERANKER_TEI_URL=http://localhost:8081
 
+# Reranker failover chain: extra rerankers tried, in order, when the one above
+# fails. Members are numbered from 1 (indices must be contiguous) and every
+# setting of member n carries the same index. A member inherits nothing from the
+# primary, so spell out everything it needs. Unset = no fallback (default): a
+# failing reranker fails the recall. End the chain with "rrf" to fail open and
+# keep the retrieval order instead.
+# HINDSIGHT_API_RERANKER_1_PROVIDER=cohere
+# HINDSIGHT_API_RERANKER_1_COHERE_API_KEY=your-cohere-api-key
+# HINDSIGHT_API_RERANKER_2_PROVIDER=rrf
+
 # Observability & Tracing (Optional - disabled by default)
 # Enable OpenTelemetry tracing for LLM calls (GenAI semantic conventions)
 # HINDSIGHT_API_OTEL_TRACES_ENABLED=true

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -926,6 +926,61 @@ ZeroEntropy's `zembed-1` supports Matryoshka dimensions: `2560`, `1280`, `640`, 
 | `HINDSIGHT_API_RERANKER_FLASHRANK_CPU_MEM_ARENA` | Enable ONNX Runtime CPU memory arena for FlashRank. When `true`, ONNX pre-allocates a memory arena that never shrinks, causing RSS to grow monotonically. `false` trades slightly slower per-call allocation for bounded RSS. | `false` |
 | `HINDSIGHT_API_RERANKER_JINA_MLX_MODEL_PATH` | Local path to downloaded `jina-reranker-v3-mlx` model (auto-downloads from HuggingFace if unset) | - |
 
+#### Reranker failover chain
+
+Reranking is a refinement stage, but by default a reranker that is unreachable takes
+recall down with it. Configure extra rerankers **by index** and Hindsight tries them
+in order: if a member fails (timeout, connection error, HTTP error, or an unusable
+response), the next one serves the request.
+
+The unindexed `HINDSIGHT_API_RERANKER_*` config is the **primary** (member 0). Extra
+members are numbered from 1, and every setting of member `n` carries the same index —
+`HINDSIGHT_API_RERANKER_<n>_<SETTING>` for any `<SETTING>` in the table above:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HINDSIGHT_API_RERANKER_<n>_PROVIDER` | Provider for fallback member `n` (`n` = 1, 2, ...). Presence of this var defines the member; indices must be contiguous from 1. Unset = no fallback (default). | - |
+| `HINDSIGHT_API_RERANKER_<n>_<SETTING>` | Any other reranker setting, for member `n` — e.g. `HINDSIGHT_API_RERANKER_1_TEI_URL`, `HINDSIGHT_API_RERANKER_1_COHERE_API_KEY`, `HINDSIGHT_API_RERANKER_1_TEI_HTTP_TIMEOUT`. | Same built-in default as the primary |
+
+An indexed member is read **in isolation**: it inherits nothing from the primary and
+nothing from the shared provider keys (`HINDSIGHT_API_COHERE_API_KEY` and friends), so
+spell out every setting it needs with its own index. Unset settings fall back to the
+same built-in defaults the primary uses. Chain-level settings
+(`HINDSIGHT_API_RERANKER_MAX_CANDIDATES`, `HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER`)
+stay global and are not indexed.
+
+```bash
+# Primary: a self-hosted reranker that is not always up.
+export HINDSIGHT_API_RERANKER_PROVIDER=tei
+export HINDSIGHT_API_RERANKER_TEI_URL=http://workstation:8081
+
+# Member 1: a hosted reranker to fall back on.
+export HINDSIGHT_API_RERANKER_1_PROVIDER=cohere
+export HINDSIGHT_API_RERANKER_1_COHERE_API_KEY=...
+
+# Member 2: last resort — no reranking, keep the fusion order rather than fail.
+export HINDSIGHT_API_RERANKER_2_PROVIDER=rrf
+```
+
+Ending the chain with `rrf` makes recall **fail open**: results come back in the order
+the retrieval stages produced, exactly as if no reranker were configured, instead of
+the request failing. Without an `rrf` member (or with every member down) the error still
+surfaces, which is the default behaviour.
+
+Notes:
+
+- Members are tried in order on every request; there is no circuit breaker, so a member
+  that is down costs its own timeout on each request before the next one is tried. Keep
+  the timeouts of an unreliable primary short (`HINDSIGHT_API_RERANKER_TEI_HTTP_TIMEOUT`
+  and the per-provider `*_TIMEOUT` settings).
+- A member that fails to initialize at startup is logged, not fatal — it is retried on
+  the next request that reaches it.
+- Scores are not comparable across providers (some return calibrated `[0, 1]` relevance,
+  others logits), so a request served by a fallback member can score differently from one
+  served by the primary. Failovers are logged at `WARNING`.
+- The indexed members are credential fields — never returned by the bank-config API, and
+  server-level only (not per-bank configurable).
+
 :::tip Sizing a TEI reranker
 
 TEI reserves one slot per text in a rerank request and rejects the request outright


### PR DESCRIPTION
Fixes #3168.

An unreachable reranker takes the whole recall down with a 500. The candidates are
already in hand at that point — the reranker only reorders them — so losing the
refinement should cost ranking quality, not the answer.

Rather than a `HINDSIGHT_API_RERANKER_REQUIRED` boolean, this reuses the shape we
already have for LLMs: **extra rerankers configured by index**, tried in order.

```bash
# Primary: self-hosted, legitimately down some of the time
export HINDSIGHT_API_RERANKER_PROVIDER=tei
export HINDSIGHT_API_RERANKER_TEI_URL=http://workstation:8081

# Member 1: hosted fallback
export HINDSIGHT_API_RERANKER_1_PROVIDER=cohere
export HINDSIGHT_API_RERANKER_1_COHERE_API_KEY=...

# Member 2: last resort — keep the retrieval order rather than fail
export HINDSIGHT_API_RERANKER_2_PROVIDER=rrf
```

The last line is the fail-open case, and it needed no new concept: the existing
`rrf` provider returns neutral scores for every pair, which is the same
neutral-score proxy the reporter built by hand, and the same output as running with
no reranker configured. It also reports itself as passthrough downstream, so a
degraded response is scored as passthrough rather than having boosts applied on top
of flat scores.

**With no indexed members — the default — nothing changes:** a failing reranker
still fails the recall.

## How it works

- The unindexed `HINDSIGHT_API_RERANKER_*` config is member 0. `HINDSIGHT_API_RERANKER_<n>_*`
  (n = 1, 2, …, contiguous) declares the fallbacks, mirroring `_parse_llm_members`.
- Every setting of member *n* carries the same index, so a fallback gets the full
  provider-specific knob set — `HINDSIGHT_API_RERANKER_1_TEI_MAX_CONCURRENT`,
  `HINDSIGHT_API_RERANKER_1_LITELLM_MAX_TOKENS_PER_DOC`, and so on — not a lowest-common
  subset.
- An indexed member is read **in isolation**: it inherits nothing from the primary and
  nothing from the shared provider keys (`HINDSIGHT_API_COHERE_API_KEY` and friends).
  Unset settings fall back to the same built-in defaults the primary uses, and
  missing-setting errors name the exact indexed variable
  (`HINDSIGHT_API_RERANKER_1_TEI_URL is required when …`).
- Chain-level settings (`RERANKER_MAX_CANDIDATES`, `RERANKER_SEND_BANK_AS_HEADER`) stay
  global and are not indexed.
- `MultiCrossEncoder.predict` advances to the next member on any error and on a
  wrong-length score list. Each member keeps its own retry budget, so we only advance
  after it has exhausted its retries. Failovers log at WARNING.
- A member that fails to **initialize** is logged, not fatal — otherwise a chain
  configured precisely for a flaky primary would still die at startup — and is retried
  on the next request that reaches it.

## Deliberate omissions

- **No round-robin.** Reranker scores are not comparable across providers (some return
  calibrated `[0, 1]` relevance, others logits that get sigmoid'd), so rotating members
  per request would make `min_score` thresholds non-deterministic between requests.
  Failover only; the strategy env var is not introduced at all rather than shipping one
  that accepts a single value.
- **No "degraded" marker in the recall response.** The failover is logged; surfacing it
  in the API response is a separate change.
- **No circuit breaker.** A member that is down costs its own timeout on each request
  before the next is tried — documented, with a pointer at the per-provider `*_TIMEOUT`
  settings. (This is also the answer to the reporter's proxy-timeout footgun: the inner
  timeout has to be well under the outer one.)

## Incidental

`CrossEncoderModel.blocking_init` replaces the `provider_name == "local"` checks at the
two initialization call sites. Those used the provider name as a proxy for "loads a model
in-process, keep it off the event loop"; the chain handles its own members' offloading,
so it needs to say "don't thread me" without lying about which provider is serving.

## Testing

`tests/test_reranker_failover_chain.py` — 17 tests: env parsing (contiguity, isolation
from the primary, per-member settings, bad-value fail-fast), chain construction through
both the patched config and the real `get_config()` proxy, indexed error messages, and
the failover behaviour itself (healthy primary untouched, unreachable primary degrading
to `rrf`, wrong-length scores, all-members-down, init failure tolerated then retried).

Verified alongside the existing reranker/config suites (`test_reranker_timeouts`,
`test_reranker_error_handling`, `test_reranker_score_normalization`,
`test_local_cross_encoder`, `test_tei_cross_encoder`, `test_cohere_cross_encoder`,
`test_google_cross_encoder`, `test_litellm_sdk_cross_encoder`, `test_config_validation`,
`test_hierarchical_config`, `test_model_init_timeout`, `test_per_operation_llm_config`) —
all green. Four existing test helpers needed a one-line fix each: they built a
`HindsightConfig` by mapping field types to zero values and turned every `list[...]`
field into `None`, and two duck-typed cross-encoder fakes needed the new
`blocking_init` attribute.
