### PR TITLE
chore(db): remove deprecated entity schema from memory_links

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/c1e7a9d3f5b2_drop_entity_schema_from_memory_links.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/c1e7a9d3f5b2_drop_entity_schema_from_memory_links.py
@@ -1,0 +1,268 @@
+"""Drop the deprecated entity schema from ``memory_links``.
+
+Entity edges are no longer materialized in ``memory_links``. Retain stores
+memory-to-entity associations in ``unit_entities``, and both read paths derive
+entity edges on demand from that table — the /graph endpoint builds them from
+shared ``unit_entities`` rows, and recall expands via the ``unit_entities``
+self-join. Migration ``e9b2c7d1f3a4`` deleted the materialized entity rows and
+current writers only ever pass ``entity_id = NULL``, so the entity-specific
+schema on ``memory_links`` is now dead weight:
+
+- the ``entity_id`` column and its FK to ``entities``
+- ``link_type = 'entity'`` in the table CHECK constraint
+- the entity index (``idx_memory_links_entity`` on PG, ``idx_ml_entity`` on Oracle)
+- the ``entity_id`` term in the function-based ``idx_memory_links_unique``
+
+Once entity edges are gone, every remaining row (temporal, semantic, and the
+causal types) has a single meaningful identity — ``(from_unit_id, to_unit_id,
+link_type)`` — so the unique index collapses to those three columns and
+preserves the existing effective uniqueness semantics.
+
+Production ``memory_links`` tables and the entity index can be very large, so
+this migration is written to avoid long exclusive locks: the residual delete is
+chunked with per-batch commits, every index is swapped with ``CONCURRENTLY``,
+and the new CHECK is added ``NOT VALID`` then validated separately so writers are
+never blocked on a full-table scan.
+
+Downgrade restores the former schema *shape* (column, FK, index, CHECK, and the
+expression unique index) but cannot reconstruct the historical entity rows that
+``e9b2c7d1f3a4`` already deleted — new retains do not produce them either, so the
+restored entity index would simply stay empty.
+
+Revision ID: c1e7a9d3f5b2
+Revises: e4a7c1b9d2f6
+Create Date: 2026-08-04
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "c1e7a9d3f5b2"
+down_revision: str | Sequence[str] | None = "e4a7c1b9d2f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_NIL_ENTITY_UUID = "00000000-0000-0000-0000-000000000000"
+_LINK_TYPES_WITHOUT_ENTITY = "'temporal', 'semantic', 'causes', 'caused_by', 'enables', 'prevents'"
+_LINK_TYPES_WITH_ENTITY = "'temporal', 'semantic', 'entity', 'causes', 'caused_by', 'enables', 'prevents'"
+
+
+def _pg_schema_prefix() -> str:
+    """Schema-qualifier for raw SQL on PG (multi-tenant search_path)."""
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def _pg_upgrade() -> None:
+    schema = _pg_schema_prefix()
+
+    # CONCURRENTLY index swaps and the DO block's per-batch COMMIT both require
+    # running outside Alembic's migration transaction — an autocommit_block
+    # commits it and switches the connection to autocommit for the duration.
+    with op.get_context().autocommit_block():
+        # 1. Defensively delete any residual entity rows. e9b2c7d1f3a4 already
+        #    did this, but a bank that predates its deployment can still carry
+        #    them, and they must be gone before the three-column unique index
+        #    (which no longer distinguishes entity rows) and the entity-free
+        #    CHECK are created. Chunked with per-batch commits so a very large
+        #    table drains in bounded transactions instead of one long-locking
+        #    delete.
+        op.execute(
+            f"""
+            DO $$
+            DECLARE
+                deleted INTEGER;
+            BEGIN
+                LOOP
+                    DELETE FROM {schema}memory_links
+                    WHERE ctid IN (
+                        SELECT ctid FROM {schema}memory_links
+                        WHERE link_type = 'entity'
+                        LIMIT 50000
+                    );
+                    GET DIAGNOSTICS deleted = ROW_COUNT;
+                    EXIT WHEN deleted = 0;
+                    COMMIT;
+                END LOOP;
+            END$$;
+            """
+        )
+
+        # 2. Drop the entity indexes. idx_memory_links_entity_covering was
+        #    already removed by e1b2c3d4f5a6; dropped again defensively.
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {schema}idx_memory_links_entity")
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {schema}idx_memory_links_entity_covering")
+
+        # 3. Replace the expression unique index with the three-column form.
+        #    Build the new one first (under a temporary name) so uniqueness is
+        #    never unprotected, then drop the old expression index and rename.
+        #    Non-entity rows already collapse to (from, to, link_type) under the
+        #    old COALESCE(entity_id, nil) expression, so this cannot find a
+        #    duplicate once the entity rows are gone.
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {schema}idx_memory_links_unique_new")
+        op.execute(
+            f"CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_memory_links_unique_new "
+            f"ON {schema}memory_links (from_unit_id, to_unit_id, link_type)"
+        )
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {schema}idx_memory_links_unique")
+        op.execute(f"ALTER INDEX IF EXISTS {schema}idx_memory_links_unique_new RENAME TO idx_memory_links_unique")
+
+        # 4. Drop the FK and the now-unreferenced column. Both are metadata-only
+        #    on PostgreSQL (DROP COLUMN marks the attribute dropped, no rewrite).
+        op.execute(f"ALTER TABLE {schema}memory_links DROP CONSTRAINT IF EXISTS fk_memory_links_entity_id_entities")
+        op.execute(f"ALTER TABLE {schema}memory_links DROP COLUMN IF EXISTS entity_id")
+
+        # 5. Recreate the link_type CHECK without 'entity'. Added NOT VALID then
+        #    validated separately: the ADD takes a brief lock without scanning,
+        #    and VALIDATE takes only SHARE UPDATE EXCLUSIVE, so concurrent reads
+        #    and writes are never blocked on the scan.
+        op.execute(f"ALTER TABLE {schema}memory_links DROP CONSTRAINT IF EXISTS memory_links_link_type_check")
+        op.execute(
+            f"ALTER TABLE {schema}memory_links ADD CONSTRAINT memory_links_link_type_check "
+            f"CHECK (link_type IN ({_LINK_TYPES_WITHOUT_ENTITY})) NOT VALID"
+        )
+        op.execute(f"ALTER TABLE {schema}memory_links VALIDATE CONSTRAINT memory_links_link_type_check")
+
+
+def _pg_downgrade() -> None:
+    schema = _pg_schema_prefix()
+
+    with op.get_context().autocommit_block():
+        # Restore the column and FK (nullable, as in the initial schema).
+        op.execute(f"ALTER TABLE {schema}memory_links ADD COLUMN IF NOT EXISTS entity_id uuid")
+        op.execute(f"ALTER TABLE {schema}memory_links DROP CONSTRAINT IF EXISTS fk_memory_links_entity_id_entities")
+        op.execute(
+            f"ALTER TABLE {schema}memory_links ADD CONSTRAINT fk_memory_links_entity_id_entities "
+            f"FOREIGN KEY (entity_id) REFERENCES {schema}entities (id) ON DELETE CASCADE"
+        )
+
+        # Restore the entity partial index.
+        op.execute(
+            f"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_memory_links_entity "
+            f"ON {schema}memory_links (entity_id) WHERE entity_id IS NOT NULL"
+        )
+
+        # Restore the expression unique index (entity_id back in the key).
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {schema}idx_memory_links_unique_old")
+        op.execute(
+            f"CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_memory_links_unique_old "
+            f"ON {schema}memory_links (from_unit_id, to_unit_id, link_type, "
+            f"COALESCE(entity_id, '{_NIL_ENTITY_UUID}'::uuid))"
+        )
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {schema}idx_memory_links_unique")
+        op.execute(f"ALTER INDEX IF EXISTS {schema}idx_memory_links_unique_old RENAME TO idx_memory_links_unique")
+
+        # Restore 'entity' as a permitted link_type.
+        op.execute(f"ALTER TABLE {schema}memory_links DROP CONSTRAINT IF EXISTS memory_links_link_type_check")
+        op.execute(
+            f"ALTER TABLE {schema}memory_links ADD CONSTRAINT memory_links_link_type_check "
+            f"CHECK (link_type IN ({_LINK_TYPES_WITH_ENTITY})) NOT VALID"
+        )
+        op.execute(f"ALTER TABLE {schema}memory_links VALIDATE CONSTRAINT memory_links_link_type_check")
+
+
+def _oracle_exec_ignoring(sql: str, *ignore_codes: int) -> None:
+    """Run a DDL statement, swallowing the given ORA-NNNNN codes for idempotency.
+
+    Oracle has no ``IF EXISTS``/``IF NOT EXISTS`` for most objects; the standard
+    pattern (see e4a7c1b9d2f6) is EXECUTE IMMEDIATE inside a PL/SQL block that
+    re-raises anything but the expected "already absent"/"already present" code.
+    """
+    conditions = " AND ".join(f"SQLCODE != {code}" for code in ignore_codes)
+    escaped = sql.replace("'", "''")
+    op.execute(
+        f"""
+        BEGIN
+            EXECUTE IMMEDIATE '{escaped}';
+        EXCEPTION WHEN OTHERS THEN
+            IF {conditions} THEN RAISE; END IF;
+        END;
+        """
+    )
+
+
+def _oracle_upgrade() -> None:
+    # 1. Defensively drain residual entity rows in bounded, committed chunks so a
+    #    large table doesn't delete under one long-held lock / huge undo segment.
+    op.execute(
+        """
+        BEGIN
+            LOOP
+                DELETE FROM memory_links WHERE link_type = 'entity' AND ROWNUM <= 50000;
+                EXIT WHEN SQL%ROWCOUNT = 0;
+                COMMIT;
+            END LOOP;
+        END;
+        """
+    )
+
+    # 2. Build the three-column unique index under a temporary name before
+    #    dropping the old expression index, then rename. Oracle DDL implicitly
+    #    commits, so ordering it this way keeps duplicate protection continuous
+    #    instead of leaving a gap between drop and create. ONLINE avoids blocking
+    #    concurrent DML during the (potentially large) index builds/drops.
+    #    ORA-00955: name already in use; ORA-01418: index does not exist.
+    _oracle_exec_ignoring("DROP INDEX idx_memory_links_unique_new", -1418)
+    _oracle_exec_ignoring(
+        "CREATE UNIQUE INDEX idx_memory_links_unique_new ON memory_links (from_unit_id, to_unit_id, link_type) ONLINE",
+        -955,
+    )
+    _oracle_exec_ignoring("DROP INDEX idx_memory_links_unique", -1418)
+    _oracle_exec_ignoring("ALTER INDEX idx_memory_links_unique_new RENAME TO idx_memory_links_unique", -1418)
+
+    # 3. Drop the entity index. ORA-01418: index does not exist.
+    _oracle_exec_ignoring("DROP INDEX idx_ml_entity ONLINE", -1418)
+
+    # 4. Drop the entity FK, then the column. ORA-02443: constraint does not
+    #    exist; ORA-00904: column does not exist.
+    _oracle_exec_ignoring("ALTER TABLE memory_links DROP CONSTRAINT fk_ml_entity", -2443)
+    _oracle_exec_ignoring("ALTER TABLE memory_links DROP COLUMN entity_id", -904)
+
+    # 5. Recreate the link_type CHECK without 'entity'. ORA-02443: constraint
+    #    does not exist; ORA-02264: name already used by an existing constraint.
+    _oracle_exec_ignoring("ALTER TABLE memory_links DROP CONSTRAINT chk_ml_link_type", -2443)
+    _oracle_exec_ignoring(
+        f"ALTER TABLE memory_links ADD CONSTRAINT chk_ml_link_type CHECK (link_type IN ({_LINK_TYPES_WITHOUT_ENTITY}))",
+        -2264,
+    )
+
+
+def _oracle_downgrade() -> None:
+    # Restore the column, FK, entity index, expression unique index, and the
+    # 'entity'-permitting CHECK. ORA-01430: column already exists; ORA-00955:
+    # name already in use; ORA-01418: index does not exist; ORA-02443/-2264:
+    # constraint absent / name in use.
+    _oracle_exec_ignoring("ALTER TABLE memory_links ADD (entity_id RAW(16))", -1430)
+    _oracle_exec_ignoring(
+        "ALTER TABLE memory_links ADD CONSTRAINT fk_ml_entity "
+        "FOREIGN KEY (entity_id) REFERENCES entities (id) ON DELETE CASCADE",
+        -2264,
+    )
+    _oracle_exec_ignoring("CREATE INDEX idx_ml_entity ON memory_links (entity_id)", -955)
+
+    _oracle_exec_ignoring("DROP INDEX idx_memory_links_unique_old", -1418)
+    _oracle_exec_ignoring(
+        "CREATE UNIQUE INDEX idx_memory_links_unique_old ON memory_links ("
+        "from_unit_id, to_unit_id, link_type, "
+        "NVL(entity_id, HEXTORAW('00000000000000000000000000000000'))) ONLINE",
+        -955,
+    )
+    _oracle_exec_ignoring("DROP INDEX idx_memory_links_unique", -1418)
+    _oracle_exec_ignoring("ALTER INDEX idx_memory_links_unique_old RENAME TO idx_memory_links_unique", -1418)
+
+    _oracle_exec_ignoring("ALTER TABLE memory_links DROP CONSTRAINT chk_ml_link_type", -2443)
+    _oracle_exec_ignoring(
+        f"ALTER TABLE memory_links ADD CONSTRAINT chk_ml_link_type CHECK (link_type IN ({_LINK_TYPES_WITH_ENTITY}))",
+        -2264,
+    )
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade, oracle=_oracle_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade, oracle=_oracle_downgrade)

--- a/hindsight-api-slim/hindsight_api/engine/db/ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops.py
@@ -182,7 +182,6 @@ class DataAccessOps(ABC):
         table: str,
         sorted_links: list[tuple],
         bank_id: str,
-        nil_entity_uuid: str,
         exists_clause: str,
         chunk_size: int = 5000,
     ) -> None:

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -142,7 +142,6 @@ class OracleOps(DataAccessOps):
         table: str,
         sorted_links: list[tuple],
         bank_id: str,
-        nil_entity_uuid: str,
         exists_clause: str,
         chunk_size: int = 5000,
     ) -> None:
@@ -153,18 +152,16 @@ class OracleOps(DataAccessOps):
         to_ids = [lnk[1] for lnk in sorted_links]
         types = [lnk[2] for lnk in sorted_links]
         weights = [lnk[3] for lnk in sorted_links]
-        entity_ids = [lnk[4] for lnk in sorted_links]
 
         await conn.executemany(
             f"""
             INSERT INTO {table}
-                (from_unit_id, to_unit_id, link_type, weight, entity_id, bank_id)
-            VALUES ($1, $2, $3, $4, $5, $6)
-            ON CONFLICT (from_unit_id, to_unit_id, link_type,
-                         COALESCE(entity_id, '{nil_entity_uuid}'::uuid))
+                (from_unit_id, to_unit_id, link_type, weight, bank_id)
+            VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT (from_unit_id, to_unit_id, link_type)
             DO NOTHING
             """,
-            [(from_ids[i], to_ids[i], types[i], weights[i], entity_ids[i], bank_id) for i in range(len(sorted_links))],
+            [(from_ids[i], to_ids[i], types[i], weights[i], bank_id) for i in range(len(sorted_links))],
         )
 
     async def bulk_insert_entities(

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -182,7 +182,6 @@ class PostgreSQLOps(DataAccessOps):
         table: str,
         sorted_links: list[tuple],
         bank_id: str,
-        nil_entity_uuid: str,
         exists_clause: str,
         chunk_size: int = 5000,
     ) -> None:
@@ -207,7 +206,6 @@ class PostgreSQLOps(DataAccessOps):
         to_ids = [lnk[1] for lnk in sorted_links]
         types = [lnk[2] for lnk in sorted_links]
         weights = [lnk[3] for lnk in sorted_links]
-        entity_ids = [lnk[4] for lnk in sorted_links]
 
         for chunk_start in range(0, len(sorted_links), chunk_size):
             chunk_end = min(chunk_start + chunk_size, len(sorted_links))
@@ -221,25 +219,23 @@ class PostgreSQLOps(DataAccessOps):
                 f"""
                 WITH locked AS (
                     SELECT id FROM {mu_table}
-                    WHERE id = ANY($7::uuid[])
+                    WHERE id = ANY($6::uuid[])
                     ORDER BY id
                     FOR KEY SHARE
                 )
                 INSERT INTO {table}
-                    (from_unit_id, to_unit_id, link_type, weight, entity_id, bank_id)
-                SELECT f, t, tp, w, e, $6
-                FROM unnest($1::uuid[], $2::uuid[], $3::text[], $4::float8[], $5::uuid[])
-                    AS u(f, t, tp, w, e)
+                    (from_unit_id, to_unit_id, link_type, weight, bank_id)
+                SELECT f, t, tp, w, $5
+                FROM unnest($1::uuid[], $2::uuid[], $3::text[], $4::float8[])
+                    AS u(f, t, tp, w)
                 WHERE f IN (SELECT id FROM locked) AND t IN (SELECT id FROM locked)
-                ON CONFLICT (from_unit_id, to_unit_id, link_type,
-                             COALESCE(entity_id, '{nil_entity_uuid}'::uuid))
+                ON CONFLICT (from_unit_id, to_unit_id, link_type)
                 DO NOTHING
                 """,
                 chunk_from,
                 chunk_to,
                 types[chunk_start:chunk_end],
                 weights[chunk_start:chunk_end],
-                entity_ids[chunk_start:chunk_end],
                 bank_id,
                 referenced,
                 timeout=300,

--- a/hindsight-api-slim/hindsight_api/engine/memories/pg/graph.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/pg/graph.py
@@ -486,9 +486,9 @@ async def enqueue_relink_victims(
     affected_str_set = {str(uid) for uid in affected_uuids}
 
     # Find units (other than the affected ones) that have an outgoing
-    # temporal/semantic link pointing at an affected unit. Entity links are
-    # intentionally excluded — they're scheduled for removal and would only
-    # add noise to the recompute job.
+    # temporal/semantic link pointing at an affected unit. Only those two link
+    # types are relinked by graph maintenance; entity edges are not stored in
+    # memory_links (they're derived from unit_entities), so nothing else applies.
     victim_rows = await conn.fetch(
         f"""
         SELECT DISTINCT from_unit_id
@@ -662,7 +662,7 @@ async def _relink_batch(
                 if time_diff_h > 24:
                     continue
                 weight = max(0.3, 1.0 - (time_diff_h / 24))
-                new_links.append((row["from_id"], str(row["id"]), "temporal", weight, None))
+                new_links.append((row["from_id"], str(row["id"]), "temporal", weight))
 
     # --- Semantic top-up ---
     # ANN must run on its own connection: it opens a nested transaction with

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7138,7 +7138,7 @@ class MemoryEngine(MemoryEngineInterface):
                             f"DELETE FROM {fq_table('invalidated_memory_units')} WHERE bank_id = $1", bank_id
                         )
 
-                        # Delete entities (cascades to unit_entities, entity_cooccurrences, memory_links with entity_id)
+                        # Delete entities (cascades to unit_entities, entity_cooccurrences)
                         await conn.execute(f"DELETE FROM {fq_table('entities')} WHERE bank_id = $1", bank_id)
 
                         # Sweep extension-owned bank-scoped tables (audit receipts,

--- a/hindsight-api-slim/hindsight_api/engine/retain/chunk_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/chunk_storage.py
@@ -103,8 +103,7 @@ async def delete_chunks_by_ids(conn, chunk_ids: list[str], bank_id: str | None =
             ORDER BY
                 LEAST(ml.from_unit_id, ml.to_unit_id),
                 GREATEST(ml.from_unit_id, ml.to_unit_id),
-                ml.link_type,
-                COALESCE(ml.entity_id, '00000000-0000-0000-0000-000000000000'::uuid)
+                ml.link_type
             FOR UPDATE OF ml
         )
         DELETE FROM {fq_table("memory_links")} ml

--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -21,9 +21,6 @@ from .types import CausalRelation, EntityResolutionResult
 
 logger = logging.getLogger(__name__)
 
-# Sentinel UUID used in the unique index to represent NULL entity_id
-_NIL_ENTITY_UUID = "00000000-0000-0000-0000-000000000000"
-
 # Maximum number of temporal links to keep per unit (from_unit_id).
 # Retrieval only reads top 10-20 per unit via LATERAL join, so keeping
 # more is wasted storage and write amplification.
@@ -34,7 +31,7 @@ def _cap_links_per_unit(links: list[tuple], max_per_unit: int = MAX_TEMPORAL_LIN
     """Keep only the top-N links per from_unit_id, ranked by weight descending.
 
     Args:
-        links: List of (from_unit_id, to_unit_id, link_type, weight, entity_id) tuples.
+        links: List of (from_unit_id, to_unit_id, link_type, weight) tuples.
         max_per_unit: Maximum number of links to retain per from_unit_id.
 
     Returns:
@@ -75,7 +72,7 @@ async def _bulk_insert_links(
 
     Args:
         conn: Database connection (must be inside a transaction).
-        links: List of (from_unit_id, to_unit_id, link_type, weight, entity_id) tuples.
+        links: List of (from_unit_id, to_unit_id, link_type, weight) tuples.
         bank_id: Bank identifier stored on memory_links for fast filtering.
         chunk_size: Max rows per INSERT statement to avoid query timeouts on
                     very large tables (100M+ rows).
@@ -103,7 +100,6 @@ async def _bulk_insert_links(
         fq_table("memory_links"),
         sorted_links,
         bank_id,
-        _NIL_ENTITY_UUID,
         exists_clause,
         chunk_size,
     )
@@ -375,7 +371,7 @@ async def create_temporal_links_batch_per_fact(
         for row in rows:
             time_diff_h = float(row["time_diff_hours"])
             weight = max(0.3, 1.0 - (time_diff_h / time_window_hours))
-            links.append((row["from_id"], str(row["id"]), "temporal", weight, None))
+            links.append((row["from_id"], str(row["id"]), "temporal", weight))
 
         # Also compute temporal links WITHIN the new batch (new units to each other)
         if len(new_units) > 1:
@@ -400,8 +396,8 @@ async def create_temporal_links_batch_per_fact(
                     if time_diff_hours <= time_window_hours:
                         weight = max(0.3, 1.0 - (time_diff_hours / time_window_hours))
                         # Create bidirectional links
-                        links.append((unit_id, other_id, "temporal", weight, None))
-                        links.append((other_id, unit_id, "temporal", weight, None))
+                        links.append((unit_id, other_id, "temporal", weight))
+                        links.append((other_id, unit_id, "temporal", weight))
 
         # Cap temporal links per unit to avoid write amplification;
         # retrieval only reads top 10-20 per unit anyway.
@@ -458,7 +454,7 @@ async def compute_semantic_links_ann(
         log_buffer: Optional logging buffer
 
     Returns:
-        List of (from_id, to_id, "semantic", similarity, None) tuples
+        List of (from_id, to_id, "semantic", similarity) tuples
         where from_id uses placeholder IDs.
     """
     if not unit_ids or not embeddings:
@@ -559,7 +555,7 @@ async def compute_semantic_links_ann(
     for row in rows:
         sim = float(min(1.0, max(0.0, row["similarity"])))
         if sim >= threshold:
-            links.append((row["from_id"], row["to_id"], "semantic", sim, None))
+            links.append((row["from_id"], row["to_id"], "semantic", sim))
 
     _log(
         log_buffer,
@@ -588,7 +584,7 @@ def compute_semantic_links_within_batch(
         threshold: Minimum cosine similarity
 
     Returns:
-        List of (from_id, to_id, "semantic", similarity, None) tuples
+        List of (from_id, to_id, "semantic", similarity) tuples
     """
     if len(unit_ids) < 2:
         return []
@@ -623,7 +619,7 @@ def compute_semantic_links_within_batch(
                 other_idx = other_indices[local_idx]
                 other_id = unit_ids[other_idx]
                 similarity = float(min(1.0, max(0.0, similarities[local_idx])))
-                links.append((unit_id, other_id, "semantic", similarity, None))
+                links.append((unit_id, other_id, "semantic", similarity))
 
     return links
 
@@ -801,7 +797,7 @@ async def _write_causal_links_batch(
                 if from_unit_id == to_unit_id:
                     continue
 
-                links.append((from_unit_id, to_unit_id, relation_type, 1.0, None))
+                links.append((from_unit_id, to_unit_id, relation_type, 1.0))
 
         if links:
             insert_start = time_mod.time()
@@ -912,7 +908,6 @@ async def rematerialize_causal_links(
             descriptor.to_unit_id,
             descriptor.link_type,
             descriptor.weight,
-            None,
         )
         for descriptor in parsed
         if descriptor is not None

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -467,7 +467,7 @@ def _remap_phase1_results(
 
     # Remap semantic ANN links (from_id uses placeholder)
     remapped_semantic = [
-        (placeholder_to_actual.get(lnk[0], lnk[0]), lnk[1], lnk[2], lnk[3], lnk[4]) for lnk in semantic_ann_links
+        (placeholder_to_actual.get(lnk[0], lnk[0]), lnk[1], lnk[2], lnk[3]) for lnk in semantic_ann_links
     ]
 
     return remapped_entity_to_unit, remapped_unit_to_entity_ids, remapped_semantic

--- a/hindsight-api-slim/hindsight_api/models.py
+++ b/hindsight-api-slim/hindsight_api/models.py
@@ -191,7 +191,6 @@ class Entity(Base):
 
     # Relationships
     unit_entities = relationship("UnitEntity", back_populates="entity", cascade="all, delete-orphan")
-    memory_links = relationship("MemoryLink", back_populates="entity", cascade="all, delete-orphan")
     cooccurrences_1 = relationship(
         "EntityCooccurrence",
         foreign_keys="EntityCooccurrence.entity_id_1",
@@ -261,7 +260,12 @@ class EntityCooccurrence(Base):
 
 
 class MemoryLink(Base):
-    """Links between memory units (temporal, semantic, entity)."""
+    """Links between memory units (temporal, semantic, causal).
+
+    Entity edges are not stored here: memory-to-entity associations live in
+    ``unit_entities``, and both the /graph endpoint and recall derive entity
+    edges from that table on demand.
+    """
 
     __tablename__ = "memory_links"
 
@@ -272,29 +276,24 @@ class MemoryLink(Base):
         UUID(as_uuid=True), ForeignKey("memory_units.id", ondelete="CASCADE"), primary_key=True
     )
     link_type: Mapped[str] = mapped_column(Text, primary_key=True)
-    entity_id: Mapped[PyUUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("entities.id", ondelete="CASCADE"), primary_key=True
-    )
     weight: Mapped[float] = mapped_column(Float, nullable=False, server_default="1.0")
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
 
     # Relationships
     from_unit = relationship("MemoryUnit", foreign_keys=[from_unit_id], back_populates="outgoing_links")
     to_unit = relationship("MemoryUnit", foreign_keys=[to_unit_id], back_populates="incoming_links")
-    entity = relationship("Entity", back_populates="memory_links")
 
     __table_args__ = (
         # Retain writes ``caused_by`` only. Keep the historical causal values
         # valid so existing rows and transfer archives remain queryable.
         CheckConstraint(
-            "link_type IN ('temporal', 'semantic', 'entity', 'causes', 'caused_by', 'enables', 'prevents')",
+            "link_type IN ('temporal', 'semantic', 'causes', 'caused_by', 'enables', 'prevents')",
             name="memory_links_link_type_check",
         ),
         CheckConstraint("weight >= 0.0 AND weight <= 1.0", name="memory_links_weight_check"),
         Index("idx_memory_links_from", "from_unit_id"),
         Index("idx_memory_links_to", "to_unit_id"),
         Index("idx_memory_links_type", "link_type"),
-        Index("idx_memory_links_entity", "entity_id", postgresql_where=sql_text("entity_id IS NOT NULL")),
         Index(
             "idx_memory_links_from_weight",
             "from_unit_id",

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -900,8 +900,8 @@ async def test_transfer_preserves_legacy_causal_links(memory, request_context):
         async with acquire_with_retry(backend) as conn:
             await conn.executemany(
                 f"INSERT INTO {fq_table('memory_links')} "
-                "(from_unit_id, to_unit_id, link_type, entity_id, bank_id, weight) "
-                "VALUES ($1, $2, $3, NULL, $4, 1.0)",
+                "(from_unit_id, to_unit_id, link_type, bank_id, weight) "
+                "VALUES ($1, $2, $3, $4, 1.0)",
                 [(from_unit_id, to_unit_id, link_type, src) for link_type in legacy_types],
             )
 

--- a/hindsight-api-slim/tests/test_graph_maintenance.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance.py
@@ -191,24 +191,10 @@ class TestEnqueueRelinkVictims:
             assert count == 0
             assert await _queue_unit_ids(conn, bank_id) == []
 
-    @pytest.mark.asyncio
-    async def test_skips_entity_links(self, memory: MemoryEngine, request_context: RequestContext):
-        """Entity links are being removed from the product — we don't enqueue for them."""
-        bank_id = f"test-gm-ent-{uuid.uuid4().hex[:8]}"
-        await _ensure_bank(memory, bank_id, request_context)
-
-        pool = await memory._get_pool()
-        async with pool.acquire() as conn:
-            doomed = await _insert_unit(conn, bank_id, "doomed")
-            survivor = await _insert_unit(conn, bank_id, "survivor")
-            # Only an entity link — should NOT trigger enqueue.
-            await _insert_link(conn, bank_id, survivor, doomed, "entity")
-
-            backend = await memory._get_backend()
-            async with conn.transaction():
-                count = await enqueue_relink_victims(conn, bank_id, [str(doomed)])
-
-            assert count == 0
+    # Entity links used to be skipped here by the ``link_type IN ('temporal',
+    # 'semantic')`` filter; they can no longer be stored in memory_links at all
+    # (the CHECK constraint rejects link_type = 'entity'), so there is nothing
+    # left to construct a "skips entity links" scenario from.
 
     @pytest.mark.asyncio
     async def test_dedupes_via_on_conflict(self, memory: MemoryEngine, request_context: RequestContext):

--- a/hindsight-api-slim/tests/test_link_utils.py
+++ b/hindsight-api-slim/tests/test_link_utils.py
@@ -63,15 +63,15 @@ class TestCapLinksPerUnit:
 
     def test_under_cap_unchanged(self):
         links = [
-            ("unit_a", "unit_x", "temporal", 0.9, None),
-            ("unit_a", "unit_y", "temporal", 0.8, None),
+            ("unit_a", "unit_x", "temporal", 0.9),
+            ("unit_a", "unit_y", "temporal", 0.8),
         ]
         result = _cap_links_per_unit(links, max_per_unit=5)
         assert len(result) == 2
 
     def test_caps_to_max_per_unit(self):
         # Create 30 links from the same unit with descending weights
-        links = [("unit_a", f"unit_{i}", "temporal", 1.0 - i * 0.01, None) for i in range(30)]
+        links = [("unit_a", f"unit_{i}", "temporal", 1.0 - i * 0.01) for i in range(30)]
         result = _cap_links_per_unit(links, max_per_unit=10)
         assert len(result) == 10
         # Should keep the highest-weight links
@@ -80,8 +80,8 @@ class TestCapLinksPerUnit:
         assert weights[0] == 1.0  # Highest weight kept
 
     def test_caps_independently_per_unit(self):
-        links_a = [("unit_a", f"target_{i}", "temporal", 0.9 - i * 0.01, None) for i in range(10)]
-        links_b = [("unit_b", f"target_{i}", "temporal", 0.8 - i * 0.01, None) for i in range(10)]
+        links_a = [("unit_a", f"target_{i}", "temporal", 0.9 - i * 0.01) for i in range(10)]
+        links_b = [("unit_b", f"target_{i}", "temporal", 0.8 - i * 0.01) for i in range(10)]
         result = _cap_links_per_unit(links_a + links_b, max_per_unit=5)
         # 5 from unit_a + 5 from unit_b
         assert len(result) == 10
@@ -91,14 +91,14 @@ class TestCapLinksPerUnit:
         assert len(from_b) == 5
 
     def test_default_max_is_temporal_constant(self):
-        links = [("unit_a", f"target_{i}", "temporal", 1.0 - i * 0.01, None) for i in range(50)]
+        links = [("unit_a", f"target_{i}", "temporal", 1.0 - i * 0.01) for i in range(50)]
         result = _cap_links_per_unit(links)
         assert len(result) == MAX_TEMPORAL_LINKS_PER_UNIT
 
     def test_preserves_tuple_structure(self):
-        links = [("from_id", "to_id", "temporal", 0.95, "entity_id")]
+        links = [("from_id", "to_id", "temporal", 0.95)]
         result = _cap_links_per_unit(links, max_per_unit=5)
-        assert result[0] == ("from_id", "to_id", "temporal", 0.95, "entity_id")
+        assert result[0] == ("from_id", "to_id", "temporal", 0.95)
 
 
 class TestComputeSemanticLinksWithinBatch:
@@ -148,7 +148,6 @@ class TestComputeSemanticLinksWithinBatch:
         for lnk in links:
             assert lnk[2] == "semantic"
             assert lnk[3] >= 0.99  # near-1.0 similarity
-            assert lnk[4] is None  # no entity_id
 
     def test_orthogonal_embeddings_no_links(self):
         """Orthogonal embeddings should have similarity=0 (below 0.7 threshold)."""
@@ -219,13 +218,12 @@ class TestComputeSemanticLinksWithinBatch:
             threshold=DEFAULT_SEMANTIC_LINK_MIN_SIMILARITY,
         )
         for lnk in links:
-            assert len(lnk) == 5
-            from_id, to_id, link_type, weight, entity_id = lnk
+            assert len(lnk) == 4
+            from_id, to_id, link_type, weight = lnk
             assert isinstance(from_id, str)
             assert isinstance(to_id, str)
             assert link_type == "semantic"
             assert 0.0 <= weight <= 1.0
-            assert entity_id is None
 
 
 class TestComputeSemanticLinksAnnPgBouncerSafety:

--- a/hindsight-api-slim/tests/test_migration_drop_memory_links_entity.py
+++ b/hindsight-api-slim/tests/test_migration_drop_memory_links_entity.py
@@ -1,0 +1,153 @@
+"""Regression for the ``memory_links`` entity-schema drop (``c1e7a9d3f5b2``).
+
+Entity edges stopped being materialized in ``memory_links`` once retain moved
+memory-to-entity associations to ``unit_entities`` and the read paths (the /graph
+endpoint and recall) began deriving entity edges from that table. Migration
+``e9b2c7d1f3a4`` deleted the stored entity rows; this migration removes the
+now-dead entity *schema* — the ``entity_id`` column and FK, the entity index,
+``link_type = 'entity'`` from the CHECK, and the ``entity_id`` term in the
+function-based unique index (which collapses to ``(from_unit_id, to_unit_id,
+link_type)``).
+
+Uses a dedicated pg0 instance (mirrors test_migration_drop_access_count) so it
+controls exactly which migrations have run and never stamps the shared test
+instance.
+"""
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+# One module-scoped pg0 instance shared across tests; pin the module to a single
+# xdist worker so concurrent workers don't race to provision the same instance
+# or re-migrate a DB another worker is reading.
+pytestmark = pytest.mark.xdist_group("migration-drop-memory-links-entity-pg0")
+
+_SCRIPT_LOCATION = str(Path(__file__).parent.parent / "hindsight_api" / "alembic")
+
+_DROP_REVISION = "c1e7a9d3f5b2"
+# Revision immediately before the drop.
+_PRE_DROP_REVISION = "e4a7c1b9d2f6"
+
+
+def _alembic_cfg(db_url: str) -> Config:
+    cfg = Config()
+    cfg.set_main_option("script_location", _SCRIPT_LOCATION)
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    cfg.set_main_option("prepend_sys_path", ".")
+    cfg.set_main_option("path_separator", "os")
+    return cfg
+
+
+def _columns(conn, table: str) -> set[str]:
+    return {
+        r[0]
+        for r in conn.execute(
+            text("SELECT column_name FROM information_schema.columns WHERE table_name = :t"),
+            {"t": table},
+        )
+    }
+
+
+def _index_exists(conn, name: str) -> bool:
+    return bool(conn.execute(text("SELECT 1 FROM pg_indexes WHERE indexname = :n"), {"n": name}).scalar())
+
+
+def _index_def(conn, name: str) -> str:
+    return conn.execute(text("SELECT indexdef FROM pg_indexes WHERE indexname = :n"), {"n": name}).scalar() or ""
+
+
+def _link_type_check_def(conn) -> str:
+    return (
+        conn.execute(
+            text("SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conname = 'memory_links_link_type_check'")
+        ).scalar()
+        or ""
+    )
+
+
+@pytest.fixture(scope="module")
+def head_db_url():
+    """pg0 instance migrated to head (includes the entity-schema drop)."""
+    from hindsight_api.pg0 import EmbeddedPostgres
+
+    # port=None lets pg0 auto-assign a free port; a hardcoded port is not xdist-safe.
+    pg0 = EmbeddedPostgres(name="hindsight-drop-ml-entity-test", port=None)
+    loop = asyncio.new_event_loop()
+    try:
+        url = loop.run_until_complete(pg0.ensure_running())
+    finally:
+        loop.close()
+
+    command.upgrade(_alembic_cfg(url), "heads")
+    return url
+
+
+def test_entity_schema_is_gone(head_db_url):
+    engine = create_engine(head_db_url)
+    try:
+        with engine.connect() as conn:
+            assert "entity_id" not in _columns(conn, "memory_links"), (
+                "memory_links.entity_id still exists at head — entity edges are derived from unit_entities"
+            )
+            assert not _index_exists(conn, "idx_memory_links_entity"), "the entity index should be gone with the column"
+    finally:
+        engine.dispose()
+
+
+def test_unique_index_is_three_columns(head_db_url):
+    engine = create_engine(head_db_url)
+    try:
+        with engine.connect() as conn:
+            definition = _index_def(conn, "idx_memory_links_unique").lower()
+            assert definition, "idx_memory_links_unique is missing"
+            assert "unique" in definition
+            for col in ("from_unit_id", "to_unit_id", "link_type"):
+                assert col in definition, f"{col} missing from idx_memory_links_unique"
+            # The old expression key coalesced a nullable entity_id; both must be gone.
+            assert "entity_id" not in definition
+            assert "coalesce" not in definition
+    finally:
+        engine.dispose()
+
+
+def test_check_rejects_entity_keeps_causal(head_db_url):
+    engine = create_engine(head_db_url)
+    try:
+        with engine.connect() as conn:
+            definition = _link_type_check_def(conn).lower()
+            assert definition, "memory_links_link_type_check is missing"
+            assert "'entity'" not in definition, "CHECK should no longer permit link_type = 'entity'"
+            for keep in ("'temporal'", "'semantic'", "'caused_by'", "'causes'", "'enables'", "'prevents'"):
+                assert keep in definition, f"CHECK dropped a still-supported link_type {keep}"
+    finally:
+        engine.dispose()
+
+
+def test_downgrade_restores_entity_schema(head_db_url):
+    """Downgrade restores the former schema shape (column, index, CHECK), and
+    re-upgrading removes it again — so the migration is not a one-way door."""
+    cfg = _alembic_cfg(head_db_url)
+    engine = create_engine(head_db_url)
+    try:
+        command.downgrade(cfg, _PRE_DROP_REVISION)
+        with engine.connect() as conn:
+            assert "entity_id" in _columns(conn, "memory_links"), "downgrade did not restore memory_links.entity_id"
+            assert _index_exists(conn, "idx_memory_links_entity")
+            assert "'entity'" in _link_type_check_def(conn).lower()
+            assert "entity_id" in _index_def(conn, "idx_memory_links_unique").lower()
+
+        command.upgrade(cfg, _DROP_REVISION)
+        with engine.connect() as conn:
+            assert "entity_id" not in _columns(conn, "memory_links")
+            assert not _index_exists(conn, "idx_memory_links_entity")
+            assert "'entity'" not in _link_type_check_def(conn).lower()
+            assert "entity_id" not in _index_def(conn, "idx_memory_links_unique").lower()
+    finally:
+        # Leave the module fixture's instance at head for any later user.
+        command.upgrade(cfg, "heads")
+        engine.dispose()


### PR DESCRIPTION
## Summary

Closes #3005.

Entity edges are no longer materialized in `memory_links`. Retain stores memory-to-entity associations in `unit_entities`, and both read paths derive entity edges from that table on demand — the `/graph` endpoint from shared `unit_entities` rows, and recall via the `unit_entities` self-join. Migration `e9b2c7d1f3a4` deleted the stored entity rows, and current writers only ever pass `entity_id = NULL`, so the entity-specific schema on `memory_links` was dead weight that made the table look like it still supported a second, materialized source of truth for entity edges.

This removes that schema and the write-path plumbing behind it.

## Schema changes (new migration, PG + Oracle)

- Defensively delete any residual `link_type = 'entity'` rows.
- Drop the `entity_id` column and its FK to `entities`.
- Drop the entity index (`idx_memory_links_entity` / `idx_ml_entity`).
- Recreate the `link_type` CHECK without `'entity'` (temporal, semantic, and the legacy causal values remain valid).
- Collapse the function-based `idx_memory_links_unique` to `(from_unit_id, to_unit_id, link_type)` — non-entity rows already deduplicate on those three columns via the old `COALESCE(entity_id, nil)` key, so effective uniqueness is preserved.

### Production-safe by construction

`memory_links` and its entity index can be very large on established banks, so the migration avoids long exclusive locks:

- the residual delete is **chunked with per-batch commits**;
- every index is swapped **`CONCURRENTLY`** (PG) / **`ONLINE`** (Oracle), building the new unique index under a temporary name and renaming so duplicate protection is never dropped;
- the new CHECK is added **`NOT VALID`** then **`VALIDATE`d** separately, so writers are never blocked on a full-table scan.

Downgrade restores the former schema *shape* but, as documented in the migration, cannot reconstruct the historical entity rows `e9b2c7d1f3a4` already deleted.

## Application code

- Remove `MemoryLink.entity_id` / `MemoryLink.entity` and `Entity.memory_links`; update the docstring and CHECK metadata.
- Simplify internal link tuples from `(from, to, link_type, weight, entity_id)` to `(from, to, link_type, weight)` across the temporal, semantic, causal, and graph-maintenance producers.
- Remove `_NIL_ENTITY_UUID` and the `nil_entity_uuid` `DataAccessOps` parameter; drop the `entity_id` column/placeholder from the PG and Oracle bulk inserts (conflict target is now `(from_unit_id, to_unit_id, link_type)`).
- Drop the dead `entity_id` tiebreaker from the chunk-storage lock ordering and a stale runtime comment.
- The graph API keeps returning dynamically derived entity edges from `unit_entities` — unchanged.

## Tests

- New `test_migration_drop_memory_links_entity.py` (dedicated pg0 instance): asserts the column/index/`entity` CHECK value are gone at head, the unique index is three columns, and the downgrade → re-upgrade round-trip restores and re-drops the shape.
- Updated `test_link_utils.py` and `test_document_transfer.py` for four-element tuples / no `entity_id` column.

## Non-goals

Unchanged: the `unit_entities` model, `link_type = 'entity'` in graph/API *response* types, entity resolution / co-occurrence / orphan cleanup, and temporal/semantic/causal link generation.
