### PR TITLE
feat(obsidian): headless CLI vault ingestion (hindsight-obsidian-sync)

### DIFF
--- a/hindsight-docs/docs-integrations/obsidian.md
+++ b/hindsight-docs/docs-integrations/obsidian.md
@@ -73,3 +73,23 @@ Open **Settings → Hindsight**:
 - **Sync vault now** — full reconcile (ingest changed notes, prune deleted ones).
 - **Ingest current note** — force-sync the active note.
 - **Open chat** — open the grounded chat panel.
+
+## Headless / CLI ingestion (no desktop app)
+
+Running your vault on an always-on server (kept current on disk by Obsidian Sync)? The same ingestion runs without the Obsidian app via the `hindsight-obsidian-sync` CLI, shipped in the same package. It drives the **same sync engine** as the plugin, so it produces identical document ids, scope tags, and prune-ownership — a vault can be synced from a server and later opened interactively elsewhere without the two ingesters fighting or duplicating documents.
+
+```bash
+npm install -g @vectorize-io/hindsight-obsidian
+
+# one-shot reconcile (cron-friendly)
+hindsight-obsidian-sync reconcile \
+  --vault ~/Vaults/Brain --bank my-vault \
+  --api-url https://api.hindsight.vectorize.io --api-token hsk_...
+
+# or keep it running and sync changes live
+hindsight-obsidian-sync reconcile --vault ~/Vaults/Brain --bank my-vault --watch
+```
+
+`--api-url` / `--api-token` fall back to `HINDSIGHT_API_URL` / `HINDSIGHT_API_TOKEN`. Other flags: `--include` / `--exclude` (repeatable), `--vault-name`, `--prefix-doc-id`, and `--index`.
+
+The sync index (the CLI's equivalent of the plugin's `data.json`) defaults to `~/.hindsight/obsidian/<vault>.json` — deliberately **outside** the vault so Obsidian Sync never propagates it. If you run the CLI and the plugin against the same bank and vault, keep their scope settings identical (include/exclude, vault name, `prefix-doc-id`): each keeps its own index and a reconcile prunes only what its own index tracks, so mismatched scope could let one delete documents the other owns.

--- a/hindsight-integrations/obsidian/.gitignore
+++ b/hindsight-integrations/obsidian/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 main.js
+dist/
 *.js.map

--- a/hindsight-integrations/obsidian/README.md
+++ b/hindsight-integrations/obsidian/README.md
@@ -67,6 +67,28 @@ Open **Settings → Hindsight**:
 - **Ingest current note** — force-sync the active note.
 - **Open chat** — open the grounded chat panel.
 
+## Headless / CLI ingestion (no desktop app)
+
+Running your vault on an always-on headless server (kept current on disk by Obsidian Sync)? The same ingestion runs without the Obsidian app, via the `hindsight-obsidian-sync` CLI shipped in this package. It drives the **same sync engine** as the plugin, so it produces identical document ids, scope tags, and prune-ownership — a vault can be synced from a server and later opened interactively elsewhere without the two ingesters fighting or duplicating documents.
+
+```bash
+npm install -g @vectorize-io/hindsight-obsidian
+
+# one-shot reconcile (cron-friendly)
+hindsight-obsidian-sync reconcile \
+  --vault ~/Vaults/Brain --bank my-vault \
+  --api-url https://api.hindsight.vectorize.io --api-token hsk_...
+
+# or keep it running and sync changes live
+hindsight-obsidian-sync reconcile --vault ~/Vaults/Brain --bank my-vault --watch
+```
+
+`--api-url` / `--api-token` fall back to `HINDSIGHT_API_URL` / `HINDSIGHT_API_TOKEN`. Other flags: `--include <folder>` / `--exclude <folder>` (repeatable), `--vault-name <name>` (defaults to the vault dir name), `--prefix-doc-id` (prefix document ids with the vault name for multi-vault banks), `--index <file>`, and `--help`.
+
+The sync index (the CLI's equivalent of the plugin's `data.json`) defaults to `~/.hindsight/obsidian/<vault>.json` — deliberately **outside** the vault so Obsidian Sync never propagates it.
+
+> **Running the CLI and the plugin against the same bank + vault?** Keep their scope config identical (`--include`/`--exclude`, `--vault-name`, `--prefix-doc-id` matching the plugin's settings). They each keep their own index, and a reconcile prunes only what its own index tracks — so mismatched scope on the two frontends could let one prune documents the other owns.
+
 ## How it works
 
 ```

--- a/hindsight-integrations/obsidian/esbuild.config.mjs
+++ b/hindsight-integrations/obsidian/esbuild.config.mjs
@@ -5,7 +5,8 @@ import { builtinModules as builtins } from "node:module";
 
 const production = process.argv[2] === "production";
 
-const context = await esbuild.context({
+// The Obsidian plugin bundle (loaded by the Obsidian/Electron host at runtime).
+const pluginContext = await esbuild.context({
   entryPoints: ["src/main.ts"],
   bundle: true,
   // Obsidian and Electron are provided by the host at runtime; never bundle them.
@@ -20,9 +21,26 @@ const context = await esbuild.context({
   minify: production,
 });
 
+// The headless CLI bin (`hindsight-obsidian-sync`). Runs in plain Node — keep
+// node builtins and chokidar external so npm resolves them at install time.
+const cliContext = await esbuild.context({
+  entryPoints: ["src/node/cli-bin.ts"],
+  bundle: true,
+  platform: "node",
+  external: ["obsidian", "electron", "chokidar", "node:*", ...builtins],
+  format: "cjs",
+  target: "node20",
+  logLevel: "info",
+  sourcemap: production ? false : "inline",
+  treeShaking: true,
+  outfile: "dist/cli.js",
+  banner: { js: "#!/usr/bin/env node" },
+  minify: production,
+});
+
 if (production) {
-  await context.rebuild();
-  await context.dispose();
+  await Promise.all([pluginContext.rebuild(), cliContext.rebuild()]);
+  await Promise.all([pluginContext.dispose(), cliContext.dispose()]);
 } else {
-  await context.watch();
+  await Promise.all([pluginContext.watch(), cliContext.watch()]);
 }

--- a/hindsight-integrations/obsidian/package-lock.json
+++ b/hindsight-integrations/obsidian/package-lock.json
@@ -8,6 +8,12 @@
       "name": "@vectorize-io/hindsight-obsidian",
       "version": "0.1.2",
       "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.0"
+      },
+      "bin": {
+        "hindsight-obsidian-sync": "dist/cli.js"
+      },
       "devDependencies": {
         "@types/node": "^22.0.0",
         "esbuild": "^0.28.1",
@@ -1007,6 +1013,21 @@
         "node": ">=18"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1514,6 +1535,19 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/rolldown": {

--- a/hindsight-integrations/obsidian/package-lock.json
+++ b/hindsight-integrations/obsidian/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "chokidar": "^4.0.0"
+        "chokidar": "^4.0.3"
       },
       "bin": {
         "hindsight-obsidian-sync": "dist/cli.js"

--- a/hindsight-integrations/obsidian/package.json
+++ b/hindsight-integrations/obsidian/package.json
@@ -32,7 +32,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "chokidar": "^4.0.0"
+    "chokidar": "^4.0.3"
   },
   "keywords": [
     "obsidian",

--- a/hindsight-integrations/obsidian/package.json
+++ b/hindsight-integrations/obsidian/package.json
@@ -3,6 +3,17 @@
   "version": "0.1.2",
   "description": "Obsidian plugin for Hindsight — sync your vault into agent memory and chat grounded on your notes",
   "license": "MIT",
+  "bin": {
+    "hindsight-obsidian-sync": "dist/cli.js"
+  },
+  "files": [
+    "dist/",
+    "main.js",
+    "manifest.json",
+    "styles.css",
+    "README.md",
+    "LICENSE"
+  ],
   "homepage": "https://hindsight.vectorize.io",
   "author": {
     "name": "Vectorize",
@@ -19,6 +30,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "chokidar": "^4.0.0"
   },
   "keywords": [
     "obsidian",

--- a/hindsight-integrations/obsidian/src/client.ts
+++ b/hindsight-integrations/obsidian/src/client.ts
@@ -1,11 +1,13 @@
 /**
- * Minimal Hindsight HTTP client for the Obsidian plugin.
+ * Minimal Hindsight HTTP client.
  *
- * Uses Obsidian's `requestUrl` (NOT `fetch`) so requests run outside the
- * renderer's CORS sandbox. No external dependencies.
+ * Transport-agnostic: the caller injects a {@link Transport} (Obsidian's
+ * `requestUrl` for the plugin renderer, `fetch` for the headless CLI). This file
+ * has no runtime dependency on `obsidian`, so it is shared verbatim by both
+ * frontends and their request semantics can never drift apart.
  */
 
-import { requestUrl, type RequestUrlParam, type RequestUrlResponse } from "obsidian";
+import type { Transport, TransportResponse } from "./transport";
 import type { ReflectOptions, ReflectResponse, RetainOptions } from "./types";
 
 /**
@@ -20,12 +22,14 @@ function encodeDocPath(documentId: string): string {
 export class HindsightClient {
   private readonly baseUrl: string;
   private readonly token: string | undefined;
+  private readonly transport: Transport;
 
-  constructor(baseUrl: string, token?: string) {
+  constructor(baseUrl: string, token: string | undefined, transport: Transport) {
     const url = (baseUrl ?? "").trim();
     if (!url) throw new Error("Hindsight API URL is required");
     this.baseUrl = url.replace(/\/+$/, "");
     this.token = token?.trim() || undefined;
+    this.transport = transport;
   }
 
   private headers(): Record<string, string> {
@@ -38,17 +42,13 @@ export class HindsightClient {
     return `${this.baseUrl}/v1/default/banks/${encodeURIComponent(bankId)}${suffix}`;
   }
 
-  private async send(method: string, url: string, body?: unknown): Promise<RequestUrlResponse> {
-    const params: RequestUrlParam = {
+  private async send(method: string, url: string, body?: unknown): Promise<TransportResponse> {
+    const resp = await this.transport({
       url,
       method,
       headers: this.headers(),
-      // Handle non-2xx ourselves so we can surface a useful message.
-      throw: false,
-    };
-    if (body !== undefined) params.body = JSON.stringify(body);
-
-    const resp = await requestUrl(params);
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
     if (resp.status < 200 || resp.status >= 300) {
       const detail = (resp.text ?? "").slice(0, 500);
       throw new Error(`Hindsight ${method} ${url} → HTTP ${resp.status}: ${detail}`);
@@ -104,11 +104,10 @@ export class HindsightClient {
   /** Lightweight reachability check for the settings "Test connection" button. */
   async health(): Promise<boolean> {
     try {
-      const resp = await requestUrl({
+      const resp = await this.transport({
         url: `${this.baseUrl}/health`,
         method: "GET",
         headers: this.headers(),
-        throw: false,
       });
       return resp.status >= 200 && resp.status < 300;
     } catch {

--- a/hindsight-integrations/obsidian/src/main.ts
+++ b/hindsight-integrations/obsidian/src/main.ts
@@ -2,6 +2,7 @@ import { type Debouncer, Notice, Plugin, TFile, addIcon, debounce, setIcon } fro
 import { HINDSIGHT_ICON_ID, HINDSIGHT_ICON_SVG, HINDSIGHT_MARK_DATA_URI } from "./branding";
 import { ChatView, VIEW_TYPE_CHAT } from "./chat-view";
 import { HindsightClient } from "./client";
+import { obsidianTransport } from "./obsidian-transport";
 import { DEFAULT_SETTINGS, type HindsightSettings, HindsightSettingTab } from "./settings";
 import { SyncEngine, type SyncConfig, type SyncIndex, type SyncVault } from "./sync";
 import { type SyncStatus, renderSyncStatus } from "./status-bar";
@@ -266,7 +267,7 @@ export default class HindsightPlugin extends Plugin {
   private rebuildClient(): void {
     try {
       this.client = this.settings.apiUrl.trim()
-        ? new HindsightClient(this.settings.apiUrl, this.settings.apiKey)
+        ? new HindsightClient(this.settings.apiUrl, this.settings.apiKey, obsidianTransport)
         : null;
     } catch {
       this.client = null;

--- a/hindsight-integrations/obsidian/src/node/cli-bin.ts
+++ b/hindsight-integrations/obsidian/src/node/cli-bin.ts
@@ -1,0 +1,15 @@
+/**
+ * Executable entrypoint for the `hindsight-obsidian-sync` bin. Kept separate from
+ * `cli.ts` (which is side-effect-free and unit-tested) so importing the CLI's
+ * functions never runs the process or calls `process.exit`.
+ */
+
+import { runCli } from "./cli";
+
+runCli(process.argv.slice(2)).then(
+  (code) => process.exit(code),
+  (err) => {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+);

--- a/hindsight-integrations/obsidian/src/node/cli.ts
+++ b/hindsight-integrations/obsidian/src/node/cli.ts
@@ -12,6 +12,7 @@
  * entrypoint lives in `cli-bin.ts`.
  */
 
+import type { FSWatcher } from "chokidar";
 import { basename, relative, resolve, sep } from "node:path";
 import { parseArgs } from "node:util";
 import { HindsightClient } from "../client";
@@ -155,15 +156,25 @@ function formatSummary(label: string, s: ReconcileSummary): string {
   return `${label}: +${s.added} added, ~${s.updated} updated, -${s.deleted} deleted, =${s.unchanged} unchanged`;
 }
 
-/** Start watch mode: an initial reconcile, then live sync until interrupted. */
-export async function startWatch(
+/** The subset of chokidar options tests tune for deterministic, fast watching. */
+export interface WatchOverrides {
+  usePolling?: boolean;
+  interval?: number;
+  awaitWriteFinish?: boolean | { stabilityThreshold?: number; pollInterval?: number };
+}
+
+/**
+ * Wire a chokidar watcher over the vault to the engine and return it (live).
+ * Split out from {@link startWatch} so tests can drive real filesystem events
+ * and then close the watcher, instead of blocking forever. `overrides` lets
+ * tests tighten the debounce / force polling for deterministic CI behavior.
+ */
+export async function watchVault(
   opts: CliOptions,
   engine: SyncEngine,
   vault: FsVault,
-  log: (msg: string) => void = console.log
-): Promise<void> {
-  log(formatSummary("initial reconcile", await engine.reconcile()));
-
+  overrides: WatchOverrides = {}
+): Promise<FSWatcher> {
   const { watch } = await import("chokidar");
   const handlers = createWatchHandlers(engine, vault);
   const toRel = (abs: string) => relative(opts.vault, abs).split(sep).join("/");
@@ -176,12 +187,24 @@ export async function startWatch(
     // Skip dotfolders (.obsidian/.trash/.git); coalesce partial saves.
     ignored: (p: string) => p.split(sep).some((seg) => seg.startsWith(".")),
     awaitWriteFinish: { stabilityThreshold: 300, pollInterval: 100 },
+    ...overrides,
   });
   watcher.on("add", (p: string) => isMarkdown(p) && handlers.onUpsert(toRel(p)).catch(report));
   watcher.on("change", (p: string) => isMarkdown(p) && handlers.onUpsert(toRel(p)).catch(report));
   watcher.on("unlink", (p: string) => isMarkdown(p) && handlers.onUnlink(toRel(p)).catch(report));
-  log(`watching ${opts.vault} for changes (Ctrl-C to stop)`);
+  return watcher;
+}
 
+/** Start watch mode: an initial reconcile, then live sync until interrupted. */
+export async function startWatch(
+  opts: CliOptions,
+  engine: SyncEngine,
+  vault: FsVault,
+  log: (msg: string) => void = console.log
+): Promise<void> {
+  log(formatSummary("initial reconcile", await engine.reconcile()));
+  await watchVault(opts, engine, vault); // returns a live watcher; let it run
+  log(`watching ${opts.vault} for changes (Ctrl-C to stop)`);
   await new Promise<never>(() => {}); // run until the process is signalled
 }
 

--- a/hindsight-integrations/obsidian/src/node/cli.ts
+++ b/hindsight-integrations/obsidian/src/node/cli.ts
@@ -131,7 +131,13 @@ export async function buildEngine(
   const vault = new FsVault(opts.vault);
   const client = new HindsightClient(opts.apiUrl, opts.apiToken, transport);
   const index = await loadIndex(opts.indexPath);
-  const engine = new SyncEngine(client, vault, buildConfig(opts), index, makePersist(opts.indexPath));
+  const engine = new SyncEngine(
+    client,
+    vault,
+    buildConfig(opts),
+    index,
+    makePersist(opts.indexPath)
+  );
   return { engine, vault };
 }
 
@@ -179,7 +185,8 @@ export async function watchVault(
   const handlers = createWatchHandlers(engine, vault);
   const toRel = (abs: string) => relative(opts.vault, abs).split(sep).join("/");
   const isMarkdown = (p: string) => p.toLowerCase().endsWith(".md");
-  const report = (err: unknown) => console.error(`[hindsight] ${err instanceof Error ? err.message : String(err)}`);
+  const report = (err: unknown) =>
+    console.error(`[hindsight] ${err instanceof Error ? err.message : String(err)}`);
 
   const watcher = watch(opts.vault, {
     ignoreInitial: true,

--- a/hindsight-integrations/obsidian/src/node/cli.ts
+++ b/hindsight-integrations/obsidian/src/node/cli.ts
@@ -1,0 +1,221 @@
+/**
+ * Headless CLI frontend for vault → Hindsight ingestion.
+ *
+ * It is a thin second frontend over the same {@link SyncEngine} the Obsidian
+ * plugin uses, so a server-synced vault produces identical document ids, tags,
+ * and prune-ownership as the plugin — the two never fight or duplicate. The only
+ * differences are the vault source (filesystem vs Obsidian API), the transport
+ * (`fetch` vs `requestUrl`), and where the sync index lives (a JSON file vs the
+ * plugin's `data.json`).
+ *
+ * Everything here is exported and side-effect-free for testing; the executable
+ * entrypoint lives in `cli-bin.ts`.
+ */
+
+import { basename, relative, resolve, sep } from "node:path";
+import { parseArgs } from "node:util";
+import { HindsightClient } from "../client";
+import { SyncEngine, type ReconcileSummary, type SyncConfig } from "../sync";
+import type { Transport } from "../transport";
+import { fetchTransport } from "./fetch-transport";
+import { FsVault } from "./fs-vault";
+import { defaultIndexPath, loadIndex, makePersist } from "./json-index";
+
+export interface CliOptions {
+  /** Absolute path to the vault root. */
+  vault: string;
+  bank: string;
+  apiUrl: string;
+  apiToken?: string;
+  include: string[];
+  exclude: string[];
+  vaultName: string;
+  prefixDocId: boolean;
+  indexPath: string;
+  watch: boolean;
+}
+
+const USAGE = `hindsight-obsidian-sync — ingest an Obsidian vault into Hindsight (headless).
+
+Usage:
+  hindsight-obsidian-sync reconcile --vault <path> --bank <id> [options]
+
+Options:
+  --vault <path>        Vault root directory (required)
+  --bank <id>           Target Hindsight bank id (required)
+  --api-url <url>       Hindsight API base URL (or env HINDSIGHT_API_URL)
+  --api-token <token>   API token (or env HINDSIGHT_API_TOKEN)
+  --include <folder>    Only sync this folder (repeatable; default: whole vault)
+  --exclude <folder>    Skip this folder (repeatable)
+  --vault-name <name>   Vault name for tags/ids (default: the vault dir name)
+  --prefix-doc-id       Prefix document ids with the vault name (multi-vault banks)
+  --index <file>        Sync-index JSON path (default: ~/.hindsight/obsidian/<vault>.json)
+  --watch               Keep running and sync changes as they happen
+  --help                Show this help
+`;
+
+/** Thrown for invalid invocations; its message is printed to stderr (exit 2). */
+export class UsageError extends Error {}
+
+/** Thrown for `--help`; its message is printed to stdout (exit 0). */
+export class HelpRequested extends Error {}
+
+/** Parse argv into fully-resolved options (applying env fallbacks + defaults). */
+export function parseCliArgs(argv: string[]): CliOptions {
+  const { values, positionals } = parseArgs({
+    args: argv,
+    allowPositionals: true,
+    options: {
+      vault: { type: "string" },
+      bank: { type: "string" },
+      "api-url": { type: "string" },
+      "api-token": { type: "string" },
+      include: { type: "string", multiple: true },
+      exclude: { type: "string", multiple: true },
+      "vault-name": { type: "string" },
+      "prefix-doc-id": { type: "boolean", default: false },
+      index: { type: "string" },
+      watch: { type: "boolean", default: false },
+      help: { type: "boolean", default: false },
+    },
+  });
+
+  if (values.help) throw new HelpRequested(USAGE);
+
+  // The only accepted subcommand is "reconcile" (also the default).
+  const command = positionals[0] ?? "reconcile";
+  if (command !== "reconcile") throw new UsageError(`unknown command "${command}"\n\n${USAGE}`);
+
+  const vaultRaw = values.vault;
+  if (!vaultRaw) throw new UsageError("--vault is required");
+  if (!values.bank) throw new UsageError("--bank is required");
+
+  const vault = resolve(vaultRaw);
+  const vaultName = values["vault-name"] || basename(vault);
+  const apiUrl = values["api-url"] || process.env.HINDSIGHT_API_URL || "";
+  if (!apiUrl) throw new UsageError("--api-url is required (or set HINDSIGHT_API_URL)");
+
+  return {
+    vault,
+    bank: values.bank,
+    apiUrl,
+    apiToken: values["api-token"] || process.env.HINDSIGHT_API_TOKEN || undefined,
+    include: values.include ?? [],
+    exclude: values.exclude ?? [],
+    vaultName,
+    prefixDocId: values["prefix-doc-id"] ?? false,
+    indexPath: values.index || defaultIndexPath(vaultName),
+    watch: values.watch ?? false,
+  };
+}
+
+export function buildConfig(opts: CliOptions): SyncConfig {
+  return {
+    bankId: opts.bank,
+    includeFolders: opts.include,
+    excludeFolders: opts.exclude,
+    vaultName: opts.vaultName,
+    prefixDocId: opts.prefixDocId,
+  };
+}
+
+/**
+ * Assemble the engine from options. `transport` is injectable so tests can drive
+ * the full stack (FsVault → SyncEngine → HindsightClient) without real network.
+ */
+export async function buildEngine(
+  opts: CliOptions,
+  transport: Transport = fetchTransport
+): Promise<{ engine: SyncEngine; vault: FsVault }> {
+  const vault = new FsVault(opts.vault);
+  const client = new HindsightClient(opts.apiUrl, opts.apiToken, transport);
+  const index = await loadIndex(opts.indexPath);
+  const engine = new SyncEngine(client, vault, buildConfig(opts), index, makePersist(opts.indexPath));
+  return { engine, vault };
+}
+
+/**
+ * Map filesystem events to engine operations. A rename arrives from chokidar as
+ * unlink(old) + add(new), which the engine handles correctly as delete-then-
+ * create — same net result as the plugin's dedicated rename path.
+ */
+export function createWatchHandlers(engine: SyncEngine, vault: FsVault) {
+  return {
+    async onUpsert(relPath: string): Promise<void> {
+      const file = vault.syncFileFor(relPath);
+      if (file) await engine.ingestFile(file, { force: true });
+    },
+    async onUnlink(relPath: string): Promise<void> {
+      await engine.handleDelete(relPath);
+    },
+  };
+}
+
+function formatSummary(label: string, s: ReconcileSummary): string {
+  return `${label}: +${s.added} added, ~${s.updated} updated, -${s.deleted} deleted, =${s.unchanged} unchanged`;
+}
+
+/** Start watch mode: an initial reconcile, then live sync until interrupted. */
+export async function startWatch(
+  opts: CliOptions,
+  engine: SyncEngine,
+  vault: FsVault,
+  log: (msg: string) => void = console.log
+): Promise<void> {
+  log(formatSummary("initial reconcile", await engine.reconcile()));
+
+  const { watch } = await import("chokidar");
+  const handlers = createWatchHandlers(engine, vault);
+  const toRel = (abs: string) => relative(opts.vault, abs).split(sep).join("/");
+  const isMarkdown = (p: string) => p.toLowerCase().endsWith(".md");
+  const report = (err: unknown) => console.error(`[hindsight] ${err instanceof Error ? err.message : String(err)}`);
+
+  const watcher = watch(opts.vault, {
+    ignoreInitial: true,
+    persistent: true,
+    // Skip dotfolders (.obsidian/.trash/.git); coalesce partial saves.
+    ignored: (p: string) => p.split(sep).some((seg) => seg.startsWith(".")),
+    awaitWriteFinish: { stabilityThreshold: 300, pollInterval: 100 },
+  });
+  watcher.on("add", (p: string) => isMarkdown(p) && handlers.onUpsert(toRel(p)).catch(report));
+  watcher.on("change", (p: string) => isMarkdown(p) && handlers.onUpsert(toRel(p)).catch(report));
+  watcher.on("unlink", (p: string) => isMarkdown(p) && handlers.onUnlink(toRel(p)).catch(report));
+  log(`watching ${opts.vault} for changes (Ctrl-C to stop)`);
+
+  await new Promise<never>(() => {}); // run until the process is signalled
+}
+
+/** Run the CLI. Returns a process exit code; never calls process.exit itself. */
+export async function runCli(
+  argv: string[],
+  log: (msg: string) => void = console.log,
+  logErr: (msg: string) => void = console.error
+): Promise<number> {
+  let opts: CliOptions;
+  try {
+    opts = parseCliArgs(argv);
+  } catch (err) {
+    if (err instanceof HelpRequested) {
+      log(err.message);
+      return 0;
+    }
+    logErr(err instanceof UsageError ? err.message : `hindsight-obsidian-sync: ${describe(err)}`);
+    return 2;
+  }
+  try {
+    const { engine, vault } = await buildEngine(opts);
+    if (opts.watch) {
+      await startWatch(opts, engine, vault, log);
+      return 0;
+    }
+    log(formatSummary("reconcile", await engine.reconcile()));
+    return 0;
+  } catch (err) {
+    logErr(`hindsight-obsidian-sync: ${describe(err)}`);
+    return 1;
+  }
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/hindsight-integrations/obsidian/src/node/fetch-transport.ts
+++ b/hindsight-integrations/obsidian/src/node/fetch-transport.ts
@@ -1,0 +1,26 @@
+/**
+ * Node {@link Transport}: a `fetch`-based implementation for the headless CLI.
+ * Outside Obsidian's renderer there is no CORS sandbox, so plain `fetch`
+ * (global since Node 18) is all we need.
+ */
+
+import type { Transport } from "../transport";
+
+function tryParseJson(text: string): unknown {
+  if (!text) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+export const fetchTransport: Transport = async (req) => {
+  const resp = await fetch(req.url, {
+    method: req.method,
+    headers: req.headers,
+    body: req.body,
+  });
+  const text = await resp.text();
+  return { status: resp.status, text, json: tryParseJson(text) };
+};

--- a/hindsight-integrations/obsidian/src/node/fs-vault.ts
+++ b/hindsight-integrations/obsidian/src/node/fs-vault.ts
@@ -1,0 +1,61 @@
+/**
+ * Filesystem {@link SyncVault}: enumerates a vault's Markdown files from disk so
+ * the shared {@link SyncEngine} can run headless, with no Obsidian runtime.
+ *
+ * Semantics are kept identical to Obsidian's `Vault`:
+ * - paths are vault-relative and POSIX-separated (so document ids/tags match the
+ *   plugin's regardless of host OS);
+ * - `stat.mtime`/`stat.ctime` are epoch milliseconds, matching `TFile.stat`;
+ * - dotfolders (`.obsidian`, `.trash`, `.git`, …) are skipped — they hold config
+ *   and history, never vault notes. Note-level include/exclude scoping is the
+ *   engine's job (`SyncConfig.includeFolders`/`excludeFolders`), not the vault's.
+ */
+
+import { readdirSync, statSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { SyncFile, SyncVault } from "../sync";
+
+export class FsVault implements SyncVault {
+  constructor(private readonly root: string) {}
+
+  getMarkdownFiles(): SyncFile[] {
+    const out: SyncFile[] = [];
+    this.walk("", out);
+    return out;
+  }
+
+  private walk(rel: string, out: SyncFile[]): void {
+    const abs = rel ? join(this.root, rel) : this.root;
+    for (const entry of readdirSync(abs, { withFileTypes: true })) {
+      // Skip dotfiles/dotfolders (.obsidian, .trash, .git, …) — config, not notes.
+      if (entry.name.startsWith(".")) continue;
+      const childRel = rel ? `${rel}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        this.walk(childRel, out);
+      } else if (entry.isFile() && entry.name.toLowerCase().endsWith(".md")) {
+        const file = this.syncFileFor(childRel);
+        if (file) out.push(file);
+      }
+    }
+  }
+
+  /**
+   * Build a {@link SyncFile} for a single vault-relative path, or null if it is
+   * gone. Used by watch mode to turn an fs event into an ingest.
+   */
+  syncFileFor(path: string): SyncFile | null {
+    try {
+      const st = statSync(join(this.root, ...path.split("/")));
+      // birthtime is unreliable on some Linux filesystems (reported as 0); fall
+      // back to ctime (inode change) so created-date tags still get a value.
+      return { path, stat: { mtime: st.mtimeMs, ctime: st.birthtimeMs || st.ctimeMs } };
+    } catch {
+      return null;
+    }
+  }
+
+  async read(file: SyncFile): Promise<string> {
+    return readFile(join(this.root, ...file.path.split("/")), "utf8");
+  }
+}

--- a/hindsight-integrations/obsidian/src/node/json-index.ts
+++ b/hindsight-integrations/obsidian/src/node/json-index.ts
@@ -1,0 +1,52 @@
+/**
+ * JSON-file persistence for the sync index, the CLI's equivalent of the plugin's
+ * `data.json`. Kept out of the vault by default (see {@link defaultIndexPath})
+ * so Obsidian Sync never propagates it and it can't collide with the plugin's
+ * own index on another machine.
+ */
+
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import type { SyncIndex } from "../sync";
+
+interface IndexFile {
+  syncIndex: SyncIndex;
+  lastSyncAt: string | null;
+}
+
+/** Default out-of-vault index location: `~/.hindsight/obsidian/<vault>.json`. */
+export function defaultIndexPath(vaultName: string): string {
+  const safe = vaultName.replace(/[^A-Za-z0-9._-]+/g, "_") || "vault";
+  return join(homedir(), ".hindsight", "obsidian", `${safe}.json`);
+}
+
+/** Load a previously-persisted index, or an empty one if absent/unreadable. */
+export async function loadIndex(path: string): Promise<SyncIndex> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch {
+    return {}; // first run — no index yet
+  }
+  try {
+    const data = JSON.parse(raw) as Partial<IndexFile>;
+    return data.syncIndex ?? {};
+  } catch {
+    // A corrupt index means a full re-ingest (hash-skips unchanged) rather than
+    // a crash; warn because orphan pruning can't run until the index is rebuilt.
+    console.warn(`[hindsight] ignoring unreadable sync index at ${path}; starting fresh`);
+    return {};
+  }
+}
+
+/** A `persist` callback for {@link SyncEngine} that atomically writes the index. */
+export function makePersist(path: string, nowIso: () => string = () => new Date().toISOString()) {
+  return async (index: SyncIndex): Promise<void> => {
+    await mkdir(dirname(path), { recursive: true });
+    const payload: IndexFile = { syncIndex: index, lastSyncAt: nowIso() };
+    const tmp = `${path}.tmp`;
+    await writeFile(tmp, `${JSON.stringify(payload, null, 2)}\n`);
+    await rename(tmp, path); // atomic replace — never leave a half-written index
+  };
+}

--- a/hindsight-integrations/obsidian/src/obsidian-transport.ts
+++ b/hindsight-integrations/obsidian/src/obsidian-transport.ts
@@ -1,0 +1,31 @@
+/**
+ * Obsidian-renderer {@link Transport}: wraps `requestUrl`, which (unlike `fetch`)
+ * runs outside the renderer's CORS sandbox. Plugin-only — this is the sole place
+ * the client path touches `obsidian`.
+ */
+
+import { requestUrl } from "obsidian";
+import type { Transport } from "./transport";
+
+/** Parse a body as JSON, returning undefined for empty or non-JSON responses. */
+function tryParseJson(text: string): unknown {
+  if (!text) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+export const obsidianTransport: Transport = async (req) => {
+  const resp = await requestUrl({
+    url: req.url,
+    method: req.method,
+    headers: req.headers,
+    body: req.body,
+    // Handle non-2xx in the client so it can surface a useful message.
+    throw: false,
+  });
+  const text = resp.text ?? "";
+  return { status: resp.status, text, json: tryParseJson(text) };
+};

--- a/hindsight-integrations/obsidian/src/transport.ts
+++ b/hindsight-integrations/obsidian/src/transport.ts
@@ -1,0 +1,26 @@
+/**
+ * HTTP transport seam for {@link HindsightClient}.
+ *
+ * The plugin runs inside Obsidian's renderer and must use `requestUrl` to escape
+ * the CORS sandbox; a headless CLI runs in Node and uses `fetch`. Keeping the
+ * client transport-agnostic lets both frontends share one client (and therefore
+ * one set of request semantics) instead of maintaining divergent copies.
+ */
+
+export interface TransportRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  /** JSON-encoded request body, omitted for GET/DELETE. */
+  body?: string;
+}
+
+export interface TransportResponse {
+  status: number;
+  /** Raw response body; used to build error messages on non-2xx. */
+  text: string;
+  /** Parsed body when it is valid JSON, otherwise undefined. */
+  json: unknown;
+}
+
+export type Transport = (req: TransportRequest) => Promise<TransportResponse>;

--- a/hindsight-integrations/obsidian/tests/client.spec.ts
+++ b/hindsight-integrations/obsidian/tests/client.spec.ts
@@ -1,18 +1,18 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { HindsightClient } from "../src/client";
-// Import the mock by path so tsc type-checks against it; vitest aliases
-// "obsidian" → this same module, so it's the singleton the client calls.
-import { requestUrl } from "./__mocks__/obsidian";
-
-const mock = requestUrl;
+import type { Transport, TransportRequest } from "../src/transport";
 
 function ok(json: unknown = {}) {
   return { status: 200, text: JSON.stringify(json), json };
 }
 
-function lastCall() {
+// A fake transport records the requests the client makes so we can assert on
+// them, exactly as the real requestUrl/fetch transports would receive them.
+const mock = vi.fn<Transport>();
+
+function lastCall(): TransportRequest {
   const call = mock.mock.calls.at(-1);
-  if (!call) throw new Error("requestUrl was not called");
+  if (!call) throw new Error("transport was not called");
   return call[0];
 }
 
@@ -23,7 +23,7 @@ describe("HindsightClient", () => {
   });
 
   it("retain posts an upsert item with document_id and replace mode", async () => {
-    const client = new HindsightClient("https://api.example.com/", "secret");
+    const client = new HindsightClient("https://api.example.com/", "secret", mock);
     await client.retain("bank x", "Folder/Note.md", "body text", { tags: ["t1"] });
 
     const params = lastCall();
@@ -40,7 +40,7 @@ describe("HindsightClient", () => {
   });
 
   it("deleteDocument encodes segments but preserves path slashes", async () => {
-    const client = new HindsightClient("https://api.example.com");
+    const client = new HindsightClient("https://api.example.com", undefined, mock);
     await client.deleteDocument("b", "Folder/My Note.md");
     const params = lastCall();
     expect(params.method).toBe("DELETE");
@@ -51,7 +51,7 @@ describe("HindsightClient", () => {
 
   it("reflect requests citations + trace when asked", async () => {
     mock.mockResolvedValue(ok({ text: "answer", based_on: { memories: [] } }));
-    const client = new HindsightClient("https://api.example.com");
+    const client = new HindsightClient("https://api.example.com", undefined, mock);
     const res = await client.reflect("b", "what?", { budget: "high", includeCitations: true });
 
     const body = JSON.parse(lastCall().body ?? "{}");
@@ -61,25 +61,25 @@ describe("HindsightClient", () => {
   });
 
   it("omits the Authorization header when no token is set", async () => {
-    const client = new HindsightClient("https://api.example.com");
+    const client = new HindsightClient("https://api.example.com", undefined, mock);
     await client.reflect("b", "q");
     expect(lastCall().headers?.Authorization).toBeUndefined();
   });
 
   it("throws a useful error on non-2xx", async () => {
     mock.mockResolvedValue({ status: 500, text: "boom", json: {} });
-    const client = new HindsightClient("https://api.example.com");
+    const client = new HindsightClient("https://api.example.com", undefined, mock);
     await expect(client.reflect("b", "q")).rejects.toThrow(/HTTP 500: boom/);
   });
 
   it("propagates a transport rejection (network/timeout)", async () => {
     mock.mockRejectedValue(new Error("net::ERR_CONNECTION_REFUSED"));
-    const client = new HindsightClient("https://api.example.com");
+    const client = new HindsightClient("https://api.example.com", undefined, mock);
     await expect(client.reflect("b", "q")).rejects.toThrow(/ERR_CONNECTION_REFUSED/);
   });
 
   it("reflect sends tag_groups when provided", async () => {
-    const client = new HindsightClient("https://api.example.com");
+    const client = new HindsightClient("https://api.example.com", undefined, mock);
     await client.reflect("b", "q", {
       tagGroups: [{ tags: ["vault:notes"], match: "all_strict" }],
       tags: ["ignored"],
@@ -90,7 +90,7 @@ describe("HindsightClient", () => {
   });
 
   it("reflect falls back to tags when only tags are given", async () => {
-    const client = new HindsightClient("https://api.example.com");
+    const client = new HindsightClient("https://api.example.com", undefined, mock);
     await client.reflect("b", "q", { tags: ["work"] });
     const body = JSON.parse(lastCall().body ?? "{}");
     expect(body.tags).toEqual(["work"]);
@@ -98,7 +98,7 @@ describe("HindsightClient", () => {
   });
 
   it("reflect sends neither tags nor tag_groups when both are empty", async () => {
-    const client = new HindsightClient("https://api.example.com");
+    const client = new HindsightClient("https://api.example.com", undefined, mock);
     await client.reflect("b", "q", { tags: [], tagGroups: [] });
     const body = JSON.parse(lastCall().body ?? "{}");
     expect(body.tags).toBeUndefined();
@@ -106,7 +106,7 @@ describe("HindsightClient", () => {
   });
 
   it("retain omits the tags field when no tags are given", async () => {
-    const client = new HindsightClient("https://api.example.com");
+    const client = new HindsightClient("https://api.example.com", undefined, mock);
     await client.retain("b", "Note.md", "body");
     const body = JSON.parse(lastCall().body ?? "{}");
     expect(body.items[0].tags).toBeUndefined();

--- a/hindsight-integrations/obsidian/tests/node/cli.spec.ts
+++ b/hindsight-integrations/obsidian/tests/node/cli.spec.ts
@@ -152,4 +152,28 @@ describe("runCli", () => {
     expect(await runCli(["--bank", "b"], () => {}, (m) => err.push(m))).toBe(2);
     expect(err.join("\n")).toMatch(/--vault is required/);
   });
+
+  it("threads --exclude through to the engine (excluded folder never POSTed)", async () => {
+    await mkdir(join(root, "Keep"), { recursive: true });
+    await mkdir(join(root, "Archive"), { recursive: true });
+    await writeFile(join(root, "Keep", "a.md"), "keep");
+    await writeFile(join(root, "Archive", "b.md"), "archive");
+
+    const posted: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body ?? "{}"));
+        if (body.items) posted.push(body.items[0].document_id);
+        return { status: 200, text: async () => "{}" } as unknown as Response;
+      })
+    );
+
+    const code = await runCli(
+      ["--vault", root, "--bank", "b", "--api-url", "https://h", "--exclude", "Archive", "--index", join(root, "i.json")],
+      () => {}
+    );
+    expect(code).toBe(0);
+    expect(posted).toEqual(["Keep/a.md"]);
+  });
 });

--- a/hindsight-integrations/obsidian/tests/node/cli.spec.ts
+++ b/hindsight-integrations/obsidian/tests/node/cli.spec.ts
@@ -1,0 +1,155 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  HelpRequested,
+  UsageError,
+  buildConfig,
+  createWatchHandlers,
+  parseCliArgs,
+  runCli,
+} from "../../src/node/cli";
+import type { FsVault } from "../../src/node/fs-vault";
+import type { SyncEngine, SyncFile } from "../../src/sync";
+
+describe("parseCliArgs", () => {
+  beforeEach(() => {
+    vi.stubEnv("HINDSIGHT_API_URL", "");
+    vi.stubEnv("HINDSIGHT_API_TOKEN", "");
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  const base = ["--vault", "/v", "--bank", "b", "--api-url", "https://h"];
+
+  it("resolves required flags and sensible defaults", () => {
+    const o = parseCliArgs(base);
+    expect(o.bank).toBe("b");
+    expect(o.apiUrl).toBe("https://h");
+    expect(o.vault).toMatch(/[/\\]v$/); // resolved to absolute
+    expect(o.vaultName).toBe("v"); // basename of the vault dir
+    expect(o.include).toEqual([]);
+    expect(o.exclude).toEqual([]);
+    expect(o.prefixDocId).toBe(false);
+    expect(o.watch).toBe(false);
+    expect(o.indexPath).toMatch(/\.hindsight[/\\]obsidian[/\\]v\.json$/);
+  });
+
+  it("collects repeatable --include/--exclude and flags", () => {
+    const o = parseCliArgs([
+      ...base,
+      "--include",
+      "Work",
+      "--include",
+      "Personal",
+      "--exclude",
+      "Archive",
+      "--prefix-doc-id",
+      "--vault-name",
+      "Brain",
+      "--index",
+      "/tmp/i.json",
+    ]);
+    expect(o.include).toEqual(["Work", "Personal"]);
+    expect(o.exclude).toEqual(["Archive"]);
+    expect(o.prefixDocId).toBe(true);
+    expect(o.vaultName).toBe("Brain");
+    expect(o.indexPath).toBe("/tmp/i.json");
+  });
+
+  it("falls back to env for api url/token", () => {
+    vi.stubEnv("HINDSIGHT_API_URL", "https://env");
+    vi.stubEnv("HINDSIGHT_API_TOKEN", "envtok");
+    const o = parseCliArgs(["--vault", "/v", "--bank", "b"]);
+    expect(o.apiUrl).toBe("https://env");
+    expect(o.apiToken).toBe("envtok");
+  });
+
+  it("requires --vault, --bank and an api url", () => {
+    expect(() => parseCliArgs(["--bank", "b", "--api-url", "h"])).toThrow(UsageError);
+    expect(() => parseCliArgs(["--vault", "/v", "--api-url", "h"])).toThrow(UsageError);
+    expect(() => parseCliArgs(["--vault", "/v", "--bank", "b"])).toThrow(/api-url/);
+  });
+
+  it("rejects an unknown subcommand and surfaces --help", () => {
+    expect(() => parseCliArgs(["frobnicate", ...base])).toThrow(UsageError);
+    expect(() => parseCliArgs(["--help"])).toThrow(HelpRequested);
+  });
+});
+
+describe("buildConfig", () => {
+  it("maps options onto a SyncConfig", () => {
+    const cfg = buildConfig(parseCliArgs(["--vault", "/v", "--bank", "b", "--api-url", "h", "--prefix-doc-id"]));
+    expect(cfg).toEqual({
+      bankId: "b",
+      includeFolders: [],
+      excludeFolders: [],
+      vaultName: "v",
+      prefixDocId: true,
+    });
+  });
+});
+
+describe("createWatchHandlers", () => {
+  it("upserts a live file and deletes on unlink", async () => {
+    const ingestFile = vi.fn(async () => "created" as const);
+    const handleDelete = vi.fn(async () => {});
+    const engine = { ingestFile, handleDelete } as unknown as SyncEngine;
+    const file: SyncFile = { path: "a.md", stat: { mtime: 1, ctime: 0 } };
+    const vault = { syncFileFor: (p: string) => (p === "a.md" ? file : null) } as unknown as FsVault;
+
+    const h = createWatchHandlers(engine, vault);
+    await h.onUpsert("a.md");
+    await h.onUpsert("gone.md"); // vanished before we could stat it → no-op
+    await h.onUnlink("a.md");
+
+    expect(ingestFile).toHaveBeenCalledExactlyOnceWith(file, { force: true });
+    expect(handleDelete).toHaveBeenCalledExactlyOnceWith("a.md");
+  });
+});
+
+describe("runCli", () => {
+  let root: string;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "hs-cli-"));
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+    vi.unstubAllGlobals();
+  });
+
+  it("reconciles a real vault end-to-end (fetch mocked), printing a summary", async () => {
+    await mkdir(join(root, "Work"), { recursive: true });
+    await writeFile(join(root, "Work", "note.md"), "# Note\nremember this");
+
+    const fetchSpy = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+      async () => ({ status: 200, text: async () => "{}" }) as unknown as Response
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+    const out: string[] = [];
+
+    const code = await runCli(
+      ["--vault", root, "--bank", "b", "--api-url", "https://h", "--index", join(root, "idx.json")],
+      (m) => out.push(m)
+    );
+
+    expect(code).toBe(0);
+    expect(out.join("\n")).toMatch(/reconcile: \+1 added/);
+    // One retain POST to the memories endpoint.
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://h/v1/default/banks/b/memories");
+    expect(init?.method).toBe("POST");
+  });
+
+  it("prints help and exits 0", async () => {
+    const out: string[] = [];
+    expect(await runCli(["--help"], (m) => out.push(m))).toBe(0);
+    expect(out.join("\n")).toMatch(/Usage:/);
+  });
+
+  it("returns exit code 2 on a usage error", async () => {
+    const err: string[] = [];
+    expect(await runCli(["--bank", "b"], () => {}, (m) => err.push(m))).toBe(2);
+    expect(err.join("\n")).toMatch(/--vault is required/);
+  });
+});

--- a/hindsight-integrations/obsidian/tests/node/cli.spec.ts
+++ b/hindsight-integrations/obsidian/tests/node/cli.spec.ts
@@ -79,7 +79,9 @@ describe("parseCliArgs", () => {
 
 describe("buildConfig", () => {
   it("maps options onto a SyncConfig", () => {
-    const cfg = buildConfig(parseCliArgs(["--vault", "/v", "--bank", "b", "--api-url", "h", "--prefix-doc-id"]));
+    const cfg = buildConfig(
+      parseCliArgs(["--vault", "/v", "--bank", "b", "--api-url", "h", "--prefix-doc-id"])
+    );
     expect(cfg).toEqual({
       bankId: "b",
       includeFolders: [],
@@ -96,7 +98,9 @@ describe("createWatchHandlers", () => {
     const handleDelete = vi.fn(async () => {});
     const engine = { ingestFile, handleDelete } as unknown as SyncEngine;
     const file: SyncFile = { path: "a.md", stat: { mtime: 1, ctime: 0 } };
-    const vault = { syncFileFor: (p: string) => (p === "a.md" ? file : null) } as unknown as FsVault;
+    const vault = {
+      syncFileFor: (p: string) => (p === "a.md" ? file : null),
+    } as unknown as FsVault;
 
     const h = createWatchHandlers(engine, vault);
     await h.onUpsert("a.md");
@@ -149,7 +153,13 @@ describe("runCli", () => {
 
   it("returns exit code 2 on a usage error", async () => {
     const err: string[] = [];
-    expect(await runCli(["--bank", "b"], () => {}, (m) => err.push(m))).toBe(2);
+    expect(
+      await runCli(
+        ["--bank", "b"],
+        () => {},
+        (m) => err.push(m)
+      )
+    ).toBe(2);
     expect(err.join("\n")).toMatch(/--vault is required/);
   });
 
@@ -170,7 +180,18 @@ describe("runCli", () => {
     );
 
     const code = await runCli(
-      ["--vault", root, "--bank", "b", "--api-url", "https://h", "--exclude", "Archive", "--index", join(root, "i.json")],
+      [
+        "--vault",
+        root,
+        "--bank",
+        "b",
+        "--api-url",
+        "https://h",
+        "--exclude",
+        "Archive",
+        "--index",
+        join(root, "i.json"),
+      ],
       () => {}
     );
     expect(code).toBe(0);

--- a/hindsight-integrations/obsidian/tests/node/e2e-http.spec.ts
+++ b/hindsight-integrations/obsidian/tests/node/e2e-http.spec.ts
@@ -35,7 +35,12 @@ beforeEach(async () => {
       body += chunk;
     });
     req.on("end", () => {
-      received.push({ method: req.method ?? "", url: req.url ?? "", auth: req.headers.authorization, body });
+      received.push({
+        method: req.method ?? "",
+        url: req.url ?? "",
+        auth: req.headers.authorization,
+        body,
+      });
       res.writeHead(200, { "content-type": "application/json" });
       res.end("{}");
     });
@@ -55,16 +60,28 @@ describe("runCli end-to-end over real HTTP", () => {
     await writeFile(join(root, "Work", "note.md"), "# Note\nships in Q3");
     const indexPath = join(root, "idx.json");
     const args = [
-      "--vault", root,
-      "--bank", "team",
-      "--api-url", baseUrl,
-      "--api-token", "hsk_secret",
-      "--vault-name", "TeamVault",
-      "--index", indexPath,
+      "--vault",
+      root,
+      "--bank",
+      "team",
+      "--api-url",
+      baseUrl,
+      "--api-token",
+      "hsk_secret",
+      "--vault-name",
+      "TeamVault",
+      "--index",
+      indexPath,
     ];
 
     // First run: the note is ingested.
-    expect(await runCli(args, () => {}, () => {})).toBe(0);
+    expect(
+      await runCli(
+        args,
+        () => {},
+        () => {}
+      )
+    ).toBe(0);
 
     const retain = received.find((r) => r.url.endsWith("/memories"));
     expect(retain).toBeDefined();
@@ -79,7 +96,13 @@ describe("runCli end-to-end over real HTTP", () => {
     // Delete the note and re-run: the document is pruned via a real DELETE.
     received.length = 0;
     await rm(join(root, "Work", "note.md"));
-    expect(await runCli(args, () => {}, () => {})).toBe(0);
+    expect(
+      await runCli(
+        args,
+        () => {},
+        () => {}
+      )
+    ).toBe(0);
 
     const del = received.find((r) => r.method === "DELETE");
     expect(del).toBeDefined();
@@ -92,7 +115,16 @@ describe("runCli end-to-end over real HTTP", () => {
     // Point at a closed port so fetch fails at the socket level.
     const errs: string[] = [];
     const code = await runCli(
-      ["--vault", root, "--bank", "b", "--api-url", "http://127.0.0.1:1", "--index", join(root, "i.json")],
+      [
+        "--vault",
+        root,
+        "--bank",
+        "b",
+        "--api-url",
+        "http://127.0.0.1:1",
+        "--index",
+        join(root, "i.json"),
+      ],
       () => {},
       (m) => errs.push(m)
     );

--- a/hindsight-integrations/obsidian/tests/node/e2e-http.spec.ts
+++ b/hindsight-integrations/obsidian/tests/node/e2e-http.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * End-to-end test against a REAL HTTP server. Runs the CLI's `runCli` over a
+ * temp vault pointed at a throwaway node:http server, so the whole stack —
+ * FsVault → SyncEngine → HindsightClient → fetch → sockets → server — runs
+ * for real, with nothing mocked. This is the closest thing to hitting a live
+ * Hindsight server that can run in CI.
+ */
+
+import { rm, mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runCli } from "../../src/node/cli";
+
+interface Captured {
+  method: string;
+  url: string;
+  auth: string | undefined;
+  body: string;
+}
+
+let root: string;
+let server: Server;
+let received: Captured[];
+let baseUrl: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "hs-e2e-"));
+  received = [];
+  server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      received.push({ method: req.method ?? "", url: req.url ?? "", auth: req.headers.authorization, body });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end("{}");
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await rm(root, { recursive: true, force: true });
+});
+
+describe("runCli end-to-end over real HTTP", () => {
+  it("POSTs a retain with the bearer token and correct document id, then DELETEs on prune", async () => {
+    await mkdir(join(root, "Work"), { recursive: true });
+    await writeFile(join(root, "Work", "note.md"), "# Note\nships in Q3");
+    const indexPath = join(root, "idx.json");
+    const args = [
+      "--vault", root,
+      "--bank", "team",
+      "--api-url", baseUrl,
+      "--api-token", "hsk_secret",
+      "--vault-name", "TeamVault",
+      "--index", indexPath,
+    ];
+
+    // First run: the note is ingested.
+    expect(await runCli(args, () => {}, () => {})).toBe(0);
+
+    const retain = received.find((r) => r.url.endsWith("/memories"));
+    expect(retain).toBeDefined();
+    expect(retain!.method).toBe("POST");
+    expect(retain!.url).toBe("/v1/default/banks/team/memories");
+    expect(retain!.auth).toBe("Bearer hsk_secret");
+    const item = JSON.parse(retain!.body).items[0];
+    expect(item.document_id).toBe("Work/note.md");
+    expect(item.content).toContain("ships in Q3");
+    expect(item.tags).toEqual(expect.arrayContaining(["vault:TeamVault", "folder:Work"]));
+
+    // Delete the note and re-run: the document is pruned via a real DELETE.
+    received.length = 0;
+    await rm(join(root, "Work", "note.md"));
+    expect(await runCli(args, () => {}, () => {})).toBe(0);
+
+    const del = received.find((r) => r.method === "DELETE");
+    expect(del).toBeDefined();
+    expect(del!.url).toBe("/v1/default/banks/team/documents/Work/note.md");
+    expect(del!.auth).toBe("Bearer hsk_secret");
+  }, 20000);
+
+  it("returns exit code 1 and reports when the server errors", async () => {
+    await writeFile(join(root, "x.md"), "# X\nbody");
+    // Point at a closed port so fetch fails at the socket level.
+    const errs: string[] = [];
+    const code = await runCli(
+      ["--vault", root, "--bank", "b", "--api-url", "http://127.0.0.1:1", "--index", join(root, "i.json")],
+      () => {},
+      (m) => errs.push(m)
+    );
+    expect(code).toBe(1);
+    expect(errs.join("\n")).toMatch(/hindsight-obsidian-sync:/);
+  }, 20000);
+});

--- a/hindsight-integrations/obsidian/tests/node/fetch-transport.spec.ts
+++ b/hindsight-integrations/obsidian/tests/node/fetch-transport.spec.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchTransport } from "../../src/node/fetch-transport";
+
+function fetchReturning(status: number, body: string) {
+  return vi.fn(async () => ({ status, text: async () => body }) as unknown as Response);
+}
+
+describe("fetchTransport", () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("forwards method, headers and body to fetch", async () => {
+    const spy = fetchReturning(200, "{}");
+    vi.stubGlobal("fetch", spy);
+
+    await fetchTransport({
+      url: "https://api.example.com/x",
+      method: "POST",
+      headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+      body: '{"a":1}',
+    });
+
+    expect(spy).toHaveBeenCalledWith("https://api.example.com/x", {
+      method: "POST",
+      headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+      body: '{"a":1}',
+    });
+  });
+
+  it("returns status, raw text, and parsed json", async () => {
+    vi.stubGlobal("fetch", fetchReturning(201, '{"ok":true}'));
+    const resp = await fetchTransport({ url: "u", method: "GET", headers: {} });
+    expect(resp.status).toBe(201);
+    expect(resp.text).toBe('{"ok":true}');
+    expect(resp.json).toEqual({ ok: true });
+  });
+
+  it("leaves json undefined for a non-JSON body (e.g. an error page)", async () => {
+    vi.stubGlobal("fetch", fetchReturning(500, "Internal Server Error"));
+    const resp = await fetchTransport({ url: "u", method: "GET", headers: {} });
+    expect(resp.status).toBe(500);
+    expect(resp.text).toBe("Internal Server Error");
+    expect(resp.json).toBeUndefined();
+  });
+});

--- a/hindsight-integrations/obsidian/tests/node/fetch-transport.spec.ts
+++ b/hindsight-integrations/obsidian/tests/node/fetch-transport.spec.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HindsightClient } from "../../src/client";
 import { fetchTransport } from "../../src/node/fetch-transport";
+import type { Transport, TransportRequest } from "../../src/transport";
 
 function fetchReturning(status: number, body: string) {
   return vi.fn(async () => ({ status, text: async () => body }) as unknown as Response);
@@ -41,5 +43,64 @@ describe("fetchTransport", () => {
     expect(resp.status).toBe(500);
     expect(resp.text).toBe("Internal Server Error");
     expect(resp.json).toBeUndefined();
+  });
+
+  it("propagates a fetch rejection (network failure) to the caller", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => Promise.reject(new Error("ECONNREFUSED"))));
+    await expect(fetchTransport({ url: "u", method: "GET", headers: {} })).rejects.toThrow(/ECONNREFUSED/);
+  });
+});
+
+describe("HindsightClient over fetchTransport (full stack)", () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("surfaces a useful error on a non-2xx response", async () => {
+    vi.stubGlobal("fetch", fetchReturning(503, "upstream down"));
+    const client = new HindsightClient("https://h", "tok", fetchTransport);
+    await expect(client.reflect("b", "q")).rejects.toThrow(/HTTP 503: upstream down/);
+  });
+
+  it("health() returns false when the transport rejects, true on 2xx", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => Promise.reject(new Error("down"))));
+    expect(await new HindsightClient("https://h", undefined, fetchTransport).health()).toBe(false);
+
+    vi.stubGlobal("fetch", fetchReturning(200, "{}"));
+    expect(await new HindsightClient("https://h", undefined, fetchTransport).health()).toBe(true);
+  });
+});
+
+describe("cross-transport request parity", () => {
+  // The same client call must produce an identical request regardless of which
+  // transport carries it — this is what guarantees the CLI and the plugin talk
+  // to Hindsight the same way.
+  function recorder(): { transport: Transport; last: () => TransportRequest } {
+    let seen: TransportRequest | undefined;
+    return {
+      transport: async (req) => {
+        seen = req;
+        return { status: 200, text: "{}", json: {} };
+      },
+      last: () => {
+        if (!seen) throw new Error("transport not called");
+        return seen;
+      },
+    };
+  }
+
+  it("retain builds the same request under two different transports", async () => {
+    const a = recorder();
+    const b = recorder();
+    await new HindsightClient("https://h/", "tok", a.transport).retain("bank", "F/n.md", "body", {
+      tags: ["t"],
+      metadata: { path: "F/n.md" },
+    });
+    await new HindsightClient("https://h/", "tok", b.transport).retain("bank", "F/n.md", "body", {
+      tags: ["t"],
+      metadata: { path: "F/n.md" },
+    });
+    expect(a.last()).toEqual(b.last());
+    expect(a.last().url).toBe("https://h/v1/default/banks/bank/memories");
+    expect(a.last().headers.Authorization).toBe("Bearer tok");
   });
 });

--- a/hindsight-integrations/obsidian/tests/node/fetch-transport.spec.ts
+++ b/hindsight-integrations/obsidian/tests/node/fetch-transport.spec.ts
@@ -46,8 +46,13 @@ describe("fetchTransport", () => {
   });
 
   it("propagates a fetch rejection (network failure) to the caller", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => Promise.reject(new Error("ECONNREFUSED"))));
-    await expect(fetchTransport({ url: "u", method: "GET", headers: {} })).rejects.toThrow(/ECONNREFUSED/);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Promise.reject(new Error("ECONNREFUSED")))
+    );
+    await expect(fetchTransport({ url: "u", method: "GET", headers: {} })).rejects.toThrow(
+      /ECONNREFUSED/
+    );
   });
 });
 
@@ -62,7 +67,10 @@ describe("HindsightClient over fetchTransport (full stack)", () => {
   });
 
   it("health() returns false when the transport rejects, true on 2xx", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => Promise.reject(new Error("down"))));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Promise.reject(new Error("down")))
+    );
     expect(await new HindsightClient("https://h", undefined, fetchTransport).health()).toBe(false);
 
     vi.stubGlobal("fetch", fetchReturning(200, "{}"));

--- a/hindsight-integrations/obsidian/tests/node/fs-vault.spec.ts
+++ b/hindsight-integrations/obsidian/tests/node/fs-vault.spec.ts
@@ -1,0 +1,75 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FsVault } from "../../src/node/fs-vault";
+
+let root: string;
+
+async function write(rel: string, content: string): Promise<void> {
+  const abs = join(root, rel);
+  await mkdir(join(abs, ".."), { recursive: true });
+  await writeFile(abs, content);
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "hs-vault-"));
+});
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe("FsVault", () => {
+  it("lists only markdown files, recursively, with POSIX-relative paths", async () => {
+    await write("root.md", "a");
+    await write("Work/Clients/acme.md", "b");
+    await write("Work/notes.txt", "not markdown");
+    await write("image.png", "binary");
+
+    const paths = new FsVault(root)
+      .getMarkdownFiles()
+      .map((f) => f.path)
+      .sort();
+
+    expect(paths).toEqual(["Work/Clients/acme.md", "root.md"]);
+  });
+
+  it("skips dotfolders like .obsidian, .trash and .git", async () => {
+    await write("keep.md", "a");
+    await write(".obsidian/plugins/x/data.md", "config");
+    await write(".trash/deleted.md", "trash");
+    await write(".git/notes.md", "git");
+
+    const paths = new FsVault(root).getMarkdownFiles().map((f) => f.path);
+    expect(paths).toEqual(["keep.md"]);
+  });
+
+  it("populates stat.mtime and stat.ctime as epoch milliseconds", async () => {
+    await write("a.md", "hello");
+    const [file] = new FsVault(root).getMarkdownFiles();
+    expect(file.stat.mtime).toBeGreaterThan(0);
+    expect(file.stat.ctime).toBeGreaterThan(0);
+    // millisecond scale, not seconds
+    expect(file.stat.mtime).toBeGreaterThan(1_000_000_000_000);
+  });
+
+  it("reads file contents", async () => {
+    await write("Notes/deep.md", "# Title\nbody");
+    const vault = new FsVault(root);
+    const file = vault.getMarkdownFiles().find((f) => f.path === "Notes/deep.md")!;
+    expect(await vault.read(file)).toBe("# Title\nbody");
+  });
+
+  it("syncFileFor returns a SyncFile for a live path and null for a missing one", async () => {
+    await write("here.md", "x");
+    const vault = new FsVault(root);
+    expect(vault.syncFileFor("here.md")?.path).toBe("here.md");
+    expect(vault.syncFileFor("gone.md")).toBeNull();
+  });
+
+  it("handles unicode and spaces in names", async () => {
+    await write("Área/notações café.md", "x");
+    const paths = new FsVault(root).getMarkdownFiles().map((f) => f.path);
+    expect(paths).toEqual(["Área/notações café.md"]);
+  });
+});

--- a/hindsight-integrations/obsidian/tests/node/json-index.spec.ts
+++ b/hindsight-integrations/obsidian/tests/node/json-index.spec.ts
@@ -1,0 +1,57 @@
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SyncIndex } from "../../src/sync";
+import { defaultIndexPath, loadIndex, makePersist } from "../../src/node/json-index";
+
+let dir: string;
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "hs-idx-"));
+});
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const INDEX: SyncIndex = { "a.md": { hash: "sha256:1", mtime: 5, syncedAt: "T0" } };
+
+describe("json-index", () => {
+  it("returns an empty index when the file does not exist", async () => {
+    expect(await loadIndex(join(dir, "missing.json"))).toEqual({});
+  });
+
+  it("round-trips an index through persist + load", async () => {
+    const path = join(dir, "sub", "idx.json"); // parent created by persist
+    await makePersist(path, () => "T1")(INDEX);
+    expect(await loadIndex(path)).toEqual(INDEX);
+  });
+
+  it("stamps lastSyncAt and nests the index under syncIndex", async () => {
+    const path = join(dir, "idx.json");
+    await makePersist(path, () => "2026-08-04T00:00:00.000Z")(INDEX);
+    const raw = JSON.parse(await readFile(path, "utf8"));
+    expect(raw).toEqual({ syncIndex: INDEX, lastSyncAt: "2026-08-04T00:00:00.000Z" });
+  });
+
+  it("writes atomically (no leftover .tmp file)", async () => {
+    const path = join(dir, "idx.json");
+    await makePersist(path, () => "T1")(INDEX);
+    const entries = await readdir(dir);
+    expect(entries).toContain("idx.json");
+    expect(entries.some((e) => e.endsWith(".tmp"))).toBe(false);
+  });
+
+  it("treats a corrupt index as empty and warns", async () => {
+    const path = join(dir, "corrupt.json");
+    await writeFile(path, "{ not json");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(await loadIndex(path)).toEqual({});
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("defaultIndexPath sanitizes the vault name and lives under ~/.hindsight/obsidian", () => {
+    const p = defaultIndexPath("My Vault/2026");
+    expect(p).toMatch(/[/\\]\.hindsight[/\\]obsidian[/\\]My_Vault_2026\.json$/);
+  });
+});

--- a/hindsight-integrations/obsidian/tests/node/reconcile-integration.spec.ts
+++ b/hindsight-integrations/obsidian/tests/node/reconcile-integration.spec.ts
@@ -217,8 +217,13 @@ function memoryVault(files: Record<string, { content: string; mtime: number; cti
 
 describe("dual-ingester parity", () => {
   it("produces identical retain requests from the filesystem and the plugin vault", async () => {
-    const noteA = "---\ntags: [work]\n---\n# A\nalpha";
-    const noteB = "# B\nbeta";
+    // Both notes carry a `created:` date in frontmatter so the created-date tags
+    // come from the note, not from filesystem ctime/birthtime — utimes can only
+    // set mtime, and birthtime behaves differently across OSes (macOS clamps it
+    // to a past mtime, Linux does not), which would otherwise make this compare
+    // platform-dependent.
+    const noteA = "---\ntags: [work]\ncreated: 2026-03-15\n---\n# A\nalpha";
+    const noteB = "---\ncreated: 2026-03-15\n---\n# B\nbeta";
     await writeNote("Work/a.md", noteA);
     await writeNote("b.md", noteB);
 

--- a/hindsight-integrations/obsidian/tests/node/reconcile-integration.spec.ts
+++ b/hindsight-integrations/obsidian/tests/node/reconcile-integration.spec.ts
@@ -13,7 +13,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HindsightClient } from "../../src/client";
 import { FsVault } from "../../src/node/fs-vault";
 import { loadIndex, makePersist } from "../../src/node/json-index";
-import { SyncEngine, type SyncConfig, type SyncFile, type SyncIndex, type SyncVault } from "../../src/sync";
+import {
+  SyncEngine,
+  type SyncConfig,
+  type SyncFile,
+  type SyncIndex,
+  type SyncVault,
+} from "../../src/sync";
 
 let root: string;
 let indexPath: string;
@@ -170,7 +176,10 @@ describe("reconcile over a filesystem vault", () => {
   });
 
   it("carries frontmatter tags and uses the created date as the timestamp", async () => {
-    await writeNote("Projects/x.md", "---\ntags: [alpha, beta]\ncreated: 2025-11-02\n---\n# X\nthe body");
+    await writeNote(
+      "Projects/x.md",
+      "---\ntags: [alpha, beta]\ncreated: 2025-11-02\n---\n# X\nthe body"
+    );
     const { client, engine } = await makeEngine();
     await engine.reconcile();
 
@@ -181,7 +190,9 @@ describe("reconcile over a filesystem vault", () => {
       { tags: string[]; metadata: Record<string, string>; timestamp?: string },
     ];
     // Frontmatter tags flow through alongside the auto-scope tags.
-    expect(opts.tags).toEqual(expect.arrayContaining(["alpha", "beta", "vault:Vault", "folder:Projects"]));
+    expect(opts.tags).toEqual(
+      expect.arrayContaining(["alpha", "beta", "vault:Vault", "folder:Projects"])
+    );
     // `created:` in frontmatter wins as the document timestamp.
     expect(opts.timestamp).toContain("2025-11-02");
     expect(opts.metadata.vault).toBe("Vault");
@@ -207,10 +218,15 @@ describe("reconcile over a filesystem vault", () => {
 });
 
 // An in-memory vault mirroring how the Obsidian plugin feeds the same engine.
-function memoryVault(files: Record<string, { content: string; mtime: number; ctime: number }>): SyncVault {
+function memoryVault(
+  files: Record<string, { content: string; mtime: number; ctime: number }>
+): SyncVault {
   return {
     getMarkdownFiles: (): SyncFile[] =>
-      Object.keys(files).map((path) => ({ path, stat: { mtime: files[path].mtime, ctime: files[path].ctime } })),
+      Object.keys(files).map((path) => ({
+        path,
+        stat: { mtime: files[path].mtime, ctime: files[path].ctime },
+      })),
     read: async (f) => files[f.path].content,
   };
 }
@@ -266,7 +282,12 @@ describe("dual-ingester parity", () => {
 
     const normalize = (calls: unknown[][]) =>
       calls
-        .map((c) => ({ docId: c[1], body: c[2], tags: [...(c[3] as { tags: string[] }).tags].sort(), meta: c[3] }))
+        .map((c) => ({
+          docId: c[1],
+          body: c[2],
+          tags: [...(c[3] as { tags: string[] }).tags].sort(),
+          meta: c[3],
+        }))
         .sort((x, y) => String(x.docId).localeCompare(String(y.docId)));
 
     expect(normalize(fsClient.retain.mock.calls)).toEqual(normalize(memClient.retain.mock.calls));

--- a/hindsight-integrations/obsidian/tests/node/reconcile-integration.spec.ts
+++ b/hindsight-integrations/obsidian/tests/node/reconcile-integration.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * Full-stack reconcile tests: FsVault (real temp dir) + JSON index + the shared
+ * SyncEngine, with a fake client capturing the API calls. Exercises the same
+ * behaviors the plugin relies on (create/update/skip/delete/rename/exclude/
+ * prefix/prune-ownership) plus a parity check that the filesystem frontend
+ * produces byte-identical requests to an in-memory (plugin-style) vault.
+ */
+
+import { mkdir, rm, mkdtemp, rename, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HindsightClient } from "../../src/client";
+import { FsVault } from "../../src/node/fs-vault";
+import { loadIndex, makePersist } from "../../src/node/json-index";
+import { SyncEngine, type SyncConfig, type SyncFile, type SyncIndex, type SyncVault } from "../../src/sync";
+
+let root: string;
+let indexPath: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "hs-recon-"));
+  indexPath = join(root, ".idx.json");
+});
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+type RetainFn = (
+  bank: string,
+  docId: string,
+  content: string,
+  opts: { tags: string[]; metadata: Record<string, string> }
+) => Promise<void>;
+
+function fakeClient() {
+  return {
+    retain: vi.fn<RetainFn>(async () => {}),
+    deleteDocument: vi.fn<(bank: string, docId: string) => Promise<void>>(async () => {}),
+  };
+}
+
+async function writeNote(rel: string, content: string): Promise<void> {
+  const abs = join(root, rel);
+  await mkdir(join(abs, ".."), { recursive: true });
+  await writeFile(abs, content);
+}
+
+async function makeEngine(config: Partial<SyncConfig> = {}) {
+  const client = fakeClient();
+  const index = await loadIndex(indexPath);
+  const engine = new SyncEngine(
+    client as unknown as HindsightClient,
+    new FsVault(root),
+    {
+      bankId: "bank",
+      includeFolders: [],
+      excludeFolders: [],
+      vaultName: "Vault",
+      prefixDocId: false,
+      ...config,
+    },
+    index,
+    makePersist(indexPath, () => "T0"),
+    () => "T0"
+  );
+  return { client, engine };
+}
+
+describe("reconcile over a filesystem vault", () => {
+  it("creates a document with scope tags + path metadata, then skips unchanged", async () => {
+    await writeNote("Work/Clients/acme.md", "# Acme\nrenewal in Q3");
+
+    const first = await makeEngine();
+    const summary = await first.engine.reconcile();
+    expect(summary).toMatchObject({ added: 1, updated: 0, deleted: 0 });
+
+    const [bank, docId, body, opts] = first.client.retain.mock.calls[0];
+    expect(bank).toBe("bank");
+    expect(docId).toBe("Work/Clients/acme.md");
+    expect(body).toContain("renewal in Q3");
+    expect(opts.tags).toEqual(
+      expect.arrayContaining(["vault:Vault", "folder:Work", "folder:Work/Clients"])
+    );
+    expect(opts.tags.some((t) => /^created:\d{4}$/.test(t))).toBe(true);
+    expect(opts.metadata.path).toBe("Work/Clients/acme.md");
+
+    // A second engine (fresh, but loading the persisted index) must skip.
+    const second = await makeEngine();
+    await second.engine.reconcile();
+    expect(second.client.retain).not.toHaveBeenCalled();
+  });
+
+  it("re-ingests when content changes but skips an mtime-only touch", async () => {
+    await writeNote("a.md", "original");
+    await (await makeEngine()).engine.reconcile();
+
+    // Content change → update.
+    await writeNote("a.md", "edited body");
+    const edit = await makeEngine();
+    expect((await edit.engine.reconcile()).updated).toBe(1);
+    expect(edit.client.retain).toHaveBeenCalledOnce();
+
+    // mtime moves but content (hash) is identical → skip, no re-ingest.
+    const future = new Date(Date.now() + 60_000);
+    await utimes(join(root, "a.md"), future, future);
+    const touch = await makeEngine();
+    const summary = await touch.engine.reconcile();
+    expect(summary).toMatchObject({ added: 0, updated: 0, unchanged: 1 });
+    expect(touch.client.retain).not.toHaveBeenCalled();
+  });
+
+  it("prunes a document when its note is deleted from disk", async () => {
+    await writeNote("gone.md", "temporary");
+    await (await makeEngine()).engine.reconcile();
+
+    await rm(join(root, "gone.md"));
+    const after = await makeEngine();
+    const summary = await after.engine.reconcile();
+    expect(summary.deleted).toBe(1);
+    expect(after.client.deleteDocument).toHaveBeenCalledWith("bank", "gone.md");
+  });
+
+  it("handles a rename as delete-old + create-new", async () => {
+    await writeNote("old.md", "movable content");
+    await (await makeEngine()).engine.reconcile();
+
+    await rename(join(root, "old.md"), join(root, "new.md"));
+    const after = await makeEngine();
+    const summary = await after.engine.reconcile();
+    expect(summary).toMatchObject({ added: 1, deleted: 1 });
+    expect(after.client.deleteDocument).toHaveBeenCalledWith("bank", "old.md");
+    const created = after.client.retain.mock.calls.map((c) => c[1]);
+    expect(created).toContain("new.md");
+  });
+
+  it("excludes a folder and prunes notes that become excluded", async () => {
+    await writeNote("Keep/a.md", "keep me");
+    await writeNote("Archive/b.md", "archive me");
+
+    // First sync with no excludes → both ingested.
+    const initial = await makeEngine();
+    expect((await initial.engine.reconcile()).added).toBe(2);
+
+    // Re-sync excluding Archive → its previously-synced doc is pruned.
+    const excluded = await makeEngine({ excludeFolders: ["Archive"] });
+    const summary = await excluded.engine.reconcile();
+    expect(summary.deleted).toBe(1);
+    expect(excluded.client.deleteDocument).toHaveBeenCalledWith("bank", "Archive/b.md");
+    expect(excluded.client.retain).not.toHaveBeenCalled(); // Keep/a.md unchanged
+  });
+
+  it("prefixes document ids with the vault name when configured", async () => {
+    await writeNote("note.md", "prefixed");
+    const { client, engine } = await makeEngine({ prefixDocId: true, vaultName: "Brain" });
+    await engine.reconcile();
+    expect(client.retain.mock.calls[0][1]).toBe("Brain/note.md");
+  });
+
+  it("only prunes documents tracked in its own index (prune ownership)", async () => {
+    await writeNote("mine.md", "owned");
+    await (await makeEngine()).engine.reconcile();
+
+    // Delete the owned note; the index also names a doc we never had on disk —
+    // reconcile must prune only what the index tracks, nothing invented.
+    await rm(join(root, "mine.md"));
+    const after = await makeEngine();
+    await after.engine.reconcile();
+    expect(after.client.deleteDocument).toHaveBeenCalledExactlyOnceWith("bank", "mine.md");
+  });
+});
+
+// An in-memory vault mirroring how the Obsidian plugin feeds the same engine.
+function memoryVault(files: Record<string, { content: string; mtime: number; ctime: number }>): SyncVault {
+  return {
+    getMarkdownFiles: (): SyncFile[] =>
+      Object.keys(files).map((path) => ({ path, stat: { mtime: files[path].mtime, ctime: files[path].ctime } })),
+    read: async (f) => files[f.path].content,
+  };
+}
+
+describe("dual-ingester parity", () => {
+  it("produces identical retain requests from the filesystem and the plugin vault", async () => {
+    const noteA = "---\ntags: [work]\n---\n# A\nalpha";
+    const noteB = "# B\nbeta";
+    await writeNote("Work/a.md", noteA);
+    await writeNote("b.md", noteB);
+
+    const config: SyncConfig = {
+      bankId: "bank",
+      includeFolders: [],
+      excludeFolders: [],
+      vaultName: "Vault",
+      prefixDocId: false,
+    };
+
+    // Filesystem frontend (CLI) — pin mtimes so timestamps match the memory vault.
+    const fixed = new Date("2026-03-15T00:00:00Z");
+    await utimes(join(root, "Work/a.md"), fixed, fixed);
+    await utimes(join(root, "b.md"), fixed, fixed);
+    const fsClient = fakeClient();
+    const fsIndex: SyncIndex = {};
+    await new SyncEngine(
+      fsClient as unknown as HindsightClient,
+      new FsVault(root),
+      config,
+      fsIndex,
+      async () => {},
+      () => "T0"
+    ).reconcile();
+
+    // Plugin-style in-memory frontend, same files/mtimes/config.
+    const memClient = fakeClient();
+    await new SyncEngine(
+      memClient as unknown as HindsightClient,
+      memoryVault({
+        "Work/a.md": { content: noteA, mtime: fixed.getTime(), ctime: fixed.getTime() },
+        "b.md": { content: noteB, mtime: fixed.getTime(), ctime: fixed.getTime() },
+      }),
+      config,
+      {},
+      async () => {},
+      () => "T0"
+    ).reconcile();
+
+    const normalize = (calls: unknown[][]) =>
+      calls
+        .map((c) => ({ docId: c[1], body: c[2], tags: [...(c[3] as { tags: string[] }).tags].sort(), meta: c[3] }))
+        .sort((x, y) => String(x.docId).localeCompare(String(y.docId)));
+
+    expect(normalize(fsClient.retain.mock.calls)).toEqual(normalize(memClient.retain.mock.calls));
+  });
+});

--- a/hindsight-integrations/obsidian/tests/node/reconcile-integration.spec.ts
+++ b/hindsight-integrations/obsidian/tests/node/reconcile-integration.spec.ts
@@ -168,6 +168,42 @@ describe("reconcile over a filesystem vault", () => {
     await after.engine.reconcile();
     expect(after.client.deleteDocument).toHaveBeenCalledExactlyOnceWith("bank", "mine.md");
   });
+
+  it("carries frontmatter tags and uses the created date as the timestamp", async () => {
+    await writeNote("Projects/x.md", "---\ntags: [alpha, beta]\ncreated: 2025-11-02\n---\n# X\nthe body");
+    const { client, engine } = await makeEngine();
+    await engine.reconcile();
+
+    const [, , , opts] = client.retain.mock.calls[0] as unknown as [
+      string,
+      string,
+      string,
+      { tags: string[]; metadata: Record<string, string>; timestamp?: string },
+    ];
+    // Frontmatter tags flow through alongside the auto-scope tags.
+    expect(opts.tags).toEqual(expect.arrayContaining(["alpha", "beta", "vault:Vault", "folder:Projects"]));
+    // `created:` in frontmatter wins as the document timestamp.
+    expect(opts.timestamp).toContain("2025-11-02");
+    expect(opts.metadata.vault).toBe("Vault");
+  });
+
+  it("skips a note whose body is empty after frontmatter (nothing to ground on)", async () => {
+    await writeNote("empty.md", "---\ntags: [x]\n---\n   \n");
+    const { client, engine } = await makeEngine();
+    const summary = await engine.reconcile();
+    expect(client.retain).not.toHaveBeenCalled();
+    expect(summary.added).toBe(0);
+  });
+
+  it("with includeFolders set, syncs only the included folder", async () => {
+    await writeNote("Work/keep.md", "included");
+    await writeNote("Personal/skip.md", "excluded");
+    const { client, engine } = await makeEngine({ includeFolders: ["Work"] });
+    await engine.reconcile();
+
+    const docIds = client.retain.mock.calls.map((c) => c[1]);
+    expect(docIds).toEqual(["Work/keep.md"]);
+  });
 });
 
 // An in-memory vault mirroring how the Obsidian plugin feeds the same engine.

--- a/hindsight-integrations/obsidian/tests/node/watch.spec.ts
+++ b/hindsight-integrations/obsidian/tests/node/watch.spec.ts
@@ -30,7 +30,9 @@ async function waitFor(pred: () => boolean, timeoutMs = 8000): Promise<void> {
 
 function fakeClient() {
   return {
-    retain: vi.fn<(bank: string, docId: string, content: string, opts: unknown) => Promise<void>>(async () => {}),
+    retain: vi.fn<(bank: string, docId: string, content: string, opts: unknown) => Promise<void>>(
+      async () => {}
+    ),
     deleteDocument: vi.fn<(bank: string, docId: string) => Promise<void>>(async () => {}),
   };
 }

--- a/hindsight-integrations/obsidian/tests/node/watch.spec.ts
+++ b/hindsight-integrations/obsidian/tests/node/watch.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * Watch-mode integration test — drives a REAL chokidar watcher over a real temp
+ * vault and asserts that create/modify/delete on disk flow through to the engine.
+ * Uses polling + a tight awaitWriteFinish so it is deterministic on CI file-
+ * systems. This exercises the external framework (chokidar), not a mock.
+ */
+
+import { rm, mkdtemp, writeFile } from "node:fs/promises";
+import { once } from "node:events";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HindsightClient } from "../../src/client";
+import { type CliOptions, watchVault } from "../../src/node/cli";
+import { FsVault } from "../../src/node/fs-vault";
+import { SyncEngine } from "../../src/sync";
+
+let root: string;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function waitFor(pred: () => boolean, timeoutMs = 8000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (pred()) return;
+    await sleep(25);
+  }
+  throw new Error("condition not met within timeout");
+}
+
+function fakeClient() {
+  return {
+    retain: vi.fn<(bank: string, docId: string, content: string, opts: unknown) => Promise<void>>(async () => {}),
+    deleteDocument: vi.fn<(bank: string, docId: string) => Promise<void>>(async () => {}),
+  };
+}
+
+function options(): CliOptions {
+  return {
+    vault: root,
+    bank: "b",
+    apiUrl: "http://unused",
+    include: [],
+    exclude: [],
+    vaultName: "V",
+    prefixDocId: false,
+    indexPath: join(root, ".idx.json"),
+    watch: true,
+  };
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "hs-watch-"));
+});
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe("watchVault (real chokidar)", () => {
+  it("ingests, updates and deletes as files change on disk; ignores non-markdown", async () => {
+    const client = fakeClient();
+    const vault = new FsVault(root);
+    const engine = new SyncEngine(
+      client as unknown as HindsightClient,
+      vault,
+      { bankId: "b", includeFolders: [], excludeFolders: [], vaultName: "V", prefixDocId: false },
+      {},
+      async () => {},
+      () => "T0"
+    );
+
+    const watcher = await watchVault(options(), engine, vault, {
+      usePolling: true,
+      interval: 20,
+      awaitWriteFinish: { stabilityThreshold: 40, pollInterval: 20 },
+    });
+    try {
+      await once(watcher, "ready");
+
+      // Create → ingest.
+      await writeFile(join(root, "live.md"), "# Live\nfirst");
+      await waitFor(() => client.retain.mock.calls.some((c) => c[1] === "live.md"));
+
+      // A non-markdown file must be ignored entirely.
+      await writeFile(join(root, "notes.txt"), "ignore me");
+      await sleep(200);
+      expect(client.retain.mock.calls.every((c) => c[1] !== "notes.txt")).toBe(true);
+
+      // Modify → re-ingest (a second retain for the same path).
+      await writeFile(join(root, "live.md"), "# Live\nsecond, changed");
+      await waitFor(() => client.retain.mock.calls.filter((c) => c[1] === "live.md").length >= 2);
+
+      // Delete → prune.
+      await rm(join(root, "live.md"));
+      await waitFor(() => client.deleteDocument.mock.calls.some((c) => c[1] === "live.md"));
+    } finally {
+      await watcher.close();
+    }
+  }, 20000);
+});

--- a/skills/hindsight-docs/references/sdks/integrations/obsidian.md
+++ b/skills/hindsight-docs/references/sdks/integrations/obsidian.md
@@ -68,3 +68,23 @@ Open **Settings → Hindsight**:
 - **Sync vault now** — full reconcile (ingest changed notes, prune deleted ones).
 - **Ingest current note** — force-sync the active note.
 - **Open chat** — open the grounded chat panel.
+
+## Headless / CLI ingestion (no desktop app)
+
+Running your vault on an always-on server (kept current on disk by Obsidian Sync)? The same ingestion runs without the Obsidian app via the `hindsight-obsidian-sync` CLI, shipped in the same package. It drives the **same sync engine** as the plugin, so it produces identical document ids, scope tags, and prune-ownership — a vault can be synced from a server and later opened interactively elsewhere without the two ingesters fighting or duplicating documents.
+
+```bash
+npm install -g @vectorize-io/hindsight-obsidian
+
+# one-shot reconcile (cron-friendly)
+hindsight-obsidian-sync reconcile \
+  --vault ~/Vaults/Brain --bank my-vault \
+  --api-url https://api.hindsight.vectorize.io --api-token hsk_...
+
+# or keep it running and sync changes live
+hindsight-obsidian-sync reconcile --vault ~/Vaults/Brain --bank my-vault --watch
+```
+
+`--api-url` / `--api-token` fall back to `HINDSIGHT_API_URL` / `HINDSIGHT_API_TOKEN`. Other flags: `--include` / `--exclude` (repeatable), `--vault-name`, `--prefix-doc-id`, and `--index`.
+
+The sync index (the CLI's equivalent of the plugin's `data.json`) defaults to `~/.hindsight/obsidian/<vault>.json` — deliberately **outside** the vault so Obsidian Sync never propagates it. If you run the CLI and the plugin against the same bank and vault, keep their scope settings identical (include/exclude, vault name, `prefix-doc-id`): each keeps its own index and a reconcile prunes only what its own index tracks, so mismatched scope could let one delete documents the other owns.


### PR DESCRIPTION
Closes #3128.

## What & why

The Obsidian integration only runs inside the desktop app (`isDesktopOnly: true`), so a vault hosted on a **headless server** (kept current on disk by Obsidian Sync) can't be ingested without either running the full Electron app hidden or hand-rolling ingestion against the HTTP API and losing the plugin's carefully-designed behavior. @0xble asked for a supported headless path.

The codebase was already set up for this: `SyncEngine` is written against the minimal `SyncVault`/`SyncFile` interfaces and **dependency-injects** the vault, sync index, and `persist` writer — the only Obsidian coupling was `requestUrl` in the client. So this is a thin **second frontend over the same engine**, which means a server-synced vault produces **identical document ids, scope tags, and prune-ownership** as the plugin — the two ingesters never fight or duplicate.

## How it's built (3 commits)

1. **`refactor`: transport seam.** Introduce a `Transport` abstraction so `HindsightClient` no longer imports `obsidian`. The plugin injects an `obsidianTransport` (`requestUrl`, to escape the renderer CORS sandbox); the CLI injects a `fetch` transport. One client, one set of request semantics — no divergent copies. Existing client tests pass unchanged (they switch from mocking `requestUrl` to injecting a fake transport).
2. **`feat`: the Node frontend** (`src/node/`):
   - `fs-vault.ts` — filesystem `SyncVault` (recursive `*.md`, POSIX-relative paths, ms `mtime`/`ctime`, skips dotfolders)
   - `fetch-transport.ts` — `fetch`-based `Transport`
   - `json-index.ts` — sync index persisted to JSON, atomic write; defaults to `~/.hindsight/obsidian/<vault>.json` (**outside** the vault, so Obsidian Sync never propagates it)
   - `cli.ts` / `cli-bin.ts` — `hindsight-obsidian-sync reconcile --vault <p> --bank <id>` with env fallbacks, `--include`/`--exclude`/`--prefix-doc-id`, and a chokidar `--watch` mode
   - Packaging: second esbuild target builds `dist/cli.js` (node, shebang); `package.json` gains the `bin`, a `files` allowlist, and `chokidar`. The plugin build (`main.js`) and the release mirror are untouched.
3. **`test`: real-framework + e2e coverage** (see below).

## Usage

```bash
npm install -g @vectorize-io/hindsight-obsidian
hindsight-obsidian-sync reconcile --vault ~/Vaults/Brain --bank my-vault \
  --api-url https://api.hindsight.vectorize.io --api-token hsk_...
# or live: add --watch
```

## Testing — 90 tests (was 46)

Deterministic units **plus** real-framework and end-to-end suites:
- **Real chokidar watch** (`watch.spec.ts`) — drives an actual watcher over a temp vault: create → ingest, modify → re-ingest, delete → prune, non-markdown ignored.
- **Real HTTP e2e** (`e2e-http.spec.ts`) — `runCli` against a live `node:http` server, nothing mocked: asserts the retain `POST` (bearer token, document id, scope tags), a real `DELETE` on prune, and exit-1 when unreachable.
- **Full-stack reconcile** over a real temp vault: create/skip/update, mtime-only touch, delete, rename, include/exclude scoping, `prefixDocId`, prune-ownership, frontmatter tags + created-date timestamp, empty-body skip.
- **Dual-ingester parity** — the filesystem and in-memory (plugin) vaults emit byte-identical retain requests.
- **Transport** — client error propagation, `health()`, fetch rejection, cross-transport request parity.

`tsc --noEmit` clean; both bundles build. The existing `test-obsidian-integration` CI job (install → tsc → build → test) covers all of it.

## Notes
- `~/.hindsight/obsidian/<vault>.json` index location is deliberately out-of-vault; the README documents the shared-scope constraint when running the CLI and plugin against the same bank.
- `@vectorize-io/hindsight-obsidian` is already npm-published on release (the release workflow runs `npm run build` — which now also emits `dist/cli.js` — and `npm ci` before publish), so `npm install -g` gets a working `hindsight-obsidian-sync` bin with chokidar.

Thanks to @0xble for the well-scoped request and the code reading that made the direction obvious.