### PR TITLE
feat(control-plane): log in with your own dataplane API key

### DIFF
--- a/hindsight-control-plane/src/app/api/auth/login/route.ts
+++ b/hindsight-control-plane/src/app/api/auth/login/route.ts
@@ -5,14 +5,19 @@ import {
   ACCESS_KEY_COOKIE,
   SESSION_MAX_AGE_SECONDS,
   createSessionToken,
+  createTenantSessionToken,
+  getSessionSecret,
+  isTenantAuthEnabled,
   sessionCookieOptions,
 } from "@/lib/auth/session";
+import { DATAPLANE_URL } from "@/lib/hindsight-client";
 
 export async function POST(request: NextRequest) {
   const accessKey = process.env.HINDSIGHT_CP_ACCESS_KEY;
+  const tenantAuth = isTenantAuthEnabled();
 
-  // If no access key is configured, return 503
-  if (!accessKey) {
+  // If no auth mechanism is configured at all, return 503
+  if (!accessKey && !tenantAuth) {
     return NextResponse.json(
       localizeApiErrorPayload(request, {
         error: "Access key not configured",
@@ -37,29 +42,72 @@ export async function POST(request: NextRequest) {
 
   const providedKey = body.key;
 
-  // Constant-time comparison to prevent timing attacks
-  const isValid = providedKey && constantTimeCompare(providedKey, accessKey);
-
-  if (!isValid) {
-    return NextResponse.json(
-      localizeApiErrorPayload(request, {
-        error: "Invalid access key",
-        errorKey: "api.errors.auth.invalidAccessKey",
-      }),
-      { status: 401 }
-    );
+  // Shared-access-key mode (unchanged). Checked first so that a deployment with
+  // both configured still honours the operator's own key.
+  if (accessKey && providedKey && constantTimeCompare(providedKey, accessKey)) {
+    return setSession(request, await createSessionToken(accessKey));
   }
 
+  // Tenant mode: the key the user typed is their own dataplane API key. The API
+  // is the only thing that can say whether it is valid, and which tenant it is,
+  // so ask it rather than keeping a second copy of that knowledge here.
+  if (tenantAuth && providedKey) {
+    const secret = getSessionSecret();
+    if (!secret) {
+      // Without a secret we cannot encrypt the key into the session, and
+      // storing it in the clear is not an acceptable fallback.
+      return NextResponse.json(
+        localizeApiErrorPayload(request, {
+          error: "Session secret not configured",
+          errorKey: "api.errors.auth.accessKeyNotConfigured",
+        }),
+        { status: 503 }
+      );
+    }
+
+    if (await isValidDataplaneKey(providedKey)) {
+      return setSession(request, await createTenantSessionToken(providedKey, secret));
+    }
+  }
+
+  return NextResponse.json(
+    localizeApiErrorPayload(request, {
+      error: "Invalid access key",
+      errorKey: "api.errors.auth.invalidAccessKey",
+    }),
+    { status: 401 }
+  );
+}
+
+function setSession(request: NextRequest, token: string) {
   const response = NextResponse.json({ success: true });
 
   response.cookies.set({
     name: ACCESS_KEY_COOKIE,
-    value: await createSessionToken(accessKey),
+    value: token,
     ...sessionCookieOptions(request),
     maxAge: SESSION_MAX_AGE_SECONDS,
   });
 
   return response;
+}
+
+/**
+ * Ask the dataplane whether this key authenticates. Any 2xx means the API
+ * accepted it and resolved it to a tenant; 401/403 means it did not. A
+ * transport error is treated as "no" — failing closed is the only safe
+ * direction for a login check.
+ */
+async function isValidDataplaneKey(apiKey: string): Promise<boolean> {
+  try {
+    const response = await fetch(`${DATAPLANE_URL}/v1/default/banks`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      cache: "no-store",
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/audit-logs/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/audit-logs/route.ts
@@ -23,7 +23,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
     const url = dataplaneBankUrl(bankId, `/audit-logs${query ? `?${query}` : ""}`);
     const response = await fetch(url, {
       method: "GET",
-      headers: getDataplaneHeaders(),
+      headers: await getDataplaneHeaders(),
     });
 
     const data = await response.json();

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/audit-logs/stats/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/audit-logs/stats/route.ts
@@ -21,7 +21,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
     const url = dataplaneBankUrl(bankId, `/audit-logs/stats${query ? `?${query}` : ""}`);
     const response = await fetch(url, {
       method: "GET",
-      headers: getDataplaneHeaders(),
+      headers: await getDataplaneHeaders(),
     });
 
     const data = await response.json();

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/config/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/config/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { lowLevelClient, sdk } from "@/lib/hindsight-client";
+import { getLowLevelClient, sdk } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(
@@ -9,7 +9,7 @@ export async function GET(
 ) {
   const { bankId } = await params;
   const response = await sdk.getBankConfig({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: bankId },
   });
   return respondWithSdk(response, "Failed to fetch bank config", { request });
@@ -35,7 +35,7 @@ export async function PATCH(
   const { updates } = body;
 
   const response = await sdk.updateBankConfig({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: bankId },
     body: { updates },
   });
@@ -48,7 +48,7 @@ export async function DELETE(
 ) {
   const { bankId } = await params;
   const response = await sdk.resetBankConfig({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: bankId },
   });
   return respondWithSdk(response, "Failed to reset bank config", { request });

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/consolidate/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/consolidate/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getLowLevelClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function POST(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
@@ -17,7 +17,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ ban
   }
 
   const response = await sdk.triggerConsolidation({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: bankId },
   });
   return respondWithSdk(response, "Failed to trigger consolidation", { request });

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/consolidation-recover/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/consolidation-recover/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getLowLevelClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function POST(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
@@ -17,7 +17,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ ban
   }
 
   const response = await sdk.recoverConsolidation({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: bankId },
   });
   return respondWithSdk(response, "Failed to recover consolidation", { request });

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/directives/[directiveId]/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/directives/[directiveId]/route.ts
@@ -21,7 +21,7 @@ export async function GET(
 
     const response = await fetch(
       dataplaneBankUrl(bankId, `/directives/${encodeURIComponent(directiveId)}`),
-      { method: "GET", headers: getDataplaneHeaders() }
+      { method: "GET", headers: await getDataplaneHeaders() }
     );
 
     if (!response.ok) {
@@ -73,7 +73,7 @@ export async function PATCH(
       dataplaneBankUrl(bankId, `/directives/${encodeURIComponent(directiveId)}`),
       {
         method: "PATCH",
-        headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+        headers: await getDataplaneHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify(body),
       }
     );
@@ -123,7 +123,7 @@ export async function DELETE(
 
     const response = await fetch(
       dataplaneBankUrl(bankId, `/directives/${encodeURIComponent(directiveId)}`),
-      { method: "DELETE", headers: getDataplaneHeaders() }
+      { method: "DELETE", headers: await getDataplaneHeaders() }
     );
 
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/directives/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/directives/route.ts
@@ -31,7 +31,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
       bankId,
       `/directives${queryParams.toString() ? `?${queryParams}` : ""}`
     );
-    const response = await fetch(url, { method: "GET", headers: getDataplaneHeaders() });
+    const response = await fetch(url, { method: "GET", headers: await getDataplaneHeaders() });
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -77,7 +77,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ ban
 
     const response = await fetch(dataplaneBankUrl(bankId, "/directives"), {
       method: "POST",
-      headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+      headers: await getDataplaneHeaders({ "Content-Type": "application/json" }),
       body: JSON.stringify(body),
     });
 

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/export/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/export/route.ts
@@ -11,7 +11,7 @@ export async function GET(
 
     const url = dataplaneBankUrl(bankId, "/export");
     const response = await fetch(url, {
-      headers: getDataplaneHeaders(),
+      headers: await getDataplaneHeaders(),
     });
 
     const data = await response.json();

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/health/llm/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/health/llm/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { lowLevelClient, sdk } from "@/lib/hindsight-client";
+import { getLowLevelClient, sdk } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function POST(
@@ -8,7 +8,7 @@ export async function POST(
 ) {
   const { bankId } = await params;
   const response = await sdk.testBankLlm({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: bankId },
   });
   return respondWithSdk(response, "Failed to test bank LLM connectivity", { request });

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/import/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/import/route.ts
@@ -15,7 +15,7 @@ export async function POST(
     const url = dataplaneBankUrl(bankId, `/import${dryRun ? "?dry_run=true" : ""}`);
     const response = await fetch(url, {
       method: "POST",
-      headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+      headers: await getDataplaneHeaders({ "Content-Type": "application/json" }),
       body: JSON.stringify(body),
     });
 

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/llm-requests/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/llm-requests/route.ts
@@ -23,7 +23,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
     const url = dataplaneBankUrl(bankId, `/llm-requests${query ? `?${query}` : ""}`);
     const response = await fetch(url, {
       method: "GET",
-      headers: getDataplaneHeaders(),
+      headers: await getDataplaneHeaders(),
     });
 
     const data = await response.json();

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/llm-requests/stats/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/llm-requests/stats/route.ts
@@ -21,7 +21,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
     const url = dataplaneBankUrl(bankId, `/llm-requests/stats${query ? `?${query}` : ""}`);
     const response = await fetch(url, {
       method: "GET",
-      headers: getDataplaneHeaders(),
+      headers: await getDataplaneHeaders(),
     });
 
     const data = await response.json();

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/clear/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/clear/route.ts
@@ -21,7 +21,7 @@ export async function POST(
 
     const response = await fetch(
       dataplaneBankUrl(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}/clear`),
-      { method: "POST", headers: getDataplaneHeaders() }
+      { method: "POST", headers: await getDataplaneHeaders() }
     );
 
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/dry-run-refresh/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/dry-run-refresh/route.ts
@@ -24,7 +24,7 @@ export async function POST(
         bankId,
         `/mental-models/${encodeURIComponent(mentalModelId)}/dry-run-refresh`
       ),
-      { method: "POST", headers: getDataplaneHeaders() }
+      { method: "POST", headers: await getDataplaneHeaders() }
     );
 
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/history/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/history/route.ts
@@ -21,7 +21,7 @@ export async function GET(
 
     const response = await fetch(
       dataplaneBankUrl(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}/history`),
-      { method: "GET", headers: getDataplaneHeaders() }
+      { method: "GET", headers: await getDataplaneHeaders() }
     );
 
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/refresh/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/refresh/route.ts
@@ -21,7 +21,7 @@ export async function POST(
 
     const response = await fetch(
       dataplaneBankUrl(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}/refresh`),
-      { method: "POST", headers: getDataplaneHeaders() }
+      { method: "POST", headers: await getDataplaneHeaders() }
     );
 
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/route.ts
@@ -21,7 +21,7 @@ export async function GET(
 
     const response = await fetch(
       dataplaneBankUrl(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}`),
-      { method: "GET", headers: getDataplaneHeaders() }
+      { method: "GET", headers: await getDataplaneHeaders() }
     );
 
     if (!response.ok) {
@@ -73,7 +73,7 @@ export async function PATCH(
       dataplaneBankUrl(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}`),
       {
         method: "PATCH",
-        headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+        headers: await getDataplaneHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify(body),
       }
     );
@@ -123,7 +123,7 @@ export async function DELETE(
 
     const response = await fetch(
       dataplaneBankUrl(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}`),
-      { method: "DELETE", headers: getDataplaneHeaders() }
+      { method: "DELETE", headers: await getDataplaneHeaders() }
     );
 
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/route.ts
@@ -43,7 +43,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
       bankId,
       `/mental-models${queryParams.toString() ? `?${queryParams}` : ""}`
     );
-    const response = await fetch(url, { method: "GET", headers: getDataplaneHeaders() });
+    const response = await fetch(url, { method: "GET", headers: await getDataplaneHeaders() });
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -89,7 +89,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ ban
 
     const response = await fetch(dataplaneBankUrl(bankId, "/mental-models"), {
       method: "POST",
-      headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+      headers: await getDataplaneHeaders({ "Content-Type": "application/json" }),
       body: JSON.stringify(body),
     });
 

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/observations/[modelId]/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/observations/[modelId]/route.ts
@@ -21,7 +21,7 @@ export async function GET(
 
     const response = await fetch(
       dataplaneBankUrl(bankId, `/memories/${encodeURIComponent(modelId)}`),
-      { method: "GET", headers: getDataplaneHeaders() }
+      { method: "GET", headers: await getDataplaneHeaders() }
     );
 
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/observations/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/observations/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getLowLevelClient } from "@/lib/hindsight-client";
 
 export async function GET(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
   try {
@@ -18,7 +18,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
 
     // Note: tags filtering is not supported by the list_memories API endpoint
     const response = await sdk.listMemories({
-      client: lowLevelClient,
+      client: await getLowLevelClient(),
       path: { bank_id: bankId },
       query: {
         type: "observation",
@@ -82,7 +82,7 @@ export async function DELETE(
     }
 
     const response = await sdk.clearObservations({
-      client: lowLevelClient,
+      client: await getLowLevelClient(),
       path: { bank_id: bankId },
     });
 

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/observations/scopes/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/observations/scopes/route.ts
@@ -18,7 +18,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
 
     const response = await fetch(
       `${DATAPLANE_URL}/v1/default/banks/${bankId}/observations/scopes`,
-      { headers: getDataplaneHeaders() }
+      { headers: await getDataplaneHeaders() }
     );
 
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/operations/[operationId]/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/operations/[operationId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient, dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { sdk, getLowLevelClient, dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(
@@ -33,7 +33,7 @@ export async function GET(
   const includePayload = url.searchParams.get("include_payload") === "true";
 
   const response = await sdk.getOperationStatus({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: bankId, operation_id: operationId },
     query: includePayload ? { include_payload: true } : undefined,
   });
@@ -70,7 +70,7 @@ export async function POST(
     const url = dataplaneBankUrl(bankId, `/operations/${encodeURIComponent(operationId)}/retry`);
     const response = await fetch(url, {
       method: "POST",
-      headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+      headers: await getDataplaneHeaders({ "Content-Type": "application/json" }),
     });
 
     const data = await response.json();
@@ -126,7 +126,7 @@ export async function DELETE(
     }
 
     const response = await sdk.deleteOperation({
-      client: lowLevelClient,
+      client: await getLowLevelClient(),
       path: { bank_id: bankId, operation_id: operationId },
     });
     return respondWithSdk(response, "Failed to delete operation", { request });

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getLowLevelClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function PUT(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
@@ -29,7 +29,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ bank
   }
 
   const response = await sdk.createOrUpdateBank({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: bankId },
     body: {
       name: body.name,
@@ -66,7 +66,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ ba
   }
 
   const response = await sdk.updateBank({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: bankId },
     body: {
       name: body.name,
@@ -94,7 +94,7 @@ export async function DELETE(
   }
 
   const response = await sdk.deleteBank({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: bankId },
   });
   return respondWithSdk(response, "Failed to delete bank", { request });

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/tags/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/tags/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
     if (offset) queryParams.append("offset", offset);
 
     const url = dataplaneBankUrl(bankId, `/tags${queryParams.toString() ? `?${queryParams}` : ""}`);
-    const response = await fetch(url, { method: "GET", headers: getDataplaneHeaders() });
+    const response = await fetch(url, { method: "GET", headers: await getDataplaneHeaders() });
 
     if (!response.ok) {
       const errorText = await response.text();

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/webhooks/[webhookId]/deliveries/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/webhooks/[webhookId]/deliveries/route.ts
@@ -15,7 +15,7 @@ export async function GET(
   const res = await fetch(
     dataplaneBankUrl(bankId, `/webhooks/${encodeURIComponent(webhookId)}/deliveries?${qs}`),
     {
-      headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+      headers: await getDataplaneHeaders({ "Content-Type": "application/json" }),
     }
   );
   const data = await res.json();

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/webhooks/[webhookId]/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/webhooks/[webhookId]/route.ts
@@ -10,7 +10,7 @@ export async function PATCH(
   const body = await request.json();
   const res = await fetch(dataplaneBankUrl(bankId, `/webhooks/${encodeURIComponent(webhookId)}`), {
     method: "PATCH",
-    headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+    headers: await getDataplaneHeaders({ "Content-Type": "application/json" }),
     body: JSON.stringify(body),
   });
   const data = await res.json();
@@ -32,7 +32,7 @@ export async function DELETE(
   const { bankId, webhookId } = await params;
   const res = await fetch(dataplaneBankUrl(bankId, `/webhooks/${encodeURIComponent(webhookId)}`), {
     method: "DELETE",
-    headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+    headers: await getDataplaneHeaders({ "Content-Type": "application/json" }),
   });
   const data = await res.json();
   if (!res.ok)

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/webhooks/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/webhooks/route.ts
@@ -5,7 +5,7 @@ import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
 export async function GET(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
   const { bankId } = await params;
   const res = await fetch(dataplaneBankUrl(bankId, "/webhooks"), {
-    headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+    headers: await getDataplaneHeaders({ "Content-Type": "application/json" }),
   });
   const data = await res.json();
   if (!res.ok)
@@ -24,7 +24,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ ban
   const body = await request.json();
   const res = await fetch(dataplaneBankUrl(bankId, "/webhooks"), {
     method: "POST",
-    headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+    headers: await getDataplaneHeaders({ "Content-Type": "application/json" }),
     body: JSON.stringify(body),
   });
   const data = await res.json();

--- a/hindsight-control-plane/src/app/api/banks/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getLowLevelClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 const HTTP_CREATED = 201;
 
 export async function GET(request: Request) {
-  const response = await sdk.listBanks({ client: lowLevelClient });
+  const response = await sdk.listBanks({ client: await getLowLevelClient() });
   return respondWithSdk(response, "Failed to fetch banks", { request });
 }
 
@@ -36,7 +36,7 @@ export async function POST(request: Request) {
   }
 
   const response = await sdk.createOrUpdateBank({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id },
     body: {},
   });

--- a/hindsight-control-plane/src/app/api/chunks/[chunkId]/route.ts
+++ b/hindsight-control-plane/src/app/api/chunks/[chunkId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getLowLevelClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(
@@ -8,7 +8,7 @@ export async function GET(
 ) {
   const { chunkId } = await params;
   const response = await sdk.getChunk({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { chunk_id: chunkId },
   });
   return respondWithSdk(response, "Failed to fetch chunk", { request });

--- a/hindsight-control-plane/src/app/api/documents/[documentId]/chunks/route.ts
+++ b/hindsight-control-plane/src/app/api/documents/[documentId]/chunks/route.ts
@@ -27,7 +27,7 @@ export async function GET(
     const response = await fetch(
       `${DATAPLANE_URL}/v1/default/banks/${bankId}/documents/${documentId}/chunks?limit=${limit}&offset=${offset}`,
       {
-        headers: getDataplaneHeaders(),
+        headers: await getDataplaneHeaders(),
       }
     );
 

--- a/hindsight-control-plane/src/app/api/documents/[documentId]/reprocess/route.ts
+++ b/hindsight-control-plane/src/app/api/documents/[documentId]/reprocess/route.ts
@@ -25,7 +25,7 @@ export async function POST(
       `${DATAPLANE_URL}/v1/default/banks/${bankId}/documents/${documentId}/reprocess`,
       {
         method: "POST",
-        headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+        headers: await getDataplaneHeaders({ "Content-Type": "application/json" }),
       }
     );
 

--- a/hindsight-control-plane/src/app/api/documents/[documentId]/route.ts
+++ b/hindsight-control-plane/src/app/api/documents/[documentId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient, dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { sdk, getLowLevelClient, dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(
@@ -22,7 +22,7 @@ export async function GET(
   }
 
   const response = await sdk.getDocument({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: bankId, document_id: documentId },
   });
   return respondWithSdk(response, "Failed to fetch document", { request });
@@ -52,7 +52,7 @@ export async function PATCH(
       dataplaneBankUrl(bankId, `/documents/${encodeURIComponent(documentId)}`),
       {
         method: "PATCH",
-        headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+        headers: await getDataplaneHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify(body),
       }
     );
@@ -95,7 +95,7 @@ export async function DELETE(
   }
 
   const response = await sdk.deleteDocument({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: bankId, document_id: documentId },
   });
   return respondWithSdk(response, "Failed to delete document", { request });

--- a/hindsight-control-plane/src/app/api/documents/route.ts
+++ b/hindsight-control-plane/src/app/api/documents/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getLowLevelClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 // Tag matching modes accepted by the dataplane's list_documents endpoint.
@@ -32,7 +32,7 @@ export async function GET(request: NextRequest) {
     tags && tagsMatchParam && TAGS_MATCH_MODES.has(tagsMatchParam) ? tagsMatchParam : undefined;
 
   const response = await sdk.listDocuments({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: bankId },
     query: { q, tags, tags_match: tagsMatch, limit, offset },
   });

--- a/hindsight-control-plane/src/app/api/documents/transfer/route.ts
+++ b/hindsight-control-plane/src/app/api/documents/transfer/route.ts
@@ -31,7 +31,7 @@ export async function GET(request: NextRequest) {
     const suffix = `/document-transfer${qs.toString() ? `?${qs.toString()}` : ""}`;
 
     const response = await fetch(dataplaneBankUrl(bankId, suffix), {
-      headers: getDataplaneHeaders(),
+      headers: await getDataplaneHeaders(),
     });
     if (!response.ok) {
       const error = await response.json().catch(() => ({ detail: response.statusText }));
@@ -98,7 +98,7 @@ export async function POST(request: NextRequest) {
     const suffix = `/document-transfer?on_conflict=${encodeURIComponent(onConflict)}`;
     const response = await fetch(dataplaneBankUrl(bankId, suffix), {
       method: "POST",
-      headers: getDataplaneHeaders(),
+      headers: await getDataplaneHeaders(),
       body: outForm,
     });
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/entities/[entityId]/regenerate/route.ts
+++ b/hindsight-control-plane/src/app/api/entities/[entityId]/regenerate/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getLowLevelClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function POST(
@@ -24,7 +24,7 @@ export async function POST(
   const decodedEntityId = decodeURIComponent(entityId);
 
   const response = await sdk.regenerateEntityObservations({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: {
       bank_id: bankId,
       entity_id: decodedEntityId,

--- a/hindsight-control-plane/src/app/api/entities/[entityId]/route.ts
+++ b/hindsight-control-plane/src/app/api/entities/[entityId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getLowLevelClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(
@@ -25,7 +25,7 @@ export async function GET(
   const decodedEntityId = decodeURIComponent(entityId);
 
   const response = await sdk.getEntity({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: {
       bank_id: bankId,
       entity_id: decodedEntityId,

--- a/hindsight-control-plane/src/app/api/entities/graph/route.ts
+++ b/hindsight-control-plane/src/app/api/entities/graph/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getLowLevelClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(request: NextRequest) {
@@ -23,7 +23,7 @@ export async function GET(request: NextRequest) {
     : undefined;
 
   const response = await sdk.getEntityGraph({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: bankId },
     query: { limit, min_count: minCount },
   });

--- a/hindsight-control-plane/src/app/api/entities/route.ts
+++ b/hindsight-control-plane/src/app/api/entities/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getLowLevelClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(request: NextRequest) {
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest) {
   const offset = searchParams.get("offset") ? Number(searchParams.get("offset")) : undefined;
 
   const response = await sdk.listEntities({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: bankId },
     query: { limit, offset },
   });

--- a/hindsight-control-plane/src/app/api/extract/route.ts
+++ b/hindsight-control-plane/src/app/api/extract/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest) {
 
     const res = await fetch(dataplaneBankUrl(bankId, "/memories/dry-run-extract"), {
       method: "POST",
-      headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+      headers: await getDataplaneHeaders({ "Content-Type": "application/json" }),
       body: JSON.stringify({
         content,
         retain_mission,

--- a/hindsight-control-plane/src/app/api/files/retain/route.ts
+++ b/hindsight-control-plane/src/app/api/files/retain/route.ts
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
     // Forward the form data to the dataplane
     const response = await fetch(url, {
       method: "POST",
-      headers: getDataplaneHeaders(),
+      headers: await getDataplaneHeaders(),
       body: formData,
       // Don't set Content-Type - let fetch handle multipart boundary
     });

--- a/hindsight-control-plane/src/app/api/graph/route.ts
+++ b/hindsight-control-plane/src/app/api/graph/route.ts
@@ -43,7 +43,7 @@ export async function GET(request: NextRequest) {
     if (chunkId) params.append("chunk_id", chunkId);
 
     const response = await fetch(`${DATAPLANE_URL}/v1/default/banks/${bankId}/graph?${params}`, {
-      headers: getDataplaneHeaders(),
+      headers: await getDataplaneHeaders(),
     });
 
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/health/route.ts
+++ b/hindsight-control-plane/src/app/api/health/route.ts
@@ -28,7 +28,7 @@ export async function GET() {
       createConfig({
         baseUrl: dataplaneUrl,
         signal: controller.signal,
-        headers: getDataplaneHeaders(),
+        headers: await getDataplaneHeaders(),
       })
     );
 

--- a/hindsight-control-plane/src/app/api/knowledge-base/export/route.ts
+++ b/hindsight-control-plane/src/app/api/knowledge-base/export/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
       );
     }
     const response = await fetch(dataplaneBankUrl(bankId, "/knowledge-base/export"), {
-      headers: getDataplaneHeaders(),
+      headers: await getDataplaneHeaders(),
     });
     if (!response.ok) {
       const error = await response.json().catch(() => ({ detail: response.statusText }));

--- a/hindsight-control-plane/src/app/api/knowledge-base/folders/route.ts
+++ b/hindsight-control-plane/src/app/api/knowledge-base/folders/route.ts
@@ -17,7 +17,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const response = await fetch(dataplaneBankUrl(bankId, "/knowledge-base/folders"), {
       method: "POST",
-      headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+      headers: await getDataplaneHeaders({ "Content-Type": "application/json" }),
       body: JSON.stringify(body),
     });
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/knowledge-base/nodes/[nodeId]/route.ts
+++ b/hindsight-control-plane/src/app/api/knowledge-base/nodes/[nodeId]/route.ts
@@ -30,7 +30,7 @@ export async function PATCH(
       ),
       {
         method: "PATCH",
-        headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+        headers: await getDataplaneHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify(body),
       }
     );
@@ -72,7 +72,7 @@ export async function DELETE(
         bank,
         `/knowledge-base/nodes/${encodeURIComponent(decodeURIComponent(nodeId))}`
       ),
-      { method: "DELETE", headers: getDataplaneHeaders() }
+      { method: "DELETE", headers: await getDataplaneHeaders() }
     );
     if (!response.ok) {
       const error = await response.json().catch(() => ({ detail: response.statusText }));

--- a/hindsight-control-plane/src/app/api/knowledge-base/pages/[pageId]/route.ts
+++ b/hindsight-control-plane/src/app/api/knowledge-base/pages/[pageId]/route.ts
@@ -23,7 +23,7 @@ export async function GET(
         bankId,
         `/knowledge-base/pages/${encodeURIComponent(decodeURIComponent(pageId))}`
       ),
-      { headers: getDataplaneHeaders() }
+      { headers: await getDataplaneHeaders() }
     );
     if (!response.ok) {
       const error = await response.json().catch(() => ({ detail: response.statusText }));

--- a/hindsight-control-plane/src/app/api/knowledge-base/pages/route.ts
+++ b/hindsight-control-plane/src/app/api/knowledge-base/pages/route.ts
@@ -17,7 +17,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const response = await fetch(dataplaneBankUrl(bankId, "/knowledge-base/pages"), {
       method: "POST",
-      headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+      headers: await getDataplaneHeaders({ "Content-Type": "application/json" }),
       body: JSON.stringify(body),
     });
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/knowledge-base/search/route.ts
+++ b/hindsight-control-plane/src/app/api/knowledge-base/search/route.ts
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest) {
     }
     const path = `/knowledge-base/search?q=${encodeURIComponent(q)}&limit=${encodeURIComponent(limit)}`;
     const response = await fetch(dataplaneBankUrl(bankId, path), {
-      headers: getDataplaneHeaders(),
+      headers: await getDataplaneHeaders(),
     });
     if (!response.ok) {
       const error = await response.json().catch(() => ({ detail: response.statusText }));

--- a/hindsight-control-plane/src/app/api/knowledge-base/tree/route.ts
+++ b/hindsight-control-plane/src/app/api/knowledge-base/tree/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
       );
     }
     const response = await fetch(dataplaneBankUrl(bankId, "/knowledge-base/tree"), {
-      headers: getDataplaneHeaders(),
+      headers: await getDataplaneHeaders(),
     });
     if (!response.ok) {
       const error = await response.json().catch(() => ({ detail: response.statusText }));

--- a/hindsight-control-plane/src/app/api/list/route.ts
+++ b/hindsight-control-plane/src/app/api/list/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { hindsightClient } from "@/lib/hindsight-client";
+import { getHindsightClient } from "@/lib/hindsight-client";
 
 export async function GET(request: NextRequest) {
   try {
@@ -34,7 +34,7 @@ export async function GET(request: NextRequest) {
     const documentId = searchParams.get("document_id") || undefined;
     const entityId = searchParams.get("entity_id") || undefined;
 
-    const response = await hindsightClient.listMemories(bankId, {
+    const response = await (await getHindsightClient()).listMemories(bankId, {
       limit,
       offset,
       type,

--- a/hindsight-control-plane/src/app/api/memories/[memoryId]/history/route.ts
+++ b/hindsight-control-plane/src/app/api/memories/[memoryId]/history/route.ts
@@ -25,7 +25,7 @@ export async function GET(
       dataplaneBankUrl(bankId, `/memories/${encodeURIComponent(memoryId)}/history`),
       {
         method: "GET",
-        headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+        headers: await getDataplaneHeaders({ "Content-Type": "application/json" }),
       }
     );
 

--- a/hindsight-control-plane/src/app/api/memories/[memoryId]/route.ts
+++ b/hindsight-control-plane/src/app/api/memories/[memoryId]/route.ts
@@ -25,7 +25,7 @@ export async function GET(
       dataplaneBankUrl(bankId, `/memories/${encodeURIComponent(memoryId)}`),
       {
         method: "GET",
-        headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+        headers: await getDataplaneHeaders({ "Content-Type": "application/json" }),
       }
     );
 
@@ -83,7 +83,7 @@ export async function PATCH(
       dataplaneBankUrl(bankId, `/memories/${encodeURIComponent(memoryId)}`),
       {
         method: "PATCH",
-        headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+        headers: await getDataplaneHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify({
           text,
           context,

--- a/hindsight-control-plane/src/app/api/memories/retain/route.ts
+++ b/hindsight-control-plane/src/app/api/memories/retain/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { hindsightClient } from "@/lib/hindsight-client";
+import { getHindsightClient } from "@/lib/hindsight-client";
 
 export async function POST(request: NextRequest) {
   try {
@@ -27,7 +27,7 @@ export async function POST(request: NextRequest) {
         }))
       : items;
 
-    const response = await hindsightClient.retainBatch(bankId, mappedItems, {
+    const response = await (await getHindsightClient()).retainBatch(bankId, mappedItems, {
       documentId: document_id,
       documentTags: document_tags,
     });

--- a/hindsight-control-plane/src/app/api/memories/retain_async/route.ts
+++ b/hindsight-control-plane/src/app/api/memories/retain_async/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getLowLevelClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function POST(request: NextRequest) {
@@ -31,7 +31,7 @@ export async function POST(request: NextRequest) {
   const { items } = body;
 
   const response = await sdk.retainMemories({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: bankId },
     body: { items, async: true },
   });

--- a/hindsight-control-plane/src/app/api/operations/[agentId]/route.ts
+++ b/hindsight-control-plane/src/app/api/operations/[agentId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getLowLevelClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(
@@ -16,7 +16,7 @@ export async function GET(
   const excludeParents = searchParams.get("exclude_parents") === "true" ? true : undefined;
 
   const response = await sdk.listOperations({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: agentId },
     query: { status, type, limit, offset, exclude_parents: excludeParents },
   });
@@ -42,7 +42,7 @@ export async function DELETE(
   }
 
   const response = await sdk.cancelOperation({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: agentId, operation_id: operationId },
   });
   return respondWithSdk(response, "Failed to cancel operation", { request });

--- a/hindsight-control-plane/src/app/api/profile/[bankId]/route.ts
+++ b/hindsight-control-plane/src/app/api/profile/[bankId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getLowLevelClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(
@@ -9,7 +9,7 @@ export async function GET(
 ) {
   const { bankId } = await params;
   const response = await sdk.getBankProfile({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: bankId },
   });
   return respondWithSdk(response, "Failed to fetch bank profile", { request });
@@ -34,7 +34,7 @@ export async function PUT(
   }
 
   const response = await sdk.createOrUpdateBank({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: bankId },
     body: body,
   });

--- a/hindsight-control-plane/src/app/api/recall/route.ts
+++ b/hindsight-control-plane/src/app/api/recall/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { lowLevelClient, sdk } from "@/lib/hindsight-client";
+import { getLowLevelClient, sdk } from "@/lib/hindsight-client";
 
 export async function POST(request: NextRequest) {
   try {
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest) {
     } = body;
 
     const response = await sdk.recallMemories({
-      client: lowLevelClient,
+      client: await getLowLevelClient(),
       path: { bank_id: bankId },
       body: {
         query,

--- a/hindsight-control-plane/src/app/api/reflect/route.ts
+++ b/hindsight-control-plane/src/app/api/reflect/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getLowLevelClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function POST(request: NextRequest) {
@@ -59,7 +59,7 @@ export async function POST(request: NextRequest) {
   }
 
   const response = await sdk.reflect({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: bankId },
     body: requestBody,
   });

--- a/hindsight-control-plane/src/app/api/stats/[agentId]/memories-timeseries/route.ts
+++ b/hindsight-control-plane/src/app/api/stats/[agentId]/memories-timeseries/route.ts
@@ -14,7 +14,7 @@ export async function GET(
       agentId,
       `/stats/memories-timeseries?period=${encodeURIComponent(period)}&time_field=${encodeURIComponent(timeField)}`
     );
-    const upstream = await fetch(url, { headers: getDataplaneHeaders() });
+    const upstream = await fetch(url, { headers: await getDataplaneHeaders() });
     const body = await upstream.json();
     return NextResponse.json(body, { status: upstream.status });
   } catch (error) {

--- a/hindsight-control-plane/src/app/api/stats/[agentId]/route.ts
+++ b/hindsight-control-plane/src/app/api/stats/[agentId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getLowLevelClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(
@@ -8,7 +8,7 @@ export async function GET(
 ) {
   const { agentId } = await params;
   const response = await sdk.getAgentStats({
-    client: lowLevelClient,
+    client: await getLowLevelClient(),
     path: { bank_id: agentId },
   });
   return respondWithSdk(response, "Failed to fetch stats", { request });

--- a/hindsight-control-plane/src/app/api/version/route.ts
+++ b/hindsight-control-plane/src/app/api/version/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getLowLevelClient } from "@/lib/hindsight-client";
 
 export async function GET(request: Request) {
   try {
     const response = await sdk.getVersion({
-      client: lowLevelClient,
+      client: await getLowLevelClient(),
     });
 
     if (response.error) {

--- a/hindsight-control-plane/src/lib/auth/session.ts
+++ b/hindsight-control-plane/src/lib/auth/session.ts
@@ -6,6 +6,104 @@ export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24;
 const CLOCK_SKEW_TOLERANCE_SECONDS = 60;
 
 /**
+ * Tenant-key auth: instead of one shared access key, each person logs in with
+ * their own dataplane API key, and the control plane makes every downstream
+ * call as that key. Because the API resolves a key to its own tenant (schema),
+ * one control plane can serve many users, each seeing only their own banks.
+ *
+ * Off by default — an unset HINDSIGHT_CP_TENANT_AUTH leaves the shared
+ * access-key behaviour exactly as it was.
+ */
+export function isTenantAuthEnabled(): boolean {
+  return process.env.HINDSIGHT_CP_TENANT_AUTH === "true";
+}
+
+const TENANT_TOKEN_PREFIX = "t1";
+
+/**
+ * Tenant session token: `t1.<issuedAtSeconds>.<base64url iv>.<base64url ciphertext>`.
+ *
+ * The user's API key is ENCRYPTED (AES-256-GCM) rather than merely signed. An
+ * httpOnly cookie already keeps it away from page scripts, but encrypting means
+ * a cookie lifted off disk cannot be unwrapped back into a working API key and
+ * replayed straight against the REST/MCP endpoints — the blast radius stays the
+ * UI session. `issuedAt` is bound in as additional authenticated data, so it
+ * cannot be edited to extend the session's life.
+ *
+ * Rotating HINDSIGHT_CP_SESSION_SECRET invalidates every outstanding session.
+ */
+export function getSessionSecret(): string | undefined {
+  return process.env.HINDSIGHT_CP_SESSION_SECRET || undefined;
+}
+
+async function aesKey(secret: string): Promise<CryptoKey> {
+  // AES-GCM needs exactly 256 bits; the secret is arbitrary-length text.
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(secret));
+  return crypto.subtle.importKey("raw", digest, { name: "AES-GCM" }, false, [
+    "encrypt",
+    "decrypt",
+  ]);
+}
+
+export async function createTenantSessionToken(apiKey: string, secret: string): Promise<string> {
+  const issuedAt = Math.floor(Date.now() / 1000).toString();
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv, additionalData: new TextEncoder().encode(issuedAt) },
+    await aesKey(secret),
+    new TextEncoder().encode(apiKey)
+  );
+  return [
+    TENANT_TOKEN_PREFIX,
+    issuedAt,
+    base64UrlEncode(iv),
+    base64UrlEncode(new Uint8Array(ciphertext)),
+  ].join(".");
+}
+
+/**
+ * Returns the API key carried by a valid, unexpired tenant session, else null.
+ *
+ * Note this does NOT re-check the key against the API — that would add a round
+ * trip to every request. Revocation still takes effect immediately, because the
+ * actual data call made with this key is what gets rejected.
+ */
+export async function readTenantSessionKey(
+  token: string | undefined,
+  secret: string | undefined
+): Promise<string | null> {
+  if (!token || !secret) return null;
+
+  const parts = token.split(".");
+  if (parts.length !== 4 || parts[0] !== TENANT_TOKEN_PREFIX) return null;
+  const [, issuedAtRaw, ivRaw, ciphertextRaw] = parts;
+
+  const issuedAt = Number(issuedAtRaw);
+  if (!Number.isInteger(issuedAt) || issuedAt <= 0) return null;
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (issuedAt > nowSeconds + CLOCK_SKEW_TOLERANCE_SECONDS) return null;
+  if (nowSeconds - issuedAt > SESSION_MAX_AGE_SECONDS) return null;
+
+  try {
+    const plaintext = await crypto.subtle.decrypt(
+      {
+        name: "AES-GCM",
+        iv: base64UrlDecode(ivRaw),
+        additionalData: new TextEncoder().encode(issuedAtRaw),
+      },
+      await aesKey(secret),
+      base64UrlDecode(ciphertextRaw)
+    );
+    const apiKey = new TextDecoder().decode(plaintext);
+    return apiKey || null;
+  } catch {
+    // Wrong secret, tampered ciphertext, or edited issuedAt — all mean "no session".
+    return null;
+  }
+}
+
+/**
  * Session token format: `<issuedAtSeconds>.<base64urlHmacSha256>`.
  *
  * The HMAC is computed over `issuedAtSeconds` using the access key as the
@@ -81,6 +179,16 @@ function base64UrlEncode(bytes: Uint8Array): string {
   let binary = "";
   for (const byte of bytes) binary += String.fromCharCode(byte);
   return btoa(binary).replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+// Backed by a plain ArrayBuffer (not ArrayBufferLike) so the result satisfies
+// BufferSource where WebCrypto expects it.
+function base64UrlDecode(value: string): Uint8Array<ArrayBuffer> {
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, "="));
+  const bytes = new Uint8Array(new ArrayBuffer(binary.length));
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
 }
 
 function constantTimeEqual(a: string, b: string): boolean {

--- a/hindsight-control-plane/src/lib/hindsight-client.ts
+++ b/hindsight-control-plane/src/lib/hindsight-client.ts
@@ -1,8 +1,16 @@
 /**
- * Shared Hindsight API client instance for the control plane.
- * Configured to connect to the dataplane API server.
+ * Hindsight API clients for the control plane.
+ *
+ * These are built PER REQUEST, not once at module scope. With tenant auth on,
+ * the key used for a downstream call is the one the logged-in person supplied,
+ * so a single control plane serves many users and the API — which resolves a
+ * key to its own tenant schema — is what enforces the boundary.
+ *
+ * They stay cheap to construct: no connection pooling, just a base URL and a
+ * header. All callers are Next route handlers, so a request scope always exists.
  */
 
+import { cookies } from "next/headers";
 import {
   HindsightClient,
   HindsightError,
@@ -11,16 +19,45 @@ import {
   sdk,
 } from "@vectorize-io/hindsight-client";
 
+import {
+  ACCESS_KEY_COOKIE,
+  getSessionSecret,
+  isTenantAuthEnabled,
+  readTenantSessionKey,
+} from "@/lib/auth/session";
+
 export const DATAPLANE_URL = process.env.HINDSIGHT_CP_DATAPLANE_API_URL || "http://localhost:8888";
 const DATAPLANE_API_KEY = process.env.HINDSIGHT_CP_DATAPLANE_API_KEY || "";
 
 /**
+ * The API key to use for this request.
+ *
+ * In tenant mode this is the caller's own key, taken from their session, and
+ * there is deliberately NO fallback to HINDSIGHT_CP_DATAPLANE_API_KEY: falling
+ * back would quietly serve a request with no valid session using the shared
+ * key, which is the one failure that would defeat the whole point. Middleware
+ * already rejects those requests; this is the second lock.
+ */
+export async function getDataplaneApiKey(): Promise<string | undefined> {
+  if (!isTenantAuthEnabled()) {
+    return DATAPLANE_API_KEY || undefined;
+  }
+  const jar = await cookies();
+  const token = jar.get(ACCESS_KEY_COOKIE)?.value;
+  const apiKey = await readTenantSessionKey(token, getSessionSecret());
+  return apiKey ?? undefined;
+}
+
+/**
  * Auth headers for direct fetch calls to the dataplane API.
  */
-export function getDataplaneHeaders(extra?: Record<string, string>): Record<string, string> {
+export async function getDataplaneHeaders(
+  extra?: Record<string, string>
+): Promise<Record<string, string>> {
   const headers: Record<string, string> = { ...extra };
-  if (DATAPLANE_API_KEY) {
-    headers["Authorization"] = `Bearer ${DATAPLANE_API_KEY}`;
+  const apiKey = await getDataplaneApiKey();
+  if (apiKey) {
+    headers["Authorization"] = `Bearer ${apiKey}`;
   }
   return headers;
 }
@@ -37,20 +74,25 @@ export function dataplaneBankUrl(bankId: string, suffix = ""): string {
 /**
  * High-level client with convenience methods
  */
-export const hindsightClient = new HindsightClient({
-  baseUrl: DATAPLANE_URL,
-  apiKey: DATAPLANE_API_KEY || undefined,
-});
+export async function getHindsightClient(): Promise<HindsightClient> {
+  return new HindsightClient({
+    baseUrl: DATAPLANE_URL,
+    apiKey: await getDataplaneApiKey(),
+  });
+}
 
 /**
  * Low-level client for direct SDK access
  */
-export const lowLevelClient = createClient(
-  createConfig({
-    baseUrl: DATAPLANE_URL,
-    headers: DATAPLANE_API_KEY ? { Authorization: `Bearer ${DATAPLANE_API_KEY}` } : undefined,
-  })
-);
+export async function getLowLevelClient() {
+  const apiKey = await getDataplaneApiKey();
+  return createClient(
+    createConfig({
+      baseUrl: DATAPLANE_URL,
+      headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined,
+    })
+  );
+}
 
 /**
  * Export SDK functions for direct API access

--- a/hindsight-control-plane/src/middleware.ts
+++ b/hindsight-control-plane/src/middleware.ts
@@ -3,7 +3,13 @@ import type { NextRequest } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
 import createIntlMiddleware from "next-intl/middleware";
 
-import { ACCESS_KEY_COOKIE, verifySessionToken } from "@/lib/auth/session";
+import {
+  ACCESS_KEY_COOKIE,
+  getSessionSecret,
+  isTenantAuthEnabled,
+  readTenantSessionKey,
+  verifySessionToken,
+} from "@/lib/auth/session";
 import { stripBasePath, withBasePath } from "@/lib/base-path";
 import { routing } from "@/i18n/routing";
 
@@ -22,14 +28,35 @@ const PUBLIC_PATTERNS = [
 
 const intlMiddleware = createIntlMiddleware(routing);
 
+/**
+ * A session is valid if it satisfies EITHER configured mode: the shared access
+ * key, or a tenant session carrying the user's own API key.
+ */
+async function isAuthenticatedRequest(request: NextRequest, accessKey: string | undefined) {
+  const sessionCookie = request.cookies.get(ACCESS_KEY_COOKIE)?.value;
+
+  if (accessKey && (await verifySessionToken(sessionCookie, accessKey))) {
+    return true;
+  }
+
+  if (isTenantAuthEnabled()) {
+    return (await readTenantSessionKey(sessionCookie, getSessionSecret())) !== null;
+  }
+
+  return false;
+}
+
 export async function middleware(request: NextRequest) {
   const accessKey = process.env.HINDSIGHT_CP_ACCESS_KEY;
+  // Tenant auth gates the app just as the shared key does — without this, turning
+  // on tenant auth alone would leave every route unauthenticated.
+  const authRequired = Boolean(accessKey) || isTenantAuthEnabled();
   const { pathname } = request.nextUrl;
   const appPathname = stripBasePath(pathname);
 
   // API routes are not locale-prefixed — handle auth directly without i18n routing.
   if (appPathname.startsWith("/api/")) {
-    if (!accessKey) {
+    if (!authRequired) {
       return NextResponse.next();
     }
 
@@ -38,10 +65,7 @@ export async function middleware(request: NextRequest) {
       return NextResponse.next();
     }
 
-    const sessionCookie = request.cookies.get(ACCESS_KEY_COOKIE)?.value;
-    const isAuthenticated = await verifySessionToken(sessionCookie, accessKey);
-
-    if (!isAuthenticated) {
+    if (!(await isAuthenticatedRequest(request, accessKey))) {
       return NextResponse.json(
         localizeApiErrorPayload(request, {
           error: "Unauthorized",
@@ -57,14 +81,11 @@ export async function middleware(request: NextRequest) {
   // Page routes: enforce auth first, then delegate to the i18n middleware for
   // locale negotiation and rewriting. With localePrefix "never" the locale is
   // never in the path, so appPathname is already the canonical route.
-  if (accessKey) {
+  if (authRequired) {
     const isPublic = PUBLIC_PATTERNS.some((pattern) => appPathname.startsWith(pattern));
 
     if (!isPublic) {
-      const sessionCookie = request.cookies.get(ACCESS_KEY_COOKIE)?.value;
-      const isAuthenticated = await verifySessionToken(sessionCookie, accessKey);
-
-      if (!isAuthenticated) {
+      if (!(await isAuthenticatedRequest(request, accessKey))) {
         // Next.js middleware redirects do not automatically inherit next.config basePath.
         // Prefix the target explicitly, but keep returnTo as the app-relative path so
         // client-side router.push() does not double-prefix after login.

--- a/hindsight-control-plane/tests/app/api/documents/route.test.ts
+++ b/hindsight-control-plane/tests/app/api/documents/route.test.ts
@@ -9,7 +9,7 @@ const { listDocuments } = vi.hoisted(() => ({
 
 vi.mock("@/lib/hindsight-client", () => ({
   sdk: { listDocuments },
-  lowLevelClient: {},
+  getLowLevelClient: vi.fn(async () => ({})),
 }));
 
 vi.mock("@/lib/sdk-response", () => ({

--- a/hindsight-control-plane/tests/app/api/files/retain/route.test.ts
+++ b/hindsight-control-plane/tests/app/api/files/retain/route.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/hindsight-client", () => ({
   dataplaneBankUrl: vi.fn(() => "http://localhost/v1/default/banks/test-bank/files/retain"),
-  getDataplaneHeaders: vi.fn(() => ({})),
+  getDataplaneHeaders: vi.fn(async () => ({})),
 }));
 
 import { POST } from "@/app/api/files/retain/route";

--- a/hindsight-control-plane/tests/lib/auth/tenant-session.test.ts
+++ b/hindsight-control-plane/tests/lib/auth/tenant-session.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  SESSION_MAX_AGE_SECONDS,
+  createSessionToken,
+  createTenantSessionToken,
+  isTenantAuthEnabled,
+  readTenantSessionKey,
+} from "@/lib/auth/session";
+
+const SECRET = "server-side-session-secret";
+const API_KEY = "hsk_0123456789abcdef0123456789abcdef";
+
+afterEach(() => {
+  vi.useRealTimers();
+  delete process.env.HINDSIGHT_CP_TENANT_AUTH;
+});
+
+describe("isTenantAuthEnabled", () => {
+  it("is off unless explicitly set to true", () => {
+    expect(isTenantAuthEnabled()).toBe(false);
+    process.env.HINDSIGHT_CP_TENANT_AUTH = "1";
+    expect(isTenantAuthEnabled()).toBe(false);
+    process.env.HINDSIGHT_CP_TENANT_AUTH = "true";
+    expect(isTenantAuthEnabled()).toBe(true);
+  });
+});
+
+describe("tenant session token", () => {
+  it("round-trips the API key", async () => {
+    const token = await createTenantSessionToken(API_KEY, SECRET);
+    await expect(readTenantSessionKey(token, SECRET)).resolves.toBe(API_KEY);
+  });
+
+  it("does not carry the key in a recoverable form", async () => {
+    const token = await createTenantSessionToken(API_KEY, SECRET);
+    expect(token).not.toContain(API_KEY);
+    // ...and the raw key is not merely base64'd into the token either.
+    expect(token).not.toContain(btoa(API_KEY).replace(/=+$/, ""));
+  });
+
+  it("rejects a token sealed with a different secret", async () => {
+    const token = await createTenantSessionToken(API_KEY, SECRET);
+    await expect(readTenantSessionKey(token, "rotated-secret")).resolves.toBeNull();
+  });
+
+  it("rejects an edited issuedAt, so a session cannot be extended", async () => {
+    const token = await createTenantSessionToken(API_KEY, SECRET);
+    const parts = token.split(".");
+    parts[1] = String(Number(parts[1]) + 5);
+    await expect(readTenantSessionKey(parts.join("."), SECRET)).resolves.toBeNull();
+  });
+
+  it("rejects tampered ciphertext", async () => {
+    const token = await createTenantSessionToken(API_KEY, SECRET);
+    const parts = token.split(".");
+    parts[3] = parts[3].slice(0, -2) + (parts[3].slice(-2) === "AA" ? "BB" : "AA");
+    await expect(readTenantSessionKey(parts.join("."), SECRET)).resolves.toBeNull();
+  });
+
+  it("expires after the session max age", async () => {
+    const token = await createTenantSessionToken(API_KEY, SECRET);
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + (SESSION_MAX_AGE_SECONDS + 60) * 1000);
+    await expect(readTenantSessionKey(token, SECRET)).resolves.toBeNull();
+  });
+
+  it("rejects a shared-access-key token, which carries no tenant identity", async () => {
+    const legacy = await createSessionToken("some-access-key");
+    await expect(readTenantSessionKey(legacy, SECRET)).resolves.toBeNull();
+  });
+
+  it("returns null when no secret is configured", async () => {
+    const token = await createTenantSessionToken(API_KEY, SECRET);
+    await expect(readTenantSessionKey(token, undefined)).resolves.toBeNull();
+    await expect(readTenantSessionKey(undefined, SECRET)).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #3183.

## Problem

The dataplane resolves an API key to a tenant. The control plane resolves its key once, at module scope:

```ts
const DATAPLANE_API_KEY = process.env.HINDSIGHT_CP_DATAPLANE_API_KEY || "";
export const hindsightClient = new HindsightClient({ baseUrl: DATAPLANE_URL, apiKey: ... });
```

So the whole process talks to the dataplane as one tenant. A deployment running a multi-tenant `TenantExtension` gets working per-user isolation over REST and MCP, and no way to reach it from the UI — short of running one control plane per user, each with its own port, access key and dataplane key.

## Approach

An opt-in mode, `HINDSIGHT_CP_TENANT_AUTH`, in which the key entered at the login screen **is** the dataplane credential:

- **Login validates against the dataplane.** The UI never invents its own notion of a valid key — it asks the dataplane, which already knows how to answer. No second source of truth.
- **The session carries that key, encrypted.** AES-256-GCM under `HINDSIGHT_CP_SESSION_SECRET`. This is a live credential, not a session identifier, so a lifted cookie should not unwrap into a working API key usable against REST or MCP outside the browser.
- **The dataplane client is built per request** from the session, replacing the module-scope singletons.

## Compatibility

Default behaviour is unchanged. With `HINDSIGHT_CP_TENANT_AUTH` unset, the existing `HINDSIGHT_CP_ACCESS_KEY` gate and the fixed `HINDSIGHT_CP_DATAPLANE_API_KEY` work exactly as before — no new UI, routes, headers or middleware behaviour appear. This follows the compatibility expectation in #2343.

## Diff shape

Most of the change is mechanical. `getDataplaneHeaders()` becomes async, so `await` propagates across the route handlers that call it — that is the bulk of the 68 files. The actual logic is three files:

- `src/lib/auth/session.ts` — encrypted tenant session alongside the existing HMAC access-key session
- `src/lib/hindsight-client.ts` — request-scoped client construction
- `src/middleware.ts` — route gating for both modes

## Verification

- `tsc --noEmit` clean
- 128 tests pass across 13 files, including a new `tests/lib/auth/tenant-session.test.ts` covering encrypt/decrypt round-trip, tampered-ciphertext rejection and expiry
- `eslint` reports 0 errors on the changed files (5 pre-existing `no-explicit-any` warnings, down from 7 at baseline)
- Exercised on a live deployment with two tenants on separate Postgres schemas: each sees only their own banks, and a revoked key stops working immediately

## Open questions

- `HINDSIGHT_CP_TENANT_AUTH` as the flag name, or fold this into a broader auth-profile concept as sketched in #2343?
- Session lifetime currently reuses `SESSION_MAX_AGE_SECONDS` (24h). For a mode where the cookie holds a real credential, a shorter default may be wanted.
- Happy to split the mechanical `await` propagation into its own commit if that makes review easier.
