### PR TITLE
perf(entity-resolution): skip fuzzy probing for exact-match-only label entities

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
+++ b/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
@@ -240,6 +240,13 @@ class EntityResolver:
         """Split values into fixed-size batches."""
         return [values[i : i + size] for i in range(0, len(values), size)]
 
+    @staticmethod
+    def _label_texts(entity_texts: list[str], taxonomy_lookup: set[str] | None, labels_cfg) -> set[str]:
+        """Subset of entity_texts that are label entities (resolved by exact match only)."""
+        if not (labels_cfg and taxonomy_lookup):
+            return set()
+        return {t for t in entity_texts if _is_label_entity(t, labels_cfg, taxonomy_lookup)}
+
     async def resolve_entities_batch(
         self,
         bank_id: str,
@@ -424,40 +431,70 @@ class EntityResolver:
         """
         entity_texts = list(set(e["text"] for e in entities_data))
 
-        # Fetch candidates for unique entity texts in bounded batches.
+        # Label entities resolve by exact match only (their canonical names are
+        # user-defined and must not be fuzzy-merged). Probing them via the trigram
+        # index only returns similar-but-distinct label values that are always
+        # discarded, and that wasted work grows with the number of values a label
+        # accumulates. Resolve label texts with an exact lookup on the unique
+        # (bank_id, LOWER(canonical_name)) index and only fuzzy-match the rest.
+        label_set = self._label_texts(entity_texts, taxonomy_lookup, labels_cfg)
+        label_texts = [t for t in entity_texts if t in label_set]
+        fuzzy_texts = [t for t in entity_texts if t not in label_set]
+
+        rows = []
+
+        # Exact, index-only lookup for label texts.
+        for entity_text_batch in self._chunked(label_texts, self.entity_resolution_batch_size):
+            rows.extend(
+                await conn.fetch(
+                    f"""
+                    SELECT e.id, e.canonical_name, e.metadata, e.last_seen, e.mention_count,
+                           q.query_text
+                    FROM unnest($2::text[]) AS q(query_text)
+                    JOIN {fq_table("entities")} e ON (
+                        e.bank_id = $1
+                        AND LOWER(e.canonical_name) = LOWER(q.query_text)
+                    )
+                    """,
+                    bank_id,
+                    entity_text_batch,
+                )
+            )
+
+        # Fetch candidates for the remaining texts in bounded batches.
         # Uses the GIN trigram index on LOWER(canonical_name) for case-insensitive
         # similarity lookup. Previous version also had LIKE '%...' substring fallbacks,
         # but those forced full sequential scans of the entities table and caused
         # TimeoutErrors on banks with 10k+ entities. Lowering the similarity threshold
         # to 0.15 (from default 0.3) catches most substring relationships while
         # staying fully index-based.
-        await conn.execute("SET pg_trgm.similarity_threshold = 0.15")
-        try:
-            rows = []
-            for entity_text_batch in self._chunked(entity_texts, self.entity_resolution_batch_size):
-                rows.extend(
-                    await conn.fetch(
-                        f"""
-                        SELECT DISTINCT ON (e.id)
-                            e.id, e.canonical_name, e.metadata, e.last_seen, e.mention_count,
-                            q.query_text
-                        FROM unnest($2::text[]) AS q(query_text)
-                        JOIN {fq_table("entities")} e ON (
-                            e.bank_id = $1
-                            AND LOWER(e.canonical_name) % LOWER(q.query_text)
-                        )
-                        """,
-                        bank_id,
-                        entity_text_batch,
-                    )
-                )
-        finally:
-            # asyncpg returns connections to the pool with session state intact,
-            # so the lowered threshold would leak to future borrowers without RESET.
+        if fuzzy_texts:
+            await conn.execute("SET pg_trgm.similarity_threshold = 0.15")
             try:
-                await conn.execute("RESET pg_trgm.similarity_threshold")
-            except Exception:
-                logger.warning("Failed to reset pg_trgm similarity threshold after candidate lookup", exc_info=True)
+                for entity_text_batch in self._chunked(fuzzy_texts, self.entity_resolution_batch_size):
+                    rows.extend(
+                        await conn.fetch(
+                            f"""
+                            SELECT DISTINCT ON (e.id)
+                                e.id, e.canonical_name, e.metadata, e.last_seen, e.mention_count,
+                                q.query_text
+                            FROM unnest($2::text[]) AS q(query_text)
+                            JOIN {fq_table("entities")} e ON (
+                                e.bank_id = $1
+                                AND LOWER(e.canonical_name) % LOWER(q.query_text)
+                            )
+                            """,
+                            bank_id,
+                            entity_text_batch,
+                        )
+                    )
+            finally:
+                # asyncpg returns connections to the pool with session state intact,
+                # so the lowered threshold would leak to future borrowers without RESET.
+                try:
+                    await conn.execute("RESET pg_trgm.similarity_threshold")
+                except Exception:
+                    logger.warning("Failed to reset pg_trgm similarity threshold after candidate lookup", exc_info=True)
 
         # Group candidates by query_text
         all_candidates: dict[str, list] = {t: [] for t in entity_texts}
@@ -530,6 +567,14 @@ class EntityResolver:
         entity_texts = list(set(e["text"] for e in entities_data))
         entities_table = fq_table("entities")
 
+        # Label entities resolve by exact match only, so the fuzzy Jaro-Winkler
+        # join only returns similar-but-distinct label values that are always
+        # discarded. Resolve label texts with an exact lookup on the unique
+        # (bank_id, LOWER(canonical_name)) index and only fuzzy-match the rest.
+        label_set = self._label_texts(entity_texts, taxonomy_lookup, labels_cfg)
+        label_texts = [t for t in entity_texts if t in label_set]
+        fuzzy_texts = [t for t in entity_texts if t not in label_set]
+
         try:
             # Batch entity texts into bounded sub-queries using JSON_TABLE to
             # expand the list into rows. UTL_MATCH.JARO_WINKLER_SIMILARITY
@@ -537,7 +582,23 @@ class EntityResolver:
             # Bounded batches mirror the PG trigram path so very wide retain
             # batches don't time out a single JOIN on large banks.
             rows = []
-            for entity_text_batch in self._chunked(entity_texts, self.entity_resolution_batch_size):
+            for entity_text_batch in self._chunked(label_texts, self.entity_resolution_batch_size):
+                rows.extend(
+                    await conn.fetch(
+                        f"""
+                        SELECT e.id, e.canonical_name, e.metadata, e.last_seen, e.mention_count,
+                               q.query_text
+                        FROM JSON_TABLE($2, '$[*]' COLUMNS (query_text VARCHAR2(4000) PATH '$')) q
+                        JOIN {entities_table} e ON (
+                            e.bank_id = $1
+                            AND LOWER(e.canonical_name) = LOWER(q.query_text)
+                        )
+                        """,
+                        bank_id,
+                        json.dumps(entity_text_batch),
+                    )
+                )
+            for entity_text_batch in self._chunked(fuzzy_texts, self.entity_resolution_batch_size):
                 rows.extend(
                     await conn.fetch(
                         f"""

--- a/hindsight-api-slim/tests/test_entity_resolver_pg_trgm.py
+++ b/hindsight-api-slim/tests/test_entity_resolver_pg_trgm.py
@@ -198,6 +198,79 @@ class TestPgTrgmAutoDetection:
         conn.execute.assert_any_await("RESET pg_trgm.similarity_threshold")
 
     @pytest.mark.asyncio
+    async def test_label_texts_use_exact_lookup_not_trigram(self):
+        """Label entities go through an exact-match query; only non-label texts hit the % probe."""
+        resolver = _make_resolver(entity_lookup="trigram")
+        conn = _make_conn(pg_trgm_available=True)
+
+        captured: list[tuple[str, tuple]] = []
+
+        async def _capture(sql, *args):
+            captured.append((sql, args))
+            return []
+
+        conn.fetch = AsyncMock(side_effect=_capture)
+
+        labels_cfg = MagicMock()
+        labels_cfg.attributes = []
+        taxonomy_lookup = {"use:use-001", "use:use-002"}
+        entities_data = [
+            {"text": "use:use-001"},
+            {"text": "use:use-002"},
+            {"text": "Alice"},
+        ]
+
+        with (
+            patch("hindsight_api.engine.entity_resolver.fq_table", side_effect=lambda table: table),
+            patch.object(resolver, "_resolve_from_candidates", new=AsyncMock(return_value=[])),
+        ):
+            await resolver._resolve_entities_batch_trigram(
+                conn=conn,
+                bank_id="test-bank",
+                entities_data=entities_data,
+                unit_event_date=None,
+                taxonomy_lookup=taxonomy_lookup,
+                labels_cfg=labels_cfg,
+            )
+
+        exact_calls = [(sql, args) for sql, args in captured if "= LOWER(q.query_text)" in sql]
+        trigram_calls = [(sql, args) for sql, args in captured if "% LOWER(q.query_text)" in sql]
+
+        # Label texts are resolved by a single exact-match query — never fuzzy-probed.
+        assert len(exact_calls) == 1
+        assert sorted(exact_calls[0][1][1]) == ["use:use-001", "use:use-002"]
+
+        # Only the non-label text reaches the trigram probe.
+        assert len(trigram_calls) == 1
+        assert trigram_calls[0][1][1] == ["Alice"]
+
+    @pytest.mark.asyncio
+    async def test_all_label_texts_skip_trigram_threshold(self):
+        """When every text is a label, the pg_trgm threshold is never set (fuzzy probe fully skipped)."""
+        resolver = _make_resolver(entity_lookup="trigram")
+        conn = _make_conn(pg_trgm_available=True)
+
+        labels_cfg = MagicMock()
+        labels_cfg.attributes = []
+        taxonomy_lookup = {"use:use-001"}
+
+        with (
+            patch("hindsight_api.engine.entity_resolver.fq_table", side_effect=lambda table: table),
+            patch.object(resolver, "_resolve_from_candidates", new=AsyncMock(return_value=[])),
+        ):
+            await resolver._resolve_entities_batch_trigram(
+                conn=conn,
+                bank_id="test-bank",
+                entities_data=[{"text": "use:use-001"}],
+                unit_event_date=None,
+                taxonomy_lookup=taxonomy_lookup,
+                labels_cfg=labels_cfg,
+            )
+
+        set_calls = [c for c in conn.execute.await_args_list if c.args and "SET pg_trgm" in str(c.args[0])]
+        assert set_calls == []
+
+    @pytest.mark.asyncio
     async def test_trigram_resets_threshold_even_when_fetch_raises(self):
         """If a batch fetch fails, RESET must still run so the lowered threshold doesn't leak to the pooled connection."""
         resolver = _make_resolver(entity_lookup="trigram", entity_resolution_batch_size=2)


### PR DESCRIPTION
## What

Label entities (from `entity_labels` config) are resolved by **exact match only** — their canonical names are user-defined and must not be fuzzy-merged (GH-1558). But `_resolve_entities_batch_trigram` sent **every** entity text — labels included — through the `pg_trgm` candidate probe, and the Oracle path did the same via `UTL_MATCH.JARO_WINKLER_SIMILARITY`.

For a label text, every fuzzy candidate is discarded downstream unless it's an exact match. The cost scales badly: as a free-text label accumulates distinct values, each probe matches proportionally more of the other values and returns them all, only to throw them away. On a bank where one text label holds tens of thousands of long, mutually-similar values, a single probe can scan and return most of them.

## Change

Partition entity texts **before** the candidate fetch:

- **Label texts** → exact lookup on the existing unique `(bank_id, LOWER(canonical_name))` btree index (`idx_entities_bank_lower_name`), O(1) per text.
- **Non-label texts** → the existing fuzzy probe, unchanged. The `pg_trgm` threshold `SET`/`RESET` is now skipped entirely when there are no fuzzy texts.

Applied symmetrically to the PostgreSQL (`pg_trgm`) and Oracle (Jaro-Winkler) strategies via a shared `_label_texts` helper.

**No behavior change:** label resolution was already exact-match-only in `_resolve_from_candidates`; this just stops feeding labels through a fuzzy scan whose results were always discarded. The exact-match query returns the same candidate shape, so a label value still resolves to its existing entity and a novel value still creates a new one.

## Tests

`tests/test_entity_resolver_pg_trgm.py`:
- `test_label_texts_use_exact_lookup_not_trigram` — label texts hit a single exact-match query; only non-label texts reach the `%` probe.
- `test_all_label_texts_skip_trigram_threshold` — when every text is a label, the `pg_trgm` threshold is never set.
- Existing tests confirm the no-labels path is unchanged (all texts still fuzzy-probed).
