### PR TITLE
feat(entity-resolution): configurable pg_trgm similarity threshold, applied at connection setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,6 +140,7 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_MIGRATION_DATABASE_URL=  # Direct PostgreSQL URL for migrations (bypasses PgBouncer). Falls back to DATABASE_URL.
 # HINDSIGHT_API_DATABASE_SCHEMA=public  # PostgreSQL schema name (default: public)
 # HINDSIGHT_API_DB_MAX_PARALLEL_WORKERS_PER_GATHER=  # Optional cap on Postgres planner parallelism for this process's pool connections. Unset leaves the server default; 0 makes background/bulk queries run serially (useful on worker processes sharing a primary with latency-sensitive traffic).
+# HINDSIGHT_API_ENTITY_TRGM_SIMILARITY_THRESHOLD=0.15  # Postgres pg_trgm.similarity_threshold applied on every pool connection, used by entity resolution's % trigram match. Must be in (0, 1]. Lower catches more substring-ish matches at higher CPU cost on large entity sets; higher is stricter and cheaper.
 # HINDSIGHT_API_MIGRATION_CONCURRENCY=1  # Tenant schemas to migrate concurrently (PG only, each in its own process; per-schema work stays sequential). Each worker has ~1-2s startup cost + uses ~3 DB connections, so it only pays off with many schemas (tens+) or slow migrations; keep concurrency*3 <= spare max_connections. Default: 1 (sequential).
 # HINDSIGHT_API_OPERATION_RETENTION_DAYS=30  # Prune terminal operation rows, payloads, and metadata after this many days; 0 (the default) keeps them forever.
 # HINDSIGHT_API_OPERATION_CLEANUP_BATCH_SIZE=1000  # Maximum expired terminal rows deleted per tenant schema in each cleanup cycle; must be positive.

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -669,6 +669,7 @@ ENV_DB_COMMAND_TIMEOUT = "HINDSIGHT_API_DB_COMMAND_TIMEOUT"
 ENV_DB_ACQUIRE_TIMEOUT = "HINDSIGHT_API_DB_ACQUIRE_TIMEOUT"
 ENV_DB_STATEMENT_TIMEOUT = "HINDSIGHT_API_DB_STATEMENT_TIMEOUT"
 ENV_DB_MAX_PARALLEL_WORKERS_PER_GATHER = "HINDSIGHT_API_DB_MAX_PARALLEL_WORKERS_PER_GATHER"
+ENV_ENTITY_TRGM_SIMILARITY_THRESHOLD = "HINDSIGHT_API_ENTITY_TRGM_SIMILARITY_THRESHOLD"
 
 # Wall-clock cap on model/connection initialization at startup. If embeddings,
 # cross-encoder, or LLM verification hang (e.g. an offline HuggingFace download
@@ -1207,6 +1208,11 @@ DEFAULT_DB_STATEMENT_TIMEOUT = 600  # seconds (Postgres statement_timeout applie
 # workers buy latency, which background work doesn't need, at the cost of
 # concurrent CPU footprint, which multi-tenant primaries do care about.
 DEFAULT_DB_MAX_PARALLEL_WORKERS_PER_GATHER: int | None = None
+# pg_trgm similarity threshold applied on every pool connection (SET
+# pg_trgm.similarity_threshold). Governs how close a name must be for the `%`
+# operator to treat it as a candidate during entity resolution: lower catches
+# more substring-ish matches at higher CPU cost, higher is stricter and cheaper.
+DEFAULT_ENTITY_TRGM_SIMILARITY_THRESHOLD = 0.15
 DEFAULT_MODEL_INIT_TIMEOUT = 300  # seconds (cap on startup model/connection init; covers first-time downloads)
 
 # Worker configuration (distributed task processing)
@@ -2376,6 +2382,7 @@ class HindsightConfig:
     db_acquire_timeout: int
     db_statement_timeout: int
     db_max_parallel_workers_per_gather: int | None
+    entity_trgm_similarity_threshold: float
     model_init_timeout: float
 
     # Worker configuration (distributed task processing)
@@ -2729,6 +2736,15 @@ class HindsightConfig:
         """Validate configuration values and raise errors for invalid combinations."""
         # Validate vector_extension
         validate_extension(self.vector_extension)
+
+        # pg_trgm requires the similarity threshold in (0, 1]. Fail fast here
+        # rather than let an out-of-range value raise on every pool connection's
+        # setup (which would leave the API unable to serve any request).
+        if not (0.0 < self.entity_trgm_similarity_threshold <= 1.0):
+            raise ValueError(
+                f"Invalid entity_trgm_similarity_threshold: {self.entity_trgm_similarity_threshold}. "
+                "Must be greater than 0 and at most 1."
+            )
 
         # Validate text_search_extension
         valid_text_search = ("native", "vchord", "pg_textsearch", "pgroonga", "pg_search")
@@ -3561,6 +3577,9 @@ class HindsightConfig:
             db_max_parallel_workers_per_gather=_parse_optional_non_negative_int(
                 ENV_DB_MAX_PARALLEL_WORKERS_PER_GATHER,
                 os.getenv(ENV_DB_MAX_PARALLEL_WORKERS_PER_GATHER),
+            ),
+            entity_trgm_similarity_threshold=float(
+                os.getenv(ENV_ENTITY_TRGM_SIMILARITY_THRESHOLD, str(DEFAULT_ENTITY_TRGM_SIMILARITY_THRESHOLD))
             ),
             model_init_timeout=float(os.getenv(ENV_MODEL_INIT_TIMEOUT, str(DEFAULT_MODEL_INIT_TIMEOUT))),
             # Worker configuration

--- a/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
+++ b/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
@@ -465,36 +465,26 @@ class EntityResolver:
         # Uses the GIN trigram index on LOWER(canonical_name) for case-insensitive
         # similarity lookup. Previous version also had LIKE '%...' substring fallbacks,
         # but those forced full sequential scans of the entities table and caused
-        # TimeoutErrors on banks with 10k+ entities. Lowering the similarity threshold
-        # to 0.15 (from default 0.3) catches most substring relationships while
-        # staying fully index-based.
-        if fuzzy_texts:
-            await conn.execute("SET pg_trgm.similarity_threshold = 0.15")
-            try:
-                for entity_text_batch in self._chunked(fuzzy_texts, self.entity_resolution_batch_size):
-                    rows.extend(
-                        await conn.fetch(
-                            f"""
-                            SELECT DISTINCT ON (e.id)
-                                e.id, e.canonical_name, e.metadata, e.last_seen, e.mention_count,
-                                q.query_text
-                            FROM unnest($2::text[]) AS q(query_text)
-                            JOIN {fq_table("entities")} e ON (
-                                e.bank_id = $1
-                                AND LOWER(e.canonical_name) % LOWER(q.query_text)
-                            )
-                            """,
-                            bank_id,
-                            entity_text_batch,
-                        )
+        # TimeoutErrors on banks with 10k+ entities. The pg_trgm similarity threshold
+        # that governs the `%` operator is applied once at pool-connection setup
+        # (HINDSIGHT_API_ENTITY_TRGM_SIMILARITY_THRESHOLD), so it is not toggled here.
+        for entity_text_batch in self._chunked(fuzzy_texts, self.entity_resolution_batch_size):
+            rows.extend(
+                await conn.fetch(
+                    f"""
+                    SELECT DISTINCT ON (e.id)
+                        e.id, e.canonical_name, e.metadata, e.last_seen, e.mention_count,
+                        q.query_text
+                    FROM unnest($2::text[]) AS q(query_text)
+                    JOIN {fq_table("entities")} e ON (
+                        e.bank_id = $1
+                        AND LOWER(e.canonical_name) % LOWER(q.query_text)
                     )
-            finally:
-                # asyncpg returns connections to the pool with session state intact,
-                # so the lowered threshold would leak to future borrowers without RESET.
-                try:
-                    await conn.execute("RESET pg_trgm.similarity_threshold")
-                except Exception:
-                    logger.warning("Failed to reset pg_trgm similarity threshold after candidate lookup", exc_info=True)
+                    """,
+                    bank_id,
+                    entity_text_batch,
+                )
+            )
 
         # Group candidates by query_text
         all_candidates: dict[str, list] = {t: [] for t in entity_texts}

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -1315,6 +1315,7 @@ class MemoryEngine(MemoryEngineInterface):
         self._db_acquire_timeout = db_acquire_timeout if db_acquire_timeout is not None else config.db_acquire_timeout
         self._db_statement_timeout = config.db_statement_timeout
         self._db_max_parallel_workers_per_gather = config.db_max_parallel_workers_per_gather
+        self._entity_trgm_similarity_threshold = config.entity_trgm_similarity_threshold
         self._run_migrations = run_migrations
         self._retain_entity_lookup = config.retain_entity_lookup
         self._retain_entity_resolution_batch_size = config.retain_entity_resolution_batch_size
@@ -3357,6 +3358,7 @@ class MemoryEngine(MemoryEngineInterface):
 
         stmt_timeout_s = self._db_statement_timeout
         max_parallel_gather = self._db_max_parallel_workers_per_gather
+        trgm_similarity_threshold = self._entity_trgm_similarity_threshold
         text_search_extension = get_config().text_search_extension
 
         # Per-connection initialization callback (PostgreSQL-specific for now)
@@ -3393,6 +3395,17 @@ class MemoryEngine(MemoryEngineInterface):
             # unaffected. 0 disables.
             if stmt_timeout_s > 0:
                 await conn.execute(f"SET statement_timeout = '{stmt_timeout_s}s'")
+
+            # Entity resolution's pg_trgm `%` probe reads this GUC. Setting it here
+            # (SET, not SET LOCAL) applies it for the connection's lifetime — and,
+            # via the pool's setup hook, after each release-time RESET ALL — so the
+            # resolver no longer has to toggle it per query. pg_trgm may be absent
+            # on the cluster; narrow the except to PostgresError so the pool still
+            # builds (the resolver falls back to the "full" strategy in that case).
+            try:
+                await conn.execute(f"SET pg_trgm.similarity_threshold = {trgm_similarity_threshold}")
+            except asyncpg.exceptions.PostgresError:
+                logger.debug("Could not set pg_trgm.similarity_threshold — pg_trgm may not be installed")
 
             # Optional cap on planner parallelism for this process's
             # connections. Deployments that run background workers against a

--- a/hindsight-api-slim/tests/test_entity_resolver_pg_trgm.py
+++ b/hindsight-api-slim/tests/test_entity_resolver_pg_trgm.py
@@ -194,8 +194,12 @@ class TestPgTrgmAutoDetection:
         batches = [call.args[2] for call in conn.fetch.call_args_list]
         assert sorted(len(batch) for batch in batches) == [1, 2, 2]
         assert {entity for batch in batches for entity in batch} == {f"Entity {idx}" for idx in range(5)}
-        conn.execute.assert_any_await("SET pg_trgm.similarity_threshold = 0.15")
-        conn.execute.assert_any_await("RESET pg_trgm.similarity_threshold")
+        # The similarity threshold is applied at pool-connection setup, not per query,
+        # so the resolver must not toggle it here.
+        set_calls = [
+            c for c in conn.execute.await_args_list if c.args and "pg_trgm.similarity_threshold" in str(c.args[0])
+        ]
+        assert set_calls == []
 
     @pytest.mark.asyncio
     async def test_label_texts_use_exact_lookup_not_trigram(self):
@@ -243,51 +247,3 @@ class TestPgTrgmAutoDetection:
         # Only the non-label text reaches the trigram probe.
         assert len(trigram_calls) == 1
         assert trigram_calls[0][1][1] == ["Alice"]
-
-    @pytest.mark.asyncio
-    async def test_all_label_texts_skip_trigram_threshold(self):
-        """When every text is a label, the pg_trgm threshold is never set (fuzzy probe fully skipped)."""
-        resolver = _make_resolver(entity_lookup="trigram")
-        conn = _make_conn(pg_trgm_available=True)
-
-        labels_cfg = MagicMock()
-        labels_cfg.attributes = []
-        taxonomy_lookup = {"use:use-001"}
-
-        with (
-            patch("hindsight_api.engine.entity_resolver.fq_table", side_effect=lambda table: table),
-            patch.object(resolver, "_resolve_from_candidates", new=AsyncMock(return_value=[])),
-        ):
-            await resolver._resolve_entities_batch_trigram(
-                conn=conn,
-                bank_id="test-bank",
-                entities_data=[{"text": "use:use-001"}],
-                unit_event_date=None,
-                taxonomy_lookup=taxonomy_lookup,
-                labels_cfg=labels_cfg,
-            )
-
-        set_calls = [c for c in conn.execute.await_args_list if c.args and "SET pg_trgm" in str(c.args[0])]
-        assert set_calls == []
-
-    @pytest.mark.asyncio
-    async def test_trigram_resets_threshold_even_when_fetch_raises(self):
-        """If a batch fetch fails, RESET must still run so the lowered threshold doesn't leak to the pooled connection."""
-        resolver = _make_resolver(entity_lookup="trigram", entity_resolution_batch_size=2)
-        conn = _make_conn(pg_trgm_available=True)
-        conn.fetch = AsyncMock(side_effect=RuntimeError("simulated timeout"))
-
-        with (
-            patch("hindsight_api.engine.entity_resolver.fq_table", side_effect=lambda table: table),
-            patch.object(resolver, "_resolve_from_candidates", new=AsyncMock(return_value=[])),
-            pytest.raises(RuntimeError, match="simulated timeout"),
-        ):
-            await resolver._resolve_entities_batch_trigram(
-                conn=conn,
-                bank_id="test-bank",
-                entities_data=[{"text": "Alice"}, {"text": "Bob"}],
-                unit_event_date=None,
-            )
-
-        conn.execute.assert_any_await("SET pg_trgm.similarity_threshold = 0.15")
-        conn.execute.assert_any_await("RESET pg_trgm.similarity_threshold")

--- a/hindsight-api-slim/tests/test_entity_trgm_threshold_config.py
+++ b/hindsight-api-slim/tests/test_entity_trgm_threshold_config.py
@@ -1,0 +1,38 @@
+"""Config parsing for HINDSIGHT_API_ENTITY_TRGM_SIMILARITY_THRESHOLD.
+
+Static (server-level) float applied as ``SET pg_trgm.similarity_threshold`` on
+every pool connection. pg_trgm only accepts a threshold in (0, 1], so an
+out-of-range value must fail fast at config load rather than break every
+connection's setup. These tests pin the default, the parse, and the bounds.
+"""
+
+import pytest
+
+from hindsight_api.config import (
+    DEFAULT_ENTITY_TRGM_SIMILARITY_THRESHOLD,
+    ENV_ENTITY_TRGM_SIMILARITY_THRESHOLD,
+    HindsightConfig,
+)
+
+
+class TestEntityTrgmThresholdConfig:
+    def test_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv(ENV_ENTITY_TRGM_SIMILARITY_THRESHOLD, raising=False)
+        config = HindsightConfig.from_env()
+        assert config.entity_trgm_similarity_threshold == DEFAULT_ENTITY_TRGM_SIMILARITY_THRESHOLD
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv(ENV_ENTITY_TRGM_SIMILARITY_THRESHOLD, "0.3")
+        config = HindsightConfig.from_env()
+        assert config.entity_trgm_similarity_threshold == 0.3
+
+    def test_upper_bound_one_is_valid(self, monkeypatch):
+        monkeypatch.setenv(ENV_ENTITY_TRGM_SIMILARITY_THRESHOLD, "1.0")
+        config = HindsightConfig.from_env()
+        assert config.entity_trgm_similarity_threshold == 1.0
+
+    @pytest.mark.parametrize("value", ["0", "0.0", "-0.1", "1.5"])
+    def test_out_of_range_fails_fast(self, monkeypatch, value):
+        monkeypatch.setenv(ENV_ENTITY_TRGM_SIMILARITY_THRESHOLD, value)
+        with pytest.raises(ValueError, match="entity_trgm_similarity_threshold"):
+            HindsightConfig.from_env()

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -56,6 +56,7 @@ Migrations will automatically create the schema if it doesn't exist and create a
 | `HINDSIGHT_API_DB_ACQUIRE_TIMEOUT` | Connection acquisition timeout in seconds. Bounds how long a caller waits for a free pool connection before failing (retried by the caller); `0` waits indefinitely. | `30` |
 | `HINDSIGHT_API_DB_STATEMENT_TIMEOUT` | Postgres `statement_timeout` applied to every pool connection, in seconds. Server-side safety net for runaway queries. Does **not** apply to Alembic migrations (which run on a separate psycopg2 engine). Set to `0` to disable. | `600` |
 | `HINDSIGHT_API_DB_MAX_PARALLEL_WORKERS_PER_GATHER` | Optional Postgres `max_parallel_workers_per_gather` applied to every pool connection of this process. Unset leaves the server default. Set to `0` on background-worker processes so bulk maintenance queries (consolidation, graph upkeep) run serially instead of fanning out across CPU cores shared with latency-sensitive traffic. | unset |
+| `HINDSIGHT_API_ENTITY_TRGM_SIMILARITY_THRESHOLD` | Postgres `pg_trgm.similarity_threshold` applied to every pool connection, governing how close a name must be for entity resolution's `%` trigram match to treat it as a candidate. Must be between `0` (exclusive) and `1`. Lower catches more substring-ish matches at higher CPU cost on large entity sets; higher is stricter and cheaper. | `0.15` |
 
 For high-concurrency workloads, increase `DB_POOL_MAX_SIZE`. Each concurrent recall/think operation can use 2-4 connections.
 

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -140,6 +140,7 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_MIGRATION_DATABASE_URL=  # Direct PostgreSQL URL for migrations (bypasses PgBouncer). Falls back to DATABASE_URL.
 # HINDSIGHT_API_DATABASE_SCHEMA=public  # PostgreSQL schema name (default: public)
 # HINDSIGHT_API_DB_MAX_PARALLEL_WORKERS_PER_GATHER=  # Optional cap on Postgres planner parallelism for this process's pool connections. Unset leaves the server default; 0 makes background/bulk queries run serially (useful on worker processes sharing a primary with latency-sensitive traffic).
+# HINDSIGHT_API_ENTITY_TRGM_SIMILARITY_THRESHOLD=0.15  # Postgres pg_trgm.similarity_threshold applied on every pool connection, used by entity resolution's % trigram match. Must be in (0, 1]. Lower catches more substring-ish matches at higher CPU cost on large entity sets; higher is stricter and cheaper.
 # HINDSIGHT_API_MIGRATION_CONCURRENCY=1  # Tenant schemas to migrate concurrently (PG only, each in its own process; per-schema work stays sequential). Each worker has ~1-2s startup cost + uses ~3 DB connections, so it only pays off with many schemas (tens+) or slow migrations; keep concurrency*3 <= spare max_connections. Default: 1 (sequential).
 # HINDSIGHT_API_OPERATION_RETENTION_DAYS=30  # Prune terminal operation rows, payloads, and metadata after this many days; 0 (the default) keeps them forever.
 # HINDSIGHT_API_OPERATION_CLEANUP_BATCH_SIZE=1000  # Maximum expired terminal rows deleted per tenant schema in each cleanup cycle; must be positive.

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -56,6 +56,7 @@ Migrations will automatically create the schema if it doesn't exist and create a
 | `HINDSIGHT_API_DB_ACQUIRE_TIMEOUT` | Connection acquisition timeout in seconds. Bounds how long a caller waits for a free pool connection before failing (retried by the caller); `0` waits indefinitely. | `30` |
 | `HINDSIGHT_API_DB_STATEMENT_TIMEOUT` | Postgres `statement_timeout` applied to every pool connection, in seconds. Server-side safety net for runaway queries. Does **not** apply to Alembic migrations (which run on a separate psycopg2 engine). Set to `0` to disable. | `600` |
 | `HINDSIGHT_API_DB_MAX_PARALLEL_WORKERS_PER_GATHER` | Optional Postgres `max_parallel_workers_per_gather` applied to every pool connection of this process. Unset leaves the server default. Set to `0` on background-worker processes so bulk maintenance queries (consolidation, graph upkeep) run serially instead of fanning out across CPU cores shared with latency-sensitive traffic. | unset |
+| `HINDSIGHT_API_ENTITY_TRGM_SIMILARITY_THRESHOLD` | Postgres `pg_trgm.similarity_threshold` applied to every pool connection, governing how close a name must be for entity resolution's `%` trigram match to treat it as a candidate. Must be between `0` (exclusive) and `1`. Lower catches more substring-ish matches at higher CPU cost on large entity sets; higher is stricter and cheaper. | `0.15` |
 
 For high-concurrency workloads, increase `DB_POOL_MAX_SIZE`. Each concurrent recall/think operation can use 2-4 connections.
 


### PR DESCRIPTION
## What

Entity resolution's pg_trgm `%` probe depends on `pg_trgm.similarity_threshold`. Until now that value was hard-coded to `0.15` and toggled **per query** — `SET` before the candidate fetch and `RESET` after (with extra RESET-on-error handling to avoid leaking the lowered threshold back into the pool).

This PR makes the threshold configurable and moves it to **connection setup**:

- New static config `HINDSIGHT_API_ENTITY_TRGM_SIMILARITY_THRESHOLD` (default `0.15`).
- Applied once as `SET pg_trgm.similarity_threshold` in the pool's per-connection setup callback (`_init_connection`), next to the other session GUCs (`statement_timeout`, `max_parallel_workers_per_gather`, ANN tuning). That callback is wired as **both** asyncpg `init` and `setup`, so the value is re-applied after the release-time `RESET ALL` and survives connection reuse.
- The resolver's trigram probe no longer touches the threshold — it runs against a connection that already has it set — so the runtime `SET`/`RESET` and its error handling are removed.

## Why

- The threshold trades recall for CPU on the `%` scan; deployments with large entity sets want to tune it (raise it to cut per-probe cost) without a code change.
- Setting it once per connection instead of on every resolution call removes two `execute` round-trips per retain batch and the RESET-on-error bookkeeping.

## Details

- **Static, not per-bank:** it's a connection-level GUC on a shared pool, so it can't vary per bank — same category as the existing `statement_timeout` / `max_parallel_workers_per_gather` connection settings.
- **Fail-fast validation:** pg_trgm only accepts `(0, 1]`. `config.validate()` rejects out-of-range values at load, so a bad setting surfaces as a clear config error instead of breaking every connection's setup (which would leave the API unable to serve).
- **pg_trgm absent:** the `SET` is wrapped to tolerate `PostgresError` (logged at debug), matching how the ANN-tuning GUCs are applied; the resolver already falls back to the `full` strategy when pg_trgm is unavailable.

## Tests

- `tests/test_entity_trgm_threshold_config.py` — default, env override, upper-bound `1.0`, and out-of-range fail-fast (`0`, `0.0`, `-0.1`, `1.5`).
- `tests/test_entity_resolver_pg_trgm.py` — updated: the trigram probe must **not** toggle the threshold at runtime; removed the now-obsolete SET/RESET and RESET-on-error assertions. The label-vs-fuzzy partitioning test is unchanged.
- `.env.example` (+ embed copy) and `docs/developer/configuration.md` updated; docs-skill reference regenerated.
