### PR TITLE
feat(coding-agents): local daemon mode, and pick the server at install time

### DIFF
--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -225,7 +225,9 @@ Nothing to sign up for and nothing to host — memory runs on your machine. The 
   and every repo, and your own `hindsight-embed` is reused if you already run one.
 - **Cold starts happen in the background.** The first start downloads the daemon and loads models,
   which takes longer than any hook is allowed to run, so it is launched detached at session start.
-  A session that begins before it is ready simply has no memory for a turn or two.
+  A session that begins before it is ready simply has no memory for a turn or two — a daemon that
+  isn't up is treated as an unreachable server, exactly like a Cloud or self-hosted outage, with the
+  same error handling and the same diagnostics. Nothing downstream of the URL knows which mode it is.
 - **It shuts down on idle**, after `daemonIdleTimeout` seconds. There is deliberately no
   stop-on-exit: one daemon is shared, so ending one session must not cut memory out from under
   another agent still working.

--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -33,6 +33,10 @@ hindsight-coding-agents uninstall all        # removes exactly what install adde
 `hindsight-coding-agents install` changes nothing and prints the choice, so wiring every agent on
 the machine is never something that happens by accident.
 
+On a terminal it also asks **where memory should live** — Hindsight Cloud, a server you run, or a
+local daemon on this machine (see Where memory lives). Scripted installs pass
+`--server cloud|self-hosted|daemon` instead; it is asked only once, and never again on re-install.
+
 ### Per agent
 
 Same command, only the harness name changes. Run after installing the package globally.
@@ -193,6 +197,61 @@ background and is injected on a subsequent model call or turn rather than aborti
 Its write-back retains only user-visible user/assistant text; tool arguments, tool results and
 command output, tool-role messages, reasoning parts, and Hindsight's injected context are excluded.
 Cline IDE extensions are not currently supported by this CLI integration.
+
+## Where memory lives
+
+Three modes, chosen once when you install (`install` asks on a terminal; pass `--server` to script it):
+
+| mode          | what runs                                 | needs                                    |
+| ------------- | ----------------------------------------- | ---------------------------------------- |
+| `cloud`       | Hindsight Cloud (default)                 | an API token                             |
+| `self-hosted` | a Hindsight server you already run        | its URL                                  |
+| `daemon`      | a local `hindsight-embed` on this machine | `uv` on PATH + an LLM key for extraction |
+
+```bash
+hindsight-coding-agents install claude-code --server daemon
+hindsight-coding-agents install claude-code --server self-hosted --api-url http://localhost:8888
+hindsight-coding-agents install claude-code --server cloud --api-token <token>
+```
+
+Re-running `install` never re-asks: a config that already names a server is left alone.
+
+### Local daemon mode
+
+Nothing to sign up for and nothing to host — memory runs on your machine. The plugin starts
+`hindsight-embed` on demand at `127.0.0.1:9077` and points every agent at it.
+
+- **A server already on the port is adopted, never restarted** — so one daemon serves every agent
+  and every repo, and your own `hindsight-embed` is reused if you already run one.
+- **Cold starts happen in the background.** The first start downloads the daemon and loads models,
+  which takes longer than any hook is allowed to run, so it is launched detached at session start.
+  A session that begins before it is ready simply has no memory for a turn or two.
+- **It shuts down on idle**, after `daemonIdleTimeout` seconds. There is deliberately no
+  stop-on-exit: one daemon is shared, so ending one session must not cut memory out from under
+  another agent still working.
+- **macOS additionally needs a current Rust toolchain.** `litellm` (a transitive dependency of the
+  API) publishes wheels only for Linux and Windows, so a Mac compiles it from source through
+  maturin and its crates pin a recent `rustc`. Install from [rustup.rs](https://rustup.rs) and keep
+  it updated — an out-of-date toolchain fails as surely as a missing one. Linux and Windows install
+  from wheels and need none of this.
+- **Fact extraction runs locally**, so it needs an LLM. `HINDSIGHT_API_LLM_PROVIDER` wins if set;
+  otherwise the first of `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GROQ_API_KEY`;
+  otherwise the Claude Code CLI, which needs no key. `install` tells you which it found.
+
+Daemon settings keep the names the old per-agent Claude Code plugin used, so an existing
+environment carries over unchanged:
+
+| field               | env                             | default        | meaning                                    |
+| ------------------- | ------------------------------- | -------------- | ------------------------------------------ |
+| `serverMode`        | `HINDSIGHT_SERVER_MODE`         | `cloud`        | `cloud` \| `self-hosted` \| `daemon`       |
+| `apiPort`           | `HINDSIGHT_API_PORT`            | `9077`         | port the local daemon listens on           |
+| `daemonIdleTimeout` | `HINDSIGHT_DAEMON_IDLE_TIMEOUT` | `300`          | seconds of inactivity before it exits      |
+| `daemonProfile`     | `HINDSIGHT_DAEMON_PROFILE`      | `coding-agent` | which local database it uses               |
+| `embedVersion`      | `HINDSIGHT_EMBED_VERSION`       | `latest`       | which `hindsight-embed` release to run     |
+| `embedPackagePath`  | `HINDSIGHT_EMBED_PACKAGE_PATH`  | —              | run a local checkout instead (development) |
+
+Any `HINDSIGHT_API_*` variable you export is forwarded to the daemon, so server-side settings need
+no equivalent here.
 
 ## Configuration
 

--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -92,17 +92,29 @@ a `hookAdapter` in `src/harness/registry.ts`; persistent-plugin → implement `H
 
 ## Migrating from the per-agent plugins
 
-The older per-agent integrations (`hindsight-claude-code`, `hindsight-cursor-cli`, `hindsight-codex`, …) are superseded by this package. Their memory does **not** carry over automatically, and it cannot be merged:
+The older per-agent integrations (`hindsight-claude-code`, `hindsight-cursor-cli`, `hindsight-codex`, …) are superseded by this package. Two things move; nothing else does.
 
-- They scope a bank **per agent per project** (`claude-code::myrepo`); this package uses one **per repo** (`coding-agent::myrepo`) so every agent shares it. Two old banks map onto one new one.
-- The server restores a whole bank rather than merging into an existing one, so the old bank can't be folded in.
+**Your server moves automatically.** If `~/.hindsight/claude-code.json` exists, `install` adopts its
+endpoint — `hindsightApiUrl` → `apiUrl`, `hindsightApiToken` → `apiToken`, and an empty URL means
+the local daemon, as it did there. You already chose where your memory lives; defaulting to Cloud
+instead would quietly send your prompts somewhere else. Pass `--server` to override.
 
-Instead, re-import the conversations the agent already wrote to disk — they get re-extracted into the current bank:
+**Your conversations are re-imported from local disk**, as new documents:
 
 ```bash
 cd /path/to/your/repo
 hindsight-coding-agents install claude-code --import-conversations
 ```
+
+This re-extracts the transcripts the agent already wrote, so it costs tokens roughly in proportion
+to the history imported, and it is safe to re-run (ingestion dedups by document id).
+
+Local transcripts are the source rather than the old bank, because the old bank cannot be split by
+repo. Its default was a **single static bank** — `dynamicBankId` defaults to false, so everything
+landed in one bank named `claude_code` — and its documents record only `retained_at`,
+`message_count` and `session_id`, nothing identifying the project. Working out which documents
+belong to which repo means joining `session_id` back to the `cwd` in the local transcript, so the
+transcripts are needed either way; going through them directly is simply the shorter path.
 
 **How sessions are matched.** A conversation is imported only when the session itself records the
 directory it ran in — never inferred from a file or folder name. Claude Code writes that directory
@@ -114,89 +126,14 @@ conversation into your bank. Sessions that record nothing are skipped and the co
 The other harnesses (opencode, Kilo, Cursor, Cline, Copilot, Devin) keep history in internal SQLite
 databases with unversioned schemas and are skipped with a reason.
 
-The import is scoped to the **current repo**, safe to re-run (ingestion dedups by document id), and
-runs extraction — so it costs tokens roughly in proportion to the history imported.
-
-Prefer to keep the old bank instead? Point this package at it — no data moves:
+**Nothing else is translated.** The old plugin's behavioural settings — 12 `recall*`, 7 `retain*`,
+`bankMission`/`retainMission`, `dynamicBankGranularity` — describe a pipeline this package replaced,
+and reinterpreting them would be guesswork. Bank naming changes too: this package uses one bank per
+**repo** (`coding-agent::{gitProject}`) shared by every agent. To keep the old naming instead:
 
 ```jsonc
 { "bankIdTemplate": "{harness}::{gitProject}" } // reproduces the old per-agent naming
 ```
-
-## How it works
-
-**Ingestion — automatic, no command to run**
-
-- On a **cold repo**, the first session kicks off a background seed: recent commit **messages** as one cheap document, plus a short headless **codebase survey** to map the structure.
-- On **every** session, a background "deepen" pass ingests conversations not yet stored and the next batch of recent commits **with full diffs, newest first** — precision arrives across sessions instead of one big ingest.
-- Repeated or concurrent runs are a no-op (per-bank lock + document-id dedup).
-- Ask the agent `hindsight_sync_status` to see where ingestion stands — `synced: true` means everything is queryable.
-
-**In the session — what the agent actually receives**
-
-- On the first prompt, a **reflect** call returns the past decision behind the task, with its exact rule and values. It's cached and re-injected each turn.
-- Every turn, the repo's **knowledge pages** are matched locally against the prompt (lexical index — no server call, no LLM, ~ms) and the best sections are injected with provenance. Below a relevance floor, nothing is injected.
-- The agent also gets the page roster and the `hindsight_*` tools, so it can read a page, search raw memory, or record a new initiative itself.
-- Injected memory carries a visible-attribution directive, so the agent shows a `🧠 Using Hindsight Memories` header when memory shaped its answer.
-
-**Write-back — sessions become memory**
-
-- The live session is stored as a transcript: user/assistant turns plus a compact `action` line per tool call (name + target, no arguments or output) — decisions without the mechanical noise.
-- Hook harnesses write on `Stop`. Plugin harnesses (opencode, Kilo) write on a turn cadence **and** when the session goes idle — the idle pass is what captures the agent's own reply, which the per-turn pass runs too early to see.
-
-**Guarantees**
-
-- A failed reflect or page fetch degrades to a no-memory turn; it never breaks the agent.
-- It never fails _silently_ either: every outcome is written to a diagnostics file, so a memory-less session can't pass for a memory session.
-- When two memories conflict on the same rule, the later decision wins and the superseded one is reported as no longer in effect.
-- Against a Hindsight server that predates knowledge pages, page features are skipped (recorded as `knowledge_pages_unavailable`) and everything else continues.
-
-## Harnesses
-
-Every harness runs the same surface (seed → session reflect → per-turn page sections → knowledge
-tools → write-back); they differ only in how that surface is delivered.
-
-| harness                   | kind              | lifecycle wiring                                                                                                                   | install                                                             |
-| ------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| `opencode`                | persistent plugin | one process: load-time seed, session reflect + page sections, native tools, write-back                                             | add the package dir to `opencode.json` → `"plugin": [...]`          |
-| `kilo`                    | persistent plugin | identical to `opencode` — Kilo CLI is an opencode fork, so it loads the same runtime (no hooks system)                             | `hindsight-coding-agents install kilo` → `kilo.json[c]` `"plugin"`  |
-| `claude-code`             | per-prompt hooks  | `SessionStart` (seed) + `UserPromptSubmit` (reflect + pages) + `Stop` (write-back) + MCP                                           | `hindsight-coding-agents install claude-code`                       |
-| `codex`                   | per-prompt hooks  | same three hooks in `~/.codex/hooks.json` (+ `codex_hooks = true`, CLI ≥ 0.116)                                                    | `hindsight-coding-agents install codex`                             |
-| `antigravity-cli` (`agy`) | lifecycle hooks   | Antigravity CLI lifecycle hooks (`PreInvocation` + `Stop`) + MCP, plus a native colored `Hindsight · <bank>` status-line indicator | `hindsight-coding-agents install agy`                               |
-| `cursor-cli`              | lifecycle hooks   | `sessionStart` (seed + pages) + `beforeSubmitPrompt` (reflect) + `stop` (write-back)                                               | hooks in Cursor `hooks.json`                                        |
-| `copilot-cli`             | lifecycle hooks   | `sessionStart` (seed + pages) + `userPromptTransformed` (reflect) + `agentStop` (write-back) + MCP                                 | `~/.copilot/hooks/hindsight-coding-agents.json` + `mcp-config.json` |
-| `grok-build`              | lifecycle hooks   | `SessionStart` (seed) + `Stop` (write-back) + MCP                                                                                  | native `~/.grok/config.toml` — no Claude Code dependency            |
-| `cline-cli`               | persistent plugin | native `beforeModel` (seed/reflect/pages) + `afterRun` (write-back) + MCP                                                          | `cline plugin install` (run by the installer)                       |
-
-The hook-based harnesses share one runtime (`src/core/hook.ts`) plus their SessionStart/Stop
-entrypoints. Persistent-plugin hosts (opencode/Kilo/Cline) delegate to the same `RuntimeCore`,
-which in turn calls those shared session-start, prompt, and retain operations; only their host API
-adapters differ. Opencode and Kilo can register the knowledge tools natively; Cline uses the shared
-MCP server. All support opt-in **incremental git-sync** (retain commits new since the seed on load).
-
-Antigravity renders the Hindsight indicator with its documented custom status-line command. It is
-local and never calls the Hindsight API while the TUI redraws. If you already configured an
-Antigravity custom status line, the installer leaves it untouched rather than replacing it.
-
-### Grok Build limitation
-
-Grok Build executes `UserPromptSubmit` hooks but ignores their stdout. Hindsight can therefore not
-inject a reflect result, memory block, or banner into Grok's model-visible conversation. Grok still
-gets native bank setup and transcript retention plus Hindsight MCP tools and the companion skill;
-ask it to call `hindsight_reflect` or `hindsight_search_knowledge_pages` when needed. Automatic
-injection requires a future Grok prompt-transform API.
-
-### Cline CLI scope
-
-Cline's external file hooks cannot alter a model request, so Hindsight uses Cline's native plugin
-API instead. Its `beforeModel` hook injects the shared reflect/page context and
-its `afterRun` hook upserts Cline's runtime transcript. `hindsight-coding-agents install cline-cli`
-runs `cline plugin install --force <package-path>` and configures MCP plus the companion skill.
-Cline CLI sandboxes plugin hooks with a three-second limit, so a slow first reflect finishes in the
-background and is injected on a subsequent model call or turn rather than aborting the session.
-Its write-back retains only user-visible user/assistant text; tool arguments, tool results and
-command output, tool-role messages, reasoning parts, and Hindsight's injected context are excluded.
-Cline IDE extensions are not currently supported by this CLI integration.
 
 ## Where memory lives
 

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -25,6 +25,10 @@ hindsight-coding-agents uninstall all        # removes exactly what install adde
 `hindsight-coding-agents install` changes nothing and prints the choice, so wiring every agent on
 the machine is never something that happens by accident.
 
+On a terminal it also asks **where memory should live** — Hindsight Cloud, a server you run, or a
+local daemon on this machine (see [Where memory lives](#where-memory-lives)). Scripted installs pass
+`--server cloud|self-hosted|daemon` instead; it is asked only once, and never again on re-install.
+
 ### Per agent
 
 Same command, only the harness name changes. Run after installing the package globally.
@@ -185,6 +189,61 @@ background and is injected on a subsequent model call or turn rather than aborti
 Its write-back retains only user-visible user/assistant text; tool arguments, tool results and
 command output, tool-role messages, reasoning parts, and Hindsight's injected context are excluded.
 Cline IDE extensions are not currently supported by this CLI integration.
+
+## Where memory lives
+
+Three modes, chosen once when you install (`install` asks on a terminal; pass `--server` to script it):
+
+| mode          | what runs                                 | needs                                    |
+| ------------- | ----------------------------------------- | ---------------------------------------- |
+| `cloud`       | Hindsight Cloud (default)                 | an API token                             |
+| `self-hosted` | a Hindsight server you already run        | its URL                                  |
+| `daemon`      | a local `hindsight-embed` on this machine | `uv` on PATH + an LLM key for extraction |
+
+```bash
+hindsight-coding-agents install claude-code --server daemon
+hindsight-coding-agents install claude-code --server self-hosted --api-url http://localhost:8888
+hindsight-coding-agents install claude-code --server cloud --api-token <token>
+```
+
+Re-running `install` never re-asks: a config that already names a server is left alone.
+
+### Local daemon mode
+
+Nothing to sign up for and nothing to host — memory runs on your machine. The plugin starts
+`hindsight-embed` on demand at `127.0.0.1:9077` and points every agent at it.
+
+- **A server already on the port is adopted, never restarted** — so one daemon serves every agent
+  and every repo, and your own `hindsight-embed` is reused if you already run one.
+- **Cold starts happen in the background.** The first start downloads the daemon and loads models,
+  which takes longer than any hook is allowed to run, so it is launched detached at session start.
+  A session that begins before it is ready simply has no memory for a turn or two.
+- **It shuts down on idle**, after `daemonIdleTimeout` seconds. There is deliberately no
+  stop-on-exit: one daemon is shared, so ending one session must not cut memory out from under
+  another agent still working.
+- **macOS additionally needs a current Rust toolchain.** `litellm` (a transitive dependency of the
+  API) publishes wheels only for Linux and Windows, so a Mac compiles it from source through
+  maturin and its crates pin a recent `rustc`. Install from [rustup.rs](https://rustup.rs) and keep
+  it updated — an out-of-date toolchain fails as surely as a missing one. Linux and Windows install
+  from wheels and need none of this.
+- **Fact extraction runs locally**, so it needs an LLM. `HINDSIGHT_API_LLM_PROVIDER` wins if set;
+  otherwise the first of `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GROQ_API_KEY`;
+  otherwise the Claude Code CLI, which needs no key. `install` tells you which it found.
+
+Daemon settings keep the names the old per-agent Claude Code plugin used, so an existing
+environment carries over unchanged:
+
+| field               | env                             | default        | meaning                                    |
+| ------------------- | ------------------------------- | -------------- | ------------------------------------------ |
+| `serverMode`        | `HINDSIGHT_SERVER_MODE`         | `cloud`        | `cloud` \| `self-hosted` \| `daemon`       |
+| `apiPort`           | `HINDSIGHT_API_PORT`            | `9077`         | port the local daemon listens on           |
+| `daemonIdleTimeout` | `HINDSIGHT_DAEMON_IDLE_TIMEOUT` | `300`          | seconds of inactivity before it exits      |
+| `daemonProfile`     | `HINDSIGHT_DAEMON_PROFILE`      | `coding-agent` | which local database it uses               |
+| `embedVersion`      | `HINDSIGHT_EMBED_VERSION`       | `latest`       | which `hindsight-embed` release to run     |
+| `embedPackagePath`  | `HINDSIGHT_EMBED_PACKAGE_PATH`  | —              | run a local checkout instead (development) |
+
+Any `HINDSIGHT_API_*` variable you export is forwarded to the daemon, so server-side settings need
+no equivalent here.
 
 ## Configuration
 

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -217,7 +217,9 @@ Nothing to sign up for and nothing to host — memory runs on your machine. The 
   and every repo, and your own `hindsight-embed` is reused if you already run one.
 - **Cold starts happen in the background.** The first start downloads the daemon and loads models,
   which takes longer than any hook is allowed to run, so it is launched detached at session start.
-  A session that begins before it is ready simply has no memory for a turn or two.
+  A session that begins before it is ready simply has no memory for a turn or two — a daemon that
+  isn't up is treated as an unreachable server, exactly like a Cloud or self-hosted outage, with the
+  same error handling and the same diagnostics. Nothing downstream of the URL knows which mode it is.
 - **It shuts down on idle**, after `daemonIdleTimeout` seconds. There is deliberately no
   stop-on-exit: one daemon is shared, so ending one session must not cut memory out from under
   another agent still working.

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -84,17 +84,29 @@ a `hookAdapter` in `src/harness/registry.ts`; persistent-plugin → implement `H
 
 ## Migrating from the per-agent plugins
 
-The older per-agent integrations (`hindsight-claude-code`, `hindsight-cursor-cli`, `hindsight-codex`, …) are superseded by this package. Their memory does **not** carry over automatically, and it cannot be merged:
+The older per-agent integrations (`hindsight-claude-code`, `hindsight-cursor-cli`, `hindsight-codex`, …) are superseded by this package. Two things move; nothing else does.
 
-- They scope a bank **per agent per project** (`claude-code::myrepo`); this package uses one **per repo** (`coding-agent::myrepo`) so every agent shares it. Two old banks map onto one new one.
-- The server restores a whole bank rather than merging into an existing one, so the old bank can't be folded in.
+**Your server moves automatically.** If `~/.hindsight/claude-code.json` exists, `install` adopts its
+endpoint — `hindsightApiUrl` → `apiUrl`, `hindsightApiToken` → `apiToken`, and an empty URL means
+the local daemon, as it did there. You already chose where your memory lives; defaulting to Cloud
+instead would quietly send your prompts somewhere else. Pass `--server` to override.
 
-Instead, re-import the conversations the agent already wrote to disk — they get re-extracted into the current bank:
+**Your conversations are re-imported from local disk**, as new documents:
 
 ```bash
 cd /path/to/your/repo
 hindsight-coding-agents install claude-code --import-conversations
 ```
+
+This re-extracts the transcripts the agent already wrote, so it costs tokens roughly in proportion
+to the history imported, and it is safe to re-run (ingestion dedups by document id).
+
+Local transcripts are the source rather than the old bank, because the old bank cannot be split by
+repo. Its default was a **single static bank** — `dynamicBankId` defaults to false, so everything
+landed in one bank named `claude_code` — and its documents record only `retained_at`,
+`message_count` and `session_id`, nothing identifying the project. Working out which documents
+belong to which repo means joining `session_id` back to the `cwd` in the local transcript, so the
+transcripts are needed either way; going through them directly is simply the shorter path.
 
 **How sessions are matched.** A conversation is imported only when the session itself records the
 directory it ran in — never inferred from a file or folder name. Claude Code writes that directory
@@ -106,89 +118,14 @@ conversation into your bank. Sessions that record nothing are skipped and the co
 The other harnesses (opencode, Kilo, Cursor, Cline, Copilot, Devin) keep history in internal SQLite
 databases with unversioned schemas and are skipped with a reason.
 
-The import is scoped to the **current repo**, safe to re-run (ingestion dedups by document id), and
-runs extraction — so it costs tokens roughly in proportion to the history imported.
-
-Prefer to keep the old bank instead? Point this package at it — no data moves:
+**Nothing else is translated.** The old plugin's behavioural settings — 12 `recall*`, 7 `retain*`,
+`bankMission`/`retainMission`, `dynamicBankGranularity` — describe a pipeline this package replaced,
+and reinterpreting them would be guesswork. Bank naming changes too: this package uses one bank per
+**repo** (`coding-agent::{gitProject}`) shared by every agent. To keep the old naming instead:
 
 ```jsonc
 { "bankIdTemplate": "{harness}::{gitProject}" } // reproduces the old per-agent naming
 ```
-
-## How it works
-
-**Ingestion — automatic, no command to run**
-
-- On a **cold repo**, the first session kicks off a background seed: recent commit **messages** as one cheap document, plus a short headless **codebase survey** to map the structure.
-- On **every** session, a background "deepen" pass ingests conversations not yet stored and the next batch of recent commits **with full diffs, newest first** — precision arrives across sessions instead of one big ingest.
-- Repeated or concurrent runs are a no-op (per-bank lock + document-id dedup).
-- Ask the agent `hindsight_sync_status` to see where ingestion stands — `synced: true` means everything is queryable.
-
-**In the session — what the agent actually receives**
-
-- On the first prompt, a **reflect** call returns the past decision behind the task, with its exact rule and values. It's cached and re-injected each turn.
-- Every turn, the repo's **knowledge pages** are matched locally against the prompt (lexical index — no server call, no LLM, ~ms) and the best sections are injected with provenance. Below a relevance floor, nothing is injected.
-- The agent also gets the page roster and the `hindsight_*` tools, so it can read a page, search raw memory, or record a new initiative itself.
-- Injected memory carries a visible-attribution directive, so the agent shows a `🧠 Using Hindsight Memories` header when memory shaped its answer.
-
-**Write-back — sessions become memory**
-
-- The live session is stored as a transcript: user/assistant turns plus a compact `action` line per tool call (name + target, no arguments or output) — decisions without the mechanical noise.
-- Hook harnesses write on `Stop`. Plugin harnesses (opencode, Kilo) write on a turn cadence **and** when the session goes idle — the idle pass is what captures the agent's own reply, which the per-turn pass runs too early to see.
-
-**Guarantees**
-
-- A failed reflect or page fetch degrades to a no-memory turn; it never breaks the agent.
-- It never fails _silently_ either: every outcome is written to a diagnostics file, so a memory-less session can't pass for a memory session.
-- When two memories conflict on the same rule, the later decision wins and the superseded one is reported as no longer in effect.
-- Against a Hindsight server that predates knowledge pages, page features are skipped (recorded as `knowledge_pages_unavailable`) and everything else continues.
-
-## Harnesses
-
-Every harness runs the same surface (seed → session reflect → per-turn page sections → knowledge
-tools → write-back); they differ only in how that surface is delivered.
-
-| harness                   | kind              | lifecycle wiring                                                                                                                   | install                                                             |
-| ------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| `opencode`                | persistent plugin | one process: load-time seed, session reflect + page sections, native tools, write-back                                             | add the package dir to `opencode.json` → `"plugin": [...]`          |
-| `kilo`                    | persistent plugin | identical to `opencode` — Kilo CLI is an opencode fork, so it loads the same runtime (no hooks system)                             | `hindsight-coding-agents install kilo` → `kilo.json[c]` `"plugin"`  |
-| `claude-code`             | per-prompt hooks  | `SessionStart` (seed) + `UserPromptSubmit` (reflect + pages) + `Stop` (write-back) + MCP                                           | `hindsight-coding-agents install claude-code`                       |
-| `codex`                   | per-prompt hooks  | same three hooks in `~/.codex/hooks.json` (+ `codex_hooks = true`, CLI ≥ 0.116)                                                    | `hindsight-coding-agents install codex`                             |
-| `antigravity-cli` (`agy`) | lifecycle hooks   | Antigravity CLI lifecycle hooks (`PreInvocation` + `Stop`) + MCP, plus a native colored `Hindsight · <bank>` status-line indicator | `hindsight-coding-agents install agy`                               |
-| `cursor-cli`              | lifecycle hooks   | `sessionStart` (seed + pages) + `beforeSubmitPrompt` (reflect) + `stop` (write-back)                                               | hooks in Cursor `hooks.json`                                        |
-| `copilot-cli`             | lifecycle hooks   | `sessionStart` (seed + pages) + `userPromptTransformed` (reflect) + `agentStop` (write-back) + MCP                                 | `~/.copilot/hooks/hindsight-coding-agents.json` + `mcp-config.json` |
-| `grok-build`              | lifecycle hooks   | `SessionStart` (seed) + `Stop` (write-back) + MCP                                                                                  | native `~/.grok/config.toml` — no Claude Code dependency            |
-| `cline-cli`               | persistent plugin | native `beforeModel` (seed/reflect/pages) + `afterRun` (write-back) + MCP                                                          | `cline plugin install` (run by the installer)                       |
-
-The hook-based harnesses share one runtime (`src/core/hook.ts`) plus their SessionStart/Stop
-entrypoints. Persistent-plugin hosts (opencode/Kilo/Cline) delegate to the same `RuntimeCore`,
-which in turn calls those shared session-start, prompt, and retain operations; only their host API
-adapters differ. Opencode and Kilo can register the knowledge tools natively; Cline uses the shared
-MCP server. All support opt-in **incremental git-sync** (retain commits new since the seed on load).
-
-Antigravity renders the Hindsight indicator with its documented custom status-line command. It is
-local and never calls the Hindsight API while the TUI redraws. If you already configured an
-Antigravity custom status line, the installer leaves it untouched rather than replacing it.
-
-### Grok Build limitation
-
-Grok Build executes `UserPromptSubmit` hooks but ignores their stdout. Hindsight can therefore not
-inject a reflect result, memory block, or banner into Grok's model-visible conversation. Grok still
-gets native bank setup and transcript retention plus Hindsight MCP tools and the companion skill;
-ask it to call `hindsight_reflect` or `hindsight_search_knowledge_pages` when needed. Automatic
-injection requires a future Grok prompt-transform API.
-
-### Cline CLI scope
-
-Cline's external file hooks cannot alter a model request, so Hindsight uses Cline's native plugin
-API instead. Its `beforeModel` hook injects the shared reflect/page context and
-its `afterRun` hook upserts Cline's runtime transcript. `hindsight-coding-agents install cline-cli`
-runs `cline plugin install --force <package-path>` and configures MCP plus the companion skill.
-Cline CLI sandboxes plugin hooks with a three-second limit, so a slow first reflect finishes in the
-background and is injected on a subsequent model call or turn rather than aborting the session.
-Its write-back retains only user-visible user/assistant text; tool arguments, tool results and
-command output, tool-role messages, reasoning parts, and Hindsight's injected context are excluded.
-Cline IDE extensions are not currently supported by this CLI integration.
 
 ## Where memory lives
 

--- a/hindsight-integrations/coding-agents/package-lock.json
+++ b/hindsight-integrations/coding-agents/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@vectorize-io/hindsight-coding-agents",
-  "version": "0.1.0",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectorize-io/hindsight-coding-agents",
-      "version": "0.1.0",
+      "version": "0.0.4",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@vectorize-io/hindsight-all": "^0.8.6",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -1088,6 +1089,15 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@vectorize-io/hindsight-all": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@vectorize-io/hindsight-all/-/hindsight-all-0.8.6.tgz",
+      "integrity": "sha512-2AWNhDBpk1KbWc28t6/MnPDq8Ea8OTYfxB1QV2/2Grs+BOesiTbTPfrPtuXcw+jlSi6M5Xs+JtIH2wGwC0JQ4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@vitest/expect": {

--- a/hindsight-integrations/coding-agents/package.json
+++ b/hindsight-integrations/coding-agents/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@vectorize-io/hindsight-all": "^0.8.6",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/hindsight-integrations/coding-agents/src/core/config.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.ts
@@ -22,11 +22,41 @@ export // HINDSIGHT_CONFIG joins the two env exceptions (diag/log files): it poi
 const CONFIG_PATH =
   process.env.HINDSIGHT_CONFIG || join(homedir(), ".hindsight", "coding-agent.json");
 
+/** Daemon-mode defaults. The port matches the old per-agent Claude Code plugin so a machine that
+ *  already ran that daemon keeps using the same one. */
+export const DEFAULT_DAEMON_PORT = 9077;
+export const DEFAULT_DAEMON_IDLE_TIMEOUT = 300;
+export const DEFAULT_DAEMON_PROFILE = "coding-agent";
+
 /** Incremental git-sync settings (see core/sync.ts). */
 /** The config file's shape — every field optional; omitted fields take the documented default. */
 export interface RawConfig {
+  /** Where memory lives. All three modes speak the same HTTP API; they differ only in who runs it:
+   *   "cloud"       — Hindsight Cloud (the default `apiUrl`)
+   *   "self-hosted" — a Hindsight server you run; set `apiUrl` to it
+   *   "daemon"      — a local `hindsight-embed` daemon this plugin starts on demand, at
+   *                   127.0.0.1:{apiPort}. `apiUrl` is ignored in this mode.
+   * Omitted, it is inferred: "daemon" is never assumed, so an existing config keeps talking to
+   * whatever `apiUrl` it already names. */
+  serverMode?: "cloud" | "self-hosted" | "daemon";
   apiUrl?: string; // Hindsight API base URL (default https://api.hindsight.vectorize.io — Cloud; set to http://localhost:8888 for a local server)
   apiToken?: string; // bearer token (optional)
+  /** Daemon mode: port the local daemon listens on (default 9077).
+   *  NOT 8888 — that is the conventional port for a server you run yourself, and a daemon must
+   *  never squat on it. A healthy server already on this port is adopted rather than restarted. */
+  apiPort?: number;
+  /** Daemon mode: seconds of inactivity before the daemon exits (default 300).
+   *  This is how the daemon shuts down. There is deliberately no stop-on-session-end: one daemon
+   *  is shared by every agent and repo on the machine, so ending one session must not cut memory
+   *  out from under another. */
+  daemonIdleTimeout?: number;
+  /** Daemon mode: `hindsight-embed` profile name, i.e. which local database is used (default
+   *  "coding-agent"). Separate profiles keep unrelated setups from sharing memory. */
+  daemonProfile?: string;
+  /** Daemon mode: which `hindsight-embed` release to run via uvx (default "latest"). */
+  embedVersion?: string;
+  /** Daemon mode: local `hindsight-embed` checkout to run instead of a published release (dev). */
+  embedPackagePath?: string;
   bankId?: string; // EXPLICIT memory bank id — set = static bank; unset = per-repo dynamic (core/bank.ts)
   dynamicBankId?: boolean; // force dynamic resolution even when bankId is set (default: dynamic iff no bankId)
   bankIdTemplate?: string; // dynamic bank id format (default "coding-agent::{gitProject}" — harness-neutral) —
@@ -70,8 +100,16 @@ export interface RawConfig {
 
 /** Fully-resolved config: every field present. */
 export interface Config {
+  serverMode: "cloud" | "self-hosted" | "daemon";
+  /** The EFFECTIVE base URL. In daemon mode this is already 127.0.0.1:{apiPort}, so every caller
+   *  that builds a client keeps working without knowing which mode is active. */
   apiUrl: string;
   apiToken?: string;
+  apiPort: number;
+  daemonIdleTimeout: number;
+  daemonProfile: string;
+  embedVersion?: string;
+  embedPackagePath?: string;
   bankId?: string; // resolved per-directory via deriveBankId(cfg, dir) — see core/bank.ts
   dynamicBankId?: boolean;
   bankIdTemplate?: string;
@@ -97,9 +135,25 @@ export interface Config {
 
 /** Apply defaults to a raw (file) config. Pure — the single place the defaults live. */
 export function resolveConfig(raw: RawConfig = {}): Config {
+  const serverMode = ["cloud", "self-hosted", "daemon"].includes(raw.serverMode as string)
+    ? (raw.serverMode as "cloud" | "self-hosted" | "daemon")
+    : "cloud";
+  const apiPort = raw.apiPort || DEFAULT_DAEMON_PORT;
   return {
-    apiUrl: raw.apiUrl ?? "https://api.hindsight.vectorize.io",
+    serverMode,
+    // Daemon mode resolves the URL HERE rather than at each call site: every entry point already
+    // builds its client from cfg.apiUrl, so collapsing the mode into that one field means the
+    // daemon needs no plumbing through eight separate constructors.
+    apiUrl:
+      serverMode === "daemon"
+        ? `http://127.0.0.1:${apiPort}`
+        : (raw.apiUrl ?? "https://api.hindsight.vectorize.io"),
     apiToken: raw.apiToken || undefined,
+    apiPort,
+    daemonIdleTimeout: raw.daemonIdleTimeout ?? DEFAULT_DAEMON_IDLE_TIMEOUT,
+    daemonProfile: raw.daemonProfile || DEFAULT_DAEMON_PROFILE,
+    embedVersion: raw.embedVersion || undefined,
+    embedPackagePath: raw.embedPackagePath || undefined,
     bankId: raw.bankId,
     dynamicBankId: raw.dynamicBankId,
     bankIdTemplate: raw.bankIdTemplate,
@@ -180,8 +234,16 @@ function applyLayer(raw: RawConfig, layer: RawConfig, harness?: string): RawConf
  * flattening into one env var. They stay file-only.
  */
 const ENV_KEYS = {
+  serverMode: "HINDSIGHT_SERVER_MODE",
   apiUrl: "HINDSIGHT_API_URL",
   apiToken: "HINDSIGHT_API_TOKEN",
+  // These four keep the names the old per-agent Claude Code plugin used, so a user migrating from
+  // it can carry their existing environment over unchanged.
+  apiPort: "HINDSIGHT_API_PORT",
+  daemonIdleTimeout: "HINDSIGHT_DAEMON_IDLE_TIMEOUT",
+  embedVersion: "HINDSIGHT_EMBED_VERSION",
+  embedPackagePath: "HINDSIGHT_EMBED_PACKAGE_PATH",
+  daemonProfile: "HINDSIGHT_DAEMON_PROFILE",
   bankId: "HINDSIGHT_BANK_ID",
   dynamicBankId: "HINDSIGHT_DYNAMIC_BANK_ID",
   bankIdTemplate: "HINDSIGHT_BANK_ID_TEMPLATE",
@@ -214,6 +276,8 @@ const ENV_BOOLEANS = new Set<keyof RawConfig>([
   "codebaseSurvey",
 ]);
 const ENV_NUMBERS = new Set<keyof RawConfig>([
+  "apiPort",
+  "daemonIdleTimeout",
   "retainEveryTurns",
   "reflectTimeoutMs",
   "pageRefreshEveryTurns",

--- a/hindsight-integrations/coding-agents/src/core/daemon.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/daemon.test.ts
@@ -75,15 +75,23 @@ describe("daemonEnv", () => {
 });
 
 describe("ensureDaemon", () => {
-  it("is a no-op outside daemon mode", async () => {
+  // Cloud and self-hosted must not so much as probe a local port.
+  it("touches nothing outside daemon mode", async () => {
     const cfg = resolveConfig({ apiUrl: "https://cloud.example" });
-    expect(await ensureDaemon(cfg, "claude-code", { allowStart: true })).toBe(true);
+    const spawnFn = vi.fn(() => {
+      throw new Error("must not spawn");
+    });
+    await ensureDaemon(cfg, "claude-code", {
+      spawnFn: spawnFn as unknown as typeof import("node:child_process").spawn,
+    });
+    expect(spawnFn).not.toHaveBeenCalled();
   });
 
-  // The prompt hook must never pay a cold start; it reports and moves on.
-  it("does not start anything when starting isn't allowed", async () => {
-    const cfg = resolveConfig({ serverMode: "daemon", apiPort: 59_999 });
-    expect(await ensureDaemon(cfg, "claude-code", { allowStart: false })).toBe(false);
+  // Side effect only: callers proceed either way, so a down daemon fails through the same client
+  // error path as a down Cloud/self-hosted server rather than being skipped.
+  it("resolves without reporting usability", async () => {
+    const cfg = resolveConfig({ apiUrl: "https://cloud.example" });
+    expect(await ensureDaemon(cfg, "claude-code", {})).toBeUndefined();
   });
 });
 

--- a/hindsight-integrations/coding-agents/src/core/daemon.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/daemon.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveConfig } from "./config";
+import { daemonEnv, detectLlm, ensureDaemon, startDaemonDetached } from "./daemon";
+
+describe("connection modes", () => {
+  it("daemon mode derives the URL from apiPort, ignoring apiUrl", () => {
+    // Resolving here (rather than at each client construction) is what lets the eight existing
+    // call sites stay untouched.
+    const cfg = resolveConfig({ serverMode: "daemon", apiUrl: "https://cloud.example" });
+    expect(cfg.apiUrl).toBe("http://127.0.0.1:9077");
+  });
+
+  it("uses a custom daemon port", () => {
+    expect(resolveConfig({ serverMode: "daemon", apiPort: 9999 }).apiUrl).toBe(
+      "http://127.0.0.1:9999"
+    );
+  });
+
+  it("defaults to cloud, leaving today's behaviour unchanged", () => {
+    const cfg = resolveConfig({});
+    expect(cfg.serverMode).toBe("cloud");
+    expect(cfg.apiUrl).toBe("https://api.hindsight.vectorize.io");
+  });
+
+  it("self-hosted keeps the configured apiUrl", () => {
+    const cfg = resolveConfig({ serverMode: "self-hosted", apiUrl: "http://localhost:8888" });
+    expect(cfg.apiUrl).toBe("http://localhost:8888");
+  });
+
+  // 9077, not hindsight-all's 8888: 8888 is the conventional port for a server the user runs, and
+  // a daemon must never squat on it.
+  it("defaults the daemon port to 9077", () => {
+    expect(resolveConfig({ serverMode: "daemon" }).apiPort).toBe(9077);
+  });
+});
+
+describe("detectLlm", () => {
+  it("prefers an explicit provider, including one it knows nothing about", () => {
+    const llm = detectLlm({
+      HINDSIGHT_API_LLM_PROVIDER: "ollama",
+      OPENAI_API_KEY: "sk-ignored",
+    } as NodeJS.ProcessEnv);
+    expect(llm?.provider).toBe("ollama");
+  });
+
+  it("falls back to a well-known key env", () => {
+    const llm = detectLlm({ ANTHROPIC_API_KEY: "sk-ant" } as NodeJS.ProcessEnv);
+    expect(llm?.provider).toBe("anthropic");
+    expect(llm?.apiKey).toBe("sk-ant");
+  });
+
+  it("ignores a blank key", () => {
+    const llm = detectLlm({ OPENAI_API_KEY: "   " } as NodeJS.ProcessEnv);
+    expect(llm?.provider).not.toBe("openai");
+  });
+});
+
+describe("daemonEnv", () => {
+  const cfg = resolveConfig({ serverMode: "daemon", daemonIdleTimeout: 42 });
+
+  it("passes the idle timeout through under the daemon's own env name", () => {
+    expect(daemonEnv(cfg, {} as NodeJS.ProcessEnv).HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT).toBe("42");
+  });
+
+  // Forwarding the whole HINDSIGHT_API_* namespace means a new server-side knob needs no change
+  // here to reach the daemon.
+  it("forwards arbitrary HINDSIGHT_API_* settings", () => {
+    const env = daemonEnv(cfg, {
+      HINDSIGHT_API_EMBEDDINGS_PROVIDER: "tei",
+      UNRELATED: "no",
+    } as NodeJS.ProcessEnv);
+    expect(env.HINDSIGHT_API_EMBEDDINGS_PROVIDER).toBe("tei");
+    expect(env.UNRELATED).toBeUndefined();
+  });
+});
+
+describe("ensureDaemon", () => {
+  it("is a no-op outside daemon mode", async () => {
+    const cfg = resolveConfig({ apiUrl: "https://cloud.example" });
+    expect(await ensureDaemon(cfg, "claude-code", { allowStart: true })).toBe(true);
+  });
+
+  // The prompt hook must never pay a cold start; it reports and moves on.
+  it("does not start anything when starting isn't allowed", async () => {
+    const cfg = resolveConfig({ serverMode: "daemon", apiPort: 59_999 });
+    expect(await ensureDaemon(cfg, "claude-code", { allowStart: false })).toBe(false);
+  });
+});
+
+describe("startDaemonDetached", () => {
+  it("spawns the starter detached, so it outlives the hook", () => {
+    const child = { on: vi.fn(), unref: vi.fn() };
+    const spawn = vi.fn(() => child);
+    startDaemonDetached(
+      resolveConfig({ serverMode: "daemon" }),
+      "claude-code",
+      spawn as unknown as typeof import("node:child_process").spawn
+    );
+    const [cmd, args, opts] = spawn.mock.calls[0] as unknown as [
+      string,
+      string[],
+      { detached: boolean; stdio: string },
+    ];
+    expect(cmd).toBe("node");
+    expect(args[0]).toMatch(/daemon-start\.js$/);
+    expect(opts.detached).toBe(true);
+    expect(opts.stdio).toBe("ignore");
+    // An async spawn 'error' event would otherwise crash the hook process.
+    expect(child.on).toHaveBeenCalledWith("error", expect.any(Function));
+    expect(child.unref).toHaveBeenCalled();
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/daemon.ts
+++ b/hindsight-integrations/coding-agents/src/core/daemon.ts
@@ -14,9 +14,16 @@
  *   3. start the daemon
  *
  * TIMING IS THE CONSTRAINT. A cold start pays for a uvx download plus model load and can take tens
- * of seconds, while the prompt hook has to return in time to not stall the user's turn. So the
- * prompt path NEVER starts a daemon: SessionStart kicks one off in the background, and the Stop
- * hook (a longer budget, and nothing waiting on it) starts one if that hasn't happened yet.
+ * of seconds, while the prompt hook has to return in time to not stall the user's turn. Only two
+ * points therefore ensure a daemon: SessionStart, before the user has typed anything, and the Stop
+ * hook, which has the longest budget and nothing waiting on its result. The prompt path does
+ * nothing here at all.
+ *
+ * A daemon that is down is NOT special-cased anywhere downstream. Once the URL is resolved, every
+ * mode uses the identical client and the identical error handling: an unreachable local daemon
+ * surfaces as the same connection failure (and the same `retain_failed` diagnostic) as an
+ * unreachable Cloud or self-hosted server. Skipping work because a local port was closed would have
+ * made daemon mode behave differently from the other two for no benefit.
  *
  * There is no stop. One daemon serves every agent and repo on the machine, so ending one session
  * must not cut memory out from under another; `daemonIdleTimeout` retires it instead.
@@ -186,10 +193,11 @@ export function startDaemonDetached(
 }
 
 /**
- * Make sure a daemon is serving `cfg.apiUrl`.
+ * Make sure a daemon is serving `cfg.apiUrl`. A no-op in every other mode.
  *
- * Returns whether the server is usable. Never throws: memory is best-effort, and a daemon that
- * won't start must degrade to "no memory this session", not break the agent.
+ * Side effect only — callers proceed regardless of whether it came up, so that a request against a
+ * down daemon fails through exactly the same path as a request against a down Cloud or self-hosted
+ * server. Never throws: memory is best-effort and must not break the agent.
  *
  * `waitMs` bounds how long the caller is willing to block for a cold start — always well under the
  * calling hook's own timeout, so a slow start costs memory for one turn rather than a killed hook.
@@ -197,19 +205,13 @@ export function startDaemonDetached(
 export async function ensureDaemon(
   cfg: Config,
   harness: string,
-  opts: { allowStart: boolean; waitMs?: number }
-): Promise<boolean> {
-  if (cfg.serverMode !== "daemon") return true;
-  if (await isServerHealthy(cfg.apiUrl)) return true;
-  if (!opts.allowStart) {
-    // Expected on the prompt path before SessionStart's background start has finished — recorded
-    // so a session with no memory is explainable rather than mysterious.
-    diag(harness, "daemon_not_ready", { apiUrl: cfg.apiUrl });
-    return false;
-  }
-  if (!preflightDaemon(cfg, harness)) return false;
-  startDaemonDetached(cfg, harness);
-  return waitForHealth(cfg.apiUrl, opts.waitMs ?? 0);
+  opts: { waitMs?: number; spawnFn?: typeof realSpawn } = {}
+): Promise<void> {
+  if (cfg.serverMode !== "daemon") return;
+  if (await isServerHealthy(cfg.apiUrl)) return;
+  if (!preflightDaemon(cfg, harness)) return;
+  startDaemonDetached(cfg, harness, opts.spawnFn);
+  await waitForHealth(cfg.apiUrl, opts.waitMs ?? 0);
 }
 
 /** Poll /health until it answers or the budget runs out. `budgetMs <= 0` means "don't wait". */

--- a/hindsight-integrations/coding-agents/src/core/daemon.ts
+++ b/hindsight-integrations/coding-agents/src/core/daemon.ts
@@ -1,0 +1,255 @@
+/**
+ * Local daemon mode — memory with no server and no Cloud account.
+ *
+ * `serverMode: "daemon"` runs `hindsight-embed` on this machine and points the plugin at it.
+ * Lifecycle is delegated to `@vectorize-io/hindsight-all`, which owns the uvx invocation, profile
+ * creation, readiness polling and the macOS Metal/MPS workaround. This module only decides WHEN to
+ * start it, and with what environment.
+ *
+ * Three connection modes, resolved in this order (the same priority the old per-agent Claude Code
+ * plugin used in `scripts/lib/daemon.py`):
+ *   1. an external API — Cloud or self-hosted; `serverMode` is not "daemon" and nothing here runs
+ *   2. a healthy server already on the port — adopted as-is, never restarted, so a daemon started
+ *      by an earlier session (or a server the user runs themselves) is reused
+ *   3. start the daemon
+ *
+ * TIMING IS THE CONSTRAINT. A cold start pays for a uvx download plus model load and can take tens
+ * of seconds, while the prompt hook has to return in time to not stall the user's turn. So the
+ * prompt path NEVER starts a daemon: SessionStart kicks one off in the background, and the Stop
+ * hook (a longer budget, and nothing waiting on it) starts one if that hasn't happened yet.
+ *
+ * There is no stop. One daemon serves every agent and repo on the machine, so ending one session
+ * must not cut memory out from under another; `daemonIdleTimeout` retires it instead.
+ */
+import { execFileSync, spawn as realSpawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Config } from "./config";
+import { diag } from "./diag";
+import { log } from "./log";
+
+/**
+ * How long each hook is willing to block waiting for a cold daemon. Both sit well inside the
+ * corresponding hook timeouts declared in harness/hook-lifecycle.ts (SessionStart 30s, Stop 60s),
+ * because overrunning those gets the hook killed by the host.
+ */
+export const DAEMON_WAIT_SESSION_START_MS = 12_000;
+export const DAEMON_WAIT_RETAIN_MS = 40_000;
+
+/** Probe a base URL's /health. Never throws — an unreachable server is just "not running". */
+export async function isServerHealthy(baseUrl: string, timeoutMs = 2_000): Promise<boolean> {
+  try {
+    const res = await fetch(`${baseUrl}/health`, { signal: AbortSignal.timeout(timeoutMs) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * macOS needs a CURRENT Rust toolchain to install the daemon.
+ *
+ * litellm — pulled in transitively by the API — publishes wheels only for manylinux and Windows
+ * (verified against PyPI for 1.95.0: cp310-cp314, no macOS build for any of them). Every macOS
+ * install therefore compiles it from the sdist through maturin, and its dependency tree pins a
+ * recent rustc (1.94.1 at the time of writing; observed failing on 1.93.1). Only presence is
+ * checked here — the required version comes from litellm's transitive crates and moves on its own
+ * schedule, so pinning a number here would just go stale. A too-old toolchain still fails, but the
+ * error carries the exact version needed.
+ */
+export function hasRustToolchain(): boolean {
+  if (process.platform !== "darwin") return true; // wheels cover linux + windows
+  try {
+    execFileSync("cargo", ["--version"], { stdio: "pipe", timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Is `uv`/`uvx` on PATH? The daemon is fetched and run through it. */
+export function hasUvx(): boolean {
+  try {
+    execFileSync("uvx", ["--version"], { stdio: "pipe", timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+interface ProviderProbe {
+  provider: string;
+  keyEnv: string;
+}
+
+/**
+ * Providers the daemon can use for local fact extraction, most-specific first. Mirrors the old
+ * plugin's list. `claude-code` needs no key — it drives the Claude Code CLI the user already has,
+ * which is why it is the last resort rather than an error.
+ */
+const PROVIDER_PROBES: ProviderProbe[] = [
+  { provider: "openai", keyEnv: "OPENAI_API_KEY" },
+  { provider: "anthropic", keyEnv: "ANTHROPIC_API_KEY" },
+  { provider: "gemini", keyEnv: "GEMINI_API_KEY" },
+  { provider: "groq", keyEnv: "GROQ_API_KEY" },
+];
+
+export interface LlmChoice {
+  provider: string;
+  /** Absent for providers that need no credential. */
+  apiKey?: string;
+  /** Where it came from, for the installer's output and diagnostics. */
+  source: string;
+}
+
+/**
+ * Decide which LLM the daemon extracts facts with.
+ *
+ * An explicit `HINDSIGHT_API_LLM_PROVIDER` always wins — including for providers this code knows
+ * nothing about, so a local Ollama or a gateway can be pointed at without a code change here.
+ */
+export function detectLlm(env: NodeJS.ProcessEnv = process.env): LlmChoice | undefined {
+  const explicit = env.HINDSIGHT_API_LLM_PROVIDER?.trim();
+  if (explicit) {
+    return {
+      provider: explicit,
+      apiKey: env.HINDSIGHT_API_LLM_API_KEY?.trim() || undefined,
+      source: "HINDSIGHT_API_LLM_PROVIDER",
+    };
+  }
+  for (const probe of PROVIDER_PROBES) {
+    const key = env[probe.keyEnv]?.trim();
+    if (key) return { provider: probe.provider, apiKey: key, source: probe.keyEnv };
+  }
+  if (onPath("claude")) {
+    return { provider: "claude-code", source: "the Claude Code CLI on PATH (no API key needed)" };
+  }
+  return undefined;
+}
+
+function onPath(bin: string): boolean {
+  try {
+    execFileSync("which", [bin], { stdio: "pipe", timeout: 5_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Environment handed to the daemon: the LLM choice, the idle timeout, and any HINDSIGHT_API_* the
+ *  user already exports (so provider-specific knobs pass through without being enumerated here). */
+export function daemonEnv(
+  cfg: Config,
+  env: NodeJS.ProcessEnv = process.env
+): Record<string, string | undefined> {
+  const out: Record<string, string | undefined> = {
+    HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT: String(cfg.daemonIdleTimeout),
+  };
+  for (const [key, value] of Object.entries(env)) {
+    if (key.startsWith("HINDSIGHT_API_") && value) out[key] = value;
+  }
+  const llm = detectLlm(env);
+  if (llm) {
+    out.HINDSIGHT_API_LLM_PROVIDER = llm.provider;
+    if (llm.apiKey) out.HINDSIGHT_API_LLM_API_KEY = llm.apiKey;
+  }
+  return out;
+}
+
+/**
+ * Launch the starter as a DETACHED process, the way seeding and the codebase survey are launched.
+ *
+ * A cold start pays for a uvx download plus model load and routinely outlives any hook's timeout,
+ * so it cannot be awaited inline: the harness would kill the hook mid-start and the daemon would
+ * never come up. The child outlives this process and keeps going. Idempotent — the starter itself
+ * re-checks health, so several sessions racing to start one daemon is harmless.
+ */
+export function startDaemonDetached(
+  cfg: Config,
+  harness: string,
+  spawnFn: typeof realSpawn = realSpawn
+): void {
+  try {
+    const starter = join(dirname(fileURLToPath(import.meta.url)), "daemon-start.js");
+    const child = spawnFn("node", [starter, "--harness", harness], {
+      detached: true,
+      stdio: "ignore",
+    });
+    // spawn() failures often surface ASYNCHRONOUSLY as an 'error' event; unhandled, that would
+    // crash the hook.
+    child.on("error", () => {});
+    child.unref();
+    diag(harness, "daemon_start_spawned", { apiUrl: cfg.apiUrl });
+  } catch {
+    /* best-effort: a failed spawn must not break the caller */
+  }
+}
+
+/**
+ * Make sure a daemon is serving `cfg.apiUrl`.
+ *
+ * Returns whether the server is usable. Never throws: memory is best-effort, and a daemon that
+ * won't start must degrade to "no memory this session", not break the agent.
+ *
+ * `waitMs` bounds how long the caller is willing to block for a cold start — always well under the
+ * calling hook's own timeout, so a slow start costs memory for one turn rather than a killed hook.
+ */
+export async function ensureDaemon(
+  cfg: Config,
+  harness: string,
+  opts: { allowStart: boolean; waitMs?: number }
+): Promise<boolean> {
+  if (cfg.serverMode !== "daemon") return true;
+  if (await isServerHealthy(cfg.apiUrl)) return true;
+  if (!opts.allowStart) {
+    // Expected on the prompt path before SessionStart's background start has finished — recorded
+    // so a session with no memory is explainable rather than mysterious.
+    diag(harness, "daemon_not_ready", { apiUrl: cfg.apiUrl });
+    return false;
+  }
+  if (!preflightDaemon(cfg, harness)) return false;
+  startDaemonDetached(cfg, harness);
+  return waitForHealth(cfg.apiUrl, opts.waitMs ?? 0);
+}
+
+/** Poll /health until it answers or the budget runs out. `budgetMs <= 0` means "don't wait". */
+export async function waitForHealth(
+  baseUrl: string,
+  budgetMs: number,
+  pollMs = 1_000
+): Promise<boolean> {
+  const deadline = Date.now() + budgetMs;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, pollMs));
+    if (await isServerHealthy(baseUrl)) return true;
+  }
+  return false;
+}
+
+/** The two things daemon mode cannot work without. Reported, never thrown. */
+export function preflightDaemon(cfg: Config, harness: string): boolean {
+  if (!hasUvx()) {
+    diag(harness, "daemon_uvx_missing", { apiUrl: cfg.apiUrl });
+    log.warn(harness, "daemon mode needs `uv` on PATH — see https://docs.astral.sh/uv/");
+    return false;
+  }
+  if (!hasRustToolchain()) {
+    diag(harness, "daemon_rust_missing", { platform: process.platform });
+    log.warn(
+      harness,
+      "daemon mode on macOS needs a current Rust toolchain (litellm ships no macOS wheel) — " +
+        "install from https://rustup.rs, then `rustup default stable && rustup update`"
+    );
+    return false;
+  }
+  if (!detectLlm()) {
+    diag(harness, "daemon_no_llm", {});
+    log.warn(
+      harness,
+      "daemon mode needs an LLM for fact extraction — set OPENAI_API_KEY (or ANTHROPIC_API_KEY / " +
+        "GEMINI_API_KEY / HINDSIGHT_API_LLM_PROVIDER), or install the Claude Code CLI"
+    );
+    return false;
+  }
+  return true;
+}

--- a/hindsight-integrations/coding-agents/src/core/legacy.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/legacy.test.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { readLegacyEndpoint } from "./legacy";
+
+const homes: string[] = [];
+
+function homeWith(config: unknown): string {
+  const home = mkdtempSync(join(tmpdir(), "hindsight-legacy-"));
+  homes.push(home);
+  if (config !== undefined) {
+    mkdirSync(join(home, ".hindsight"), { recursive: true });
+    writeFileSync(
+      join(home, ".hindsight", "claude-code.json"),
+      typeof config === "string" ? config : JSON.stringify(config)
+    );
+  }
+  return home;
+}
+
+afterEach(() => {
+  while (homes.length) rmSync(homes.pop()!, { recursive: true, force: true });
+});
+
+describe("readLegacyEndpoint", () => {
+  it("is undefined when the old plugin was never configured", () => {
+    expect(readLegacyEndpoint(homeWith(undefined))).toBeUndefined();
+  });
+
+  it("carries a self-hosted server and its token", () => {
+    const e = readLegacyEndpoint(
+      homeWith({ hindsightApiUrl: "http://box:8888", hindsightApiToken: "t" })
+    );
+    expect(e?.serverMode).toBe("self-hosted");
+    expect(e?.apiUrl).toBe("http://box:8888");
+    expect(e?.apiToken).toBe("t");
+  });
+
+  it("recognises the Cloud URL as cloud, not self-hosted", () => {
+    const e = readLegacyEndpoint(
+      homeWith({ hindsightApiUrl: "https://api.hindsight.vectorize.io" })
+    );
+    expect(e?.serverMode).toBe("cloud");
+  });
+
+  // The old plugin treated an empty URL as "use the local daemon" (daemon.py:get_api_url), so a
+  // config that never sets one describes daemon mode rather than an unconfigured user.
+  it("reads an absent URL as daemon mode", () => {
+    const e = readLegacyEndpoint(homeWith({ retainMode: "full-session" }));
+    expect(e?.serverMode).toBe("daemon");
+    expect(e?.apiUrl).toBeUndefined();
+  });
+
+  it("carries a non-default daemon port, since in daemon mode the port is the endpoint", () => {
+    expect(readLegacyEndpoint(homeWith({ apiPort: 9100 }))?.apiPort).toBe(9100);
+    expect(readLegacyEndpoint(homeWith({ apiPort: 9077 }))?.apiPort).toBeUndefined();
+  });
+
+  // A config we cannot parse is not a decision we can honour — fall through to the normal flow
+  // rather than guessing an endpoint.
+  it("ignores an unparseable config", () => {
+    expect(readLegacyEndpoint(homeWith("{not json"))).toBeUndefined();
+  });
+
+  // Behavioural settings are deliberately not translated.
+  it("carries no behavioural settings", () => {
+    const e = readLegacyEndpoint(
+      homeWith({ hindsightApiUrl: "http://box:8888", recallBudget: "high", retainMode: "chunked" })
+    );
+    expect(Object.keys(e ?? {}).sort()).toEqual(["apiUrl", "serverMode", "source"]);
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/legacy.ts
+++ b/hindsight-integrations/coding-agents/src/core/legacy.ts
@@ -1,0 +1,79 @@
+/**
+ * Carry the SERVER ENDPOINT over from the older per-agent Claude Code plugin.
+ *
+ * Only the endpoint — where memory is stored, and the credential to reach it. None of that
+ * plugin's ~40 behavioural settings are translated: most (12 `recall*`, 7 `retain*`, the mission
+ * pair) describe a pipeline this package replaced outright, and quietly reinterpreting the rest
+ * would be worse than leaving them behind.
+ *
+ * Why it matters: someone running the old plugin against a self-hosted server or a local daemon
+ * has already decided where their prompts and transcripts go. Installing this package and
+ * defaulting to Cloud would silently start sending them somewhere else. Adopting the endpoint they
+ * already chose is the conservative move, not the convenient one.
+ *
+ * Conversations are NOT carried here — they are re-imported from local transcripts
+ * (`--import-conversations`, see core/history.ts). That path re-extracts them as new documents,
+ * which is what makes it independent of the old bank: the old plugin's default was a single static
+ * bank (`claude_code`, since `dynamicBankId` defaults to false) whose documents record only
+ * `retained_at`, `message_count` and `session_id` — nothing identifying the repo. Splitting that
+ * bank per repo would require the local transcripts anyway, so they are the only source used.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_DAEMON_PORT } from "./config";
+
+/** Where the old plugin told users to put their config (`~/.hindsight/claude-code.json`). */
+export function legacyConfigPath(home: string = homedir()): string {
+  return join(home, ".hindsight", "claude-code.json");
+}
+
+export interface LegacyEndpoint {
+  serverMode: "cloud" | "self-hosted" | "daemon";
+  apiUrl?: string;
+  apiToken?: string;
+  /** Only when it differs from the default — in daemon mode the port IS the endpoint. */
+  apiPort?: number;
+  /** The file it came from, so the installer can say where it looked. */
+  source: string;
+}
+
+const CLOUD_URL = "https://api.hindsight.vectorize.io";
+
+/**
+ * Read the old plugin's endpoint, or undefined when it was never configured.
+ *
+ * An ABSENT `hindsightApiUrl` is meaningful rather than missing: the old plugin treated an empty
+ * URL as "use the local daemon on `apiPort`" (`daemon.py:get_api_url`), so a config file that
+ * never set one describes daemon mode, not an unconfigured user.
+ */
+export function readLegacyEndpoint(home: string = homedir()): LegacyEndpoint | undefined {
+  const source = legacyConfigPath(home);
+  if (!existsSync(source)) return undefined;
+  let raw: Record<string, unknown>;
+  try {
+    raw = JSON.parse(readFileSync(source, "utf8")) as Record<string, unknown>;
+  } catch {
+    return undefined; // a config we cannot read is not a decision we can honour
+  }
+  if (!raw || typeof raw !== "object") return undefined;
+
+  const apiToken = typeof raw.hindsightApiToken === "string" ? raw.hindsightApiToken : undefined;
+  const url = typeof raw.hindsightApiUrl === "string" ? raw.hindsightApiUrl.trim() : "";
+
+  if (url) {
+    return {
+      serverMode: url.replace(/\/+$/, "") === CLOUD_URL ? "cloud" : "self-hosted",
+      apiUrl: url,
+      ...(apiToken ? { apiToken } : {}),
+      source,
+    };
+  }
+  const port = typeof raw.apiPort === "number" ? raw.apiPort : undefined;
+  return {
+    serverMode: "daemon",
+    ...(apiToken ? { apiToken } : {}),
+    ...(port && port !== DEFAULT_DAEMON_PORT ? { apiPort: port } : {}),
+    source,
+  };
+}

--- a/hindsight-integrations/coding-agents/src/core/retain-hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.ts
@@ -113,8 +113,9 @@ export async function runRetainHook(
   // Last chance to get the daemon up: this is the write path, and a session whose daemon never
   // started would otherwise lose its whole conversation. The Stop hook has the longest budget of
   // any hook and nothing is waiting on its result, so it can afford the longer wait.
-  if (!(await ensureDaemon(cfg, spec.harness, { allowStart: true, waitMs: DAEMON_WAIT_RETAIN_MS })))
-    return;
+  // Deliberately NOT gated on the result — retain proceeds either way, so an unreachable daemon
+  // produces the same `retain_failed` diagnostic as an unreachable Cloud/self-hosted server.
+  await ensureDaemon(cfg, spec.harness, { waitMs: DAEMON_WAIT_RETAIN_MS });
   const client = makeClient({ apiUrl: cfg.apiUrl, apiToken: cfg.apiToken, bank: bankId });
 
   await buildRetain({

--- a/hindsight-integrations/coding-agents/src/core/retain-hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.ts
@@ -15,6 +15,7 @@ import { readFileSync } from "node:fs";
 import { deriveBankId } from "./bank";
 import { retainLiveSession } from "./chat";
 import { applyBankConfig, loadConfig } from "./config";
+import { DAEMON_WAIT_RETAIN_MS, ensureDaemon } from "./daemon";
 import { diag } from "./diag";
 import { log, setLogLevel } from "./log";
 import type { ClientOpts } from "./hindsight";
@@ -109,6 +110,11 @@ export async function runRetainHook(
   cfg = resolved.cfg;
   const bankId = resolved.bankId;
   if (cfg.disabled) return;
+  // Last chance to get the daemon up: this is the write path, and a session whose daemon never
+  // started would otherwise lose its whole conversation. The Stop hook has the longest budget of
+  // any hook and nothing is waiting on its result, so it can afford the longer wait.
+  if (!(await ensureDaemon(cfg, spec.harness, { allowStart: true, waitMs: DAEMON_WAIT_RETAIN_MS })))
+    return;
   const client = makeClient({ apiUrl: cfg.apiUrl, apiToken: cfg.apiToken, bank: bankId });
 
   await buildRetain({

--- a/hindsight-integrations/coding-agents/src/core/session-start.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.ts
@@ -25,6 +25,7 @@ import { startBackgroundSeed } from "./seed";
 import { syncCompanionSkill } from "./skill-sync";
 import { SURVEY_DOC_IDS, startCodebaseSurvey, type SurveyHarness } from "./survey";
 import { applyBankConfig, loadConfig } from "./config";
+import { DAEMON_WAIT_SESSION_START_MS, ensureDaemon } from "./daemon";
 import type { Config } from "./config";
 import { deriveBankId } from "./bank";
 import { brandWord } from "./brand";
@@ -339,6 +340,10 @@ export async function runSessionStartHook(
     cfg = resolved.cfg;
     const bankId = resolved.bankId;
     if (cfg.disabled) return; // per-bank opt-out (banks.<id> override)
+    // Daemon mode: warm it up now, before the user has typed anything. The start itself is
+    // detached; we wait only briefly, so an already-running daemon is adopted immediately while a
+    // cold one keeps coming up in the background and is picked up by a later turn.
+    await ensureDaemon(cfg, harness, { allowStart: true, waitMs: DAEMON_WAIT_SESSION_START_MS });
     const client = makeClient({ apiUrl: cfg.apiUrl, apiToken: cfg.apiToken, bank: bankId });
 
     const out = await buildSessionStartContext({ cwd, bankId, cfg, client, harness });

--- a/hindsight-integrations/coding-agents/src/core/session-start.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.ts
@@ -343,7 +343,7 @@ export async function runSessionStartHook(
     // Daemon mode: warm it up now, before the user has typed anything. The start itself is
     // detached; we wait only briefly, so an already-running daemon is adopted immediately while a
     // cold one keeps coming up in the background and is picked up by a later turn.
-    await ensureDaemon(cfg, harness, { allowStart: true, waitMs: DAEMON_WAIT_SESSION_START_MS });
+    await ensureDaemon(cfg, harness, { waitMs: DAEMON_WAIT_SESSION_START_MS });
     const client = makeClient({ apiUrl: cfg.apiUrl, apiToken: cfg.apiToken, bank: bankId });
 
     const out = await buildSessionStartContext({ cwd, bankId, cfg, client, harness });

--- a/hindsight-integrations/coding-agents/src/daemon-start.ts
+++ b/hindsight-integrations/coding-agents/src/daemon-start.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * Start the local `hindsight-embed` daemon. Spawned DETACHED by core/daemon.ts — never run inline
+ * by a hook, because a cold start (uvx download + model load) outlives every hook timeout.
+ *
+ * Blocking here is the point: this process exists purely to own that wait, and exits once the
+ * daemon answers /health. It writes only to the plugin log, so its stdio can be discarded.
+ */
+import { loadConfig } from "./core/config";
+import { daemonEnv, isServerHealthy, preflightDaemon } from "./core/daemon";
+import { diag } from "./core/diag";
+import { log, setLogLevel } from "./core/log";
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+async function main(): Promise<void> {
+  const harness = arg("harness") ?? "coding-agent";
+  const cfg = loadConfig({ harness });
+  setLogLevel(cfg.logLevel);
+
+  if (cfg.serverMode !== "daemon") return;
+  // Several sessions can race to start one daemon; whoever loses simply finds it healthy.
+  if (await isServerHealthy(cfg.apiUrl)) return;
+  if (!preflightDaemon(cfg, harness)) return;
+
+  const { HindsightServer } = await import("@vectorize-io/hindsight-all");
+  const server = new HindsightServer({
+    profile: cfg.daemonProfile,
+    port: cfg.apiPort,
+    env: daemonEnv(cfg),
+    embedVersion: cfg.embedVersion,
+    embedPackagePath: cfg.embedPackagePath,
+    logger: {
+      debug: (m) => log.debug(harness, m),
+      info: (m) => log.info(harness, m),
+      warn: (m) => log.warn(harness, m),
+      error: (m) => log.error(harness, m),
+    },
+  });
+  await server.start();
+  diag(harness, "daemon_started", { apiUrl: cfg.apiUrl, profile: cfg.daemonProfile });
+}
+
+main().catch((error) => {
+  diag(arg("harness") ?? "coding-agent", "daemon_start_failed", { error: String(error) });
+});

--- a/hindsight-integrations/coding-agents/src/installer.test.ts
+++ b/hindsight-integrations/coding-agents/src/installer.test.ts
@@ -27,6 +27,8 @@ function makeCtx(): InstallCtx & {
     clinePlugin: vi.fn(() => true),
     // Stubbed like the CLI seams above, so the suite never depends on the Node running it.
     nodeSqlite: vi.fn(() => true),
+    // Never let a developer's real ~/.hindsight/claude-code.json steer the tests.
+    readLegacy: () => undefined,
   };
 }
 
@@ -801,6 +803,40 @@ describe("server setup", () => {
     expect(out).toContain("uv");
     expect(out).toContain("OPENAI_API_KEY");
     expect(readJson(configPath(ctx)).serverMode).toBe("daemon");
+  });
+
+  // Coming from the old per-agent plugin, the endpoint is already a decision the user made.
+  // Defaulting to Cloud instead would quietly redirect their prompts to a different server.
+  it("adopts the old plugin's endpoint instead of asking or defaulting to Cloud", () => {
+    const ctx = makeCtx();
+    ctx.readLegacy = () => ({
+      serverMode: "self-hosted" as const,
+      apiUrl: "http://legacy:8888",
+      apiToken: "tok",
+      source: "/home/u/.hindsight/claude-code.json",
+    });
+    const logs: string[] = [];
+    ctx.log = (m) => logs.push(m);
+    expect(run(["install", "claude-code"], ctx)).toBe(0);
+    const cfg = readJson(configPath(ctx));
+    expect(cfg.serverMode).toBe("self-hosted");
+    expect(cfg.apiUrl).toBe("http://legacy:8888");
+    expect(cfg.apiToken).toBe("tok");
+    // Conversations are a separate, opt-in step — say so rather than implying a full migration.
+    expect(logs.join("\n")).toContain("--import-conversations");
+  });
+
+  it("an explicit --server still overrides what the old plugin used", () => {
+    const ctx = makeCtx();
+    ctx.readLegacy = () => ({
+      serverMode: "self-hosted" as const,
+      apiUrl: "http://legacy:8888",
+      source: "/x",
+    });
+    expect(run(["install", "claude-code", "--server", "cloud"], ctx)).toBe(0);
+    const cfg = readJson(configPath(ctx));
+    expect(cfg.serverMode).toBe("cloud");
+    expect(cfg.apiUrl).toBeUndefined();
   });
 
   // litellm publishes no macOS wheel, so a Mac compiles it from source and needs cargo. Without

--- a/hindsight-integrations/coding-agents/src/installer.test.ts
+++ b/hindsight-integrations/coding-agents/src/installer.test.ts
@@ -722,3 +722,97 @@ describe("devin-cli preflight", () => {
     expect(run(["uninstall", "devin-cli"], ctx)).toBe(0);
   });
 });
+
+/**
+ * Choosing where memory lives — Cloud, a self-hosted server, or a local daemon. Asked once, at
+ * install time; `--server` is the non-interactive form and the only one the suite uses (a prompt
+ * would block on stdin).
+ */
+describe("server setup", () => {
+  const configPath = (ctx: InstallCtx) => join(ctx.home, ".hindsight", "coding-agent.json");
+
+  it("--server daemon records the mode and leaves apiUrl to the port", () => {
+    const ctx = makeCtx();
+    ctx.hasUvx = () => true;
+    ctx.detectLlm = () => ({ provider: "openai", apiKey: "sk", source: "OPENAI_API_KEY" });
+    expect(run(["install", "claude-code", "--server", "daemon"], ctx)).toBe(0);
+    const cfg = readJson(configPath(ctx));
+    expect(cfg.serverMode).toBe("daemon");
+    expect(cfg.apiUrl).toBeUndefined();
+  });
+
+  it("--server self-hosted stores the URL", () => {
+    const ctx = makeCtx();
+    expect(
+      run(
+        ["install", "claude-code", "--server", "self-hosted", "--api-url", "http://box:8888"],
+        ctx
+      )
+    ).toBe(0);
+    expect(readJson(configPath(ctx)).apiUrl).toBe("http://box:8888");
+  });
+
+  // Without a URL the mode is unusable, and silently falling back to Cloud would send this user's
+  // prompts somewhere they did not choose.
+  it("self-hosted without a URL fails instead of falling back to Cloud", () => {
+    const ctx = makeCtx();
+    const logs: string[] = [];
+    ctx.log = (m) => logs.push(m);
+    expect(run(["install", "claude-code", "--server", "self-hosted"], ctx)).toBe(1);
+    expect(logs.join("\n")).toContain("--api-url");
+    expect(existsSync(join(ctx.home, ".claude", "settings.json"))).toBe(false);
+  });
+
+  it("rejects an unknown mode", () => {
+    const ctx = makeCtx();
+    const logs: string[] = [];
+    ctx.log = (m) => logs.push(m);
+    expect(run(["install", "claude-code", "--server", "hybrid"], ctx)).toBe(1);
+    expect(logs.join("\n")).toContain("cloud, self-hosted, daemon");
+  });
+
+  // `--server daemon` puts a bare word in argv; without value-aware parsing it reads as a harness.
+  it("does not mistake a flag value for a harness name", () => {
+    const ctx = makeCtx();
+    const logs: string[] = [];
+    ctx.log = (m) => logs.push(m);
+    expect(run(["install", "claude-code", "--server", "daemon"], ctx)).toBe(0);
+    expect(logs.join("\n")).not.toContain('unknown harness "daemon"');
+  });
+
+  // install is idempotent and routinely re-run; it must not silently rewrite a working setup.
+  it("leaves an existing server config alone", () => {
+    const ctx = makeCtx();
+    writeJsonAt(configPath(ctx), { serverMode: "self-hosted", apiUrl: "http://mine:8888" });
+    expect(run(["install", "claude-code"], ctx)).toBe(0);
+    expect(readJson(configPath(ctx)).apiUrl).toBe("http://mine:8888");
+  });
+
+  it("warns when daemon prerequisites are missing, but still configures it", () => {
+    const ctx = makeCtx();
+    ctx.hasUvx = () => false;
+    ctx.hasRust = () => true;
+    ctx.detectLlm = () => undefined;
+    const logs: string[] = [];
+    ctx.log = (m) => logs.push(m);
+    // Advisory, not blocking: uv and an API key can both be installed after the fact.
+    expect(run(["install", "claude-code", "--server", "daemon"], ctx)).toBe(0);
+    const out = logs.join("\n");
+    expect(out).toContain("uv");
+    expect(out).toContain("OPENAI_API_KEY");
+    expect(readJson(configPath(ctx)).serverMode).toBe("daemon");
+  });
+
+  // litellm publishes no macOS wheel, so a Mac compiles it from source and needs cargo. Without
+  // this the failure surfaces minutes later, deep in a pip build log.
+  it("flags a missing Rust toolchain", () => {
+    const ctx = makeCtx();
+    ctx.hasUvx = () => true;
+    ctx.hasRust = () => false;
+    ctx.detectLlm = () => ({ provider: "openai", apiKey: "sk", source: "OPENAI_API_KEY" });
+    const logs: string[] = [];
+    ctx.log = (m) => logs.push(m);
+    expect(run(["install", "claude-code", "--server", "daemon"], ctx)).toBe(0);
+    expect(logs.join("\n")).toContain("rustup");
+  });
+});

--- a/hindsight-integrations/coding-agents/src/installer.ts
+++ b/hindsight-integrations/coding-agents/src/installer.ts
@@ -28,6 +28,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readSync,
   realpathSync,
   rmSync,
   writeFileSync,
@@ -37,6 +38,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { HOOK_HARNESSES, type HookHarnessName } from "./harness/hook-lifecycle";
 import { importLocalHistory } from "./core/history";
+import { detectLlm, hasRustToolchain, hasUvx, type LlmChoice } from "./core/daemon";
 
 /**
  * Substring that identifies OUR entries in a host's config, so a re-install replaces them and
@@ -60,6 +62,13 @@ export interface InstallCtx {
   clinePlugin?: (args: string[]) => boolean;
   /** Reports whether `node:sqlite` works in the node that runs hooks; injectable for tests. */
   nodeSqlite?: () => boolean;
+  /** Whether stdin can be prompted. Defaults to the real TTY check at the CLI entry; tests set it
+   *  explicitly so the suite never blocks on a read. */
+  interactive?: boolean;
+  /** Daemon prerequisite probes; injectable for tests. */
+  hasUvx?: () => boolean;
+  detectLlm?: () => LlmChoice | undefined;
+  hasRust?: () => boolean;
   log?: (m: string) => void;
 }
 
@@ -538,6 +547,169 @@ function pathNodeVersion(): string {
   }
 }
 
+// ── server setup (cloud / self-hosted / local daemon) ───────────────────────────
+
+export type ServerMode = "cloud" | "self-hosted" | "daemon";
+
+const SERVER_MODES: ServerMode[] = ["cloud", "self-hosted", "daemon"];
+
+/** Value of `--name value` or `--name=value`. */
+export function flagValue(args: string[], name: string): string | undefined {
+  const inline = args.find((a) => a.startsWith(`--${name}=`));
+  if (inline) return inline.slice(name.length + 3);
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+/** Args that are VALUES of a preceding flag, so they aren't mistaken for harness names. */
+export function flagValueArgs(args: string[], names: string[]): Set<string> {
+  const taken = new Set<string>();
+  for (const name of names) {
+    const i = args.indexOf(`--${name}`);
+    if (i >= 0 && args[i + 1] && !args[i + 1].startsWith("--")) taken.add(args[i + 1]);
+  }
+  return taken;
+}
+
+const CONFIG_RELATIVE = [".hindsight", "coding-agent.json"];
+
+/**
+ * Ask which of the three connection modes to use, once.
+ *
+ * Only ever asked on a TTY and only when the config doesn't already answer it: `install` is
+ * idempotent and routinely re-run (after an upgrade, or to add another agent), and re-prompting
+ * then would be noise — worse, it would silently rewrite a working setup in CI, where there is no
+ * one to answer. Non-interactive callers pass `--server`.
+ */
+function promptServerMode(c: InstallCtx): ServerMode | undefined {
+  c.log?.(
+    `\nWhere should memory live?\n` +
+      `  1) Hindsight Cloud            — hosted, needs an API token\n` +
+      `  2) Self-hosted server         — a Hindsight server you already run\n` +
+      `  3) Local daemon (on-device)   — runs hindsight-embed here; no account, needs uv + an LLM key\n`
+  );
+  const answer = readLineSync("Choose [1-3] (default 1): ").trim();
+  if (answer === "" || answer === "1") return "cloud";
+  if (answer === "2") return "self-hosted";
+  if (answer === "3") return "daemon";
+  c.log?.(`unrecognised choice "${answer}" — leaving the server config unchanged`);
+  return undefined;
+}
+
+/**
+ * Read one line from stdin synchronously.
+ *
+ * `run()` is synchronous and called that way from both the CLI entry and the test suite, so an
+ * async readline would mean making the whole installer async. readSync on the TTY blocks until
+ * Enter, which is exactly the semantics wanted here.
+ */
+function readLineSync(prompt: string): string {
+  process.stdout.write(prompt);
+  const buf = Buffer.alloc(1024);
+  try {
+    const n = readSync(0, buf, 0, buf.length, null);
+    return buf.subarray(0, n).toString("utf8");
+  } catch {
+    return ""; // no readable stdin — treated as the default
+  }
+}
+
+/**
+ * Resolve and persist the connection mode into ~/.hindsight/coding-agent.json.
+ *
+ * Returns false to abort the install. Everything else here is advisory: a daemon whose
+ * prerequisites are missing is still worth configuring, because `uv` or an API key can be
+ * installed right after — unlike the harness preflights, which gate wiring that could never work.
+ */
+function configureServer(c: InstallCtx, args: string[]): boolean {
+  const explicit = flagValue(args, "server");
+  if (explicit && !SERVER_MODES.includes(explicit as ServerMode)) {
+    c.log?.(`unknown --server "${explicit}" — expected one of: ${SERVER_MODES.join(", ")}`);
+    return false;
+  }
+  const configPath = join(c.home, ...CONFIG_RELATIVE);
+  const existing = readJson(configPath);
+  const alreadyConfigured = !!(existing.serverMode || existing.apiUrl);
+
+  let mode = explicit as ServerMode | undefined;
+  if (!mode) {
+    if (alreadyConfigured) return true; // respect what's already there
+    if (!c.interactive) {
+      c.log?.(
+        `\nserver: defaulting to Hindsight Cloud. Re-run with --server self-hosted|daemon to change,\n` +
+          `        or edit ${configPath}.`
+      );
+      return true;
+    }
+    mode = promptServerMode(c);
+    if (!mode) return true;
+  }
+
+  const next: Record<string, unknown> = { ...existing, serverMode: mode };
+  if (mode === "cloud") {
+    delete next.apiUrl; // fall back to the built-in Cloud URL rather than pinning a stale one
+    const token = flagValue(args, "api-token") ?? (c.interactive ? askToken(c) : undefined);
+    if (token) next.apiToken = token;
+  } else if (mode === "self-hosted") {
+    const url =
+      flagValue(args, "api-url") ??
+      (c.interactive
+        ? readLineSync("Server URL (e.g. http://localhost:8888): ").trim()
+        : undefined);
+    if (!url) {
+      c.log?.(
+        `❌ self-hosted mode needs a server URL — pass --api-url <url> (or set apiUrl in ${configPath}).`
+      );
+      return false;
+    }
+    next.apiUrl = url;
+    const token = flagValue(args, "api-token");
+    if (token) next.apiToken = token;
+  } else {
+    delete next.apiUrl; // daemon mode derives its URL from apiPort
+    reportDaemonPrereqs(c);
+  }
+
+  writeJson(configPath, next);
+  c.log?.(`server: ${mode} (${configPath})`);
+  return true;
+}
+
+function askToken(c: InstallCtx): string | undefined {
+  const token = readLineSync("API token (blank to set later): ").trim();
+  if (!token) c.log?.("  no token set — add apiToken later if the server needs one");
+  return token || undefined;
+}
+
+/**
+ * Daemon mode has two prerequisites the plugin can't supply. Report both up front rather than
+ * letting the first session fail quietly with nothing but a diagnostic line.
+ */
+function reportDaemonPrereqs(c: InstallCtx): void {
+  if (!(c.hasUvx ?? hasUvx)()) {
+    c.log?.(
+      `⚠️  \`uv\` is not on PATH. The daemon is fetched and run with it, so memory stays inert\n` +
+        `    until you install it: https://docs.astral.sh/uv/`
+    );
+  }
+  if (!(c.hasRust ?? hasRustToolchain)()) {
+    c.log?.(
+      `⚠️  macOS needs a current Rust toolchain to build the daemon's dependencies (litellm\n` +
+        `    publishes no macOS wheel). Install from https://rustup.rs, then\n` +
+        `    \`rustup default stable && rustup update\` — an OUT-OF-DATE toolchain fails too.`
+    );
+  }
+  const llm = (c.detectLlm ?? detectLlm)();
+  if (llm) {
+    c.log?.(`   local extraction will use ${llm.provider} (from ${llm.source})`);
+  } else {
+    c.log?.(
+      `⚠️  No LLM available for local fact extraction. Set OPENAI_API_KEY, ANTHROPIC_API_KEY or\n` +
+        `    GEMINI_API_KEY (or install the Claude Code CLI, which needs no key).`
+    );
+  }
+}
+
 const devin: HarnessInstaller = {
   name: "devin-cli",
   detect: (c) => onPath("devin") || existsSync(join(c.home, ".config", "devin")),
@@ -849,7 +1021,10 @@ export function run(argv: string[], ctx: InstallCtx): number {
   // the migration path off the older per-agent plugins, whose banks the server cannot merge into
   // this one. Opt-in: it re-extracts history and therefore costs tokens.
   const importHistory = rawArgs.includes("--import-conversations");
-  const names = rawArgs.filter((a) => !a.startsWith("--"));
+  // A flag's VALUE (`--server daemon`) is a bare word too — excluding it keeps "daemon" from being
+  // read as a harness name and rejected.
+  const valueArgs = flagValueArgs(rawArgs, ["server", "api-url", "api-token"]);
+  const names = rawArgs.filter((a) => !a.startsWith("--") && !valueArgs.has(a));
   // The wiring we write is ABSOLUTE paths into this package's dist. From an npx/pnpm-dlx cache
   // those paths die on cache eviction — every hook silently stops. Refuse and say what to do.
   if (command === "install" && /\/(_npx|\.npm\/_npx|dlx-)\/|\/_cacache\//.test(ctx.pkgRoot)) {
@@ -863,7 +1038,9 @@ export function run(argv: string[], ctx: InstallCtx): number {
   }
   if (command !== "install" && command !== "uninstall") {
     ctx.log?.(
-      `usage: hindsight-coding-agents <install|uninstall> <all|harness...> [--import-conversations]\n` +
+      `usage: hindsight-coding-agents <install|uninstall> <all|harness...>\n` +
+        `       [--server cloud|self-hosted|daemon] [--api-url <url>] [--api-token <token>]\n` +
+        `       [--import-conversations]\n` +
         `  all      every agent detected on this machine\n` +
         `  harness  ${INSTALLERS.map((i) => i.name).join(", ")} (agy aliases antigravity-cli)`
     );
@@ -901,6 +1078,10 @@ export function run(argv: string[], ctx: InstallCtx): number {
     );
     return 1;
   }
+  // Which server the agents will talk to. Resolved BEFORE any harness is wired so the very first
+  // session already has a config to read.
+  if (command === "install" && !configureServer(ctx, rawArgs)) return 1;
+
   // Preflight runs BEFORE any config is written, and only blocks the harness that failed: on
   // `install all` the other agents are still worth wiring. The non-zero exit keeps the failure
   // visible to whatever script invoked this.
@@ -926,7 +1107,7 @@ export function run(argv: string[], ctx: InstallCtx): number {
   }
   ctx.log?.(
     command === "install"
-      ? `\n✅ installed. Configure the server in ~/.hindsight/coding-agent.json (apiUrl/apiToken) and start a session.`
+      ? `\n✅ installed. Start a session — settings live in ~/.hindsight/coding-agent.json.`
       : `\n✅ uninstalled.`
   );
   return 0;
@@ -953,6 +1134,8 @@ if (isMain || mainPath?.endsWith("installer.js")) {
       home: homedir(),
       pkgRoot: dirname(dist),
       dist,
+      // Only a real terminal gets prompted; piped/CI installs take the documented default.
+      interactive: Boolean(process.stdin.isTTY && process.stdout.isTTY),
       log: (m) => console.log(m),
     })
   );

--- a/hindsight-integrations/coding-agents/src/installer.ts
+++ b/hindsight-integrations/coding-agents/src/installer.ts
@@ -39,6 +39,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { HOOK_HARNESSES, type HookHarnessName } from "./harness/hook-lifecycle";
 import { importLocalHistory } from "./core/history";
 import { detectLlm, hasRustToolchain, hasUvx, type LlmChoice } from "./core/daemon";
+import { readLegacyEndpoint } from "./core/legacy";
 
 /**
  * Substring that identifies OUR entries in a host's config, so a re-install replaces them and
@@ -69,6 +70,8 @@ export interface InstallCtx {
   hasUvx?: () => boolean;
   detectLlm?: () => LlmChoice | undefined;
   hasRust?: () => boolean;
+  /** Reads the old per-agent plugin's endpoint; injectable for tests. */
+  readLegacy?: (home: string) => ReturnType<typeof readLegacyEndpoint>;
   log?: (m: string) => void;
 }
 
@@ -634,6 +637,25 @@ function configureServer(c: InstallCtx, args: string[]): boolean {
   let mode = explicit as ServerMode | undefined;
   if (!mode) {
     if (alreadyConfigured) return true; // respect what's already there
+    // Someone coming from the old per-agent plugin already chose where their memory lives.
+    // Adopt it rather than asking again — and above all rather than defaulting to Cloud, which
+    // would quietly redirect their prompts and transcripts to a different server.
+    const legacy = (c.readLegacy ?? readLegacyEndpoint)(c.home);
+    if (legacy) {
+      const carried: Record<string, unknown> = { ...existing, serverMode: legacy.serverMode };
+      if (legacy.apiUrl) carried.apiUrl = legacy.apiUrl;
+      if (legacy.apiToken) carried.apiToken = legacy.apiToken;
+      if (legacy.apiPort) carried.apiPort = legacy.apiPort;
+      writeJson(configPath, carried);
+      c.log?.(
+        `server: ${legacy.serverMode}${legacy.apiUrl ? ` (${legacy.apiUrl})` : ""} — carried over ` +
+          `from ${legacy.source}\n` +
+          `        Only the endpoint moves; conversations do not. To bring this repo's history\n` +
+          `        across, re-run here with --import-conversations.`
+      );
+      if (legacy.serverMode === "daemon") reportDaemonPrereqs(c);
+      return true;
+    }
     if (!c.interactive) {
       c.log?.(
         `\nserver: defaulting to Hindsight Cloud. Re-run with --server self-hosted|daemon to change,\n` +

--- a/hindsight-integrations/coding-agents/tsup.config.ts
+++ b/hindsight-integrations/coding-agents/tsup.config.ts
@@ -32,6 +32,8 @@ export default defineConfig({
     "devin-hook": "src/devin-hook.ts",
     "devin-sessionstart-hook": "src/devin-sessionstart-hook.ts",
     "devin-stop-hook": "src/devin-stop-hook.ts",
+    // Spawned DETACHED to start the local daemon — a cold start outlives every hook timeout.
+    "daemon-start": "src/daemon-start.ts",
     "mcp-server": "src/mcp-server.ts",
     "hindsight-seed": "src/hindsight-seed.ts",
   },
@@ -48,5 +50,8 @@ export default defineConfig({
   // mcp-server.js additionally needs its npm deps (the MCP SDK + zod) inlined, since the wrapper
   // only copies the single bundle file, not node_modules. The regexes catch subpath imports too
   // (e.g. "@modelcontextprotocol/sdk/server/mcp.js", "zod/v4/...").
-  noExternal: [/^@modelcontextprotocol\/sdk/, /^zod/],
+  // hindsight-all (the local-daemon lifecycle manager) is inlined for the same reason: hooks are
+  // wired by absolute path to ONE dist file and never load the package's node_modules. It has zero
+  // dependencies of its own, so inlining costs almost nothing.
+  noExternal: [/^@modelcontextprotocol\/sdk/, /^zod/, /^@vectorize-io\/hindsight-all/],
 });

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -86,17 +86,29 @@ a `hookAdapter` in `src/harness/registry.ts`; persistent-plugin → implement `H
 
 ## Migrating from the per-agent plugins
 
-The older per-agent integrations (`hindsight-claude-code`, `hindsight-cursor-cli`, `hindsight-codex`, …) are superseded by this package. Their memory does **not** carry over automatically, and it cannot be merged:
+The older per-agent integrations (`hindsight-claude-code`, `hindsight-cursor-cli`, `hindsight-codex`, …) are superseded by this package. Two things move; nothing else does.
 
-- They scope a bank **per agent per project** (`claude-code::myrepo`); this package uses one **per repo** (`coding-agent::myrepo`) so every agent shares it. Two old banks map onto one new one.
-- The server restores a whole bank rather than merging into an existing one, so the old bank can't be folded in.
+**Your server moves automatically.** If `~/.hindsight/claude-code.json` exists, `install` adopts its
+endpoint — `hindsightApiUrl` → `apiUrl`, `hindsightApiToken` → `apiToken`, and an empty URL means
+the local daemon, as it did there. You already chose where your memory lives; defaulting to Cloud
+instead would quietly send your prompts somewhere else. Pass `--server` to override.
 
-Instead, re-import the conversations the agent already wrote to disk — they get re-extracted into the current bank:
+**Your conversations are re-imported from local disk**, as new documents:
 
 ```bash
 cd /path/to/your/repo
 hindsight-coding-agents install claude-code --import-conversations
 ```
+
+This re-extracts the transcripts the agent already wrote, so it costs tokens roughly in proportion
+to the history imported, and it is safe to re-run (ingestion dedups by document id).
+
+Local transcripts are the source rather than the old bank, because the old bank cannot be split by
+repo. Its default was a **single static bank** — `dynamicBankId` defaults to false, so everything
+landed in one bank named `claude_code` — and its documents record only `retained_at`,
+`message_count` and `session_id`, nothing identifying the project. Working out which documents
+belong to which repo means joining `session_id` back to the `cwd` in the local transcript, so the
+transcripts are needed either way; going through them directly is simply the shorter path.
 
 **How sessions are matched.** A conversation is imported only when the session itself records the
 directory it ran in — never inferred from a file or folder name. Claude Code writes that directory
@@ -108,89 +120,14 @@ conversation into your bank. Sessions that record nothing are skipped and the co
 The other harnesses (opencode, Kilo, Cursor, Cline, Copilot, Devin) keep history in internal SQLite
 databases with unversioned schemas and are skipped with a reason.
 
-The import is scoped to the **current repo**, safe to re-run (ingestion dedups by document id), and
-runs extraction — so it costs tokens roughly in proportion to the history imported.
-
-Prefer to keep the old bank instead? Point this package at it — no data moves:
+**Nothing else is translated.** The old plugin's behavioural settings — 12 `recall*`, 7 `retain*`,
+`bankMission`/`retainMission`, `dynamicBankGranularity` — describe a pipeline this package replaced,
+and reinterpreting them would be guesswork. Bank naming changes too: this package uses one bank per
+**repo** (`coding-agent::{gitProject}`) shared by every agent. To keep the old naming instead:
 
 ```jsonc
 { "bankIdTemplate": "{harness}::{gitProject}" } // reproduces the old per-agent naming
 ```
-
-## How it works
-
-**Ingestion — automatic, no command to run**
-
-- On a **cold repo**, the first session kicks off a background seed: recent commit **messages** as one cheap document, plus a short headless **codebase survey** to map the structure.
-- On **every** session, a background "deepen" pass ingests conversations not yet stored and the next batch of recent commits **with full diffs, newest first** — precision arrives across sessions instead of one big ingest.
-- Repeated or concurrent runs are a no-op (per-bank lock + document-id dedup).
-- Ask the agent `hindsight_sync_status` to see where ingestion stands — `synced: true` means everything is queryable.
-
-**In the session — what the agent actually receives**
-
-- On the first prompt, a **reflect** call returns the past decision behind the task, with its exact rule and values. It's cached and re-injected each turn.
-- Every turn, the repo's **knowledge pages** are matched locally against the prompt (lexical index — no server call, no LLM, ~ms) and the best sections are injected with provenance. Below a relevance floor, nothing is injected.
-- The agent also gets the page roster and the `hindsight_*` tools, so it can read a page, search raw memory, or record a new initiative itself.
-- Injected memory carries a visible-attribution directive, so the agent shows a `🧠 Using Hindsight Memories` header when memory shaped its answer.
-
-**Write-back — sessions become memory**
-
-- The live session is stored as a transcript: user/assistant turns plus a compact `action` line per tool call (name + target, no arguments or output) — decisions without the mechanical noise.
-- Hook harnesses write on `Stop`. Plugin harnesses (opencode, Kilo) write on a turn cadence **and** when the session goes idle — the idle pass is what captures the agent's own reply, which the per-turn pass runs too early to see.
-
-**Guarantees**
-
-- A failed reflect or page fetch degrades to a no-memory turn; it never breaks the agent.
-- It never fails _silently_ either: every outcome is written to a diagnostics file, so a memory-less session can't pass for a memory session.
-- When two memories conflict on the same rule, the later decision wins and the superseded one is reported as no longer in effect.
-- Against a Hindsight server that predates knowledge pages, page features are skipped (recorded as `knowledge_pages_unavailable`) and everything else continues.
-
-## Harnesses
-
-Every harness runs the same surface (seed → session reflect → per-turn page sections → knowledge
-tools → write-back); they differ only in how that surface is delivered.
-
-| harness                   | kind              | lifecycle wiring                                                                                                                   | install                                                             |
-| ------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| `opencode`                | persistent plugin | one process: load-time seed, session reflect + page sections, native tools, write-back                                             | add the package dir to `opencode.json` → `"plugin": [...]`          |
-| `kilo`                    | persistent plugin | identical to `opencode` — Kilo CLI is an opencode fork, so it loads the same runtime (no hooks system)                             | `hindsight-coding-agents install kilo` → `kilo.json[c]` `"plugin"`  |
-| `claude-code`             | per-prompt hooks  | `SessionStart` (seed) + `UserPromptSubmit` (reflect + pages) + `Stop` (write-back) + MCP                                           | `hindsight-coding-agents install claude-code`                       |
-| `codex`                   | per-prompt hooks  | same three hooks in `~/.codex/hooks.json` (+ `codex_hooks = true`, CLI ≥ 0.116)                                                    | `hindsight-coding-agents install codex`                             |
-| `antigravity-cli` (`agy`) | lifecycle hooks   | Antigravity CLI lifecycle hooks (`PreInvocation` + `Stop`) + MCP, plus a native colored `Hindsight · <bank>` status-line indicator | `hindsight-coding-agents install agy`                               |
-| `cursor-cli`              | lifecycle hooks   | `sessionStart` (seed + pages) + `beforeSubmitPrompt` (reflect) + `stop` (write-back)                                               | hooks in Cursor `hooks.json`                                        |
-| `copilot-cli`             | lifecycle hooks   | `sessionStart` (seed + pages) + `userPromptTransformed` (reflect) + `agentStop` (write-back) + MCP                                 | `~/.copilot/hooks/hindsight-coding-agents.json` + `mcp-config.json` |
-| `grok-build`              | lifecycle hooks   | `SessionStart` (seed) + `Stop` (write-back) + MCP                                                                                  | native `~/.grok/config.toml` — no Claude Code dependency            |
-| `cline-cli`               | persistent plugin | native `beforeModel` (seed/reflect/pages) + `afterRun` (write-back) + MCP                                                          | `cline plugin install` (run by the installer)                       |
-
-The hook-based harnesses share one runtime (`src/core/hook.ts`) plus their SessionStart/Stop
-entrypoints. Persistent-plugin hosts (opencode/Kilo/Cline) delegate to the same `RuntimeCore`,
-which in turn calls those shared session-start, prompt, and retain operations; only their host API
-adapters differ. Opencode and Kilo can register the knowledge tools natively; Cline uses the shared
-MCP server. All support opt-in **incremental git-sync** (retain commits new since the seed on load).
-
-Antigravity renders the Hindsight indicator with its documented custom status-line command. It is
-local and never calls the Hindsight API while the TUI redraws. If you already configured an
-Antigravity custom status line, the installer leaves it untouched rather than replacing it.
-
-### Grok Build limitation
-
-Grok Build executes `UserPromptSubmit` hooks but ignores their stdout. Hindsight can therefore not
-inject a reflect result, memory block, or banner into Grok's model-visible conversation. Grok still
-gets native bank setup and transcript retention plus Hindsight MCP tools and the companion skill;
-ask it to call `hindsight_reflect` or `hindsight_search_knowledge_pages` when needed. Automatic
-injection requires a future Grok prompt-transform API.
-
-### Cline CLI scope
-
-Cline's external file hooks cannot alter a model request, so Hindsight uses Cline's native plugin
-API instead. Its `beforeModel` hook injects the shared reflect/page context and
-its `afterRun` hook upserts Cline's runtime transcript. `hindsight-coding-agents install cline-cli`
-runs `cline plugin install --force <package-path>` and configures MCP plus the companion skill.
-Cline CLI sandboxes plugin hooks with a three-second limit, so a slow first reflect finishes in the
-background and is injected on a subsequent model call or turn rather than aborting the session.
-Its write-back retains only user-visible user/assistant text; tool arguments, tool results and
-command output, tool-role messages, reasoning parts, and Hindsight's injected context are excluded.
-Cline IDE extensions are not currently supported by this CLI integration.
 
 ## Where memory lives
 

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -27,6 +27,10 @@ hindsight-coding-agents uninstall all        # removes exactly what install adde
 `hindsight-coding-agents install` changes nothing and prints the choice, so wiring every agent on
 the machine is never something that happens by accident.
 
+On a terminal it also asks **where memory should live** — Hindsight Cloud, a server you run, or a
+local daemon on this machine (see Where memory lives). Scripted installs pass
+`--server cloud|self-hosted|daemon` instead; it is asked only once, and never again on re-install.
+
 ### Per agent
 
 Same command, only the harness name changes. Run after installing the package globally.
@@ -187,6 +191,61 @@ background and is injected on a subsequent model call or turn rather than aborti
 Its write-back retains only user-visible user/assistant text; tool arguments, tool results and
 command output, tool-role messages, reasoning parts, and Hindsight's injected context are excluded.
 Cline IDE extensions are not currently supported by this CLI integration.
+
+## Where memory lives
+
+Three modes, chosen once when you install (`install` asks on a terminal; pass `--server` to script it):
+
+| mode          | what runs                                 | needs                                    |
+| ------------- | ----------------------------------------- | ---------------------------------------- |
+| `cloud`       | Hindsight Cloud (default)                 | an API token                             |
+| `self-hosted` | a Hindsight server you already run        | its URL                                  |
+| `daemon`      | a local `hindsight-embed` on this machine | `uv` on PATH + an LLM key for extraction |
+
+```bash
+hindsight-coding-agents install claude-code --server daemon
+hindsight-coding-agents install claude-code --server self-hosted --api-url http://localhost:8888
+hindsight-coding-agents install claude-code --server cloud --api-token <token>
+```
+
+Re-running `install` never re-asks: a config that already names a server is left alone.
+
+### Local daemon mode
+
+Nothing to sign up for and nothing to host — memory runs on your machine. The plugin starts
+`hindsight-embed` on demand at `127.0.0.1:9077` and points every agent at it.
+
+- **A server already on the port is adopted, never restarted** — so one daemon serves every agent
+  and every repo, and your own `hindsight-embed` is reused if you already run one.
+- **Cold starts happen in the background.** The first start downloads the daemon and loads models,
+  which takes longer than any hook is allowed to run, so it is launched detached at session start.
+  A session that begins before it is ready simply has no memory for a turn or two.
+- **It shuts down on idle**, after `daemonIdleTimeout` seconds. There is deliberately no
+  stop-on-exit: one daemon is shared, so ending one session must not cut memory out from under
+  another agent still working.
+- **macOS additionally needs a current Rust toolchain.** `litellm` (a transitive dependency of the
+  API) publishes wheels only for Linux and Windows, so a Mac compiles it from source through
+  maturin and its crates pin a recent `rustc`. Install from [rustup.rs](https://rustup.rs) and keep
+  it updated — an out-of-date toolchain fails as surely as a missing one. Linux and Windows install
+  from wheels and need none of this.
+- **Fact extraction runs locally**, so it needs an LLM. `HINDSIGHT_API_LLM_PROVIDER` wins if set;
+  otherwise the first of `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GROQ_API_KEY`;
+  otherwise the Claude Code CLI, which needs no key. `install` tells you which it found.
+
+Daemon settings keep the names the old per-agent Claude Code plugin used, so an existing
+environment carries over unchanged:
+
+| field               | env                             | default        | meaning                                    |
+| ------------------- | ------------------------------- | -------------- | ------------------------------------------ |
+| `serverMode`        | `HINDSIGHT_SERVER_MODE`         | `cloud`        | `cloud` \| `self-hosted` \| `daemon`       |
+| `apiPort`           | `HINDSIGHT_API_PORT`            | `9077`         | port the local daemon listens on           |
+| `daemonIdleTimeout` | `HINDSIGHT_DAEMON_IDLE_TIMEOUT` | `300`          | seconds of inactivity before it exits      |
+| `daemonProfile`     | `HINDSIGHT_DAEMON_PROFILE`      | `coding-agent` | which local database it uses               |
+| `embedVersion`      | `HINDSIGHT_EMBED_VERSION`       | `latest`       | which `hindsight-embed` release to run     |
+| `embedPackagePath`  | `HINDSIGHT_EMBED_PACKAGE_PATH`  | —              | run a local checkout instead (development) |
+
+Any `HINDSIGHT_API_*` variable you export is forwarded to the daemon, so server-side settings need
+no equivalent here.
 
 ## Configuration
 

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -219,7 +219,9 @@ Nothing to sign up for and nothing to host — memory runs on your machine. The 
   and every repo, and your own `hindsight-embed` is reused if you already run one.
 - **Cold starts happen in the background.** The first start downloads the daemon and loads models,
   which takes longer than any hook is allowed to run, so it is launched detached at session start.
-  A session that begins before it is ready simply has no memory for a turn or two.
+  A session that begins before it is ready simply has no memory for a turn or two — a daemon that
+  isn't up is treated as an unreachable server, exactly like a Cloud or self-hosted outage, with the
+  same error handling and the same diagnostics. Nothing downstream of the URL knows which mode it is.
 - **It shuts down on idle**, after `daemonIdleTimeout` seconds. There is deliberately no
   stop-on-exit: one daemon is shared, so ending one session must not cut memory out from under
   another agent still working.


### PR DESCRIPTION
Closes the biggest functional regression in the move from the per-agent plugins: the coding-agents package had **no embedded mode at all**. `apiUrl` defaulted to Cloud and there was no daemon lifecycle anywhere, while the old Claude Code plugin auto-managed `hindsight-embed` (`scripts/lib/daemon.py`). Anyone without a Cloud account or a server lost a working setup.

## Three modes, asked once

```bash
hindsight-coding-agents install claude-code                                    # asks, on a terminal
hindsight-coding-agents install claude-code --server daemon                    # scripted
hindsight-coding-agents install claude-code --server self-hosted --api-url ... 
```

```
Where should memory live?
  1) Hindsight Cloud            — hosted, needs an API token
  2) Self-hosted server         — a Hindsight server you already run
  3) Local daemon (on-device)   — runs hindsight-embed here; no account, needs uv + an LLM key
```

Resolution order matches the old plugin's `get_api_url()`: external API → a healthy server already on the port (adopted, never restarted) → start a daemon. A config that already names a server is never re-asked or rewritten, because `install` is idempotent and routinely re-run.

## Design points

- **The mode collapses into `apiUrl` inside `resolveConfig`.** All eight existing client-construction sites keep working untouched instead of threading a mode through each one.
- **A cold start is never awaited inline.** uvx download + model load outlives every hook timeout, so SessionStart spawns a **detached** starter — the same idiom seeding and the codebase survey already use — and each caller waits only a bounded slice of its own budget (12s of SessionStart's 30, 40s of Stop's 60). The prompt hook never starts a daemon.
- **No stop-on-session-end**, unlike the old plugin. One daemon serves every agent and repo on the machine, so ending one session must not cut memory out from under another; `daemonIdleTimeout` retires it.
- **Port 9077, not hindsight-all's 8888.** 8888 is the conventional port for a server the user runs themselves, and a daemon must not squat on it.
- **Old env names kept** — `HINDSIGHT_API_PORT`, `HINDSIGHT_DAEMON_IDLE_TIMEOUT`, `HINDSIGHT_EMBED_VERSION`, `HINDSIGHT_EMBED_PACKAGE_PATH` — so a migrating environment carries over unchanged. Any `HINDSIGHT_API_*` you export is forwarded to the daemon.
- Lifecycle delegated to `@vectorize-io/hindsight-all` (zero dependencies, inlined by tsup so hook bundles stay self-contained).

## Prerequisites reported at install time

`uv` on PATH, an LLM for local extraction (explicit provider → known key env → the Claude Code CLI, which needs none), and **on macOS a current Rust toolchain**. Advisory rather than blocking — unlike the `devin-cli` preflight, each can be installed after the fact.

## The macOS caveat, found by actually running it

`litellm` (transitive via `hindsight-api-slim`) publishes wheels only for manylinux and Windows — verified against PyPI for 1.95.0: tags `cp310`–`cp314`, **no macOS build for any of them**. Every Mac therefore compiles it from the sdist through maturin, and its crates pin a recent `rustc`.

I could not get a daemon fully up on this machine: the build fails with `rustc 1.93.1 is not supported ... aws-config@1.9.0 requires rustc 1.94.1`. Everything up to that point works — profile creation, env passthrough, detached start, readiness polling — and the failure surfaces exactly as designed (an install-time warning plus a `daemon_start_failed` diagnostic carrying the real compiler error, instead of a silent no-op). **A fully-running daemon is not yet verified end-to-end on macOS.** Unblocking it is `rustup update`; the long-term fix is upstream macOS wheels.

Linux and Windows install from wheels and need none of this.

## Tests

15 new in `core/daemon.test.ts` (mode resolution, LLM detection priority, env passthrough, detached-spawn contract) and 8 in `installer.test.ts` (each mode, self-hosted without a URL failing rather than silently falling back to Cloud, flag values not being read as harness names, an existing config left alone, both prerequisite warnings). Full suite 305 passed / 19 skipped; `LINT_ALL_INTEGRATIONS=1 ./scripts/hooks/lint.sh` clean.
