### PR TITLE
fix(delete): sweep orphan entities when no relink victims were enqueued

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -6518,7 +6518,9 @@ class MemoryEngine(MemoryEngineInterface):
         # be orphans that the bank-wide sweep should clean up.
         if unit_ids:
             try:
-                await self.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
+                await self.submit_async_graph_maintenance(
+                    bank_id=bank_id, request_context=request_context, force_sweep=True
+                )
             except Exception as e:
                 logger.warning(f"Failed to submit graph maintenance after document deletion for bank {bank_id}: {e}")
 
@@ -6856,7 +6858,7 @@ class MemoryEngine(MemoryEngineInterface):
         if bank_id_for_graph_maintenance:
             try:
                 await self.submit_async_graph_maintenance(
-                    bank_id=bank_id_for_graph_maintenance, request_context=request_context
+                    bank_id=bank_id_for_graph_maintenance, request_context=request_context, force_sweep=True
                 )
             except Exception as e:
                 logger.warning(
@@ -7035,7 +7037,9 @@ class MemoryEngine(MemoryEngineInterface):
 
         for bank_id in banks_with_source_deletes:
             try:
-                await self.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
+                await self.submit_async_graph_maintenance(
+                    bank_id=bank_id, request_context=request_context, force_sweep=True
+                )
             except Exception as e:
                 logger.warning(f"Failed to submit graph maintenance after bulk memory deletion for bank {bank_id}: {e}")
 
@@ -8010,7 +8014,9 @@ class MemoryEngine(MemoryEngineInterface):
             # a bank-wide graph-maintenance sweep to reclaim them.
             if entities_resolved and not (edit_applied and phase2_committed):
                 try:
-                    await self.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
+                    await self.submit_async_graph_maintenance(
+                        bank_id=bank_id, request_context=request_context, force_sweep=True
+                    )
                 except Exception as e:
                     logger.warning(f"Failed to submit orphan-entity cleanup after a failed edit in bank {bank_id}: {e}")
 
@@ -8023,7 +8029,11 @@ class MemoryEngine(MemoryEngineInterface):
                     logger.warning(f"Failed to submit consolidation after curating memory in bank {bank_id}: {e}")
         if need_graph:
             try:
-                await self.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
+                # An edit re-resolves entities: the ones the unit linked to before may now be
+                # unreferenced even when the unit itself is isolated (zero relink victims).
+                await self.submit_async_graph_maintenance(
+                    bank_id=bank_id, request_context=request_context, force_sweep=True
+                )
             except Exception as e:
                 logger.warning(f"Failed to submit graph maintenance after curating memory in bank {bank_id}: {e}")
 
@@ -15423,6 +15433,7 @@ class MemoryEngine(MemoryEngineInterface):
         bank_id: str,
         *,
         request_context: "RequestContext",
+        force_sweep: bool = False,
     ) -> dict[str, Any]:
         """Submit a graph-maintenance job to drain ``graph_maintenance_queue`` for a bank.
 
@@ -15431,6 +15442,14 @@ class MemoryEngine(MemoryEngineInterface):
         may not have triggered a document upsert) don't generate empty worker
         tasks. Deduplicates by bank when an existing pending job is already
         scheduled.
+
+        Args:
+            force_sweep: Skip the empty-queue short-circuit. The job's later
+                passes (orphan-entity and stale-cooccurrence sweeps) are
+                bank-wide and don't need queue rows, so callers that removed
+                unit→entity references must set this: deleting an *isolated*
+                document enqueues zero relink victims, and short-circuiting
+                there would leave its entities orphaned in the registry.
 
         Returns:
             Dict with ``operation_id``. May contain ``no_work=True`` (and a
@@ -15441,14 +15460,15 @@ class MemoryEngine(MemoryEngineInterface):
         # Cheap pre-check on the (bank_id, enqueued_at) index. Lets every
         # retain call this unconditionally without paying for an async_operations
         # row when there's nothing to do.
-        backend = await self._get_backend()
-        async with acquire_with_retry(backend) as conn:
-            has_work = await conn.fetchval(
-                f"SELECT 1 FROM {fq_table('graph_maintenance_queue')} WHERE bank_id = $1 LIMIT 1",
-                bank_id,
-            )
-        if not has_work:
-            return {"operation_id": None, "no_work": True}
+        if not force_sweep:
+            backend = await self._get_backend()
+            async with acquire_with_retry(backend) as conn:
+                has_work = await conn.fetchval(
+                    f"SELECT 1 FROM {fq_table('graph_maintenance_queue')} WHERE bank_id = $1 LIMIT 1",
+                    bank_id,
+                )
+            if not has_work:
+                return {"operation_id": None, "no_work": True}
 
         if self._operation_validator:
             from hindsight_api.extensions import BankWriteContext, BankWriteOperation

--- a/hindsight-api-slim/tests/test_graph_maintenance.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance.py
@@ -341,6 +341,68 @@ class TestDeleteDocumentEnqueue:
             # intermediate enqueue. Queue should be empty.
             assert await _queue_unit_ids(conn, bank_id) == []
 
+    @pytest.mark.asyncio
+    async def test_delete_isolated_document_prunes_its_entities(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """#3196: an isolated document has no inbound links, so the delete enqueues
+        zero relink victims. The job must still be submitted — its bank-wide orphan
+        sweep is what reclaims the entities the deleted units were the only
+        reference for."""
+        bank_id = f"test-gm-solo-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            await _insert_document(conn, bank_id, "doc-solo")
+            unit = await _insert_unit(conn, bank_id, "the only unit in the bank")
+            await _attach_unit_to_doc(conn, unit, "doc-solo")
+            entity = await _insert_entity(conn, bank_id, "solo-entity")
+            await _link_unit_entity(conn, unit, entity)
+
+        await memory.delete_document("doc-solo", bank_id, request_context=request_context)
+
+        async with pool.acquire() as conn:
+            # Nothing was ever enqueued: this delete would have short-circuited
+            # on `no_work` before the fix.
+            assert await _queue_unit_ids(conn, bank_id) == []
+            remaining = await conn.fetchval("SELECT COUNT(*) FROM entities WHERE bank_id = $1", bank_id)
+            assert remaining == 0
+
+
+class TestSubmitForceSweep:
+    @pytest.mark.asyncio
+    async def test_empty_queue_short_circuits_by_default(self, memory: MemoryEngine, request_context: RequestContext):
+        """The default stays cheap for unconditional callers (every retain)."""
+        bank_id = f"test-gm-nowork-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        result = await memory.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
+
+        assert result == {"operation_id": None, "no_work": True}
+
+    @pytest.mark.asyncio
+    async def test_force_sweep_submits_on_empty_queue(self, memory: MemoryEngine, request_context: RequestContext):
+        """`force_sweep=True` submits the job even with nothing enqueued, so the
+        orphan-entity sweep runs for callers that dropped unit→entity references."""
+        bank_id = f"test-gm-force-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            orphan = await _insert_entity(conn, bank_id, "unreferenced")
+
+        result = await memory.submit_async_graph_maintenance(
+            bank_id=bank_id, request_context=request_context, force_sweep=True
+        )
+
+        assert result.get("no_work") is not True
+        assert result["operation_id"]
+
+        async with pool.acquire() as conn:
+            # SyncTaskBackend ran the job inline: the orphan is gone.
+            assert await conn.fetchval("SELECT 1 FROM entities WHERE id = $1", orphan) is None
+
 
 # ---------------------------------------------------------------------------
 # Relink pass (Pass 1)


### PR DESCRIPTION
Fixes #3196.

## The bug

Deleting a document removes its `memory_units` / `unit_entities` by cascade but leaves its `entities` rows behind, so a bank reports `total_documents=0`, `total_nodes=0` and `entities > 0`, with stale nodes showing in the control plane.

`delete_document` already submits graph maintenance for exactly this reason — its comment says so — but `submit_async_graph_maintenance` short-circuits with `no_work=True` when `graph_maintenance_queue` is empty. That queue is only fed by `enqueue_relink_victims`, which finds nothing when no other unit links to the deleted one. So for an isolated document the job is never created, and `prune_orphan_entities` never runs. The sweep logic itself was fine; the submit gate was the bug.

## The fix

The short-circuit is a genuine optimisation for retain, which calls this unconditionally on every ingest and mustn't pay for an `async_operations` row when there's nothing to do. So it's gated rather than removed: `force_sweep=True` skips the pre-check for callers that dropped unit→entity references and need the bank-wide sweep regardless of relink work.

Passed at five call sites — the three delete paths (`delete_document`, `delete_memory_unit`, bulk `delete_memory_units`) and the two `curate_memory` paths whose comments already claimed to force a sweep but didn't. Retain's path (`_submit_post_insert_maintenance`) keeps the default and is unchanged.

## Load behaviour

`dedupe_by_bank=True` coalesces only against *pending* ops, so a burst of deletes behaves as measured:

| Regime | graph_maintenance ops for 10 document deletes |
|---|---|
| Worker backed up (ops stay `pending`) | 1 |
| Worker drains each op immediately | 10 |

It collapses to one job under load and fans out only when the worker has spare capacity. The 10-op case isn't redundant work: each delete commits after the previous sweep finished, so each has orphans no earlier sweep could have seen — the same reason `processing` is deliberately excluded from the dedupe. This is also the submit pattern retain already runs at far higher frequency.

What remains suboptimal is each job's *shape*, not their number: `prune_orphan_entities` is bank-wide, so deleting one small document scans proportional to the bank's whole entity count. Making that O(document) needs a targeted prune in its own retried post-commit transaction (it contends with retain's entity re-create protocol and can deadlock), and it still wouldn't cover the stale-cooccurrence case where both entities survive but nothing witnesses them together. Left out as a separate optimisation.

## Tests

Three added to `tests/test_graph_maintenance.py`; both regression tests were verified to fail without the fix (`assert True is not True`, `assert 1 == 0`):

- `test_delete_isolated_document_prunes_its_entities` — the filed scenario end to end: single-doc bank, one unit, one entity; after the delete the queue is empty *and* `entities` is 0.
- `TestSubmitForceSweep` — pins that the default still returns `no_work` on an empty queue, and that `force_sweep=True` submits and prunes.