### PR TITLE
fix(deps): make macOS installs work without a Rust toolchain

### DIFF
--- a/hindsight-api-slim/pyproject.toml
+++ b/hindsight-api-slim/pyproject.toml
@@ -63,7 +63,17 @@ dependencies = [
     # cp314 wheel and their sdist fails to build because PyO3 0.23.5 rejects
     # any interpreter newer than 3.13. 1.93.0 adds cp314 wheels and a PyO3 that
     # builds on 3.14.
-    "litellm>=1.93.0",
+    "litellm>=1.93.0; sys_platform != 'darwin'",
+    # macOS: litellm publishes NO macOS wheels for any release >= 1.92.0 (only
+    # manylinux + win_amd64), so every install compiles the sdist's Rust/PyO3
+    # bridge — which requires a Rust toolchain most users don't have, and as of
+    # 1.95.0 (vendored aws-smithy crates) rustc >= 1.94.1 on top. Pin to the
+    # 1.91.x line, the last releases shipping pure-python py3-none-any wheels,
+    # so a plain `uvx hindsight-api` works on a stock Mac. The 1.93.0 floor's
+    # Python 3.14 rationale doesn't apply here: pure wheels install on any
+    # interpreter without building anything. Revisit when litellm ships macOS
+    # wheels (tracked upstream in BerriAI/litellm#31261).
+    "litellm>=1.91.3,<1.92; sys_platform == 'darwin'",
     "markitdown[pdf,docx,pptx,xlsx,xls]>=0.1.4", # File to markdown conversion
     "obstore>=0.4.0", # S3/GCS/Azure object storage client (Rust-backed)
     "winloop>=0.1.0; sys_platform == 'win32'",

--- a/uv.lock
+++ b/uv.lock
@@ -1695,7 +1695,8 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-text-splitters" },
     { name = "langsmith" },
-    { name = "litellm" },
+    { name = "litellm", version = "1.91.4", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+    { name = "litellm", version = "1.93.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
     { name = "markitdown", extra = ["docx", "pdf", "pptx", "xls", "xlsx"] },
     { name = "obstore" },
     { name = "openai" },
@@ -1828,7 +1829,8 @@ requires-dist = [
     { name = "langchain-core", specifier = ">=1.2.22" },
     { name = "langchain-text-splitters", specifier = ">=0.3.0" },
     { name = "langsmith", specifier = ">=0.8.18" },
-    { name = "litellm", specifier = ">=1.93.0" },
+    { name = "litellm", marker = "sys_platform != 'darwin'", specifier = ">=1.93.0" },
+    { name = "litellm", marker = "sys_platform == 'darwin'", specifier = ">=1.91.3,<1.92" },
     { name = "llama-cpp-python", extras = ["server"], marker = "extra == 'local-llm'", specifier = ">=0.3.0" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx", "xls"], specifier = ">=0.1.4" },
     { name = "mlx", marker = "sys_platform != 'win32' and extra == 'local-ml'", specifier = ">=0.31.0" },
@@ -2482,8 +2484,47 @@ wheels = [
 
 [[package]]
 name = "litellm"
+version = "1.91.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version < '3.12' and sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/2a/a544cfdf8957accd303a99923f55c9fadc3a919d4ed6feca45e73001cade/litellm-1.91.4.tar.gz", hash = "sha256:b810d4c9e63e46908f4eeb14dde76b9811ca7101bec6290eb2522abd273c076d", size = 14875903, upload-time = "2026-07-19T02:45:39.187Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/8c/da17d91fc56532b36a27109447016d67e4618afc4447e8c4023240e920f5/litellm-1.91.4-py3-none-any.whl", hash = "sha256:d2c4bb42e99a01c8c01182a1c4aae534bcbfd7329f6ff8c634eab1e38ca58126", size = 16673648, upload-time = "2026-07-19T02:45:36.38Z" },
+]
+
+[[package]]
+name = "litellm"
 version = "1.93.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'win32'",
+]
 dependencies = [
     { name = "aiohttp" },
     { name = "click" },


### PR DESCRIPTION
## Problem

A stock macOS install of the published packages is currently broken: `@vectorize-io/hindsight-all` (and any `uvx hindsight-api` / `hindsight-embed` install) fails during daemon startup with:

```
× Failed to build `litellm==1.95.0`
error: rustc 1.93.1 is not supported by the following packages:
  aws-config@1.9.0 requires rustc 1.94.1
  ...
```

Two stacked causes, both in litellm's packaging:

1. **litellm publishes no macOS wheels for any release ≥ 1.92.0** (only manylinux + win_amd64; ≤ 1.91.4 shipped pure-python `py3-none-any` wheels). Every fresh macOS install therefore compiles the sdist's Rust/PyO3 bridge — silently requiring a Rust toolchain most users don't have.
2. **1.95.0 newly vendors the aws-smithy crates**, which require rustc ≥ 1.94.1 — so since its release, even Macs *with* a reasonably current Rust toolchain fail. Our floor `litellm>=1.93.0` resolves straight to it.

Linux and Windows are unaffected (wheels exist for cp310–cp314).

## Fix

Split the requirement with platform markers in `hindsight-api-slim/pyproject.toml`:

- `sys_platform != 'darwin'` — keep the existing `>=1.93.0` floor (unchanged resolution; CI still locks 1.93.0).
- `sys_platform == 'darwin'` — pin to `>=1.91.3,<1.92`, the last line shipping pure-python wheels, so a plain install needs **no compiler at all**. The 1.93.0 floor's Python 3.14 rationale (cp314 platform wheels) doesn't apply to pure wheels.

The 1.91.x line is only ~3 weeks older than 1.95.0 (1.91.4 published 2026-07-19), and every litellm API hindsight uses (`acompletion`, `Router`, `aembedding`, `arerank`, `drop_params`, `get_max_tokens`, `litellm.exceptions`) is present and stable there.

Revisit when litellm ships macOS wheels — tracked upstream in BerriAI/litellm#31261.

## Verification (macOS arm64)

- Reproduced the failure with the published `@vectorize-io/hindsight-all@0.8.6` → daemon start dies building litellm 1.95.0.
- Confirmed the sdist regression point: 1.93.0/1.94.0/1.94.1 vendor no aws crates and build with rustc 1.93.1; 1.95.0 requires 1.94.1.
- With this change: fresh workspace resolve picks litellm **1.91.4 (pure wheel, no build step)**; the embedded daemon boots via the `hindsight-all` npm lifecycle manager (`embedPackagePath` → this branch), health check passes, and a **real synchronous retain + recall** ran LLM fact extraction through litellm (Gemini) successfully.
- Non-darwin lock entries are byte-identical to before (litellm stays 1.93.0), so Linux CI exercises the same versions as main.

Once merged, the next core release makes this reach users automatically: `hindsight-embed@X` always launches `hindsight-api@X`, and the npm package defaults to `hindsight-embed@latest`.

Interim workaround for users on current releases: `UV_CONSTRAINT=<file with "litellm<1.95.0">` (uvx honors it), or `rustup update`.
