### PR TITLE
fix(worker): report bank-blocked consolidation tasks

### DIFF
--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -168,6 +168,17 @@ class SlotAvailability:
     """Remaining shared pool capacity (usable by any operation type)."""
 
 
+@dataclass
+class PendingBreakdown:
+    """Mutually exclusive claim states for pending operations."""
+
+    total: int = 0
+    claimable: int = 0
+    payload_null: int = 0
+    retry_blocked: int = 0
+    bank_blocked: int = 0
+
+
 class WorkerPoller:
     """
     Polls the database for pending tasks and executes them.
@@ -1339,16 +1350,16 @@ class WorkerPoller:
             global_pending = 0
             all_worker_counts: dict[str, int] = {}
             # operation_type -> aggregated bucket counts across schemas
-            pending_breakdown: dict[str, dict[str, int]] = {}
+            pending_breakdown: dict[str, PendingBreakdown] = {}
 
             async with self._backend.acquire() as conn:
                 for schema in schemas_to_query:
                     table = fq_table("async_operations", schema)
 
-                    # Bucket pending rows by the same predicates the claim query
-                    # filters on, so an operator can see why pending > 0 but
-                    # nothing is being claimed (orphaned batch_retain parents,
-                    # retry backoff, etc.).
+                    # Classify each pending row once, in claim-filter order. The
+                    # previous independent SUMs could double-count a row and did
+                    # not model consolidation's same-bank serialization, which
+                    # made blocked consolidations appear claimable (#3194).
                     # Use SUM(CASE WHEN ...) instead of COUNT(*) FILTER (WHERE ...)
                     # for Oracle compatibility — FILTER is PG-specific.
                     try:
@@ -1357,12 +1368,30 @@ class WorkerPoller:
                             SELECT
                                 operation_type,
                                 COUNT(*) AS total,
-                                SUM(CASE WHEN task_payload IS NULL THEN 1 ELSE 0 END) AS payload_null,
-                                SUM(CASE WHEN next_retry_at IS NOT NULL AND next_retry_at > now()
-                                    THEN 1 ELSE 0 END) AS retry_blocked,
-                                SUM(CASE WHEN worker_id IS NOT NULL THEN 1 ELSE 0 END) AS assigned
-                            FROM {table}
-                            WHERE status = 'pending'
+                                SUM(CASE WHEN claim_state = 'claimable' THEN 1 ELSE 0 END) AS claimable,
+                                SUM(CASE WHEN claim_state = 'payload_null' THEN 1 ELSE 0 END) AS payload_null,
+                                SUM(CASE WHEN claim_state = 'retry_blocked' THEN 1 ELSE 0 END) AS retry_blocked,
+                                SUM(CASE WHEN claim_state = 'bank_blocked' THEN 1 ELSE 0 END) AS bank_blocked
+                            FROM (
+                                SELECT
+                                    pending_op.operation_type,
+                                    CASE
+                                        WHEN pending_op.task_payload IS NULL THEN 'payload_null'
+                                        WHEN pending_op.next_retry_at IS NOT NULL
+                                            AND pending_op.next_retry_at > now() THEN 'retry_blocked'
+                                        WHEN pending_op.operation_type = 'consolidation'
+                                            AND EXISTS (
+                                                SELECT 1
+                                                FROM {table} processing_op
+                                                WHERE processing_op.operation_type = 'consolidation'
+                                                  AND processing_op.status = 'processing'
+                                                  AND processing_op.bank_id = pending_op.bank_id
+                                            ) THEN 'bank_blocked'
+                                        ELSE 'claimable'
+                                    END AS claim_state
+                                FROM {table} pending_op
+                                WHERE pending_op.status = 'pending'
+                            ) classified
                             GROUP BY operation_type
                             """
                         )
@@ -1371,13 +1400,12 @@ class WorkerPoller:
                         breakdown_rows = []
                     for br in breakdown_rows:
                         op_type = br["operation_type"] or "unknown"
-                        bucket = pending_breakdown.setdefault(
-                            op_type, {"total": 0, "payload_null": 0, "retry_blocked": 0, "assigned": 0}
-                        )
-                        bucket["total"] += br["total"]
-                        bucket["payload_null"] += br["payload_null"]
-                        bucket["retry_blocked"] += br["retry_blocked"]
-                        bucket["assigned"] += br["assigned"]
+                        bucket = pending_breakdown.setdefault(op_type, PendingBreakdown())
+                        bucket.total += br["total"]
+                        bucket.claimable += br["claimable"]
+                        bucket.payload_null += br["payload_null"]
+                        bucket.retry_blocked += br["retry_blocked"]
+                        bucket.bank_blocked += br["bank_blocked"]
                         global_pending += br["total"]
 
                     try:
@@ -1495,20 +1523,20 @@ class WorkerPoller:
             logger.debug(f"Pool stats unavailable: {e}")
             return "unavailable"
 
-    def _log_pending_breakdown(self, breakdown: dict[str, dict[str, int]]) -> None:
+    def _log_pending_breakdown(self, breakdown: dict[str, PendingBreakdown]) -> None:
         """Emit one [PENDING_BREAKDOWN] line bucketing pending rows by claimability.
 
-        Each bucket mirrors a predicate in the claim query:
+        Each pending row belongs to exactly one bucket:
           * payload_null   - row has no task_payload (e.g. batch_retain parent
                              whose reconciliation never fired); claim query
                              skips it forever
           * retry_blocked  - next_retry_at is still in the future
-          * assigned       - worker_id already set; another worker owns it
+          * bank_blocked   - consolidation is serialized behind another
+                             processing consolidation for the same bank
+          * claimable      - row passes the durable claim predicates
 
-        ``claimable`` is the residual that *should* be picked up on the next
-        poll. If ``claimable > 0`` while workers report free slots, the bug is
-        somewhere else (lock contention, tenant discovery, etc.) - this line
-        narrows the search.
+        A worker_id on a pending row is not a blocker: the claim transaction
+        overwrites it when moving the row to processing.
         """
         if not breakdown:
             return
@@ -1516,13 +1544,21 @@ class WorkerPoller:
         parts = []
         for op_type in sorted(breakdown):
             b = breakdown[op_type]
-            claimable = b["total"] - b["payload_null"] - b["retry_blocked"] - b["assigned"]
             parts.append(
-                f"{op_type}: total={b['total']} claimable={claimable} "
-                f"payload_null={b['payload_null']} retry_blocked={b['retry_blocked']} "
-                f"assigned={b['assigned']}"
+                f"{op_type}: total={b.total} claimable={b.claimable} "
+                f"payload_null={b.payload_null} retry_blocked={b.retry_blocked} "
+                f"bank_blocked={b.bank_blocked}"
             )
         logger.info(f"[PENDING_BREAKDOWN] {' | '.join(parts)}")
+
+        consolidation = breakdown.get("consolidation")
+        if consolidation is not None and consolidation.bank_blocked > 0:
+            logger.info(
+                f"[CONSOLIDATION_BLOCKED] {consolidation.bank_blocked} pending consolidation task(s) are waiting "
+                "for a processing consolidation on the same bank. Run 'hindsight-admin worker-status' to verify "
+                "the owner; if that worker is no longer running, release its tasks with "
+                "'hindsight-admin decommission-worker <worker-id>'."
+            )
 
     def _log_per_task_lines(self, active_tasks: dict[str, ActiveTaskInfo], now: float) -> None:
         """Emit one [WORKER_TASK] line per in-flight task and dump stuck stacks.

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -2921,21 +2921,40 @@ async def test_pending_breakdown_explains_unclaimable_rows(pool, backend, clean_
     bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
     await _ensure_bank(pool, bank_id)
 
+    blocked_bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+    await _ensure_bank(pool, blocked_bank_id)
+    await pool.execute(
+        """
+        INSERT INTO async_operations
+            (operation_id, bank_id, operation_type, status, task_payload, worker_id)
+        VALUES ($1, $2, 'consolidation', 'processing', $3::jsonb, 'dead-worker')
+        """,
+        uuid.uuid4(),
+        blocked_bank_id,
+        json.dumps({"type": "consolidation", "bank_id": blocked_bank_id}),
+    )
+
     # Mix of pending rows that the claim query treats differently:
-    #   * payload_null  - batch_retain parent (orphan candidate)
+    #   * payload_null  - batch_retain parent (also future-dated to verify precedence)
     #   * retry_blocked - failed once, scheduled an hour out
-    #   * assigned      - worker_id stamped (e.g. left over from a prior crash
-    #                     that re-queued without clearing worker_id)
+    #   * worker_id set  - still claimable; claiming overwrites a stale value
     #   * claimable     - normal retain ready to go
-    #   * consolidation - normal consolidation, also claimable
+    #   * consolidation - one claimable, one blocked by same-bank processing
     rows = [
-        ("batch_retain", None, None, None),  # payload_null
-        ("retain", json.dumps({"type": "test"}), "future", None),  # retry_blocked
-        ("retain", json.dumps({"type": "test"}), None, "ghost-worker"),  # assigned
-        ("retain", json.dumps({"type": "test"}), None, None),  # claimable
-        ("consolidation", json.dumps({"type": "test"}), None, None),  # claimable
+        (bank_id, "batch_retain", None, "future", "ghost-worker"),  # payload_null wins
+        (bank_id, "retain", json.dumps({"type": "test"}), "future", None),  # retry_blocked
+        (bank_id, "retain", json.dumps({"type": "test"}), None, "ghost-worker"),  # claimable
+        (bank_id, "retain", json.dumps({"type": "test"}), None, None),  # claimable
+        (bank_id, "consolidation", json.dumps({"type": "test"}), None, None),  # claimable
+        (
+            blocked_bank_id,
+            "consolidation",
+            json.dumps({"type": "test"}),
+            None,
+            None,
+        ),  # bank_blocked
     ]
-    for op_type, payload, retry_marker, worker_id in rows:
+    for row_bank_id, op_type, payload, retry_marker, worker_id in rows:
         op_id = uuid.uuid4()
         await pool.execute(
             """
@@ -2947,7 +2966,7 @@ async def test_pending_breakdown_explains_unclaimable_rows(pool, backend, clean_
                     $6)
             """,
             op_id,
-            bank_id,
+            row_bank_id,
             op_type,
             payload,
             retry_marker,
@@ -2980,9 +2999,21 @@ async def test_pending_breakdown_explains_unclaimable_rows(pool, backend, clean_
 
     assert buckets["batch_retain"]["payload_null"] >= 1
     assert buckets["retain"]["retry_blocked"] >= 1
-    assert buckets["retain"]["assigned"] >= 1
-    assert buckets["retain"]["claimable"] >= 1
+    assert buckets["retain"]["claimable"] >= 2
     assert buckets["consolidation"]["claimable"] >= 1
+    assert buckets["consolidation"]["bank_blocked"] >= 1
+
+    # Every row must be classified exactly once. Independent counters used to
+    # overlap and made the residual claimable count inaccurate.
+    for bucket in buckets.values():
+        assert bucket["total"] == (
+            bucket["claimable"] + bucket["payload_null"] + bucket["retry_blocked"] + bucket["bank_blocked"]
+        )
+
+    blocked_lines = [r.message for r in caplog.records if r.message.startswith("[CONSOLIDATION_BLOCKED]")]
+    assert len(blocked_lines) == 1, f"Expected exactly one blocked-consolidation line, got: {blocked_lines}"
+    assert "hindsight-admin worker-status" in blocked_lines[0]
+    assert "hindsight-admin decommission-worker <worker-id>" in blocked_lines[0]
 
 
 class TestSummariseChildErrorMessages:


### PR DESCRIPTION
## Summary

- classify pending-operation diagnostics into mutually exclusive buckets that match the durable claim predicates
- report a consolidation as `bank_blocked` when another processing consolidation owns the same bank
- emit an actionable recovery hint using `worker-status` and `decommission-worker` after the owner is confirmed dead
- cover the #3194 state and overlapping filters with a regression test

## Root cause

The claim path intentionally serializes consolidation per bank. A processing consolidation owned by an earlier worker therefore blocks a pending consolidation for that bank, but `[PENDING_BREAKDOWN]` did not model this rule and incorrectly reported the pending row as `claimable=1`.

This preserves the serialization guard. Automatically taking over an old-looking processing task would risk running two live consolidations for the same bank because worker ownership is not protected by a lease or fencing token. The new diagnostic identifies the actual blocker and points operators to the existing explicit recovery path.

## Tests

- `./scripts/hooks/lint.sh`
- `./scripts/hooks/check-unused.sh`
- `cd hindsight-api-slim && uv run pytest tests/test_worker.py -q` (104 passed)
- `cd hindsight-api-slim && uv run pytest tests/test_worker.py::test_pending_breakdown_explains_unclaimable_rows -q`

Fixes #3194
