### PR TITLE
fix: remove stale global memory_units vector index via migration; make reconcile hands-off

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/f2a6d8c4b1e9_drop_stale_global_memory_units_vector_index.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/f2a6d8c4b1e9_drop_stale_global_memory_units_vector_index.py
@@ -1,0 +1,85 @@
+"""Repair: drop the stale global memory_units vector index on per-bank backends.
+
+Revision ID: f2a6d8c4b1e9
+Revises: c1e7a9d3f5b2
+Create Date: 2026-08-06
+
+Migration d5e6f7a8b9c0 dropped the global ``idx_memory_units_embedding`` for
+per-bank backends (every vector search is bank + fact_type scoped and served
+by the ``idx_mu_emb_*`` partial indexes; the global index is never chosen by
+the planner). However, older versions of the post-migration reconcile
+(``ensure_vector_extension``) recreated the index when they found none, so
+schemas that were provisioned or reconciled in that window carry it to this
+day — paying a second vector graph insertion on every ``memory_units`` write
+for an index no query uses.
+
+This repair drops the leftover index. It is intentionally a migration, not
+runtime reconcile behavior: ``DROP INDEX`` takes an ACCESS EXCLUSIVE lock on
+``memory_units``, which belongs in the versioned, once-per-schema migration
+path — not in code that runs at unpredictable times during startup or tenant
+provisioning. The reconcile now leaves memory_units vector-index DDL to
+migrations entirely on per-bank backends.
+
+ScaNN deployments keep the global index by design (filtered vector search over
+a global index; per-bank partial indexes cannot be built safely there), so the
+migration is a no-op for them.
+"""
+
+import os
+from collections.abc import Sequence
+
+from alembic import context, op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "f2a6d8c4b1e9"
+down_revision: str | Sequence[str] | None = "c1e7a9d3f5b2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _pg_schema_prefix() -> str:
+    """Schema-qualifier for raw SQL on PG (multi-tenant search_path)."""
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def _configured_vector_extension() -> str:
+    ext = os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector").lower()
+    if ext not in {"pgvector", "pgvectorscale", "vchord", "scann"}:
+        raise ValueError(
+            f"Invalid HINDSIGHT_API_VECTOR_EXTENSION: {ext}. Must be 'pgvector', 'vchord', 'pgvectorscale', or 'scann'"
+        )
+    return ext
+
+
+def _pg_upgrade() -> None:
+    # ScaNN uses a global vector index by design — nothing stale to repair.
+    if _configured_vector_extension() == "scann":
+        return
+    schema = _pg_schema_prefix()
+    # DROP INDEX needs ACCESS EXCLUSIVE on memory_units. While it waits for
+    # in-flight transactions, every new query on the table queues behind it,
+    # so on a write-busy schema an unbounded wait can pile up traffic. Fail
+    # fast instead: the migration errors, the schema stays below head, and
+    # the next migration pass retries — preferable to freezing the table.
+    # SET LOCAL scopes the timeout to this migration's transaction.
+    op.execute("SET LOCAL lock_timeout = '10s'")
+    op.execute(f"DROP INDEX IF EXISTS {schema}idx_memory_units_embedding")
+
+
+def _pg_downgrade() -> None:
+    # Intentional no-op: recreating a potentially multi-GB vector index that no
+    # query uses is not a safe downgrade action. Downgrading past d5e6f7a8b9c0
+    # restores the global index for deployments that genuinely need it.
+    pass
+
+
+def upgrade() -> None:
+    # PG-only repair: the stale index is a PostgreSQL artifact of the old
+    # reconcile; Oracle deployments never had a reconcile that created it.
+    run_for_dialect(pg=_pg_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade)

--- a/hindsight-api-slim/hindsight_api/migrations.py
+++ b/hindsight-api-slim/hindsight_api/migrations.py
@@ -624,33 +624,51 @@ def ensure_vector_extension(
             ).scalar()
 
             # Check current index type by querying pg_indexes
-            current_index_info = conn.execute(
+            current_index_rows = conn.execute(
                 text("""
-                    SELECT indexdef
+                    SELECT indexdef, indexname
                     FROM pg_indexes
                     WHERE schemaname = :schema
                       AND tablename = :table_name
                       AND indexname LIKE :index_pattern
                 """),
                 {"schema": schema_name, "table_name": table_name, "index_pattern": "%embedding%"},
-            ).fetchone()
+            ).fetchall()
 
-            if not current_index_info:
-                if table_name == "memory_units" and uses_per_bank_vector_indexes(target_ext):
-                    # Per-bank backends never use a GLOBAL memory_units vector index.
-                    # Every vector search is bank + fact_type scoped and served by the
-                    # per-(bank, fact_type) partial indexes created at bank-creation time
-                    # (bank_utils.create_bank_vector_indexes); the planner never picks a
-                    # global index when bank_id is in the WHERE clause, which is exactly
-                    # why migration d5e6f7a8b9c0 drops it for these backends. So don't
-                    # create one here either — not even on an empty schema with no per-bank
-                    # indexes yet (those are built when the first bank is created). Verified
-                    # via EXPLAIN: the query uses idx_mu_emb_* whether or not the global
-                    # index exists, so creating it is dead weight.
+            if table_name == "memory_units" and uses_per_bank_vector_indexes(target_ext):
+                # Per-bank backends never use a GLOBAL memory_units vector index.
+                # Every vector search is bank + fact_type scoped and served by the
+                # per-(bank, fact_type) partial indexes created at bank-creation time
+                # (bank_utils.create_bank_vector_indexes); the planner never picks a
+                # global index when bank_id is in the WHERE clause, which is exactly
+                # why migration d5e6f7a8b9c0 drops it for these backends.
+                #
+                # The reconcile is strictly hands-off here, in BOTH directions:
+                # never create the index (dead weight — an older version of this
+                # branch did, which is how legacy schemas ended up carrying it),
+                # and never drop or rebuild one that exists. Runtime DROP/CREATE
+                # INDEX takes an ACCESS EXCLUSIVE lock on memory_units at
+                # unpredictable times (startup, tenant provisioning); index DDL
+                # belongs in the versioned migration path. Leftover globals are
+                # removed by migration f2a6d8c4b1e9. This continue also keeps
+                # memory_units out of the type-mismatch reconcile below, which
+                # would otherwise recreate a global index with the new type on a
+                # backend switch.
+                if current_index_rows:
+                    stale_names = ", ".join(row[1] for row in current_index_rows)
+                    logger.info(
+                        f"Global vector index ({stale_names}) present on {schema_name}.memory_units "
+                        f"with per-bank backend ({target_ext}); left untouched — removed by "
+                        f"migration f2a6d8c4b1e9"
+                    )
+                else:
                     logger.debug(
                         f"Per-bank vector backend ({target_ext}); skipping global {index_name} creation on {table_name}"
                     )
-                    continue
+                continue
+
+            current_index_info = current_index_rows[0] if current_index_rows else None
+            if not current_index_info:
                 logger.warning(f"No embedding index found for {table_name}, will create it if safe")
                 mismatched_tables.append((table_name, index_name, None, row_count))
                 continue

--- a/hindsight-api-slim/tests/test_ensure_vector_no_global_index.py
+++ b/hindsight-api-slim/tests/test_ensure_vector_no_global_index.py
@@ -1,20 +1,30 @@
-"""ensure_vector_extension must not create the (unused) global memory_units index.
+"""The global memory_units vector index on per-bank backends: never created, migrated away.
 
 For per-bank backends (pgvector / pgvectorscale / vchord) every vector search is
 bank + fact_type scoped and served by the per-(bank, fact_type) partial indexes
 created at bank-creation time. The global `idx_memory_units_embedding` is never
-chosen by the planner (migration d5e6f7a8b9c0 drops it for exactly this reason),
-so the post-migration reconcile must not recreate it on a fresh schema.
+chosen by the planner (migration d5e6f7a8b9c0 drops it for exactly this reason).
+
+Contract under test:
+- the post-migration reconcile (`ensure_vector_extension`) must not recreate the
+  index on a fresh schema;
+- the reconcile must be hands-off when a legacy schema still carries the index
+  (no runtime DROP INDEX — that DDL belongs in the migration path);
+- migration f2a6d8c4b1e9 removes the leftover index.
 """
 
 import asyncio
+from pathlib import Path
 
 import pytest
-from sqlalchemy import create_engine, text
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import Connection, create_engine, text
 
+import hindsight_api
 from hindsight_api._vector_index import uses_per_bank_vector_indexes
 from hindsight_api.config import HindsightConfig
-from hindsight_api.migrations import ensure_vector_extension, run_migrations
+from hindsight_api.migrations import ensure_vector_extension, run_migrations, to_libpq_url
 
 
 @pytest.fixture(scope="module")
@@ -30,21 +40,50 @@ def vec_db_url():
         loop.close()
 
 
-def test_per_bank_backend_does_not_create_global_memory_units_index(vec_db_url):
-    config = HindsightConfig.from_env()
-    vec = config.vector_extension
+def _skip_unless_per_bank_backend() -> str:
+    vec = HindsightConfig.from_env().vector_extension
     if not uses_per_bank_vector_indexes(vec):
         pytest.skip(f"backend {vec!r} uses a global vector index by design (no per-bank indexes)")
+    return vec
 
-    schema = "vecidx_fresh"
 
-    engine = create_engine(vec_db_url)
+def _global_index_count(conn: Connection, schema: str) -> int:
+    return conn.execute(
+        text(
+            "SELECT COUNT(*) FROM pg_indexes "
+            "WHERE schemaname = :schema AND tablename = 'memory_units' "
+            "AND indexname = 'idx_memory_units_embedding'"
+        ),
+        {"schema": schema},
+    ).scalar()
+
+
+def _reset_schema(db_url: str, schema: str) -> None:
+    engine = create_engine(db_url)
     try:
         with engine.connect() as conn:
             conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
             conn.commit()
     finally:
         engine.dispose()
+
+
+def _alembic_config(db_url: str, schema: str) -> Config:
+    """Programmatic alembic config matching what run_migrations builds."""
+    cfg = Config()
+    cfg.set_main_option("script_location", str(Path(hindsight_api.__file__).parent / "alembic"))
+    cfg.set_main_option("sqlalchemy.url", to_libpq_url(db_url))
+    cfg.set_main_option("path_separator", "os")
+    cfg.set_main_option("target_schema", schema)
+    return cfg
+
+
+@pytest.mark.xdist_group("vecidx_pg0")
+def test_per_bank_backend_does_not_create_global_memory_units_index(vec_db_url):
+    vec = _skip_unless_per_bank_backend()
+
+    schema = "vecidx_fresh"
+    _reset_schema(vec_db_url, schema)
 
     run_migrations(vec_db_url, schema=schema)
     # Fresh, empty schema (no banks yet) → the reconcile must be a no-op for the
@@ -54,17 +93,85 @@ def test_per_bank_backend_does_not_create_global_memory_units_index(vec_db_url):
     engine = create_engine(vec_db_url)
     try:
         with engine.connect() as conn:
-            global_index_count = conn.execute(
-                text(
-                    "SELECT COUNT(*) FROM pg_indexes "
-                    "WHERE schemaname = :schema AND tablename = 'memory_units' "
-                    "AND indexname = 'idx_memory_units_embedding'"
-                ),
-                {"schema": schema},
-            ).scalar()
+            global_index_count = _global_index_count(conn, schema)
             conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
             conn.commit()
     finally:
         engine.dispose()
 
     assert global_index_count == 0
+
+
+@pytest.mark.xdist_group("vecidx_pg0")
+def test_reconcile_leaves_stale_global_index_untouched(vec_db_url):
+    """The reconcile must not perform runtime index DDL: a leftover global index
+    stays until the migration removes it (no surprise ACCESS EXCLUSIVE locks at
+    startup/provisioning time)."""
+    vec = _skip_unless_per_bank_backend()
+
+    schema = "vecidx_stale_global"
+    _reset_schema(vec_db_url, schema)
+    run_migrations(vec_db_url, schema=schema)
+
+    engine = create_engine(vec_db_url)
+    try:
+        # Simulate the legacy state: an older reconcile recreated the global
+        # index after migration d5e6f7a8b9c0 dropped it.
+        with engine.connect() as conn:
+            conn.execute(
+                text(
+                    f'CREATE INDEX idx_memory_units_embedding ON "{schema}".memory_units '
+                    "USING hnsw (embedding vector_cosine_ops)"
+                )
+            )
+            conn.commit()
+            assert _global_index_count(conn, schema) == 1
+
+        ensure_vector_extension(vec_db_url, vector_extension=vec, schema=schema)
+
+        with engine.connect() as conn:
+            count_after = _global_index_count(conn, schema)
+            conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+            conn.commit()
+    finally:
+        engine.dispose()
+
+    assert count_after == 1
+
+
+@pytest.mark.xdist_group("vecidx_pg0")
+def test_migration_drops_stale_global_index(vec_db_url):
+    """Upgrading from the pre-repair revision removes a leftover global index."""
+    _skip_unless_per_bank_backend()
+
+    schema = "vecidx_migration_repair"
+    _reset_schema(vec_db_url, schema)
+    run_migrations(vec_db_url, schema=schema)
+
+    cfg = _alembic_config(vec_db_url, schema)
+    # Step back below the repair migration, then plant the legacy index the
+    # way an older reconcile would have left it.
+    command.downgrade(cfg, "f2a6d8c4b1e9@-1")
+
+    engine = create_engine(vec_db_url)
+    try:
+        with engine.connect() as conn:
+            conn.execute(
+                text(
+                    f'CREATE INDEX idx_memory_units_embedding ON "{schema}".memory_units '
+                    "USING hnsw (embedding vector_cosine_ops)"
+                )
+            )
+            conn.commit()
+            assert _global_index_count(conn, schema) == 1
+
+        command.upgrade(cfg, "heads")
+
+        with engine.connect() as conn:
+            count_after = _global_index_count(conn, schema)
+            conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+            conn.commit()
+    finally:
+        engine.dispose()
+
+    assert count_after == 0


### PR DESCRIPTION
## Problem

For per-bank vector backends (pgvector / pgvectorscale / vchord), every vector search is bank + fact_type scoped and served by the per-(bank, fact_type) partial indexes (`idx_mu_emb_*`). Migration `d5e6f7a8b9c0` drops the global `idx_memory_units_embedding` for exactly this reason, and `ensure_vector_extension` refuses to *create* it on these backends ("dead weight").

However, deployments that ran an **older version of the reconcile** — which recreated the global index after the migration dropped it — carry it forever: the "index type OK" path sees a matching index type and keeps it. Nothing ever cleans it up.

The cost is not just disk. Every `memory_units` INSERT pays a **second vector graph insertion** (hundreds to thousands of high-dimensional distance computations, growing with index size) into an index no query uses. Under a write-heavy multi-tenant workload this roughly **doubles vector-indexing CPU on the primary** and adds significant WAL volume.

## Fix — split by responsibility

**1. Migration `f2a6d8c4b1e9` drops the leftover index.** Index DDL belongs in the versioned, once-per-schema migration path — `DROP INDEX` takes an `ACCESS EXCLUSIVE` lock on `memory_units` and must not fire at unpredictable times from runtime code (startup, tenant provisioning). No-op for ScaNN (global index is by design there); PG-only (Oracle never ran the old reconcile). The drop runs under `SET LOCAL lock_timeout = '10s'` — on a write-busy schema it fails fast and retries on the next migration pass instead of queuing all traffic behind the ACCESS EXCLUSIVE wait.

**2. `ensure_vector_extension` becomes strictly hands-off** for `memory_units` on per-bank backends: never creates the global index (as before), never drops one, and no longer routes it through the type-mismatch reconcile — which would otherwise **recreate** a global index with the new type on a backend switch (a second latent path to the same problem).

## Test plan

- [x] `test_migration_drops_stale_global_index` — alembic `downgrade f2a6d8c4b1e9@-1` → plant the legacy index → `upgrade heads` → index gone
- [x] `test_reconcile_leaves_stale_global_index_untouched` — reconcile performs no runtime DDL on a legacy schema
- [x] `test_per_bank_backend_does_not_create_global_memory_units_index` — fresh schemas still get no global index
- [x] Full `test_migration_shape.py` suite passes with the new revision (dialect dispatcher, autocommit rules)
- [x] `ruff` / `ty` clean

Note: tests in this module share one embedded-postgres instance on a fixed port, so they're pinned to a single `xdist_group`.
