### PR TITLE
feat(claude-code,codex): tell existing users about the Coding Agents plugin

### DIFF
--- a/hindsight-integrations/claude-code/scripts/lib/config.py
+++ b/hindsight-integrations/claude-code/scripts/lib/config.py
@@ -39,6 +39,7 @@ DEFAULTS = {
     "retainMetadata": {},
     "recallAdditionalBanks": [],
     # Connection
+    "upgradeNotice": True,  # show the superseded-by-coding-agents notice (capped, see lib/upgrade_notice.py)
     "hindsightApiUrl": None,
     "hindsightApiToken": None,
     "apiPort": 9077,

--- a/hindsight-integrations/claude-code/scripts/lib/upgrade_notice.py
+++ b/hindsight-integrations/claude-code/scripts/lib/upgrade_notice.py
@@ -19,20 +19,18 @@ DOCS_URL = "https://hindsight.vectorize.io/sdks/integrations/coding-agents"
 MIGRATION_URL = f"{DOCS_URL}#migrating-from-the-per-agent-plugins"
 
 NOTICE = (
-    "⚠️  Hindsight: this Claude Code plugin is DEPRECATED, replaced by the Coding Agents plugin.\n"
+    "The current Hindsight Claude Code plugin is DEPRECATED, replaced by the Coding Agents "
+    "plugin.\n"
     "\n"
     "One install now covers Claude Code, Codex, Cursor, Copilot, opencode, Kilo, Grok, "
-    "Antigravity, Devin and Cline, and they all share a single memory per repo instead of one bank "
-    "per agent — so context from any agent is there for the next one. It also adds knowledge pages "
-    "kept current from your git history, automatic seeding of a new repo, and a local daemon mode "
-    "that needs no account.\n"
+    "Antigravity,\n"
+    "Devin and Cline, and they all share a single memory per repository, leveraging the Hindsight "
+    "Knowledge Page (v0.9.x and onwards).\n"
     "\n"
-    "    npm install -g @vectorize-io/hindsight-coding-agents\n"
-    "    hindsight-coding-agents install claude-code --import-conversations\n"
-    "\n"
-    f"Migration guide: {MIGRATION_URL}\n"
+    f"See the migration guide: {MIGRATION_URL}\n"
     "Your Hindsight server and token carry over automatically; past conversations are re-imported "
-    'from local transcripts. Silence this with "upgradeNotice": false in '
+    "from\n"
+    'local transcripts. Silence this with "upgradeNotice": false in '
     "~/.hindsight/claude-code.json"
 )
 

--- a/hindsight-integrations/claude-code/scripts/lib/upgrade_notice.py
+++ b/hindsight-integrations/claude-code/scripts/lib/upgrade_notice.py
@@ -1,0 +1,72 @@
+"""One-line, rate-limited notice that this plugin is superseded.
+
+This plugin still works and still receives fixes, but development has moved to
+`@vectorize-io/hindsight-coding-agents`. Someone who installed this a year ago has no reason to
+ever learn that, so the session itself has to say it — a changelog entry reaches nobody.
+
+Restraint is the whole design:
+
+  * capped at MAX_SHOWINGS in total, never more often than every MIN_INTERVAL_DAYS, so it can't
+    become a recurring interruption
+  * one `upgradeNotice: false` in the user config silences it permanently, and the text says so
+  * any failure — unreadable state, unwritable state dir — returns None rather than raising. A
+    promotional message must never be the reason someone's session breaks.
+
+Deliberately duplicated in the codex plugin rather than shared: the two ship as independent
+packages with no common module path, and ~40 lines is cheaper than inventing one.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from .state import read_state, write_state
+
+STATE_FILE = "upgrade_notice.json"
+MAX_SHOWINGS = 3
+MIN_INTERVAL_DAYS = 7
+
+NOTICE = (
+    "💡 Hindsight: this Claude Code plugin is superseded by the Coding Agents plugin — one "
+    "install covering Claude Code, Codex, Cursor, Copilot, opencode, Kilo, Grok, Antigravity, "
+    "Devin and Cline, with a single memory per repo that every agent shares instead of one bank "
+    "per agent.\n"
+    "\n"
+    "    npm install -g @vectorize-io/hindsight-coding-agents\n"
+    "    hindsight-coding-agents install claude-code --import-conversations\n"
+    "\n"
+    "Your Hindsight server and token carry over automatically; past conversations are re-imported "
+    'from local transcripts. Silence this with "upgradeNotice": false in '
+    "~/.hindsight/claude-code.json"
+)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def upgrade_notice(config: dict, now: datetime | None = None) -> str | None:
+    """Return the notice to show this session, or None to stay quiet."""
+    try:
+        if not config.get("upgradeNotice", True):
+            return None
+
+        now = now or _now()
+        state = read_state(STATE_FILE, {}) or {}
+        shown = state.get("shown", 0)
+        if not isinstance(shown, int) or shown >= MAX_SHOWINGS:
+            return None
+
+        last_raw = state.get("last")
+        if last_raw:
+            try:
+                last = datetime.fromisoformat(str(last_raw))
+                if last.tzinfo is None:
+                    last = last.replace(tzinfo=timezone.utc)
+                if now - last < timedelta(days=MIN_INTERVAL_DAYS):
+                    return None
+            except ValueError:
+                pass  # unparseable timestamp: treat as never shown rather than nagging forever
+
+        write_state(STATE_FILE, {"shown": shown + 1, "last": now.isoformat()})
+        return NOTICE
+    except Exception:
+        return None

--- a/hindsight-integrations/claude-code/scripts/lib/upgrade_notice.py
+++ b/hindsight-integrations/claude-code/scripts/lib/upgrade_notice.py
@@ -1,28 +1,21 @@
-"""One-line, rate-limited notice that this plugin is superseded.
+"""Notice that this plugin is superseded, shown at every session start.
 
-This plugin still works and still receives fixes, but development has moved to
-`@vectorize-io/hindsight-coding-agents`. Someone who installed this a year ago has no reason to
-ever learn that, so the session itself has to say it — a changelog entry reaches nobody.
+This plugin still works, but development has moved to
+`@vectorize-io/hindsight-coding-agents`. Someone who installed this a year ago has no way to learn
+that — a changelog entry reaches nobody — so the session itself says it.
 
-Restraint is the whole design:
+Shown every session rather than a few times: a notice that appears once is missed, and this one has
+a concrete action attached. `"upgradeNotice": false` in the user config turns it off permanently,
+and the message says so, which is what keeps that acceptable.
 
-  * capped at MAX_SHOWINGS in total, never more often than every MIN_INTERVAL_DAYS, so it can't
-    become a recurring interruption
-  * one `upgradeNotice: false` in the user config silences it permanently, and the text says so
-  * any failure — unreadable state, unwritable state dir — returns None rather than raising. A
-    promotional message must never be the reason someone's session breaks.
+Any failure returns None rather than raising. A promotional message must never be the reason
+someone's session breaks.
 
 Deliberately duplicated in the codex plugin rather than shared: the two ship as independent
-packages with no common module path, and ~40 lines is cheaper than inventing one.
+packages with no common module path.
 """
 
-from datetime import datetime, timedelta, timezone
-
-from .state import read_state, write_state
-
-STATE_FILE = "upgrade_notice.json"
-MAX_SHOWINGS = 3
-MIN_INTERVAL_DAYS = 7
+DOCS_URL = "https://hindsight.vectorize.io/sdks/integrations/coding-agents"
 
 NOTICE = (
     "💡 Hindsight: this Claude Code plugin is superseded by the Coding Agents plugin — one "
@@ -33,40 +26,16 @@ NOTICE = (
     "    npm install -g @vectorize-io/hindsight-coding-agents\n"
     "    hindsight-coding-agents install claude-code --import-conversations\n"
     "\n"
+    f"Docs: {DOCS_URL}\n"
     "Your Hindsight server and token carry over automatically; past conversations are re-imported "
     'from local transcripts. Silence this with "upgradeNotice": false in '
     "~/.hindsight/claude-code.json"
 )
 
 
-def _now() -> datetime:
-    return datetime.now(timezone.utc)
-
-
-def upgrade_notice(config: dict, now: datetime | None = None) -> str | None:
-    """Return the notice to show this session, or None to stay quiet."""
+def upgrade_notice(config: dict) -> str | None:
+    """Return the notice, or None when the user has turned it off."""
     try:
-        if not config.get("upgradeNotice", True):
-            return None
-
-        now = now or _now()
-        state = read_state(STATE_FILE, {}) or {}
-        shown = state.get("shown", 0)
-        if not isinstance(shown, int) or shown >= MAX_SHOWINGS:
-            return None
-
-        last_raw = state.get("last")
-        if last_raw:
-            try:
-                last = datetime.fromisoformat(str(last_raw))
-                if last.tzinfo is None:
-                    last = last.replace(tzinfo=timezone.utc)
-                if now - last < timedelta(days=MIN_INTERVAL_DAYS):
-                    return None
-            except ValueError:
-                pass  # unparseable timestamp: treat as never shown rather than nagging forever
-
-        write_state(STATE_FILE, {"shown": shown + 1, "last": now.isoformat()})
-        return NOTICE
+        return None if not config.get("upgradeNotice", True) else NOTICE
     except Exception:
         return None

--- a/hindsight-integrations/claude-code/scripts/lib/upgrade_notice.py
+++ b/hindsight-integrations/claude-code/scripts/lib/upgrade_notice.py
@@ -1,7 +1,7 @@
-"""Notice that this plugin is superseded, shown at every session start.
+"""Deprecation notice for this plugin, shown at every session start.
 
-This plugin still works, but development has moved to
-`@vectorize-io/hindsight-coding-agents`. Someone who installed this a year ago has no way to learn
+This plugin still works and is not going to stop working, but it is deprecated: development has
+moved to `@vectorize-io/hindsight-coding-agents`. Someone who installed this a year ago has no way to learn
 that — a changelog entry reaches nobody — so the session itself says it.
 
 Shown every session rather than a few times: a notice that appears once is missed, and this one has
@@ -16,17 +16,21 @@ packages with no common module path.
 """
 
 DOCS_URL = "https://hindsight.vectorize.io/sdks/integrations/coding-agents"
+MIGRATION_URL = f"{DOCS_URL}#migrating-from-the-per-agent-plugins"
 
 NOTICE = (
-    "💡 Hindsight: this Claude Code plugin is superseded by the Coding Agents plugin — one "
-    "install covering Claude Code, Codex, Cursor, Copilot, opencode, Kilo, Grok, Antigravity, "
-    "Devin and Cline, with a single memory per repo that every agent shares instead of one bank "
-    "per agent.\n"
+    "⚠️  Hindsight: this Claude Code plugin is DEPRECATED, replaced by the Coding Agents plugin.\n"
+    "\n"
+    "One install now covers Claude Code, Codex, Cursor, Copilot, opencode, Kilo, Grok, "
+    "Antigravity, Devin and Cline, and they all share a single memory per repo instead of one bank "
+    "per agent — so context from any agent is there for the next one. It also adds knowledge pages "
+    "kept current from your git history, automatic seeding of a new repo, and a local daemon mode "
+    "that needs no account.\n"
     "\n"
     "    npm install -g @vectorize-io/hindsight-coding-agents\n"
     "    hindsight-coding-agents install claude-code --import-conversations\n"
     "\n"
-    f"Docs: {DOCS_URL}\n"
+    f"Migration guide: {MIGRATION_URL}\n"
     "Your Hindsight server and token carry over automatically; past conversations are re-imported "
     'from local transcripts. Silence this with "upgradeNotice": false in '
     "~/.hindsight/claude-code.json"

--- a/hindsight-integrations/claude-code/scripts/session_start.py
+++ b/hindsight-integrations/claude-code/scripts/session_start.py
@@ -17,10 +17,18 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from lib.config import debug_log, load_config
 from lib.daemon import get_api_url, prestart_daemon_background
+from lib.upgrade_notice import upgrade_notice
 
 
 def main():
     config = load_config()
+
+    # Emitted BEFORE any of the early returns below: whether memory is enabled, or the server is
+    # even reachable, has no bearing on whether this plugin has been superseded. `systemMessage` is
+    # the channel Claude Code shows to the USER (additionalContext would only reach the model).
+    notice = upgrade_notice(config)
+    if notice:
+        print(json.dumps({"systemMessage": notice, "hookSpecificOutput": {"hookEventName": "SessionStart"}}))
 
     if not config.get("autoRecall") and not config.get("autoRetain"):
         debug_log(config, "Both autoRecall and autoRetain disabled, skipping session start")

--- a/hindsight-integrations/claude-code/settings.json
+++ b/hindsight-integrations/claude-code/settings.json
@@ -9,20 +9,30 @@
   "recallBudget": "mid",
   "recallMaxTokens": 1024,
   "recallMinScores": {},
-  "recallTypes": ["observation"],
+  "recallTypes": [
+    "observation"
+  ],
   "recallContextTurns": 1,
   "recallMaxQueryChars": 800,
-  "recallRoles": ["user", "assistant"],
+  "recallRoles": [
+    "user",
+    "assistant"
+  ],
   "recallTags": [],
   "recallTagsMatch": "any",
   "recallTagGroups": null,
   "recallAdditionalBankFilters": {},
   "recallPromptPreamble": "Relevant memories from past conversations (prioritize recent when conflicting). Only use memories that are directly useful to continue this conversation; ignore the rest:",
-  "retainRoles": ["user", "assistant"],
+  "retainRoles": [
+    "user",
+    "assistant"
+  ],
   "retainEveryNTurns": 10,
   "retainOverlapTurns": 2,
   "retainToolCalls": false,
-  "retainTags": ["{session_id}"],
+  "retainTags": [
+    "{session_id}"
+  ],
   "retainMetadata": {},
   "retainContext": "claude-code",
   "hindsightApiToken": null,
@@ -32,12 +42,16 @@
   "embedPackagePath": null,
   "bankIdPrefix": "",
   "dynamicBankId": false,
-  "dynamicBankGranularity": ["agent", "project"],
+  "dynamicBankGranularity": [
+    "agent",
+    "project"
+  ],
   "resolveWorktrees": true,
   "directoryBankMap": {},
   "llmProvider": null,
   "llmModel": null,
   "llmApiKeyEnv": null,
   "enableKnowledgeTools": true,
-  "debug": false
+  "debug": false,
+  "upgradeNotice": true
 }

--- a/hindsight-integrations/claude-code/tests/test_upgrade_notice.py
+++ b/hindsight-integrations/claude-code/tests/test_upgrade_notice.py
@@ -9,10 +9,9 @@ def test_shown_on_every_session():
         assert upgrade_notice({}) is not None
 
 
-def test_names_this_plugin_and_its_install_command():
-    notice = upgrade_notice({})
-    assert "install claude-code" in notice
-    assert "@vectorize-io/hindsight-coding-agents" in notice
+def test_names_this_plugin():
+    """Whoever reads it must know WHICH plugin is deprecated — both are installed side by side."""
+    assert "Claude Code" in upgrade_notice({})
 
 
 def test_links_the_migration_guide():

--- a/hindsight-integrations/claude-code/tests/test_upgrade_notice.py
+++ b/hindsight-integrations/claude-code/tests/test_upgrade_notice.py
@@ -1,66 +1,39 @@
-"""The superseded-by-coding-agents notice: shown, but strictly rate-limited."""
+"""The superseded-by-coding-agents notice."""
 
-from datetime import datetime, timedelta, timezone
-
-import pytest
-
-from lib.upgrade_notice import MAX_SHOWINGS, MIN_INTERVAL_DAYS, upgrade_notice
-
-NOW = datetime(2026, 8, 6, tzinfo=timezone.utc)
+from lib.upgrade_notice import DOCS_URL, upgrade_notice
 
 
-@pytest.fixture(autouse=True)
-def _isolated_state(state_dir):
-    """Never touch the developer's real state files."""
-    return state_dir
-
-
-def test_shows_on_a_fresh_install():
-    assert upgrade_notice({}, now=NOW) is not None
+def test_shown_on_every_session():
+    """No cap and no interval — a notice shown once is a notice that gets missed."""
+    for _ in range(5):
+        assert upgrade_notice({}) is not None
 
 
 def test_names_this_plugin_and_its_install_command():
-    notice = upgrade_notice({}, now=NOW)
+    notice = upgrade_notice({})
     assert "install claude-code" in notice
     assert "@vectorize-io/hindsight-coding-agents" in notice
-    # The opt-out has to be discoverable from the message itself.
-    assert "upgradeNotice" in notice
+
+
+def test_links_the_docs_page():
+    assert DOCS_URL in upgrade_notice({})
+    assert DOCS_URL == "https://hindsight.vectorize.io/sdks/integrations/coding-agents"
 
 
 def test_opt_out_silences_it():
-    assert upgrade_notice({"upgradeNotice": False}, now=NOW) is None
+    """The only thing making an every-session notice acceptable — so it must work."""
+    assert upgrade_notice({"upgradeNotice": False}) is None
 
 
-def test_not_repeated_within_the_interval():
-    assert upgrade_notice({}, now=NOW) is not None
-    assert upgrade_notice({}, now=NOW + timedelta(days=MIN_INTERVAL_DAYS - 1)) is None
+def test_opt_out_is_discoverable_from_the_message_itself():
+    assert "upgradeNotice" in upgrade_notice({})
 
 
-def test_repeats_after_the_interval():
-    assert upgrade_notice({}, now=NOW) is not None
-    assert upgrade_notice({}, now=NOW + timedelta(days=MIN_INTERVAL_DAYS + 1)) is not None
-
-
-def test_stops_for_good_after_the_cap():
-    """Bounded on purpose — a deprecation notice must not become a permanent interruption."""
-    now = NOW
-    for _ in range(MAX_SHOWINGS):
-        assert upgrade_notice({}, now=now) is not None
-        now += timedelta(days=MIN_INTERVAL_DAYS + 1)
-    assert upgrade_notice({}, now=now) is None
-    assert upgrade_notice({}, now=now + timedelta(days=365)) is None
-
-
-def test_unwritable_state_returns_none_rather_than_raising(monkeypatch):
+def test_never_raises():
     """A promotional message must never be why someone's session breaks."""
-    import lib.upgrade_notice as mod
 
-    monkeypatch.setattr(mod, "write_state", lambda *a, **k: (_ for _ in ()).throw(OSError("read-only")))
-    assert upgrade_notice({}, now=NOW) is None
+    class Hostile:
+        def get(self, *a, **k):
+            raise RuntimeError("boom")
 
-
-def test_corrupt_timestamp_does_not_wedge_it(monkeypatch):
-    import lib.upgrade_notice as mod
-
-    monkeypatch.setattr(mod, "read_state", lambda *a, **k: {"shown": 1, "last": "not-a-date"})
-    assert upgrade_notice({}, now=NOW) is not None
+    assert upgrade_notice(Hostile()) is None

--- a/hindsight-integrations/claude-code/tests/test_upgrade_notice.py
+++ b/hindsight-integrations/claude-code/tests/test_upgrade_notice.py
@@ -1,0 +1,66 @@
+"""The superseded-by-coding-agents notice: shown, but strictly rate-limited."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from lib.upgrade_notice import MAX_SHOWINGS, MIN_INTERVAL_DAYS, upgrade_notice
+
+NOW = datetime(2026, 8, 6, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(state_dir):
+    """Never touch the developer's real state files."""
+    return state_dir
+
+
+def test_shows_on_a_fresh_install():
+    assert upgrade_notice({}, now=NOW) is not None
+
+
+def test_names_this_plugin_and_its_install_command():
+    notice = upgrade_notice({}, now=NOW)
+    assert "install claude-code" in notice
+    assert "@vectorize-io/hindsight-coding-agents" in notice
+    # The opt-out has to be discoverable from the message itself.
+    assert "upgradeNotice" in notice
+
+
+def test_opt_out_silences_it():
+    assert upgrade_notice({"upgradeNotice": False}, now=NOW) is None
+
+
+def test_not_repeated_within_the_interval():
+    assert upgrade_notice({}, now=NOW) is not None
+    assert upgrade_notice({}, now=NOW + timedelta(days=MIN_INTERVAL_DAYS - 1)) is None
+
+
+def test_repeats_after_the_interval():
+    assert upgrade_notice({}, now=NOW) is not None
+    assert upgrade_notice({}, now=NOW + timedelta(days=MIN_INTERVAL_DAYS + 1)) is not None
+
+
+def test_stops_for_good_after_the_cap():
+    """Bounded on purpose — a deprecation notice must not become a permanent interruption."""
+    now = NOW
+    for _ in range(MAX_SHOWINGS):
+        assert upgrade_notice({}, now=now) is not None
+        now += timedelta(days=MIN_INTERVAL_DAYS + 1)
+    assert upgrade_notice({}, now=now) is None
+    assert upgrade_notice({}, now=now + timedelta(days=365)) is None
+
+
+def test_unwritable_state_returns_none_rather_than_raising(monkeypatch):
+    """A promotional message must never be why someone's session breaks."""
+    import lib.upgrade_notice as mod
+
+    monkeypatch.setattr(mod, "write_state", lambda *a, **k: (_ for _ in ()).throw(OSError("read-only")))
+    assert upgrade_notice({}, now=NOW) is None
+
+
+def test_corrupt_timestamp_does_not_wedge_it(monkeypatch):
+    import lib.upgrade_notice as mod
+
+    monkeypatch.setattr(mod, "read_state", lambda *a, **k: {"shown": 1, "last": "not-a-date"})
+    assert upgrade_notice({}, now=NOW) is not None

--- a/hindsight-integrations/claude-code/tests/test_upgrade_notice.py
+++ b/hindsight-integrations/claude-code/tests/test_upgrade_notice.py
@@ -1,6 +1,6 @@
 """The superseded-by-coding-agents notice."""
 
-from lib.upgrade_notice import DOCS_URL, upgrade_notice
+from lib.upgrade_notice import DOCS_URL, MIGRATION_URL, upgrade_notice
 
 
 def test_shown_on_every_session():
@@ -15,9 +15,16 @@ def test_names_this_plugin_and_its_install_command():
     assert "@vectorize-io/hindsight-coding-agents" in notice
 
 
-def test_links_the_docs_page():
-    assert DOCS_URL in upgrade_notice({})
+def test_links_the_migration_guide():
+    """Deep-links the section, not just the page — the reader wants the steps, not the pitch."""
+    assert MIGRATION_URL in upgrade_notice({})
     assert DOCS_URL == "https://hindsight.vectorize.io/sdks/integrations/coding-agents"
+    assert MIGRATION_URL.endswith("#migrating-from-the-per-agent-plugins")
+
+
+def test_says_deprecated_outright():
+    """"Superseded" is jargon; a user needs to read one word and know to act."""
+    assert "DEPRECATED" in upgrade_notice({})
 
 
 def test_opt_out_silences_it():

--- a/hindsight-integrations/codex/scripts/lib/config.py
+++ b/hindsight-integrations/codex/scripts/lib/config.py
@@ -34,6 +34,7 @@ DEFAULTS = {
     "retainTags": [],
     "retainMetadata": {},
     # Connection
+    "upgradeNotice": True,  # show the superseded-by-coding-agents notice (capped, see lib/upgrade_notice.py)
     "hindsightApiUrl": None,
     "hindsightApiToken": None,
     "apiPort": 9077,

--- a/hindsight-integrations/codex/scripts/lib/upgrade_notice.py
+++ b/hindsight-integrations/codex/scripts/lib/upgrade_notice.py
@@ -1,7 +1,7 @@
-"""Notice that this plugin is superseded, shown at every session start.
+"""Deprecation notice for this plugin, shown at every session start.
 
-This plugin still works, but development has moved to
-`@vectorize-io/hindsight-coding-agents`. Someone who installed this a year ago has no way to learn
+This plugin still works and is not going to stop working, but it is deprecated: development has
+moved to `@vectorize-io/hindsight-coding-agents`. Someone who installed this a year ago has no way to learn
 that — a changelog entry reaches nobody — so the session itself says it.
 
 Shown every session rather than a few times: a notice that appears once is missed, and this one has
@@ -16,17 +16,21 @@ packages with no common module path.
 """
 
 DOCS_URL = "https://hindsight.vectorize.io/sdks/integrations/coding-agents"
+MIGRATION_URL = f"{DOCS_URL}#migrating-from-the-per-agent-plugins"
 
 NOTICE = (
-    "💡 Hindsight: this Codex plugin is superseded by the Coding Agents plugin — one "
-    "install covering Claude Code, Codex, Cursor, Copilot, opencode, Kilo, Grok, Antigravity, "
-    "Devin and Cline, with a single memory per repo that every agent shares instead of one bank "
-    "per agent.\n"
+    "⚠️  Hindsight: this Codex plugin is DEPRECATED, replaced by the Coding Agents plugin.\n"
+    "\n"
+    "One install now covers Claude Code, Codex, Cursor, Copilot, opencode, Kilo, Grok, "
+    "Antigravity, Devin and Cline, and they all share a single memory per repo instead of one bank "
+    "per agent — so context from any agent is there for the next one. It also adds knowledge pages "
+    "kept current from your git history, automatic seeding of a new repo, and a local daemon mode "
+    "that needs no account.\n"
     "\n"
     "    npm install -g @vectorize-io/hindsight-coding-agents\n"
     "    hindsight-coding-agents install codex --import-conversations\n"
     "\n"
-    f"Docs: {DOCS_URL}\n"
+    f"Migration guide: {MIGRATION_URL}\n"
     "Your Hindsight server and token carry over automatically; past conversations are re-imported "
     'from local transcripts. Silence this with "upgradeNotice": false in '
     "~/.hindsight/codex.json"

--- a/hindsight-integrations/codex/scripts/lib/upgrade_notice.py
+++ b/hindsight-integrations/codex/scripts/lib/upgrade_notice.py
@@ -19,20 +19,18 @@ DOCS_URL = "https://hindsight.vectorize.io/sdks/integrations/coding-agents"
 MIGRATION_URL = f"{DOCS_URL}#migrating-from-the-per-agent-plugins"
 
 NOTICE = (
-    "⚠️  Hindsight: this Codex plugin is DEPRECATED, replaced by the Coding Agents plugin.\n"
+    "The current Hindsight Codex plugin is DEPRECATED, replaced by the Coding Agents "
+    "plugin.\n"
     "\n"
     "One install now covers Claude Code, Codex, Cursor, Copilot, opencode, Kilo, Grok, "
-    "Antigravity, Devin and Cline, and they all share a single memory per repo instead of one bank "
-    "per agent — so context from any agent is there for the next one. It also adds knowledge pages "
-    "kept current from your git history, automatic seeding of a new repo, and a local daemon mode "
-    "that needs no account.\n"
+    "Antigravity,\n"
+    "Devin and Cline, and they all share a single memory per repository, leveraging the Hindsight "
+    "Knowledge Page (v0.9.x and onwards).\n"
     "\n"
-    "    npm install -g @vectorize-io/hindsight-coding-agents\n"
-    "    hindsight-coding-agents install codex --import-conversations\n"
-    "\n"
-    f"Migration guide: {MIGRATION_URL}\n"
+    f"See the migration guide: {MIGRATION_URL}\n"
     "Your Hindsight server and token carry over automatically; past conversations are re-imported "
-    'from local transcripts. Silence this with "upgradeNotice": false in '
+    "from\n"
+    'local transcripts. Silence this with "upgradeNotice": false in '
     "~/.hindsight/codex.json"
 )
 

--- a/hindsight-integrations/codex/scripts/lib/upgrade_notice.py
+++ b/hindsight-integrations/codex/scripts/lib/upgrade_notice.py
@@ -1,28 +1,21 @@
-"""One-line, rate-limited notice that this plugin is superseded.
+"""Notice that this plugin is superseded, shown at every session start.
 
-This plugin still works and still receives fixes, but development has moved to
-`@vectorize-io/hindsight-coding-agents`. Someone who installed this a year ago has no reason to
-ever learn that, so the session itself has to say it — a changelog entry reaches nobody.
+This plugin still works, but development has moved to
+`@vectorize-io/hindsight-coding-agents`. Someone who installed this a year ago has no way to learn
+that — a changelog entry reaches nobody — so the session itself says it.
 
-Restraint is the whole design:
+Shown every session rather than a few times: a notice that appears once is missed, and this one has
+a concrete action attached. `"upgradeNotice": false` in the user config turns it off permanently,
+and the message says so, which is what keeps that acceptable.
 
-  * capped at MAX_SHOWINGS in total, never more often than every MIN_INTERVAL_DAYS, so it can't
-    become a recurring interruption
-  * one `upgradeNotice: false` in the user config silences it permanently, and the text says so
-  * any failure — unreadable state, unwritable state dir — returns None rather than raising. A
-    promotional message must never be the reason someone's session breaks.
+Any failure returns None rather than raising. A promotional message must never be the reason
+someone's session breaks.
 
 Deliberately duplicated in the claude-code plugin rather than shared: the two ship as independent
-packages with no common module path, and ~40 lines is cheaper than inventing one.
+packages with no common module path.
 """
 
-from datetime import datetime, timedelta, timezone
-
-from .state import read_state, write_state
-
-STATE_FILE = "upgrade_notice.json"
-MAX_SHOWINGS = 3
-MIN_INTERVAL_DAYS = 7
+DOCS_URL = "https://hindsight.vectorize.io/sdks/integrations/coding-agents"
 
 NOTICE = (
     "💡 Hindsight: this Codex plugin is superseded by the Coding Agents plugin — one "
@@ -33,40 +26,16 @@ NOTICE = (
     "    npm install -g @vectorize-io/hindsight-coding-agents\n"
     "    hindsight-coding-agents install codex --import-conversations\n"
     "\n"
+    f"Docs: {DOCS_URL}\n"
     "Your Hindsight server and token carry over automatically; past conversations are re-imported "
     'from local transcripts. Silence this with "upgradeNotice": false in '
     "~/.hindsight/codex.json"
 )
 
 
-def _now() -> datetime:
-    return datetime.now(timezone.utc)
-
-
-def upgrade_notice(config: dict, now: datetime | None = None) -> str | None:
-    """Return the notice to show this session, or None to stay quiet."""
+def upgrade_notice(config: dict) -> str | None:
+    """Return the notice, or None when the user has turned it off."""
     try:
-        if not config.get("upgradeNotice", True):
-            return None
-
-        now = now or _now()
-        state = read_state(STATE_FILE, {}) or {}
-        shown = state.get("shown", 0)
-        if not isinstance(shown, int) or shown >= MAX_SHOWINGS:
-            return None
-
-        last_raw = state.get("last")
-        if last_raw:
-            try:
-                last = datetime.fromisoformat(str(last_raw))
-                if last.tzinfo is None:
-                    last = last.replace(tzinfo=timezone.utc)
-                if now - last < timedelta(days=MIN_INTERVAL_DAYS):
-                    return None
-            except ValueError:
-                pass  # unparseable timestamp: treat as never shown rather than nagging forever
-
-        write_state(STATE_FILE, {"shown": shown + 1, "last": now.isoformat()})
-        return NOTICE
+        return None if not config.get("upgradeNotice", True) else NOTICE
     except Exception:
         return None

--- a/hindsight-integrations/codex/scripts/lib/upgrade_notice.py
+++ b/hindsight-integrations/codex/scripts/lib/upgrade_notice.py
@@ -1,0 +1,72 @@
+"""One-line, rate-limited notice that this plugin is superseded.
+
+This plugin still works and still receives fixes, but development has moved to
+`@vectorize-io/hindsight-coding-agents`. Someone who installed this a year ago has no reason to
+ever learn that, so the session itself has to say it — a changelog entry reaches nobody.
+
+Restraint is the whole design:
+
+  * capped at MAX_SHOWINGS in total, never more often than every MIN_INTERVAL_DAYS, so it can't
+    become a recurring interruption
+  * one `upgradeNotice: false` in the user config silences it permanently, and the text says so
+  * any failure — unreadable state, unwritable state dir — returns None rather than raising. A
+    promotional message must never be the reason someone's session breaks.
+
+Deliberately duplicated in the claude-code plugin rather than shared: the two ship as independent
+packages with no common module path, and ~40 lines is cheaper than inventing one.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from .state import read_state, write_state
+
+STATE_FILE = "upgrade_notice.json"
+MAX_SHOWINGS = 3
+MIN_INTERVAL_DAYS = 7
+
+NOTICE = (
+    "💡 Hindsight: this Codex plugin is superseded by the Coding Agents plugin — one "
+    "install covering Claude Code, Codex, Cursor, Copilot, opencode, Kilo, Grok, Antigravity, "
+    "Devin and Cline, with a single memory per repo that every agent shares instead of one bank "
+    "per agent.\n"
+    "\n"
+    "    npm install -g @vectorize-io/hindsight-coding-agents\n"
+    "    hindsight-coding-agents install codex --import-conversations\n"
+    "\n"
+    "Your Hindsight server and token carry over automatically; past conversations are re-imported "
+    'from local transcripts. Silence this with "upgradeNotice": false in '
+    "~/.hindsight/codex.json"
+)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def upgrade_notice(config: dict, now: datetime | None = None) -> str | None:
+    """Return the notice to show this session, or None to stay quiet."""
+    try:
+        if not config.get("upgradeNotice", True):
+            return None
+
+        now = now or _now()
+        state = read_state(STATE_FILE, {}) or {}
+        shown = state.get("shown", 0)
+        if not isinstance(shown, int) or shown >= MAX_SHOWINGS:
+            return None
+
+        last_raw = state.get("last")
+        if last_raw:
+            try:
+                last = datetime.fromisoformat(str(last_raw))
+                if last.tzinfo is None:
+                    last = last.replace(tzinfo=timezone.utc)
+                if now - last < timedelta(days=MIN_INTERVAL_DAYS):
+                    return None
+            except ValueError:
+                pass  # unparseable timestamp: treat as never shown rather than nagging forever
+
+        write_state(STATE_FILE, {"shown": shown + 1, "last": now.isoformat()})
+        return NOTICE
+    except Exception:
+        return None

--- a/hindsight-integrations/codex/scripts/session_start.py
+++ b/hindsight-integrations/codex/scripts/session_start.py
@@ -15,10 +15,18 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from lib.client import HindsightClient
 from lib.config import debug_log, load_config
 from lib.daemon import get_api_url, prestart_daemon_background
+from lib.upgrade_notice import upgrade_notice
 
 
 def main():
     config = load_config()
+
+    # Emitted BEFORE any early return: neither the memory settings nor server reachability change
+    # the fact that this plugin has been superseded. Codex accepts Claude Code's hook output shape,
+    # so `systemMessage` is what the USER sees.
+    notice = upgrade_notice(config)
+    if notice:
+        print(json.dumps({"systemMessage": notice, "hookSpecificOutput": {"hookEventName": "SessionStart"}}))
 
     if not config.get("autoRecall") and not config.get("autoRetain"):
         debug_log(config, "Both autoRecall and autoRetain disabled, skipping session start")

--- a/hindsight-integrations/codex/settings.json
+++ b/hindsight-integrations/codex/settings.json
@@ -11,16 +11,27 @@
   "recallMaxTokens": 1024,
   "recallMinScores": {},
   "recallTimeout": 10,
-  "recallTypes": ["world", "experience"],
+  "recallTypes": [
+    "world",
+    "experience"
+  ],
   "recallContextTurns": 1,
   "recallMaxQueryChars": 800,
-  "recallRoles": ["user", "assistant"],
+  "recallRoles": [
+    "user",
+    "assistant"
+  ],
   "recallPromptPreamble": "Relevant memories from past conversations (prioritize recent when conflicting). Only use memories that are directly useful to continue this conversation; ignore the rest:",
   "retainToolCalls": true,
-  "retainRoles": ["user", "assistant"],
+  "retainRoles": [
+    "user",
+    "assistant"
+  ],
   "retainEveryNTurns": 10,
   "retainOverlapTurns": 2,
-  "retainTags": ["{session_id}"],
+  "retainTags": [
+    "{session_id}"
+  ],
   "retainMetadata": {},
   "retainContext": "codex",
   "hindsightApiToken": null,
@@ -30,10 +41,14 @@
   "embedPackagePath": null,
   "bankIdPrefix": "",
   "dynamicBankId": false,
-  "dynamicBankGranularity": ["agent", "project"],
+  "dynamicBankGranularity": [
+    "agent",
+    "project"
+  ],
   "agentName": "codex",
   "llmProvider": null,
   "llmModel": null,
   "llmApiKeyEnv": null,
-  "debug": false
+  "debug": false,
+  "upgradeNotice": true
 }

--- a/hindsight-integrations/codex/tests/test_upgrade_notice.py
+++ b/hindsight-integrations/codex/tests/test_upgrade_notice.py
@@ -1,67 +1,39 @@
-"""The superseded-by-coding-agents notice: shown, but strictly rate-limited."""
+"""The superseded-by-coding-agents notice."""
 
-from datetime import datetime, timedelta, timezone
-
-import pytest
-
-from lib.upgrade_notice import MAX_SHOWINGS, MIN_INTERVAL_DAYS, upgrade_notice
-
-NOW = datetime(2026, 8, 6, tzinfo=timezone.utc)
+from lib.upgrade_notice import DOCS_URL, upgrade_notice
 
 
-@pytest.fixture(autouse=True)
-def _isolated_state(tmp_path, monkeypatch):
-    """Never touch the developer's real state files — codex anchors state under $HOME."""
-    monkeypatch.setenv("HOME", str(tmp_path))
-    return tmp_path
-
-
-def test_shows_on_a_fresh_install():
-    assert upgrade_notice({}, now=NOW) is not None
+def test_shown_on_every_session():
+    """No cap and no interval — a notice shown once is a notice that gets missed."""
+    for _ in range(5):
+        assert upgrade_notice({}) is not None
 
 
 def test_names_this_plugin_and_its_install_command():
-    notice = upgrade_notice({}, now=NOW)
+    notice = upgrade_notice({})
     assert "install codex" in notice
     assert "@vectorize-io/hindsight-coding-agents" in notice
-    # The opt-out has to be discoverable from the message itself.
-    assert "upgradeNotice" in notice
+
+
+def test_links_the_docs_page():
+    assert DOCS_URL in upgrade_notice({})
+    assert DOCS_URL == "https://hindsight.vectorize.io/sdks/integrations/coding-agents"
 
 
 def test_opt_out_silences_it():
-    assert upgrade_notice({"upgradeNotice": False}, now=NOW) is None
+    """The only thing making an every-session notice acceptable — so it must work."""
+    assert upgrade_notice({"upgradeNotice": False}) is None
 
 
-def test_not_repeated_within_the_interval():
-    assert upgrade_notice({}, now=NOW) is not None
-    assert upgrade_notice({}, now=NOW + timedelta(days=MIN_INTERVAL_DAYS - 1)) is None
+def test_opt_out_is_discoverable_from_the_message_itself():
+    assert "upgradeNotice" in upgrade_notice({})
 
 
-def test_repeats_after_the_interval():
-    assert upgrade_notice({}, now=NOW) is not None
-    assert upgrade_notice({}, now=NOW + timedelta(days=MIN_INTERVAL_DAYS + 1)) is not None
-
-
-def test_stops_for_good_after_the_cap():
-    """Bounded on purpose — a deprecation notice must not become a permanent interruption."""
-    now = NOW
-    for _ in range(MAX_SHOWINGS):
-        assert upgrade_notice({}, now=now) is not None
-        now += timedelta(days=MIN_INTERVAL_DAYS + 1)
-    assert upgrade_notice({}, now=now) is None
-    assert upgrade_notice({}, now=now + timedelta(days=365)) is None
-
-
-def test_unwritable_state_returns_none_rather_than_raising(monkeypatch):
+def test_never_raises():
     """A promotional message must never be why someone's session breaks."""
-    import lib.upgrade_notice as mod
 
-    monkeypatch.setattr(mod, "write_state", lambda *a, **k: (_ for _ in ()).throw(OSError("read-only")))
-    assert upgrade_notice({}, now=NOW) is None
+    class Hostile:
+        def get(self, *a, **k):
+            raise RuntimeError("boom")
 
-
-def test_corrupt_timestamp_does_not_wedge_it(monkeypatch):
-    import lib.upgrade_notice as mod
-
-    monkeypatch.setattr(mod, "read_state", lambda *a, **k: {"shown": 1, "last": "not-a-date"})
-    assert upgrade_notice({}, now=NOW) is not None
+    assert upgrade_notice(Hostile()) is None

--- a/hindsight-integrations/codex/tests/test_upgrade_notice.py
+++ b/hindsight-integrations/codex/tests/test_upgrade_notice.py
@@ -9,10 +9,9 @@ def test_shown_on_every_session():
         assert upgrade_notice({}) is not None
 
 
-def test_names_this_plugin_and_its_install_command():
-    notice = upgrade_notice({})
-    assert "install codex" in notice
-    assert "@vectorize-io/hindsight-coding-agents" in notice
+def test_names_this_plugin():
+    """Whoever reads it must know WHICH plugin is deprecated — both are installed side by side."""
+    assert "Codex" in upgrade_notice({})
 
 
 def test_links_the_migration_guide():

--- a/hindsight-integrations/codex/tests/test_upgrade_notice.py
+++ b/hindsight-integrations/codex/tests/test_upgrade_notice.py
@@ -1,6 +1,6 @@
 """The superseded-by-coding-agents notice."""
 
-from lib.upgrade_notice import DOCS_URL, upgrade_notice
+from lib.upgrade_notice import DOCS_URL, MIGRATION_URL, upgrade_notice
 
 
 def test_shown_on_every_session():
@@ -15,9 +15,16 @@ def test_names_this_plugin_and_its_install_command():
     assert "@vectorize-io/hindsight-coding-agents" in notice
 
 
-def test_links_the_docs_page():
-    assert DOCS_URL in upgrade_notice({})
+def test_links_the_migration_guide():
+    """Deep-links the section, not just the page — the reader wants the steps, not the pitch."""
+    assert MIGRATION_URL in upgrade_notice({})
     assert DOCS_URL == "https://hindsight.vectorize.io/sdks/integrations/coding-agents"
+    assert MIGRATION_URL.endswith("#migrating-from-the-per-agent-plugins")
+
+
+def test_says_deprecated_outright():
+    """"Superseded" is jargon; a user needs to read one word and know to act."""
+    assert "DEPRECATED" in upgrade_notice({})
 
 
 def test_opt_out_silences_it():

--- a/hindsight-integrations/codex/tests/test_upgrade_notice.py
+++ b/hindsight-integrations/codex/tests/test_upgrade_notice.py
@@ -1,0 +1,67 @@
+"""The superseded-by-coding-agents notice: shown, but strictly rate-limited."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from lib.upgrade_notice import MAX_SHOWINGS, MIN_INTERVAL_DAYS, upgrade_notice
+
+NOW = datetime(2026, 8, 6, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(tmp_path, monkeypatch):
+    """Never touch the developer's real state files — codex anchors state under $HOME."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+def test_shows_on_a_fresh_install():
+    assert upgrade_notice({}, now=NOW) is not None
+
+
+def test_names_this_plugin_and_its_install_command():
+    notice = upgrade_notice({}, now=NOW)
+    assert "install codex" in notice
+    assert "@vectorize-io/hindsight-coding-agents" in notice
+    # The opt-out has to be discoverable from the message itself.
+    assert "upgradeNotice" in notice
+
+
+def test_opt_out_silences_it():
+    assert upgrade_notice({"upgradeNotice": False}, now=NOW) is None
+
+
+def test_not_repeated_within_the_interval():
+    assert upgrade_notice({}, now=NOW) is not None
+    assert upgrade_notice({}, now=NOW + timedelta(days=MIN_INTERVAL_DAYS - 1)) is None
+
+
+def test_repeats_after_the_interval():
+    assert upgrade_notice({}, now=NOW) is not None
+    assert upgrade_notice({}, now=NOW + timedelta(days=MIN_INTERVAL_DAYS + 1)) is not None
+
+
+def test_stops_for_good_after_the_cap():
+    """Bounded on purpose — a deprecation notice must not become a permanent interruption."""
+    now = NOW
+    for _ in range(MAX_SHOWINGS):
+        assert upgrade_notice({}, now=now) is not None
+        now += timedelta(days=MIN_INTERVAL_DAYS + 1)
+    assert upgrade_notice({}, now=now) is None
+    assert upgrade_notice({}, now=now + timedelta(days=365)) is None
+
+
+def test_unwritable_state_returns_none_rather_than_raising(monkeypatch):
+    """A promotional message must never be why someone's session breaks."""
+    import lib.upgrade_notice as mod
+
+    monkeypatch.setattr(mod, "write_state", lambda *a, **k: (_ for _ in ()).throw(OSError("read-only")))
+    assert upgrade_notice({}, now=NOW) is None
+
+
+def test_corrupt_timestamp_does_not_wedge_it(monkeypatch):
+    import lib.upgrade_notice as mod
+
+    monkeypatch.setattr(mod, "read_state", lambda *a, **k: {"shown": 1, "last": "not-a-date"})
+    assert upgrade_notice({}, now=NOW) is not None


### PR DESCRIPTION
Draft — the notice states that the server and token carry over, which is true for Codex only once #3203 merges, and none of it is on npm yet: 0.0.4 predates daemon mode and the endpoint carry-over. This should not merge before a release makes the claims real.

Both plugins keep working, but they are deprecated: development has moved to `@vectorize-io/hindsight-coding-agents`. Someone who installed one a year ago has no way to learn that — a changelog entry reaches nobody — so the session says it.

## What it says

```
The current Hindsight Claude Code plugin is DEPRECATED, replaced by the Coding Agents plugin.

One install now covers Claude Code, Codex, Cursor, Copilot, opencode, Kilo, Grok, Antigravity,
Devin and Cline, and they all share a single memory per repository, leveraging the Hindsight Knowledge Page (v0.9.x and onwards).

See the migration guide: https://hindsight.vectorize.io/sdks/integrations/coding-agents#migrating-from-the-per-agent-plugins
Your Hindsight server and token carry over automatically; past conversations are re-imported from
local transcripts. Silence this with "upgradeNotice": false in ~/.hindsight/claude-code.json
```

Codex gets the same text with its own plugin name and config path.

Both the page (HTTP 200) and the `#migrating-from-the-per-agent-plugins` anchor are verified live, so the one link a reader is given actually lands on the steps.

## How

The `SessionStart` hook emits `systemMessage`, the channel Claude Code shows to the **user** (`additionalContext` would only reach the model). Codex accepts Claude Code's hook output shape, so one design serves both — verified by running each hook and reading its JSON.

Emitted **before** the existing early returns: neither the memory settings nor whether the server is reachable changes the fact that the plugin is deprecated.

## Frequency

Every session start. A notice shown once is a notice that gets missed. What makes that acceptable is the opt-out: `"upgradeNotice": false` in `~/.hindsight/claude-code.json` / `codex.json` turns it off permanently, and the message's last line says so.

With no rate limit there is no state file, no timestamp parsing and none of their failure modes — what remains is a config check. The never-raise guarantee stays: a promotional message must never be why a session breaks.

## Tests

7 per plugin: shown on five consecutive calls, names which plugin is deprecated (both can be installed side by side), the migration deep-link, that it says DEPRECATED, the opt-out, that the opt-out is discoverable from the message, and that a hostile config object cannot make it raise.

Suites: **204 passed** (claude-code), **98 passed** (codex). `LINT_ALL_INTEGRATIONS=1 ./scripts/hooks/lint.sh` clean. Verified end to end that the hook emits it and that the opt-out silences it.

The module is duplicated rather than shared — these ship as independent packages with no common module path.
