### PR TITLE
perf(entity-resolution): exclude label entities from the trigram fuzzy-match index

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/b3e8d1c6f4a9_entity_kind_partial_trgm_index.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/b3e8d1c6f4a9_entity_kind_partial_trgm_index.py
@@ -1,0 +1,213 @@
+"""Add entities.entity_kind and exclude label entities from the trigram index.
+
+Label entities (values of ``entity_labels`` config groups, stored as
+``key:value`` canonical names) resolve by exact match only — fuzzy resolution
+must never merge distinct label values (#1558), and since #3187 they are looked
+up via the exact-match unique index rather than probed through pg_trgm. Their
+rows were still covered by the shared trigram index, so every fuzzy probe for a
+*regular* entity name pulled them into its candidate set only to discard them
+in the bitmap recheck. On banks where a free-text label group accumulated tens
+of thousands of mutually-similar values this recheck-discard overhead dominated
+database CPU under ingest bursts (#3208).
+
+"Is this row a label" was previously derived at runtime from the bank's
+``entity_labels`` config, which an index predicate cannot reference — so the
+classification is now materialised on the row:
+
+1. Add ``entity_kind`` ("regular"/"label", CHECK-constrained) on both dialects.
+   A kind column rather than a boolean so future entity kinds don't need
+   another column.
+2. Backfill per bank by classifying ``canonical_name`` against the bank's
+   ``entity_labels`` config with the same ``is_label_entity()`` the resolver
+   uses at insert time — a SQL reimplementation would be a second source of
+   truth (and the map-group recursion doesn't translate). Banks hold at most
+   tens of thousands of entities, so the synchronous per-bank backfill is fine.
+   Label configs supplied only by a tenant extension (not stored in
+   ``banks.config``) can't be seen here; their rows stay "regular", which
+   costs index size but never correctness — label *texts* still resolve via
+   the exact-match unique index.
+3. Rebuild the PG trigram index as a partial index excluding label rows.
+   Built CONCURRENTLY (autocommit block, invalid-leftover sweep, IF NOT
+   EXISTS — same shape as 2071c7518f88) and only then drop the old full
+   index, so fuzzy probes never lose index coverage. Skipped entirely when
+   pg_trgm is absent (the resolver falls back to the "full" strategy, #626).
+
+Oracle has no trigram index — it fuzzy-matches with a UTL_MATCH scan — so it
+only gets the column + backfill; the resolver adds the matching
+``entity_kind != 'label'`` filter to that scan.
+
+Revision ID: b3e8d1c6f4a9
+Revises: f2a6d8c4b1e9
+Create Date: 2026-08-06
+"""
+
+import json
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import context, op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "b3e8d1c6f4a9"
+down_revision: str | Sequence[str] | None = "f2a6d8c4b1e9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_OLD_INDEX = "entities_canonical_name_lower_trgm_idx"
+_NEW_INDEX = "entities_canonical_name_lower_trgm_nonlabel_idx"
+
+
+def _pg_schema_prefix() -> str:
+    """Schema-qualifier for raw SQL on PG (multi-tenant search_path)."""
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def _backfill_entity_kind(schema: str) -> None:
+    """Set entity_kind='label' on rows matching their bank's entity_labels config.
+
+    Runs the resolver's own classification (``is_label_entity``) per bank in
+    Python rather than reimplementing the enum/text/map prefix rules in SQL.
+    Shared by both dialects: plain SELECT/UPDATE with expanding IN binds.
+    """
+    from hindsight_api.engine.retain.entity_labels import (
+        build_labels_lookup,
+        is_label_entity,
+        parse_entity_labels,
+    )
+
+    bind = op.get_bind()
+    banks = bind.execute(sa.text(f"SELECT bank_id, config FROM {schema}banks")).fetchall()
+    for bank_id, raw_config in banks:
+        # PG JSONB arrives as a dict; Oracle CLOB arrives as a LOB object on
+        # raw text() fetches (oracledb's fetch_lobs default) — read it into a
+        # JSON string first.
+        if raw_config is not None and not isinstance(raw_config, (str, dict)):
+            raw_config = raw_config.read()
+        config = json.loads(raw_config) if isinstance(raw_config, str) else (raw_config or {})
+        labels_cfg = parse_entity_labels(config.get("entity_labels"))
+        if labels_cfg is None:
+            continue
+        lookup = build_labels_lookup(labels_cfg)
+        rows = bind.execute(
+            sa.text(f"SELECT id, canonical_name FROM {schema}entities WHERE bank_id = :bank_id"),
+            {"bank_id": bank_id},
+        ).fetchall()
+        label_ids = [entity_id for entity_id, name in rows if is_label_entity(name, labels_cfg, lookup)]
+        # Chunked to stay under Oracle's 1000-element IN limit; also keeps PG
+        # bind arrays bounded.
+        for start in range(0, len(label_ids), 500):
+            chunk = label_ids[start : start + 500]
+            stmt = sa.text(f"UPDATE {schema}entities SET entity_kind = 'label' WHERE id IN :ids").bindparams(
+                sa.bindparam("ids", expanding=True)
+            )
+            bind.execute(stmt, {"ids": chunk})
+
+
+def _pg_upgrade() -> None:
+    bind = op.get_bind()
+    schema = _pg_schema_prefix()
+    # `or None` collapses an unset option and an explicit empty string into NULL
+    # so the COALESCE below falls back to current_schema() in both cases.
+    target_schema = context.config.get_main_option("target_schema") or None
+
+    # IF NOT EXISTS: the transactional part below commits when the autocommit
+    # block is entered, so a failure during the CONCURRENTLY build leaves the
+    # revision unstamped with the column already added — the retry must not
+    # trip over it. The constant default is a metadata-only change on PG 11+.
+    op.execute(
+        f"ALTER TABLE {schema}entities ADD COLUMN IF NOT EXISTS entity_kind TEXT DEFAULT 'regular' NOT NULL "
+        f"CONSTRAINT chk_entities_entity_kind CHECK (entity_kind IN ('regular', 'label'))"
+    )
+    _backfill_entity_kind(schema)
+
+    # Without pg_trgm neither the old index nor the extension's opclass exists;
+    # the resolver already runs the "full" strategy there (#626).
+    has_trgm = bind.execute(sa.text("SELECT EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm')")).scalar()
+    if not has_trgm:
+        return
+
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction block; the
+    # autocommit_block runs each statement outside Alembic's migration
+    # transaction. Build the partial index first and drop the old full index
+    # only afterwards, so fuzzy probes never lose index coverage.
+    with op.get_context().autocommit_block():
+        # A CONCURRENTLY build that errored on a previous run leaves an INVALID
+        # index of this name behind, which IF NOT EXISTS would skip forever.
+        leftover_invalid = bind.execute(
+            sa.text(
+                "SELECT NOT i.indisvalid "
+                "FROM pg_class c "
+                "JOIN pg_index i ON c.oid = i.indexrelid "
+                "JOIN pg_namespace n ON c.relnamespace = n.oid "
+                "WHERE c.relname = :index_name "
+                "  AND n.nspname = COALESCE(:target_schema, current_schema())"
+            ),
+            {"index_name": _NEW_INDEX, "target_schema": target_schema},
+        ).scalar()
+        if leftover_invalid:
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {schema}{_NEW_INDEX}")
+
+        # The predicate must textually match the resolver's candidate query
+        # (`entity_kind != 'label'`) for the planner to choose this index.
+        op.execute(
+            f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {_NEW_INDEX} "
+            f"ON {schema}entities USING GIN (LOWER(canonical_name) gin_trgm_ops) "
+            f"WHERE entity_kind != 'label'"
+        )
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {schema}{_OLD_INDEX}")
+
+
+def _pg_downgrade() -> None:
+    bind = op.get_bind()
+    schema = _pg_schema_prefix()
+
+    has_trgm = bind.execute(sa.text("SELECT EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm')")).scalar()
+    if has_trgm:
+        # Restore the full index before dropping the partial one so fuzzy
+        # probes keep index coverage throughout.
+        with op.get_context().autocommit_block():
+            op.execute(
+                f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {_OLD_INDEX} "
+                f"ON {schema}entities USING GIN (LOWER(canonical_name) gin_trgm_ops)"
+            )
+    # Dropping the column also drops the partial index and CHECK constraint.
+    op.execute(f"ALTER TABLE {schema}entities DROP COLUMN IF EXISTS entity_kind")
+
+
+def _oracle_upgrade() -> None:
+    # Swallow ORA-01430 (column already exists) so a retry after a mid-run
+    # failure is idempotent — Oracle DDL auto-commits statement by statement.
+    op.execute(
+        """
+        BEGIN
+            EXECUTE IMMEDIATE 'ALTER TABLE entities ADD (entity_kind VARCHAR2(16) DEFAULT ''regular'' NOT NULL
+                CONSTRAINT chk_entities_entity_kind CHECK (entity_kind IN (''regular'', ''label'')))';
+        EXCEPTION WHEN OTHERS THEN
+            IF SQLCODE != -1430 THEN RAISE; END IF;
+        END;
+        """
+    )
+    _backfill_entity_kind("")
+
+
+def _oracle_downgrade() -> None:
+    # Swallow ORA-00904 (column does not exist).
+    op.execute(
+        """
+        BEGIN
+            EXECUTE IMMEDIATE 'ALTER TABLE entities DROP COLUMN entity_kind';
+        EXCEPTION WHEN OTHERS THEN
+            IF SQLCODE != -904 THEN RAISE; END IF;
+        END;
+        """
+    )
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade, oracle=_oracle_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade, oracle=_oracle_downgrade)

--- a/hindsight-api-slim/hindsight_api/engine/db/ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops.py
@@ -200,8 +200,13 @@ class DataAccessOps(ABC):
         bank_id: str,
         entity_names: list[str],
         entity_dates: list,
+        entity_kinds: list[str],
     ) -> dict[str, str]:
         """Bulk insert entities with ON CONFLICT DO NOTHING, returning id-by-lowercase-name.
+
+        ``entity_kinds`` ("regular"/"label", parallel to ``entity_names``) is
+        stored on the row so label entities stay out of the partial trigram
+        index (#3208).
 
         PG uses INSERT ... SELECT FROM unnest() with RETURNING.
         Non-PG inserts row-by-row then SELECTs.
@@ -231,6 +236,7 @@ class DataAccessOps(ABC):
         bank_id: str,
         entity_ids: list[str],
         canonical_names: list[str],
+        entity_kinds: list[str],
     ) -> None:
         """Lock resolved parents and re-create any pruned since Phase-1 resolution.
 

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -171,22 +171,24 @@ class OracleOps(DataAccessOps):
         bank_id: str,
         entity_names: list[str],
         entity_dates: list,
+        entity_kinds: list[str],
     ) -> dict[str, str]:
         # Row-by-row insert with duplicate suppression.
         # Can't use RETURNING with ON CONFLICT DO NOTHING reliably,
         # so INSERT (ignoring dups) then SELECT all IDs at the end.
         id_by_name: dict[str, str] = {}
-        for name, event_date in zip(entity_names, entity_dates):
+        for name, event_date, kind in zip(entity_names, entity_dates, entity_kinds):
             ts = event_date if event_date else datetime.now(UTC)
             await conn.execute(
                 f"""
-                INSERT INTO {table} (bank_id, canonical_name, first_seen, last_seen, mention_count)
-                VALUES ($1, $2, $3, $3, 0)
+                INSERT INTO {table} (bank_id, canonical_name, first_seen, last_seen, mention_count, entity_kind)
+                VALUES ($1, $2, $3, $3, 0, $4)
                 ON CONFLICT (bank_id, LOWER(canonical_name)) DO NOTHING
                 """,
                 bank_id,
                 name,
                 ts,
+                kind,
             )
         # Now SELECT all the entities we just inserted (or that already existed)
         for name in entity_names:
@@ -233,6 +235,7 @@ class OracleOps(DataAccessOps):
         bank_id: str,
         entity_ids: list[str],
         canonical_names: list[str],
+        entity_kinds: list[str],
     ) -> None:
         # Oracle has no FOR KEY SHARE; FOR UPDATE is the row-lock equivalent that
         # blocks a concurrent prune DELETE until this transaction commits. Lock
@@ -247,11 +250,14 @@ class OracleOps(DataAccessOps):
             )
         await conn.executemany(
             f"""
-            INSERT INTO {table} (id, bank_id, canonical_name)
-            VALUES ($1, $2, $3)
+            INSERT INTO {table} (id, bank_id, canonical_name, entity_kind)
+            VALUES ($1, $2, $3, $4)
             ON CONFLICT DO NOTHING
             """,
-            [(entity_id, bank_id, canonical_name) for entity_id, canonical_name in zip(entity_ids, canonical_names)],
+            [
+                (entity_id, bank_id, canonical_name, kind)
+                for entity_id, canonical_name, kind in zip(entity_ids, canonical_names, entity_kinds)
+            ],
         )
 
     async def bulk_insert_unit_entities(

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -248,6 +248,7 @@ class PostgreSQLOps(DataAccessOps):
         bank_id: str,
         entity_names: list[str],
         entity_dates: list,
+        entity_kinds: list[str],
     ) -> dict[str, str]:
         # ORDER BY LOWER(name) so every concurrent batch inserts in the same order
         # as the conflict target (bank_id, LOWER(canonical_name)). ON CONFLICT DO
@@ -259,9 +260,9 @@ class PostgreSQLOps(DataAccessOps):
         # the database's own collation the single arbiter for all writers.
         inserted_rows = await conn.fetch(
             f"""
-            INSERT INTO {table} (bank_id, canonical_name, first_seen, last_seen, mention_count)
-            SELECT $1, name, COALESCE(event_date, now()), COALESCE(event_date, now()), 0
-            FROM unnest($2::text[], $3::timestamptz[]) AS t(name, event_date)
+            INSERT INTO {table} (bank_id, canonical_name, first_seen, last_seen, mention_count, entity_kind)
+            SELECT $1, name, COALESCE(event_date, now()), COALESCE(event_date, now()), 0, kind
+            FROM unnest($2::text[], $3::timestamptz[], $4::text[]) AS t(name, event_date, kind)
             ORDER BY LOWER(name)
             ON CONFLICT (bank_id, LOWER(canonical_name))
             DO NOTHING
@@ -270,6 +271,7 @@ class PostgreSQLOps(DataAccessOps):
             bank_id,
             entity_names,
             entity_dates,
+            entity_kinds,
         )
         return {row["name_lower"]: row["id"] for row in inserted_rows}
 
@@ -301,6 +303,7 @@ class PostgreSQLOps(DataAccessOps):
         bank_id: str,
         entity_ids: list[str],
         canonical_names: list[str],
+        entity_kinds: list[str],
     ) -> None:
         # One statement, one round-trip (same shape as bulk_insert_links):
         #   * the CTE takes FOR KEY SHARE on every parent that still exists,
@@ -319,15 +322,16 @@ class PostgreSQLOps(DataAccessOps):
                 ORDER BY id
                 FOR KEY SHARE
             )
-            INSERT INTO {table} (id, bank_id, canonical_name)
-            SELECT t.entity_id, $1, t.canonical_name
-            FROM unnest($2::uuid[], $3::text[]) AS t(entity_id, canonical_name)
+            INSERT INTO {table} (id, bank_id, canonical_name, entity_kind)
+            SELECT t.entity_id, $1, t.canonical_name, t.entity_kind
+            FROM unnest($2::uuid[], $3::text[], $4::text[]) AS t(entity_id, canonical_name, entity_kind)
             WHERE t.entity_id NOT IN (SELECT id FROM locked)
             ON CONFLICT DO NOTHING
             """,
             bank_id,
             entity_ids,
             canonical_names,
+            entity_kinds,
         )
 
     async def bulk_insert_unit_entities(

--- a/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
+++ b/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
@@ -41,6 +41,8 @@ class _EntityToCreate:
     event_date: datetime | None
     # Label entities (from entity_labels config) are never fuzzy-merged in-batch — their
     # canonical names are user-defined (e.g. "use:use-001") and must stay distinct (GH-1558).
+    # Also stored on the row as entities.entity_kind so label rows stay out of the
+    # partial trigram index (#3208).
     is_label: bool = False
 
 
@@ -358,10 +360,16 @@ class EntityResolver:
 
     @staticmethod
     def _label_texts(entity_texts: list[str], taxonomy_lookup: set[str] | None, labels_cfg) -> set[str]:
-        """Subset of entity_texts that are label entities (resolved by exact match only)."""
-        if not (labels_cfg and taxonomy_lookup):
+        """Subset of entity_texts that are label entities (resolved by exact match only).
+
+        Only gate on the config, not on the lookup set: text/map groups have no
+        fixed vocabulary, so a config with only those groups builds an EMPTY
+        lookup — its labels are classified by key prefix inside
+        ``is_label_entity``, and gating on the set would miss them entirely.
+        """
+        if not labels_cfg:
             return set()
-        return {t for t in entity_texts if _is_label_entity(t, labels_cfg, taxonomy_lookup)}
+        return {t for t in entity_texts if _is_label_entity(t, labels_cfg, taxonomy_lookup or set())}
 
     async def resolve_entities_batch(
         self,
@@ -584,6 +592,12 @@ class EntityResolver:
         # TimeoutErrors on banks with 10k+ entities. The pg_trgm similarity threshold
         # that governs the `%` operator is applied once at pool-connection setup
         # (HINDSIGHT_API_ENTITY_TRGM_SIMILARITY_THRESHOLD), so it is not toggled here.
+        # ``entity_kind != 'label'`` matches the predicate of the partial trigram
+        # index (label rows are exact-match-only, so they can never be a
+        # legitimate fuzzy result — without the filter they only inflate the
+        # candidate set and get discarded in the bitmap recheck, #3208). The
+        # clause must textually match the index predicate for the planner to
+        # choose the partial index.
         for entity_text_batch in self._chunked(fuzzy_texts, self.entity_resolution_batch_size):
             rows.extend(
                 await conn.fetch(
@@ -594,6 +608,7 @@ class EntityResolver:
                     FROM unnest($2::text[]) AS q(query_text)
                     JOIN {fq_table("entities")} e ON (
                         e.bank_id = $1
+                        AND e.entity_kind != 'label'
                         AND LOWER(e.canonical_name) % LOWER(q.query_text)
                     )
                     """,
@@ -713,6 +728,7 @@ class EntityResolver:
                         FROM JSON_TABLE($2, '$[*]' COLUMNS (query_text VARCHAR2(4000) PATH '$')) q
                         JOIN {entities_table} e ON (
                             e.bank_id = $1
+                            AND e.entity_kind != 'label'
                             AND UTL_MATCH.JARO_WINKLER_SIMILARITY(LOWER(e.canonical_name), LOWER(q.query_text)) > 70
                         )
                         """,
@@ -847,10 +863,10 @@ class EntityResolver:
             # Label entities (from entity_labels config) use exact matching only.
             # Their canonical names are user-defined (e.g., "use:use-001"),
             # so fuzzy resolution must NOT merge distinct label values that
-            # happen to be textually similar (GH-1558).
-            is_label = bool(
-                labels_cfg and taxonomy_lookup and _is_label_entity(entity_text, labels_cfg, taxonomy_lookup)
-            )
+            # happen to be textually similar (GH-1558). Don't gate on the
+            # lookup set — it is empty for text/map-only configs, whose labels
+            # classify by key prefix (see _label_texts).
+            is_label = bool(labels_cfg and _is_label_entity(entity_text, labels_cfg, taxonomy_lookup or set()))
 
             if not candidates:
                 # Will create new entity
@@ -865,7 +881,9 @@ class EntityResolver:
                 entity_text_lower = entity_text.lower()
                 for candidate_id, canonical_name, metadata, last_seen, mention_count in candidates:
                     if canonical_name.lower() == entity_text_lower:
-                        exact_match = ResolvedEntity(entity_id=candidate_id, canonical_name=canonical_name)
+                        exact_match = ResolvedEntity(
+                            entity_id=candidate_id, canonical_name=canonical_name, entity_kind="label"
+                        )
                         break
                 if exact_match:
                     resolved[idx] = exact_match
@@ -885,6 +903,13 @@ class EntityResolver:
             nearby_entity_set = {e["text"].lower() for e in nearby_entities if e["text"] != entity_text}
 
             for candidate_id, canonical_name, metadata, last_seen, mention_count in candidates:
+                # A label row can never be a fuzzy-match target (#1558): the
+                # trigram/UTL_MATCH probes exclude them in SQL via entity_kind,
+                # but the "full" fallback strategy loads every bank entity, so
+                # a textually-close label value could still outscore the 0.6
+                # threshold here (e.g. "topic empathy" vs "topic:empathy").
+                if labels_cfg and _is_label_entity(canonical_name, labels_cfg, taxonomy_lookup or set()):
+                    continue
                 score = 0.0
 
                 # 1. Name similarity (0-0.5)
@@ -945,6 +970,7 @@ class EntityResolver:
             class _NameGroup:
                 name: str
                 event_date: datetime | None
+                is_label: bool
                 indices: list[int] = field(default_factory=list)
 
             groups: dict[str, _NameGroup] = {}
@@ -955,7 +981,10 @@ class EntityResolver:
                 key = canonical.lower()
                 group = groups.get(key)
                 if group is None:
-                    group = _NameGroup(name=canonical, event_date=e.event_date)
+                    # Labels key on themselves and the dedup pass only clusters
+                    # non-label names, so the first member's is_label holds for
+                    # every member of the group.
+                    group = _NameGroup(name=canonical, event_date=e.event_date, is_label=e.is_label)
                     groups[key] = group
                 elif e.event_date is not None and (group.event_date is None or e.event_date < group.event_date):
                     # Keep the earliest event_date across the cluster ("first seen").
@@ -966,6 +995,7 @@ class EntityResolver:
             sorted_groups = sorted(groups.items())
             entity_names = [g.name for _, g in sorted_groups]
             entity_dates = [g.event_date for _, g in sorted_groups]
+            entity_kinds = ["label" if g.is_label else "regular" for _, g in sorted_groups]
             # Stored canonical name per lowercase key, so a resurrected parent
             # keeps the name it was created/matched with rather than a fallback.
             canonical_by_name = {name_lower: g.name for name_lower, g in sorted_groups}
@@ -981,6 +1011,7 @@ class EntityResolver:
                 bank_id,
                 entity_names,
                 entity_dates,
+                entity_kinds,
             )
 
             # Fallback SELECT for names that conflicted (another worker won the race).
@@ -1019,8 +1050,11 @@ class EntityResolver:
                 entity_id = id_by_name.get(name_lower)
                 if entity_id:
                     canonical_name = canonical_by_name.get(name_lower, g.name)
+                    kind = "label" if g.is_label else "regular"
                     for original_idx in g.indices:
-                        resolved[original_idx] = ResolvedEntity(entity_id=entity_id, canonical_name=canonical_name)
+                        resolved[original_idx] = ResolvedEntity(
+                            entity_id=entity_id, canonical_name=canonical_name, entity_kind=kind
+                        )
                         pending.append(_EntityStat(entity_id=str(entity_id), event_date=g.event_date))
 
         # Accumulate into the resolver's pending list; the orchestrator flushes
@@ -1075,6 +1109,7 @@ class EntityResolver:
             bank_id,
             [entity.entity_id for entity in unique],
             [entity.canonical_name for entity in unique],
+            [entity.entity_kind for entity in unique],
         )
 
     async def link_units_to_entities_batch(

--- a/hindsight-api-slim/hindsight_api/engine/retain/types.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/types.py
@@ -280,10 +280,17 @@ class ResolvedEntity:
     mention), captured during Phase-1 resolution. It is threaded to Phase 2 so a
     parent pruned between phases can be re-created with its real name — the row
     is gone by then, so the name is otherwise unrecoverable (#2662).
+
+    ``entity_kind`` mirrors the ``entities.entity_kind`` column ("regular" or
+    "label"). It is carried for the same reason as ``canonical_name``: a pruned
+    label parent re-created by the Phase-2 reassert must keep its kind, or it
+    would re-enter the partial trigram index that label rows are excluded
+    from (#3208).
     """
 
     entity_id: str
     canonical_name: str
+    entity_kind: str = "regular"
 
     def __post_init__(self) -> None:
         # Callers pass UUID objects or strings; normalize once so downstream

--- a/hindsight-api-slim/tests/test_entity_resolver.py
+++ b/hindsight-api-slim/tests/test_entity_resolver.py
@@ -161,6 +161,95 @@ async def test_resolve_entities_batch_handles_unicode_lower_conflicts(pg0_db_url
         await backend.shutdown()
 
 
+@pytest.mark.asyncio
+async def test_label_entities_stored_and_reasserted_with_label_kind(pg0_db_url):
+    """Label entities are created with entity_kind='label' and keep it through
+    the Phase-2 reassert.
+
+    The kind decides membership in the partial trigram index (#3208): a label
+    row resurrected as 'regular' would silently re-enter the index, so the
+    resurrect path is the interesting one to pin, not just the insert.
+    """
+    resolved_url = await resolve_database_url(pg0_db_url)
+    backend = create_database_backend("postgresql")
+    await backend.initialize(resolved_url, min_size=1, max_size=2, command_timeout=30)
+    bank_id = f"test-entity-kind-{uuid.uuid4().hex[:8]}"
+    # Free-text label group: any "topic:..." text classifies as a label.
+    entity_labels = [{"key": "topic", "type": "text", "description": "session topic"}]
+    resolver = EntityResolver(pool=backend, entity_lookup="trigram")
+
+    try:
+        async with backend.acquire() as conn:
+            resolved = await resolver.resolve_entities_batch(
+                bank_id=bank_id,
+                entities_data=[
+                    {"text": "topic:algebra", "nearby_entities": []},
+                    {"text": "Alice", "nearby_entities": []},
+                ],
+                context="entity kind storage",
+                unit_event_date=None,
+                conn=conn,
+                entity_labels=entity_labels,
+            )
+
+            async def _kinds_by_name():
+                rows = await conn.fetch("SELECT canonical_name, entity_kind FROM entities WHERE bank_id = $1", bank_id)
+                return {row["canonical_name"]: row["entity_kind"] for row in rows}
+
+            assert await _kinds_by_name() == {"topic:algebra": "label", "Alice": "regular"}
+            kinds_resolved = {e.canonical_name: e.entity_kind for e in resolved}
+            assert kinds_resolved == {"topic:algebra": "label", "Alice": "regular"}
+
+            # Simulate the prune-between-phases race: rows vanish after Phase-1
+            # resolution, then the Phase-2 reassert re-creates them.
+            await conn.execute("DELETE FROM entities WHERE bank_id = $1", bank_id)
+            await resolver.reassert_entities_batch(bank_id, resolved, conn)
+            assert await _kinds_by_name() == {"topic:algebra": "label", "Alice": "regular"}
+    finally:
+        async with backend.acquire() as conn:
+            await conn.execute("DELETE FROM entities WHERE bank_id = $1", bank_id)
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_fuzzy_scoring_never_merges_regular_text_into_label_row():
+    """A regular text must not fuzzy-merge into a label row (#1558).
+
+    The trigram/UTL_MATCH probes exclude label rows in SQL (entity_kind
+    filter), but the "full" fallback strategy loads every bank entity, so the
+    Python scoring loop must skip label-classified candidates itself. The
+    candidate here would clear the 0.6 merge threshold on name similarity plus
+    temporal proximity if it weren't skipped.
+    """
+    from types import SimpleNamespace
+
+    from hindsight_api.engine.retain.entity_labels import build_labels_lookup, parse_entity_labels
+
+    now = datetime.now(timezone.utc)
+    labels_cfg = parse_entity_labels([{"key": "topic", "type": "text"}])
+    ops = SimpleNamespace(
+        bulk_insert_entities=AsyncMock(return_value={"topic empathy": "new-entity-id"}),
+        fetch_missing_entity_ids=AsyncMock(return_value=[]),
+    )
+    resolver = EntityResolver(pool=SimpleNamespace(ops=ops), entity_lookup="full")
+
+    resolved = await resolver._resolve_from_candidates(
+        conn=AsyncMock(),
+        bank_id="bank-1",
+        # "topic empathy" (no colon) is NOT a label text, so it goes through
+        # fuzzy scoring rather than the exact-match label branch.
+        entities_data=[{"text": "topic empathy", "nearby_entities": [], "event_date": now}],
+        unit_event_date=now,
+        all_candidates={"topic empathy": [("label-row-id", "topic:empathy", {}, now, 5)]},
+        cooccurrence_map={},
+        taxonomy_lookup=build_labels_lookup(labels_cfg),
+        labels_cfg=labels_cfg,
+    )
+
+    assert resolved == [ResolvedEntity(entity_id="new-entity-id", canonical_name="topic empathy")]
+    ops.bulk_insert_entities.assert_awaited_once()
+
+
 # ---------------------------------------------------------------------------
 # Oracle fuzzy entity resolution — unit tests (mock conn, no live DB)
 # ---------------------------------------------------------------------------

--- a/hindsight-api-slim/tests/test_entity_resolver_pg_trgm.py
+++ b/hindsight-api-slim/tests/test_entity_resolver_pg_trgm.py
@@ -247,3 +247,46 @@ class TestPgTrgmAutoDetection:
         # Only the non-label text reaches the trigram probe.
         assert len(trigram_calls) == 1
         assert trigram_calls[0][1][1] == ["Alice"]
+
+    @pytest.mark.asyncio
+    async def test_fuzzy_probe_excludes_label_rows(self):
+        """The trigram candidate query filters label rows with the partial-index predicate.
+
+        The clause must textually match the partial index's WHERE
+        (``entity_kind != 'label'``) or the planner falls back to a seq scan;
+        the exact-match label lookup must NOT carry it (label rows are exactly
+        what it resolves).
+        """
+        resolver = _make_resolver(entity_lookup="trigram")
+        conn = _make_conn(pg_trgm_available=True)
+
+        captured: list[str] = []
+
+        async def _capture(sql, *args):
+            captured.append(sql)
+            return []
+
+        conn.fetch = AsyncMock(side_effect=_capture)
+
+        labels_cfg = MagicMock()
+        labels_cfg.attributes = []
+        taxonomy_lookup = {"use:use-001"}
+        entities_data = [{"text": "use:use-001"}, {"text": "Alice"}]
+
+        with (
+            patch("hindsight_api.engine.entity_resolver.fq_table", side_effect=lambda table: table),
+            patch.object(resolver, "_resolve_from_candidates", new=AsyncMock(return_value=[])),
+        ):
+            await resolver._resolve_entities_batch_trigram(
+                conn=conn,
+                bank_id="test-bank",
+                entities_data=entities_data,
+                unit_event_date=None,
+                taxonomy_lookup=taxonomy_lookup,
+                labels_cfg=labels_cfg,
+            )
+
+        fuzzy_sqls = [sql for sql in captured if "% LOWER(q.query_text)" in sql]
+        exact_sqls = [sql for sql in captured if "= LOWER(q.query_text)" in sql]
+        assert fuzzy_sqls and all("entity_kind != 'label'" in sql for sql in fuzzy_sqls)
+        assert exact_sqls and all("entity_kind" not in sql for sql in exact_sqls)

--- a/hindsight-api-slim/tests/test_migration_entity_kind.py
+++ b/hindsight-api-slim/tests/test_migration_entity_kind.py
@@ -1,0 +1,190 @@
+"""Regression for the ``entity_kind`` column + partial trigram index (``b3e8d1c6f4a9``).
+
+Label entities resolve by exact match only, so their rows in the shared trigram
+index were pure fuzzy-probe overhead (#3208). The migration materialises the
+runtime label classification into ``entities.entity_kind``, backfills existing
+rows per bank from the bank's ``entity_labels`` config, and rebuilds the
+trigram index as a partial index excluding label rows.
+
+The backfill is the risky part — it re-runs the resolver's ``is_label_entity``
+classification inside the migration — so this test migrates a dedicated pg0 to
+the revision *before* the change, seeds a bank with an ``entity_labels`` config
+plus pre-existing label/regular entity rows, and verifies the upgrade
+classifies exactly the label rows.
+
+Uses a dedicated pg0 instance (mirrors test_migration_drop_access_count) so it
+controls exactly which migrations have run and never stamps the shared test
+instance.
+"""
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+# Single worker for the module: the tests share one module-scoped pg0 instance
+# and the downgrade test re-migrates a DB the others read.
+pytestmark = pytest.mark.xdist_group("migration-entity-kind-pg0")
+
+_SCRIPT_LOCATION = str(Path(__file__).parent.parent / "hindsight_api" / "alembic")
+
+_REVISION = "b3e8d1c6f4a9"
+# Revision immediately before the entity_kind change.
+_PRE_REVISION = "f2a6d8c4b1e9"
+
+_OLD_INDEX = "entities_canonical_name_lower_trgm_idx"
+_NEW_INDEX = "entities_canonical_name_lower_trgm_nonlabel_idx"
+
+_BANK_WITH_LABELS = "entity-kind-bank-labels"
+_BANK_WITHOUT_LABELS = "entity-kind-bank-plain"
+
+# One enum group and one free-text group, exercising both classification rules
+# the backfill must reproduce (exact lookup-set hit vs. key-prefix match).
+_ENTITY_LABELS_CONFIG = {
+    "entity_labels": [
+        {"key": "engagement", "type": "value", "values": [{"value": "active"}]},
+        {"key": "topic", "type": "text"},
+    ]
+}
+
+# canonical_name -> expected entity_kind after the backfill.
+_SEEDED_LABEL_BANK_ROWS = {
+    "engagement:active": "label",
+    "topic:quadratic equations": "label",
+    "Alice Chen": "regular",
+    # Looks label-ish but matches no configured group: must stay regular.
+    "grade:B+": "regular",
+}
+
+
+def _alembic_cfg(db_url: str) -> Config:
+    cfg = Config()
+    cfg.set_main_option("script_location", _SCRIPT_LOCATION)
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    cfg.set_main_option("prepend_sys_path", ".")
+    cfg.set_main_option("path_separator", "os")
+    return cfg
+
+
+def _index_def(conn, name: str) -> str | None:
+    return conn.execute(
+        text("SELECT indexdef FROM pg_indexes WHERE indexname = :n"),
+        {"n": name},
+    ).scalar()
+
+
+@pytest.fixture(scope="module")
+def head_db_url():
+    """pg0 migrated to just before the change, seeded, then upgraded to head."""
+    from hindsight_api.pg0 import EmbeddedPostgres
+
+    # port=None lets pg0 auto-assign a free port; a hardcoded port is not xdist-safe.
+    pg0 = EmbeddedPostgres(name="hindsight-entity-kind-test", port=None)
+    loop = asyncio.new_event_loop()
+    try:
+        url = loop.run_until_complete(pg0.ensure_running())
+    finally:
+        loop.close()
+
+    cfg = _alembic_cfg(url)
+
+    # pg0 instances persist between test runs, so a previous session leaves the
+    # DB at head with the seed rows already present (and already backfilled).
+    # Reset to an empty schema so the pre-revision seeding below is genuinely
+    # pre-migration on every run; the migration chain recreates extensions.
+    engine = create_engine(url)
+    with engine.begin() as conn:
+        conn.execute(text("DROP SCHEMA public CASCADE"))
+        conn.execute(text("CREATE SCHEMA public"))
+
+    command.upgrade(cfg, _PRE_REVISION)
+
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text("INSERT INTO banks (bank_id, config) VALUES (:b, CAST(:c AS jsonb)), (:b2, '{}'::jsonb)"),
+                {"b": _BANK_WITH_LABELS, "c": json.dumps(_ENTITY_LABELS_CONFIG), "b2": _BANK_WITHOUT_LABELS},
+            )
+            for name in _SEEDED_LABEL_BANK_ROWS:
+                conn.execute(
+                    text("INSERT INTO entities (bank_id, canonical_name) VALUES (:b, :n)"),
+                    {"b": _BANK_WITH_LABELS, "n": name},
+                )
+            # Same names in a bank with NO label config: none may be reclassified.
+            for name in _SEEDED_LABEL_BANK_ROWS:
+                conn.execute(
+                    text("INSERT INTO entities (bank_id, canonical_name) VALUES (:b, :n)"),
+                    {"b": _BANK_WITHOUT_LABELS, "n": name},
+                )
+    finally:
+        engine.dispose()
+
+    command.upgrade(cfg, "heads")
+    return url
+
+
+def test_backfill_classifies_only_configured_label_rows(head_db_url):
+    engine = create_engine(head_db_url)
+    try:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text("SELECT canonical_name, entity_kind FROM entities WHERE bank_id = :b"),
+                {"b": _BANK_WITH_LABELS},
+            ).fetchall()
+            assert dict(rows) == _SEEDED_LABEL_BANK_ROWS
+
+            plain = (
+                conn.execute(
+                    text("SELECT DISTINCT entity_kind FROM entities WHERE bank_id = :b"),
+                    {"b": _BANK_WITHOUT_LABELS},
+                )
+                .scalars()
+                .all()
+            )
+            assert plain == ["regular"], "a bank without entity_labels config must not be reclassified"
+    finally:
+        engine.dispose()
+
+
+def test_trigram_index_is_partial_and_replaces_old_one(head_db_url):
+    engine = create_engine(head_db_url)
+    try:
+        with engine.connect() as conn:
+            new_def = _index_def(conn, _NEW_INDEX)
+            assert new_def is not None, "partial trigram index missing at head"
+            # pg_indexes normalises `!=` to `<>`.
+            assert "WHERE" in new_def and "entity_kind" in new_def and "'label'" in new_def, new_def
+            assert "gin_trgm_ops" in new_def, new_def
+            assert _index_def(conn, _OLD_INDEX) is None, "old full trigram index should be dropped"
+    finally:
+        engine.dispose()
+
+
+def test_downgrade_restores_full_index_and_drops_column(head_db_url):
+    cfg = _alembic_cfg(head_db_url)
+    engine = create_engine(head_db_url)
+    try:
+        command.downgrade(cfg, _PRE_REVISION)
+        with engine.connect() as conn:
+            cols = {
+                r[0]
+                for r in conn.execute(
+                    text("SELECT column_name FROM information_schema.columns WHERE table_name = 'entities'")
+                )
+            }
+            assert "entity_kind" not in cols
+            assert _index_def(conn, _OLD_INDEX) is not None, "downgrade must restore the full trigram index"
+            assert _index_def(conn, _NEW_INDEX) is None, "dropping the column must drop the partial index"
+
+        command.upgrade(cfg, _REVISION)
+        with engine.connect() as conn:
+            assert _index_def(conn, _NEW_INDEX) is not None
+            assert _index_def(conn, _OLD_INDEX) is None
+    finally:
+        # Leave the module fixture's instance at head for any later user.
+        command.upgrade(cfg, "heads")
+        engine.dispose()

--- a/hindsight-api-slim/tests/test_retain_entity_prune_race.py
+++ b/hindsight-api-slim/tests/test_retain_entity_prune_race.py
@@ -41,11 +41,13 @@ async def test_oracle_reassert_locks_in_stable_order_then_reinserts():
     idempotently re-insert the same rows in that order."""
     resolver = EntityResolver(pool=SimpleNamespace(ops=OracleOps()))
     conn = AsyncMock()
-    # Deliberately out of order and duplicated on the way in.
+    # Deliberately out of order and duplicated on the way in. Bob is a label
+    # entity: the re-insert must carry each parent's entity_kind, or a pruned
+    # label row would resurrect as 'regular' and re-enter fuzzy matching.
     resolved_entities = [
-        ResolvedEntity(entity_id=_ID_B, canonical_name="Bob"),
+        ResolvedEntity(entity_id=_ID_B, canonical_name="Bob", entity_kind="label"),
         ResolvedEntity(entity_id=_ID_A, canonical_name="Alice"),
-        ResolvedEntity(entity_id=_ID_B, canonical_name="Bob"),
+        ResolvedEntity(entity_id=_ID_B, canonical_name="Bob", entity_kind="label"),
     ]
 
     await resolver.reassert_entities_batch("bank-1", resolved_entities, conn)
@@ -56,7 +58,7 @@ async def test_oracle_reassert_locks_in_stable_order_then_reinserts():
 
     insert_sql, rows = conn.executemany.await_args.args
     assert "ON CONFLICT DO NOTHING" in insert_sql
-    assert rows == [(_ID_A, "bank-1", "Alice"), (_ID_B, "bank-1", "Bob")]
+    assert rows == [(_ID_A, "bank-1", "Alice", "regular"), (_ID_B, "bank-1", "Bob", "label")]
 
 
 @pytest.mark.asyncio
@@ -98,7 +100,9 @@ async def test_reassert_locks_existing_parent_until_child_insert(pg0_db_url):
             bank_id,
         )
         wrapped_phase2 = PostgresConnection(phase2_conn)
-        await ops.bulk_reassert_entities(wrapped_phase2, "entities", bank_id, [str(entity_id)], ["Alice Smith"])
+        await ops.bulk_reassert_entities(
+            wrapped_phase2, "entities", bank_id, [str(entity_id)], ["Alice Smith"], ["regular"]
+        )
 
         # The pruner cannot delete the locked parent — it blocks and times out.
         await prune_conn.execute("SET statement_timeout = '500ms'")

--- a/hindsight-docs/docs/developer/api/memory-banks.mdx
+++ b/hindsight-docs/docs/developer/api/memory-banks.mdx
@@ -170,6 +170,8 @@ Each entry in `entity_labels` is a **label group** — one classification dimens
 }
 ```
 
+**How label entities resolve.** Regular entities resolve fuzzily so close name variants merge ("Alice" / "Alice Chen"). Label entities are different: their canonical names are user-defined, so two similar-looking values (`use:use-001` / `use:use-002`) must stay distinct. They therefore resolve by **exact match only** and are stored with `entity_kind = "label"`, which keeps them out of fuzzy name matching entirely — a free-text label group accumulating thousands of similar values doesn't slow down resolution of the bank's regular entities. The classification is fixed when the entity is first stored; removing a label group later doesn't reclassify its existing entities.
+
 ### entities_allow_free_form
 
 By default, entity labels are extracted **alongside** regular named entities (people, places, concepts). Set to `false` to disable free-form extraction so only label entities are stored:

--- a/hindsight-docs/docs/developer/retain.md
+++ b/hindsight-docs/docs/developer/retain.md
@@ -101,6 +101,8 @@ If "Alice" appears with "Google" and "Stanford" multiple times, a new "Alice" me
 
 You can define a controlled vocabulary of `key:value` classification labels (e.g. `pedagogy:scaffolding`, `engagement:active`) that are extracted at retain time and stored as entities. Because labels become entities, they automatically link related memories in the knowledge graph and improve both semantic and keyword retrieval. Labels can optionally also write to the memory unit's tags, enabling standard tag-based filtering during recall and reflect.
 
+Unlike regular entities, label entities never merge by name similarity — distinct label values must stay distinct, so they resolve by exact match only and are excluded from fuzzy name matching altogether.
+
 See [entity_labels in the bank config](/developer/api/memory-banks#entity-labels) for full configuration details.
 
 ---

--- a/skills/hindsight-docs/references/developer/api/memory-banks.md
+++ b/skills/hindsight-docs/references/developer/api/memory-banks.md
@@ -163,6 +163,8 @@ Each entry in `entity_labels` is a **label group** — one classification dimens
 }
 ```
 
+**How label entities resolve.** Regular entities resolve fuzzily so close name variants merge ("Alice" / "Alice Chen"). Label entities are different: their canonical names are user-defined, so two similar-looking values (`use:use-001` / `use:use-002`) must stay distinct. They therefore resolve by **exact match only** and are stored with `entity_kind = "label"`, which keeps them out of fuzzy name matching entirely — a free-text label group accumulating thousands of similar values doesn't slow down resolution of the bank's regular entities. The classification is fixed when the entity is first stored; removing a label group later doesn't reclassify its existing entities.
+
 ### entities_allow_free_form
 
 By default, entity labels are extracted **alongside** regular named entities (people, places, concepts). Set to `false` to disable free-form extraction so only label entities are stored:

--- a/skills/hindsight-docs/references/developer/retain.md
+++ b/skills/hindsight-docs/references/developer/retain.md
@@ -101,6 +101,8 @@ If "Alice" appears with "Google" and "Stanford" multiple times, a new "Alice" me
 
 You can define a controlled vocabulary of `key:value` classification labels (e.g. `pedagogy:scaffolding`, `engagement:active`) that are extracted at retain time and stored as entities. Because labels become entities, they automatically link related memories in the knowledge graph and improve both semantic and keyword retrieval. Labels can optionally also write to the memory unit's tags, enabling standard tag-based filtering during recall and reflect.
 
+Unlike regular entities, label entities never merge by name similarity — distinct label values must stay distinct, so they resolve by exact match only and are excluded from fuzzy name matching altogether.
+
 See [entity_labels in the bank config](api/memory-banks.md#entity-labels) for full configuration details.
 
 ---


### PR DESCRIPTION
Closes #3208.

Label entities (values of `entity_labels` config groups) resolve by exact match only, yet their rows were still covered by the shared trigram index — every fuzzy probe for a *regular* entity pulled them into its candidate set only to discard them in the bitmap recheck. On banks where a free-text label group accumulated tens of thousands of mutually-similar values, this recheck-discard overhead dominated database CPU under ingest bursts.

## What changed

- **`entities.entity_kind`** (`'regular'`/`'label'`, CHECK-constrained, both dialects), set at insert time by the resolver — which already knows the classification. A kind column rather than a boolean so future entity kinds don't need another schema change. The Phase-2 reassert carries the kind on `ResolvedEntity`, so a label parent pruned between phases resurrects as a label instead of silently re-entering the index.
- **Partial trigram index**: `entities_canonical_name_lower_trgm_nonlabel_idx ... WHERE entity_kind != 'label'` replaces the full index. Built `CONCURRENTLY` (autocommit block, invalid-leftover sweep, create-before-drop so fuzzy probes never lose coverage), skipped when `pg_trgm` is absent. The trigram candidate query gains the textually-matching `AND e.entity_kind != 'label'` predicate; the Oracle UTL_MATCH fuzzy scan gets the same filter (no index there, but the same wasted-scan semantics).
- **Backfill**: the migration classifies each bank's existing `canonical_name`s against that bank's `entity_labels` config using the same `is_label_entity()` the resolver uses — no SQL reimplementation of the enum/text/map rules. Banks top out at 10–20k entities, so the synchronous per-bank backfill is fine. Label configs supplied only by a tenant extension can't be seen by the migration; those rows stay `regular`, which costs index size but never correctness.
- **Bug fix uncovered by testing**: label classification was gated on the *enum lookup set* being non-empty. A config with only `text`/`map` groups builds an empty set, so its labels were never recognised — neither by the #3187 exact-lookup split nor by the new insert-time kind. The gate is now on the config itself. Relatedly, the `full` fallback strategy could fuzzy-*merge* a regular text into a label row (e.g. `topic empathy` → `topic:empathy` clears the 0.6 threshold with temporal proximity); the scoring loop now skips label-classified candidates, matching what the SQL probes enforce.

Bank import needs no changes: transfer archives treat entities as derived data and re-resolve them through the standard retain Phase 1, which now stamps the kind. Admin backup/restore is likewise unaffected — restore COPYs by the backup's column list, so `entity_kind` fills from its default for older backups.

## Expected impact

- Trigram index size drops in proportion to label-row share (>60% in the observed bank).
- Fuzzy probe candidate sets return to normal size — probe cost drops by roughly the recheck-discard ratio.
- Structurally prevents any text-label-heavy bank from degrading fuzzy matching for its own regular entities.

## Tests

- `test_migration_entity_kind.py` (dedicated pg0): backfill classifies exactly the configured label rows (enum + free-text groups, unconfigured banks untouched), partial index replaces the old one, downgrade restores the full index and drops the column.
- `test_entity_resolver.py`: end-to-end insert + reassert keep `entity_kind='label'` on a live PG; new unit test pins that fuzzy scoring never merges a regular text into a label row.
- `test_entity_resolver_pg_trgm.py`: the fuzzy probe SQL carries the partial-index predicate; the exact label lookup doesn't.

Known tradeoff (documented in the docs + migration): the kind freezes classification at insert time. Removing a label group later leaves its ex-label rows out of the fuzzy index (exact match still works); rows created before a group existed stay in the index (overhead only).
