### PR TITLE
docs(templates): recommend more integrations per template, not just Hermes

### DIFF
--- a/hindsight-docs/src/data/templates.json
+++ b/hindsight-docs/src/data/templates.json
@@ -9,8 +9,8 @@
         "litellm",
         "langgraph",
         "pydantic-ai",
-        "ai-sdk",
-        "chat",
+        "vercel-ai-sdk",
+        "vercel-chat",
         "crewai",
         "ag2",
         "agno",
@@ -53,6 +53,9 @@
       "description": "For agents that talk to many people across chat platforms (Telegram, Discord, Slack). Keeps per-person profiles distinct, learns each community's norms, and tracks open threads across users.",
       "category": "chat",
       "integrations": [
+        "langgraph",
+        "crewai",
+        "agno",
         "hermes"
       ],
       "manifest_file": "templates/hermes-gateway-bot.json"
@@ -63,6 +66,9 @@
       "description": "For orchestrations of specialized agents. Remembers decisions and their rationale, ownership boundaries, hand-offs, and how past escalations were resolved. High literalism and skepticism for precise coordination.",
       "category": "orchestration",
       "integrations": [
+        "langgraph",
+        "crewai",
+        "autogen",
         "hermes"
       ],
       "manifest_file": "templates/hermes-orchestrator.json"
@@ -73,6 +79,9 @@
       "description": "For support and client-comms agents. Remembers customer issues, resolutions, sentiment, and account context so every interaction is informed. High empathy, never re-asks known details.",
       "category": "support",
       "integrations": [
+        "langgraph",
+        "crewai",
+        "dify",
         "hermes"
       ],
       "manifest_file": "templates/customer-support.json"
@@ -83,6 +92,9 @@
       "description": "For research, monitoring, and knowledge-work agents that write briefings and digests or maintain a second brain. Learns the user's interests, tracks what to ignore to sharpen curation, and compounds durable knowledge with sources over time.",
       "category": "research",
       "integrations": [
+        "obsidian",
+        "llamaindex",
+        "langgraph",
         "hermes"
       ],
       "manifest_file": "templates/research-assistant.json"


### PR DESCRIPTION
## What

Four bank templates listed only **`hermes`** as a recommended harness — making them look Hermes-exclusive, even though each template's memory pattern fits other agents just as well. This adds a small, curated set of the most relevant integrations to each (keeping `hermes`), so the [Bank Templates Hub](https://hindsight.vectorize.io/templates) shows they're generally useful.

| Template | Before | After |
|---|---|---|
| `hermes-gateway-bot` | hermes | langgraph, crewai, agno, hermes |
| `hermes-orchestrator` | hermes | langgraph, crewai, autogen, hermes |
| `customer-support` | hermes | langgraph, crewai, dify, hermes |
| `research-assistant` | hermes | obsidian, llamaindex, langgraph, hermes |

Also fixes two stale icon IDs on the `conversation` template (`ai-sdk` → `vercel-ai-sdk`, `chat` → `vercel-chat`) so its icons resolve.

## Notes

- **`hermes` is kept on all seven templates**, so the Hermes `memory setup` template picker (which filters on the `hermes` tag) is unaffected.
- Every integration ID resolves to an entry in `integrations.json` (icons render).

## Verification

- All 7 templates pass `check-templates.mjs`; `check-integrations.mjs` green; local docs build succeeds.
