### PR TITLE
fix(worker): serialise graph_maintenance per bank when claiming

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -1290,6 +1290,78 @@ class OracleOps(DataAccessOps):
             *params,
         )
 
+    async def _claim_graph_maintenance_tasks(
+        self,
+        conn,
+        table: str,
+        claimed_ids: list,
+        limit: int,
+        busy_bank_ids: list[str],
+    ) -> list:
+        """Claim graph_maintenance tasks, at most one per bank.
+
+        Same rationale as the PostgreSQL dialect: two concurrent runs against
+        one bank just convoy on the entity_cooccurrences row locks the first
+        run holds, and ``bank_id != ALL(busy)`` alone is not enough because
+        submit-time dedupe_by_bank only inspects 'pending' rows, so a bank can
+        accumulate many pending rows while one is in flight.
+
+        Oracle has no DISTINCT ON and rejects a row-limited SELECT ... FOR
+        UPDATE (ORA-02014), so this uses the two-step idiom
+        prune_terminal_operations uses: pick the deterministic bounded
+        candidate set first (ROW_NUMBER() = 1 per bank), then lock only those
+        rows re-checking eligibility, FOR UPDATE OF ... SKIP LOCKED.
+        """
+        if limit <= 0:
+            return []
+
+        conditions = []
+        params: list = []
+        idx = 1
+        if busy_bank_ids:
+            conditions.append(f"bank_id != ALL(${idx}::text[])")
+            params.append(busy_bank_ids)
+            idx += 1
+        if claimed_ids:
+            conditions.append(f"operation_id != ALL(${idx}::uuid[])")
+            params.append(claimed_ids)
+            idx += 1
+        extra_clause = (" AND " + " AND ".join(conditions)) if conditions else ""
+        params.append(limit)
+
+        candidates = await conn.fetch(
+            f"""
+            SELECT operation_id FROM (
+                SELECT operation_id, created_at,
+                       ROW_NUMBER() OVER (PARTITION BY bank_id ORDER BY created_at) AS bank_rank
+                FROM {table}
+                WHERE status = 'pending'
+                  AND task_payload IS NOT NULL
+                  AND operation_type = 'graph_maintenance'
+                  AND (next_retry_at IS NULL OR next_retry_at <= NOW()){extra_clause}
+            )
+            WHERE bank_rank = 1
+            ORDER BY created_at
+            LIMIT ${idx}
+            """,
+            *params,
+        )
+        if not candidates:
+            return []
+
+        candidate_ids = [row["operation_id"] for row in candidates]
+        return await conn.fetch(
+            f"""
+            SELECT gm_task.operation_id, gm_task.operation_type, gm_task.task_payload, gm_task.retry_count
+            FROM {table} gm_task
+            WHERE gm_task.operation_id = ANY($1)
+              AND gm_task.status = 'pending'
+            ORDER BY gm_task.created_at
+            FOR UPDATE OF gm_task.operation_id SKIP LOCKED
+            """,
+            candidate_ids,
+        )
+
     async def claim_tasks(
         self,
         conn,
@@ -1303,6 +1375,16 @@ class OracleOps(DataAccessOps):
         """Oracle two-step claiming to avoid ORA-02014 with NOT EXISTS + FOR UPDATE."""
         all_rows = []
         claimed_ids = []
+
+        # Banks with a graph_maintenance run already in flight. Same guard the
+        # consolidation phases apply, computed once and shared by both call sites.
+        busy_gm_banks = await conn.fetch(
+            f"""
+            SELECT DISTINCT bank_id FROM {table}
+            WHERE operation_type = 'graph_maintenance' AND status = 'processing'
+            """,
+        )
+        busy_gm_bank_ids = [r["bank_id"] for r in busy_gm_banks]
 
         # --- Phase 1: claim from reserved pools ---
         for op_type, limit in reserved_limits.items():
@@ -1326,6 +1408,8 @@ class OracleOps(DataAccessOps):
                     limit,
                     consolidation_bank_priority,
                 )
+            elif op_type == "graph_maintenance":
+                rows = await self._claim_graph_maintenance_tasks(conn, table, claimed_ids, limit, busy_gm_bank_ids)
             else:
                 rows = await conn.fetch(
                     f"""
@@ -1358,7 +1442,7 @@ class OracleOps(DataAccessOps):
                     FROM {table}
                     WHERE status = 'pending'
                       AND task_payload IS NOT NULL
-                      AND operation_type != 'consolidation'
+                      AND operation_type NOT IN ('consolidation', 'graph_maintenance')
                       AND (next_retry_at IS NULL OR next_retry_at <= NOW())
                       AND operation_id != ALL($1::uuid[])
                     ORDER BY created_at
@@ -1375,7 +1459,7 @@ class OracleOps(DataAccessOps):
                     FROM {table}
                     WHERE status = 'pending'
                       AND task_payload IS NOT NULL
-                      AND operation_type != 'consolidation'
+                      AND operation_type NOT IN ('consolidation', 'graph_maintenance')
                       AND (next_retry_at IS NULL OR next_retry_at <= NOW())
                     ORDER BY created_at
                     LIMIT $1
@@ -1411,6 +1495,18 @@ class OracleOps(DataAccessOps):
                 for row in rows:
                     claimed_ids.append(row["operation_id"])
                     all_rows.append(row)
+
+            # 2c. graph_maintenance (bank-serialised, same rationale as 2b): a
+            # second concurrent run against one bank does no extra work, it just
+            # convoys on the entity_cooccurrences row locks the first run holds.
+            if remaining_shared > 0:
+                rows = await self._claim_graph_maintenance_tasks(
+                    conn, table, claimed_ids, remaining_shared, busy_gm_bank_ids
+                )
+                for row in rows:
+                    claimed_ids.append(row["operation_id"])
+                    all_rows.append(row)
+                remaining_shared -= len(rows)
 
         if not all_rows:
             return []

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -1347,6 +1347,59 @@ class PostgreSQLOps(DataAccessOps):
             *params,
         )
 
+    async def _claim_graph_maintenance_tasks(
+        self,
+        conn,
+        table: str,
+        claimed_ids: list,
+        limit: int,
+        busy_bank_ids: list[str],
+    ) -> list:
+        """Claim graph_maintenance tasks, at most one per bank.
+
+        Two concurrent runs against the same bank produce no extra work: the
+        second blocks on the entity_cooccurrences and graph_maintenance_queue row
+        locks the first already holds, and on a large graph each sweep takes tens
+        of seconds. Enough of them arrive to occupy every worker slot and starve
+        retain entirely.
+
+        Both halves are needed. ``bank_id != ALL(busy)`` keeps a bank that is
+        already running one out of this batch, and DISTINCT ON keeps a single
+        batch from claiming two rows for the same bank — submit-time
+        dedupe_by_bank only inspects 'pending' rows, so a bank can accumulate
+        many pending rows while one is in flight.
+
+        DISTINCT ON cannot be combined with FOR UPDATE, so candidates are chosen
+        in a CTE and the base-table rows locked through a join, as
+        claim_graph_maintenance_batch does.
+        """
+        if limit <= 0:
+            return []
+        return await conn.fetch(
+            f"""
+            WITH candidates AS (
+                SELECT DISTINCT ON (bank_id) operation_id
+                FROM {table}
+                WHERE status = 'pending'
+                  AND task_payload IS NOT NULL
+                  AND operation_type = 'graph_maintenance'
+                  AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+                  AND bank_id != ALL($1::text[])
+                  AND operation_id != ALL($2::uuid[])
+                ORDER BY bank_id, created_at
+            )
+            SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count
+            FROM {table} o
+            JOIN candidates c ON c.operation_id = o.operation_id
+            ORDER BY o.created_at
+            LIMIT $3
+            FOR UPDATE OF o SKIP LOCKED
+            """,
+            busy_bank_ids,
+            claimed_ids,
+            limit,
+        )
+
     async def claim_tasks(
         self,
         conn,
@@ -1359,6 +1412,16 @@ class PostgreSQLOps(DataAccessOps):
     ):
         all_rows = []
         claimed_ids = []
+
+        # Banks with a graph_maintenance run already in flight. Same guard the
+        # consolidation phases apply, computed once and shared by both call sites.
+        busy_gm_banks = await conn.fetch(
+            f"""
+            SELECT DISTINCT bank_id FROM {table}
+            WHERE operation_type = 'graph_maintenance' AND status = 'processing'
+            """,
+        )
+        busy_gm_bank_ids = [r["bank_id"] for r in busy_gm_banks]
 
         # --- Phase 1: claim from reserved pools ---
         for op_type, limit in reserved_limits.items():
@@ -1382,6 +1445,8 @@ class PostgreSQLOps(DataAccessOps):
                     limit,
                     consolidation_bank_priority,
                 )
+            elif op_type == "graph_maintenance":
+                rows = await self._claim_graph_maintenance_tasks(conn, table, claimed_ids, limit, busy_gm_bank_ids)
             else:
                 rows = await conn.fetch(
                     f"""
@@ -1414,7 +1479,7 @@ class PostgreSQLOps(DataAccessOps):
                     FROM {table}
                     WHERE status = 'pending'
                       AND task_payload IS NOT NULL
-                      AND operation_type != 'consolidation'
+                      AND operation_type NOT IN ('consolidation', 'graph_maintenance')
                       AND (next_retry_at IS NULL OR next_retry_at <= NOW())
                       AND operation_id != ALL($1::uuid[])
                     ORDER BY created_at
@@ -1431,7 +1496,7 @@ class PostgreSQLOps(DataAccessOps):
                     FROM {table}
                     WHERE status = 'pending'
                       AND task_payload IS NOT NULL
-                      AND operation_type != 'consolidation'
+                      AND operation_type NOT IN ('consolidation', 'graph_maintenance')
                       AND (next_retry_at IS NULL OR next_retry_at <= NOW())
                     ORDER BY created_at
                     LIMIT $1
@@ -1467,6 +1532,18 @@ class PostgreSQLOps(DataAccessOps):
                 for row in rows:
                     claimed_ids.append(row["operation_id"])
                     all_rows.append(row)
+
+            # 2c. graph_maintenance (bank-serialised, same rationale as 2b): a
+            # second concurrent run against one bank does no extra work, it just
+            # convoys on the entity_cooccurrences row locks the first run holds.
+            if remaining_shared > 0:
+                rows = await self._claim_graph_maintenance_tasks(
+                    conn, table, claimed_ids, remaining_shared, busy_gm_bank_ids
+                )
+                for row in rows:
+                    claimed_ids.append(row["operation_id"])
+                    all_rows.append(row)
+                remaining_shared -= len(rows)
 
         if not all_rows:
             return []

--- a/hindsight-api-slim/tests/test_graph_maintenance_claim_serialization.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance_claim_serialization.py
@@ -1,0 +1,149 @@
+"""
+Tests for per-bank serialisation of graph_maintenance at claim time.
+
+Two concurrent graph_maintenance runs against the same bank produce no extra
+work — the second convoys on the row locks the first holds — so claim_tasks
+must (a) skip banks with a run already 'processing' and (b) claim at most one
+per bank within a single batch, since submit-time dedupe_by_bank only inspects
+'pending' rows and a bank can accumulate many pending rows while one is in
+flight.
+
+See issue #3230.
+"""
+
+import json
+import uuid
+
+import pytest
+import pytest_asyncio
+
+
+async def _ensure_bank(pool, bank_id: str) -> None:
+    """Upsert a minimal bank row so FK on async_operations passes."""
+    await pool.execute(
+        "INSERT INTO banks (bank_id, name) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        bank_id,
+        bank_id,
+    )
+
+
+# Use loadgroup to ensure these tests run in the same worker
+# since they share database state
+pytestmark = pytest.mark.xdist_group("worker_tests")
+
+
+@pytest_asyncio.fixture
+async def backend(pg0_db_url):
+    """Create a DatabaseBackend for worker tests."""
+    from hindsight_api.engine.db import create_database_backend
+    from hindsight_api.pg0 import resolve_database_url
+
+    resolved_url = await resolve_database_url(pg0_db_url)
+
+    b = create_database_backend("postgresql")
+    await b.initialize(resolved_url, min_size=2, max_size=10, command_timeout=30)
+    yield b
+    await b.shutdown()
+
+
+@pytest_asyncio.fixture
+async def pool(backend):
+    """Expose the raw asyncpg pool from the backend for direct DB access in tests."""
+    yield backend.get_pool()
+
+
+@pytest_asyncio.fixture
+async def clean_operations(pool):
+    """Clean up async_operations table before and after tests."""
+    await pool.execute("DELETE FROM async_operations WHERE status = 'pending'")
+    yield
+    await pool.execute("DELETE FROM async_operations WHERE bank_id LIKE 'test-worker-%'")
+
+
+async def _insert_op(pool, bank_id: str, op_type: str, status: str, worker_id: str | None = None) -> uuid.UUID:
+    """Insert one operation row with a claimable payload."""
+    op_id = uuid.uuid4()
+    payload = json.dumps({"type": op_type, "bank_id": bank_id, "operation_id": str(op_id)})
+    await pool.execute(
+        """
+        INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload, worker_id)
+        VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+        """,
+        op_id,
+        bank_id,
+        op_type,
+        status,
+        payload,
+        worker_id,
+    )
+    return op_id
+
+
+def _make_poller(backend):
+    from hindsight_api.worker import WorkerPoller
+
+    return WorkerPoller(
+        backend=backend,
+        worker_id="test-gm-claim-worker",
+        executor=lambda x: None,
+    )
+
+
+async def _status_of(pool, op_id) -> str:
+    return await pool.fetchval("SELECT status FROM async_operations WHERE operation_id = $1", op_id)
+
+
+class TestGraphMaintenanceClaimSerialization:
+    @pytest.mark.asyncio
+    async def test_second_run_not_claimed_while_bank_busy(self, pool, backend, clean_operations):
+        """A pending graph_maintenance for a bank with one already processing stays pending."""
+        bank_a = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_a)
+        await _insert_op(pool, bank_a, "graph_maintenance", "processing", worker_id="other-worker")
+        pending_id = await _insert_op(pool, bank_a, "graph_maintenance", "pending")
+
+        claimed = await _make_poller(backend).claim_batch()
+
+        claimed_ids = {t.operation_id for t in claimed}
+        assert str(pending_id) not in claimed_ids, "must not claim while the bank has a run in flight"
+        assert await _status_of(pool, pending_id) == "pending"
+
+    @pytest.mark.asyncio
+    async def test_single_batch_claims_at_most_one_per_bank(self, pool, backend, clean_operations):
+        """One claim batch takes at most one graph_maintenance per bank."""
+        bank_a = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_a)
+        op_ids = [await _insert_op(pool, bank_a, "graph_maintenance", "pending") for _ in range(5)]
+
+        claimed = await _make_poller(backend).claim_batch()
+
+        ours = [t for t in claimed if t.operation_id in {str(i) for i in op_ids}]
+        assert len(ours) == 1, f"expected exactly one same-bank claim, got {len(ours)}"
+
+    @pytest.mark.asyncio
+    async def test_idle_bank_still_claimed_while_another_is_busy(self, pool, backend, clean_operations):
+        """Serialisation is per bank: a busy bank A must not block idle bank B."""
+        bank_a = f"test-worker-{uuid.uuid4().hex[:8]}"
+        bank_b = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_a)
+        await _ensure_bank(pool, bank_b)
+        await _insert_op(pool, bank_a, "graph_maintenance", "processing", worker_id="other-worker")
+        b_pending = await _insert_op(pool, bank_b, "graph_maintenance", "pending")
+
+        claimed = await _make_poller(backend).claim_batch()
+
+        claimed_ids = {t.operation_id for t in claimed}
+        assert str(b_pending) in claimed_ids, "an idle bank must still be claimable"
+
+    @pytest.mark.asyncio
+    async def test_other_operation_types_unaffected(self, pool, backend, clean_operations):
+        """The guard must not starve other operation types on the same bank."""
+        bank_a = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_a)
+        await _insert_op(pool, bank_a, "graph_maintenance", "processing", worker_id="other-worker")
+        retain_id = await _insert_op(pool, bank_a, "retain", "pending")
+
+        claimed = await _make_poller(backend).claim_batch()
+
+        claimed_ids = {t.operation_id for t in claimed}
+        assert str(retain_id) in claimed_ids, "retain on the same bank must still be claimed"


### PR DESCRIPTION
## Summary

`graph_maintenance` has no per-bank serialisation at claim time. `consolidation` does — `claim_tasks` excludes banks with a consolidation already `processing` — but `graph_maintenance` is claimed via the generic shared-pool query with no bank awareness.

Two concurrent `graph_maintenance` runs against the same bank produce no extra work: each is the same bank-wide sweep (relink drain + `prune_orphan_entities` + `prune_stale_cooccurrences`), so the second immediately blocks on the `entity_cooccurrences` / `graph_maintenance_queue` row locks the first holds. On a large graph each run takes tens of seconds, and enough arrive (seven enqueue sites) to occupy every free worker slot, all convoyed behind one another.

Observed in production (0.8.6-slim, bank of 94,921 units, ~46k `entities`, ~478k `entity_cooccurrences`): **nine** concurrent runs against one bank formed a six-deep Postgres blocking chain and starved retain to zero completions for ~4 hours. Still reproducible at time of filing — three same-bank runs in one `[WORKER_TASK]` log tick, 4 `processing` + 22 `pending` for the one bank. Full evidence in #3230.

## The fix

Mirrors the existing consolidation bank-serialisation structure in `claim_tasks`, both dialects — no new mechanism:

1. Compute banks with a `graph_maintenance` already `processing` once per claim cycle.
2. Reserved pool: `graph_maintenance` claims go through a dedicated helper (like `_claim_consolidation_tasks`).
3. Shared pool: the generic query now excludes `graph_maintenance` (as it already excluded `consolidation`), and a new phase 2c claims it bank-serialised.
4. The helper claims **at most one per bank within a single batch** (`DISTINCT ON (bank_id)` in a CTE, locking the base table through a join — `DISTINCT ON` cannot be combined with `FOR UPDATE`; same idiom as `claim_graph_maintenance_batch`).

Point 4 is required, not defence-in-depth: submit-time `dedupe_by_bank` only inspects `'pending'` rows, so once a run is in flight every subsequent enqueue becomes a new pending row (22 same-bank pending rows observed live). Without it, one batch claims several for the same bank — the new test demonstrates 5 claimed on `main`.

Oracle: no `DISTINCT ON`, and row-limited `SELECT ... FOR UPDATE` raises ORA-02014, so the Oracle helper uses the two-step candidates-then-lock idiom `prune_terminal_operations` already uses, with `ROW_NUMBER() OVER (PARTITION BY bank_id ORDER BY created_at) = 1` and `FOR UPDATE OF ... SKIP LOCKED`. Implemented for dialect parity; not exercised locally (Oracle tests are gated behind the `oracle` marker and an `ORACLE_TEST_DSN` I don't have — existing repo convention).

No advisory locks: unusable behind connection poolers and managed PG (#2817).

## Disclosure

With this guard, a `graph_maintenance` row wedged in `processing` blocks that bank's graph maintenance until the row is released. #3229 fixes the known paths that create such rows (cancelled tasks, failed terminal writes, shutdown); these two changes are independent but strongest together.

## Tests

`tests/test_graph_maintenance_claim_serialization.py`, real Postgres (pg0):

- `test_second_run_not_claimed_while_bank_busy` — **fails on `main`** (row is claimed), passes with fix.
- `test_single_batch_claims_at_most_one_per_bank` — **fails on `main`** (`got 5`), passes with fix.
- `test_idle_bank_still_claimed_while_another_is_busy` — guards against over-blocking (passes both ways).
- `test_other_operation_types_unaffected` — a busy bank's `retain` is still claimed (passes both ways).

```
$ uv run pytest -n0 tests/test_graph_maintenance_claim_serialization.py
4 passed
$ uv run pytest -n0 tests/test_worker.py
104 passed
$ uv run pytest tests/test_graph_maintenance.py tests/test_graph_maintenance_deadlock.py \
    tests/test_graph_maintenance_queue_race.py tests/test_enqueue_graph_maintenance_ordered.py
32 passed
```

Fixes #3230
