### PR TITLE
fix(worker): reconcile operations a worker still owns when it stops

### DIFF
--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -31,6 +31,13 @@ from .stage import StageHolder, bind_holder
 # pass through unchanged.
 _RETAIN_OP_TYPES = {"retain", "batch_retain", "file_convert_retain"}
 
+# How long shutdown waits for cancelled tasks to unwind before it reconciles
+# their operations. Short: the tasks have already been cancelled and the process
+# is on its way out — this only gives a task mid-way through its own terminal
+# write the chance to land it, so shutdown does not hand back a row that is
+# about to be marked completed.
+_CANCEL_DRAIN_TIMEOUT = 5.0
+
 
 def _metric_operation_label(operation_type: str | None) -> str:
     if operation_type in _RETAIN_OP_TYPES:
@@ -846,7 +853,20 @@ class WorkerPoller:
         except Exception as e:
             logger.error(f"Task {task.operation_id} failed: {e}")
             traceback.print_exc()
-            await self._mark_failed(task.operation_id, str(e), task.schema)
+            try:
+                await self._mark_failed(task.operation_id, str(e), task.schema)
+            except Exception:
+                # Marking a task failed is itself a DB write, and it can fail
+                # (pool exhausted, connection reset, statement timeout). Without
+                # this rescue the row stays 'processing' under a worker that has
+                # already forgotten it: _cleanup_task drops it from _active_tasks,
+                # recover_own_tasks only runs at startup, and no dead-worker logic
+                # applies because the worker is alive. See issue #3228.
+                logger.exception(f"Could not mark task {task.operation_id} failed; reconciling it for re-claim")
+                try:
+                    await self._reclaim_own_processing_tasks(task.schema, operation_id=task.operation_id)
+                except Exception:
+                    logger.exception(f"Could not reconcile task {task.operation_id}; it stays 'processing'")
             terminal_success = False
 
         # Record the metric outside the executor's exception scope so a metrics
@@ -858,6 +878,88 @@ class WorkerPoller:
                 )
             except Exception:
                 logger.warning(f"Failed to record worker operation metric for {task.operation_id}", exc_info=True)
+
+    async def _reclaim_own_processing_tasks(self, schema: str | None, *, operation_id: str | None = None) -> int:
+        """Reconcile rows still claimed by this worker in one schema.
+
+        Rows under the retry budget go back to 'pending'; rows at/over it are
+        moved to 'failed' so a task that reliably kills its worker cannot be
+        re-claimed forever (claim → grind → die → reclaim → …, see #2675/#2834).
+        Batch API operations are excluded — they are long-lived by design and
+        `_recover_batch_operations` resets them without spending a retry.
+
+        Every caller that reconciles this worker's own rows goes through here so
+        the guards stay in one place: startup recovery (`recover_own_tasks`),
+        shutdown release (`release_own_tasks`), and the single-operation rescue
+        when a terminal write itself fails (`operation_id` set).
+
+        Returns:
+            Number of rows reset to pending (not including those failed).
+        """
+        table = fq_table("async_operations", schema)
+        max_retries = self._max_retries
+        # Two separate UPDATEs so their row counts are meaningful:
+        #   1. Rows under the limit → increment retry_count, reset to pending
+        #   2. Rows at/over the limit → move to failed with a clear reason
+        op_filter = "AND operation_id = $3" if operation_id is not None else ""
+        op_args = [operation_id] if operation_id is not None else []
+        async with self._backend.acquire() as conn:
+            # Rows under the limit: increment retry_count and reset to pending
+            result = await conn.execute(
+                f"""
+                UPDATE {table}
+                SET status = 'pending', worker_id = NULL, claimed_at = NULL,
+                    retry_count = COALESCE(retry_count, 0) + 1, updated_at = now()
+                WHERE status = 'processing' AND worker_id = $1
+                  AND result_metadata->>'batch_id' IS NULL
+                  AND COALESCE(retry_count, 0) < $2
+                  {op_filter}
+                """,
+                self._worker_id,
+                max_retries,
+                *op_args,
+            )
+            # Rows that exceeded the limit: move to failed. RETURNING gives us
+            # the ids so their parent aggregators can be rolled up below — a
+            # batch_retain child sub-batch carries parent_operation_id (not
+            # batch_id) in its metadata, so it IS eligible to be failed here,
+            # and without propagating that terminal state the parent is stranded
+            # in 'processing' forever (the same crash loop this fixes, one level up).
+            failed_rows = await conn.fetch(
+                f"""
+                UPDATE {table}
+                SET status = 'failed', worker_id = NULL, claimed_at = NULL,
+                    error_message = 'exceeded max recovery attempts (retry_count >= {max_retries})',
+                    completed_at = now(), updated_at = now()
+                WHERE status = 'processing' AND worker_id = $1
+                  AND result_metadata->>'batch_id' IS NULL
+                  AND COALESCE(retry_count, 0) >= $2
+                  {op_filter}
+                RETURNING operation_id
+                """,
+                self._worker_id,
+                max_retries,
+                *op_args,
+            )
+
+        # Roll each failed child up to its parent aggregator, one transaction
+        # per child so a single problematic parent can't undo the others —
+        # mirrors the per-task transaction the in-process _mark_failed path uses.
+        # The failing UPDATE above already committed, so the children stay failed
+        # regardless; _maybe_update_parent_operation no-ops for tasks without a
+        # parent_operation_id.
+        for failed_row in failed_rows:
+            async with self._backend.acquire() as conn:
+                async with conn.transaction():
+                    await self._maybe_update_parent_operation(str(failed_row["operation_id"]), schema, conn)
+
+        if failed_rows:
+            schema_display = f'"{schema}"' if schema else str(schema)
+            logger.warning(
+                f"Worker {self._worker_id} moved {len(failed_rows)} tasks to 'failed' "
+                f"(exceeded {max_retries} recovery attempts in schema {schema_display})"
+            )
+        return _updated_row_count(result)
 
     async def recover_own_tasks(self) -> int:
         """
@@ -883,66 +985,10 @@ class WorkerPoller:
 
         for schema in schemas:
             try:
-                table = fq_table("async_operations", schema)
-
                 # First, recover batch API operations (before resetting worker tasks)
-                batch_count = await self._recover_batch_operations(schema)
-                total_count += batch_count
+                total_count += await self._recover_batch_operations(schema)
 
-                # Then reset normal worker tasks. Crash-interrupted tasks count
-                # toward the retry budget (worker_max_retries / HINDSIGHT_API_WORKER_MAX_RETRIES).
-                # Without this, a task that kills the worker (OOM, infinite loop)
-                # is reset forever: claim → grind → crash → recover → re-claim…
-                # Two separate UPDATEs so their row counts are meaningful:
-                #   1. Tasks under limit → increment retry_count, reset to pending
-                #   2. Tasks at/over limit → move to failed with a clear reason
-                max_retries = self._max_retries
-                async with self._backend.acquire() as conn:
-                    # Tasks under the limit: increment retry_count and reset to pending
-                    result = await conn.execute(
-                        f"""
-                        UPDATE {table}
-                        SET status = 'pending', worker_id = NULL, claimed_at = NULL,
-                            retry_count = COALESCE(retry_count, 0) + 1, updated_at = now()
-                        WHERE status = 'processing' AND worker_id = $1
-                          AND result_metadata->>'batch_id' IS NULL
-                          AND COALESCE(retry_count, 0) < $2
-                        """,
-                        self._worker_id,
-                        max_retries,
-                    )
-                    # Tasks that exceeded the limit: move to failed. RETURNING
-                    # gives us the ids so their parent aggregators can be rolled
-                    # up below — a batch_retain child sub-batch carries
-                    # parent_operation_id (not batch_id) in its metadata, so it IS
-                    # eligible to be failed here, and without propagating that
-                    # terminal state the parent is stranded in 'processing' forever
-                    # (the same crash loop this method fixes, one level up).
-                    failed_rows = await conn.fetch(
-                        f"""
-                        UPDATE {table}
-                        SET status = 'failed', worker_id = NULL, claimed_at = NULL,
-                            error_message = 'exceeded max recovery attempts after crash (retry_count >= {max_retries})',
-                            completed_at = now(), updated_at = now()
-                        WHERE status = 'processing' AND worker_id = $1
-                          AND result_metadata->>'batch_id' IS NULL
-                          AND COALESCE(retry_count, 0) >= $2
-                        RETURNING operation_id
-                        """,
-                        self._worker_id,
-                        max_retries,
-                    )
-
-                # Roll each failed child up to its parent aggregator, one
-                # transaction per child so a single problematic parent can't undo
-                # the others — mirrors the per-task transaction the in-process
-                # _mark_failed path uses. The failing UPDATE above already committed,
-                # so the children stay failed regardless; _maybe_update_parent_operation
-                # no-ops for tasks without a parent_operation_id.
-                for failed_row in failed_rows:
-                    async with self._backend.acquire() as conn:
-                        async with conn.transaction():
-                            await self._maybe_update_parent_operation(str(failed_row["operation_id"]), schema, conn)
+                total_count += await self._reclaim_own_processing_tasks(schema)
 
                 # Finalize batch_retain parents that the aggregation left behind
                 # (crash between a child's terminal commit and the parent update,
@@ -950,17 +996,6 @@ class WorkerPoller:
                 # NULL payload — unclaimable and invisible to failed_operations —
                 # until reconciled. See issue #2985.
                 await self._reconcile_orphaned_parents(schema)
-
-                pending_count = int(result.split()[-1]) if result else 0
-                failed_count = len(failed_rows)
-                total_count += pending_count
-                if failed_count > 0:
-                    schema_display = f'"{schema}"' if schema else str(schema)
-                    logger.warning(
-                        f"Worker {self._worker_id} moved {failed_count} tasks to 'failed' "
-                        f"(exceeded {max_retries} recovery attempts in schema "
-                        f"{schema_display})"
-                    )
             except Exception as e:
                 # Format schema for logging: custom schemas in quotes, None as-is
                 schema_display = f'"{schema}"' if schema else str(schema)
@@ -968,6 +1003,41 @@ class WorkerPoller:
 
         if total_count > 0:
             logger.info(f"Worker {self._worker_id} recovered {total_count} stale tasks from previous run")
+        return total_count
+
+    async def release_own_tasks(self) -> int:
+        """Hand back every operation this worker still owns, at shutdown.
+
+        The counterpart to `recover_own_tasks`: the same reconciliation, run when
+        the worker stops rather than when it starts. Without it, work cancelled
+        past the drain timeout stays 'processing' under a worker id that is never
+        coming back (the default id is derived from the hostname, so in a
+        container it never recurs) and no client polling that operation ever sees
+        it finish. See issue #3228.
+
+        Deliberately skips the batch-operation and orphaned-parent passes:
+        those are not scoped to this worker's rows, so they stay a startup
+        concern where no other worker can be mid-flight on them.
+
+        Returns:
+            Number of operations returned to pending.
+        """
+        # Nothing here may raise: this runs on the shutdown path, where the DB
+        # being unwell is exactly the case that strands rows, and an exception
+        # escaping would abort the rest of the teardown.
+        try:
+            schemas = await self._get_schemas()
+        except Exception as e:
+            logger.warning(f"Worker {self._worker_id} could not list schemas to release its in-flight tasks: {e}")
+            return 0
+
+        total_count = 0
+        for schema in schemas:
+            try:
+                total_count += await self._reclaim_own_processing_tasks(schema)
+            except Exception as e:
+                schema_display = f'"{schema}"' if schema else str(schema)
+                logger.warning(f"Worker {self._worker_id} failed to release tasks for schema {schema_display}: {e}")
         return total_count
 
     async def _recover_batch_operations(self, schema: str | None) -> int:
@@ -1239,6 +1309,10 @@ class WorkerPoller:
         """
         Signal shutdown and wait for current tasks to complete.
 
+        Whatever is still claimed by this worker once the drain is over — work
+        cancelled past the timeout, or a row stranded earlier by a terminal
+        write that never landed — is handed back to 'pending' before returning.
+
         Args:
             timeout: Maximum time to wait for in-flight tasks (seconds)
         """
@@ -1246,6 +1320,7 @@ class WorkerPoller:
         self._shutdown.set()
 
         # Wait for in-flight tasks to complete
+        drained = False
         start_time = asyncio.get_event_loop().time()
         while asyncio.get_event_loop().time() - start_time < timeout:
             async with self._in_flight_lock:
@@ -1254,7 +1329,8 @@ class WorkerPoller:
 
             if in_flight == 0:
                 logger.info(f"Worker {self._worker_id} graceful shutdown complete")
-                return
+                drained = True
+                break
 
             logger.info(f"Worker {self._worker_id} waiting for {in_flight} in-flight tasks")
 
@@ -1264,13 +1340,31 @@ class WorkerPoller:
             else:
                 await asyncio.sleep(0.5)
 
-        logger.warning(f"Worker {self._worker_id} shutdown timeout after {timeout}s, cancelling remaining tasks")
+        if not drained:
+            logger.warning(f"Worker {self._worker_id} shutdown timeout after {timeout}s, cancelling remaining tasks")
 
-        # Cancel remaining tasks
-        async with self._in_flight_lock:
-            for operation_id, info in list(self._active_tasks.items()):
-                if not info.bg_task.done():
-                    info.bg_task.cancel()
+            # Cancel remaining tasks
+            cancelled: list[asyncio.Task] = []
+            async with self._in_flight_lock:
+                for operation_id, info in list(self._active_tasks.items()):
+                    if not info.bg_task.done():
+                        info.bg_task.cancel()
+                        cancelled.append(info.bg_task)
+
+            # Let the cancellations land before reconciling. asyncio.CancelledError
+            # derives from BaseException, so it escapes every `except Exception` in
+            # _execute_task_inner and no terminal state is ever written — but a task
+            # partway through its own terminal write must be allowed to finish it,
+            # or we would hand back a row it is about to complete.
+            if cancelled:
+                await asyncio.wait(cancelled, timeout=_CANCEL_DRAIN_TIMEOUT)
+
+        # Anything still 'processing' under this worker id is work nobody is
+        # running. Hand it back now instead of waiting for a startup recovery
+        # that a hostname-derived worker id will never see again (issue #3228).
+        released = await self.release_own_tasks()
+        if released:
+            logger.warning(f"Worker {self._worker_id} returned {released} in-flight operations to 'pending'")
 
     async def _log_progress_if_due(self):
         """Log progress stats every PROGRESS_LOG_INTERVAL seconds.

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -1659,6 +1659,199 @@ class TestWorkerRecovery:
         assert parent_row["status"] == "pending"
 
 
+class TestTaskReleaseOnStop:
+    """A task that stops running must not leave its operation 'processing'.
+
+    Both paths strand the row under a worker id that is never coming back:
+    shutdown cancelling in-flight work past the drain timeout, and _mark_failed
+    (itself a DB write) failing. See issue #3228.
+    """
+
+    async def _insert_pending(self, pool, bank_id: str) -> uuid.UUID:
+        """Insert one claimable pending operation, returning its id."""
+        op_id = uuid.uuid4()
+        payload = json.dumps({"type": "test_task", "bank_id": bank_id, "operation_id": str(op_id)})
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload)
+            VALUES ($1, $2, 'test', 'pending', $3::jsonb)
+            """,
+            op_id,
+            bank_id,
+            payload,
+        )
+        return op_id
+
+    async def _claim_ours(self, poller, op_id) -> object:
+        """Claim until our operation comes back (other rows may be queued too)."""
+        claimed = await poller.claim_batch()
+        ours = [t for t in claimed if t.operation_id == str(op_id)]
+        assert len(ours) == 1, "test operation should have been claimed"
+        return ours[0]
+
+    async def _wait_for_status(self, pool, op_id, status: str, timeout: float = 5.0):
+        """Poll until the row leaves 'processing'; return the final row."""
+        deadline = asyncio.get_event_loop().time() + timeout
+        while True:
+            row = await pool.fetchrow(
+                "SELECT status, worker_id, claimed_at, retry_count FROM async_operations WHERE operation_id = $1",
+                op_id,
+            )
+            if row["status"] == status or asyncio.get_event_loop().time() > deadline:
+                return row
+            await asyncio.sleep(0.05)
+
+    @pytest.mark.asyncio
+    async def test_shutdown_releases_cancelled_operations(self, pool, backend, clean_operations):
+        """shutdown_graceful must hand back the rows whose tasks it cancelled."""
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+        op_id = await self._insert_pending(pool, bank_id)
+
+        started = asyncio.Event()
+        block = asyncio.Event()
+
+        async def blocking_executor(task_dict):
+            started.set()
+            await block.wait()
+
+        poller = WorkerPoller(backend=backend, worker_id="release-worker", executor=blocking_executor)
+        task = await self._claim_ours(poller, op_id)
+
+        row = await pool.fetchrow("SELECT status, worker_id FROM async_operations WHERE operation_id = $1", op_id)
+        assert row["status"] == "processing"
+        assert row["worker_id"] == "release-worker"
+
+        await poller.execute_task(task)
+        await asyncio.wait_for(started.wait(), timeout=5)
+
+        await poller.shutdown_graceful(timeout=0.1)
+
+        row = await pool.fetchrow(
+            "SELECT status, worker_id, claimed_at, retry_count FROM async_operations WHERE operation_id = $1",
+            op_id,
+        )
+        assert row["status"] == "pending", "shutdown must not strand a row it cancelled"
+        assert row["worker_id"] is None
+        assert row["claimed_at"] is None
+        assert row["retry_count"] == 1, "an interrupted run counts against the retry budget"
+
+    @pytest.mark.asyncio
+    async def test_shutdown_fails_operation_over_retry_budget(self, pool, backend, clean_operations):
+        """A row already at the retry limit is failed, not handed back forever."""
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+        op_id = await self._insert_pending(pool, bank_id)
+
+        started = asyncio.Event()
+        block = asyncio.Event()
+
+        async def blocking_executor(task_dict):
+            started.set()
+            await block.wait()
+
+        poller = WorkerPoller(backend=backend, worker_id="release-worker", executor=blocking_executor, max_retries=2)
+        task = await self._claim_ours(poller, op_id)
+        await pool.execute("UPDATE async_operations SET retry_count = 2 WHERE operation_id = $1", op_id)
+
+        await poller.execute_task(task)
+        await asyncio.wait_for(started.wait(), timeout=5)
+
+        await poller.shutdown_graceful(timeout=0.1)
+
+        row = await pool.fetchrow(
+            "SELECT status, worker_id, error_message FROM async_operations WHERE operation_id = $1",
+            op_id,
+        )
+        assert row["status"] == "failed", "a row over the retry budget must not be re-claimed forever"
+        assert row["worker_id"] is None
+        assert "retry_count" in row["error_message"]
+
+    @pytest.mark.asyncio
+    async def test_shutdown_leaves_completed_operation_alone(self, pool, backend, clean_operations):
+        """A task that finished during the drain keeps its terminal state."""
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+        op_id = await self._insert_pending(pool, bank_id)
+
+        async def quick_executor(task_dict):
+            return None
+
+        poller = WorkerPoller(backend=backend, worker_id="release-worker", executor=quick_executor)
+        task = await self._claim_ours(poller, op_id)
+
+        await poller.execute_task(task)
+        await poller.shutdown_graceful(timeout=5.0)
+
+        row = await pool.fetchrow(
+            "SELECT status, retry_count FROM async_operations WHERE operation_id = $1",
+            op_id,
+        )
+        assert row["status"] == "completed"
+        assert row["retry_count"] == 0, "a completed task must not be charged a retry"
+
+    @pytest.mark.asyncio
+    async def test_shutdown_does_not_touch_other_workers(self, pool, backend, clean_operations):
+        """The release is scoped to this worker's own rows."""
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+        other_op_id = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload, worker_id, claimed_at)
+            VALUES ($1, $2, 'test', 'processing', '{}'::jsonb, 'other-worker', now())
+            """,
+            other_op_id,
+            bank_id,
+        )
+
+        poller = WorkerPoller(backend=backend, worker_id="release-worker", executor=lambda x: None)
+        await poller.shutdown_graceful(timeout=0.1)
+
+        row = await pool.fetchrow(
+            "SELECT status, worker_id FROM async_operations WHERE operation_id = $1",
+            other_op_id,
+        )
+        assert row["status"] == "processing", "another live worker's row must be left alone"
+        assert row["worker_id"] == "other-worker"
+
+    @pytest.mark.asyncio
+    async def test_failed_terminal_write_releases_operation(self, pool, backend, clean_operations):
+        """If _mark_failed itself raises, the row is reconciled, not stranded."""
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+        op_id = await self._insert_pending(pool, bank_id)
+
+        async def failing_executor(task_dict):
+            raise RuntimeError("executor blew up")
+
+        poller = WorkerPoller(backend=backend, worker_id="release-worker", executor=failing_executor)
+
+        async def broken_mark_failed(operation_id, error_message, schema):
+            raise RuntimeError("pool exhausted")
+
+        poller._mark_failed = broken_mark_failed
+
+        task = await self._claim_ours(poller, op_id)
+        await poller.execute_task(task)
+
+        row = await self._wait_for_status(pool, op_id, "pending")
+        assert row["status"] == "pending", "a failed terminal write must not strand the row"
+        assert row["worker_id"] is None
+        assert row["claimed_at"] is None
+        assert row["retry_count"] == 1
+
+
 class TestConcurrentWorkers:
     """Tests for concurrent worker task claiming (FOR UPDATE SKIP LOCKED)."""
 


### PR DESCRIPTION
## Summary

An in-flight task that stops running without reaching its terminal-marking code leaves its `async_operations` row `processing` under a **live** worker, forever. The worker has already forgotten it (`_cleanup_task` dropped it from `_active_tasks` and freed the slot), `recover_own_tasks` only runs at startup, and no dead-worker handling applies because the worker is alive. Clients polling that operation wait indefinitely.

Two paths get there:

1. **`shutdown_graceful` cancels and walks away.** After the drain timeout it calls `bg_task.cancel()` on each in-flight task and returns. `asyncio.CancelledError` derives from `BaseException`, so it escapes every `except Exception` in `_execute_task_inner` and no terminal state is ever written. Every rollout with work in flight past the grace period strands it — and under the default hostname-derived worker id in a container, the id never recurs, so no future startup recovery ever picks it up either.
2. **`_mark_failed` is itself a DB write.** If it raises inside the `except Exception` branch (pool exhausted, connection reset, statement timeout), the exception escapes uncaught with the row still `processing`. This is the path consistent with the production evidence in #3228: a pod running 39h without a restart holding two rows `processing` for 38h.

## The fix

`recover_own_tasks` already knows how to reconcile this worker's own rows correctly. The change extracts that logic into `_reclaim_own_processing_tasks(schema, *, operation_id=None)` and reuses it from both new sites, rather than writing a second, laxer version of the same UPDATE. That keeps the guards that make it safe in one place:

- scoped to `status = 'processing' AND worker_id = <self>`, so it never touches another worker's rows and is a no-op the moment a task lands its own terminal state — no cross-worker coordination, no liveness inference;
- batch API operations excluded (`result_metadata->>'batch_id' IS NULL`) — they are long-lived by design and `_recover_batch_operations` resets them without spending a retry;
- rows at/over `max_retries` moved to `failed` with their parent aggregators rolled up, so a task that reliably kills its worker exhausts its budget instead of being re-claimed forever (#2675/#2834). The claim query has no retry cap of its own, so dropping this would reintroduce that loop.

Call sites:

- **`shutdown_graceful`** → new `release_own_tasks()`, the shutdown counterpart to `recover_own_tasks`: the same per-schema reconciliation, run when the worker stops instead of only when it starts. It deliberately skips the batch-operation and orphaned-parent passes, which are not scoped to this worker's rows and stay a startup concern. It also runs on the clean-drain path, so a row stranded earlier still gets reconciled. Nothing in it raises — at shutdown, an unwell DB is exactly the case that strands rows, and an exception escaping would abort the rest of the teardown.
- **`_execute_task_inner`** → the `_mark_failed` call is wrapped; if the terminal write cannot land, the same reconciliation runs for that one operation.

`shutdown_graceful` now also **waits for the cancellations to land** (`asyncio.wait`, 5s cap) before reconciling. Cancellation is not delivered synchronously, so releasing immediately after `.cancel()` would hand back rows whose tasks are still unwinding — including one partway through its own terminal write, which another worker could then claim and run concurrently.

## Tests

Five tests in `tests/test_worker.py::TestTaskReleaseOnStop`, using that module's existing fixtures:

- `test_shutdown_releases_cancelled_operations` — blocked task, `shutdown_graceful(timeout=0.1)`; row ends `pending` / `worker_id NULL` / `retry_count 1`.
- `test_shutdown_fails_operation_over_retry_budget` — same, with `retry_count` already at the limit; row ends `failed`, not handed back.
- `test_shutdown_leaves_completed_operation_alone` — a task that finishes during the drain keeps `completed` and is not charged a retry.
- `test_shutdown_does_not_touch_other_workers` — another worker's `processing` row is untouched.
- `test_failed_terminal_write_releases_operation` — executor raises and `_mark_failed` is patched to raise; row ends `pending`.

The three that exercise the new behaviour fail on `main`; the two guard tests pass there and must keep passing.

```
$ uv run pytest tests/test_worker.py -q
109 passed
$ uv run pytest tests/test_subbatch_multichunk_coverage.py tests/test_async_batch_retain.py \
    tests/test_batch_api.py tests/test_retain_transient_extraction_failure.py tests/test_worker_wall_timeout.py -q
57 passed
```

Fixes #3228. Supersedes #3229, which fixed the same issue with a parallel copy of the reconciliation SQL that dropped the retry cap and the batch-operation exclusion, and released rows before their cancellations had landed.
