### PR TITLE
fix(worker): serialise graph_maintenance per bank at claim time

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops.py
@@ -25,6 +25,68 @@ from .base import DatabaseConnection
 from .result import ResultRow
 
 
+def graph_maintenance_bank_serialization_sql(table: str, alias: str) -> str:
+    """SQL predicate serialising ``graph_maintenance`` claims per bank (#3230).
+
+    Every graph_maintenance run is the same bank-wide sweep — the payload carries
+    only ``bank_id``, and ``run_graph_maintenance_job`` drains the whole queue —
+    so a second concurrent run for one bank adds no work. It is worse than
+    useless: ``claim_graph_maintenance_batch`` locks queue rows ``FOR UPDATE``
+    *without* ``SKIP LOCKED`` (it is written assuming a single runner per bank),
+    so the runs convoy on each other's row locks while each holds a worker slot.
+
+    Same guarantee ``consolidation`` already gets from its ``bank_id != ALL(busy)``
+    exclusion, and the same caveat: a row wedged in 'processing' holds its bank
+    until something releases it (``hindsight-admin recover``, or a restart with a
+    stable ``HINDSIGHT_API_WORKER_ID`` so ``recover_own_tasks`` matches it). That
+    is a general gap in claim recovery, not specific to graph_maintenance.
+
+    Two differences from the consolidation form, both forced by the shape of this
+    problem:
+
+    * It is a **predicate**, not a separate claim phase. Pulling graph_maintenance
+      into its own phase after the generic shared-pool query would drop it below
+      every other operation type: it has no reserved-slot floor
+      (``WORKER_SLOT_TYPE_DEFAULTS`` gives consolidation 2 and graph_maintenance
+      0), and the poller's fairness pass calls ``claim_tasks`` with
+      ``shared_limit=1``, so a single pending retain would starve it indefinitely.
+      As a predicate it keeps competing by ``created_at``.
+    * It also suppresses every same-bank row but the oldest **within one batch**.
+      Excluding busy banks alone does not: with several pending rows and nothing
+      yet processing, one batch claims them all — the convoy, unchanged. Several
+      pending rows per bank are reachable through the recovery paths
+      (``_reclaim_own_processing_tasks`` resets *all* of a worker's processing
+      rows in one statement, from ``recover_own_tasks`` at startup and
+      ``release_own_tasks`` at shutdown, plus ``_schedule_retry`` /
+      ``_defer_operation`` / ``hindsight-admin recover``).
+
+    The candidate row is always 'pending' and the 'pending' branch is
+    strictly-older, so the subquery can never match the candidate itself. The
+    fragment carries no SQL comments on purpose — it is rewritten for Oracle by
+    regex (``db/oracle.py``).
+
+    Args:
+        table: Fully-qualified async_operations table.
+        alias: Alias of the outer candidate row in the calling query.
+    """
+    return f"""
+        ({alias}.operation_type <> 'graph_maintenance' OR NOT EXISTS (
+            SELECT 1 FROM {table} gm_peer
+            WHERE gm_peer.bank_id = {alias}.bank_id
+              AND gm_peer.operation_type = 'graph_maintenance'
+              AND (
+                  gm_peer.status = 'processing'
+                  OR (gm_peer.status = 'pending'
+                      AND gm_peer.task_payload IS NOT NULL
+                      AND (gm_peer.next_retry_at IS NULL OR gm_peer.next_retry_at <= NOW())
+                      AND (gm_peer.created_at < {alias}.created_at
+                           OR (gm_peer.created_at = {alias}.created_at
+                               AND gm_peer.operation_id < {alias}.operation_id)))
+              )
+        ))
+    """
+
+
 @dataclass
 class TagListingParts:
     """Backend-specific SQL fragments for the tag listing query."""
@@ -600,6 +662,10 @@ class DataAccessOps(ABC):
         PG implementation can use NOT EXISTS + FOR UPDATE SKIP LOCKED in one query.
         Oracle implementation uses two-step claims (query busy banks first, then
         claim excluding them) to avoid ORA-02014.
+
+        Implementations must apply :func:`graph_maintenance_bank_serialization_sql`
+        to every query that can return a ``graph_maintenance`` row, so at most one
+        such row per bank is ever in flight.
 
         Args:
             consolidation_bank_priority: Per-bank priority for consolidation scheduling.

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -10,7 +10,13 @@ import uuid as uuid_mod
 from datetime import UTC, datetime
 
 from .base import DatabaseConnection
-from .ops import DataAccessOps, LinkExpansionRows, TagListingParts, UpdatedWindow
+from .ops import (
+    DataAccessOps,
+    LinkExpansionRows,
+    TagListingParts,
+    UpdatedWindow,
+    graph_maintenance_bank_serialization_sql,
+)
 from .result import DictResultRow as ResultRow
 
 ORACLE_IN_LIST_LIMIT = 1000
@@ -1332,13 +1338,14 @@ class OracleOps(DataAccessOps):
             else:
                 rows = await conn.fetch(
                     f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count
-                    FROM {table}
-                    WHERE status = 'pending'
-                      AND task_payload IS NOT NULL
-                      AND operation_type = $1
-                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                    ORDER BY created_at
+                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count
+                    FROM {table} o
+                    WHERE o.status = 'pending'
+                      AND o.task_payload IS NOT NULL
+                      AND o.operation_type = $1
+                      AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
+                      AND {graph_maintenance_bank_serialization_sql(table, "o")}
+                    ORDER BY o.created_at
                     LIMIT $2
                     FOR UPDATE SKIP LOCKED
                     """,
@@ -1353,18 +1360,21 @@ class OracleOps(DataAccessOps):
         # --- Phase 2: claim from shared pool ---
         remaining_shared = shared_limit
         if remaining_shared > 0:
-            # 2a. Non-consolidation tasks
+            # 2a. Non-consolidation tasks. graph_maintenance stays in this
+            # created_at-ordered query — see graph_maintenance_bank_serialization_sql
+            # for why it is a predicate rather than a phase of its own.
             if claimed_ids:
                 rows = await conn.fetch(
                     f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count
-                    FROM {table}
-                    WHERE status = 'pending'
-                      AND task_payload IS NOT NULL
-                      AND operation_type != 'consolidation'
-                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                      AND operation_id != ALL($1::uuid[])
-                    ORDER BY created_at
+                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count
+                    FROM {table} o
+                    WHERE o.status = 'pending'
+                      AND o.task_payload IS NOT NULL
+                      AND o.operation_type != 'consolidation'
+                      AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
+                      AND o.operation_id != ALL($1::uuid[])
+                      AND {graph_maintenance_bank_serialization_sql(table, "o")}
+                    ORDER BY o.created_at
                     LIMIT $2
                     FOR UPDATE SKIP LOCKED
                     """,
@@ -1374,13 +1384,14 @@ class OracleOps(DataAccessOps):
             else:
                 rows = await conn.fetch(
                     f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count
-                    FROM {table}
-                    WHERE status = 'pending'
-                      AND task_payload IS NOT NULL
-                      AND operation_type != 'consolidation'
-                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                    ORDER BY created_at
+                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count
+                    FROM {table} o
+                    WHERE o.status = 'pending'
+                      AND o.task_payload IS NOT NULL
+                      AND o.operation_type != 'consolidation'
+                      AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
+                      AND {graph_maintenance_bank_serialization_sql(table, "o")}
+                    ORDER BY o.created_at
                     LIMIT $1
                     FOR UPDATE SKIP LOCKED
                     """,

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -7,7 +7,13 @@ efficient batch operations.
 from datetime import datetime
 
 from .base import DatabaseConnection
-from .ops import DataAccessOps, LinkExpansionRows, TagListingParts, UpdatedWindow
+from .ops import (
+    DataAccessOps,
+    LinkExpansionRows,
+    TagListingParts,
+    UpdatedWindow,
+    graph_maintenance_bank_serialization_sql,
+)
 from .result import ResultRow
 
 
@@ -1389,13 +1395,14 @@ class PostgreSQLOps(DataAccessOps):
             else:
                 rows = await conn.fetch(
                     f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count
-                    FROM {table}
-                    WHERE status = 'pending'
-                      AND task_payload IS NOT NULL
-                      AND operation_type = $1
-                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                    ORDER BY created_at
+                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count
+                    FROM {table} o
+                    WHERE o.status = 'pending'
+                      AND o.task_payload IS NOT NULL
+                      AND o.operation_type = $1
+                      AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
+                      AND {graph_maintenance_bank_serialization_sql(table, "o")}
+                    ORDER BY o.created_at
                     LIMIT $2
                     FOR UPDATE SKIP LOCKED
                     """,
@@ -1410,18 +1417,21 @@ class PostgreSQLOps(DataAccessOps):
         # --- Phase 2: claim from shared pool ---
         remaining_shared = shared_limit
         if remaining_shared > 0:
-            # 2a. Non-consolidation tasks
+            # 2a. Non-consolidation tasks. graph_maintenance stays in this
+            # created_at-ordered query — see graph_maintenance_bank_serialization_sql
+            # for why it is a predicate rather than a phase of its own.
             if claimed_ids:
                 rows = await conn.fetch(
                     f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count
-                    FROM {table}
-                    WHERE status = 'pending'
-                      AND task_payload IS NOT NULL
-                      AND operation_type != 'consolidation'
-                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                      AND operation_id != ALL($1::uuid[])
-                    ORDER BY created_at
+                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count
+                    FROM {table} o
+                    WHERE o.status = 'pending'
+                      AND o.task_payload IS NOT NULL
+                      AND o.operation_type != 'consolidation'
+                      AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
+                      AND o.operation_id != ALL($1::uuid[])
+                      AND {graph_maintenance_bank_serialization_sql(table, "o")}
+                    ORDER BY o.created_at
                     LIMIT $2
                     FOR UPDATE SKIP LOCKED
                     """,
@@ -1431,13 +1441,14 @@ class PostgreSQLOps(DataAccessOps):
             else:
                 rows = await conn.fetch(
                     f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count
-                    FROM {table}
-                    WHERE status = 'pending'
-                      AND task_payload IS NOT NULL
-                      AND operation_type != 'consolidation'
-                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                    ORDER BY created_at
+                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count
+                    FROM {table} o
+                    WHERE o.status = 'pending'
+                      AND o.task_payload IS NOT NULL
+                      AND o.operation_type != 'consolidation'
+                      AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
+                      AND {graph_maintenance_bank_serialization_sql(table, "o")}
+                    ORDER BY o.created_at
                     LIMIT $1
                     FOR UPDATE SKIP LOCKED
                     """,

--- a/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
@@ -29,6 +29,12 @@ The worker dedupes on bank: a second job for the same bank is dropped
 while one is pending. Once processing starts, a new job becomes the
 *next* pending slot — so work enqueued during processing gets picked up
 by the follow-up run.
+
+That follow-up run is *deferred*, not parallel: ``claim_tasks`` will not claim a
+graph_maintenance row for a bank that already has one in flight (#3230). Two
+concurrent runs would do no extra work anyway — each is this same bank-wide
+sweep — while convoying on each other's row locks and holding a worker slot
+each.
 """
 
 from __future__ import annotations

--- a/hindsight-api-slim/hindsight_api/engine/memories/pg/graph.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/pg/graph.py
@@ -531,9 +531,14 @@ async def relink_pass(
 ) -> dict:
     """Drain ``graph_maintenance_queue`` for ``bank_id``, topping up lost links.
 
-    Per-iteration loop: claim → top up → commit. We rely on submit-time
-    dedup to keep at most one job per bank running, so no need for
-    SKIP LOCKED.
+    Per-iteration loop: claim → top up → commit. We rely on at most one job per
+    bank running, so no need for SKIP LOCKED. Submit-time dedup alone does NOT
+    give that — it only inspects 'pending' rows — so the guarantee comes from
+    ``claim_tasks``, which refuses to claim a graph_maintenance row for a bank
+    that already has one in flight (``graph_maintenance_bank_serialization_sql``,
+    #3230). Without it these claims convoy: they lock queue rows ``FOR UPDATE``
+    with no ``SKIP LOCKED``, so a second run blocks on the first while holding a
+    worker slot.
 
     Takes ``backend`` rather than a connection because the loop spans several
     transactions — one per claimed batch, plus a separate connection for the ANN

--- a/hindsight-api-slim/tests/test_graph_maintenance_claim_serialization.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance_claim_serialization.py
@@ -1,0 +1,308 @@
+"""Per-bank serialisation of graph_maintenance at claim time (#3230).
+
+Every graph_maintenance run is the same bank-wide sweep — the payload carries
+only ``bank_id`` and ``run_graph_maintenance_job`` drains the whole queue — so a
+second concurrent run for one bank adds no work while convoying on the first
+run's queue-row locks (``claim_graph_maintenance_batch`` locks ``FOR UPDATE``
+with no ``SKIP LOCKED``) and holding a worker slot.
+
+``claim_tasks`` therefore refuses to claim a graph_maintenance row for a bank
+that already has one in flight, and takes at most one per bank per batch. It
+does that with a predicate on the ordinary shared-pool query rather than a
+claim phase of its own, so graph_maintenance keeps competing by ``created_at``
+instead of dropping below every other operation type — it has no reserved-slot
+floor, and the poller's fairness pass claims with ``shared_limit=1``.
+
+These call ``ops.claim_tasks`` directly rather than ``WorkerPoller.claim_batch``
+so the slot limits under test are exact and not a function of ambient in-flight
+work in the shared test database.
+"""
+
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+
+# Use loadgroup to ensure these tests run in the same worker
+# since they share database state
+pytestmark = pytest.mark.xdist_group("worker_tests")
+
+_TABLE = "async_operations"
+
+
+@pytest_asyncio.fixture
+async def backend(pg0_db_url):
+    """Create a DatabaseBackend for claim tests."""
+    from hindsight_api.engine.db import create_database_backend
+    from hindsight_api.pg0 import resolve_database_url
+
+    resolved_url = await resolve_database_url(pg0_db_url)
+
+    b = create_database_backend("postgresql")
+    await b.initialize(resolved_url, min_size=2, max_size=10, command_timeout=30)
+    yield b
+    await b.shutdown()
+
+
+@pytest_asyncio.fixture
+async def pool(backend):
+    """Expose the raw asyncpg pool from the backend for direct DB access in tests."""
+    yield backend.get_pool()
+
+
+@pytest_asyncio.fixture
+async def clean_operations(pool):
+    """Isolate these tests from other pending work in the shared schema.
+
+    Same rationale as test_worker.py's fixture: the claim queries scan the whole
+    schema, so stale pending rows from other tests would be claimed here and
+    consume the (deliberately small) slot limits under test.
+    """
+    await pool.execute("DELETE FROM async_operations WHERE status = 'pending'")
+    yield
+    await pool.execute("DELETE FROM async_operations WHERE bank_id LIKE 'test-gmclaim-%'")
+
+
+async def _make_bank(pool) -> str:
+    """Create a bank with a unique id so concurrent runs can't collide."""
+    bank_id = f"test-gmclaim-{uuid.uuid4().hex[:8]}"
+    await pool.execute(
+        "INSERT INTO banks (bank_id, name) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        bank_id,
+        bank_id,
+    )
+    return bank_id
+
+
+async def _insert_op(
+    pool,
+    bank_id: str,
+    op_type: str,
+    status: str = "pending",
+    *,
+    created_at: datetime | None = None,
+    claimed_at: datetime | None = None,
+    next_retry_at: datetime | None = None,
+    worker_id: str | None = None,
+) -> uuid.UUID:
+    """Insert one operation row with a claimable payload."""
+    op_id = uuid.uuid4()
+    payload = json.dumps({"type": op_type, "bank_id": bank_id, "operation_id": str(op_id)})
+    await pool.execute(
+        f"""
+        INSERT INTO {_TABLE}
+            (operation_id, bank_id, operation_type, status, task_payload, worker_id, next_retry_at,
+             created_at, claimed_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7,
+                COALESCE($8, now()), $9, now())
+        """,
+        op_id,
+        bank_id,
+        op_type,
+        status,
+        payload,
+        worker_id,
+        next_retry_at,
+        created_at,
+        claimed_at,
+    )
+    return op_id
+
+
+async def _claim(backend, *, shared: int = 10, reserved: dict[str, int] | None = None) -> set[str]:
+    """Run one claim cycle and return the claimed operation ids as strings."""
+    async with backend.acquire() as conn:
+        async with conn.transaction():
+            rows = await backend.ops.claim_tasks(
+                conn,
+                _TABLE,
+                "test-gmclaim-worker",
+                reserved or {},
+                shared,
+            )
+    return {str(row["operation_id"]) for row in rows}
+
+
+async def _status_of(pool, op_id: uuid.UUID) -> str:
+    return await pool.fetchval(f"SELECT status FROM {_TABLE} WHERE operation_id = $1", op_id)
+
+
+@pytest.mark.asyncio
+async def test_not_claimed_while_bank_has_run_in_flight(pool, backend, clean_operations):
+    """A pending graph_maintenance is left alone while its bank has one processing."""
+    bank = await _make_bank(pool)
+    await _insert_op(pool, bank, "graph_maintenance", "processing", claimed_at=datetime.now(UTC), worker_id="other")
+    pending = await _insert_op(pool, bank, "graph_maintenance")
+
+    claimed = await _claim(backend)
+
+    assert str(pending) not in claimed
+    assert await _status_of(pool, pending) == "pending"
+
+
+@pytest.mark.asyncio
+async def test_single_batch_claims_at_most_one_per_bank(pool, backend, clean_operations):
+    """One batch takes a single graph_maintenance per bank — the oldest.
+
+    Multiple pending rows for one bank are reachable despite submit-time dedup:
+    ``recover_own_tasks`` resets every processing row for a worker back to
+    pending in one statement, and _schedule_retry / _defer_operation / the admin
+    recover command each restore rows independently.
+    """
+    bank = await _make_bank(pool)
+    base = datetime.now(UTC) - timedelta(minutes=10)
+    op_ids = [
+        await _insert_op(pool, bank, "graph_maintenance", created_at=base + timedelta(seconds=i)) for i in range(5)
+    ]
+
+    claimed = await _claim(backend)
+
+    ours = [op for op in op_ids if str(op) in claimed]
+    assert len(ours) == 1, f"expected exactly one same-bank claim, got {len(ours)}"
+    assert ours[0] == op_ids[0], "the oldest pending row should be the one claimed"
+
+
+@pytest.mark.asyncio
+async def test_idle_bank_still_claimed_while_another_is_busy(pool, backend, clean_operations):
+    """The guard is per bank, not global: a different bank is unaffected."""
+    busy_bank = await _make_bank(pool)
+    idle_bank = await _make_bank(pool)
+    await _insert_op(pool, busy_bank, "graph_maintenance", "processing", claimed_at=datetime.now(UTC))
+    blocked = await _insert_op(pool, busy_bank, "graph_maintenance")
+    claimable = await _insert_op(pool, idle_bank, "graph_maintenance")
+
+    claimed = await _claim(backend)
+
+    assert str(claimable) in claimed
+    assert str(blocked) not in claimed
+
+
+@pytest.mark.asyncio
+async def test_other_operation_types_unaffected(pool, backend, clean_operations):
+    """A busy bank's non-graph_maintenance work is still claimed."""
+    bank = await _make_bank(pool)
+    await _insert_op(pool, bank, "graph_maintenance", "processing", claimed_at=datetime.now(UTC))
+    retain = await _insert_op(pool, bank, "retain")
+
+    claimed = await _claim(backend)
+
+    assert str(retain) in claimed
+
+
+@pytest.mark.asyncio
+async def test_not_starved_by_newer_pending_work(pool, backend, clean_operations):
+    """graph_maintenance still wins the shared slot when it is the oldest row.
+
+    The poller's fairness pass claims with ``shared_limit=1`` and
+    graph_maintenance has no reserved-slot floor, so claiming it in a phase
+    *after* the generic shared-pool query would let any single pending retain
+    starve it indefinitely. As a predicate on that same query it keeps its place
+    in the created_at ordering.
+    """
+    bank = await _make_bank(pool)
+    older = await _insert_op(pool, bank, "graph_maintenance", created_at=datetime.now(UTC) - timedelta(minutes=5))
+    await _insert_op(pool, bank, "retain")
+
+    claimed = await _claim(backend, shared=1)
+
+    assert claimed == {str(older)}
+
+
+@pytest.mark.asyncio
+async def test_retry_blocked_older_row_does_not_block_a_claimable_one(pool, backend, clean_operations):
+    """An older row still in retry backoff must not hold up its bank.
+
+    It cannot be claimed itself, so counting it as "goes first" would stall the
+    bank's graph maintenance for the whole backoff window.
+    """
+    bank = await _make_bank(pool)
+    await _insert_op(
+        pool,
+        bank,
+        "graph_maintenance",
+        created_at=datetime.now(UTC) - timedelta(minutes=5),
+        next_retry_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+    claimable = await _insert_op(pool, bank, "graph_maintenance")
+
+    claimed = await _claim(backend)
+
+    assert str(claimable) in claimed
+
+
+def test_guard_survives_the_oracle_sql_rewrite():
+    """The shared predicate must still be valid Oracle after db/oracle.py rewrites it.
+
+    Oracle tests need an ORACLE_TEST_DSN this suite does not have, so the dialect
+    parity of this guard is otherwise unverified. The rewriter is pure text
+    substitution, so assert on its output directly: PG-only spellings must be
+    gone, and the ROWNUM row limit must land on the *outer* WHERE rather than the
+    subquery's (the rewriter replaces only the first WHERE it sees).
+    """
+    from hindsight_api.engine.db.ops import graph_maintenance_bank_serialization_sql
+    from hindsight_api.engine.db.oracle import _rewrite_pg_to_oracle
+
+    table = "async_operations"
+    rewritten = _rewrite_pg_to_oracle(
+        f"""
+        SELECT o.operation_id FROM {table} o
+        WHERE o.status = 'pending'
+          AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
+          AND o.operation_id != ALL($1::uuid[])
+          AND {graph_maintenance_bank_serialization_sql(table, "o")}
+        ORDER BY o.created_at
+        LIMIT $2
+        FOR UPDATE SKIP LOCKED
+        """
+    ).query
+
+    assert "NOW()" not in rewritten and "SYSTIMESTAMP" in rewritten
+    assert "!= ALL" not in rewritten and "::uuid[]" not in rewritten
+    assert "LIMIT" not in rewritten
+    assert "FOR UPDATE SKIP LOCKED" in rewritten
+    assert "WHERE ROWNUM <= :2 AND o.status = 'pending'" in rewritten
+    # The correlated subquery keeps its own unmodified WHERE.
+    assert "WHERE gm_peer.bank_id = o.bank_id" in rewritten
+
+
+@pytest.mark.asyncio
+async def test_reserved_pool_is_serialised_too(pool, backend, clean_operations):
+    """The guard also applies when graph_maintenance has reserved slots.
+
+    WORKER_SLOT_TYPE_DEFAULTS gives it 0 by default, but an operator can raise
+    HINDSIGHT_API_WORKER_GRAPH_MAINTENANCE_RESERVED_SLOTS, which routes claims
+    through the reserved-pool query instead of the shared one.
+    """
+    bank = await _make_bank(pool)
+    base = datetime.now(UTC) - timedelta(minutes=10)
+    op_ids = [
+        await _insert_op(pool, bank, "graph_maintenance", created_at=base + timedelta(seconds=i)) for i in range(3)
+    ]
+
+    claimed = await _claim(backend, shared=0, reserved={"graph_maintenance": 5})
+
+    ours = [op for op in op_ids if str(op) in claimed]
+    assert len(ours) == 1, f"expected exactly one same-bank claim, got {len(ours)}"
+
+
+@pytest.mark.asyncio
+async def test_reserved_and_shared_phases_do_not_double_claim(pool, backend, clean_operations):
+    """A reserved-pool claim blocks the shared pool from taking a second one.
+
+    The two phases run in one transaction, so the row claimed in phase 1 is still
+    'pending' when the shared query runs and is excluded from it by operation_id.
+    It has to keep blocking through the guard's older-pending branch instead,
+    otherwise one cycle hands the same bank two concurrent runs.
+    """
+    bank = await _make_bank(pool)
+    base = datetime.now(UTC) - timedelta(minutes=10)
+    op_ids = [
+        await _insert_op(pool, bank, "graph_maintenance", created_at=base + timedelta(seconds=i)) for i in range(3)
+    ]
+
+    claimed = await _claim(backend, shared=5, reserved={"graph_maintenance": 1})
+
+    ours = [op for op in op_ids if str(op) in claimed]
+    assert len(ours) == 1, f"expected exactly one same-bank claim across both phases, got {len(ours)}"


### PR DESCRIPTION
## Summary

`graph_maintenance` has no per-bank serialisation at claim time. Two concurrent runs against one bank do no extra work — the payload carries only `bank_id`, `run_graph_maintenance_job` discards the request context, and the relink pass drains the whole queue — so both runs are the same bank-wide sweep.

It is worse than redundant. `claim_graph_maintenance_batch` locks queue rows `FOR UPDATE` **without** `SKIP LOCKED`, deliberately, because it is written assuming one runner per bank (its docstring said submit-time dedup guaranteed that; it does not — dedup only inspects `'pending'` rows). So the runs convoy on each other's row locks while each holds a worker slot. Reported in #3230: nine concurrent runs on one bank, a six-deep blocking chain, retain starved to zero for ~4h.

## The fix

The same guarantee `consolidation` already has, expressed as a predicate on the existing claim queries and shared between both dialects (`graph_maintenance_bank_serialization_sql` in `db/ops.py`).

Two things differ from the consolidation form, both forced by the shape of the problem:

**It is a predicate, not a separate claim phase.** A trailing phase works for `consolidation` only because it has a reserved-slot floor of 2 (`WORKER_SLOT_TYPE_DEFAULTS`); `graph_maintenance` has 0, and the poller's fairness pass calls `claim_tasks` with `shared_limit=1` (`poller.py:459`). A single pending retain would then consume the shared slot in the generic query and `graph_maintenance` would never be claimed at all — the queue grows, links are never topped up. As a predicate on that same query it keeps its place in the `created_at` ordering. `test_not_starved_by_newer_pending_work` covers this.

**It also takes at most one same-bank row per batch.** Excluding busy banks alone does not cover that: with several pending rows and nothing yet `processing`, one batch claims them all — the convoy, unchanged. Several pending rows per bank are reachable through the recovery paths: `recover_own_tasks` resets *every* processing row for a worker back to pending in one statement, and `_schedule_retry` / `_defer_operation` / `hindsight-admin recover` each restore rows independently. That, not the submit path, is where #3230's 22 simultaneously-pending rows come from — submit-time `dedupe_by_bank` is atomic (it takes `FOR NO KEY UPDATE` on the bank row before the check), so it yields at most one pending row per bank.

Inherited caveat, unchanged from `consolidation`: a row wedged in `processing` holds its bank until something releases it — `hindsight-admin recover`, or a restart with a stable `HINDSIGHT_API_WORKER_ID` so `recover_own_tasks` matches it. That is a general gap in claim recovery (there is no time-based stale-claim reaper for *any* operation type), not something specific to graph_maintenance, and it is not addressed here.

No advisory locks (#2817), no new table, no new config flag.

## Relationship to #3231

Same issue, different mechanism. #3231 adds a dedicated claim phase after the generic shared-pool query, which introduces the starvation described above. This supersedes it.

## Tests

`tests/test_graph_maintenance_claim_serialization.py`, real Postgres, 9 tests. These call `ops.claim_tasks` directly rather than `WorkerPoller.claim_batch`, so the slot limits under test are exact and not a function of ambient in-flight work in the shared test DB.

Fail on `main`, pass with the fix:
- `test_not_claimed_while_bank_has_run_in_flight`
- `test_single_batch_claims_at_most_one_per_bank` (also asserts it is the *oldest* row)
- `test_idle_bank_still_claimed_while_another_is_busy`
- `test_reserved_pool_is_serialised_too`
- `test_reserved_and_shared_phases_do_not_double_claim`

Guard against over-blocking (pass both ways — these are what a naive guard breaks):
- `test_not_starved_by_newer_pending_work`
- `test_retry_blocked_older_row_does_not_block_a_claimable_one`
- `test_other_operation_types_unaffected`

Dialect parity: `test_guard_survives_the_oracle_sql_rewrite` asserts on `_rewrite_pg_to_oracle`'s output directly (`NOW()` → `SYSTIMESTAMP` in both the outer query and the correlated subquery, `!= ALL` expanded, `LIMIT` → `ROWNUM` injected on the *outer* `WHERE` rather than the subquery's). Oracle integration tests need an `ORACLE_TEST_DSN` I don't have, so this is the check that the shared fragment stays valid there.

```
$ uv run pytest -n0 tests/test_graph_maintenance_claim_serialization.py tests/test_worker.py
                                                                            -> 113 passed
$ uv run pytest -n0 tests/test_graph_maintenance.py tests/test_graph_maintenance_deadlock.py \
      tests/test_graph_maintenance_queue_race.py tests/test_enqueue_graph_maintenance_ordered.py
                                                                            -> 32 passed
$ ./scripts/hooks/lint.sh                                                   -> All lints passed
$ uv run ty check hindsight_api/                                            -> All checks passed
```

Fixes #3230
