### PR TITLE
fix(import): classify label entities when restoring a bank (#3236)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -4411,12 +4411,21 @@ class MemoryEngine(MemoryEngineInterface):
                 request_context=request_context,
             )
             await self._validate_operation(self._operation_validator.validate_create_bank(ctx))
-        resolved_config = await self._config_resolver.resolve_full_config(bank_id, request_context)
+
+        async def _resolve_restored_config() -> HindsightConfig:
+            # import_bank calls this once it has restored the archive's bank row.
+            # Resolving here rather than before the call is the whole point: the
+            # target bank does not exist yet (import refuses to write into an
+            # existing bank), so a config resolved now would hold global + tenant
+            # values and none of the bank's own — which left every label entity in
+            # an imported bank classified as regular (#3236).
+            return await self._config_resolver.resolve_full_config(bank_id, request_context)
+
         return await import_bank(
             backend=backend,
             embeddings_model=self.embeddings,
             entity_resolver=self.entity_resolver,
-            config=resolved_config,
+            resolve_config=_resolve_restored_config,
             format_date_fn=self._format_readable_date,
             archive_bytes=archive_bytes,
             target_bank_id=target_bank_id,

--- a/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
@@ -14,6 +14,7 @@ import json
 import logging
 import uuid
 import zipfile
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime
 from typing import Any, Literal
@@ -353,7 +354,7 @@ async def import_bank(
     backend: Any,
     embeddings_model: Any,
     entity_resolver: Any,
-    config: Any,
+    resolve_config: Callable[[], Awaitable[Any]],
     format_date_fn: Any,
     archive_bytes: bytes,
     target_bank_id: str | None = None,
@@ -372,6 +373,12 @@ async def import_bank(
     for a fresh id. A migration restores *exact* state, so unlike the document
     import it fires no retain webhooks and triggers no consolidation/graph
     maintenance: observations and mental models are restored as exported.
+
+    Takes ``resolve_config`` rather than a resolved config because the only correct
+    moment to resolve one is *inside* this function, after the archive's bank row
+    lands. Before that the target bank does not exist (import refuses to write into
+    an existing one), so any config a caller resolved carries global + tenant values
+    and none of the bank's own — which is exactly the bug in #3236.
     """
     if ops is None:
         ops = backend.ops
@@ -415,6 +422,16 @@ async def import_bank(
         internal_id = await conn.fetchval(f"SELECT internal_id FROM {fq_table('banks')} WHERE bank_id = $1", bank_id)
         if internal_id is not None:
             await bank_utils.create_bank_vector_indexes(conn, bank_id, str(internal_id), ops=ops)
+
+    # Only now does the bank row — and with it the archive's own config — exist, so
+    # this is where the config the documents are replayed with has to come from.
+    # Until #3236 the import ran on a config resolved before the restore, which
+    # could not contain the bank's `entity_labels`: every label entity was
+    # classified as a regular one, which both exposed label values to fuzzy merging
+    # (#3187) and left them inside the trigram index that the partial index is
+    # supposed to keep them out of (#3208), so an imported bank silently lost that
+    # fix.
+    config = await resolve_config()
 
     doc_result = await import_documents(
         backend=backend,

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -1276,3 +1276,80 @@ async def test_import_rejects_invalid_on_conflict(memory, request_context):
             archive_bytes=buffer.getvalue(),
             on_conflict="bogus",
         )
+
+
+@pytest.mark.asyncio
+async def test_bank_import_classifies_label_entities(memory, request_context):
+    """An imported bank's label entities are stored with entity_kind='label'.
+
+    Regression for #3236. `import_bank_async` resolved the target bank's config
+    before restoring the archive's bank row — and import refuses to write into an
+    existing bank, so `entity_labels` was necessarily empty for the whole import.
+    Every label entity was then classified as regular, which exposes label values
+    to fuzzy merging (#3187) and leaves them inside the trigram index the partial
+    index (#3208) exists to keep them out of, so an imported bank silently lost
+    that fix. Measured on a real 12k-entity export: 5,355 of its entities were
+    label values and every one of them came back as 'regular'.
+    """
+    bank = _unique_bank("bank_label_kind")
+    label_entity = "brief_bio:enjoys long walks on the beach"
+    regular_entity = "Alice"
+    try:
+        await memory.get_bank_profile(bank_id=bank, request_context=request_context)
+        await memory._config_resolver.update_bank_config(
+            bank,
+            {"entity_labels": [{"key": "brief_bio", "type": "text", "description": "one-line bio"}]},
+        )
+        await _retain(memory, bank, "Alice enjoys long walks.", request_context, "doc-1")
+
+        backend = await memory._get_backend()
+        # Link the entities to a fact directly: the mock LLM's extraction does not
+        # emit a label-shaped entity, and what matters here is what the *import*
+        # makes of the entities the archive carries (export derives a fact's
+        # entities from unit_entities, so linking is what puts them in the archive).
+        async with acquire_with_retry(backend) as conn:
+            # Must be an exported fact type attached to a document, or export
+            # never sees the link and the archive carries no entities at all.
+            unit_id = await conn.fetchval(
+                f"SELECT id FROM {fq_table('memory_units')} WHERE bank_id = $1 "
+                "AND document_id IS NOT NULL AND fact_type IN ('world', 'experience') LIMIT 1",
+                bank,
+            )
+            assert unit_id is not None, "no facts to attach entities to"
+            for name in (label_entity, regular_entity):
+                # Retain may already have created the regular one.
+                entity_id = await conn.fetchval(
+                    f"SELECT id FROM {fq_table('entities')} WHERE bank_id = $1 AND LOWER(canonical_name) = LOWER($2)",
+                    bank,
+                    name,
+                ) or await conn.fetchval(
+                    f"INSERT INTO {fq_table('entities')} (bank_id, canonical_name) VALUES ($1, $2) RETURNING id",
+                    bank,
+                    name,
+                )
+                await conn.execute(
+                    f"INSERT INTO {fq_table('unit_entities')} (unit_id, entity_id) VALUES ($1, $2) "
+                    "ON CONFLICT DO NOTHING",
+                    unit_id,
+                    entity_id,
+                )
+
+        from hindsight_api.engine.transfer import export_bank
+
+        async with acquire_with_retry(backend) as conn:
+            archive = await export_bank(conn, bank)
+        await memory.delete_bank(bank, request_context=request_context)
+        await memory.import_bank_async(archive, request_context)
+
+        async with acquire_with_retry(backend) as conn:
+            kinds = {
+                row["canonical_name"]: row["entity_kind"]
+                for row in await conn.fetch(
+                    f"SELECT canonical_name, entity_kind FROM {fq_table('entities')} WHERE bank_id = $1",
+                    bank,
+                )
+            }
+        assert kinds.get(label_entity) == "label", kinds
+        assert kinds.get(regular_entity) == "regular", kinds
+    finally:
+        await memory.delete_bank(bank, request_context=request_context)


### PR DESCRIPTION
Fixes #3236.

Found while benchmarking #3208/#3214 against a real production export.

## The bug

`import_bank_async` resolved the target bank's config **before** `import_bank`
restored the archive's bank row:

```python
resolved_config = await self._config_resolver.resolve_full_config(bank_id, request_context)
return await import_bank(..., config=resolved_config, ...)
```

The bank cannot exist at that point — import explicitly refuses to write into an
existing bank — so that resolve only ever sees global + tenant config. The bank's
own `entity_labels`, which the archive carries in `banks.json`, arrives later. Retain
Phase 1 then classified **every** label entity in the imported bank as `regular`.

Consequences:

- **#3208/#3214 was silently inactive on imported banks**: the partial index
  `WHERE entity_kind != 'label'` excluded nothing, so every fuzzy probe kept paying
  the recheck-discard cost the index exists to remove.
- **Label values were fuzzy-merged during the import** — the exact-match-only path
  (#3187) keys off the same classification, so distinct label values could collapse
  into one another (#1558).
- The migration backfill doesn't cover it: it runs once, and a bank imported
  afterwards has nothing to correct it.

## The fix

`import_bank` now takes `resolve_config` (a callback) instead of a resolved config,
and calls it right after the bank row is restored. This is deliberately not an
optional extra parameter alongside `config`: the only correct moment to resolve is
inside `import_bank`, so making it the only way to supply one keeps the next caller
from reintroducing the bug. `import_bank_async` is the sole caller.

## Measured on a real export

862 documents / 38,162 facts, bank has a free-text `brief_bio` label group. Imported
into an emptied instance (all other banks dropped — the trigram index has no
`bank_id`, so a leftover bank pollutes any measurement here):

| | pre-#3187 baseline | main as shipped | main + this fix |
|---|---|---|---|
| entity resolution during import | 471.75 s | 382.61 s | **26.01 s** |
| share of import spent resolving | 45.8% | 40.9% | **3.1%** |
| import wall-clock | 1030.76 s | 934.93 s | 850.00 s |
| entities stamped `label` | n/a (no column) | 0 | **5,719** |

**18.1× less entity-resolution work than the baseline and 14.7× less than main as
shipped** — on this bank the defect was hiding nearly the whole benefit of #3214.

(The 500 `label` rows visible on unfixed main in the issue came from a post-import
ingest burst, not the import. A post-hoc backfill classified 5,355; the fixed import
produces 5,719 because the broken path had fuzzy-merged some distinct label values
into each other.)

## Test

`test_bank_import_classifies_label_entities`: configure `entity_labels`, export,
delete, import, assert the label entity returns as `entity_kind='label'` and a
regular one as `'regular'`. Verified it fails on `main` with `'regular' != 'label'`.

`test_document_transfer.py`, `test_admin_bank_transfer.py`,
`test_repair_bank_vector_indexes.py`, `test_hermes_templates_import.py`,
`test_entity_resolver.py` and `test_entity_labels.py` pass; `lint.sh` + `ty` clean.
