### PR TITLE
test(vector-index): resolve the repair migration's parent instead of branch@-1

### DIFF
--- a/hindsight-api-slim/tests/test_ensure_vector_no_global_index.py
+++ b/hindsight-api-slim/tests/test_ensure_vector_no_global_index.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import pytest
 from alembic import command
 from alembic.config import Config
+from alembic.script import ScriptDirectory
 from sqlalchemy import Connection, create_engine, text
 
 import hindsight_api
@@ -66,6 +67,10 @@ def _reset_schema(db_url: str, schema: str) -> None:
             conn.commit()
     finally:
         engine.dispose()
+
+
+# The repair migration under test: drops the stale global memory_units index.
+_REPAIR_REVISION = "f2a6d8c4b1e9"
 
 
 def _alembic_config(db_url: str, schema: str) -> Config:
@@ -151,7 +156,18 @@ def test_migration_drops_stale_global_index(vec_db_url):
     cfg = _alembic_config(vec_db_url, schema)
     # Step back below the repair migration, then plant the legacy index the
     # way an older reconcile would have left it.
-    command.downgrade(cfg, "f2a6d8c4b1e9@-1")
+    #
+    # The parent is resolved from the revision map rather than written as
+    # "f2a6d8c4b1e9@-1": that is alembic's branch@relative syntax, which counts
+    # back from the *head* of the branch containing the revision, not from the
+    # revision itself. It meant "the parent" only while the repair migration was
+    # head, so the first migration added on top of it (b3e8d1c6f4a9) made this
+    # downgrade stop ON the repair migration instead of below it — the stale index
+    # was then planted after the drop had already run, the upgrade never re-ran it,
+    # and the test failed for reasons unrelated to the behaviour under test.
+    parent = ScriptDirectory.from_config(cfg).get_revision(_REPAIR_REVISION).down_revision
+    assert isinstance(parent, str), f"expected a single parent for {_REPAIR_REVISION}, got {parent!r}"
+    command.downgrade(cfg, parent)
 
     engine = create_engine(vec_db_url)
     try:


### PR DESCRIPTION
Fixes the `test-api (1/3)` failure that has been red on main for every PR since #3214 merged (seen on #3237, #3235, #3234).

## What broke

`test_migration_drops_stale_global_index` steps below the repair migration before planting a stale global index:

```python
command.downgrade(cfg, "f2a6d8c4b1e9@-1")
```

`f2a6d8c4b1e9@-1` is alembic's **branch@relative** syntax — it counts back from the *head* of the branch containing that revision, not from the revision itself. While f2a6d8c4b1e9 was head, that happened to be its parent, so the test worked.

#3214 added `b3e8d1c6f4a9` on top of it. `@-1` now resolves to f2a6d8c4b1e9 itself, so:

```
Running downgrade b3e8d1c6f4a9 -> f2a6d8c4b1e9    ← stops ON the repair migration
Running upgrade   f2a6d8c4b1e9 -> b3e8d1c6f4a9    ← the drop never re-runs
```

The stale index gets planted *after* the drop has already run, the upgrade never re-runs it, and the assertion fails with `assert 1 == 0`. The migration under test is fine — only the test's setup was wrong, and any migration landing after the repair would have triggered it.

## Fix

Resolve the parent from the revision map:

```python
parent = ScriptDirectory.from_config(cfg).get_revision(_REPAIR_REVISION).down_revision
command.downgrade(cfg, parent)
```

This cannot rot when the next migration lands on top.

## Verified

- The three tests in the file pass.
- With `DROP INDEX IF EXISTS ...` disabled in f2a6d8c4b1e9, the test fails again (`assert 1 == 0`) — so it still exercises the behaviour it claims to, rather than passing vacuously.
- `lint.sh` clean.