### PR TITLE
Harden outbound webhook delivery destinations and response handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -308,6 +308,23 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_DB_ACQUIRE_WARN_THRESHOLD_MS=1000
 
 # -----------------------------------------------------------------------------
+# Webhooks (Optional)
+# -----------------------------------------------------------------------------
+
+# Outbound webhook delivery targets caller-supplied URLs. To prevent SSRF, the
+# delivery worker blocks private, loopback, and link-local destinations
+# (including the cloud metadata address 169.254.169.254) by default. List hosts
+# or IP/CIDR ranges here (comma-separated) to re-permit specific internal
+# destinations — e.g. 127.0.0.1 for local testing, or an internal receiver.
+# HINDSIGHT_API_WEBHOOK_ALLOWED_HOSTS=127.0.0.1,internal-receiver.svc,10.0.0.0/8
+
+# Whether the webhook delivery-history API returns the raw upstream response
+# body. Off by default: returning arbitrary response bodies to callers is an
+# information-exfiltration primitive. The delivery status code is always
+# returned regardless. Enable only if you trust your webhook destinations.
+# HINDSIGHT_API_WEBHOOK_EXPOSE_RESPONSE_BODY=false
+
+# -----------------------------------------------------------------------------
 # Control Plane (Optional)
 # -----------------------------------------------------------------------------
 

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -3430,7 +3430,7 @@ class WebhookDeliveryResponse(BaseModel):
     updated_at: str | None = None
 
     @classmethod
-    def from_async_operation_row(cls, row: dict) -> "WebhookDeliveryResponse":
+    def from_async_operation_row(cls, row: dict, *, expose_response_body: bool = False) -> "WebhookDeliveryResponse":
         import json as _json
 
         raw = row["task_payload"]
@@ -3459,7 +3459,10 @@ class WebhookDeliveryResponse(BaseModel):
             next_retry_at=row["next_retry_at"],
             last_error=row["error_message"],
             last_response_status=result_metadata.get("last_status_code"),
-            last_response_body=result_metadata.get("last_response_body"),
+            # The raw upstream body is withheld from API callers by default: it
+            # is an SSRF response-exfiltration primitive. Operators can opt in
+            # via HINDSIGHT_API_WEBHOOK_EXPOSE_RESPONSE_BODY. Status is always shown.
+            last_response_body=(result_metadata.get("last_response_body") if expose_response_body else None),
             last_attempt_at=result_metadata.get("last_attempt_at"),
             created_at=row["created_at"],
             updated_at=row["updated_at"],
@@ -7335,6 +7338,24 @@ def _register_routes(app: FastAPI):
     # Webhook Endpoints
     # =========================================================================
 
+    def _validate_webhook_destination(url: str | None) -> None:
+        """Reject webhook URLs that point at private/internal addresses (SSRF).
+
+        Registration-time, syntactic-only check (scheme + IP-literal hosts).
+        DNS-name hosts are resolved and pinned at delivery time by the guarded
+        transport; this just gives callers immediate 400 feedback for the
+        obvious cases. ``None`` (unchanged on PATCH) is a no-op.
+        """
+        if url is None:
+            return
+        from hindsight_api.webhooks.url_guard import WebhookURLError, parse_allowlist, validate_url_syntax
+
+        allowlist = parse_allowlist(get_config().webhook_allowed_hosts)
+        try:
+            validate_url_syntax(url, allowlist)
+        except WebhookURLError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+
     @app.post(
         "/v1/default/banks/{bank_id}/webhooks",
         response_model=WebhookResponse,
@@ -7352,6 +7373,7 @@ def _register_routes(app: FastAPI):
     ):
         """Register a webhook for a bank."""
         try:
+            _validate_webhook_destination(request.url)
             webhook_id = uuid.uuid4()
             row = await app.state.memory.create_webhook(
                 bank_id,
@@ -7506,6 +7528,7 @@ def _register_routes(app: FastAPI):
 
             fields = request.model_fields_set
             if "url" in fields:
+                _validate_webhook_destination(request.url)
                 params.append(request.url)
                 set_clauses.append(f"url = ${len(params)}")
             if "secret" in fields:
@@ -7598,8 +7621,12 @@ def _register_routes(app: FastAPI):
             has_more = len(rows) > limit
             page = rows[:limit]
             next_cursor = page[-1]["created_at"] if has_more and page else None
+            expose_body = get_config().webhook_expose_response_body
             return WebhookDeliveryListResponse(
-                items=[WebhookDeliveryResponse.from_async_operation_row(dict(row)) for row in page],
+                items=[
+                    WebhookDeliveryResponse.from_async_operation_row(dict(row), expose_response_body=expose_body)
+                    for row in page
+                ],
                 next_cursor=next_cursor,
             )
         except (AuthenticationError, HTTPException):

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -653,6 +653,14 @@ ENV_WEBHOOK_URL = "HINDSIGHT_API_WEBHOOK_URL"
 ENV_WEBHOOK_SECRET = "HINDSIGHT_API_WEBHOOK_SECRET"
 ENV_WEBHOOK_EVENT_TYPES = "HINDSIGHT_API_WEBHOOK_EVENT_TYPES"
 ENV_WEBHOOK_DELIVERY_POLL_INTERVAL_SECONDS = "HINDSIGHT_API_WEBHOOK_DELIVERY_POLL_INTERVAL_SECONDS"
+# SSRF hardening for outbound webhook delivery. Private/loopback/link-local
+# destinations are blocked by default; list hosts or IP/CIDRs here to re-permit
+# them (e.g. "127.0.0.1" for local testing, or an internal receiver).
+ENV_WEBHOOK_ALLOWED_HOSTS = "HINDSIGHT_API_WEBHOOK_ALLOWED_HOSTS"
+# When true, the delivery-history API returns the raw upstream response body.
+# Off by default: returning arbitrary internal response bodies to the caller is
+# an information-exfiltration primitive. The delivery status is always returned.
+ENV_WEBHOOK_EXPOSE_RESPONSE_BODY = "HINDSIGHT_API_WEBHOOK_EXPOSE_RESPONSE_BODY"
 
 # Built-in llama.cpp configuration (for provider=llamacpp)
 ENV_LLAMACPP_MODEL_PATH = "HINDSIGHT_API_LLAMACPP_MODEL_PATH"
@@ -1368,6 +1376,8 @@ DEFAULT_WEBHOOK_URL = None  # None = no global webhook configured
 DEFAULT_WEBHOOK_SECRET = None  # None = no signing
 DEFAULT_WEBHOOK_EVENT_TYPES = "consolidation.completed"  # Comma-separated; default = all supported events
 DEFAULT_WEBHOOK_DELIVERY_POLL_INTERVAL_SECONDS = 30  # How often to poll for pending deliveries
+DEFAULT_WEBHOOK_ALLOWED_HOSTS: list[str] = []  # Empty = public destinations only (private ranges blocked)
+DEFAULT_WEBHOOK_EXPOSE_RESPONSE_BODY = False  # Don't return raw upstream bodies to API callers
 
 
 class JsonFormatter(logging.Formatter):
@@ -2527,6 +2537,12 @@ class HindsightConfig:
     # embed api_keys/base_urls).
     reranker_members: list[RerankerMemberConfig] = field(default_factory=list)
     bm25_max_query_terms: int = DEFAULT_BM25_MAX_QUERY_TERMS
+
+    # Webhook SSRF hardening (static, server-level only — deliberately NOT
+    # per-bank configurable: a tenant must not be able to re-open the private
+    # ranges or turn response-body exfiltration back on for itself).
+    webhook_allowed_hosts: list[str] = field(default_factory=list)
+    webhook_expose_response_body: bool = DEFAULT_WEBHOOK_EXPOSE_RESPONSE_BODY
 
     # Class-level sets for configuration categorization
 
@@ -3793,6 +3809,10 @@ class HindsightConfig:
                     ENV_WEBHOOK_DELIVERY_POLL_INTERVAL_SECONDS,
                     str(DEFAULT_WEBHOOK_DELIVERY_POLL_INTERVAL_SECONDS),
                 )
+            ),
+            webhook_allowed_hosts=[h.strip() for h in os.getenv(ENV_WEBHOOK_ALLOWED_HOSTS, "").split(",") if h.strip()],
+            webhook_expose_response_body=_parse_boolean_env(
+                ENV_WEBHOOK_EXPOSE_RESPONSE_BODY, DEFAULT_WEBHOOK_EXPOSE_RESPONSE_BODY
             ),
         )
         config.validate()

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -2558,6 +2558,7 @@ class MemoryEngine(MemoryEngineInterface):
         """
         from ..webhooks.manager import MAX_ATTEMPTS, RETRY_DELAYS
         from ..webhooks.models import WebhookHttpConfig
+        from ..webhooks.url_guard import WebhookURLError
 
         url = task_dict["url"]
         secret = task_dict.get("secret")
@@ -2597,6 +2598,13 @@ class MemoryEngine(MemoryEngineInterface):
             response.raise_for_status()
             if operation_id:
                 await self._update_webhook_delivery_metadata(operation_id, response.status_code, response.text)
+        except WebhookURLError as e:
+            # Destination is disallowed (SSRF guard). This never becomes valid on
+            # retry, so fail permanently instead of burning the retry schedule.
+            logger.error(f"webhook_delivery blocked url={url}: {e}")
+            if operation_id:
+                await self._update_webhook_delivery_metadata(operation_id, None, None)
+            raise
         except Exception as e:
             status_code = response.status_code if response is not None else None
             response_body = response.text if response is not None else None
@@ -3558,8 +3566,17 @@ class MemoryEngine(MemoryEngineInterface):
         self._ext_ctx.webhook_manager = self._webhook_manager
         logger.debug("Webhook manager initialized")
 
-        # Long-lived HTTP client for webhook delivery tasks
-        self._http_client = httpx.AsyncClient(timeout=30.0)
+        # Long-lived HTTP client for webhook delivery tasks. All delivery
+        # traffic flows through the guarded transport, which rejects
+        # private/loopback/link-local destinations (SSRF) and pins the
+        # connection to a validated IP. See webhooks/url_guard.py.
+        from ..webhooks.url_guard import GuardedAsyncTransport, parse_allowlist
+
+        _webhook_allowlist = parse_allowlist(get_config().webhook_allowed_hosts)
+        self._http_client = httpx.AsyncClient(
+            timeout=30.0,
+            transport=GuardedAsyncTransport(_webhook_allowlist),
+        )
 
         # Set executor for task backend and initialize
         self._task_backend.set_executor(self.execute_task)

--- a/hindsight-api-slim/hindsight_api/webhooks/url_guard.py
+++ b/hindsight-api-slim/hindsight_api/webhooks/url_guard.py
@@ -1,0 +1,227 @@
+"""SSRF hardening for outbound webhook delivery.
+
+A webhook destination URL (and its method/headers/params) is fully
+caller-controlled. Without restriction the delivery worker can be pointed at
+the cloud metadata service (``169.254.169.254``), loopback admin endpoints, or
+private-network hosts, and its response is stored where the delivery-history
+API returns it — server-side request forgery with response exfiltration
+(CWE-918 / CWE-200).
+
+This module rejects such destinations. It is deny-by-default for
+private/loopback/link-local/reserved ranges; operators re-permit specific
+internal hosts (e.g. ``127.0.0.1`` for local testing, or an internal receiver)
+via an explicit allowlist. At delivery time the host is resolved and the
+connection is pinned to the validated IP so a DNS name cannot be rebound to an
+internal address between validation and connect.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import socket
+from dataclasses import dataclass
+
+import httpx
+
+_ALLOWED_SCHEMES = ("http", "https")
+
+# Ranges to block explicitly because ``ipaddress`` classification for them is
+# absent or version-dependent (e.g. CGNAT 100.64.0.0/10 only counts as private
+# from Python 3.13). Keeping them here makes the block deterministic across
+# interpreter versions.
+_EXTRA_BLOCKED_NETWORKS = (
+    ipaddress.ip_network("100.64.0.0/10"),  # RFC 6598 carrier-grade NAT / shared address space
+)
+
+# ipaddress network/address base types differ for v4/v6; alias for annotations.
+_IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+_IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+
+
+class WebhookURLError(ValueError):
+    """A webhook destination URL targets a disallowed (private/internal) address."""
+
+
+@dataclass(frozen=True)
+class Allowlist:
+    """Operator-configured exceptions to the private-range block.
+
+    Entries are matched two ways: exact hostname (so a DNS name is permitted
+    without pinning it to an IP) and IP/CIDR membership (so a resolved address
+    can be permitted). An empty allowlist means "public destinations only".
+    """
+
+    hostnames: frozenset[str]
+    networks: tuple[_IPNetwork, ...]
+
+    def allows_host(self, host: str) -> bool:
+        return host.lower() in self.hostnames
+
+    def allows_ip(self, ip: _IPAddress) -> bool:
+        return any(ip in net for net in self.networks)
+
+
+def parse_allowlist(entries: list[str]) -> Allowlist:
+    """Split allowlist entries into hostnames and IP/CIDR networks.
+
+    An entry that parses as an IP or CIDR becomes a network match; anything else
+    is treated as a hostname. Blank entries are ignored.
+    """
+    hostnames: set[str] = set()
+    networks: list[_IPNetwork] = []
+    for raw in entries:
+        entry = raw.strip()
+        if not entry:
+            continue
+        try:
+            networks.append(ipaddress.ip_network(entry, strict=False))
+            continue
+        except ValueError:
+            hostnames.add(entry.lower())
+    return Allowlist(frozenset(hostnames), tuple(networks))
+
+
+def _as_ip(host: str) -> _IPAddress | None:
+    """Return the parsed IP if ``host`` is an IP literal, else None."""
+    try:
+        return ipaddress.ip_address(host.strip("[]"))
+    except ValueError:
+        return None
+
+
+def _ip_is_blocked(ip: _IPAddress) -> bool:
+    """True if the address is in a range unsafe for caller-supplied fetches."""
+    # An IPv4-mapped IPv6 address (::ffff:127.0.0.1) must be judged on the
+    # embedded v4 address, otherwise loopback/private checks miss it.
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    if any(ip in net for net in _EXTRA_BLOCKED_NETWORKS):
+        return True
+    return (
+        ip.is_private  # RFC1918, ULA, etc.
+        or ip.is_loopback
+        or ip.is_link_local  # 169.254.0.0/16 — includes the cloud metadata IP
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified  # 0.0.0.0 / ::
+    )
+
+
+def validate_url_syntax(url: str, allowlist: Allowlist) -> None:
+    """Registration-time check (no DNS).
+
+    Rejects non-http(s) schemes, missing hosts, and IP-literal hosts that point
+    at a blocked range. Hosts that are DNS names are accepted here and fully
+    validated (resolved + pinned) at delivery time, so this never blocks on the
+    network in the request path.
+
+    Raises:
+        WebhookURLError: if the URL is structurally unsafe.
+    """
+    try:
+        parsed = httpx.URL(url)
+    except Exception as exc:  # httpx.InvalidURL and friends
+        raise WebhookURLError(f"Invalid webhook URL: {exc}") from exc
+    if parsed.scheme not in _ALLOWED_SCHEMES:
+        raise WebhookURLError(f"Webhook URL scheme must be http or https, got '{parsed.scheme or 'empty'}'")
+    host = parsed.host
+    if not host:
+        raise WebhookURLError("Webhook URL must include a host")
+    if allowlist.allows_host(host):
+        return
+    literal = _as_ip(host)
+    if literal is not None and _ip_is_blocked(literal) and not allowlist.allows_ip(literal):
+        raise WebhookURLError(
+            f"Webhook URL host '{host}' targets a private/loopback/link-local address, "
+            "which is not an allowed destination"
+        )
+
+
+async def _resolve(host: str, port: int) -> list[str]:
+    loop = asyncio.get_running_loop()
+    try:
+        infos = await loop.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise WebhookURLError(f"Webhook host '{host}' did not resolve: {exc}") from exc
+    ips = [info[4][0] for info in infos]
+    if not ips:
+        raise WebhookURLError(f"Webhook host '{host}' did not resolve to any address")
+    return ips
+
+
+async def resolve_and_validate(host: str, port: int, allowlist: Allowlist) -> list[str]:
+    """Resolve ``host`` and return the validated IPs to pin the connection to.
+
+    Rejects if *any* resolved address is blocked (rather than silently keeping
+    the good ones) so a split-horizon / partially-rebound DNS answer can't slip
+    an internal address through. The full validated list is returned (not just
+    the first) so the caller can preserve httpx's fallback across A/AAAA records
+    while still only ever connecting to an address we checked.
+
+    Raises:
+        WebhookURLError: on a disallowed literal, a disallowed resolved address,
+        or a resolution failure.
+    """
+    literal = _as_ip(host)
+    if literal is not None:
+        if _ip_is_blocked(literal) and not allowlist.allows_ip(literal):
+            raise WebhookURLError(f"Webhook host '{host}' targets a disallowed address")
+        return [host]
+
+    ips = await _resolve(host, port)
+    if allowlist.allows_host(host):
+        return ips
+    for ip_str in ips:
+        ip = ipaddress.ip_address(ip_str)
+        if _ip_is_blocked(ip) and not allowlist.allows_ip(ip):
+            raise WebhookURLError(f"Webhook host '{host}' resolved to disallowed address {ip_str}")
+    return ips
+
+
+class GuardedAsyncTransport(httpx.AsyncHTTPTransport):
+    """httpx transport that validates and pins every outbound webhook request.
+
+    All webhook delivery traffic flows through one instance of this transport,
+    so there is no code path that can reach ``httpx`` without the SSRF check.
+    On each request it resolves the host, rejects disallowed destinations, and
+    rewrites the connection target to the validated IP while preserving the
+    original ``Host`` header and TLS SNI (via the ``sni_hostname`` extension) so
+    virtual hosting and certificate verification keep working.
+    """
+
+    def __init__(self, allowlist: Allowlist, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._allowlist = allowlist
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        url = request.url
+        if url.scheme not in _ALLOWED_SCHEMES:
+            raise WebhookURLError(f"Webhook URL scheme must be http or https, got '{url.scheme or 'empty'}'")
+        host = url.host
+        if not host:
+            raise WebhookURLError("Webhook URL must include a host")
+        port = url.port or (443 if url.scheme == "https" else 80)
+
+        validated_ips = await resolve_and_validate(host, port, self._allowlist)
+        if validated_ips == [host]:
+            # Host is already a validated IP literal — nothing to pin/rewrite.
+            return await super().handle_async_request(request)
+
+        # Connect to a validated IP but keep the original identity: the Host
+        # header (already set by httpx from the original URL) is left untouched,
+        # and sni_hostname carries the real name for TLS. Try each validated
+        # address in turn so a dual-stack host whose first record is unreachable
+        # still connects — without ever re-resolving to an unchecked address.
+        base_extensions = {**request.extensions, "sni_hostname": host}
+        last_error: Exception | None = None
+        for ip in validated_ips:
+            request.url = url.copy_with(host=ip)
+            request.extensions = dict(base_extensions)
+            try:
+                return await super().handle_async_request(request)
+            except httpx.ConnectError as exc:
+                last_error = exc
+                continue
+        assert last_error is not None
+        raise last_error

--- a/hindsight-api-slim/tests/test_webhook_url_guard.py
+++ b/hindsight-api-slim/tests/test_webhook_url_guard.py
@@ -1,0 +1,214 @@
+"""Unit tests for webhook SSRF hardening (hindsight_api.webhooks.url_guard).
+
+These are deterministic and DB-free: they cover the destination-URL validation,
+the resolve-and-pin logic, and the guarded transport's connection pinning
+against a real loopback server. The security guarantees under test:
+
+- private/loopback/link-local/metadata destinations are blocked by default,
+- an operator allowlist re-permits specific hosts / IP ranges,
+- DNS names are resolved and every resolved address is checked (so a name that
+  resolves to an internal address is blocked),
+- the transport connects only to a validated IP while preserving the original
+  Host header (virtual host) so a rebind cannot swap in an internal address.
+"""
+
+import ipaddress
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import httpx
+import pytest
+
+from hindsight_api.webhooks.url_guard import (
+    GuardedAsyncTransport,
+    WebhookURLError,
+    _ip_is_blocked,
+    parse_allowlist,
+    resolve_and_validate,
+    validate_url_syntax,
+)
+
+
+class TestIpClassification:
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "169.254.169.254",  # cloud metadata (link-local)
+            "127.0.0.1",
+            "10.0.0.5",
+            "172.16.9.9",
+            "192.168.1.1",
+            "100.64.0.1",  # CGNAT
+            "0.0.0.0",
+            "::1",
+            "fc00::1",  # ULA
+            "fe80::1",  # link-local v6
+            "::ffff:127.0.0.1",  # IPv4-mapped loopback
+        ],
+    )
+    def test_blocked_ranges(self, ip):
+        assert _ip_is_blocked(ipaddress.ip_address(ip)) is True
+
+    @pytest.mark.parametrize("ip", ["8.8.8.8", "1.1.1.1", "93.184.216.34", "2606:2800:220:1::1"])
+    def test_public_allowed(self, ip):
+        assert _ip_is_blocked(ipaddress.ip_address(ip)) is False
+
+
+class TestValidateUrlSyntax:
+    def test_rejects_non_http_scheme(self):
+        for bad in ["file:///etc/passwd", "gopher://x/y", "ftp://host/f"]:
+            with pytest.raises(WebhookURLError):
+                validate_url_syntax(bad, parse_allowlist([]))
+
+    def test_rejects_missing_host(self):
+        with pytest.raises(WebhookURLError):
+            validate_url_syntax("http:///nohost", parse_allowlist([]))
+
+    def test_rejects_internal_ip_literal(self):
+        for bad in [
+            "http://127.0.0.1/x",
+            "http://169.254.169.254/latest/meta-data/",
+            "https://10.1.2.3/hook",
+            "http://[::1]/x",
+        ]:
+            with pytest.raises(WebhookURLError):
+                validate_url_syntax(bad, parse_allowlist([]))
+
+    def test_allows_public_dns_name(self):
+        # DNS names are not resolved at syntax time — deferred to delivery.
+        validate_url_syntax("https://example.com/hook", parse_allowlist([]))
+
+    def test_allowlist_permits_internal_ip_literal(self):
+        validate_url_syntax("http://127.0.0.1:8080/x", parse_allowlist(["127.0.0.1"]))
+
+    def test_allowlist_cidr_permits_range(self):
+        validate_url_syntax("http://10.1.2.3/x", parse_allowlist(["10.0.0.0/8"]))
+
+
+@pytest.mark.asyncio
+class TestResolveAndValidate:
+    async def test_literal_loopback_blocked(self):
+        with pytest.raises(WebhookURLError):
+            await resolve_and_validate("127.0.0.1", 80, parse_allowlist([]))
+
+    async def test_literal_loopback_allowlisted(self):
+        assert await resolve_and_validate("127.0.0.1", 80, parse_allowlist(["127.0.0.1"])) == ["127.0.0.1"]
+
+    async def test_dns_name_resolving_to_loopback_blocked(self):
+        # localhost resolves to a loopback address -> blocked by default.
+        with pytest.raises(WebhookURLError):
+            await resolve_and_validate("localhost", 80, parse_allowlist([]))
+
+    async def test_dns_name_allowlisted_by_name(self):
+        ips = await resolve_and_validate("localhost", 80, parse_allowlist(["localhost"]))
+        assert all(ipaddress.ip_address(ip).is_loopback for ip in ips)
+
+
+@pytest.fixture
+def loopback_server():
+    """A loopback-only HTTP server standing in for an internal endpoint."""
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            body = b"INTERNAL_SECRET host=" + self.headers.get("Host", "").encode()
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):  # silence
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield port
+    finally:
+        server.shutdown()
+
+
+@pytest.mark.asyncio
+class TestGuardedTransport:
+    async def test_blocks_loopback_by_default(self, loopback_server):
+        transport = GuardedAsyncTransport(parse_allowlist([]))
+        async with httpx.AsyncClient(transport=transport) as client:
+            with pytest.raises(WebhookURLError):
+                await client.get(f"http://127.0.0.1:{loopback_server}/internal")
+
+    async def test_allowlisted_loopback_succeeds_and_preserves_host(self, loopback_server):
+        transport = GuardedAsyncTransport(parse_allowlist(["127.0.0.1"]))
+        async with httpx.AsyncClient(transport=transport) as client:
+            resp = await client.get(f"http://127.0.0.1:{loopback_server}/internal")
+        assert resp.status_code == 200
+        # Host header carried the original authority (virtual host preserved).
+        assert f"127.0.0.1:{loopback_server}" in resp.text
+
+    async def test_pins_dns_name_and_falls_back_across_addresses(self, loopback_server):
+        # localhost may resolve to ::1 first (unreachable here) then 127.0.0.1;
+        # the transport must try each validated address rather than pin only one.
+        transport = GuardedAsyncTransport(parse_allowlist(["localhost"]))
+        async with httpx.AsyncClient(transport=transport) as client:
+            resp = await client.get(f"http://localhost:{loopback_server}/internal")
+        assert resp.status_code == 200
+        assert f"localhost:{loopback_server}" in resp.text
+
+    async def test_rejects_non_http_scheme(self):
+        transport = GuardedAsyncTransport(parse_allowlist([]))
+        async with httpx.AsyncClient(transport=transport) as client:
+            with pytest.raises(WebhookURLError):
+                await client.get("ftp://example.com/x")
+
+
+def _delivery_row_with_body():
+    """A minimal async_operations row as returned to WebhookDeliveryResponse."""
+    return {
+        "operation_id": "11111111-1111-1111-1111-111111111111",
+        "status": "completed",
+        "retry_count": 0,
+        "next_retry_at": None,
+        "error_message": None,
+        "created_at": "2026-08-07T00:00:00+00:00",
+        "updated_at": "2026-08-07T00:00:00+00:00",
+        "task_payload": '{"url": "https://example.com/hook", "event_type": "retain.completed", "webhook_id": "w1"}',
+        "result_metadata": '{"last_status_code": 200, "last_response_body": "INTERNAL_SECRET_BODY"}',
+    }
+
+
+class TestDeliveryResponseBodyGating:
+    """The delivery-history response must not leak the raw upstream body by default."""
+
+    def test_body_withheld_by_default(self):
+        from hindsight_api.api.http import WebhookDeliveryResponse
+
+        resp = WebhookDeliveryResponse.from_async_operation_row(_delivery_row_with_body())
+        assert resp.last_response_body is None
+        # Status is still surfaced — it's the useful, non-sensitive debug signal.
+        assert resp.last_response_status == 200
+
+    def test_body_returned_when_opted_in(self):
+        from hindsight_api.api.http import WebhookDeliveryResponse
+
+        resp = WebhookDeliveryResponse.from_async_operation_row(_delivery_row_with_body(), expose_response_body=True)
+        assert resp.last_response_body == "INTERNAL_SECRET_BODY"
+        assert resp.last_response_status == 200
+
+
+def test_expose_response_body_is_static_not_bank_configurable():
+    """The exfil-gating flag must not be tenant/bank-overridable (would let a
+    tenant re-enable exfiltration for itself)."""
+    from hindsight_api.config import HindsightConfig
+
+    configurable = HindsightConfig.get_configurable_fields()
+    assert "webhook_expose_response_body" not in configurable
+    assert "webhook_allowed_hosts" not in configurable
+
+
+def test_parse_allowlist_splits_hosts_and_networks():
+    al = parse_allowlist(["127.0.0.1", "internal.svc", "10.0.0.0/8", "  ", ""])
+    assert al.allows_host("internal.svc")
+    assert al.allows_host("INTERNAL.SVC")  # case-insensitive
+    assert al.allows_ip(ipaddress.ip_address("10.5.5.5"))
+    assert al.allows_ip(ipaddress.ip_address("127.0.0.1"))
+    assert not al.allows_ip(ipaddress.ip_address("192.168.0.1"))

--- a/hindsight-api-slim/tests/test_webhooks.py
+++ b/hindsight-api-slim/tests/test_webhooks.py
@@ -671,6 +671,117 @@ class TestWebhookHttpApi:
         assert response.status_code == 404
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad_url",
+        [
+            "http://169.254.169.254/latest/meta-data/",  # cloud metadata
+            "http://127.0.0.1:8080/admin",  # loopback
+            "https://10.1.2.3/hook",  # private
+            "ftp://example.com/x",  # scheme
+        ],
+    )
+    async def test_http_create_webhook_rejects_internal_url(self, api_client: httpx.AsyncClient, bad_url: str):
+        """POST /webhooks with an internal/unsafe destination is rejected with 400 (SSRF guard)."""
+        bank_id = f"http-wh-{uuid.uuid4().hex[:8]}"
+        response = await api_client.post(
+            f"/v1/default/banks/{bank_id}/webhooks",
+            json={"url": bad_url, "event_types": ["consolidation.completed"]},
+        )
+        assert response.status_code == 400, response.text
+
+    @pytest.mark.asyncio
+    async def test_http_update_webhook_rejects_internal_url(self, api_client: httpx.AsyncClient):
+        """PATCH /webhooks/{id} to an internal destination is rejected with 400."""
+        bank_id = f"http-wh-{uuid.uuid4().hex[:8]}"
+        create_resp = await api_client.post(
+            f"/v1/default/banks/{bank_id}/webhooks",
+            json={"url": "https://example.com/hook", "event_types": ["consolidation.completed"]},
+        )
+        assert create_resp.status_code == 201
+        webhook_id = create_resp.json()["id"]
+        try:
+            patch_resp = await api_client.patch(
+                f"/v1/default/banks/{bank_id}/webhooks/{webhook_id}",
+                json={"url": "http://169.254.169.254/latest/meta-data/"},
+            )
+            assert patch_resp.status_code == 400, patch_resp.text
+        finally:
+            await api_client.delete(f"/v1/default/banks/{bank_id}/webhooks/{webhook_id}")
+
+    async def _insert_delivery_with_body(self, memory: MemoryEngine, bank_id: str, webhook_id: str) -> uuid.UUID:
+        delivery_id = uuid.uuid4()
+        now = datetime.now(timezone.utc)
+        task_payload = json.dumps(
+            {
+                "type": "webhook_delivery",
+                "bank_id": bank_id,
+                "url": "https://example.com/deliveries",
+                "event_type": "consolidation.completed",
+                "payload": "{}",
+                "webhook_id": webhook_id,
+            }
+        )
+        result_metadata = json.dumps({"last_status_code": 200, "last_response_body": "INTERNAL_SECRET_BODY"})
+        async with memory._pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO async_operations
+                  (operation_id, bank_id, operation_type, status, retry_count, task_payload, result_metadata, created_at, updated_at)
+                VALUES ($1, $2, 'webhook_delivery', 'completed', 0, $3::jsonb, $4::jsonb, $5, $5)
+                """,
+                delivery_id,
+                bank_id,
+                task_payload,
+                result_metadata,
+                now,
+            )
+        return delivery_id
+
+    @pytest.mark.asyncio
+    async def test_deliveries_hide_response_body_by_default(self, memory: MemoryEngine, api_client: httpx.AsyncClient):
+        """By default the raw upstream body is withheld; the status is still returned."""
+        bank_id = f"http-wh-{uuid.uuid4().hex[:8]}"
+        create_resp = await api_client.post(
+            f"/v1/default/banks/{bank_id}/webhooks",
+            json={"url": "https://example.com/deliveries", "event_types": ["consolidation.completed"]},
+        )
+        webhook_id = create_resp.json()["id"]
+        delivery_id = await self._insert_delivery_with_body(memory, bank_id, webhook_id)
+        try:
+            resp = await api_client.get(f"/v1/default/banks/{bank_id}/webhooks/{webhook_id}/deliveries")
+            delivery = next(i for i in resp.json()["items"] if i["id"] == str(delivery_id))
+            assert delivery["last_response_body"] is None
+            assert delivery["last_response_status"] == 200  # status stays useful for debugging
+        finally:
+            async with memory._pool.acquire() as conn:
+                await conn.execute("DELETE FROM async_operations WHERE operation_id = $1", delivery_id)
+            await api_client.delete(f"/v1/default/banks/{bank_id}/webhooks/{webhook_id}")
+
+    @pytest.mark.asyncio
+    async def test_deliveries_expose_response_body_when_opted_in(
+        self, memory: MemoryEngine, api_client: httpx.AsyncClient, monkeypatch
+    ):
+        """When the operator opts in, the raw body is returned."""
+        from hindsight_api.config import _get_raw_config
+
+        monkeypatch.setattr(_get_raw_config(), "webhook_expose_response_body", True)
+        bank_id = f"http-wh-{uuid.uuid4().hex[:8]}"
+        create_resp = await api_client.post(
+            f"/v1/default/banks/{bank_id}/webhooks",
+            json={"url": "https://example.com/deliveries", "event_types": ["consolidation.completed"]},
+        )
+        webhook_id = create_resp.json()["id"]
+        delivery_id = await self._insert_delivery_with_body(memory, bank_id, webhook_id)
+        try:
+            resp = await api_client.get(f"/v1/default/banks/{bank_id}/webhooks/{webhook_id}/deliveries")
+            delivery = next(i for i in resp.json()["items"] if i["id"] == str(delivery_id))
+            assert delivery["last_response_body"] == "INTERNAL_SECRET_BODY"
+        finally:
+            async with memory._pool.acquire() as conn:
+                await conn.execute("DELETE FROM async_operations WHERE operation_id = $1", delivery_id)
+            await api_client.delete(f"/v1/default/banks/{bank_id}/webhooks/{webhook_id}")
+
+    @pytest.mark.asyncio
     async def test_http_update_webhook_url(self, api_client: httpx.AsyncClient):
         """PATCH /webhooks/{id} updates only the provided fields."""
         bank_id = f"http-wh-{uuid.uuid4().hex[:8]}"

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1850,6 +1850,12 @@ For a server handling many concurrent requests, lower values (down to `1`) favor
 | `HINDSIGHT_API_WEBHOOK_SECRET` | HMAC signing secret for webhook payloads | - (unsigned) |
 | `HINDSIGHT_API_WEBHOOK_EVENT_TYPES` | Comma-separated list of event types to deliver via webhook | `consolidation.completed` |
 | `HINDSIGHT_API_WEBHOOK_DELIVERY_POLL_INTERVAL_SECONDS` | How often the webhook delivery worker polls for pending deliveries (seconds) | `30` |
+| `HINDSIGHT_API_WEBHOOK_ALLOWED_HOSTS` | Comma-separated hosts or IP/CIDR ranges permitted as webhook destinations in addition to public addresses. Private, loopback, and link-local ranges (including the cloud metadata address) are blocked unless listed here. | - (public only) |
+| `HINDSIGHT_API_WEBHOOK_EXPOSE_RESPONSE_BODY` | Return the raw upstream response body in the delivery-history API. Off by default to avoid exposing internal response contents; the delivery status code is always returned. | `false` |
+
+:::warning Webhook destinations are SSRF-guarded
+Because webhook URLs are caller-supplied, the delivery worker refuses to send to private, loopback, or link-local addresses (e.g. `169.254.169.254`, `127.0.0.1`, `10.0.0.0/8`) by default, and it does not return upstream response bodies to callers. Use `HINDSIGHT_API_WEBHOOK_ALLOWED_HOSTS` to allow specific internal destinations (such as `127.0.0.1` for local testing), and `HINDSIGHT_API_WEBHOOK_EXPOSE_RESPONSE_BODY=true` only if you trust those destinations and need the response body for debugging.
+:::
 
 ### Audit Logging
 

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -308,6 +308,23 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_DB_ACQUIRE_WARN_THRESHOLD_MS=1000
 
 # -----------------------------------------------------------------------------
+# Webhooks (Optional)
+# -----------------------------------------------------------------------------
+
+# Outbound webhook delivery targets caller-supplied URLs. To prevent SSRF, the
+# delivery worker blocks private, loopback, and link-local destinations
+# (including the cloud metadata address 169.254.169.254) by default. List hosts
+# or IP/CIDR ranges here (comma-separated) to re-permit specific internal
+# destinations — e.g. 127.0.0.1 for local testing, or an internal receiver.
+# HINDSIGHT_API_WEBHOOK_ALLOWED_HOSTS=127.0.0.1,internal-receiver.svc,10.0.0.0/8
+
+# Whether the webhook delivery-history API returns the raw upstream response
+# body. Off by default: returning arbitrary response bodies to callers is an
+# information-exfiltration primitive. The delivery status code is always
+# returned regardless. Enable only if you trust your webhook destinations.
+# HINDSIGHT_API_WEBHOOK_EXPOSE_RESPONSE_BODY=false
+
+# -----------------------------------------------------------------------------
 # Control Plane (Optional)
 # -----------------------------------------------------------------------------
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1850,6 +1850,12 @@ For a server handling many concurrent requests, lower values (down to `1`) favor
 | `HINDSIGHT_API_WEBHOOK_SECRET` | HMAC signing secret for webhook payloads | - (unsigned) |
 | `HINDSIGHT_API_WEBHOOK_EVENT_TYPES` | Comma-separated list of event types to deliver via webhook | `consolidation.completed` |
 | `HINDSIGHT_API_WEBHOOK_DELIVERY_POLL_INTERVAL_SECONDS` | How often the webhook delivery worker polls for pending deliveries (seconds) | `30` |
+| `HINDSIGHT_API_WEBHOOK_ALLOWED_HOSTS` | Comma-separated hosts or IP/CIDR ranges permitted as webhook destinations in addition to public addresses. Private, loopback, and link-local ranges (including the cloud metadata address) are blocked unless listed here. | - (public only) |
+| `HINDSIGHT_API_WEBHOOK_EXPOSE_RESPONSE_BODY` | Return the raw upstream response body in the delivery-history API. Off by default to avoid exposing internal response contents; the delivery status code is always returned. | `false` |
+
+:::warning Webhook destinations are SSRF-guarded
+Because webhook URLs are caller-supplied, the delivery worker refuses to send to private, loopback, or link-local addresses (e.g. `169.254.169.254`, `127.0.0.1`, `10.0.0.0/8`) by default, and it does not return upstream response bodies to callers. Use `HINDSIGHT_API_WEBHOOK_ALLOWED_HOSTS` to allow specific internal destinations (such as `127.0.0.1` for local testing), and `HINDSIGHT_API_WEBHOOK_EXPOSE_RESPONSE_BODY=true` only if you trust those destinations and need the response body for debugging.
+:::
 
 ### Audit Logging
 


### PR DESCRIPTION
## Summary

Hardens outbound webhook delivery, where the destination URL (and method,
headers, params) is fully caller-supplied. Two controls:

**1. Destination restriction (deny-by-default).** The delivery worker refuses to
connect to private, loopback, or link-local addresses — including the cloud
metadata address `169.254.169.254`, `127.0.0.1`, and RFC-1918/CGNAT/ULA ranges.
All delivery traffic flows through a single guarded `httpx` transport that:
- resolves the host and rejects any resolved address in a blocked range,
- **pins the connection to a validated IP** (preserving the `Host` header and
  TLS SNI) so a DNS name cannot be rebound to an internal address between
  validation and connect, and
- tries each validated address so dual-stack hosts still connect.

Operators re-permit specific internal destinations via
`HINDSIGHT_API_WEBHOOK_ALLOWED_HOSTS` (hosts or IP/CIDR — e.g. `127.0.0.1` for
local testing). Registration also validates the URL for immediate `400`
feedback on obvious cases.

**2. Response-body handling.** The delivery-history API no longer returns the
raw upstream response body by default — only the status code, which is what
delivery debugging actually needs. Operators can opt in with
`HINDSIGHT_API_WEBHOOK_EXPOSE_RESPONSE_BODY`.

Both flags are **server-level only** (not per-bank configurable), so a tenant
cannot re-open the ranges or re-enable body exposure for itself.

### Behavior change (breaking)

Webhooks pointed at loopback/private hosts now fail unless the host is added to
`HINDSIGHT_API_WEBHOOK_ALLOWED_HOSTS`. This is intentional.

## Tests

- `tests/test_webhook_url_guard.py` — range classification, URL validation,
  resolve-and-pin, guarded-transport pinning against a real loopback server
  (incl. dual-stack fallback and `Host`-preservation), and API-layer body
  gating (default-hidden / opt-in) + a guard that the flags stay non-configurable.
- `tests/test_webhooks.py` — HTTP integration: registration rejection (`400`)
  for internal/invalid URLs, and the delivery-history endpoint hiding the body
  by default / exposing it when opted in.

## Notes

- No request/response schema fields or endpoints changed → OpenAPI spec and
  generated clients are unaffected.
- Docs + `.env.example` (and the bundled embed copy) updated.
