### PR TITLE
feat(coding-agents): add Prime Agent as a supported harness

### DIFF
--- a/hindsight-control-plane/public/img/harness/prime-agent.svg
+++ b/hindsight-control-plane/public/img/harness/prime-agent.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#383e45" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="32" cy="32" r="6" fill="#383e45" stroke="none" />
+  <circle cx="16" cy="18" r="4" />
+  <circle cx="48" cy="18" r="4" />
+  <circle cx="16" cy="46" r="4" />
+  <circle cx="48" cy="46" r="4" />
+  <path d="M20 20 L28 29" />
+  <path d="M44 20 L36 29" />
+  <path d="M20 44 L28 35" />
+  <path d="M44 44 L36 35" />
+</svg>

--- a/hindsight-control-plane/src/lib/harness-logo.ts
+++ b/hindsight-control-plane/src/lib/harness-logo.ts
@@ -83,6 +83,12 @@ export const HARNESS_LOGO_REGISTRY: Record<string, HarnessLogoEntry> = {
   "grok-build": { id: "grok-build", label: "Grok Build", src: "/img/harness/grok-build.svg" },
   kilo: { id: "kilo", label: "Kilo CLI", src: "/img/harness/kilo.svg" },
   opencode: { id: "opencode", label: "OpenCode", src: "/img/harness/opencode.png" },
+  "prime-agent": {
+    id: "prime-agent",
+    label: "Prime Agent",
+    src: "/img/harness/prime-agent.svg",
+    invertOnDark: true,
+  },
 };
 
 const HARNESS_TAG_PREFIX = "harness:";

--- a/hindsight-control-plane/tests/lib/harness-logo.test.ts
+++ b/hindsight-control-plane/tests/lib/harness-logo.test.ts
@@ -49,6 +49,7 @@ describe("resolveHarnessLogo", () => {
     "grok-build",
     "kilo",
     "opencode",
+    "prime-agent",
   ];
   // Ids the integration used to emit. Kept so documents already retained under
   // them keep their logo; a new id never belongs here.

--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -9,7 +9,7 @@ description: "One Hindsight memory plugin for coding agents — per-repo memory 
 
 Long-term project memory for **coding agents**, backed by [Hindsight](https://vectorize.io/hindsight).
 One package, several agents: a shared reflect-and-inject core with a thin entry point per agent
-(**opencode**, **Kilo CLI**, **Cline CLI**, **Claude Code**, **Codex CLI**, **Antigravity CLI**, **Cursor CLI**, **GitHub Copilot CLI**, **Grok Build**). Ingestion is fully
+(**opencode**, **Kilo CLI**, **Cline CLI**, **Prime Agent**, **Claude Code**, **Codex CLI**, **Antigravity CLI**, **Cursor CLI**, **GitHub Copilot CLI**, **Grok Build**). Ingestion is fully
 automatic — there is no setup command: a repo's git history and conversations flow into its memory
 bank in the background as you work.
 
@@ -118,6 +118,14 @@ npx @vectorize-io/hindsight-coding-agents install cline-cli
 ```
 
 A native plugin via `cline plugin install`, plus MCP and the companion skill.
+
+#### <img src="/img/harness/prime-agent.svg" alt="" width="20" height="20" /> Prime Agent
+
+```bash
+npx @vectorize-io/hindsight-coding-agents install prime-agent
+```
+
+An extension entry in `~/.prime/agent/settings.json` — native tools, no MCP needed.
 
 Uninstall the same way: `npx @vectorize-io/hindsight-coding-agents uninstall claude-code` (or `uninstall all`).
 

--- a/hindsight-docs/static/img/harness/prime-agent.svg
+++ b/hindsight-docs/static/img/harness/prime-agent.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#383e45" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="32" cy="32" r="6" fill="#383e45" stroke="none" />
+  <circle cx="16" cy="18" r="4" />
+  <circle cx="48" cy="18" r="4" />
+  <circle cx="16" cy="46" r="4" />
+  <circle cx="48" cy="46" r="4" />
+  <path d="M20 20 L28 29" />
+  <path d="M44 20 L36 29" />
+  <path d="M20 44 L28 35" />
+  <path d="M44 44 L36 35" />
+</svg>

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -2,7 +2,7 @@
 
 Long-term project memory for **coding agents**, backed by [Hindsight](https://vectorize.io/hindsight).
 One package, several agents: a shared reflect-and-inject core with a thin entry point per agent
-(**opencode**, **Kilo CLI**, **Cline CLI**, **Claude Code**, **Codex CLI**, **Antigravity CLI**, **Cursor CLI**, **GitHub Copilot CLI**, **Grok Build**). Ingestion is fully
+(**opencode**, **Kilo CLI**, **Cline CLI**, **Prime Agent**, **Claude Code**, **Codex CLI**, **Antigravity CLI**, **Cursor CLI**, **GitHub Copilot CLI**, **Grok Build**). Ingestion is fully
 automatic — there is no setup command: a repo's git history and conversations flow into its memory
 bank in the background as you work.
 
@@ -111,6 +111,14 @@ npx @vectorize-io/hindsight-coding-agents install cline-cli
 ```
 
 A native plugin via `cline plugin install`, plus MCP and the companion skill.
+
+#### <img src="https://hindsight.vectorize.io/img/harness/prime-agent.svg" alt="" width="20" height="20" /> Prime Agent
+
+```bash
+npx @vectorize-io/hindsight-coding-agents install prime-agent
+```
+
+An extension entry in `~/.prime/agent/settings.json` — native tools, no MCP needed.
 
 Uninstall the same way: `npx @vectorize-io/hindsight-coding-agents uninstall claude-code` (or `uninstall all`).
 

--- a/hindsight-integrations/coding-agents/e2e/Dockerfile.prime-agent
+++ b/hindsight-integrations/coding-agents/e2e/Dockerfile.prime-agent
@@ -1,0 +1,6 @@
+FROM hindsight-coding-agents-e2e-base
+# Prime Agent ships no npm package: its upstream repo is a private monorepo and the vendor
+# installer is the only distribution. It lands the binary in ~/.local/bin, which the base image
+# does not have on PATH.
+ENV PATH="/root/.local/bin:${PATH}"
+RUN curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh && command -v prime-agent

--- a/hindsight-integrations/coding-agents/package.json
+++ b/hindsight-integrations/coding-agents/package.json
@@ -43,6 +43,11 @@
       }
     ]
   },
+  "pi": {
+    "extensions": [
+      "./dist/prime-agent.js"
+    ]
+  },
   "scripts": {
     "build": "tsup",
     "clean": "rm -rf dist",

--- a/hindsight-integrations/coding-agents/src/core/transcript-prime-agent.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript-prime-agent.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { type PaMessage, readPrimeAgentMessages } from "./transcript-prime-agent";
+
+describe("readPrimeAgentMessages", () => {
+  it("keeps user/assistant text + compact action turns; drops other roles/blocks and tool args", () => {
+    const messages: PaMessage[] = [
+      // non-conversational role: dropped
+      { role: "system", content: [{ type: "text", text: "you are prime-agent" }] },
+      // string content is accepted as a prose turn
+      { role: "user", content: "add retry backoff to the uploader" },
+      // assistant message: text + a toolCall (args NOT retained) + a dropped reasoning block
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "thinking…" },
+          { type: "text", text: "I'll add exponential backoff." },
+          { type: "toolCall", name: "bash", arguments: { command: "npm test" } },
+        ],
+      },
+      // assistant message with only a toolCall: just the compact action line
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", name: "read", arguments: { path: "nope.ts" } }],
+      },
+    ];
+
+    expect(readPrimeAgentMessages(messages)).toEqual([
+      { role: "user", content: "add retry backoff to the uploader" },
+      { role: "assistant", content: "I'll add exponential backoff." },
+      { role: "action", content: "bash npm test" },
+      { role: "action", content: "read nope.ts" },
+    ]);
+  });
+
+  it("strips injected memory that leaks into a kept message", () => {
+    const messages: PaMessage[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "<hindsight_memories>\nleak\n</hindsight_memories>\nWhy retry?" },
+        ],
+      },
+    ];
+    expect(readPrimeAgentMessages(messages)).toEqual([{ role: "user", content: "Why retry?" }]);
+  });
+
+  it("never throws on malformed entries", () => {
+    const messages = [
+      null,
+      {},
+      { role: "user" },
+      { role: "assistant", content: [null, 3, "x"] },
+    ] as unknown as PaMessage[];
+    expect(() => readPrimeAgentMessages(messages)).not.toThrow();
+    expect(readPrimeAgentMessages(messages)).toEqual([]);
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/transcript-prime-agent.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript-prime-agent.ts
@@ -1,0 +1,71 @@
+/**
+ * Prime Agent live-transcript normalizer.
+ *
+ * Prime Agent hands an extension the completed exchange as an in-memory message list on the
+ * `agent_end` event (not a JSONL file like Claude/Codex), so this is a pure function over that list,
+ * mirroring transcript-opencode.ts. It produces the same rich `TransportTurn[]` shape (prose turns +
+ * compact `role:"action"` tool turns) and reuses the shared `stripInjectedMemory`/`actionLine`
+ * helpers so a retain never feeds injected memory back into recall and tool noise stays out of the
+ * bank.
+ */
+import type { TransportTurn } from "./chat";
+import { actionLine, stripInjectedMemory } from "./transcript-util";
+
+/** Structural subset of a Prime Agent message content block (TextBlock | ToolCallBlock | dropped). */
+export interface PaBlock {
+  type?: string;
+  text?: string; // text block
+  name?: string; // toolCall block: the tool name
+  arguments?: unknown; // toolCall block: the call input
+}
+
+/** Structural subset of a Prime Agent message ({ role, content }). */
+export interface PaMessage {
+  role?: string;
+  content?: unknown; // string | PaBlock[]
+}
+
+/**
+ * Render one Prime Agent message into turns. Text (string content or text blocks) joins into one
+ * prose turn (injected-memory stripped); each `toolCall` block becomes its own compact
+ * `role:"action"` turn (tool name + primary target via `actionLine` — no args, no output). Other
+ * block types and non-conversational roles are dropped.
+ */
+function renderMessage(m: PaMessage): TransportTurn[] {
+  if (!m || typeof m !== "object") return [];
+  const role = m.role;
+  if (role !== "user" && role !== "assistant") return [];
+
+  const texts: string[] = [];
+  const actions: TransportTurn[] = [];
+
+  if (typeof m.content === "string") {
+    const t = stripInjectedMemory(m.content).trim();
+    if (t) texts.push(t);
+  } else if (Array.isArray(m.content)) {
+    for (const part of m.content) {
+      if (!part || typeof part !== "object") continue;
+      const block = part as PaBlock;
+      if (block.type === "text" && typeof block.text === "string") {
+        const t = stripInjectedMemory(block.text).trim();
+        if (t) texts.push(t);
+      } else if (block.type === "toolCall" && typeof block.name === "string") {
+        actions.push({ role: "action", content: actionLine(block.name, block.arguments) });
+      }
+    }
+  }
+
+  const out: TransportTurn[] = [];
+  const joined = texts.join("\n").trim();
+  if (joined) out.push({ role, content: joined });
+  out.push(...actions);
+  return out;
+}
+
+/**
+ * Normalize Prime Agent's `agent_end` message list into transcript turns (user/assistant prose plus
+ * compact action turns for tool calls). Never throws on malformed entries.
+ */
+export function readPrimeAgentMessages(messages: readonly PaMessage[]): TransportTurn[] {
+  return (messages || []).flatMap((m) => renderMessage(m));
+}

--- a/hindsight-integrations/coding-agents/src/e2e/harnesses.ts
+++ b/hindsight-integrations/coding-agents/src/e2e/harnesses.ts
@@ -190,6 +190,20 @@ export const clineDockerSetup: HarnessDockerSetup = {
   command: (prompt) => ["cline", "--auto-approve", "true", "--cwd", "/workspace", prompt],
 };
 
+/**
+ * Prime Agent — extension host. `-p` runs one prompt non-interactively and prints the reply.
+ * Auth is the whole `~/.prime/agent` directory (auth.json plus the kernel venv it provisions on
+ * first login), so the mount is the directory rather than a single credential file.
+ */
+export const primeAgentDockerSetup: HarnessDockerSetup = {
+  name: "prime-agent",
+  hindsightHarness: "prime-agent",
+  credentialPath: () => authPath("PRIME_AGENT_E2E_AUTH_PATH", ".prime", "agent", "auth.json"),
+  credentialTarget: "/root/.prime/agent/auth.json",
+  installCommand: "hindsight-coding-agents install prime-agent",
+  command: (prompt) => ["prime-agent", "-p", prompt],
+};
+
 /** Every harness the unified Docker E2E can drive, in a stable order. */
 export const ALL_HARNESS_SETUPS: HarnessDockerSetup[] = [
   codexDockerSetup,
@@ -201,4 +215,5 @@ export const ALL_HARNESS_SETUPS: HarnessDockerSetup[] = [
   grokDockerSetup,
   devinDockerSetup,
   clineDockerSetup,
+  primeAgentDockerSetup,
 ];

--- a/hindsight-integrations/coding-agents/src/harness/registry.test.ts
+++ b/hindsight-integrations/coding-agents/src/harness/registry.test.ts
@@ -8,6 +8,7 @@ describe("HARNESS_NAMES", () => {
         "opencode",
         "kilo",
         "cline-cli",
+        "prime-agent",
         "claude-code",
         "cursor-cli",
         "codex",
@@ -17,7 +18,7 @@ describe("HARNESS_NAMES", () => {
         "grok-build",
       ])
     );
-    expect(HARNESS_NAMES).toHaveLength(10);
+    expect(HARNESS_NAMES).toHaveLength(11);
   });
 });
 

--- a/hindsight-integrations/coding-agents/src/harness/registry.ts
+++ b/hindsight-integrations/coding-agents/src/harness/registry.ts
@@ -45,6 +45,8 @@ export const HARNESS_NAMES = [
   "kilo",
   // Cline CLI loads dist/cline.js through its native plugin manager; file hooks cannot inject.
   "cline-cli",
+  // Prime Agent loads dist/prime-agent.js as an extension (src/prime-agent.ts); no hook binary.
+  "prime-agent",
   "claude-code",
   "cursor-cli",
   "codex",
@@ -69,9 +71,15 @@ export async function getHarness(name: string): Promise<HarnessAdapter> {
   // The persistent-plugin harnesses: their runtime is built by their own plugin entrypoint (which
   // owns the @opencode-ai/plugin dependency this file must stay free of), never via this registry.
   // Backfill still resolves them here for the chatReader.
-  if (name === "opencode" || name === "kilo" || name === "cline-cli") {
+  if (name === "opencode" || name === "kilo" || name === "cline-cli" || name === "prime-agent") {
     const entry =
-      name === "opencode" ? "src/index.ts" : name === "kilo" ? "src/kilo.ts" : "src/cline.ts";
+      name === "opencode"
+        ? "src/index.ts"
+        : name === "kilo"
+          ? "src/kilo.ts"
+          : name === "cline-cli"
+            ? "src/cline.ts"
+            : "src/prime-agent.ts";
     return noRuntimeAdapter(
       name,
       `${name}'s runtime is built by ${entry} (the ${name} plugin entrypoint), not via the harness registry`

--- a/hindsight-integrations/coding-agents/src/installer.test.ts
+++ b/hindsight-integrations/coding-agents/src/installer.test.ts
@@ -439,6 +439,40 @@ describe("opencode installer", () => {
   });
 });
 
+describe("prime-agent installer", () => {
+  const cfgPath = (ctx: InstallCtx) => join(ctx.home, ".prime", "agent", "settings.json");
+  const entry = (ctx: InstallCtx) => join(ctx.pkgRoot, "dist", "prime-agent.js");
+
+  it("install adds the built extension to the extensions array exactly once, even across reinstalls", () => {
+    const ctx = makeCtx();
+    expect(run(["install", "prime-agent"], ctx)).toBe(0);
+    run(["install", "prime-agent"], ctx);
+    expect(readJson(cfgPath(ctx)).extensions).toEqual([entry(ctx)]);
+  });
+
+  it("preserves other extension entries", () => {
+    const ctx = makeCtx();
+    writeJsonAt(cfgPath(ctx), { extensions: ["/some/other/ext.js"] });
+    run(["install", "prime-agent"], ctx);
+    expect(readJson(cfgPath(ctx)).extensions).toEqual(["/some/other/ext.js", entry(ctx)]);
+  });
+
+  it("uninstall removes our entry and deletes the extensions key when empty", () => {
+    const ctx = makeCtx();
+    run(["install", "prime-agent"], ctx);
+    run(["uninstall", "prime-agent"], ctx);
+    expect(readJson(cfgPath(ctx)).extensions).toBeUndefined();
+  });
+
+  it("uninstall keeps the extensions key when other entries remain", () => {
+    const ctx = makeCtx();
+    writeJsonAt(cfgPath(ctx), { extensions: ["/some/other/ext.js"] });
+    run(["install", "prime-agent"], ctx);
+    run(["uninstall", "prime-agent"], ctx);
+    expect(readJson(cfgPath(ctx)).extensions).toEqual(["/some/other/ext.js"]);
+  });
+});
+
 describe("cursor-cli installer", () => {
   const hooksPath = (ctx: InstallCtx) => join(ctx.home, ".cursor", "hooks.json");
   const mcpPath = (ctx: InstallCtx) => join(ctx.home, ".cursor", "mcp.json");
@@ -585,6 +619,7 @@ describe("run() CLI behavior", () => {
     expect(INSTALLERS.map((i) => i.name)).toEqual([
       "opencode",
       "kilo",
+      "prime-agent",
       "claude-code",
       "codex",
       "antigravity-cli",

--- a/hindsight-integrations/coding-agents/src/installer.ts
+++ b/hindsight-integrations/coding-agents/src/installer.ts
@@ -252,6 +252,37 @@ const opencode: HarnessInstaller = {
 };
 
 /**
+ * Prime Agent (PrimeIntellect) — a persistent plugin loaded as an extension. Register the built
+ * `dist/prime-agent.js` in the `extensions` array of `~/.prime/agent/settings.json`; Prime Agent
+ * loads that file's default export at session start. The entry path contains MARKER (the package is
+ * `hindsight-coding-agents`), so uninstall's MARKER filter removes exactly what install added.
+ */
+const primeAgent: HarnessInstaller = {
+  name: "prime-agent",
+  detect: (c) => onPath("prime-agent") || existsSync(join(c.home, ".prime", "agent")),
+  install(c) {
+    const path = join(c.home, ".prime", "agent", "settings.json");
+    const cfg = readJson(path);
+    const entry = join(c.pkgRoot, "dist", "prime-agent.js");
+    const exts: string[] = Array.isArray(cfg.extensions) ? cfg.extensions : [];
+    cfg.extensions = [...exts.filter((p) => !String(p).includes(MARKER)), entry];
+    writeJson(path, cfg);
+    c.log?.(`prime-agent: extension registered in ${path}`);
+  },
+  uninstall(c) {
+    const path = join(c.home, ".prime", "agent", "settings.json");
+    if (!existsSync(path)) return;
+    const cfg = readJson(path);
+    if (Array.isArray(cfg.extensions)) {
+      cfg.extensions = cfg.extensions.filter((p: string) => !String(p).includes(MARKER));
+      if (!cfg.extensions.length) delete cfg.extensions;
+      writeJson(path, cfg);
+    }
+    c.log?.("prime-agent: extension entry removed");
+  },
+};
+
+/**
  * Kilo Code CLI — an opencode fork, so registration is opencode's: append our entry to the config's
  * `plugin` array. Two Kilo-specific wrinkles:
  *
@@ -1102,6 +1133,7 @@ const cline: HarnessInstaller = {
 export const INSTALLERS: HarnessInstaller[] = [
   opencode,
   kilo,
+  primeAgent,
   claudeCode,
   codex,
   antigravity,

--- a/hindsight-integrations/coding-agents/src/prime-agent.test.ts
+++ b/hindsight-integrations/coding-agents/src/prime-agent.test.ts
@@ -1,0 +1,123 @@
+import { z } from "zod";
+import { describe, expect, it, vi } from "vitest";
+import type { ToolSpec } from "./core/knowledge-tools";
+import { createPrimeAgentHooks, toPrimeAgentTool } from "./prime-agent";
+
+describe("Prime Agent extension adapter", () => {
+  it("recalls on each prompt and appends the injection to the system prompt", async () => {
+    const onPrompt = vi.fn(async () => {});
+    const core = {
+      onPrompt,
+      getInjection: vi.fn(() => "<hindsight_memories>remember this</hindsight_memories>"),
+      onTranscript: vi.fn(async () => {}),
+    };
+    const hooks = createPrimeAgentHooks(core as never);
+
+    const result = await hooks.beforeAgentStart(
+      { prompt: "  plan the change  ", systemPrompt: "You are Prime Agent." },
+      "session-1"
+    );
+
+    expect(onPrompt).toHaveBeenCalledOnce();
+    expect(onPrompt).toHaveBeenCalledWith("session-1", "plan the change");
+    expect(result?.systemPrompt).toBe(
+      "You are Prime Agent.\n\n<hindsight_memories>remember this</hindsight_memories>"
+    );
+  });
+
+  it("injects nothing when the core has no injection for this turn", async () => {
+    const core = {
+      onPrompt: vi.fn(async () => {}),
+      getInjection: vi.fn(() => undefined),
+      onTranscript: vi.fn(async () => {}),
+    };
+    const hooks = createPrimeAgentHooks(core as never);
+    const result = await hooks.beforeAgentStart({ prompt: "hi", systemPrompt: "sys" }, "session-1");
+    expect(result).toBeUndefined();
+  });
+
+  it("waits for the shared SessionStart decision before the first reflect", async () => {
+    let releaseSessionStart: (() => void) | undefined;
+    const sessionStart = new Promise<void>((resolve) => {
+      releaseSessionStart = resolve;
+    });
+    const core = {
+      onPrompt: vi.fn(async () => {}),
+      getInjection: vi.fn(() => undefined),
+      onTranscript: vi.fn(async () => {}),
+    };
+    const hooks = createPrimeAgentHooks(core as never, sessionStart);
+    const pending = hooks.beforeAgentStart(
+      { prompt: "first prompt", systemPrompt: "sys" },
+      "session-1"
+    );
+
+    await Promise.resolve();
+    expect(core.onPrompt).not.toHaveBeenCalled();
+    releaseSessionStart?.();
+    await pending;
+    expect(core.onPrompt).toHaveBeenCalledWith("session-1", "first prompt");
+  });
+
+  it("writes back the converted transcript on agent_end", async () => {
+    const onTranscript = vi.fn(async () => {});
+    const core = {
+      onPrompt: vi.fn(async () => {}),
+      getInjection: vi.fn(() => undefined),
+      onTranscript,
+    };
+    const hooks = createPrimeAgentHooks(core as never);
+
+    await hooks.agentEnd(
+      {
+        messages: [
+          { role: "user", content: [{ type: "text", text: "remember the preference" }] },
+          {
+            role: "assistant",
+            content: [
+              { type: "text", text: "I will do that." },
+              { type: "toolCall", name: "read", arguments: { path: "README.md" } },
+            ],
+          },
+        ],
+      },
+      "session-1"
+    );
+
+    expect(onTranscript).toHaveBeenCalledWith("session-1", [
+      { role: "user", content: "remember the preference" },
+      { role: "assistant", content: "I will do that." },
+      { role: "action", content: "read README.md" },
+    ]);
+  });
+
+  it("does not write back an empty exchange", async () => {
+    const onTranscript = vi.fn(async () => {});
+    const core = {
+      onPrompt: vi.fn(async () => {}),
+      getInjection: vi.fn(() => undefined),
+      onTranscript,
+    };
+    const hooks = createPrimeAgentHooks(core as never);
+    await hooks.agentEnd({ messages: [] }, "session-1");
+    expect(onTranscript).not.toHaveBeenCalled();
+  });
+
+  it("adapts a knowledge ToolSpec into a Prime Agent native tool with a JSON-Schema parameters object", async () => {
+    const spec: ToolSpec = {
+      name: "hindsight_search_knowledge_pages",
+      description: "Search the knowledge pages",
+      inputSchema: { query: z.string(), limit: z.number().optional() },
+      handler: async () => ({ content: [{ type: "text", text: "page A\npage B" }] }),
+    };
+
+    const def = toPrimeAgentTool(spec);
+    expect(def.name).toBe("hindsight_search_knowledge_pages");
+    expect(def.label).toBe("hindsight_search_knowledge_pages");
+    expect(def.parameters.type).toBe("object");
+    expect((def.parameters.properties as Record<string, unknown>).query).toBeDefined();
+
+    const result = await def.execute("call-1", { query: "x" });
+    expect(result.content).toEqual([{ type: "text", text: "page A\npage B" }]);
+  });
+});

--- a/hindsight-integrations/coding-agents/src/prime-agent.ts
+++ b/hindsight-integrations/coding-agents/src/prime-agent.ts
@@ -1,0 +1,184 @@
+/**
+ * Prime Agent's extension entrypoint.
+ *
+ * Prime Agent (PrimeIntellect) loads distributed packages listed in `~/.prime/agent/settings.json`
+ * and calls each extension's default export with its `pi` API. This wires Prime Agent's
+ * `before_agent_start` (recall + system-prompt injection) and `agent_end` (transcript write-back)
+ * onto the shared RuntimeCore — the same reflect-and-inject core every Hindsight harness uses — and
+ * registers the `hindsight_*` knowledge tools natively via `pi.registerTool`. The memory behaviour
+ * itself stays in RuntimeCore; this file only adapts Prime Agent's API at its boundary.
+ */
+import { z } from "zod";
+import { deriveBankId } from "./core/bank";
+import { applyBankConfig, loadConfig } from "./core/config";
+import { diag } from "./core/diag";
+import { HindsightClient } from "./core/hindsight";
+import type { ToolSpec } from "./core/knowledge-tools";
+import { RuntimeCore } from "./core/runtime";
+import { type PaMessage, readPrimeAgentMessages } from "./core/transcript-prime-agent";
+
+const HARNESS = "prime-agent";
+
+// ── Structural subset of Prime Agent's extension API (@earendil-works/pi-coding-agent) ──────────
+// Declared locally so this package takes no dependency on the fast-moving Prime Agent SDK; the real
+// runtime passes a compatible object at load time.
+
+interface BeforeAgentStartEvent {
+  type: "before_agent_start";
+  /** The raw user prompt text. */
+  prompt: string;
+  /** The fully assembled system prompt for this turn. */
+  systemPrompt: string;
+}
+
+interface AgentEndEvent {
+  type: "agent_end";
+  /** The conversation messages for the completed agent loop. */
+  messages: readonly PaMessage[];
+}
+
+interface BeforeAgentStartResult {
+  systemPrompt?: string;
+}
+
+interface SessionManagerLike {
+  getSessionId(): string;
+}
+
+interface ExtensionContext {
+  hasUI: boolean;
+  ui: { notify(message: string, type?: "info" | "warning" | "error"): void };
+  sessionManager: SessionManagerLike;
+}
+
+/** A JSON-Schema-shaped parameters object. Prime Agent forwards it to the model provider verbatim. */
+type JsonSchema = Record<string, unknown>;
+
+interface ToolDefinition {
+  name: string;
+  label: string;
+  description: string;
+  parameters: JsonSchema;
+  execute(
+    toolCallId: string,
+    params: Record<string, unknown>
+  ): Promise<{ content: { type: "text"; text: string }[]; details: unknown }>;
+}
+
+interface ExtensionAPI {
+  on(
+    event: "before_agent_start",
+    handler: (
+      event: BeforeAgentStartEvent,
+      ctx: ExtensionContext
+    ) => Promise<BeforeAgentStartResult | void> | BeforeAgentStartResult | void
+  ): void;
+  on(
+    event: "agent_end",
+    handler: (event: AgentEndEvent, ctx: ExtensionContext) => Promise<void> | void
+  ): void;
+  registerTool(definition: ToolDefinition): void;
+}
+
+export type ExtensionFactory = (pi: ExtensionAPI) => void;
+
+/**
+ * Adapt a harness-agnostic ToolSpec (MCP-shaped, shared by every harness) to a Prime Agent native
+ * tool. The spec's Zod raw shape is converted to a JSON Schema for `parameters` — Prime Agent passes
+ * that straight to the model provider (it does not run TypeBox validation on tool args), so a plain
+ * JSON Schema is exactly what the tool needs. The spec's handler returns an MCP `{content:[{text}]}`
+ * result and never throws, so we surface the joined text back to the model.
+ */
+export function toPrimeAgentTool(spec: ToolSpec): ToolDefinition {
+  const parameters = z.toJSONSchema(z.object(spec.inputSchema)) as JsonSchema;
+  return {
+    name: spec.name,
+    label: spec.name,
+    description: spec.description,
+    parameters,
+    async execute(_toolCallId: string, params: Record<string, unknown>) {
+      const r = await spec.handler(params);
+      const text = r.content?.map((c) => c.text).join("\n") || "";
+      return { content: [{ type: "text", text }], details: null };
+    },
+  };
+}
+
+/**
+ * Make the host-specific Prime Agent hooks testable without importing Prime Agent's SDK. RuntimeCore
+ * is the shared lifecycle implementation; this adapter only converts Prime Agent messages at its
+ * boundary and never calls Hindsight directly.
+ */
+export function createPrimeAgentHooks(
+  core: Pick<RuntimeCore, "onPrompt" | "getInjection" | "onTranscript">,
+  sessionStart?: Promise<void>
+) {
+  let sessionStartAwaited = false;
+  return {
+    async beforeAgentStart(
+      event: { prompt: string; systemPrompt: string },
+      sessionId: string
+    ): Promise<BeforeAgentStartResult | undefined> {
+      if (!sessionStartAwaited) {
+        sessionStartAwaited = true;
+        // Awaiting the shared SessionStart lifecycle before the first prompt preserves the invariant
+        // that a brand-new bank skips its first auto-reflect instead of spending that synthesis
+        // before it has any knowledge (mirrors the other harnesses).
+        await sessionStart;
+      }
+      const prompt = event.prompt.trim();
+      if (prompt) await core.onPrompt(sessionId, prompt);
+      const injection = core.getInjection(sessionId);
+      if (!injection) {
+        diag(HARNESS, "inject_empty", { session: sessionId });
+        return undefined;
+      }
+      diag(HARNESS, "inject_ok", { session: sessionId, chars: injection.length });
+      return { systemPrompt: `${event.systemPrompt}\n\n${injection}` };
+    },
+    async agentEnd(event: { messages: readonly PaMessage[] }, sessionId: string): Promise<void> {
+      const turns = readPrimeAgentMessages(event.messages);
+      if (turns.length) await core.onTranscript(sessionId, turns);
+    },
+  };
+}
+
+function createRuntime(repoPath: string): RuntimeCore | undefined {
+  let cfg = loadConfig({ harness: HARNESS });
+  if (cfg.disabled) return undefined;
+  const resolved = applyBankConfig(cfg, deriveBankId(cfg, repoPath, HARNESS));
+  cfg = resolved.cfg;
+  if (cfg.disabled) return undefined;
+  const client = new HindsightClient({
+    apiUrl: cfg.apiUrl,
+    apiToken: cfg.apiToken,
+    bank: resolved.bankId,
+  });
+  return new RuntimeCore(client, resolved.bankId, cfg, HARNESS);
+}
+
+/**
+ * Prime Agent extension factory. Loaded once per session in the project directory; resolves config
+ * and bank from `process.cwd()`, registers the knowledge tools, kicks off the shared cold-seed, and
+ * wires the recall/retain hooks.
+ */
+const extension: ExtensionFactory = (pi) => {
+  const repoPath = process.cwd();
+  const core = createRuntime(repoPath);
+  if (!core) return;
+
+  for (const spec of core.toolSpecs()) pi.registerTool(toPrimeAgentTool(spec));
+
+  // Fire-and-forget cold seed (bank check + background git seed + knowledge preamble); the first
+  // before_agent_start awaits it via createPrimeAgentHooks.
+  const sessionStart = core.seedIfCold(repoPath);
+  const hooks = createPrimeAgentHooks(core, sessionStart);
+
+  pi.on("before_agent_start", (event, ctx) =>
+    hooks.beforeAgentStart(event, ctx.sessionManager.getSessionId())
+  );
+  pi.on("agent_end", (event, ctx) => hooks.agentEnd(event, ctx.sessionManager.getSessionId()));
+};
+
+export { extension };
+export default extension;

--- a/hindsight-integrations/coding-agents/src/prime-agent.ts
+++ b/hindsight-integrations/coding-agents/src/prime-agent.ts
@@ -154,7 +154,7 @@ function createRuntime(repoPath: string): RuntimeCore | undefined {
     apiToken: cfg.apiToken,
     bank: resolved.bankId,
   });
-  return new RuntimeCore(client, resolved.bankId, cfg, HARNESS);
+  return new RuntimeCore(client, resolved.bankId, cfg, HARNESS, repoPath);
 }
 
 /**

--- a/hindsight-integrations/coding-agents/tsup.config.ts
+++ b/hindsight-integrations/coding-agents/tsup.config.ts
@@ -20,6 +20,9 @@ export default defineConfig({
     // Cline CLI loads this module through `cline plugin install`; file hooks cannot mutate
     // model requests, so the native beforeModel hook is the reliable injection path.
     cline: "src/cline.ts",
+    // Prime Agent loads this module as an extension (default export) by absolute path from its
+    // settings.json `extensions` array, so it must be self-contained like the hook bins.
+    "prime-agent": "src/prime-agent.ts",
     "grok-hook": "src/grok-hook.ts",
     "grok-sessionstart-hook": "src/grok-sessionstart-hook.ts",
     "grok-stop-hook": "src/grok-stop-hook.ts",

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -4,7 +4,7 @@
 
 Long-term project memory for **coding agents**, backed by [Hindsight](https://vectorize.io/hindsight).
 One package, several agents: a shared reflect-and-inject core with a thin entry point per agent
-(**opencode**, **Kilo CLI**, **Cline CLI**, **Claude Code**, **Codex CLI**, **Antigravity CLI**, **Cursor CLI**, **GitHub Copilot CLI**, **Grok Build**). Ingestion is fully
+(**opencode**, **Kilo CLI**, **Cline CLI**, **Prime Agent**, **Claude Code**, **Codex CLI**, **Antigravity CLI**, **Cursor CLI**, **GitHub Copilot CLI**, **Grok Build**). Ingestion is fully
 automatic — there is no setup command: a repo's git history and conversations flow into its memory
 bank in the background as you work.
 
@@ -113,6 +113,14 @@ npx @vectorize-io/hindsight-coding-agents install cline-cli
 ```
 
 A native plugin via `cline plugin install`, plus MCP and the companion skill.
+
+####  Prime Agent
+
+```bash
+npx @vectorize-io/hindsight-coding-agents install prime-agent
+```
+
+An extension entry in `~/.prime/agent/settings.json` — native tools, no MCP needed.
 
 Uninstall the same way: `npx @vectorize-io/hindsight-coding-agents uninstall claude-code` (or `uninstall all`).
 


### PR DESCRIPTION
## Summary

Adds **Prime Agent** ([PrimeIntellect](https://github.com/PrimeIntellect-ai/prime-agent)) as a supported harness in `@vectorize-io/hindsight-coding-agents`, instead of a standalone package.

This gives Prime Agent the full shared **reflect-and-inject** core that opencode / Cline / Claude Code use — auto-seed from git, knowledge-page injection, 🧠 visible attribution, per-repo bank naming (`coding-agent::{gitProject}`), unified config (`~/.hindsight/coding-agent.json`), and backfill — rather than the basic REST recall/retain of the earlier standalone approach.

> Refactors the previous standalone `@vectorize-io/hindsight-prime-agent` package (earlier version of this PR) into a coding-agents harness, per review direction.

## How it works

Prime Agent's extension API (`pi.on("before_agent_start" | "agent_end")`, `pi.registerTool`) is a distinct plugin contract, so it mirrors the **Cline** adapter (its own entry + testable hooks), not the opencode shortcut:

- **`src/prime-agent.ts`** — the extension factory (default export). Resolves config/bank from `process.cwd()`, builds the `HindsightClient` + `RuntimeCore`, registers the `hindsight_*` knowledge tools natively (`pi.registerTool`), kicks off the shared cold-seed, and wires:
  - `before_agent_start` → `core.onPrompt` → `core.getInjection`, appended to the system prompt
  - `agent_end` → `core.onTranscript` (transcript write-back)
- **`src/core/transcript-prime-agent.ts`** — normalizes Prime Agent's `agent_end` messages into the shared `TransportTurn[]` (prose + compact action turns), mirroring `transcript-opencode.ts`.
- **Native tool adapter** — converts each shared `ToolSpec` (Zod raw shape) to a JSON Schema via `z.toJSONSchema`; Prime Agent forwards it to the model provider (it doesn't run TypeBox validation on tool args), so no extra dependency is needed.
- **Installer** — registers the built `dist/prime-agent.js` in the `extensions` array of `~/.prime/agent/settings.json` (idempotent, MARKER-based uninstall), mirroring the opencode installer.

## What's included

- New harness + transcript normalizer, wired into the registry and installer (`HARNESS_NAMES`, `INSTALLERS`), tsup entry, and `package.json` `pi.extensions`.
- Tests: hooks (recall injection, retain, session-start await), the tool adapter, the transcript converter, and the installer install/uninstall round-trip.
- README entry + synced docs page (`docs-integrations/coding-agents.md`) + harness icon.
- No new CI/release entry — Prime Agent ships inside the existing `coding-agents` package (one package, one CI job).

## Verification

- `npx tsc --noEmit` clean; `npm test` 355 pass; `npm run build` emits a self-contained `dist/prime-agent.js`.
- Installer install/uninstall round-trip covered by unit tests.
- Verified end to end against a running Hindsight: loading the built `dist/prime-agent.js` as a Prime Agent extension registers both hooks + the 8 `hindsight_*` tools, retains via `agent_end`, and `before_agent_start` injects the recalled knowledge block into the model's system prompt.

## Note

The standalone-package companion to the upstream contribution (issue [PrimeIntellect-ai/prime-agent#769](https://github.com/PrimeIntellect-ai/prime-agent/issues/769) + PR [#771](https://github.com/PrimeIntellect-ai/prime-agent/pull/771)) is superseded by this harness. The harness icon `prime-agent.svg` is a brand-neutral placeholder.
