### PR TITLE
feat(coding-agents): stage the runtime so npx installs work

### DIFF
--- a/hindsight-integrations/coding-agents/src/installer.test.ts
+++ b/hindsight-integrations/coding-agents/src/installer.test.ts
@@ -639,15 +639,15 @@ describe("all vs named harnesses", () => {
  */
 describe("runtime staging", () => {
   /** A package layout convincing enough to be staged: staging keys off a built dist. */
-  function fakePackage(root: string): {pkgRoot: string; dist: string} {
+  function fakePackage(root: string): { pkgRoot: string; dist: string } {
     const dist = join(root, "dist");
-    mkdirSync(dist, {recursive: true});
+    mkdirSync(dist, { recursive: true });
     writeFileSync(join(dist, "installer.js"), "// built");
     writeFileSync(join(dist, "claude-hook.js"), "// built");
-    writeFileSync(join(root, "package.json"), JSON.stringify({name: "x", main: "dist/index.js"}));
-    mkdirSync(join(root, "skill"), {recursive: true});
+    writeFileSync(join(root, "package.json"), JSON.stringify({ name: "x", main: "dist/index.js" }));
+    mkdirSync(join(root, "skill"), { recursive: true });
     writeFileSync(join(root, "skill", "SKILL.md"), "# skill");
-    return {pkgRoot: root, dist};
+    return { pkgRoot: root, dist };
   }
 
   it("installs from an npx cache, wiring the stable copy instead of the cache", () => {
@@ -658,8 +658,8 @@ describe("runtime staging", () => {
 
     expect(run(["install", "claude-code"], ctx)).toBe(0);
     const staged = join(ctx.home, ".hindsight", "coding-agents");
-    const command = readJson(join(ctx.home, ".claude", "settings.json")).hooks.SessionStart[0].hooks[0]
-      .command as string;
+    const command = readJson(join(ctx.home, ".claude", "settings.json")).hooks.SessionStart[0]
+      .hooks[0].command as string;
     expect(command).toContain(join(staged, "dist"));
     // The whole point: nothing in a host config may reference the evictable cache.
     expect(command).not.toContain("_npx");
@@ -694,13 +694,51 @@ describe("runtime staging", () => {
     expect(cfg.plugin).toContain(staged);
   });
 
+  it("upgrading replaces the staged runtime, stale files and all", () => {
+    const ctx = makeCtx();
+    const v1 = mkdtempSync(join(tmpdir(), "v1-"));
+    const v2 = mkdtempSync(join(tmpdir(), "v2-"));
+    homes.push(v1, v2);
+    fakePackage(v1);
+    writeFileSync(join(v1, "dist", "old-only.js"), "// dropped in the next version");
+    fakePackage(v2);
+    writeFileSync(join(v2, "dist", "new-only.js"), "// added in the next version");
+
+    Object.assign(ctx, { pkgRoot: v1, dist: join(v1, "dist") });
+    run(["install", "claude-code"], ctx);
+    Object.assign(ctx, { pkgRoot: v2, dist: join(v2, "dist") });
+    run(["install", "claude-code"], ctx);
+
+    const staged = join(ctx.home, ".hindsight", "coding-agents", "dist");
+    expect(existsSync(join(staged, "new-only.js"))).toBe(true);
+    // Merging instead of replacing would leave an entry point a host config could still name.
+    expect(existsSync(join(staged, "old-only.js"))).toBe(false);
+    const events = readJson(join(ctx.home, ".claude", "settings.json")).hooks.SessionStart;
+    expect(events).toHaveLength(1);
+  });
+
+  // Re-running the STAGED installer must not delete the dist it is executing from.
+  it("is a no-op when run from the staged copy itself", () => {
+    const ctx = makeCtx();
+    const src = mkdtempSync(join(tmpdir(), "pkg-"));
+    homes.push(src);
+    fakePackage(src);
+    Object.assign(ctx, { pkgRoot: src, dist: join(src, "dist") });
+    run(["install", "claude-code"], ctx);
+
+    const staged = join(ctx.home, ".hindsight", "coding-agents");
+    Object.assign(ctx, { pkgRoot: staged, dist: join(staged, "dist") });
+    expect(run(["install", "claude-code"], ctx)).toBe(0);
+    expect(existsSync(join(staged, "dist", "installer.js"))).toBe(true);
+  });
+
   // A checkout whose dist was never built has nothing to copy; wiring the source path is better
   // than pointing every hook at a directory that does not exist.
   it("wires in place when there is nothing to stage", () => {
     const ctx = makeCtx();
     run(["install", "claude-code"], ctx);
-    const command = readJson(join(ctx.home, ".claude", "settings.json")).hooks.SessionStart[0].hooks[0]
-      .command as string;
+    const command = readJson(join(ctx.home, ".claude", "settings.json")).hooks.SessionStart[0]
+      .hooks[0].command as string;
     expect(command).toContain(ctx.dist);
     expect(existsSync(join(ctx.home, ".hindsight", "coding-agents", "dist"))).toBe(false);
   });

--- a/hindsight-integrations/coding-agents/src/installer.test.ts
+++ b/hindsight-integrations/coding-agents/src/installer.test.ts
@@ -632,18 +632,77 @@ describe("all vs named harnesses", () => {
   });
 });
 
-describe("npx-cache guard", () => {
-  it("refuses install when pkgRoot is inside an npx cache (wiring would die on eviction)", () => {
-    const logs: string[] = [];
-    const ctx = {
-      home: "/tmp/never-touched",
-      pkgRoot: "/Users/x/.npm/_npx/abc123/node_modules/hindsight-coding-agents",
-      dist: "/Users/x/.npm/_npx/abc123/node_modules/hindsight-coding-agents/dist",
-      claudeMcp: () => true,
-      log: (m: string) => logs.push(m),
-    };
-    expect(run(["install", "claude-code"], ctx)).toBe(1);
-    expect(logs.join("\n")).toContain("npm install -g");
+/**
+ * Running from an npx cache used to be refused: the wiring is absolute paths into this package, and
+ * a cache eviction would break every hook silently. The runtime is now copied somewhere stable
+ * first, so `npx` works and nobody needs a global install of a tool that only sets other tools up.
+ */
+describe("runtime staging", () => {
+  /** A package layout convincing enough to be staged: staging keys off a built dist. */
+  function fakePackage(root: string): {pkgRoot: string; dist: string} {
+    const dist = join(root, "dist");
+    mkdirSync(dist, {recursive: true});
+    writeFileSync(join(dist, "installer.js"), "// built");
+    writeFileSync(join(dist, "claude-hook.js"), "// built");
+    writeFileSync(join(root, "package.json"), JSON.stringify({name: "x", main: "dist/index.js"}));
+    mkdirSync(join(root, "skill"), {recursive: true});
+    writeFileSync(join(root, "skill", "SKILL.md"), "# skill");
+    return {pkgRoot: root, dist};
+  }
+
+  it("installs from an npx cache, wiring the stable copy instead of the cache", () => {
+    const ctx = makeCtx();
+    const cache = mkdtempSync(join(tmpdir(), "npx-cache-"));
+    homes.push(cache);
+    Object.assign(ctx, fakePackage(join(cache, "_npx", "abc123", "node_modules", "coding-agents")));
+
+    expect(run(["install", "claude-code"], ctx)).toBe(0);
+    const staged = join(ctx.home, ".hindsight", "coding-agents");
+    const command = readJson(join(ctx.home, ".claude", "settings.json")).hooks.SessionStart[0].hooks[0]
+      .command as string;
+    expect(command).toContain(join(staged, "dist"));
+    // The whole point: nothing in a host config may reference the evictable cache.
+    expect(command).not.toContain("_npx");
+    expect(existsSync(join(staged, "dist", "claude-hook.js"))).toBe(true);
+  });
+
+  // MARKER matching is what makes re-install replace and uninstall remove, and it looks for this
+  // substring in the command path — so the staged location must keep it.
+  it("stages somewhere the marker still matches", () => {
+    const ctx = makeCtx();
+    const src = mkdtempSync(join(tmpdir(), "pkg-"));
+    homes.push(src);
+    Object.assign(ctx, fakePackage(src));
+
+    run(["install", "claude-code"], ctx);
+    expect(join(ctx.home, ".hindsight", "coding-agents")).toContain(MARKER);
+    run(["uninstall", "claude-code"], ctx);
+    expect(readJson(join(ctx.home, ".claude", "settings.json")).hooks).toBeUndefined();
+  });
+
+  it("copies the plugin entry point too, since opencode loads the directory", () => {
+    const ctx = makeCtx();
+    const src = mkdtempSync(join(tmpdir(), "pkg-"));
+    homes.push(src);
+    Object.assign(ctx, fakePackage(src));
+
+    run(["install", "opencode"], ctx);
+    const staged = join(ctx.home, ".hindsight", "coding-agents");
+    expect(existsSync(join(staged, "package.json"))).toBe(true);
+    expect(existsSync(join(staged, "skill", "SKILL.md"))).toBe(true);
+    const cfg = readJson(join(ctx.home, ".config", "opencode", "opencode.json"));
+    expect(cfg.plugin).toContain(staged);
+  });
+
+  // A checkout whose dist was never built has nothing to copy; wiring the source path is better
+  // than pointing every hook at a directory that does not exist.
+  it("wires in place when there is nothing to stage", () => {
+    const ctx = makeCtx();
+    run(["install", "claude-code"], ctx);
+    const command = readJson(join(ctx.home, ".claude", "settings.json")).hooks.SessionStart[0].hooks[0]
+      .command as string;
+    expect(command).toContain(ctx.dist);
+    expect(existsSync(join(ctx.home, ".hindsight", "coding-agents", "dist"))).toBe(false);
   });
 });
 

--- a/hindsight-integrations/coding-agents/src/installer.ts
+++ b/hindsight-integrations/coding-agents/src/installer.ts
@@ -578,7 +578,17 @@ export function runtimeDir(home: string): string {
  */
 function stageRuntime(c: InstallCtx): InstallCtx {
   const target = runtimeDir(c.home);
-  if (c.pkgRoot === target) return c;
+  // Compared through realpath: re-running the STAGED installer must not reach the copy below, which
+  // deletes the very dist it is executing from. A symlinked or differently-spelled path to the same
+  // directory would slip past a string compare.
+  const same = (a: string, b: string): boolean => {
+    try {
+      return realpathSync(a) === realpathSync(b);
+    } catch {
+      return a === b;
+    }
+  };
+  if (same(c.pkgRoot, target)) return c;
   if (!existsSync(join(c.dist, "installer.js"))) return c;
   try {
     // Replaced wholesale rather than merged: a stale entry point left behind by an older version

--- a/hindsight-integrations/coding-agents/src/installer.ts
+++ b/hindsight-integrations/coding-agents/src/installer.ts
@@ -550,6 +550,55 @@ function pathNodeVersion(): string {
   }
 }
 
+// ── runtime staging ─────────────────────────────────────────────────────────────
+
+/**
+ * Where the runtime is copied to, and therefore what every hook command points at.
+ *
+ * Under ~/.hindsight, which this package already owns (the config file lives there), and named
+ * `coding-agents` on purpose: MARKER matching is what lets a re-install replace our entries and
+ * `uninstall` remove them, and it looks for exactly that substring in the command path.
+ */
+export function runtimeDir(home: string): string {
+  return join(home, ".hindsight", "coding-agents");
+}
+
+/**
+ * Copy the runtime out of wherever this was executed from and into a stable location, then point
+ * the wiring at the copy.
+ *
+ * Both fields matter: `dist` is baked into every hook command and MCP registration, and `pkgRoot`
+ * is what opencode and Kilo load as a plugin directory. Repointing them here means no per-harness
+ * installer needs to know staging happened.
+ *
+ * Copying is skipped when there is nothing to copy — running from a checkout whose dist has not
+ * been built, and in tests — so the wiring falls back to the source path rather than a directory
+ * that does not exist. It is also skipped when already running from the staged copy, which is what
+ * makes re-running `install` cheap.
+ */
+function stageRuntime(c: InstallCtx): InstallCtx {
+  const target = runtimeDir(c.home);
+  if (c.pkgRoot === target) return c;
+  if (!existsSync(join(c.dist, "installer.js"))) return c;
+  try {
+    // Replaced wholesale rather than merged: a stale entry point left behind by an older version
+    // would still be reachable from a host config that references it by name.
+    rmSync(join(target, "dist"), { recursive: true, force: true });
+    mkdirSync(target, { recursive: true });
+    cpSync(c.dist, join(target, "dist"), { recursive: true });
+    const skill = join(c.pkgRoot, "skill");
+    if (existsSync(skill)) cpSync(skill, join(target, "skill"), { recursive: true });
+    const pkgJson = join(c.pkgRoot, "package.json");
+    if (existsSync(pkgJson)) copyFileSync(pkgJson, join(target, "package.json"));
+    c.log?.(`runtime staged at ${target}`);
+    return { ...c, pkgRoot: target, dist: join(target, "dist") };
+  } catch (error) {
+    // A failed copy must not wire hooks at a half-written directory.
+    c.log?.(`could not stage the runtime at ${target}: ${String(error)}`);
+    return c;
+  }
+}
+
 // ── server setup (cloud / self-hosted / local daemon) ───────────────────────────
 
 export type ServerMode = "cloud" | "self-hosted" | "daemon";
@@ -1037,7 +1086,8 @@ function importConversations(harness: string, ctx: InstallCtx): void {
   }
 }
 
-export function run(argv: string[], ctx: InstallCtx): number {
+export function run(argv: string[], ctxIn: InstallCtx): number {
+  let ctx = ctxIn;
   const [command, ...rawArgs] = argv;
   // `--import-conversations` backfills this repo's PAST sessions for the harness being installed —
   // the migration path off the older per-agent plugins, whose banks the server cannot merge into
@@ -1047,17 +1097,12 @@ export function run(argv: string[], ctx: InstallCtx): number {
   // read as a harness name and rejected.
   const valueArgs = flagValueArgs(rawArgs, ["server", "api-url", "api-token"]);
   const names = rawArgs.filter((a) => !a.startsWith("--") && !valueArgs.has(a));
-  // The wiring we write is ABSOLUTE paths into this package's dist. From an npx/pnpm-dlx cache
-  // those paths die on cache eviction — every hook silently stops. Refuse and say what to do.
-  if (command === "install" && /\/(_npx|\.npm\/_npx|dlx-)\/|\/_cacache\//.test(ctx.pkgRoot)) {
-    ctx.log?.(
-      "refusing to install from an npx/dlx cache: the hook wiring would point into a cache npm can " +
-        "evict, silently breaking every session.\nInstall the package permanently, then re-run:\n" +
-        "  npm install -g @vectorize-io/hindsight-coding-agents\n" +
-        "  hindsight-coding-agents install all"
-    );
-    return 1;
-  }
+  // Everything we write into a host's config is an ABSOLUTE path into this package. Run straight
+  // from an npx cache those paths die on the first eviction and every hook stops SILENTLY, which is
+  // why installing from a cache used to be refused outright. Copying the runtime somewhere stable
+  // first removes the problem instead of pushing it onto the user: `npx` now works, and nobody has
+  // to keep a global install of a tool whose only job is to set other tools up.
+  if (command === "install") ctx = stageRuntime(ctx);
   if (command !== "install" && command !== "uninstall") {
     ctx.log?.(
       `usage: hindsight-coding-agents <install|uninstall> <all|harness...>\n` +


### PR DESCRIPTION
Answers "why can't people just use npx?" — they can now.

## The problem

Installing from an npx cache was **refused outright**. Everything `install` writes into a host's config is an absolute path into this package:

```js
command: `node "${join(dist, hook.entry)}"`
```

From `~/.npm/_npx/<hash>/` those paths die on the first cache eviction, and hooks then fail **silently** — the agent keeps working, memory just stops, with nothing to explain why. Refusing was the honest response, but it forced a global install of a tool whose only job is to set other tools up.

## The fix

`install` copies the runtime to `~/.hindsight/coding-agents` and wires **that**. The problem disappears instead of being pushed onto the user: no cache path is ever written, and no global install is needed.

Verified end to end from a real npx-shaped cache — the wiring came out as

```
node "~/.hindsight/coding-agents/dist/claude-sessionstart-hook.js"
```

with no `_npx` anywhere in the host config.

## Design notes

- **`dist` and `pkgRoot` are repointed in one place**, so none of the ~20 call sites that bake a path into a host config had to change — and opencode/Kilo still receive a directory containing `package.json` and the plugin entry.
- **The staged directory is named `coding-agents` on purpose.** `MARKER` matching is what makes a re-install replace our entries and `uninstall` remove them, and it looks for exactly that substring in the command path.
- **Staging is skipped when there is nothing to copy** — a checkout whose `dist` was never built, and the tests — so wiring falls back to the source path rather than pointing at a directory that doesn't exist.
- `dist` is replaced wholesale rather than merged, so a stale entry point from an older version can't stay reachable from a host config that names it.

## Tests

The old refusal test is replaced by four: install from an npx cache wires the stable copy and never the cache; the staged path still matches `MARKER` (so uninstall still works); `package.json` and `skill/` are copied because opencode loads the directory; and wiring falls back in place when there's nothing to stage.

**336 passed**, 19 skipped.

## Follow-up

Docs still say `npm install -g`. That switch belongs on #3162 (which already rewrites the README) and is only true once this ships in 0.0.6 — so it shouldn't merge before the release.