### PR TITLE
feat(coding-agents): styled installer UI, arrow-key server picker, required Cloud token

### DIFF
--- a/hindsight-integrations/coding-agents/package-lock.json
+++ b/hindsight-integrations/coding-agents/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectorize-io/hindsight-coding-agents",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectorize-io/hindsight-coding-agents",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@vectorize-io/hindsight-all": "^0.8.6",

--- a/hindsight-integrations/coding-agents/src/install-ui.test.ts
+++ b/hindsight-integrations/coding-agents/src/install-ui.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInstallerUi,
+  fitSelectRow,
+  selectKeyAction,
+  splitKeys,
+  type InstallerUi,
+} from "./install-ui";
+
+/** Renderer under a fixed clock and captured output; colors off unless a test opts in. */
+function makeUi(command?: string, colors = false): { ui: InstallerUi; lines: string[] } {
+  const lines: string[] = [];
+  let tick = 0;
+  const ui = createInstallerUi({
+    home: "/home/u",
+    command,
+    version: "1.2.3",
+    harnessNames: ["claude-code", "codex"],
+    auxNames: ["server"],
+    colors,
+    write: (l) => lines.push(l),
+    now: () => (tick += 250),
+  });
+  return { ui, lines };
+}
+
+describe("installer UI renderer", () => {
+  it("frames the run, groups messages by harness prefix, and picks symbols from phrasing", () => {
+    const { ui, lines } = makeUi("install");
+    ui.intro();
+    ui.log("detected: claude-code, codex");
+    ui.log("claude-code: hooks merged into /home/u/.claude/settings.json");
+    // A message without a harness prefix must land inside the currently open group.
+    ui.log("skill installed at /home/u/.claude/skills/hindsight-coding-agent");
+    ui.log(
+      "claude-code: could not run `claude mcp add` — register the tools manually:\n" +
+        '  claude mcp add --scope user hindsight -- node "/opt/dist/mcp-server.js"'
+    );
+    ui.log("codex: hooks merged into /home/u/.codex/hooks.json");
+    ui.outro(0);
+
+    const out = lines.join("\n");
+    expect(out).toContain("┌  Hindsight coding agents  v1.2.3");
+    expect(out).toContain("○ detected: claude-code, codex");
+    expect(out).toContain("◇  claude-code");
+    expect(out).toContain("◇  codex");
+    // $HOME shortened to ~ everywhere.
+    expect(out).toContain("✓ hooks merged into ~/.claude/settings.json");
+    expect(out).not.toContain("/home/u/");
+    // Manual-step phrasing renders as a warning, continuation line stays on the rail.
+    expect(out).toContain("▲ could not run `claude mcp add`");
+    expect(out).toContain("│    claude mcp add --scope user hindsight");
+    // The prefixless skill line sits between the two group headers, i.e. inside claude-code's group.
+    const claudeAt = lines.findIndex((l) => l.includes("◇  claude-code"));
+    const skillAt = lines.findIndex((l) => l.includes("skill installed"));
+    const codexAt = lines.findIndex((l) => l.includes("◇  codex"));
+    expect(claudeAt).toBeLessThan(skillAt);
+    expect(skillAt).toBeLessThan(codexAt);
+    expect(out).toMatch(/└ {2}✓ Installed 2 agents in \d+\.\ds/);
+    expect(out).toContain("~/.hindsight/coding-agent.json");
+  });
+
+  it("renders the server-setup step as a group but does not count it as an agent", () => {
+    const { ui, lines } = makeUi("install");
+    ui.intro();
+    ui.log(
+      "\nWhere should memory live?\n  1) Hindsight Cloud\n  2) Self-hosted\n  3) Local daemon\n"
+    );
+    ui.log("server: daemon (/home/u/.hindsight/coding-agent.json)");
+    ui.log("codex: hooks merged into /home/u/.codex/hooks.json");
+    ui.outro(0);
+    const out = lines.join("\n");
+    // The mode question is an info line with quiet option detail, not a completed action.
+    expect(out).toContain("○ Where should memory live?");
+    expect(out).toContain("│    1) Hindsight Cloud");
+    expect(out).toContain("◇  server");
+    expect(out).toContain("✓ daemon (~/.hindsight/coding-agent.json)");
+    expect(out).toMatch(/Installed 1 agent in/); // codex only — server is a step, not an agent
+  });
+
+  it("adopts run()'s own emoji severity markers instead of double-marking", () => {
+    const { ui, lines } = makeUi("install");
+    ui.intro();
+    ui.log(
+      "\n❌ codex: `node:sqlite` is unavailable in the node on PATH.\n   Upgrade to Node 22.5."
+    );
+    ui.log("⚠️  `uv` is not on PATH. The daemon is fetched and run with it.");
+    ui.outro(1);
+    const out = lines.join("\n");
+    // The ❌ line still opens its harness group once the marker is stripped.
+    expect(out).toContain("◇  codex");
+    expect(out).toContain("✖ `node:sqlite` is unavailable");
+    expect(out).not.toContain("❌");
+    expect(out).toContain("▲ `uv` is not on PATH");
+    expect(out).not.toContain("⚠️");
+  });
+
+  it("never doubles the rail spacer between intro, groups, and outro", () => {
+    const { ui, lines } = makeUi("install");
+    ui.intro();
+    ui.log("claude-code: hooks merged into /home/u/.claude/settings.json");
+    ui.outro(0);
+    for (let i = 1; i < lines.length; i++) {
+      if (lines[i] === "│") expect(lines[i - 1]).not.toBe("│");
+    }
+  });
+
+  it("counts a single agent without the plural s", () => {
+    const { ui, lines } = makeUi("uninstall");
+    ui.intro();
+    ui.log("codex: hooks + MCP section + skill removed");
+    ui.outro(0);
+    expect(lines.join("\n")).toMatch(/✓ Uninstalled 1 agent in \d+\.\ds/);
+  });
+
+  it("renders guard-path failures as an error and an aborted outro when nothing was wired", () => {
+    const { ui, lines } = makeUi("install");
+    ui.intro();
+    ui.log('unknown harness "nope" — expected "all" or one of: claude-code, codex');
+    ui.outro(1);
+    const out = lines.join("\n");
+    expect(out).toContain('✖ unknown harness "nope"');
+    expect(out).toContain("✖ Aborted — nothing was changed.");
+    expect(out).not.toContain("Installed");
+  });
+
+  it("reports a partial failure honestly once some agents were already wired", () => {
+    const { ui, lines } = makeUi("install");
+    ui.intro();
+    ui.log("codex: hooks merged into /home/u/.codex/hooks.json");
+    ui.log("\n❌ not installed: devin-cli — this machine can't run it (see above).");
+    ui.outro(1);
+    const out = lines.join("\n");
+    expect(out).toContain("✖ Completed with errors — see above.");
+    expect(out).not.toContain("nothing was changed");
+  });
+
+  it("closes a bare usage run with just the frame — no success banner", () => {
+    const { ui, lines } = makeUi(undefined);
+    ui.intro();
+    ui.log(
+      "usage: hindsight-coding-agents <install|uninstall> <all|harness...>\n  all  every agent"
+    );
+    ui.outro(0);
+    const out = lines.join("\n");
+    expect(out).toContain("○ usage:");
+    expect(out).not.toContain("Installed");
+    expect(lines.at(-2)).toBe("└");
+  });
+
+  it("renders an indented follow-up message as detail lines, not a fresh ✓ item", () => {
+    const { ui, lines } = makeUi("install");
+    ui.intro();
+    ui.log("claude-code: conversation import did not finish — re-run it any time with:");
+    ui.log('  node "/opt/dist/deepen.js" --repo "/home/u/w" --conversations "/tmp/c.json"');
+    const detail = lines.at(-1)!;
+    expect(detail).toContain('node "/opt/dist/deepen.js"');
+    expect(detail).not.toContain("✓");
+    expect(detail.startsWith("│    ")).toBe(true);
+  });
+
+  it("names the overridden config path in the outro when one is set", () => {
+    const lines: string[] = [];
+    const ui = createInstallerUi({
+      home: "/home/u",
+      command: "install",
+      harnessNames: ["codex"],
+      configPath: "/tmp/config.json",
+      colors: false,
+      write: (l) => lines.push(l),
+      now: (() => {
+        let t = 0;
+        return () => (t += 100);
+      })(),
+    });
+    ui.intro();
+    ui.log("codex: hooks merged into /home/u/.codex/hooks.json");
+    ui.outro(0);
+    expect(lines.join("\n")).toContain("settings live in /tmp/config.json.");
+    expect(lines.join("\n")).not.toContain("~/.hindsight");
+  });
+
+  it("styles readline prompts onto the rail", () => {
+    const { ui } = makeUi("install");
+    expect(ui.prompt("Choose [1-3] (default 1): ")).toBe("│  Choose [1-3] (default 1): ");
+  });
+
+  it("select keys: arrows wrap, vi keys move, Enter submits, digits shortcut, Esc/q/Ctrl+C cancel", () => {
+    expect(selectKeyAction("\x1b[B", 0, 3)).toEqual({ kind: "move", index: 1 });
+    expect(selectKeyAction("\x1b[B", 2, 3)).toEqual({ kind: "move", index: 0 }); // wraps down
+    expect(selectKeyAction("\x1b[A", 0, 3)).toEqual({ kind: "move", index: 2 }); // wraps up
+    expect(selectKeyAction("j", 0, 3)).toEqual({ kind: "move", index: 1 });
+    expect(selectKeyAction("k", 1, 3)).toEqual({ kind: "move", index: 0 });
+    expect(selectKeyAction("\r", 1, 3)).toEqual({ kind: "submit", index: 1 });
+    expect(selectKeyAction("3", 0, 3)).toEqual({ kind: "submit", index: 2 });
+    expect(selectKeyAction("9", 0, 3)).toEqual({ kind: "none", index: 0 }); // out of range
+    expect(selectKeyAction("\x1b", 1, 3)).toEqual({ kind: "cancel", index: 1 });
+    expect(selectKeyAction("q", 1, 3)).toEqual({ kind: "cancel", index: 1 });
+    expect(selectKeyAction("\x03", 1, 3)).toEqual({ kind: "cancel", index: 1 });
+    expect(selectKeyAction("x", 1, 3)).toEqual({ kind: "none", index: 1 });
+  });
+
+  it("splits a burst of keys from one read into individual tokens", () => {
+    // Key repeat / paste: ↓ then Enter arriving in a single read must act as two keys.
+    expect(splitKeys("\x1b[B\r")).toEqual(["\x1b[B", "\r"]);
+    expect(splitKeys("\x1b[A\x1b[A\x1b[B")).toEqual(["\x1b[A", "\x1b[A", "\x1b[B"]);
+    expect(splitKeys("2\r")).toEqual(["2", "\r"]);
+    expect(splitKeys("\x1b")).toEqual(["\x1b"]); // a lone Esc stays a cancel key
+    expect(splitKeys("jk")).toEqual(["j", "k"]);
+    expect(splitKeys("\x1b[")).toEqual(["\x1b["]); // truncated CSI at chunk end doesn't crash
+  });
+
+  it("fits select rows to the terminal width so a row can never wrap", () => {
+    const label = "Local daemon (on-device)";
+    const hint = "runs hindsight-embed here; no account, needs uv + an LLM key";
+    // Wide terminal: everything fits untouched.
+    const wide = fitSelectRow(label, hint, 120);
+    expect(wide).toEqual({ label, hint: ` — ${hint}` });
+    // Narrow terminal: the hint is truncated with an ellipsis, the label survives.
+    const narrow = fitSelectRow(label, hint, 60);
+    expect(narrow.label).toBe(label);
+    expect(narrow.hint.endsWith("…")).toBe(true);
+    expect(narrow.label.length + narrow.hint.length).toBeLessThanOrEqual(60 - 6);
+    // Tiny terminal: even the label is cut, and the hint is dropped entirely.
+    const tiny = fitSelectRow(label, hint, 20);
+    expect(tiny.hint).toBe("");
+    expect(tiny.label.endsWith("…")).toBe(true);
+    expect(tiny.label.length).toBeLessThanOrEqual(20 - 6);
+    // No hint at all stays stable.
+    expect(fitSelectRow("Cloud", undefined, 80)).toEqual({ label: "Cloud", hint: "" });
+  });
+
+  it("emits ANSI only when colors are on", () => {
+    const on = makeUi("install", true);
+    on.ui.intro();
+    on.ui.log("claude-code: hooks merged into /home/u/.claude/settings.json");
+    on.ui.outro(0);
+    expect(on.lines.join("\n")).toContain("\x1b[");
+
+    const off = makeUi("install", false);
+    off.ui.intro();
+    off.ui.log("claude-code: hooks merged into /home/u/.claude/settings.json");
+    off.ui.outro(0);
+    expect(off.lines.join("\n")).not.toContain("\x1b[");
+  });
+});

--- a/hindsight-integrations/coding-agents/src/install-ui.ts
+++ b/hindsight-integrations/coding-agents/src/install-ui.ts
@@ -1,0 +1,328 @@
+/**
+ * Styled terminal renderer for the installer CLI (clack/Vercel-style rail).
+ *
+ * The install/uninstall engine reports plain prefixed strings ("<harness>: <what happened>")
+ * through InstallCtx.log — a deliberately dumb channel that tests and programmatic callers
+ * consume as-is. This module is the only place that turns that stream into the framed,
+ * colorized output the interactive CLI shows: a message prefixed with a known harness name
+ * opens a step group, the phrasing adapters already use picks the ✓/▲/✖ symbol, and absolute
+ * paths under $HOME are shortened to ~. The renderer sits ON the log channel rather than
+ * threading a structured UI through every adapter, so the engine stays renderer-agnostic and
+ * the installer tests keep asserting on plain text.
+ *
+ * Zero-dependency by design: the installer must run from a bare `npm install -g` with nothing
+ * but node builtins, so no chalk/@clack/prompts.
+ */
+import { execFileSync } from "node:child_process";
+import { readSync } from "node:fs";
+import { brandWord } from "./core/brand";
+
+export interface InstallerUiOptions {
+  home: string;
+  /** argv[2], used by the outro to say what completed (install vs uninstall vs usage). */
+  command?: string;
+  version?: string;
+  /** Names whose "<name>: " prefix opens a step group AND count as installed agents. */
+  harnessNames: string[];
+  /** Extra group names (e.g. "server") that render like a harness but aren't agents. */
+  auxNames?: string[];
+  /** Where settings actually live (HINDSIGHT_CONFIG override); the outro names this file. */
+  configPath?: string;
+  /** Test overrides: deterministic colors, captured output, fixed clock. */
+  colors?: boolean;
+  write?: (line: string) => void;
+  now?: () => number;
+}
+
+export interface InstallerUi {
+  intro(): void;
+  /** Style an interactive question so readline prompts sit on the rail like log lines. */
+  prompt(question: string): string;
+  /** Arrow-key picker: chosen index, null when cancelled (Esc/q/Ctrl+C), undefined when a raw
+   *  TTY isn't available — the caller then falls back to its plain numeric prompt. */
+  select(
+    question: string,
+    options: SelectOption[],
+    defaultIndex: number
+  ): number | null | undefined;
+  log(message: string): void;
+  outro(exitCode: number): void;
+}
+
+export interface SelectOption {
+  label: string;
+  hint?: string;
+}
+
+export interface SelectKeyResult {
+  kind: "move" | "submit" | "cancel" | "none";
+  index: number;
+}
+
+/**
+ * Fit one option row into the terminal width. The redraw moves the cursor up N LOGICAL rows —
+ * a row that wraps occupies two physical rows, the cursor lands mid-list, and every keypress
+ * repaints over the wrong lines (content visibly duplicates). So a row must never wrap: the
+ * hint gives way first, then the label. Pure so the edge cases are unit-testable.
+ */
+export function fitSelectRow(
+  label: string,
+  hint: string | undefined,
+  width: number
+): { label: string; hint: string } {
+  const room = Math.max(10, width - 6); // "│  ❯ " prefix + one spare column
+  let hintText = hint ? ` — ${hint}` : "";
+  if (label.length > room) return { label: `${label.slice(0, room - 1)}…`, hint: "" };
+  if (label.length + hintText.length > room) {
+    hintText = `${hintText.slice(0, room - label.length - 1)}…`;
+  }
+  return { label, hint: hintText };
+}
+
+/**
+ * Split one stdin read into individual keys. Fast typing, key repeat, or a paste delivers several
+ * keys in a single read — treating the whole chunk as one token made those inputs match nothing
+ * and the picker sat there ignoring them. CSI sequences (ESC [ … final byte) stay whole; every
+ * other byte is its own key.
+ */
+export function splitKeys(chunk: string): string[] {
+  const keys: string[] = [];
+  for (let i = 0; i < chunk.length; ) {
+    if (chunk[i] === "\x1b" && chunk[i + 1] === "[") {
+      let j = i + 2;
+      while (j < chunk.length && !(chunk[j] >= "@" && chunk[j] <= "~")) j++;
+      keys.push(chunk.slice(i, Math.min(j + 1, chunk.length)));
+      i = j + 1;
+    } else {
+      keys.push(chunk[i]);
+      i += 1;
+    }
+  }
+  return keys;
+}
+
+/**
+ * Pure keypress reducer for select() — the interactive shell around it (raw mode, redraw) is
+ * deliberately thin so THIS is what carries the behavior and the unit tests. Digits still submit
+ * directly, so the muscle memory from the old numbered menu keeps working.
+ */
+export function selectKeyAction(key: string, index: number, count: number): SelectKeyResult {
+  if (key === "\x1b[A" || key === "k") return { kind: "move", index: (index + count - 1) % count };
+  if (key === "\x1b[B" || key === "j") return { kind: "move", index: (index + 1) % count };
+  if (key === "\r" || key === "\n") return { kind: "submit", index };
+  // Ctrl+C, a lone Esc, or q cancel; arrow sequences arrive atomically and match above first.
+  if (key === "\x03" || key === "\x1b" || key === "q") return { kind: "cancel", index };
+  const digit = Number.parseInt(key, 10);
+  if (digit >= 1 && digit <= count) return { kind: "submit", index: digit - 1 };
+  return { kind: "none", index };
+}
+
+/**
+ * Adapter messages are prose, not levels — severity is inferred from the phrasing they already
+ * use. Every "warn" phrasing means "wired, but something was skipped or needs a manual step";
+ * "error" phrasings only occur on run()'s guard paths, which abort before touching any config.
+ */
+const WARN_RE =
+  /\bskipped\b|could not|manually|preserved|did not finish|unrecognised|add `hooks = true`/i;
+const ERROR_RE = /unknown harness|no supported coding agents|name a harness/;
+const INFO_RE = /^usage:|^detected: |\?$/; // a line ending in "?" introduces a question, not a result
+
+/** run() also marks severity itself with a leading emoji; adopt it instead of double-marking. */
+const EMOJI_KIND: Record<string, "ok" | "warn" | "error"> = {
+  "✅": "ok",
+  "⚠️": "warn",
+  "❌": "error",
+};
+
+export function createInstallerUi(o: InstallerUiOptions): InstallerUi {
+  const sink = o.write ?? ((line: string) => console.log(line));
+  // Track the last emitted line so spacer rails never double up (intro/outro/group all want a
+  // blank `│` next to them, and any two of those can be adjacent).
+  let lastLine = "";
+  const write = (line: string): void => {
+    lastLine = line;
+    sink(line);
+  };
+  // Honor NO_COLOR (https://no-color.org) and drop ANSI when output is piped; the frame itself
+  // stays, so captured logs keep the structure.
+  const colors =
+    o.colors ??
+    (process.stdout.isTTY === true &&
+      process.env.NO_COLOR === undefined &&
+      process.env.TERM !== "dumb");
+  const now = o.now ?? Date.now;
+  const paint = (code: string, s: string): string => (colors ? `\x1b[${code}m${s}\x1b[0m` : s);
+  const dim = (s: string): string => paint("2", s);
+  const bold = (s: string): string => paint("1", s);
+  const green = (s: string): string => paint("32", s);
+  const yellow = (s: string): string => paint("33", s);
+  const red = (s: string): string => paint("31", s);
+  const cyan = (s: string): string => paint("36", s);
+  const bar = dim("│");
+  const symbol = { ok: green("✓"), warn: yellow("▲"), error: red("✖"), info: dim("○") };
+
+  // Messages embed absolute config paths; shorten $HOME so the action stays the eye-catcher.
+  const tidy = (s: string): string => s.replaceAll(o.home, "~");
+  // The lookbehind keeps URL slashes ("http://…") from being treated as a path start.
+  const dimPaths = (s: string): string => s.replace(/(?<![:\w/])~?\/[^\s"',)]+/g, (m) => dim(m));
+
+  const prefixRe = new RegExp(`^(${[...o.harnessNames, ...(o.auxNames ?? [])].join("|")}): `);
+  const startedAt = now();
+  let group: string | null = null;
+  // Only harness groups count toward the outro's "Installed N agents" — the server-setup group
+  // is a step, not an agent.
+  let groups = 0;
+
+  function classify(line: string): keyof typeof symbol {
+    if (INFO_RE.test(line)) return "info";
+    if (ERROR_RE.test(line)) return "error";
+    if (WARN_RE.test(line)) return "warn";
+    return "ok";
+  }
+
+  const spacer = (): void => {
+    if (lastLine !== bar) write(bar);
+  };
+
+  function openGroup(name: string): void {
+    spacer();
+    write(`${cyan("◇")}  ${bold(name)}`);
+    group = name;
+    if (o.harnessNames.includes(name)) groups++;
+  }
+
+  return {
+    intro(): void {
+      write("");
+      write(
+        `${dim("┌")}  ${colors ? brandWord() : "Hindsight"} ${bold("coding agents")}` +
+          (o.version ? `  ${dim(`v${o.version}`)}` : "")
+      );
+      write(bar);
+    },
+
+    /** Style an interactive question so readline prompts sit on the rail like log lines. */
+    prompt(question: string): string {
+      return `${bar}  ${question}`;
+    },
+
+    select(question: string, options: SelectOption[], defaultIndex: number) {
+      // Raw mode comes from stty, NOT process.stdin.setRawMode: touching process.stdin flips
+      // fd 0 non-blocking and starts the very EAGAIN dance readLineSync had to be cured of.
+      // No stty (Windows, exotic shells) → undefined, and the caller falls back to numbers.
+      const stty = (args: string[]): string =>
+        execFileSync("stty", args, { stdio: ["inherit", "pipe", "pipe"], encoding: "utf8" }).trim();
+      let savedTty: string;
+      try {
+        savedTty = stty(["-g"]);
+        stty(["raw", "-echo"]);
+      } catch {
+        return undefined;
+      }
+      // Raw mode disables newline translation, so every rendered line ends in \r\n explicitly.
+      const render = (index: number, redraw: boolean): void => {
+        const width = process.stdout.columns || 80;
+        const rows = options.map((opt, i) => {
+          const on = i === index;
+          const pointer = on ? cyan("❯") : " ";
+          const fitted = fitSelectRow(opt.label, opt.hint, width);
+          const label = on ? bold(fitted.label) : fitted.label;
+          return `\x1b[2K${bar}  ${pointer} ${label}${fitted.hint ? dim(fitted.hint) : ""}`;
+        });
+        if (redraw) process.stdout.write(`\x1b[${options.length}A`); // back to the first option row
+        process.stdout.write(rows.map((r) => `\r${r}\r\n`).join(""));
+      };
+      lastLine = "select"; // whatever follows on the rail must re-emit its own spacer
+      // Belt and braces for the cursor-up math: \x1b[?7l turns terminal autowrap off for the
+      // picker's lifetime (restored in finally), so even a mis-measured row clips instead of
+      // wrapping and the repaint always covers the right lines.
+      process.stdout.write("\x1b[?7l");
+      process.stdout.write(`${bar}  ${symbol.info} ${dim(question)} ${dim("(↑/↓, Enter)")}\r\n`);
+      let index = Math.min(Math.max(defaultIndex, 0), options.length - 1);
+      render(index, false);
+      const buf = Buffer.alloc(16);
+      try {
+        for (;;) {
+          let n: number;
+          try {
+            n = readSync(0, buf, 0, buf.length, null);
+          } catch (e) {
+            if ((e as NodeJS.ErrnoException).code !== "EAGAIN") return null; // stdin gone → cancel
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 25);
+            continue;
+          }
+          if (n === 0) return null; // EOF → cancel
+          // One read can hold several keys (key repeat, paste) — apply them all in order.
+          for (const key of splitKeys(buf.subarray(0, n).toString("latin1"))) {
+            const action = selectKeyAction(key, index, options.length);
+            index = action.index;
+            if (action.kind === "move") render(index, true);
+            else if (action.kind === "submit") {
+              render(index, true); // repaint so a digit shortcut also shows its row selected
+              return index;
+            } else if (action.kind === "cancel") return null;
+          }
+        }
+      } finally {
+        process.stdout.write("\x1b[?7h"); // re-enable autowrap
+        try {
+          stty([savedTty!]);
+        } catch {
+          // the terminal stays raw only if restoring fails AND the process lives on — accept it
+        }
+      }
+    },
+
+    log(message: string): void {
+      const text = tidy(message).replace(/^\n+|\n+$/g, "");
+      if (!text) return;
+      const lines = text.split("\n");
+      // A message that begins indented is detail for the previous one (e.g. the re-run command a
+      // failed history import prints as its own log call) — keep it quiet, not behind a fresh ✓.
+      if (/^\s/.test(lines[0])) {
+        for (const l of lines) write(`${bar}    ${dim(l.trim())}`);
+        return;
+      }
+      // Emoji severity comes first: preflight failures read "❌ devin-cli: …", and the harness
+      // prefix must still open its group once the marker is stripped.
+      const emoji = lines[0].match(/^(✅|❌|⚠️)\s*/u);
+      if (emoji) lines[0] = lines[0].slice(emoji[0].length);
+      const prefixed = lines[0].match(prefixRe);
+      if (prefixed) {
+        if (prefixed[1] !== group) openGroup(prefixed[1]);
+        lines[0] = lines[0].slice(prefixed[0].length);
+      }
+      const kind = emoji ? EMOJI_KIND[emoji[1]] : classify(lines[0]);
+      write(`${bar}  ${symbol[kind]} ${kind === "info" ? dim(lines[0]) : dimPaths(lines[0])}`);
+      // Continuation lines carry detail (a command to run, the harness list) — keep them quiet.
+      for (const rest of lines.slice(1)) write(`${bar}    ${dim(rest.trim())}`);
+    },
+
+    outro(exitCode: number): void {
+      spacer();
+      if (exitCode !== 0) {
+        // Guard paths exit before anything was wired; a preflight-blocked harness exits non-zero
+        // AFTER wiring the others (run() only opens groups for work it actually did).
+        write(
+          `${dim("└")}  ${red("✖")} ${groups ? "Completed with errors — see above." : "Aborted — nothing was changed."}`
+        );
+      } else if (o.command === "install" || o.command === "uninstall") {
+        const secs = ((now() - startedAt) / 1000).toFixed(1);
+        const agents = `${groups} agent${groups === 1 ? "" : "s"}`;
+        if (o.command === "install") {
+          const settings = o.configPath ? tidy(o.configPath) : "~/.hindsight/coding-agent.json";
+          write(`${dim("└")}  ${green("✓")} Installed ${agents} in ${secs}s`);
+          write(`   ${dim(`Start a session — settings live in ${settings}.`)}`);
+        } else {
+          write(
+            `${dim("└")}  ${green("✓")} Uninstalled ${agents} in ${secs}s — Hindsight entries removed, *.hindsight-backup files left in place.`
+          );
+        }
+      } else {
+        // Bare usage: nothing happened, just close the frame.
+        write(dim("└"));
+      }
+      write("");
+    },
+  };
+}

--- a/hindsight-integrations/coding-agents/src/installer.test.ts
+++ b/hindsight-integrations/coding-agents/src/installer.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -41,7 +41,14 @@ function writeJsonAt(path: string, value: unknown): void {
   writeFileSync(path, JSON.stringify(value, null, 2) + "\n");
 }
 
+// configureServer honors HINDSIGHT_CONFIG — a developer shell exporting it must not leak the
+// suite's --server writes into their real config file ("" is falsy → the per-test home is used).
+beforeEach(() => {
+  vi.stubEnv("HINDSIGHT_CONFIG", "");
+});
+
 afterEach(() => {
+  vi.unstubAllEnvs();
   while (homes.length) rmSync(homes.pop()!, { recursive: true, force: true });
   vi.clearAllMocks();
 });
@@ -830,6 +837,42 @@ describe("devin-cli preflight", () => {
 describe("server setup", () => {
   const configPath = (ctx: InstallCtx) => join(ctx.home, ".hindsight", "coding-agent.json");
 
+  // The runtime reads HINDSIGHT_CONFIG first (core/config.ts CONFIG_PATH); the wizard must write
+  // that same file, or a user with the var set is configured into a file sessions never read.
+  it("honors HINDSIGHT_CONFIG for both the already-configured check and the write", () => {
+    const ctx = makeCtx();
+    const override = join(ctx.home, "elsewhere", "config.json");
+    vi.stubEnv("HINDSIGHT_CONFIG", override);
+    try {
+      expect(run(["install", "claude-code", "--server", "daemon"], ctx)).toBe(0);
+      expect(readJson(override).serverMode).toBe("daemon");
+      expect(existsSync(configPath(ctx))).toBe(false); // the default path stays untouched
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("uses the injected arrow-key picker when interactive, mapping index → mode", () => {
+    const ctx = makeCtx();
+    ctx.interactive = true;
+    ctx.hasUvx = () => true;
+    ctx.hasRust = () => true;
+    ctx.detectLlm = () => ({ provider: "openai", apiKey: "sk", source: "OPENAI_API_KEY" });
+    ctx.selectPrompt = vi.fn(() => 2); // third row = daemon
+    expect(run(["install", "claude-code"], ctx)).toBe(0);
+    expect(ctx.selectPrompt).toHaveBeenCalledOnce();
+    expect(readJson(configPath(ctx)).serverMode).toBe("daemon");
+  });
+
+  it("a cancelled picker leaves the server config untouched but still installs", () => {
+    const ctx = makeCtx();
+    ctx.interactive = true;
+    ctx.selectPrompt = () => null;
+    expect(run(["install", "claude-code"], ctx)).toBe(0);
+    expect(existsSync(configPath(ctx))).toBe(false);
+    expect(existsSync(join(ctx.home, ".claude", "settings.json"))).toBe(true);
+  });
+
   it("--server daemon records the mode and leaves apiUrl to the port", () => {
     const ctx = makeCtx();
     ctx.hasUvx = () => true;
@@ -932,10 +975,32 @@ describe("server setup", () => {
       apiUrl: "http://legacy:8888",
       source: "/x",
     });
-    expect(run(["install", "claude-code", "--server", "cloud"], ctx)).toBe(0);
+    expect(run(["install", "claude-code", "--server", "cloud", "--api-token", "tok"], ctx)).toBe(0);
     const cfg = readJson(configPath(ctx));
     expect(cfg.serverMode).toBe("cloud");
     expect(cfg.apiUrl).toBeUndefined();
+  });
+
+  it("--server cloud stores the required token", () => {
+    const ctx = makeCtx();
+    expect(
+      run(["install", "claude-code", "--server", "cloud", "--api-token", "sk-cloud"], ctx)
+    ).toBe(0);
+    const cfg = readJson(configPath(ctx));
+    expect(cfg.serverMode).toBe("cloud");
+    expect(cfg.apiToken).toBe("sk-cloud");
+  });
+
+  // A Cloud config without a token only surfaces later as 401s on the first session — refuse
+  // up front instead, like self-hosted without a URL.
+  it("--server cloud without a token fails instead of writing a config that 401s", () => {
+    const ctx = makeCtx();
+    const logs: string[] = [];
+    ctx.log = (m) => logs.push(m);
+    expect(run(["install", "claude-code", "--server", "cloud"], ctx)).toBe(1);
+    expect(logs.join("\n")).toContain("--api-token");
+    expect(existsSync(configPath(ctx))).toBe(false);
+    expect(existsSync(join(ctx.home, ".claude", "settings.json"))).toBe(false);
   });
 
   // litellm publishes no macOS wheel, so a Mac compiles it from source and needs cargo. Without

--- a/hindsight-integrations/coding-agents/src/installer.ts
+++ b/hindsight-integrations/coding-agents/src/installer.ts
@@ -34,12 +34,14 @@ import {
   writeFileSync,
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
+import { isatty } from "node:tty";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { HOOK_HARNESSES, type HookHarnessName } from "./harness/hook-lifecycle";
 import { importLocalHistory } from "./core/history";
 import { detectLlm, hasRustToolchain, hasUvx, type LlmChoice } from "./core/daemon";
 import { readLegacyEndpoint } from "./core/legacy";
+import { createInstallerUi, type SelectOption } from "./install-ui";
 
 /**
  * Substring that identifies OUR entries in a host's config, so a re-install replaces them and
@@ -73,6 +75,15 @@ export interface InstallCtx {
   /** Reads an old per-agent plugin's endpoint; injectable for tests. */
   readLegacy?: (home: string, prefer: readonly string[]) => ReturnType<typeof readLegacyEndpoint>;
   log?: (m: string) => void;
+  /** Styles an interactive readLineSync prompt (the CLI passes the InstallerUi rail style). */
+  promptStyle?: (q: string) => string;
+  /** Arrow-key picker (the CLI passes InstallerUi.select). Chosen index; null = cancelled;
+   *  undefined = raw TTY unavailable, fall back to the numeric prompt. */
+  selectPrompt?: (
+    question: string,
+    options: SelectOption[],
+    defaultIndex: number
+  ) => number | null | undefined;
 }
 
 function readJson(path: string): Record<string, any> {
@@ -166,14 +177,17 @@ function stripHarnessHooks(hooks: Record<string, any>, harness: HookHarnessName)
   }
 }
 
-/** Copy the packaged companion SKILL into a host's skills directory (idempotent overwrite). */
-function installSkill(c: InstallCtx, skillsBase: string): void {
+/** Copy the packaged companion SKILL into a host's skills directory (idempotent overwrite).
+ * The log line carries the harness prefix like every adapter message: several adapters install
+ * the skill before their first own log, and an unprefixed line would render under the PREVIOUS
+ * harness's group in the CLI output. */
+function installSkill(c: InstallCtx, harness: string, skillsBase: string): void {
   const src = join(c.pkgRoot, "skill");
   if (!existsSync(join(src, "SKILL.md"))) return;
   const dst = join(skillsBase, "hindsight-coding-agent");
   mkdirSync(skillsBase, { recursive: true });
   cpSync(src, dst, { recursive: true });
-  c.log?.(`skill installed at ${dst}`);
+  c.log?.(`${harness}: skill installed at ${dst}`);
 }
 
 function uninstallSkill(c: InstallCtx, skillsBase: string): void {
@@ -307,7 +321,7 @@ const claudeCode: HarnessInstaller = {
     c.log?.(`claude-code: hooks merged into ${path}`);
     // Companion SKILL: every skills-capable host gets it (claude/antigravity/cursor native dirs;
     // codex via the ~/.agents/skills standard).
-    installSkill(c, join(c.home, ".claude", "skills"));
+    installSkill(c, "claude-code", join(c.home, ".claude", "skills"));
     const mcp = c.claudeMcp ?? defaultClaudeMcp;
     // `claude mcp add` REFUSES when the name is taken ("MCP server hindsight already exists in
     // user config") — so on a machine that already had Hindsight, a re-install could never
@@ -401,7 +415,7 @@ const codex: HarnessInstaller = {
       writeFileSync(tomlPath, `${toml.replace(/\n*$/, "\n\n")}${additions.join("\n\n")}\n`);
       c.log?.(`codex: appended ${additions.length} section(s) to ${tomlPath}`);
     }
-    installSkill(c, join(c.home, ".agents", "skills")); // agentskills-standard shared dir
+    installSkill(c, "codex", join(c.home, ".agents", "skills")); // agentskills-standard shared dir
   },
   uninstall(c) {
     const hooksPath = join(c.home, ".codex", "hooks.json");
@@ -489,7 +503,7 @@ const antigravity: HarnessInstaller = {
       );
     }
     c.log?.(`antigravity-cli: hooks merged into ${hooksPath}, MCP into ${mcpPath}`);
-    installSkill(c, join(c.home, ".gemini", "config", "skills"));
+    installSkill(c, "antigravity-cli", join(c.home, ".gemini", "config", "skills"));
   },
   uninstall(c) {
     const hooksPath = join(c.home, ".gemini", "config", "hooks.json");
@@ -643,17 +657,41 @@ const CONFIG_RELATIVE = [".hindsight", "coding-agent.json"];
  * then would be noise — worse, it would silently rewrite a working setup in CI, where there is no
  * one to answer. Non-interactive callers pass `--server`.
  */
+const SERVER_CHOICES: { mode: ServerMode; label: string; hint: string }[] = [
+  { mode: "cloud", label: "Hindsight Cloud", hint: "hosted, needs an API token" },
+  { mode: "self-hosted", label: "Self-hosted server", hint: "a Hindsight server you already run" },
+  {
+    mode: "daemon",
+    label: "Local daemon (on-device)",
+    hint: "runs hindsight-embed here; no account, needs uv + an LLM key",
+  },
+];
+
 function promptServerMode(c: InstallCtx): ServerMode | undefined {
+  // Preferred UX: arrow-key picker (digits still submit directly). It reports undefined when a
+  // raw TTY isn't available (no stty, exotic shell) — then the plain numbered menu below still
+  // works everywhere a line can be read.
+  if (c.selectPrompt) {
+    const picked = c.selectPrompt(
+      "Where should memory live?",
+      SERVER_CHOICES.map(({ label, hint }) => ({ label, hint })),
+      0
+    );
+    if (picked === null) {
+      c.log?.("no server chosen — leaving the server config unchanged");
+      return undefined;
+    }
+    if (picked !== undefined) return SERVER_CHOICES[picked].mode;
+  }
   c.log?.(
     `\nWhere should memory live?\n` +
-      `  1) Hindsight Cloud            — hosted, needs an API token\n` +
-      `  2) Self-hosted server         — a Hindsight server you already run\n` +
-      `  3) Local daemon (on-device)   — runs hindsight-embed here; no account, needs uv + an LLM key\n`
+      SERVER_CHOICES.map((o, i) => `  ${i + 1}) ${o.label.padEnd(28)}— ${o.hint}`).join("\n") +
+      `\n`
   );
-  const answer = readLineSync("Choose [1-3] (default 1): ").trim();
-  if (answer === "" || answer === "1") return "cloud";
-  if (answer === "2") return "self-hosted";
-  if (answer === "3") return "daemon";
+  const answer = readLineSync(c, "Choose [1-3] (default 1): ").trim();
+  if (answer === "") return "cloud";
+  const digit = Number.parseInt(answer, 10);
+  if (digit >= 1 && digit <= SERVER_CHOICES.length) return SERVER_CHOICES[digit - 1].mode;
   c.log?.(`unrecognised choice "${answer}" — leaving the server config unchanged`);
   return undefined;
 }
@@ -665,14 +703,25 @@ function promptServerMode(c: InstallCtx): ServerMode | undefined {
  * async readline would mean making the whole installer async. readSync on the TTY blocks until
  * Enter, which is exactly the semantics wanted here.
  */
-function readLineSync(prompt: string): string {
-  process.stdout.write(prompt);
+function readLineSync(c: InstallCtx, prompt: string): string {
+  process.stdout.write((c.promptStyle ?? ((s: string) => s))(prompt));
   const buf = Buffer.alloc(1024);
-  try {
-    const n = readSync(0, buf, 0, buf.length, null);
-    return buf.subarray(0, n).toString("utf8");
-  } catch {
-    return ""; // no readable stdin — treated as the default
+  // Touching process.stdin ANYWHERE flips a TTY fd 0 to non-blocking (its getter initializes the
+  // TTY stream), after which readSync throws EAGAIN instead of waiting for Enter. The old
+  // blanket catch treated that as "no stdin" — so the picker printed its menu and every answer
+  // silently became the default. The CLI entry now probes the TTY with tty.isatty (no stream
+  // init), and EAGAIN here waits for input rather than fabricating an empty answer.
+  for (;;) {
+    try {
+      const n = readSync(0, buf, 0, buf.length, null);
+      return buf.subarray(0, n).toString("utf8");
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "EAGAIN") {
+        return ""; // genuinely no readable stdin — treated as the default
+      }
+      // Sleep 50ms without spinning; Atomics.wait is allowed on Node's main thread.
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
+    }
   }
 }
 
@@ -689,7 +738,10 @@ function configureServer(c: InstallCtx, args: string[], installing: readonly str
     c.log?.(`unknown --server "${explicit}" — expected one of: ${SERVER_MODES.join(", ")}`);
     return false;
   }
-  const configPath = join(c.home, ...CONFIG_RELATIVE);
+  // The runtime resolves its config as HINDSIGHT_CONFIG || ~/.hindsight/coding-agent.json
+  // (core/config.ts CONFIG_PATH). The wizard must honor the same override, or a user with that
+  // var set would be configured into a file their sessions never read.
+  const configPath = process.env.HINDSIGHT_CONFIG || join(c.home, ...CONFIG_RELATIVE);
   const existing = readJson(configPath);
   const alreadyConfigured = !!(existing.serverMode || existing.apiUrl);
 
@@ -729,13 +781,21 @@ function configureServer(c: InstallCtx, args: string[], installing: readonly str
   const next: Record<string, unknown> = { ...existing, serverMode: mode };
   if (mode === "cloud") {
     delete next.apiUrl; // fall back to the built-in Cloud URL rather than pinning a stale one
+    // Cloud always authenticates — a config without a token only surfaces later as 401s on the
+    // first session, so the token is REQUIRED here (it used to be "blank to set later").
     const token = flagValue(args, "api-token") ?? (c.interactive ? askToken(c) : undefined);
-    if (token) next.apiToken = token;
+    if (!token) {
+      c.log?.(
+        `❌ Hindsight Cloud needs an API token — pass --api-token <token> (or set apiToken in ${configPath}).`
+      );
+      return false;
+    }
+    next.apiToken = token;
   } else if (mode === "self-hosted") {
     const url =
       flagValue(args, "api-url") ??
       (c.interactive
-        ? readLineSync("Server URL (e.g. http://localhost:8888): ").trim()
+        ? readLineSync(c, "Server URL (e.g. http://localhost:8888): ").trim()
         : undefined);
     if (!url) {
       c.log?.(
@@ -756,10 +816,16 @@ function configureServer(c: InstallCtx, args: string[], installing: readonly str
   return true;
 }
 
+/** Cloud tokens are mandatory: re-ask a couple of times rather than writing a config that 401s
+ *  on the first session. Three blank answers mean the user doesn't have one at hand — give up
+ *  and let the cloud branch abort with the actionable message. */
 function askToken(c: InstallCtx): string | undefined {
-  const token = readLineSync("API token (blank to set later): ").trim();
-  if (!token) c.log?.("  no token set — add apiToken later if the server needs one");
-  return token || undefined;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const token = readLineSync(c, "API token (required for Hindsight Cloud): ").trim();
+    if (token) return token;
+    c.log?.("  a token is required — find yours in the Hindsight Cloud dashboard");
+  }
+  return undefined;
 }
 
 /**
@@ -865,7 +931,7 @@ const cursor: HarnessInstaller = {
     };
     writeJson(mcpPath, mcp);
     c.log?.(`cursor-cli: hooks merged into ${hooksPath}, MCP into ${mcpPath}`);
-    installSkill(c, join(c.home, ".cursor", "skills"));
+    installSkill(c, "cursor-cli", join(c.home, ".cursor", "skills"));
   },
   uninstall(c) {
     const hooksPath = join(c.home, ".cursor", "hooks.json");
@@ -906,7 +972,7 @@ const copilot: HarnessInstaller = {
       hindsight: { command: "node", args: [join(c.dist, "mcp-server.js")] },
     };
     writeJson(mcpPath, mcp);
-    installSkill(c, join(c.home, ".copilot", "skills"));
+    installSkill(c, "copilot-cli", join(c.home, ".copilot", "skills"));
     c.log?.(`copilot-cli: hooks installed at ${hooksPath}, MCP into ${mcpPath}`);
   },
   uninstall(c) {
@@ -955,7 +1021,7 @@ const grok: HarnessInstaller = {
       copyFileSync(path, `${path}.hindsight-backup`);
     mkdirSync(dirname(path), { recursive: true });
     writeFileSync(path, `${withoutOurs.replace(/\n*$/, "\n")}${block}`);
-    installSkill(c, join(c.home, ".grok", "skills"));
+    installSkill(c, "grok-build", join(c.home, ".grok", "skills"));
     c.log?.(`grok-build: native hooks + MCP installed in ${path}`);
   },
   uninstall(c) {
@@ -1008,7 +1074,7 @@ const cline: HarnessInstaller = {
       },
     };
     writeJson(mcpPath, mcp);
-    installSkill(c, join(c.home, ".cline", "data", "settings", "skills"));
+    installSkill(c, "cline-cli", join(c.home, ".cline", "data", "settings", "skills"));
     c.log?.(
       installed
         ? "cline-cli: native plugin + MCP + skill installed"
@@ -1119,7 +1185,8 @@ export function run(argv: string[], ctxIn: InstallCtx): number {
         `       [--server cloud|self-hosted|daemon] [--api-url <url>] [--api-token <token>]\n` +
         `       [--import-conversations]\n` +
         `  all      every agent detected on this machine\n` +
-        `  harness  ${INSTALLERS.map((i) => i.name).join(", ")} (agy aliases antigravity-cli)`
+        `  harness  ${INSTALLERS.map((i) => i.name).join(", ")} (agy aliases antigravity-cli)\n` +
+        `  agents/CI: without a TTY nothing ever prompts — pass --server (and --api-url/--api-token) to choose`
     );
     return command ? 1 : 0;
   }
@@ -1190,11 +1257,8 @@ export function run(argv: string[], ctxIn: InstallCtx): number {
     );
     return 1;
   }
-  ctx.log?.(
-    command === "install"
-      ? `\n✅ installed. Start a session — settings live in ~/.hindsight/coding-agent.json.`
-      : `\n✅ uninstalled.`
-  );
+  // No completion message here: the CLI entry's InstallerUi outro reports success (and where the
+  // settings live), so run() stays a silent-on-success engine for programmatic use.
   return 0;
 }
 
@@ -1214,15 +1278,36 @@ const mainPath = process.argv[1]
 const isMain = mainPath && import.meta.url === pathToFileURL(mainPath).href;
 if (isMain || mainPath?.endsWith("installer.js")) {
   const dist = dirname(fileURLToPath(import.meta.url));
-  process.exit(
-    run(process.argv.slice(2), {
-      home: homedir(),
-      pkgRoot: dirname(dist),
-      dist,
-      // Only a real terminal gets prompted; piped/CI installs take the documented default.
-      interactive: Boolean(process.stdin.isTTY && process.stdout.isTTY),
-      log: (m) => console.log(m),
-    })
-  );
+  const pkgRoot = dirname(dist);
+  let version: string | undefined;
+  try {
+    version = JSON.parse(readFileSync(join(pkgRoot, "package.json"), "utf8")).version;
+  } catch {
+    version = undefined; // cosmetic only — a header without a version beats a crashed installer
+  }
+  const ui = createInstallerUi({
+    home: homedir(),
+    command: process.argv[2],
+    version,
+    harnessNames: INSTALLERS.map((i) => i.name),
+    // configureServer's messages render as their own "server" group, but don't count as an agent.
+    auxNames: ["server"],
+    configPath: process.env.HINDSIGHT_CONFIG || undefined,
+  });
+  ui.intro();
+  const code = run(process.argv.slice(2), {
+    home: homedir(),
+    pkgRoot,
+    dist,
+    // Only a real terminal gets prompted; piped/CI installs take the documented default.
+    // tty.isatty, NOT process.stdin.isTTY: the process.stdin getter initializes the stdin TTY
+    // stream, which puts fd 0 in non-blocking mode and breaks readLineSync (see there).
+    interactive: Boolean(isatty(0) && isatty(1)),
+    log: ui.log,
+    promptStyle: ui.prompt,
+    selectPrompt: ui.select,
+  });
+  ui.outro(code);
+  process.exit(code);
 }
 /* c8 ignore stop */


### PR DESCRIPTION
## What

Modernizes the `hindsight-coding-agents install` CLI output and fixes the interactive server picker.

**Styled output** (`src/install-ui.ts`, zero-dep): clack/Vercel-style rail — brand-gradient header with version, one step group per harness (keyed on the `"<name>: "` log prefix, so the engine and its tests stay renderer-agnostic), ✓/▲/✖ severity inferred from message phrasing plus `run()`'s own ✅/⚠️/❌ markers, `$HOME` shortened to `~`, and honest outros (a preflight-blocked partial install says "Completed with errors", not "nothing was changed"). Colors drop on `NO_COLOR`/piped output; the frame stays.

**Arrow-key server picker**: `❯` pointer, ↑/↓/`j`/`k` + Enter, digit shortcuts still submit, Esc/`q`/Ctrl+C cancels (config left unchanged). Rows truncate to the terminal width and autowrap is disabled during repaint, so narrow terminals don't duplicate lines; one stdin read holding several keys (key repeat, paste) is split into individual tokens. Raw mode uses `stty`, with the plain numbered prompt as fallback wherever a raw TTY isn't available.

## Fixes

- **The v0.0.4/v0.0.5 picker never actually waited for input**: the CLI entry's `process.stdin.isTTY` probe initializes the stdin TTY stream, flipping fd 0 to non-blocking; `fs.readSync` then throws `EAGAIN` and the blanket catch turned every question into its silent default (always Cloud, never asked). Now probed with `tty.isatty` (a plain syscall) and `readLineSync` treats `EAGAIN` as wait-for-input.
- **`configureServer` ignored `HINDSIGHT_CONFIG`**: the wizard wrote `~/.hindsight/coding-agent.json` even when the runtime was reading the override path — users with the var set were configured into a file their sessions never read. The outro also names the actual settings file now.
- **Hindsight Cloud API token is now required**: interactive re-asks (3 attempts, then aborts with the actionable message); `--server cloud` without `--api-token` refuses up front instead of writing a config that only surfaces as 401s on the first session — mirroring self-hosted without `--api-url`.

## Unchanged for agents/CI

Without a TTY nothing ever prompts (defaults to Cloud with a hint, writes no config); `--server cloud|self-hosted|daemon` + `--api-url`/`--api-token` for explicit non-interactive choice — now spelled out in the usage text.

## Testing

- 342 vitest tests green (12 new renderer tests, key-reducer/row-fitting/splitKeys unit tests, `selectPrompt` injection, required-token and `HINDSIGHT_CONFIG` regression tests; the suite now stubs `HINDSIGHT_CONFIG` so a developer shell exporting it can't leak `--server` writes into their real config).
- Interactive flows verified over a real pty (arrow selection incl. burst input, blank-token re-ask, 60-column terminal fit, cancel paths, EOF mid-question).
- `lint.sh` green.
