### PR TITLE
fix(engine): stop concurrent bank deletes from deadlocking on vector-index DDL

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -4,6 +4,7 @@ Uses unnest(), LATERAL, DISTINCT ON, and native array operations for
 efficient batch operations.
 """
 
+import asyncio
 from datetime import datetime
 
 from .base import DatabaseConnection
@@ -40,6 +41,23 @@ def pg_search_vector_expr(
 
 class PostgreSQLOps(DataAccessOps):
     """PostgreSQL-specific data access operations using unnest and LATERAL."""
+
+    def __init__(self) -> None:
+        # Per-table serialization of per-bank vector-index DDL within this
+        # process. Concurrent index DDL on one relation deadlocks by design:
+        # DROP INDEX CONCURRENTLY holds ShareUpdateExclusive while it waits out
+        # every transaction whose snapshot could still see the index — including
+        # other sessions' index DDL queued on that same lock — so many banks
+        # deleted at once form a wait cycle Postgres resolves by killing one.
+        # A session advisory lock would serialize this across processes too, but
+        # advisory locks are banned here (poolers hand sessions around; see the
+        # Database Locking standard). In-process the asyncio lock removes the
+        # cycle outright; across processes the callers' retry-with-backoff
+        # absorbs the (now much rarer) collisions.
+        self._index_ddl_locks: dict[str, asyncio.Lock] = {}
+
+    def _index_ddl_lock(self, table: str) -> asyncio.Lock:
+        return self._index_ddl_locks.setdefault(table, asyncio.Lock())
 
     @property
     def uses_observation_sources_table(self) -> bool:
@@ -857,14 +875,15 @@ class PostgreSQLOps(DataAccessOps):
         fact_types: dict[str, str],
     ) -> None:
         escaped = bank_id.replace("'", "''")
-        for ft, suffix in fact_types.items():
-            uid = str(internal_id).replace("-", "")[:16]
-            idx = f"idx_mu_emb_{suffix}_{uid}"
-            await conn.execute(
-                f"CREATE INDEX IF NOT EXISTS {idx} "
-                f"ON {table} {index_clause} "
-                f"WHERE fact_type = '{ft}' AND bank_id = '{escaped}'"
-            )
+        async with self._index_ddl_lock(table):
+            for ft, suffix in fact_types.items():
+                uid = str(internal_id).replace("-", "")[:16]
+                idx = f"idx_mu_emb_{suffix}_{uid}"
+                await conn.execute(
+                    f"CREATE INDEX IF NOT EXISTS {idx} "
+                    f"ON {table} {index_clause} "
+                    f"WHERE fact_type = '{ft}' AND bank_id = '{escaped}'"
+                )
 
     async def drop_bank_vector_indexes(
         self,
@@ -879,10 +898,13 @@ class PostgreSQLOps(DataAccessOps):
         # table; CONCURRENTLY does not conflict with DML. The caller
         # (delete_bank) runs this on an autocommit connection after its delete
         # transaction has committed — CONCURRENTLY cannot run inside a tx.
-        for ft, suffix in fact_types.items():
-            uid = str(internal_id).replace("-", "")[:16]
-            idx = f"idx_mu_emb_{suffix}_{uid}"
-            await conn.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {schema}.{idx}")
+        # The lock key must match create_bank_vector_indexes', whose `table`
+        # is the fq name this reconstructs from `schema`.
+        async with self._index_ddl_lock(f"{schema}.memory_units"):
+            for ft, suffix in fact_types.items():
+                uid = str(internal_id).replace("-", "")[:16]
+                idx = f"idx_mu_emb_{suffix}_{uid}"
+                await conn.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {schema}.{idx}")
 
     def get_entity_resolution_strategy(self) -> str:
         return "trigram"

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7294,13 +7294,21 @@ class MemoryEngine(MemoryEngineInterface):
 
             # Drop per-bank vector indexes AFTER the transaction commits: the
             # drop runs CONCURRENTLY (see ops.drop_bank_vector_indexes), which
-            # cannot run inside a transaction block. retry_with_backoff absorbs
-            # the residual transient deadlock a concurrent index build/drop on
-            # the shared memory_units table can still trigger (sqlstate 40P01 /
-            # ORA-00060) so a delete is never lost to a transient lock cycle.
+            # cannot run inside a transaction block. Same-process drops are
+            # serialized by the ops-level DDL lock; retry_with_backoff absorbs
+            # the residual cross-process deadlock a concurrent index build/drop
+            # on the shared memory_units table can still trigger (sqlstate
+            # 40P01 / ORA-00060) so a delete is never lost to a transient lock
+            # cycle. Sized well above the defaults: a many-process delete storm
+            # (CI teardown ran 8 workers' drops at once) drains at roughly one
+            # deadlock victim per deadlock_timeout (1s), so the default ~2.4s
+            # of backoff lost every retry; ~30s of jittered backoff outlasts
+            # any realistic pile-up.
             if bank_internal_id:
                 await retry_with_backoff(
-                    lambda: bank_utils.drop_bank_vector_indexes(conn, bank_internal_id, ops=self._backend.ops)
+                    lambda: bank_utils.drop_bank_vector_indexes(conn, bank_internal_id, ops=self._backend.ops),
+                    max_retries=7,
+                    max_delay=10.0,
                 )
 
         # A store that keeps memories outside SQL leaves memory_units empty, so every DELETE

--- a/hindsight-api-slim/tests/test_bank_vector_index_ddl_lock.py
+++ b/hindsight-api-slim/tests/test_bank_vector_index_ddl_lock.py
@@ -1,0 +1,127 @@
+"""Per-bank vector-index DDL is serialized per table within a process.
+
+Concurrent index DDL on the shared ``memory_units`` table deadlocks by design:
+DROP INDEX CONCURRENTLY holds ShareUpdateExclusive while waiting out every
+other session whose snapshot could still see the index — including other
+sessions' queued index DDL. CI's end-of-run teardown (all xdist workers
+deleting their banks at once) forms exactly that cycle, and the delete path's
+default retry budget (~2.4s) could not outlast the storm (run 31195108586,
+test-api 3/3). Advisory locks are banned in this codebase (poolers), so the
+fix is an in-process asyncio lock on ``PostgreSQLOps`` plus a much larger
+jittered retry budget for the cross-process residue.
+
+Two layers are proven here:
+
+* unit (fake conn): create and drop DDL for one table never interleave, the
+  create and drop sides contend on the same lock, and the lock is released
+  when a statement raises;
+* integration: a many-bank concurrent ``delete_bank`` storm — the CI failure
+  shape — completes without ``DeadlockDetectedError``.
+"""
+
+import asyncio
+import uuid
+
+import pytest
+
+from hindsight_api.engine.db.ops_postgresql import PostgreSQLOps
+from hindsight_api.engine.retain.bank_utils import _BANK_INDEX_FACT_TYPES, _bank_index_name, _vector_index_clause
+
+_SCHEMA = "public"
+_INDEX_CLAUSE = "USING hnsw (embedding vector_cosine_ops)"
+
+
+class _OverlapTrackingConn:
+    """Fake DatabaseConnection asserting no two DDL statements ever overlap.
+
+    Each execute parks on the event loop long enough that unserialized callers
+    would interleave, and records the highest number of in-flight statements.
+    """
+
+    def __init__(self, fail_on: str | None = None):
+        self.calls: list[str] = []
+        self.max_in_flight = 0
+        self._in_flight = 0
+        self._fail_on = fail_on
+
+    async def execute(self, query, *args, **kwargs):
+        self.calls.append(query)
+        self._in_flight += 1
+        self.max_in_flight = max(self.max_in_flight, self._in_flight)
+        try:
+            await asyncio.sleep(0.01)
+            if self._fail_on and self._fail_on in query:
+                raise RuntimeError(f"boom on: {query}")
+        finally:
+            self._in_flight -= 1
+        return "OK"
+
+
+async def test_concurrent_create_and_drop_on_one_table_serialize():
+    ops = PostgreSQLOps()
+    conn = _OverlapTrackingConn()
+    table = f"{_SCHEMA}.memory_units"
+
+    await asyncio.gather(
+        ops.drop_bank_vector_indexes(conn, _SCHEMA, uuid.uuid4().hex, _BANK_INDEX_FACT_TYPES),
+        ops.drop_bank_vector_indexes(conn, _SCHEMA, uuid.uuid4().hex, _BANK_INDEX_FACT_TYPES),
+        # The drop side reconstructs the create side's fq-table key from
+        # `schema`, so a create must queue behind the drops too.
+        ops.create_bank_vector_indexes(conn, table, "bank-1", uuid.uuid4().hex, _INDEX_CLAUSE, _BANK_INDEX_FACT_TYPES),
+    )
+
+    assert len(conn.calls) == 3 * len(_BANK_INDEX_FACT_TYPES)
+    assert conn.max_in_flight == 1, "vector-index DDL statements overlapped despite the per-table lock"
+
+
+async def test_different_tables_do_not_contend():
+    ops = PostgreSQLOps()
+    assert ops._index_ddl_lock("a.memory_units") is ops._index_ddl_lock("a.memory_units")
+    assert ops._index_ddl_lock("a.memory_units") is not ops._index_ddl_lock("b.memory_units")
+
+
+async def test_lock_released_when_ddl_raises():
+    ops = PostgreSQLOps()
+    conn = _OverlapTrackingConn(fail_on="DROP INDEX CONCURRENTLY")
+    with pytest.raises(RuntimeError):
+        await ops.drop_bank_vector_indexes(conn, _SCHEMA, uuid.uuid4().hex, _BANK_INDEX_FACT_TYPES)
+
+    # A subsequent create must not hang on a lock the failed drop never released.
+    await asyncio.wait_for(
+        ops.create_bank_vector_indexes(
+            conn, f"{_SCHEMA}.memory_units", "bank-1", uuid.uuid4().hex, _INDEX_CLAUSE, _BANK_INDEX_FACT_TYPES
+        ),
+        timeout=2.0,
+    )
+
+
+async def test_concurrent_bank_delete_storm_does_not_deadlock(memory, request_context):
+    """The CI failure shape: every worker tears down its banks at once.
+
+    Eight banks (24 partial indexes) dropped concurrently previously wedged
+    into a DROP INDEX CONCURRENTLY wait cycle; serialized behind the per-table
+    lock the storm must complete without DeadlockDetectedError.
+    """
+    if _vector_index_clause() is None:
+        pytest.skip("backend does not use per-bank vector indexes")
+
+    bank_ids = [f"test-ddl-lock-{uuid.uuid4().hex[:8]}" for _ in range(8)]
+    for bank_id in bank_ids:
+        await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    backend = await memory._get_backend()
+    async with backend.acquire() as conn:
+        internal_ids = {
+            bank_id: str(await conn.fetchval("SELECT internal_id FROM banks WHERE bank_id = $1", bank_id))
+            for bank_id in bank_ids
+        }
+
+    await asyncio.gather(*(memory.delete_bank(bank_id, request_context=request_context) for bank_id in bank_ids))
+
+    async with backend.acquire() as conn:
+        for bank_id in bank_ids:
+            for ft in _BANK_INDEX_FACT_TYPES:
+                idx = _bank_index_name(ft, internal_ids[bank_id])
+                assert not await conn.fetchval(
+                    "SELECT 1 FROM pg_indexes WHERE schemaname = $1 AND indexname = $2", _SCHEMA, idx
+                ), f"index {idx} survived delete_bank"


### PR DESCRIPTION
## Problem

The recurring api-slim CI "deadlock detected" flake (last seen on #3244's run, `test-api (3/3)`: 4 failed + 1 teardown error) is not in the failing tests — every failure has the same stack: fixture teardown → `delete_bank` → `drop_bank_vector_indexes` → `DROP INDEX CONCURRENTLY` on the shared `memory_units` table.

At end of run every xdist worker tears down its banks at once. `DROP INDEX CONCURRENTLY` takes ShareUpdateExclusive on the table, then waits (ShareLock on virtual xids) for every transaction whose snapshot could still see the index — **including the other workers' queued index DDL**, which are themselves waiting on that ShareUpdateExclusive lock. That's a cycle; Postgres kills one victim per `deadlock_timeout`. The failed run's wait graphs show 5+ backends tangled. The existing retry absorber on the drop path (default policy: ~2.4s of backoff) is far smaller than the storm, so all 4 attempts re-deadlocked.

Beyond CI, the same window exists in production for concurrent bank deletes: the delete transaction has already committed, so the caller gets a spurious error for a delete that succeeded, plus orphaned empty partial indexes.

## Fix

Two layers, no advisory locks (banned by the project's Database Locking standard — poolers):

1. **In-process serialization**: `PostgreSQLOps` now holds one `asyncio.Lock` per fq table and takes it around both per-bank index DDL paths (`create_bank_vector_indexes`, `drop_bank_vector_indexes`). Concurrent deletes within one API process — the common production case, and the shape of the new storm test — can no longer form the cycle at all.
2. **Retry budget sized to the storm** for the cross-process residue (CI's xdist workers, multi-replica deployments): the drop path's `retry_with_backoff` goes from the defaults (3 retries, 5s cap ≈ 2.4s total) to 7 retries with a 10s cap (~30s of equal-jitter backoff). A pile-up drains at roughly one victim per `deadlock_timeout` (1s), so this outlasts any realistic storm.

## Tests

`tests/test_bank_vector_index_ddl_lock.py`:
- fake-conn overlap tracker proves create/drop DDL on one table never interleave, create and drop contend on the same key, and the lock is released when a statement raises;
- integration storm test: 8 banks (24 partial indexes) deleted concurrently — the CI failure shape — completes and leaves no indexes behind.

Existing `test_repair_bank_vector_indexes.py` suite still passes.
