### PR TITLE
Fix background seed harness attribution

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/session-start.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.test.ts
@@ -20,7 +20,7 @@ describe("buildSessionStartContext", () => {
       startSeed,
       startSurvey,
     });
-    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300 });
+    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { harness: "claude-code", limit: 300 });
     expect(startSurvey).toHaveBeenCalledWith("/repo/dir", {
       harness: "claude-code",
       model: "haiku",
@@ -53,9 +53,26 @@ describe("buildSessionStartContext", () => {
       startSeed,
       startSurvey,
     });
-    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300 });
+    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { harness: "claude-code", limit: 300 });
     expect(startSurvey).not.toHaveBeenCalled();
     expect(out.systemMessage).toContain("is learning");
+  });
+
+  it("passes a non-default harness to the background seed", async () => {
+    const client = { listDocumentIds: async () => new Set<string>(), listPages: listPagesOk };
+    const startSeed = vi.fn();
+
+    await buildSessionStartContext({
+      cwd: "/repo/dir",
+      bankId: "bank-1",
+      cfg: resolveConfig({ codebaseSurvey: false }),
+      client,
+      harness: "codex",
+      hasGit: () => true,
+      startSeed,
+    });
+
+    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { harness: "codex", limit: 300 });
   });
 
   it("non-git dir -> no seed, listDocumentIds not called, roster preamble only (no learning note)", async () => {
@@ -123,7 +140,7 @@ describe("buildSessionStartContext", () => {
     });
     // The live bank is consulted, and an empty bank seeds — no client-side flag can contradict it.
     expect(called).toBe(true);
-    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300 });
+    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { harness: "claude-code", limit: 300 });
     expect(out.systemMessage).toContain("is learning");
   });
 
@@ -141,7 +158,7 @@ describe("buildSessionStartContext", () => {
       startSurvey,
     });
     // The engine is idempotent, so every warm session start re-fires it to pick up missing work.
-    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300 });
+    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { harness: "claude-code", limit: 300 });
     // The cold-only extras stay off: no survey, no user-facing learning note.
     expect(startSurvey).not.toHaveBeenCalled();
     expect(out.additionalContext).toContain("- Component map (p1)");
@@ -188,7 +205,7 @@ describe("buildSessionStartContext", () => {
       startSeed,
     });
     // Seeding is unaffected by a listPages failure.
-    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300 });
+    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { harness: "claude-code", limit: 300 });
     // Empty-state roster preamble still renders (no page names, no throw).
     expect(out.additionalContext).toContain("<hindsight_knowledge>");
     expect(out.additionalContext).toContain("No knowledge pages yet");

--- a/hindsight-integrations/coding-agents/src/core/session-start.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.ts
@@ -138,7 +138,7 @@ export async function buildSessionStartContext(args: {
   harness?: string;
   stateDir?: string;
   hasGit?: (dir: string) => boolean;
-  startSeed?: (repoDir: string, opts?: { limit?: number }) => void;
+  startSeed?: (repoDir: string, opts?: { harness?: string; limit?: number }) => void;
   startSurvey?: (
     repoDir: string,
     opts?: { harness?: SurveyHarness; model?: string; budgetUsd?: number }
@@ -208,7 +208,7 @@ export async function buildSessionStartContext(args: {
           // idempotent (per-bank lock, dedup by document id) and each run does only the missing
           // work: cold seed, newly appeared conversations, the next per-commit diff batch. The
           // one-time extras stay cold-gated below.
-          startSeed(cwd, { limit: cfg.seedLimit });
+          startSeed(cwd, { harness, limit: cfg.seedLimit });
           // Cold iff the bank has zero source:git docs (an undefined result — server error — is
           // NOT treated as cold; we never surveyed/noted on an unconfirmed-empty bank).
           if (docIds.size === 0) {


### PR DESCRIPTION
## Problem

Session-start seeding omits the resolved harness when it starts the background seed. The seed process then falls back to `opencode`, so git-history documents can be written to a different bank from the same session's survey documents.

Closes #3247.

## Fix

Pass the resolved session harness into `startSeed` and update the injected callback type. Add a regression case using a non-default harness, while keeping the existing session-start assertions exact.

## Test

- `npm test -- --run src/core/session-start.test.ts` (19 passed)
- `npm run build`
- `./scripts/hooks/lint.sh`
- `git diff --check`

## Risk

Low. This only forwards an existing option at the call site; the background seed implementation already accepts the harness and serializes it into the child-process arguments.