### PR TITLE
Reject implausible temporal year matches

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/query_analyzer.py
+++ b/hindsight-api-slim/hindsight_api/engine/query_analyzer.py
@@ -378,6 +378,14 @@ class DateparserQueryAnalyzer(QueryAnalyzer):
         ]
         scored_results = [entry for entry in scored_results if entry[0] > 0]
 
+        # Bare integers (ports, ticket IDs, model numbers) are parsed as years
+        # and otherwise outrank every genuine relative-date match. Filter them
+        # before ranking so a plausible date elsewhere in the query can still
+        # win instead of silently disabling temporal retrieval. See issue #3250.
+        earliest_year = max(1, reference_date.year - 120)
+        latest_year = min(9999, reference_date.year + 20)
+        scored_results = [entry for entry in scored_results if earliest_year <= entry[2].year <= latest_year]
+
         if not scored_results:
             return QueryAnalysis(temporal_constraint=None)
 

--- a/hindsight-api-slim/hindsight_api/engine/query_analyzer.py
+++ b/hindsight-api-slim/hindsight_api/engine/query_analyzer.py
@@ -90,6 +90,7 @@ _PERIOD_WORDS = {
     "noon",
     "midnight",
 }
+_BARE_YEAR_PADDING_WORDS = {"and", "at", "from", "in", "on", "the"}
 
 
 # Every token _date_match_score can award points for, in one alternation.
@@ -150,6 +151,26 @@ def _date_match_score(text: str) -> int:
     if token_set & _PERIOD_WORDS:
         score += 20
     return score
+
+
+def _is_implausible_bare_year_match(text: str, parsed_date: datetime, reference_date: datetime) -> bool:
+    """Return whether dateparser treated an isolated identifier as a year.
+
+    dateparser may include a neighbouring preposition or conjunction in the
+    matched span (for example, ``"9077 and"``), so checking ``isdigit()`` is
+    not sufficient. Preserve explicit calendar expressions such as
+    ``1890-03-05`` and ``March 1890`` even when their year is far from the
+    reference date.
+    """
+    earliest_year = max(1, reference_date.year - 120)
+    latest_year = min(9999, reference_date.year + 20)
+    if earliest_year <= parsed_date.year <= latest_year:
+        return False
+
+    tokens = _TOKEN_RE.findall(text.lower())
+    year_tokens = [token for token in tokens if len(token) == 4 and token.isdigit()]
+    padding_tokens = [token for token in tokens if token not in year_tokens]
+    return len(year_tokens) == 1 and all(token in _BARE_YEAR_PADDING_WORDS for token in padding_tokens)
 
 
 class TemporalConstraint(BaseModel):
@@ -372,7 +393,7 @@ class DateparserQueryAnalyzer(QueryAnalyzer):
         # by longest span, so an explicit date ("in May", "2026-06-10") always
         # beats an earlier weak word regardless of position. See issue #2768.
         scored_results = [
-            (_date_match_score(text), len(text), date)
+            (_date_match_score(text), len(text), date, text)
             for text, date in results
             if not is_embedded_cjk_dateparser_match(query, text)
         ]
@@ -382,15 +403,15 @@ class DateparserQueryAnalyzer(QueryAnalyzer):
         # and otherwise outrank every genuine relative-date match. Filter them
         # before ranking so a plausible date elsewhere in the query can still
         # win instead of silently disabling temporal retrieval. See issue #3250.
-        earliest_year = max(1, reference_date.year - 120)
-        latest_year = min(9999, reference_date.year + 20)
-        scored_results = [entry for entry in scored_results if earliest_year <= entry[2].year <= latest_year]
+        scored_results = [
+            entry for entry in scored_results if not _is_implausible_bare_year_match(entry[3], entry[2], reference_date)
+        ]
 
         if not scored_results:
             return QueryAnalysis(temporal_constraint=None)
 
         # Highest signal score wins; ties broken by the longest matched span.
-        _, _, parsed_date = max(scored_results, key=lambda entry: (entry[0], entry[1]))
+        _, _, parsed_date, _ = max(scored_results, key=lambda entry: (entry[0], entry[1]))
 
         # Create constraint for single day
         start_date = parsed_date.replace(hour=0, minute=0, second=0, microsecond=0)

--- a/hindsight-api-slim/tests/test_query_analyzer.py
+++ b/hindsight-api-slim/tests/test_query_analyzer.py
@@ -908,6 +908,29 @@ def test_query_analyzer_keeps_real_month_with_leading_weak_word(query_analyzer):
 
 
 @pytest.mark.parametrize(
+    "query",
+    ["is hindsight listening on port 9077", "check job 4417 for Castle Pines"],
+)
+def test_query_analyzer_rejects_implausible_bare_number_year(query_analyzer, query):
+    """#3250: common identifiers must not become temporal constraints."""
+    reference_date = datetime(2026, 8, 7, 12, 0, 0)
+
+    analysis = query_analyzer.analyze(query, reference_date)
+
+    assert analysis.temporal_constraint is None
+
+
+def test_query_analyzer_keeps_plausible_date_with_implausible_number(query_analyzer):
+    """Filtering happens before ranking so a real date elsewhere can win."""
+    reference_date = datetime(2026, 8, 7, 12, 0, 0)  # Friday
+
+    analysis = query_analyzer.analyze("port 9077 and also last Tuesday", reference_date)
+
+    assert analysis.temporal_constraint is not None
+    assert analysis.temporal_constraint.start_date.date() == datetime(2026, 8, 4).date()
+
+
+@pytest.mark.parametrize(
     ("query", "start", "end"),
     [
         # Relative days.

--- a/hindsight-api-slim/tests/test_query_analyzer.py
+++ b/hindsight-api-slim/tests/test_query_analyzer.py
@@ -931,6 +931,24 @@ def test_query_analyzer_keeps_plausible_date_with_implausible_number(query_analy
 
 
 @pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("notes from 1890-03-05", datetime(1890, 3, 5)),
+        ("the roadmap milestone on 2050-01-15", datetime(2050, 1, 15)),
+        ("notes from March 1890", datetime(1890, 3, 1)),
+    ],
+)
+def test_query_analyzer_keeps_explicit_dates_outside_bare_year_window(query_analyzer, query, expected):
+    """The plausibility window applies to isolated years, not full dates."""
+    reference_date = datetime(2026, 8, 7, 12, 0, 0)
+
+    analysis = query_analyzer.analyze(query, reference_date)
+
+    assert analysis.temporal_constraint is not None
+    assert analysis.temporal_constraint.start_date.date() == expected.date()
+
+
+@pytest.mark.parametrize(
     ("query", "start", "end"),
     [
         # Relative days.


### PR DESCRIPTION
## Problem

Dateparser treats bare integers such as port and ticket numbers as years. Because digit-bearing matches receive the highest temporal score, a query like `port 9077` produces a non-null year-9077 constraint and silently empties the temporal retrieval arm.

Closes #3250.

## Fix

Filter parsed candidates to a reference-relative plausibility window before selecting the strongest match. Filtering before `max()` preserves a genuine relative or explicit date elsewhere in the same query.

## Test

- `uv run pytest tests/test_query_analyzer.py -q` (429 passed)
- `./scripts/hooks/lint.sh`
- repository pre-commit hooks
- `git diff --check`

## Risk

Low to moderate. Dates more than 120 years in the past or 20 years in the future are no longer inferred by the fallback dateparser path. Explicit period parsing remains unchanged, and the bounds are clamped for low/high reference years.