### PR TITLE
fix(api): return 400 for malformed UUID on GET /entities/{id} and /memories/{id}/history

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -4391,6 +4391,8 @@ def _register_routes(app: FastAPI):
             return data
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except (AuthenticationError, HTTPException):
             raise
         except Exception as e:
@@ -5012,6 +5014,8 @@ def _register_routes(app: FastAPI):
             )
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except (AuthenticationError, HTTPException):
             raise
         except Exception as e:

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8851,6 +8851,10 @@ class MemoryEngine(MemoryEngineInterface):
         Returns None if the memory is not found or is not an observation.
         Returns a list of history entries (most recent first), each with source_facts resolved.
         """
+        try:
+            memory_uuid = uuid.UUID(memory_id)
+        except ValueError:
+            raise ValueError(f"Invalid memory_id: '{memory_id}' is not a valid UUID")
         await self._authenticate_tenant(request_context)
         if self._operation_validator:
             from hindsight_api.extensions import BankReadContext, BankReadOperation
@@ -8867,7 +8871,7 @@ class MemoryEngine(MemoryEngineInterface):
                 FROM {fq_table("memory_units")}
                 WHERE id = $1 AND bank_id = $2
                 """,
-                uuid.UUID(memory_id),
+                memory_uuid,
                 bank_id,
             )
             if not row:
@@ -8885,7 +8889,7 @@ class MemoryEngine(MemoryEngineInterface):
                 WHERE observation_id = $1
                 ORDER BY changed_at ASC, id ASC
                 """,
-                uuid.UUID(memory_id),
+                memory_uuid,
             )
             if not history_rows:
                 return []
@@ -11520,6 +11524,10 @@ class MemoryEngine(MemoryEngineInterface):
         request_context: "RequestContext",
     ) -> dict[str, Any] | None:
         """Get entity details including metadata and observations."""
+        try:
+            entity_uuid = uuid.UUID(entity_id)
+        except ValueError:
+            raise ValueError(f"Invalid entity_id: '{entity_id}' is not a valid UUID")
         await self._authenticate_tenant(request_context)
         if self._operation_validator:
             from hindsight_api.extensions import BankReadContext, BankReadOperation
@@ -11538,7 +11546,7 @@ class MemoryEngine(MemoryEngineInterface):
                 WHERE bank_id = $1 AND id = $2
                 """,
                 bank_id,
-                uuid.UUID(entity_id),
+                entity_uuid,
             )
 
         if not entity_row:

--- a/hindsight-api-slim/tests/test_get_entity_uuid_validation.py
+++ b/hindsight-api-slim/tests/test_get_entity_uuid_validation.py
@@ -1,0 +1,65 @@
+"""Regression tests for UUID validation on get_entity and get_observation_history.
+
+Mirrors the pattern in test_delete_memory_units_validation.py: a stub engine
+that bypasses __init__ so the pure-Python validation branches are exercised
+without a DB connection.
+
+get_memory_unit and update_memory_unit already validate their memory_id
+against uuid.UUID (PR #3062, commit in #906). get_entity and
+get_observation_history were missed - a malformed id raised a bare
+ValueError from the stdlib that the HTTP handler mapped to 500 instead
+of 400.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from hindsight_api import RequestContext
+from hindsight_api.engine.memory_engine import MemoryEngine
+
+
+def _stub_engine() -> MemoryEngine:
+    engine = object.__new__(MemoryEngine)
+    engine._authenticate_tenant = AsyncMock()
+    engine._operation_validator = None
+    # 让 _get_backend 返回一个 mock conn，但它永远不会被到达
+    # 因为 uuid.UUID(bad) 会先 raise
+    engine._get_backend = AsyncMock(return_value=MagicMock())
+    return engine
+
+
+BAD_UUID = "not-a-uuid"
+
+
+@pytest.mark.asyncio
+async def test_get_entity_rejects_malformed_uuid():
+    """get_entity 应对畸形 UUID raise ValueError（而非让 uuid.UUID 裸抛）。"""
+    engine = _stub_engine()
+
+    with pytest.raises(ValueError, match="Invalid entity_id"):
+        await engine.get_entity(
+            bank_id="test-bank",
+            entity_id=BAD_UUID,
+            request_context=RequestContext(api_key="anything"),
+        )
+
+    # 不应该到达 DB 层
+    engine._get_backend.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_observation_history_rejects_malformed_uuid():
+    """get_observation_history 应对畸形 UUID raise ValueError。"""
+    engine = _stub_engine()
+
+    with pytest.raises(ValueError, match="Invalid memory_id"):
+        await engine.get_observation_history(
+            bank_id="test-bank",
+            memory_id=BAD_UUID,
+            request_context=RequestContext(api_key="anything"),
+        )
+
+    engine._get_backend.assert_not_awaited()


### PR DESCRIPTION
Two read endpoints pass their path parameter straight to `uuid.UUID()` without a try/except, so a malformed id raises a bare `ValueError` from the stdlib. The HTTP handlers catch `OperationValidationError` and `Exception` but not `ValueError`, so it falls through to the generic 500 path.

A typo or copy-paste error in the id — a normal user mistake on a public endpoint — surfaces as a 500 ("badly formed hexadecimal UUID string") instead of a clean 400. This is the same gap #3062 fixed for `recall_async` and #906 fixed for `get_memory_unit` / `update_memory_unit` / `delete_memory_units`.

**`get_entity`** (memory_engine.py) — `uuid.UUID(entity_id)` bare in the `conn.fetchrow` args.

**`get_observation_history`** (memory_engine.py) — `uuid.UUID(memory_id)` bare at two call sites.

The fix wraps both in the same `try/except ValueError` the already-validated siblings use, and adds an `except ValueError -> 400` branch to the two HTTP handlers (`api_get_entity`, `api_get_observation_history`), matching `api_get_memory`.

Tests mirror `test_delete_memory_units_validation.py` — a stub engine that bypasses `__init__` so the validation branch is exercised without a database. Both tests fail on unfixed code (bare 'badly formed hexadecimal UUID string') and pass after the wrap.
