### PR TITLE
Pin embed to the metapackage release

### DIFF
--- a/hindsight-all-slim/pyproject.toml
+++ b/hindsight-all-slim/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.11"
 dependencies = [
     "hindsight-api-slim==0.9.0",
     "hindsight-client>=0.0.7",
-    "hindsight-embed>=0.1.0",
+    "hindsight-embed==0.9.0",
 ]
 
 [tool.uv.sources]

--- a/hindsight-all/pyproject.toml
+++ b/hindsight-all/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.11"
 dependencies = [
     "hindsight-api-slim[all]==0.9.0",
     "hindsight-client>=0.0.7",
-    "hindsight-embed>=0.1.0",
+    "hindsight-embed==0.9.0",
 ]
 
 [tool.uv.sources]

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -91,6 +91,19 @@ for pin_file in "${META_PIN_FILES[@]}"; do
     fi
 done
 
+# hindsight-all also bundles the embedded daemon. Keep it in lockstep with the
+# metapackage so upgrades cannot retain an older, still-compatible release.
+EMBED_PIN_FILES=("hindsight-all/pyproject.toml" "hindsight-all-slim/pyproject.toml")
+for pin_file in "${EMBED_PIN_FILES[@]}"; do
+    if [ -f "$pin_file" ]; then
+        print_info "Repinning hindsight-embed in $pin_file"
+        sed -i.bak -E "s/\"hindsight-embed(==|>=)[0-9]+\.[0-9]+\.[0-9]+\"/\"hindsight-embed==$VERSION\"/g" "$pin_file"
+        rm "${pin_file}.bak"
+    else
+        print_warn "File $pin_file not found, skipping"
+    fi
+done
+
 DEV_PYPROJECT="hindsight-dev/pyproject.toml"
 if [ -f "$DEV_PYPROJECT" ]; then
     print_info "Repinning hindsight-api in $DEV_PYPROJECT"


### PR DESCRIPTION
## Summary

- pin `hindsight-embed` to the matching `hindsight-all` / `hindsight-all-slim` release
- teach the release script to advance both embed pins with each version bump

This prevents `pip install --upgrade hindsight-all` from keeping an older embed package that still satisfies the previous broad lower bound.

Closes #3252.

## Tests

- `bash -n scripts/release.sh`
- `uv lock --check`
- built both metapackage wheels and verified their metadata requires `hindsight-embed==0.9.0`
- exercised the release-script substitution against both metapackage files with a synthetic next version
- `git diff --check`

## Risk

Low. The change only tightens metapackage dependency metadata and keeps that pin synchronized during future releases. Direct `hindsight-embed` installs remain independently selectable.
