### PR TITLE
fix(ollama): support gpt-oss thinking parameter

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -1463,7 +1463,7 @@ class OpenAICompatibleLLM(LLMInterface):
             "model": self.model,
             "messages": messages,
             "stream": False,
-            "think": False,  # Disable thinking for reasoning models (qwen3.5, etc.)
+            "think": "low" if "gpt-oss" in self.model.lower() else False,  
         }
 
         # Add schema as format parameter for structured output

--- a/hindsight-api-slim/tests/test_ollama_native_think.py
+++ b/hindsight-api-slim/tests/test_ollama_native_think.py
@@ -1,0 +1,85 @@
+"""
+Regression tests for Ollama native API think parameter handling.
+
+The gpt-oss models require a string thinking level such as "low",
+while other Ollama reasoning models such as qwen3.5 continue to
+use think=False.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from pydantic import BaseModel
+
+from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+
+
+class _SampleOutput(BaseModel):
+    summary: str
+
+
+def _make_ollama_llm(model: str) -> OpenAICompatibleLLM:
+    return OpenAICompatibleLLM(
+        provider="ollama",
+        api_key="",
+        base_url="http://localhost:11434/v1",
+        model=model,
+    )
+
+
+def _mock_ollama_response(content: dict) -> httpx.Response:
+    body = {
+        "model": "test-model",
+        "message": {
+            "role": "assistant",
+            "content": json.dumps(content),
+        },
+        "done": True,
+    }
+    return httpx.Response(200, json=body)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model", "expected_think"),
+    [
+        ("gpt-oss:20b", "low"),
+        ("qwen3.5:2b", False),
+    ],
+)
+async def test_ollama_native_think_parameter(model, expected_think):
+    """Use a thinking level for gpt-oss while preserving False for other models."""
+
+    llm = _make_ollama_llm(model)
+    captured_payloads: list[dict] = []
+
+    async def _capture_post(url, *, json=None, **kwargs):
+        captured_payloads.append(json)
+        return _mock_ollama_response({"summary": "test"})
+
+    with patch(
+        "httpx.AsyncClient.post",
+        new_callable=lambda: lambda: AsyncMock(side_effect=_capture_post),
+    ):
+        await llm._call_ollama_native(
+            messages=[{"role": "user", "content": "hello"}],
+            response_format=_SampleOutput,
+            max_completion_tokens=512,
+            temperature=0.1,
+            max_retries=0,
+            initial_backoff=1.0,
+            max_backoff=10.0,
+            skip_validation=True,
+        )
+
+    assert len(captured_payloads) == 1
+
+    payload = captured_payloads[0]
+
+    assert payload["think"] == expected_think
+
+    assert "format" in payload
+    assert payload["options"]["num_predict"] == 512
+    assert payload["options"]["temperature"] == 0.1

--- a/hindsight-api-slim/tests/test_ollama_native_think.py
+++ b/hindsight-api-slim/tests/test_ollama_native_think.py
@@ -2,8 +2,7 @@
 Regression tests for Ollama native API think parameter handling.
 
 The gpt-oss models require a string thinking level such as "low",
-while other Ollama reasoning models such as qwen3.5 continue to
-use think=False.
+while other Ollama reasoning models continue to use think=False.
 """
 
 import json
@@ -53,15 +52,14 @@ async def test_ollama_native_think_parameter(model, expected_think):
     """Use a thinking level for gpt-oss while preserving False for other models."""
 
     llm = _make_ollama_llm(model)
-    captured_payloads: list[dict] = []
 
-    async def _capture_post(url, *, json=None, **kwargs):
-        captured_payloads.append(json)
-        return _mock_ollama_response({"summary": "test"})
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _mock_ollama_response({"summary": "test"})
+    mock_client.__aenter__.return_value = mock_client
 
     with patch(
-        "httpx.AsyncClient.post",
-        new_callable=lambda: lambda: AsyncMock(side_effect=_capture_post),
+        "hindsight_api.engine.providers.openai_compatible_llm.httpx.AsyncClient",
+        return_value=mock_client,
     ):
         await llm._call_ollama_native(
             messages=[{"role": "user", "content": "hello"}],
@@ -74,12 +72,13 @@ async def test_ollama_native_think_parameter(model, expected_think):
             skip_validation=True,
         )
 
-    assert len(captured_payloads) == 1
+    request = mock_client.post.call_args
 
-    payload = captured_payloads[0]
+    assert request is not None
+
+    payload = request.kwargs["json"]
 
     assert payload["think"] == expected_think
-
     assert "format" in payload
     assert payload["options"]["num_predict"] == 512
     assert payload["options"]["temperature"] == 0.1


### PR DESCRIPTION
## Summary

Fix Ollama native structured-output requests for gpt-oss models.

Previously, `think` was hardcoded to `False`, which causes structured
fact extraction to fail with gpt-oss models.

This change uses `think="low"` for gpt-oss models while preserving
the existing `think=False` behavior for other Ollama reasoning models.

## Testing

- Added regression coverage for the Ollama native API path.
- Verifies the `think` parameter for both gpt-oss and non-gpt-oss models.
- Verifies structured-output format is still included.

Fixes #3246