### PR TITLE
fix(coding-agents): seed the actual harness, not the "opencode" default (#3247, #3248)

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/config.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.test.ts
@@ -54,6 +54,17 @@ describe("loadConfig layering", () => {
     expect(loadConfig({ path: globalCfg }).bankId).toBe("shared"); // no harness: base only
   });
 
+  it("resolves harness to the ASKING harness when the file sets none — not the opencode default (#3247)", () => {
+    writeJson(globalCfg, { bankId: "shared" }); // no explicit `harness:` field
+    expect(loadConfig({ path: globalCfg, harness: "claude-code" }).harness).toBe("claude-code");
+    expect(loadConfig({ path: globalCfg, harness: "kilo" }).harness).toBe("kilo");
+  });
+
+  it("an explicit harness field in the config file still wins over the asking harness", () => {
+    writeJson(globalCfg, { harness: "opencode" });
+    expect(loadConfig({ path: globalCfg, harness: "claude-code" }).harness).toBe("opencode");
+  });
+
   it("legacy string signature still works as the global path", () => {
     writeJson(globalCfg, { bankId: "legacy" });
     expect(loadConfig(globalCfg).bankId).toBe("legacy");

--- a/hindsight-integrations/coding-agents/src/core/config.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.ts
@@ -314,7 +314,12 @@ export function loadConfig(opts: LoadOptions | string = {}): Config {
   const o: LoadOptions = typeof opts === "string" ? { path: opts } : opts; // legacy: loadConfig(path)
   // Env first so the FILE wins on any field it sets.
   const withEnv = applyLayer({}, readEnvConfig(), o.harness);
-  return resolveConfig(applyLayer(withEnv, readRaw(o.path ?? CONFIG_PATH), o.harness));
+  const raw = applyLayer(withEnv, readRaw(o.path ?? CONFIG_PATH), o.harness);
+  // The harness that ASKED is the correct fallback for an unset `harness` field — not a hardcoded
+  // "opencode", whose silent default misfiled every other harness's background seed into an
+  // `opencode::<project>` bank (#3247). An explicit `harness:` in the config file still wins.
+  if (!raw.harness && o.harness) raw.harness = o.harness;
+  return resolveConfig(raw);
 }
 
 /** Bank-resolution fields are meaningless inside a `banks.<id>` section (they can't change the id

--- a/hindsight-integrations/coding-agents/src/core/missions.ts
+++ b/hindsight-integrations/coding-agents/src/core/missions.ts
@@ -63,7 +63,10 @@ export const DOCUMENT_MISSION =
 export const OBSERVATIONS_MISSION =
   "Consolidate durable knowledge about THIS codebase — recurring patterns, conventions, module " +
   "responsibilities, and how components relate — from the ingested commits and conversations. " +
-  "Favor stable structural understanding over one-off details.";
+  "Favor stable structural understanding over one-off details. When a new fact contradicts or " +
+  "supersedes an existing observation, UPDATE that observation to reflect the current state rather " +
+  "than creating a sibling alongside it; note that the rule was revised and when, so the superseded " +
+  "version is visible as history rather than as a competing claim.";
 
 export const RETAIN_STRATEGIES = {
   git: { retain_mission: GIT_MISSION, retain_extraction_mode: "verbose" },

--- a/hindsight-integrations/coding-agents/src/core/session-start.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.test.ts
@@ -20,7 +20,7 @@ describe("buildSessionStartContext", () => {
       startSeed,
       startSurvey,
     });
-    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300 });
+    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300, harness: "claude-code" });
     expect(startSurvey).toHaveBeenCalledWith("/repo/dir", {
       harness: "claude-code",
       model: "haiku",
@@ -40,6 +40,25 @@ describe("buildSessionStartContext", () => {
     expect(out.deferInitialReflect).toBe(true);
   });
 
+  it("threads the ASKING harness to the background seed (not the config loader's default) — #3247", async () => {
+    // Regression: the seed used to fire without a harness, so deepen.js fell back to the config
+    // loader's "opencode" default and misfiled a non-opencode session's survey + git history into
+    // an `opencode::<project>` bank. The seed must receive the harness that asked.
+    const client = { listDocumentIds: async () => new Set<string>(), listPages: listPagesOk };
+    const startSeed = vi.fn();
+    await buildSessionStartContext({
+      cwd: "/repo/dir",
+      bankId: "bank-1",
+      cfg: resolveConfig(),
+      client,
+      harness: "codex",
+      hasGit: () => true,
+      startSeed,
+      startSurvey: vi.fn(),
+    });
+    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300, harness: "codex" });
+  });
+
   it("cold git repo + codebaseSurvey:false -> starts the seed but NOT the survey", async () => {
     const client = { listDocumentIds: async () => new Set<string>(), listPages: listPagesOk };
     const startSeed = vi.fn();
@@ -53,7 +72,7 @@ describe("buildSessionStartContext", () => {
       startSeed,
       startSurvey,
     });
-    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300 });
+    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300, harness: "claude-code" });
     expect(startSurvey).not.toHaveBeenCalled();
     expect(out.systemMessage).toContain("is learning");
   });
@@ -123,7 +142,7 @@ describe("buildSessionStartContext", () => {
     });
     // The live bank is consulted, and an empty bank seeds — no client-side flag can contradict it.
     expect(called).toBe(true);
-    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300 });
+    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300, harness: "claude-code" });
     expect(out.systemMessage).toContain("is learning");
   });
 
@@ -141,7 +160,7 @@ describe("buildSessionStartContext", () => {
       startSurvey,
     });
     // The engine is idempotent, so every warm session start re-fires it to pick up missing work.
-    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300 });
+    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300, harness: "claude-code" });
     // The cold-only extras stay off: no survey, no user-facing learning note.
     expect(startSurvey).not.toHaveBeenCalled();
     expect(out.additionalContext).toContain("- Component map (p1)");
@@ -188,7 +207,7 @@ describe("buildSessionStartContext", () => {
       startSeed,
     });
     // Seeding is unaffected by a listPages failure.
-    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300 });
+    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300, harness: "claude-code" });
     // Empty-state roster preamble still renders (no page names, no throw).
     expect(out.additionalContext).toContain("<hindsight_knowledge>");
     expect(out.additionalContext).toContain("No knowledge pages yet");

--- a/hindsight-integrations/coding-agents/src/core/session-start.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.ts
@@ -138,7 +138,7 @@ export async function buildSessionStartContext(args: {
   harness?: string;
   stateDir?: string;
   hasGit?: (dir: string) => boolean;
-  startSeed?: (repoDir: string, opts?: { limit?: number }) => void;
+  startSeed?: (repoDir: string, opts?: { limit?: number; harness?: string }) => void;
   startSurvey?: (
     repoDir: string,
     opts?: { harness?: SurveyHarness; model?: string; budgetUsd?: number }
@@ -208,7 +208,10 @@ export async function buildSessionStartContext(args: {
           // idempotent (per-bank lock, dedup by document id) and each run does only the missing
           // work: cold seed, newly appeared conversations, the next per-commit diff batch. The
           // one-time extras stay cold-gated below.
-          startSeed(cwd, { limit: cfg.seedLimit });
+          // Pass the ASKING harness through: without it deepen.js falls back to the config
+          // loader's harness default and misfiles this session's survey + git history into the
+          // wrong bank (e.g. `opencode::<project>` for a claude-code session). See #3247.
+          startSeed(cwd, { limit: cfg.seedLimit, harness });
           // Cold iff the bank has zero source:git docs (an undefined result — server error — is
           // NOT treated as cold; we never surveyed/noted on an unconfirmed-empty bank).
           if (docIds.size === 0) {


### PR DESCRIPTION
## Summary

Fixes two coding-agents issues.

### #3247 — background seed misfiles into `opencode::<project>`

`buildSessionStartContext` fired the background seed with `startSeed(cwd, { limit })` — **without** the harness — while the codebase-survey spawn right beside it correctly passed `harness`. With no `--harness`, `deepen.js` resolved `{harness}` from `cfg.harness`, which fell back to a hardcoded `"opencode"`. So every non-opencode session's codebase survey + git history were written to `opencode::<project>` (a phantom bank nothing reads), while the session hooks correctly wrote to `<harness>::<project>`. This also silently affected `kilo` and opencode-fork harnesses.

**Fix:**
- `session-start.ts` — forward the asking harness to `startSeed`, mirroring the survey spawn.
- `config.ts` — `loadConfig` now resolves `cfg.harness` to the harness that asked when the config file sets none, instead of the silent `"opencode"` default (an explicit `harness:` in the file still wins). Defuses the hardcode for every real caller.

### #3248 — `OBSERVATIONS_MISSION` had no supersession rule

Added a supersession clause so a revised convention **updates** its existing observation instead of accumulating a contradictory sibling — matching the language already used in `CONVERSATION_MISSION` and `REFLECT_MISSION`.

## Testing

- **Unit:** added regression tests — `session-start.test.ts` (seed receives the asking harness, using a non-default `codex`) and `config.test.ts` (`cfg.harness` = asking harness when unset; explicit file value still wins). Full suite: 317 passed, tsc clean, build clean.
- **End-to-end (built artifacts):** the real `claude-sessionstart-hook.js` now spawns `deepen.js … --harness claude-code`, and `deepen.js --harness claude-code` resolves `bank=claude-code::<project>` (vs `opencode::<project>` on the old path).

Closes #3247
Closes #3248