### PR TITLE
fix(coding-agents): deduplicate identical async retains

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/chat.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.test.ts
@@ -68,7 +68,11 @@ describe("retainLiveSession", () => {
     expect(documentId).toBe("conversation:s2");
     expect(tags).toEqual(["source:chat"]);
     expect(strategy).toBe("conversation");
-    expect(opts).toMatchObject({ async: true, timestamp: "2026-01-01T00:00:00Z" });
+    expect(opts).toMatchObject({
+      async: true,
+      idempotent: true,
+      timestamp: "2026-01-01T00:00:00Z",
+    });
     expect(opts.metadata).toMatchObject({
       source: "chat",
       session_id: "s2",

--- a/hindsight-integrations/coding-agents/src/core/chat.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.ts
@@ -1,7 +1,8 @@
 /**
  * Harness-agnostic chat memory: the JSON user/assistant transcript schema shared by BOTH the
  * backfill (ingest past sessions) and the live runtime write-back. A leading `system` turn carries
- * the REF-ID tracer; every turn gets an ABSOLUTE timestamp.
+ * the REF-ID tracer. Backfilled turns always get an absolute timestamp; live turns preserve the
+ * source transcript timestamp when one exists and never fabricate one during a retry.
  */
 import type { HindsightClient } from "./hindsight";
 import type { ChatSession } from "./types";
@@ -14,8 +15,15 @@ export interface TransportTurn {
 }
 
 /** Prepend the REF-ID system turn to a set of already-normalized turns. */
-export function withRefId(refId: string, turns: TransportTurn[], baseTs: string): TransportTurn[] {
-  return [{ role: "system", content: `REF-ID: ${refId}`, timestamp: baseTs }, ...turns];
+export function withRefId(
+  refId: string,
+  turns: TransportTurn[],
+  baseTs?: string
+): TransportTurn[] {
+  return [
+    { role: "system", content: `REF-ID: ${refId}`, ...(baseTs ? { timestamp: baseTs } : {}) },
+    ...turns,
+  ];
 }
 
 /**
@@ -25,7 +33,7 @@ export function withRefId(refId: string, turns: TransportTurn[], baseTs: string)
  * atomic unit (`retain_structured_chunk_size`), so a turn is never split mid-thought. The REF-ID
  * system turn leads; tool activity is already compacted into `role:"action"` turns.
  */
-export function renderSessionJsonl(refId: string, turns: TransportTurn[], baseTs: string): string {
+export function renderSessionJsonl(refId: string, turns: TransportTurn[], baseTs?: string): string {
   return withRefId(refId, turns, baseTs)
     .map((t) => JSON.stringify(t))
     .join("\n");
@@ -99,7 +107,7 @@ export async function retainLiveSession(
   client: HindsightClient,
   sessionId: string,
   turns: TransportTurn[],
-  startTs: string,
+  startTs?: string,
   harness?: string
 ): Promise<void> {
   const refId = `conversation:${sessionId}`;
@@ -110,7 +118,7 @@ export async function retainLiveSession(
     ["source:chat", ...(harness ? [`harness:${harness}`] : [])],
     "conversation",
     {
-      timestamp: startTs,
+      ...(startTs ? { timestamp: startTs } : {}),
       async: true,
       idempotent: true,
       metadata: {

--- a/hindsight-integrations/coding-agents/src/core/chat.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.ts
@@ -112,6 +112,7 @@ export async function retainLiveSession(
     {
       timestamp: startTs,
       async: true,
+      idempotent: true,
       metadata: {
         source: "chat",
         session_id: sessionId,

--- a/hindsight-integrations/coding-agents/src/core/hindsight.retain.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.retain.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HindsightClient } from "./hindsight";
+
+afterEach(() => vi.restoreAllMocks());
+
+function retainRequest(content: string) {
+  const requests: unknown[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_url: string, init: RequestInit) => {
+      requests.push(JSON.parse(String(init.body)));
+      return { ok: true, status: 200, json: async () => ({ operation_id: "op-1" }) } as Response;
+    })
+  );
+
+  const client = new HindsightClient({ apiUrl: "http://hindsight.test", bank: "coding" });
+  return client
+    .retain(content, "coding agent session", "conversation:s1", ["source:chat"], "conversation", {
+      async: true,
+      idempotent: true,
+      timestamp: "2026-01-01T00:00:00Z",
+      metadata: { source: "chat", session_id: "s1" },
+    })
+    .then(() => requests[0] as { operation_id?: string });
+}
+
+describe("HindsightClient idempotent retain", () => {
+  it("adds one stable UUID operation_id for an identical async retain", async () => {
+    const first = await retainRequest("first turn");
+    const second = await retainRequest("first turn");
+
+    expect(first.operation_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+    );
+    expect(second.operation_id).toBe(first.operation_id);
+  });
+
+  it("uses a different operation_id when the retained payload changes", async () => {
+    const first = await retainRequest("first turn");
+    const second = await retainRequest("first turn with another message");
+
+    expect(second.operation_id).not.toBe(first.operation_id);
+  });
+
+  it("leaves ordinary retains unchanged", async () => {
+    const requests: unknown[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        requests.push(JSON.parse(String(init.body)));
+        return { ok: true, status: 200, json: async () => ({ operation_id: "op-1" }) } as Response;
+      })
+    );
+    const client = new HindsightClient({ apiUrl: "http://hindsight.test", bank: "coding" });
+
+    await client.retain("one-off", "manual", "document:1", ["source:manual"], "document");
+
+    expect(requests[0]).not.toHaveProperty("operation_id");
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/hindsight.retain.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.retain.test.ts
@@ -29,9 +29,9 @@ describe("HindsightClient idempotent retain", () => {
     const first = await retainRequest("first turn");
     const second = await retainRequest("first turn");
 
-    expect(first.operation_id).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
-    );
+    // Independently generated with Python's uuid.uuid5 using the documented fixed namespace and
+    // JSON.stringify({ bank, item }) name contract.
+    expect(first.operation_id).toBe("ffaf4a12-7452-532a-aa72-9b829994c903");
     expect(second.operation_id).toBe(first.operation_id);
   });
 

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -6,6 +6,7 @@
  * creates knowledge pages. Nothing here knows about opencode/claude-code/etc.
  */
 import { CODING_BANK_TEMPLATE, PAGE_MAX_TOKENS, PAGE_TRIGGER, PAGES } from "./missions";
+import { createHash } from "node:crypto";
 import { sleep } from "./util";
 
 /** One node of GET /knowledge-base/tree. Only the fields this client reads. */
@@ -29,6 +30,8 @@ export interface RetainOpts {
   timestamp?: string; // when the content occurred (temporal ranking)
   metadata?: Record<string, string>; // source provenance (returned with recalls)
   async?: boolean; // enqueue server-side (default) vs block on extraction
+  /** Reuse the server operation when this exact async retain is retried. */
+  idempotent?: boolean;
 }
 
 /** Raised when the target server predates the knowledge-pages API surface. */
@@ -41,6 +44,21 @@ export class KnowledgePagesUnavailableError extends Error {
 }
 
 const TERMINAL = new Set(["completed", "failed", "cancelled", "error"]);
+
+function retainOperationId(bank: string, item: Record<string, unknown>): string {
+  const bytes = createHash("sha256")
+    .update("hindsight-coding-agents/retain-operation/v1\0")
+    .update(JSON.stringify({ bank, item }))
+    .digest()
+    .subarray(0, 16);
+
+  // A content-derived UUID prevents a retried Stop hook from creating another operation, while a
+  // changed transcript deliberately gets a new operation instead of replaying stale work.
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
 
 export class HindsightClient {
   readonly apiUrl: string;
@@ -107,7 +125,11 @@ export class HindsightClient {
     if (opts.timestamp) item.timestamp = opts.timestamp;
     if (opts.metadata) item.metadata = opts.metadata;
     const isAsync = opts.async !== false;
-    const r = await this.req("POST", this.bankUrl("/memories"), { items: [item], async: isAsync });
+    const r = await this.req("POST", this.bankUrl("/memories"), {
+      items: [item],
+      async: isAsync,
+      ...(isAsync && opts.idempotent ? { operation_id: retainOperationId(this.bank, item) } : {}),
+    });
     if (isAsync) {
       try {
         const j = (await r.json()) as { operation_id?: string };

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -45,19 +45,27 @@ export class KnowledgePagesUnavailableError extends Error {
 
 const TERMINAL = new Set(["completed", "failed", "cancelled", "error"]);
 
-function retainOperationId(bank: string, item: Record<string, unknown>): string {
-  const bytes = createHash("sha256")
-    .update("hindsight-coding-agents/retain-operation/v1\0")
-    .update(JSON.stringify({ bank, item }))
+// UUIDv5(URL namespace, "https://github.com/vectorize-io/hindsight/tree/main/" +
+// "hindsight-integrations/coding-agents#retain-operation/v1"). The operation name is the
+// canonical JSON string produced by JSON.stringify({ bank, item }).
+const RETAIN_OPERATION_NAMESPACE = "61cecd19-ec9a-56d6-aa7e-7e891b8b2bcb";
+
+function uuidV5(namespace: string, name: string): string {
+  const namespaceBytes = Buffer.from(namespace.replaceAll("-", ""), "hex");
+  const bytes = createHash("sha1")
+    .update(namespaceBytes)
+    .update(name, "utf8")
     .digest()
     .subarray(0, 16);
 
-  // A content-derived UUID prevents a retried Stop hook from creating another operation, while a
-  // changed transcript deliberately gets a new operation instead of replaying stale work.
   bytes[6] = (bytes[6] & 0x0f) | 0x50;
   bytes[8] = (bytes[8] & 0x3f) | 0x80;
   const hex = bytes.toString("hex");
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function retainOperationId(bank: string, item: Record<string, unknown>): string {
+  return uuidV5(RETAIN_OPERATION_NAMESPACE, JSON.stringify({ bank, item }));
 }
 
 export class HindsightClient {

--- a/hindsight-integrations/coding-agents/src/core/retain-hook.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.test.ts
@@ -1,9 +1,10 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HindsightClient } from "./hindsight";
 import { buildRetain, runRetainHook } from "./retain-hook";
+import { readCodexTranscript } from "./transcript-codex";
 
 let root: string;
 let file: string;
@@ -109,6 +110,74 @@ describe("buildRetain", () => {
         client,
       })
     ).resolves.toBeUndefined();
+  });
+
+  it("renders the same Codex retain on repeated Stop and changes only after the rollout changes", async () => {
+    const item = (payload: unknown, timestamp?: string) =>
+      JSON.stringify({ type: "response_item", ...(timestamp ? { timestamp } : {}), payload });
+    writeFileSync(
+      file,
+      item(
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "make Stop idempotent" }],
+        },
+        "2026-08-10T10:00:00.000Z"
+      )
+    );
+
+    const retainSpy = vi.fn().mockResolvedValue(undefined);
+    const client = { retain: retainSpy } as unknown as HindsightClient;
+    const args = {
+      harness: "codex",
+      sessionId: "sess-codex",
+      transcriptPath: file,
+      client,
+      readTranscript: readCodexTranscript,
+    };
+
+    await buildRetain(args);
+    await buildRetain(args);
+
+    expect(retainSpy).toHaveBeenCalledTimes(2);
+    expect(retainSpy.mock.calls[1]).toEqual(retainSpy.mock.calls[0]);
+
+    appendFileSync(
+      file,
+      `\n${item(
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "done" }],
+        },
+        "2026-08-10T10:00:01.000Z"
+      )}`
+    );
+    await buildRetain(args);
+
+    expect(retainSpy).toHaveBeenCalledTimes(3);
+    expect(retainSpy.mock.calls[2][0]).not.toBe(retainSpy.mock.calls[0][0]);
+    expect(retainSpy.mock.calls[2][5]).toEqual(retainSpy.mock.calls[0][5]);
+  });
+
+  it("does not fabricate a timestamp when a transcript has none", async () => {
+    const retainSpy = vi.fn().mockResolvedValue(undefined);
+    const client = { retain: retainSpy } as unknown as HindsightClient;
+    const args = {
+      harness: "codex",
+      sessionId: "legacy",
+      transcriptPath: file,
+      client,
+      readTranscript: () => [{ role: "user", content: "legacy transcript" }],
+    };
+
+    await buildRetain(args);
+    await buildRetain(args);
+
+    expect(retainSpy.mock.calls[1]).toEqual(retainSpy.mock.calls[0]);
+    expect(retainSpy.mock.calls[0][5]).not.toHaveProperty("timestamp");
+    expect(JSON.parse(retainSpy.mock.calls[0][0].split("\n")[0])).not.toHaveProperty("timestamp");
   });
 });
 

--- a/hindsight-integrations/coding-agents/src/core/retain-hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.ts
@@ -65,7 +65,9 @@ export async function buildRetain(args: {
   const turns = readTranscript(transcriptPath);
   if (turns.length === 0) return;
 
-  const startTs = turns[0]?.timestamp ?? new Date().toISOString();
+  // A retry must render the same payload. Codex and Claude normally provide a stable source
+  // timestamp; if an older/malformed transcript does not, omit it instead of fabricating wall time.
+  const startTs = turns[0]?.timestamp;
   const t0 = Date.now();
   try {
     await retainLiveSession(client as HindsightClient, sessionId, turns, startTs, harness);

--- a/hindsight-integrations/coding-agents/src/core/transcript-codex.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript-codex.test.ts
@@ -15,7 +15,8 @@ afterEach(() => {
   rmSync(root, { recursive: true, force: true });
 });
 
-const item = (payload: unknown) => JSON.stringify({ type: "response_item", payload });
+const item = (payload: unknown, timestamp?: string) =>
+  JSON.stringify({ type: "response_item", ...(timestamp ? { timestamp } : {}), payload });
 
 describe("readCodexTranscript", () => {
   it("keeps user/assistant text + compact action turns; drops developer/synthetic/reasoning/outputs/injected", () => {
@@ -116,6 +117,39 @@ describe("readCodexTranscript", () => {
     );
     const turns = readCodexTranscript(file);
     expect(turns).toEqual([{ role: "user", content: "Why retry?" }]);
+  });
+
+  it("preserves stable rollout timestamps on retained message and action turns", () => {
+    writeFileSync(
+      file,
+      [
+        item(
+          {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "retry this retain" }],
+          },
+          "2026-08-10T10:00:00.000Z"
+        ),
+        item(
+          { type: "function_call", name: "shell", arguments: '{"command":"npm test"}' },
+          "2026-08-10T10:00:01.000Z"
+        ),
+      ].join("\n")
+    );
+
+    expect(readCodexTranscript(file)).toEqual([
+      {
+        role: "user",
+        content: "retry this retain",
+        timestamp: "2026-08-10T10:00:00.000Z",
+      },
+      {
+        role: "action",
+        content: "shell npm test",
+        timestamp: "2026-08-10T10:00:01.000Z",
+      },
+    ]);
   });
 
   it("strips <hook_prompt> transport wrappers from user messages: a pure hook_prompt yields no turn; mixed content keeps only the real text", () => {

--- a/hindsight-integrations/coding-agents/src/core/transcript-codex.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript-codex.ts
@@ -38,6 +38,7 @@ interface Payload {
 }
 interface RolloutLine {
   type?: string;
+  timestamp?: string;
   payload?: Payload;
 }
 
@@ -83,6 +84,7 @@ export function readCodexTranscript(path: string): TransportTurn[] {
     if (line.type !== "response_item") continue;
     const p = line.payload;
     if (!p || typeof p !== "object") continue;
+    const timestamp = typeof line.timestamp === "string" ? line.timestamp : undefined;
 
     if (p.type === "message") {
       // `developer` messages are Codex's system prompt + OUR injected hook context → drop entirely.
@@ -90,7 +92,7 @@ export function readCodexTranscript(path: string): TransportTurn[] {
       const text = stripInjectedMemory(messageText(p)).trim();
       if (!text) continue;
       if (p.role === "user" && isSyntheticUserText(text)) continue;
-      turns.push({ role: p.role, content: text });
+      turns.push({ role: p.role, content: text, ...(timestamp ? { timestamp } : {}) });
     } else if (p.type === "function_call" && typeof p.name === "string") {
       let input: unknown;
       try {
@@ -98,7 +100,11 @@ export function readCodexTranscript(path: string): TransportTurn[] {
       } catch {
         input = undefined;
       }
-      turns.push({ role: "action", content: actionLine(p.name, input) });
+      turns.push({
+        role: "action",
+        content: actionLine(p.name, input),
+        ...(timestamp ? { timestamp } : {}),
+      });
     }
     // reasoning / other payloads: dropped.
   }


### PR DESCRIPTION
## Summary

- Closes #3280.
- Add opt-in idempotency for asynchronous Coding Agents retains using the server's existing `operation_id` contract.
- Derive an RFC UUIDv5 operation ID from the exact retained bank, document identity, and payload.
- Preserve Codex rollout timestamps when they exist and avoid fabricating a current timestamp when they do not.
- Make repeated Stop processing over an unchanged rollout produce the same payload and operation ID, while changed rollout content still produces a distinct operation.

## Root cause

The Coding Agents client did not send an operation ID for asynchronous live-session retains. The first implementation made identity payload-scoped, but Codex transcripts without source timestamps still received a new `Date().toISOString()` value on every Stop. That changed the rendered payload and defeated deduplication across manual repeated Stops.

The final implementation keeps the timestamp optional throughout the Codex transcript and retain path. Source timestamps are preserved; absent timestamps remain absent deterministically.

## Validation

```text
Focused chat, retain-client, retain-hook and Codex transcript tests
  16 tests passed

TypeScript --noEmit
  passed

Production build
  passed

Lock-exact combined integration suite containing this branch
  37 files passed, 367 tests passed
```

The regressions cover identical repeated Stop processing, changed rollout content, legacy transcripts without timestamps, RFC UUIDv5 vectors, ordinary retain compatibility, and the live-session call path.

## Scope

- No Hindsight server API, migration, schema, database, worker, retry, or persistence-layer change.
- No hook configuration change.
- No session-scoped identity that could collapse a later changed transcript into an earlier operation.

