### PR TITLE
feat(coding-agents): add configurable document attribution

### DIFF
--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -5,7 +5,7 @@ description: "One Hindsight memory plugin for coding agents — per-repo memory 
 ---
 
 {/* GENERATED from hindsight-integrations/coding-agents/README.md — edit that file, then run
-    node hindsight-docs/scripts/sync-coding-agents-doc.mjs */}
+node hindsight-docs/scripts/sync-coding-agents-doc.mjs */}
 
 Long-term project memory for **coding agents**, backed by [Hindsight](https://vectorize.io/hindsight).
 One package, several agents: a shared reflect-and-inject core with a thin entry point per agent
@@ -289,6 +289,27 @@ hook by Codex...), so one shared config serves several agents side by side:
 }
 ```
 
+Documents written by the integration can carry additional provenance tags and metadata. Values
+support `{gitProject}`, `{project}`, `{harness}`, `{cwd}`, and `{bankId}`
+placeholders. The same resolved values are applied to session transcripts, git documents, survey
+markers/findings, initiative markers, and documents saved through `hindsight_ingest_document`:
+
+```jsonc
+{
+  "retainTags": ["project:{gitProject}", "harness:{harness}"],
+  "retainMetadata": {
+    "project": "{gitProject}",
+    "workspace": "{cwd}",
+  },
+}
+```
+
+Tags are merged with the integration's built-in source tags, never substituted for them. Duplicate
+tags are removed. A tag whose resolved value ends in an empty namespace component (for example
+`"project:"`) is omitted. Values containing an unknown placeholder are rejected rather than retained
+with ambiguous attribution. `{cwd}` records an absolute local path; use it only when that disclosure
+is appropriate for the configured Hindsight server.
+
 ### Reference
 
 | field                   | default                              | meaning                                                                                                                                                                                                                             |
@@ -310,6 +331,8 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `surveyBudgetUsd`       | `2`                                  | survey spend cap — Claude recipe only (`claude -p --max-budget-usd`); other agents rely on their read-only sandbox                                                                                                                  |
 | `retainSessions`        | `true`                               | plugin-harness write-back (opencode, Kilo): async upsert of the session transcript every turn, plus an idle flush that captures the reply the per-turn pass can't see (set `false` to opt out; hook harnesses always write on Stop) |
 | `retainEveryTurns`      | `1`                                  | opencode write-back cadence (user turns)                                                                                                                                                                                            |
+| `retainTags`            | `[]`                                 | extra tags for every retained document; supports `{gitProject}`, `{project}`, `{harness}`, `{cwd}`, and `{bankId}` templates                                                                                                        |
+| `retainMetadata`        | `{}`                                 | extra string metadata for every retained document; supports the same templates as `retainTags`                                                                                                                                      |
 | `logLevel`              | `"info"`                             | plugin-log verbosity (`"debug"` \| `"info"` \| `"warn"` \| `"error"`); `HINDSIGHT_LOG_LEVEL` env overrides                                                                                                                          |
 | `gitIngest`             | `"message"`                          | git depth for seeding AND staying current (same engine): `"message"` = commit messages only (one doc, re-upserted when HEAD moves); `"full"` = messages + per-commit full diffs (progressive, newest first); `"none"` = git off     |
 | `harnesses.<name>`      | —                                    | per-harness override of any field above                                                                                                                                                                                             |

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -282,6 +282,27 @@ hook by Codex...), so one shared config serves several agents side by side:
 }
 ```
 
+Documents written by the integration can carry additional provenance tags and metadata. Values
+support `{gitProject}`, `{project}`, `{harness}`, `{cwd}`, and `{bankId}`
+placeholders. The same resolved values are applied to session transcripts, git documents, survey
+markers/findings, initiative markers, and documents saved through `hindsight_ingest_document`:
+
+```jsonc
+{
+  "retainTags": ["project:{gitProject}", "harness:{harness}"],
+  "retainMetadata": {
+    "project": "{gitProject}",
+    "workspace": "{cwd}",
+  },
+}
+```
+
+Tags are merged with the integration's built-in source tags, never substituted for them. Duplicate
+tags are removed. A tag whose resolved value ends in an empty namespace component (for example
+`"project:"`) is omitted. Values containing an unknown placeholder are rejected rather than retained
+with ambiguous attribution. `{cwd}` records an absolute local path; use it only when that disclosure
+is appropriate for the configured Hindsight server.
+
 ### Reference
 
 | field                   | default                              | meaning                                                                                                                                                                                                                             |
@@ -303,6 +324,8 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `surveyBudgetUsd`       | `2`                                  | survey spend cap — Claude recipe only (`claude -p --max-budget-usd`); other agents rely on their read-only sandbox                                                                                                                  |
 | `retainSessions`        | `true`                               | plugin-harness write-back (opencode, Kilo): async upsert of the session transcript every turn, plus an idle flush that captures the reply the per-turn pass can't see (set `false` to opt out; hook harnesses always write on Stop) |
 | `retainEveryTurns`      | `1`                                  | opencode write-back cadence (user turns)                                                                                                                                                                                            |
+| `retainTags`            | `[]`                                 | extra tags for every retained document; supports `{gitProject}`, `{project}`, `{harness}`, `{cwd}`, and `{bankId}` templates                                                                                                        |
+| `retainMetadata`        | `{}`                                 | extra string metadata for every retained document; supports the same templates as `retainTags`                                                                                                                                      |
 | `logLevel`              | `"info"`                             | plugin-log verbosity (`"debug"` \| `"info"` \| `"warn"` \| `"error"`); `HINDSIGHT_LOG_LEVEL` env overrides                                                                                                                          |
 | `gitIngest`             | `"message"`                          | git depth for seeding AND staying current (same engine): `"message"` = commit messages only (one doc, re-upserted when HEAD moves); `"full"` = messages + per-commit full diffs (progressive, newest first); `"none"` = git off     |
 | `harnesses.<name>`      | —                                    | per-harness override of any field above                                                                                                                                                                                             |

--- a/hindsight-integrations/coding-agents/src/cline.ts
+++ b/hindsight-integrations/coding-agents/src/cline.ts
@@ -193,7 +193,7 @@ function createRuntime(workspaceRoot: string | undefined): RuntimeCore | undefin
     apiToken: cfg.apiToken,
     bank: resolved.bankId,
   });
-  return new RuntimeCore(client, resolved.bankId, cfg, HARNESS);
+  return new RuntimeCore(client, resolved.bankId, cfg, HARNESS, workspaceRoot || process.cwd());
 }
 
 const plugin: ClinePlugin = {

--- a/hindsight-integrations/coding-agents/src/core/chat.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.ts
@@ -6,6 +6,7 @@
 import type { HindsightClient } from "./hindsight";
 import type { ChatSession } from "./types";
 import { pool } from "./util";
+import { mergeMetadata, mergeTags, type RetainAttribution } from "./retain-attribution";
 
 export interface TransportTurn {
   role: string;
@@ -35,7 +36,7 @@ export function renderSessionJsonl(refId: string, turns: TransportTurn[], baseTs
 export async function ingestChats(
   client: HindsightClient,
   sessions: ChatSession[],
-  opts: { concurrency?: number; log?: (m: string) => void } = {}
+  opts: { concurrency?: number; log?: (m: string) => void; attribution?: RetainAttribution } = {}
 ): Promise<number> {
   const log = opts.log ?? (() => {});
   if (!sessions.length) {
@@ -69,11 +70,14 @@ export async function ingestChats(
         turns.map((x) => JSON.stringify(x)).join("\n"),
         "developer chat",
         `chat:${id}`,
-        ["source:chat"],
+        mergeTags(["source:chat"], opts.attribution?.tags),
         "conversation",
         {
           timestamp: baseIso,
-          metadata: { source: "chat", chat: id, ref_id: `chat:${id}` },
+          metadata: mergeMetadata(
+            { source: "chat", chat: id, ref_id: `chat:${id}` },
+            opts.attribution?.metadata
+          ),
         }
       );
     },
@@ -100,24 +104,28 @@ export async function retainLiveSession(
   sessionId: string,
   turns: TransportTurn[],
   startTs: string,
-  harness?: string
+  harness?: string,
+  attribution?: RetainAttribution
 ): Promise<void> {
   const refId = `conversation:${sessionId}`;
   await client.retain(
     renderSessionJsonl(refId, turns, startTs),
     "coding agent session",
     refId,
-    ["source:chat", ...(harness ? [`harness:${harness}`] : [])],
+    mergeTags(["source:chat", ...(harness ? [`harness:${harness}`] : [])], attribution?.tags),
     "conversation",
     {
       timestamp: startTs,
       async: true,
-      metadata: {
-        source: "chat",
-        session_id: sessionId,
-        ref_id: refId,
-        ...(harness ? { harness } : {}),
-      },
+      metadata: mergeMetadata(
+        {
+          source: "chat",
+          session_id: sessionId,
+          ref_id: refId,
+          ...(harness ? { harness } : {}),
+        },
+        attribution?.metadata
+      ),
     }
   );
 }

--- a/hindsight-integrations/coding-agents/src/core/config.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.test.ts
@@ -144,6 +144,21 @@ describe("banks.<id>.bank — rename inside the banks tree", () => {
   });
 });
 
+describe("retain provenance configuration", () => {
+  it("resolves valid string tags and metadata while ignoring malformed values", () => {
+    const cfg = resolveConfig({
+      retainTags: ["project:{gitProject}", 42 as unknown as string],
+      retainMetadata: {
+        project: "{gitProject}",
+        invalid: 42 as unknown as string,
+      },
+    });
+
+    expect(cfg.retainTags).toEqual(["project:{gitProject}"]);
+    expect(cfg.retainMetadata).toEqual({ project: "{gitProject}" });
+  });
+});
+
 /**
  * Env vars are a FALLBACK beneath the config file — for containers, CI and secret managers that
  * inject a token rather than writing a credential to disk. The file must keep winning wherever it

--- a/hindsight-integrations/coding-agents/src/core/config.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.ts
@@ -67,6 +67,11 @@ export interface RawConfig {
   disabled?: boolean; // hard off-switch — inert plugin, for a no-memory baseline (default false)
   retainSessions?: boolean; // opencode plugin write-back (default true; set false to opt out). Hook harnesses always write back on Stop and ignore this flag.
   retainEveryTurns?: number; // write-back cadence in user turns (default 1: async upsert every turn)
+  /** Extra tags applied to every retained document. Supports {gitProject}, {project}, {harness},
+   *  {cwd}, and {bankId} placeholders. */
+  retainTags?: string[];
+  /** Extra string metadata applied to every retained document, with the same placeholders. */
+  retainMetadata?: Record<string, string>;
   reflectTimeoutMs?: number; // session-start reflect timeout (default 120000; hooks cap lower internally)
   autoReflect?: boolean; // inject a one-time reflect synthesis on the session's first prompt (default true; false = the agent reflects only via the hindsight_reflect tool, and the tool guide tells it to do so on new goals)
   pageRefreshEveryTurns?: number; // knowledge-page refresh cadence in user turns (default 10)
@@ -119,6 +124,8 @@ export interface Config {
   disabled: boolean;
   retainSessions: boolean;
   retainEveryTurns: number;
+  retainTags: string[];
+  retainMetadata: Record<string, string>;
   reflectTimeoutMs: number;
   autoReflect: boolean;
   pageRefreshEveryTurns: number;
@@ -163,6 +170,17 @@ export function resolveConfig(raw: RawConfig = {}): Config {
     disabled: raw.disabled ?? false,
     retainSessions: raw.retainSessions ?? true, // opencode: write back by default (parity with hook-harness Stop)
     retainEveryTurns: raw.retainEveryTurns || 1,
+    retainTags: Array.isArray(raw.retainTags)
+      ? raw.retainTags.filter((tag): tag is string => typeof tag === "string")
+      : [],
+    retainMetadata:
+      raw.retainMetadata && typeof raw.retainMetadata === "object"
+        ? Object.fromEntries(
+            Object.entries(raw.retainMetadata).filter(
+              (entry): entry is [string, string] => typeof entry[1] === "string"
+            )
+          )
+        : {},
     reflectTimeoutMs: raw.reflectTimeoutMs || 120000,
     autoReflect: raw.autoReflect ?? true,
     pageRefreshEveryTurns: raw.pageRefreshEveryTurns || 10,

--- a/hindsight-integrations/coding-agents/src/core/git.ts
+++ b/hindsight-integrations/coding-agents/src/core/git.ts
@@ -10,6 +10,7 @@ import { resolve } from "node:path";
 import { projectNameOf } from "./bank";
 import type { HindsightClient } from "./hindsight";
 import { pool } from "./util";
+import { mergeMetadata, mergeTags, type RetainAttribution } from "./retain-attribution";
 
 const US = "\x1f";
 const RS = "\x1e"; // record separator between commits in gitLogText
@@ -68,7 +69,8 @@ export async function retainCommit(
   client: HindsightClient,
   repo: string,
   sha: string,
-  repoName: string
+  repoName: string,
+  attribution?: RetainAttribution
 ): Promise<void> {
   const [h, an, ae, aISO, cISO, subj, body] = git(
     repo,
@@ -83,26 +85,41 @@ export async function retainCommit(
     `REF-ID: git:${sha.slice(0, 12)}\n` +
     `Git commit ${sha.slice(0, 12)} in the ${repoName} repository (${an}, ${aISO}).\n\n` +
     `Message:\n${msg}\n\nDiff:\n${diff}`;
-  await client.retain(content, `git commit in ${repoName}`, `git:${sha}`, ["source:git"], "git", {
-    timestamp: aISO, // the memory's timestamp is the commit's author date
-    metadata: {
-      source: "git",
-      repo: repoName,
-      commit: h,
-      short_sha: sha.slice(0, 12),
-      author: an,
-      author_email: ae,
-      authored_at: aISO,
-      committed_at: cISO,
-      subject: subj,
-    },
-  });
+  await client.retain(
+    content,
+    `git commit in ${repoName}`,
+    `git:${sha}`,
+    mergeTags(["source:git"], attribution?.tags),
+    "git",
+    {
+      timestamp: aISO, // the memory's timestamp is the commit's author date
+      metadata: mergeMetadata(
+        {
+          source: "git",
+          repo: repoName,
+          commit: h,
+          short_sha: sha.slice(0, 12),
+          author: an,
+          author_email: ae,
+          authored_at: aISO,
+          committed_at: cISO,
+          subject: subj,
+        },
+        attribution?.metadata
+      ),
+    }
+  );
 }
 
 export async function ingestGit(
   client: HindsightClient,
   repo: string,
-  opts: { limit?: number; concurrency?: number; log?: (m: string) => void } = {}
+  opts: {
+    limit?: number;
+    concurrency?: number;
+    log?: (m: string) => void;
+    attribution?: RetainAttribution;
+  } = {}
 ): Promise<number> {
   const log = opts.log ?? (() => {});
   // NEWEST-first: recent commits (the project's own decision commits) extract before the ancient
@@ -116,7 +133,7 @@ export async function ingestGit(
     shas,
     opts.concurrency ?? 8,
     async (sha) => {
-      await retainCommit(client, repo, sha, repoName);
+      await retainCommit(client, repo, sha, repoName, opts.attribution);
     },
     (i, e) => {
       failures++;
@@ -173,7 +190,9 @@ export function gitLogText(repo: string, limit: number): string {
 export async function ingestGitLog(
   client: HindsightClient,
   repo: string,
-  opts: { limit: number; log?: (m: string) => void } = { limit: 300 }
+  opts: { limit: number; log?: (m: string) => void; attribution?: RetainAttribution } = {
+    limit: 300,
+  }
 ): Promise<number> {
   const log = opts.log ?? (() => {});
   const text = gitLogText(repo, opts.limit);
@@ -192,9 +211,12 @@ export async function ingestGitLog(
       text,
       `git commit-message history (last ${n}) for ${repoName}`,
       `gitlog:${repoName}`,
-      ["source:git", "source:git-log", ...(head ? [`gitlog-head:${head}`] : [])],
+      mergeTags(
+        ["source:git", "source:git-log", ...(head ? [`gitlog-head:${head}`] : [])],
+        opts.attribution?.tags
+      ),
       "gitlog",
-      { async: true }
+      { async: true, metadata: opts.attribution?.metadata }
     );
     log(`[gitlog] done: ${n} commit messages ingested as 1 document under strategy 'gitlog'`);
     return 0;

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -7,6 +7,7 @@
  */
 import { CODING_BANK_TEMPLATE, PAGE_MAX_TOKENS, PAGE_TRIGGER, PAGES } from "./missions";
 import { sleep } from "./util";
+import { mergeMetadata, mergeTags, type RetainAttribution } from "./retain-attribution";
 
 /** One node of GET /knowledge-base/tree. Only the fields this client reads. */
 export interface KnowledgeNode {
@@ -414,6 +415,7 @@ export class HindsightClient {
     title: string;
     summary: string;
     relatesToPageId?: string;
+    attribution?: RetainAttribution;
   }): Promise<{ page_id: string }> {
     // `/knowledge-base/pages` mints its OWN page id (kp-…); we can't set it. So for a new initiative
     // we create the page first and adopt the server-assigned id — that id is what the return value
@@ -448,9 +450,9 @@ export class HindsightClient {
       content,
       "initiative marker",
       markerId,
-      ["knowledge:feature-work", `relatedPageId:${pageId}`],
+      mergeTags(["knowledge:feature-work", `relatedPageId:${pageId}`], args.attribution?.tags),
       "document",
-      { async: true }
+      { async: true, metadata: args.attribution?.metadata }
     );
     return { page_id: pageId };
   }

--- a/hindsight-integrations/coding-agents/src/core/knowledge-tools.ts
+++ b/hindsight-integrations/coding-agents/src/core/knowledge-tools.ts
@@ -20,6 +20,7 @@ import type { ZodRawShape } from "zod";
 import type { HindsightClient } from "./hindsight";
 import { syncStatus } from "./status";
 import { loadConfig } from "./config";
+import { mergeMetadata, mergeTags, type RetainAttribution } from "./retain-attribution";
 
 export interface ToolResult {
   // Index signature so this structurally satisfies the MCP SDK's CallToolResult (which carries
@@ -61,7 +62,7 @@ function guarded(fn: (args: any) => Promise<unknown>): (args: any) => Promise<To
 export function buildKnowledgeTools(
   client: HindsightClient,
   bankId: string,
-  opts: { repoDir?: string; harness?: string } = {}
+  opts: { repoDir?: string; harness?: string; attribution?: RetainAttribution } = {}
 ): ToolSpec[] {
   return [
     {
@@ -201,7 +202,12 @@ export function buildKnowledgeTools(
         relates_to_page_id: z.string().optional(),
       },
       handler: guarded(async ({ title, summary, relates_to_page_id }) =>
-        client.captureInitiative({ title, summary, relatesToPageId: relates_to_page_id })
+        client.captureInitiative({
+          title,
+          summary,
+          relatesToPageId: relates_to_page_id,
+          attribution: opts.attribution,
+        })
       ),
     },
     {
@@ -221,13 +227,23 @@ export function buildKnowledgeTools(
             .toLowerCase()
             .replace(/[^a-z0-9]+/g, "-")
             .replace(/^-+|-+$/g, "") || "doc";
+        const metadata = mergeMetadata(
+          opts.harness ? { harness: opts.harness } : {},
+          opts.attribution?.metadata
+        );
         await client.retain(
           content,
           "ingested document",
           docId,
-          ["source:upload", ...(opts.harness ? [`harness:${opts.harness}`] : [])],
+          mergeTags(
+            ["source:upload", ...(opts.harness ? [`harness:${opts.harness}`] : [])],
+            opts.attribution?.tags
+          ),
           "document",
-          { async: true, metadata: opts.harness ? { harness: opts.harness } : undefined }
+          {
+            async: true,
+            ...(Object.keys(metadata).length ? { metadata } : {}),
+          }
         );
         return { ok: true, doc_id: docId };
       }),

--- a/hindsight-integrations/coding-agents/src/core/retain-attribution.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-attribution.test.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveRetainAttribution } from "./retain-attribution";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("resolveRetainAttribution", () => {
+  it("resolves project, harness, cwd, and bank placeholders", () => {
+    const root = mkdtempSync(join(tmpdir(), "hs-retain-tags-"));
+    roots.push(root);
+
+    expect(
+      resolveRetainAttribution(
+        {
+          retainTags: ["project:{gitProject}", "harness:{harness}", "bank:{bankId}"],
+          retainMetadata: { cwd: "{cwd}", project: "{project}" },
+        },
+        root,
+        "codex",
+        "default"
+      )
+    ).toEqual({
+      tags: [`project:${root.split("/").at(-1)}`, "harness:codex", "bank:default"],
+      metadata: { cwd: root, project: root.split("/").at(-1) },
+    });
+  });
+
+  it("deduplicates tags and drops templates with an empty namespace value", () => {
+    expect(
+      resolveRetainAttribution(
+        { retainTags: ["source:chat", "source:chat", "optional:"] },
+        "/tmp/project",
+        "codex",
+        "default"
+      ).tags
+    ).toEqual(["source:chat"]);
+  });
+
+  it("omits values containing unknown placeholders instead of storing ambiguous attribution", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(
+      resolveRetainAttribution(
+        {
+          retainTags: ["project:{missing}", "harness:{harness}", "other:{missing}"],
+          retainMetadata: { project: "{missing}", harness: "{harness}" },
+        },
+        "/tmp/project",
+        "codex",
+        "default"
+      )
+    ).toEqual({ tags: ["harness:codex"], metadata: { harness: "codex" } });
+    expect(error).toHaveBeenCalledTimes(1);
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/retain-attribution.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-attribution.ts
@@ -1,0 +1,80 @@
+import { basename } from "node:path";
+import { projectNameOf } from "./bank";
+
+export interface RetainAttributionConfig {
+  retainTags?: string[];
+  retainMetadata?: Record<string, string>;
+}
+
+export interface RetainAttribution {
+  tags: string[];
+  metadata: Record<string, string>;
+}
+
+const PLACEHOLDER = /\{([a-zA-Z]+)\}/g;
+
+/** Resolve user-configured provenance once, then merge it into every document written for a repo. */
+export function resolveRetainAttribution(
+  config: RetainAttributionConfig,
+  directory: string,
+  harness: string,
+  bankId: string
+): RetainAttribution {
+  const resolvers: Record<string, () => string> = {
+    bankId: () => bankId,
+    cwd: () => directory,
+    gitProject: () => projectNameOf(directory),
+    harness: () => harness,
+    project: () => (directory ? basename(directory) : "unknown"),
+  };
+  const warned = new Set<string>();
+  const render = (template: string): string | undefined => {
+    let valid = true;
+    const rendered = template.replace(PLACEHOLDER, (_, name: string) => {
+      const resolver = resolvers[name];
+      if (!resolver) {
+        valid = false;
+        if (!warned.has(name)) {
+          warned.add(name);
+          console.error(
+            `hindsight: unknown retain template placeholder "{${name}}" — valid: ` +
+              Object.keys(resolvers)
+                .sort()
+                .map((key) => `{${key}}`)
+                .join(", ")
+          );
+        }
+        return "";
+      }
+      return resolver();
+    });
+    return valid ? rendered : undefined;
+  };
+
+  const tags = [
+    ...new Set(
+      (config.retainTags ?? [])
+        .map(render)
+        .filter((tag): tag is string => tag !== undefined)
+        .map((tag) => tag.trim())
+    ),
+  ].filter((tag) => tag && !tag.endsWith(":"));
+  const metadata = Object.fromEntries(
+    Object.entries(config.retainMetadata ?? {})
+      .map(([key, value]) => [key, render(value)?.trim()])
+      .filter((entry): entry is [string, string] => entry[1] !== undefined)
+      .filter(([, value]) => value !== "")
+  );
+  return { tags, metadata };
+}
+
+export function mergeTags(base: string[], extra: string[] = []): string[] {
+  return [...new Set([...base, ...extra])];
+}
+
+export function mergeMetadata(
+  base: Record<string, string>,
+  extra: Record<string, string> = {}
+): Record<string, string> {
+  return { ...extra, ...base };
+}

--- a/hindsight-integrations/coding-agents/src/core/retain-hook.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.test.ts
@@ -88,6 +88,43 @@ describe("buildRetain", () => {
     expect(retainSpy).not.toHaveBeenCalled();
   });
 
+  it("merges configured attribution into the session document", async () => {
+    writeFileSync(
+      file,
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-01-01T00:00:00Z",
+        message: { role: "user", content: "hello" },
+      })
+    );
+    const retainSpy = vi.fn().mockResolvedValue(undefined);
+
+    await buildRetain({
+      harness: "codex",
+      sessionId: "sess-tags",
+      transcriptPath: file,
+      client: { retain: retainSpy } as unknown as HindsightClient,
+      attribution: {
+        tags: ["project:potcodev", "auto:codex-transcript"],
+        metadata: { project: "potcodev", cwd: "/work/potcodev" },
+      },
+    });
+
+    const [, , , tags, , opts] = retainSpy.mock.calls[0];
+    expect(tags).toEqual([
+      "source:chat",
+      "harness:codex",
+      "project:potcodev",
+      "auto:codex-transcript",
+    ]);
+    expect(opts.metadata).toMatchObject({
+      source: "chat",
+      harness: "codex",
+      project: "potcodev",
+      cwd: "/work/potcodev",
+    });
+  });
+
   it("fails open on retain error", async () => {
     writeFileSync(
       file,

--- a/hindsight-integrations/coding-agents/src/core/retain-hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.ts
@@ -22,6 +22,7 @@ import type { ClientOpts } from "./hindsight";
 import { HindsightClient } from "./hindsight";
 import { readClaudeTranscript } from "./transcript";
 import type { TransportTurn } from "./chat";
+import { resolveRetainAttribution, type RetainAttribution } from "./retain-attribution";
 
 export interface RetainHookEventFields {
   sessionId?: string;
@@ -40,6 +41,7 @@ export interface RetainHookSpec {
   parse(event: Record<string, unknown>): RetainHookEventFields;
   /** Harness-specific transcript parser. Defaults to the Claude JSONL reader. */
   readTranscript?: TranscriptReader;
+  attribution?: RetainAttribution;
 }
 
 /** Minimal client shape `buildRetain` needs — `HindsightClient` satisfies it structurally. */
@@ -68,7 +70,14 @@ export async function buildRetain(args: {
   const startTs = turns[0]?.timestamp ?? new Date().toISOString();
   const t0 = Date.now();
   try {
-    await retainLiveSession(client as HindsightClient, sessionId, turns, startTs, harness);
+    await retainLiveSession(
+      client as HindsightClient,
+      sessionId,
+      turns,
+      startTs,
+      harness,
+      args.attribution
+    );
     diag(harness, "retain_ok", { ms: Date.now() - t0, turns: turns.length, session: sessionId });
   } catch (e) {
     log.warn(harness, "session write-back failed", {
@@ -117,6 +126,7 @@ export async function runRetainHook(
   // produces the same `retain_failed` diagnostic as an unreachable Cloud/self-hosted server.
   await ensureDaemon(cfg, spec.harness, { waitMs: DAEMON_WAIT_RETAIN_MS });
   const client = makeClient({ apiUrl: cfg.apiUrl, apiToken: cfg.apiToken, bank: bankId });
+  const attribution = resolveRetainAttribution(cfg, cwd, spec.harness, bankId);
 
   await buildRetain({
     harness: spec.harness,
@@ -124,5 +134,6 @@ export async function runRetainHook(
     transcriptPath,
     client,
     readTranscript: spec.readTranscript,
+    attribution,
   });
 }

--- a/hindsight-integrations/coding-agents/src/core/runtime.ts
+++ b/hindsight-integrations/coding-agents/src/core/runtime.ts
@@ -22,10 +22,12 @@ import { retainLiveSession, type TransportTurn } from "./chat";
 import { buildSessionStartContext } from "./session-start";
 import { buildHookOutput } from "./hook";
 import { sessionCacheFile, writeSessionCache } from "./session-cache";
+import { resolveRetainAttribution, type RetainAttribution } from "./retain-attribution";
 
 const HARNESS = "opencode";
 
 export class RuntimeCore {
+  private readonly retainAttribution: RetainAttribution;
   private readonly injection = new Map<string, string>(); // sessionId -> this turn's injection block
   private readonly turnCount = new Map<string, number>(); // sessionId -> user-turn counter (cadence)
   private readonly sessionState = new Map<
@@ -49,9 +51,11 @@ export class RuntimeCore {
      * retained transcript's harness field, so Kilo sessions don't masquerade as opencode ones.
      * Defaults to opencode, the original (and only other) plugin harness.
      */
-    readonly harness: string = HARNESS
+    readonly harness: string = HARNESS,
+    repoDir: string = process.cwd()
   ) {
     setLogLevel(cfg.logLevel);
+    this.retainAttribution = resolveRetainAttribution(cfg, repoDir, harness, bankId);
   }
 
   setNotifier(notify: (title: string, message: string) => void): void {
@@ -69,7 +73,10 @@ export class RuntimeCore {
 
   /** The hindsight_* knowledge + recall tools, bound to this bank, for the harness to register natively. */
   toolSpecs(): ToolSpec[] {
-    return buildKnowledgeTools(this.client, this.bankId, { harness: this.harness });
+    return buildKnowledgeTools(this.client, this.bankId, {
+      harness: this.harness,
+      attribution: this.retainAttribution,
+    });
   }
 
   get writeBackEnabled(): boolean {
@@ -238,7 +245,14 @@ export class RuntimeCore {
     trigger = "turn"
   ): void {
     const t0 = Date.now();
-    void retainLiveSession(this.client, sessionId, turns, startTs, this.harness)
+    void retainLiveSession(
+      this.client,
+      sessionId,
+      turns,
+      startTs,
+      this.harness,
+      this.retainAttribution
+    )
       .then(() =>
         diag(this.harness, "retain_ok", {
           ms: Date.now() - t0,

--- a/hindsight-integrations/coding-agents/src/core/session-start.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.test.ts
@@ -20,7 +20,7 @@ describe("buildSessionStartContext", () => {
       startSeed,
       startSurvey,
     });
-    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300 });
+    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300, harness: "claude-code" });
     expect(startSurvey).toHaveBeenCalledWith("/repo/dir", {
       harness: "claude-code",
       model: "haiku",
@@ -53,7 +53,7 @@ describe("buildSessionStartContext", () => {
       startSeed,
       startSurvey,
     });
-    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300 });
+    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300, harness: "claude-code" });
     expect(startSurvey).not.toHaveBeenCalled();
     expect(out.systemMessage).toContain("is learning");
   });
@@ -123,7 +123,7 @@ describe("buildSessionStartContext", () => {
     });
     // The live bank is consulted, and an empty bank seeds — no client-side flag can contradict it.
     expect(called).toBe(true);
-    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300 });
+    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300, harness: "claude-code" });
     expect(out.systemMessage).toContain("is learning");
   });
 
@@ -141,7 +141,7 @@ describe("buildSessionStartContext", () => {
       startSurvey,
     });
     // The engine is idempotent, so every warm session start re-fires it to pick up missing work.
-    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300 });
+    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300, harness: "claude-code" });
     // The cold-only extras stay off: no survey, no user-facing learning note.
     expect(startSurvey).not.toHaveBeenCalled();
     expect(out.additionalContext).toContain("- Component map (p1)");
@@ -188,7 +188,7 @@ describe("buildSessionStartContext", () => {
       startSeed,
     });
     // Seeding is unaffected by a listPages failure.
-    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300 });
+    expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300, harness: "claude-code" });
     // Empty-state roster preamble still renders (no page names, no throw).
     expect(out.additionalContext).toContain("<hindsight_knowledge>");
     expect(out.additionalContext).toContain("No knowledge pages yet");

--- a/hindsight-integrations/coding-agents/src/core/session-start.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.ts
@@ -35,6 +35,7 @@ import { parsePageList, buildKnowledgePreamble, type PageRef } from "./knowledge
 import type { ClientOpts } from "./hindsight";
 import { HindsightClient } from "./hindsight";
 import { sessionCacheFile, writeSessionCache } from "./session-cache";
+import { mergeTags, resolveRetainAttribution } from "./retain-attribution";
 
 /** Minimal client shape `buildSessionStartContext` needs. */
 interface SeedContextClient {
@@ -49,7 +50,7 @@ interface SeedContextClient {
     documentId: string,
     tags: string[],
     strategy: string,
-    opts?: { async?: boolean }
+    opts?: { async?: boolean; metadata?: Record<string, string> }
   ): Promise<void>;
 }
 
@@ -156,6 +157,7 @@ export async function buildSessionStartContext(args: {
   const startSurvey = args.startSurvey ?? startCodebaseSurvey;
   const resolveHeadSha = args.headSha ?? gitHeadSha;
   const countCommitsSince = args.commitsSince ?? commitsSince;
+  const attribution = resolveRetainAttribution(cfg, cwd, harness, bankId);
 
   // Codebase-survey baseline (Option A): the bank is the only state, so the HEAD at the last survey
   // is recorded IN the bank as a tiny `survey-baseline:<sha>` marker doc (tag source:survey-baseline;
@@ -173,9 +175,9 @@ export async function buildSessionStartContext(args: {
             `(Internal marker: no memories are extracted from this document.)`,
           "hindsight codebase-survey baseline",
           `${SURVEY_BASELINE_PREFIX}${sha}`,
-          [SURVEY_BASELINE_TAG],
+          mergeTags([SURVEY_BASELINE_TAG], attribution.tags),
           "survey",
-          { async: true }
+          { async: true, metadata: attribution.metadata }
         )
       ).catch(() => {});
     } catch {
@@ -208,7 +210,7 @@ export async function buildSessionStartContext(args: {
           // idempotent (per-bank lock, dedup by document id) and each run does only the missing
           // work: cold seed, newly appeared conversations, the next per-commit diff batch. The
           // one-time extras stay cold-gated below.
-          startSeed(cwd, { limit: cfg.seedLimit });
+          startSeed(cwd, { limit: cfg.seedLimit, harness });
           // Cold iff the bank has zero source:git docs (an undefined result — server error — is
           // NOT treated as cold; we never surveyed/noted on an unconfirmed-empty bank).
           if (docIds.size === 0) {

--- a/hindsight-integrations/coding-agents/src/core/survey.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/survey.test.ts
@@ -105,6 +105,7 @@ describe("startCodebaseSurvey", () => {
     expect(argv).toContain(`mcp_servers.hindsight.command="node"`);
     expect(argv).toContain(`mcp_servers.hindsight.args=["/x/mcp-server.js"]`);
     expect(argv).toContain(`mcp_servers.hindsight.env.HINDSIGHT_MCP_PROJECT_CWD="/repo"`);
+    expect(argv).toContain(`mcp_servers.hindsight.env.HINDSIGHT_MCP_HARNESS="codex"`);
     // No Claude-only flags leak into the codex recipe.
     expect(argv).not.toContain("--model");
     expect(argv).not.toContain("--disallowedTools");

--- a/hindsight-integrations/coding-agents/src/core/survey.ts
+++ b/hindsight-integrations/coding-agents/src/core/survey.ts
@@ -216,6 +216,8 @@ function buildSurveyPlan(
           `mcp_servers.hindsight.args=["${opts.mcpServerPath}"]`,
           "-c",
           `mcp_servers.hindsight.env.HINDSIGHT_MCP_PROJECT_CWD="${repoDir}"`,
+          "-c",
+          `mcp_servers.hindsight.env.HINDSIGHT_MCP_HARNESS="codex"`,
           SURVEY_PROMPT,
         ],
         env,

--- a/hindsight-integrations/coding-agents/src/deepen.ts
+++ b/hindsight-integrations/coding-agents/src/deepen.ts
@@ -34,6 +34,11 @@ import { pool } from "./core/util";
 import { getHarness, HARNESS_NAMES } from "./harness/registry";
 import { diag } from "./core/diag";
 import { log as plog, setLogLevel } from "./core/log";
+import {
+  mergeTags,
+  resolveRetainAttribution,
+  type RetainAttribution,
+} from "./core/retain-attribution";
 
 const DIFF_BATCH = 50; // per-run cap on per-commit diff ingestion (bounded session cost)
 const CONCURRENCY = 4;
@@ -59,6 +64,12 @@ if (cfg.disabled) {
 const HARNESS = arg("harness") ?? cfg0.harness;
 const API_URL = arg("api-url") ?? cfg.apiUrl;
 const API_TOKEN = arg("api-token") ?? cfg.apiToken;
+const ATTRIBUTION: RetainAttribution = resolveRetainAttribution(
+  cfg,
+  REPO ?? process.cwd(),
+  HARNESS,
+  FINAL_BANK ?? BANK ?? "coding"
+);
 const CONV = arg("conversations");
 const GITLOG_LIMIT = arg("gitlog-limit") ? Number(arg("gitlog-limit")) : (cfg.seedLimit ?? 300);
 // harness override (benchmark/e2e want deterministic depth regardless of user config)
@@ -151,7 +162,11 @@ async function main() {
     const sessions = all.filter((s, i) => !chatIds.has(`chat:${s.id || `s${i}`}`));
     if (all.length !== sessions.length)
       log(`[chat] ${all.length - sessions.length} conversations already ingested — skipping those`);
-    const chatFails = await ingestChats(client, sessions, { concurrency: CONCURRENCY, log });
+    const chatFails = await ingestChats(client, sessions, {
+      concurrency: CONCURRENCY,
+      log,
+      attribution: ATTRIBUTION,
+    });
 
     // ── git: seeding and syncing are the SAME code — this idempotent pass runs every session,
     // so "keep the bank current" is just "run it again". cfg.gitIngest picks the depth:
@@ -171,7 +186,11 @@ async function main() {
       if (gitlogCurrent) {
         log("[gitlog] current with HEAD — skipping");
       } else {
-        gitFails += await ingestGitLog(client, REPO!, { limit: GITLOG_LIMIT, log });
+        gitFails += await ingestGitLog(client, REPO!, {
+          limit: GITLOG_LIMIT,
+          log,
+          attribution: ATTRIBUTION,
+        });
       }
       // Self-cleanup: earlier versions named the gitlog doc per WORKTREE (gitlog:my-repo-wt2 …),
       // duplicating the history in the shared bank. Delete any gitlog doc that isn't the
@@ -208,7 +227,7 @@ async function main() {
             await pool(
               shas,
               CONCURRENCY,
-              (sha) => retainCommit(client, REPO!, sha, repoName),
+              (sha) => retainCommit(client, REPO!, sha, repoName, ATTRIBUTION),
               () => {
                 gitFails++;
               }
@@ -245,9 +264,9 @@ async function main() {
               `(Internal marker: no memories are extracted from this document.)`,
             "hindsight codebase-survey baseline",
             best.id,
-            ["source:survey-baseline", "survey-state:done"],
+            mergeTags(["source:survey-baseline", "survey-state:done"], ATTRIBUTION.tags),
             "survey",
-            { async: true }
+            { async: true, metadata: ATTRIBUTION.metadata }
           );
           log(`[survey] marker ${best.id} flipped to completed`);
         }

--- a/hindsight-integrations/coding-agents/src/harness/plugin-entry.ts
+++ b/hindsight-integrations/coding-agents/src/harness/plugin-entry.ts
@@ -40,7 +40,7 @@ export function createPluginEntry(harness: string): Plugin {
       apiToken: cfg.apiToken,
       bank: bankId,
     });
-    const core = new RuntimeCore(client, bankId, cfg, harness);
+    const core = new RuntimeCore(client, bankId, cfg, harness, projectDir || process.cwd());
     // Visible presence via the host's own notice API (POST /tui/show-toast) — never stderr, which
     // these TUIs render at the cursor, wedging text against the input bar.
     const oc = (input as { client?: { tui?: { showToast?: (o: unknown) => Promise<unknown> } } })

--- a/hindsight-integrations/coding-agents/src/mcp-server.ts
+++ b/hindsight-integrations/coding-agents/src/mcp-server.ts
@@ -15,6 +15,7 @@ import { applyBankConfig, loadConfig, type Config } from "./core/config";
 import { deriveBankId } from "./core/bank";
 import { HindsightClient } from "./core/hindsight";
 import { buildKnowledgeTools, type ToolSpec } from "./core/knowledge-tools";
+import { resolveRetainAttribution } from "./core/retain-attribution";
 
 /**
  * Which tools this server should expose for a given config. Pure + SDK-free so the
@@ -22,8 +23,21 @@ import { buildKnowledgeTools, type ToolSpec } from "./core/knowledge-tools";
  * Hindsight (mirrors the hooks' `cfg.disabled` check) exposes NO tools — the server still
  * connects, it just has nothing registered.
  */
-export function selectTools(cfg: Config, client: HindsightClient, bankId: string): ToolSpec[] {
-  return cfg.disabled ? [] : buildKnowledgeTools(client, bankId, { repoDir: process.cwd() });
+export function selectTools(
+  cfg: Config,
+  client: HindsightClient,
+  bankId: string,
+  opts: { cwd?: string; harness?: string } = {}
+): ToolSpec[] {
+  const cwd = opts.cwd ?? process.cwd();
+  const harness = opts.harness ?? cfg.harness;
+  return cfg.disabled
+    ? []
+    : buildKnowledgeTools(client, bankId, {
+        repoDir: cwd,
+        harness,
+        attribution: resolveRetainAttribution(cfg, cwd, harness, bankId),
+      });
 }
 
 async function main() {
@@ -36,7 +50,7 @@ async function main() {
   const client = new HindsightClient({ apiUrl: cfg.apiUrl, apiToken: cfg.apiToken, bank: bankId });
 
   const server = new McpServer({ name: "hindsight", version: "0.1.0" });
-  for (const t of selectTools(cfg, client, bankId)) {
+  for (const t of selectTools(cfg, client, bankId, { cwd, harness })) {
     server.tool(t.name, t.description, t.inputSchema, t.handler);
   }
 


### PR DESCRIPTION
Add optional templated tags and metadata to documents written by the coding-agents integration.

```jsonc
{
  "retainTags": [
    "project:{gitProject}",
    "harness:{harness}"
  ],
  "retainMetadata": {
    "project": "{gitProject}",
    "workspace": "{cwd}"
  }
}
```

Configured attribution is applied consistently to:

- Live coding-agent session transcripts
- Imported conversations
- Git commit-message history
- Full Git commit and diff ingestion
- Codebase survey findings and lifecycle markers
- Initiative markers
- Documents saved through `hindsight_ingest_document`

## Motivation

The integration currently adds fixed source tags such as `source:chat` and `source:git`, but it does not provide a way to attach deployment-specific document provenance consistently across every ingestion path.

This makes it difficult to distinguish documents by:

- Repository or project
- Working directory
- Coding-agent harness
- Resolved memory bank
- Custom ingestion category

Reliable attribution supports filtering, diagnosis, shared-bank layouts, monorepos, related repositories, and future document-management tooling.

Recording provenance when the document is created is more reliable than attempting to reconstruct its origin later from document contents or surviving local conversation archives.

## Configuration

The following placeholders are supported by `retainTags` and `retainMetadata`:

- `{gitProject}`: worktree-aware Git project name
- `{project}`: working-directory basename
- `{harness}`: coding-agent harness
- `{cwd}`: absolute working directory
- `{bankId}`: resolved Hindsight bank ID

Configured tags are merged with the integration's built-in source tags rather than replacing them. Duplicate tags are removed.

Built-in metadata takes precedence over configured metadata, preventing fields such as source, session identity, or Git commit identity from being overridden.

Templates containing unknown placeholders are rejected rather than persisted with ambiguous values. Empty namespace tags such as `project:` are omitted.

`{cwd}` is opt-in because it records an absolute local path. It should only be enabled when disclosing that path to the configured Hindsight server is appropriate.

## Compatibility

This change is additive and disabled by default:

- `retainTags` defaults to `[]`
- `retainMetadata` defaults to `{}`
- Existing bank routing is unchanged
- Existing retention behavior is unchanged
- Existing built-in tags and metadata remain present
- Existing documents are not modified or reprocessed

## Implementation

Attribution is resolved for the active repository, harness, and bank, then passed through the existing ingestion paths.

The behavior is wired consistently across:

- Hook-based harnesses
- Stop and SessionStart processing
- Native plugin runtimes
- MCP document ingestion
- Cline
- Deepen processing
- Conversation imports
- Git ingestion
- Codebase surveys
- Initiative capture

## Verification

- Attribution, configuration, and retain-hook tests pass: 26/26
- Coding-agents package build passes
- TypeScript declaration generation passes
- Prettier checks pass
- `git diff --check` passes