### PR TITLE
fix(coding-agents): fall back from filesystem-root worktrees

### DIFF
--- a/hindsight-integrations/coding-agents/src/harness/plugin-entry.test.ts
+++ b/hindsight-integrations/coding-agents/src/harness/plugin-entry.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { resolveProjectDirectory } from "./plugin-entry";
+
+describe("resolveProjectDirectory", () => {
+  it("prefers a meaningful worktree", () => {
+    expect(
+      resolveProjectDirectory({
+        worktree: "/Users/me/project",
+        directory: "/Users/me/workspace",
+      })
+    ).toBe("/Users/me/project");
+  });
+
+  it("falls back from the POSIX root to the workspace directory", () => {
+    expect(resolveProjectDirectory({ worktree: "/", directory: "/Users/me/workspace" })).toBe(
+      "/Users/me/workspace"
+    );
+  });
+
+  it.each(["C:\\", "C:/"])(
+    "falls back from the Windows root %s to the workspace directory",
+    (worktree) => {
+      expect(resolveProjectDirectory({ worktree, directory: "C:\\Users\\me\\workspace" })).toBe(
+        "C:\\Users\\me\\workspace"
+      );
+    }
+  );
+
+  it("falls back when worktree is empty", () => {
+    expect(resolveProjectDirectory({ worktree: "", directory: "/Users/me/workspace" })).toBe(
+      "/Users/me/workspace"
+    );
+  });
+});

--- a/hindsight-integrations/coding-agents/src/harness/plugin-entry.ts
+++ b/hindsight-integrations/coding-agents/src/harness/plugin-entry.ts
@@ -10,6 +10,7 @@
  * the `harnesses.<name>` config section and feeds `{harness}` bank templating.
  */
 import type { Plugin } from "@opencode-ai/plugin";
+import { posix, win32 } from "node:path";
 import { deriveBankId } from "../core/bank";
 import { applyBankConfig, loadConfig } from "../core/config";
 import { log } from "../core/log";
@@ -21,13 +22,25 @@ import { opencodeAdapter } from "./opencode";
 /** Hold toasts until this long after init — see the notifier comment below. */
 const TOAST_MOUNT_GRACE_MS = 3000;
 
+function isFilesystemRoot(path: string): boolean {
+  return posix.parse(path).root === path || win32.parse(path).root === path;
+}
+
+export function resolveProjectDirectory(input?: {
+  worktree?: string;
+  directory?: string;
+}): string | undefined {
+  const worktree = input?.worktree;
+  return worktree && !isFilesystemRoot(worktree) ? worktree : input?.directory;
+}
+
 /**
  * Build the default export for a persistent-plugin host. `harness` is the name the host is known
  * by ("opencode", "kilo"), used for config lookup, bank derivation and log scoping.
  */
 export function createPluginEntry(harness: string): Plugin {
   return async (input) => {
-    const projectDir = input?.worktree || input?.directory;
+    const projectDir = resolveProjectDirectory(input);
     let cfg = loadConfig({ harness });
     if (cfg.disabled) return {}; // inert: same agent, no memory (baseline parity)
 


### PR DESCRIPTION
## Problem

OpenCode can report the filesystem root as `input.worktree` while `input.directory` contains the actual workspace. Treating that root as the project directory bypasses `mapPathToBank`, produces an empty `gitProject`, and sends git operations to the filesystem root.

Closes #3278.

## Fix

Treat POSIX and Windows filesystem roots as unusable worktree values and fall back to `input.directory`. Non-root worktrees keep their existing priority. Added focused coverage for meaningful worktrees, POSIX root, both Windows root forms, and an empty worktree.

## Test

- `npm test` in `hindsight-integrations/coding-agents` (350 tests)
- `npm run build` in `hindsight-integrations/coding-agents`
- Prettier check for the changed files
- `git diff --check`

## Risk

Low. The selection changes only when the host reports a filesystem root or an empty worktree; normal repositories and linked worktrees retain the current behavior.