### PR TITLE
fix(reflect): provide the current date for temporal reasoning

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
@@ -8,6 +8,7 @@ The reflect agent uses hierarchical retrieval:
 """
 
 import json
+from datetime import datetime, timezone
 from typing import Any
 
 from .tokenization import count_cl100k_tokens
@@ -18,6 +19,15 @@ _FINAL_PROMPT_CONTEXT_FRACTION = 0.8
 
 _DEFAULT_ROLE = "You are a reflection agent that answers questions by reasoning over retrieved memories."
 _DEFAULT_FINAL_ROLE = "You are a thoughtful assistant that synthesizes answers from retrieved memories."
+
+
+def _current_utc_date() -> str:
+    """Return today's UTC date for time-relative reflect reasoning."""
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _current_date_section() -> str:
+    return f"## Current Date\nThe current date is {_current_utc_date()} (UTC)."
 
 
 def _extract_directive_rules(directives: list[dict[str, Any]]) -> list[str]:
@@ -150,6 +160,8 @@ def build_system_prompt_for_tools(
 
     parts.extend(
         [
+            _current_date_section(),
+            "",
             "## LANGUAGE RULE (default - directives take precedence)",
             "- By default, detect the language of the user's question and respond in that SAME language.",
             "- If the question is in Chinese, respond in Chinese. If in Japanese, respond in Japanese.",
@@ -567,6 +579,7 @@ def build_final_system_prompt(
     role_section = escape_for_prompt(mission.strip()) if mission else _DEFAULT_FINAL_ROLE
 
     parts = [build_directives_section(directives) if directives else ""]
+    parts.append(_current_date_section())
     parts.append(_FINAL_SYSTEM_PROMPT_BASE.format(role_section=role_section))
     parts.append(_FINAL_LANGUAGE_RULE)
     parts.append(build_directives_reminder(directives) if directives else "")

--- a/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
@@ -21,13 +21,18 @@ _DEFAULT_ROLE = "You are a reflection agent that answers questions by reasoning 
 _DEFAULT_FINAL_ROLE = "You are a thoughtful assistant that synthesizes answers from retrieved memories."
 
 
-def _current_utc_date() -> str:
-    """Return today's UTC date for time-relative reflect reasoning."""
-    return datetime.now(timezone.utc).date().isoformat()
+def _current_utc_datetime() -> str:
+    """Return the current UTC date and time for time-relative reflect reasoning.
+
+    Minute precision (not seconds) so requests within the same minute share an
+    identical prompt string — the finest granularity that still keeps prompt
+    caching viable for bursty traffic.
+    """
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
 
-def _current_date_section() -> str:
-    return f"## Current Date\nThe current date is {_current_utc_date()} (UTC)."
+def _current_datetime_section() -> str:
+    return f"## Current Date and Time\nThe current date and time is {_current_utc_datetime()}."
 
 
 def _extract_directive_rules(directives: list[dict[str, Any]]) -> list[str]:
@@ -160,8 +165,6 @@ def build_system_prompt_for_tools(
 
     parts.extend(
         [
-            _current_date_section(),
-            "",
             "## LANGUAGE RULE (default - directives take precedence)",
             "- By default, detect the language of the user's question and respond in that SAME language.",
             "- If the question is in Chinese, respond in Chinese. If in Japanese, respond in Japanese.",
@@ -404,6 +407,13 @@ def build_system_prompt_for_tools(
         ]
     )
 
+    # Volatile "now" reference goes here — after all the static instructions and
+    # right before the bank-specific/custom data. Everything above is identical
+    # across banks and requests, so it stays a cacheable prefix; only this
+    # timestamp and the custom tail below fall outside the cache.
+    parts.append("")
+    parts.append(_current_datetime_section())
+
     parts.append("")
     parts.append(f"## Memory Bank: {name}")
 
@@ -579,10 +589,12 @@ def build_final_system_prompt(
     role_section = escape_for_prompt(mission.strip()) if mission else _DEFAULT_FINAL_ROLE
 
     parts = [build_directives_section(directives) if directives else ""]
-    parts.append(_current_date_section())
     parts.append(_FINAL_SYSTEM_PROMPT_BASE.format(role_section=role_section))
     parts.append(_FINAL_LANGUAGE_RULE)
     parts.append(build_directives_reminder(directives) if directives else "")
+    # Volatile "now" reference last, so the static/per-bank instructions above
+    # remain a cacheable prefix and only this timestamp falls outside the cache.
+    parts.append(_current_datetime_section())
 
     return "\n\n".join(p.strip() for p in parts if p.strip()) + output_language_directive(llm_output_language)
 

--- a/hindsight-api-slim/tests/test_reflect_prompt_builder.py
+++ b/hindsight-api-slim/tests/test_reflect_prompt_builder.py
@@ -19,9 +19,18 @@ without hiding what each one produces — the ``_assemble`` helper is a
 mechanical join, not a re-implementation of the builder.
 """
 
+import pytest
+
+from hindsight_api.engine.reflect import prompts
 from hindsight_api.engine.reflect.prompts import build_final_system_prompt, build_system_prompt_for_tools
 
 BANK = {"name": "TestBank", "mission": ""}
+
+
+@pytest.fixture(autouse=True)
+def _freeze_current_date(monkeypatch):
+    monkeypatch.setattr(prompts, "_current_utc_date", lambda: "2026-08-09")
+
 
 _HEADER = (
     "CRITICAL: You MUST ONLY use information from retrieved tool results. "
@@ -29,6 +38,11 @@ _HEADER = (
 )
 
 _DEFAULT_ROLE = "You are a reflection agent that answers questions by reasoning over retrieved memories."
+
+_CURRENT_DATE = """\
+## Current Date
+The current date is 2026-08-09 (UTC).
+"""
 
 _LANGUAGE_AND_RULES = """\
 ## LANGUAGE RULE (default - directives take precedence)
@@ -297,6 +311,7 @@ def _assemble(
     parts.append("")
     parts.append("Answer the user's question by reasoning over retrieved memories.")
     parts.append("")
+    parts.append(_CURRENT_DATE)
     parts.append(_LANGUAGE_AND_RULES)
     parts.append(retrieval)
     parts.append(_QUERY_STRATEGY)
@@ -560,6 +575,7 @@ _FRENCH_DIRECTIVE = {
 
 def test_final_prompt_always_includes_language_rule():
     prompt = build_final_system_prompt()
+    assert "The current date is 2026-08-09 (UTC)." in prompt
     assert "## LANGUAGE" in prompt
     assert "SAME language as the user's question" in prompt
 

--- a/hindsight-api-slim/tests/test_reflect_prompt_builder.py
+++ b/hindsight-api-slim/tests/test_reflect_prompt_builder.py
@@ -28,8 +28,8 @@ BANK = {"name": "TestBank", "mission": ""}
 
 
 @pytest.fixture(autouse=True)
-def _freeze_current_date(monkeypatch):
-    monkeypatch.setattr(prompts, "_current_utc_date", lambda: "2026-08-09")
+def _freeze_current_datetime(monkeypatch):
+    monkeypatch.setattr(prompts, "_current_utc_datetime", lambda: "2026-08-09 14:32 UTC")
 
 
 _HEADER = (
@@ -39,10 +39,7 @@ _HEADER = (
 
 _DEFAULT_ROLE = "You are a reflection agent that answers questions by reasoning over retrieved memories."
 
-_CURRENT_DATE = """\
-## Current Date
-The current date is 2026-08-09 (UTC).
-"""
+_CURRENT_DATETIME = "## Current Date and Time\nThe current date and time is 2026-08-09 14:32 UTC."
 
 _LANGUAGE_AND_RULES = """\
 ## LANGUAGE RULE (default - directives take precedence)
@@ -311,7 +308,6 @@ def _assemble(
     parts.append("")
     parts.append("Answer the user's question by reasoning over retrieved memories.")
     parts.append("")
-    parts.append(_CURRENT_DATE)
     parts.append(_LANGUAGE_AND_RULES)
     parts.append(retrieval)
     parts.append(_QUERY_STRATEGY)
@@ -320,6 +316,8 @@ def _assemble(
     parts.append(workflow)
     parts.append("")
     parts.append(_OUTPUT_FORMAT)
+    parts.append("")
+    parts.append(_CURRENT_DATETIME)
     parts.append("")
     parts.append(_BANK_HEADER + trailer)
     return "\n".join(parts)
@@ -575,7 +573,7 @@ _FRENCH_DIRECTIVE = {
 
 def test_final_prompt_always_includes_language_rule():
     prompt = build_final_system_prompt()
-    assert "The current date is 2026-08-09 (UTC)." in prompt
+    assert "The current date and time is 2026-08-09 14:32 UTC." in prompt
     assert "## LANGUAGE" in prompt
     assert "SAME language as the user's question" in prompt
 


### PR DESCRIPTION
## Summary

- add the current UTC date to the reflect agent's retrieval prompt
- repeat the date in the separate final-synthesis prompt
- freeze the date in exact-output prompt tests so the assertions stay deterministic

## Why

Reflect can compare fact timestamps with each other, but it currently has no reference point for time-relative questions. As a result, recently elapsed plans can remain classified as upcoming even when their `occurred_start` is correct.

Using an explicit UTC date keeps the implicit fix narrow and avoids implying a bank-local timezone that the server does not know.

Closes #3279.

## Tests

- `uv run pytest -q tests/test_reflect_prompt_builder.py` (22 passed)
- `uv run ruff check hindsight_api/engine/reflect/prompts.py tests/test_reflect_prompt_builder.py`
- `uv run ruff format --check hindsight_api/engine/reflect/prompts.py tests/test_reflect_prompt_builder.py`
- repository pre-commit hooks, including lint (passed)

I also ran `tests/test_reflect_agent.py` alongside the prompt tests: 61 passed, while four environment-backed cases could not initialize because this checkout has no LLM key and its configured SOCKS proxy lacks `socksio`. The focused prompt suite and all static gates passed.
