### PR TITLE
fix(coding-agents): approve Codex survey ingestion

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/survey.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/survey.test.ts
@@ -105,6 +105,9 @@ describe("startCodebaseSurvey", () => {
     expect(argv).toContain(`mcp_servers.hindsight.command="node"`);
     expect(argv).toContain(`mcp_servers.hindsight.args=["/x/mcp-server.js"]`);
     expect(argv).toContain(`mcp_servers.hindsight.env.HINDSIGHT_MCP_PROJECT_CWD="/repo"`);
+    expect(argv).toContain(
+      `mcp_servers.hindsight.tools.hindsight_ingest_document.approval_mode="approve"`
+    );
     // No Claude-only flags leak into the codex recipe.
     expect(argv).not.toContain("--model");
     expect(argv).not.toContain("--disallowedTools");

--- a/hindsight-integrations/coding-agents/src/core/survey.ts
+++ b/hindsight-integrations/coding-agents/src/core/survey.ts
@@ -204,6 +204,8 @@ function buildSurveyPlan(
       // self-contained (doesn't require the user's config.toml to already have hindsight). Model is
       // left to Codex's configured default — Codex model ids differ from Claude's, and the read-only
       // sandbox + the bounded prompt are the cost/safety controls (Codex has no per-run budget flag).
+      // `codex exec` cannot answer approval prompts, so preapprove only the ingestion tool that this
+      // background survey needs; the read-only sandbox still prevents repository writes.
       return {
         bin,
         args: [
@@ -216,6 +218,8 @@ function buildSurveyPlan(
           `mcp_servers.hindsight.args=["${opts.mcpServerPath}"]`,
           "-c",
           `mcp_servers.hindsight.env.HINDSIGHT_MCP_PROJECT_CWD="${repoDir}"`,
+          "-c",
+          `mcp_servers.hindsight.tools.hindsight_ingest_document.approval_mode="approve"`,
           SURVEY_PROMPT,
         ],
         env,


### PR DESCRIPTION
## Summary

- preapprove only hindsight_ingest_document for detached Codex codebase surveys
- keep the existing read-only filesystem sandbox and user-wide approval policy unchanged
- add a regression assertion for the generated Codex command

## Root cause

The survey runs through non-interactive codex exec. Without a per-tool approval override, the MCP write asks for approval that the background process cannot answer, so Codex reports user cancelled MCP tool call and the survey findings are never ingested.

This is the integration-side workaround for the Codex behavior tracked in openai/codex#16685.

## Validation

- npx tsc --noEmit
- npm test (345 tests)
- npm run build
- ./scripts/hooks/lint.sh