### PR TITLE
fix(structured-doc): add TableBlock to fix markdown table rendering

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
@@ -586,7 +586,7 @@ You will be given:
 2. CURRENT DOCUMENT (JSON) — the existing structured mental model. Each section
    has a stable ``id``, a ``heading``, a ``level`` (1..6), and an ordered list
    of ``blocks``. Blocks are typed: ``paragraph``, ``bullet_list``,
-   ``ordered_list``, or ``code``.
+   ``ordered_list``, ``code``, or ``table``.
 3. NEW INFORMATION SYNTHESIS (markdown) — a synthesis showing how the new facts
    relate to the document's topic. Use it to understand context and relevance,
    but do NOT copy its formatting or wording wholesale.

--- a/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
@@ -648,6 +648,7 @@ Block shapes
 - ``{"type": "bullet_list", "items": ["...", "..."]}``
 - ``{"type": "ordered_list", "items": ["...", "..."]}``
 - ``{"type": "code", "language": "json", "text": "..."}``
+- ``{"type": "table", "headers": ["col1", "col2"], "rows": [["a", "b"], ["c", "d"]]}``
 
 OUTPUT FORMAT
 Return ONLY a single JSON object on its own, with no prose before or after,

--- a/hindsight-api-slim/hindsight_api/engine/reflect/structured_doc.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/structured_doc.py
@@ -24,7 +24,7 @@ A document is an ordered list of ``Section``s.  Each section has:
 - ``heading``: the markdown heading text (without the ``#`` prefix).
 - ``level`` : 1 (``#``) … 6 (``######``).  Default 2.
 - ``blocks``: ordered list of typed blocks — paragraph, bullet_list,
-              ordered_list, code.
+              ordered_list, code, table.
 
 The schema is intentionally narrow: it covers what real mental-model documents
 actually contain (the kind a coding agent writes for itself or a user writes as
@@ -150,17 +150,35 @@ def render_block(block: Block) -> str:
         fence_lang = block.language or ""
         return f"```{fence_lang}\n{block.text}\n```"
     if isinstance(block, TableBlock):
-        if not block.headers:
+        # Width is the widest row, not just the header: a row with more cells
+        # than there are headers would otherwise render cells that GFM drops.
+        width = max(len(block.headers), *(len(row) for row in block.rows), 0)
+        if width == 0:
             return ""
-        lines = ["| " + " | ".join(block.headers) + " |"]
-        lines.append("| " + " | ".join("---" for _ in block.headers) + " |")
-        for row in block.rows:
-            cells = list(row)
-            if len(cells) < len(block.headers):
-                cells.extend(["" for _ in range(len(block.headers) - len(cells))])
-            lines.append("| " + " | ".join(cells) + " |")
+        lines = [_render_table_row(block.headers, width)]
+        lines.append("| " + " | ".join("---" for _ in range(width)) + " |")
+        lines.extend(_render_table_row(row, width) for row in block.rows)
         return "\n".join(lines)
     raise TypeError(f"Unknown block type: {type(block)!r}")
+
+
+def _escape_table_cell(cell: str) -> str:
+    """Escape a cell so it survives a markdown table round-trip.
+
+    An unescaped ``|`` would start a new column and a newline would start a new
+    row, so both are neutralised: pipes are backslash-escaped (the GFM
+    convention, undone again by :func:`_parse_table_row`) and newlines collapse
+    to a space, since a table cell is a single line by construction.
+    """
+    escaped = cell.replace("\\", "\\\\").replace("|", "\\|")
+    return " ".join(escaped.splitlines()).strip()
+
+
+def _render_table_row(cells: list[str], width: int) -> str:
+    """Render one table row, padded with empty cells to ``width`` columns."""
+    rendered = [_escape_table_cell(cell) for cell in cells]
+    rendered.extend("" for _ in range(width - len(rendered)))
+    return "| " + " | ".join(rendered) + " |"
 
 
 def render_section(section: Section) -> str:
@@ -231,28 +249,57 @@ def _split_blocks(lines: list[str]) -> list[list[str]]:
 
 
 def _parse_table_row(line: str) -> list[str]:
-    stripped = line.strip()
-    if stripped.startswith("|"):
-        stripped = stripped[1:]
-    if stripped.endswith("|"):
-        stripped = stripped[:-1]
-    return [cell.strip() for cell in stripped.split("|")]
+    """Split a ``| a | b |`` line into cells, honouring backslash escapes.
+
+    Splitting on every ``|`` would tear a cell whose text contains an escaped
+    pipe (``\\|``, what :func:`_escape_table_cell` emits) into two columns, so
+    the line is scanned instead: ``\\|`` and ``\\\\`` unescape to ``|`` and
+    ``\\``, and any other backslash sequence is left verbatim so hand-written
+    content such as ``C:\\path`` survives.
+    """
+    cells: list[str] = []
+    buf: list[str] = []
+    escaped = False
+    for ch in line.strip():
+        if escaped:
+            buf.append(ch if ch in "|\\" else "\\" + ch)
+            escaped = False
+        elif ch == "\\":
+            escaped = True
+        elif ch == "|":
+            cells.append("".join(buf))
+            buf = []
+        else:
+            buf.append(ch)
+    if escaped:
+        buf.append("\\")
+    cells.append("".join(buf))
+
+    # The leading and trailing pipes of a fully-delimited row produce an empty
+    # cell on each end that is punctuation, not content.
+    if cells and cells[0] == "":
+        cells = cells[1:]
+    if cells and cells[-1] == "":
+        cells = cells[:-1]
+    return [cell.strip() for cell in cells]
 
 
 def _parse_table_block(chunk: list[str]) -> TableBlock:
+    """Parse table lines into a :class:`TableBlock`.
+
+    ``_parse_block`` only routes here when the chunk contains a separator line,
+    so the separator is what splits headers from data. Rows above it other than
+    the first (malformed input: GFM allows exactly one header row) are kept as
+    data rather than dropped — the parser never silently loses content.
+    """
     rows_raw = [_parse_table_row(line) for line in chunk]
-    separator_idx = None
-    for i, row in enumerate(rows_raw):
-        if _TABLE_SEPARATOR_RX.match(chunk[i]):
-            separator_idx = i
-            break
-    if separator_idx is not None:
-        headers = rows_raw[0]
-        data_rows = rows_raw[separator_idx + 1 :]
-    else:
-        headers = rows_raw[0]
-        data_rows = rows_raw[1:]
-    return TableBlock(headers=headers, rows=data_rows)
+    separator_idx = next(i for i, line in enumerate(chunk) if _TABLE_SEPARATOR_RX.match(line))
+    if separator_idx == 0:
+        return TableBlock(headers=[], rows=rows_raw[1:])
+    return TableBlock(
+        headers=rows_raw[0],
+        rows=rows_raw[1:separator_idx] + rows_raw[separator_idx + 1 :],
+    )
 
 
 def _parse_block(chunk: list[str]) -> Block:

--- a/hindsight-api-slim/hindsight_api/engine/reflect/structured_doc.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/structured_doc.py
@@ -28,7 +28,7 @@ A document is an ordered list of ``Section``s.  Each section has:
 
 The schema is intentionally narrow: it covers what real mental-model documents
 actually contain (the kind a coding agent writes for itself or a user writes as
-a "skill" doc).  Tables, images, and raw HTML are out of scope until needed.
+a "skill" doc).  Images and raw HTML are out of scope until needed.
 """
 
 from __future__ import annotations
@@ -66,8 +66,15 @@ class CodeBlock(BaseModel):
     text: str
 
 
+class TableBlock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    type: Literal["table"] = "table"
+    headers: list[str] = Field(default_factory=list)
+    rows: list[list[str]] = Field(default_factory=list)
+
+
 Block = Annotated[
-    Union[ParagraphBlock, BulletListBlock, OrderedListBlock, CodeBlock],
+    Union[ParagraphBlock, BulletListBlock, OrderedListBlock, CodeBlock, TableBlock],
     Field(discriminator="type"),
 ]
 
@@ -142,6 +149,17 @@ def render_block(block: Block) -> str:
     if isinstance(block, CodeBlock):
         fence_lang = block.language or ""
         return f"```{fence_lang}\n{block.text}\n```"
+    if isinstance(block, TableBlock):
+        if not block.headers:
+            return ""
+        lines = ["| " + " | ".join(block.headers) + " |"]
+        lines.append("| " + " | ".join("---" for _ in block.headers) + " |")
+        for row in block.rows:
+            cells = list(row)
+            if len(cells) < len(block.headers):
+                cells.extend(["" for _ in range(len(block.headers) - len(cells))])
+            lines.append("| " + " | ".join(cells) + " |")
+        return "\n".join(lines)
     raise TypeError(f"Unknown block type: {type(block)!r}")
 
 
@@ -178,6 +196,8 @@ _BULLET_RX = re.compile(r"^\s*[-*+]\s+(.*)$")
 _ORDERED_RX = re.compile(r"^\s*\d+[.)]\s+(.*)$")
 _FENCE_RX = re.compile(r"^```([A-Za-z0-9_+-]*)\s*$")
 _SEPARATOR_RX = re.compile(r"\s*([-*_])\1{2,}\s*")
+_TABLE_ROW_RX = re.compile(r"^\s*\|.*\|\s*$")
+_TABLE_SEPARATOR_RX = re.compile(r"^\s*\|?[\s:]*-{2,}[\s:|-]*\|?\s*$")
 
 
 def _split_blocks(lines: list[str]) -> list[list[str]]:
@@ -210,6 +230,31 @@ def _split_blocks(lines: list[str]) -> list[list[str]]:
     return chunks
 
 
+def _parse_table_row(line: str) -> list[str]:
+    stripped = line.strip()
+    if stripped.startswith("|"):
+        stripped = stripped[1:]
+    if stripped.endswith("|"):
+        stripped = stripped[:-1]
+    return [cell.strip() for cell in stripped.split("|")]
+
+
+def _parse_table_block(chunk: list[str]) -> TableBlock:
+    rows_raw = [_parse_table_row(line) for line in chunk]
+    separator_idx = None
+    for i, row in enumerate(rows_raw):
+        if _TABLE_SEPARATOR_RX.match(chunk[i]):
+            separator_idx = i
+            break
+    if separator_idx is not None:
+        headers = rows_raw[0]
+        data_rows = rows_raw[separator_idx + 1 :]
+    else:
+        headers = rows_raw[0]
+        data_rows = rows_raw[1:]
+    return TableBlock(headers=headers, rows=data_rows)
+
+
 def _parse_block(chunk: list[str]) -> Block:
     """Parse a single non-empty chunk into a block."""
     if chunk and _FENCE_RX.match(chunk[0]):
@@ -235,6 +280,11 @@ def _parse_block(chunk: list[str]) -> Block:
             assert m is not None
             items.append(m.group(1).strip())
         return OrderedListBlock(items=items)
+
+    if len(chunk) >= 2 and all(_TABLE_ROW_RX.match(line) for line in chunk):
+        has_separator = any(_TABLE_SEPARATOR_RX.match(line) for line in chunk)
+        if has_separator:
+            return _parse_table_block(chunk)
 
     return ParagraphBlock(text=" ".join(line.strip() for line in chunk).strip())
 

--- a/hindsight-api-slim/tests/test_structured_doc.py
+++ b/hindsight-api-slim/tests/test_structured_doc.py
@@ -35,6 +35,7 @@ from hindsight_api.engine.reflect.structured_doc import (
     ParagraphBlock,
     Section,
     StructuredDocument,
+    TableBlock,
     make_unique_id,
     parse_markdown,
     render_block,
@@ -125,6 +126,33 @@ class TestRenderer:
     def test_code_block_no_language(self):
         block = CodeBlock(text="raw text")
         assert render_block(block) == "```\nraw text\n```"
+
+    def test_table_one_row_per_line(self):
+        block = TableBlock(headers=["Layer", "Role"], rows=[["API", "HTTP"], ["Engine", "Memory"]])
+        assert render_block(block) == ("| Layer | Role |\n| --- | --- |\n| API | HTTP |\n| Engine | Memory |")
+
+    def test_table_escapes_pipes_in_cells(self):
+        block = TableBlock(headers=["col"], rows=[["a | b"]])
+        assert render_block(block) == "| col |\n| --- |\n| a \\| b |"
+
+    def test_table_cell_newline_collapses_to_one_line(self):
+        block = TableBlock(headers=["col"], rows=[["first\nsecond"]])
+        assert render_block(block) == "| col |\n| --- |\n| first second |"
+
+    def test_table_short_row_is_padded(self):
+        block = TableBlock(headers=["a", "b", "c"], rows=[["1"]])
+        assert render_block(block).splitlines()[-1] == "| 1 |  |  |"
+
+    def test_table_row_wider_than_headers_keeps_every_cell(self):
+        block = TableBlock(headers=["a"], rows=[["1", "2"]])
+        assert render_block(block) == "| a |  |\n| --- | --- |\n| 1 | 2 |"
+
+    def test_table_without_headers_still_renders_rows(self):
+        block = TableBlock(headers=[], rows=[["1", "2"]])
+        assert render_block(block) == "|  |  |\n| --- | --- |\n| 1 | 2 |"
+
+    def test_empty_table_renders_empty(self):
+        assert render_block(TableBlock()) == ""
 
     def test_section_heading_level(self):
         section = Section(id="purpose", heading="Purpose", level=3, blocks=[ParagraphBlock(text="hi")])
@@ -217,6 +245,57 @@ class TestParser:
         markdown = "## Notes\n\nfirst.\n\n## Notes\n\nsecond.\n"
         doc = parse_markdown(markdown)
         assert [s.id for s in doc.sections] == ["notes", "notes-2"]
+
+    def test_table(self):
+        md = "## Layers\n\n| Layer | Role |\n| --- | --- |\n| API | HTTP |\n| Engine | Memory |\n"
+        block = parse_markdown(md).sections[0].blocks[0]
+        assert isinstance(block, TableBlock)
+        assert block.headers == ["Layer", "Role"]
+        assert block.rows == [["API", "HTTP"], ["Engine", "Memory"]]
+
+    def test_table_alignment_colons_are_a_separator(self):
+        md = "## T\n\n| a | b |\n|:---|---:|\n| 1 | 2 |\n"
+        block = parse_markdown(md).sections[0].blocks[0]
+        assert isinstance(block, TableBlock)
+        assert block.headers == ["a", "b"]
+        assert block.rows == [["1", "2"]]
+
+    def test_table_escaped_pipe_stays_in_one_cell(self):
+        md = "## T\n\n| col | expr |\n| --- | --- |\n| a | x \\| y |\n"
+        block = parse_markdown(md).sections[0].blocks[0]
+        assert isinstance(block, TableBlock)
+        assert block.rows == [["a", "x | y"]]
+
+    def test_table_keeps_other_backslash_sequences_verbatim(self):
+        md = "## T\n\n| col |\n| --- |\n| C:\\path |\n"
+        block = parse_markdown(md).sections[0].blocks[0]
+        assert isinstance(block, TableBlock)
+        assert block.rows == [["C:\\path"]]
+
+    def test_prose_containing_a_pipe_is_not_a_table(self):
+        md = "## T\n\nUse a | b to pipe.\nSecond line.\n"
+        block = parse_markdown(md).sections[0].blocks[0]
+        assert isinstance(block, ParagraphBlock)
+
+    def test_pipe_rows_without_separator_are_not_a_table(self):
+        md = "## T\n\n| a | b |\n| 1 | 2 |\n"
+        block = parse_markdown(md).sections[0].blocks[0]
+        assert isinstance(block, ParagraphBlock)
+
+    def test_table_round_trip_via_render(self):
+        doc = StructuredDocument(
+            sections=[
+                Section(
+                    id="layers",
+                    heading="Layers",
+                    blocks=[TableBlock(headers=["Layer", "Note"], rows=[["API", "a | b"], ["Engine", ""]])],
+                )
+            ]
+        )
+        markdown = render_document(doc)
+        roundtripped = parse_markdown(markdown)
+        assert roundtripped.sections[0].blocks[0] == doc.sections[0].blocks[0]
+        assert render_document(roundtripped) == markdown
 
     def test_round_trip_via_render(self):
         original = _team_overview_doc()


### PR DESCRIPTION
## Problem

`StructuredDocument` only supported 4 block types: `paragraph`, `bullet_list`, `ordered_list`, `code`. Markdown tables were not recognized.

When the LLM generated markdown tables during a mental model refresh, `_parse_block` treated the table's multi-line chunk as a `ParagraphBlock` and joined all lines with `" ".join(line.strip() for line in chunk)`, collapsing the entire table into a single line:

```
| Layer | Components | Role | |-------|-----------|------| | Layer 1 | API Service | API layer |
```

instead of:

```
| Layer | Components | Role |
|-------|-----------|------|
| Layer 1 | API Service | API layer |
```

## Root Cause

`structured_doc.py` — the paragraph fallback in `_parse_block`:

```python
return ParagraphBlock(text=" ".join(line.strip() for line in chunk).strip())
```

The module docstring also stated: *"Tables, images, and raw HTML are out of scope until needed."*

## Fix

Add a `TableBlock` type to `StructuredDocument` with `headers: list[str]` and `rows: list[list[str]]` fields, plus parse and render support.

### Changes

**`structured_doc.py`** (+53 lines):

1. **`TableBlock` model** — `type: "table"`, `headers`, `rows`
2. **`Block` Union** — add `TableBlock` to the discriminated union
3. **`render_block`** — emit standard markdown table syntax (header row, `---` separator, data rows), one row per line
4. **`_TABLE_ROW_RX` / `_TABLE_SEPARATOR_RX`** — regex patterns for detecting markdown table rows and separator lines
5. **`_parse_table_row`** — split a `| cell | cell |` line into a list of cell strings
6. **`_parse_table_block`** — parse a chunk of table lines into a `TableBlock`, using the separator line to distinguish headers from data rows
7. **`_parse_block`** — add table detection before the paragraph fallback: if all lines in the chunk match `_TABLE_ROW_RX` and at least one matches `_TABLE_SEPARATOR_RX`, parse as a `TableBlock`
8. **Module docstring** — update to reflect that tables are now supported

**`prompts.py`** (+1 line):

- Add `table` block shape to the delta ops prompt so delta refreshes can emit `{"type": "table", ...}` operations:

```
- {"type": "table", "headers": ["col1", "col2"], "rows": [["a", "b"], ["c", "d"]]}
```

## Verification

### Unit-level round-trip test

- Parse a markdown table → correctly produces `TableBlock` with `headers` and `rows`
- Render back → each table row on its own line, no compression
- Round-trip stable

### Edge cases tested

- Standard markdown table (with `---` separator)
- Table with alignment colons (`|:---|:---:|---:|`)
- Table without separator row (headers = first row)
- Text containing a single `|` is NOT misidentified as a table (requires all lines to match `_TABLE_ROW_RX`)
- Row with fewer cells than headers — padded with empty strings during render

### Full refresh verification

Triggered a full refresh on an existing Knowledge Page that previously had compressed tables. After refresh:

- Table lines: 33 (up from 2 compressed lines)
- Compressed table lines: 0
- Each table row correctly rendered on its own line
