### PR TITLE
fix(coding-agents): stream oversized Codex rollouts

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/transcript-codex-large.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript-codex-large.test.ts
@@ -1,0 +1,48 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync: vi.fn(() => {
+      const error = new Error("Cannot create a string longer than 0x1fffffe8 characters");
+      Object.assign(error, { code: "ERR_STRING_TOO_LONG" });
+      throw error;
+    }),
+  };
+});
+
+import { readCodexTranscript } from "./transcript-codex";
+
+let root: string;
+let file: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "hs-codex-large-transcript-"));
+  file = join(root, "rollout.jsonl");
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("readCodexTranscript oversized rollout handling", () => {
+  it("parses JSONL without reading the complete file into one string", () => {
+    writeFileSync(
+      file,
+      JSON.stringify({
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "keep streaming" }],
+        },
+      })
+    );
+
+    expect(readCodexTranscript(file)).toEqual([{ role: "user", content: "keep streaming" }]);
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/transcript-codex.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript-codex.ts
@@ -20,7 +20,8 @@
  * prevents a retain→recall feedback loop (plus stripInjectedMemory as a defensive second pass on the
  * text we do keep). Fail-open: never throws on a missing file or a malformed line.
  */
-import { readFileSync } from "node:fs";
+import { closeSync, openSync, readSync } from "node:fs";
+import { StringDecoder } from "node:string_decoder";
 import type { TransportTurn } from "./chat";
 import { actionLine, stripInjectedMemory } from "./transcript-util";
 
@@ -39,6 +40,35 @@ interface Payload {
 interface RolloutLine {
   type?: string;
   payload?: Payload;
+}
+
+const READ_BUFFER_BYTES = 64 * 1024;
+
+/** Yield UTF-8 JSONL records without materializing the complete rollout as one JS string. */
+function* readLines(path: string): Generator<string> {
+  const fd = openSync(path, "r");
+  const buffer = Buffer.allocUnsafe(READ_BUFFER_BYTES);
+  const decoder = new StringDecoder("utf8");
+  let pending = "";
+
+  try {
+    for (;;) {
+      const bytesRead = readSync(fd, buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      pending += decoder.write(buffer.subarray(0, bytesRead));
+
+      let newline: number;
+      while ((newline = pending.indexOf("\n")) !== -1) {
+        yield pending.slice(0, newline);
+        pending = pending.slice(newline + 1);
+      }
+    }
+
+    pending += decoder.end();
+    if (pending) yield pending;
+  } finally {
+    closeSync(fd);
+  }
 }
 
 /** Codex records its startup instructions (AGENTS.md + environment_context) as a normal user
@@ -60,47 +90,44 @@ function messageText(payload: Payload): string {
  *  Drops developer/system + synthetic-startup + reasoning + injected memory + empty turns.
  *  Never throws on bad lines. */
 export function readCodexTranscript(path: string): TransportTurn[] {
-  let raw: string;
+  const turns: TransportTurn[] = [];
   try {
-    raw = readFileSync(path, "utf8");
+    for (const rawLine of readLines(path)) {
+      const trimmed = rawLine.trim();
+      if (!trimmed) continue;
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      if (typeof parsed !== "object" || parsed === null) continue;
+      const line = parsed as RolloutLine;
+      if (line.type !== "response_item") continue;
+      const p = line.payload;
+      if (!p || typeof p !== "object") continue;
+
+      if (p.type === "message") {
+        // `developer` messages are Codex's system prompt + OUR injected hook context → drop entirely.
+        if (p.role !== "user" && p.role !== "assistant") continue;
+        const text = stripInjectedMemory(messageText(p)).trim();
+        if (!text) continue;
+        if (p.role === "user" && isSyntheticUserText(text)) continue;
+        turns.push({ role: p.role, content: text });
+      } else if (p.type === "function_call" && typeof p.name === "string") {
+        let input: unknown;
+        try {
+          input = JSON.parse(p.arguments || "");
+        } catch {
+          input = undefined;
+        }
+        turns.push({ role: "action", content: actionLine(p.name, input) });
+      }
+      // reasoning / other payloads: dropped.
+    }
   } catch {
     return [];
-  }
-
-  const turns: TransportTurn[] = [];
-  for (const rawLine of raw.split("\n")) {
-    const trimmed = rawLine.trim();
-    if (!trimmed) continue;
-
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(trimmed);
-    } catch {
-      continue;
-    }
-    if (typeof parsed !== "object" || parsed === null) continue;
-    const line = parsed as RolloutLine;
-    if (line.type !== "response_item") continue;
-    const p = line.payload;
-    if (!p || typeof p !== "object") continue;
-
-    if (p.type === "message") {
-      // `developer` messages are Codex's system prompt + OUR injected hook context → drop entirely.
-      if (p.role !== "user" && p.role !== "assistant") continue;
-      const text = stripInjectedMemory(messageText(p)).trim();
-      if (!text) continue;
-      if (p.role === "user" && isSyntheticUserText(text)) continue;
-      turns.push({ role: p.role, content: text });
-    } else if (p.type === "function_call" && typeof p.name === "string") {
-      let input: unknown;
-      try {
-        input = JSON.parse(p.arguments || "");
-      } catch {
-        input = undefined;
-      }
-      turns.push({ role: "action", content: actionLine(p.name, input) });
-    }
-    // reasoning / other payloads: dropped.
   }
 
   return turns;


### PR DESCRIPTION
## Summary

- Stream Codex JSONL rollouts instead of decoding the complete file into one
  JavaScript string.
- Preserve the existing record parser, filters, and fail-open contract.
- Add a regression for the `ERR_STRING_TOO_LONG` boundary.

Closes #3292.

## Root cause

`readCodexTranscript()` used `readFileSync(path, "utf8")`. Oversized Codex
rollouts therefore fail before parsing with Node's `ERR_STRING_TOO_LONG`. The
reader catches the exception and returns no turns, causing the Stop hook to
exit successfully without submitting a retain.

## Why this shape

The rollout format is JSONL, so whole-file materialization is unnecessary.
Incremental UTF-8 decoding bounds memory by the largest record while leaving
all existing parsing semantics in one place. `StringDecoder` preserves UTF-8
code points split across read buffers.

## Validation

```text
Regression on old implementation
  failed: expected one turn, received []

npm test -- --run src/core/transcript-codex.test.ts src/core/transcript-codex-large.test.ts
  2 files passed, 7 tests passed

HINDSIGHT_CONFIG=<empty-test-config> npm test
  35 files passed, 346 tests passed

npm run build
  ESM and DTS builds passed

Read-only oversized-rollout parser proof
  4/4 files parsed successfully; largest file >2.4 GB

openclaw-autoreview --mode local
  clean: no accepted/actionable findings
```

## Scope

- No dependency changes.
- No server API, database, worker, chunk-delta, or operation-id changes.
- No hook configuration or retained-content changes.
- This is separate from async retain idempotency in #3281.
