### PR TITLE
fix(retain): sweep observations written during the document delete

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memories/pg/writes.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/pg/writes.py
@@ -252,8 +252,9 @@ async def delete_stale_observations(
     2. Reset ``consolidated_at = NULL`` on the surviving source memories so
        they get re-consolidated under fresh observations on the next run.
 
-    Must be called within an active transaction, before the source memories
-    are deleted.
+    Must be called within an active transaction, normally before the source
+    memories are deleted. The lookup matches the observation's own
+    ``source_memory_ids``, so a repeat call afterwards is valid and idempotent.
 
     Returns the number of observations deleted.
     """

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -293,6 +293,17 @@ async def handle_document_tracking(
             bank_id,
         )
 
+        # Sweep again: an observation a concurrent consolidation inserted between
+        # the pre-delete sweep and the delete is invisible to both, and no later
+        # pass can reach it once its sources are gone. Idempotent.
+        if existing_unit_ids:
+            late = await delete_stale_observations_for_memories(conn, bank_id, existing_unit_ids, ops=ops)
+            if late:
+                logger.info(
+                    f"[RETAIN] Document {document_id}: swept {late} observation(s) written between "
+                    f"the pre-delete sweep and the delete"
+                )
+
     # Insert document (or update if exists from concurrent operations)
     await _upsert_document_row(
         conn,

--- a/hindsight-api-slim/tests/test_observation_invalidation.py
+++ b/hindsight-api-slim/tests/test_observation_invalidation.py
@@ -434,6 +434,70 @@ class TestDocumentUpsertObservationCleanup:
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
+    @pytest.mark.asyncio
+    async def test_upsert_document_sweeps_observation_written_during_the_delete(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """Observations written between the pre-delete sweep and the delete are swept too.
+
+        A concurrent consolidation may insert an observation while the upsert sits
+        between the two: its sources are still live, so the FOR SHARE check in
+        ``_filter_live_source_memories`` passes. The pre-delete sweep never saw the
+        row, and once the sources are gone no consolidation batch can reach it.
+        """
+        from hindsight_api.engine.retain import fact_storage
+
+        bank_id = f"test-upsert-obs-race-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        doc_id = str(uuid.uuid4())
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO documents (id, bank_id, original_text, content_hash, created_at, updated_at)
+                VALUES ($1, $2, 'old version', 'hash-old', NOW(), NOW())
+                """,
+                doc_id,
+                bank_id,
+            )
+            doc_mem = await _insert_memory(memory, conn, bank_id, "Old fact A.", "experience", document_id=doc_id)
+
+        real_sweep = fact_storage.delete_stale_observations_for_memories
+        late_obs: list[uuid.UUID] = []
+
+        async def _sweep_then_insert_late_observation(conn, bank, fact_ids, ops=None):
+            deleted = await real_sweep(conn, bank, fact_ids, ops=ops)
+            if not late_obs:
+                late_obs.append(await _insert_observation(memory, conn, bank, "Written mid-delete.", [doc_mem]))
+            return deleted
+
+        with patch.object(fact_storage, "delete_stale_observations_for_memories", _sweep_then_insert_late_observation):
+            async with pool.acquire() as conn:
+                async with conn.transaction():
+                    await fact_storage.handle_document_tracking(
+                        conn,
+                        bank_id=bank_id,
+                        document_id=doc_id,
+                        combined_content="new version replacing old facts",
+                        is_first_batch=True,
+                        retain_params=None,
+                        document_tags=None,
+                        ops=memory._backend.ops,
+                    )
+
+        assert late_obs, "fixture did not insert the racing observation"
+        async with pool.acquire() as conn:
+            obs_ids = await _get_observation_ids(conn, bank_id)
+            assert str(late_obs[0]) not in obs_ids, (
+                "Observation written between the pre-delete sweep and the delete was left "
+                "orphaned: its source memory_units are gone and no consolidation batch can "
+                "reach it again"
+            )
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
 
 # ---------------------------------------------------------------------------
 # Tests: delete_bank with fact_type filter


### PR DESCRIPTION
## Summary

Closes one more window in which a document replace leaves orphan observations. Reported in #3294.

`handle_document_tracking` sweeps the observations derived from the outgoing memories before deleting them (#1101), and #1090 closed the window where a source is hard-deleted *during* the consolidation LLM call. What remains is the gap between those two steps:

```python
if existing_unit_ids:
    invalidated = await delete_stale_observations_for_memories(conn, bank_id, existing_unit_ids, ops=ops)
    ...
await store.delete_document(conn=conn, fq_table=fq_table, bank_id=bank_id, document_id=document_id, txn=txn)
```

An observation a concurrent consolidation inserts in between is invisible to both. Its sources were still live when `_filter_live_source_memories` checked them `FOR SHARE`, so the insert is legitimate; the sweep had already run, so it never saw the row. The delete then orphans it permanently: consolidation batches are built from facts, so an observation whose sources are all gone is never selected into a batch again.

## Change

Sweep once more after the delete, for the same ids. `delete_stale_observations` matches on the observation's own `source_memory_ids` rather than joining live rows, so the repeat call is valid after the sources are gone, and idempotent — normally it finds nothing. The docstring said "before the source memories are deleted"; it now states that a repeat call afterwards is valid.

Cheap: one extra query per replaced document, only when the document had outgoing memories, inside the transaction that is already open.

## Test

`test_upsert_document_sweeps_observation_written_during_the_delete` reproduces the window deterministically: it patches the sweep so that an observation referencing the outgoing memory is inserted right after the first sweep call, then runs `handle_document_tracking`.

- without the change: fails on the orphan assertion, while `test_upsert_document_removes_observations_from_outgoing_memories` still passes
- with the change: `tests/test_observation_invalidation.py` 27 passed

`tests/test_retain.py` and `tests/test_async_batch_retain.py` are unchanged against a clean tree (the `TestFactExtractionQuality` failures here are a missing LLM key in my environment, identical with and without the patch). `./scripts/hooks/lint.sh` passes, `ty check hindsight_api/` passes.

## Note

This closes the window it describes. I have not proved it is the only cause of the orphans in #3294 — that reproduction ran two replaces in short succession with auto-consolidation active, and the bank also had no way to clean the residue afterwards. Deliberately not marked as closing the issue.
