### PR TITLE
fix(mcp): pass the retain strategy to the worker

### DIFF
--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -644,6 +644,7 @@ def _register_retain(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                 result = await memory.submit_async_retain(
                     bank_id=target_bank,
                     contents=[content_dict],
+                    strategy=content_dict.pop("strategy", None),
                     request_context=request_context,
                 )
                 return {
@@ -698,6 +699,7 @@ def _register_retain(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                 result = await memory.submit_async_retain(
                     bank_id=target_bank,
                     contents=[content_dict],
+                    strategy=content_dict.pop("strategy", None),
                     request_context=request_context,
                 )
                 return {

--- a/hindsight-api-slim/tests/test_mcp_tools.py
+++ b/hindsight-api-slim/tests/test_mcp_tools.py
@@ -1062,6 +1062,19 @@ class TestRetainNewParams:
         contents = call_args.kwargs["contents"]
         assert contents[0]["document_id"] == "doc-1"
 
+    async def test_retain_passes_strategy_to_the_worker(self, mock_memory):
+        """The strategy must travel as the submit argument, not inside the content item.
+
+        ``submit_async_retain`` only puts a strategy into the task payload when it
+        is passed as the keyword; a strategy left inside the content dict never
+        reaches the worker, so every strategy override silently falls back to the
+        bank configuration.
+        """
+        mcp = _make_mcp_server(mock_memory, {"retain"})
+        await _tools(mcp)["retain"].fn(content="test", strategy="documents")
+        call_args = mock_memory.submit_async_retain.call_args
+        assert call_args.kwargs["strategy"] == "documents"
+
     async def test_retain_without_new_params_backward_compat(self, mock_memory):
         """Existing behavior preserved when new params not provided."""
         mcp = _make_mcp_server(mock_memory, {"retain"})

--- a/hindsight-api-slim/tests/test_mcp_tools.py
+++ b/hindsight-api-slim/tests/test_mcp_tools.py
@@ -1070,7 +1070,13 @@ class TestRetainNewParams:
         reaches the worker, so every strategy override silently falls back to the
         bank configuration.
         """
-        mcp = _make_mcp_server(mock_memory, {"retain"})
+        mcp = _make_mcp_server(mock_memory, {"retain"}, include_bank_id=True)
+        await _tools(mcp)["retain"].fn(content="test", strategy="documents")
+        call_args = mock_memory.submit_async_retain.call_args
+        assert call_args.kwargs["strategy"] == "documents"
+
+    async def test_retain_passes_strategy_single_bank(self, mock_memory):
+        mcp = _make_mcp_server(mock_memory, {"retain"}, include_bank_id=False)
         await _tools(mcp)["retain"].fn(content="test", strategy="documents")
         call_args = mock_memory.submit_async_retain.call_args
         assert call_args.kwargs["strategy"] == "documents"


### PR DESCRIPTION
## Summary

The MCP `retain` tool accepts a `strategy` but never delivers it to the worker, so every strategy override is silently ignored and the bank-level configuration is used instead.

`build_content_dict` puts the strategy into the content item, and the call passes only the contents:

```python
content_dict, error = build_content_dict(content, context, timestamp, tags, metadata, document_id, strategy, update_mode)
...
result = await memory.submit_async_retain(
    bank_id=target_bank,
    contents=[content_dict],
    request_context=request_context,
)
```

`submit_async_retain` writes the strategy into the task payload from its own keyword argument only:

```python
if strategy:
    task_payload["strategy"] = strategy
```

Nothing reads a strategy back out of the content items, so the payload has none, `apply_strategy()` never runs, and `retain_mission`, `entity_labels`, `retain_chunk_size` and `entities_allow_free_form` all fall back to the bank config. No error, no warning.

Both async `retain` registrations are affected. `sync_retain`, a few lines below, already does it correctly — this PR applies the same idiom:

```python
strategy=content_dict.pop("strategy", None),
```

`api_retain` (REST) is unaffected: it groups items by `item.strategy` and forwards it.

## Impact

Measured on a bank whose `canonical_document` strategy restricts `record_type` to `state`, `rule`, `procedure` via per-strategy `entity_labels`, importing the same three documents twice:

| Import path | Facts | Types outside the strategy schema |
|---|---|---|
| MCP | 123 | 4 (3 `analysis`, 1 `decision`) |
| REST, identical config | 61 | 0 |

The illegal values are only possible because the bank-level vocabulary was in force — with the strategy's `entity_labels` applied, `build_labels_model()` turns them into a `Literal[...]` that structured output cannot violate.

Worth noting for triage: the dry-run extract endpoint cannot reveal this, because it strips the extracted labels from its response. The defect is only visible in the stored facts, where it looks like model non-compliance rather than lost configuration.

## Test

`test_retain_passes_strategy_to_the_worker` asserts that `submit_async_retain` receives `strategy` as a keyword. It fails without the change; the existing `TestRetainNewParams` cases keep passing. `tests/test_mcp_tools.py`: 201 passed. `./scripts/hooks/lint.sh` passes.
