### PR TITLE
fix delta retain observation cleanup

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/chunk_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/chunk_storage.py
@@ -55,7 +55,7 @@ async def load_existing_chunks(conn, bank_id: str, document_id: str) -> list[Exi
     ]
 
 
-async def delete_chunks_by_ids(conn, chunk_ids: list[str], bank_id: str | None = None, txn=None) -> None:
+async def delete_chunks_by_ids(conn, chunk_ids: list[str], bank_id: str | None = None, txn=None, ops=None) -> None:
     """
     Delete specific chunks by their IDs.
 
@@ -76,6 +76,44 @@ async def delete_chunks_by_ids(conn, chunk_ids: list[str], bank_id: str | None =
     from ..memories import META_CHUNK_ID, DeletePredicate, get_memories
 
     _store = get_memories()
+    if bank_id:
+        if _store.writes_memory_rows_in_sql:
+            rows = await conn.fetch(
+                f"""
+                SELECT id
+                FROM {fq_table("memory_units")}
+                WHERE bank_id = $1
+                  AND chunk_id = ANY($2::text[])
+                  AND fact_type IN ('experience', 'world')
+                """,
+                bank_id,
+                chunk_ids,
+            )
+            outgoing_unit_ids = [str(row["id"]) for row in rows]
+        else:
+            outgoing_unit_ids = []
+            for chunk_id in chunk_ids:
+                page_token = ""
+                while True:
+                    page = await _store.scan_memories(
+                        conn=conn,
+                        fq_table=fq_table,
+                        bank_id=bank_id,
+                        fact_types=["experience", "world"],
+                        metadata_equals={META_CHUNK_ID: chunk_id},
+                        limit=500,
+                        page_token=page_token,
+                    )
+                    outgoing_unit_ids.extend(memory.unit_id for memory in page.memories)
+                    page_token = page.next_page_token
+                    if not page_token:
+                        break
+
+        if outgoing_unit_ids:
+            from .fact_storage import delete_stale_observations_for_memories
+
+            await delete_stale_observations_for_memories(conn, bank_id, outgoing_unit_ids, ops=ops)
+
     if bank_id and not _store.writes_memory_rows_in_sql:
         for _cid in chunk_ids:
             await _store.delete_where(bank_id, DeletePredicate(metadata_equals={META_CHUNK_ID: _cid}), txn=txn)

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -2571,7 +2571,13 @@ async def _try_delta_retain(
                     for idx in changed_indices + removed_indices
                     if idx in existing_by_index
                 ]
-                await chunk_storage.delete_chunks_by_ids(conn, chunks_to_delete, bank_id, txn=_group_txn)
+                await chunk_storage.delete_chunks_by_ids(
+                    conn,
+                    chunks_to_delete,
+                    bank_id,
+                    txn=_group_txn,
+                    ops=pool.ops,
+                )
                 log_buffer.append(
                     f"  Deleted {len(chunks_to_delete)} chunks "
                     f"({len(changed_indices)} changed + {len(removed_indices)} removed) "

--- a/hindsight-api-slim/tests/test_observation_invalidation.py
+++ b/hindsight-api-slim/tests/test_observation_invalidation.py
@@ -33,6 +33,7 @@ async def _insert_memory(
     text: str,
     fact_type: str = "experience",
     document_id: str | None = None,
+    chunk_id: str | None = None,
 ) -> uuid.UUID:
     """Seed one memory through the store, bypassing the LLM retain pipeline.
 
@@ -47,7 +48,7 @@ async def _insert_memory(
         tags=[],
         context=None,
         document_id=document_id,
-        chunk_id=None,
+        chunk_id=chunk_id,
         metadata=None,
         observation_scopes=None,
         entities=[],
@@ -431,6 +432,72 @@ class TestDocumentUpsertObservationCleanup:
             # The two doc-scoped memories are gone via FK cascade.
             doc_mem_count = await _count_surviving(conn, bank_id, [doc_mem_a, doc_mem_b])
             assert doc_mem_count == 0
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_delta_chunk_delete_removes_observations_from_outgoing_memories(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        from hindsight_api.engine.retain.chunk_storage import delete_chunks_by_ids
+
+        bank_id = f"test-delta-obs-cleanup-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        doc_id = str(uuid.uuid4())
+        chunk_id = f"{bank_id}_{doc_id}_0"
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO documents (id, bank_id, original_text, content_hash, created_at, updated_at)
+                VALUES ($1, $2, 'old version', 'hash-old', NOW(), NOW())
+                """,
+                doc_id,
+                bank_id,
+            )
+            await conn.execute(
+                """
+                INSERT INTO chunks (chunk_id, document_id, bank_id, chunk_index, chunk_text, content_hash)
+                VALUES ($1, $2, $3, 0, 'old chunk', 'chunk-hash-old')
+                """,
+                chunk_id,
+                doc_id,
+                bank_id,
+            )
+            outgoing_mem = await _insert_memory(
+                memory,
+                conn,
+                bank_id,
+                "Old chunk fact.",
+                "experience",
+                document_id=doc_id,
+                chunk_id=chunk_id,
+            )
+            surviving_mem = await _insert_memory(memory, conn, bank_id, "Unchanged fact.")
+            obs_id = await _insert_observation(
+                memory,
+                conn,
+                bank_id,
+                "Observation joining changed and unchanged chunks.",
+                [outgoing_mem, surviving_mem],
+            )
+
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                await delete_chunks_by_ids(
+                    conn,
+                    [chunk_id],
+                    bank_id,
+                    ops=memory._backend.ops,
+                )
+
+        async with pool.acquire() as conn:
+            obs_ids = await _get_observation_ids(conn, bank_id)
+            assert str(obs_id) not in obs_ids
+            assert await _count_surviving(conn, bank_id, [outgoing_mem]) == 0
+            assert await _get_consolidated_at(conn, surviving_mem, bank_id) is None
 
         await memory.delete_bank(bank_id, request_context=request_context)
 


### PR DESCRIPTION
## Problem

Delta retain deletes changed and removed chunks directly. That cascade removes their source memories without invalidating observations derived from them, leaving stale observations with missing `source_memory_ids` (#3294).

## Fix

Collect the source-memory IDs owned by the chunks before deletion and run the existing observation invalidation path in the same transaction. The lookup supports both SQL-backed and external memory stores. The delta orchestrator now passes the backend ops needed by the cleanup query.

## Test

- Added a PostgreSQL regression covering a changed-chunk observation with a surviving co-source; it verifies the observation is deleted, the outgoing source is removed, and the survivor is requeued for consolidation.
- `pytest -n 0 tests/test_observation_invalidation.py::TestDocumentUpsertObservationCleanup::test_delta_chunk_delete_removes_observations_from_outgoing_memories -q`
- `pytest tests/test_chunk_storage_delete_ordering.py -q`
- Ruff check and format check for the changed Python files
- Repository pre-commit hooks passed

## Risk

Low to moderate. Chunk deletion now performs one bounded source lookup plus the existing cleanup routine before the cascade. The cleanup is limited to observations referencing memories owned by the chunks being replaced; unchanged source memories survive and are reset for reconsolidation.

Fixes #3294.
