### PR TITLE
fix: skip consolidation recall for empty tagged scopes

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -760,6 +760,39 @@ async def _count_observations_for_scope(
     return total
 
 
+async def _has_observations_for_scope(
+    conn: "Connection",
+    bank_id: str,
+    tags: list[str],
+) -> bool:
+    """Return whether a strict tagged scope contains any observations.
+
+    This deliberately performs a cheap existence probe before consolidation's
+    vector recall. Filtered ANN search can otherwise scan the bank-wide HNSW
+    index until the database timeout when a brand-new scope has no candidates.
+    """
+    store = get_memories()
+    if store.writes_memory_rows_in_sql:
+        found = await conn.fetchval(
+            f"SELECT 1 FROM {fq_table('memory_units')} "
+            "WHERE bank_id = $1 AND fact_type = 'observation' "
+            "AND tags IS NOT NULL AND tags != '{}' AND tags @> $2::varchar[] LIMIT 1",
+            bank_id,
+            tags,
+        )
+        return found is not None
+    page = await store.scan_memories(
+        conn=conn,
+        fq_table=fq_table,
+        bank_id=bank_id,
+        fact_types=["observation"],
+        tags=tags,
+        tags_match="all_strict",
+        limit=1,
+    )
+    return bool(page.memories)
+
+
 @dataclass(frozen=True)
 class _ScopeLimitRule:
     """One ``observation_scope_limits`` rule: a scope pattern -> an observation cap.
@@ -1825,28 +1858,49 @@ async def _process_memory_batch(
     # Map the source memories this batch consumes onto the consolidation trace.
     record_source_memory_ids([str(m["id"]) for m in memories])
 
+    # Determine effective tag scope for observations. All memories in a batch
+    # share one tag set (enforced by batching).
+    if obs_tags_override is not None:
+        fact_tags = obs_tags_override
+    else:
+        fact_tags = memories[0].get("tags") or [] if memories else []
+
     # 1. Parallel recalls — one per fact
     # When obs_tags_override is set, use it as the observation scope for all facts.
     t0 = time.time()
     observation_scope_tags = obs_tags_override if obs_tags_override is not None else None
-    recall_tasks = [
-        _find_related_observations(
-            memory_engine=memory_engine,
-            bank_id=bank_id,
-            query=m["text"],
-            request_context=request_context,
-            tags=observation_scope_tags if observation_scope_tags is not None else (m.get("tags") or []),
-        )
-        for m in memories
-    ]
-    per_fact_recalls = await asyncio.gather(*recall_tasks)
+    has_scoped_observations = True
+    if fact_tags:
+        async with acquire_with_retry(pool) as scope_conn:
+            has_scoped_observations = await _has_observations_for_scope(scope_conn, bank_id, fact_tags)
+
+    if has_scoped_observations:
+        recall_tasks = [
+            _find_related_observations(
+                memory_engine=memory_engine,
+                bank_id=bank_id,
+                query=m["text"],
+                request_context=request_context,
+                tags=observation_scope_tags if observation_scope_tags is not None else (m.get("tags") or []),
+            )
+            for m in memories
+        ]
+        per_fact_recalls = await asyncio.gather(*recall_tasks)
+    else:
+        # A new tagged scope has nothing to retrieve. Returning empty secure
+        # candidate sets lets the LLM create its first observation without a
+        # bank-wide filtered ANN query that can exhaust db_command_timeout.
+        per_fact_recalls = []
     if perf:
         perf.record_timing("recall", time.time() - t0)
 
     # 2. Build per-fact observation sets (keyed by memory ID string) for secure action validation
-    per_fact_obs_ids: dict[str, set[str]] = {
-        str(memories[i]["id"]): {str(obs.id) for obs in r.results} for i, r in enumerate(per_fact_recalls)
-    }
+    if per_fact_recalls:
+        per_fact_obs_ids: dict[str, set[str]] = {
+            str(memories[i]["id"]): {str(obs.id) for obs in r.results} for i, r in enumerate(per_fact_recalls)
+        }
+    else:
+        per_fact_obs_ids = {str(memory["id"]): set() for memory in memories}
 
     # Union all observations (deduped by id)
     seen_ids: set[str] = set()
@@ -1860,14 +1914,6 @@ async def _process_memory_batch(
                 union_observations.append(obs)
         if recall_result.source_facts:
             union_source_facts.update(recall_result.source_facts)
-
-    # Determine effective tag scope for observations.
-    # When obs_tags_override is set, use it; otherwise use the memory's own tags.
-    if obs_tags_override is not None:
-        fact_tags = obs_tags_override
-    else:
-        # All memories in the batch share the same tag set (enforced by batching)
-        fact_tags = memories[0].get("tags") or [] if memories else []
 
     # 2b. Compute remaining observation slots for this scope (if limit configured).
     # The cap is resolved per-scope: an observation_scope_limits rule may override

--- a/hindsight-api-slim/tests/test_consolidation_empty_scope.py
+++ b/hindsight-api-slim/tests/test_consolidation_empty_scope.py
@@ -1,0 +1,146 @@
+"""Regression tests for consolidation of a new tagged observation scope."""
+
+import types
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from unittest.mock import ANY, AsyncMock, patch
+
+from hindsight_api.engine.consolidation import consolidator as C
+from hindsight_api.engine.memory_engine import MemoryEngine
+
+
+@asynccontextmanager
+async def _acquire_connection(_pool: object) -> AsyncIterator[object]:
+    yield object()
+
+
+async def test_new_tag_scope_skips_filtered_observation_recall() -> None:
+    """A zero-observation scope must reach CREATE without running ANN recall."""
+    memory_id = str(uuid.uuid4())
+    memories = [{"id": memory_id, "text": "The user prefers basil.", "tags": ["user:alice"]}]
+    create_action = C._CreateAction(text="The user prefers basil.", source_fact_ids=[memory_id])
+    llm_result = C._BatchLLMResult(creates=[create_action])
+    scope_probe = AsyncMock(return_value=False)
+    recall = AsyncMock()
+    create = AsyncMock(return_value="created")
+
+    with (
+        patch.object(C, "acquire_with_retry", _acquire_connection),
+        patch.object(C, "_has_observations_for_scope", scope_probe),
+        patch.object(C, "_find_related_observations", recall),
+        patch.object(C, "_consolidate_batch_with_llm", AsyncMock(return_value=llm_result)),
+        patch.object(C, "_effective_scope_limit", return_value=-1),
+        patch.object(C, "_dedup_active", return_value=False),
+        patch.object(C, "_execute_create_action", create),
+    ):
+        result = await C._process_memory_batch(
+            pool=object(),
+            memory_engine=types.SimpleNamespace(),
+            llm_config=object(),
+            bank_id="bank-1",
+            memories=memories,
+            request_context=object(),
+            config=object(),
+        )
+
+    scope_probe.assert_awaited_once_with(ANY, "bank-1", ["user:alice"])
+    recall.assert_not_awaited()
+    create.assert_awaited_once()
+    assert create.await_args.kwargs["source_fact_tags"] == ["user:alice"]
+    assert result == ([{"action": "created"}], 0, False)
+    assert create.await_args.kwargs["source_memory_ids"] == [memory_id]
+
+
+async def test_existing_tag_scope_preserves_strict_observation_recall() -> None:
+    """The guard must not change recall for a scope that already has observations."""
+    memory_id = str(uuid.uuid4())
+    memories = [{"id": memory_id, "text": "The user prefers basil.", "tags": ["user:alice"]}]
+    create_action = C._CreateAction(text="The user prefers basil.", source_fact_ids=[memory_id])
+    llm_result = C._BatchLLMResult(creates=[create_action])
+    scope_probe = AsyncMock(return_value=True)
+    recall_result = types.SimpleNamespace(results=[], source_facts={})
+    recall = AsyncMock(return_value=recall_result)
+
+    with (
+        patch.object(C, "acquire_with_retry", _acquire_connection),
+        patch.object(C, "_has_observations_for_scope", scope_probe),
+        patch.object(C, "_find_related_observations", recall),
+        patch.object(C, "_consolidate_batch_with_llm", AsyncMock(return_value=llm_result)),
+        patch.object(C, "_effective_scope_limit", return_value=-1),
+        patch.object(C, "_dedup_active", return_value=False),
+        patch.object(C, "_execute_create_action", AsyncMock(return_value="created")),
+    ):
+        await C._process_memory_batch(
+            pool=object(),
+            memory_engine=types.SimpleNamespace(),
+            llm_config=object(),
+            bank_id="bank-1",
+            memories=memories,
+            request_context=object(),
+            config=object(),
+        )
+
+    scope_probe.assert_awaited_once()
+    recall.assert_awaited_once()
+    assert recall.await_args.kwargs["tags"] == ["user:alice"]
+
+
+async def test_scope_probe_uses_bounded_strict_store_scan() -> None:
+    """External memory stores receive the same all-strict scope with a one-row limit."""
+    store = types.SimpleNamespace(
+        writes_memory_rows_in_sql=False,
+        scan_memories=AsyncMock(return_value=types.SimpleNamespace(memories=[])),
+    )
+
+    with patch.object(C, "get_memories", return_value=store):
+        found = await C._has_observations_for_scope(object(), "bank-1", ["user:alice"])
+
+    assert found is False
+    store.scan_memories.assert_awaited_once()
+    assert store.scan_memories.await_args.kwargs["fact_types"] == ["observation"]
+    assert store.scan_memories.await_args.kwargs["tags"] == ["user:alice"]
+    assert store.scan_memories.await_args.kwargs["tags_match"] == "all_strict"
+    assert store.scan_memories.await_args.kwargs["limit"] == 1
+
+
+async def test_scope_probe_uses_sql_existence_query() -> None:
+    """The default store probes existence instead of counting or sorting vectors."""
+    conn = types.SimpleNamespace(fetchval=AsyncMock(return_value=1))
+    store = types.SimpleNamespace(writes_memory_rows_in_sql=True)
+
+    with patch.object(C, "get_memories", return_value=store):
+        found = await C._has_observations_for_scope(conn, "bank-1", ["user:alice"])
+
+    assert found is True
+    query, bank_id, tags = conn.fetchval.await_args.args
+    assert "SELECT 1" in query
+    assert "fact_type = 'observation'" in query
+    assert "tags @> $2::varchar[]" in query
+    assert "LIMIT 1" in query
+    assert bank_id == "bank-1"
+    assert tags == ["user:alice"]
+
+
+async def test_scope_probe_executes_against_postgres(memory: MemoryEngine, request_context) -> None:
+    """The existence query returns quickly and keeps strict containment semantics in PostgreSQL."""
+    bank_id = f"test-empty-scope-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    try:
+        async with memory._pool.acquire() as conn:
+            assert await C._has_observations_for_scope(conn, bank_id, ["user:alice"]) is False
+            await conn.execute(
+                """
+                INSERT INTO memory_units (id, bank_id, text, fact_type, tags, proof_count)
+                VALUES ($1, $2, $3, 'observation', $4, 1)
+                """,
+                uuid.uuid4(),
+                bank_id,
+                "Alice prefers basil.",
+                ["user:alice", "project:garden"],
+            )
+            assert await C._has_observations_for_scope(conn, bank_id, ["user:alice"]) is True
+            assert await C._has_observations_for_scope(conn, bank_id, ["user:bob"]) is False
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_consolidation_scope_parallelism.py
+++ b/hindsight-api-slim/tests/test_consolidation_scope_parallelism.py
@@ -37,7 +37,6 @@ from hindsight_api.engine.consolidation.consolidator import (
 from hindsight_api.engine.memory_engine import MemoryEngine
 from hindsight_api.engine.providers.mock_llm import MockLLM
 
-
 # ---------------------------------------------------------------------------
 # Fixtures + helpers
 # ---------------------------------------------------------------------------
@@ -504,8 +503,8 @@ async def test_per_batch_log_line_attributes_only_own_work(memory: MemoryEngine,
 @pytest.mark.asyncio
 async def test_disjoint_scopes_run_concurrently(memory: MemoryEngine, request_context):
     """When write-scope sets are pairwise disjoint, the dispatcher must let
-    groups run in parallel — we should observe simultaneous in-flight recalls
-    on *different* scopes."""
+    groups run in parallel — we should observe simultaneous in-flight scope
+    probes on *different* scopes, even when each new scope skips ANN recall."""
     bank_id = f"test-disjoint-{uuid.uuid4().hex[:8]}"
     await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
 
@@ -514,9 +513,9 @@ async def test_disjoint_scopes_run_concurrently(memory: MemoryEngine, request_co
     distinct_concurrent_scopes_seen = 0
     in_flight_scopes: set[frozenset[str]] = set()
     sample_lock = asyncio.Lock()
-    orig_find = consolidator_mod._find_related_observations
+    orig_probe = consolidator_mod._has_observations_for_scope
 
-    async def tracked_find(*, memory_engine, bank_id, query, request_context, tags=None):
+    async def tracked_probe(conn, bank_id, tags):
         nonlocal distinct_concurrent_scopes_seen
         scope = frozenset(tags or [])
         async with sample_lock:
@@ -525,13 +524,7 @@ async def test_disjoint_scopes_run_concurrently(memory: MemoryEngine, request_co
                 distinct_concurrent_scopes_seen = len(in_flight_scopes)
         try:
             await asyncio.sleep(0.1)  # widen the window so concurrency is observable
-            return await orig_find(
-                memory_engine=memory_engine,
-                bank_id=bank_id,
-                query=query,
-                request_context=request_context,
-                tags=tags,
-            )
+            return await orig_probe(conn, bank_id, tags)
         finally:
             async with sample_lock:
                 in_flight_scopes.discard(scope)
@@ -549,7 +542,7 @@ async def test_disjoint_scopes_run_concurrently(memory: MemoryEngine, request_co
             with (
                 _override_config(memory, consolidation_llm_parallelism=3, consolidation_llm_batch_size=1),
                 patch.object(memory, "submit_async_consolidation"),
-                patch.object(consolidator_mod, "_find_related_observations", tracked_find),
+                patch.object(consolidator_mod, "_has_observations_for_scope", tracked_probe),
             ):
                 result = await run_consolidation_job(
                     memory_engine=memory, bank_id=bank_id, request_context=request_context
@@ -559,9 +552,9 @@ async def test_disjoint_scopes_run_concurrently(memory: MemoryEngine, request_co
 
         assert result["status"] == "completed"
         # Three disjoint scopes + parallelism=3 → at some moment we should
-        # see at least 2 distinct in-flight scopes.
+        # see at least 2 distinct in-flight scope probes.
         assert distinct_concurrent_scopes_seen >= 2, (
-            f"expected concurrent in-flight recalls across disjoint scopes, "
+            f"expected concurrent in-flight probes across disjoint scopes, "
             f"max observed = {distinct_concurrent_scopes_seen}"
         )
     finally:


### PR DESCRIPTION
## Summary

- probe a tagged observation scope with a bounded `SELECT 1 ... LIMIT 1` before consolidation recall
- skip per-fact semantic/BM25 recalls only when that strict scope has no observations yet
- preserve `all_strict` isolation and support external memory-store extensions with a bounded strict scan
- keep disjoint scope probes parallel

## Root cause

For a brand-new tagged scope, each fact launched a filtered ANN + BM25 observation recall even though the scope had zero candidates. On large banks the filtered HNSW arm could reach `db_command_timeout`, abort the batch, and trigger exponential retries.

The new existence preflight lets consolidation create the first observation for the scope without weakening tag matching or increasing timeouts.

Fixes #3301.

## Validation

- `uv run pytest tests/test_consolidation_empty_scope.py tests/test_consolidation_dedup.py tests/test_consolidation_scope_parallelism.py tests/test_consolidation.py::test_count_observations_for_scope -q` — 56 passed
- `./scripts/hooks/lint.sh` — passed
- `uv run ty check hindsight_api/engine/consolidation/consolidator.py` — passed
- regression includes a real embedded PostgreSQL/pgvector execution of the existence query

## Base

The fork branch is based exactly on release tag `v0.9.0` (`b12646f49`).
