### PR TITLE
fix(db): drop the vestigial memory_links.entity_id FK that stalls graph maintenance

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/c4f7a2e9b6d1_drop_vestigial_memory_links_entity_fk.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/c4f7a2e9b6d1_drop_vestigial_memory_links_entity_fk.py
@@ -1,0 +1,165 @@
+"""Drop the vestigial ``memory_links.entity_id`` → ``entities.id`` FK.
+
+``fk_memory_links_entity_id_entities`` was installed by the initial schema
+migration (``5a366d414dce``) with ``ON DELETE CASCADE``, back when entity edges
+were materialised as ``memory_links`` rows with ``link_type = 'entity'``. That
+representation is gone: ``e1b2c3d4f5a6`` dropped the entity index and
+``e9b2c7d1f3a4`` deleted every ``link_type = 'entity'`` row, and no writer has
+populated ``entity_id`` since — ``_bulk_insert_links`` passes ``None`` for every
+row it inserts. On the bank this was diagnosed against,
+``SELECT count(*) FROM memory_links WHERE entity_id IS NOT NULL`` returns 0 out
+of 26,750,591 rows and ``pg_stats.null_frac`` for the column is 1.
+
+The constraint protects nothing, but it is not free. ``memory_links`` has no
+index leading on ``entity_id`` (``e1b2c3d4f5a6`` dropped the last one), so
+PostgreSQL's referential-integrity trigger has to sequentially scan the whole
+table once per deleted ``entities`` row. Measured on a fully-cached ~2.7 GB
+``memory_links``: **1.278 s per parent row deleted**.
+
+That makes ``prune_orphan_entities`` (graph maintenance Pass 2) unrunnable on
+any bank with a real orphan backlog. The anti-join that finds the orphans is
+cheap (~70 ms, indexed by ``idx_unit_entities_entity_unit``), but the DELETE it
+drives pays the cascade scan per row: ~157 orphans ≈ 200 s against asyncpg's
+60 s client-side ``command_timeout`` (``DEFAULT_DB_COMMAND_TIMEOUT``). The sweep
+times out, rolls back, and retries — ``_SWEEP_MAX_RETRIES = 8`` means nine
+attempts and ~560 s of wasted work per job. Because it rolls back it never makes
+partial progress, so past roughly 47 orphans a bank can never recover on its
+own, and ``prune_stale_cooccurrences`` (same transaction, runs second) stops
+running entirely.
+
+What this migration does:
+
+* Drops ``fk_memory_links_entity_id_entities`` on PostgreSQL, idempotently
+  (``DROP CONSTRAINT IF EXISTS``) — the constraint has already been dropped by
+  hand on at least one production database as an emergency unblock, so the
+  migration must reconcile a schema that is *ahead* of head rather than fail on
+  it.
+
+What this migration deliberately does NOT do: drop the ``entity_id`` column.
+See the comment above ``_pg_schema_prefix`` below for why.
+
+PostgreSQL-only, by the same reasoning as ``9f8e7d6c5b4a``: Oracle keeps
+``idx_ml_entity`` on ``memory_links(entity_id)`` (``o1a2b3c4d5e6``), so its
+``fk_ml_entity`` cascade is an index lookup, not a table scan — the pathology
+being fixed here does not exist there, and the Oracle baseline still creates the
+constraint as part of the table DDL.
+
+Revision ID: c4f7a2e9b6d1
+Revises: b3e8d1c6f4a9
+Create Date: 2026-08-10
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "c4f7a2e9b6d1"
+down_revision: str | Sequence[str] | None = "b3e8d1c6f4a9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_FK_NAME = "fk_memory_links_entity_id_entities"
+
+# Why the ``entity_id`` COLUMN stays, even though it is 100% NULL and nothing
+# reads it:
+#
+# 1. It is a key column of ``idx_memory_links_unique``
+#    ``(from_unit_id, to_unit_id, link_type, COALESCE(entity_id, nil_uuid))``,
+#    which is the arbiter of the retain hot path's
+#    ``ON CONFLICT ... DO NOTHING`` in ``PostgresOps.bulk_insert_links``.
+#    Dropping the column drops that index, and rebuilding a unique index over
+#    26.7M rows has to happen CONCURRENTLY or it takes an ACCESS EXCLUSIVE lock
+#    on the busiest table in the schema for the duration of the build.
+# 2. The ON CONFLICT target must then change in lockstep, in the same deploy, in
+#    three places that are not deployed atomically with the migration:
+#    ``ops.bulk_insert_links``' abstract signature (it takes ``nil_entity_uuid``),
+#    ``ops_postgresql.bulk_insert_links``, and ``ops_oracle.bulk_insert_links``.
+#    An old API pod talking to a new schema — the normal state of a rolling
+#    deploy — would fail every link insert with "no unique or exclusion
+#    constraint matching the ON CONFLICT specification", i.e. retain breaks.
+# 3. Oracle's baseline (``o1a2b3c4d5e6``) declares the same column in the table
+#    DDL and the same NVL-based unique index, so a column drop is a two-dialect
+#    schema change, not a one-line PG cleanup.
+#
+# None of that buys anything the outage cares about: the cascade scan is caused
+# by the *constraint*, not by the column. A 16-byte-nullable column that is NULL
+# in every row costs 1 bit of null bitmap per row and nothing else. Removing the
+# column is a worthwhile follow-up, but it is a separate, coordinated change
+# with its own rollout story — not something to bundle into an outage fix.
+
+
+def _pg_schema_prefix() -> str:
+    """Schema-qualifier for raw SQL on PG (multi-tenant search_path)."""
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def _pg_upgrade() -> None:
+    schema = _pg_schema_prefix()
+    # IF EXISTS is load-bearing, not defensive boilerplate: production already
+    # ran this ALTER by hand, so on that database the constraint is gone while
+    # alembic_version still says b3e8d1c6f4a9. Without IF EXISTS the migration
+    # would abort there and leave the version table permanently behind.
+    #
+    # This is a catalogue-only change: DROP CONSTRAINT takes a brief ACCESS
+    # EXCLUSIVE lock on memory_links and does not touch the heap, so it is
+    # instant regardless of table size.
+    op.execute(f"ALTER TABLE {schema}memory_links DROP CONSTRAINT IF EXISTS {_FK_NAME}")
+
+
+def _pg_downgrade() -> None:
+    schema = _pg_schema_prefix()
+
+    # The restore is faithful *for the data that exists*: entity_id is NULL in
+    # every row, and a NULL FK column is trivially satisfied, so re-adding the
+    # constraint cannot fail on current data.
+    #
+    # It is NOT perfectly reversible in general. If a downgrade is ever run on a
+    # database that somehow acquired non-NULL entity_id values pointing at
+    # deleted entities while the constraint was absent, VALIDATE will fail and
+    # the downgrade will abort — correctly. Nothing in the codebase can produce
+    # such a row (every writer passes NULL), so this is a theoretical edge, but
+    # the failure mode is "downgrade refuses" rather than "silent corruption",
+    # which is the right way round.
+    #
+    # ADD ... NOT VALID then VALIDATE, rather than a plain ADD CONSTRAINT: a
+    # validating ADD holds ACCESS EXCLUSIVE on memory_links (and SHARE ROW
+    # EXCLUSIVE on entities) for a full seq scan of 26.7M rows. NOT VALID takes
+    # the exclusive lock only for the catalogue write; VALIDATE then runs under
+    # SHARE UPDATE EXCLUSIVE, which does not block reads or writes. The two must
+    # be separate transactions, hence the autocommit block.
+    #
+    # Note the downgrade reinstates the cascade scan, and therefore reinstates
+    # the prune_orphan_entities outage. That is what "restore the prior schema"
+    # means here; it is intentional and it is why the upgrade direction is the
+    # one you want.
+    with op.get_context().autocommit_block():
+        # Symmetric with the upgrade's IF EXISTS: a database that still has the
+        # constraint (never upgraded, or re-added by hand) must not make the
+        # downgrade blow up on "constraint already exists".
+        op.execute(f"ALTER TABLE {schema}memory_links DROP CONSTRAINT IF EXISTS {_FK_NAME}")
+        op.execute(
+            f"""
+            ALTER TABLE {schema}memory_links
+                ADD CONSTRAINT {_FK_NAME}
+                FOREIGN KEY (entity_id)
+                REFERENCES {schema}entities (id)
+                ON DELETE CASCADE
+                NOT VALID
+            """
+        )
+        op.execute(f"ALTER TABLE {schema}memory_links VALIDATE CONSTRAINT {_FK_NAME}")
+
+
+def upgrade() -> None:
+    # Oracle slot intentionally absent → no-op there. Oracle indexes
+    # memory_links(entity_id) (idx_ml_entity), so its equivalent constraint
+    # (fk_ml_entity) cascades via an index lookup and does not exhibit the
+    # per-parent-row seq scan this migration exists to remove.
+    run_for_dialect(pg=_pg_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade)

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -446,9 +446,21 @@ class PostgreSQLOps(DataAccessOps):
         bank_id: str,
     ) -> int:
         # Scoped by entities.bank_id (indexed). The NOT EXISTS subquery is
-        # backed by idx_ue_entity on unit_entities(entity_id), so this stays
-        # linear in the number of entities in the bank — not in the size of
-        # unit_entities globally.
+        # backed by idx_unit_entities_entity_unit on unit_entities
+        # (entity_id, unit_id) — the standalone idx_ue_entity this comment used
+        # to name is not a PG index at all: it was dropped by h3i4j5k6l7m8 /
+        # e1b2c3d4f5a6 and the name now survives only in the Oracle baseline.
+        # So the anti-join stays linear in the number of entities in the bank —
+        # not in the size of unit_entities globally.
+        #
+        # The anti-join is not what makes this statement expensive; the DELETE's
+        # cascade children are. Every ON DELETE CASCADE child of `entities` must
+        # have an index leading on its FK column, or its RI trigger degrades to
+        # a per-parent-row seq scan of the child table. `memory_links` had no
+        # such index and cost 1.278 s per orphan pruned — enough to blow the
+        # 60 s asyncpg command_timeout on any real backlog — until migration
+        # c4f7a2e9b6d1 dropped that (vestigial) FK. Keep the invariant in mind
+        # before adding a new cascade child.
         result = await conn.execute(
             f"""
             DELETE FROM {entities_table} e

--- a/hindsight-api-slim/hindsight_api/models.py
+++ b/hindsight-api-slim/hindsight_api/models.py
@@ -191,7 +191,9 @@ class Entity(Base):
 
     # Relationships
     unit_entities = relationship("UnitEntity", back_populates="entity", cascade="all, delete-orphan")
-    memory_links = relationship("MemoryLink", back_populates="entity", cascade="all, delete-orphan")
+    # No ``memory_links`` relationship: entity edges are no longer materialised
+    # in ``memory_links`` (see ``MemoryLink.entity_id``), and the FK backing the
+    # relationship was dropped by migration ``c4f7a2e9b6d1``.
     cooccurrences_1 = relationship(
         "EntityCooccurrence",
         foreign_keys="EntityCooccurrence.entity_id_1",
@@ -272,16 +274,22 @@ class MemoryLink(Base):
         UUID(as_uuid=True), ForeignKey("memory_units.id", ondelete="CASCADE"), primary_key=True
     )
     link_type: Mapped[str] = mapped_column(Text, primary_key=True)
-    entity_id: Mapped[PyUUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("entities.id", ondelete="CASCADE"), primary_key=True
-    )
+    # Vestigial. Entity edges are derived from ``unit_entities`` on demand
+    # (``e9b2c7d1f3a4`` deleted the last ``link_type = 'entity'`` row), so this
+    # column is NULL in every row. It is kept only because it is a key column of
+    # the ``idx_memory_links_unique`` COALESCE index that arbitrates retain's
+    # ``ON CONFLICT``. It carries NO ForeignKey: the ``ON DELETE CASCADE`` FK to
+    # ``entities`` was dropped by migration ``c4f7a2e9b6d1`` — with no index
+    # leading on ``entity_id``, its RI trigger seq-scanned all of
+    # ``memory_links`` per deleted entity (1.278 s/row), which made
+    # ``prune_orphan_entities`` time out permanently.
+    entity_id: Mapped[PyUUID | None] = mapped_column(UUID(as_uuid=True), primary_key=True)
     weight: Mapped[float] = mapped_column(Float, nullable=False, server_default="1.0")
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
 
     # Relationships
     from_unit = relationship("MemoryUnit", foreign_keys=[from_unit_id], back_populates="outgoing_links")
     to_unit = relationship("MemoryUnit", foreign_keys=[to_unit_id], back_populates="incoming_links")
-    entity = relationship("Entity", back_populates="memory_links")
 
     __table_args__ = (
         # Retain writes ``caused_by`` only. Keep the historical causal values

--- a/hindsight-api-slim/tests/test_memory_links_entity_fk_dropped.py
+++ b/hindsight-api-slim/tests/test_memory_links_entity_fk_dropped.py
@@ -1,0 +1,101 @@
+"""Schema invariant: memory_links must have no FK on ``entity_id``.
+
+Locks in migration ``c4f7a2e9b6d1``. ``fk_memory_links_entity_id_entities``
+was an ``ON DELETE CASCADE`` FK from ``memory_links.entity_id`` to
+``entities.id``, left behind after ``e9b2c7d1f3a4`` deleted the last
+``link_type = 'entity'`` row and ``e1b2c3d4f5a6`` dropped the last index
+leading on ``entity_id``.
+
+With no such index, PostgreSQL's referential-integrity trigger sequentially
+scans all of ``memory_links`` once per deleted ``entities`` row — measured at
+1.278 s per row on a ~2.7 GB / 26.7M-row table. That made
+``prune_orphan_entities`` (graph maintenance Pass 2) exceed the 60 s asyncpg
+``command_timeout`` on any bank with more than ~47 orphan entities, roll back,
+retry nine times, and never make progress — which also starved
+``prune_stale_cooccurrences`` in the same transaction.
+
+The FK protected nothing (``entity_id`` is NULL in every row and no writer sets
+it), so it is gone. If a future migration re-adds any FK on this column, this
+test fails — re-introducing the outage would otherwise be invisible until a
+bank accumulated orphans in production.
+
+The column itself deliberately stays: it is a key column of
+``idx_memory_links_unique``, which arbitrates retain's ``ON CONFLICT``. That is
+asserted here too, so a future "cleanup" that drops the column has to come here
+and think about the ``ON CONFLICT`` target first.
+"""
+
+import asyncpg
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_memory_links_entity_id_has_no_foreign_key(pg0_db_url):
+    """No FK constraint may reference memory_links.entity_id."""
+    conn = await asyncpg.connect(pg0_db_url)
+    try:
+        rows = await conn.fetch(
+            """
+            SELECT c.conname
+            FROM pg_constraint c
+            JOIN pg_attribute a
+              ON a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
+            WHERE c.conrelid = 'public.memory_links'::regclass
+              AND c.contype = 'f'
+              AND a.attname = 'entity_id'
+            """
+        )
+    finally:
+        await conn.close()
+
+    assert rows == [], (
+        "memory_links.entity_id must carry no FOREIGN KEY: "
+        f"found {[r['conname'] for r in rows]}. Migration c4f7a2e9b6d1 dropped "
+        "fk_memory_links_entity_id_entities because its ON DELETE CASCADE, "
+        "unbacked by any index leading on entity_id, seq-scanned the whole "
+        "table per deleted entity and made prune_orphan_entities time out "
+        "permanently. Do not re-add an FK here without first adding an index "
+        "on memory_links(entity_id)."
+    )
+
+
+@pytest.mark.asyncio
+async def test_memory_links_entity_id_column_still_exists(pg0_db_url):
+    """The column stays — idx_memory_links_unique keys on COALESCE(entity_id, ...)."""
+    conn = await asyncpg.connect(pg0_db_url)
+    try:
+        col = await conn.fetchval(
+            """
+            SELECT a.attname
+            FROM pg_attribute a
+            WHERE a.attrelid = 'public.memory_links'::regclass
+              AND a.attname = 'entity_id'
+              AND a.attnum > 0
+              AND NOT a.attisdropped
+            """
+        )
+        unique_index = await conn.fetchval(
+            """
+            SELECT indexdef
+            FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND tablename = 'memory_links'
+              AND indexname = 'idx_memory_links_unique'
+            """
+        )
+    finally:
+        await conn.close()
+
+    assert col == "entity_id", (
+        "memory_links.entity_id was dropped. That is a bigger change than it "
+        "looks: it drops idx_memory_links_unique, which is the arbiter of the "
+        "ON CONFLICT (from_unit_id, to_unit_id, link_type, COALESCE(entity_id, "
+        "...)) in PostgresOps.bulk_insert_links. Dropping the column requires "
+        "rebuilding that unique index CONCURRENTLY and changing the ON CONFLICT "
+        "target in ops.py, ops_postgresql.py and ops_oracle.py in the same "
+        "deploy, or every link insert on an old pod fails."
+    )
+    assert unique_index is not None and "entity_id" in unique_index, (
+        "idx_memory_links_unique must still key on entity_id via COALESCE — "
+        f"got {unique_index!r}. See PostgresOps.bulk_insert_links."
+    )


### PR DESCRIPTION
## The failure

`prune_orphan_entities` — graph maintenance Pass 2 — has not completed on four
of our production banks for a week. The `overlord` bank's
`prune_stale_cooccurrences` (same transaction, runs second) has therefore not
run since 3 August.

Each job burns ~560 s and rolls back with zero progress:

```
prune_orphan_entities  →  asyncpg command_timeout (60 s)  →  ROLLBACK
  ×9  (_SWEEP_MAX_RETRIES = 8, plus the initial attempt, with backoff)
```

## Root cause

`memory_links.entity_id` still carries `fk_memory_links_entity_id_entities`
— `FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE` — from
the initial schema migration `5a366d414dce`, back when entity edges were
materialised as `memory_links` rows.

That representation is gone. `e1b2c3d4f5a6` dropped the last index leading on
`entity_id`, and `e9b2c7d1f3a4` deleted every `link_type = 'entity'` row. The
constraint was never dropped with them.

An `ON DELETE CASCADE` child with **no index leading on its FK column** makes
PostgreSQL's referential-integrity trigger sequentially scan the entire child
table once per deleted parent row. `memory_links` is 26,750,591 rows / ~2676 MB
and its indexes are `(bank_id, link_type)`, `(from_unit_id, …)`,
`(to_unit_id, …)`, and the unique on
`(from_unit_id, to_unit_id, link_type, COALESCE(entity_id, …))` — none of which
lead on `entity_id`.

**Measured: 1.278 s per parent row deleted, fully cached.**

So the sweep is a cheap SELECT driving a ruinously expensive DELETE:

| step | cost |
|---|---|
| orphan anti-join (`idx_unit_entities_entity_unit`, correct plan) | ~70 ms |
| DELETE of ~157 orphan entities, via the cascade | ~200 s |
| asyncpg client-side `command_timeout` (`DEFAULT_DB_COMMAND_TIMEOUT`) | 60 s |

Because it rolls back, it never makes partial progress — so this is
self-compounding. Past roughly **47 orphans** a bank can never recover on its
own. Four banks are over that line.

## The constraint protects nothing

Verified directly against production:

```sql
SELECT count(*) FROM memory_links WHERE entity_id IS NOT NULL;
-- 0     (out of 26,750,591)
```

and `pg_stats.null_frac` for the column is `1`. Nothing writes it —
`_bulk_insert_links` passes `None` for every row.

## ⚠️ Production is already ahead of migration head

As an emergency unblock, the constraint has **already been dropped on the live
database**:

```sql
ALTER TABLE memory_links DROP CONSTRAINT fk_memory_links_entity_id_entities;
```

So that database has the constraint gone while `alembic_version` still reads
`b3e8d1c6f4a9`. The migration must reconcile that, not fail on it — hence
`DROP CONSTRAINT IF EXISTS`, which here is load-bearing rather than defensive
boilerplate. Verified both ways (see "Verification").

## What this PR does

**Migration `c4f7a2e9b6d1`** (`down_revision = 'b3e8d1c6f4a9'`, confirmed head
at branch time):

* `upgrade()` — `ALTER TABLE memory_links DROP CONSTRAINT IF EXISTS
  fk_memory_links_entity_id_entities`. Catalogue-only; instant regardless of
  table size.
* `downgrade()` — a real restore: `DROP … IF EXISTS` (symmetry), then
  `ADD CONSTRAINT … NOT VALID` followed by `VALIDATE CONSTRAINT` in an
  `autocommit_block`. A plain validating `ADD` would hold `ACCESS EXCLUSIVE`
  on `memory_links` across a seq scan of 26.7M rows; `NOT VALID` takes the
  exclusive lock only for the catalogue write and `VALIDATE` then runs under
  `SHARE UPDATE EXCLUSIVE`, blocking neither reads nor writes.

  **Reversibility, stated honestly:** the restore is faithful for the data that
  exists — `entity_id` is NULL in every row and a NULL FK column is trivially
  satisfied, so `VALIDATE` cannot fail on current data. It is not reversible in
  general: a database that somehow acquired non-NULL `entity_id` values
  pointing at deleted entities while the constraint was absent would fail
  `VALIDATE` and the downgrade would abort. Nothing in the codebase can produce
  such a row. The failure mode is "downgrade refuses", not "silent corruption",
  which is the right way round. This is said in a comment in the migration too.

**PostgreSQL-only**, same call as `9f8e7d6c5b4a`: Oracle's baseline
(`o1a2b3c4d5e6`) keeps `idx_ml_entity` on `memory_links(entity_id)`, so its
`fk_ml_entity` cascade is an index lookup, not a table scan. The pathology does
not exist there and the Oracle slot is deliberately left empty (with a comment
saying so).

### Decision: the `entity_id` COLUMN stays

I grepped the whole repo for `memory_links.entity_id` before deciding. Dropping
the column is materially riskier than dropping the constraint, and buys nothing
the outage cares about:

1. It is a key column of `idx_memory_links_unique`
   `(from_unit_id, to_unit_id, link_type, COALESCE(entity_id, nil_uuid))`,
   which is the **arbiter of the retain hot path's `ON CONFLICT … DO NOTHING`**
   in `PostgresOps.bulk_insert_links`. Dropping the column drops that index;
   rebuilding a unique index over 26.7M rows must happen `CONCURRENTLY` or it
   takes `ACCESS EXCLUSIVE` on the busiest table in the schema for the duration.
2. The `ON CONFLICT` target would have to change **in lockstep, in the same
   deploy**, in three places that do not deploy atomically with the migration:
   `ops.bulk_insert_links` (its signature takes `nil_entity_uuid`),
   `ops_postgresql.bulk_insert_links`, and `ops_oracle.bulk_insert_links`. An
   old API pod against a new schema — the normal state of a rolling deploy —
   fails **every link insert** with *"no unique or exclusion constraint matching
   the ON CONFLICT specification"*. That is retain down.
3. Oracle's baseline declares the same column and the same NVL-based unique
   index, so it is a two-dialect schema change, not a one-line PG cleanup.

The cascade scan is caused by the **constraint**, not the column. A nullable
column that is NULL in every row costs one null-bitmap bit per row. Removing it
is a worthwhile follow-up with its own rollout story — not something to bundle
into an outage fix.

### Also in this PR

* **`models.py`** — `MemoryLink.entity_id` loses its `ForeignKey`, and the
  `Entity.memory_links` / `MemoryLink.entity` relationship pair goes with it
  (SQLAlchemy cannot keep the relationship without the FK). This is the durable
  half: without it, a future `alembic revision --autogenerate` would happily
  resurrect the constraint. Mapper configuration verified clean.
* **`ops_postgresql.prune_orphan_entities`** — the comment claimed the anti-join
  is backed by `idx_ue_entity`. That is not a PostgreSQL index: it was dropped
  by `h3i4j5k6l7m8` / `e1b2c3d4f5a6` and the name now survives only in the
  Oracle baseline. The real index is `idx_unit_entities_entity_unit` on
  `(entity_id, unit_id)`. Corrected, and the comment now records the invariant
  that broke here: *every* `ON DELETE CASCADE` child of `entities` needs an
  index leading on its FK column.
* **`tests/test_memory_links_entity_fk_dropped.py`** — schema invariant test in
  the shape of the existing `test_memory_links_deferred_fk.py`. Asserts no FK on
  `memory_links.entity_id`, and asserts the column + its unique index still
  exist so a future "cleanup" that drops the column has to come here and think
  about the `ON CONFLICT` target first.

## Verification

Against a real PostgreSQL 18 (pg0), driving alembic directly:

```
after downgrade -> b3e8d1c6f4a9            fk=[('fk_memory_links_entity_id_entities', validated=True)] version=b3e8d1c6f4a9
CASE1 upgrade (fk present)                 fk=[]  version=c4f7a2e9b6d1
CASE2 pre (hand-dropped, version behind)   fk=[]  version=b3e8d1c6f4a9      <- production's shape
CASE2 upgrade (fk already gone)            fk=[]  version=c4f7a2e9b6d1
CASE3 pre (fk re-added at head)            fk=[('fk_memory_links_entity_id_entities', validated=True)] version=c4f7a2e9b6d1
CASE3 downgrade (fk pre-existing)          fk=[('fk_memory_links_entity_id_entities', validated=True)] version=b3e8d1c6f4a9
final upgrade                              fk=[]  version=c4f7a2e9b6d1
```

CASE2 is the one that matters: the migration applies cleanly on the database
where the constraint was already dropped by hand.

The new test was also confirmed to **fail on the bug** — re-adding the
constraint by hand makes
`test_memory_links_entity_id_has_no_foreign_key` fail with the intended message,
so it guards an outcome rather than a code path.

```
$ uv run pytest tests/test_graph_maintenance.py tests/test_db_abstraction.py \
    tests/test_sql_schema_safety.py tests/test_memory_links_deferred_fk.py \
    tests/test_memory_links_entity_fk_dropped.py \
    tests/test_memory_links_to_unit_id_concurrent_delete.py \
    tests/test_migration_shape.py tests/test_causal_link_taxonomy.py \
    tests/test_bank_stats.py
================ 360 passed, 95 skipped, 28 warnings in 55.71s =================

$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
631 files already formatted

$ uv run ty check hindsight_api/
Found 22 diagnostics     # identical count on origin/main — no regression
```

## Recommendations (not implemented here — deliberately out of scope)

Both of these are about the *class* of failure, which will recur with any future
cascade child; this PR only removes today's instance.

1. **`prune_orphan_entities` should be batched and/or given its own timeout,
   regardless of this fix.** The shape — a cheap SELECT whose DELETE is
   expensive via cascade — is inherently unpredictable from the planner's cost
   estimate, and the all-or-nothing transaction is what makes it
   *self-compounding* rather than merely slow: because it rolls back, a bank
   past the threshold can never claw its way back. A `LIMIT n` + loop with a
   commit per batch would degrade to "slow but progressing" instead of "stuck
   forever". I'd rate that a higher-value durability change than the timeout
   knob.

2. **The 60 s `command_timeout` against a 600 s `statement_timeout` is the wrong
   way round.** As it stands, asyncpg gives up on the client side while the
   server keeps working for up to another 540 s: the client sees a timeout and
   retries, the server is still holding locks and burning I/O on the abandoned
   statement, and the retry piles onto it. For background maintenance the two
   should be paired the other way — server timeout at or below the client
   timeout — so the server is the one that aborts and the client learns about it
   promptly. Alternatively, give the maintenance path its own longer
   `command_timeout` (it has no client waiting on it) rather than sharing the
   interactive default.

Happy to take either as a follow-up PR.
