### PR TITLE
fix(llm): forward extra body to Codex requests

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -381,6 +381,7 @@ def create_llm_provider(
             base_url=base_url,
             model=model,
             reasoning_effort=reasoning_effort,
+            extra_body=extra_body,
         )
 
     elif provider_lower == "claude-code":

--- a/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
@@ -127,6 +127,7 @@ class CodexLLM(LLMInterface):
         base_url: str,
         model: str,
         reasoning_effort: str = "low",
+        extra_body: dict[str, Any] | None = None,
         **kwargs: Any,
     ):
         """Initialize Codex LLM provider."""
@@ -177,6 +178,7 @@ class CodexLLM(LLMInterface):
         # Reasoning summary controls presentation separately from the backend's
         # reasoning effort, which is sent unchanged in each request payload.
         self.reasoning_summary = self._map_reasoning_effort(reasoning_effort)
+        self._extra_body = dict(extra_body or {})
 
         # HTTP client for SSE streaming
         self._client = httpx.AsyncClient(timeout=120.0)
@@ -457,6 +459,7 @@ class CodexLLM(LLMInterface):
             "include": ["reasoning.encrypted_content"],
             "prompt_cache_key": str(uuid.uuid4()),
         }
+        payload.update(self._extra_body)
 
         if use_forced_tool and schema is not None:
             # Single function tool whose parameters ARE the response schema;
@@ -845,6 +848,7 @@ class CodexLLM(LLMInterface):
             "include": ["reasoning.encrypted_content"],
             "prompt_cache_key": str(uuid.uuid4()),
         }
+        payload.update(self._extra_body)
 
         headers = self._build_request_headers()
 

--- a/hindsight-api-slim/tests/test_codex_extra_body.py
+++ b/hindsight-api-slim/tests/test_codex_extra_body.py
@@ -1,0 +1,75 @@
+"""Regression tests for Codex extra request-body parameters."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from hindsight_api.engine.llm_wrapper import create_llm_provider
+from hindsight_api.engine.providers.codex_llm import CodexLLM
+
+
+def build_llm(extra_body: dict | None = None) -> CodexLLM:
+    with (
+        patch.object(CodexLLM, "_load_codex_auth", return_value=("token", "account")),
+        patch.object(CodexLLM, "_load_codex_refresh_token", return_value=None),
+    ):
+        return CodexLLM(
+            provider="openai-codex",
+            api_key="ignored",
+            base_url="https://chatgpt.com/backend-api",
+            model="gpt-5.6-luna",
+            extra_body=extra_body,
+        )
+
+
+def test_factory_forwards_extra_body() -> None:
+    with (
+        patch.object(CodexLLM, "_load_codex_auth", return_value=("token", "account")),
+        patch.object(CodexLLM, "_load_codex_refresh_token", return_value=None),
+    ):
+        llm = create_llm_provider(
+            provider="openai-codex",
+            api_key="ignored",
+            base_url="https://chatgpt.com/backend-api",
+            model="gpt-5.6-luna",
+            reasoning_effort="low",
+            extra_body={"service_tier": "priority"},
+        )
+
+    assert llm._extra_body == {"service_tier": "priority"}
+
+
+@pytest.mark.asyncio
+async def test_call_merges_extra_body_into_request() -> None:
+    llm = build_llm({"service_tier": "priority"})
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+
+    with (
+        patch.object(llm._client, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(llm, "_parse_sse_stream", new_callable=AsyncMock, return_value="ok"),
+    ):
+        mock_post.return_value = response
+        await llm.call(messages=[{"role": "user", "content": "hello"}], max_retries=0)
+
+    assert mock_post.call_args.kwargs["json"]["service_tier"] == "priority"
+
+
+@pytest.mark.asyncio
+async def test_call_with_tools_merges_extra_body_into_request() -> None:
+    llm = build_llm({"service_tier": "priority"})
+    response = MagicMock(status_code=200)
+    response.raise_for_status.return_value = None
+
+    with (
+        patch.object(llm._client, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(llm, "_parse_sse_tool_stream", new_callable=AsyncMock, return_value=(None, [])),
+    ):
+        mock_post.return_value = response
+        await llm.call_with_tools(
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[],
+            max_retries=0,
+        )
+
+    assert mock_post.call_args.kwargs["json"]["service_tier"] == "priority"


### PR DESCRIPTION
## What

Forward `HINDSIGHT_API_LLM_EXTRA_BODY` to the `openai-codex` provider and merge it into both normal and tool-call request payloads. This allows opt-in Codex request fields such as `{"service_tier": "priority"}` without adding a provider-specific setting.

Closes #3298.

## Tests

- `uv run pytest tests/test_codex_extra_body.py tests/test_codex_reasoning_effort.py tests/test_codex_tool_choice.py tests/test_codex_strict_schema.py tests/test_llm_extra_body.py -q` (43 passed)
- Ruff check and format check on the changed Python files
- Repository pre-commit hooks

## Risk

Low. Empty configuration preserves the existing payload, and the new path only copies configured extra fields into the two Codex request bodies.
