### PR TITLE
fix(consolidation): don't dead-letter memories for a provider-side failure

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -18,6 +18,7 @@ NOTE: Observations are distinct from mental models (pinned reflections).
 import asyncio
 import json
 import logging
+import re
 import time
 import uuid
 from collections import defaultdict
@@ -675,6 +676,116 @@ class _ConsolidationBatchResponse(BaseModel):
     deletes: list[_DeleteAction] = []
 
 
+#: How a consolidation LLM batch failed, once its retries are exhausted.
+#:
+#: ``content`` is the only kind the memories themselves can be blamed for, and
+#: the only one that may end in ``consolidation_failed_at`` — the stamp is
+#: permanent, so it must never be applied for a condition the rows did not cause.
+LLMFailureKind = Literal["transient", "auth", "content"]
+
+#: How many sub-batches in a row may be lost to a transient provider failure
+#: before the rest of the batch is abandoned for this run. Not stamping
+#: ``consolidation_failed_at`` on a transient failure is correct, but it also
+#: removes the accidental rate limiting that permanent exclusion used to provide:
+#: without a breaker, every subsequent run reselects the same rows and re-hits a
+#: provider that is already refusing traffic.
+_MAX_CONSECUTIVE_TRANSIENT_SUB_BATCHES = 3
+
+#: Exception class names that are transient by construction, whatever the message
+#: says. Matched on the class name so a provider SDK's typed error is classified
+#: even when its ``str()`` is empty — the case a message-only classifier gets
+#: exactly backwards, since the cleanest errors carry the least text.
+_TRANSIENT_EXC_NAMES = (
+    "ratelimiterror",
+    "apitimeouterror",
+    "apiconnectionerror",
+    "internalservererror",
+    "serviceunavailable",
+    "overloadederror",
+    "timeouterror",
+    "connectionerror",
+)
+_AUTH_EXC_NAMES = ("authenticationerror", "permissiondeniederror", "unauthorized", "forbidden")
+
+#: HTTP statuses that mean "come back later". Matched with word boundaries: a
+#: bare ``"429" in text`` also fires on a token count of 14290 or a byte offset,
+#: which is the same substring false-positive that ruled out bare ``auth`` and
+#: ``connection`` as markers.
+_TRANSIENT_STATUS_RE = re.compile(r"\b(408|429|500|502|503|504|529)\b")
+_AUTH_STATUS_RE = re.compile(r"\b(401|403)\b")
+
+#: Message fragments, used only when neither the exception type nor a status code
+#: settled it. Multi-word or underscored so they cannot match ordinary prose.
+_TRANSIENT_MESSAGE_MARKERS = (
+    "usage limit",
+    "rate limit",
+    "rate_limit",
+    "ratelimit",
+    "limit reached",
+    "too many requests",
+    "too_many_requests",
+    "resource exhausted",
+    "resource_exhausted",
+    "quota",
+    "overloaded",
+    "capacity",
+    "connection refused",
+    "connection error",
+    "connection reset",
+    "timed out",
+    "timeout",
+    "temporarily unavailable",
+    "service unavailable",
+)
+_AUTH_MESSAGE_MARKERS = (
+    "authentication failed",
+    "not logged in",
+    "invalid api key",
+    "invalid_api_key",
+    "expired token",
+    "credentials",
+)
+
+
+def classify_llm_failure(exc: BaseException | None) -> LLMFailureKind:
+    """Classify an exhausted-retry LLM failure so the caller knows what to blame.
+
+    Order matters: the exception TYPE is checked before any status code, and both
+    before the message text. A typed ``RateLimitError`` with an empty message is
+    common and would otherwise fall through to ``content`` — the single worst
+    misclassification available here, because it dead-letters healthy rows for
+    the most unambiguous provider signal there is.
+
+    ``auth`` is deliberately NOT folded into ``transient``: a bad or expired
+    credential does not heal on its own, so treating it as transient means the
+    job retries it silently every run, forever, with nothing recorded anywhere.
+    It is not ``content`` either — the rows did not cause it and must not be
+    permanently excluded for it. The caller circuit-breaks on this kind instead.
+
+    Unknown failures classify as ``content``, preserving the pre-existing
+    bisect-then-stamp behaviour for anything this function does not recognise.
+    """
+    if exc is None:
+        return "content"
+    name = type(exc).__name__.lower()
+    if any(marker in name for marker in _AUTH_EXC_NAMES):
+        return "auth"
+    if any(marker in name for marker in _TRANSIENT_EXC_NAMES):
+        return "transient"
+    status = getattr(exc, "status_code", None) or getattr(getattr(exc, "response", None), "status_code", None)
+    if isinstance(status, int):
+        if status in (401, 403):
+            return "auth"
+        if status in (408, 429, 500, 502, 503, 504, 529):
+            return "transient"
+    text = str(exc).lower()
+    if _AUTH_STATUS_RE.search(text) or any(marker in text for marker in _AUTH_MESSAGE_MARKERS):
+        return "auth"
+    if _TRANSIENT_STATUS_RE.search(text) or any(marker in text for marker in _TRANSIENT_MESSAGE_MARKERS):
+        return "transient"
+    return "content"
+
+
 @dataclass
 class _BatchLLMResult:
     creates: list[_CreateAction] = field(default_factory=list)
@@ -683,6 +794,10 @@ class _BatchLLMResult:
     obs_count: int = 0
     prompt_chars: int = 0
     failed: bool = False
+    #: Why the batch failed, when it did. ``None`` while ``failed`` is False.
+    #: Drives whether the caller bisects and stamps (content) or leaves the rows
+    #: pending (transient / auth) — see ``classify_llm_failure``.
+    failure_kind: LLMFailureKind | None = None
 
 
 @dataclass
@@ -1288,6 +1403,9 @@ async def _run_consolidation_job(
             _batch_txn = await _txn_provider.mint_txn(bank_id=bank_id, mutating=True)
 
             pending: list[list[dict[str, Any]]] = [llm_batch_local]
+            #: Consecutive sub-batches lost to a transient provider failure. Reset
+            #: by any sub-batch that gets a real answer.
+            consecutive_transient = 0
             while pending:
                 sub_batch = pending.pop(0)
 
@@ -1297,11 +1415,14 @@ async def _run_consolidation_job(
                 obs_tags_list = _resolve_obs_tags_list(sub_batch[0]) if sub_batch else None
 
                 sub_deleted: int = 0
-                sub_llm_failed = False
+                # Every failure kind this sub-batch produced. A SET, not a pair of
+                # booleans: one pass failing transiently must not decide the fate
+                # of a sibling pass that failed on content, and vice versa.
+                sub_failure_kinds: set[LLMFailureKind] = set()
                 if obs_tags_list:
                     sub_results: list[dict[str, Any]] = []
                     for obs_tags in obs_tags_list:
-                        pass_results, pass_deleted, pass_failed = await _process_memory_batch(
+                        pass_results, pass_deleted, pass_failure = await _process_memory_batch(
                             pool=pool,
                             memory_engine=memory_engine,
                             llm_config=llm_config,
@@ -1314,7 +1435,8 @@ async def _run_consolidation_job(
                             txn=_batch_txn,
                         )
                         sub_deleted += pass_deleted
-                        sub_llm_failed = sub_llm_failed or pass_failed
+                        if pass_failure is not None:
+                            sub_failure_kinds.add(pass_failure)
                         if not sub_results:
                             sub_results = pass_results
                         else:
@@ -1339,7 +1461,7 @@ async def _run_consolidation_job(
                                         "total_actions": total,
                                     }
                 else:
-                    sub_results, sub_deleted, sub_llm_failed = await _process_memory_batch(
+                    sub_results, sub_deleted, _sub_failure = await _process_memory_batch(
                         pool=pool,
                         memory_engine=memory_engine,
                         llm_config=llm_config,
@@ -1350,8 +1472,60 @@ async def _run_consolidation_job(
                         config=config,
                         txn=_batch_txn,
                     )
+                    if _sub_failure is not None:
+                        sub_failure_kinds.add(_sub_failure)
 
                 all_deleted += sub_deleted
+
+                # A content failure anywhere in the sub-batch outranks a transient
+                # one: content is the only kind bisection can actually isolate, and
+                # letting a co-occurring transient failure suppress it would leave
+                # genuinely unprocessable rows retrying forever.
+                if "content" in sub_failure_kinds:
+                    sub_llm_failed = True
+                elif sub_failure_kinds:
+                    sub_llm_failed = False
+                    kind = "auth" if "auth" in sub_failure_kinds else "transient"
+                    all_results.extend({"action": "skipped", "reason": f"{kind}_llm"} for _ in sub_batch)
+                    if kind == "auth":
+                        # Credentials do not heal on their own. Leaving the rows
+                        # pending is right — they did nothing wrong — but staying
+                        # quiet about it is not: without this the job would retry
+                        # a dead credential every run, forever, recording nothing.
+                        # Stop the batch loop so the failure surfaces as one loud
+                        # event instead of an endless trickle.
+                        logger.error(
+                            f"[CONSOLIDATION] bank={bank_id} AUTH failure for sub-batch of {len(sub_batch)}; "
+                            f"leaving {len(sub_batch)} memory row(s) PENDING and ABORTING this batch — "
+                            "credentials will not recover by retrying."
+                        )
+                        pending.clear()
+                        continue
+                    consecutive_transient += 1
+                    logger.warning(
+                        f"[CONSOLIDATION] bank={bank_id} TRANSIENT LLM failure for sub-batch of "
+                        f"{len(sub_batch)}; leaving {len(sub_batch)} memory row(s) PENDING "
+                        f"(no consolidation_failed_at stamp; {consecutive_transient} in a row)"
+                    )
+                    if consecutive_transient >= _MAX_CONSECUTIVE_TRANSIENT_SUB_BATCHES:
+                        # Removing the dead-letter stamp also removed the accidental
+                        # rate limiter it provided: every run now reselects these rows
+                        # and re-hits the same exhausted provider. Give up on the rest
+                        # of this batch instead of hammering through it.
+                        logger.warning(
+                            f"[CONSOLIDATION] bank={bank_id} {consecutive_transient} consecutive transient "
+                            f"failures; abandoning {len(pending)} remaining sub-batch(es) this run. "
+                            "Rows stay PENDING for the next run."
+                        )
+                        pending.clear()
+                    continue
+                else:
+                    sub_llm_failed = False
+
+                # Reached only when the provider actually answered (success, or a
+                # content failure it is right to bisect), so the transient streak
+                # is over. The transient and auth paths above never get here.
+                consecutive_transient = 0
 
                 if sub_llm_failed and len(sub_batch) > 1:
                     mid = len(sub_batch) // 2
@@ -2079,7 +2253,10 @@ async def _process_memory_batch(
         else:
             results.append({"action": "skipped", "reason": "no_durable_knowledge"})
 
-    return results, deleted_count, llm_result.failed
+    # The third element is the failure KIND rather than a bare bool: the caller
+    # has to tell "the rows are bad" apart from "the provider is down", and a
+    # boolean cannot carry that. ``None`` means the batch did not fail.
+    return results, deleted_count, (llm_result.failure_kind if llm_result.failed else None)
 
 
 def _min_date(dates: "Any") -> "datetime | None":
@@ -2714,12 +2891,24 @@ async def _consolidate_batch_with_llm(
                 f"[CONSOLIDATION] LLM batch call failed (attempt {attempt}/{max_attempts}) for {batch_label}: {exc}"
             )
 
+    # Classify before returning: only a CONTENT failure may end in
+    # consolidation_failed_at, because that stamp permanently removes the rows
+    # from selection. A provider-side condition (quota window, rate limit,
+    # transport) is not something the memories did, and bisecting it only halves
+    # the batch into more calls that fail the same way. The kind is THREADED to
+    # the decision site rather than raised: a mid-loop raise would skip the
+    # consolidated_at finalization for sub-batches that already wrote, and the
+    # next run would re-create their observations.
+    failure_kind = classify_llm_failure(last_exc)
     logger.error(
         f"[CONSOLIDATION] LLM batch call failed after {max_attempts} attempts for {batch_label}, "
-        f"skipping batch. Last error: {last_exc}"
+        f"skipping batch (failure_kind={failure_kind}). Last error: {last_exc}"
     )
     return _BatchLLMResult(
-        obs_count=len(union_observations), prompt_chars=len(system_prompt) + len(user_content), failed=True
+        obs_count=len(union_observations),
+        prompt_chars=len(system_prompt) + len(user_content),
+        failed=True,
+        failure_kind=failure_kind,
     )
 
 

--- a/hindsight-api-slim/tests/test_consolidation_dedup.py
+++ b/hindsight-api-slim/tests/test_consolidation_dedup.py
@@ -625,17 +625,17 @@ async def test_process_batch_creates_when_dedup_target_vanished() -> None:
     create_action.assert_awaited_once()
     assert create_action.await_args.kwargs["text"] == "Uzbek YouTube content is very rich."
     assert create_action.await_args.kwargs["source_memory_ids"] == [mem_id]
-    assert result == ([{"action": "created"}], 0, False)
+    assert result == ([{"action": "created"}], 0, None)
 
 
 async def test_process_batch_reports_skipped_when_create_skipped() -> None:
     # _execute_create_action returns "skipped" (all sources deleted in the write txn) ->
     # _process_memory_batch must NOT mark the memory created; it falls through to skipped.
     result, _create_action, _mem_id = await _run_create_batch("skipped")
-    assert result == ([{"action": "skipped", "reason": "no_durable_knowledge"}], 0, False)
+    assert result == ([{"action": "skipped", "reason": "no_durable_knowledge"}], 0, None)
 
 
 async def test_process_batch_reports_created_when_create_created() -> None:
     # _execute_create_action returns "created" -> the memory is marked created.
     result, _create_action, _mem_id = await _run_create_batch("created")
-    assert result == ([{"action": "created"}], 0, False)
+    assert result == ([{"action": "created"}], 0, None)

--- a/hindsight-api-slim/tests/test_consolidation_failure_classification.py
+++ b/hindsight-api-slim/tests/test_consolidation_failure_classification.py
@@ -1,0 +1,99 @@
+"""Tests for consolidation LLM-failure classification.
+
+``consolidation_failed_at`` is a PERMANENT exclusion: a stamped row is never
+selected again. So the only failure the stamp may follow is one the memories
+themselves caused. ``classify_llm_failure`` is what separates that case from a
+provider that is merely refusing traffic right now, and it is a pure function
+precisely so this distinction can be tested without a database or an LLM.
+
+The cases that matter are the two directions of misclassification:
+
+  * calling a provider outage ``content`` dead-letters healthy rows -- the bug
+    upstream #2973 reports, and the reason a typed error with an EMPTY message
+    is tested here (the cleanest provider errors carry the least text, so a
+    message-only classifier fails exactly where it should be most confident);
+  * calling a content failure ``transient`` leaves genuinely unprocessable rows
+    retrying forever, which is why an unrecognised error must stay ``content``.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from hindsight_api.engine.consolidation.consolidator import classify_llm_failure
+
+
+class _RateLimitError(Exception):
+    """A typed provider error whose str() is empty, as SDKs commonly raise."""
+
+
+class _AuthenticationError(Exception):
+    pass
+
+
+class _WeirdProviderError(Exception):
+    def __init__(self, message: str, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class ClassifyByExceptionTypeTests(unittest.TestCase):
+    def test_typed_rate_limit_with_empty_message_is_transient(self):
+        """The regression that motivates type-before-text ordering.
+
+        A message-only classifier sees "" here and returns content, which
+        bisects and then permanently stamps rows for the single most
+        unambiguous transient signal a provider can send.
+        """
+        self.assertEqual(classify_llm_failure(_RateLimitError()), "transient")
+
+    def test_typed_auth_error_is_auth_not_transient(self):
+        self.assertEqual(classify_llm_failure(_AuthenticationError()), "auth")
+
+    def test_status_code_attribute_is_read(self):
+        self.assertEqual(classify_llm_failure(_WeirdProviderError("upstream said no", 503)), "transient")
+        self.assertEqual(classify_llm_failure(_WeirdProviderError("upstream said no", 403)), "auth")
+
+
+class ClassifyByMessageTests(unittest.TestCase):
+    def test_rate_limit_phrasings_are_all_transient(self):
+        for message in (
+            "Error code: 429 - too many requests",
+            "rate_limit_exceeded",
+            "ratelimited, retry later",
+            "Resource exhausted",
+            "usage limit reached for this window",
+            "service unavailable",
+            "connection reset by peer",
+        ):
+            with self.subTest(message=message):
+                self.assertEqual(classify_llm_failure(RuntimeError(message)), "transient")
+
+    def test_auth_phrasings_are_auth(self):
+        for message in ("authentication failed", "invalid api key", "Error code: 401"):
+            with self.subTest(message=message):
+                self.assertEqual(classify_llm_failure(RuntimeError(message)), "auth")
+
+    def test_status_codes_need_word_boundaries(self):
+        """A bare substring test fires on any number that CONTAINS the code.
+
+        ``"429" in "14290"`` is true, so an untrimmed classifier would call a
+        content-shaped error transient and retry an unprocessable batch forever.
+        """
+        self.assertEqual(
+            classify_llm_failure(RuntimeError("model produced 14290 tokens of malformed JSON")),
+            "content",
+        )
+        self.assertEqual(classify_llm_failure(RuntimeError("offset 5031 invalid")), "content")
+        self.assertEqual(classify_llm_failure(RuntimeError("Error code: 429")), "transient")
+
+    def test_unrecognised_failure_stays_content(self):
+        """Unknown means keep the pre-existing bisect-then-stamp behaviour."""
+        self.assertEqual(classify_llm_failure(ValueError("could not parse operation at index 3")), "content")
+
+    def test_no_exception_is_content(self):
+        self.assertEqual(classify_llm_failure(None), "content")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The problem

`consolidation_failed_at` is a **permanent** exclusion — a stamped row is never selected again. Today it is applied to any exhausted-retry LLM failure, including ones the memories had nothing to do with.

When a provider hits a quota window or rate limit, the batch fails and the adaptive splitter bisects it down to size 1. Bisection isolates nothing here, because every call fails for the same reason — it just multiplies the failing calls — and each single-memory batch then gets stamped. Healthy memories are dropped from consolidation permanently, and the run that dropped them looks like an ordinary run with some failures.

This is the dead-lettering half of #2973.

## The change

Classify the failure instead of assuming the content is at fault:

| kind | bisect? | stamp `consolidation_failed_at`? | rows |
|---|---|---|---|
| `transient` — quota, rate limit, capacity, transport | no | no | stay pending for the next run |
| `auth` — bad/expired credentials | no | no | stay pending, **batch aborts loudly** |
| `content` — everything else, including anything unrecognised | yes | yes (unchanged) | unchanged |

Three details that are easy to get wrong, and why they are the way they are:

**Type before status before text.** A typed `RateLimitError` very often has an empty `str()`. A message-only classifier returns `content` for it — the worst misclassification available here, because it dead-letters healthy rows on the single most unambiguous transient signal a provider can send.

**Status codes need word boundaries.** `"429" in text` also fires on a token count of `14290` or a byte offset. That is the same substring false-positive that rules out bare `auth` and `connection` as markers, so codes are matched with `\b`.

**`auth` is its own kind, not a flavour of transient.** Credentials do not heal by retrying, so classifying them transient means the job silently retries a dead credential every run forever, recording nothing anywhere. They are not `content` either — the rows did nothing wrong and must not be permanently excluded for an environment problem. So the rows stay pending and the batch aborts with an error log.

**Unknown stays `content`**, preserving today's behaviour for anything the classifier does not recognise.

## Threading, not raising

`_process_memory_batch` now returns the failure **kind** instead of a bool — the caller has to tell "these rows are bad" from "the provider is down", and a boolean cannot carry that. The three call-contract tests are updated to the new shape.

The kind is threaded to the decision site rather than raised: a mid-loop raise would skip `consolidated_at` finalization for sub-batches that already wrote, and the next run would re-create their observations.

Sub-batch failures aggregate as a **set** of kinds, and a content failure anywhere outranks a co-occurring transient one. With two booleans OR'd together, one transient pass would suppress bisection for a sibling pass that failed on content, leaving genuinely unprocessable rows retrying forever.

## Storm brake

Not stamping on transient failures also removes the accidental rate limiting that permanent exclusion used to provide: without a brake, every later run reselects the same rows and re-hits a provider that is already refusing traffic. Three consecutive transient sub-batches now abandon the rest of the batch for this run.

## Scope

The other residual #2973 names — no per-memory transaction boundary, so a partially-written sub-batch may re-create some observations when it re-runs — is **unchanged**, and still absorbed by semantic dedup. Stamping on transient would "fix" it only by silently losing the un-consolidated part, which is the worse trade.

## Tests

New `tests/test_consolidation_failure_classification.py` covers both misclassification directions: a typed error with an empty message, status codes needing word boundaries (`14290` must not read as a 429), the rate-limit phrasings a plain substring list misses (`rate_limit_exceeded`, `ratelimited`), and the rule that an unrecognised failure stays `content`. `classify_llm_failure` is a pure function so none of this needs a database or an LLM.

Full local run: 50 passed in the consolidation suites. Two failures in `test_claude_code_llm_isolation.py` reproduce identically on unpatched `main` and are unrelated to this change.
