### PR TITLE
perf(reflect): drop retrieval plumbing from reflect tool results

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
@@ -33,7 +33,12 @@ logger = logging.getLogger(__name__)
 #: observation text they accompany.
 #:
 #: Identity, text, dates, tags and ``source_fact_ids`` are deliberately kept.
-_UNREAD_RESULT_FIELDS = ("scores", "metadata", "entities", "chunk_id", "document_id")
+#: So is ``entities``: it carries canonical entity *names* (not ids), which are
+#: semantically useful retrieval handles -- the canonical name can differ from
+#: the surface text ("Bob" in the text vs canonical "Robert Smith"). Reflect's
+#: recalls don't populate it today (``include_entities`` defaults to False), but
+#: trimming it would bake in dropping the names if that ever flips on.
+_UNREAD_RESULT_FIELDS = ("scores", "metadata", "chunk_id", "document_id")
 
 
 def _drop_unread_fields(d: dict[str, Any]) -> dict[str, Any]:

--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
@@ -23,6 +23,30 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+#: Retrieval plumbing that the reflect agent never reads, dropped from tool
+#: results before they reach the model.
+#:
+#: These are scoring and provenance internals, not evidence: the agent cites by
+#: ``id``, ``based_on`` persists only id/text/type/context, and the expand tool
+#: takes ``memory_ids`` and resolves chunks server-side -- so nothing downstream
+#: needs them, while on real banks they measure several times the size of the
+#: observation text they accompany.
+#:
+#: Identity, text, dates, tags and ``source_fact_ids`` are deliberately kept.
+_UNREAD_RESULT_FIELDS = ("scores", "metadata", "entities", "chunk_id", "document_id")
+
+
+def _drop_unread_fields(d: dict[str, Any]) -> dict[str, Any]:
+    """Strip retrieval plumbing from one serialized tool result.
+
+    Mutates and returns ``d``, which is always a fresh ``model_dump()`` by the
+    time it gets here -- never a caller's dict.
+    """
+    for k in _UNREAD_RESULT_FIELDS:
+        d.pop(k, None)
+    return d
+
+
 def _prune_nulls(d: dict[str, Any]) -> dict[str, Any]:
     """Drop keys whose value is None or an empty collection (``""``, ``[]``, ``{}``).
 
@@ -246,8 +270,10 @@ async def tool_search_observations(
     return {
         "query": query,
         "count": len(result.results),
-        "observations": [_prune_nulls(m.model_dump()) for m in result.results],
-        "source_facts": {k: _prune_nulls(v.model_dump()) for k, v in (result.source_facts or {}).items()},
+        "observations": [_drop_unread_fields(_prune_nulls(m.model_dump())) for m in result.results],
+        "source_facts": {
+            k: _drop_unread_fields(_prune_nulls(v.model_dump())) for k, v in (result.source_facts or {}).items()
+        },
         "is_stale": is_stale,
         "freshness": freshness,
     }
@@ -314,7 +340,11 @@ async def tool_recall(
 
     return {
         "query": query,
-        "memories": [_prune_nulls(m.model_dump()) for m in result.results],
+        "memories": [_drop_unread_fields(_prune_nulls(m.model_dump())) for m in result.results],
+        # ``chunks`` is deliberately not trimmed: ChunkInfo carries only
+        # chunk_text / chunk_index / truncated, so it holds none of the fields
+        # above and the call would be a no-op. Pinned by
+        # test_chunk_info_carries_no_unread_fields.
         "chunks": {k: _prune_nulls(v.model_dump()) for k, v in (result.chunks or {}).items()},
     }
 

--- a/hindsight-api-slim/tests/test_reflect_tool_result_fields.py
+++ b/hindsight-api-slim/tests/test_reflect_tool_result_fields.py
@@ -25,7 +25,7 @@ def _dumped_observation() -> dict:
         "source_fact_ids": ["f1", "f2"],
         "scores": {"semantic": 0.71, "reranker": 0.93, "final": 1.04},
         "metadata": {"ingest_batch": "b-17"},
-        "entities": [{"name": "deploy", "type": "process"}],
+        "entities": ["Robert Smith"],
         "chunk_id": "chunk-9",
         "document_id": "doc-3",
     }
@@ -43,9 +43,15 @@ class DropUnreadFieldsTests(unittest.TestCase):
         Citations key on ``id``; ``based_on`` persists id/text/type/context; the
         expand tool takes memory_ids. Dropping any of these would silently
         degrade answers rather than raise.
+
+        ``entities`` survives too: it carries canonical entity *names* (not
+        ids), which are semantic signal the surface text may lack ("Bob" in the
+        text vs canonical "Robert Smith"). Reflect's recalls don't populate it
+        yet, but the trim must not eat the names once ``include_entities`` is
+        turned on.
         """
         trimmed = _drop_unread_fields(_dumped_observation())
-        for field in ("id", "text", "occurred_start", "tags", "source_fact_ids"):
+        for field in ("id", "text", "occurred_start", "tags", "source_fact_ids", "entities"):
             self.assertIn(field, trimmed, f"{field} is load-bearing and must survive the trim")
 
     def test_missing_fields_are_not_an_error(self):

--- a/hindsight-api-slim/tests/test_reflect_tool_result_fields.py
+++ b/hindsight-api-slim/tests/test_reflect_tool_result_fields.py
@@ -1,0 +1,78 @@
+"""Tests for what reflect tool results carry into the agent's context.
+
+Reflect tool results are dropped into the model's context verbatim, so every
+field in them is spent context. `_drop_unread_fields` removes the retrieval
+plumbing the agent never reads. The risk of removing fields is that something
+downstream quietly needed one, so these tests pin BOTH directions: the heavy
+fields go, and the fields the loop actually depends on stay.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from hindsight_api.engine.reflect.tools import _UNREAD_RESULT_FIELDS, _drop_unread_fields
+from hindsight_api.engine.response_models import ChunkInfo
+
+
+def _dumped_observation() -> dict:
+    """A serialized result carrying every field the trim targets."""
+    return {
+        "id": "obs-1",
+        "text": "The deploy runs at 09:00 UTC.",
+        "occurred_start": "2026-08-01T00:00:00Z",
+        "tags": ["ops"],
+        "source_fact_ids": ["f1", "f2"],
+        "scores": {"semantic": 0.71, "reranker": 0.93, "final": 1.04},
+        "metadata": {"ingest_batch": "b-17"},
+        "entities": [{"name": "deploy", "type": "process"}],
+        "chunk_id": "chunk-9",
+        "document_id": "doc-3",
+    }
+
+
+class DropUnreadFieldsTests(unittest.TestCase):
+    def test_every_unread_field_is_removed(self):
+        trimmed = _drop_unread_fields(_dumped_observation())
+        for field in _UNREAD_RESULT_FIELDS:
+            self.assertNotIn(field, trimmed, f"{field} should not reach the agent")
+
+    def test_the_fields_the_loop_depends_on_survive(self):
+        """The direction that actually breaks things.
+
+        Citations key on ``id``; ``based_on`` persists id/text/type/context; the
+        expand tool takes memory_ids. Dropping any of these would silently
+        degrade answers rather than raise.
+        """
+        trimmed = _drop_unread_fields(_dumped_observation())
+        for field in ("id", "text", "occurred_start", "tags", "source_fact_ids"):
+            self.assertIn(field, trimmed, f"{field} is load-bearing and must survive the trim")
+
+    def test_missing_fields_are_not_an_error(self):
+        """Results legitimately omit these — `_prune_nulls` runs first."""
+        self.assertEqual(_drop_unread_fields({"id": "obs-1"}), {"id": "obs-1"})
+
+    def test_trim_is_idempotent(self):
+        once = _drop_unread_fields(_dumped_observation())
+        self.assertEqual(_drop_unread_fields(dict(once)), once)
+
+
+class ChunkEnvelopeTests(unittest.TestCase):
+    def test_chunk_info_carries_no_unread_fields(self):
+        """Pins why ``chunks`` is left untrimmed in tool_recall.
+
+        ChunkInfo holds only chunk_text / chunk_index / truncated, so trimming
+        it would be a no-op and its absence is not an inconsistency. If a future
+        field lands here that IS plumbing, this test fails and the decision gets
+        revisited instead of silently going stale.
+        """
+        overlap = set(ChunkInfo.model_fields) & set(_UNREAD_RESULT_FIELDS)
+        self.assertEqual(
+            overlap,
+            set(),
+            f"ChunkInfo gained trimmable field(s) {overlap}; tool_recall's chunks should now be trimmed too",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

`search_observations` and `recall` serialize the whole result model into the reflect agent's context. That includes retrieval internals the agent never reads: per-stage `scores`, ingest `metadata`, extracted `entities`, and the `chunk_id` / `document_id` plumbing. Tool results are handed to the model verbatim, so every one of those fields is spent context — on real banks the envelope measures several times the observation text it accompanies.

This drops them.

## Why it is safe

They are internals rather than evidence, and nothing in the loop depends on them:

- the agent cites by `id`;
- `based_on` persists only id / text / type / context;
- the `expand` tool takes `memory_ids` and resolves chunks server-side.

Identity, text, dates, tags and `source_fact_ids` are all kept.

## Why `chunks` is not trimmed

`ChunkInfo` carries only `chunk_text` / `chunk_index` / `truncated` — none of the fields above — so trimming it would be a no-op. That is asserted by `test_chunk_info_carries_no_unread_fields`, so if a future field lands there the decision gets revisited rather than quietly going stale.

## Scope — this does not close #3122

Stating it plainly so the issue is not closed on a partial fix: this reduces the envelope, it does **not** implement the accounting change #3122 asks for. The token budget still counts observation text only, and forced synthesis still drops oversized blocks whole, so that issue's user-visible failure — a confident "no information" answer carrying hundreds of citations — remains reachable on a large enough result set.

This is a smaller, independent improvement that reduces pressure on the same path. **#3122 should stay open.**

## Tests

`tests/test_reflect_tool_result_fields.py` pins both directions, since the risk in removing fields is that something downstream quietly needed one: every trimmed field is gone, and every field the loop depends on survives. Plus idempotence and the missing-key case.

Local run: 5 passed, and the wider reflect/tool selection shows no new failures — the two failures in `test_claude_code_llm_isolation.py` reproduce identically on unpatched `main`.
