### PR TITLE
fix(search): use backend-aware Knowledge Page queries

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -13333,11 +13333,10 @@ class MemoryEngine(MemoryEngineInterface):
     ) -> list[dict[str, Any]]:
         """Doc-level hybrid search over a bank's knowledge pages.
 
-        Fuses a full-text match (``mm.search_vector``, a generated tsvector over the
-        page name + content) with vector similarity (``mm.embedding``) using
-        Reciprocal Rank Fusion, in a single round trip. No reranker — this path is
-        tuned for latency. Returns pages ranked by fused score, each with a short
-        content snippet. Folders are excluded.
+        Fuses backend-specific lexical search with vector similarity
+        (``mm.embedding``) using Reciprocal Rank Fusion, in a single round trip.
+        No reranker — this path is tuned for latency. Returns pages ranked by
+        fused score, each with a short content snippet. Folders are excluded.
         """
         await self._authenticate_tenant(request_context)
         query = (query or "").strip()
@@ -13358,28 +13357,39 @@ class MemoryEngine(MemoryEngineInterface):
         join = self._kp_join()
 
         backend = await self._get_backend()
+        assert self._dialect is not None
+        config = get_config()
         async with acquire_with_retry(backend) as conn:
             if emb_str is not None:
-                # Vector arm (ANN over mm.embedding) + BM25 arm (mm.search_vector),
-                # each ranked independently, then RRF-fused (k=60) in SQL.
+                embedding_param = self._dialect.param(1)
+                bank_param = self._dialect.param(2)
+                query_param = self._dialect.param(3)
+                vector_distance = self._dialect.vector_distance("mm.embedding", embedding_param)
+                text_plan = self._dialect.knowledge_page_text_search_plan(
+                    query_param=query_param,
+                    text_search_extension=config.text_search_extension,
+                    native_language=config.text_search_extension_native_language,
+                )
+                # Vector and lexical arms are ranked independently, then
+                # RRF-fused (k=60). The dialect owns the non-portable operators.
                 sql = f"""
                     WITH vec AS (
                         SELECT kp.id AS page_id,
-                               ROW_NUMBER() OVER (ORDER BY mm.embedding <=> $1::vector) AS rnk
+                               ROW_NUMBER() OVER (ORDER BY {vector_distance}) AS rnk
                         FROM {join}
-                        WHERE kp.bank_id = $2 AND kp.kind = 'page' AND mm.embedding IS NOT NULL
-                        ORDER BY mm.embedding <=> $1::vector
+                        WHERE kp.bank_id = {bank_param} AND kp.kind = 'page' AND mm.embedding IS NOT NULL
+                        ORDER BY {vector_distance}
                         LIMIT {fetch}
                     ),
                     bm AS (
                         SELECT kp.id AS page_id,
                                ROW_NUMBER() OVER (
-                                   ORDER BY ts_rank_cd(mm.search_vector, websearch_to_tsquery('english', $3)) DESC
+                                   ORDER BY {text_plan.order_by}
                                ) AS rnk
                         FROM {join}
-                        WHERE kp.bank_id = $2 AND kp.kind = 'page'
-                              AND mm.search_vector @@ websearch_to_tsquery('english', $3)
-                        ORDER BY ts_rank_cd(mm.search_vector, websearch_to_tsquery('english', $3)) DESC
+                        WHERE kp.bank_id = {bank_param} AND kp.kind = 'page'
+                              AND ({text_plan.match_condition})
+                        ORDER BY {text_plan.order_by}
                         LIMIT {fetch}
                     ),
                     fused AS (
@@ -13388,9 +13398,10 @@ class MemoryEngine(MemoryEngineInterface):
                         FROM vec FULL OUTER JOIN bm ON vec.page_id = bm.page_id
                     )
                     SELECT kp.id, kp.name, kp.mental_model_id,
-                           LEFT(mm.content, 280) AS snippet, mm.last_refreshed_at AS updated_at, f.score
+                           SUBSTR(mm.content, 1, 280) AS snippet,
+                           mm.last_refreshed_at AS updated_at, f.score
                     FROM fused f
-                    JOIN {kp} kp ON kp.id = f.page_id AND kp.bank_id = $2
+                    JOIN {kp} kp ON kp.id = f.page_id AND kp.bank_id = {bank_param}
                     LEFT JOIN {mm} mm ON mm.id = kp.mental_model_id AND mm.bank_id = kp.bank_id
                     ORDER BY f.score DESC
                     LIMIT {limit}
@@ -13398,14 +13409,22 @@ class MemoryEngine(MemoryEngineInterface):
                 rows = await conn.fetch(sql, emb_str, bank_id, query)
             else:
                 # Embedding unavailable → BM25-only fallback (still useful).
+                bank_param = self._dialect.param(1)
+                query_param = self._dialect.param(2)
+                text_plan = self._dialect.knowledge_page_text_search_plan(
+                    query_param=query_param,
+                    text_search_extension=config.text_search_extension,
+                    native_language=config.text_search_extension_native_language,
+                )
                 sql = f"""
                     SELECT kp.id, kp.name, kp.mental_model_id,
-                           LEFT(mm.content, 280) AS snippet, mm.last_refreshed_at AS updated_at,
-                           ts_rank_cd(mm.search_vector, websearch_to_tsquery('english', $2)) AS score
+                           SUBSTR(mm.content, 1, 280) AS snippet,
+                           mm.last_refreshed_at AS updated_at,
+                           {text_plan.score_expression} AS score
                     FROM {join}
-                    WHERE kp.bank_id = $1 AND kp.kind = 'page'
-                          AND mm.search_vector @@ websearch_to_tsquery('english', $2)
-                    ORDER BY score DESC
+                    WHERE kp.bank_id = {bank_param} AND kp.kind = 'page'
+                          AND ({text_plan.match_condition})
+                    ORDER BY {text_plan.order_by}
                     LIMIT {limit}
                 """
                 rows = await conn.fetch(sql, bank_id, query)

--- a/hindsight-api-slim/hindsight_api/engine/sql/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/base.py
@@ -5,6 +5,20 @@ Business logic calls these methods instead of embedding raw SQL fragments.
 """
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class KnowledgePageTextSearchPlan:
+    """Database-owned SQL fragments for a Knowledge Page lexical-search arm.
+
+    Scores are normalized so larger values always mean a better match. The
+    match condition must exclude non-matches before rank fusion.
+    """
+
+    score_expression: str
+    match_condition: str
+    order_by: str
 
 
 class SQLDialect(ABC):
@@ -145,6 +159,22 @@ class SQLDialect(ABC):
 
         Returns:
             Expression suitable for ORDER BY ... ASC.
+        """
+        ...
+
+    @abstractmethod
+    def knowledge_page_text_search_plan(
+        self,
+        *,
+        query_param: str,
+        text_search_extension: str,
+        native_language: str,
+    ) -> KnowledgePageTextSearchPlan:
+        """Build the lexical-search expressions for ``mental_models``.
+
+        Knowledge Pages live on the ``mental_models`` table (alias ``mm``).
+        Column types, match operators, score direction, and index contracts vary
+        by database and text-search extension, so they belong to the dialect.
         """
         ...
 

--- a/hindsight-api-slim/hindsight_api/engine/sql/oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/oracle.py
@@ -5,7 +5,7 @@ vector distance (VECTOR_DISTANCE), full-text search (Oracle Text), and
 other non-portable patterns.
 """
 
-from .base import SQLDialect
+from .base import KnowledgePageTextSearchPlan, SQLDialect
 
 
 class OracleDialect(SQLDialect):
@@ -112,6 +112,27 @@ class OracleDialect(SQLDialect):
 
     def text_search_order(self, col: str, query_param: str, *, index_name: str | None = None) -> str:
         return "SCORE(1) DESC"
+
+    def knowledge_page_text_search_plan(
+        self,
+        *,
+        query_param: str,
+        text_search_extension: str,
+        native_language: str,
+    ) -> KnowledgePageTextSearchPlan:
+        """Keep Knowledge Page search vector-only on Oracle.
+
+        Oracle's baseline has a CTXSYS index for ``memory_units.text`` but not
+        for ``mental_models.content``. A false lexical arm preserves vector
+        search without pretending that Knowledge Page text search is indexed.
+        The bind remains referenced because python-oracledb rejects unused binds.
+        """
+        del text_search_extension, native_language
+        return KnowledgePageTextSearchPlan(
+            score_expression="0",
+            match_condition=f"{query_param} IS NULL AND 1 = 0",
+            order_by="mm.id",
+        )
 
     # -- Fuzzy string matching -------------------------------------------
 

--- a/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
@@ -5,7 +5,7 @@ vector distance (pgvector), full-text search (VectorChord BM25 / tsvector),
 and other non-portable patterns.
 """
 
-from .base import SQLDialect
+from .base import KnowledgePageTextSearchPlan, SQLDialect
 
 
 class PostgreSQLDialect(SQLDialect):
@@ -54,6 +54,70 @@ class PostgreSQLDialect(SQLDialect):
             # VectorChord BM25 — lower distance = better, so ASC
             return f"{col} <@> to_bm25query({query_param}, '{index_name}') ASC"
         return f"ts_rank_cd({col}, to_tsquery({query_param})) DESC"
+
+    def knowledge_page_text_search_plan(
+        self,
+        *,
+        query_param: str,
+        text_search_extension: str,
+        native_language: str,
+    ) -> KnowledgePageTextSearchPlan:
+        """Return the lexical plan matching ``idx_mental_models_text_search``."""
+        if text_search_extension == "vchord":
+            # <&> returns negative BM25. Negate it so all plans expose a score
+            # where larger is better, and gate zero-score padded rows.
+            score = (
+                "-(mm.search_vector <&> to_bm25query('idx_mental_models_text_search', "
+                f"tokenize({query_param}, 'llmlingua2')))"
+            )
+            return KnowledgePageTextSearchPlan(
+                score_expression=score,
+                match_condition=f"{score} > 0",
+                order_by=f"{score} DESC",
+            )
+
+        if text_search_extension == "pg_textsearch":
+            # The shipped mental-model migration indexes ``content``. <@>
+            # returns negative BM25; zero is a non-match.
+            distance = f"mm.content <@> to_bm25query({query_param}, 'idx_mental_models_text_search')"
+            return KnowledgePageTextSearchPlan(
+                score_expression=f"-({distance})",
+                match_condition=f"{distance} < 0",
+                order_by=f"{distance} ASC",
+            )
+
+        if text_search_extension == "pgroonga":
+            score = "pgroonga_score(mm.tableoid, mm.ctid)"
+            # This must repeat the PGroonga expression-index definition exactly.
+            document = "(COALESCE(mm.name, '') || ' ' || mm.content)"
+            return KnowledgePageTextSearchPlan(
+                score_expression=score,
+                match_condition=f"{document} &@~ pgroonga_query_escape({query_param})",
+                order_by=f"{score} DESC",
+            )
+
+        if text_search_extension == "pg_search":
+            score = "paradedb.score(mm.id)"
+            match = (
+                "mm.id @@@ paradedb.boolean(should => ARRAY["
+                f"paradedb.match('name', {query_param}), "
+                f"paradedb.match('content', {query_param})"
+                "])"
+            )
+            return KnowledgePageTextSearchPlan(
+                score_expression=score,
+                match_condition=match,
+                order_by=f"{score} DESC",
+            )
+
+        # The language is validated as a PostgreSQL identifier in config.
+        tsquery = f"websearch_to_tsquery('{native_language}', {query_param})"
+        score = f"ts_rank_cd(mm.search_vector, {tsquery})"
+        return KnowledgePageTextSearchPlan(
+            score_expression=score,
+            match_condition=f"mm.search_vector @@ {tsquery}",
+            order_by=f"{score} DESC",
+        )
 
     # -- Fuzzy string matching -------------------------------------------
 

--- a/hindsight-api-slim/tests/test_db_abstraction.py
+++ b/hindsight-api-slim/tests/test_db_abstraction.py
@@ -5,7 +5,10 @@ without requiring a live database connection.
 """
 
 import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -145,6 +148,113 @@ class TestPostgreSQLDialect:
     def test_text_search_score_tsvector(self, d):
         result = d.text_search_score("text", "$1")
         assert "ts_rank_cd" in result
+
+    @pytest.mark.parametrize(
+        ("extension", "score_fragment", "match_fragment"),
+        [
+            (
+                "native",
+                "ts_rank_cd(mm.search_vector, websearch_to_tsquery('french', $3))",
+                "mm.search_vector @@ websearch_to_tsquery('french', $3)",
+            ),
+            (
+                "vchord",
+                "-(mm.search_vector <&> to_bm25query('idx_mental_models_text_search', tokenize($3, 'llmlingua2')))",
+                "> 0",
+            ),
+            (
+                "pg_textsearch",
+                "-(mm.content <@> to_bm25query($3, 'idx_mental_models_text_search'))",
+                "mm.content <@> to_bm25query($3, 'idx_mental_models_text_search') < 0",
+            ),
+            (
+                "pgroonga",
+                "pgroonga_score(mm.tableoid, mm.ctid)",
+                "(COALESCE(mm.name, '') || ' ' || mm.content) &@~ pgroonga_query_escape($3)",
+            ),
+            (
+                "pg_search",
+                "paradedb.score(mm.id)",
+                "mm.id @@@ paradedb.boolean(should => ARRAY[",
+            ),
+        ],
+    )
+    def test_knowledge_page_text_search_plan_is_backend_aware(
+        self,
+        d,
+        extension,
+        score_fragment,
+        match_fragment,
+    ):
+        plan = d.knowledge_page_text_search_plan(
+            query_param="$3",
+            text_search_extension=extension,
+            native_language="french",
+        )
+
+        assert score_fragment in plan.score_expression
+        assert match_fragment in plan.match_condition
+        assert plan.order_by.endswith((" ASC", " DESC"))
+
+    def test_knowledge_page_pg_search_plan_targets_both_indexed_fields(self, d):
+        plan = d.knowledge_page_text_search_plan(
+            query_param="$3",
+            text_search_extension="pg_search",
+            native_language="english",
+        )
+
+        assert "paradedb.match('name', $3)" in plan.match_condition
+        assert "paradedb.match('content', $3)" in plan.match_condition
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("embedding", [[[0.1, 0.2]], []])
+    async def test_knowledge_page_search_uses_backend_plan_with_or_without_embedding(
+        self,
+        monkeypatch,
+        embedding,
+    ):
+        from hindsight_api.engine.memory_engine import MemoryEngine
+
+        engine = object.__new__(MemoryEngine)
+        engine.embeddings = object()
+        engine._dialect = PostgreSQLDialect()
+        engine._authenticate_tenant = AsyncMock()
+        engine._get_backend = AsyncMock(return_value=object())
+
+        conn = AsyncMock(spec=DatabaseConnection)
+        conn.fetch.return_value = []
+
+        @asynccontextmanager
+        async def fake_acquire(_backend: object) -> AsyncIterator[DatabaseConnection]:
+            yield conn
+
+        monkeypatch.setattr("hindsight_api.engine.memory_engine.acquire_with_retry", fake_acquire)
+        monkeypatch.setattr(
+            "hindsight_api.engine.retain.embedding_utils.generate_embeddings_batch",
+            AsyncMock(return_value=embedding),
+        )
+        monkeypatch.setattr(
+            "hindsight_api.engine.memory_engine.get_config",
+            lambda: SimpleNamespace(
+                database_backend="postgresql",
+                database_schema="public",
+                text_search_extension="pgroonga",
+                text_search_extension_native_language="english",
+            ),
+        )
+
+        results = await MemoryEngine.search_knowledge_pages(
+            engine,
+            "bank",
+            "한글 English",
+            request_context=object(),
+        )
+
+        assert results == []
+        sql = conn.fetch.await_args.args[0]
+        assert "&@~ pgroonga_query_escape" in sql
+        assert "pgroonga_score(mm.tableoid, mm.ctid)" in sql
+        assert "ts_rank_cd" not in sql
 
     def test_similarity(self, d):
         assert d.similarity("col", "$1") == "similarity(col, $1)"
@@ -399,6 +509,16 @@ class TestOracleDialect:
 
     def test_current_timestamp(self, d):
         assert d.current_timestamp() == "SYSTIMESTAMP"
+
+    def test_knowledge_page_text_plan_disables_unindexed_lexical_arm(self, d):
+        plan = d.knowledge_page_text_search_plan(
+            query_param=":3",
+            text_search_extension="native",
+            native_language="english",
+        )
+
+        assert ":3" in plan.match_condition
+        assert "1 = 0" in plan.match_condition
 
     def test_build_semantic_arm(self, d):
         arm = d.build_semantic_arm(


### PR DESCRIPTION
## Summary

- move Knowledge Page lexical matching and scoring into the SQL dialect
- provide explicit plans for native, VChord, pg_textsearch, PGroonga, and pg_search
- use the same plan in hybrid and embedding-unavailable text-only paths
- exclude backend-specific padded or zero-score non-matches

## Root cause

`search_knowledge_pages` always emitted native PostgreSQL `tsvector` SQL. On VChord this compares a `bm25vector` with a `tsquery` and returns HTTP 500; the same architectural mismatch affects every non-native backend. The dialect now owns operators, score direction, filtering, and indexed expressions.

Closes #3268.

## Verification

- backend SQL regression coverage for all five PostgreSQL text-search backends
- targeted mental-model, Knowledge Page, transfer, and DB-abstraction pytest suite: 136 passed on the combined integration branch
- Ruff and ty checks passed for changed production files
- disposable PG18 + PGroonga HTTP canary returned the expected page for Korean-only, English-only, and mixed queries, and `EXPLAIN` used `idx_mental_models_text_search`

This PR is independent of the transfer fix in #3308.