### PR TITLE
fix(transfer): preserve Knowledge Page search state

### DIFF
--- a/hindsight-api-slim/hindsight_api/admin/cli.py
+++ b/hindsight-api-slim/hindsight_api/admin/cli.py
@@ -847,6 +847,7 @@ def import_bank_command(
         f"Imported bank '{result.bank_id}': {result.documents_imported} doc(s), "
         f"{result.facts_imported} fact(s), {result.observations_imported} observation(s), "
         f"{result.mental_models_imported} mental model(s), "
+        f"{result.knowledge_pages_imported} Knowledge Page node(s), "
         f"{result.mental_model_history_imported} mm-history row(s), {result.directives_imported} directive(s), "
         f"{result.webhooks_imported} webhook(s), {result.history_rows_imported} history row(s)"
     )

--- a/hindsight-api-slim/hindsight_api/engine/db/ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops.py
@@ -102,6 +102,20 @@ class DataAccessOps(ABC):
         """
         return True  # Default: use junction table (Oracle)
 
+    def mental_model_search_vector_expr(
+        self,
+        config: Any,
+        *,
+        name_col: str = "name",
+        content_col: str = "content",
+    ) -> str | None:
+        """Stored lexical projection for a mental-model document, if any.
+
+        Oracle and PostgreSQL base-column search backends maintain no stored
+        projection here. PostgreSQL VChord overrides this capability.
+        """
+        return None
+
     # -- Bulk insert operations ------------------------------------------
 
     @abstractmethod

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -38,8 +38,40 @@ def pg_search_vector_expr(
     return None
 
 
+def pg_mental_model_search_vector_expr(
+    config,
+    *,
+    name_col: str = "name",
+    content_col: str = "content",
+) -> str | None:
+    """Build the stored lexical projection for a mental-model document.
+
+    VChord is the only backend whose mental-model projection must be written by
+    the application. Native PostgreSQL uses a generated ``tsvector`` column,
+    while pg_textsearch, PGroonga, and pg_search index ``name``/``content``
+    directly and retain only a dummy ``search_vector`` column.
+    """
+    if config.text_search_extension != "vchord":
+        return None
+    combined = f"COALESCE({name_col}, '') || ' ' || COALESCE({content_col}, '')"
+    return f"tokenize({combined}, 'llmlingua2')::bm25_catalog.bm25vector"
+
+
 class PostgreSQLOps(DataAccessOps):
     """PostgreSQL-specific data access operations using unnest and LATERAL."""
+
+    def mental_model_search_vector_expr(
+        self,
+        config,
+        *,
+        name_col: str = "name",
+        content_col: str = "content",
+    ) -> str | None:
+        return pg_mental_model_search_vector_expr(
+            config,
+            name_col=name_col,
+            content_col=content_col,
+        )
 
     @property
     def uses_observation_sources_table(self) -> bool:

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -4418,10 +4418,11 @@ class MemoryEngine(MemoryEngineInterface):
     ) -> "BankImportResult":
         """Restore a whole bank from an :func:`transfer.export_bank` archive.
 
-        Re-embeds facts with this instance's embedding model and rebuilds links and
-        indexes; restores bank config, mental models, directives and webhooks as
-        exported (no consolidation/webhooks — a migration restores exact state). The
-        target bank must not already exist (import restores a whole bank, not a merge).
+        Re-embeds facts and mental models with this instance's embedding model and
+        rebuilds links/search projections; restores bank config, Knowledge Pages,
+        directives and webhooks as exported (no consolidation/webhooks — a migration
+        restores exact state). The target bank must not already exist (import restores
+        a whole bank, not a merge).
         """
         from .transfer import import_bank
         from .transfer.importer import parse_bank_archive

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -11818,6 +11818,8 @@ class MemoryEngine(MemoryEngineInterface):
         # Convert embedding to string for asyncpg vector type
         embedding_str = str(embedding[0]) if embedding else None
 
+        config = get_config()
+
         if not mental_model_id:
             mental_model_id = f"mm-{uuid.uuid4().hex}"
 
@@ -11833,11 +11835,18 @@ class MemoryEngine(MemoryEngineInterface):
                     conn=conn,
                 )
                 if mental_model_id:
+                    search_vector_expr = backend.ops.mental_model_search_vector_expr(
+                        config,
+                        name_col="$3",
+                        content_col="$5",
+                    )
+                    search_vector_column = ", search_vector" if search_vector_expr else ""
+                    search_vector_value = f", {search_vector_expr}" if search_vector_expr else ""
                     row = await conn.fetchrow(
                         f"""
                         INSERT INTO {fq_table("mental_models")}
-                        (id, bank_id, subtype, name, description, source_query, content, embedding, tags, max_tokens, trigger)
-                        VALUES ($1, $2, 'pinned', $3, ' ', $4, $5, $6, $7, COALESCE($8, 2048), COALESCE($9, '{{"refresh_after_consolidation": false}}'::jsonb))
+                        (id, bank_id, subtype, name, description, source_query, content, embedding, tags, max_tokens, trigger{search_vector_column})
+                        VALUES ($1, $2, 'pinned', $3, ' ', $4, $5, $6, $7, COALESCE($8, 2048), COALESCE($9, '{{"refresh_after_consolidation": false}}'::jsonb){search_vector_value})
                         RETURNING id, bank_id, name, source_query, content, tags,
                                   last_refreshed_at, created_at, reflect_response,
                                   max_tokens, trigger, structured_content
@@ -11853,11 +11862,18 @@ class MemoryEngine(MemoryEngineInterface):
                         json.dumps(trigger) if trigger else None,
                     )
                 else:
+                    search_vector_expr = backend.ops.mental_model_search_vector_expr(
+                        config,
+                        name_col="$2",
+                        content_col="$4",
+                    )
+                    search_vector_column = ", search_vector" if search_vector_expr else ""
+                    search_vector_value = f", {search_vector_expr}" if search_vector_expr else ""
                     row = await conn.fetchrow(
                         f"""
                         INSERT INTO {fq_table("mental_models")}
-                        (bank_id, subtype, name, description, source_query, content, embedding, tags, max_tokens, trigger)
-                        VALUES ($1, 'pinned', $2, ' ', $3, $4, $5, $6, COALESCE($7, 2048), COALESCE($8, '{{"refresh_after_consolidation": false}}'::jsonb))
+                        (bank_id, subtype, name, description, source_query, content, embedding, tags, max_tokens, trigger{search_vector_column})
+                        VALUES ($1, 'pinned', $2, ' ', $3, $4, $5, $6, COALESCE($7, 2048), COALESCE($8, '{{"refresh_after_consolidation": false}}'::jsonb){search_vector_value})
                         RETURNING id, bank_id, name, source_query, content, tags,
                                   last_refreshed_at, created_at, reflect_response,
                                   max_tokens, trigger, structured_content
@@ -12761,34 +12777,42 @@ class MemoryEngine(MemoryEngineInterface):
                 await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
         backend = await self._get_backend()
 
-        # Compute the new embedding BEFORE acquiring a pooled connection: a slow
-        # embedder must never pin a DB connection. The embedding text depends only
-        # on the incoming name/content, never on DB state, so it can be done here.
+        # Resolve the canonical document before embedding it. Name-only and
+        # content-only writes must include the other stored half; otherwise the
+        # embedding and lexical projection silently describe different text.
+        previous_content: str | None = None
+        previous_reflect_response: dict[str, Any] | None = None
+        effective_name: str | None = None
+        effective_content: str | None = None
         new_embedding_str: str | None = None
-        if content is not None:
-            embedding_text = f"{name or ''} {content}"
-            embedding = await embedding_utils.generate_embeddings_batch(self.embeddings, [embedding_text])
-            if embedding:
-                new_embedding_str = str(embedding[0])
-
-        async with acquire_with_retry(backend) as conn:
-            # If content is changing, fetch current content + reflect_response to record history
-            previous_content: str | None = None
-            previous_reflect_response: dict[str, Any] | None = None
-            if content is not None:
+        document_changed = name is not None or content is not None
+        if document_changed:
+            async with acquire_with_retry(backend) as conn:
                 current_row = await conn.fetchrow(
-                    f"SELECT content, reflect_response FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
+                    f"SELECT name, content, reflect_response FROM {fq_table('mental_models')} "
+                    "WHERE bank_id = $1 AND id = $2",
                     bank_id,
                     mental_model_id,
                 )
-                if current_row:
-                    previous_content = current_row["content"]
-                    raw_rr = current_row["reflect_response"]
-                    if isinstance(raw_rr, str):
-                        previous_reflect_response = json.loads(raw_rr) if raw_rr else None
-                    else:
-                        previous_reflect_response = raw_rr
+            if current_row is None:
+                return None
+            effective_name = name if name is not None else current_row["name"]
+            effective_content = content if content is not None else current_row["content"]
+            if content is not None:
+                previous_content = current_row["content"]
+                raw_rr = current_row["reflect_response"]
+                if isinstance(raw_rr, str):
+                    previous_reflect_response = json.loads(raw_rr) if raw_rr else None
+                else:
+                    previous_reflect_response = raw_rr
 
+            # Embedding remains outside pooled connections: providers can be slow.
+            embedding_text = f"{effective_name} {effective_content}"
+            embedding = await embedding_utils.generate_embeddings_batch(self.embeddings, [embedding_text])
+            if embedding and embedding[0]:
+                new_embedding_str = str(embedding[0])
+
+        async with acquire_with_retry(backend) as conn:
             # Build dynamic update
             updates = []
             params: list[Any] = [bank_id, mental_model_id]
@@ -12833,11 +12857,6 @@ class MemoryEngine(MemoryEngineInterface):
                             slim["trace"] = previous_trace
                         slim_reflect_response = slim or None
                     record_mm_history = True
-                # Apply the embedding computed above (off-connection).
-                if new_embedding_str is not None:
-                    updates.append(f"embedding = ${param_idx}")
-                    params.append(new_embedding_str)
-                    param_idx += 1
             elif refresh_watermark is not None:
                 # A successful delta refresh can find no topic-relevant facts even though
                 # the coarse staleness query found new rows. Advance the watermark to the
@@ -12847,6 +12866,23 @@ class MemoryEngine(MemoryEngineInterface):
                 updates.append(f"last_refreshed_at = ${param_idx}")
                 params.append(refresh_watermark)
                 param_idx += 1
+
+            if document_changed:
+                # Setting NULL when the provider returns no embedding is safer
+                # than retaining a vector for the previous document.
+                updates.append(f"embedding = ${param_idx}")
+                params.append(new_embedding_str)
+                param_idx += 1
+
+                search_vector_expr = backend.ops.mental_model_search_vector_expr(
+                    get_config(),
+                    name_col=f"${param_idx}",
+                    content_col=f"${param_idx + 1}",
+                )
+                if search_vector_expr:
+                    updates.append(f"search_vector = {search_vector_expr}")
+                    params.extend([effective_name, effective_content])
+                    param_idx += 2
 
             if reflect_response is not None:
                 updates.append(f"reflect_response = ${param_idx}")
@@ -12988,12 +13024,34 @@ class MemoryEngine(MemoryEngineInterface):
         backend = await self._get_backend()
 
         async with acquire_with_retry(backend) as conn:
+            current_name = await conn.fetchval(
+                f"SELECT name FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                mental_model_id,
+            )
+        if current_name is None:
+            return None
+
+        embedding = await embedding_utils.generate_embeddings_batch(self.embeddings, [f"{current_name} "])
+        embedding_str = str(embedding[0]) if embedding and embedding[0] else None
+
+        search_vector_expr = backend.ops.mental_model_search_vector_expr(
+            get_config(),
+            name_col="name",
+            content_col="''",
+        )
+        search_vector_clause = (
+            f",\n                    search_vector = {search_vector_expr}" if search_vector_expr else ""
+        )
+
+        async with acquire_with_retry(backend) as conn:
             row = await conn.fetchrow(
                 f"""
                 UPDATE {fq_table("mental_models")}
                 SET content = '',
                     structured_content = NULL,
-                    last_refreshed_source_query = NULL
+                    last_refreshed_source_query = NULL,
+                    embedding = $3{search_vector_clause}
                 WHERE bank_id = $1 AND id = $2
                 RETURNING id, bank_id, name, source_query, content, tags,
                           last_refreshed_at, created_at, reflect_response,
@@ -13001,6 +13059,7 @@ class MemoryEngine(MemoryEngineInterface):
                 """,
                 bank_id,
                 mental_model_id,
+                embedding_str,
             )
 
         return self._row_to_mental_model(row) if row else None
@@ -13425,21 +13484,65 @@ class MemoryEngine(MemoryEngineInterface):
     async def rename_knowledge_node(
         self, bank_id: str, node_id: str, name: str, *, request_context: "RequestContext"
     ) -> dict[str, Any] | None:
-        """Rename a folder or page node."""
+        """Rename a folder or a page and its backing mental-model document."""
         await self._authenticate_tenant(request_context)
         backend = await self._get_backend()
+
         async with acquire_with_retry(backend) as conn:
-            row = await conn.fetchrow(
+            current = await conn.fetchrow(
                 f"""
-                UPDATE {fq_table("knowledge_pages")}
-                SET name = $3, updated_at = now()
-                WHERE bank_id = $1 AND id = $2
-                RETURNING {self._KP_COLUMNS}
+                SELECT kp.kind, kp.mental_model_id, mm.content AS mm_content
+                FROM {fq_table("knowledge_pages")} kp
+                LEFT JOIN {fq_table("mental_models")} mm
+                  ON mm.id = kp.mental_model_id AND mm.bank_id = kp.bank_id
+                WHERE kp.bank_id = $1 AND kp.id = $2
                 """,
                 bank_id,
                 node_id,
-                name,
             )
+        if current is None:
+            return None
+
+        embedding_str: str | None = None
+        if current["kind"] == "page" and current["mental_model_id"] is not None:
+            embedding = await embedding_utils.generate_embeddings_batch(
+                self.embeddings,
+                [f"{name} {current['mm_content'] or ''}"],
+            )
+            embedding_str = str(embedding[0]) if embedding and embedding[0] else None
+
+        search_vector_expr = backend.ops.mental_model_search_vector_expr(
+            get_config(),
+            name_col="$3",
+            content_col="content",
+        )
+        search_vector_clause = f", search_vector = {search_vector_expr}" if search_vector_expr else ""
+
+        async with acquire_with_retry(backend) as conn:
+            async with conn.transaction():
+                row = await conn.fetchrow(
+                    f"""
+                    UPDATE {fq_table("knowledge_pages")}
+                    SET name = $3, updated_at = now()
+                    WHERE bank_id = $1 AND id = $2
+                    RETURNING {self._KP_COLUMNS}
+                    """,
+                    bank_id,
+                    node_id,
+                    name,
+                )
+                if current["kind"] == "page" and current["mental_model_id"] is not None:
+                    await conn.execute(
+                        f"""
+                        UPDATE {fq_table("mental_models")}
+                        SET name = $3, embedding = $4{search_vector_clause}
+                        WHERE bank_id = $1 AND id = $2
+                        """,
+                        bank_id,
+                        current["mental_model_id"],
+                        name,
+                        embedding_str,
+                    )
         return self._row_to_knowledge_node(row) if row else None
 
     async def update_knowledge_page(

--- a/hindsight-api-slim/hindsight_api/engine/transfer/export.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/export.py
@@ -70,7 +70,9 @@ _REPLAYED_TABLES = frozenset(
 )
 # Carried verbatim as JSON rows (bank config + synthesized state). Embedding-bearing
 # rows have their vector stripped (see _DERIVED_COLUMNS) and are re-embedded on import.
-_BANK_ROW_TABLES = ("banks", "mental_models", "directives", "webhooks")
+# Knowledge Pages retain stable ids and their backing mental-model ids; import
+# restores their self-referential tree parent-first.
+_BANK_ROW_TABLES = ("banks", "mental_models", "knowledge_pages", "directives", "webhooks")
 # Bank-scoped child-history carried verbatim. Unlike observations, mental models
 # keep their (id, bank_id) across export/import, so their refresh history can be
 # re-attached. The surrogate ``id`` is dropped on dump so the target reassigns it
@@ -88,12 +90,6 @@ _SKIP_TABLES = frozenset(
         # to fresh ids, so carrying them would only produce dangling associations.
         # Revert anything worth keeping on the source before migrating.
         "invalidated_memory_units",
-        # Knowledge-base folder/page tree (client-managed metadata over the carried
-        # mental models). Not carried yet: its self-referential parent_id FK needs a
-        # parents-first (topological) restore order, which the generic per-row
-        # _restore_rows doesn't provide — a follow-up. The mental models themselves
-        # ARE carried, so the target can recreate the tree.
-        "knowledge_pages",
     }
 )
 # Derived columns dropped from carried rows so the target regenerates them with
@@ -294,11 +290,11 @@ async def export_bank(
 
     Produces a superset of the documents archive: the logical
     document/fact/observation export (replayed and re-embedded on import) plus
-    the bank's config, mental models, directives and webhooks as JSON rows. With
-    ``include_history`` the operational tails (audit_log, llm_requests) are also
-    carried. Intended for migrating a bank to a new instance configured with a
-    different embedding model / vector / text-search backend — every vector is
-    regenerated on the target, so nothing here is encoder-specific.
+    the bank's config, mental models, Knowledge Page tree, directives and webhooks
+    as JSON rows. With ``include_history`` the operational tails (audit_log,
+    llm_requests) are also carried. Intended for migrating a bank to a new instance
+    configured with a different embedding model / vector / text-search backend —
+    every vector is regenerated on the target, so nothing here is encoder-specific.
 
     ``conn`` is a live connection scoped to the bank's schema (the admin CLI sets
     ``_current_schema`` and passes its raw connection; the engine acquires one
@@ -343,6 +339,7 @@ async def export_bank(
             observation_count=len(observations),
             archive_type="bank",
             mental_model_count=len(bank_rows.get("mental_models", [])),
+            knowledge_page_count=len(bank_rows.get("knowledge_pages", [])),
             directive_count=len(bank_rows.get("directives", [])),
             webhook_count=len(bank_rows.get("webhooks", [])),
             includes_history=include_history,
@@ -352,12 +349,13 @@ async def export_bank(
 
     logger.info(
         "[transfer] Exported bank %s: %d document(s), %d fact(s), %d observation(s), "
-        "%d mental model(s), %d directive(s), %d webhook(s)%s",
+        "%d mental model(s), %d Knowledge Page node(s), %d directive(s), %d webhook(s)%s",
         bank_id,
         len(documents),
         fact_total,
         len(observations),
         len(bank_rows.get("mental_models", [])),
+        len(bank_rows.get("knowledge_pages", [])),
         len(bank_rows.get("directives", [])),
         len(bank_rows.get("webhooks", [])),
         " (with history)" if include_history else "",

--- a/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
@@ -228,9 +228,10 @@ async def import_documents(
     return result
 
 
-# Bank-level config/state tables restored verbatim from a whole-bank archive.
-# Order matters for foreign keys: banks (parent) is restored before any child.
-_BANK_CHILD_TABLES = ("mental_models", "directives", "webhooks")
+# Bank-level config/state tables restored from a whole-bank archive. Order matters
+# for foreign keys: banks precede every child; mental_models precede their
+# Knowledge Pages; Knowledge Page parents precede children.
+_BANK_CHILD_TABLES = ("mental_models", "knowledge_pages", "directives", "webhooks")
 # Child-history carried verbatim; restored after its parent (mental_models) so the
 # foreign key resolves. Surrogate ids were dropped on export (the target reassigns
 # them), so these restore via fresh IDENTITY values.
@@ -245,6 +246,7 @@ class BankImportResult:
     facts_imported: int = 0
     observations_imported: int = 0
     mental_models_imported: int = 0
+    knowledge_pages_imported: int = 0
     mental_model_history_imported: int = 0
     directives_imported: int = 0
     webhooks_imported: int = 0
@@ -256,7 +258,8 @@ class ParsedBankArchive:
     """The bank-level sections of a whole-bank archive (documents read separately)."""
 
     manifest: TransferManifest
-    # table name -> list of verbatim row dicts (banks, mental_models, directives, webhooks)
+    # table name -> carried row dicts (banks, mental_models, Knowledge Pages,
+    # directives, webhooks)
     bank_rows: dict[str, list[dict]] = field(default_factory=dict)
     # table name -> rows (audit_log, llm_requests), present only with --include-history
     history_rows: dict[str, list[dict]] = field(default_factory=dict)
@@ -349,6 +352,124 @@ async def _restore_rows(
     return inserted
 
 
+def _knowledge_pages_parent_first(rows: list[dict]) -> list[dict]:
+    """Return a stable parent-before-child ordering for a Knowledge Page tree.
+
+    The table has a self-referential ``parent_id`` foreign key, so archive order
+    is not a valid restore order. Reject dangling parents and cycles before any
+    import writes occur instead of leaving a partially restored tree.
+    """
+    if not rows:
+        return []
+
+    row_ids = [row.get("id") for row in rows]
+    if any(row_id is None for row_id in row_ids):
+        raise ValueError("Invalid Knowledge Pages archive: every node must have an id")
+    if len(set(row_ids)) != len(row_ids):
+        raise ValueError("Invalid Knowledge Pages archive: duplicate node id")
+
+    known_ids = set(row_ids)
+    missing_parents = {
+        row.get("parent_id")
+        for row in rows
+        if row.get("parent_id") is not None and row.get("parent_id") not in known_ids
+    }
+    if missing_parents:
+        raise ValueError(f"Invalid Knowledge Pages archive: missing parent node(s): {sorted(missing_parents)!r}")
+
+    ordered: list[dict] = []
+    restored_ids: set[Any] = set()
+    pending = list(rows)
+    while pending:
+        ready = [row for row in pending if row.get("parent_id") is None or row.get("parent_id") in restored_ids]
+        if not ready:
+            unresolved = sorted(str(row["id"]) for row in pending)
+            raise ValueError(f"Invalid Knowledge Pages archive: parent cycle among node(s): {unresolved!r}")
+        for row in ready:
+            ordered.append(row)
+            restored_ids.add(row["id"])
+        ready_ids = {id(row) for row in ready}
+        pending = [row for row in pending if id(row) not in ready_ids]
+    return ordered
+
+
+def _validate_knowledge_page_models(rows: list[dict], mental_model_rows: list[dict]) -> None:
+    """Reject Knowledge Page nodes that cannot preserve their source meaning.
+
+    A folder is structural and must not reference a mental model. A page is a
+    projection of exactly one carried mental model, so accepting a missing or
+    dangling reference would either fail after document replay or silently
+    restore a page with no content.
+    """
+    mental_model_ids = {row.get("id") for row in mental_model_rows if row.get("id") is not None}
+    nodes_by_id = {row.get("id"): row for row in rows}
+    for row in rows:
+        node_id = row.get("id")
+        kind = row.get("kind")
+        mental_model_id = row.get("mental_model_id")
+        if kind == "folder":
+            if mental_model_id is not None:
+                raise ValueError(f"Invalid Knowledge Pages archive: folder '{node_id}' references a mental model")
+        elif kind == "page":
+            if mental_model_id is None or mental_model_id not in mental_model_ids:
+                raise ValueError(
+                    f"Invalid Knowledge Pages archive: page '{node_id}' references missing mental model "
+                    f"'{mental_model_id}'"
+                )
+        else:
+            raise ValueError(f"Invalid Knowledge Pages archive: node '{node_id}' has unsupported kind '{kind}'")
+
+        parent_id = row.get("parent_id")
+        if parent_id is not None and nodes_by_id[parent_id].get("kind") != "folder":
+            raise ValueError(f"Invalid Knowledge Pages archive: parent '{parent_id}' is not a folder")
+
+
+async def _reembed_mental_model_rows(rows: list[dict], embeddings_model: Any) -> list[dict]:
+    """Attach target-model embeddings to carried mental-model rows.
+
+    Export deliberately strips encoder-specific vectors. Generate every target
+    vector before the import writes its bank row so an embedding failure cannot
+    leave a half-created target bank.
+    """
+    if not rows:
+        return []
+    texts = [f"{row.get('name') or ''} {row.get('content') or ''}" for row in rows]
+    embeddings = await embedding_processing.generate_embeddings_batch(embeddings_model, texts)
+    if len(embeddings) != len(rows):
+        raise RuntimeError(
+            f"Mental-model embedding count mismatch during bank import: expected {len(rows)}, got {len(embeddings)}"
+        )
+    return [{**row, "embedding": str(embedding)} for row, embedding in zip(rows, embeddings)]
+
+
+async def _restore_mental_models(
+    conn: Any,
+    rows: list[dict],
+    *,
+    bank_id: str,
+    config: Any,
+    ops: Any,
+    bank_rows_json_encoding: BankRowsJSONEncoding,
+) -> int:
+    """Restore carried mental models and rebuild the target text projection."""
+    inserted = await _restore_rows(
+        conn,
+        "mental_models",
+        rows,
+        bank_rows_json_encoding=bank_rows_json_encoding,
+    )
+    # Native PostgreSQL regenerates its generated tsvector on INSERT, while
+    # base-column backends index name/content directly. VChord is the only
+    # backend needing an application-maintained mental-model projection.
+    search_vector_expr = ops.mental_model_search_vector_expr(config)
+    if inserted and search_vector_expr:
+        await conn.execute(
+            f"UPDATE {fq_table('mental_models')} SET search_vector = {search_vector_expr} WHERE bank_id = $1",
+            bank_id,
+        )
+    return inserted
+
+
 async def import_bank(
     *,
     backend: Any,
@@ -363,9 +484,11 @@ async def import_bank(
 ) -> BankImportResult:
     """Restore a whole bank from a ``export_bank`` archive into the target instance.
 
-    Re-embeds facts with the *target* instance's embedding model and rebuilds links,
-    entities and search/vector indexes — the path for migrating a bank to an instance
-    configured with a different embedding model / vector / text-search backend.
+    Re-embeds facts and mental models with the *target* instance's embedding model,
+    rebuilds their search projections, and rebuilds links/entities — the path for
+    migrating a bank to an instance configured with a different embedding model /
+    vector / text-search backend. Knowledge Page ids, hierarchy and backing
+    mental-model references are preserved.
 
     The **target bank must not already exist**: import restores a complete bank
     (config + facts + mental models + …) and is not a merge. If a bank with the
@@ -394,6 +517,30 @@ async def import_bank(
             for row in rows:
                 if "bank_id" in row:
                     row["bank_id"] = bank_id
+
+    # Validate all Knowledge Page relationships before the first write. These can
+    # fail independently of PostgreSQL and should leave no partially-created
+    # target bank.
+    knowledge_page_rows = _knowledge_pages_parent_first(parsed.bank_rows.get("knowledge_pages", []))
+    raw_mental_model_rows = parsed.bank_rows.get("mental_models", [])
+    _validate_knowledge_page_models(knowledge_page_rows, raw_mental_model_rows)
+
+    # Fail an obvious existing-target import before paying to embed mental
+    # models. The guarded check immediately before INSERT remains below so two
+    # concurrent importers cannot race this preflight into a merge.
+    async with acquire_with_retry(backend) as conn:
+        if await conn.fetchval(f"SELECT 1 FROM {fq_table('banks')} WHERE bank_id = $1", bank_id):
+            raise ValueError(
+                f"Target bank '{bank_id}' already exists; import-bank restores into a fresh bank "
+                f"(it is not a merge). Delete the bank first, or pass a different target bank id."
+            )
+
+    # Generate every target-model vector before creating the bank, so an
+    # embedding-provider failure cannot leave a partially restored target.
+    mental_model_rows = await _reembed_mental_model_rows(
+        raw_mental_model_rows,
+        embeddings_model,
+    )
 
     async with acquire_with_retry(backend) as conn:
         # Refuse to import into an existing bank — this restores a whole bank, it
@@ -452,10 +599,18 @@ async def import_bank(
         observations_imported=doc_result.observations_imported,
     )
     async with acquire_with_retry(backend) as conn:
-        result.mental_models_imported = await _restore_rows(
+        result.mental_models_imported = await _restore_mental_models(
             conn,
-            "mental_models",
-            parsed.bank_rows.get("mental_models", []),
+            mental_model_rows,
+            bank_id=bank_id,
+            config=config,
+            ops=ops,
+            bank_rows_json_encoding=bank_rows_json_encoding,
+        )
+        result.knowledge_pages_imported = await _restore_rows(
+            conn,
+            "knowledge_pages",
+            knowledge_page_rows,
             bank_rows_json_encoding=bank_rows_json_encoding,
         )
         # Restored after mental_models so the (mental_model_id, bank_id) FK resolves.
@@ -488,12 +643,14 @@ async def import_bank(
 
     logger.info(
         "[transfer] Imported bank %s: %d doc(s), %d fact(s), %d observation(s), "
-        "%d mental model(s), %d mm-history row(s), %d directive(s), %d webhook(s), %d history row(s)",
+        "%d mental model(s), %d Knowledge Page node(s), %d mm-history row(s), "
+        "%d directive(s), %d webhook(s), %d history row(s)",
         bank_id,
         result.documents_imported,
         result.facts_imported,
         result.observations_imported,
         result.mental_models_imported,
+        result.knowledge_pages_imported,
         result.mental_model_history_imported,
         result.directives_imported,
         result.webhooks_imported,

--- a/hindsight-api-slim/hindsight_api/engine/transfer/schema.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/schema.py
@@ -145,9 +145,11 @@ class TransferManifest(BaseModel):
     fact_count: int = 0
     observation_count: int = 0
     # "documents" = doc/fact/observation subset; "bank" = whole-bank export
-    # (also carries bank config, mental models, directives, webhooks).
+    # (also carries bank config, mental models, Knowledge Pages, directives,
+    # webhooks).
     archive_type: Literal["documents", "bank"] = "documents"
     mental_model_count: int = 0
+    knowledge_page_count: int = 0
     directive_count: int = 0
     webhook_count: int = 0
     # True when --include-history carried audit_log / llm_requests.

--- a/hindsight-api-slim/hindsight_api/migrations.py
+++ b/hindsight-api-slim/hindsight_api/migrations.py
@@ -816,10 +816,7 @@ def ensure_text_search_extension(
     engine = create_engine(to_libpq_url(database_url), poolclass=NullPool)
     with engine.connect() as conn:
         # Tables with search_vector columns to check
-        tables_to_check = [
-            "memory_units",
-            "reflections",  # Renamed from pinned_reflections in p1k2l3m4n5o6 migration
-        ]
+        tables_to_check = ["memory_units", "mental_models"]
 
         # Determine target column type and index type
         if text_search_extension == "vchord":
@@ -933,6 +930,21 @@ def ensure_text_search_extension(
 
         # If no mismatches, we're done
         if not mismatched_tables:
+            if text_search_extension == "vchord":
+                # VChord's bm25vector is not generated. Older mental-model write
+                # paths never populated it, so a physically-correct deployment
+                # can still have a completely empty lexical index.
+                conn.execute(
+                    text(f"""
+                        UPDATE {schema_name}.mental_models
+                        SET search_vector = tokenize(
+                            COALESCE(name, '') || ' ' || COALESCE(content, ''),
+                            'llmlingua2'
+                        )::bm25_catalog.bm25vector
+                        WHERE search_vector IS NULL
+                    """)
+                )
+                conn.commit()
             logger.debug(f"All text search columns/indexes match configured extension: {text_search_extension}")
             return
 
@@ -960,7 +972,7 @@ def ensure_text_search_extension(
                 f"the following tables contain data: {table_list}. "
                 f"To change text search extension, you must either:\n"
                 f"  1. Clear all data: DELETE FROM {schema_name}.memory_units; "
-                f"DELETE FROM {schema_name}.reflections; then restart\n"
+                f"DELETE FROM {schema_name}.mental_models; then restart\n"
                 f"  2. Use the current text search extension (set HINDSIGHT_API_TEXT_SEARCH_EXTENSION='{current_ext}')"
             )
 
@@ -1009,7 +1021,7 @@ def ensure_text_search_extension(
                 # Different expression for each table
                 if table_name == "memory_units":
                     index_expr = "(COALESCE(text, '') || ' ' || COALESCE(context, ''))"
-                else:  # reflections
+                else:  # mental_models
                     index_expr = "(COALESCE(name, '') || ' ' || content)"
 
                 conn.execute(
@@ -1041,7 +1053,7 @@ def ensure_text_search_extension(
                     index_expr = (
                         "(COALESCE(text, '') || ' ' || COALESCE(context, '') || ' ' || COALESCE(text_signals, ''))"
                     )
-                else:  # reflections
+                else:  # mental_models
                     index_expr = "(COALESCE(name, '') || ' ' || content)"
 
                 logger.info(f"Creating pgroonga index on {table_name}")
@@ -1070,7 +1082,7 @@ def ensure_text_search_extension(
                         ("text", "context", "text_signals"),
                         pg_search_tokenizer,
                     )
-                else:  # reflections
+                else:  # mental_models
                     bm25_cols = pg_search_bm25_columns(
                         "id",
                         ("name", "content"),
@@ -1088,11 +1100,23 @@ def ensure_text_search_extension(
                 )
             else:  # native
                 logger.info(f"Creating tsvector column on {table_name}")
-                # Plain tsvector column. The application populates search_vector
-                # at INSERT time via to_tsvector($lang, ...) using the configured
-                # HINDSIGHT_API_TEXT_SEARCH_EXTENSION_NATIVE_LANGUAGE — see
-                # ops_postgresql.insert_facts_batch.
-                conn.execute(text(f"ALTER TABLE {schema_name}.{table_name} ADD COLUMN search_vector tsvector"))
+                if table_name == "mental_models":
+                    # Mental models existed with a generated native column before
+                    # runtime reconciliation learned about text backends. Preserve
+                    # that contract so every name/content write stays current.
+                    conn.execute(
+                        text(f"""
+                            ALTER TABLE {schema_name}.{table_name}
+                            ADD COLUMN search_vector tsvector
+                            GENERATED ALWAYS AS (
+                                to_tsvector('english', COALESCE(name, '') || ' ' || COALESCE(content, ''))
+                            ) STORED
+                        """)
+                    )
+                else:
+                    # Memory-unit writes populate this plain column with the
+                    # configured native language in ops_postgresql.
+                    conn.execute(text(f"ALTER TABLE {schema_name}.{table_name} ADD COLUMN search_vector tsvector"))
 
                 # Create GIN index
                 logger.info(f"Creating GIN index on {table_name}")

--- a/hindsight-api-slim/tests/test_db_abstraction.py
+++ b/hindsight-api-slim/tests/test_db_abstraction.py
@@ -946,6 +946,29 @@ class TestPostgreSQLSearchVector:
         # These index the base text columns directly; search_vector stays empty.
         assert pg_search_vector_expr(self._cfg(ext)) is None
 
+    def test_mental_model_expr_builds_vchord_name_content_document(self):
+        from hindsight_api.engine.db.ops_postgresql import PostgreSQLOps
+
+        expr = PostgreSQLOps().mental_model_search_vector_expr(
+            self._cfg("vchord"),
+            name_col="$3",
+            content_col="$4",
+        )
+        assert expr is not None
+        assert "COALESCE($3, '') || ' ' || COALESCE($4, '')" in expr
+        assert "tokenize(" in expr and "::bm25_catalog.bm25vector" in expr
+
+    @pytest.mark.parametrize("ext", ["native", "pgroonga", "pg_textsearch", "pg_search"])
+    def test_mental_model_expr_none_when_database_maintains_base_document(self, ext):
+        from hindsight_api.engine.db.ops_postgresql import PostgreSQLOps
+
+        assert PostgreSQLOps().mental_model_search_vector_expr(self._cfg(ext)) is None
+
+    def test_oracle_mental_model_search_document_has_no_stored_projection(self):
+        from hindsight_api.engine.db.ops_oracle import OracleOps
+
+        assert OracleOps().mental_model_search_vector_expr(self._cfg("native")) is None
+
     def test_expr_accepts_custom_column_refs(self):
         from hindsight_api.engine.db.ops_postgresql import pg_search_vector_expr
 

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -10,6 +10,8 @@ import json
 import uuid
 import zipfile
 from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
 
 import httpx
 import pytest
@@ -209,6 +211,85 @@ def test_export_bank_covers_schema():
     assert sum(len(b) for b in buckets) == len(classified), "a table is classified in more than one bucket"
 
 
+def test_knowledge_pages_restore_order_is_parent_first_and_rejects_bad_trees():
+    from hindsight_api.engine.transfer.importer import (
+        _knowledge_pages_parent_first,
+        _validate_knowledge_page_models,
+    )
+
+    rows = [
+        {"id": "grandchild", "parent_id": "child"},
+        {"id": "child", "parent_id": "root"},
+        {"id": "root", "parent_id": None},
+        {"id": "other-root", "parent_id": None},
+    ]
+    assert [row["id"] for row in _knowledge_pages_parent_first(rows)] == [
+        "root",
+        "other-root",
+        "child",
+        "grandchild",
+    ]
+
+    with pytest.raises(ValueError, match="missing parent"):
+        _knowledge_pages_parent_first([{"id": "orphan", "parent_id": "missing"}])
+    with pytest.raises(ValueError, match="parent cycle"):
+        _knowledge_pages_parent_first(
+            [
+                {"id": "a", "parent_id": "b"},
+                {"id": "b", "parent_id": "a"},
+            ]
+        )
+
+    mental_models = [{"id": "mm-page"}]
+    valid_rows = [
+        {"id": "folder", "parent_id": None, "kind": "folder", "mental_model_id": None},
+        {"id": "page", "parent_id": "folder", "kind": "page", "mental_model_id": "mm-page"},
+    ]
+    _validate_knowledge_page_models(valid_rows, mental_models)
+
+    with pytest.raises(ValueError, match="missing mental model"):
+        _validate_knowledge_page_models(
+            [{"id": "page", "parent_id": None, "kind": "page", "mental_model_id": "mm-missing"}],
+            mental_models,
+        )
+    with pytest.raises(ValueError, match="is not a folder"):
+        _validate_knowledge_page_models(
+            [
+                {"id": "page-1", "parent_id": None, "kind": "page", "mental_model_id": "mm-page"},
+                {"id": "page-2", "parent_id": "page-1", "kind": "page", "mental_model_id": "mm-page"},
+            ],
+            mental_models,
+        )
+
+
+@pytest.mark.asyncio
+async def test_mental_model_restore_rebuilds_backend_projection(monkeypatch):
+    from hindsight_api.engine.transfer import importer
+
+    restore_rows = AsyncMock(return_value=2)
+    monkeypatch.setattr(importer, "_restore_rows", restore_rows)
+    conn = AsyncMock()
+    ops = Mock()
+    ops.mental_model_search_vector_expr.return_value = (
+        "tokenize(COALESCE(name, '') || ' ' || COALESCE(content, ''), 'llmlingua2')::bm25vector"
+    )
+
+    inserted = await importer._restore_mental_models(
+        conn,
+        [{"id": "mm-1"}, {"id": "mm-2"}],
+        bank_id="bank",
+        config=SimpleNamespace(text_search_extension="vchord"),
+        ops=ops,
+        bank_rows_json_encoding="serialized",
+    )
+
+    assert inserted == 2
+    sql, bank_id = conn.execute.await_args.args
+    assert "SET search_vector = tokenize" in sql
+    assert "WHERE bank_id = $1" in sql
+    assert bank_id == "bank"
+
+
 def test_export_jsonb_coercion_preserves_decoded_scalar_string():
     """Admin connections decode JSONB before the transfer exporter sees it."""
     from hindsight_api.engine.transfer.export import _as_jsonb
@@ -297,6 +378,15 @@ async def test_export_bank_contents(memory, request_context):
     webhook_id = uuid.uuid4()
     try:
         await _retain(memory, bank, "Carol lives in Paris.", request_context, "doc-1")
+        folder = await memory.create_knowledge_folder(bank, "Guides", request_context=request_context)
+        await memory.create_knowledge_page(
+            bank,
+            "Paris",
+            "What do we know about Paris?",
+            "Carol lives in Paris.",
+            parent_id=folder["id"],
+            request_context=request_context,
+        )
         backend = await memory._get_backend()
         async with acquire_with_retry(backend) as conn:
             await conn.execute(
@@ -316,19 +406,23 @@ async def test_export_bank_contents(memory, request_context):
             names = set(zf.namelist())
             manifest = TransferManifest.model_validate_json(zf.read("manifest.json"))
             bank_rows = json.loads(zf.read("banks.json"))
+            knowledge_pages = json.loads(zf.read("knowledge_pages.json"))
             webhooks = json.loads(zf.read("webhooks.json"))
 
         assert manifest.archive_type == "bank"
         assert manifest.bank_rows_json_encoding == "serialized"
         assert manifest.document_count == 1
         assert manifest.webhook_count == 1
+        assert manifest.knowledge_page_count == 2
         assert "mental_models.json" in names and "directives.json" in names
+        assert "knowledge_pages.json" in names
         assert "mental_model_history.json" in names
         assert any(d.endswith(".json") and d.startswith("documents/") for d in names)
         # No history files unless requested.
         assert not any(n.startswith("history/") for n in names)
         # The bank row and webhook are carried.
         assert [r["bank_id"] for r in bank_rows] == [bank]
+        assert {row["kind"] for row in knowledge_pages} == {"folder", "page"}
         assert webhooks[0]["bank_id"] == bank and webhooks[0]["url"] == "https://example.com/hook"
         # No embeddings anywhere — the target instance regenerates them.
         assert "embedding" not in archive.decode("utf-8", errors="ignore")
@@ -382,11 +476,25 @@ async def _bank_content_snapshot(memory, bank_id):
             f"SELECT name, content, priority, is_active FROM {fq_table('directives')} WHERE bank_id = $1", bank_id
         )
         mms = await conn.fetch(
-            f"SELECT subtype, name, description, tags FROM {fq_table('mental_models')} WHERE bank_id = $1", bank_id
+            f"SELECT id, subtype, name, description, tags FROM {fq_table('mental_models')} WHERE bank_id = $1",
+            bank_id,
+        )
+        pages = await conn.fetch(
+            f"SELECT id, parent_id, kind, name, mental_model_id, managed, sort_order "
+            f"FROM {fq_table('knowledge_pages')} WHERE bank_id = $1",
+            bank_id,
         )
         null_emb = await conn.fetchval(
             f"SELECT count(*) FROM {fq_table('memory_units')} "
             f"WHERE bank_id = $1 AND fact_type != 'observation' AND embedding IS NULL",
+            bank_id,
+        )
+        null_mm_emb = await conn.fetchval(
+            f"SELECT count(*) FROM {fq_table('mental_models')} WHERE bank_id = $1 AND embedding IS NULL",
+            bank_id,
+        )
+        null_mm_search = await conn.fetchval(
+            f"SELECT count(*) FROM {fq_table('mental_models')} WHERE bank_id = $1 AND search_vector IS NULL",
             bank_id,
         )
     return {
@@ -401,9 +509,23 @@ async def _bank_content_snapshot(memory, bank_id):
         "webhooks": sorted((h["url"], tuple(h["event_types"] or []), h["enabled"]) for h in hooks),
         "directives": sorted((d["name"], d["content"], d["priority"], d["is_active"]) for d in dirs),
         "mental_models": sorted(
-            (m["subtype"], m["name"], m["description"], tuple(sorted(m["tags"] or []))) for m in mms
+            (m["id"], m["subtype"], m["name"], m["description"], tuple(sorted(m["tags"] or []))) for m in mms
+        ),
+        "knowledge_pages": sorted(
+            (
+                p["id"],
+                p["parent_id"],
+                p["kind"],
+                p["name"],
+                p["mental_model_id"],
+                p["managed"],
+                p["sort_order"],
+            )
+            for p in pages
         ),
         "null_embeddings": null_emb,
+        "null_mental_model_embeddings": null_mm_emb,
+        "null_mental_model_search_vectors": null_mm_search,
     }
 
 
@@ -547,10 +669,12 @@ async def test_bank_import_preserves_consolidation_lifecycle(memory, request_con
 @pytest.mark.asyncio
 async def test_bank_export_import_exact_roundtrip(memory, request_context):
     """A whole-bank archive restores EXACT bank content (config, docs, facts,
-    observations, entities, links, webhooks, directives, mental models) with facts
-    re-embedded. Uses export → delete → import so ids round-trip without collisions
-    (mirroring a fresh target instance)."""
+    observations, entities, links, webhooks, directives, mental models and
+    Knowledge Pages with vectors re-embedded. Uses export → delete → import under
+    a different bank id so stable object ids round-trip without collisions while
+    every bank-scoped row is proven to remap to the isolated target bank."""
     bank = _unique_bank("bank_exact")
+    target_bank = _unique_bank("bank_exact_target")
     try:
         await _retain(memory, bank, "Alice works at Google. Bob works at Microsoft.", request_context, "doc-1")
         await _retain(memory, bank, "Carol lives in Paris.", request_context, "doc-2")
@@ -595,26 +719,40 @@ async def test_bank_export_import_exact_roundtrip(memory, request_context):
             tags=["people"],
             request_context=request_context,
         )
+        folder = await memory.create_knowledge_folder(bank, "People", request_context=request_context)
+        await memory.create_knowledge_page(
+            bank,
+            "Locations",
+            "Where do people live?",
+            "Carol lives in Paris.",
+            parent_id=folder["id"],
+            tags=["people"],
+            request_context=request_context,
+        )
 
         before = await _bank_content_snapshot(memory, bank)
         # Sanity: the source genuinely has rich content in every section we carry.
         assert before["facts"] and before["entities"] and before["links"]
         assert before["webhooks"] and before["directives"] and before["mental_models"]
+        assert before["knowledge_pages"]
         assert before["bank"][0] == "My Bank"
 
         from hindsight_api.engine.transfer import export_bank
 
         async with acquire_with_retry(backend) as conn:
             archive = await export_bank(conn, bank)
-        # Delete then restore into the same id — exact round-trip, no PK collisions.
+        # Delete the source to model a separate target database (several carried
+        # object ids are globally unique), then restore under a different bank id
+        # to exercise --target-bank remapping on every carried child row.
         await memory.delete_bank(bank, request_context=request_context)
-        result = await memory.import_bank_async(archive, request_context)
-        assert result.bank_id == bank
+        result = await memory.import_bank_async(archive, request_context, target_bank_id=target_bank)
+        assert result.bank_id == target_bank
         assert result.webhooks_imported == 1
         assert result.directives_imported == 1
-        assert result.mental_models_imported == 1
+        assert result.mental_models_imported == 2
+        assert result.knowledge_pages_imported == 2
 
-        after = await _bank_content_snapshot(memory, bank)
+        after = await _bank_content_snapshot(memory, target_bank)
         # Semantic links are an ANN-approximate retrieval index regenerated from the
         # (re-embedded) facts; their count depends on whether ANN runs incrementally
         # per document (import) or as a final whole-bank pass (original retain), so
@@ -626,8 +764,11 @@ async def test_bank_export_import_exact_roundtrip(memory, request_context):
         assert after_semantic > 0, "semantic links should be regenerated on import"
         # Facts were re-embedded on import (no NULL vectors).
         assert after["null_embeddings"] == 0
+        assert after["null_mental_model_embeddings"] == 0
+        assert after["null_mental_model_search_vectors"] == 0
     finally:
         await memory.delete_bank(bank, request_context=request_context)
+        await memory.delete_bank(target_bank, request_context=request_context)
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_knowledge_base.py
+++ b/hindsight-api-slim/tests/test_knowledge_base.py
@@ -319,6 +319,25 @@ class TestMoveRenameDelete:
         assert resp.status_code == 200, resp.text
         assert resp.json()["name"] == "Compliance"
 
+    async def test_page_rename_updates_backing_mental_model(
+        self, api_client, kb_bank, memory: MemoryEngine, request_context
+    ):
+        bank_id, ids = kb_bank
+        resp = await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.orders}",
+            json={"name": "Order Operations"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["name"] == "Order Operations"
+
+        mental_model = await memory.get_mental_model(
+            bank_id,
+            ids.orders_mm,
+            request_context=request_context,
+        )
+        assert mental_model is not None
+        assert mental_model["name"] == "Order Operations"
+
     async def test_update_page_options(self, api_client, kb_bank):
         bank_id, ids = kb_bank
         resp = await api_client.patch(

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -2255,8 +2255,15 @@ class TestMentalModelTriggerSchema:
 class TestClearMentalModel:
     """Test clear_mental_model resets content so next refresh is full."""
 
-    async def test_clear_resets_content(self, memory: MemoryEngine, request_context):
+    async def test_clear_resets_content(self, memory: MemoryEngine, request_context, monkeypatch):
         """Clear sets content to empty string and nulls structured/tracking fields."""
+        original_generate = embedding_utils.generate_embeddings_batch
+        embedded_documents: list[list[str]] = []
+
+        async def recording_generate(*args, **kwargs):
+            embedded_documents.append(args[1])
+            return await original_generate(*args, **kwargs)
+
         bank_id = f"test-mm-clear-{uuid.uuid4().hex[:8]}"
         await memory.get_bank_profile(bank_id, request_context=request_context)
 
@@ -2268,6 +2275,8 @@ class TestClearMentalModel:
             request_context=request_context,
         )
         assert mm["content"] == "Some existing content"
+
+        monkeypatch.setattr(embedding_utils, "generate_embeddings_batch", recording_generate)
 
         cleared = await memory.clear_mental_model(
             bank_id=bank_id,
@@ -2282,6 +2291,16 @@ class TestClearMentalModel:
         # Re-fetch to confirm persistence
         fetched = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
         assert fetched["content"] == ""
+        assert embedded_documents == [["Test Model "]]
+        async with memory._pool.acquire() as conn:
+            search_vector = await conn.fetchval(
+                "SELECT search_vector::text FROM mental_models WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                mm["id"],
+            )
+        assert "exist" not in search_vector
+        assert "content" not in search_vector
+        assert "test" in search_vector and "model" in search_vector
 
         await memory.delete_bank(bank_id, request_context=request_context)
 

--- a/hindsight-api-slim/tests/test_reflections.py
+++ b/hindsight-api-slim/tests/test_reflections.py
@@ -195,6 +195,49 @@ class TestMentalModelsCRUD:
         await memory.delete_bank(bank_id, request_context=request_context)
 
     @pytest.mark.asyncio
+    async def test_name_only_update_rebuilds_canonical_search_document(
+        self, memory: MemoryEngine, request_context, monkeypatch
+    ):
+        """A name-only edit embeds stored content and refreshes native FTS."""
+        from hindsight_api.engine.retain import embedding_utils
+
+        bank_id = f"test-mental-model-name-{uuid.uuid4().hex[:8]}"
+        mental_model = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Original Name",
+            source_query="Original Query",
+            content="Canonical Body",
+            request_context=request_context,
+        )
+
+        original_generate = embedding_utils.generate_embeddings_batch
+        embedded_documents: list[list[str]] = []
+
+        async def recording_generate(*args, **kwargs):
+            embedded_documents.append(args[1])
+            return await original_generate(*args, **kwargs)
+
+        monkeypatch.setattr(embedding_utils, "generate_embeddings_batch", recording_generate)
+        updated = await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mental_model["id"],
+            name="Updated Name",
+            request_context=request_context,
+        )
+
+        assert updated is not None and updated["name"] == "Updated Name"
+        assert embedded_documents == [["Updated Name Canonical Body"]]
+        async with memory._pool.acquire() as conn:
+            search_vector = await conn.fetchval(
+                "SELECT search_vector::text FROM mental_models WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                mental_model["id"],
+            )
+        assert "updat" in search_vector
+        assert "canon" in search_vector
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
     async def test_delete_mental_model(self, memory: MemoryEngine, request_context):
         """Test deleting a mental model."""
         bank_id = f"test-mental-model-delete-{uuid.uuid4().hex[:8]}"

--- a/hindsight-api-slim/tests/test_text_search_reconciliation.py
+++ b/hindsight-api-slim/tests/test_text_search_reconciliation.py
@@ -1,0 +1,63 @@
+"""Regression coverage for runtime text-search reconciliation."""
+
+from contextlib import contextmanager
+
+from hindsight_api import migrations
+
+
+class _Result:
+    def __init__(self, *, scalar=None, row=None):
+        self._scalar = scalar
+        self._row = row
+
+    def scalar(self):
+        return self._scalar
+
+    def fetchone(self):
+        return self._row
+
+
+class _VChordConnection:
+    def __init__(self):
+        self.table_checks: list[str] = []
+        self.statements: list[str] = []
+        self.commits = 0
+
+    def execute(self, statement, params=None):
+        sql = str(statement)
+        self.statements.append(sql)
+        if "information_schema.tables" in sql:
+            self.table_checks.append(params["table_name"])
+            return _Result(scalar=True)
+        if "information_schema.columns" in sql:
+            return _Result(row=("USER-DEFINED", "bm25vector"))
+        if "FROM pg_indexes" in sql:
+            return _Result(row=("bm25", "CREATE INDEX USING bm25"))
+        return _Result()
+
+    def commit(self):
+        self.commits += 1
+
+
+class _Engine:
+    def __init__(self, conn):
+        self.conn = conn
+
+    @contextmanager
+    def connect(self):
+        yield self.conn
+
+
+def test_vchord_reconciliation_targets_and_backfills_mental_models(monkeypatch):
+    conn = _VChordConnection()
+    monkeypatch.setattr(migrations, "create_engine", lambda *args, **kwargs: _Engine(conn))
+
+    migrations.ensure_text_search_extension("postgresql://unused", text_search_extension="vchord")
+
+    assert conn.table_checks == ["memory_units", "mental_models"]
+    assert all("reflections" not in statement for statement in conn.statements)
+    assert any(
+        "UPDATE public.mental_models" in statement and "WHERE search_vector IS NULL" in statement
+        for statement in conn.statements
+    )
+    assert conn.commits == 1

--- a/hindsight-docs/docs/developer/admin-cli.md
+++ b/hindsight-docs/docs/developer/admin-cli.md
@@ -313,7 +313,7 @@ hindsight-admin worker-status --schema tenant_acme
 
 ### export-bank
 
-Export an entire bank to a portable ZIP archive — documents, facts, observations, bank configuration, mental models, directives, and webhooks. Embeddings are **never** included; they are regenerated on import. This is the source half of a cross-instance migration (e.g. moving to a different embedding model, vector extension, or text-search backend). PostgreSQL only.
+Export an entire bank to a portable ZIP archive — documents, facts, observations, bank configuration, mental models, Knowledge Pages, directives, and webhooks. Embeddings and text-search projections are **never** included; they are regenerated on import. Knowledge Page ids, hierarchy, and backing mental-model references are preserved. This is the source half of a cross-instance migration (e.g. moving to a different embedding model, vector extension, or text-search backend). PostgreSQL only.
 
 ```bash
 hindsight-admin export-bank --bank <BANK_ID> --output <FILE.zip> [OPTIONS]
@@ -343,7 +343,7 @@ Read-only — safe to run against a live instance.
 
 ### import-bank
 
-Restore a whole-bank archive (produced by `export-bank`) into **this** instance. Facts are re-embedded with this instance's configured embedding model and links/indexes are rebuilt; bank configuration, mental models, directives, and webhooks are restored exactly. No LLM fact-extraction runs, and because a migration restores state, it does **not** fire webhooks or re-run consolidation. PostgreSQL only.
+Restore a whole-bank archive (produced by `export-bank`) into **this** instance. Facts and mental models are re-embedded with this instance's configured embedding model and links/indexes/search projections are rebuilt; bank configuration, mental-model content/history, Knowledge Pages, directives, and webhooks are restored. No LLM fact-extraction runs, and because a migration restores state, it does **not** fire webhooks or re-run consolidation. PostgreSQL only.
 
 ```bash
 hindsight-admin import-bank --archive <FILE.zip> [OPTIONS]
@@ -376,7 +376,7 @@ Import restores a **whole bank** (config, facts, mental models, …) — it is *
 
 Changing a bank's **embedding model** (e.g. a 384-dim encoder → a 1024-dim one), **vector extension** (pgvector / vchord / pgvectorscale), or **text-search backend** can't be done in place on a populated bank — the stored vectors and indexes are tied to those settings. Because every embedding and index is a deterministic function of text already on disk, the supported path is to **move the bank to a fresh instance configured with the new settings and re-derive everything there — with no LLM re-extraction**.
 
-`export-bank` / `import-bank` carry documents, facts, observations, bank config, mental models, directives, and webhooks — but never embeddings, which the target instance regenerates with its own model.
+`export-bank` / `import-bank` carry documents, facts, observations, bank config, mental models and their history, Knowledge Pages, directives, and webhooks — but never embeddings or text-search projections, which the target instance regenerates for its own model and backend. Knowledge Page ids, parent-child hierarchy, and backing mental-model references are preserved.
 
 **Blue-green runbook:**
 

--- a/skills/hindsight-docs/references/developer/admin-cli.md
+++ b/skills/hindsight-docs/references/developer/admin-cli.md
@@ -313,7 +313,7 @@ hindsight-admin worker-status --schema tenant_acme
 
 ### export-bank
 
-Export an entire bank to a portable ZIP archive — documents, facts, observations, bank configuration, mental models, directives, and webhooks. Embeddings are **never** included; they are regenerated on import. This is the source half of a cross-instance migration (e.g. moving to a different embedding model, vector extension, or text-search backend). PostgreSQL only.
+Export an entire bank to a portable ZIP archive — documents, facts, observations, bank configuration, mental models, Knowledge Pages, directives, and webhooks. Embeddings and text-search projections are **never** included; they are regenerated on import. Knowledge Page ids, hierarchy, and backing mental-model references are preserved. This is the source half of a cross-instance migration (e.g. moving to a different embedding model, vector extension, or text-search backend). PostgreSQL only.
 
 ```bash
 hindsight-admin export-bank --bank <BANK_ID> --output <FILE.zip> [OPTIONS]
@@ -343,7 +343,7 @@ Read-only — safe to run against a live instance.
 
 ### import-bank
 
-Restore a whole-bank archive (produced by `export-bank`) into **this** instance. Facts are re-embedded with this instance's configured embedding model and links/indexes are rebuilt; bank configuration, mental models, directives, and webhooks are restored exactly. No LLM fact-extraction runs, and because a migration restores state, it does **not** fire webhooks or re-run consolidation. PostgreSQL only.
+Restore a whole-bank archive (produced by `export-bank`) into **this** instance. Facts and mental models are re-embedded with this instance's configured embedding model and links/indexes/search projections are rebuilt; bank configuration, mental-model content/history, Knowledge Pages, directives, and webhooks are restored. No LLM fact-extraction runs, and because a migration restores state, it does **not** fire webhooks or re-run consolidation. PostgreSQL only.
 
 ```bash
 hindsight-admin import-bank --archive <FILE.zip> [OPTIONS]
@@ -376,7 +376,7 @@ Import restores a **whole bank** (config, facts, mental models, …) — it is *
 
 Changing a bank's **embedding model** (e.g. a 384-dim encoder → a 1024-dim one), **vector extension** (pgvector / vchord / pgvectorscale), or **text-search backend** can't be done in place on a populated bank — the stored vectors and indexes are tied to those settings. Because every embedding and index is a deterministic function of text already on disk, the supported path is to **move the bank to a fresh instance configured with the new settings and re-derive everything there — with no LLM re-extraction**.
 
-`export-bank` / `import-bank` carry documents, facts, observations, bank config, mental models, directives, and webhooks — but never embeddings, which the target instance regenerates with its own model.
+`export-bank` / `import-bank` carry documents, facts, observations, bank config, mental models and their history, Knowledge Pages, directives, and webhooks — but never embeddings or text-search projections, which the target instance regenerates for its own model and backend. Knowledge Page ids, parent-child hierarchy, and backing mental-model references are preserved.
 
 **Blue-green runbook:**
 


### PR DESCRIPTION
## Summary

- include Knowledge Pages and mental-model history in whole-bank archives
- validate page/model references and restore the page tree parent-first
- re-embed carried mental models with the target provider and rebuild the target text projection
- preserve bank configuration and optional operational history while retaining the fresh-target preflight

## Root cause

Whole-bank export skipped `knowledge_pages` and stripped mental-model derived state. Import restored mental-model rows without regenerating embeddings or the target backend projection, so a cross-instance migration could lose the page tree and leave its search state unusable.

Closes #3308.

## Dependency

Depends on #3313 for the backend capability used to rebuild mental-model search state. This branch contains that prerequisite commit; the transfer-specific review commit is `07d091b2a`.

## Verification

- document-transfer suite: 27 passed
- targeted mental-model, Knowledge Page, transfer, and DB-abstraction suite: 136 passed on the combined integration branch
- Ruff and ty checks passed for changed production files
- fresh PG18 + PGroonga target canary restored 1 mental model, 2 Knowledge Page nodes, 1 mental-model history row, and 5 operational-history rows
- source and target page/model checksums and counts matched; embeddings were regenerated; parent links and Korean/English/mixed HTTP search survived a database restart

The same-instance clone collision tracked in #3270 is a separate existing lane. This PR targets the documented cross-instance migration path and does not duplicate that work.