### PR TITLE
fix(docker): repair PGroonga Compose image

### DIFF
--- a/docker/docker-compose/pgroonga/Dockerfile
+++ b/docker/docker-compose/pgroonga/Dockerfile
@@ -3,21 +3,11 @@
 # pgroonga is a multilingual full-text search extension built on Groonga.
 # It works out of the box for CJK (Chinese, Japanese, Korean) and other
 # non-whitespace-segmented languages via the TokenBigram tokenizer.
-FROM groonga/pgroonga:latest-debian-pg17
+FROM groonga/pgroonga:4.0.8-debian-17
 
 # Install pgvector on top of the pgroonga base image (which already provides
-# pgroonga and the Groonga library).
+# pgroonga, the Groonga library, and the PostgreSQL PGDG package repository).
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    git \
-    postgresql-server-dev-17 \
+    postgresql-17-pgvector=0.8.6-1.pgdg13+1 \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-RUN cd /tmp && \
-    git clone --branch v0.8.0 https://github.com/pgvector/pgvector.git && \
-    cd pgvector && \
-    make && \
-    make install
-
-RUN rm -rf /tmp/pgvector && \
-    apt-get purge -y --auto-remove build-essential git postgresql-server-dev-17


### PR DESCRIPTION
## Summary

- replace the nonexistent `groonga/pgroonga:latest-debian-pg17` base with the published pinned `groonga/pgroonga:4.0.8-debian-17` image
- install the pinned PostgreSQL 17 pgvector 0.8.6 package from PGDG

## Root cause

The shipped PGroonga recipe cannot build because its base-image tag does not exist. Pinning the actual PGroonga Debian 17 tag also makes the example reproducible instead of following an ambiguous latest tag.

Closes #3311.

## Verification

- registry inspection confirmed the published PGroonga tag is multi-architecture, including arm64
- disposable arm64 PostgreSQL smoke test loaded PGroonga 4.0.8 and pgvector 0.8.6
- Korean/English `&@~` matching and pgvector distance queries passed

The local PG18 integration image used for downstream migration rehearsal is intentionally not included; this PR only repairs the existing upstream PG17 recipe.