### PR TITLE
fix(api): knowledge-base search 500s on non-native text-search backends (#3268)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -16,24 +16,34 @@ def pg_search_vector_expr(
     *,
     text_col: str = "text",
     context_col: str = "context",
-    signals_col: str = "text_signals",
+    signals_col: str | None = "text_signals",
+    native_inline: bool = True,
 ) -> str | None:
     """SQL expression that builds ``search_vector`` for the configured PG text-search backend.
 
-    Single source of truth shared by the batch insert (over the ``input_data``
-    CTE columns) and the curation revert recompute (over a ``memory_units`` row),
-    so the two can never drift. Returns ``None`` for backends that leave
-    ``search_vector`` unpopulated — pgroonga / pg_textsearch / pg_search index the
-    base text columns directly and keep only a dummy column, so there is nothing
-    to build.
+    Single source of truth shared by ``memory_units`` (the batch insert over the
+    ``input_data`` CTE columns and the curation-revert recompute) and
+    ``mental_models`` (the knowledge-page writes), so the per-backend tokenization
+    can never drift between the two tables. Returns ``None`` for backends that
+    leave ``search_vector`` unpopulated — pgroonga / pg_textsearch / pg_search
+    index the base text columns directly and keep only a dummy column, so there is
+    nothing to build.
+
+    The ``*_col`` arguments are the SQL for each text source (a column name or a
+    bind placeholder); pass ``signals_col=None`` for a two-column table like
+    ``mental_models`` (name + content). Pass ``native_inline=False`` when the
+    table's native ``search_vector`` is a GENERATED column that populates itself
+    (``mental_models``) — writing it inline would fail; only vchord's plain
+    bm25vector column then needs an explicit value.
 
     ``text_search_extension_native_language`` is validated as a PG identifier in
     ``HindsightConfig.validate()``, so embedding it as a SQL literal is safe.
     """
-    combined = f"COALESCE({text_col}, '') || ' ' || COALESCE({context_col}, '') || ' ' || COALESCE({signals_col}, '')"
+    cols = [text_col, context_col] + ([signals_col] if signals_col is not None else [])
+    combined = " || ' ' || ".join(f"COALESCE({c}, '')" for c in cols)
     if config.text_search_extension == "vchord":
         return f"tokenize({combined}, 'llmlingua2')::bm25_catalog.bm25vector"
-    if config.text_search_extension == "native":
+    if config.text_search_extension == "native" and native_inline:
         return f"to_tsvector('{config.text_search_extension_native_language}'::regconfig, {combined})"
     return None
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -51,6 +51,7 @@ from ..worker.stage import set_stage
 from .audit import AuditLogger, audit_context
 from .bank_stats_cache import BankStatsCache, DistributedBankStatsCache
 from .db import DatabaseBackend, create_database_backend
+from .db.ops_postgresql import pg_search_vector_expr
 from .db_budget import budgeted_operation
 from .llm_interface import ProviderRateLimitResetError
 from .llm_trace import (
@@ -11833,12 +11834,25 @@ class MemoryEngine(MemoryEngineInterface):
                     request_context,
                     conn=conn,
                 )
+                # VectorChord needs mental_models.search_vector tokenized on write:
+                # its column is a plain bm25vector read by idx_mental_models_text_search
+                # (native's is GENERATED; pg_search/pg_textsearch/pgroonga index base
+                # columns), so every other backend leaves it out. Same tokenization the
+                # memory_units write path uses (pg_search_vector_expr / insert_facts_batch),
+                # over name + content — native_inline=False because mm's native column
+                # populates itself.
+                config = get_config()
                 if mental_model_id:
+                    sv_expr = pg_search_vector_expr(
+                        config, text_col="$3", context_col="$5", signals_col=None, native_inline=False
+                    )
+                    sv_col = ", search_vector" if sv_expr else ""
+                    sv_val = f", {sv_expr}" if sv_expr else ""
                     row = await conn.fetchrow(
                         f"""
                         INSERT INTO {fq_table("mental_models")}
-                        (id, bank_id, subtype, name, description, source_query, content, embedding, tags, max_tokens, trigger)
-                        VALUES ($1, $2, 'pinned', $3, ' ', $4, $5, $6, $7, COALESCE($8, 2048), COALESCE($9, '{{"refresh_after_consolidation": false}}'::jsonb))
+                        (id, bank_id, subtype, name, description, source_query, content, embedding, tags, max_tokens, trigger{sv_col})
+                        VALUES ($1, $2, 'pinned', $3, ' ', $4, $5, $6, $7, COALESCE($8, 2048), COALESCE($9, '{{"refresh_after_consolidation": false}}'::jsonb){sv_val})
                         RETURNING id, bank_id, name, source_query, content, tags,
                                   last_refreshed_at, created_at, reflect_response,
                                   max_tokens, trigger, structured_content
@@ -11854,11 +11868,16 @@ class MemoryEngine(MemoryEngineInterface):
                         json.dumps(trigger) if trigger else None,
                     )
                 else:
+                    sv_expr = pg_search_vector_expr(
+                        config, text_col="$2", context_col="$4", signals_col=None, native_inline=False
+                    )
+                    sv_col = ", search_vector" if sv_expr else ""
+                    sv_val = f", {sv_expr}" if sv_expr else ""
                     row = await conn.fetchrow(
                         f"""
                         INSERT INTO {fq_table("mental_models")}
-                        (bank_id, subtype, name, description, source_query, content, embedding, tags, max_tokens, trigger)
-                        VALUES ($1, 'pinned', $2, ' ', $3, $4, $5, $6, COALESCE($7, 2048), COALESCE($8, '{{"refresh_after_consolidation": false}}'::jsonb))
+                        (bank_id, subtype, name, description, source_query, content, embedding, tags, max_tokens, trigger{sv_col})
+                        VALUES ($1, 'pinned', $2, ' ', $3, $4, $5, $6, COALESCE($7, 2048), COALESCE($8, '{{"refresh_after_consolidation": false}}'::jsonb){sv_val})
                         RETURNING id, bank_id, name, source_query, content, tags,
                                   last_refreshed_at, created_at, reflect_response,
                                   max_tokens, trigger, structured_content
@@ -12799,14 +12818,22 @@ class MemoryEngine(MemoryEngineInterface):
             record_mm_history = False
             slim_reflect_response: dict[str, Any] | None = None
 
+            # Track the SQL for the search_vector source columns: the new bind
+            # placeholder when the field is being updated, else the existing column
+            # (unchanged). Used to re-tokenize search_vector for vchord below.
+            name_sql = "name"
+            content_sql = "content"
+
             if name is not None:
                 updates.append(f"name = ${param_idx}")
                 params.append(name)
+                name_sql = f"${param_idx}"
                 param_idx += 1
 
             if content is not None:
                 updates.append(f"content = ${param_idx}")
                 params.append(content)
+                content_sql = f"${param_idx}"
                 param_idx += 1
                 if refresh_watermark is None:
                     updates.append("last_refreshed_at = NOW()")
@@ -12883,6 +12910,17 @@ class MemoryEngine(MemoryEngineInterface):
                 updates.append(f"structured_content = ${param_idx}")
                 params.append(json.dumps(structured_content))
                 param_idx += 1
+
+            # Re-tokenize search_vector when the searchable text (name/content)
+            # changed, but only for vchord — its bm25vector column is written
+            # inline (native is a GENERATED column that updates itself; the other
+            # backends index base columns). Same helper as the insert/recall paths.
+            if name is not None or content is not None:
+                sv_expr = pg_search_vector_expr(
+                    get_config(), text_col=name_sql, context_col=content_sql, signals_col=None, native_inline=False
+                )
+                if sv_expr:
+                    updates.append(f"search_vector = {sv_expr}")
 
             if not updates:
                 return None
@@ -12988,13 +13026,20 @@ class MemoryEngine(MemoryEngineInterface):
             await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
         backend = await self._get_backend()
 
+        # Content is cleared to '', so re-tokenize search_vector from the name
+        # alone — vchord only (see update_mental_model). Non-vchord backends leave
+        # the column untouched (generated / base-column indexed).
+        sv_expr = pg_search_vector_expr(
+            get_config(), text_col="name", context_col="''", signals_col=None, native_inline=False
+        )
+        sv_clause = f", search_vector = {sv_expr}" if sv_expr else ""
         async with acquire_with_retry(backend) as conn:
             row = await conn.fetchrow(
                 f"""
                 UPDATE {fq_table("mental_models")}
                 SET content = '',
                     structured_content = NULL,
-                    last_refreshed_source_query = NULL
+                    last_refreshed_source_query = NULL{sv_clause}
                 WHERE bank_id = $1 AND id = $2
                 RETURNING id, bank_id, name, source_query, content, tags,
                           last_refreshed_at, created_at, reflect_response,
@@ -13363,67 +13408,51 @@ class MemoryEngine(MemoryEngineInterface):
         mm = fq_table("mental_models")
         join = self._kp_join()
 
-        # BM25 clauses for the configured text-search backend. `None` means the
-        # backend can't do BM25 over knowledge pages (e.g. vchord) → vector-only.
+        # BM25 clauses for the configured text-search backend (same per-backend
+        # dispatch the memory-recall BM25 arm uses — see knowledge_bm25_arm).
         text_search_extension = get_config().text_search_extension
 
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
             if emb_str is not None:
                 bm25 = knowledge_bm25_arm(text_search_extension, table_alias="mm", text_param="$3")
-                if bm25 is not None:
-                    # Vector arm (ANN over mm.embedding) + BM25 arm, each ranked
-                    # independently, then RRF-fused (k=60) in SQL.
-                    sql = f"""
-                        WITH vec AS (
-                            SELECT kp.id AS page_id,
-                                   ROW_NUMBER() OVER (ORDER BY mm.embedding <=> $1::vector) AS rnk
-                            FROM {join}
-                            WHERE kp.bank_id = $2 AND kp.kind = 'page' AND mm.embedding IS NOT NULL
-                            ORDER BY mm.embedding <=> $1::vector
-                            LIMIT {fetch}
-                        ),
-                        bm AS (
-                            SELECT kp.id AS page_id,
-                                   ROW_NUMBER() OVER (ORDER BY {bm25.order_by}) AS rnk
-                            FROM {join}
-                            WHERE kp.bank_id = $2 AND kp.kind = 'page'
-                                  {bm25.match_filter}
-                            ORDER BY {bm25.order_by}
-                            LIMIT {fetch}
-                        ),
-                        fused AS (
-                            SELECT COALESCE(vec.page_id, bm.page_id) AS page_id,
-                                   COALESCE(1.0 / (60 + vec.rnk), 0) + COALESCE(1.0 / (60 + bm.rnk), 0) AS score
-                            FROM vec FULL OUTER JOIN bm ON vec.page_id = bm.page_id
-                        )
-                        SELECT kp.id, kp.name, kp.mental_model_id,
-                               LEFT(mm.content, 280) AS snippet, mm.last_refreshed_at AS updated_at, f.score
-                        FROM fused f
-                        JOIN {kp} kp ON kp.id = f.page_id AND kp.bank_id = $2
-                        LEFT JOIN {mm} mm ON mm.id = kp.mental_model_id AND mm.bank_id = kp.bank_id
-                        ORDER BY f.score DESC
-                        LIMIT {limit}
-                    """
-                    rows = await conn.fetch(sql, emb_str, bank_id, query)
-                else:
-                    # Backend without a usable knowledge BM25 index → vector-only.
-                    sql = f"""
-                        SELECT kp.id, kp.name, kp.mental_model_id,
-                               LEFT(mm.content, 280) AS snippet, mm.last_refreshed_at AS updated_at,
-                               1 - (mm.embedding <=> $1::vector) AS score
+                # Vector arm (ANN over mm.embedding) + BM25 arm, each ranked
+                # independently, then RRF-fused (k=60) in SQL.
+                sql = f"""
+                    WITH vec AS (
+                        SELECT kp.id AS page_id,
+                               ROW_NUMBER() OVER (ORDER BY mm.embedding <=> $1::vector) AS rnk
                         FROM {join}
                         WHERE kp.bank_id = $2 AND kp.kind = 'page' AND mm.embedding IS NOT NULL
                         ORDER BY mm.embedding <=> $1::vector
-                        LIMIT {limit}
-                    """
-                    rows = await conn.fetch(sql, emb_str, bank_id)
+                        LIMIT {fetch}
+                    ),
+                    bm AS (
+                        SELECT kp.id AS page_id,
+                               ROW_NUMBER() OVER (ORDER BY {bm25.order_by}) AS rnk
+                        FROM {join}
+                        WHERE kp.bank_id = $2 AND kp.kind = 'page'
+                              {bm25.match_filter}
+                        ORDER BY {bm25.order_by}
+                        LIMIT {fetch}
+                    ),
+                    fused AS (
+                        SELECT COALESCE(vec.page_id, bm.page_id) AS page_id,
+                               COALESCE(1.0 / (60 + vec.rnk), 0) + COALESCE(1.0 / (60 + bm.rnk), 0) AS score
+                        FROM vec FULL OUTER JOIN bm ON vec.page_id = bm.page_id
+                    )
+                    SELECT kp.id, kp.name, kp.mental_model_id,
+                           LEFT(mm.content, 280) AS snippet, mm.last_refreshed_at AS updated_at, f.score
+                    FROM fused f
+                    JOIN {kp} kp ON kp.id = f.page_id AND kp.bank_id = $2
+                    LEFT JOIN {mm} mm ON mm.id = kp.mental_model_id AND mm.bank_id = kp.bank_id
+                    ORDER BY f.score DESC
+                    LIMIT {limit}
+                """
+                rows = await conn.fetch(sql, emb_str, bank_id, query)
             else:
-                bm25 = knowledge_bm25_arm(text_search_extension, table_alias="mm", text_param="$2")
-                if bm25 is None:
-                    # No embedding and no usable BM25 backend → nothing to search on.
-                    return []
                 # Embedding unavailable → BM25-only fallback (still useful).
+                bm25 = knowledge_bm25_arm(text_search_extension, table_alias="mm", text_param="$2")
                 sql = f"""
                     SELECT kp.id, kp.name, kp.mental_model_id,
                            LEFT(mm.content, 280) AS snippet, mm.last_refreshed_at AS updated_at,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -71,6 +71,7 @@ from .operation_metadata import (
     RetainOutcomeMetadata,
 )
 from .sql import SQLDialect, create_sql_dialect
+from .sql.postgresql import knowledge_bm25_arm
 
 # Context variable for current schema (async-safe, per-task isolation)
 # Note: default is None, actual default comes from config via get_current_schema()
@@ -13333,11 +13334,16 @@ class MemoryEngine(MemoryEngineInterface):
     ) -> list[dict[str, Any]]:
         """Doc-level hybrid search over a bank's knowledge pages.
 
-        Fuses a full-text match (``mm.search_vector``, a generated tsvector over the
-        page name + content) with vector similarity (``mm.embedding``) using
-        Reciprocal Rank Fusion, in a single round trip. No reranker — this path is
-        tuned for latency. Returns pages ranked by fused score, each with a short
-        content snippet. Folders are excluded.
+        Fuses a full-text (BM25) match over the page name + content with vector
+        similarity (``mm.embedding``) using Reciprocal Rank Fusion, in a single
+        round trip. No reranker — this path is tuned for latency. Returns pages
+        ranked by fused score, each with a short content snippet. Folders are
+        excluded.
+
+        The BM25 arm is dispatched on the configured text-search backend
+        (:func:`knowledge_bm25_arm`); backends whose ``mental_models`` BM25 index
+        is unpopulated (``vchord``) degrade to a vector-only search rather than
+        erroring.
         """
         await self._authenticate_tenant(request_context)
         query = (query or "").strip()
@@ -13357,55 +13363,75 @@ class MemoryEngine(MemoryEngineInterface):
         mm = fq_table("mental_models")
         join = self._kp_join()
 
+        # BM25 clauses for the configured text-search backend. `None` means the
+        # backend can't do BM25 over knowledge pages (e.g. vchord) → vector-only.
+        text_search_extension = get_config().text_search_extension
+
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
             if emb_str is not None:
-                # Vector arm (ANN over mm.embedding) + BM25 arm (mm.search_vector),
-                # each ranked independently, then RRF-fused (k=60) in SQL.
-                sql = f"""
-                    WITH vec AS (
-                        SELECT kp.id AS page_id,
-                               ROW_NUMBER() OVER (ORDER BY mm.embedding <=> $1::vector) AS rnk
+                bm25 = knowledge_bm25_arm(text_search_extension, table_alias="mm", text_param="$3")
+                if bm25 is not None:
+                    # Vector arm (ANN over mm.embedding) + BM25 arm, each ranked
+                    # independently, then RRF-fused (k=60) in SQL.
+                    sql = f"""
+                        WITH vec AS (
+                            SELECT kp.id AS page_id,
+                                   ROW_NUMBER() OVER (ORDER BY mm.embedding <=> $1::vector) AS rnk
+                            FROM {join}
+                            WHERE kp.bank_id = $2 AND kp.kind = 'page' AND mm.embedding IS NOT NULL
+                            ORDER BY mm.embedding <=> $1::vector
+                            LIMIT {fetch}
+                        ),
+                        bm AS (
+                            SELECT kp.id AS page_id,
+                                   ROW_NUMBER() OVER (ORDER BY {bm25.order_by}) AS rnk
+                            FROM {join}
+                            WHERE kp.bank_id = $2 AND kp.kind = 'page'
+                                  {bm25.match_filter}
+                            ORDER BY {bm25.order_by}
+                            LIMIT {fetch}
+                        ),
+                        fused AS (
+                            SELECT COALESCE(vec.page_id, bm.page_id) AS page_id,
+                                   COALESCE(1.0 / (60 + vec.rnk), 0) + COALESCE(1.0 / (60 + bm.rnk), 0) AS score
+                            FROM vec FULL OUTER JOIN bm ON vec.page_id = bm.page_id
+                        )
+                        SELECT kp.id, kp.name, kp.mental_model_id,
+                               LEFT(mm.content, 280) AS snippet, mm.last_refreshed_at AS updated_at, f.score
+                        FROM fused f
+                        JOIN {kp} kp ON kp.id = f.page_id AND kp.bank_id = $2
+                        LEFT JOIN {mm} mm ON mm.id = kp.mental_model_id AND mm.bank_id = kp.bank_id
+                        ORDER BY f.score DESC
+                        LIMIT {limit}
+                    """
+                    rows = await conn.fetch(sql, emb_str, bank_id, query)
+                else:
+                    # Backend without a usable knowledge BM25 index → vector-only.
+                    sql = f"""
+                        SELECT kp.id, kp.name, kp.mental_model_id,
+                               LEFT(mm.content, 280) AS snippet, mm.last_refreshed_at AS updated_at,
+                               1 - (mm.embedding <=> $1::vector) AS score
                         FROM {join}
                         WHERE kp.bank_id = $2 AND kp.kind = 'page' AND mm.embedding IS NOT NULL
                         ORDER BY mm.embedding <=> $1::vector
-                        LIMIT {fetch}
-                    ),
-                    bm AS (
-                        SELECT kp.id AS page_id,
-                               ROW_NUMBER() OVER (
-                                   ORDER BY ts_rank_cd(mm.search_vector, websearch_to_tsquery('english', $3)) DESC
-                               ) AS rnk
-                        FROM {join}
-                        WHERE kp.bank_id = $2 AND kp.kind = 'page'
-                              AND mm.search_vector @@ websearch_to_tsquery('english', $3)
-                        ORDER BY ts_rank_cd(mm.search_vector, websearch_to_tsquery('english', $3)) DESC
-                        LIMIT {fetch}
-                    ),
-                    fused AS (
-                        SELECT COALESCE(vec.page_id, bm.page_id) AS page_id,
-                               COALESCE(1.0 / (60 + vec.rnk), 0) + COALESCE(1.0 / (60 + bm.rnk), 0) AS score
-                        FROM vec FULL OUTER JOIN bm ON vec.page_id = bm.page_id
-                    )
-                    SELECT kp.id, kp.name, kp.mental_model_id,
-                           LEFT(mm.content, 280) AS snippet, mm.last_refreshed_at AS updated_at, f.score
-                    FROM fused f
-                    JOIN {kp} kp ON kp.id = f.page_id AND kp.bank_id = $2
-                    LEFT JOIN {mm} mm ON mm.id = kp.mental_model_id AND mm.bank_id = kp.bank_id
-                    ORDER BY f.score DESC
-                    LIMIT {limit}
-                """
-                rows = await conn.fetch(sql, emb_str, bank_id, query)
+                        LIMIT {limit}
+                    """
+                    rows = await conn.fetch(sql, emb_str, bank_id)
             else:
+                bm25 = knowledge_bm25_arm(text_search_extension, table_alias="mm", text_param="$2")
+                if bm25 is None:
+                    # No embedding and no usable BM25 backend → nothing to search on.
+                    return []
                 # Embedding unavailable → BM25-only fallback (still useful).
                 sql = f"""
                     SELECT kp.id, kp.name, kp.mental_model_id,
                            LEFT(mm.content, 280) AS snippet, mm.last_refreshed_at AS updated_at,
-                           ts_rank_cd(mm.search_vector, websearch_to_tsquery('english', $2)) AS score
+                           {bm25.score_expr} AS score
                     FROM {join}
                     WHERE kp.bank_id = $1 AND kp.kind = 'page'
-                          AND mm.search_vector @@ websearch_to_tsquery('english', $2)
-                    ORDER BY score DESC
+                          {bm25.match_filter}
+                    ORDER BY {bm25.order_by}
                     LIMIT {limit}
                 """
                 rows = await conn.fetch(sql, bank_id, query)

--- a/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
@@ -5,7 +5,98 @@ vector distance (pgvector), full-text search (VectorChord BM25 / tsvector),
 and other non-portable patterns.
 """
 
+from dataclasses import dataclass
+
 from .base import SQLDialect
+
+
+@dataclass(frozen=True)
+class KnowledgeBm25Arm:
+    """Backend-specific BM25 clauses for the knowledge-page full-text arm.
+
+    ``score_expr`` is a relevance score where higher = more relevant (used in the
+    SELECT list of the BM25-only fallback). ``order_by`` is the arm's ranking
+    expression (kept separate so distance-based backends can order by the raw,
+    index-friendly ``ASC`` distance). ``match_filter`` is a WHERE predicate that
+    keeps only genuine term matches, already prefixed with ``AND `` — empty when
+    the backend ranks every row and needs no gate.
+    """
+
+    score_expr: str
+    order_by: str
+    match_filter: str
+
+
+def knowledge_bm25_arm(
+    text_search_extension: str,
+    *,
+    table_alias: str,
+    text_param: str,
+) -> KnowledgeBm25Arm | None:
+    """BM25 clauses for ``search_knowledge_pages`` on a given text-search backend.
+
+    Mirrors :meth:`PostgreSQLDialect.build_bm25_arm` but targets the
+    ``mental_models`` BM25 index (``idx_mental_models_text_search`` over the
+    page ``name`` + ``content``) that backs knowledge pages. Without this
+    dispatch the native tsvector SQL (``ts_rank_cd`` / ``@@``) is sent to every
+    backend and 500s wherever ``mental_models.search_vector`` is not a tsvector
+    (see issue #3268).
+
+    ``table_alias`` is the alias the ``mental_models`` row carries in the query
+    (``mm``); ``text_param`` is the bind placeholder holding the query text.
+
+    Returns ``None`` when the backend has no usable BM25 for knowledge pages, so
+    the caller degrades to a vector-only search instead of 500ing. That is the
+    case for ``vchord``: its ``search_vector`` bm25vector column is only ever
+    populated by tokenizing on write, and mental-model writes never do so (unlike
+    ``memory_units``), leaving the column — and therefore its BM25 index — empty.
+
+    ``pgroonga`` is intentionally served by the native branch: the
+    ``mental_models`` table is never reconciled to pgroonga structures
+    (``ensure_text_search_extension`` checks the pre-rename ``reflections`` name),
+    so it keeps the migration-time generated tsvector column.
+    """
+    a = table_alias
+    p = text_param
+
+    if text_search_extension == "vchord":
+        # bm25vector column never populated for mental_models — no BM25 possible.
+        return None
+
+    if text_search_extension == "pg_search":
+        # ParadeDB pg_search: BM25 index over (id, name, content), key_field='id'.
+        # Fan the query across both indexed text fields with paradedb.boolean.
+        score = f"paradedb.score({a}.id)"
+        return KnowledgeBm25Arm(
+            score_expr=score,
+            order_by=f"{score} DESC",
+            match_filter=(
+                f"AND {a}.id @@@ paradedb.boolean(should => ARRAY["
+                f"paradedb.match('name', {p}), paradedb.match('content', {p})])"
+            ),
+        )
+
+    if text_search_extension == "pg_textsearch":
+        # Timescale pg_textsearch: BM25 index over the `content` column. `<@>` is a
+        # distance (lower = closer), so negate it for a higher-is-better score and
+        # order by the raw ASC distance so the index drives the ordering.
+        distance = f"{a}.content <@> to_bm25query({p}, 'idx_mental_models_text_search')"
+        return KnowledgeBm25Arm(
+            score_expr=f"-({distance})",
+            order_by=f"{distance} ASC",
+            match_filter="",
+        )
+
+    # native (and pgroonga — see docstring): generated tsvector over name + content.
+    # The generating expression hard-codes the 'english' config (see the
+    # learnings/pinned_reflections migration), so query with 'english' regardless
+    # of the configured native language.
+    score = f"ts_rank_cd({a}.search_vector, websearch_to_tsquery('english', {p}))"
+    return KnowledgeBm25Arm(
+        score_expr=score,
+        order_by=f"{score} DESC",
+        match_filter=f"AND {a}.search_vector @@ websearch_to_tsquery('english', {p})",
+    )
 
 
 class PostgreSQLDialect(SQLDialect):

--- a/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
@@ -32,24 +32,18 @@ def knowledge_bm25_arm(
     *,
     table_alias: str,
     text_param: str,
-) -> KnowledgeBm25Arm | None:
+) -> KnowledgeBm25Arm:
     """BM25 clauses for ``search_knowledge_pages`` on a given text-search backend.
 
-    Mirrors :meth:`PostgreSQLDialect.build_bm25_arm` but targets the
-    ``mental_models`` BM25 index (``idx_mental_models_text_search`` over the
-    page ``name`` + ``content``) that backs knowledge pages. Without this
+    Mirrors :meth:`PostgreSQLDialect.build_bm25_arm` (the memory-recall BM25 arm)
+    but targets the ``mental_models`` BM25 index (``idx_mental_models_text_search``
+    over the page ``name`` + ``content``) that backs knowledge pages. Without this
     dispatch the native tsvector SQL (``ts_rank_cd`` / ``@@``) is sent to every
     backend and 500s wherever ``mental_models.search_vector`` is not a tsvector
     (see issue #3268).
 
     ``table_alias`` is the alias the ``mental_models`` row carries in the query
     (``mm``); ``text_param`` is the bind placeholder holding the query text.
-
-    Returns ``None`` when the backend has no usable BM25 for knowledge pages, so
-    the caller degrades to a vector-only search instead of 500ing. That is the
-    case for ``vchord``: its ``search_vector`` bm25vector column is only ever
-    populated by tokenizing on write, and mental-model writes never do so (unlike
-    ``memory_units``), leaving the column — and therefore its BM25 index — empty.
 
     ``pgroonga`` is intentionally served by the native branch: the
     ``mental_models`` table is never reconciled to pgroonga structures
@@ -60,8 +54,20 @@ def knowledge_bm25_arm(
     p = text_param
 
     if text_search_extension == "vchord":
-        # bm25vector column never populated for mental_models — no BM25 possible.
-        return None
+        # VectorChord BM25 over the bm25vector search_vector column, identical to
+        # build_bm25_arm's vchord form. This only returns rows because the
+        # mental_models write path now tokenizes search_vector for vchord
+        # (pg_search_vector_expr, native_inline=False) the same way memory_units
+        # does — the column is plain, not generated, so it must be filled on write.
+        # <&> is the NEGATIVE score (lower = more relevant); negate it.
+        expr = f"-({a}.search_vector <&> to_bm25query('idx_mental_models_text_search', tokenize({p}, 'llmlingua2')))"
+        return KnowledgeBm25Arm(
+            score_expr=expr,
+            order_by=f"{expr} DESC",
+            # Gate on a positive score: the operator ranks every row, so a bare
+            # LIMIT would pad the arm with zero-score non-matches.
+            match_filter=f"AND {expr} > 0",
+        )
 
     if text_search_extension == "pg_search":
         # ParadeDB pg_search: BM25 index over (id, name, content), key_field='id'.

--- a/hindsight-api-slim/tests/test_knowledge_bm25_dispatch.py
+++ b/hindsight-api-slim/tests/test_knowledge_bm25_dispatch.py
@@ -3,18 +3,24 @@
 ``search_knowledge_pages`` used to hard-code the native tsvector SQL
 (``ts_rank_cd`` / ``@@``) for every text-search backend, so it 500'd on
 ``pg_search`` / ``pg_textsearch`` / ``vchord`` where ``mental_models.search_vector``
-is not a tsvector. These tests pin the per-backend SQL the dispatcher emits so the
-regression can't silently come back — they need no live extension because they
+is not a tsvector. These tests pin the per-backend SQL the read dispatcher emits,
+and the write-side ``search_vector`` tokenization the ``mental_models`` insert/
+update reuse from the memory-recall path. They need no live extension because they
 assert on the generated SQL, the way ``test_multilingual_bm25`` does.
 """
 
+from types import SimpleNamespace
+
+from hindsight_api.engine.db.ops_postgresql import pg_search_vector_expr
 from hindsight_api.engine.sql.postgresql import KnowledgeBm25Arm, knowledge_bm25_arm
 
 
+def _cfg(ext: str) -> SimpleNamespace:
+    return SimpleNamespace(text_search_extension=ext, text_search_extension_native_language="english")
+
+
 def _arm(ext: str) -> KnowledgeBm25Arm:
-    arm = knowledge_bm25_arm(ext, table_alias="mm", text_param="$3")
-    assert arm is not None, f"{ext} unexpectedly degraded to vector-only"
-    return arm
+    return knowledge_bm25_arm(ext, table_alias="mm", text_param="$3")
 
 
 def test_native_uses_tsvector_operators():
@@ -52,10 +58,17 @@ def test_pg_textsearch_ranks_content_by_bm25_distance():
     assert "ts_rank_cd" not in arm.order_by
 
 
-def test_vchord_degrades_to_vector_only():
-    # vchord's mental_models bm25vector column is never populated on write, so its
-    # BM25 index is empty — the caller must fall back to a vector-only search.
-    assert knowledge_bm25_arm("vchord", table_alias="mm", text_param="$3") is None
+def test_vchord_ranks_over_bm25vector_search_vector():
+    arm = _arm("vchord")
+    # Negated <&> distance over the bm25vector column and the mental_models index,
+    # gated on a positive score — the same operator build_bm25_arm uses.
+    assert (
+        arm.score_expr
+        == "-(mm.search_vector <&> to_bm25query('idx_mental_models_text_search', tokenize($3, 'llmlingua2')))"
+    )
+    assert arm.order_by.endswith(" DESC")
+    assert arm.match_filter.endswith(" > 0")
+    assert "ts_rank_cd" not in arm.score_expr
 
 
 def test_text_param_and_alias_are_threaded_through():
@@ -63,3 +76,34 @@ def test_text_param_and_alias_are_threaded_through():
     assert "paradedb.score(kbm.id)" == arm.score_expr
     assert "kbm.id @@@" in arm.match_filter
     assert "paradedb.match('name', $7)" in arm.match_filter
+
+
+# --- write side: search_vector tokenization for mental_models ---------------
+# mental_models is a two-column (name + content) table whose native search_vector
+# is a GENERATED column, so only vchord needs an inline write (native_inline=False).
+
+
+def test_mm_write_tokenizes_only_for_vchord():
+    for ext in ("native", "pgroonga", "pg_search", "pg_textsearch"):
+        assert (
+            pg_search_vector_expr(_cfg(ext), text_col="$3", context_col="$5", signals_col=None, native_inline=False)
+            is None
+        ), f"{ext} must leave mental_models.search_vector unwritten"
+
+    vchord = pg_search_vector_expr(
+        _cfg("vchord"), text_col="$3", context_col="$5", signals_col=None, native_inline=False
+    )
+    assert vchord == "tokenize(COALESCE($3, '') || ' ' || COALESCE($5, ''), 'llmlingua2')::bm25_catalog.bm25vector"
+
+
+def test_memory_units_default_expr_is_unchanged():
+    # The recall/insert path keeps its three-column, native-inline behaviour.
+    assert pg_search_vector_expr(_cfg("native")) == (
+        "to_tsvector('english'::regconfig, "
+        "COALESCE(text, '') || ' ' || COALESCE(context, '') || ' ' || COALESCE(text_signals, ''))"
+    )
+    assert pg_search_vector_expr(_cfg("vchord")) == (
+        "tokenize(COALESCE(text, '') || ' ' || COALESCE(context, '') || ' ' || COALESCE(text_signals, ''), "
+        "'llmlingua2')::bm25_catalog.bm25vector"
+    )
+    assert pg_search_vector_expr(_cfg("pg_search")) is None

--- a/hindsight-api-slim/tests/test_knowledge_bm25_dispatch.py
+++ b/hindsight-api-slim/tests/test_knowledge_bm25_dispatch.py
@@ -1,0 +1,65 @@
+"""Backend dispatch for the knowledge-page BM25 arm (issue #3268).
+
+``search_knowledge_pages`` used to hard-code the native tsvector SQL
+(``ts_rank_cd`` / ``@@``) for every text-search backend, so it 500'd on
+``pg_search`` / ``pg_textsearch`` / ``vchord`` where ``mental_models.search_vector``
+is not a tsvector. These tests pin the per-backend SQL the dispatcher emits so the
+regression can't silently come back — they need no live extension because they
+assert on the generated SQL, the way ``test_multilingual_bm25`` does.
+"""
+
+from hindsight_api.engine.sql.postgresql import KnowledgeBm25Arm, knowledge_bm25_arm
+
+
+def _arm(ext: str) -> KnowledgeBm25Arm:
+    arm = knowledge_bm25_arm(ext, table_alias="mm", text_param="$3")
+    assert arm is not None, f"{ext} unexpectedly degraded to vector-only"
+    return arm
+
+
+def test_native_uses_tsvector_operators():
+    arm = _arm("native")
+    # The mental_models tsvector is generated with the 'english' config, so the
+    # query must use 'english' regardless of the configured native language.
+    assert "ts_rank_cd(mm.search_vector, websearch_to_tsquery('english', $3))" in arm.score_expr
+    assert arm.match_filter == "AND mm.search_vector @@ websearch_to_tsquery('english', $3)"
+
+
+def test_pgroonga_is_served_by_the_native_branch():
+    # mental_models is never reconciled to pgroonga structures, so it keeps the
+    # generated tsvector column and must use the native operators.
+    assert knowledge_bm25_arm("pgroonga", table_alias="mm", text_param="$3") == _arm("native")
+
+
+def test_pg_search_uses_paradedb_over_base_columns():
+    arm = _arm("pg_search")
+    assert arm.score_expr == "paradedb.score(mm.id)"
+    assert "mm.id @@@ paradedb.boolean(should => ARRAY[" in arm.match_filter
+    assert "paradedb.match('name', $3)" in arm.match_filter
+    assert "paradedb.match('content', $3)" in arm.match_filter
+    # Must not fall back to the native tsvector function.
+    assert "ts_rank_cd" not in arm.score_expr
+    assert "ts_rank_cd" not in arm.order_by
+
+
+def test_pg_textsearch_ranks_content_by_bm25_distance():
+    arm = _arm("pg_textsearch")
+    # `<@>` is a distance (lower = closer): order ASC, negate for the score.
+    assert arm.order_by == "mm.content <@> to_bm25query($3, 'idx_mental_models_text_search') ASC"
+    assert arm.score_expr == "-(mm.content <@> to_bm25query($3, 'idx_mental_models_text_search'))"
+    # It ranks every row, so there is no boolean match gate.
+    assert arm.match_filter == ""
+    assert "ts_rank_cd" not in arm.order_by
+
+
+def test_vchord_degrades_to_vector_only():
+    # vchord's mental_models bm25vector column is never populated on write, so its
+    # BM25 index is empty — the caller must fall back to a vector-only search.
+    assert knowledge_bm25_arm("vchord", table_alias="mm", text_param="$3") is None
+
+
+def test_text_param_and_alias_are_threaded_through():
+    arm = knowledge_bm25_arm("pg_search", table_alias="kbm", text_param="$7")
+    assert "paradedb.score(kbm.id)" == arm.score_expr
+    assert "kbm.id @@@" in arm.match_filter
+    assert "paradedb.match('name', $7)" in arm.match_filter


### PR DESCRIPTION
Fixes #3268.

## Problem

`GET /v1/{tenant}/banks/{bank}/knowledge-base/search` returned **HTTP 500 for every bank** whenever `HINDSIGHT_API_TEXT_SEARCH_EXTENSION` was not `native`:

```
asyncpg.exceptions.UndefinedFunctionError: function ts_rank_cd(text, tsquery) does not exist
```

`search_knowledge_pages` hard-coded the native tsvector SQL (`ts_rank_cd` / `@@` over `mm.search_vector`) in both its BM25 arm and its no-embedding fallback. But `mental_models.search_vector` is only a `tsvector` under `native`; under `pg_search` / `pg_textsearch` it's a dummy `TEXT` column, and under `vchord` a `bm25vector`. Recall was unaffected because its BM25 arm already dispatches on the backend (`PostgreSQLDialect.build_bm25_arm`) and its writes tokenize `search_vector` per backend (`pg_search_vector_expr`); knowledge search was the one path that did neither.

## Fix — reuse the memory-recall BM25/vector logic, end to end

Rather than a bespoke path, this reuses the exact per-backend machinery recall already uses, on both the read and write side, so knowledge search behaves identically across all five backends.

**Read** — `knowledge_bm25_arm()` (new, in the PG dialect next to `build_bm25_arm`) emits the BM25 arm against the `idx_mental_models_text_search` index over the page `name` + `content`:

| backend | knowledge BM25 arm |
|---|---|
| `native` / `pgroonga` | generated tsvector — `ts_rank_cd` / `@@` (pgroonga keeps the tsvector; it is never reconciled to pgroonga structures) |
| `pg_search` | `paradedb.score(id)` / `@@@ paradedb.boolean(...)` over `(id, name, content)` |
| `pg_textsearch` | BM25 distance (`<@> to_bm25query`) over the `content` column |
| `vchord` | negated `<&>` distance over the `bm25vector` column, gated `> 0` — same operator as `build_bm25_arm` |

**Write** — the reason vchord couldn't work before: `mental_models.search_vector` is a plain, never-written `bm25vector` column (unlike `memory_units`, whose writes tokenize it). This threads the shared `pg_search_vector_expr` helper through the three `mental_models` write sites (create-pinned INSERT, update UPDATE — re-tokenized only when `name`/`content` change — and clear), so vchord now populates `search_vector` the same way `insert_facts_batch` / the consolidator do for `memory_units`.

The helper gains two keyword args so it can serve both tables from one source of truth:
- `signals_col=None` — two-column tables (`mental_models` = name + content).
- `native_inline=False` — `mental_models`' native `search_vector` is a **GENERATED** column that populates itself, so only vchord's plain column needs an explicit value. `memory_units` keeps its three-column, native-inline behaviour unchanged.

With the write gap closed, the read side no longer degrades or 500s on any backend, so `search_knowledge_pages` drops its vector-only / empty-result special cases.

## Known non-goal (documented in the code)

The issue's "possibly related latent issue" — `ensure_text_search_extension`'s `tables_to_check` still lists the pre-rename `reflections` — is left as-is. It only affects *switching* text-search backends (not the reported 500), and naively adding `mental_models` to that list would hard-fail existing **pgroonga** deployments that already hold knowledge-page data (tsvector → want-pgroonga mismatch with data present). A safe fix needs a data-preserving in-place conversion and belongs in its own change.

## Tests

`tests/test_knowledge_bm25_dispatch.py` pins, with no live extension needed:
- the read BM25 SQL each of the five backends emits (including the vchord arm);
- the write-side `search_vector` tokenization — only vchord writes it for `mental_models`, and `memory_units`' default three-column expression is unchanged.

The existing `test_knowledge_base.py::TestSearch` continues to cover the native path end-to-end; the native SQL is operator-identical to before.
