### PR TITLE
fix(config): validate bank config value types and stop them wedging tasks (#3218)

### DIFF
--- a/hindsight-api-slim/hindsight_api/config_resolver.py
+++ b/hindsight-api-slim/hindsight_api/config_resolver.py
@@ -11,8 +11,10 @@ multiple API servers.
 import asyncio
 import json
 import logging
-from dataclasses import asdict, replace
-from typing import TYPE_CHECKING, Any
+from dataclasses import asdict, fields, replace
+from functools import lru_cache
+from types import UnionType
+from typing import TYPE_CHECKING, Any, Union, get_args, get_origin
 
 from hindsight_api.config import (
     RECALL_BUDGET_FUNCTIONS,
@@ -295,7 +297,8 @@ class ConfigResolver:
 
                     # Only return active overrides for configurable fields. JSON null is a tombstone
                     # for "Server Default" in the bank-config UI and should not override defaults.
-                    return {k: v for k, v in normalized.items() if k in self._configurable_fields and v is not None}
+                    active = {k: v for k, v in normalized.items() if k in self._configurable_fields and v is not None}
+                    return _coerce_stored_bank_overrides(bank_id, active)
         except Exception as e:
             logger.error(f"Failed to load bank config for {bank_id}: {e}")
 
@@ -335,7 +338,7 @@ class ConfigResolver:
                         k: v for k, v in normalized.items() if k in self._configurable_fields and v is not None
                     }
                     if overrides:
-                        result[row["bank_id"]] = overrides
+                        result[row["bank_id"]] = _coerce_stored_bank_overrides(row["bank_id"], overrides)
         except Exception as e:
             logger.error(f"Failed to bulk-load bank configs: {e}")
         return result
@@ -419,6 +422,11 @@ class ConfigResolver:
                 logger.warning(f"Failed to check permissions for bank {bank_id}: {e}")
                 # Continue without permission check (fail open for backward compatibility)
 
+        # Validate every value against its declared field type before the
+        # field-specific checks below, so a wrong-shaped value is reported as such
+        # instead of tripping a structural validator with a confusing message.
+        _validate_config_value_types(normalized_updates)
+
         # Validate entity_labels structure
         if "entity_labels" in normalized_updates and normalized_updates["entity_labels"] is not None:
             from .engine.retain.entity_labels import parse_entity_labels
@@ -435,6 +443,16 @@ class ConfigResolver:
                 raise ValueError(
                     "Strategy names must not be empty strings. Remove entries with empty names before saving."
                 )
+            # A strategy's overrides are applied with dataclasses.replace() at retain
+            # time, so a wrong-shaped value there wedges the bank exactly as a
+            # top-level one would. Same contract, same door.
+            for strategy_name, strategy_overrides in normalized_updates["retain_strategies"].items():
+                if not isinstance(strategy_overrides, dict):
+                    raise ValueError(f"Invalid retain strategy {strategy_name!r}: must be an object")
+                try:
+                    _validate_config_value_types(normalize_config_dict(strategy_overrides))
+                except ValueError as e:
+                    raise ValueError(f"Invalid retain strategy {strategy_name!r}: {e}") from e
 
         # Validate recall budget fields
         _validate_recall_budget_updates(normalized_updates)
@@ -528,6 +546,147 @@ class ConfigResolver:
             )
 
         logger.info(f"Reset bank config for {bank_id} to defaults")
+
+
+# Fields whose accepted input shape is deliberately wider than the dataclass
+# annotation, because a dedicated structural validator normalizes them later.
+_WIDENED_FIELD_TYPES: dict[str, tuple[type, ...]] = {
+    # parse_entity_labels() accepts both the bare list of label groups and the
+    # {"attributes": [...]} envelope, though the field is annotated `list | None`.
+    "entity_labels": (list, dict),
+}
+
+
+def _runtime_types(declared: Any) -> tuple[type, ...]:
+    """Runtime-checkable base classes for a dataclass field annotation.
+
+    Unwraps unions (``str | None``) and generic aliases (``list[str]`` -> ``list``);
+    ``None`` is dropped because callers handle the tombstone separately. Returns an
+    empty tuple for anything not reducible to concrete classes, which the callers
+    read as "no type contract to enforce".
+    """
+    if declared is type(None):
+        return ()
+    origin = get_origin(declared)
+    if origin in (Union, UnionType):
+        return tuple(t for arg in get_args(declared) for t in _runtime_types(arg))
+    if origin is not None:
+        return (origin,) if isinstance(origin, type) else ()
+    return (declared,) if isinstance(declared, type) else ()
+
+
+@lru_cache(maxsize=1)
+def _configurable_field_types() -> dict[str, tuple[type, ...]]:
+    """Map each configurable field to the value types it accepts."""
+    configurable = HindsightConfig.get_configurable_fields()
+    field_types: dict[str, tuple[type, ...]] = {}
+    for field in fields(HindsightConfig):
+        if field.name not in configurable:
+            continue
+        allowed = _WIDENED_FIELD_TYPES.get(field.name) or _runtime_types(field.type)
+        if allowed:
+            field_types[field.name] = allowed
+    return field_types
+
+
+def _value_matches_type(value: Any, allowed: tuple[type, ...]) -> bool:
+    """Whether ``value`` satisfies a field's declared type contract."""
+    if isinstance(value, bool):
+        # bool is an int subclass; it must not slip into a numeric field.
+        return bool in allowed
+    if isinstance(value, int) and float in allowed:
+        # JSON draws no int/float distinction: 1 is a valid ratio.
+        return True
+    return isinstance(value, allowed)
+
+
+# Field types are reported to API clients, so name them the way the JSON payload
+# reads rather than by their Python class.
+_TYPE_DESCRIPTIONS: dict[type, str] = {
+    bool: "a boolean",
+    int: "an integer",
+    float: "a number",
+    str: "a string",
+    list: "a list",
+    dict: "an object",
+}
+
+
+def _describe_types(allowed: tuple[type, ...]) -> str:
+    return " or ".join(dict.fromkeys(_TYPE_DESCRIPTIONS.get(t, t.__name__) for t in allowed))
+
+
+def _validate_config_value_types(updates: dict[str, Any]) -> None:
+    """Reject values whose type contradicts the declared HindsightConfig type.
+
+    Without this, the bank-config API happily stores e.g. a JSON object in
+    ``observations_mission``; the write succeeds and the bank then fails every
+    consolidation with ``expected string or bytes-like object, got 'dict'`` from
+    deep inside prompt assembly (issue #3218). Reject at the door instead, naming
+    the field and the expected type.
+    """
+    field_types = _configurable_field_types()
+    for key, value in updates.items():
+        allowed = field_types.get(key)
+        # None is the "clear this override" tombstone; unknown keys are rejected
+        # elsewhere as non-configurable.
+        if allowed is None or value is None:
+            continue
+        if not _value_matches_type(value, allowed):
+            raise ValueError(f"{key} must be {_describe_types(allowed)}, got {type(value).__name__}")
+
+
+def _coerce_stored_bank_overrides(bank_id: str, overrides: dict[str, Any], where: str = "") -> dict[str, Any]:
+    """Make stored bank overrides safe to consume, tolerating pre-validation shapes.
+
+    ``_validate_config_value_types`` rejects bad types at write time, but banks
+    configured before that landed can still hold e.g. a JSON object in a
+    string-typed field. Every consumer that treats such a value as text blows up
+    identically on every run (``escape_for_prompt`` -> ``re.sub`` ->
+    "expected string or bytes-like object, got 'dict'"), so the bank's
+    consolidation never recovers on its own (issue #3218).
+
+    String fields are JSON-encoded, which preserves the author's intent — the
+    structure still reaches the prompt, as text. Anything else is dropped so the
+    bank falls back to the tenant/global value rather than wedging.
+
+    ``where`` labels the location in warnings; it is set when recursing into a
+    retain strategy, whose overrides reach the same fields via ``apply_strategy``.
+    """
+    field_types = _configurable_field_types()
+    coerced: dict[str, Any] = {}
+    for key, value in overrides.items():
+        allowed = field_types.get(key)
+        # None passes through: the caller has already dropped top-level tombstones,
+        # and inside a retain strategy a null is a deliberate override to None.
+        if allowed is None or value is None or _value_matches_type(value, allowed):
+            coerced[key] = value
+            continue
+        if str in allowed:
+            coerced[key] = json.dumps(value, ensure_ascii=False)
+            logger.warning(
+                f"Bank {bank_id} config field '{key}'{where} holds a {type(value).__name__} but is a string field; "
+                f"using its JSON encoding. Re-save this field as a string to silence this warning."
+            )
+        else:
+            logger.warning(
+                f"Bank {bank_id} config field '{key}'{where} holds a {type(value).__name__} but must be "
+                f"{_describe_types(allowed)}; ignoring the override and falling back to the server default."
+            )
+
+    # Strategy overrides are spliced onto the resolved config by apply_strategy(),
+    # so a bad value nested there wedges the bank just as a top-level one does.
+    strategies = coerced.get("retain_strategies")
+    if isinstance(strategies, dict):
+        coerced["retain_strategies"] = {
+            name: (
+                _coerce_stored_bank_overrides(bank_id, strategy, where=f" in retain strategy {name!r}")
+                if isinstance(strategy, dict)
+                else strategy
+            )
+            for name, strategy in strategies.items()
+        }
+    return coerced
 
 
 _RECALL_BUDGET_FIXED_KEYS = (

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -46,7 +46,7 @@ from ..config import (
 )
 from ..tracing import create_operation_span
 from ..utils import mask_network_location
-from ..worker.exceptions import DeferOperation, RetryTaskAt
+from ..worker.exceptions import DeferOperation, RetryTaskAt, format_task_error
 from ..worker.stage import set_stage
 from .audit import AuditLogger, audit_context
 from .bank_stats_cache import BankStatsCache, DistributedBankStatsCache
@@ -2328,18 +2328,21 @@ class MemoryEngine(MemoryEngineInterface):
                 # and lose the "not a failure" semantics entirely.
                 raise
             except Exception as e:
-                logger.error(f"Task execution failed: {task_type}, error: {e}")
+                # exc_info, not a bare print_exc(): the traceback is the only pointer
+                # to the offending call site, and under production log volume the
+                # stderr copy is unattributed and rotates away first (issue #3218).
+                error_message = format_task_error(e)
+                logger.error(f"Task execution failed: {task_type}, error: {error_message}", exc_info=True)
                 import traceback
 
                 error_traceback = traceback.format_exc()
-                traceback.print_exc()
 
                 if task_type == "file_convert_retain":
                     # Non-retryable: mark as failed immediately.
                     # Conversion failures won't improve on retry (missing OCR, corrupted file, etc.)
                     logger.error(f"Not retrying task {task_type} (non-retryable), marking as failed")
                     if operation_id:
-                        await self._mark_operation_failed(operation_id, str(e), error_traceback)
+                        await self._mark_operation_failed(operation_id, error_message, error_traceback)
                 elif _is_non_retryable_task_error(e):
                     # Non-retryable: deterministic task failures (integrity violations,
                     # invalid embedding dimensions, etc.) will not succeed by rerunning
@@ -2351,11 +2354,11 @@ class MemoryEngine(MemoryEngineInterface):
                             operation_id=operation_id,
                             status="failed",
                             result=None,
-                            error_message=str(e),
+                            error_message=error_message,
                             schema=schema,
                         )
                     if operation_id:
-                        await self._mark_operation_failed(operation_id, str(e), error_traceback)
+                        await self._mark_operation_failed(operation_id, error_message, error_traceback)
                 else:
                     if task_type == "consolidation" and operation_id:
                         # Fire failure webhook (non-transactional — operation not yet marked failed;
@@ -2365,7 +2368,7 @@ class MemoryEngine(MemoryEngineInterface):
                             operation_id=operation_id,
                             status="failed",
                             result=None,
-                            error_message=str(e),
+                            error_message=error_message,
                             schema=schema,
                         )
 
@@ -2397,7 +2400,7 @@ class MemoryEngine(MemoryEngineInterface):
                         backoff = _consolidation_retry_backoff_seconds(retry_count)
                         raise RetryTaskAt(
                             retry_at=datetime.now(UTC) + timedelta(seconds=backoff),
-                            message=str(e),
+                            message=error_message,
                         )
 
                     # Retryable: use RetryTaskAt if under the retry limit, else re-raise (poller marks failed).
@@ -2409,7 +2412,7 @@ class MemoryEngine(MemoryEngineInterface):
                     if retry_count < config.worker_max_retries:
                         raise RetryTaskAt(
                             retry_at=datetime.now(UTC) + timedelta(seconds=config.worker_task_retry_backoff_seconds),
-                            message=str(e),
+                            message=error_message,
                         )
                     raise
 

--- a/hindsight-api-slim/hindsight_api/worker/exceptions.py
+++ b/hindsight-api-slim/hindsight_api/worker/exceptions.py
@@ -1,6 +1,19 @@
 from datetime import datetime
 
 
+def format_task_error(e: BaseException) -> str:
+    """Render an exception for a task failure log line / stored error_message.
+
+    Always prefixes the exception class. Plenty of exceptions carry an empty
+    ``str()`` — ``TimeoutError()``, ``CancelledError()``, a bare ``raise
+    SomeError()`` — and the bare interpolation those log lines used produced
+    ``Task execution failed: graph_maintenance, error: ``, which says nothing at
+    all about what went wrong (issue #3218).
+    """
+    message = str(e)
+    return f"{type(e).__name__}: {message}" if message else type(e).__name__
+
+
 class RetryTaskAt(Exception):
     """Raise from a task handler to schedule a retry at a specific time."""
 

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -13,7 +13,6 @@ import io
 import json
 import logging
 import time
-import traceback
 from collections import Counter
 from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass
@@ -22,7 +21,7 @@ from typing import TYPE_CHECKING, Any
 from ..config import get_config
 from ..engine.schema import fq_table_explicit as fq_table
 from ..metrics import get_metrics_collector
-from .exceptions import DeferOperation, RetryTaskAt
+from .exceptions import DeferOperation, RetryTaskAt, format_task_error
 from .stage import StageHolder, bind_holder
 
 # Map DB operation_type -> metric `operation` label, collapsing the retain
@@ -851,10 +850,12 @@ class WorkerPoller:
             # Retry is not a terminal outcome — do not record a completion.
             await self._schedule_retry(task.operation_id, e.retry_at, str(e), task.schema)
         except Exception as e:
-            logger.error(f"Task {task.operation_id} failed: {e}")
-            traceback.print_exc()
+            # exc_info rather than print_exc(): the stderr copy carries no task id
+            # and is the first thing lost to log rotation (issue #3218).
+            error_message = format_task_error(e)
+            logger.error(f"Task {task.operation_id} failed: {error_message}", exc_info=True)
             try:
-                await self._mark_failed(task.operation_id, str(e), task.schema)
+                await self._mark_failed(task.operation_id, error_message, task.schema)
             except Exception:
                 # Marking a task failed is itself a DB write, and it can fail
                 # (pool exhausted, connection reset, statement timeout). Without
@@ -1298,8 +1299,7 @@ class WorkerPoller:
                 logger.info(f"Worker {self._worker_id} polling loop cancelled")
                 break
             except Exception as e:
-                logger.error(f"Worker {self._worker_id} error in polling loop: {e}")
-                traceback.print_exc()
+                logger.error(f"Worker {self._worker_id} error in polling loop: {format_task_error(e)}", exc_info=True)
                 # Backoff on error
                 await asyncio.sleep(1)
 

--- a/hindsight-api-slim/tests/test_bank_config_value_types.py
+++ b/hindsight-api-slim/tests/test_bank_config_value_types.py
@@ -1,0 +1,160 @@
+"""Tests for type validation of bank config values (write side + read side).
+
+The bank-config API accepted `dict[str, Any]` updates without ever checking the
+values against the declared ``HindsightConfig`` field types, so a client could
+store a JSON object in a string-typed field such as ``observations_mission``.
+The write succeeded; the bank then failed *every* consolidation with
+``expected string or bytes-like object, got 'dict'`` raised by ``re.sub`` inside
+prompt assembly, deterministically, forever. See issue #3218.
+
+Two halves are covered here:
+  * write side — the value is rejected with a message naming field and type;
+  * read side  — a bank already carrying the bad value resolves to something
+    usable instead of wedging.
+"""
+
+import pytest
+
+from hindsight_api.config_resolver import (
+    _coerce_stored_bank_overrides,
+    _configurable_field_types,
+    _validate_config_value_types,
+)
+from hindsight_api.engine.consolidation.prompts import build_consolidation_input
+from hindsight_api.worker.exceptions import format_task_error
+
+
+# The fields found holding JSON objects in the field report on #3218.
+_STRING_FIELDS = (
+    "observations_mission",
+    "retain_mission",
+    "reflect_mission",
+    "retain_custom_instructions",
+)
+
+_BAD_MISSION = {"rules": ["only keep preferences"], "budget": 3}
+
+
+class TestValidateConfigValueTypes:
+    def test_every_configurable_field_has_a_type_contract(self):
+        from hindsight_api.config import HindsightConfig
+
+        # A field with no derivable contract would silently accept anything.
+        assert _configurable_field_types().keys() == HindsightConfig.get_configurable_fields()
+
+    def test_no_op_passes(self):
+        _validate_config_value_types({})
+        # Non-configurable keys are rejected by the caller, not here.
+        _validate_config_value_types({"unrelated_field": {"any": "shape"}})
+
+    def test_dict_in_string_field_raises(self):
+        for field in _STRING_FIELDS:
+            with pytest.raises(ValueError, match=field) as exc:
+                _validate_config_value_types({field: _BAD_MISSION})
+            # The message must name the expected and the actual type, so the 400
+            # tells the caller what to send instead.
+            assert "must be a string" in str(exc.value)
+            assert "got dict" in str(exc.value)
+
+    def test_valid_values_pass(self):
+        _validate_config_value_types(
+            {
+                "observations_mission": "Keep preferences and skills.",
+                "retain_chunk_size": 4000,
+                "enable_observations": True,
+                "mcp_enabled_tools": ["recall"],
+                "memory_defense": {"mode": "off"},
+                "recall_budget_adaptive_low": 0.05,
+            }
+        )
+
+    def test_none_clears_override(self):
+        for field in _STRING_FIELDS:
+            _validate_config_value_types({field: None})
+
+    def test_int_accepted_for_float_field(self):
+        # JSON draws no int/float distinction; a ratio of 1 must not 400.
+        _validate_config_value_types({"recall_budget_adaptive_high": 1})
+
+    def test_bool_rejected_for_numeric_field(self):
+        # bool is an int subclass and would sneak past a naive isinstance check.
+        with pytest.raises(ValueError, match="retain_chunk_size"):
+            _validate_config_value_types({"retain_chunk_size": True})
+
+    def test_string_rejected_for_numeric_and_bool_fields(self):
+        with pytest.raises(ValueError, match="retain_chunk_size"):
+            _validate_config_value_types({"retain_chunk_size": "4000"})
+        with pytest.raises(ValueError, match="enable_observations"):
+            _validate_config_value_types({"enable_observations": "true"})
+
+    def test_entity_labels_accepts_both_supported_shapes(self):
+        # Annotated `list | None`, but parse_entity_labels() also takes the
+        # {"attributes": [...]} envelope — the contract must not narrow that.
+        _validate_config_value_types({"entity_labels": []})
+        _validate_config_value_types({"entity_labels": {"attributes": []}})
+        with pytest.raises(ValueError, match="entity_labels"):
+            _validate_config_value_types({"entity_labels": "person"})
+
+
+class TestCoerceStoredBankOverrides:
+    def test_clean_overrides_pass_through_unchanged(self):
+        overrides = {"observations_mission": "Keep preferences.", "retain_chunk_size": 4000}
+        assert _coerce_stored_bank_overrides("bank1", overrides) == overrides
+
+    def test_dict_in_string_field_is_json_encoded(self):
+        coerced = _coerce_stored_bank_overrides("bank1", {"observations_mission": _BAD_MISSION})
+        mission = coerced["observations_mission"]
+        assert isinstance(mission, str)
+        # Semantics preserved: the structure still reaches the prompt, as text.
+        assert "only keep preferences" in mission
+
+    def test_non_coercible_override_is_dropped(self):
+        # An int field cannot be salvaged; the bank must fall back to the
+        # server default rather than resolve to a value nothing can use.
+        coerced = _coerce_stored_bank_overrides("bank1", {"retain_chunk_size": {"size": 4000}})
+        assert "retain_chunk_size" not in coerced
+
+    def test_coercion_warns_with_the_bank_and_field(self, caplog):
+        with caplog.at_level("WARNING"):
+            _coerce_stored_bank_overrides("bank1", {"observations_mission": _BAD_MISSION})
+        assert "bank1" in caplog.text
+        assert "observations_mission" in caplog.text
+
+    def test_strategy_overrides_are_coerced_too(self):
+        # apply_strategy() splices these onto the resolved config, so a nested
+        # bad value wedges the bank exactly as a top-level one does.
+        coerced = _coerce_stored_bank_overrides(
+            "bank1",
+            {"retain_strategies": {"chat": {"retain_mission": _BAD_MISSION, "retain_chunk_size": 4000}}},
+        )
+        chat = coerced["retain_strategies"]["chat"]
+        assert isinstance(chat["retain_mission"], str)
+        assert chat["retain_chunk_size"] == 4000
+
+    def test_strategy_null_override_is_preserved(self):
+        # Inside a strategy, null is a deliberate override to None (unlike a
+        # top-level null, which is the "use the server default" tombstone).
+        coerced = _coerce_stored_bank_overrides(
+            "bank1", {"retain_strategies": {"chat": {"retain_structured_chunk_size": None}}}
+        )
+        assert coerced["retain_strategies"]["chat"] == {"retain_structured_chunk_size": None}
+
+    def test_coerced_mission_survives_prompt_assembly(self):
+        """The exact reported failure: a dict mission reaching prompt assembly."""
+        with pytest.raises(TypeError, match="expected string or bytes-like object"):
+            build_consolidation_input("facts", "observations", observations_mission=_BAD_MISSION)
+
+        coerced = _coerce_stored_bank_overrides("bank1", {"observations_mission": _BAD_MISSION})
+        prompt = build_consolidation_input(
+            "facts", "observations", observations_mission=coerced["observations_mission"]
+        )
+        assert "only keep preferences" in prompt
+
+
+class TestFormatTaskError:
+    def test_message_is_prefixed_with_the_exception_class(self):
+        assert format_task_error(ValueError("boom")) == "ValueError: boom"
+
+    def test_empty_message_still_identifies_the_exception(self):
+        # The reported `Task execution failed: graph_maintenance, error: ` case.
+        assert format_task_error(TimeoutError()) == "TimeoutError"

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -1422,6 +1422,28 @@ async def test_patch_config_rejection_does_not_create_bank(api_client):
 
 
 @pytest.mark.asyncio
+async def test_patch_config_rejects_wrong_value_type(api_client):
+    """A JSON object in a string-typed field must 400, not be stored (#3218).
+
+    Storing it succeeded before, and the bank then failed every consolidation
+    with ``expected string or bytes-like object, got 'dict'`` from inside prompt
+    assembly — deterministically, so the bank never recovered.
+    """
+    test_bank_id = f"patch_bad_type_{datetime.now().timestamp()}"
+
+    response = await api_client.patch(
+        f"/v1/default/banks/{test_bank_id}/config",
+        json={"updates": {"observations_mission": {"rules": ["only preferences"], "budget": 3}}},
+    )
+    assert response.status_code == 400, response.text
+    detail = response.json()["detail"]
+    assert "observations_mission" in detail
+    assert "must be a string" in detail
+
+    await _assert_bank_missing(api_client, test_bank_id)
+
+
+@pytest.mark.asyncio
 async def test_patch_config_does_not_apply_client_field_permissions_to_projected_defaults(
     api_client,
     memory,


### PR DESCRIPTION
Fixes #3218

## The bug

`observations_mission` is annotated `str | None`, but `BankConfigUpdate.updates` is `dict[str, Any]` and `validate_bank_config_updates` only ever checked **key names** — configurability, credentials, and a handful of field-specific rules. Values went unchecked, so a JSON object landed in the JSONB column untouched.

On the next consolidation, `build_consolidation_input` → `escape_for_prompt` → `re.sub` received a `dict`, which is exactly:

```
Task execution failed: consolidation, error: expected string or bytes-like object, got 'dict'
```

Deterministic, so the bank's consolidation never recovered on its own. A sweep of one deployment found **7 banks across 7 tenants** in this state, spread by a third-party tool that writes structured JSON into the mission/instruction fields.

## The fix

**Write side** — `_validate_config_value_types` checks every value against the field's dataclass annotation and raises `ValueError`, which the endpoint already maps to a 400 naming the field and the expected type:

```
observations_mission must be a string, got dict
```

- `bool` is rejected for numeric fields (it is an `int` subclass and would slip past a naive `isinstance`); `int` is accepted for `float` fields, since JSON draws no int/float distinction.
- `entity_labels` keeps its wider contract (`list` *or* `{"attributes": [...]}`) via an explicit exemption — its annotation is narrower than what `parse_entity_labels` accepts.
- Nested `retain_strategies` overrides get the same check. `apply_strategy` splices them onto the resolved config with `dataclasses.replace`, so they reach the same fields through a second door; validating only the top level would leave the hole open.

**Read side** — banks configured before this landed are tolerated rather than wedged. A non-string in a string field is JSON-encoded, which is both the remediation already applied in the field (`jsonb_set(config, key, to_jsonb((config->key)::text))`) and semantics-preserving: the structure still reaches the prompt, as text. Anything not coercible is dropped with a WARNING naming bank and field, so the bank falls back to the tenant/global value. Applies to `_load_bank_config`, its bulk variant, and nested strategy overrides.

One subtlety: a top-level `null` is the "use the server default" tombstone and is filtered before coercion, but a `null` *inside* a strategy is a deliberate override to `None`. Coercion passes `None` through so it does not silently drop the latter.

**Observability** — the second half of the issue. `format_task_error` prefixes the exception class, so the reported

```
Task execution failed: graph_maintenance, error:
```

(an exception whose `str()` is empty) becomes `error: TimeoutError`. Task-failure paths in `memory_engine.py` and `poller.py` now log `exc_info=True` instead of a bare `traceback.print_exc()` — the stderr copy carries no task id and is the first thing lost to log rotation. The same formatted message is what lands in the stored `error_message` and the failure webhook.

## Tests

- `tests/test_bank_config_value_types.py` (18 tests) covers both halves, including the literal reported failure: `build_consolidation_input` with a dict mission raises the reported `TypeError`, and the coerced value assembles cleanly. A guard test asserts every configurable field has a derivable type contract, so a future annotation change cannot silently disable validation.
- `test_patch_config_rejects_wrong_value_type` in `test_http_api_integration.py`: the PATCH 400s and does not create the bank.
- `test_hierarchical_config`, `test_bank_templates`, `test_bank_template_configurable_fields`, all `-k consolidation` (265 tests), and the worker/poller suites pass. `lint.sh` and `ty check` clean.

## Compatibility

A client sending `"4000"` for `retain_chunk_size` now gets a 400 where it previously stored a string that would have broken retain later. The control-plane bank-config UI `parseInt`s all six of its numeric inputs, so it is unaffected. No API schema change (`updates` stays `dict[str, Any]`), so no OpenAPI/client regeneration.
