### PR TITLE
perf(query-analyzer): skip dateparser when the query has no date signal

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/query_analyzer.py
+++ b/hindsight-api-slim/hindsight_api/engine/query_analyzer.py
@@ -82,6 +82,7 @@ _PERIOD_WORDS = {
     "decade",
     "century",
     "weekend",
+    "recently",
     "morning",
     "afternoon",
     "evening",
@@ -248,6 +249,20 @@ class DateparserQueryAnalyzer(QueryAnalyzer):
         if isinstance(period_result, tuple):
             start_date, end_date = period_result
             return QueryAnalysis(temporal_constraint=TemporalConstraint(start_date=start_date, end_date=end_date))
+
+        # Skip search_dates() when its outcome is already decided. Every span it
+        # returns is a substring of the query, so the span's token set is a subset
+        # of the query's; _date_match_score sums set-membership indicators over
+        # that token set, so no span can score above the whole query. A query
+        # scoring zero therefore cannot produce a span that survives the
+        # `entry[0] > 0` filter below — the call would pay for full locale
+        # detection only to yield no constraint.
+        #
+        # Must stay after extract_period: _TOKEN_RE is [a-z0-9]+, so every CJK
+        # query scores zero, and Chinese expressions are resolved by
+        # chinese_temporal_periods.py inside extract_period above.
+        if _date_match_score(query) == 0:
+            return QueryAnalysis(temporal_constraint=None)
 
         # Lazy load dateparser (only imports on first call, then cached)
         self.load()

--- a/hindsight-api-slim/tests/test_query_analyzer.py
+++ b/hindsight-api-slim/tests/test_query_analyzer.py
@@ -1063,3 +1063,83 @@ def test_query_analyzer_explicit_date_with_restricted_language(query_analyzer):
 
     assert analysis.temporal_constraint is not None
     assert analysis.temporal_constraint.start_date.date() == datetime(2022, 10, 31).date()
+
+
+def test_query_analyzer_skips_dateparser_without_date_signal(monkeypatch):
+    """A query with no date signal must not reach search_dates.
+
+    _date_match_score sums set-membership indicators over the token set, and every
+    span search_dates returns is a substring of the query — so a zero-scoring query
+    cannot yield a span that survives the score filter. Calling dateparser would pay
+    for full locale detection only to return no constraint.
+    """
+    analyzer = DateparserQueryAnalyzer()
+    analyzer.load()
+
+    called = []
+
+    def fake_search_dates(query, **kwargs):
+        called.append(query)
+        return None
+
+    monkeypatch.setattr(analyzer, "_search_dates", fake_search_dates)
+
+    analysis = analyzer.analyze("what degree did I graduate with", datetime(2025, 1, 15, 12, 0, 0))
+
+    assert analysis.temporal_constraint is None
+    assert not called, "a query with no date signal must not reach dateparser"
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "what did we decide on 2026-06-10",  # digit
+        "what did we discuss in May",  # month word
+        "what did the team ship recently",  # period word
+    ],
+)
+def test_query_analyzer_reaches_dateparser_with_date_signal(monkeypatch, query):
+    """A query carrying a date signal must still reach search_dates.
+
+    Cases are limited to signals extract_period does not resolve itself: it
+    short-circuits "yesterday" and "last week" before the dateparser call, so
+    those would not exercise the gate.
+    """
+    analyzer = DateparserQueryAnalyzer()
+    analyzer.load()
+
+    called = []
+    real_search_dates = analyzer._search_dates
+
+    def spy_search_dates(q, **kwargs):
+        called.append(q)
+        return real_search_dates(q, **kwargs)
+
+    monkeypatch.setattr(analyzer, "_search_dates", spy_search_dates)
+
+    analyzer.analyze(query, datetime(2025, 1, 15, 12, 0, 0))
+
+    assert called, f"{query!r} carries a date signal and must reach dateparser"
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_start", "expected_end"),
+    [
+        ("上周我去了朝阳区", datetime(2025, 1, 6), datetime(2025, 1, 12)),
+        ("昨天的会议", datetime(2025, 1, 14), datetime(2025, 1, 14)),
+        ("五月三日发生了什么", datetime(2024, 5, 3), datetime(2024, 5, 3)),
+        ("去年六月", datetime(2024, 6, 1), datetime(2024, 6, 30)),
+    ],
+)
+def test_query_analyzer_chinese_survives_score_gate(query_analyzer, query, expected_start, expected_end):
+    """Chinese temporal expressions must keep resolving through extract_period.
+
+    _TOKEN_RE is [a-z0-9]+, so every CJK query scores zero. The gate sits after
+    extract_period precisely so chinese_temporal_periods.py still runs — this is a
+    regression guard against moving it earlier.
+    """
+    analysis = query_analyzer.analyze(query, datetime(2025, 1, 15, 12, 0, 0))
+
+    assert analysis.temporal_constraint is not None
+    assert analysis.temporal_constraint.start_date.date() == expected_start.date()
+    assert analysis.temporal_constraint.end_date.date() == expected_end.date()


### PR DESCRIPTION
`search_dates()` is the dominant cost of temporal parsing on the recall path. This PR skips the calls whose outcome is already decided, dropping mean from 70.5 ms to 5.8 ms on locomo10 with P50 at zero and output unchanged.

`analyze()` calls `search_dates()` on every query that `extract_period` does not match. For 80% of them the outcome is decided before the call:

- Every span `search_dates` returns is a **substring** of the query, so the span's token set is a **subset** of the query's.
- `_date_match_score` (`query_analyzer.py:94`) is a sum of set-membership indicators over that token set — one digit check plus four word-list intersections. No indicator can fire for a subset without firing for the superset.
- So `score(query)` is an **upper bound** on every span's score. A query scoring zero cannot produce a span that survives the `entry[0] > 0` filter at `:291`.

Such a call pays for full locale detection only to return no constraint. This PR checks the whole query first and returns early.

While adding the check I found `recently` missing from `_PERIOD_WORDS`, fixed here as well — see below.

## Evidence

`locomo10.json`, 1986 questions, `reference_date` fixed at 2026-07-31:

| | count |
|---|---|
| `extract_period` already short-circuits | 121 (6%) |
| Reaches `search_dates`, whole query scores zero | **1600 (80%)** |
| Reaches `search_dates` with a signal | 265 (13%) |

Running `search_dates` on those 1600 queries produces **992 spans**, of which **zero** score above 0:

```
272x 'to'    214x 'did'    96x 'do'    66x 'Sam'
 65x 'on'     57x 'Tim'    23x 'an'    22x 'her'
 ... 44 distinct spans
```

These are the over-matches #2768 describes — short words that resolve as a weekday or month abbreviation in some locale. The existing score filter already rejects every one of them; the gate avoids producing them.

**Output is unchanged across all 1986 queries** (compared per query as `str(temporal_constraint)`).

## Latency

300 questions (`random.seed(42)`), each timed 3x taking the minimum, fully offline. Both arms run the default `languages=None` (automatic locale detection) — the state every deployment gets out of the box, since `HINDSIGHT_API_QUERY_ANALYZER_LANGUAGES` (#3154) is unset by default:

| languages=None | mean (ms) | P50 | P95 | P99 |
|---|---|---|---|---|
| without gate (current default) | 70.47 | 63.08 | 133.00 | 159.38 |
| with gate | **5.80** | **0.06** | 57.72 | 105.49 |

P99 improves far less than the mean: the 20% of queries that do carry a date signal still pay the full cost. **The gate removes calls whose outcome is known; it does not make temporal parsing faster.**

Arm order was swapped to rule out warm-up bias — the gate's mean was 5.80 / 5.81 ms across the two orderings.

## `recently` in `_PERIOD_WORDS`

`_PERIOD_WORDS` covers `last` / `next` / `this` / `past` / `coming` / `ago`, but not `recently`. So `"what did the team ship recently"` scores zero while dateparser does attempt to resolve it — meaning the gate would skip a query the analyzer could have answered.

Two existing tests surfaced this: `test_query_analyzer_languages_passed_through` and `test_query_analyzer_dateparser_crash_returns_no_constraint` both use `"tell me what happened recently with the project"`, and the comment in the latter states it was deliberately chosen as a query that reaches the dateparser call. With `recently` scored, they still reach it.

Effect on locomo10:

| | |
|---|---|
| Whole-query scores changed (0 → 20) | 51 |
| **Span scores changed** | **0** |
| Final output changed | **0** |
| Gate short-circuits | 1638 → 1600 |

Span scores are untouched because dateparser never returns `recently` as a standalone span — it returns `to` / `did` / `me`. #2768's rejection of bare abbreviations is therefore unaffected.

## Why the gate must follow `extract_period`

`_TOKEN_RE` is `[a-z0-9]+`, so **every CJK query scores zero**, while Chinese temporal expressions are resolved by `chinese_temporal_periods.py` inside `extract_period`. The gate has to sit after it.

Verified unchanged (`reference_date` 2026-07-31):

| Query | current | with gate |
|---|---|---|
| 上周我去了朝阳区 | 2026-07-20 to 2026-07-26 | same |
| 五月三日发生了什么 | 2026-05-03 to 2026-05-03 | same |
| 二零二三年六月三日 | 2023-06-03 to 2023-06-03 | same |
| 昨天的会议 | 2026-07-30 to 2026-07-30 | same |
| 去年六月 | 2025-06-01 to 2025-06-30 | same |
| 三个月前 | 2026-04-30 to 2026-04-30 | same |
| 上个月的开销 | 2026-06-01 to 2026-06-30 | same |

A parametrized regression test asserts this, guarding against moving the gate earlier.

## Non-English explicit dates

The theoretical risk is an input `extract_period` does not cover, that scores zero, yet `search_dates` could have parsed. I constructed 24 candidates across es / fr / it / de / ru / ja / ko / fi (month words, relative phrases, spelled-out dates) and **found none**:

| Class | Sample | Score | Why unaffected |
|---|---|---|---|
| Contains a digit | `el 3 de junio de 2023`, `3 июня 2023`, `2023年6月3日` | 100 | Digit signal is language-independent |
| Spelled-out date | `sechster Juni`, `первого июня`, `junio tres` | 0 | `search_dates` already returns `None` |
| CJK relative | `前年六月`, `おととし六月` | 0 | Resolved by `extract_period` |
| Non-English relative | `el pasado junio`, `letzten Juni`, `giugno scorso` | 0 | `search_dates` already returns `None` |

## Relationship to #3154

#3154 (merged) added `HINDSIGHT_API_QUERY_ANALYZER_LANGUAGES`, whose default must stay `None` — narrowing the locale set degrades explicit dates in unlisted locales to a **wrong date** rather than to no constraint, so only single-language corpora can safely restrict it. Multilingual deployments keep paying for full detection.

The two are orthogonal:

| Configuration | mean (ms) | P50 |
|---|---|---|
| auto, no gate | 70.47 | 63.08 |
| **auto, gate** | **5.80** | **0.06** |
| `languages=["en"]`, no gate | 0.20 | 0.17 |
| `languages=["en"]`, gate | 0.11 | 0.05 |

The gate needs no configuration and makes no language assumption.

## Relationship to #3250 / #3259

#3250 (open) reports a different problem in the same function: `_date_match_score` awards +100 for any digit — the highest score it can give — so a bare integer (a port or ticket number) wins the `max()` and yields an implausible-year constraint (`port 9077` → `9077-08-07`). #3259 is addressing it with a year-plausibility filter applied before `max()`.

The two act at different points and do not conflict:

| | Position | Fixes |
|---|---|---|
| #3259 | after `:291`, filters existing candidates | bare integers scoring as the strongest signal |
| this PR | before `:251`, skips the call entirely | calls whose outcome is already known |

This PR incidentally narrows #3250's blast radius: the 1600 short-circuited queries never reach dateparser, so they cannot produce such a constraint. It is not a fix, though — a query carrying both a real date signal and a bare integer (`"what did we ship on port 9077 last week"`) still reaches dateparser and still needs #3259.

**A data point that may help #3259**: its review notes that `search_dates` absorbs padding into the span (returning `'9077 and'` rather than `'9077'`), which makes span-text-based checks fragile. Across the 992 spans produced by the 1600 queries this PR short-circuits, all **44 distinct spans are whole words** (`to` / `did` / `Sam` / `on` / `Tim` …) — no intra-word fragments observed. Padding absorption is real, but at least on locomo10 spans do not cut into the middle of a word.

#3140 (open) also targets this function's cost, via query length limits — orthogonal to this change.

## Known boundary

Equivalence rests on spans being substrings of the query. If dateparser ever returned a fragment from *inside* a word — `may` out of `mayonnaise` — the subset relation would not hold (`mayonnaise` is one token and misses `_MONTH_WORDS`; `may` hits it), and the gate would reject a query dateparser could have parsed. Not observed across the 1986 locomo questions (all 992 spans are whole words), but worth recording.

This shares a root cause with the span-boundary issue raised in #3259's review: `search_dates` span boundaries are not reliable — it absorbs padding (`'9077 and'`) and could in principle cut into a word.

## Testing

`tests/test_query_analyzer.py`, 8 new cases:

- `recently` carries a period signal
- No date signal → `search_dates` not called, no constraint returned
- Digit / month word / period word → `search_dates` still reached (3 parametrized)
- Chinese expressions still resolve through `extract_period` (4 parametrized regression guard)

434 passed locally (426 existing + 8 new).

Environment: Apple Silicon MacBook Pro, Python 3.11.15, dateparser 1.2.2.
