### PR TITLE
fix(knowledge-pages): show exact freshness in page detail

### DIFF
--- a/hindsight-control-plane/src/components/knowledge-base-view.tsx
+++ b/hindsight-control-plane/src/components/knowledge-base-view.tsx
@@ -96,6 +96,10 @@ export function KnowledgeBaseView() {
   // Derived from the backing mental model's reflect_response (not the page endpoint).
   const [supportingCount, setSupportingCount] = useState(0);
   const [selectedMmId, setSelectedMmId] = useState<string | null>(null);
+  const [exactPageStaleness, setExactPageStaleness] = useState<{
+    pageId: string;
+    isStale: boolean;
+  } | null>(null);
   // Non-null while the provenance dialog (the backing model's based_on) is open.
   const [provenanceMmId, setProvenanceMmId] = useState<string | null>(null);
   // Mirror of open tabs for the auto-refresh interval / openPage without re-arming.
@@ -211,12 +215,13 @@ export function KnowledgeBaseView() {
   );
   const folders = useMemo(() => allNodes.filter((n) => n.kind === "folder"), [allNodes]);
 
-  // Sync status for the open page, read from the tree (the page detail response
-  // doesn't carry it); updates as the auto-refresh poll refreshes the tree.
-  const selectedStale = useMemo(
-    () => (selected ? (allNodes.find((n) => n.id === selected.id)?.is_stale ?? null) : null),
-    [selected, allNodes]
-  );
+  // The tree's watermark result is only an approximation. The existing backing-MM
+  // request below returns the exact result, so prefer it when it belongs to this tab.
+  const selectedStale = useMemo(() => {
+    if (!selected) return null;
+    if (exactPageStaleness?.pageId === selected.id) return exactPageStaleness.isStale;
+    return allNodes.find((n) => n.id === selected.id)?.is_stale ?? null;
+  }, [selected, allNodes, exactPageStaleness]);
 
   // Provenance count: fetch the open page's backing mental model and sum the
   // source memories (world/experience/observation) in its reflect_response —
@@ -224,12 +229,14 @@ export function KnowledgeBaseView() {
   useEffect(() => {
     if (!selected || !currentBank) {
       setSupportingCount(0);
+      setExactPageStaleness(null);
       return;
     }
     const mmId = allNodes.find((n) => n.id === selected.id)?.mental_model_id;
     setSelectedMmId(mmId ?? null);
     if (!mmId) {
       setSupportingCount(0);
+      setExactPageStaleness(null);
       return;
     }
     let cancelled = false;
@@ -237,6 +244,9 @@ export function KnowledgeBaseView() {
       .getMentalModel(currentBank, mmId)
       .then((mm) => {
         if (cancelled) return;
+        setExactPageStaleness(
+          typeof mm.is_stale === "boolean" ? { pageId: selected.id, isStale: mm.is_stale } : null
+        );
         const basedOn = mm.reflect_response?.based_on ?? {};
         const count = (["world", "experience", "observation"] as const).reduce(
           (sum, ft) => sum + (basedOn[ft]?.length ?? 0),


### PR DESCRIPTION
## Why

The Knowledge Pages tree reports freshness using a bank-wide write watermark. That is intentionally conservative: a page can be marked `is_stale: true` even when the new memory is outside the page's scope.

When a page is opened, the control plane already fetches its backing mental model to show provenance. That response includes the exact scope-aware `is_stale` value, but the page header was still reading the tree's approximate value. As a result, a page could show “May need refresh” in its detail view even when its exact freshness check reported that it was current. This makes the detail view appear inconsistent and reduces trust in the status indicator.

## What changed

- Prefer the exact backing mental model freshness result for the open page.
- Fall back to the tree watermark result while the exact result is unavailable.
- Keep the tree polling strategy and API behavior unchanged.

This makes the detail view use information it already retrieved, so there is no additional request or database cost. It does not attempt to change the tree's deliberately conservative semantics.

## Verification

- `./scripts/hooks/lint.sh`
- `npm test` (119 tests)