### PR TITLE
fix(api): gate knowledge-base routes through the operation validator (#3312)

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -5573,39 +5573,26 @@ def _register_routes(app: FastAPI):
     ):
         """Export a bank's knowledge base as a flat markdown bundle."""
         try:
-            nodes = await app.state.memory.list_knowledge_nodes(bank_id=bank_id, request_context=request_context)
+            export = await app.state.memory.export_knowledge_base(bank_id=bank_id, request_context=request_context)
             files = [
-                KnowledgePageBundleFile(path=page_markdown.INDEX_FILENAME, content=page_markdown.render_index(nodes))
-            ]
-            for node in nodes:
-                if node.get("kind") != "page":
-                    continue
-                page = await app.state.memory.get_knowledge_page(
-                    bank_id=bank_id, page_id=node["id"], request_context=request_context
+                KnowledgePageBundleFile(
+                    path=page_markdown.INDEX_FILENAME, content=page_markdown.render_index(export.nodes)
                 )
-                if page is None:
-                    continue
+            ]
+            for page in export.pages:
                 files.append(
                     KnowledgePageBundleFile(
-                        path=page_markdown.page_filename(node["id"]), content=page_markdown.render_document(page)
+                        path=page_markdown.page_filename(page.node_id),
+                        content=page_markdown.render_document(page.page),
                     )
                 )
-                if node.get("mental_model_id"):
-                    history = (
-                        await app.state.memory.get_mental_model_history(
-                            bank_id=bank_id,
-                            mental_model_id=node["mental_model_id"],
-                            request_context=request_context,
+                if page.history:
+                    files.append(
+                        KnowledgePageBundleFile(
+                            path=page_markdown.log_filename(page.node_id),
+                            content=page_markdown.render_log(page.page, page.history),
                         )
-                        or []
                     )
-                    if history:
-                        files.append(
-                            KnowledgePageBundleFile(
-                                path=page_markdown.log_filename(node["id"]),
-                                content=page_markdown.render_log(page, history),
-                            )
-                        )
             return KnowledgePageBundleResponse(files=files)
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -20,8 +20,8 @@ import logging
 import sys
 import time
 import uuid
-from collections.abc import AsyncIterator, Awaitable, Callable
-from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
+from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Literal, NoReturn, ParamSpec, TypeVar, cast, overload
@@ -103,6 +103,32 @@ class _BankTemplateImportAuthorizationState:
 _bank_template_import_authorization: contextvars.ContextVar[_BankTemplateImportAuthorizationState | None] = (
     contextvars.ContextVar("bank_template_import_authorization", default=None)
 )
+
+# Set by a knowledge-base engine method that has already run its own validator
+# gate, so the nested bank read/write and mental-model hooks it triggers are not
+# invoked a second time. Keeps each knowledge-base route to exactly one validator
+# hook: create_knowledge_page validates once, then creates its backing mental
+# model; export_knowledge_base validates once, then reads every page.
+_nested_operation_authorized: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "nested_operation_authorized", default=False
+)
+
+
+@contextmanager
+def _authorize_nested_operations() -> "Iterator[None]":
+    """Suppress validator hooks on nested engine calls within this scope.
+
+    The outer operation has already validated the caller's access to the bank, so
+    the reads/writes it performs internally (its backing mental model, or every
+    page during an export) must not re-invoke the validator.
+    """
+    token = _nested_operation_authorized.set(True)
+    try:
+        yield
+    finally:
+        _nested_operation_authorized.reset(token)
+
+
 MENTAL_MODEL_PENDING_CONTENT = "Generating content..."
 
 
@@ -1185,6 +1211,28 @@ class _MemoryRevertPlan:
     mentioned_at: datetime | None
     names: list[str]
     embedding: str | None = None
+
+
+@dataclass
+class KnowledgeBaseExportPage:
+    """A single page's rendered inputs for a knowledge-base export bundle."""
+
+    node_id: str
+    page: dict[str, Any]  # node merged with its mental model's content
+    mental_model_id: str | None
+    history: list[dict[str, Any]]
+
+
+@dataclass
+class KnowledgeBaseExport:
+    """Everything needed to render an export bundle, gathered under a single gate.
+
+    ``nodes`` is every folder/page node (for the index); ``pages`` carries each
+    page's content and refresh history.
+    """
+
+    nodes: list[dict[str, Any]]
+    pages: list[KnowledgeBaseExportPage]
 
 
 class MemoryEngine(MemoryEngineInterface):
@@ -11810,7 +11858,7 @@ class MemoryEngine(MemoryEngineInterface):
             The created pinned mental model dict
         """
         await self._authenticate_tenant(request_context)
-        if self._operation_validator:
+        if self._operation_validator and not _nested_operation_authorized.get():
             from hindsight_api.extensions import BankWriteContext, BankWriteOperation
 
             if not self._consume_preauthorized_bank_write(
@@ -12777,7 +12825,7 @@ class MemoryEngine(MemoryEngineInterface):
             Updated pinned mental model dict or None if not found
         """
         await self._authenticate_tenant(request_context)
-        if self._operation_validator:
+        if self._operation_validator and not _nested_operation_authorized.get():
             from hindsight_api.extensions import BankWriteContext, BankWriteOperation
 
             if not self._consume_preauthorized_bank_write(
@@ -13080,7 +13128,7 @@ class MemoryEngine(MemoryEngineInterface):
             True if deleted, False if not found
         """
         await self._authenticate_tenant(request_context)
-        if self._operation_validator:
+        if self._operation_validator and not _nested_operation_authorized.get():
             from hindsight_api.extensions import BankWriteContext, BankWriteOperation
 
             ctx = BankWriteContext(
@@ -13230,6 +13278,15 @@ class MemoryEngine(MemoryEngineInterface):
         ``managed`` lets a client tag a node as system-owned vs. hand-authored.
         """
         await self._authenticate_tenant(request_context)
+        if self._operation_validator and not _nested_operation_authorized.get():
+            from hindsight_api.extensions import BankWriteContext, BankWriteOperation
+
+            ctx = BankWriteContext(
+                bank_id=bank_id,
+                operation=BankWriteOperation.CREATE_KNOWLEDGE_FOLDER,
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
         backend = await self._get_backend()
         folder_id = f"kf-{uuid.uuid4().hex}"
         async with acquire_with_retry(backend) as conn:
@@ -13277,45 +13334,57 @@ class MemoryEngine(MemoryEngineInterface):
         "already exists" (surfaced by the API as a 409).
         """
         await self._authenticate_tenant(request_context)
-        # The mental model carries the content (and is created+validated by the
-        # existing path, including lazy bank creation); the node only refs it.
-        mm = await self.create_mental_model(
-            bank_id=bank_id,
-            name=name,
-            source_query=source_query,
-            content=content,
-            mental_model_id=mental_model_id,
-            tags=tags,
-            max_tokens=max_tokens if max_tokens is not None else self.KNOWLEDGE_PAGE_DEFAULT_MAX_TOKENS,
-            trigger=trigger if trigger is not None else dict(self.KNOWLEDGE_PAGE_DEFAULT_TRIGGER),
-            request_context=request_context,
-        )
-        backend = await self._get_backend()
-        page_id = f"kp-{uuid.uuid4().hex}"
-        try:
-            async with acquire_with_retry(backend) as conn:
-                async with conn.transaction():
-                    await self._kp_assert_folder_parent(conn, bank_id, parent_id)
-                    row = await conn.fetchrow(
-                        f"""
-                        INSERT INTO {fq_table("knowledge_pages")}
-                            (id, bank_id, parent_id, kind, name, mental_model_id, managed)
-                        VALUES ($1, $2, $3, 'page', $4, $5, $6)
-                        RETURNING {self._KP_COLUMNS}
-                        """,
-                        page_id,
-                        bank_id,
-                        parent_id,
-                        name,
-                        mm["id"],
-                        managed,
-                    )
-        except asyncpg.UniqueViolationError:
-            # Duplicate page name in this folder (uq_kp_folder_pagename). Roll back
-            # by deleting the orphan mental model we just created, then signal the
-            # caller that the page already exists.
-            await self.delete_mental_model(bank_id, mm["id"], request_context=request_context)
-            return None
+        if self._operation_validator and not _nested_operation_authorized.get():
+            from hindsight_api.extensions import BankWriteContext, BankWriteOperation
+
+            ctx = BankWriteContext(
+                bank_id=bank_id,
+                operation=BankWriteOperation.CREATE_KNOWLEDGE_PAGE,
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
+        # The mental model carries the content (and is created by the existing
+        # path, including lazy bank creation); the node only refs it. The write is
+        # already authorized above, so the nested mental-model create/delete run
+        # without invoking the validator a second time.
+        with _authorize_nested_operations():
+            mm = await self.create_mental_model(
+                bank_id=bank_id,
+                name=name,
+                source_query=source_query,
+                content=content,
+                mental_model_id=mental_model_id,
+                tags=tags,
+                max_tokens=max_tokens if max_tokens is not None else self.KNOWLEDGE_PAGE_DEFAULT_MAX_TOKENS,
+                trigger=trigger if trigger is not None else dict(self.KNOWLEDGE_PAGE_DEFAULT_TRIGGER),
+                request_context=request_context,
+            )
+            backend = await self._get_backend()
+            page_id = f"kp-{uuid.uuid4().hex}"
+            try:
+                async with acquire_with_retry(backend) as conn:
+                    async with conn.transaction():
+                        await self._kp_assert_folder_parent(conn, bank_id, parent_id)
+                        row = await conn.fetchrow(
+                            f"""
+                            INSERT INTO {fq_table("knowledge_pages")}
+                                (id, bank_id, parent_id, kind, name, mental_model_id, managed)
+                            VALUES ($1, $2, $3, 'page', $4, $5, $6)
+                            RETURNING {self._KP_COLUMNS}
+                            """,
+                            page_id,
+                            bank_id,
+                            parent_id,
+                            name,
+                            mm["id"],
+                            managed,
+                        )
+            except asyncpg.UniqueViolationError:
+                # Duplicate page name in this folder (uq_kp_folder_pagename). Roll back
+                # by deleting the orphan mental model we just created, then signal the
+                # caller that the page already exists.
+                await self.delete_mental_model(bank_id, mm["id"], request_context=request_context)
+                return None
         node = self._row_to_knowledge_node(row)
         # Surface the mental-model metadata so the caller can render markdown or
         # schedule a content refresh without a second fetch.
@@ -13340,6 +13409,15 @@ class MemoryEngine(MemoryEngineInterface):
         stays on the single mental-model read, which is where a user asks for it.
         """
         await self._authenticate_tenant(request_context)
+        if self._operation_validator and not _nested_operation_authorized.get():
+            from hindsight_api.extensions import BankReadContext, BankReadOperation
+
+            ctx = BankReadContext(
+                bank_id=bank_id,
+                operation=BankReadOperation.GET_KNOWLEDGE_BASE_TREE,
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
         # Resolve the watermark before taking a connection — on a cache miss it
         # acquires one of its own, and holding two is how the pool deadlocks.
         watermark = await self._bank_write_watermark(bank_id) if with_staleness else None
@@ -13368,6 +13446,15 @@ class MemoryEngine(MemoryEngineInterface):
     ) -> dict[str, Any] | None:
         """Return a page node merged with its mental model's content (for markdown rendering)."""
         await self._authenticate_tenant(request_context)
+        if self._operation_validator and not _nested_operation_authorized.get():
+            from hindsight_api.extensions import BankReadContext, BankReadOperation
+
+            ctx = BankReadContext(
+                bank_id=bank_id,
+                operation=BankReadOperation.GET_KNOWLEDGE_PAGE,
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
             row = await conn.fetchrow(
@@ -13402,6 +13489,15 @@ class MemoryEngine(MemoryEngineInterface):
         erroring.
         """
         await self._authenticate_tenant(request_context)
+        if self._operation_validator and not _nested_operation_authorized.get():
+            from hindsight_api.extensions import BankReadContext, BankReadOperation
+
+            ctx = BankReadContext(
+                bank_id=bank_id,
+                operation=BankReadOperation.SEARCH_KNOWLEDGE_BASE,
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
         query = (query or "").strip()
         if not query:
             return []
@@ -13493,6 +13589,15 @@ class MemoryEngine(MemoryEngineInterface):
     ) -> dict[str, Any] | None:
         """Rename a folder or page node."""
         await self._authenticate_tenant(request_context)
+        if self._operation_validator and not _nested_operation_authorized.get():
+            from hindsight_api.extensions import BankWriteContext, BankWriteOperation
+
+            ctx = BankWriteContext(
+                bank_id=bank_id,
+                operation=BankWriteOperation.RENAME_KNOWLEDGE_NODE,
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
             row = await conn.fetchrow(
@@ -13529,6 +13634,15 @@ class MemoryEngine(MemoryEngineInterface):
         against the new question.
         """
         await self._authenticate_tenant(request_context)
+        if self._operation_validator and not _nested_operation_authorized.get():
+            from hindsight_api.extensions import BankWriteContext, BankWriteOperation
+
+            ctx = BankWriteContext(
+                bank_id=bank_id,
+                operation=BankWriteOperation.UPDATE_KNOWLEDGE_PAGE,
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
             row = await conn.fetchrow(
@@ -13539,15 +13653,18 @@ class MemoryEngine(MemoryEngineInterface):
             )
         if row is None or row["mental_model_id"] is None:
             return None
-        await self.update_mental_model(
-            bank_id=bank_id,
-            mental_model_id=row["mental_model_id"],
-            source_query=source_query,
-            tags=tags,
-            max_tokens=max_tokens,
-            trigger=trigger,
-            request_context=request_context,
-        )
+        # The write is already authorized above; the backing mental-model update
+        # runs without re-invoking the validator.
+        with _authorize_nested_operations():
+            await self.update_mental_model(
+                bank_id=bank_id,
+                mental_model_id=row["mental_model_id"],
+                source_query=source_query,
+                tags=tags,
+                max_tokens=max_tokens,
+                trigger=trigger,
+                request_context=request_context,
+            )
         async with acquire_with_retry(backend) as conn:
             node_row = await conn.fetchrow(
                 f"SELECT {self._KP_PAGE_SELECT} FROM {self._kp_join()} "
@@ -13562,6 +13679,15 @@ class MemoryEngine(MemoryEngineInterface):
     ) -> dict[str, Any] | None:
         """Re-parent a node, rejecting self-parenting and cycles."""
         await self._authenticate_tenant(request_context)
+        if self._operation_validator and not _nested_operation_authorized.get():
+            from hindsight_api.extensions import BankWriteContext, BankWriteOperation
+
+            ctx = BankWriteContext(
+                bank_id=bank_id,
+                operation=BankWriteOperation.MOVE_KNOWLEDGE_NODE,
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
         if new_parent_id == node_id:
             raise ValueError("A node cannot be its own parent")
         backend = await self._get_backend()
@@ -13605,6 +13731,15 @@ class MemoryEngine(MemoryEngineInterface):
         rows. The subtree is gathered in Python so the logic is dialect-agnostic.
         """
         await self._authenticate_tenant(request_context)
+        if self._operation_validator and not _nested_operation_authorized.get():
+            from hindsight_api.extensions import BankWriteContext, BankWriteOperation
+
+            ctx = BankWriteContext(
+                bank_id=bank_id,
+                operation=BankWriteOperation.DELETE_KNOWLEDGE_NODE,
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
             async with conn.transaction():
@@ -13641,6 +13776,57 @@ class MemoryEngine(MemoryEngineInterface):
                     node_id,
                 )
         return True
+
+    async def export_knowledge_base(self, bank_id: str, *, request_context: "RequestContext") -> KnowledgeBaseExport:
+        """Gather every node, page content, and refresh history for an export bundle.
+
+        Validated once as a single knowledge-base export read — the per-page reads
+        it performs run under that authorization so the whole export costs exactly
+        one validator hook and leaks no content when the caller is denied. The API
+        layer renders the returned data into a markdown bundle.
+        """
+        await self._authenticate_tenant(request_context)
+        if self._operation_validator and not _nested_operation_authorized.get():
+            from hindsight_api.extensions import BankReadContext, BankReadOperation
+
+            ctx = BankReadContext(
+                bank_id=bank_id,
+                operation=BankReadOperation.EXPORT_KNOWLEDGE_BASE,
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+
+        with _authorize_nested_operations():
+            nodes = await self.list_knowledge_nodes(bank_id=bank_id, request_context=request_context)
+            pages: list[KnowledgeBaseExportPage] = []
+            for node in nodes:
+                if node.get("kind") != "page":
+                    continue
+                page = await self.get_knowledge_page(
+                    bank_id=bank_id, page_id=node["id"], request_context=request_context
+                )
+                if page is None:
+                    continue
+                mental_model_id = node.get("mental_model_id")
+                history: list[dict[str, Any]] = []
+                if mental_model_id:
+                    history = (
+                        await self.get_mental_model_history(
+                            bank_id=bank_id,
+                            mental_model_id=mental_model_id,
+                            request_context=request_context,
+                        )
+                        or []
+                    )
+                pages.append(
+                    KnowledgeBaseExportPage(
+                        node_id=node["id"],
+                        page=page,
+                        mental_model_id=mental_model_id,
+                        history=history,
+                    )
+                )
+        return KnowledgeBaseExport(nodes=nodes, pages=pages)
 
     async def compute_mental_model_is_stale(
         self,

--- a/hindsight-api-slim/hindsight_api/extensions/operation_validator.py
+++ b/hindsight-api-slim/hindsight_api/extensions/operation_validator.py
@@ -317,6 +317,7 @@ class ConsolidateResult:
 class BankReadOperation(StrEnum):
     """Bank-scoped read operation names passed to validate_bank_read."""
 
+    EXPORT_KNOWLEDGE_BASE = "export_knowledge_base"
     GET_BANK_CONFIG = "get_bank_config"
     GET_BANK_PROFILE = "get_bank_profile"
     GET_BANK_STATS = "get_bank_stats"
@@ -327,6 +328,8 @@ class BankReadOperation(StrEnum):
     GET_ENTITY_GRAPH = "get_entity_graph"
     GET_ENTITY_STATE = "get_entity_state"
     GET_GRAPH_DATA = "get_graph_data"
+    GET_KNOWLEDGE_BASE_TREE = "get_knowledge_base_tree"
+    GET_KNOWLEDGE_PAGE = "get_knowledge_page"
     GET_MEMORIES_TIMESERIES = "get_memories_timeseries"
     GET_MEMORY_UNIT = "get_memory_unit"
     GET_OBSERVATION_HISTORY = "get_observation_history"
@@ -343,6 +346,7 @@ class BankReadOperation(StrEnum):
     LIST_TAGS = "list_tags"
     LIST_WEBHOOK_DELIVERIES = "list_webhook_deliveries"
     LIST_WEBHOOKS = "list_webhooks"
+    SEARCH_KNOWLEDGE_BASE = "search_knowledge_base"
 
 
 class BankWriteOperation(StrEnum):
@@ -353,15 +357,20 @@ class BankWriteOperation(StrEnum):
     CLEAR_OBSERVATIONS = "clear_observations"
     CLEAR_OBSERVATIONS_FOR_MEMORY = "clear_observations_for_memory"
     CREATE_DIRECTIVE = "create_directive"
+    CREATE_KNOWLEDGE_FOLDER = "create_knowledge_folder"
+    CREATE_KNOWLEDGE_PAGE = "create_knowledge_page"
     CREATE_MENTAL_MODEL = "create_mental_model"
     CREATE_WEBHOOK = "create_webhook"
     DELETE_BANK = "delete_bank"
     DELETE_DIRECTIVE = "delete_directive"
     DELETE_DOCUMENT = "delete_document"
+    DELETE_KNOWLEDGE_NODE = "delete_knowledge_node"
     DELETE_MENTAL_MODEL = "delete_mental_model"
     DELETE_OPERATION = "delete_operation"
     DELETE_WEBHOOK = "delete_webhook"
     MERGE_BANK_MISSION = "merge_bank_mission"
+    MOVE_KNOWLEDGE_NODE = "move_knowledge_node"
+    RENAME_KNOWLEDGE_NODE = "rename_knowledge_node"
     REPROCESS_DOCUMENT = "reprocess_document"
     RESET_BANK_CONFIG = "reset_bank_config"
     RETRY_FAILED_CONSOLIDATION = "retry_failed_consolidation"
@@ -375,6 +384,7 @@ class BankWriteOperation(StrEnum):
     UPDATE_BANK_DISPOSITION = "update_bank_disposition"
     UPDATE_DIRECTIVE = "update_directive"
     UPDATE_DOCUMENT = "update_document"
+    UPDATE_KNOWLEDGE_PAGE = "update_knowledge_page"
     UPDATE_MEMORY_UNIT = "update_memory_unit"
     UPDATE_MENTAL_MODEL = "update_mental_model"
     UPDATE_WEBHOOK = "update_webhook"
@@ -858,7 +868,9 @@ class OperationValidatorExtension(Extension, ABC):
         Validate a bank read operation before execution.
 
         Override to implement custom validation logic for bank reads
-        (get_bank_profile, get_bank_stats).
+        (get_bank_profile, get_bank_stats, and the knowledge-base reads —
+        knowledge_base_tree / get_knowledge_page / search_knowledge_base /
+        export_knowledge_base, which expose mental-model content).
 
         Args:
             ctx: Context containing:
@@ -877,7 +889,10 @@ class OperationValidatorExtension(Extension, ABC):
 
         Override to implement custom validation logic for bank writes
         (delete_bank, update_bank, update_bank_disposition, set_bank_mission,
-        merge_bank_mission, clear_observations, clear_observations_for_memory).
+        merge_bank_mission, clear_observations, clear_observations_for_memory,
+        and the knowledge-base writes — create_knowledge_folder /
+        create_knowledge_page / update_knowledge_page / rename_knowledge_node /
+        move_knowledge_node / delete_knowledge_node).
 
         Args:
             ctx: Context containing:

--- a/hindsight-api-slim/tests/test_knowledge_base.py
+++ b/hindsight-api-slim/tests/test_knowledge_base.py
@@ -12,10 +12,80 @@ from datetime import datetime, timedelta, timezone
 import pytest_asyncio
 
 from hindsight_api.engine.memory_engine import MemoryEngine, _may_need_refresh
+from hindsight_api.extensions import (
+    BankReadContext,
+    BankReadOperation,
+    BankWriteContext,
+    BankWriteOperation,
+    OperationValidatorExtension,
+    ValidationResult,
+)
 
 
 def _enc(bank_id: str) -> str:
     return urllib.parse.quote(bank_id, safe="")
+
+
+class _RecordingValidator(OperationValidatorExtension):
+    """A validator that records every bank read/write and rejects one operation.
+
+    A concrete subclass (not a MagicMock) so every inherited hook — including the
+    async post-hooks the background mental-model refresh worker fires after a page
+    create — is a real coroutine. Only the named operation is rejected; every other
+    hook (including DELETE_BANK, used by the ``kb_bank`` fixture teardown) accepts.
+    """
+
+    def __init__(
+        self,
+        *,
+        reject_read: BankReadOperation | None = None,
+        reject_write: BankWriteOperation | None = None,
+        reason: str = "operation is forbidden",
+    ) -> None:
+        super().__init__({})
+        self._reject_read = reject_read
+        self._reject_write = reject_write
+        self._reason = reason
+        self.read_ops: list[BankReadOperation] = []
+        self.write_ops: list[BankWriteOperation] = []
+
+    async def validate_retain(self, ctx) -> ValidationResult:
+        return ValidationResult.accept()
+
+    async def validate_recall(self, ctx) -> ValidationResult:
+        return ValidationResult.accept()
+
+    async def validate_reflect(self, ctx) -> ValidationResult:
+        return ValidationResult.accept()
+
+    async def validate_bank_read(self, ctx: BankReadContext) -> ValidationResult:
+        self.read_ops.append(ctx.operation)
+        if ctx.operation is self._reject_read:
+            return ValidationResult.reject(self._reason)
+        return ValidationResult.accept()
+
+    async def validate_bank_write(self, ctx: BankWriteContext) -> ValidationResult:
+        self.write_ops.append(ctx.operation)
+        if ctx.operation is self._reject_write:
+            return ValidationResult.reject(self._reason)
+        return ValidationResult.accept()
+
+
+def _kb_validator(
+    *,
+    reject_read: BankReadOperation | None = None,
+    reject_write: BankWriteOperation | None = None,
+    reason: str = "operation is forbidden",
+) -> _RecordingValidator:
+    return _RecordingValidator(reject_read=reject_read, reject_write=reject_write, reason=reason)
+
+
+def _read_ops(validator: _RecordingValidator) -> list[BankReadOperation]:
+    return list(validator.read_ops)
+
+
+def _write_ops(validator: _RecordingValidator) -> list[BankWriteOperation]:
+    return list(validator.write_ops)
 
 
 class _Seed:
@@ -376,3 +446,248 @@ class TestMoveRenameDelete:
         # the backing mental model is gone too
         mm = await memory.get_mental_model(bank_id, ids.orders_mm, request_context=request_context)
         assert mm is None
+
+
+class TestAuthorizationReadDenied:
+    """A validator that denies a knowledge-base read blocks it with 403 and leaks
+    nothing — knowledge pages render mental-model content, so this is the sharp
+    edge of #3312 (read-your-neighbour's-synthesized-memories)."""
+
+    async def test_tree_denied(self, api_client, kb_bank, memory, monkeypatch):
+        bank_id, ids = kb_bank
+        validator = _kb_validator(reject_read=BankReadOperation.GET_KNOWLEDGE_BASE_TREE)
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+        resp = await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/tree")
+        assert resp.status_code == 403, resp.text
+        assert "Orders" not in resp.text
+        assert _read_ops(validator) == [BankReadOperation.GET_KNOWLEDGE_BASE_TREE]
+
+    async def test_get_page_denied(self, api_client, kb_bank, memory, monkeypatch):
+        bank_id, ids = kb_bank
+        validator = _kb_validator(reject_read=BankReadOperation.GET_KNOWLEDGE_PAGE)
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+        resp = await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/pages/{ids.orders}")
+        assert resp.status_code == 403, resp.text
+        assert "One row per order." not in resp.text
+        assert _read_ops(validator) == [BankReadOperation.GET_KNOWLEDGE_PAGE]
+
+    async def test_search_denied(self, api_client, kb_bank, memory, monkeypatch):
+        bank_id, ids = kb_bank
+        validator = _kb_validator(reject_read=BankReadOperation.SEARCH_KNOWLEDGE_BASE)
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+        resp = await api_client.get(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/search",
+            params={"q": "orders"},
+        )
+        assert resp.status_code == 403, resp.text
+        assert "Orders" not in resp.text
+        assert _read_ops(validator) == [BankReadOperation.SEARCH_KNOWLEDGE_BASE]
+
+    async def test_export_denied_leaks_nothing_and_gates_once(self, api_client, kb_bank, memory, monkeypatch):
+        bank_id, ids = kb_bank
+        validator = _kb_validator(reject_read=BankReadOperation.EXPORT_KNOWLEDGE_BASE)
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+        resp = await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/export")
+        assert resp.status_code == 403, resp.text
+        assert "One row per order." not in resp.text
+        # A single export read gate — the per-page reads never run on a denied path.
+        assert _read_ops(validator) == [BankReadOperation.EXPORT_KNOWLEDGE_BASE]
+
+
+class TestAuthorizationWriteDenied:
+    """A validator that denies a knowledge-base write blocks it with 403 and leaves
+    the tree unchanged."""
+
+    async def _tree_names(self, api_client, bank_id) -> set[str]:
+        tree = (await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/tree")).json()
+
+        def walk(nodes):
+            for n in nodes:
+                yield n["name"]
+                yield from walk(n.get("children", []))
+
+        return set(walk(tree["roots"]))
+
+    async def test_create_folder_denied(self, api_client, kb_bank, memory, monkeypatch):
+        bank_id, ids = kb_bank
+        before = await self._tree_names(api_client, bank_id)
+        validator = _kb_validator(reject_write=BankWriteOperation.CREATE_KNOWLEDGE_FOLDER)
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+        resp = await api_client.post(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/folders",
+            json={"name": "Guides", "parent_id": None},
+        )
+        assert resp.status_code == 403, resp.text
+        assert _write_ops(validator) == [BankWriteOperation.CREATE_KNOWLEDGE_FOLDER]
+        monkeypatch.setattr(memory, "_operation_validator", None)
+        assert await self._tree_names(api_client, bank_id) == before
+
+    async def test_create_page_denied(self, api_client, kb_bank, memory, monkeypatch):
+        bank_id, ids = kb_bank
+        before = await self._tree_names(api_client, bank_id)
+        validator = _kb_validator(reject_write=BankWriteOperation.CREATE_KNOWLEDGE_PAGE)
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+        resp = await api_client.post(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/pages",
+            json={"name": "New page", "source_query": "what is new?"},
+        )
+        assert resp.status_code == 403, resp.text
+        # Rejected before the backing mental model is created — a single write hook.
+        assert _write_ops(validator) == [BankWriteOperation.CREATE_KNOWLEDGE_PAGE]
+        monkeypatch.setattr(memory, "_operation_validator", None)
+        assert await self._tree_names(api_client, bank_id) == before
+
+    async def test_rename_denied(self, api_client, kb_bank, memory, monkeypatch):
+        bank_id, ids = kb_bank
+        validator = _kb_validator(reject_write=BankWriteOperation.RENAME_KNOWLEDGE_NODE)
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+        resp = await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.policies}",
+            json={"name": "Compliance"},
+        )
+        assert resp.status_code == 403, resp.text
+        assert _write_ops(validator) == [BankWriteOperation.RENAME_KNOWLEDGE_NODE]
+        monkeypatch.setattr(memory, "_operation_validator", None)
+        assert "Policies" in await self._tree_names(api_client, bank_id)
+
+    async def test_move_denied(self, api_client, kb_bank, memory, monkeypatch):
+        bank_id, ids = kb_bank
+        validator = _kb_validator(reject_write=BankWriteOperation.MOVE_KNOWLEDGE_NODE)
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+        resp = await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.loose}",
+            json={"parent_id": ids.policies},
+        )
+        assert resp.status_code == 403, resp.text
+        assert _write_ops(validator) == [BankWriteOperation.MOVE_KNOWLEDGE_NODE]
+
+    async def test_update_page_denied(self, api_client, kb_bank, memory, monkeypatch):
+        bank_id, ids = kb_bank
+        validator = _kb_validator(reject_write=BankWriteOperation.UPDATE_KNOWLEDGE_PAGE)
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+        resp = await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.orders}",
+            json={"source_query": "changed"},
+        )
+        assert resp.status_code == 403, resp.text
+        # Rejected before touching the backing mental model — a single write hook.
+        assert _write_ops(validator) == [BankWriteOperation.UPDATE_KNOWLEDGE_PAGE]
+
+    async def test_delete_denied(self, api_client, kb_bank, memory, monkeypatch):
+        bank_id, ids = kb_bank
+        validator = _kb_validator(reject_write=BankWriteOperation.DELETE_KNOWLEDGE_NODE)
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+        resp = await api_client.delete(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.runbooks}")
+        assert resp.status_code == 403, resp.text
+        assert _write_ops(validator) == [BankWriteOperation.DELETE_KNOWLEDGE_NODE]
+        monkeypatch.setattr(memory, "_operation_validator", None)
+        assert "Runbooks" in await self._tree_names(api_client, bank_id)
+
+    async def test_denied_create_leaves_no_bank_behind(self, api_client, memory, request_context, monkeypatch):
+        """An unauthorized create must not lazily provision the target bank."""
+        bank_id = f"kb-denied-create-{uuid.uuid4().hex[:8]}"
+        validator = _kb_validator(reject_write=BankWriteOperation.CREATE_KNOWLEDGE_FOLDER)
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+        resp = await api_client.post(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/folders",
+            json={"name": "Guides", "parent_id": None},
+        )
+        assert resp.status_code == 403, resp.text
+        monkeypatch.setattr(memory, "_operation_validator", None)
+        assert await memory.get_bank_profile(bank_id, request_context=request_context, create_if_missing=False) is None
+
+
+class TestAuthorizationSuccessHookCounts:
+    """Successful knowledge-base routes invoke exactly one validator hook — the
+    knowledge-base operation — and never the nested mental-model hooks."""
+
+    async def test_reads_gate_once(self, api_client, kb_bank, memory, monkeypatch):
+        bank_id, ids = kb_bank
+        validator = _kb_validator()
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+
+        validator.read_ops.clear()
+        await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/tree")
+        assert _read_ops(validator) == [BankReadOperation.GET_KNOWLEDGE_BASE_TREE]
+
+        validator.read_ops.clear()
+        await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/pages/{ids.orders}")
+        assert _read_ops(validator) == [BankReadOperation.GET_KNOWLEDGE_PAGE]
+
+        validator.read_ops.clear()
+        await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/search", params={"q": "orders"})
+        assert _read_ops(validator) == [BankReadOperation.SEARCH_KNOWLEDGE_BASE]
+
+    async def test_export_gates_once_and_suppresses_nested_reads(self, api_client, kb_bank, memory, monkeypatch):
+        bank_id, ids = kb_bank
+        validator = _kb_validator()
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+        validator.read_ops.clear()
+        resp = await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/export")
+        assert resp.status_code == 200, resp.text
+        # Exactly one gate for the whole bundle; the per-page reads run under it.
+        assert _read_ops(validator) == [BankReadOperation.EXPORT_KNOWLEDGE_BASE]
+
+    async def test_create_page_gates_once_without_nested_mental_model_write(
+        self, kb_bank, memory, request_context, monkeypatch
+    ):
+        # Tested at the engine level: the HTTP route additionally schedules an
+        # async refresh whose background worker later writes the generated content
+        # (a separate, legitimately metered UPDATE_MENTAL_MODEL). Here we assert the
+        # synchronous create in isolation — the backing CREATE_MENTAL_MODEL is
+        # suppressed, so the KB write is the only bank_write hook.
+        bank_id, ids = kb_bank
+        validator = _kb_validator()
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+        validator.write_ops.clear()
+        node = await memory.create_knowledge_page(
+            bank_id,
+            "Fresh page",
+            "what is fresh?",
+            "content",
+            request_context=request_context,
+        )
+        assert node is not None
+        assert _write_ops(validator) == [BankWriteOperation.CREATE_KNOWLEDGE_PAGE]
+
+    async def test_writes_gate_once(self, api_client, kb_bank, memory, monkeypatch):
+        bank_id, ids = kb_bank
+        validator = _kb_validator()
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+
+        validator.write_ops.clear()
+        await api_client.post(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/folders", json={"name": "Guides"})
+        assert _write_ops(validator) == [BankWriteOperation.CREATE_KNOWLEDGE_FOLDER]
+
+        validator.write_ops.clear()
+        await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.policies}",
+            json={"name": "Compliance"},
+        )
+        assert _write_ops(validator) == [BankWriteOperation.RENAME_KNOWLEDGE_NODE]
+
+        validator.write_ops.clear()
+        await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.orders}",
+            json={"tags": ["type:runbook"]},
+        )
+        assert _write_ops(validator) == [BankWriteOperation.UPDATE_KNOWLEDGE_PAGE]
+
+        validator.write_ops.clear()
+        await api_client.delete(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.billing}")
+        assert _write_ops(validator) == [BankWriteOperation.DELETE_KNOWLEDGE_NODE]
+
+
+class TestAuthorizationDisabled:
+    """Without an operation validator (OSS default), knowledge-base routes are
+    unauthenticated-by-tenant and work exactly as before."""
+
+    async def test_engine_calls_do_not_raise(self, memory, request_context):
+        assert memory._operation_validator is None
+        bank_id = f"kb-noauth-{uuid.uuid4().hex[:8]}"
+        folder = await memory.create_knowledge_folder(bank_id, "Docs", request_context=request_context)
+        nodes = await memory.list_knowledge_nodes(bank_id=bank_id, request_context=request_context)
+        assert folder["id"] in {n["id"] for n in nodes}
+        export = await memory.export_knowledge_base(bank_id=bank_id, request_context=request_context)
+        assert any(n["id"] == folder["id"] for n in export.nodes)
+        await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## Problem

All routes under `/v1/default/banks/{bank_id}/knowledge-base/*` reached the engine without ever invoking `OperationValidatorExtension`. On a deployment that relies on the validator for bank-level authorization (multi-tenant, one instance shared by many owners), any authenticated tenant caller could read, create, move, or delete **any** bank's knowledge tree by knowing its `bank_id`.

Because knowledge pages render mental-model content (`GET .../pages/{id}`, `.../search`, `.../export`), this was a read-your-neighbour's-synthesized-memories hole — even though the direct mental-model routes *are* gated. The KB route handlers already carried a dead `except OperationValidationError` clause, so gating was clearly intended but never wired.

Fixes #3312. Follow-up to #3036 / #2488.

## Changes

**`extensions/operation_validator.py`** — add knowledge-base members to the operation enums:
- `BankReadOperation`: `GET_KNOWLEDGE_BASE_TREE`, `GET_KNOWLEDGE_PAGE`, `SEARCH_KNOWLEDGE_BASE`, `EXPORT_KNOWLEDGE_BASE`
- `BankWriteOperation`: `CREATE_KNOWLEDGE_FOLDER`, `CREATE_KNOWLEDGE_PAGE`, `UPDATE_KNOWLEDGE_PAGE`, `RENAME_KNOWLEDGE_NODE`, `MOVE_KNOWLEDGE_NODE`, `DELETE_KNOWLEDGE_NODE`

**`engine/memory_engine.py`**
- Gate all nine KB engine methods through `_validate_operation` before any read or write, mirroring `validate_mental_model_get` / `validate_mental_model_refresh`. This makes the KB routes' previously-dead `OperationValidationError` handlers reachable.
- Add a request-local `_nested_operation_authorized` contextvar (+ `_authorize_nested_operations()`), so composite methods (`create_knowledge_page` → `create_mental_model`, `update_knowledge_page` → `update_mental_model`) and the new `export_knowledge_base` fire **exactly one** validator hook and never auto-create a bank on an unauthorized path.
- Move export bundle data-gathering into `export_knowledge_base` (returns typed `KnowledgeBaseExport` / `KnowledgeBaseExportPage`); the handler only renders markdown. Export now gates once and leaks nothing when denied.

**`api/http.py`** — export route calls the new engine method; no more read-orchestration in the handler. No HTTP contract change (no OpenAPI/client regen needed).

## Tests

`tests/test_knowledge_base.py` gains `TestAuthorizationReadDenied` / `WriteDenied` / `SuccessHookCounts` / `Disabled`, driven by a real `OperationValidatorExtension` subclass:
- Deny `bank_read` → `GET .../tree|pages/{id}|search|export` return **403** and leak no content.
- Deny `bank_write` → `POST .../folders|pages`, `PATCH`/`DELETE .../nodes/{id}` return **403** and leave the tree unchanged.
- Denied create on a missing bank leaves no bank row behind.
- Success paths assert exact read/write hook counts (create-page's one-hook guarantee is asserted at the engine level, since the create-page **route** additionally schedules an async refresh whose worker writes a separately-metered `UPDATE_MENTAL_MODEL`).

## Verification

`ruff`, `ty`, and `./scripts/hooks/lint.sh` pass. **39** knowledge-base tests and **119** regression tests (`test_extensions` + `test_mental_models` + `test_mental_model_hooks`) pass locally.
