### PR TITLE
feat(bank-template): make every bank config field export+importable

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2646,6 +2646,24 @@ class BankTemplateConfig(BaseModel):
         description="Persist raw source text (documents.original_text / chunks.chunk_text). "
         "Set false to keep only derived facts.",
     )
+    enable_auto_consolidation: bool | None = Field(
+        default=None, description="Automatically consolidate observations after retain"
+    )
+    consolidation_max_memories_per_round: int | None = Field(
+        default=None, description="Max memory units fed into a single consolidation round"
+    )
+    consolidation_llm_parallelism: int | None = Field(
+        default=None, description="Number of consolidation LLM batches processed concurrently"
+    )
+    recall_include_chunks: bool | None = Field(default=None, description="Include raw chunks in recall results")
+    recall_max_tokens: int | None = Field(default=None, description="Max tokens of results returned by recall")
+    recall_chunks_max_tokens: int | None = Field(
+        default=None, description="Max tokens of raw chunks returned by recall (when recall_include_chunks is set)"
+    )
+    memory_defense: dict | None = Field(
+        default=None,
+        description="Memory Defense policy for this bank (validated against the DefensePolicy schema on write)",
+    )
 
     def get_config_updates(self) -> dict[str, Any]:
         """Return only the fields that were explicitly set (non-None)."""

--- a/hindsight-api-slim/tests/test_bank_template_full_roundtrip.py
+++ b/hindsight-api-slim/tests/test_bank_template_full_roundtrip.py
@@ -19,6 +19,22 @@ endpoint filters bank overrides through exactly that set — so the sample table
 below is checked against it. A newly added template field fails
 ``test_sample_values_cover_every_exportable_field`` until it gets a value here,
 which is the point: the round-trip must not silently stop covering it.
+
+Adding a per-bank config field is a multi-step flow, and each step here fails
+until the previous one is done — so a half-wired field cannot land quietly:
+
+1. add it to ``_CONFIGURABLE_FIELDS`` → ``test_every_configurable_field_is_exportable``
+   fails until it is declared on ``BankTemplateConfig``;
+2. declare it there → ``test_sample_values_cover_every_exportable_field`` fails
+   until it has a value in ``_SAMPLE_VALUES``;
+3. give it a value → the round-trip below actually exercises it end to end;
+4. changing ``BankTemplateConfig`` also moves the OpenAPI spec, the generated
+   clients and ``bank-template-schema.json``, so CI's ``verify-generated-files``
+   fails until those are regenerated.
+
+(``test_bank_config_value_types`` adds a fifth: every configurable field must
+have a derivable type contract.) See #3218 for what a half-wired config field
+costs in production.
 """
 
 from __future__ import annotations
@@ -32,6 +48,7 @@ import pytest_asyncio
 
 from hindsight_api.api import create_app
 from hindsight_api.api.http import BankTemplateConfig
+from hindsight_api.config import HindsightConfig
 
 
 # One value per BankTemplateConfig field, each chosen to differ visibly from the
@@ -92,6 +109,16 @@ _SAMPLE_VALUES: dict[str, Any] = {
     "recall_budget_max": 1500,
     "audit_log_enabled": True,
     "store_document_text": False,
+    "enable_auto_consolidation": False,
+    "consolidation_max_memories_per_round": 42,
+    "consolidation_llm_parallelism": 3,
+    "recall_include_chunks": True,
+    "recall_max_tokens": 9000,
+    "recall_chunks_max_tokens": 4500,
+    # Validated against the DefensePolicy schema on write (parse_policy), so this
+    # must be a real policy — and carrying a rule means the round-trip covers the
+    # nested list, not just the top-level flag.
+    "memory_defense": {"enabled": True, "rules": [{"on": "sensitive_data", "action": "redact"}]},
 }
 
 
@@ -115,6 +142,26 @@ async def _read_overrides(api_client: httpx.AsyncClient, bank_id: str) -> dict[s
     resp = await api_client.get(f"/v1/default/banks/{bank_id}/config")
     assert resp.status_code == 200, resp.text
     return resp.json()["overrides"]
+
+
+def test_every_configurable_field_is_exportable():
+    """Every per-bank config field must be part of the template engine.
+
+    A field in ``_CONFIGURABLE_FIELDS`` but not on ``BankTemplateConfig`` is
+    settable per bank yet invisible to export/import: cloning a bank silently
+    drops it, and the clone runs on the server default while looking correctly
+    configured. The two sets must match exactly — an intentional exclusion is a
+    decision to record here, in an explicit set with a reason, not an omission.
+    """
+    configurable = HindsightConfig.get_configurable_fields()
+    exportable = set(BankTemplateConfig.model_fields)
+    assert configurable == exportable, (
+        f"bank config and the template engine have drifted:\n"
+        f"  configurable but not exportable (add to BankTemplateConfig): "
+        f"{sorted(configurable - exportable)}\n"
+        f"  exportable but not configurable (remove, or add to _CONFIGURABLE_FIELDS): "
+        f"{sorted(exportable - configurable)}"
+    )
 
 
 def test_sample_values_cover_every_exportable_field():

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -5145,6 +5145,27 @@ components:
         store_document_text:
           nullable: true
           type: boolean
+        enable_auto_consolidation:
+          nullable: true
+          type: boolean
+        consolidation_max_memories_per_round:
+          nullable: true
+          type: integer
+        consolidation_llm_parallelism:
+          nullable: true
+          type: integer
+        recall_include_chunks:
+          nullable: true
+          type: boolean
+        recall_max_tokens:
+          nullable: true
+          type: integer
+        recall_chunks_max_tokens:
+          nullable: true
+          type: integer
+        memory_defense:
+          additionalProperties: {}
+          nullable: true
       title: BankTemplateConfig
     BankTemplateDirective:
       description: |-

--- a/hindsight-clients/go/model_bank_template_config.go
+++ b/hindsight-clients/go/model_bank_template_config.go
@@ -57,6 +57,13 @@ type BankTemplateConfig struct {
 	RecallBudgetMax NullableInt32 `json:"recall_budget_max,omitempty"`
 	AuditLogEnabled NullableBool `json:"audit_log_enabled,omitempty"`
 	StoreDocumentText NullableBool `json:"store_document_text,omitempty"`
+	EnableAutoConsolidation NullableBool `json:"enable_auto_consolidation,omitempty"`
+	ConsolidationMaxMemoriesPerRound NullableInt32 `json:"consolidation_max_memories_per_round,omitempty"`
+	ConsolidationLlmParallelism NullableInt32 `json:"consolidation_llm_parallelism,omitempty"`
+	RecallIncludeChunks NullableBool `json:"recall_include_chunks,omitempty"`
+	RecallMaxTokens NullableInt32 `json:"recall_max_tokens,omitempty"`
+	RecallChunksMaxTokens NullableInt32 `json:"recall_chunks_max_tokens,omitempty"`
+	MemoryDefense map[string]interface{} `json:"memory_defense,omitempty"`
 }
 
 // NewBankTemplateConfig instantiates a new BankTemplateConfig object
@@ -1627,6 +1634,291 @@ func (o *BankTemplateConfig) UnsetStoreDocumentText() {
 	o.StoreDocumentText.Unset()
 }
 
+// GetEnableAutoConsolidation returns the EnableAutoConsolidation field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetEnableAutoConsolidation() bool {
+	if o == nil || IsNil(o.EnableAutoConsolidation.Get()) {
+		var ret bool
+		return ret
+	}
+	return *o.EnableAutoConsolidation.Get()
+}
+
+// GetEnableAutoConsolidationOk returns a tuple with the EnableAutoConsolidation field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetEnableAutoConsolidationOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.EnableAutoConsolidation.Get(), o.EnableAutoConsolidation.IsSet()
+}
+
+// HasEnableAutoConsolidation returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasEnableAutoConsolidation() bool {
+	if o != nil && o.EnableAutoConsolidation.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetEnableAutoConsolidation gets a reference to the given NullableBool and assigns it to the EnableAutoConsolidation field.
+func (o *BankTemplateConfig) SetEnableAutoConsolidation(v bool) {
+	o.EnableAutoConsolidation.Set(&v)
+}
+// SetEnableAutoConsolidationNil sets the value for EnableAutoConsolidation to be an explicit nil
+func (o *BankTemplateConfig) SetEnableAutoConsolidationNil() {
+	o.EnableAutoConsolidation.Set(nil)
+}
+
+// UnsetEnableAutoConsolidation ensures that no value is present for EnableAutoConsolidation, not even an explicit nil
+func (o *BankTemplateConfig) UnsetEnableAutoConsolidation() {
+	o.EnableAutoConsolidation.Unset()
+}
+
+// GetConsolidationMaxMemoriesPerRound returns the ConsolidationMaxMemoriesPerRound field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetConsolidationMaxMemoriesPerRound() int32 {
+	if o == nil || IsNil(o.ConsolidationMaxMemoriesPerRound.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.ConsolidationMaxMemoriesPerRound.Get()
+}
+
+// GetConsolidationMaxMemoriesPerRoundOk returns a tuple with the ConsolidationMaxMemoriesPerRound field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetConsolidationMaxMemoriesPerRoundOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.ConsolidationMaxMemoriesPerRound.Get(), o.ConsolidationMaxMemoriesPerRound.IsSet()
+}
+
+// HasConsolidationMaxMemoriesPerRound returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasConsolidationMaxMemoriesPerRound() bool {
+	if o != nil && o.ConsolidationMaxMemoriesPerRound.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetConsolidationMaxMemoriesPerRound gets a reference to the given NullableInt32 and assigns it to the ConsolidationMaxMemoriesPerRound field.
+func (o *BankTemplateConfig) SetConsolidationMaxMemoriesPerRound(v int32) {
+	o.ConsolidationMaxMemoriesPerRound.Set(&v)
+}
+// SetConsolidationMaxMemoriesPerRoundNil sets the value for ConsolidationMaxMemoriesPerRound to be an explicit nil
+func (o *BankTemplateConfig) SetConsolidationMaxMemoriesPerRoundNil() {
+	o.ConsolidationMaxMemoriesPerRound.Set(nil)
+}
+
+// UnsetConsolidationMaxMemoriesPerRound ensures that no value is present for ConsolidationMaxMemoriesPerRound, not even an explicit nil
+func (o *BankTemplateConfig) UnsetConsolidationMaxMemoriesPerRound() {
+	o.ConsolidationMaxMemoriesPerRound.Unset()
+}
+
+// GetConsolidationLlmParallelism returns the ConsolidationLlmParallelism field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetConsolidationLlmParallelism() int32 {
+	if o == nil || IsNil(o.ConsolidationLlmParallelism.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.ConsolidationLlmParallelism.Get()
+}
+
+// GetConsolidationLlmParallelismOk returns a tuple with the ConsolidationLlmParallelism field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetConsolidationLlmParallelismOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.ConsolidationLlmParallelism.Get(), o.ConsolidationLlmParallelism.IsSet()
+}
+
+// HasConsolidationLlmParallelism returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasConsolidationLlmParallelism() bool {
+	if o != nil && o.ConsolidationLlmParallelism.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetConsolidationLlmParallelism gets a reference to the given NullableInt32 and assigns it to the ConsolidationLlmParallelism field.
+func (o *BankTemplateConfig) SetConsolidationLlmParallelism(v int32) {
+	o.ConsolidationLlmParallelism.Set(&v)
+}
+// SetConsolidationLlmParallelismNil sets the value for ConsolidationLlmParallelism to be an explicit nil
+func (o *BankTemplateConfig) SetConsolidationLlmParallelismNil() {
+	o.ConsolidationLlmParallelism.Set(nil)
+}
+
+// UnsetConsolidationLlmParallelism ensures that no value is present for ConsolidationLlmParallelism, not even an explicit nil
+func (o *BankTemplateConfig) UnsetConsolidationLlmParallelism() {
+	o.ConsolidationLlmParallelism.Unset()
+}
+
+// GetRecallIncludeChunks returns the RecallIncludeChunks field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetRecallIncludeChunks() bool {
+	if o == nil || IsNil(o.RecallIncludeChunks.Get()) {
+		var ret bool
+		return ret
+	}
+	return *o.RecallIncludeChunks.Get()
+}
+
+// GetRecallIncludeChunksOk returns a tuple with the RecallIncludeChunks field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetRecallIncludeChunksOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RecallIncludeChunks.Get(), o.RecallIncludeChunks.IsSet()
+}
+
+// HasRecallIncludeChunks returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasRecallIncludeChunks() bool {
+	if o != nil && o.RecallIncludeChunks.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRecallIncludeChunks gets a reference to the given NullableBool and assigns it to the RecallIncludeChunks field.
+func (o *BankTemplateConfig) SetRecallIncludeChunks(v bool) {
+	o.RecallIncludeChunks.Set(&v)
+}
+// SetRecallIncludeChunksNil sets the value for RecallIncludeChunks to be an explicit nil
+func (o *BankTemplateConfig) SetRecallIncludeChunksNil() {
+	o.RecallIncludeChunks.Set(nil)
+}
+
+// UnsetRecallIncludeChunks ensures that no value is present for RecallIncludeChunks, not even an explicit nil
+func (o *BankTemplateConfig) UnsetRecallIncludeChunks() {
+	o.RecallIncludeChunks.Unset()
+}
+
+// GetRecallMaxTokens returns the RecallMaxTokens field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetRecallMaxTokens() int32 {
+	if o == nil || IsNil(o.RecallMaxTokens.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.RecallMaxTokens.Get()
+}
+
+// GetRecallMaxTokensOk returns a tuple with the RecallMaxTokens field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetRecallMaxTokensOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RecallMaxTokens.Get(), o.RecallMaxTokens.IsSet()
+}
+
+// HasRecallMaxTokens returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasRecallMaxTokens() bool {
+	if o != nil && o.RecallMaxTokens.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRecallMaxTokens gets a reference to the given NullableInt32 and assigns it to the RecallMaxTokens field.
+func (o *BankTemplateConfig) SetRecallMaxTokens(v int32) {
+	o.RecallMaxTokens.Set(&v)
+}
+// SetRecallMaxTokensNil sets the value for RecallMaxTokens to be an explicit nil
+func (o *BankTemplateConfig) SetRecallMaxTokensNil() {
+	o.RecallMaxTokens.Set(nil)
+}
+
+// UnsetRecallMaxTokens ensures that no value is present for RecallMaxTokens, not even an explicit nil
+func (o *BankTemplateConfig) UnsetRecallMaxTokens() {
+	o.RecallMaxTokens.Unset()
+}
+
+// GetRecallChunksMaxTokens returns the RecallChunksMaxTokens field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetRecallChunksMaxTokens() int32 {
+	if o == nil || IsNil(o.RecallChunksMaxTokens.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.RecallChunksMaxTokens.Get()
+}
+
+// GetRecallChunksMaxTokensOk returns a tuple with the RecallChunksMaxTokens field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetRecallChunksMaxTokensOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RecallChunksMaxTokens.Get(), o.RecallChunksMaxTokens.IsSet()
+}
+
+// HasRecallChunksMaxTokens returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasRecallChunksMaxTokens() bool {
+	if o != nil && o.RecallChunksMaxTokens.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRecallChunksMaxTokens gets a reference to the given NullableInt32 and assigns it to the RecallChunksMaxTokens field.
+func (o *BankTemplateConfig) SetRecallChunksMaxTokens(v int32) {
+	o.RecallChunksMaxTokens.Set(&v)
+}
+// SetRecallChunksMaxTokensNil sets the value for RecallChunksMaxTokens to be an explicit nil
+func (o *BankTemplateConfig) SetRecallChunksMaxTokensNil() {
+	o.RecallChunksMaxTokens.Set(nil)
+}
+
+// UnsetRecallChunksMaxTokens ensures that no value is present for RecallChunksMaxTokens, not even an explicit nil
+func (o *BankTemplateConfig) UnsetRecallChunksMaxTokens() {
+	o.RecallChunksMaxTokens.Unset()
+}
+
+// GetMemoryDefense returns the MemoryDefense field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetMemoryDefense() map[string]interface{} {
+	if o == nil {
+		var ret map[string]interface{}
+		return ret
+	}
+	return o.MemoryDefense
+}
+
+// GetMemoryDefenseOk returns a tuple with the MemoryDefense field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetMemoryDefenseOk() (map[string]interface{}, bool) {
+	if o == nil || IsNil(o.MemoryDefense) {
+		return map[string]interface{}{}, false
+	}
+	return o.MemoryDefense, true
+}
+
+// HasMemoryDefense returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasMemoryDefense() bool {
+	if o != nil && !IsNil(o.MemoryDefense) {
+		return true
+	}
+
+	return false
+}
+
+// SetMemoryDefense gets a reference to the given map[string]interface{} and assigns it to the MemoryDefense field.
+func (o *BankTemplateConfig) SetMemoryDefense(v map[string]interface{}) {
+	o.MemoryDefense = v
+}
+
 func (o BankTemplateConfig) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -1750,6 +2042,27 @@ func (o BankTemplateConfig) ToMap() (map[string]interface{}, error) {
 	}
 	if o.StoreDocumentText.IsSet() {
 		toSerialize["store_document_text"] = o.StoreDocumentText.Get()
+	}
+	if o.EnableAutoConsolidation.IsSet() {
+		toSerialize["enable_auto_consolidation"] = o.EnableAutoConsolidation.Get()
+	}
+	if o.ConsolidationMaxMemoriesPerRound.IsSet() {
+		toSerialize["consolidation_max_memories_per_round"] = o.ConsolidationMaxMemoriesPerRound.Get()
+	}
+	if o.ConsolidationLlmParallelism.IsSet() {
+		toSerialize["consolidation_llm_parallelism"] = o.ConsolidationLlmParallelism.Get()
+	}
+	if o.RecallIncludeChunks.IsSet() {
+		toSerialize["recall_include_chunks"] = o.RecallIncludeChunks.Get()
+	}
+	if o.RecallMaxTokens.IsSet() {
+		toSerialize["recall_max_tokens"] = o.RecallMaxTokens.Get()
+	}
+	if o.RecallChunksMaxTokens.IsSet() {
+		toSerialize["recall_chunks_max_tokens"] = o.RecallChunksMaxTokens.Get()
+	}
+	if o.MemoryDefense != nil {
+		toSerialize["memory_defense"] = o.MemoryDefense
 	}
 	return toSerialize, nil
 }

--- a/hindsight-clients/python/hindsight_client_api/models/bank_template_config.py
+++ b/hindsight-clients/python/hindsight_client_api/models/bank_template_config.py
@@ -66,7 +66,14 @@ class BankTemplateConfig(BaseModel):
     recall_budget_max: Optional[StrictInt] = None
     audit_log_enabled: Optional[StrictBool] = None
     store_document_text: Optional[StrictBool] = None
-    __properties: ClassVar[List[str]] = ["reflect_mission", "retain_mission", "retain_extraction_mode", "retain_custom_instructions", "retain_chunk_size", "retain_structured_chunk_size", "enable_observations", "observations_mission", "enable_temporal_retrieval", "enable_graph_retrieval", "enable_reranking", "disposition_skepticism", "disposition_literalism", "disposition_empathy", "entity_labels", "entities_allow_free_form", "retain_default_strategy", "retain_strategies", "retain_chunk_batch_size", "mcp_enabled_tools", "consolidation_llm_batch_size", "consolidation_source_facts_max_tokens", "consolidation_source_facts_max_tokens_per_observation", "max_observations_per_scope", "observation_scope_limits", "reflect_source_facts_max_tokens", "llm_gemini_safety_settings", "recall_budget_function", "recall_budget_fixed_low", "recall_budget_fixed_mid", "recall_budget_fixed_high", "recall_budget_adaptive_low", "recall_budget_adaptive_mid", "recall_budget_adaptive_high", "recall_budget_min", "recall_budget_max", "audit_log_enabled", "store_document_text"]
+    enable_auto_consolidation: Optional[StrictBool] = None
+    consolidation_max_memories_per_round: Optional[StrictInt] = None
+    consolidation_llm_parallelism: Optional[StrictInt] = None
+    recall_include_chunks: Optional[StrictBool] = None
+    recall_max_tokens: Optional[StrictInt] = None
+    recall_chunks_max_tokens: Optional[StrictInt] = None
+    memory_defense: Optional[Dict[str, Any]] = None
+    __properties: ClassVar[List[str]] = ["reflect_mission", "retain_mission", "retain_extraction_mode", "retain_custom_instructions", "retain_chunk_size", "retain_structured_chunk_size", "enable_observations", "observations_mission", "enable_temporal_retrieval", "enable_graph_retrieval", "enable_reranking", "disposition_skepticism", "disposition_literalism", "disposition_empathy", "entity_labels", "entities_allow_free_form", "retain_default_strategy", "retain_strategies", "retain_chunk_batch_size", "mcp_enabled_tools", "consolidation_llm_batch_size", "consolidation_source_facts_max_tokens", "consolidation_source_facts_max_tokens_per_observation", "max_observations_per_scope", "observation_scope_limits", "reflect_source_facts_max_tokens", "llm_gemini_safety_settings", "recall_budget_function", "recall_budget_fixed_low", "recall_budget_fixed_mid", "recall_budget_fixed_high", "recall_budget_adaptive_low", "recall_budget_adaptive_mid", "recall_budget_adaptive_high", "recall_budget_min", "recall_budget_max", "audit_log_enabled", "store_document_text", "enable_auto_consolidation", "consolidation_max_memories_per_round", "consolidation_llm_parallelism", "recall_include_chunks", "recall_max_tokens", "recall_chunks_max_tokens", "memory_defense"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -304,6 +311,41 @@ class BankTemplateConfig(BaseModel):
         if self.store_document_text is None and "store_document_text" in self.model_fields_set:
             _dict['store_document_text'] = None
 
+        # set to None if enable_auto_consolidation (nullable) is None
+        # and model_fields_set contains the field
+        if self.enable_auto_consolidation is None and "enable_auto_consolidation" in self.model_fields_set:
+            _dict['enable_auto_consolidation'] = None
+
+        # set to None if consolidation_max_memories_per_round (nullable) is None
+        # and model_fields_set contains the field
+        if self.consolidation_max_memories_per_round is None and "consolidation_max_memories_per_round" in self.model_fields_set:
+            _dict['consolidation_max_memories_per_round'] = None
+
+        # set to None if consolidation_llm_parallelism (nullable) is None
+        # and model_fields_set contains the field
+        if self.consolidation_llm_parallelism is None and "consolidation_llm_parallelism" in self.model_fields_set:
+            _dict['consolidation_llm_parallelism'] = None
+
+        # set to None if recall_include_chunks (nullable) is None
+        # and model_fields_set contains the field
+        if self.recall_include_chunks is None and "recall_include_chunks" in self.model_fields_set:
+            _dict['recall_include_chunks'] = None
+
+        # set to None if recall_max_tokens (nullable) is None
+        # and model_fields_set contains the field
+        if self.recall_max_tokens is None and "recall_max_tokens" in self.model_fields_set:
+            _dict['recall_max_tokens'] = None
+
+        # set to None if recall_chunks_max_tokens (nullable) is None
+        # and model_fields_set contains the field
+        if self.recall_chunks_max_tokens is None and "recall_chunks_max_tokens" in self.model_fields_set:
+            _dict['recall_chunks_max_tokens'] = None
+
+        # set to None if memory_defense (nullable) is None
+        # and model_fields_set contains the field
+        if self.memory_defense is None and "memory_defense" in self.model_fields_set:
+            _dict['memory_defense'] = None
+
         return _dict
 
     @classmethod
@@ -353,7 +395,14 @@ class BankTemplateConfig(BaseModel):
             "recall_budget_min": obj.get("recall_budget_min"),
             "recall_budget_max": obj.get("recall_budget_max"),
             "audit_log_enabled": obj.get("audit_log_enabled"),
-            "store_document_text": obj.get("store_document_text")
+            "store_document_text": obj.get("store_document_text"),
+            "enable_auto_consolidation": obj.get("enable_auto_consolidation"),
+            "consolidation_max_memories_per_round": obj.get("consolidation_max_memories_per_round"),
+            "consolidation_llm_parallelism": obj.get("consolidation_llm_parallelism"),
+            "recall_include_chunks": obj.get("recall_include_chunks"),
+            "recall_max_tokens": obj.get("recall_max_tokens"),
+            "recall_chunks_max_tokens": obj.get("recall_chunks_max_tokens"),
+            "memory_defense": obj.get("memory_defense")
         })
         return _obj
 

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -684,6 +684,50 @@ export type BankTemplateConfig = {
    * Persist raw source text (documents.original_text / chunks.chunk_text). Set false to keep only derived facts.
    */
   store_document_text?: boolean | null;
+  /**
+   * Enable Auto Consolidation
+   *
+   * Automatically consolidate observations after retain
+   */
+  enable_auto_consolidation?: boolean | null;
+  /**
+   * Consolidation Max Memories Per Round
+   *
+   * Max memory units fed into a single consolidation round
+   */
+  consolidation_max_memories_per_round?: number | null;
+  /**
+   * Consolidation Llm Parallelism
+   *
+   * Number of consolidation LLM batches processed concurrently
+   */
+  consolidation_llm_parallelism?: number | null;
+  /**
+   * Recall Include Chunks
+   *
+   * Include raw chunks in recall results
+   */
+  recall_include_chunks?: boolean | null;
+  /**
+   * Recall Max Tokens
+   *
+   * Max tokens of results returned by recall
+   */
+  recall_max_tokens?: number | null;
+  /**
+   * Recall Chunks Max Tokens
+   *
+   * Max tokens of raw chunks returned by recall (when recall_include_chunks is set)
+   */
+  recall_chunks_max_tokens?: number | null;
+  /**
+   * Memory Defense
+   *
+   * Memory Defense policy for this bank (validated against the DefensePolicy schema on write)
+   */
+  memory_defense?: {
+    [key: string]: unknown;
+  } | null;
 };
 
 /**

--- a/hindsight-docs/docs/developer/api/bank-templates.mdx
+++ b/hindsight-docs/docs/developer/api/bank-templates.mdx
@@ -88,7 +88,14 @@ All of `bank`, `mental_models`, and `directives` are optional. Omit any section 
 
 ### Bank Config Fields
 
-All fields in `bank` are optional. Only the fields you include will be set as per-bank overrides — everything else inherits from the server/tenant defaults.
+Every per-bank configuration setting can be carried in a template, so an exported
+bank reproduces its full configuration when imported elsewhere. All fields in
+`bank` are optional — only the fields you include are set as per-bank overrides,
+and everything else inherits from the server/tenant defaults.
+
+The complete, always-current list is the [template JSON
+Schema](/bank-template-schema.json); each field means the same thing it does in
+[Configuration](../configuration.md). The most commonly used ones:
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/hindsight-docs/static/bank-template-schema.json
+++ b/hindsight-docs/static/bank-template-schema.json
@@ -514,6 +514,98 @@
           "default": null,
           "description": "Persist raw source text (documents.original_text / chunks.chunk_text). Set false to keep only derived facts.",
           "title": "Store Document Text"
+        },
+        "enable_auto_consolidation": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Automatically consolidate observations after retain",
+          "title": "Enable Auto Consolidation"
+        },
+        "consolidation_max_memories_per_round": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Max memory units fed into a single consolidation round",
+          "title": "Consolidation Max Memories Per Round"
+        },
+        "consolidation_llm_parallelism": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Number of consolidation LLM batches processed concurrently",
+          "title": "Consolidation Llm Parallelism"
+        },
+        "recall_include_chunks": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Include raw chunks in recall results",
+          "title": "Recall Include Chunks"
+        },
+        "recall_max_tokens": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Max tokens of results returned by recall",
+          "title": "Recall Max Tokens"
+        },
+        "recall_chunks_max_tokens": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Max tokens of raw chunks returned by recall (when recall_include_chunks is set)",
+          "title": "Recall Chunks Max Tokens"
+        },
+        "memory_defense": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Memory Defense policy for this bank (validated against the DefensePolicy schema on write)",
+          "title": "Memory Defense"
         }
       },
       "title": "BankTemplateConfig",

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -7797,6 +7797,91 @@
             ],
             "title": "Store Document Text",
             "description": "Persist raw source text (documents.original_text / chunks.chunk_text). Set false to keep only derived facts."
+          },
+          "enable_auto_consolidation": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Enable Auto Consolidation",
+            "description": "Automatically consolidate observations after retain"
+          },
+          "consolidation_max_memories_per_round": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consolidation Max Memories Per Round",
+            "description": "Max memory units fed into a single consolidation round"
+          },
+          "consolidation_llm_parallelism": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consolidation Llm Parallelism",
+            "description": "Number of consolidation LLM batches processed concurrently"
+          },
+          "recall_include_chunks": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Include Chunks",
+            "description": "Include raw chunks in recall results"
+          },
+          "recall_max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Max Tokens",
+            "description": "Max tokens of results returned by recall"
+          },
+          "recall_chunks_max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Chunks Max Tokens",
+            "description": "Max tokens of raw chunks returned by recall (when recall_include_chunks is set)"
+          },
+          "memory_defense": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Memory Defense",
+            "description": "Memory Defense policy for this bank (validated against the DefensePolicy schema on write)"
           }
         },
         "type": "object",

--- a/skills/hindsight-docs/references/developer/api/bank-templates.md
+++ b/skills/hindsight-docs/references/developer/api/bank-templates.md
@@ -77,7 +77,14 @@ All of `bank`, `mental_models`, and `directives` are optional. Omit any section 
 
 ### Bank Config Fields
 
-All fields in `bank` are optional. Only the fields you include will be set as per-bank overrides — everything else inherits from the server/tenant defaults.
+Every per-bank configuration setting can be carried in a template, so an exported
+bank reproduces its full configuration when imported elsewhere. All fields in
+`bank` are optional — only the fields you include are set as per-bank overrides,
+and everything else inherits from the server/tenant defaults.
+
+The complete, always-current list is the template JSON
+Schema; each field means the same thing it does in
+[Configuration](../configuration.md). The most commonly used ones:
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -7797,6 +7797,91 @@
             ],
             "title": "Store Document Text",
             "description": "Persist raw source text (documents.original_text / chunks.chunk_text). Set false to keep only derived facts."
+          },
+          "enable_auto_consolidation": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Enable Auto Consolidation",
+            "description": "Automatically consolidate observations after retain"
+          },
+          "consolidation_max_memories_per_round": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consolidation Max Memories Per Round",
+            "description": "Max memory units fed into a single consolidation round"
+          },
+          "consolidation_llm_parallelism": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consolidation Llm Parallelism",
+            "description": "Number of consolidation LLM batches processed concurrently"
+          },
+          "recall_include_chunks": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Include Chunks",
+            "description": "Include raw chunks in recall results"
+          },
+          "recall_max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Max Tokens",
+            "description": "Max tokens of results returned by recall"
+          },
+          "recall_chunks_max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Chunks Max Tokens",
+            "description": "Max tokens of raw chunks returned by recall (when recall_include_chunks is set)"
+          },
+          "memory_defense": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Memory Defense",
+            "description": "Memory Defense policy for this bank (validated against the DefensePolicy schema on write)"
           }
         },
         "type": "object",


### PR DESCRIPTION
Follow-up to #3319 and #3324.

## The gap

Seven per-bank configurable fields were never declared on `BankTemplateConfig`, so export/import silently dropped them:

`consolidation_llm_parallelism` · `consolidation_max_memories_per_round` · `enable_auto_consolidation` · `memory_defense` · `recall_chunks_max_tokens` · `recall_include_chunks` · `recall_max_tokens`

Cloning a bank produced a clone that *looked* correctly configured while quietly running on the server defaults for those seven. `memory_defense` being one of them is the sharp edge: a bank's defense policy did not travel with it.

All seven are now part of the template engine, so an exported bank reproduces its full configuration on import. `BankTemplateConfig` goes 38 → 45 fields, matching `_CONFIGURABLE_FIELDS` exactly.

## Failing loudly next time

The rest of the change is about not having to notice this again. Adding a per-bank config field is a multi-step flow, and each step now fails until the previous one is done:

1. Add it to `_CONFIGURABLE_FIELDS` → **`test_every_configurable_field_is_exportable`** fails until it is declared on `BankTemplateConfig`. The guard is bidirectional — a template field that isn't configurable also fails, since the engine would reject it at import with "Unknown configuration fields".
2. Declare it there → **`test_sample_values_cover_every_exportable_field`** fails until it has a value in `_SAMPLE_VALUES`.
3. Give it a value → **`test_every_exportable_field_survives_export_then_import`** exercises it end to end.
4. Touching `BankTemplateConfig` moves the OpenAPI spec, the generated clients, and `bank-template-schema.json` → **`verify-generated-files`** fails until those are regenerated.

(#3319 added a fifth: every configurable field must have a derivable type contract.)

The checklist is written into the test module docstring so it reads as a to-do, not an error. An intentional exclusion is now a decision to record in the guard with a reason — not an omission nobody sees.

## Docs

The bank-templates page listed **15 of 45** fields in a hand-maintained table. It was already stale before this PR and would contradict "every field is supported" the moment it drifted again. It now states the guarantee and points at the generated JSON Schema as the authoritative list, keeping the common fields as examples — so the thing that rots is generated, not typed by hand.

## Verified by mutation

Each of these was applied, confirmed to fail, then reverted:

1. A configurable field with no template field → `configurable but not exportable (add to BankTemplateConfig): ['newly_added_knob']`
2. A template field that isn't configurable → `exportable but not configurable (remove, or add to _CONFIGURABLE_FIELDS): ['stray_template_field']`
3. A template field with no sample value → `missing values for ['stray_template_field']`

## Tests

166 pass across `test_http_api_integration`, `test_bank_template_full_roundtrip`, `test_bank_templates`, `test_bank_template_configurable_fields`, `test_bank_config_value_types`, `test_hierarchical_config`. The round-trip now covers all 45 fields, including `memory_defense` carrying a real `DefensePolicy` rule so the nested list round-trips too. Generated files regenerated and confirmed idempotent; `lint.sh` clean; docs build passes.
