### PR TITLE
fix(control-plane): surface direct request failures

### DIFF
--- a/hindsight-control-plane/src/components/bank-selector.tsx
+++ b/hindsight-control-plane/src/components/bank-selector.tsx
@@ -95,6 +95,7 @@ function BankSelectorInner() {
   const tNavBank = useTranslations("nav.bank");
   const tCommon = useTranslations("common");
   const tAddDocument = useTranslations("addDocument");
+  const tApiError = useTranslations("api.errors.files");
   const { currentBank, setCurrentBank, banks, bankInfos, banksLoading, loadBanks } = useBank();
   const { theme, toggleTheme } = useTheme();
   const { features } = useFeatures();
@@ -401,8 +402,9 @@ function BankSelectorInner() {
 
       // Navigate to documents view
       router.push(bankRoute(currentBank!, "?view=documents"));
-    } catch {
-      // Error toast is shown automatically by the API client interceptor
+    } catch (error) {
+      // Multipart uploads bypass the API client's shared error interceptor.
+      toast.error(error instanceof Error ? error.message : tApiError("upload"));
     } finally {
       setIsCreatingDoc(false);
       setUploadProgress("");

--- a/hindsight-control-plane/src/components/documents-view.tsx
+++ b/hindsight-control-plane/src/components/documents-view.tsx
@@ -719,6 +719,7 @@ export function DocumentsView() {
   const t = useTranslations("documentsView");
   const tCommon = useTranslations("common");
   const tBank = useTranslations("bank");
+  const tApiError = useTranslations("api.errors.documents");
   const { currentBank } = useBank();
   const { features } = useFeatures();
   const [documents, setDocuments] = useState<any[]>([]);
@@ -1223,8 +1224,9 @@ export function DocumentsView() {
       triggerDownload(blob, `${currentBank}${suffix}.zip`);
       toast.success(t("exportSuccess"));
       setExportDialogOpen(false);
-    } catch {
-      // Errors surface via the API client / route; nothing extra to do here.
+    } catch (error) {
+      // Binary transfer requests bypass the API client's shared error interceptor.
+      toast.error(error instanceof Error ? error.message : tApiError("export"));
     } finally {
       setExporting(false);
     }
@@ -1264,8 +1266,9 @@ export function DocumentsView() {
       loadDocuments(currentPage);
       setImportDialogOpen(false);
       setImportFile(null);
-    } catch {
-      // Error toast handled by the API client.
+    } catch (error) {
+      // Multipart transfer requests bypass the API client's shared error interceptor.
+      toast.error(error instanceof Error ? error.message : tApiError("import"));
     } finally {
       setImporting(false);
     }

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -1661,7 +1661,7 @@ export class ControlPlaneClient {
       let errorMessage = `HTTP ${response.status}`;
       try {
         const errorData = await response.json();
-        errorMessage = errorData.error || errorMessage;
+        errorMessage = describeErrorDetails(errorData.error ?? errorData.detail) || errorMessage;
       } catch {
         // Ignore parse errors
       }
@@ -1694,7 +1694,7 @@ export class ControlPlaneClient {
       let errorMessage = `HTTP ${response.status}`;
       try {
         const errorData = await response.json();
-        errorMessage = errorData.error || errorMessage;
+        errorMessage = describeErrorDetails(errorData.error ?? errorData.detail) || errorMessage;
       } catch {
         // Ignore parse errors
       }
@@ -1752,7 +1752,7 @@ export class ControlPlaneClient {
       let errorMessage = `HTTP ${response.status}`;
       try {
         const errorData = await response.json();
-        errorMessage = errorData.error || errorMessage;
+        errorMessage = describeErrorDetails(errorData.error ?? errorData.detail) || errorMessage;
       } catch {
         // Ignore parse errors
       }

--- a/hindsight-control-plane/tests/lib/api.test.ts
+++ b/hindsight-control-plane/tests/lib/api.test.ts
@@ -131,3 +131,80 @@ describe("ControlPlaneClient.deleteOperation", () => {
     );
   });
 });
+
+describe("ControlPlaneClient direct fetch error formatting", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let client: ControlPlaneClient;
+
+  beforeEach(() => {
+    client = new ControlPlaneClient();
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("preserves the transfer API's validation detail for the import view", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ detail: "Invalid transfer archive: manifest.json is missing" }), {
+        status: 400,
+      })
+    );
+
+    const file = new File(["not a transfer archive"], "documents.zip", { type: "application/zip" });
+
+    await expect(client.importDocuments("bank-a", file)).rejects.toMatchObject({
+      message: "Invalid transfer archive: manifest.json is missing",
+      status: 400,
+    });
+  });
+
+  it("prefers an error message over a transfer API detail", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "Transfer imports are disabled", detail: "Ignored detail" }), {
+        status: 404,
+      })
+    );
+
+    const file = new File(["transfer archive"], "documents.zip", { type: "application/zip" });
+
+    await expect(client.importDocuments("bank-a", file)).rejects.toMatchObject({
+      message: "Transfer imports are disabled",
+      status: 404,
+    });
+  });
+
+  it("formats structured validation details from direct upload requests", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ detail: { violations: [{ message: "File type is not supported" }] } }), {
+        status: 422,
+      })
+    );
+
+    const file = new File(["unsupported"], "document.zip", { type: "application/zip" });
+
+    await expect(
+      client.uploadFiles({
+        bank_id: "bank-a",
+        files: [file],
+      })
+    ).rejects.toMatchObject({
+      message: "File type is not supported",
+      status: 422,
+    });
+  });
+
+  it("formats structured validation details from binary download requests", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ detail: { violations: [{ message: "Export is disabled" }] } }), {
+        status: 404,
+      })
+    );
+
+    await expect(client.exportDocuments("bank-a")).rejects.toMatchObject({
+      message: "Export is disabled",
+      status: 404,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- show failures from direct document export, transfer import, and file upload requests
- format structured API validation details before rendering them
- cover direct request error formatting in the control-plane client tests

Related to #3327

## Testing
- npm test
- npm run i18n:check
- ./scripts/hooks/lint.sh