### PR TITLE
fix(search): use PGroonga for Knowledge Pages

### DIFF
--- a/hindsight-api-slim/hindsight_api/_text_search.py
+++ b/hindsight-api-slim/hindsight_api/_text_search.py
@@ -1,0 +1,23 @@
+"""Text-search SQL shapes shared by index DDL and the queries that must hit it.
+
+A PostgreSQL expression index is only selectable when the query repeats the
+indexed expression verbatim, so the DDL (``migrations.py`` and the Alembic
+versions) and the read arms (``engine/sql/postgresql.py``) cannot be allowed to
+drift. Both sides call the helpers here — same idea as
+``_pg_search.pg_search_bm25_columns``.
+"""
+
+
+def mental_models_text_document(alias: str | None = None) -> str:
+    """The ``mental_models`` full-text document: model/page name + content.
+
+    Mirrors the generating expression of the native tsvector column created by
+    the ``n9i0j1k2l3m4`` (learnings / pinned_reflections) migration, so every
+    backend indexes and queries the exact same document. ``content`` is NOT NULL,
+    hence the deliberate lack of a ``COALESCE`` around it.
+
+    ``alias`` qualifies the columns for queries that join the table (``mm``);
+    leave it unset for DDL, where the expression is already table-scoped.
+    """
+    prefix = f"{alias}." if alias else ""
+    return f"(COALESCE({prefix}name, '') || ' ' || {prefix}content)"

--- a/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
@@ -45,10 +45,8 @@ def knowledge_bm25_arm(
     ``table_alias`` is the alias the ``mental_models`` row carries in the query
     (``mm``); ``text_param`` is the bind placeholder holding the query text.
 
-    ``pgroonga`` is intentionally served by the native branch: the
-    ``mental_models`` table is never reconciled to pgroonga structures
-    (``ensure_text_search_extension`` checks the pre-rename ``reflections`` name),
-    so it keeps the migration-time generated tsvector column.
+    PGroonga keeps the migration-time generated tsvector as a rollback projection,
+    but queries the multilingual expression index over ``name + content``.
     """
     a = table_alias
     p = text_param
@@ -93,7 +91,18 @@ def knowledge_bm25_arm(
             match_filter="",
         )
 
-    # native (and pgroonga — see docstring): generated tsvector over name + content.
+    if text_search_extension == "pgroonga":
+        score = f"pgroonga_score({a}.tableoid, {a}.ctid)"
+        # Repeat idx_mental_models_text_search's expression exactly so PostgreSQL
+        # can select the PGroonga expression index.
+        document = f"(COALESCE({a}.name, '') || ' ' || {a}.content)"
+        return KnowledgeBm25Arm(
+            score_expr=score,
+            order_by=f"{score} DESC",
+            match_filter=f"AND {document} &@~ pgroonga_query_escape({p})",
+        )
+
+    # native: generated tsvector over name + content.
     # The generating expression hard-codes the 'english' config (see the
     # learnings/pinned_reflections migration), so query with 'english' regardless
     # of the configured native language.

--- a/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
@@ -7,6 +7,7 @@ and other non-portable patterns.
 
 from dataclasses import dataclass
 
+from ..._text_search import mental_models_text_document
 from .base import SQLDialect
 
 
@@ -45,8 +46,9 @@ def knowledge_bm25_arm(
     ``table_alias`` is the alias the ``mental_models`` row carries in the query
     (``mm``); ``text_param`` is the bind placeholder holding the query text.
 
-    PGroonga keeps the migration-time generated tsvector as a rollback projection,
-    but queries the multilingual expression index over ``name + content``.
+    ``pgroonga`` queries the multilingual expression index over ``name +
+    content``; ``ensure_text_search_extension`` reconciles ``mental_models`` to
+    that shape (dummy TEXT ``search_vector``) like every other pgroonga table.
     """
     a = table_alias
     p = text_param
@@ -92,13 +94,18 @@ def knowledge_bm25_arm(
         )
 
     if text_search_extension == "pgroonga":
+        # Same operator/score pair as build_bm25_arm's pgroonga form. The filter
+        # repeats idx_mental_models_text_search's indexed expression verbatim (via
+        # the shared helper) so the planner can select that expression index —
+        # pgroonga_score() only returns a real score off a pgroonga index scan and
+        # silently reads 0 for every row otherwise, so the id tiebreak keeps the
+        # arm's ordering deterministic if the planner ever picks another plan.
+        # pgroonga_query_escape neutralises operator characters in user text.
         score = f"pgroonga_score({a}.tableoid, {a}.ctid)"
-        # Repeat idx_mental_models_text_search's expression exactly so PostgreSQL
-        # can select the PGroonga expression index.
-        document = f"(COALESCE({a}.name, '') || ' ' || {a}.content)"
+        document = mental_models_text_document(a)
         return KnowledgeBm25Arm(
             score_expr=score,
-            order_by=f"{score} DESC",
+            order_by=f"{score} DESC, {a}.id",
             match_filter=f"AND {document} &@~ pgroonga_query_escape({p})",
         )
 

--- a/hindsight-api-slim/hindsight_api/migrations.py
+++ b/hindsight-api-slim/hindsight_api/migrations.py
@@ -29,6 +29,7 @@ from sqlalchemy import Connection, create_engine, text
 from sqlalchemy.pool import NullPool
 
 from ._pg_search import normalize_pg_search_tokenizer, pg_search_bm25_columns
+from ._text_search import mental_models_text_document
 from ._vector_index import (
     bootstrap_extension,
     configured_vector_extension,
@@ -783,6 +784,34 @@ def ensure_vector_extension(
         logger.info(f"Successfully reconciled vector indexes for {target_ext}")
 
 
+def _reconcile_needs_no_backfill(
+    text_search_extension: str,
+    table_name: str,
+    current_column_type: str | None,
+    current_index_type: str | None,
+) -> bool:
+    """Is this mismatch safe to reconcile even though the table holds rows?
+
+    Only one transition qualifies: ``mental_models`` sitting on the migration-time
+    native tsvector projection while pgroonga is configured. pgroonga indexes
+    ``name + content`` directly, so the replacement ``search_vector`` is a dummy
+    column with nothing to backfill — dropping the derived tsvector loses no data
+    the reconciler would have to recompute.
+
+    This state exists on every pgroonga deployment because the reconciler used to
+    check the pre-rename ``reflections`` table name and therefore never converted
+    mental models (issue #3307). Every other transition (anything writing
+    ``memory_units``, or a target column that stores a per-row tsvector/bm25vector)
+    needs values only the write path can produce, so it stays fail-closed.
+    """
+    return (
+        text_search_extension == "pgroonga"
+        and table_name == "mental_models"
+        and current_column_type == "tsvector"
+        and current_index_type in {None, "gin"}
+    )
+
+
 def ensure_text_search_extension(
     database_url: str,
     text_search_extension: str = "native",
@@ -797,7 +826,8 @@ def ensure_text_search_extension(
     - If they match configured extension: no action needed
     - If they differ and tables are empty: drop old column/index, recreate with new type
     - If they differ and tables have data: raise error with migration guidance,
-      except for the derived-only mental-model native-to-PGroonga transition
+      except for the mental-model native-to-pgroonga transition, which needs no
+      backfill (pgroonga indexes the base columns) and so is safe while populated
 
     Args:
         database_url: SQLAlchemy database URL
@@ -827,9 +857,9 @@ def ensure_text_search_extension(
             target_column_type = "text"
             target_index_type = "bm25"
         elif text_search_extension == "pgroonga":
-            # PGroonga indexes the base text document directly. memory_units uses
-            # a dummy TEXT search_vector; a legacy mental_models tsvector is also
-            # accepted so it can remain as a rollback-compatible native projection.
+            # pgroonga indexes the base text columns directly. We keep a dummy
+            # TEXT column named search_vector for symmetry with pg_textsearch
+            # and so the column-type mismatch detection above keeps working.
             target_column_type = "text"
             target_index_type = "pgroonga"
         elif text_search_extension == "pg_search":
@@ -910,12 +940,7 @@ def ensure_text_search_extension(
             want_pg_search = text_search_extension == "pg_search"
 
             # Check if column and index types match target
-            preserves_native_mental_models = (
-                text_search_extension == "pgroonga"
-                and table_name == "mental_models"
-                and current_column_type == "tsvector"
-            )
-            column_matches = current_column_type == target_column_type or preserves_native_mental_models
+            column_matches = current_column_type == target_column_type
             index_matches = current_index_type == target_index_type if current_index_type else False
             # When both target and current sit at column=text/index=bm25, the
             # access-method check alone can't tell pg_textsearch from pg_search —
@@ -935,8 +960,12 @@ def ensure_text_search_extension(
                 # Check if table has data
                 row_count = conn.execute(text(f"SELECT COUNT(*) FROM {schema_name}.{table_name}")).scalar()
 
-                safe_populated_reconcile = preserves_native_mental_models and current_index_type in {None, "gin"}
-                if row_count > 0 and not safe_populated_reconcile:
+                if row_count > 0 and not _reconcile_needs_no_backfill(
+                    text_search_extension,
+                    table_name,
+                    current_column_type,
+                    current_index_type,
+                ):
                     tables_with_data.append((table_name, row_count))
             else:
                 logger.debug(f"Text search OK for {table_name}: {current_column_type}/{current_index_type}")
@@ -974,41 +1003,27 @@ def ensure_text_search_extension(
                 f"  2. Use the current text search extension (set HINDSIGHT_API_TEXT_SEARCH_EXTENSION='{current_ext}')"
             )
 
-        # Tables are empty, except for the safe derived-only mental-model
-        # native-to-PGroonga transition admitted above.
+        # Tables are empty, except for the backfill-free mental-model
+        # native-to-pgroonga transition admitted above.
+        #
+        # Every statement below is written to be safely re-executable: replicas
+        # boot concurrently during a rolling restart and each runs this
+        # reconciliation, so a plain CREATE/ADD would crash whichever replica
+        # loses the race to the first one's committed DDL.
         logger.info(f"Recreating text search columns/indexes for {text_search_extension}")
 
         for table_name, current_col_type, current_idx_type, _was_pg_search in mismatched_tables:
-            preserve_native_projection = (
-                text_search_extension == "pgroonga"
-                and table_name == "mental_models"
-                and current_col_type == "tsvector"
-                and current_idx_type in {None, "gin"}
-            )
-
             # Drop existing index if it exists
             if current_idx_type:
-                if preserve_native_projection:
-                    # Keep the native GIN index under a non-canonical name. New
-                    # code uses PGroonga while old rolling instances and rollback
-                    # builds can still run their tsvector query without a table scan.
-                    logger.info(f"Preserving native rollback index on {table_name}")
-                    conn.execute(
-                        text(f"""
-                            ALTER INDEX {schema_name}.idx_{table_name.replace(".", "_")}_text_search
-                            RENAME TO idx_{table_name.replace(".", "_")}_text_search_native
-                        """)
-                    )
-                else:
-                    logger.info(f"Dropping {current_idx_type} index on {table_name}")
-                    conn.execute(
-                        text(f"""
-                            DROP INDEX IF EXISTS {schema_name}.idx_{table_name.replace(".", "_")}_text_search
-                        """)
-                    )
+                logger.info(f"Dropping {current_idx_type} index on {table_name}")
+                conn.execute(
+                    text(f"""
+                        DROP INDEX IF EXISTS {schema_name}.idx_{table_name.replace(".", "_")}_text_search
+                    """)
+                )
 
             # Drop existing column if it exists
-            if current_col_type and not preserve_native_projection:
+            if current_col_type:
                 logger.info(f"Dropping {current_col_type} column on {table_name}")
                 conn.execute(text(f"ALTER TABLE {schema_name}.{table_name} DROP COLUMN IF EXISTS search_vector"))
 
@@ -1017,14 +1032,17 @@ def ensure_text_search_extension(
                 logger.info(f"Creating bm25vector column on {table_name}")
                 # Note: vchord_bm25 extension creates types in bm25_catalog schema
                 conn.execute(
-                    text(f"ALTER TABLE {schema_name}.{table_name} ADD COLUMN search_vector bm25_catalog.bm25vector")
+                    text(
+                        f"ALTER TABLE {schema_name}.{table_name} "
+                        f"ADD COLUMN IF NOT EXISTS search_vector bm25_catalog.bm25vector"
+                    )
                 )
 
                 # Create BM25 index
                 logger.info(f"Creating BM25 index on {table_name}")
                 conn.execute(
                     text(f"""
-                        CREATE INDEX idx_{table_name.replace(".", "_")}_text_search
+                        CREATE INDEX IF NOT EXISTS idx_{table_name.replace(".", "_")}_text_search
                         ON {schema_name}.{table_name}
                         USING bm25 (search_vector bm25_catalog.bm25_ops)
                     """)
@@ -1032,19 +1050,21 @@ def ensure_text_search_extension(
             elif text_search_extension == "pg_textsearch":
                 logger.info(f"Creating TEXT column on {table_name}")
                 # Dummy TEXT column for consistency (indexes operate on base columns)
-                conn.execute(text(f"ALTER TABLE {schema_name}.{table_name} ADD COLUMN search_vector TEXT"))
+                conn.execute(
+                    text(f"ALTER TABLE {schema_name}.{table_name} ADD COLUMN IF NOT EXISTS search_vector TEXT")
+                )
 
                 # Create BM25 index on expression
                 logger.info(f"Creating BM25 index on {table_name}")
                 # Different expression for each table
                 if table_name == "memory_units":
                     index_expr = "(COALESCE(text, '') || ' ' || COALESCE(context, ''))"
-                else:  # reflections
-                    index_expr = "(COALESCE(name, '') || ' ' || content)"
+                else:  # mental_models
+                    index_expr = mental_models_text_document()
 
                 conn.execute(
                     text(f"""
-                        CREATE INDEX idx_{table_name.replace(".", "_")}_text_search
+                        CREATE INDEX IF NOT EXISTS idx_{table_name.replace(".", "_")}_text_search
                         ON {schema_name}.{table_name}
                         USING bm25({index_expr})
                         WITH (text_config='english')
@@ -1060,21 +1080,21 @@ def ensure_text_search_extension(
                     if not has_ext:
                         raise
 
-                if preserve_native_projection:
-                    logger.info(f"Keeping native tsvector rollback projection on {table_name}")
-                else:
-                    logger.info(f"Creating dummy TEXT search_vector on {table_name} for pgroonga")
-                    # PGroonga indexes the base text column directly, but other
-                    # table shapes keep a dummy column for schema symmetry.
-                    conn.execute(text(f"ALTER TABLE {schema_name}.{table_name} ADD COLUMN search_vector TEXT"))
+                logger.info(f"Creating dummy TEXT search_vector on {table_name} for pgroonga")
+                # pgroonga indexes the base text columns directly, but we keep a
+                # dummy search_vector column for symmetry with pg_textsearch and
+                # so the column-type mismatch detection above keeps working.
+                conn.execute(
+                    text(f"ALTER TABLE {schema_name}.{table_name} ADD COLUMN IF NOT EXISTS search_vector TEXT")
+                )
 
                 # pgroonga index expression mirrors pg_textsearch
                 if table_name == "memory_units":
                     index_expr = (
                         "(COALESCE(text, '') || ' ' || COALESCE(context, '') || ' ' || COALESCE(text_signals, ''))"
                     )
-                else:  # mental_models
-                    index_expr = "(COALESCE(name, '') || ' ' || content)"
+                else:  # mental_models — knowledge_bm25_arm repeats this verbatim
+                    index_expr = mental_models_text_document()
 
                 logger.info(f"Creating pgroonga index on {table_name}")
                 # TokenBigram is the polyglot default — falls back to whitespace
@@ -1083,7 +1103,7 @@ def ensure_text_search_extension(
                 # case folding, etc.) which materially improves Japanese recall.
                 conn.execute(
                     text(f"""
-                        CREATE INDEX idx_{table_name.replace(".", "_")}_text_search
+                        CREATE INDEX IF NOT EXISTS idx_{table_name.replace(".", "_")}_text_search
                         ON {schema_name}.{table_name}
                         USING pgroonga ({index_expr})
                         WITH (tokenizer='TokenBigram', normalizer='NormalizerNFKC150')
@@ -1092,7 +1112,9 @@ def ensure_text_search_extension(
             elif text_search_extension == "pg_search":
                 logger.info(f"Creating TEXT column on {table_name}")
                 # Dummy TEXT column for schema symmetry; pg_search indexes operate on base columns.
-                conn.execute(text(f"ALTER TABLE {schema_name}.{table_name} ADD COLUMN search_vector TEXT"))
+                conn.execute(
+                    text(f"ALTER TABLE {schema_name}.{table_name} ADD COLUMN IF NOT EXISTS search_vector TEXT")
+                )
 
                 # ParadeDB BM25 index over the table's primary key and text columns.
                 # Column list mirrors what the initial / text_signals migrations create.
@@ -1102,7 +1124,7 @@ def ensure_text_search_extension(
                         ("text", "context", "text_signals"),
                         pg_search_tokenizer,
                     )
-                else:  # reflections
+                else:  # mental_models
                     bm25_cols = pg_search_bm25_columns(
                         "id",
                         ("name", "content"),
@@ -1112,7 +1134,7 @@ def ensure_text_search_extension(
                 logger.info(f"Creating ParadeDB BM25 index on {table_name}")
                 conn.execute(
                     text(f"""
-                        CREATE INDEX idx_{table_name.replace(".", "_")}_text_search
+                        CREATE INDEX IF NOT EXISTS idx_{table_name.replace(".", "_")}_text_search
                         ON {schema_name}.{table_name}
                         USING bm25 ({bm25_cols})
                         WITH (key_field='id')
@@ -1121,27 +1143,34 @@ def ensure_text_search_extension(
             else:  # native
                 logger.info(f"Creating tsvector column on {table_name}")
                 if table_name == "mental_models":
-                    # Mental-model write paths rely on the native projection being
-                    # generated from the canonical name + content document.
+                    # No write path populates mental_models.search_vector for
+                    # native (pg_search_vector_expr passes native_inline=False),
+                    # so it must be GENERATED exactly like the learnings /
+                    # pinned_reflections migration creates it — a plain column
+                    # here would stay NULL and silently empty knowledge search.
+                    # The 'english' config is hard-coded there and in
+                    # knowledge_bm25_arm's native branch; keep all three in step.
                     conn.execute(
                         text(f"""
                             ALTER TABLE {schema_name}.{table_name}
-                            ADD COLUMN search_vector tsvector
+                            ADD COLUMN IF NOT EXISTS search_vector tsvector
                             GENERATED ALWAYS AS (
-                                to_tsvector('english', COALESCE(name, '') || ' ' || COALESCE(content, ''))
+                                to_tsvector('english', {mental_models_text_document()})
                             ) STORED
                         """)
                     )
                 else:
                     # memory_units writes populate this plain column with the
                     # configured native language in ops_postgresql.
-                    conn.execute(text(f"ALTER TABLE {schema_name}.{table_name} ADD COLUMN search_vector tsvector"))
+                    conn.execute(
+                        text(f"ALTER TABLE {schema_name}.{table_name} ADD COLUMN IF NOT EXISTS search_vector tsvector")
+                    )
 
                 # Create GIN index
                 logger.info(f"Creating GIN index on {table_name}")
                 conn.execute(
                     text(f"""
-                        CREATE INDEX idx_{table_name.replace(".", "_")}_text_search
+                        CREATE INDEX IF NOT EXISTS idx_{table_name.replace(".", "_")}_text_search
                         ON {schema_name}.{table_name}
                         USING gin(search_vector)
                     """)

--- a/hindsight-api-slim/hindsight_api/migrations.py
+++ b/hindsight-api-slim/hindsight_api/migrations.py
@@ -796,7 +796,8 @@ def ensure_text_search_extension(
     in the database and adjusts them if necessary:
     - If they match configured extension: no action needed
     - If they differ and tables are empty: drop old column/index, recreate with new type
-    - If they differ and tables have data: raise error with migration guidance
+    - If they differ and tables have data: raise error with migration guidance,
+      except for the derived-only mental-model native-to-PGroonga transition
 
     Args:
         database_url: SQLAlchemy database URL
@@ -816,10 +817,7 @@ def ensure_text_search_extension(
     engine = create_engine(to_libpq_url(database_url), poolclass=NullPool)
     with engine.connect() as conn:
         # Tables with search_vector columns to check
-        tables_to_check = [
-            "memory_units",
-            "reflections",  # Renamed from pinned_reflections in p1k2l3m4n5o6 migration
-        ]
+        tables_to_check = ["memory_units", "mental_models"]
 
         # Determine target column type and index type
         if text_search_extension == "vchord":
@@ -829,9 +827,9 @@ def ensure_text_search_extension(
             target_column_type = "text"
             target_index_type = "bm25"
         elif text_search_extension == "pgroonga":
-            # pgroonga indexes the base text column directly. We keep a dummy
-            # TEXT column named search_vector for symmetry with pg_textsearch
-            # and so the column-type mismatch detection above keeps working.
+            # PGroonga indexes the base text document directly. memory_units uses
+            # a dummy TEXT search_vector; a legacy mental_models tsvector is also
+            # accepted so it can remain as a rollback-compatible native projection.
             target_column_type = "text"
             target_index_type = "pgroonga"
         elif text_search_extension == "pg_search":
@@ -889,13 +887,19 @@ def ensure_text_search_extension(
                 text("""
                     SELECT am.amname, pi.indexdef
                     FROM pg_indexes pi
-                    JOIN pg_class c ON c.relname = pi.indexname
+                    JOIN pg_class c
+                      ON c.relname = pi.indexname
+                     AND c.relnamespace = to_regnamespace(pi.schemaname)
                     JOIN pg_am am ON am.oid = c.relam
                     WHERE pi.schemaname = :schema
                       AND pi.tablename = :table_name
-                      AND pi.indexname LIKE '%text_search%'
+                      AND pi.indexname = :index_name
                 """),
-                {"schema": schema_name, "table_name": table_name},
+                {
+                    "schema": schema_name,
+                    "table_name": table_name,
+                    "index_name": f"idx_{table_name.replace('.', '_')}_text_search",
+                },
             ).fetchone()
 
             current_index_type = current_index_info[0] if current_index_info else None
@@ -906,7 +910,12 @@ def ensure_text_search_extension(
             want_pg_search = text_search_extension == "pg_search"
 
             # Check if column and index types match target
-            column_matches = current_column_type == target_column_type
+            preserves_native_mental_models = (
+                text_search_extension == "pgroonga"
+                and table_name == "mental_models"
+                and current_column_type == "tsvector"
+            )
+            column_matches = current_column_type == target_column_type or preserves_native_mental_models
             index_matches = current_index_type == target_index_type if current_index_type else False
             # When both target and current sit at column=text/index=bm25, the
             # access-method check alone can't tell pg_textsearch from pg_search —
@@ -926,7 +935,8 @@ def ensure_text_search_extension(
                 # Check if table has data
                 row_count = conn.execute(text(f"SELECT COUNT(*) FROM {schema_name}.{table_name}")).scalar()
 
-                if row_count > 0:
+                safe_populated_reconcile = preserves_native_mental_models and current_index_type in {None, "gin"}
+                if row_count > 0 and not safe_populated_reconcile:
                     tables_with_data.append((table_name, row_count))
             else:
                 logger.debug(f"Text search OK for {table_name}: {current_column_type}/{current_index_type}")
@@ -960,25 +970,45 @@ def ensure_text_search_extension(
                 f"the following tables contain data: {table_list}. "
                 f"To change text search extension, you must either:\n"
                 f"  1. Clear all data: DELETE FROM {schema_name}.memory_units; "
-                f"DELETE FROM {schema_name}.reflections; then restart\n"
+                f"DELETE FROM {schema_name}.mental_models; then restart\n"
                 f"  2. Use the current text search extension (set HINDSIGHT_API_TEXT_SEARCH_EXTENSION='{current_ext}')"
             )
 
-        # Tables are empty, safe to recreate columns/indexes
+        # Tables are empty, except for the safe derived-only mental-model
+        # native-to-PGroonga transition admitted above.
         logger.info(f"Recreating text search columns/indexes for {text_search_extension}")
 
         for table_name, current_col_type, current_idx_type, _was_pg_search in mismatched_tables:
+            preserve_native_projection = (
+                text_search_extension == "pgroonga"
+                and table_name == "mental_models"
+                and current_col_type == "tsvector"
+                and current_idx_type in {None, "gin"}
+            )
+
             # Drop existing index if it exists
             if current_idx_type:
-                logger.info(f"Dropping {current_idx_type} index on {table_name}")
-                conn.execute(
-                    text(f"""
-                        DROP INDEX IF EXISTS {schema_name}.idx_{table_name.replace(".", "_")}_text_search
-                    """)
-                )
+                if preserve_native_projection:
+                    # Keep the native GIN index under a non-canonical name. New
+                    # code uses PGroonga while old rolling instances and rollback
+                    # builds can still run their tsvector query without a table scan.
+                    logger.info(f"Preserving native rollback index on {table_name}")
+                    conn.execute(
+                        text(f"""
+                            ALTER INDEX {schema_name}.idx_{table_name.replace(".", "_")}_text_search
+                            RENAME TO idx_{table_name.replace(".", "_")}_text_search_native
+                        """)
+                    )
+                else:
+                    logger.info(f"Dropping {current_idx_type} index on {table_name}")
+                    conn.execute(
+                        text(f"""
+                            DROP INDEX IF EXISTS {schema_name}.idx_{table_name.replace(".", "_")}_text_search
+                        """)
+                    )
 
             # Drop existing column if it exists
-            if current_col_type:
+            if current_col_type and not preserve_native_projection:
                 logger.info(f"Dropping {current_col_type} column on {table_name}")
                 conn.execute(text(f"ALTER TABLE {schema_name}.{table_name} DROP COLUMN IF EXISTS search_vector"))
 
@@ -1030,18 +1060,20 @@ def ensure_text_search_extension(
                     if not has_ext:
                         raise
 
-                logger.info(f"Creating dummy TEXT search_vector on {table_name} for pgroonga")
-                # pgroonga indexes the base text column directly, but we keep a
-                # dummy search_vector column for symmetry with pg_textsearch and
-                # so the column-type mismatch detection above keeps working.
-                conn.execute(text(f"ALTER TABLE {schema_name}.{table_name} ADD COLUMN search_vector TEXT"))
+                if preserve_native_projection:
+                    logger.info(f"Keeping native tsvector rollback projection on {table_name}")
+                else:
+                    logger.info(f"Creating dummy TEXT search_vector on {table_name} for pgroonga")
+                    # PGroonga indexes the base text column directly, but other
+                    # table shapes keep a dummy column for schema symmetry.
+                    conn.execute(text(f"ALTER TABLE {schema_name}.{table_name} ADD COLUMN search_vector TEXT"))
 
                 # pgroonga index expression mirrors pg_textsearch
                 if table_name == "memory_units":
                     index_expr = (
                         "(COALESCE(text, '') || ' ' || COALESCE(context, '') || ' ' || COALESCE(text_signals, ''))"
                     )
-                else:  # reflections
+                else:  # mental_models
                     index_expr = "(COALESCE(name, '') || ' ' || content)"
 
                 logger.info(f"Creating pgroonga index on {table_name}")
@@ -1088,11 +1120,22 @@ def ensure_text_search_extension(
                 )
             else:  # native
                 logger.info(f"Creating tsvector column on {table_name}")
-                # Plain tsvector column. The application populates search_vector
-                # at INSERT time via to_tsvector($lang, ...) using the configured
-                # HINDSIGHT_API_TEXT_SEARCH_EXTENSION_NATIVE_LANGUAGE — see
-                # ops_postgresql.insert_facts_batch.
-                conn.execute(text(f"ALTER TABLE {schema_name}.{table_name} ADD COLUMN search_vector tsvector"))
+                if table_name == "mental_models":
+                    # Mental-model write paths rely on the native projection being
+                    # generated from the canonical name + content document.
+                    conn.execute(
+                        text(f"""
+                            ALTER TABLE {schema_name}.{table_name}
+                            ADD COLUMN search_vector tsvector
+                            GENERATED ALWAYS AS (
+                                to_tsvector('english', COALESCE(name, '') || ' ' || COALESCE(content, ''))
+                            ) STORED
+                        """)
+                    )
+                else:
+                    # memory_units writes populate this plain column with the
+                    # configured native language in ops_postgresql.
+                    conn.execute(text(f"ALTER TABLE {schema_name}.{table_name} ADD COLUMN search_vector tsvector"))
 
                 # Create GIN index
                 logger.info(f"Creating GIN index on {table_name}")

--- a/hindsight-api-slim/tests/test_knowledge_bm25_dispatch.py
+++ b/hindsight-api-slim/tests/test_knowledge_bm25_dispatch.py
@@ -31,10 +31,12 @@ def test_native_uses_tsvector_operators():
     assert arm.match_filter == "AND mm.search_vector @@ websearch_to_tsquery('english', $3)"
 
 
-def test_pgroonga_is_served_by_the_native_branch():
-    # mental_models is never reconciled to pgroonga structures, so it keeps the
-    # generated tsvector column and must use the native operators.
-    assert knowledge_bm25_arm("pgroonga", table_alias="mm", text_param="$3") == _arm("native")
+def test_pgroonga_uses_multilingual_expression_index():
+    arm = _arm("pgroonga")
+    assert arm.score_expr == "pgroonga_score(mm.tableoid, mm.ctid)"
+    assert arm.order_by == "pgroonga_score(mm.tableoid, mm.ctid) DESC"
+    assert arm.match_filter == ("AND (COALESCE(mm.name, '') || ' ' || mm.content) &@~ pgroonga_query_escape($3)")
+    assert "ts_rank_cd" not in arm.score_expr
 
 
 def test_pg_search_uses_paradedb_over_base_columns():

--- a/hindsight-api-slim/tests/test_knowledge_bm25_dispatch.py
+++ b/hindsight-api-slim/tests/test_knowledge_bm25_dispatch.py
@@ -11,6 +11,7 @@ assert on the generated SQL, the way ``test_multilingual_bm25`` does.
 
 from types import SimpleNamespace
 
+from hindsight_api._text_search import mental_models_text_document
 from hindsight_api.engine.db.ops_postgresql import pg_search_vector_expr
 from hindsight_api.engine.sql.postgresql import KnowledgeBm25Arm, knowledge_bm25_arm
 
@@ -34,9 +35,17 @@ def test_native_uses_tsvector_operators():
 def test_pgroonga_uses_multilingual_expression_index():
     arm = _arm("pgroonga")
     assert arm.score_expr == "pgroonga_score(mm.tableoid, mm.ctid)"
-    assert arm.order_by == "pgroonga_score(mm.tableoid, mm.ctid) DESC"
-    assert arm.match_filter == ("AND (COALESCE(mm.name, '') || ' ' || mm.content) &@~ pgroonga_query_escape($3)")
-    assert "ts_rank_cd" not in arm.score_expr
+    assert arm.match_filter == "AND (COALESCE(mm.name, '') || ' ' || mm.content) &@~ pgroonga_query_escape($3)"
+    # pgroonga_score() reads 0 off any plan that did not use the pgroonga index,
+    # so the ordering carries a tiebreak instead of collapsing to input order.
+    assert arm.order_by == "pgroonga_score(mm.tableoid, mm.ctid) DESC, mm.id"
+
+
+def test_pgroonga_filter_repeats_the_indexed_expression_verbatim():
+    """The expression index is only selectable when the query repeats its
+    expression exactly — so both sides must come from the shared helper."""
+    assert mental_models_text_document("mm") in _arm("pgroonga").match_filter
+    assert mental_models_text_document() == "(COALESCE(name, '') || ' ' || content)"
 
 
 def test_pg_search_uses_paradedb_over_base_columns():

--- a/hindsight-api-slim/tests/test_text_search_reconciliation.py
+++ b/hindsight-api-slim/tests/test_text_search_reconciliation.py
@@ -1,11 +1,25 @@
-"""Regression coverage for runtime text-search reconciliation."""
+"""Regression coverage for runtime text-search reconciliation.
 
+``ensure_text_search_extension`` issues DDL against a live database at startup,
+so these tests drive it through a fake connection that records every statement.
+The assertions are about *which* statements are emitted (and that they are all
+re-executable), not about a real schema — the shapes themselves are covered by
+the migration suites.
+"""
+
+import re
 from contextlib import contextmanager
 from dataclasses import dataclass
 
 import pytest
 
 from hindsight_api import migrations
+from hindsight_api._text_search import mental_models_text_document
+
+_COUNT_TABLE = re.compile(r"SELECT COUNT\(\*\) FROM \S+\.(\w+)")
+# Statements that change the schema; each one must be safely re-executable
+# because replicas boot concurrently and all run this reconciliation.
+_DDL_PREFIXES = ("ALTER", "CREATE", "DROP")
 
 
 class _Result:
@@ -48,13 +62,18 @@ class _Connection:
         if "FROM pg_indexes" in sql:
             table = self.tables[params["table_name"]]
             return _Result(row=(table.index, table.indexdef) if table.index else None)
-        if sql.lstrip().startswith("SELECT COUNT(*)"):
-            table_name = sql.split(".", 1)[1].split()[0]
-            return _Result(scalar=self.tables[table_name].rows)
+        count_target = _COUNT_TABLE.search(" ".join(sql.split()))
+        if count_target:
+            return _Result(scalar=self.tables[count_target.group(1)].rows)
         return _Result()
 
     def commit(self):
         self.commits += 1
+
+    @property
+    def ddl(self) -> list[str]:
+        normalized = (" ".join(s.split()) for s in self.statements)
+        return [s for s in normalized if s.startswith(_DDL_PREFIXES)]
 
 
 class _Engine:
@@ -66,18 +85,27 @@ class _Engine:
         yield self.conn
 
 
-def _run(monkeypatch, tables: dict[str, _TableState], extension="pgroonga"):
+def _connect(monkeypatch, tables: dict[str, _TableState]) -> _Connection:
     conn = _Connection(tables)
     monkeypatch.setattr(migrations, "create_engine", lambda *args, **kwargs: _Engine(conn))
+    return conn
+
+
+def _run(monkeypatch, tables: dict[str, _TableState], extension="pgroonga") -> _Connection:
+    conn = _connect(monkeypatch, tables)
     migrations.ensure_text_search_extension("postgresql://unused", text_search_extension=extension)
     return conn
 
 
-def _normalized_statements(conn):
-    return [" ".join(statement.split()) for statement in conn.statements]
+def _assert_no_schema_changes(conn: _Connection) -> None:
+    assert conn.ddl == []
+    assert conn.commits == 0
 
 
-def test_populated_legacy_mental_models_adds_pgroonga_without_losing_native_rollback(monkeypatch):
+def test_populated_legacy_mental_models_converts_to_pgroonga(monkeypatch):
+    """The one populated transition that is allowed: the derived tsvector that
+    reconciliation used to skip (it checked the pre-rename `reflections` name)
+    is replaced by the pgroonga expression index. Nothing needs a backfill."""
     conn = _run(
         monkeypatch,
         {
@@ -85,70 +113,87 @@ def test_populated_legacy_mental_models_adds_pgroonga_without_losing_native_roll
             "mental_models": _TableState(column="tsvector", index="gin", rows=5),
         },
     )
-    statements = _normalized_statements(conn)
 
     assert conn.table_checks == ["memory_units", "mental_models"]
-    assert any(
-        "ALTER INDEX public.idx_mental_models_text_search RENAME TO idx_mental_models_text_search_native" in statement
-        for statement in statements
-    )
-    assert not any("DROP COLUMN" in statement and "mental_models" in statement for statement in statements)
-    assert any(
-        "CREATE INDEX idx_mental_models_text_search ON public.mental_models "
-        "USING pgroonga ((COALESCE(name, '') || ' ' || content))" in statement
-        for statement in statements
-    )
-    assert not any("DELETE FROM" in statement for statement in statements)
+    assert conn.ddl == [
+        "DROP INDEX IF EXISTS public.idx_mental_models_text_search",
+        "ALTER TABLE public.mental_models DROP COLUMN IF EXISTS search_vector",
+        "CREATE EXTENSION IF NOT EXISTS pgroonga CASCADE",
+        "ALTER TABLE public.mental_models ADD COLUMN IF NOT EXISTS search_vector TEXT",
+        "CREATE INDEX IF NOT EXISTS idx_mental_models_text_search ON public.mental_models "
+        f"USING pgroonga ({mental_models_text_document()}) "
+        "WITH (tokenizer='TokenBigram', normalizer='NormalizerNFKC150')",
+    ]
+    # memory_units already matched, so it is left alone entirely.
+    assert not any("memory_units" in statement for statement in conn.ddl)
     assert conn.commits == 1
 
 
-def test_dual_projection_pgroonga_state_is_idempotent(monkeypatch):
+def test_pgroonga_state_is_idempotent(monkeypatch):
     conn = _run(
         monkeypatch,
         {
             "memory_units": _TableState(column="text", index="pgroonga", rows=20),
-            "mental_models": _TableState(column="tsvector", index="pgroonga", rows=5),
+            "mental_models": _TableState(column="text", index="pgroonga", rows=5),
         },
     )
 
     assert conn.table_checks == ["memory_units", "mental_models"]
-    assert conn.commits == 0
-    assert not any(statement.lstrip().startswith(("ALTER", "CREATE", "DROP")) for statement in conn.statements)
+    _assert_no_schema_changes(conn)
 
 
 def test_populated_memory_units_backend_switch_remains_fail_closed(monkeypatch):
-    conn = _Connection(
+    conn = _connect(
+        monkeypatch,
         {
             "memory_units": _TableState(column="tsvector", index="gin", rows=20),
             "mental_models": _TableState(column="tsvector", index="gin", rows=5),
-        }
+        },
     )
-    monkeypatch.setattr(migrations, "create_engine", lambda *args, **kwargs: _Engine(conn))
 
     with pytest.raises(RuntimeError, match=r"memory_units\(20 rows\)"):
         migrations.ensure_text_search_extension("postgresql://unused", text_search_extension="pgroonga")
 
-    assert conn.commits == 0
-    assert not any(statement.lstrip().startswith(("ALTER", "CREATE", "DROP")) for statement in conn.statements)
+    _assert_no_schema_changes(conn)
 
 
 def test_populated_unknown_mental_model_index_remains_fail_closed(monkeypatch):
-    conn = _Connection(
+    """Only the native tsvector/GIN shape is derived-only; anything else may hold
+    values the reconciler cannot recompute, so it must still refuse."""
+    conn = _connect(
+        monkeypatch,
         {
             "memory_units": _TableState(column="text", index="pgroonga", rows=20),
             "mental_models": _TableState(column="tsvector", index="bm25", rows=5),
-        }
+        },
     )
-    monkeypatch.setattr(migrations, "create_engine", lambda *args, **kwargs: _Engine(conn))
 
     with pytest.raises(RuntimeError, match=r"mental_models\(5 rows\)"):
         migrations.ensure_text_search_extension("postgresql://unused", text_search_extension="pgroonga")
 
-    assert conn.commits == 0
-    assert not any(statement.lstrip().startswith(("ALTER", "CREATE", "DROP")) for statement in conn.statements)
+    _assert_no_schema_changes(conn)
 
 
-def test_empty_mental_models_native_reconcile_restores_generated_projection(monkeypatch):
+def test_populated_mental_models_backfill_backend_remains_fail_closed(monkeypatch):
+    """vchord's bm25vector must be tokenized per row on write, so converting a
+    populated table would leave every existing row unsearchable."""
+    conn = _connect(
+        monkeypatch,
+        {
+            "memory_units": _TableState(column="bm25vector", index="bm25", rows=20),
+            "mental_models": _TableState(column="tsvector", index="gin", rows=5),
+        },
+    )
+
+    with pytest.raises(RuntimeError, match=r"mental_models\(5 rows\)"):
+        migrations.ensure_text_search_extension("postgresql://unused", text_search_extension="vchord")
+
+    _assert_no_schema_changes(conn)
+
+
+def test_empty_mental_models_native_reconcile_creates_generated_projection(monkeypatch):
+    """No write path fills mental_models.search_vector for native, so the column
+    has to generate itself (see pg_search_vector_expr's native_inline=False)."""
     conn = _run(
         monkeypatch,
         {
@@ -157,10 +202,45 @@ def test_empty_mental_models_native_reconcile_restores_generated_projection(monk
         },
         extension="native",
     )
-    statements = _normalized_statements(conn)
 
-    assert any(
-        "ADD COLUMN search_vector tsvector GENERATED ALWAYS AS" in statement and "COALESCE(name, '')" in statement
-        for statement in statements
+    assert (
+        "ALTER TABLE public.mental_models ADD COLUMN IF NOT EXISTS search_vector tsvector "
+        f"GENERATED ALWAYS AS ( to_tsvector('english', {mental_models_text_document()}) ) STORED" in conn.ddl
     )
     assert conn.commits == 1
+
+
+def test_empty_memory_units_native_reconcile_creates_plain_column(monkeypatch):
+    conn = _run(
+        monkeypatch,
+        {
+            "memory_units": _TableState(column="text", index="pgroonga", rows=0),
+            "mental_models": _TableState(column="tsvector", index="gin", rows=0),
+        },
+        extension="native",
+    )
+
+    assert "ALTER TABLE public.memory_units ADD COLUMN IF NOT EXISTS search_vector tsvector" in conn.ddl
+
+
+@pytest.mark.parametrize("extension", ["native", "vchord", "pg_textsearch", "pgroonga", "pg_search"])
+def test_reconcile_ddl_is_re_executable(monkeypatch, extension):
+    """Replicas boot concurrently during a rolling restart and each runs this
+    reconciliation, so the loser of the race must not crash on DDL the winner
+    already committed."""
+    conn = _run(
+        monkeypatch,
+        {
+            "memory_units": _TableState(column=None, index=None, rows=0),
+            "mental_models": _TableState(column=None, index=None, rows=0),
+        },
+        extension=extension,
+    )
+
+    assert conn.ddl, "expected reconciliation to emit DDL"
+    for statement in conn.ddl:
+        assert re.match(
+            r"(CREATE (INDEX|EXTENSION) IF NOT EXISTS|DROP INDEX IF EXISTS"
+            r"|ALTER TABLE \S+ (ADD|DROP) COLUMN IF (NOT )?EXISTS)",
+            statement,
+        ), f"non re-executable DDL: {statement}"

--- a/hindsight-api-slim/tests/test_text_search_reconciliation.py
+++ b/hindsight-api-slim/tests/test_text_search_reconciliation.py
@@ -1,0 +1,166 @@
+"""Regression coverage for runtime text-search reconciliation."""
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+import pytest
+
+from hindsight_api import migrations
+
+
+class _Result:
+    def __init__(self, *, scalar=None, row=None):
+        self._scalar = scalar
+        self._row = row
+
+    def scalar(self):
+        return self._scalar
+
+    def fetchone(self):
+        return self._row
+
+
+@dataclass(frozen=True)
+class _TableState:
+    column: str | None
+    index: str | None
+    rows: int
+    indexdef: str = ""
+
+
+class _Connection:
+    def __init__(self, tables: dict[str, _TableState]):
+        self.tables = tables
+        self.statements: list[str] = []
+        self.table_checks: list[str] = []
+        self.commits = 0
+
+    def execute(self, statement, params=None):
+        sql = str(statement)
+        self.statements.append(sql)
+        if "information_schema.tables" in sql:
+            table_name = params["table_name"]
+            self.table_checks.append(table_name)
+            return _Result(scalar=table_name in self.tables)
+        if "information_schema.columns" in sql:
+            column_type = self.tables[params["table_name"]].column
+            return _Result(row=("USER-DEFINED", column_type) if column_type else None)
+        if "FROM pg_indexes" in sql:
+            table = self.tables[params["table_name"]]
+            return _Result(row=(table.index, table.indexdef) if table.index else None)
+        if sql.lstrip().startswith("SELECT COUNT(*)"):
+            table_name = sql.split(".", 1)[1].split()[0]
+            return _Result(scalar=self.tables[table_name].rows)
+        return _Result()
+
+    def commit(self):
+        self.commits += 1
+
+
+class _Engine:
+    def __init__(self, conn):
+        self.conn = conn
+
+    @contextmanager
+    def connect(self):
+        yield self.conn
+
+
+def _run(monkeypatch, tables: dict[str, _TableState], extension="pgroonga"):
+    conn = _Connection(tables)
+    monkeypatch.setattr(migrations, "create_engine", lambda *args, **kwargs: _Engine(conn))
+    migrations.ensure_text_search_extension("postgresql://unused", text_search_extension=extension)
+    return conn
+
+
+def _normalized_statements(conn):
+    return [" ".join(statement.split()) for statement in conn.statements]
+
+
+def test_populated_legacy_mental_models_adds_pgroonga_without_losing_native_rollback(monkeypatch):
+    conn = _run(
+        monkeypatch,
+        {
+            "memory_units": _TableState(column="text", index="pgroonga", rows=20),
+            "mental_models": _TableState(column="tsvector", index="gin", rows=5),
+        },
+    )
+    statements = _normalized_statements(conn)
+
+    assert conn.table_checks == ["memory_units", "mental_models"]
+    assert any(
+        "ALTER INDEX public.idx_mental_models_text_search RENAME TO idx_mental_models_text_search_native" in statement
+        for statement in statements
+    )
+    assert not any("DROP COLUMN" in statement and "mental_models" in statement for statement in statements)
+    assert any(
+        "CREATE INDEX idx_mental_models_text_search ON public.mental_models "
+        "USING pgroonga ((COALESCE(name, '') || ' ' || content))" in statement
+        for statement in statements
+    )
+    assert not any("DELETE FROM" in statement for statement in statements)
+    assert conn.commits == 1
+
+
+def test_dual_projection_pgroonga_state_is_idempotent(monkeypatch):
+    conn = _run(
+        monkeypatch,
+        {
+            "memory_units": _TableState(column="text", index="pgroonga", rows=20),
+            "mental_models": _TableState(column="tsvector", index="pgroonga", rows=5),
+        },
+    )
+
+    assert conn.table_checks == ["memory_units", "mental_models"]
+    assert conn.commits == 0
+    assert not any(statement.lstrip().startswith(("ALTER", "CREATE", "DROP")) for statement in conn.statements)
+
+
+def test_populated_memory_units_backend_switch_remains_fail_closed(monkeypatch):
+    conn = _Connection(
+        {
+            "memory_units": _TableState(column="tsvector", index="gin", rows=20),
+            "mental_models": _TableState(column="tsvector", index="gin", rows=5),
+        }
+    )
+    monkeypatch.setattr(migrations, "create_engine", lambda *args, **kwargs: _Engine(conn))
+
+    with pytest.raises(RuntimeError, match=r"memory_units\(20 rows\)"):
+        migrations.ensure_text_search_extension("postgresql://unused", text_search_extension="pgroonga")
+
+    assert conn.commits == 0
+    assert not any(statement.lstrip().startswith(("ALTER", "CREATE", "DROP")) for statement in conn.statements)
+
+
+def test_populated_unknown_mental_model_index_remains_fail_closed(monkeypatch):
+    conn = _Connection(
+        {
+            "memory_units": _TableState(column="text", index="pgroonga", rows=20),
+            "mental_models": _TableState(column="tsvector", index="bm25", rows=5),
+        }
+    )
+    monkeypatch.setattr(migrations, "create_engine", lambda *args, **kwargs: _Engine(conn))
+
+    with pytest.raises(RuntimeError, match=r"mental_models\(5 rows\)"):
+        migrations.ensure_text_search_extension("postgresql://unused", text_search_extension="pgroonga")
+
+    assert conn.commits == 0
+    assert not any(statement.lstrip().startswith(("ALTER", "CREATE", "DROP")) for statement in conn.statements)
+
+
+def test_empty_mental_models_native_reconcile_restores_generated_projection(monkeypatch):
+    conn = _run(
+        monkeypatch,
+        {
+            "memory_units": _TableState(column="tsvector", index="gin", rows=0),
+            "mental_models": _TableState(column="text", index="pgroonga", rows=0),
+        },
+        extension="native",
+    )
+    statements = _normalized_statements(conn)
+
+    assert any(
+        "ADD COLUMN search_vector tsvector GENERATED ALWAYS AS" in statement and "COALESCE(name, '')" in statement
+        for statement in statements
+    )
+    assert conn.commits == 1


### PR DESCRIPTION
## Summary

- route the Knowledge Page lexical arm through the real PGroonga `name + content` expression index
- reconcile `mental_models` instead of the retired `reflections` table name
- convert a populated `mental_models` to the ordinary pgroonga shape (dummy TEXT `search_vector` + expression index) rather than keeping the native tsvector beside it
- make every reconciliation statement re-executable, so replicas booting concurrently do not crash on each other's DDL
- keep populated `memory_units` backend switches and unknown mental-model index shapes fail-closed

## Root cause

#3318 fixed backend dispatch for Knowledge Page search, but intentionally served PGroonga through the native `ts_rank_cd()` branch because runtime reconciliation still checked `reflections`. After that table was renamed to `mental_models`, normal PGroonga deployments converted `memory_units` but silently left mental models on their migration-time native projection — so knowledge pages never got multilingual tokenization, and no backend switch has touched that table since the rename.

This follow-up uses the same escaped PGroonga operator and score function as memory recall. The query repeats the PGroonga expression-index document exactly so PostgreSQL can select `idx_mental_models_text_search`; both sides now build that document from one shared helper (`_text_search.mental_models_text_document`), because an expression index is only selectable while the two stay byte-identical.

## Why a populated table can be converted

`mental_models.search_vector` is *derived*. PGroonga indexes `name + content` directly and keeps `search_vector` only as a dummy TEXT column for schema symmetry, so the conversion has nothing to backfill — dropping the generated tsvector loses no value the reconciler would have to recompute. That is the whole exception, and it is expressed as `_reconcile_needs_no_backfill()`.

Everything else stays fail-closed exactly as before: a target column that stores a per-row value (`native`'s tsvector, `vchord`'s bm25vector) cannot be filled for rows already in the table, and `memory_units` is never converted in place. This PR is not a general in-place backend migrator.

## Rollout and rollback

New instances use PGroonga. Reconciliation is idempotent and every statement is `IF [NOT] EXISTS`, which matters because replicas boot concurrently during a rolling restart and each one runs this reconciliation — on a populated database the loser of the race would otherwise fail startup on DDL the winner had already committed. DDL is transactional. Building the non-concurrent index may briefly block mental-model writes during startup; it does not call an embedding provider or rewrite base data.

**Rollback caveat:** an instance running a build without this change reads `mental_models.search_vector` as a tsvector, so Knowledge Page search returns 500 there once the column is a dummy TEXT — during the rolling window for not-yet-replaced replicas, and after a rollback until this build is restored. Memory recall is unaffected. An earlier revision of this PR kept the native tsvector and its GIN index alongside PGroonga to avoid this; that hybrid was dropped deliberately in favour of one well-defined per-backend schema.

## Also fixed here

- the index lookup joined `pg_class` on index name alone, so in a multi-tenant deployment it could read the access method of a same-named index in another tenant's schema — it is now schema-qualified and matched by exact index name
- reconciling `mental_models` to `native` created a plain tsvector column, which no write path populates (`pg_search_vector_expr` passes `native_inline=False`) and which would have left knowledge search silently empty; it is now `GENERATED`, matching the `learnings` / `pinned_reflections` migration expression exactly
- the PGroonga arm carries an id tiebreak, since `pgroonga_score()` reads 0 on any plan that did not use the PGroonga index

## Verification

- `./scripts/hooks/lint.sh` (Ruff, formatting, ty, ESLint/Prettier) and `./scripts/hooks/check-unused.sh`: clean
- backend dispatch, reconciliation, DB abstraction, backup/restore, schema-isolation and parallel-schema regressions: 66 passed
- Knowledge Page search integration class on native PostgreSQL: 3 passed
- reconciler driven against a live PostgreSQL: the generated-column DDL parses and indexes name + content, re-running it is a no-op, and a populated backfill-needing switch is still refused
- disposable PostgreSQL 18 + PGroonga 4.0.8 + pgvector 0.8.6 canary (against the earlier hybrid revision of this PR):
  - Korean/English RRF query succeeded and ranked the Korean page first
  - `EXPLAIN` selected `idx_mental_models_text_search`
  - escaped operator-like query text did not raise

Note: no CI job runs PGroonga, so that branch is covered by unit tests over the emitted SQL plus the canary above; the re-run against the final non-hybrid revision is still worth doing before merge.

Follow-up to #3318. Part of #3307.
