### PR TITLE
fix(coding-agents): write back only the new turns (append + idempotent retain)

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/chat.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.test.ts
@@ -161,7 +161,11 @@ describe("retainLiveSession — incremental write-back", () => {
     expect(recovery[0]).toBe(
       renderSessionJsonl("conversation:s1", turns(6), "2026-01-01T00:00:00Z")
     );
-    expect(cursors.read("s1")).toEqual({ turns: 6, fingerprint: expect.any(String) });
+    expect(cursors.read("s1")).toEqual({
+      turns: 6,
+      fingerprint: expect.any(String),
+      bank: "coding-agent::repo",
+    });
   });
 
   it("never appends against a server that ignores operation_id", async () => {
@@ -221,6 +225,48 @@ describe("retainLiveSession — incremental write-back", () => {
       { mode: "replace", turns: 6 },
       { mode: "append", turns: 3 },
       { mode: "append", turns: 1 },
+    ]);
+  });
+
+  it("keeps two sessions in the same directory independent", async () => {
+    // Same repo => same bank, but each session owns its own document and its own cursor, so two
+    // agents running side by side in one checkout never append into each other's conversation.
+    const { retain, client } = stubClient();
+    const cursors = memoryCursorStore();
+    const writeAs = (id: string, list: TransportTurn[]) =>
+      retainLiveSession(client, id, list, "2026-01-01T00:00:00Z", "codex", { cursors });
+
+    await writeAs("sess-a", turns(2));
+    await writeAs("sess-b", turns(4));
+    await writeAs("sess-a", turns(3));
+
+    const docs = retain.mock.calls.map((c) => c[2]);
+    expect(docs).toEqual(["conversation:sess-a", "conversation:sess-b", "conversation:sess-a"]);
+    // sess-b's longer transcript did not advance sess-a's cursor: its append is turn 2 alone.
+    expect(retain.mock.calls[1][5].updateMode).toBeUndefined(); // first write for sess-b
+    expect(retain.mock.calls[2][5].updateMode).toBe("append");
+    expect((retain.mock.calls[2][0] as string).split("\n")).toHaveLength(1);
+    expect(cursors.read("sess-a")?.turns).toBe(3);
+    expect(cursors.read("sess-b")?.turns).toBe(4);
+  });
+
+  it("replaces rather than appends when the session moved to another bank", async () => {
+    const sent: { bank: string; mode: string }[] = [];
+    const mk = (bank: string) =>
+      ({
+        bank,
+        supportsIdempotentRetain: async () => true,
+        retain: vi.fn(async (_c: string, ...rest: unknown[]) => {
+          sent.push({ bank, mode: (rest[4] as { updateMode?: string }).updateMode ?? "replace" });
+        }),
+      }) as unknown as HindsightClient;
+    const cursors = memoryCursorStore();
+
+    await write(mk("repo-a"), turns(5), cursors);
+    await write(mk("repo-b"), turns(8), cursors); // user cd'd into another repo mid-session
+    expect(sent).toEqual([
+      { bank: "repo-a", mode: "replace" },
+      { bank: "repo-b", mode: "replace" },
     ]);
   });
 

--- a/hindsight-integrations/coding-agents/src/core/chat.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.test.ts
@@ -182,6 +182,48 @@ describe("retainLiveSession — incremental write-back", () => {
     expect(retain.mock.calls.map((c) => c[5].updateMode)).toEqual([undefined, undefined]);
   });
 
+  it("serialises overlapping write-backs so neither appends a slice the other already sent", async () => {
+    // The runtime fires retains without awaiting them: a turn-driven one and an idle-driven one can
+    // overlap. Unserialised, both planned an append from the same cursor position and submitted
+    // overlapping slices, duplicating turns inside the document.
+    const submitted: { mode: string; turns: number }[] = [];
+    const gates: (() => void)[] = [];
+    const retain = vi.fn((content: string, ...rest: unknown[]) => {
+      const o = rest[4] as { updateMode?: string };
+      submitted.push({ mode: o.updateMode ?? "replace", turns: content.split("\n").length });
+      return new Promise<void>((resolve) => gates.push(resolve));
+    });
+    const client = {
+      retain,
+      bank: "b",
+      supportsIdempotentRetain: async () => true,
+    } as unknown as HindsightClient;
+    const cursors = memoryCursorStore();
+
+    const first = write(client, turns(5), cursors);
+    await vi.waitFor(() => expect(gates).toHaveLength(1));
+    gates[0]();
+    await first;
+
+    const a = write(client, turns(8), cursors);
+    const b = write(client, turns(9), cursors);
+    // Only ONE request is in flight: the second write-back waits for the first to be confirmed.
+    await vi.waitFor(() => expect(gates).toHaveLength(2));
+    expect(submitted).toHaveLength(2);
+    gates[1]();
+    await a;
+    await vi.waitFor(() => expect(gates).toHaveLength(3));
+    gates[2]();
+    await b;
+
+    // 6 = REF-ID + 5 turns, then turns 5-7, then turn 8 alone — every turn sent exactly once.
+    expect(submitted).toEqual([
+      { mode: "replace", turns: 6 },
+      { mode: "append", turns: 3 },
+      { mode: "append", turns: 1 },
+    ]);
+  });
+
   it("keeps the write-back when the capability probe itself fails", async () => {
     const retain = vi.fn().mockResolvedValue(undefined);
     const client = {

--- a/hindsight-integrations/coding-agents/src/core/chat.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.test.ts
@@ -165,6 +165,7 @@ describe("retainLiveSession — incremental write-back", () => {
       turns: 6,
       fingerprint: expect.any(String),
       bank: "coding-agent::repo",
+      appends: 0, // the recovery replace re-established the document, restarting the re-sync count
     });
   });
 

--- a/hindsight-integrations/coding-agents/src/core/chat.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { HindsightClient } from "./hindsight";
 import { renderSessionJsonl, retainLiveSession, type TransportTurn } from "./chat";
+import { memoryCursorStore, type RetainCursorStore } from "./retain-cursor";
 
 describe("renderSessionJsonl", () => {
   const turns: TransportTurn[] = [
@@ -68,11 +69,130 @@ describe("retainLiveSession", () => {
     expect(documentId).toBe("conversation:s2");
     expect(tags).toEqual(["source:chat"]);
     expect(strategy).toBe("conversation");
-    expect(opts).toMatchObject({ async: true, timestamp: "2026-01-01T00:00:00Z" });
+    expect(opts).toMatchObject({ timestamp: "2026-01-01T00:00:00Z" });
     expect(opts.metadata).toMatchObject({
       source: "chat",
       session_id: "s2",
       ref_id: "conversation:s2",
     });
+  });
+});
+
+describe("retainLiveSession — incremental write-back", () => {
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+  const turn = (i: number): TransportTurn => ({ role: "user", content: `turn ${i}` });
+  const turns = (n: number) => Array.from({ length: n }, (_, i) => turn(i));
+
+  /** Client double: `supported` is what GET /version would have told us about operation_id. */
+  const stubClient = (supported = true) => {
+    const retain = vi.fn().mockResolvedValue(undefined);
+    return {
+      retain,
+      client: {
+        retain,
+        bank: "coding-agent::repo",
+        supportsIdempotentRetain: async () => supported,
+      } as unknown as HindsightClient,
+    };
+  };
+
+  const write = (client: HindsightClient, turnList: TransportTurn[], cursors: RetainCursorStore) =>
+    retainLiveSession(client, "s1", turnList, "2026-01-01T00:00:00Z", "codex", { cursors });
+
+  it("replaces on the first write, then appends only the new turns", async () => {
+    const { retain, client } = stubClient();
+    const cursors = memoryCursorStore();
+
+    await write(client, turns(2), cursors);
+    const first = retain.mock.calls[0];
+    expect(first[5].updateMode).toBeUndefined();
+    expect(first[0]).toBe(renderSessionJsonl("conversation:s1", turns(2), "2026-01-01T00:00:00Z"));
+
+    await write(client, turns(5), cursors);
+    const second = retain.mock.calls[1];
+    expect(second[5].updateMode).toBe("append");
+    // Only the three new turns, and no REF-ID header: the document already carries one.
+    expect((second[0] as string).split("\n").map((l) => JSON.parse(l) as TransportTurn)).toEqual([
+      turn(2),
+      turn(3),
+      turn(4),
+    ]);
+    expect(second[2]).toBe("conversation:s1"); // same document id — append targets it
+  });
+
+  it("sends a stable v5 operation_id so a resubmitted write is not applied twice", async () => {
+    const a = stubClient();
+    const b = stubClient();
+    await write(a.client, turns(3), memoryCursorStore());
+    await write(b.client, turns(3), memoryCursorStore());
+    const opId = a.retain.mock.calls[0][5].operationId;
+    expect(opId).toMatch(UUID_RE);
+    expect(b.retain.mock.calls[0][5].operationId).toBe(opId);
+  });
+
+  it("gives a different operation_id to a different payload", async () => {
+    const { retain, client } = stubClient();
+    const cursors = memoryCursorStore();
+    await write(client, turns(2), cursors);
+    await write(client, turns(5), cursors);
+    expect(retain.mock.calls[0][5].operationId).not.toBe(retain.mock.calls[1][5].operationId);
+  });
+
+  it("skips the write entirely when no turn was added", async () => {
+    const { retain, client } = stubClient();
+    const cursors = memoryCursorStore();
+    await write(client, turns(3), cursors);
+    await write(client, turns(3), cursors);
+    expect(retain).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces the whole document after a failed write, instead of appending onto an unknown state", async () => {
+    const { retain, client } = stubClient();
+    const cursors = memoryCursorStore();
+    await write(client, turns(2), cursors);
+
+    retain.mockRejectedValueOnce(new Error("timeout"));
+    await expect(write(client, turns(4), cursors)).rejects.toThrow("timeout");
+    expect(cursors.read("s1")?.dirty).toBe(true);
+
+    await write(client, turns(6), cursors);
+    const recovery = retain.mock.calls[2];
+    expect(recovery[5].updateMode).toBeUndefined();
+    expect(recovery[0]).toBe(
+      renderSessionJsonl("conversation:s1", turns(6), "2026-01-01T00:00:00Z")
+    );
+    expect(cursors.read("s1")).toEqual({ turns: 6, fingerprint: expect.any(String) });
+  });
+
+  it("never appends against a server that ignores operation_id", async () => {
+    const { retain, client } = stubClient(false);
+    const cursors = memoryCursorStore();
+    await write(client, turns(2), cursors);
+    await write(client, turns(5), cursors);
+    expect(retain.mock.calls.map((c) => c[5].updateMode)).toEqual([undefined, undefined]);
+    expect(retain.mock.calls[1][0]).toBe(
+      renderSessionJsonl("conversation:s1", turns(5), "2026-01-01T00:00:00Z")
+    );
+  });
+
+  it("replaces (never appends) when no cursor store is supplied", async () => {
+    const { retain, client } = stubClient();
+    await retainLiveSession(client, "s1", turns(2), "2026-01-01T00:00:00Z", "codex");
+    await retainLiveSession(client, "s1", turns(5), "2026-01-01T00:00:00Z", "codex");
+    expect(retain.mock.calls.map((c) => c[5].updateMode)).toEqual([undefined, undefined]);
+  });
+
+  it("keeps the write-back when the capability probe itself fails", async () => {
+    const retain = vi.fn().mockResolvedValue(undefined);
+    const client = {
+      retain,
+      bank: "b",
+      supportsIdempotentRetain: async () => {
+        throw new Error("unreachable");
+      },
+    } as unknown as HindsightClient;
+    await write(client, turns(2), memoryCursorStore());
+    expect(retain).toHaveBeenCalledTimes(1);
+    expect(retain.mock.calls[0][5].updateMode).toBeUndefined();
   });
 });

--- a/hindsight-integrations/coding-agents/src/core/chat.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.ts
@@ -4,7 +4,9 @@
  * the REF-ID tracer; every turn gets an ABSOLUTE timestamp.
  */
 import type { HindsightClient } from "./hindsight";
+import { fingerprintTurns, planRetain, type RetainCursorStore } from "./retain-cursor";
 import type { ChatSession } from "./types";
+import { uuidV5 } from "./uuid";
 import { pool } from "./util";
 
 export interface TransportTurn {
@@ -86,13 +88,29 @@ export async function ingestChats(
   return failures;
 }
 
+/** Capability probe for the append path. Any failure answers "no": a write-back must never be lost
+ *  because we couldn't work out whether the cheaper form of it was available. */
+async function supportsAppend(client: HindsightClient): Promise<boolean> {
+  try {
+    return await client.supportsIdempotentRetain();
+  } catch {
+    return false;
+  }
+}
+
 /**
- * Live write-back: upsert a running session under a stable document_id. Same id => Hindsight
- * reprocesses the FULL conversation, so the settled decision is extracted from the whole thing.
+ * Live write-back: upsert a running session under a stable document_id, sending only what is new.
+ *
+ * Given a cursor store, a session that has already been written APPENDS the turns added since the
+ * last successful write; the server concatenates them onto the stored document (with "\n", which is
+ * why the transcript is JSONL) and re-chunks. Without one — first write, a rewritten transcript, an
+ * unconfirmed previous write, or a server too old to be idempotent — it falls back to REPLACING the
+ * whole document, which is what this always used to do. See core/retain-cursor.ts for why every
+ * uncertain case resolves that way.
  *
  * Uses the same `conversation` strategy as backfilled chats — one strategy for all developer
  * conversations; the mission scales extraction to the substance. The content is a JSON transcript
- * (renderSessionJson) whose tool activity is compacted into `role:"action"` turns
+ * (renderSessionJsonl) whose tool activity is compacted into `role:"action"` turns
  * (see core/transcript*.ts).
  */
 export async function retainLiveSession(
@@ -100,18 +118,43 @@ export async function retainLiveSession(
   sessionId: string,
   turns: TransportTurn[],
   startTs: string,
-  harness?: string
+  harness?: string,
+  opts: { cursors?: RetainCursorStore } = {}
 ): Promise<void> {
   const refId = `conversation:${sessionId}`;
+  const cursors = opts.cursors;
+  const prior = cursors?.read(sessionId);
+  const plan = planRetain(turns, prior, {
+    appendSupported: Boolean(cursors) && (await supportsAppend(client)),
+  });
+  if (plan.mode === "skip") return;
+
+  const content =
+    plan.mode === "append"
+      ? turns
+          .slice(plan.fromTurn)
+          .map((t) => JSON.stringify(t))
+          .join("\n")
+      : renderSessionJsonl(refId, turns, startTs);
+
+  // Claim the new position BEFORE the write and mark it unconfirmed: a client that times out on a
+  // request the server did commit must not append the same turns twice, and an overlapping retain
+  // (the runtime never awaits) must not re-send the slice already in flight.
+  const next = { turns: turns.length, fingerprint: fingerprintTurns(turns, turns.length) };
+  cursors?.write(sessionId, { ...next, dirty: true });
+
   await client.retain(
-    renderSessionJsonl(refId, turns, startTs),
+    content,
     "coding agent session",
     refId,
     ["source:chat", ...(harness ? [`harness:${harness}`] : [])],
     "conversation",
     {
       timestamp: startTs,
-      async: true,
+      updateMode: plan.mode === "append" ? "append" : undefined,
+      // Identity of THIS payload: a resubmission of the same bytes is collapsed server-side into
+      // the original operation instead of extracting (or appending) twice.
+      operationId: uuidV5(`${client.bank}\n${refId}\n${plan.mode}\n${content}`),
       metadata: {
         source: "chat",
         session_id: sessionId,
@@ -120,4 +163,5 @@ export async function retainLiveSession(
       },
     }
   );
+  cursors?.write(sessionId, next);
 }

--- a/hindsight-integrations/coding-agents/src/core/chat.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.ts
@@ -121,10 +121,13 @@ function serialize(
   // Chain off the previous write-back whether it succeeded or failed — a failure leaves the cursor
   // dirty, which the next call needs to see so it can replace rather than append.
   const next = (perSession.get(sessionId) ?? Promise.resolve()).then(write, write);
-  perSession.set(
-    sessionId,
-    next.catch(() => {})
-  );
+  const tail = next.catch(() => {});
+  perSession.set(sessionId, tail);
+  // Drop the entry once it is settled AND still the tail, so a host that outlives many sessions
+  // (opencode runs for days) doesn't accumulate one resolved promise per session id forever.
+  void tail.then(() => {
+    if (perSession.get(sessionId) === tail) perSession.delete(sessionId);
+  });
   return next;
 }
 
@@ -169,7 +172,8 @@ async function writeSession(
 ): Promise<void> {
   const refId = `conversation:${sessionId}`;
   const appendSupported = Boolean(cursors) && (await supportsAppend(client));
-  const plan = planRetain(turns, cursors?.read(sessionId), { appendSupported, bank: client.bank });
+  const prior = cursors?.read(sessionId);
+  const plan = planRetain(turns, prior, { appendSupported, bank: client.bank });
   if (plan.mode === "skip") return;
 
   const content =
@@ -186,6 +190,8 @@ async function writeSession(
     turns: turns.length,
     fingerprint: fingerprintTurns(turns, turns.length),
     bank: client.bank,
+    // A full write re-establishes the document, so the re-sync countdown starts over.
+    appends: plan.mode === "append" ? (prior?.appends ?? 0) + 1 : 0,
   };
   cursors?.write(sessionId, { ...next, dirty: true });
 

--- a/hindsight-integrations/coding-agents/src/core/chat.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.ts
@@ -99,6 +99,36 @@ async function supportsAppend(client: HindsightClient): Promise<boolean> {
 }
 
 /**
+ * One write-back at a time per session, keyed by the store the cursors live in.
+ *
+ * The persistent-plugin runtime fires retains without awaiting them (a turn-driven one and an
+ * idle-driven one can overlap), and reading the cursor is not atomic with claiming it — there is an
+ * await in between. Two overlapping calls therefore both planned an append from the SAME position
+ * and submitted overlapping slices, duplicating turns inside the document; and even serialising the
+ * claim alone would leave an append racing a replace on the wire, where the order they land in
+ * decides whether the result is correct. Chaining the whole read-plan-send-confirm cycle is what
+ * makes the cursor mean what it says: the second call sees the first call's CONFIRMED position.
+ */
+const writeBacks = new WeakMap<RetainCursorStore, Map<string, Promise<void>>>();
+
+function serialize(
+  cursors: RetainCursorStore,
+  sessionId: string,
+  write: () => Promise<void>
+): Promise<void> {
+  const perSession = writeBacks.get(cursors) ?? new Map<string, Promise<void>>();
+  writeBacks.set(cursors, perSession);
+  // Chain off the previous write-back whether it succeeded or failed — a failure leaves the cursor
+  // dirty, which the next call needs to see so it can replace rather than append.
+  const next = (perSession.get(sessionId) ?? Promise.resolve()).then(write, write);
+  perSession.set(
+    sessionId,
+    next.catch(() => {})
+  );
+  return next;
+}
+
+/**
  * Live write-back: upsert a running session under a stable document_id, sending only what is new.
  *
  * Given a cursor store, a session that has already been written APPENDS the turns added since the
@@ -121,12 +151,25 @@ export async function retainLiveSession(
   harness?: string,
   opts: { cursors?: RetainCursorStore } = {}
 ): Promise<void> {
-  const refId = `conversation:${sessionId}`;
   const cursors = opts.cursors;
-  const prior = cursors?.read(sessionId);
-  const plan = planRetain(turns, prior, {
-    appendSupported: Boolean(cursors) && (await supportsAppend(client)),
-  });
+  if (!cursors) return writeSession(client, sessionId, turns, startTs, harness);
+  // Serialised so the plan is made against the previous write-back's CONFIRMED cursor (see above).
+  return serialize(cursors, sessionId, () =>
+    writeSession(client, sessionId, turns, startTs, harness, cursors)
+  );
+}
+
+async function writeSession(
+  client: HindsightClient,
+  sessionId: string,
+  turns: TransportTurn[],
+  startTs: string,
+  harness?: string,
+  cursors?: RetainCursorStore
+): Promise<void> {
+  const refId = `conversation:${sessionId}`;
+  const appendSupported = Boolean(cursors) && (await supportsAppend(client));
+  const plan = planRetain(turns, cursors?.read(sessionId), { appendSupported });
   if (plan.mode === "skip") return;
 
   const content =
@@ -137,9 +180,8 @@ export async function retainLiveSession(
           .join("\n")
       : renderSessionJsonl(refId, turns, startTs);
 
-  // Claim the new position BEFORE the write and mark it unconfirmed: a client that times out on a
-  // request the server did commit must not append the same turns twice, and an overlapping retain
-  // (the runtime never awaits) must not re-send the slice already in flight.
+  // Claim the new position BEFORE the write and mark it unconfirmed, so a client that times out on
+  // a request the server did commit replaces next time instead of appending the same turns twice.
   const next = { turns: turns.length, fingerprint: fingerprintTurns(turns, turns.length) };
   cursors?.write(sessionId, { ...next, dirty: true });
 

--- a/hindsight-integrations/coding-agents/src/core/chat.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.ts
@@ -169,7 +169,7 @@ async function writeSession(
 ): Promise<void> {
   const refId = `conversation:${sessionId}`;
   const appendSupported = Boolean(cursors) && (await supportsAppend(client));
-  const plan = planRetain(turns, cursors?.read(sessionId), { appendSupported });
+  const plan = planRetain(turns, cursors?.read(sessionId), { appendSupported, bank: client.bank });
   if (plan.mode === "skip") return;
 
   const content =
@@ -182,7 +182,11 @@ async function writeSession(
 
   // Claim the new position BEFORE the write and mark it unconfirmed, so a client that times out on
   // a request the server did commit replaces next time instead of appending the same turns twice.
-  const next = { turns: turns.length, fingerprint: fingerprintTurns(turns, turns.length) };
+  const next = {
+    turns: turns.length,
+    fingerprint: fingerprintTurns(turns, turns.length),
+    bank: client.bank,
+  };
   cursors?.write(sessionId, { ...next, dirty: true });
 
   await client.retain(

--- a/hindsight-integrations/coding-agents/src/core/git.ts
+++ b/hindsight-integrations/coding-agents/src/core/git.ts
@@ -193,8 +193,7 @@ export async function ingestGitLog(
       `git commit-message history (last ${n}) for ${repoName}`,
       `gitlog:${repoName}`,
       ["source:git", "source:git-log", ...(head ? [`gitlog-head:${head}`] : [])],
-      "gitlog",
-      { async: true }
+      "gitlog"
     );
     log(`[gitlog] done: ${n} commit messages ingested as 1 document under strategy 'gitlog'`);
     return 0;

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -6,7 +6,7 @@
  * creates knowledge pages. Nothing here knows about opencode/claude-code/etc.
  */
 import { CODING_BANK_TEMPLATE, PAGE_MAX_TOKENS, PAGE_TRIGGER, PAGES } from "./missions";
-import { sleep } from "./util";
+import { semverGte, sleep } from "./util";
 
 /** One node of GET /knowledge-base/tree. Only the fields this client reads. */
 export interface KnowledgeNode {
@@ -28,8 +28,18 @@ export interface ClientOpts {
 export interface RetainOpts {
   timestamp?: string; // when the content occurred (temporal ranking)
   metadata?: Record<string, string>; // source provenance (returned with recalls)
-  async?: boolean; // enqueue server-side (default) vs block on extraction
+  /** "append" concatenates `content` onto the stored document instead of replacing it — the whole
+   *  point of the live write-back cursor (core/retain-cursor.ts). Requires a document_id. */
+  updateMode?: "append";
+  /** Deterministic operation id: re-submitting the same payload returns the original operation
+   *  instead of admitting a second one. Ignored by servers older than 0.8.6. */
+  operationId?: string;
 }
+
+/** First release whose retain endpoint honours a caller-supplied `operation_id` (#2937, v0.8.6).
+ *  Below it the field is silently ignored — unknown request fields are not rejected — so an append
+ *  could be applied twice without us ever knowing. Hence: no idempotency, no append. */
+export const MIN_IDEMPOTENT_RETAIN_VERSION = "0.8.6";
 
 /** Raised when the target server predates the knowledge-pages API surface. */
 export class KnowledgePagesUnavailableError extends Error {
@@ -49,6 +59,8 @@ export class HindsightClient {
   readonly opIds: string[] = []; // async operation ids collected by retain(), for drain()
   /** Tri-state capability probe: unknown until the first page request, then cached. */
   knowledgePagesSupported: boolean | undefined;
+  /** Tri-state capability probe: unknown until the first append-mode retain, then cached. */
+  private idempotentRetain: boolean | undefined;
   private readonly log: (msg: string) => void;
 
   constructor(o: ClientOpts) {
@@ -88,7 +100,8 @@ export class HindsightClient {
     return r;
   }
 
-  /** Retain one memory. Async by default: enqueue extraction server-side and collect its op-id for drain(). */
+  /** Retain one memory. ALWAYS async: enqueue extraction server-side and collect its op-id for
+   *  drain(). Nothing in this plugin can afford to block a coding agent's hook on extraction. */
   async retain(
     content: string,
     context: string,
@@ -106,15 +119,39 @@ export class HindsightClient {
     };
     if (opts.timestamp) item.timestamp = opts.timestamp;
     if (opts.metadata) item.metadata = opts.metadata;
-    const isAsync = opts.async !== false;
-    const r = await this.req("POST", this.bankUrl("/memories"), { items: [item], async: isAsync });
-    if (isAsync) {
-      try {
-        const j = (await r.json()) as { operation_id?: string };
-        if (j.operation_id) this.opIds.push(j.operation_id);
-      } catch {
-        /* ignore */
-      }
+    if (opts.updateMode) item.update_mode = opts.updateMode;
+    const body: Record<string, unknown> = { items: [item], async: true };
+    if (opts.operationId) body.operation_id = opts.operationId;
+    const r = await this.req("POST", this.bankUrl("/memories"), body);
+    try {
+      const j = (await r.json()) as { operation_id?: string };
+      if (j.operation_id) this.opIds.push(j.operation_id);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  /**
+   * Whether this server honours `operation_id` on an async retain, and can therefore be appended to
+   * safely (see MIN_IDEMPOTENT_RETAIN_VERSION). Probed once per client via GET /version; anything
+   * unreachable, unparseable or older answers "no", which costs efficiency, never correctness.
+   */
+  async supportsIdempotentRetain(): Promise<boolean> {
+    if (this.idempotentRetain === undefined) {
+      this.idempotentRetain = await this.probeIdempotentRetain();
+      this.log(`server retain idempotency: ${this.idempotentRetain ? "supported" : "unavailable"}`);
+    }
+    return this.idempotentRetain;
+  }
+
+  private async probeIdempotentRetain(): Promise<boolean> {
+    try {
+      const r = await this.req("GET", `${this.apiUrl}/version`);
+      if (!r.ok) return false;
+      const j = (await r.json()) as { api_version?: string };
+      return semverGte(j.api_version, MIN_IDEMPOTENT_RETAIN_VERSION);
+    } catch {
+      return false;
     }
   }
 
@@ -449,8 +486,7 @@ export class HindsightClient {
       "initiative marker",
       markerId,
       ["knowledge:feature-work", `relatedPageId:${pageId}`],
-      "document",
-      { async: true }
+      "document"
     );
     return { page_id: pageId };
   }

--- a/hindsight-integrations/coding-agents/src/core/knowledge-tools.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/knowledge-tools.test.ts
@@ -237,7 +237,7 @@ describe("buildKnowledgeTools", () => {
       "my-title",
       ["source:upload"],
       "document",
-      { async: true }
+      {} // no harness in these tests: nothing to stamp
     );
     expect(JSON.parse(result.content[0].text)).toEqual({ ok: true, doc_id: "my-title" });
   });
@@ -253,7 +253,7 @@ describe("buildKnowledgeTools", () => {
       "repo-core-concepts",
       ["source:upload"],
       "document",
-      { async: true }
+      {} // no harness in these tests: nothing to stamp
     );
   });
 
@@ -268,7 +268,7 @@ describe("buildKnowledgeTools", () => {
       "repo-component-map-v2-final",
       ["source:upload"],
       "document",
-      { async: true }
+      {} // no harness in these tests: nothing to stamp
     );
   });
 
@@ -283,7 +283,7 @@ describe("buildKnowledgeTools", () => {
       "doc",
       ["source:upload"],
       "document",
-      { async: true }
+      {} // no harness in these tests: nothing to stamp
     );
   });
 

--- a/hindsight-integrations/coding-agents/src/core/knowledge-tools.ts
+++ b/hindsight-integrations/coding-agents/src/core/knowledge-tools.ts
@@ -227,7 +227,7 @@ export function buildKnowledgeTools(
           docId,
           ["source:upload", ...(opts.harness ? [`harness:${opts.harness}`] : [])],
           "document",
-          { async: true, metadata: opts.harness ? { harness: opts.harness } : undefined }
+          { metadata: opts.harness ? { harness: opts.harness } : undefined }
         );
         return { ok: true, doc_id: docId };
       }),

--- a/hindsight-integrations/coding-agents/src/core/retain-cursor.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-cursor.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { TransportTurn } from "./chat";
-import { fingerprintTurns, memoryCursorStore, planRetain } from "./retain-cursor";
+import {
+  fingerprintTurns,
+  MAX_APPENDS_BEFORE_RESYNC,
+  memoryCursorStore,
+  planRetain,
+} from "./retain-cursor";
 
 const turn = (i: number): TransportTurn => ({ role: "user", content: `turn ${i}` });
 const turns = (n: number, from = 0): TransportTurn[] =>
@@ -62,6 +67,18 @@ describe("planRetain", () => {
     const all = turns(5);
     expect(planRetain(all, cursorFor(all, 3), { ...SUPPORTED, bank: "other-repo" })).toEqual({
       mode: "replace",
+    });
+  });
+
+  it("forces a full write after a run of appends, so one lost write cannot cost the session", () => {
+    // Retains are async: a write can be acknowledged and still fail server-side afterwards, and a
+    // replayed operation_id will not redo it. The periodic replace bounds that loss.
+    const all = turns(5);
+    const run = { ...cursorFor(all, 3), appends: MAX_APPENDS_BEFORE_RESYNC };
+    expect(planRetain(all, run, SUPPORTED)).toEqual({ mode: "replace" });
+    expect(planRetain(all, { ...run, appends: MAX_APPENDS_BEFORE_RESYNC - 1 }, SUPPORTED)).toEqual({
+      mode: "append",
+      fromTurn: 3,
     });
   });
 

--- a/hindsight-integrations/coding-agents/src/core/retain-cursor.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-cursor.test.ts
@@ -6,12 +6,15 @@ const turn = (i: number): TransportTurn => ({ role: "user", content: `turn ${i}`
 const turns = (n: number, from = 0): TransportTurn[] =>
   Array.from({ length: n }, (_, i) => turn(from + i));
 
+const BANK = "coding-agent::repo";
+
 const cursorFor = (all: TransportTurn[], count: number) => ({
   turns: count,
   fingerprint: fingerprintTurns(all, count),
+  bank: BANK,
 });
 
-const SUPPORTED = { appendSupported: true };
+const SUPPORTED = { appendSupported: true, bank: BANK };
 
 describe("planRetain", () => {
   it("appends only the turns added since the last write", () => {
@@ -47,7 +50,17 @@ describe("planRetain", () => {
 
   it("replaces when the server cannot deduplicate a resubmitted write", () => {
     const all = turns(5);
-    expect(planRetain(all, cursorFor(all, 3), { appendSupported: false })).toEqual({
+    expect(planRetain(all, cursorFor(all, 3), { appendSupported: false, bank: BANK })).toEqual({
+      mode: "replace",
+    });
+  });
+
+  it("replaces when the session moved to another bank", () => {
+    // Same session id, different bank: the hook derives the bank from each event's cwd, so a
+    // session that moves between repos (#3133) would otherwise append its tail into a bank that
+    // holds no document for it, silently losing everything before the move.
+    const all = turns(5);
+    expect(planRetain(all, cursorFor(all, 3), { ...SUPPORTED, bank: "other-repo" })).toEqual({
       mode: "replace",
     });
   });
@@ -80,9 +93,9 @@ describe("memoryCursorStore", () => {
   it("keeps cursors per session", () => {
     const store = memoryCursorStore();
     expect(store.read("a")).toBeUndefined();
-    store.write("a", { turns: 2, fingerprint: "f" });
-    store.write("b", { turns: 7, fingerprint: "g" });
-    expect(store.read("a")).toEqual({ turns: 2, fingerprint: "f" });
-    expect(store.read("b")).toEqual({ turns: 7, fingerprint: "g" });
+    store.write("a", { turns: 2, fingerprint: "f", bank: "b1" });
+    store.write("b", { turns: 7, fingerprint: "g", bank: "b1" });
+    expect(store.read("a")).toEqual({ turns: 2, fingerprint: "f", bank: "b1" });
+    expect(store.read("b")).toEqual({ turns: 7, fingerprint: "g", bank: "b1" });
   });
 });

--- a/hindsight-integrations/coding-agents/src/core/retain-cursor.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-cursor.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { TransportTurn } from "./chat";
+import { fingerprintTurns, memoryCursorStore, planRetain } from "./retain-cursor";
+
+const turn = (i: number): TransportTurn => ({ role: "user", content: `turn ${i}` });
+const turns = (n: number, from = 0): TransportTurn[] =>
+  Array.from({ length: n }, (_, i) => turn(from + i));
+
+const cursorFor = (all: TransportTurn[], count: number) => ({
+  turns: count,
+  fingerprint: fingerprintTurns(all, count),
+});
+
+const SUPPORTED = { appendSupported: true };
+
+describe("planRetain", () => {
+  it("appends only the turns added since the last write", () => {
+    const all = turns(5);
+    expect(planRetain(all, cursorFor(all, 3), SUPPORTED)).toEqual({ mode: "append", fromTurn: 3 });
+  });
+
+  it("replaces the whole document on the first write of a session", () => {
+    expect(planRetain(turns(3), undefined, SUPPORTED)).toEqual({ mode: "replace" });
+  });
+
+  it("replaces when the previous write was never confirmed", () => {
+    // The one case that would DUPLICATE turns inside the document if we appended anyway: the
+    // server may or may not hold the last slice, and only a replace settles it.
+    const all = turns(5);
+    expect(planRetain(all, { ...cursorFor(all, 3), dirty: true }, SUPPORTED)).toEqual({
+      mode: "replace",
+    });
+  });
+
+  it("replaces when the transcript was rewritten rather than extended", () => {
+    // Compaction: same turn count, different content. Appending would splice two conversations.
+    const original = turns(5);
+    const stale = cursorFor(original, 3);
+    const compacted = [{ role: "user", content: "summary of earlier work" }, ...turns(4, 10)];
+    expect(planRetain(compacted, stale, SUPPORTED)).toEqual({ mode: "replace" });
+  });
+
+  it("replaces when the transcript shrank below the cursor", () => {
+    const all = turns(5);
+    expect(planRetain(turns(2), cursorFor(all, 4), SUPPORTED)).toEqual({ mode: "replace" });
+  });
+
+  it("replaces when the server cannot deduplicate a resubmitted write", () => {
+    const all = turns(5);
+    expect(planRetain(all, cursorFor(all, 3), { appendSupported: false })).toEqual({
+      mode: "replace",
+    });
+  });
+
+  it("skips when nothing was added since the last write", () => {
+    const all = turns(4);
+    expect(planRetain(all, cursorFor(all, 4), SUPPORTED)).toEqual({ mode: "skip" });
+  });
+
+  it("skips an empty transcript", () => {
+    expect(planRetain([], undefined, SUPPORTED)).toEqual({ mode: "skip" });
+  });
+});
+
+describe("fingerprintTurns", () => {
+  it("changes when the retained prefix changes, not when later turns are appended", () => {
+    const all = turns(5);
+    expect(fingerprintTurns([...all, turn(99)], 3)).toBe(fingerprintTurns(all, 3));
+    const edited = [turn(0), { role: "user", content: "edited" }, ...turns(3, 2)];
+    expect(fingerprintTurns(edited, 3)).not.toBe(fingerprintTurns(all, 3));
+  });
+
+  it("distinguishes prefixes of different length", () => {
+    const all = turns(5);
+    expect(fingerprintTurns(all, 2)).not.toBe(fingerprintTurns(all, 3));
+  });
+});
+
+describe("memoryCursorStore", () => {
+  it("keeps cursors per session", () => {
+    const store = memoryCursorStore();
+    expect(store.read("a")).toBeUndefined();
+    store.write("a", { turns: 2, fingerprint: "f" });
+    store.write("b", { turns: 7, fingerprint: "g" });
+    expect(store.read("a")).toEqual({ turns: 2, fingerprint: "f" });
+    expect(store.read("b")).toEqual({ turns: 7, fingerprint: "g" });
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/retain-cursor.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-cursor.ts
@@ -34,9 +34,23 @@ export interface RetainCursor {
    *  per hook invocation from that event's cwd — a session that moves between repos (#3133) keeps
    *  its id and changes bank, and the new bank holds no document to append to. */
   bank: string;
+  /** Appends written since the last full document write (see MAX_APPENDS_BEFORE_RESYNC). */
+  appends?: number;
   /** A write was started and not confirmed: the next retain must replace, not append. */
   dirty?: boolean;
 }
+
+/**
+ * Force a full write every so often, however healthy the cursor looks.
+ *
+ * Retains are async: the server acknowledges the submission and extracts later, so a write can be
+ * confirmed to us and still fail server-side afterwards — and a resubmitted `operation_id` replays
+ * the original operation whatever its status, so those turns would never be sent again. Replacing
+ * everything was self-healing precisely because it re-sent the whole document each time; appending
+ * gives that up, and this bounds what a single lost write can cost to the turns since the last
+ * re-sync rather than to the rest of the session.
+ */
+export const MAX_APPENDS_BEFORE_RESYNC = 20;
 
 /**
  * Identity of the first `count` turns — every one of them, hashed incrementally.
@@ -71,6 +85,7 @@ export function planRetain(
   if (!opts.appendSupported || !cursor || cursor.dirty) return { mode: "replace" };
   // A different bank holds no document for this session: appending would store the tail alone.
   if (cursor.bank !== opts.bank) return { mode: "replace" };
+  if ((cursor.appends ?? 0) >= MAX_APPENDS_BEFORE_RESYNC) return { mode: "replace" };
   // Fewer turns than we wrote: the transcript shrank, so it was rewritten, not extended.
   if (cursor.turns > turns.length) return { mode: "replace" };
   if (fingerprintTurns(turns, cursor.turns) !== cursor.fingerprint) return { mode: "replace" };

--- a/hindsight-integrations/coding-agents/src/core/retain-cursor.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-cursor.ts
@@ -1,0 +1,89 @@
+/**
+ * How much of a live session has already been written to its `conversation:<id>` document.
+ *
+ * Without a cursor every write-back re-uploads the WHOLE conversation: a long session re-sends the
+ * entire transcript on every Stop (and every N turns under the persistent-plugin runtime), which is
+ * what makes a runaway session unretainable rather than merely large. With one, a retain sends only
+ * the turns added since the last successful write, using the server's `update_mode: "append"`.
+ *
+ * Append is only correct while our view of the document matches the server's, so this deliberately
+ * falls back to a FULL REPLACE — which is idempotent by construction and therefore always safe —
+ * whenever that cannot be established:
+ *
+ *   - no cursor          first write-back of the session, or the cache was evicted.
+ *   - fingerprint drift  the transcript was REWRITTEN rather than extended (Claude Code compaction,
+ *                        a truncated/rotated rollout), so what we already sent is no longer a prefix
+ *                        of what we hold and an append would splice two different conversations.
+ *   - dirty              the previous retain failed, or its outcome is unknown (the client aborts at
+ *                        15s while the server may well have committed it). Appending on top of an
+ *                        unknown state is the one way to DUPLICATE turns inside the document, so we
+ *                        rewrite the whole thing instead and let replace re-establish the truth.
+ *
+ * `dirty` is set BEFORE the request and cleared after it succeeds, so an overlapping retain (the
+ * runtime fires them without awaiting) sees the advanced cursor and does not re-send the same slice.
+ */
+import { createHash } from "node:crypto";
+import type { TransportTurn } from "./chat";
+
+export interface RetainCursor {
+  /** Turns already written to the document (index into the normalized transcript). */
+  turns: number;
+  /** Identity of the written prefix — detects a rewritten transcript (see module doc). */
+  fingerprint: string;
+  /** A write was started and not confirmed: the next retain must replace, not append. */
+  dirty?: boolean;
+}
+
+/**
+ * Identity of the first `count` turns — every one of them, hashed incrementally.
+ *
+ * Sampling the ends is not enough: a transcript whose MIDDLE was rewritten (an edited or redacted
+ * turn) still starts and ends the same way, and would then be appended to as though nothing had
+ * changed. Hashing the whole prefix costs O(prefix) per retain, far less than the replace it avoids
+ * — the same bytes through a digest instead of over the network — and it streams, so nothing here
+ * materializes a second copy of the transcript.
+ */
+export function fingerprintTurns(turns: TransportTurn[], count: number): string {
+  const h = createHash("sha1").update(String(count));
+  for (let i = 0; i < count; i++) h.update("\n" + JSON.stringify(turns[i]));
+  return h.digest("hex");
+}
+
+export type RetainPlan =
+  | { mode: "replace" }
+  | { mode: "append"; fromTurn: number }
+  | { mode: "skip" };
+
+/**
+ * Decide how to write `turns` given what we last wrote. See the module doc for why every uncertain
+ * case resolves to "replace" — the expensive-but-correct option — rather than to an append.
+ */
+export function planRetain(
+  turns: TransportTurn[],
+  cursor: RetainCursor | undefined,
+  opts: { appendSupported: boolean }
+): RetainPlan {
+  if (!turns.length) return { mode: "skip" };
+  if (!opts.appendSupported || !cursor || cursor.dirty) return { mode: "replace" };
+  // Fewer turns than we wrote: the transcript shrank, so it was rewritten, not extended.
+  if (cursor.turns > turns.length) return { mode: "replace" };
+  if (fingerprintTurns(turns, cursor.turns) !== cursor.fingerprint) return { mode: "replace" };
+  if (cursor.turns === turns.length) return { mode: "skip" }; // nothing new since the last write
+  return { mode: "append", fromTurn: cursor.turns };
+}
+
+/** Per-session cursor storage. Hook harnesses are a fresh process per event so theirs is file-backed
+ *  (core/session-cache.ts); the persistent-plugin runtime keeps its own in memory. */
+export interface RetainCursorStore {
+  read(sessionId: string): RetainCursor | undefined;
+  write(sessionId: string, cursor: RetainCursor): void;
+}
+
+/** In-memory store for a long-lived host (opencode/kilo). */
+export function memoryCursorStore(): RetainCursorStore {
+  const cursors = new Map<string, RetainCursor>();
+  return {
+    read: (sessionId) => cursors.get(sessionId),
+    write: (sessionId, cursor) => void cursors.set(sessionId, cursor),
+  };
+}

--- a/hindsight-integrations/coding-agents/src/core/retain-cursor.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-cursor.ts
@@ -30,6 +30,10 @@ export interface RetainCursor {
   turns: number;
   /** Identity of the written prefix — detects a rewritten transcript (see module doc). */
   fingerprint: string;
+  /** The bank the document was written to. The cursor is keyed by session, but the bank is derived
+   *  per hook invocation from that event's cwd — a session that moves between repos (#3133) keeps
+   *  its id and changes bank, and the new bank holds no document to append to. */
+  bank: string;
   /** A write was started and not confirmed: the next retain must replace, not append. */
   dirty?: boolean;
 }
@@ -61,10 +65,12 @@ export type RetainPlan =
 export function planRetain(
   turns: TransportTurn[],
   cursor: RetainCursor | undefined,
-  opts: { appendSupported: boolean }
+  opts: { appendSupported: boolean; bank: string }
 ): RetainPlan {
   if (!turns.length) return { mode: "skip" };
   if (!opts.appendSupported || !cursor || cursor.dirty) return { mode: "replace" };
+  // A different bank holds no document for this session: appending would store the tail alone.
+  if (cursor.bank !== opts.bank) return { mode: "replace" };
   // Fewer turns than we wrote: the transcript shrank, so it was rewritten, not extended.
   if (cursor.turns > turns.length) return { mode: "replace" };
   if (fingerprintTurns(turns, cursor.turns) !== cursor.fingerprint) return { mode: "replace" };

--- a/hindsight-integrations/coding-agents/src/core/retain-hook.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HindsightClient } from "./hindsight";
 import { buildRetain, runRetainHook } from "./retain-hook";
+import { memoryCursorStore, type RetainCursorStore } from "./retain-cursor";
 
 let root: string;
 let file: string;
@@ -128,5 +129,111 @@ describe("runRetainHook anti-recursion guard", () => {
     // proves the guard fired first.
     await runRetainHook({ harness: "claude-code", parse: () => ({}) }, makeClient);
     expect(makeClient).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildRetain — incremental write-back across Stop hooks", () => {
+  const line = (i: number) =>
+    JSON.stringify({
+      type: "user",
+      timestamp: `2026-01-01T00:00:0${i}Z`,
+      message: { role: "user", content: `turn ${i}` },
+    });
+
+  /** One Stop-hook invocation over the transcript as it stands. Each hook run is a fresh process in
+   *  production, so only the cursor store carries state between these calls. */
+  const stop = async (client: HindsightClient, cursors: RetainCursorStore) =>
+    buildRetain({
+      harness: "codex",
+      sessionId: "sess-append",
+      transcriptPath: file,
+      client,
+      cursors,
+    });
+
+  const stubClient = () => {
+    const retain = vi.fn().mockResolvedValue(undefined);
+    return {
+      retain,
+      client: {
+        retain,
+        bank: "coding-agent::repo",
+        supportsIdempotentRetain: async () => true,
+      } as unknown as HindsightClient,
+    };
+  };
+
+  it("sends the whole session once, then only the turns the session grew by", async () => {
+    const { retain, client } = stubClient();
+    const cursors = memoryCursorStore();
+
+    writeFileSync(file, [line(0), line(1)].join("\n"));
+    await stop(client, cursors);
+
+    writeFileSync(file, [line(0), line(1), line(2)].join("\n"));
+    await stop(client, cursors);
+
+    expect(retain).toHaveBeenCalledTimes(2);
+    // First write carries the REF-ID header plus both turns; the second carries turn 2 alone.
+    expect((retain.mock.calls[0][0] as string).split("\n")).toHaveLength(3);
+    expect(retain.mock.calls[0][5].updateMode).toBeUndefined();
+    const appended = (retain.mock.calls[1][0] as string).split("\n");
+    expect(appended).toHaveLength(1);
+    expect(JSON.parse(appended[0])).toMatchObject({ role: "user", content: "turn 2" });
+    expect(retain.mock.calls[1][5].updateMode).toBe("append");
+  });
+
+  it("does not write again when the session ended without new turns", async () => {
+    const { retain, client } = stubClient();
+    const cursors = memoryCursorStore();
+    writeFileSync(file, [line(0), line(1)].join("\n"));
+    await stop(client, cursors);
+    await stop(client, cursors);
+    expect(retain).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces the document when the transcript was rewritten rather than extended", async () => {
+    const { retain, client } = stubClient();
+    const cursors = memoryCursorStore();
+    writeFileSync(file, [line(0), line(1), line(2)].join("\n"));
+    await stop(client, cursors);
+
+    // Compaction: earlier turns replaced by a summary, then the session continues.
+    writeFileSync(
+      file,
+      [
+        JSON.stringify({
+          type: "user",
+          timestamp: "2026-01-01T00:00:09Z",
+          message: { role: "user", content: "summary of the work so far" },
+        }),
+        line(3),
+      ].join("\n")
+    );
+    await stop(client, cursors);
+
+    expect(retain.mock.calls[1][5].updateMode).toBeUndefined();
+    const rewritten = (retain.mock.calls[1][0] as string).split("\n");
+    expect(rewritten).toHaveLength(3); // REF-ID + the two turns that now exist
+    expect(JSON.parse(rewritten[1])).toMatchObject({ content: "summary of the work so far" });
+  });
+
+  it("a failed write is not silently skipped by the next one — it replaces", async () => {
+    const { retain, client } = stubClient();
+    const cursors = memoryCursorStore();
+    writeFileSync(file, [line(0), line(1)].join("\n"));
+    await stop(client, cursors);
+
+    retain.mockRejectedValueOnce(new Error("server unreachable"));
+    writeFileSync(file, [line(0), line(1), line(2)].join("\n"));
+    await stop(client, cursors); // buildRetain swallows the failure by design
+
+    writeFileSync(file, [line(0), line(1), line(2), line(3)].join("\n"));
+    await stop(client, cursors);
+
+    expect(retain).toHaveBeenCalledTimes(3);
+    expect(retain.mock.calls[2][5].updateMode).toBeUndefined();
+    // Everything the failed append would have carried is back in the replaced document.
+    expect((retain.mock.calls[2][0] as string).split("\n")).toHaveLength(5);
   });
 });

--- a/hindsight-integrations/coding-agents/src/core/retain-hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.ts
@@ -20,6 +20,8 @@ import { diag } from "./diag";
 import { log, setLogLevel } from "./log";
 import type { ClientOpts } from "./hindsight";
 import { HindsightClient } from "./hindsight";
+import type { RetainCursorStore } from "./retain-cursor";
+import { fileCursorStore } from "./session-cache";
 import { readClaudeTranscript } from "./transcript";
 import type { TransportTurn } from "./chat";
 
@@ -42,9 +44,12 @@ export interface RetainHookSpec {
   readTranscript?: TranscriptReader;
 }
 
-/** Minimal client shape `buildRetain` needs — `HindsightClient` satisfies it structurally. */
+/** Minimal client shape `buildRetain` needs — `HindsightClient` satisfies it structurally. The
+ *  capability probe is part of the contract: appending to a document is only safe against a server
+ *  that can deduplicate a resubmitted write (see core/retain-cursor.ts). */
 interface RetainClient {
   retain: HindsightClient["retain"];
+  supportsIdempotentRetain: HindsightClient["supportsIdempotentRetain"];
 }
 
 /**
@@ -58,6 +63,8 @@ export async function buildRetain(args: {
   transcriptPath: string;
   client: RetainClient;
   readTranscript?: TranscriptReader;
+  /** Injectable for tests; defaults to the per-session temp file (a Stop hook has no memory). */
+  cursors?: RetainCursorStore;
 }): Promise<void> {
   const { harness, sessionId, transcriptPath, client } = args;
   const readTranscript = args.readTranscript ?? readClaudeTranscript;
@@ -68,7 +75,9 @@ export async function buildRetain(args: {
   const startTs = turns[0]?.timestamp ?? new Date().toISOString();
   const t0 = Date.now();
   try {
-    await retainLiveSession(client as HindsightClient, sessionId, turns, startTs, harness);
+    await retainLiveSession(client as HindsightClient, sessionId, turns, startTs, harness, {
+      cursors: args.cursors ?? fileCursorStore(harness),
+    });
     diag(harness, "retain_ok", { ms: Date.now() - t0, turns: turns.length, session: sessionId });
   } catch (e) {
     log.warn(harness, "session write-back failed", {

--- a/hindsight-integrations/coding-agents/src/core/runtime.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/runtime.test.ts
@@ -47,6 +47,7 @@ describe("RuntimeCore session-idle write-back", () => {
 
     // The turn-driven path sees only what existed BEFORE the reply.
     await runtime.onTranscript("s1", [turn("user", "how do we round?")]);
+    await new Promise((r) => setTimeout(r, 0)); // retain is fire-and-forget
     expect(retained).toHaveLength(1);
     expect(String(retained[0].turns)).not.toContain("we round half up");
 

--- a/hindsight-integrations/coding-agents/src/core/runtime.ts
+++ b/hindsight-integrations/coding-agents/src/core/runtime.ts
@@ -19,6 +19,7 @@ import { log, setLogLevel } from "./log";
 import type { HindsightClient } from "./hindsight";
 import { buildKnowledgeTools, type ToolSpec } from "./knowledge-tools";
 import { retainLiveSession, type TransportTurn } from "./chat";
+import { memoryCursorStore } from "./retain-cursor";
 import { buildSessionStartContext } from "./session-start";
 import { buildHookOutput } from "./hook";
 import { sessionCacheFile, writeSessionCache } from "./session-cache";
@@ -32,6 +33,8 @@ export class RuntimeCore {
     string,
     { startTs: string; retainedUsers: number; retainedTurns: number }
   >();
+  /** Live write-back cursors. In memory, unlike the hook harnesses': this host outlives the session. */
+  private readonly cursors = memoryCursorStore();
   /** Pulls a session's CURRENT transcript from the host (set by the adapter); see onSessionIdle. */
   private fetchTranscript?: (sessionId: string) => Promise<TransportTurn[]>;
   private lastInjection = ""; // most recent turn's injection block, keyed by nothing (see getInjection)
@@ -238,7 +241,9 @@ export class RuntimeCore {
     trigger = "turn"
   ): void {
     const t0 = Date.now();
-    void retainLiveSession(this.client, sessionId, turns, startTs, this.harness)
+    void retainLiveSession(this.client, sessionId, turns, startTs, this.harness, {
+      cursors: this.cursors,
+    })
       .then(() =>
         diag(this.harness, "retain_ok", {
           ms: Date.now() - t0,

--- a/hindsight-integrations/coding-agents/src/core/session-cache.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-cache.test.ts
@@ -1,0 +1,50 @@
+import { rmSync } from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  fileCursorStore,
+  readSessionCache,
+  sessionCacheFile,
+  writeSessionCache,
+} from "./session-cache";
+
+const HARNESS = "codex-cursor-test";
+const sessions = ["s1", "s2"];
+
+afterEach(() => {
+  for (const s of sessions) rmSync(sessionCacheFile(HARNESS, s), { force: true });
+});
+
+describe("fileCursorStore", () => {
+  it("round-trips a cursor across processes (a Stop hook has no memory)", () => {
+    // Two stores, as two separate hook invocations would build them.
+    fileCursorStore(HARNESS).write("s1", { turns: 4, fingerprint: "abc", dirty: true });
+    expect(fileCursorStore(HARNESS).read("s1")).toEqual({
+      turns: 4,
+      fingerprint: "abc",
+      dirty: true,
+    });
+  });
+
+  it("keeps cursors separate per session", () => {
+    const store = fileCursorStore(HARNESS);
+    store.write("s1", { turns: 1, fingerprint: "a" });
+    store.write("s2", { turns: 9, fingerprint: "b" });
+    expect(store.read("s1")).toEqual({ turns: 1, fingerprint: "a" });
+    expect(store.read("s2")).toEqual({ turns: 9, fingerprint: "b" });
+  });
+
+  it("reads as absent when the session was never written — the caller then replaces", () => {
+    expect(fileCursorStore(HARNESS).read("s1")).toBeUndefined();
+  });
+
+  it("preserves the rest of the session cache it shares a file with", () => {
+    const file = sessionCacheFile(HARNESS, "s1");
+    writeSessionCache(file, { turns: 3, reflectAnswer: "already ran" });
+    fileCursorStore(HARNESS).write("s1", { turns: 2, fingerprint: "f" });
+    expect(readSessionCache(file)).toEqual({
+      turns: 3,
+      reflectAnswer: "already ran",
+      retain: { turns: 2, fingerprint: "f" },
+    });
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/session-cache.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-cache.test.ts
@@ -17,20 +17,21 @@ afterEach(() => {
 describe("fileCursorStore", () => {
   it("round-trips a cursor across processes (a Stop hook has no memory)", () => {
     // Two stores, as two separate hook invocations would build them.
-    fileCursorStore(HARNESS).write("s1", { turns: 4, fingerprint: "abc", dirty: true });
+    fileCursorStore(HARNESS).write("s1", { turns: 4, fingerprint: "abc", bank: "b1", dirty: true });
     expect(fileCursorStore(HARNESS).read("s1")).toEqual({
       turns: 4,
       fingerprint: "abc",
+      bank: "b1",
       dirty: true,
     });
   });
 
   it("keeps cursors separate per session", () => {
     const store = fileCursorStore(HARNESS);
-    store.write("s1", { turns: 1, fingerprint: "a" });
-    store.write("s2", { turns: 9, fingerprint: "b" });
-    expect(store.read("s1")).toEqual({ turns: 1, fingerprint: "a" });
-    expect(store.read("s2")).toEqual({ turns: 9, fingerprint: "b" });
+    store.write("s1", { turns: 1, fingerprint: "a", bank: "b1" });
+    store.write("s2", { turns: 9, fingerprint: "b", bank: "b1" });
+    expect(store.read("s1")).toEqual({ turns: 1, fingerprint: "a", bank: "b1" });
+    expect(store.read("s2")).toEqual({ turns: 9, fingerprint: "b", bank: "b1" });
   });
 
   it("reads as absent when the session was never written — the caller then replaces", () => {
@@ -40,11 +41,11 @@ describe("fileCursorStore", () => {
   it("preserves the rest of the session cache it shares a file with", () => {
     const file = sessionCacheFile(HARNESS, "s1");
     writeSessionCache(file, { turns: 3, reflectAnswer: "already ran" });
-    fileCursorStore(HARNESS).write("s1", { turns: 2, fingerprint: "f" });
+    fileCursorStore(HARNESS).write("s1", { turns: 2, fingerprint: "f", bank: "b1" });
     expect(readSessionCache(file)).toEqual({
       turns: 3,
       reflectAnswer: "already ran",
-      retain: { turns: 2, fingerprint: "f" },
+      retain: { turns: 2, fingerprint: "f", bank: "b1" },
     });
   });
 });

--- a/hindsight-integrations/coding-agents/src/core/session-cache.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-cache.ts
@@ -2,6 +2,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import type { PageRef } from "./knowledge-injection";
+import type { RetainCursor, RetainCursorStore } from "./retain-cursor";
 
 /** Process-shared state for hook harnesses. SessionStart and prompt hooks are separate Node
  * processes, so this temp-file handoff carries lifecycle decisions without writing user config or
@@ -12,6 +13,8 @@ export interface SessionCache {
   /** SessionStart saw a new/empty bank; consume this on prompt one, then allow reflect. */
   deferInitialReflect?: boolean;
   pages?: { atTurn: number; list: PageRef[] };
+  /** How much of this session's transcript is already in its document (core/retain-cursor.ts). */
+  retain?: RetainCursor;
 }
 
 export function sessionCacheFile(harness: string, sessionId: string): string {
@@ -33,4 +36,21 @@ export function writeSessionCache(cacheFile: string, cache: SessionCache): void 
   } catch {
     /* session state is best-effort */
   }
+}
+
+/**
+ * Retain cursor kept in the per-session temp file, for the hook harnesses: Stop runs in a fresh
+ * process every time, so "what have I already written" cannot live in memory.
+ *
+ * Losing this file (temp cleanup, reboot) is not a correctness problem — a missing cursor means the
+ * next retain replaces the whole document, which is exactly what the plugin did before appends.
+ */
+export function fileCursorStore(harness: string): RetainCursorStore {
+  return {
+    read: (sessionId) => readSessionCache(sessionCacheFile(harness, sessionId)).retain,
+    write: (sessionId, cursor) => {
+      const file = sessionCacheFile(harness, sessionId);
+      writeSessionCache(file, { ...readSessionCache(file), retain: cursor });
+    },
+  };
 }

--- a/hindsight-integrations/coding-agents/src/core/session-start.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.test.ts
@@ -286,7 +286,6 @@ describe("buildSessionStartContext — periodic re-survey (bank-stored commit co
     `survey-baseline:${sha}`,
     ["source:survey-baseline"],
     "survey", // survey-lifecycle strategy (marker rule: zero extraction)
-    expect.anything(),
   ];
 
   it(">= threshold since the latest reachable baseline -> re-surveys + records a new baseline", async () => {

--- a/hindsight-integrations/coding-agents/src/core/session-start.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.ts
@@ -32,7 +32,7 @@ import { brandWord } from "./brand";
 import { diag } from "./diag";
 import { setLogLevel } from "./log";
 import { parsePageList, buildKnowledgePreamble, type PageRef } from "./knowledge-injection";
-import type { ClientOpts } from "./hindsight";
+import type { ClientOpts, RetainOpts } from "./hindsight";
 import { HindsightClient } from "./hindsight";
 import { sessionCacheFile, writeSessionCache } from "./session-cache";
 
@@ -49,7 +49,7 @@ interface SeedContextClient {
     documentId: string,
     tags: string[],
     strategy: string,
-    opts?: { async?: boolean }
+    opts?: RetainOpts
   ): Promise<void>;
 }
 
@@ -174,8 +174,7 @@ export async function buildSessionStartContext(args: {
           "hindsight codebase-survey baseline",
           `${SURVEY_BASELINE_PREFIX}${sha}`,
           [SURVEY_BASELINE_TAG],
-          "survey",
-          { async: true }
+          "survey"
         )
       ).catch(() => {});
     } catch {

--- a/hindsight-integrations/coding-agents/src/core/util.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/util.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { semverGte } from "./util";
+
+describe("semverGte", () => {
+  it("compares numerically, not lexically", () => {
+    expect(semverGte("0.10.0", "0.9.0")).toBe(true);
+    expect(semverGte("0.9.0", "0.10.0")).toBe(false);
+  });
+
+  it("decides the retain-idempotency floor correctly", () => {
+    expect(semverGte("0.8.6", "0.8.6")).toBe(true);
+    expect(semverGte("0.8.5", "0.8.6")).toBe(false); // one patch short
+    expect(semverGte("0.9.0", "0.8.6")).toBe(true);
+    expect(semverGte("1.0.0", "0.8.6")).toBe(true);
+  });
+
+  it("treats an unknown version as too old — a capability probe must fail closed", () => {
+    expect(semverGte(undefined, "0.8.6")).toBe(false);
+    expect(semverGte("", "0.8.6")).toBe(false);
+    expect(semverGte("dev", "0.8.6")).toBe(false);
+  });
+
+  it("compares by the numeric part of a pre-release or build-tagged version", () => {
+    expect(semverGte("0.9.0rc1", "0.8.6")).toBe(true);
+    expect(semverGte("0.8.5+dev", "0.8.6")).toBe(false);
+  });
+
+  it("treats a missing patch component as zero", () => {
+    expect(semverGte("0.9", "0.8.6")).toBe(true);
+    expect(semverGte("0.8", "0.8.6")).toBe(false);
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/util.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/util.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { MIN_IDEMPOTENT_RETAIN_VERSION } from "./hindsight";
 import { semverGte } from "./util";
 
 describe("semverGte", () => {
@@ -8,10 +9,13 @@ describe("semverGte", () => {
   });
 
   it("decides the retain-idempotency floor correctly", () => {
-    expect(semverGte("0.8.6", "0.8.6")).toBe(true);
-    expect(semverGte("0.8.5", "0.8.6")).toBe(false); // one patch short
-    expect(semverGte("0.9.0", "0.8.6")).toBe(true);
-    expect(semverGte("1.0.0", "0.8.6")).toBe(true);
+    // Pinned to the real constant: operation_id first shipped in v0.8.6 (#2937/#2947).
+    const floor = MIN_IDEMPOTENT_RETAIN_VERSION;
+    expect(floor).toBe("0.8.6");
+    expect(semverGte("0.8.6", floor)).toBe(true);
+    expect(semverGte("0.8.5", floor)).toBe(false); // one patch short
+    expect(semverGte("0.9.0", floor)).toBe(true);
+    expect(semverGte("1.0.0", floor)).toBe(true);
   });
 
   it("treats an unknown version as too old — a capability probe must fail closed", () => {

--- a/hindsight-integrations/coding-agents/src/core/util.ts
+++ b/hindsight-integrations/coding-agents/src/core/util.ts
@@ -2,6 +2,23 @@
 
 export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
+/** `version >= min`, comparing numeric major/minor/patch. A missing or unparseable version is
+ *  treated as OLDER than anything — capability probes must fail closed, not assume support.
+ *  Pre-release/build suffixes ("0.9.0rc1", "0.9.0+dev") compare by their numeric part. */
+export function semverGte(version: string | undefined, min: string): boolean {
+  const parts = (v: string) => {
+    const m = v.trim().match(/^(\d+)\.(\d+)(?:\.(\d+))?/);
+    return m ? [Number(m[1]), Number(m[2]), Number(m[3] ?? 0)] : undefined;
+  };
+  const a = version ? parts(version) : undefined;
+  const b = parts(min);
+  if (!a || !b) return false;
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] > b[i];
+  }
+  return true;
+}
+
 /** Bounded-concurrency map: run `fn` over `items`, at most `n` in flight. Never rejects on item error. */
 export async function pool<T>(
   items: T[],

--- a/hindsight-integrations/coding-agents/src/core/uuid.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/uuid.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { HINDSIGHT_NAMESPACE, uuidV5 } from "./uuid";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const DNS_NAMESPACE = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+
+describe("uuidV5", () => {
+  it("matches the published RFC 4122 vector", () => {
+    // The canonical uuid5(NAMESPACE_DNS, "python.org") — proves the digest, version and variant
+    // bits are laid out the way every other implementation (including the server's) expects.
+    expect(uuidV5("python.org", DNS_NAMESPACE)).toBe("886313e1-3b8a-5372-9b90-0c9aee199e5d");
+  });
+
+  it("is a well-formed v5 UUID — the API rejects anything else as an operation_id", () => {
+    expect(uuidV5("conversation:s1")).toMatch(UUID_RE);
+  });
+
+  it("is deterministic per name and separates distinct names", () => {
+    expect(uuidV5("a")).toBe(uuidV5("a"));
+    expect(uuidV5("a")).not.toBe(uuidV5("b"));
+  });
+
+  it("separates names across namespaces", () => {
+    expect(uuidV5("a", HINDSIGHT_NAMESPACE)).not.toBe(uuidV5("a", DNS_NAMESPACE));
+  });
+
+  it("rejects a malformed namespace rather than silently hashing garbage", () => {
+    expect(() => uuidV5("a", "not-a-uuid")).toThrow(/invalid UUID namespace/);
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/uuid.ts
+++ b/hindsight-integrations/coding-agents/src/core/uuid.ts
@@ -1,0 +1,31 @@
+/**
+ * Deterministic UUIDv5 (RFC 4122 §4.3) — the identity for idempotent retains.
+ *
+ * The server admits one async operation per `operation_id` (#2937), so deriving that id from the
+ * payload makes a re-submission of the SAME content a no-op instead of a second extraction run.
+ * It has to be deterministic (no randomUUID) and a valid UUID — the API rejects anything else.
+ */
+import { createHash } from "node:crypto";
+
+/** Namespace for every id this plugin derives. Arbitrary but FIXED: changing it re-mints every
+ *  operation id and silently disables dedup against everything already submitted. */
+export const HINDSIGHT_NAMESPACE = "e75686a4-e923-4326-a0d1-358f1c6c3eb4";
+
+/** RFC 4122 v5 (SHA-1) UUID for `name` within `namespace`. */
+export function uuidV5(name: string, namespace: string = HINDSIGHT_NAMESPACE): string {
+  const ns = Buffer.from(namespace.replace(/-/g, ""), "hex");
+  if (ns.length !== 16) throw new Error(`invalid UUID namespace: ${namespace}`);
+  const bytes = Buffer.from(
+    createHash("sha1").update(ns).update(Buffer.from(name, "utf8")).digest().subarray(0, 16)
+  );
+  bytes[6] = (bytes[6] & 0x0f) | 0x50; // version 5
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // RFC 4122 variant
+  const hex = bytes.toString("hex");
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20),
+  ].join("-");
+}

--- a/hindsight-integrations/coding-agents/src/deepen.ts
+++ b/hindsight-integrations/coding-agents/src/deepen.ts
@@ -246,8 +246,7 @@ async function main() {
             "hindsight codebase-survey baseline",
             best.id,
             ["source:survey-baseline", "survey-state:done"],
-            "survey",
-            { async: true }
+            "survey"
           );
           log(`[survey] marker ${best.id} flipped to completed`);
         }


### PR DESCRIPTION
## Problem

The live write-back re-uploaded the **whole** conversation on every Stop, and every N turns under the persistent-plugin runtime. A long session therefore re-sent its entire transcript each time, which is what turns a large session into an *unretainable* one rather than merely a slow one.

Measured on a 170 MB Codex rollout (400k turns): 451 MB heap, 532 MB RSS, and a 137 MB single-string document per write — against V8's hard 537 M-char string limit. The server has supported `update_mode: "append"` since #932; the plugin never used it.

Related reports, same root cause: #3292 (oversized rollouts silently skip Stop retains), #3280 (duplicate async retains), #3282 (oversized replacements bypass delta retain).

## What this does

**Sends only the new turns.** A per-session cursor records how much of the transcript is already in the `conversation:<id>` document; subsequent retains append the turns added since. The server joins them onto the stored text with `"\n"` — which is exactly why the transcript has always been JSONL.

**Every uncertain case falls back to a full replace**, which is idempotent by construction, so any doubt about what the server holds is resolved by rewriting the document:

| condition | why append is unsafe |
|---|---|
| no cursor | first write of the session, or the cache was evicted |
| fingerprint drift | the transcript was *rewritten*, not extended (compaction, truncated rollout) |
| dirty | the previous write failed, or timed out with the server possibly committing it |
| bank mismatch | the session moved to a different bank, which holds no document for it |
| server < 0.8.6 | it cannot deduplicate a resubmitted write |

**Idempotent conversation retains.** A deterministic v5 `operation_id` collapses a resubmitted write into the original operation. This is what makes append safe: `req()` aborts at 15s with no retry, and a server that committed the write anyway would otherwise receive the same turns again.

**`RetainOpts.async` removed.** No caller ever passed `false`. Retains are always async — nothing here can afford to block a coding agent's hook on extraction.

## Versioning

Request-side `operation_id` landed in `31218127e` (#2937/#2947) and first shipped in **v0.8.6** — not 0.9.x. `update_mode` is far older (#932, April).

`RetainRequest` has no `extra="forbid"`, so an older server *silently ignores* `operation_id` rather than rejecting it — which is precisely why append needs a real gate rather than optimism. A cached `GET /version` probe decides; anything unreachable, unparseable, or older keeps replacing. The probe fails closed and never costs a write-back: if it throws, the answer is "no append".

Only conversation retains carry a deterministic id. Backfill, git, knowledge and survey retains keep replacing and deliberately stay non-idempotent, so re-retaining identical content after a document is deleted still restores it.

## Two bugs caught in review, both with regression tests

**Overlapping write-backs duplicated turns.** The runtime fires retains without awaiting them, and reading the cursor was not atomic with claiming it — the capability probe awaits in between. Two overlapping calls both planned an append from the same position:

```
replace(REF-ID + turns 0-4), append(turns 5-7), append(turns 5-8)   ← 5,6,7 duplicated
```

Serialising only the claim would not have been enough either: that leaves an append racing a replace on the wire, where landing order decides the outcome. The whole read-plan-send-confirm cycle is now chained per session.

**A session that changed bank appended into the wrong one.** The cursor was keyed by `(harness, session id)`, but the bank is re-derived from each hook event's `cwd` — so a session that moves between repos (#3133) keeps its id and changes bank:

```
bank repo-a: replace(REF-ID + turns 0-4)
bank repo-b: append(turns 5-7)      ← turns 0-4 never existed here
```

The cursor now records the bank it wrote to.

## Behaviour on resume and on concurrent sessions

- **Concurrent sessions in one directory**: same bank, but the document id, the cursor and the serialization chain are all per-session — they never touch each other.
- **Resume**: the cursor is file-backed for the hook harnesses (Stop is a fresh process every time, so it had to be), in-memory for opencode/kilo. Losing it — host restart, temp cleanup — degrades to one full replace, never to lost turns.

## Known limitations

- A deployment with `store_document_text` disabled rejects appends outright (`memory_engine.py:3982`), and the version probe cannot see that. It self-heals (failed write → dirty → replace), but roughly half the retains would fail first. A sticky "this server refuses appends" flag is a few lines if anyone hits it.
- If the document is deleted server-side while the cursor survives in the same bank, the next append writes only the tail. Nothing on the client can detect this.

## Test

`npx vitest run` in `hindsight-integrations/coding-agents`: **391 passed**, 19 skipped. `tsc --noEmit` clean, `./scripts/hooks/lint.sh` clean, `npm run build` clean.

New coverage: the append/replace decision matrix, prefix fingerprinting, deterministic UUIDv5 (against the published RFC 4122 vector), the version gate, cursor persistence across processes, the incremental path end-to-end through the Stop hook, write-back serialisation, session isolation, and bank change mid-session.
