### PR TITLE
fix(coding-agents,ci): drop the periodic re-sync; stop running doc examples for integration changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       cli: ${{ steps.filter.outputs.cli }}
       docker: ${{ steps.filter.outputs.docker }}
       helm: ${{ steps.filter.outputs.helm }}
-      docs: ${{ steps.filter.outputs.docs }}
+      doc-examples: ${{ steps.filter.outputs.doc-examples }}
       embed: ${{ steps.filter.outputs.embed }}
       all-npm: ${{ steps.filter.outputs.all-npm }}
       hindsight-all: ${{ steps.filter.outputs.hindsight-all }}
@@ -117,12 +117,17 @@ jobs:
             - 'docker/**'
           helm:
             - 'helm/**'
-          docs:
-            - 'hindsight-docs/**'
-            - '*.md'
-            # Integration changes can add/rename integrations, which the docs
-            # build's integrations check validates against integrations.json.
-            - 'hindsight-integrations/**'
+          # The RUNNABLE samples only. This replaces a broad `docs` filter that also
+          # matched 'hindsight-docs/**', '*.md' and 'hindsight-integrations/**' — the
+          # last of those so an integration rename would be caught by the docs build's
+          # integrations check, except that build (build-docs) has no `if:` and runs
+          # unconditionally anyway. test-doc-examples was the filter's only consumer,
+          # and it executes every sample against a live LLM-backed server, so every
+          # integration and prose-only PR paid for four provider-credentialed runs that
+          # none of those files can affect.
+          doc-examples:
+            - 'hindsight-docs/examples/**'
+            - 'scripts/test-doc-examples.sh'
           embed:
             - 'hindsight-embed/**'
           all-npm:
@@ -4692,7 +4697,7 @@ jobs:
       needs.detect-changes.outputs.clients-python == 'true' ||
       needs.detect-changes.outputs.clients-go == 'true' ||
       needs.detect-changes.outputs.cli == 'true' ||
-      needs.detect-changes.outputs.docs == 'true' ||
+      needs.detect-changes.outputs.doc-examples == 'true' ||
       needs.detect-changes.outputs.ci == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/hindsight-integrations/coding-agents/src/core/chat.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.test.ts
@@ -165,7 +165,6 @@ describe("retainLiveSession — incremental write-back", () => {
       turns: 6,
       fingerprint: expect.any(String),
       bank: "coding-agent::repo",
-      appends: 0, // the recovery replace re-established the document, restarting the re-sync count
     });
   });
 

--- a/hindsight-integrations/coding-agents/src/core/chat.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.ts
@@ -172,8 +172,7 @@ async function writeSession(
 ): Promise<void> {
   const refId = `conversation:${sessionId}`;
   const appendSupported = Boolean(cursors) && (await supportsAppend(client));
-  const prior = cursors?.read(sessionId);
-  const plan = planRetain(turns, prior, { appendSupported, bank: client.bank });
+  const plan = planRetain(turns, cursors?.read(sessionId), { appendSupported, bank: client.bank });
   if (plan.mode === "skip") return;
 
   const content =
@@ -190,8 +189,6 @@ async function writeSession(
     turns: turns.length,
     fingerprint: fingerprintTurns(turns, turns.length),
     bank: client.bank,
-    // A full write re-establishes the document, so the re-sync countdown starts over.
-    appends: plan.mode === "append" ? (prior?.appends ?? 0) + 1 : 0,
   };
   cursors?.write(sessionId, { ...next, dirty: true });
 

--- a/hindsight-integrations/coding-agents/src/core/retain-cursor.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-cursor.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { TransportTurn } from "./chat";
-import {
-  fingerprintTurns,
-  MAX_APPENDS_BEFORE_RESYNC,
-  memoryCursorStore,
-  planRetain,
-} from "./retain-cursor";
+import { fingerprintTurns, memoryCursorStore, planRetain } from "./retain-cursor";
 
 const turn = (i: number): TransportTurn => ({ role: "user", content: `turn ${i}` });
 const turns = (n: number, from = 0): TransportTurn[] =>
@@ -67,18 +62,6 @@ describe("planRetain", () => {
     const all = turns(5);
     expect(planRetain(all, cursorFor(all, 3), { ...SUPPORTED, bank: "other-repo" })).toEqual({
       mode: "replace",
-    });
-  });
-
-  it("forces a full write after a run of appends, so one lost write cannot cost the session", () => {
-    // Retains are async: a write can be acknowledged and still fail server-side afterwards, and a
-    // replayed operation_id will not redo it. The periodic replace bounds that loss.
-    const all = turns(5);
-    const run = { ...cursorFor(all, 3), appends: MAX_APPENDS_BEFORE_RESYNC };
-    expect(planRetain(all, run, SUPPORTED)).toEqual({ mode: "replace" });
-    expect(planRetain(all, { ...run, appends: MAX_APPENDS_BEFORE_RESYNC - 1 }, SUPPORTED)).toEqual({
-      mode: "append",
-      fromTurn: 3,
     });
   });
 

--- a/hindsight-integrations/coding-agents/src/core/retain-cursor.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-cursor.ts
@@ -34,23 +34,9 @@ export interface RetainCursor {
    *  per hook invocation from that event's cwd — a session that moves between repos (#3133) keeps
    *  its id and changes bank, and the new bank holds no document to append to. */
   bank: string;
-  /** Appends written since the last full document write (see MAX_APPENDS_BEFORE_RESYNC). */
-  appends?: number;
   /** A write was started and not confirmed: the next retain must replace, not append. */
   dirty?: boolean;
 }
-
-/**
- * Force a full write every so often, however healthy the cursor looks.
- *
- * Retains are async: the server acknowledges the submission and extracts later, so a write can be
- * confirmed to us and still fail server-side afterwards — and a resubmitted `operation_id` replays
- * the original operation whatever its status, so those turns would never be sent again. Replacing
- * everything was self-healing precisely because it re-sent the whole document each time; appending
- * gives that up, and this bounds what a single lost write can cost to the turns since the last
- * re-sync rather than to the rest of the session.
- */
-export const MAX_APPENDS_BEFORE_RESYNC = 20;
 
 /**
  * Identity of the first `count` turns — every one of them, hashed incrementally.
@@ -85,7 +71,6 @@ export function planRetain(
   if (!opts.appendSupported || !cursor || cursor.dirty) return { mode: "replace" };
   // A different bank holds no document for this session: appending would store the tail alone.
   if (cursor.bank !== opts.bank) return { mode: "replace" };
-  if ((cursor.appends ?? 0) >= MAX_APPENDS_BEFORE_RESYNC) return { mode: "replace" };
   // Fewer turns than we wrote: the transcript shrank, so it was rewritten, not extended.
   if (cursor.turns > turns.length) return { mode: "replace" };
   if (fingerprintTurns(turns, cursor.turns) !== cursor.fingerprint) return { mode: "replace" };


### PR DESCRIPTION
Follow-up to #3336. Two changes, both about cost.

## Drop the periodic re-sync

`MAX_APPENDS_BEFORE_RESYNC` forced a full document write every 20 appends. On a long session that re-uploads the entire transcript on a fixed cadence — the exact expense the append path exists to avoid. Removed, along with the `appends` counter on the cursor.

**What it was insuring against, now accepted as a known gap.** Retains are async: the server acknowledges the submission and extracts later, so a write can be confirmed to us and still fail afterwards — and `_resolve_retain_replay` returns a prior operation whatever its status, so resubmitting the same payload will not redo it. Those turns are never re-sent.

The scope of that gap is narrow, and everything else still self-heals:

| trigger | still replaces? |
|---|---|
| no cursor (first write, evicted cache, resumed session) | yes |
| fingerprint drift (compaction, rewritten transcript) | yes |
| dirty (write failed or timed out *visibly*) | yes |
| bank change | yes |
| server < 0.8.6 | yes |
| **acknowledged write that fails server-side later** | **no — uncovered** |

So a failure we can see still triggers a full rewrite on the next retain. Only a silent post-acknowledgement failure leaves a hole, and that hole is bounded to the turns in that one write rather than growing.

## Stop running the doc examples for integration changes

`test-doc-examples` gated on a `docs` filter that matched `hindsight-integrations/**`. That breadth was added so an integration rename would be caught by the docs build's integrations check — except `build-docs` has no `if:` at all and runs on every PR regardless, so it never needed the filter.

The only consumer of that breadth was the doc-examples matrix, which executes every runnable sample against a live LLM-backed server. Net effect: four provider-credentialed jobs on every integration PR (and every prose-only docs PR), none of which those files can affect. #3336 paid for exactly that.

It now gates on a `doc-examples` filter covering the samples themselves (`hindsight-docs/examples/**`, where `scripts/test-doc-examples.sh` reads them from) and the runner script. Core, client, CLI and `ci` triggers are unchanged, so any change that can actually break a sample still runs the matrix.

`docs` had no other consumer in any workflow, so it is removed rather than left as config nothing reads.

Note: this PR touches `.github/**`, so `ci == 'true'` and the doc-examples matrix runs here — which is the point, it exercises the new filter end to end. A subsequent integration-only PR should show all four skipping.

## Test

`npx vitest run` in `hindsight-integrations/coding-agents`: **391 passed**, 19 skipped (the re-sync test is gone; every other guarantee keeps its coverage). `tsc --noEmit`, `./scripts/hooks/lint.sh` and prettier all clean. Workflow YAML parsed and asserted: `docs` output and filter gone, `doc-examples` present with the narrow paths, no dangling references.
