### PR TITLE
fix(coding-agents): route repository surveys explicitly

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
@@ -26,8 +26,8 @@ describe("seeded knowledge-page queries", () => {
   ])("anchors %s to its survey findings and excludes repair chatter", (name, documentId) => {
     const page = PAGES.find((candidate) => candidate.name === name);
     expect(page?.source_query).toContain(documentId);
-    expect(page?.source_query).toMatch(/exclude|do not describe/i);
-    expect(page?.source_query).toMatch(/survey ingestion/i);
+    expect(page?.source_query).toMatch(/actual/i);
+    expect(page?.source_query).toMatch(/repair|remediation/i);
   });
 });
 

--- a/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
@@ -18,6 +18,19 @@ function stubFetch(calls: any[], jsonImpl: () => Promise<unknown> = async () => 
   );
 }
 
+describe("seeded knowledge-page queries", () => {
+  it.each([
+    ["Component map", "repository-component-map"],
+    ["Core concepts", "repository-core-concepts"],
+    ["Conventions and patterns", "repository-conventions-and-patterns"],
+  ])("anchors %s to its survey findings and excludes repair chatter", (name, documentId) => {
+    const page = PAGES.find((candidate) => candidate.name === name);
+    expect(page?.source_query).toContain(documentId);
+    expect(page?.source_query).toMatch(/exclude|do not describe/i);
+    expect(page?.source_query).toMatch(/survey ingestion/i);
+  });
+});
+
 /** The knowledge-base surface is the ONLY page surface: nothing here may touch /mental-models,
  *  or ids stop resolving (search returns kp-… node ids) and seeded pages fall out of the search
  *  corpus (it joins through knowledge_pages). */

--- a/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
@@ -23,12 +23,15 @@ describe("seeded knowledge-page queries", () => {
     ["Component map", "repository-component-map"],
     ["Core concepts", "repository-core-concepts"],
     ["Conventions and patterns", "repository-conventions-and-patterns"],
-  ])("anchors %s to its canonical survey findings and asks for repository facts", (name, documentId) => {
-    const page = PAGES.find((candidate) => candidate.name === name);
-    expect(page?.source_query).toContain(documentId);
-    expect(page?.source_query).toMatch(/actual/i);
-    expect(page?.source_query).toMatch(/repository/i);
-  });
+  ])(
+    "anchors %s to its canonical survey findings and asks for repository facts",
+    (name, documentId) => {
+      const page = PAGES.find((candidate) => candidate.name === name);
+      expect(page?.source_query).toContain(documentId);
+      expect(page?.source_query).toMatch(/actual/i);
+      expect(page?.source_query).toMatch(/repository/i);
+    }
+  );
 });
 
 /** The knowledge-base surface is the ONLY page surface: nothing here may touch /mental-models,

--- a/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
@@ -23,11 +23,11 @@ describe("seeded knowledge-page queries", () => {
     ["Component map", "repository-component-map"],
     ["Core concepts", "repository-core-concepts"],
     ["Conventions and patterns", "repository-conventions-and-patterns"],
-  ])("anchors %s to its survey findings and excludes repair chatter", (name, documentId) => {
+  ])("anchors %s to its canonical survey findings and asks for repository facts", (name, documentId) => {
     const page = PAGES.find((candidate) => candidate.name === name);
     expect(page?.source_query).toContain(documentId);
     expect(page?.source_query).toMatch(/actual/i);
-    expect(page?.source_query).toMatch(/repair|remediation/i);
+    expect(page?.source_query).toMatch(/repository/i);
   });
 });
 

--- a/hindsight-integrations/coding-agents/src/core/knowledge-tools.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/knowledge-tools.test.ts
@@ -2,8 +2,9 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { buildKnowledgeTools } from "./knowledge-tools";
+import { buildKnowledgeTools, SURVEY_DOCUMENT_TAGS } from "./knowledge-tools";
 import type { HindsightClient } from "./hindsight";
+import { SURVEY_DOC_IDS } from "./survey";
 
 /** Minimal stub of the HindsightClient surface the tools call — no SDK, no network. */
 function stubClient(overrides: Partial<Record<string, ReturnType<typeof vi.fn>>> = {}) {
@@ -35,6 +36,16 @@ const EXPECTED_TOOLS = [
 ];
 
 describe("buildKnowledgeTools", () => {
+  it("keeps router survey ids and knowledge tags aligned with the canonical survey contract", () => {
+    expect(Object.keys(SURVEY_DOCUMENT_TAGS).sort()).toEqual([...SURVEY_DOC_IDS].sort());
+    expect(SURVEY_DOCUMENT_TAGS).toEqual({
+      "repository-component-map": ["knowledge:component"],
+      "repository-core-concepts": ["knowledge:concept"],
+      "repository-conventions-and-patterns": ["knowledge:convention"],
+      "repository-tech-stack-and-features": [],
+    });
+  });
+
   it("returns exactly the eight expected tools (as a set)", () => {
     const client = stubClient();
     const tools = buildKnowledgeTools(client, "repo-a");
@@ -286,8 +297,12 @@ describe("buildKnowledgeTools", () => {
     "routes the survey document %s through the survey strategy and deterministic tags",
     async (title, docId, knowledgeTags) => {
       const client = stubClient();
+      const stampFor = vi.fn(() => ({
+        tags: ["project:repo-a"],
+        metadata: { project: "repo-a" },
+      }));
       const tool = findTool(
-        buildKnowledgeTools(client, "repo-a", { harness: "codex" }),
+        buildKnowledgeTools(client, "repo-a", { harness: "codex", stampFor }),
         "hindsight_ingest_document"
       );
 
@@ -297,10 +312,11 @@ describe("buildKnowledgeTools", () => {
         "survey findings",
         "codebase survey",
         docId,
-        ["source:survey", ...knowledgeTags, "harness:codex"],
+        ["project:repo-a", "source:survey", ...knowledgeTags, "harness:codex"],
         "survey",
-        { async: true, metadata: { harness: "codex" } }
+        { metadata: { project: "repo-a", harness: "codex" } }
       );
+      expect(stampFor).toHaveBeenCalledOnce();
       expect(JSON.parse(result.content[0].text)).toEqual({ ok: true, doc_id: docId });
     }
   );

--- a/hindsight-integrations/coding-agents/src/core/knowledge-tools.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/knowledge-tools.test.ts
@@ -273,6 +273,38 @@ describe("buildKnowledgeTools", () => {
     expect(JSON.parse(result.content[0].text)).toEqual({ ok: true, doc_id: "my-title" });
   });
 
+  it.each([
+    ["Repository component map", "repository-component-map", ["knowledge:component"]],
+    ["Repository core concepts", "repository-core-concepts", ["knowledge:concept"]],
+    [
+      "Repository conventions and patterns",
+      "repository-conventions-and-patterns",
+      ["knowledge:convention"],
+    ],
+    ["Repository tech stack and features", "repository-tech-stack-and-features", []],
+  ])(
+    "routes the survey document %s through the survey strategy and deterministic tags",
+    async (title, docId, knowledgeTags) => {
+      const client = stubClient();
+      const tool = findTool(
+        buildKnowledgeTools(client, "repo-a", { harness: "codex" }),
+        "hindsight_ingest_document"
+      );
+
+      const result = await tool.handler({ title, content: "survey findings" });
+
+      expect(client.retain).toHaveBeenCalledWith(
+        "survey findings",
+        "codebase survey",
+        docId,
+        ["source:survey", ...knowledgeTags, "harness:codex"],
+        "survey",
+        { async: true, metadata: { harness: "codex" } }
+      );
+      expect(JSON.parse(result.content[0].text)).toEqual({ ok: true, doc_id: docId });
+    }
+  );
+
   it("hindsight_ingest_document collapses internal whitespace runs in the title into single hyphens", async () => {
     const client = stubClient();
     const tools = buildKnowledgeTools(client, "repo-a");

--- a/hindsight-integrations/coding-agents/src/core/knowledge-tools.ts
+++ b/hindsight-integrations/coding-agents/src/core/knowledge-tools.ts
@@ -58,6 +58,13 @@ function guarded(fn: (args: any) => Promise<unknown>): (args: any) => Promise<To
   };
 }
 
+const SURVEY_DOCUMENT_TAGS: Readonly<Record<string, readonly string[]>> = {
+  "repository-component-map": ["knowledge:component"],
+  "repository-core-concepts": ["knowledge:concept"],
+  "repository-conventions-and-patterns": ["knowledge:convention"],
+  "repository-tech-stack-and-features": [],
+};
+
 /** Build the knowledge-page + recall MCP tool specs, bound to one client/bank. */
 export function buildKnowledgeTools(
   client: HindsightClient,
@@ -232,18 +239,21 @@ export function buildKnowledgeTools(
           ...stamp?.metadata,
           ...(opts.harness ? { harness: opts.harness } : {}),
         };
+        const surveyTags = SURVEY_DOCUMENT_TAGS[docId];
+        const isSurveyDocument = surveyTags !== undefined;
         await client.retain(
           content,
-          "ingested document",
+          isSurveyDocument ? "codebase survey" : "ingested document",
           docId,
           [
             ...new Set([
               ...(stamp?.tags ?? []),
-              "source:upload",
+              isSurveyDocument ? "source:survey" : "source:upload",
+              ...(surveyTags ?? []),
               ...(opts.harness ? [`harness:${opts.harness}`] : []),
             ]),
           ],
-          "document",
+          isSurveyDocument ? "survey" : "document",
           Object.keys(metadata).length ? { metadata } : {}
         );
         return { ok: true, doc_id: docId };

--- a/hindsight-integrations/coding-agents/src/core/knowledge-tools.ts
+++ b/hindsight-integrations/coding-agents/src/core/knowledge-tools.ts
@@ -21,6 +21,7 @@ import type { HindsightClient } from "./hindsight";
 import { syncStatus } from "./status";
 import { loadConfig } from "./config";
 import type { RetainStamp } from "./retain-stamp";
+import { SURVEY_DOC_IDS } from "./survey";
 
 export interface ToolResult {
   // Index signature so this structurally satisfies the MCP SDK's CallToolResult (which carries
@@ -58,12 +59,20 @@ function guarded(fn: (args: any) => Promise<unknown>): (args: any) => Promise<To
   };
 }
 
-const SURVEY_DOCUMENT_TAGS: Readonly<Record<string, readonly string[]>> = {
+// The survey agent ingests through the same public tool as user documents. Only its four canonical
+// title slugs may select the survey strategy; every other title must retain ordinary upload semantics.
+export const SURVEY_DOCUMENT_TAGS = {
   "repository-component-map": ["knowledge:component"],
   "repository-core-concepts": ["knowledge:concept"],
   "repository-conventions-and-patterns": ["knowledge:convention"],
   "repository-tech-stack-and-features": [],
-};
+} as const satisfies Readonly<
+  Record<(typeof SURVEY_DOC_IDS)[number], readonly `knowledge:${string}`[]>
+>;
+
+function isSurveyDocumentId(id: string): id is (typeof SURVEY_DOC_IDS)[number] {
+  return (SURVEY_DOC_IDS as readonly string[]).includes(id);
+}
 
 /** Build the knowledge-page + recall MCP tool specs, bound to one client/bank. */
 export function buildKnowledgeTools(
@@ -239,8 +248,8 @@ export function buildKnowledgeTools(
           ...stamp?.metadata,
           ...(opts.harness ? { harness: opts.harness } : {}),
         };
-        const surveyTags = SURVEY_DOCUMENT_TAGS[docId];
-        const isSurveyDocument = surveyTags !== undefined;
+        const isSurveyDocument = isSurveyDocumentId(docId);
+        const surveyTags = isSurveyDocument ? SURVEY_DOCUMENT_TAGS[docId] : undefined;
         await client.retain(
           content,
           isSurveyDocument ? "codebase survey" : "ingested document",

--- a/hindsight-integrations/coding-agents/src/core/missions.ts
+++ b/hindsight-integrations/coding-agents/src/core/missions.ts
@@ -196,29 +196,27 @@ export const PAGES: KnowledgePage[] = [
   {
     name: "Component map",
     source_query:
-      "Using durable facts about this repository, especially findings from the " +
-      "repository-component-map survey document, what are its actual main components, modules, " +
-      "directories, and subsystems? Explain each responsibility and their data flow or dependencies. " +
-      "Do not describe survey ingestion, page generation, tags, harness diagnosis, or remediation " +
-      "work unless one of those is itself an actual repository component.",
+      "Using durable facts about this repository, prioritize the canonical " +
+      "repository-component-map survey findings. Describe the actual main components, modules, " +
+      "directories, and subsystems, including each responsibility and their data flow or dependencies. " +
+      "Treat the survey document as evidence about the repository rather than as a component itself.",
     tags: ["knowledge:component"],
   },
   {
     name: "Core concepts",
     source_query:
-      "Using durable facts about this repository, especially findings from the " +
-      "repository-core-concepts survey document, what are its actual domain concepts, abstractions, " +
-      "and key entities? Define the vocabulary a contributor must understand and each concept's role. " +
-      "Exclude discussions about survey ingestion, page generation, tag repair, and harness diagnosis.",
+      "Using durable facts about this repository, prioritize the canonical " +
+      "repository-core-concepts survey findings. Describe its actual domain concepts, abstractions, " +
+      "and key entities, defining the vocabulary a contributor must understand and each concept's role.",
     tags: ["knowledge:concept"],
   },
   {
     name: "Conventions and patterns",
     source_query:
-      "Based primarily on the repository-conventions-and-patterns survey findings, describe this " +
-      "repository's actual recurring practices for naming, structure, testing, error handling, " +
-      "safety, and change execution. Give concrete contributor-facing conventions and treat " +
-      "transient operational status or repair discussion as non-authoritative.",
+      "Using durable facts about this repository, prioritize the canonical " +
+      "repository-conventions-and-patterns survey findings. Describe its actual recurring practices " +
+      "for naming, structure, testing, error handling, safety, and change execution, and give concrete " +
+      "contributor-facing conventions supported by repository evidence.",
     tags: ["knowledge:convention"],
   },
   {

--- a/hindsight-integrations/coding-agents/src/core/missions.ts
+++ b/hindsight-integrations/coding-agents/src/core/missions.ts
@@ -215,11 +215,10 @@ export const PAGES: KnowledgePage[] = [
   {
     name: "Conventions and patterns",
     source_query:
-      "Using durable facts about this repository, especially findings from the " +
-      "repository-conventions-and-patterns survey document, what actual conventions and recurring " +
-      "patterns does it follow for naming, structure, testing, error handling, safety, and change " +
-      "execution? Exclude discussions whose subject is survey ingestion, page generation, tag repair, " +
-      "or harness diagnosis.",
+      "Based primarily on the repository-conventions-and-patterns survey findings, describe this " +
+      "repository's actual recurring practices for naming, structure, testing, error handling, " +
+      "safety, and change execution. Give concrete contributor-facing conventions and treat " +
+      "transient operational status or repair discussion as non-authoritative.",
     tags: ["knowledge:convention"],
   },
   {

--- a/hindsight-integrations/coding-agents/src/core/missions.ts
+++ b/hindsight-integrations/coding-agents/src/core/missions.ts
@@ -196,25 +196,30 @@ export const PAGES: KnowledgePage[] = [
   {
     name: "Component map",
     source_query:
-      "From this project's commit history and past discussions, what are the main " +
-      "components/modules/subsystems, what is each responsible for, and how do they relate to or " +
-      "depend on one another? Describe the structure and responsibilities.",
+      "Using durable facts about this repository, especially findings from the " +
+      "repository-component-map survey document, what are its actual main components, modules, " +
+      "directories, and subsystems? Explain each responsibility and their data flow or dependencies. " +
+      "Do not describe survey ingestion, page generation, tags, harness diagnosis, or remediation " +
+      "work unless one of those is itself an actual repository component.",
     tags: ["knowledge:component"],
   },
   {
     name: "Core concepts",
     source_query:
-      "What are the core concepts, domain abstractions, and key entities in this project — " +
-      "the vocabulary a developer must understand? For each, explain what it represents and its role, " +
-      "drawn from how they are introduced and discussed across the history and conversations.",
+      "Using durable facts about this repository, especially findings from the " +
+      "repository-core-concepts survey document, what are its actual domain concepts, abstractions, " +
+      "and key entities? Define the vocabulary a contributor must understand and each concept's role. " +
+      "Exclude discussions about survey ingestion, page generation, tag repair, and harness diagnosis.",
     tags: ["knowledge:concept"],
   },
   {
     name: "Conventions and patterns",
     source_query:
-      "What conventions, idioms, and recurring patterns does this project follow — its " +
-      "approach to testing, error handling, naming, structure, and how changes are typically made? " +
-      "Describe how THIS project does things, as evidenced across its history and discussions.",
+      "Using durable facts about this repository, especially findings from the " +
+      "repository-conventions-and-patterns survey document, what actual conventions and recurring " +
+      "patterns does it follow for naming, structure, testing, error handling, safety, and change " +
+      "execution? Exclude discussions whose subject is survey ingestion, page generation, tag repair, " +
+      "or harness diagnosis.",
     tags: ["knowledge:convention"],
   },
   {

--- a/hindsight-integrations/coding-agents/src/core/session-start.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.test.ts
@@ -474,4 +474,31 @@ describe("buildSessionStartContext — crashed-survey retry (baseline without fi
     expect(startSurvey).toHaveBeenCalledTimes(1);
     expect(out).toBeTruthy();
   });
+
+  it("does not re-fire when dedicated source:survey findings exist", async () => {
+    const startSurvey = vi.fn();
+    await buildSessionStartContext({
+      cwd: "/tmp/x",
+      bankId: "bank-1",
+      cfg: resolveConfig({ surveyRefreshCommits: 50 }),
+      client: {
+        listDocumentIds: async (tag: string) =>
+          tag === "source:survey-baseline"
+            ? new Set(["survey-baseline:aaa"])
+            : tag === "source:survey"
+              ? new Set(["repository-component-map"])
+              : tag === "source:upload"
+                ? new Set<string>()
+                : new Set(["git:abc"]),
+        listPages: async () => ({ items: [] }),
+        retain: vi.fn(),
+      },
+      hasGit: () => true,
+      startSeed: vi.fn(),
+      startSurvey,
+      headSha: () => "bbb",
+      commitsSince: () => 1,
+    });
+    expect(startSurvey).not.toHaveBeenCalled();
+  });
 });

--- a/hindsight-integrations/coding-agents/src/core/session-start.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.ts
@@ -253,11 +253,14 @@ export async function buildSessionStartContext(args: {
               const sinceLast = counts.length ? Math.min(...counts) : null;
               // A baseline without FINDINGS means the surveyed agent died before ingesting (no
               // CLI on PATH, budget kill) — the marker alone must not suppress retries forever.
-              const uploads = await client
-                .listDocumentIds("source:upload")
-                .catch(() => new Set<string>());
+              const [surveys, uploads] = await Promise.all([
+                client.listDocumentIds("source:survey").catch(() => new Set<string>()),
+                // Backward compatibility for banks seeded before survey documents had a dedicated tag.
+                client.listDocumentIds("source:upload").catch(() => new Set<string>()),
+              ]);
               const findingsAbsent =
-                counts.length > 0 && !SURVEY_DOC_IDS.some((id) => uploads.has(id));
+                counts.length > 0 &&
+                !SURVEY_DOC_IDS.some((id) => surveys.has(id) || uploads.has(id));
               if ((sinceLast !== null && sinceLast >= cfg.surveyRefreshCommits) || findingsAbsent) {
                 startSurvey(cwd, {
                   harness: harness as SurveyHarness,

--- a/hindsight-integrations/coding-agents/src/core/status.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/status.test.ts
@@ -135,6 +135,21 @@ describe("syncStatus", () => {
     expect(s.chatDocs).toBe(2);
   });
 
+  it("counts dedicated survey documents while retaining source:upload compatibility", async () => {
+    const client = stubClient({
+      listDocumentIds: async (tag: string) =>
+        tag === "source:git"
+          ? new Set(["gitlog:repo"])
+          : tag === "source:survey"
+            ? new Set(["repository-component-map", "repository-core-concepts"])
+            : tag === "source:upload"
+              ? new Set(["repository-conventions-and-patterns"])
+              : new Set<string>(),
+    });
+    const s = await syncStatus(client, "bank-1");
+    expect(s.surveyDocs).toBe(3);
+  });
+
   it("gitDiffTarget is null for a non-git repoDir; gitlog match is by repo basename", async () => {
     dir = mkdtempSync(join(tmpdir(), "hs-status-nogit-"));
     const client = stubClient({ gitIds: [`gitlog:${basename(dir)}`] });

--- a/hindsight-integrations/coding-agents/src/core/status.ts
+++ b/hindsight-integrations/coding-agents/src/core/status.ts
@@ -64,8 +64,12 @@ export async function syncStatus(
   const chatIds = await client.listDocumentIds("source:chat").catch(() => new Set<string>());
   const pages = parsePageList(await client.listPages().catch(() => null));
   const activeOps = await client.activeOperations().catch(() => null);
-  const uploads = await client.listDocumentIds("source:upload").catch(() => new Set<string>());
-  const surveyDocs = SURVEY_DOC_IDS.filter((id) => uploads.has(id)).length;
+  const [surveys, uploads] = await Promise.all([
+    client.listDocumentIds("source:survey").catch(() => new Set<string>()),
+    // Backward compatibility for banks seeded before survey documents had a dedicated tag.
+    client.listDocumentIds("source:upload").catch(() => new Set<string>()),
+  ]);
+  const surveyDocs = SURVEY_DOC_IDS.filter((id) => surveys.has(id) || uploads.has(id)).length;
 
   // Survey observability: the survey-baseline:<sha> markers Chris's re-survey mechanism writes.
   // Most recent baseline REACHABLE from HEAD wins (dead branches/rebases leave unreachable markers).

--- a/hindsight-integrations/coding-agents/src/deepen.ts
+++ b/hindsight-integrations/coding-agents/src/deepen.ts
@@ -238,8 +238,12 @@ async function main() {
     // baseline marker from "researching…" to "completed" (lazy — the detached survey agent can't
     // reliably do it itself). The `survey-state:done` tag makes this a one-time upsert.
     try {
-      const uploads = await client.listDocumentIds("source:upload").catch(() => new Set<string>());
-      if (SURVEY_DOC_IDS.some((id) => uploads.has(id))) {
+      const [surveys, uploads] = await Promise.all([
+        client.listDocumentIds("source:survey").catch(() => new Set<string>()),
+        // Backward compatibility for banks seeded before survey documents had a dedicated tag.
+        client.listDocumentIds("source:upload").catch(() => new Set<string>()),
+      ]);
+      if (SURVEY_DOC_IDS.some((id) => surveys.has(id) || uploads.has(id))) {
         const markers = await client.listDocumentIds("source:survey-baseline");
         const done = await client
           .listDocumentIds("survey-state:done")


### PR DESCRIPTION
## Summary

- Route the four canonical repository-survey documents through the `survey` strategy instead of generic document ingestion.
- Attach deterministic `source:survey`, harness, retain-attribution, and structural knowledge tags.
- Ground Component map, Core concepts, and Conventions page queries in their canonical survey evidence using repository-generic wording.
- Make sync status, crashed-survey retry detection, and completion-marker handling recognize `source:survey` while retaining compatibility with legacy `source:upload` banks.
- Keep the router's document IDs compile-time aligned with the survey producer's canonical `SURVEY_DOC_IDS` contract.

## Root cause

`hindsight_ingest_document` treats every title as a generic uploaded document. The repository survey uses that public tool for four fixed findings, so vanilla ingestion classifies them as `document` / `source:upload`, while the seeded Knowledge Pages expect deterministic structural tags. Page population therefore depends on incidental extraction instead of the native survey contract.

## Current-main refresh

This branch was rebuilt on current `main` (`64ede361`) instead of mechanically preserving the historical implementation. It keeps the current mission/template ownership model, current retain attribution, and the current client contract. It does not restore removed retain options or unrelated historical template changes.

## Validation

```text
Focused survey/router/readers
  104 tests passed

Full Coding Agents suite
  45 files passed, 493 tests passed

TypeScript --noEmit
  passed

Production build and declarations
  passed

Prettier and git diff --check
  passed

Independent review
  safe to merge; no blockers
```

No live Hindsight retain or page-refresh mutation was performed during this refresh. The earlier local data remediation is not part of this source PR.

## Compatibility

- Non-survey `hindsight_ingest_document` calls retain `document` / `source:upload` behavior.
- Existing banks whose survey findings use `source:upload` remain supported.
- Existing user-owned missions are not overwritten.
- No server API, database schema, migration, dependency, or hook-configuration change.
