### PR TITLE
feat(coding-agents): retainTags / retainMetadata, with HINDSIGHT_RETAIN_TAGS (#3269, #2896)

### DIFF
--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -270,8 +270,10 @@ Configuration is **one JSON file**: `~/.hindsight/coding-agent.json`. Layering, 
 4. its `harnesses.<name>` section — per-agent override
 
 Environment variables are a **fallback**: the file wins wherever it sets a value, so adding env to
-an existing setup changes nothing. The map-valued settings (`mapPathToBank`, `harnesses`, `banks`)
-are file-only — nested branching doesn't survive flattening into one variable.
+an existing setup changes nothing. `retainTags` takes a comma-separated list
+(`HINDSIGHT_RETAIN_TAGS="project:{gitProject},env:work"`); entries are trimmed and blanks dropped.
+The map-valued settings (`mapPathToBank`, `harnesses`, `banks`, `retainMetadata`) are file-only —
+per-key branching doesn't survive flattening into one variable.
 
 There is deliberately no repo-carried config file — per-repo bank routing is `mapPathToBank`,
 per-agent differences are `harnesses.<name>`.

--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -300,6 +300,8 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `bankIdTemplate`        | `"coding-agent::{gitProject}"`       | dynamic bank id format; the default makes every agent share one bank per repo                                                                                                                                                       |
 | `mapPathToBank`         | —                                    | absolute path → bank; **longest prefix wins**; overrides everything                                                                                                                                                                 |
 | `resolveWorktrees`      | `true`                               | `{gitProject}`: linked worktrees share the main repo's bank                                                                                                                                                                         |
+| `retainTags`            | —                                    | extra tags on every session write-back, e.g. `["project:{gitProject}"]` — see [Recording where a memory came from](#recording-where-a-memory-came-from)                                                                              |
+| `retainMetadata`        | —                                    | extra metadata on every session write-back, e.g. `{"repo": "{gitProject}"}`                                                                                                                                                          |
 | `disabled`              | `false`                              | hard off-switch (inert plugin/hook — a no-memory baseline)                                                                                                                                                                          |
 | `reflectTimeoutMs`      | `120000`                             | session-reflect timeout (hook harnesses additionally cap it at 25s to fit the host's hook window); on timeout the session runs without reflect (recorded)                                                                           |
 | `pageRefreshEveryTurns` | `10`                                 | refetch the knowledge pages and re-inject the page roster + tool guide every N user turns                                                                                                                                           |
@@ -381,6 +383,29 @@ Coding memory is **per repository**. Resolution order for the working directory:
 
 The default `"coding-agent::{gitProject}"` is **harness-neutral**, so opencode, Claude Code, and Codex
 all share one memory per repo — use `"{harness}-{gitProject}"` to split per agent instead.
+
+### Recording where a memory came from
+
+With a bank per repo, the bank _is_ the answer to "where did this come from". On a deliberately
+**shared** bank — one bank holding cross-project knowledge so facts recall everywhere — it isn't:
+every memory looks alike. `retainTags` and `retainMetadata` stamp that provenance onto each session
+write-back:
+
+```jsonc
+{
+  "bankId": "shared", // one bank for everything
+  "retainTags": ["project:{gitProject}", "env:work"],
+  "retainMetadata": { "repo": "{gitProject}" }
+}
+```
+
+Recalls can then filter by `project:<repo>`, and every document shows which repository it came out
+of. Both accept the same placeholders as `bankIdTemplate` — `{gitProject}`, `{project}`,
+`{harness}`, `{channel}`, `{user}` — plus `{bankId}`, `{sessionId}` and `{timestamp}`.
+`{gitProject}` is worktree-aware here too, so every linked worktree of a repo stamps one name.
+
+The plugin's own `source:` and `harness:` tags are reserved: entries in those namespaces are ignored
+with a warning, so a document's agent attribution always reflects the agent that actually wrote it.
 
 ## Diagnostics & logging
 

--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -300,8 +300,8 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `bankIdTemplate`        | `"coding-agent::{gitProject}"`       | dynamic bank id format; the default makes every agent share one bank per repo                                                                                                                                                       |
 | `mapPathToBank`         | —                                    | absolute path → bank; **longest prefix wins**; overrides everything                                                                                                                                                                 |
 | `resolveWorktrees`      | `true`                               | `{gitProject}`: linked worktrees share the main repo's bank                                                                                                                                                                         |
-| `retainTags`            | —                                    | extra tags on every session write-back, e.g. `["project:{gitProject}"]` — see [Recording where a memory came from](#recording-where-a-memory-came-from)                                                                              |
-| `retainMetadata`        | —                                    | extra metadata on every session write-back, e.g. `{"repo": "{gitProject}"}`                                                                                                                                                          |
+| `retainTags`            | —                                    | extra tags on every session write-back, e.g. `["project:{gitProject}"]` — see **Recording where a memory came from** below                                                                                                          |
+| `retainMetadata`        | —                                    | extra metadata on every session write-back, e.g. `{"repo": "{gitProject}"}`                                                                                                                                                         |
 | `disabled`              | `false`                              | hard off-switch (inert plugin/hook — a no-memory baseline)                                                                                                                                                                          |
 | `reflectTimeoutMs`      | `120000`                             | session-reflect timeout (hook harnesses additionally cap it at 25s to fit the host's hook window); on timeout the session runs without reflect (recorded)                                                                           |
 | `pageRefreshEveryTurns` | `10`                                 | refetch the knowledge pages and re-inject the page roster + tool guide every N user turns                                                                                                                                           |
@@ -395,7 +395,7 @@ write-back:
 {
   "bankId": "shared", // one bank for everything
   "retainTags": ["project:{gitProject}", "env:work"],
-  "retainMetadata": { "repo": "{gitProject}" }
+  "retainMetadata": { "repo": "{gitProject}" },
 }
 ```
 

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -293,6 +293,8 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `bankIdTemplate`        | `"coding-agent::{gitProject}"`       | dynamic bank id format; the default makes every agent share one bank per repo                                                                                                                                                       |
 | `mapPathToBank`         | —                                    | absolute path → bank; **longest prefix wins**; overrides everything                                                                                                                                                                 |
 | `resolveWorktrees`      | `true`                               | `{gitProject}`: linked worktrees share the main repo's bank                                                                                                                                                                         |
+| `retainTags`            | —                                    | extra tags on every session write-back, e.g. `["project:{gitProject}"]` — see **Recording where a memory came from** below                                                                                                          |
+| `retainMetadata`        | —                                    | extra metadata on every session write-back, e.g. `{"repo": "{gitProject}"}`                                                                                                                                                         |
 | `disabled`              | `false`                              | hard off-switch (inert plugin/hook — a no-memory baseline)                                                                                                                                                                          |
 | `reflectTimeoutMs`      | `120000`                             | session-reflect timeout (hook harnesses additionally cap it at 25s to fit the host's hook window); on timeout the session runs without reflect (recorded)                                                                           |
 | `pageRefreshEveryTurns` | `10`                                 | refetch the knowledge pages and re-inject the page roster + tool guide every N user turns                                                                                                                                           |
@@ -374,6 +376,29 @@ Coding memory is **per repository**. Resolution order for the working directory:
 
 The default `"coding-agent::{gitProject}"` is **harness-neutral**, so opencode, Claude Code, and Codex
 all share one memory per repo — use `"{harness}-{gitProject}"` to split per agent instead.
+
+### Recording where a memory came from
+
+With a bank per repo, the bank _is_ the answer to "where did this come from". On a deliberately
+**shared** bank — one bank holding cross-project knowledge so facts recall everywhere — it isn't:
+every memory looks alike. `retainTags` and `retainMetadata` stamp that provenance onto each session
+write-back:
+
+```jsonc
+{
+  "bankId": "shared", // one bank for everything
+  "retainTags": ["project:{gitProject}", "env:work"],
+  "retainMetadata": { "repo": "{gitProject}" },
+}
+```
+
+Recalls can then filter by `project:<repo>`, and every document shows which repository it came out
+of. Both accept the same placeholders as `bankIdTemplate` — `{gitProject}`, `{project}`,
+`{harness}`, `{channel}`, `{user}` — plus `{bankId}`, `{sessionId}` and `{timestamp}`.
+`{gitProject}` is worktree-aware here too, so every linked worktree of a repo stamps one name.
+
+The plugin's own `source:` and `harness:` tags are reserved: entries in those namespaces are ignored
+with a warning, so a document's agent attribution always reflects the agent that actually wrote it.
 
 ## Ingestion internals (no CLI)
 

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -263,8 +263,10 @@ Configuration is **one JSON file**: `~/.hindsight/coding-agent.json`. Layering, 
 4. its `harnesses.<name>` section — per-agent override
 
 Environment variables are a **fallback**: the file wins wherever it sets a value, so adding env to
-an existing setup changes nothing. The map-valued settings (`mapPathToBank`, `harnesses`, `banks`)
-are file-only — nested branching doesn't survive flattening into one variable.
+an existing setup changes nothing. `retainTags` takes a comma-separated list
+(`HINDSIGHT_RETAIN_TAGS="project:{gitProject},env:work"`); entries are trimmed and blanks dropped.
+The map-valued settings (`mapPathToBank`, `harnesses`, `banks`, `retainMetadata`) are file-only —
+per-key branching doesn't survive flattening into one variable.
 
 There is deliberately no repo-carried config file — per-repo bank routing is `mapPathToBank`,
 per-agent differences are `harnesses.<name>`.

--- a/hindsight-integrations/coding-agents/src/cline.ts
+++ b/hindsight-integrations/coding-agents/src/cline.ts
@@ -193,7 +193,7 @@ function createRuntime(workspaceRoot: string | undefined): RuntimeCore | undefin
     apiToken: cfg.apiToken,
     bank: resolved.bankId,
   });
-  return new RuntimeCore(client, resolved.bankId, cfg, HARNESS);
+  return new RuntimeCore(client, resolved.bankId, cfg, HARNESS, workspaceRoot || process.cwd());
 }
 
 const plugin: ClinePlugin = {

--- a/hindsight-integrations/coding-agents/src/core/bank.ts
+++ b/hindsight-integrations/coding-agents/src/core/bank.ts
@@ -23,6 +23,7 @@
 import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { basename, dirname, join, normalize, sep } from "node:path";
+import { applyTemplate } from "./template";
 
 export interface BankConfig {
   bankId?: string;
@@ -38,7 +39,6 @@ const DEFAULT_BANK_NAME = "coding";
 // banks and avoid collisions with other Hindsight banks. Deliberately NOT `{harness}::…` (that would
 // split memory per agent, defeating cross-agent sharing).
 const DEFAULT_TEMPLATE = "coding-agent::{gitProject}";
-const PLACEHOLDER = /\{([a-zA-Z]+)\}/g;
 
 /** Main-worktree root for a directory inside a git repo (worktree- and bare-repo-aware), else null. */
 export function getProjectRootFromGit(directory: string): string | null {
@@ -103,18 +103,5 @@ export function deriveBankId(config: BankConfig, directory: string, harness = "c
     channel: () => process.env.HINDSIGHT_CHANNEL_ID || "default",
     user: () => process.env.HINDSIGHT_USER_ID || "anonymous",
   };
-  return (config.bankIdTemplate || DEFAULT_TEMPLATE).replace(PLACEHOLDER, (_, name: string) => {
-    const r = resolvers[name];
-    if (!r) {
-      console.error(
-        `hindsight: unknown bankIdTemplate placeholder "{${name}}" — valid: ` +
-          Object.keys(resolvers)
-            .sort()
-            .map((k) => `{${k}}`)
-            .join(", ")
-      );
-      return "unknown";
-    }
-    return r();
-  });
+  return applyTemplate(config.bankIdTemplate || DEFAULT_TEMPLATE, resolvers, "bankIdTemplate");
 }

--- a/hindsight-integrations/coding-agents/src/core/chat.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.test.ts
@@ -270,6 +270,45 @@ describe("retainLiveSession — incremental write-back", () => {
     ]);
   });
 
+  it("stamps configured tags and metadata onto the write-back", async () => {
+    const { retain, client } = stubClient();
+    await retainLiveSession(client, "s1", turns(2), "2026-01-01T00:00:00Z", "codex", {
+      cursors: memoryCursorStore(),
+      stamp: { tags: ["project:acme-api", "env:work"], metadata: { repo: "acme-api" } },
+    });
+    expect(retain.mock.calls[0][3]).toEqual([
+      "project:acme-api",
+      "env:work",
+      "source:chat",
+      "harness:codex",
+    ]);
+    expect(retain.mock.calls[0][5].metadata).toMatchObject({
+      repo: "acme-api",
+      source: "chat",
+      harness: "codex",
+    });
+  });
+
+  it("keeps built-in metadata authoritative and does not double a tag", async () => {
+    // The documents list filters on `source:chat` and draws its agent logo from `metadata.harness`,
+    // so the built-ins are written last and win. (retainTags entries in those namespaces are
+    // dropped earlier, at the source — see retain-stamp.test.ts.)
+    const { retain, client } = stubClient();
+    await retainLiveSession(client, "s1", turns(2), "2026-01-01T00:00:00Z", "codex", {
+      cursors: memoryCursorStore(),
+      stamp: {
+        tags: ["source:chat", "env:work"],
+        metadata: { harness: "not-codex", source: "elsewhere", session_id: "spoofed" },
+      },
+    });
+    expect(retain.mock.calls[0][3]).toEqual(["source:chat", "env:work", "harness:codex"]);
+    expect(retain.mock.calls[0][5].metadata).toMatchObject({
+      harness: "codex",
+      source: "chat",
+      session_id: "s1",
+    });
+  });
+
   it("keeps the write-back when the capability probe itself fails", async () => {
     const retain = vi.fn().mockResolvedValue(undefined);
     const client = {

--- a/hindsight-integrations/coding-agents/src/core/chat.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.ts
@@ -5,6 +5,7 @@
  */
 import type { HindsightClient } from "./hindsight";
 import { fingerprintTurns, planRetain, type RetainCursorStore } from "./retain-cursor";
+import type { RetainStamp } from "./retain-stamp";
 import type { ChatSession } from "./types";
 import { uuidV5 } from "./uuid";
 import { pool } from "./util";
@@ -152,13 +153,13 @@ export async function retainLiveSession(
   turns: TransportTurn[],
   startTs: string,
   harness?: string,
-  opts: { cursors?: RetainCursorStore } = {}
+  opts: { cursors?: RetainCursorStore; stamp?: RetainStamp } = {}
 ): Promise<void> {
   const cursors = opts.cursors;
-  if (!cursors) return writeSession(client, sessionId, turns, startTs, harness);
+  if (!cursors) return writeSession(client, sessionId, turns, startTs, harness, opts.stamp);
   // Serialised so the plan is made against the previous write-back's CONFIRMED cursor (see above).
   return serialize(cursors, sessionId, () =>
-    writeSession(client, sessionId, turns, startTs, harness, cursors)
+    writeSession(client, sessionId, turns, startTs, harness, opts.stamp, cursors)
   );
 }
 
@@ -168,6 +169,7 @@ async function writeSession(
   turns: TransportTurn[],
   startTs: string,
   harness?: string,
+  stamp?: RetainStamp,
   cursors?: RetainCursorStore
 ): Promise<void> {
   const refId = `conversation:${sessionId}`;
@@ -196,7 +198,15 @@ async function writeSession(
     content,
     "coding agent session",
     refId,
-    ["source:chat", ...(harness ? [`harness:${harness}`] : [])],
+    // Configured tags first, built-ins last and deduped: `source:chat` and `harness:<id>` are what
+    // the documents list filters and draws its agent logo from, so a template cannot displace them.
+    [
+      ...new Set([
+        ...(stamp?.tags ?? []),
+        "source:chat",
+        ...(harness ? [`harness:${harness}`] : []),
+      ]),
+    ],
     "conversation",
     {
       timestamp: startTs,
@@ -205,6 +215,7 @@ async function writeSession(
       // the original operation instead of extracting (or appending) twice.
       operationId: uuidV5(`${client.bank}\n${refId}\n${plan.mode}\n${content}`),
       metadata: {
+        ...stamp?.metadata, // configured first: the built-ins below win on any key collision
         source: "chat",
         session_id: sessionId,
         ref_id: refId,

--- a/hindsight-integrations/coding-agents/src/core/config.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { loadConfig, applyBankConfig, resolveConfig } from "./config";
+import { loadConfig, applyBankConfig, readEnvConfig, resolveConfig } from "./config";
 
 let root: string;
 let globalCfg: string;
@@ -237,5 +237,27 @@ describe("retainTags / retainMetadata", () => {
     });
     expect(cfg.retainTags).toEqual(["ok"]);
     expect(cfg.retainMetadata).toEqual({ good: "x" });
+  });
+});
+
+describe("HINDSIGHT_RETAIN_TAGS", () => {
+  it("reads a comma-separated list — the env form of retainTags (#2896)", () => {
+    expect(
+      readEnvConfig({ HINDSIGHT_RETAIN_TAGS: "project:{gitProject},env:work" }).retainTags
+    ).toEqual(["project:{gitProject}", "env:work"]);
+  });
+
+  it("trims entries and drops empties, so a trailing comma is not an empty tag", () => {
+    expect(readEnvConfig({ HINDSIGHT_RETAIN_TAGS: " a , ,b, " }).retainTags).toEqual(["a", "b"]);
+  });
+
+  it("is absent when unset or empty, leaving the file value alone", () => {
+    expect(readEnvConfig({}).retainTags).toBeUndefined();
+    expect(readEnvConfig({ HINDSIGHT_RETAIN_TAGS: "" }).retainTags).toBeUndefined();
+    expect(readEnvConfig({ HINDSIGHT_RETAIN_TAGS: " , " }).retainTags).toBeUndefined();
+  });
+
+  it("has no retainMetadata counterpart — map-valued settings stay file-only", () => {
+    expect(readEnvConfig({ HINDSIGHT_RETAIN_METADATA: "repo=x" }).retainMetadata).toBeUndefined();
   });
 });

--- a/hindsight-integrations/coding-agents/src/core/config.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.test.ts
@@ -212,3 +212,30 @@ describe("environment fallback", () => {
     expect(cfg.surveyModel).toBe("haiku");
   });
 });
+
+describe("retainTags / retainMetadata", () => {
+  it("default to empty, so a retain is unchanged unless configured", () => {
+    const cfg = resolveConfig({});
+    expect(cfg.retainTags).toEqual([]);
+    expect(cfg.retainMetadata).toEqual({});
+  });
+
+  it("carries templates through verbatim — resolution happens per retain", () => {
+    const cfg = resolveConfig({
+      retainTags: ["project:{gitProject}"],
+      retainMetadata: { repo: "{gitProject}" },
+    });
+    expect(cfg.retainTags).toEqual(["project:{gitProject}"]);
+    expect(cfg.retainMetadata).toEqual({ repo: "{gitProject}" });
+  });
+
+  it("ignores non-string entries rather than failing the whole retain", () => {
+    // A config typo (a number, a nested object) would otherwise reach the API as a tag.
+    const cfg = resolveConfig({
+      retainTags: ["ok", 42, null, "  "] as unknown as string[],
+      retainMetadata: { good: "x", bad: { nested: true } } as unknown as Record<string, string>,
+    });
+    expect(cfg.retainTags).toEqual(["ok"]);
+    expect(cfg.retainMetadata).toEqual({ good: "x" });
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/config.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.ts
@@ -1,11 +1,11 @@
 /**
- * ONE config file: ~/.hindsight/coding-agent.json (JSON, no environment variables — the sole
- * exception is HINDSIGHT_DIAG_FILE for the diagnostics path).
+ * ONE config file: ~/.hindsight/coding-agent.json.
  *
  * Layering, later wins per field:
  *   1. built-in defaults
- *   2. the config file's top level
- *   3. its `harnesses.<name>` section for the asking harness
+ *   2. environment variables (ENV_KEYS below) — a FALLBACK for containers, CI and secret managers
+ *   3. the config file's top level
+ *   4. its `harnesses.<name>` section for the asking harness
  *
  * There is deliberately NO project-local config: a second, repo-carried file was both a security
  * surface (untrusted repos influencing memory behavior) and a second place to look. Per-repo bank
@@ -250,9 +250,9 @@ function applyLayer(raw: RawConfig, layer: RawConfig, harness?: string): RawConf
  * containers, CI, and secret managers that inject `HINDSIGHT_API_TOKEN` rather than writing a
  * credential to disk.
  *
- * The map-valued settings (mapPathToBank, harnesses, banks) are deliberately absent: they are
- * nested structures whose whole point is per-repo/per-harness branching, which does not survive
- * flattening into one env var. They stay file-only.
+ * The map-valued settings (mapPathToBank, harnesses, banks, retainMetadata) are deliberately
+ * absent: they are structures whose whole point is per-repo/per-harness/per-key branching, which
+ * does not survive flattening into one env var. They stay file-only.
  */
 const ENV_KEYS = {
   serverMode: "HINDSIGHT_SERVER_MODE",
@@ -284,9 +284,12 @@ const ENV_KEYS = {
   surveyRefreshCommits: "HINDSIGHT_SURVEY_REFRESH_COMMITS",
   logLevel: "HINDSIGHT_LOG_LEVEL",
   gitIngest: "HINDSIGHT_GIT_INGEST",
+  // Comma-separated, e.g. HINDSIGHT_RETAIN_TAGS="project:{gitProject},env:work". A LIST rather than
+  // a map, so it flattens cleanly; its sibling retainMetadata stays file-only for the reason above.
+  retainTags: "HINDSIGHT_RETAIN_TAGS",
 } as const satisfies Partial<Record<keyof RawConfig, string>>;
 
-/** Fields parsed as booleans/numbers; everything else is taken as a string. */
+/** Fields parsed as booleans/numbers/comma-separated lists; everything else is taken as a string. */
 const ENV_BOOLEANS = new Set<keyof RawConfig>([
   "dynamicBankId",
   "resolveWorktrees",
@@ -296,6 +299,7 @@ const ENV_BOOLEANS = new Set<keyof RawConfig>([
   "autoSeed",
   "codebaseSurvey",
 ]);
+const ENV_LISTS = new Set<keyof RawConfig>(["retainTags"]);
 const ENV_NUMBERS = new Set<keyof RawConfig>([
   "apiPort",
   "daemonIdleTimeout",
@@ -319,6 +323,13 @@ export function readEnvConfig(env: NodeJS.ProcessEnv = process.env): RawConfig {
     if (value === undefined || value.trim() === "") continue;
     if (ENV_BOOLEANS.has(key)) {
       out[key] = ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
+    } else if (ENV_LISTS.has(key)) {
+      // Empty entries dropped, so a trailing comma or "a,,b" is a typo rather than an empty tag.
+      const items = value
+        .split(",")
+        .map((v) => v.trim())
+        .filter(Boolean);
+      if (items.length) out[key] = items;
     } else if (ENV_NUMBERS.has(key)) {
       const n = Number(value);
       if (Number.isFinite(n)) out[key] = n;

--- a/hindsight-integrations/coding-agents/src/core/config.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.ts
@@ -84,6 +84,14 @@ export interface RawConfig {
    *  "full"    = messages + every recent commit's full diff (progressive batches, newest first);
    *  "none"    = git ingestion off entirely. Default "message" (cheap by default; opt into depth). */
   gitIngest?: "message" | "full" | "none";
+  /** Extra tags stamped on every session write-back, e.g. ["project:{gitProject}", "env:work"].
+   *  Placeholders: {gitProject} {project} {harness} {bankId} {sessionId} {timestamp} {channel}
+   *  {user} (see core/retain-stamp.ts). Mainly for a SHARED bank, where the bank id no longer says
+   *  which repo a memory came from. Built-in tags win on conflict. */
+  retainTags?: string[];
+  /** Extra metadata stamped on every session write-back, e.g. {"repo": "{gitProject}"}. Same
+   *  placeholders as retainTags; built-in metadata (harness attribution) wins on conflict. */
+  retainMetadata?: Record<string, string>;
   /** Per-harness overrides of any of the fields above, keyed by harness name ("opencode",
    *  "claude-code", ...). Lets one config file give each agent its own bank/settings. */
   harnesses?: Record<string, Omit<RawConfig, "harnesses">>;
@@ -129,6 +137,8 @@ export interface Config {
   surveyBudgetUsd: number;
   surveyRefreshCommits: number;
   gitIngest: "message" | "full" | "none";
+  retainTags: string[];
+  retainMetadata: Record<string, string>;
   banks: Record<string, Omit<RawConfig, "banks" | "harnesses"> & { bank?: string }>;
   logLevel: "debug" | "info" | "warn" | "error";
 }
@@ -175,6 +185,17 @@ export function resolveConfig(raw: RawConfig = {}): Config {
     gitIngest: ["message", "full", "none"].includes(raw.gitIngest as string)
       ? (raw.gitIngest as "message" | "full" | "none")
       : "message",
+    // Hostile input is a config typo, not an attack: keep only string entries so a stray number or
+    // nested object cannot reach the API as a tag and fail the whole retain.
+    retainTags: Array.isArray(raw.retainTags)
+      ? raw.retainTags.filter((t): t is string => typeof t === "string" && t.trim() !== "")
+      : [],
+    retainMetadata:
+      raw.retainMetadata && typeof raw.retainMetadata === "object"
+        ? Object.fromEntries(
+            Object.entries(raw.retainMetadata).filter(([, v]) => typeof v === "string")
+          )
+        : {},
     banks: raw.banks && typeof raw.banks === "object" ? raw.banks : {},
     logLevel: ["debug", "info", "warn", "error"].includes(raw.logLevel as string)
       ? (raw.logLevel as "debug" | "info" | "warn" | "error")

--- a/hindsight-integrations/coding-agents/src/core/retain-hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.ts
@@ -21,6 +21,7 @@ import { log, setLogLevel } from "./log";
 import type { ClientOpts } from "./hindsight";
 import { HindsightClient } from "./hindsight";
 import type { RetainCursorStore } from "./retain-cursor";
+import { buildRetainStamp, type RetainStamp } from "./retain-stamp";
 import { fileCursorStore } from "./session-cache";
 import { readClaudeTranscript } from "./transcript";
 import type { TransportTurn } from "./chat";
@@ -63,6 +64,8 @@ export async function buildRetain(args: {
   transcriptPath: string;
   client: RetainClient;
   readTranscript?: TranscriptReader;
+  /** Configured retainTags/retainMetadata, already resolved for this session (core/retain-stamp.ts). */
+  stamp?: RetainStamp;
   /** Injectable for tests; defaults to the per-session temp file (a Stop hook has no memory). */
   cursors?: RetainCursorStore;
 }): Promise<void> {
@@ -77,6 +80,7 @@ export async function buildRetain(args: {
   try {
     await retainLiveSession(client as HindsightClient, sessionId, turns, startTs, harness, {
       cursors: args.cursors ?? fileCursorStore(harness),
+      stamp: args.stamp,
     });
     diag(harness, "retain_ok", { ms: Date.now() - t0, turns: turns.length, session: sessionId });
   } catch (e) {
@@ -133,5 +137,11 @@ export async function runRetainHook(
     transcriptPath,
     client,
     readTranscript: spec.readTranscript,
+    stamp: buildRetainStamp(cfg, {
+      directory: cwd,
+      harness: spec.harness,
+      bankId,
+      sessionId: sessionId || "no-session",
+    }),
   });
 }

--- a/hindsight-integrations/coding-agents/src/core/retain-stamp.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-stamp.test.ts
@@ -1,0 +1,102 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildRetainStamp } from "./retain-stamp";
+
+let repo: string;
+const ctx = (over: Partial<Parameters<typeof buildRetainStamp>[1]> = {}) => ({
+  directory: repo,
+  harness: "codex",
+  bankId: "shared-bank",
+  sessionId: "sess-1",
+  ...over,
+});
+
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), "hs-stamp-repo-"));
+  execFileSync("git", ["init", "-q"], { cwd: repo });
+});
+
+afterEach(() => {
+  rmSync(repo, { recursive: true, force: true });
+  delete process.env.HINDSIGHT_USER_ID;
+  delete process.env.HINDSIGHT_CHANNEL_ID;
+});
+
+describe("buildRetainStamp", () => {
+  it("adds nothing when neither setting is configured", () => {
+    expect(buildRetainStamp({}, ctx())).toEqual({ tags: [], metadata: {} });
+    expect(buildRetainStamp({ retainTags: [], retainMetadata: {} }, ctx())).toEqual({
+      tags: [],
+      metadata: {},
+    });
+  });
+
+  it("resolves {gitProject} to the repo name — the #3269 use case", () => {
+    const { tags, metadata } = buildRetainStamp(
+      { retainTags: ["project:{gitProject}"], retainMetadata: { repo: "{gitProject}" } },
+      ctx()
+    );
+    const name = repo.split("/").pop()!;
+    expect(tags).toEqual([`project:${name}`]);
+    expect(metadata).toEqual({ repo: name });
+  });
+
+  it("resolves the rest of the vocabulary", () => {
+    process.env.HINDSIGHT_USER_ID = "nico";
+    process.env.HINDSIGHT_CHANNEL_ID = "team";
+    const { tags } = buildRetainStamp(
+      {
+        retainTags: ["h:{harness}", "b:{bankId}", "s:{sessionId}", "u:{user}", "c:{channel}"],
+      },
+      ctx()
+    );
+    expect(tags).toEqual(["h:codex", "b:shared-bank", "s:sess-1", "u:nico", "c:team"]);
+  });
+
+  it("resolves {project} from the directory basename, without git", () => {
+    const { tags } = buildRetainStamp({ retainTags: ["p:{project}"] }, ctx());
+    expect(tags).toEqual([`p:${repo.split("/").pop()}`]);
+  });
+
+  it("stamps a literal tag with no placeholders unchanged", () => {
+    expect(buildRetainStamp({ retainTags: ["env:work"] }, ctx()).tags).toEqual(["env:work"]);
+  });
+
+  it("substitutes 'unknown' for a typo'd placeholder rather than an empty string", () => {
+    // An empty substitution yields a tag like `project:` that looks configured but matches nothing;
+    // applyTemplate also names the offending setting on stderr.
+    expect(buildRetainStamp({ retainTags: ["project:{gitproject}"] }, ctx()).tags).toEqual([
+      "project:unknown",
+    ]);
+  });
+
+  it("drops tags in the plugin's own namespaces, so attribution cannot be forged", () => {
+    // A configured `harness:x` would sit next to the real one and make the document match a
+    // documents-list filter for an agent that never wrote it.
+    const { tags } = buildRetainStamp(
+      { retainTags: ["harness:not-codex", "source:elsewhere", "env:work"] },
+      ctx()
+    );
+    expect(tags).toEqual(["env:work"]);
+  });
+
+  it("drops a tag that resolves to nothing", () => {
+    expect(buildRetainStamp({ retainTags: ["   "] }, ctx()).tags).toEqual([]);
+  });
+
+  it("resolves {timestamp} to an ISO-8601 instant", () => {
+    const { metadata } = buildRetainStamp({ retainMetadata: { at: "{timestamp}" } }, ctx());
+    expect(metadata.at).toMatch(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/);
+  });
+
+  it("gives one retain a single consistent {timestamp} across tags and metadata", () => {
+    const { tags, metadata } = buildRetainStamp(
+      { retainTags: ["t:{timestamp}"], retainMetadata: { at: "{timestamp}" } },
+      ctx()
+    );
+    expect(tags[0]).toBe(`t:${metadata.at}`);
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/retain-stamp.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-stamp.ts
@@ -1,0 +1,107 @@
+/**
+ * `retainTags` / `retainMetadata` — user-defined provenance on the memories this plugin writes.
+ *
+ * Every conversation retain already carries `source:chat` and `harness:<id>`, which say WHAT wrote
+ * the memory but nothing about WHERE it came from. That is fine while each repo has its own bank,
+ * since the bank itself is the answer. It stops being fine on a deliberately SHARED bank — one bank
+ * holding cross-project knowledge so facts recall everywhere — where a retained fact then carries no
+ * record of the repository it came out of (#3269).
+ *
+ * So both settings take `{placeholder}` templates, resolved per retain against the same vocabulary
+ * the dynamic bank id uses, plus the things only a retain knows (its bank and session):
+ *
+ *   {gitProject} worktree-aware repo name      {project}  working-directory basename
+ *   {harness}    the agent that wrote it       {bankId}   the bank being written to
+ *   {sessionId}  the agent session             {timestamp} ISO-8601, resolved at retain time
+ *   {channel}    $HINDSIGHT_CHANNEL_ID         {user}     $HINDSIGHT_USER_ID
+ *
+ * The built-in tags and metadata always win over configured ones. `harness` in particular is load-
+ * bearing: the control plane resolves a document's agent logo from `metadata.harness` and the
+ * `harness:<id>` tag, so letting a template overwrite them would break attribution for everyone
+ * looking at the documents list.
+ */
+import { applyTemplate, type Resolvers } from "./template";
+import { log } from "./log";
+import { projectNameOf } from "./bank";
+import { basename } from "node:path";
+
+/** Tag namespaces the plugin owns — see the filter in buildRetainStamp. */
+const RESERVED_TAG_PREFIX = /^(source|harness):/;
+
+export interface RetainStampContext {
+  /** Working directory the retain is being written from — the repo, for {project}/{gitProject}. */
+  directory: string;
+  harness: string;
+  bankId: string;
+  sessionId: string;
+}
+
+export interface RetainStamp {
+  tags: string[];
+  metadata: Record<string, string>;
+}
+
+export interface RetainStampConfig {
+  retainTags?: string[];
+  retainMetadata?: Record<string, string>;
+}
+
+function resolversFor(ctx: RetainStampContext): Resolvers {
+  return {
+    // Worktree-aware like the bank id, so every linked worktree of a repo stamps the SAME name —
+    // otherwise a shared bank ends up with `project:app` and `project:app-wt2` for one repository.
+    gitProject: () => projectNameOf(ctx.directory),
+    project: () => (ctx.directory ? basename(ctx.directory) : "unknown"),
+    harness: () => ctx.harness,
+    bankId: () => ctx.bankId,
+    sessionId: () => ctx.sessionId,
+    timestamp: () => new Date().toISOString(),
+    channel: () => process.env.HINDSIGHT_CHANNEL_ID || "default",
+    user: () => process.env.HINDSIGHT_USER_ID || "anonymous",
+  };
+}
+
+/**
+ * Resolve the configured tags and metadata for one retain. Returns empty collections when neither
+ * setting is configured, which is the default — this adds nothing to a retain unless asked.
+ */
+export function buildRetainStamp(cfg: RetainStampConfig, ctx: RetainStampContext): RetainStamp {
+  const hasTags = Boolean(cfg.retainTags?.length);
+  const hasMetadata = Boolean(cfg.retainMetadata && Object.keys(cfg.retainMetadata).length);
+  if (!hasTags && !hasMetadata) return { tags: [], metadata: {} };
+
+  // Built lazily and memoized: {gitProject} shells out to git, and a config using it in both a tag
+  // and a metadata value should not pay for that twice per retain.
+  const base = resolversFor(ctx);
+  const cache = new Map<string, string>();
+  const resolvers: Resolvers = Object.fromEntries(
+    Object.entries(base).map(([name, resolve]) => [
+      name,
+      () => {
+        const hit = cache.get(name);
+        if (hit !== undefined) return hit;
+        const value = resolve();
+        cache.set(name, value);
+        return value;
+      },
+    ])
+  );
+
+  const tags = (cfg.retainTags ?? [])
+    .map((t) => applyTemplate(t, resolvers, "retainTags").trim())
+    .filter(Boolean)
+    // `source:` and `harness:` are the plugin's own namespaces: the documents list filters on them
+    // and resolves each document's agent logo from `harness:<id>`. A configured `harness:something`
+    // would sit alongside the real one and make the document match a filter for an agent that never
+    // wrote it, so those are dropped with a warning rather than silently honoured.
+    .filter((t) => {
+      if (!RESERVED_TAG_PREFIX.test(t)) return true;
+      log.warn("retain-stamp", "ignoring reserved retainTags entry", { tag: t });
+      return false;
+    });
+  const metadata: Record<string, string> = {};
+  for (const [key, value] of Object.entries(cfg.retainMetadata ?? {})) {
+    metadata[key] = applyTemplate(value, resolvers, "retainMetadata");
+  }
+  return { tags, metadata };
+}

--- a/hindsight-integrations/coding-agents/src/core/runtime.ts
+++ b/hindsight-integrations/coding-agents/src/core/runtime.ts
@@ -20,6 +20,7 @@ import type { HindsightClient } from "./hindsight";
 import { buildKnowledgeTools, type ToolSpec } from "./knowledge-tools";
 import { retainLiveSession, type TransportTurn } from "./chat";
 import { memoryCursorStore } from "./retain-cursor";
+import { buildRetainStamp } from "./retain-stamp";
 import { buildSessionStartContext } from "./session-start";
 import { buildHookOutput } from "./hook";
 import { sessionCacheFile, writeSessionCache } from "./session-cache";
@@ -52,7 +53,10 @@ export class RuntimeCore {
      * retained transcript's harness field, so Kilo sessions don't masquerade as opencode ones.
      * Defaults to opencode, the original (and only other) plugin harness.
      */
-    readonly harness: string = HARNESS
+    readonly harness: string = HARNESS,
+    /** Workspace root this host opened — the SAME directory bank resolution used, so a
+     *  `{gitProject}` in retainTags names the repo the bank was derived from. */
+    private readonly projectDir: string = process.cwd()
   ) {
     setLogLevel(cfg.logLevel);
   }
@@ -243,6 +247,12 @@ export class RuntimeCore {
     const t0 = Date.now();
     void retainLiveSession(this.client, sessionId, turns, startTs, this.harness, {
       cursors: this.cursors,
+      stamp: buildRetainStamp(this.cfg, {
+        directory: this.projectDir,
+        harness: this.harness,
+        bankId: this.bankId,
+        sessionId,
+      }),
     })
       .then(() =>
         diag(this.harness, "retain_ok", {

--- a/hindsight-integrations/coding-agents/src/core/template.ts
+++ b/hindsight-integrations/coding-agents/src/core/template.ts
@@ -1,0 +1,33 @@
+/**
+ * `{placeholder}` substitution, shared by the two things that template: the dynamic bank id
+ * (core/bank.ts) and the retain stamp — `retainTags` / `retainMetadata` (core/retain-stamp.ts).
+ *
+ * Each call site supplies its OWN resolver map rather than drawing on one global set, because the
+ * valid placeholders genuinely differ: a bank id cannot reference `{bankId}` without chasing its own
+ * tail, and a retain stamp has a session and a bank that bank derivation has not computed yet. An
+ * unknown placeholder resolves to "unknown" and says so on stderr, naming the ones that would have
+ * worked — a silent empty string is how you end up with a tag like `project:` and no idea why.
+ */
+
+const PLACEHOLDER = /\{([a-zA-Z_]+)\}/g;
+
+export type Resolvers = Record<string, () => string>;
+
+/** Substitute every `{name}` in `template` using `resolvers`. `what` names the setting in the
+ *  error message, so a typo points at the config key that carries it. */
+export function applyTemplate(template: string, resolvers: Resolvers, what: string): string {
+  return template.replace(PLACEHOLDER, (_, name: string) => {
+    const resolve = resolvers[name];
+    if (!resolve) {
+      console.error(
+        `hindsight: unknown ${what} placeholder "{${name}}" — valid: ` +
+          Object.keys(resolvers)
+            .sort()
+            .map((k) => `{${k}}`)
+            .join(", ")
+      );
+      return "unknown";
+    }
+    return resolve();
+  });
+}

--- a/hindsight-integrations/coding-agents/src/harness/plugin-entry.ts
+++ b/hindsight-integrations/coding-agents/src/harness/plugin-entry.ts
@@ -53,7 +53,7 @@ export function createPluginEntry(harness: string): Plugin {
       apiToken: cfg.apiToken,
       bank: bankId,
     });
-    const core = new RuntimeCore(client, bankId, cfg, harness);
+    const core = new RuntimeCore(client, bankId, cfg, harness, projectDir || process.cwd());
     // Visible presence via the host's own notice API (POST /tui/show-toast) — never stderr, which
     // these TUIs render at the cursor, wedging text against the input bar.
     const oc = (input as { client?: { tui?: { showToast?: (o: unknown) => Promise<unknown> } } })

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -295,6 +295,8 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `bankIdTemplate`        | `"coding-agent::{gitProject}"`       | dynamic bank id format; the default makes every agent share one bank per repo                                                                                                                                                       |
 | `mapPathToBank`         | —                                    | absolute path → bank; **longest prefix wins**; overrides everything                                                                                                                                                                 |
 | `resolveWorktrees`      | `true`                               | `{gitProject}`: linked worktrees share the main repo's bank                                                                                                                                                                         |
+| `retainTags`            | —                                    | extra tags on every session write-back, e.g. `["project:{gitProject}"]` — see [Recording where a memory came from](#recording-where-a-memory-came-from)                                                                              |
+| `retainMetadata`        | —                                    | extra metadata on every session write-back, e.g. `{"repo": "{gitProject}"}`                                                                                                                                                          |
 | `disabled`              | `false`                              | hard off-switch (inert plugin/hook — a no-memory baseline)                                                                                                                                                                          |
 | `reflectTimeoutMs`      | `120000`                             | session-reflect timeout (hook harnesses additionally cap it at 25s to fit the host's hook window); on timeout the session runs without reflect (recorded)                                                                           |
 | `pageRefreshEveryTurns` | `10`                                 | refetch the knowledge pages and re-inject the page roster + tool guide every N user turns                                                                                                                                           |
@@ -376,6 +378,29 @@ Coding memory is **per repository**. Resolution order for the working directory:
 
 The default `"coding-agent::{gitProject}"` is **harness-neutral**, so opencode, Claude Code, and Codex
 all share one memory per repo — use `"{harness}-{gitProject}"` to split per agent instead.
+
+### Recording where a memory came from
+
+With a bank per repo, the bank _is_ the answer to "where did this come from". On a deliberately
+**shared** bank — one bank holding cross-project knowledge so facts recall everywhere — it isn't:
+every memory looks alike. `retainTags` and `retainMetadata` stamp that provenance onto each session
+write-back:
+
+```jsonc
+{
+  "bankId": "shared", // one bank for everything
+  "retainTags": ["project:{gitProject}", "env:work"],
+  "retainMetadata": { "repo": "{gitProject}" }
+}
+```
+
+Recalls can then filter by `project:<repo>`, and every document shows which repository it came out
+of. Both accept the same placeholders as `bankIdTemplate` — `{gitProject}`, `{project}`,
+`{harness}`, `{channel}`, `{user}` — plus `{bankId}`, `{sessionId}` and `{timestamp}`.
+`{gitProject}` is worktree-aware here too, so every linked worktree of a repo stamps one name.
+
+The plugin's own `source:` and `harness:` tags are reserved: entries in those namespaces are ignored
+with a warning, so a document's agent attribution always reflects the agent that actually wrote it.
 
 ## Diagnostics & logging
 

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -265,8 +265,10 @@ Configuration is **one JSON file**: `~/.hindsight/coding-agent.json`. Layering, 
 4. its `harnesses.<name>` section — per-agent override
 
 Environment variables are a **fallback**: the file wins wherever it sets a value, so adding env to
-an existing setup changes nothing. The map-valued settings (`mapPathToBank`, `harnesses`, `banks`)
-are file-only — nested branching doesn't survive flattening into one variable.
+an existing setup changes nothing. `retainTags` takes a comma-separated list
+(`HINDSIGHT_RETAIN_TAGS="project:{gitProject},env:work"`); entries are trimmed and blanks dropped.
+The map-valued settings (`mapPathToBank`, `harnesses`, `banks`, `retainMetadata`) are file-only —
+per-key branching doesn't survive flattening into one variable.
 
 There is deliberately no repo-carried config file — per-repo bank routing is `mapPathToBank`,
 per-agent differences are `harnesses.<name>`.

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -295,8 +295,8 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `bankIdTemplate`        | `"coding-agent::{gitProject}"`       | dynamic bank id format; the default makes every agent share one bank per repo                                                                                                                                                       |
 | `mapPathToBank`         | —                                    | absolute path → bank; **longest prefix wins**; overrides everything                                                                                                                                                                 |
 | `resolveWorktrees`      | `true`                               | `{gitProject}`: linked worktrees share the main repo's bank                                                                                                                                                                         |
-| `retainTags`            | —                                    | extra tags on every session write-back, e.g. `["project:{gitProject}"]` — see [Recording where a memory came from](#recording-where-a-memory-came-from)                                                                              |
-| `retainMetadata`        | —                                    | extra metadata on every session write-back, e.g. `{"repo": "{gitProject}"}`                                                                                                                                                          |
+| `retainTags`            | —                                    | extra tags on every session write-back, e.g. `["project:{gitProject}"]` — see **Recording where a memory came from** below                                                                                                          |
+| `retainMetadata`        | —                                    | extra metadata on every session write-back, e.g. `{"repo": "{gitProject}"}`                                                                                                                                                         |
 | `disabled`              | `false`                              | hard off-switch (inert plugin/hook — a no-memory baseline)                                                                                                                                                                          |
 | `reflectTimeoutMs`      | `120000`                             | session-reflect timeout (hook harnesses additionally cap it at 25s to fit the host's hook window); on timeout the session runs without reflect (recorded)                                                                           |
 | `pageRefreshEveryTurns` | `10`                                 | refetch the knowledge pages and re-inject the page roster + tool guide every N user turns                                                                                                                                           |
@@ -390,7 +390,7 @@ write-back:
 {
   "bankId": "shared", // one bank for everything
   "retainTags": ["project:{gitProject}", "env:work"],
-  "retainMetadata": { "repo": "{gitProject}" }
+  "retainMetadata": { "repo": "{gitProject}" },
 }
 ```
 


### PR DESCRIPTION
Closes #3269 — the first of the superseded-plugin issues to need actual work on Coding Agents rather than a "this is already fixed, please migrate" comment.

## The gap

Every conversation retain carries `source:chat` and `harness:<id>` — *what* wrote the memory, nothing about *where* it came from:

```ts
tags:     ["source:chat", "harness:codex"]
metadata: { source, session_id, ref_id, harness }
```

That's fine while each repo has its own bank: the bank *is* the answer. It stops being fine in the setup the issue describes — one deliberately **shared** bank holding cross-project knowledge so facts recall everywhere — where a retained fact then carries no record of the repository it came out of. Coding Agents had no `retainTags`/`retainMetadata` surface at all, so there was no way to express it.

## What this adds

```jsonc
{
  "bankId": "shared",
  "retainTags": ["project:{gitProject}", "env:work"],
  "retainMetadata": { "repo": "{gitProject}" }
}
```

Placeholders are the vocabulary the dynamic bank id already uses — `{gitProject}` `{project}` `{harness}` `{channel}` `{user}` — plus what only a retain knows: `{bankId}` `{sessionId}` `{timestamp}`.

`{gitProject}` is **worktree-aware** here for the same reason it is in bank resolution: otherwise a shared bank collects `project:app` and `project:app-wt2` for one repository.

Unconfigured, this adds nothing to a retain — `buildRetainStamp` returns empty collections and the retain is byte-identical to before.

## Two things a template deliberately cannot do

- **Built-in metadata wins.** Configured entries are spread first, built-ins last.
- **`source:` and `harness:` tags are reserved**, dropped with a warning.

Both protect attribution: the documents list filters on those tags and resolves each document's agent logo from `metadata.harness` / `harness:<id>` (see the harness-attribution section in CLAUDE.md). A configured `harness:not-codex` would otherwise sit next to the real tag and make the document match a filter for an agent that never wrote it.

## Shape

`{placeholder}` substitution moves into `core/template.ts`, now shared with `core/bank.ts` instead of duplicated. Each call site keeps its **own** resolver map rather than drawing on one global set, because the valid placeholders genuinely differ — a bank id cannot reference `{bankId}` without chasing its own tail, and a retain stamp knows a session and a bank that bank derivation hasn't computed yet. An unknown placeholder resolves to `unknown` and names the offending setting on stderr; a silent empty string is how you end up with a tag like `project:` and no idea why.

Resolution is memoized per retain, so a config using `{gitProject}` in both a tag and a metadata value shells out to git once, not twice.

`RuntimeCore` gains the workspace root it was never given — the same directory bank resolution used — so `{gitProject}` in the opencode/kilo path names the repo the bank was derived from.

## Test

**418 passed**, 19 skipped. `tsc --noEmit`, `./scripts/hooks/lint.sh`, prettier clean.

New coverage: each placeholder resolved against a real git repo, worktree-aware `{gitProject}`, a typo'd placeholder becoming `unknown` rather than empty, reserved tags dropped, non-string config entries ignored (a typo shouldn't reach the API as a tag and fail the retain), one consistent `{timestamp}` across tags and metadata in a single retain, and end-to-end that the stamp reaches `client.retain` with the built-ins still authoritative.

## Docs

Settings table rows plus a **Recording where a memory came from** section under bank resolution, framed around the shared-bank case that motivates it.

## Also closes #2896 — `HINDSIGHT_RETAIN_TAGS`

The old Claude Code plugin had `HINDSIGHT_RECALL_TAGS` and no retain counterpart, so per-project retain tagging could only live in the global file. Now that `retainTags` exists here it joins the env surface on the existing convention (`HINDSIGHT_` + field in SCREAMING_SNAKE, still a **fallback** the file wins over), as a comma-separated list:

```bash
HINDSIGHT_RETAIN_TAGS="project:{gitProject},env:work"
```

Entries are trimmed and blanks dropped, so a trailing comma is a typo rather than an empty tag reaching the API. `retainMetadata` deliberately gets no env form — it is map-valued, and per-key branching doesn't survive flattening into one variable, the same rule already applied to `mapPathToBank` / `harnesses` / `banks`.

This also corrects `config.ts`'s header, which still claimed the plugin reads no environment variables at all — untrue since `ENV_KEYS` was added.
