### PR TITLE
fix(gemini): fail fast on deterministic 400 INVALID_ARGUMENT (#3256)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
@@ -576,23 +576,14 @@ class GeminiLLM(LLMInterface):
                     logger.error(f"Gemini auth error (HTTP {e.code}), not retrying: {str(e)}")
                     raise
 
-                # Diagnostic dump (opt-in) of the exact request behind any 4xx, captured
-                # before the cache-drop retry below rebuilds the config so we see what failed.
-                dump_request_on_4xx(
-                    scope=scope,
-                    provider=self.provider,
-                    model=self.model,
-                    err=e,
-                    request=generation_config,
-                    messages=gemini_contents,
-                )
-
                 # Cached-request safety net: a stale/invalid/expired CachedContent
                 # (or an incompatibility like cache + tool_config) surfaces as a 400.
                 # Retrying the same cached request can't recover, so on the first
                 # such failure drop the cache, invalidate it so later operations
                 # recreate it, and retry THIS call inline with the prefix inlined.
-                # Caching must never break a request.
+                # Caching must never break a request. Handled before the 400
+                # fail-fast below so a recoverable cache-400 isn't mistaken for a
+                # deterministic rejection.
                 if cache_active and e.code == 400:
                     logger.warning(f"Gemini cached call failed (400); retrying uncached. Reason: {str(e)}")
                     if self._cache_manager is not None and cached_prefix is not None:
@@ -601,8 +592,31 @@ class GeminiLLM(LLMInterface):
                     generation_config = _build_generation_config(cache_active)
                     continue
 
-                # Retry on retryable errors (rate limits, server errors, client errors)
-                if e.code in (400, 429, 500, 502, 503, 504) or (e.code and e.code >= 500):
+                # Diagnostic dump of the exact request behind any 4xx. Forced on for a
+                # non-recoverable 400 (see below) so its content-free structural profile
+                # is always in the log on first occurrence; other 4xx dump only under
+                # the opt-in HINDSIGHT_API_LLM_DEBUG_DUMP_4XX flag.
+                dump_request_on_4xx(
+                    scope=scope,
+                    provider=self.provider,
+                    model=self.model,
+                    err=e,
+                    request=generation_config,
+                    messages=gemini_contents,
+                    force=e.code == 400,
+                )
+
+                # HTTP 400 INVALID_ARGUMENT is a deterministic client-side rejection
+                # (malformed schema, oversized prompt section, bad generation param).
+                # Now that the recoverable cache-400 is ruled out, retrying it — and
+                # the batch retry ladder above — just repeats an identical rejected
+                # call, so fail fast instead of burning the retry budget (#3256).
+                if e.code == 400:
+                    logger.error(f"Gemini rejected request (HTTP 400 INVALID_ARGUMENT), not retrying: {str(e)}")
+                    raise
+
+                # Retry on retryable errors (rate limits, server errors)
+                if e.code in (429, 500, 502, 503, 504) or (e.code and e.code >= 500):
                     last_exception = e
                     if attempt < max_retries:
                         backoff = min(initial_backoff * (2**attempt), max_backoff)
@@ -885,21 +899,12 @@ class GeminiLLM(LLMInterface):
                     logger.error(f"Gemini auth error (HTTP {e.code}), not retrying: {str(e)}")
                     raise
 
-                # Diagnostic dump (opt-in) of the exact request behind any 4xx, captured
-                # before the cache-drop retry below rebuilds the config so we see what failed.
-                dump_request_on_4xx(
-                    scope=scope,
-                    provider=self.provider,
-                    model=self.model,
-                    err=e,
-                    request=config,
-                    messages=active_contents,
-                )
-
                 # Cached-request safety net (see ``call``): a stale/invalid cache or
                 # a cache+tool_config conflict surfaces as a 400. Drop the cache,
                 # invalidate it for later operations, and retry THIS call inline
                 # with the prefix + tools re-sent. Caching must never break a call.
+                # Handled before the 400 fail-fast below so a recoverable cache-400
+                # isn't mistaken for a deterministic rejection.
                 if cache_active and e.code == 400:
                     logger.warning(f"Gemini cached tool call failed (400); retrying uncached. Reason: {str(e)}")
                     if self._cache_manager is not None and cached_prefix is not None:
@@ -907,6 +912,28 @@ class GeminiLLM(LLMInterface):
                     cache_active = False
                     config = _build_tools_config(cache_active)
                     continue
+
+                # Diagnostic dump of the exact request behind any 4xx. Forced on for a
+                # non-recoverable 400 so its content-free structural profile is always
+                # in the log on first occurrence; other 4xx dump only under the opt-in
+                # HINDSIGHT_API_LLM_DEBUG_DUMP_4XX flag.
+                dump_request_on_4xx(
+                    scope=scope,
+                    provider=self.provider,
+                    model=self.model,
+                    err=e,
+                    request=config,
+                    messages=active_contents,
+                    force=e.code == 400,
+                )
+
+                # HTTP 400 INVALID_ARGUMENT is a deterministic client-side rejection;
+                # now that the recoverable cache-400 is ruled out, retrying it — and
+                # the batch retry ladder above — just repeats an identical rejected
+                # call, so fail fast instead of burning the retry budget (#3256).
+                if e.code == 400:
+                    logger.error(f"Gemini rejected tool request (HTTP 400 INVALID_ARGUMENT), not retrying: {str(e)}")
+                    raise
 
                 # Retry on retryable errors
                 last_exception = e

--- a/hindsight-api-slim/hindsight_api/engine/providers/llm_debug.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/llm_debug.py
@@ -135,25 +135,41 @@ def dump_request_on_4xx(
     err: Any,
     request: Any = None,
     messages: Any = None,
+    force: bool = False,
 ) -> None:
     """Log the exact request behind an LLM 4xx when the diagnostic is enabled.
 
-    No-op unless ``HINDSIGHT_API_LLM_DEBUG_DUMP_4XX`` is truthy and ``err`` carries a
-    4xx status. ``request`` is whatever the provider assembled (a Pydantic config, a
-    kwargs dict, ...); ``messages`` overrides where the per-message previews come from
+    No-op unless ``err`` carries a 4xx status AND either the
+    ``HINDSIGHT_API_LLM_DEBUG_DUMP_4XX`` flag is truthy or ``force`` is set.
+    ``request`` is whatever the provider assembled (a Pydantic config, a kwargs
+    dict, ...); ``messages`` overrides where the per-message previews come from
     (defaults to the message list found inside ``request``).
+
+    ``force`` is for deterministic rejections a retry can't fix (e.g. a 400
+    ``INVALID_ARGUMENT``): the structural profile — request config, per-message
+    sizes — is logged on the first (and only) failure so an otherwise-opaque
+    black box is diagnosable in production without flipping a flag and
+    reproducing (#3256). Message *previews* stay gated behind the opt-in flag, so
+    the forced structural dump never spills user content — only per-part sizes.
     """
-    if not _enabled():
+    enabled = _enabled()
+    if not (enabled or force):
         return
     code = status_code_of(err)
     if code is None or not (400 <= code < 500):
         return
+    # Previews carry user content, so they ride only on the explicit opt-in; a
+    # forced dump logs the structural profile (config + per-part sizes) alone.
+    include_previews = enabled
     try:
         cfg_repr = _serialize_config(request)
         summary = []
         for msg in _resolve_messages(request, messages) or []:
             m = _message_preview(msg)
-            summary.append({"role": m.role, "chars": len(m.text), "preview": m.text[:_PREVIEW_CHARS]})
+            entry: dict[str, Any] = {"role": m.role, "chars": len(m.text)}
+            if include_previews:
+                entry["preview"] = m.text[:_PREVIEW_CHARS]
+            summary.append(entry)
         logger.error(
             "[LLM_4XX_DUMP] provider=%s model=%s scope=%s code=%s err=%s config=%s contents=%s",
             provider,

--- a/hindsight-api-slim/tests/test_gemini_400_fail_fast.py
+++ b/hindsight-api-slim/tests/test_gemini_400_fail_fast.py
@@ -1,0 +1,156 @@
+"""Gemini deterministic-400 handling (#3256).
+
+An HTTP 400 ``INVALID_ARGUMENT`` is a deterministic client-side rejection: the
+schema/prompt/generation-config the bank compiled is malformed, so every retry
+repeats an identical rejected call. These tests pin the two fixes:
+
+1. Retry classification — a 400 fails fast; it must NOT consume the LLM retry
+   budget (nor, above it, the batch retry ladder). A retryable 503 still burns
+   the full budget, so the distinction is real.
+2. Diagnosability — a 400 always emits the content-free structural profile
+   (``[LLM_4XX_DUMP]``) even with the opt-in flag off, so the otherwise-opaque
+   failure is diagnosable on first occurrence. A recoverable cache-400 must not
+   be mistaken for a deterministic rejection.
+"""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip("google.genai")
+
+from google.genai import errors as genai_errors  # noqa: E402
+
+
+def _make_gemini_provider():
+    """Return a GeminiLLM instance with a mocked genai.Client."""
+    with patch("google.genai.Client") as mock_client_cls:
+        mock_client_cls.return_value = MagicMock()
+        from hindsight_api.engine.providers.gemini_llm import GeminiLLM
+
+        provider = GeminiLLM(
+            provider="gemini",
+            api_key="fake-api-key",
+            base_url="",
+            model="gemini-2.5-flash",
+        )
+        provider._client = MagicMock()
+        return provider
+
+
+def _api_error(code: int, status: str = "INVALID_ARGUMENT") -> genai_errors.APIError:
+    return genai_errors.APIError(code, {"error": {"message": f"{status}: rejected", "status": status}})
+
+
+@pytest.mark.asyncio
+async def test_call_400_fails_fast_without_consuming_retries():
+    """A 400 raises after a single attempt — no retry budget is burned."""
+    provider = _make_gemini_provider()
+    generate = AsyncMock(side_effect=_api_error(400))
+    provider._client.aio.models.generate_content = generate
+
+    with pytest.raises(genai_errors.APIError) as excinfo:
+        await provider.call(
+            messages=[{"role": "user", "content": "hi"}],
+            scope="consolidation",
+            max_retries=4,
+            initial_backoff=0.0,
+        )
+
+    assert excinfo.value.code == 400
+    assert generate.call_count == 1  # NOT 5 (1 + 4 retries)
+
+
+@pytest.mark.asyncio
+async def test_call_503_still_consumes_full_retry_budget():
+    """A retryable error still burns the budget — the fail-fast is 400-specific."""
+    provider = _make_gemini_provider()
+    generate = AsyncMock(side_effect=_api_error(503, status="UNAVAILABLE"))
+    provider._client.aio.models.generate_content = generate
+
+    with pytest.raises(genai_errors.APIError):
+        await provider.call(
+            messages=[{"role": "user", "content": "hi"}],
+            scope="consolidation",
+            max_retries=3,
+            initial_backoff=0.0,
+        )
+
+    assert generate.call_count == 4  # 1 + 3 retries
+
+
+@pytest.mark.asyncio
+async def test_call_with_tools_400_fails_fast():
+    """The tool path fails fast on 400 too."""
+    provider = _make_gemini_provider()
+    generate = AsyncMock(side_effect=_api_error(400))
+    provider._client.aio.models.generate_content = generate
+
+    with pytest.raises(genai_errors.APIError) as excinfo:
+        await provider.call_with_tools(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {"name": "noop", "description": "n", "parameters": {"type": "object"}},
+                }
+            ],
+            scope="consolidation",
+            max_retries=4,
+            initial_backoff=0.0,
+        )
+
+    assert excinfo.value.code == 400
+    assert generate.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_call_400_always_dumps_structural_profile(monkeypatch, caplog):
+    """The structural profile is logged on a 400 even with the opt-in flag off,
+    and carries no user content (only per-part sizes)."""
+    from hindsight_api.config import ENV_LLM_DEBUG_DUMP_4XX, clear_config_cache
+
+    monkeypatch.delenv(ENV_LLM_DEBUG_DUMP_4XX, raising=False)
+    clear_config_cache()
+
+    provider = _make_gemini_provider()
+    provider._client.aio.models.generate_content = AsyncMock(side_effect=_api_error(400))
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(genai_errors.APIError):
+            await provider.call(
+                messages=[{"role": "user", "content": "sensitive memory text"}],
+                scope="consolidation",
+                max_retries=4,
+                initial_backoff=0.0,
+            )
+
+    assert "[LLM_4XX_DUMP]" in caplog.text
+    assert "code=400" in caplog.text
+    assert "sensitive memory text" not in caplog.text  # forced dump omits previews
+    clear_config_cache()
+
+
+@pytest.mark.asyncio
+async def test_call_503_does_not_force_dump(monkeypatch, caplog):
+    """A retryable non-4xx never triggers the forced structural dump."""
+    from hindsight_api.config import ENV_LLM_DEBUG_DUMP_4XX, clear_config_cache
+
+    monkeypatch.delenv(ENV_LLM_DEBUG_DUMP_4XX, raising=False)
+    clear_config_cache()
+
+    provider = _make_gemini_provider()
+    provider._client.aio.models.generate_content = AsyncMock(side_effect=_api_error(503, status="UNAVAILABLE"))
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(genai_errors.APIError):
+            await provider.call(
+                messages=[{"role": "user", "content": "hi"}],
+                scope="consolidation",
+                max_retries=1,
+                initial_backoff=0.0,
+            )
+
+    assert "[LLM_4XX_DUMP]" not in caplog.text
+    clear_config_cache()

--- a/hindsight-api-slim/tests/test_llm_4xx_dump.py
+++ b/hindsight-api-slim/tests/test_llm_4xx_dump.py
@@ -116,6 +116,39 @@ def test_dump_pydantic_config_with_separate_contents(monkeypatch, caplog):
     assert "gemini hi" in caplog.text  # content preview
 
 
+# ── force: always-on structural profile for deterministic rejections ───────────
+
+
+def test_force_dumps_structural_profile_when_flag_off(monkeypatch, caplog):
+    """A forced dump (deterministic 400) logs even with the opt-in flag off, but
+    carries only the structural profile — config + per-part sizes, no previews."""
+    _disable(monkeypatch)
+    request = {"messages": [{"role": "user", "content": "secret memory content"}]}
+    with caplog.at_level(logging.ERROR):
+        _dump(err=SimpleNamespace(status_code=400), request=request, force=True)
+    assert "[LLM_4XX_DUMP]" in caplog.text
+    assert '"chars": 21' in caplog.text  # per-part size is logged
+    assert "secret memory content" not in caplog.text  # but user content is not
+    assert "preview" not in caplog.text
+
+
+def test_force_is_still_noop_on_non_4xx(monkeypatch, caplog):
+    """force bypasses the opt-in flag, not the 4xx gate."""
+    _disable(monkeypatch)
+    with caplog.at_level(logging.ERROR):
+        _dump(err=SimpleNamespace(status_code=500), request={"messages": []}, force=True)
+    assert "[LLM_4XX_DUMP]" not in caplog.text
+
+
+def test_force_includes_previews_when_flag_also_on(monkeypatch, caplog):
+    """With the opt-in flag on, a forced dump still gets the full preview."""
+    _enable(monkeypatch)
+    request = {"messages": [{"role": "user", "content": "visible content"}]}
+    with caplog.at_level(logging.ERROR):
+        _dump(err=SimpleNamespace(status_code=400), request=request, force=True)
+    assert '"preview": "visible content"' in caplog.text
+
+
 # ── safety: truncation + never-raise ───────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

Fixes #3256. One bank deterministically fails every `consolidation+structured` Gemini call with `400 INVALID_ARGUMENT`. Two gaps made this both wasteful and undiagnosable:

1. **Retry classification** — `gemini_llm.py` treated HTTP 400 as retryable. In `call()` the retryable set literally included `400`; in `call_with_tools()` the tail retried *every* remaining `APIError`. A deterministic 400 therefore burned all 4 LLM attempts × the batch retry ladder above it = 12+ identical rejected calls per consolidation cycle, recurring every cycle since skipped batches are re-attempted next run.
2. **Diagnosability** — the content-safe `dump_request_on_4xx` diagnostic existed but was opt-in and off by default, so in production this class of failure is a black box.

## Changes

- **Fail fast on 400** in both `call()` and `call_with_tools()`. The recoverable cache-400 one-shot (drop cache → retry uncached) is reordered *above* the fail-fast so a cache issue is still recovered and isn't mistaken for a hard rejection. Only `429`/`5xx` still consume the retry budget.
- **`dump_request_on_4xx(..., force=...)`** — a deterministic 400 now *always* logs its structural profile (request config = schema + generation config, plus per-part **sizes**) on its first (and, now, only) occurrence, even with `HINDSIGHT_API_LLM_DEBUG_DUMP_4XX` off. Message **previews stay gated behind the opt-in flag**, so the forced dump never spills user content.

## Tests

- `tests/test_gemini_400_fail_fast.py` — 400 raises after a single call; a 503 still burns the full budget (the distinction is real); tool path fails fast; the forced dump logs per-part sizes but not message content; a 503 never force-dumps.
- `tests/test_llm_4xx_dump.py` — added `force` cases: structural-only when the flag is off, still 4xx-gated, previews included when the flag is also on.

All deterministic mechanics — no LLM-behaviour change, so no judge test. Scoped to the Gemini provider (the filed symptom).
