### PR TITLE
fix(ci): compare OpenAPI against the merge-base; build benchmark role configs whole

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5101,13 +5101,26 @@ jobs:
           exit 0
         fi
 
-        echo "Checking OpenAPI compatibility against base branch: $BASE_BRANCH"
+        # Compare against the point this branch was cut from, NOT the live tip of
+        # the base branch. Using the tip reports every endpoint main has gained
+        # since the branch was cut as "removed by this PR" — a false positive that
+        # fails PRs which touch no spec at all, and whose only cure is an unrelated
+        # rebase. The merge-base answers the question the check actually asks:
+        # did *this branch* remove something?
+        MERGE_BASE="$(git merge-base "origin/$BASE_BRANCH" HEAD)"
 
-        # Extract the old OpenAPI spec from base branch
-        git show "origin/$BASE_BRANCH:hindsight-docs/static/openapi.json" > /tmp/old-openapi.json
+        if [ -z "$MERGE_BASE" ]; then
+          echo "⚠️  Warning: Could not determine merge-base with $BASE_BRANCH. Skipping compatibility check."
+          exit 0
+        fi
+
+        echo "Checking OpenAPI compatibility against $BASE_BRANCH merge-base: $MERGE_BASE"
+
+        # Extract the old OpenAPI spec from the merge-base
+        git show "$MERGE_BASE:hindsight-docs/static/openapi.json" > /tmp/old-openapi.json
 
         if [ ! -s /tmp/old-openapi.json ]; then
-          echo "⚠️  Warning: Could not find OpenAPI spec in base branch. Skipping compatibility check."
+          echo "⚠️  Warning: Could not find OpenAPI spec at the merge-base. Skipping compatibility check."
           exit 0
         fi
 
@@ -5148,6 +5161,42 @@ jobs:
       run: |
         cd hindsight-dev
         uv run cli-coverage-check
+
+  # hindsight-dev/tests had no job of its own, so nothing ran it: the benchmark
+  # harness was only exercised by the nightly Performance Tests workflow, where a
+  # plain construction bug in the answer/judge LLM config surfaced as a red
+  # benchmark hours later instead of on the PR that introduced it.
+  test-dev:
+    needs: [detect-changes]
+    if: >-
+      (github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.core == 'true' ||
+      needs.detect-changes.outputs.dev == 'true' ||
+      needs.detect-changes.outputs.ci == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha || '' }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version-file: ".python-version"
+
+    - name: Install hindsight-dev dependencies
+      run: |
+        cd hindsight-dev && uv sync --frozen --extra test --index-strategy unsafe-best-match
+
+    - name: Run hindsight-dev tests
+      working-directory: hindsight-dev
+      run: uv run pytest tests/ -v
 
   # Report CI status back to the PR for pull_request_review events.
   # GitHub does not automatically link pull_request_review check runs to the PR,

--- a/hindsight-dev/benchmarks/common/benchmark_runner.py
+++ b/hindsight-dev/benchmarks/common/benchmark_runner.py
@@ -217,17 +217,9 @@ class LLMAnswerEvaluator:
         Uses HINDSIGHT_API_JUDGE_LLM_* env vars with fallback to HINDSIGHT_API_LLM_* for
         benchmark-specific LLM configuration (separate from the API config system).
         """
-        import os
+        from .llm_role_config import JUDGE_ROLE, build_role_llm_config
 
-        from hindsight_api.engine.llm_wrapper import LLMConfig
-
-        self.llm_config = LLMConfig(
-            provider=os.getenv("HINDSIGHT_API_JUDGE_LLM_PROVIDER", os.getenv("HINDSIGHT_API_LLM_PROVIDER", "openai")),
-            api_key=os.getenv("HINDSIGHT_API_JUDGE_LLM_API_KEY", os.getenv("HINDSIGHT_API_LLM_API_KEY", "")),
-            base_url=os.getenv("HINDSIGHT_API_JUDGE_LLM_BASE_URL", os.getenv("HINDSIGHT_API_LLM_BASE_URL", "")),
-            model=os.getenv("HINDSIGHT_API_JUDGE_LLM_MODEL", os.getenv("HINDSIGHT_API_LLM_MODEL", "gpt-4o-mini")),
-            reasoning_effort="high",
-        )
+        self.llm_config = build_role_llm_config(JUDGE_ROLE)
         self.client = self.llm_config._client
         self.model = self.llm_config.model
 

--- a/hindsight-dev/benchmarks/common/llm_role_config.py
+++ b/hindsight-dev/benchmarks/common/llm_role_config.py
@@ -1,0 +1,66 @@
+"""Build the benchmark-role LLM configs (answer generator, judge).
+
+Benchmarks configure two LLMs independently of the API's own config system: the
+answer generator (``HINDSIGHT_API_ANSWER_LLM_*``) and the judge
+(``HINDSIGHT_API_JUDGE_LLM_*``), each falling back to the shared
+``HINDSIGHT_API_LLM_*`` values.
+
+Each call site used to build its own ``LLMConfig`` from four env vars —
+provider, api_key, base_url, model — and nothing else. ``LLMConfig.__init__``
+deliberately does not read the environment for provider-specific settings (its
+docstring says the caller resolves them; ``LLMConfig.from_env`` is where the API
+does it), so those hand-rolled configs silently dropped every Vertex AI setting.
+With ``provider=vertexai`` the constructor then raised
+"HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID is required" before a single question ran,
+which is what broke the scheduled LoComo benchmark.
+"""
+
+from __future__ import annotations
+
+import os
+
+from hindsight_api.engine.llm_wrapper import LLMConfig
+
+# Roles a benchmark can configure separately from the engine's own LLM.
+ANSWER_ROLE = "ANSWER"
+JUDGE_ROLE = "JUDGE"
+
+
+def _role_env(role: str, suffix: str, default: str = "") -> str:
+    """Read ``HINDSIGHT_API_<ROLE>_LLM_<SUFFIX>``, falling back to the shared var."""
+    return os.getenv(
+        f"HINDSIGHT_API_{role}_LLM_{suffix}",
+        os.getenv(f"HINDSIGHT_API_LLM_{suffix}", default),
+    )
+
+
+def build_role_llm_config(
+    role: str,
+    *,
+    default_model: str = "gpt-4o-mini",
+    reasoning_effort: str = "high",
+) -> LLMConfig:
+    """Build the ``LLMConfig`` for a benchmark role.
+
+    Args:
+        role: ``ANSWER_ROLE`` or ``JUDGE_ROLE`` — selects the env var prefix.
+        default_model: Model to use when neither the role nor the shared var is set.
+        reasoning_effort: Passed straight through to ``LLMConfig``.
+
+    Returns:
+        A config carrying the provider-specific settings as well as the common
+        ones, so providers that need more than an api_key (currently Vertex AI)
+        are usable for benchmark roles.
+    """
+    return LLMConfig(
+        provider=_role_env(role, "PROVIDER", "openai"),
+        api_key=_role_env(role, "API_KEY"),
+        base_url=_role_env(role, "BASE_URL"),
+        model=_role_env(role, "MODEL", default_model),
+        reasoning_effort=reasoning_effort,
+        # Vertex AI authenticates with a project/region/service account rather
+        # than an api_key, and LLMConfig requires the project id up front.
+        vertexai_project_id=_role_env(role, "VERTEXAI_PROJECT_ID") or None,
+        vertexai_region=_role_env(role, "VERTEXAI_REGION") or None,
+        vertexai_service_account_key=_role_env(role, "VERTEXAI_SERVICE_ACCOUNT_KEY") or None,
+    )

--- a/hindsight-dev/benchmarks/locomo/locomo_benchmark.py
+++ b/hindsight-dev/benchmarks/locomo/locomo_benchmark.py
@@ -6,13 +6,11 @@ Provides dataset, answer generator, and evaluator for the LoComo benchmark.
 
 import asyncio
 import json
-import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import pydantic
-from hindsight_api.engine.llm_wrapper import LLMConfig
 
 from benchmarks.common.benchmark_runner import (
     BenchmarkDataset,
@@ -20,6 +18,7 @@ from benchmarks.common.benchmark_runner import (
     LLMAnswerEvaluator,
     LLMAnswerGenerator,
 )
+from benchmarks.common.llm_role_config import ANSWER_ROLE, build_role_llm_config
 
 
 class LoComoDataset(BenchmarkDataset):
@@ -114,13 +113,7 @@ class LoComoAnswerGenerator(LLMAnswerGenerator):
         Uses HINDSIGHT_API_ANSWER_LLM_* env vars with fallback to HINDSIGHT_API_LLM_* for
         benchmark-specific LLM configuration (separate from the API config system).
         """
-        self.llm_config = LLMConfig(
-            provider=os.getenv("HINDSIGHT_API_ANSWER_LLM_PROVIDER", os.getenv("HINDSIGHT_API_LLM_PROVIDER", "openai")),
-            api_key=os.getenv("HINDSIGHT_API_ANSWER_LLM_API_KEY", os.getenv("HINDSIGHT_API_LLM_API_KEY", "")),
-            base_url=os.getenv("HINDSIGHT_API_ANSWER_LLM_BASE_URL", os.getenv("HINDSIGHT_API_LLM_BASE_URL", "")),
-            model=os.getenv("HINDSIGHT_API_ANSWER_LLM_MODEL", os.getenv("HINDSIGHT_API_LLM_MODEL", "gpt-4o-mini")),
-            reasoning_effort="high",
-        )
+        self.llm_config = build_role_llm_config(ANSWER_ROLE)
         self.client = self.llm_config._client
         self.model = self.llm_config.model
 

--- a/hindsight-dev/benchmarks/longmemeval/longmemeval_benchmark.py
+++ b/hindsight-dev/benchmarks/longmemeval/longmemeval_benchmark.py
@@ -6,13 +6,11 @@ Provides dataset, answer generator, and evaluator for the LongMemEval benchmark.
 
 import asyncio
 import json
-import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import pydantic
-from hindsight_api.engine.llm_wrapper import LLMConfig
 
 from benchmarks.common.benchmark_runner import (
     BenchmarkDataset,
@@ -20,6 +18,7 @@ from benchmarks.common.benchmark_runner import (
     LLMAnswerEvaluator,
     LLMAnswerGenerator,
 )
+from benchmarks.common.llm_role_config import ANSWER_ROLE, build_role_llm_config
 
 
 class LongMemEvalDataset(BenchmarkDataset):
@@ -150,13 +149,7 @@ class LongMemEvalAnswerGenerator(LLMAnswerGenerator):
         """
         # Uses HINDSIGHT_API_ANSWER_LLM_* env vars with fallback to HINDSIGHT_API_LLM_* for
         # benchmark-specific LLM configuration (separate from the API config system).
-        self.llm_config = LLMConfig(
-            provider=os.getenv("HINDSIGHT_API_ANSWER_LLM_PROVIDER", os.getenv("HINDSIGHT_API_LLM_PROVIDER", "openai")),
-            api_key=os.getenv("HINDSIGHT_API_ANSWER_LLM_API_KEY", os.getenv("HINDSIGHT_API_LLM_API_KEY", "")),
-            base_url=os.getenv("HINDSIGHT_API_ANSWER_LLM_BASE_URL", os.getenv("HINDSIGHT_API_LLM_BASE_URL", "")),
-            model=os.getenv("HINDSIGHT_API_ANSWER_LLM_MODEL", os.getenv("HINDSIGHT_API_LLM_MODEL", "gpt-4o-mini")),
-            reasoning_effort="high",
-        )
+        self.llm_config = build_role_llm_config(ANSWER_ROLE)
         self.client = self.llm_config._client
         self.model = self.llm_config.model
         self.context_format = context_format

--- a/hindsight-dev/tests/test_llm_role_config.py
+++ b/hindsight-dev/tests/test_llm_role_config.py
@@ -1,0 +1,59 @@
+"""Unit tests for benchmark role LLM config (no network, no credentials)."""
+
+import pytest
+
+from benchmarks.common.llm_role_config import ANSWER_ROLE, JUDGE_ROLE, build_role_llm_config
+
+
+def test_role_vars_win_over_shared_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "openai")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_MODEL", "shared-model")
+    monkeypatch.setenv("HINDSIGHT_API_ANSWER_LLM_MODEL", "answer-model")
+
+    config = build_role_llm_config(ANSWER_ROLE)
+
+    assert config.provider == "openai"
+    assert config.model == "answer-model"
+
+
+def test_falls_back_to_shared_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HINDSIGHT_API_JUDGE_LLM_MODEL", raising=False)
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "openai")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_MODEL", "shared-model")
+
+    config = build_role_llm_config(JUDGE_ROLE)
+
+    assert config.model == "shared-model"
+
+
+@pytest.mark.parametrize("role", [ANSWER_ROLE, JUDGE_ROLE])
+def test_vertexai_project_id_reaches_the_config(role: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression: the scheduled LoComo run died before its first question.
+
+    Each benchmark role built its LLMConfig from provider/api_key/base_url/model
+    alone. LLMConfig does not read the environment for provider-specific
+    settings, so every Vertex AI value was dropped and the constructor raised
+    "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID is required" — even though the
+    workflow exports it. Vertex AI authenticates with a project rather than an
+    api_key, so this asserts the passthrough, not just that construction works.
+    """
+    monkeypatch.setenv(f"HINDSIGHT_API_{role}_LLM_PROVIDER", "vertexai")
+    monkeypatch.setenv(f"HINDSIGHT_API_{role}_LLM_MODEL", "google/gemini-2.5-flash")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID", "test-project")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_VERTEXAI_REGION", "europe-west4")
+
+    config = build_role_llm_config(role)
+
+    assert config.provider == "vertexai"
+    # LLMConfig strips the google/ prefix for the native Vertex SDK.
+    assert config.model == "gemini-2.5-flash"
+
+
+def test_vertexai_without_project_id_still_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The passthrough must not paper over genuinely missing configuration."""
+    monkeypatch.setenv("HINDSIGHT_API_ANSWER_LLM_PROVIDER", "vertexai")
+    monkeypatch.delenv("HINDSIGHT_API_ANSWER_LLM_VERTEXAI_PROJECT_ID", raising=False)
+    monkeypatch.delenv("HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID", raising=False)
+
+    with pytest.raises(ValueError, match="VERTEXAI_PROJECT_ID"):
+        build_role_llm_config(ANSWER_ROLE)

--- a/hindsight-dev/tests/test_llm_role_config.py
+++ b/hindsight-dev/tests/test_llm_role_config.py
@@ -1,12 +1,29 @@
 """Unit tests for benchmark role LLM config (no network, no credentials)."""
 
+import os
+
 import pytest
 
 from benchmarks.common.llm_role_config import ANSWER_ROLE, JUDGE_ROLE, build_role_llm_config
 
 
+@pytest.fixture(autouse=True)
+def clean_llm_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start every test from an empty LLM environment.
+
+    Otherwise these tests read whatever the developer's .env or shell happens to
+    export: they passed locally off a real HINDSIGHT_API_LLM_API_KEY and then
+    failed in CI, where no key exists, with "API key is required for openai".
+    Each test now declares the variables it depends on.
+    """
+    for name in list(os.environ):
+        if name.startswith("HINDSIGHT_API_") and "LLM" in name:
+            monkeypatch.delenv(name, raising=False)
+
+
 def test_role_vars_win_over_shared_vars(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "openai")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "test-key")
     monkeypatch.setenv("HINDSIGHT_API_LLM_MODEL", "shared-model")
     monkeypatch.setenv("HINDSIGHT_API_ANSWER_LLM_MODEL", "answer-model")
 
@@ -17,8 +34,8 @@ def test_role_vars_win_over_shared_vars(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 def test_falls_back_to_shared_vars(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("HINDSIGHT_API_JUDGE_LLM_MODEL", raising=False)
     monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "openai")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "test-key")
     monkeypatch.setenv("HINDSIGHT_API_LLM_MODEL", "shared-model")
 
     config = build_role_llm_config(JUDGE_ROLE)
@@ -52,8 +69,6 @@ def test_vertexai_project_id_reaches_the_config(role: str, monkeypatch: pytest.M
 def test_vertexai_without_project_id_still_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     """The passthrough must not paper over genuinely missing configuration."""
     monkeypatch.setenv("HINDSIGHT_API_ANSWER_LLM_PROVIDER", "vertexai")
-    monkeypatch.delenv("HINDSIGHT_API_ANSWER_LLM_VERTEXAI_PROJECT_ID", raising=False)
-    monkeypatch.delenv("HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID", raising=False)
 
     with pytest.raises(ValueError, match="VERTEXAI_PROJECT_ID"):
         build_role_llm_config(ANSWER_ROLE)


### PR DESCRIPTION
Fixes two CI failures that go red without anything being wrong with the code under test, and closes the coverage gap that let the second one reach a nightly job.

## 1. OpenAPI compatibility fails PRs that touch no spec

The check extracts the "old" spec from the **live tip** of the base branch:

```bash
git show "origin/$BASE_BRANCH:hindsight-docs/static/openapi.json" > /tmp/old-openapi.json
```

So every endpoint main has gained since a branch was cut is reported as removed *by that branch*. Three open PRs failed this way today — #3339, `codex/fix-real-pgroonga-knowledge-search`, `fix/3122-reflect-evidence-starvation` — all on `/health/live` and `/health/ready`, added to main by #3329. None of them touch the spec. The only cure was an unrelated rebase, which is also why the failure looks intermittent.

Compare against the merge-base instead, which asks what the check means to ask: *did this branch remove something?*

Verified with the real specs from the failing run — old logic fails, new logic passes, and a genuine removal still fails:

```
OLD (tip of main vs branch):   ✗ /health/ready, /health/live "Endpoint removed"
NEW (merge-base vs branch):    ✓ No backwards compatibility issues found
NEW (branch that deletes /health): ✗ /health "Endpoint removed"   <- still caught
```

## 2. Scheduled LoComo benchmark dies before its first question

Red every night since at least Aug 8 (runs 31243330018, 31298331427, 31361726575), always:

```
File "hindsight-dev/benchmarks/locomo/locomo_benchmark.py", line 117, in __init__
    self.llm_config = LLMConfig(
ValueError: HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID is required for Vertex AI provider.
```

The workflow *does* export that variable — the engine itself starts fine. But each benchmark role built its `LLMConfig` from exactly four env vars (provider, api_key, base_url, model), and `LLMConfig.__init__` deliberately does not read the environment for provider-specific settings — its docstring says the caller resolves them, and `LLMConfig.from_env` is where the API does. Every Vertex AI value was silently dropped, and Vertex authenticates with a project rather than an api_key.

The same four-var construction was copy-pasted at **three** sites — `locomo`, `longmemeval`, and the shared judge in `benchmark_runner` — and the locomo job sets `vertexai` for all of them, so fixing only the crashing one would have moved the failure down a line. All three now use one builder that carries project/region/service-account through.

Reproduced the crash and verified the fix under the locomo job's exact env:

```
$ ...ANSWER_LLM_PROVIDER=vertexai (no project id)   -> ValueError (reproduces CI)
$ ...with HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID set -> locomo/longmemeval/judge all construct
```

## 3. `hindsight-dev/tests` never ran in CI

No job ran it — `upgrade_tests/` was wired up, `tests/` was not. That is why a plain construction bug had to be found by a nightly benchmark hours later instead of by the PR that introduced it. Added a `test-dev` job gated on the existing `dev`/`core`/`ci` change filters, so those tests plus the new regression test run on PRs. Ran the job's exact commands locally: **13 passed**.

## Not fixed here, deliberately

- **`test_llm_trace.py::test_disabled_writes_no_rows`** (`assert 2 == 0`) failed once on #3339 and passed on re-run. I could not reproduce it in 3 local runs, and my first theory was wrong — the `trace_api_client` fixture *does* restore `_enabled`. Rather than ship a speculative fix I'd rather leave it accurately described; happy to open a tracking issue.
- **`test-api (3/3)` + `check-cli-coverage` on `async-document-export`** are that PR's own work (`export_documents` missing from `WORKER_SLOT_TYPE_DEFAULTS` and from CLI coverage), not infrastructure.
- **Docker Hub 502s and HF model-download timeouts** in the Docker build jobs are external flakiness; the model step already retries.
