### PR TITLE
fix(retain): cut oversized sub-batches on native chunk boundaries (#3282)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -37,6 +37,7 @@ from ..config import (
     DEFAULT_RECALL_INCLUDE_CHUNKS,
     DEFAULT_RECALL_MAX_TOKENS,
     DEFAULT_REFLECT_SOURCE_FACTS_MAX_TOKENS,
+    DEFAULT_RETAIN_CHUNK_SIZE,
     DEFAULT_STORE_DOCUMENT_TEXT,
     ENV_MODEL_INIT_TIMEOUT,
     HindsightConfig,
@@ -599,11 +600,19 @@ class _SubBatchSplit:
     orchestrator uses this as the ``documents.original_text`` payload
     so that slicing an item across sub-batches does not persist a
     partial body (see issue #1838).
+
+    ``chunk_counts[i]`` is how many native chunks ``sub_batches[i]``
+    holds. The splitter knows this exactly (it cut on native chunk
+    boundaries), so callers must read it from here rather than
+    re-deriving it: the orchestrator consumes each item's ``content``
+    while streaming, and re-chunking afterwards silently yields 1
+    (see issue #1888).
     """
 
     sub_batches: list[list[RetainContentDict]]
     origin_indices: list[list[int]]
     document_body_overrides: list[str | None] = field(default_factory=list)
+    chunk_counts: list[int] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -612,20 +621,128 @@ class _RetainChunkingConfig:
     structured_chunk_size: int | None
 
 
+def _pack_native_chunks(chunks: list[str], tokens_per_batch: int) -> list[list[str]]:
+    """Group consecutive native chunks into runs of at most ``tokens_per_batch``.
+
+    A single chunk over the budget becomes a run of its own: the native chunk is
+    the atom of the retain pipeline and must never be cut (see
+    ``_split_contents_into_sub_batches``).
+    """
+    runs: list[list[str]] = []
+    current: list[str] = []
+    current_tokens = 0
+    for chunk in chunks:
+        chunk_tokens = count_tokens(chunk)
+        if current and current_tokens + chunk_tokens > tokens_per_batch:
+            runs.append(current)
+            current, current_tokens = [], 0
+        current.append(chunk)
+        current_tokens += chunk_tokens
+    if current:
+        runs.append(current)
+    return runs
+
+
+def _rejoin_native_chunks(
+    chunks: list[str],
+    chunk_size: int,
+    structured_chunk_size: int | None,
+) -> str | None:
+    """Rebuild the sub-batch text for a run of consecutive native chunks.
+
+    Returns the joined text only when re-chunking it reproduces ``chunks``
+    exactly — the alignment the whole split depends on. ``None`` means no
+    faithful join exists for this run and the caller must fall back to one
+    sub-batch per chunk, which ``chunk_text``'s idempotency guarantees.
+    """
+    from .retain import fact_extraction
+
+    if len(chunks) == 1:
+        return chunks[0]
+
+    candidates: list[str] = []
+    # A JSON conversation array is re-serialized per chunk, so its pieces have
+    # to be merged back into one array — concatenating them as text yields
+    # "[...]\n[...]", which is not valid JSON and re-chunks as prose (#2409).
+    try:
+        merged: list[Any] = []
+        for chunk in chunks:
+            parsed = json.loads(chunk)
+            if not isinstance(parsed, list):
+                raise ValueError("not a conversation array")
+            merged.extend(parsed)
+        candidates.append(json.dumps(merged, ensure_ascii=False))
+    except (json.JSONDecodeError, ValueError, TypeError):
+        pass
+    candidates.append("\n\n".join(chunks))
+    candidates.append("\n".join(chunks))
+
+    for text in candidates:
+        if fact_extraction.chunk_text(text, chunk_size, structured_chunk_size=structured_chunk_size) == chunks:
+            return text
+    return None
+
+
+def _screen_document_body_overrides(
+    overrides: list[str | None],
+    config: HindsightConfig,
+) -> list[str | None]:
+    """Memory Defense screen each distinct document body override once.
+
+    The splitter hands every slice of an oversized item the same body, so
+    screening it inside the retain path would rescan the whole document once
+    per sub-batch (issue #3282). Screen here instead — the orchestrator takes
+    an override as already screened (see ``redact_document_body``).
+    """
+    from .retain.orchestrator import redact_document_body
+
+    screened: dict[str, str] = {}
+    result: list[str | None] = []
+    for body in overrides:
+        if body is None:
+            result.append(None)
+            continue
+        if body not in screened:
+            screened[body] = redact_document_body(body, config)
+        result.append(screened[body])
+    return result
+
+
 def _split_contents_into_sub_batches(
     contents: list[RetainContentDict],
     tokens_per_batch: int,
+    *,
+    chunk_size: int,
+    structured_chunk_size: int | None = None,
 ) -> _SubBatchSplit:
     """Pack retain contents into sub-batches whose combined token count
     stays at or below ``tokens_per_batch``.
 
-    Any single item that already exceeds the budget is chunked via
-    ``fact_extraction.chunk_text`` (paragraph/sentence aware, or
-    conversation-turn aware for JSON arrays and JSONL) and each chunk becomes its
-    own single-item sub-batch. Without this, an oversized single item
-    would pass through as a ``1/1`` sub-batch holding the entire
-    payload — which contradicts the splitter's log and lets the
-    orchestrator OOM under realistic memory limits (see issue #1571).
+    Any single item that already exceeds the budget is cut into slices, because
+    passing it through as one ``1/1`` sub-batch contradicts the splitter's log
+    and OOMs the orchestrator under realistic memory limits (see issue #1571).
+
+    **Slices are always cut on native chunk boundaries** — the same
+    ``chunk_text(chunk_size, structured_chunk_size)`` boundaries the retain
+    pipeline itself uses — and every slice is verified to re-chunk back to
+    exactly the chunks it holds. That keeps one invariant true no matter how a
+    document arrives:
+
+        the chunks stored for a document depend only on its body,
+        never on how transport split it.
+
+    Everything downstream is built on that invariant and silently degrades
+    without it: delta retain and the streaming recovery pass both match stored
+    chunks by content hash (a slice cutting mid-chunk matches nothing, so
+    unchanged history is re-extracted — issue #3282), and ``chunk_index``
+    bookkeeping assumes a slice contributes a whole number of chunks (#1888).
+    A slice therefore honours ``tokens_per_batch`` only down to one native
+    chunk; below that, ``retain_chunk_size`` is the real bound.
+
+    ``chunk_size``/``structured_chunk_size`` have no default on purpose: they
+    must be the bank's resolved retain chunking settings, and quietly falling
+    back to the global default would reintroduce exactly the misalignment this
+    function exists to prevent.
 
     Used by the in-process ``retain_batch_async`` path, which processes
     the returned sub-batches SEQUENTIALLY with ``is_first_batch=(i==1)``.
@@ -635,52 +752,54 @@ def _split_contents_into_sub_batches(
     """
     from .retain import fact_extraction
 
-    # chunk_text takes a char budget; cl100k_base averages ~3-4 chars
-    # per token on natural-language input. Use 3x for headroom so a
-    # chunk's token count is comfortably under tokens_per_batch even
-    # when content tokenizes denser than average (code, JSON).
-    char_budget = max(tokens_per_batch * 3, 1)
+    def _chunks_of(text: str) -> list[str]:
+        return fact_extraction.chunk_text(text, chunk_size, structured_chunk_size=structured_chunk_size)
 
     sub_batches: list[list[RetainContentDict]] = []
     origin_indices: list[list[int]] = []
     document_body_overrides: list[str | None] = []
+    chunk_counts: list[int] = []
     current_batch: list[RetainContentDict] = []
     current_batch_origins: list[int] = []
     current_batch_tokens = 0
+    current_batch_chunks = 0
 
     def _flush() -> None:
-        nonlocal current_batch, current_batch_origins, current_batch_tokens
+        nonlocal current_batch, current_batch_origins, current_batch_tokens, current_batch_chunks
         if current_batch:
             sub_batches.append(current_batch)
             origin_indices.append(current_batch_origins)
             document_body_overrides.append(None)
+            chunk_counts.append(current_batch_chunks)
             current_batch = []
             current_batch_origins = []
             current_batch_tokens = 0
+            current_batch_chunks = 0
 
     for original_idx, item in enumerate(contents):
         content_str = item.get("content", "") or ""
         item_tokens = count_tokens(content_str)
 
         if item_tokens > tokens_per_batch:
-            # Oversized single item: flush anything in flight, then
-            # chunk the content and emit each chunk as its own
-            # single-item sub-batch. The sub-batches share the
-            # original item's document_id and metadata so the
-            # orchestrator's first-batch document tracking still
-            # cascade-deletes the prior document version on slice 1.
-            # Each slice carries ``content_str`` as the document body
-            # override so the orchestrator writes the full original
-            # text to documents.original_text — not just its own slice
-            # (otherwise the last slice would clobber the body with a
-            # truncated payload; see issue #1838).
+            # Oversized single item: flush anything in flight, then emit runs of
+            # whole native chunks as single-item sub-batches. The sub-batches
+            # share the original item's document_id and metadata so the
+            # orchestrator's first-batch document tracking still cascade-deletes
+            # the prior document version on slice 1. Each slice carries
+            # ``content_str`` as the document body override so the orchestrator
+            # writes the full original text to documents.original_text — not
+            # just its own slice (otherwise the last slice would clobber the
+            # body with a truncated payload; see issue #1838).
             _flush()
-            chunks = fact_extraction.chunk_text(content_str, char_budget)
-            for chunk in chunks:
-                chunk_item = cast(RetainContentDict, {**item, "content": chunk})
-                sub_batches.append([chunk_item])
-                origin_indices.append([original_idx])
-                document_body_overrides.append(content_str)
+            for run in _pack_native_chunks(_chunks_of(content_str), tokens_per_batch):
+                joined = _rejoin_native_chunks(run, chunk_size, structured_chunk_size)
+                slices = [(joined, len(run))] if joined is not None else [(chunk, 1) for chunk in run]
+                for slice_text, slice_chunk_count in slices:
+                    chunk_item = cast(RetainContentDict, {**item, "content": slice_text})
+                    sub_batches.append([chunk_item])
+                    origin_indices.append([original_idx])
+                    document_body_overrides.append(content_str)
+                    chunk_counts.append(slice_chunk_count)
             continue
 
         if current_batch and current_batch_tokens + item_tokens > tokens_per_batch:
@@ -688,12 +807,14 @@ def _split_contents_into_sub_batches(
         current_batch.append(item)
         current_batch_origins.append(original_idx)
         current_batch_tokens += item_tokens
+        current_batch_chunks += len(_chunks_of(content_str))
 
     _flush()
     return _SubBatchSplit(
         sub_batches=sub_batches,
         origin_indices=origin_indices,
         document_body_overrides=document_body_overrides,
+        chunk_counts=chunk_counts,
     )
 
 
@@ -4073,10 +4194,26 @@ class MemoryEngine(MemoryEngineInterface):
                 f"Large batch detected ({total_tokens:,} tokens from {len(contents)} items). Splitting into sub-batches of ~{tokens_per_batch:,} tokens each..."
             )
 
-            split = _split_contents_into_sub_batches(contents, tokens_per_batch)
+            # Slices are cut on the bank's own chunk boundaries, so resolve the
+            # retain config before splitting — the splitter and the orchestrator
+            # must chunk identically for the slices to line up with what gets
+            # stored (see _split_contents_into_sub_batches).
+            retain_config = await self._resolve_retain_config(bank_id, request_context, strategy)
+            chunking_config = self._retain_chunking_config(retain_config)
+
+            split = _split_contents_into_sub_batches(
+                contents,
+                tokens_per_batch,
+                chunk_size=chunking_config.chunk_size,
+                structured_chunk_size=chunking_config.structured_chunk_size,
+            )
             sub_batches = split.sub_batches
             origin_indices = split.origin_indices
-            document_body_overrides = split.document_body_overrides
+            # Every slice of an oversized item carries the same full body as its
+            # documents.original_text payload, and that body never goes through
+            # per-item screening. Screen each distinct body once here rather than
+            # inside every sub-batch (issue #3282).
+            document_body_overrides = _screen_document_body_overrides(split.document_body_overrides, retain_config)
 
             sub_batch_sizes = [len(b) for b in sub_batches]
             # Keep the per-sub-batch sizes log compact when an oversize
@@ -4102,12 +4239,10 @@ class MemoryEngine(MemoryEngineInterface):
             # chunk_index sequence rather than restart at 0 — otherwise the
             # derived chunk_id ({bank}_{doc}_{index}) collides and later
             # sub-batches overwrite earlier chunks, leaving only one sub-batch's
-            # worth of chunks/memories (issue #1888). Counting uses the same
-            # bank-resolved, strategy-applied chunk size the orchestrator chunks
-            # with, so the offsets match the chunk_index values it assigns.
+            # worth of chunks/memories (issue #1888). The counts come from the
+            # splitter, which cut the slices on those very chunk boundaries.
             from .retain import fact_extraction, fact_storage
 
-            chunking_config = await self._resolve_retain_chunking_config(bank_id, request_context, strategy)
             chunk_offsets: dict[str, int] = {}
 
             # In update_mode="append", retain_batch prepends the existing document
@@ -4164,27 +4299,13 @@ class MemoryEngine(MemoryEngineInterface):
                 sub_doc_id = document_id or (sub_batch[0].get("document_id") if len(sub_batch) == 1 else None)
                 sub_offset = chunk_offsets.get(sub_doc_id, 0) if sub_doc_id else 0
 
-                # Count the chunks this sub-batch will produce BEFORE handing it
-                # to the orchestrator. retain_batch consumes (pops) each item's
-                # "content" while streaming, so reading it back after the call
-                # yields "" — and chunk_text("") returns [""] (count 1),
-                # advancing the per-document cursor by 1 regardless of the real
-                # chunk count. For slices that each span several chunks the next
-                # sub-batch then restarts ~1 slot in, colliding chunk_ids and
-                # overwriting earlier chunks (only ~1 new chunk survives per
-                # sub-batch). Capture it here while content is still present.
-                sub_chunk_count = 0
-                if sub_doc_id:
-                    sub_chunk_count = sum(
-                        len(
-                            fact_extraction.chunk_text(
-                                item.get("content", "") or "",
-                                chunking_config.chunk_size,
-                                structured_chunk_size=chunking_config.structured_chunk_size,
-                            )
-                        )
-                        for item in sub_batch
-                    )
+                # How many chunks this sub-batch contributes, from the splitter.
+                # It must NOT be re-derived here: retain_batch consumes (pops)
+                # each item's "content" while streaming, so reading it back
+                # after the call yields "" — and chunk_text("") returns [""]
+                # (count 1), advancing the per-document cursor by 1 regardless
+                # of the real chunk count (issue #1888).
+                sub_chunk_count = split.chunk_counts[i - 1]
 
                 sub_results, sub_usage, sub_processed = await self._retain_batch_async_internal(
                     bank_id=bank_id,
@@ -4319,19 +4440,18 @@ class MemoryEngine(MemoryEngineInterface):
         except Exception as e:
             logger.warning(f"Failed to submit graph maintenance task for bank {bank_id}: {e}")
 
-    async def _resolve_retain_chunking_config(
+    async def _resolve_retain_config(
         self,
         bank_id: str,
         request_context: "RequestContext",
         strategy: str | None,
-    ) -> _RetainChunkingConfig:
-        """Resolve the effective retain chunking settings for a bank.
+    ) -> HindsightConfig:
+        """Resolve the config a retain runs under, strategy overrides applied.
 
-        Mirrors the bank-config + strategy resolution that
-        ``_retain_batch_async_internal`` applies before handing config to the
-        orchestrator, so chunk-count estimates used for per-document
-        chunk_index offsets match the chunk_index values the orchestrator
-        actually assigns.
+        Mirrors what ``_retain_batch_async_internal`` resolves before handing
+        config to the orchestrator, so anything the splitting caller derives
+        from it (chunk boundaries, Memory Defense screening) matches what the
+        orchestrator then does with each sub-batch.
         """
         from hindsight_api.config_resolver import apply_strategy
 
@@ -4339,9 +4459,14 @@ class MemoryEngine(MemoryEngineInterface):
         effective_strategy = strategy or resolved_config.retain_default_strategy
         if effective_strategy:
             resolved_config = apply_strategy(resolved_config, effective_strategy)
+        return resolved_config
+
+    @staticmethod
+    def _retain_chunking_config(config: HindsightConfig) -> _RetainChunkingConfig:
+        """The chunk boundaries ``config`` implies, as the retain pipeline uses them."""
         return _RetainChunkingConfig(
-            chunk_size=getattr(resolved_config, "retain_chunk_size", 3000),
-            structured_chunk_size=getattr(resolved_config, "retain_structured_chunk_size", None),
+            chunk_size=getattr(config, "retain_chunk_size", DEFAULT_RETAIN_CHUNK_SIZE),
+            structured_chunk_size=getattr(config, "retain_structured_chunk_size", None),
         )
 
     async def _retain_batch_async_internal(

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -51,15 +51,20 @@ def utcnow():
     return datetime.now(UTC)
 
 
-def _redact_document_body(body: str, config: Any) -> str:
+def redact_document_body(body: str, config: Any) -> str:
     """Apply Memory Defense redaction to a document body.
 
     Per-item screening only scrubs the chunked content that goes through
-    `screen()`. When a sub-batch carries `document_body_override` (the full
-    original text of an oversized item — see `_split_contents_into_sub_batches`),
-    that override bypasses screening and would persist verbatim into
-    `documents.original_text`. Apply the same redactor here so the document
-    body is scrubbed regardless of which path produced it.
+    `screen()`. A `document_body_override` (the full original text of an
+    oversized item — see `_split_contents_into_sub_batches`) never goes through
+    `screen()` and would otherwise persist verbatim into
+    `documents.original_text`, so the splitting caller runs it through this
+    redactor once, before handing the same body to every slice.
+
+    **Callers of this module must pass an override that is already screened.**
+    The retain path here deliberately does not re-screen it: every slice of an
+    oversized item carries the identical body, so re-screening would rescan the
+    whole document once per sub-batch (issue #3282).
     """
     try:
         policy = parse_policy(getattr(config, "memory_defense", None))
@@ -75,19 +80,17 @@ def _redact_document_body(body: str, config: Any) -> str:
 def _is_strict_append_of_stored_document(
     stored_original_text: str | None,
     document_body_override: str | None,
-    config: Any,
 ) -> bool:
     """Return whether an oversized document body strictly appends stored text.
 
-    ``documents.original_text`` is sanitized and may also be Memory Defense
-    redacted before persistence. Apply those same transformations to the
-    complete incoming body before comparing it with the stored prefix.
+    ``documents.original_text`` is sanitized before persistence (the override
+    arrives Memory Defense redacted — see ``redact_document_body``), so apply
+    the same sanitization before comparing it with the stored prefix.
     """
     if stored_original_text is None or document_body_override is None:
         return False
 
-    redacted_body = _redact_document_body(document_body_override, config)
-    sanitized_body = fact_extraction._sanitize_text(redacted_body) or ""
+    sanitized_body = fact_extraction._sanitize_text(document_body_override) or ""
     return len(sanitized_body) > len(stored_original_text) and sanitized_body.startswith(stored_original_text)
 
 
@@ -1367,9 +1370,9 @@ async def _streaming_retain_batch(
     # so documents.original_text stores the complete payload, not just this
     # slice (issue #1838).
     if document_body_override is not None:
-        # The override is the unmodified original body — apply redaction so
-        # secrets in oversized inputs don't bypass screening.
-        combined_content = _redact_document_body(document_body_override, config)
+        # Already Memory Defense screened by the caller that produced it
+        # (see redact_document_body) — do not rescan it per slice.
+        combined_content = document_body_override
     else:
         combined_content = "\n".join([c.get("content", "") for c in contents_dicts])
     # Memory: contents_dicts content strings are now captured in combined_content.
@@ -2337,7 +2340,6 @@ async def _try_delta_retain(
         if _is_strict_append_of_stored_document(
             original_text_at_load,
             document_body_override,
-            config,
         ):
             log_buffer.append(
                 "[delta] First oversized slice has no stored chunk match, but "
@@ -2526,10 +2528,10 @@ async def _try_delta_retain(
                 step_start = time.time()
                 # When this sub-batch is one slice of an oversized item
                 # split across multiple sub-batches, store the full body
-                # (issue #1838) instead of just the slice. Redact the
-                # override since it bypassed per-chunk screening.
+                # (issue #1838) instead of just the slice. The override
+                # arrives already screened (see redact_document_body).
                 if document_body_override is not None:
-                    combined_content = _redact_document_body(document_body_override, config)
+                    combined_content = document_body_override
                 else:
                     combined_content = "\n".join([c.get("content", "") for c in contents_dicts])
                 retain_params, merged_tags = _build_retain_params(contents_dicts, document_tags)
@@ -2718,10 +2720,10 @@ async def _delta_metadata_only(
                 )
                 return None
             # When this sub-batch is a slice of an oversized item, write the
-            # full original body (issue #1838) instead of just the slice.
-            # Redact the override since it bypassed per-chunk screening.
+            # full original body (issue #1838) instead of just the slice. The
+            # override arrives already screened (see redact_document_body).
             if document_body_override is not None:
-                combined_content = _redact_document_body(document_body_override, config)
+                combined_content = document_body_override
             else:
                 combined_content = "\n".join([c.get("content", "") for c in contents_dicts])
             retain_params, merged_tags = _build_retain_params(contents_dicts, document_tags)

--- a/hindsight-api-slim/tests/test_batch_chunking.py
+++ b/hindsight-api-slim/tests/test_batch_chunking.py
@@ -157,6 +157,40 @@ def test_split_slices_are_whole_native_chunks(body):
     assert rechunked == native_chunks, "slices did not reproduce the document's native chunks"
 
 
+def test_split_falls_back_to_one_chunk_per_slice_when_no_faithful_join_exists(monkeypatch):
+    """When a run of chunks cannot be rejoined faithfully, each chunk ships alone.
+
+    Packing several chunks into one slice is only safe while the joined text
+    re-chunks back to exactly those chunks. If no candidate join does (a
+    content shape whose chunker is not reconstructible from its own output),
+    the splitter must degrade to one chunk per sub-batch — trivially aligned by
+    ``chunk_text``'s idempotency — rather than ship a slice whose boundaries
+    disagree with what gets stored (issue #3282).
+    """
+    from hindsight_api.engine.retain import fact_extraction
+
+    # Over the budget so it takes the oversized-item path; the stubbed chunks
+    # are small enough that the packer wants all three in a single slice.
+    body = "unjoinable body. " * 500
+    chunks = ["chunk one", "chunk two", "chunk three"]
+
+    def _fake_chunk_text(text, max_chars, structured_chunk_size=None):
+        # Only the original body chunks into `chunks`; every rejoin attempt
+        # comes back as something else, so verification always fails.
+        return list(chunks) if text == body else ["something else entirely"]
+
+    monkeypatch.setattr(fact_extraction, "chunk_text", _fake_chunk_text)
+
+    split = _split_contents_into_sub_batches(
+        [{"content": body, "document_id": "doc-unjoinable"}],
+        tokens_per_batch=100,
+        chunk_size=3000,
+    )
+
+    assert [b[0]["content"] for b in split.sub_batches] == chunks
+    assert split.chunk_counts == [1, 1, 1]
+
+
 def test_split_slice_never_cuts_a_native_chunk_under_a_tiny_budget():
     """A budget below one native chunk cannot shrink the slice past that chunk.
 

--- a/hindsight-api-slim/tests/test_batch_chunking.py
+++ b/hindsight-api-slim/tests/test_batch_chunking.py
@@ -1,6 +1,7 @@
 """Test automatic batch chunking based on character count."""
 
 import asyncio
+import json
 import os
 
 import pytest
@@ -11,6 +12,7 @@ from hindsight_api.engine.memory_engine import (
     _split_contents_into_sub_batches,
     count_tokens,
 )
+from hindsight_api.engine.retain.fact_extraction import chunk_text
 
 # ---------------------------------------------------------------------------
 # Regression tests for issue #1571: the splitter must actually chunk an
@@ -31,6 +33,7 @@ def test_split_single_oversized_item_produces_multiple_sub_batches():
     split = _split_contents_into_sub_batches(
         [{"content": big_content, "document_id": "doc-oversize"}],
         tokens_per_batch,
+        chunk_size=3000,
     )
 
     assert len(split.sub_batches) > 1, (
@@ -59,7 +62,7 @@ def test_split_oversized_item_preserves_document_id_and_metadata():
         "tags": ["t1", "t2"],
     }
 
-    split = _split_contents_into_sub_batches([item], tokens_per_batch)
+    split = _split_contents_into_sub_batches([item], tokens_per_batch, chunk_size=3000)
 
     assert len(split.sub_batches) > 1
     for batch in split.sub_batches:
@@ -85,7 +88,7 @@ def test_split_mixed_batch_chunks_only_oversized_items():
         {"content": small_b, "document_id": "doc-c"},
     ]
 
-    split = _split_contents_into_sub_batches(contents, tokens_per_batch)
+    split = _split_contents_into_sub_batches(contents, tokens_per_batch, chunk_size=3000)
 
     # We expect: [small_a packed] then N chunks of big, then [small_b packed].
     # At minimum: > 2 sub-batches (a + multiple big chunks + c).
@@ -104,6 +107,76 @@ def test_split_mixed_batch_chunks_only_oversized_items():
     assert big_origin_count > small_a_origin_count
 
 
+def _conversation_payload(turns: int = 120) -> str:
+    return json.dumps(
+        [{"role": "user" if i % 2 == 0 else "assistant", "content": f"turn {i} " + "blah " * 60} for i in range(turns)]
+    )
+
+
+def _jsonl_payload(lines: int = 200) -> str:
+    return "\n".join(json.dumps({"i": i, "text": "line " + "x " * 80}) for i in range(lines))
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param(
+            "\n\n".join(f"Section {i}. " + f"marker{i} filler word here. " * 117 for i in range(10)), id="prose"
+        ),
+        pytest.param(_conversation_payload(), id="json-conversation"),
+        pytest.param(_jsonl_payload(), id="jsonl"),
+    ],
+)
+def test_split_slices_are_whole_native_chunks(body):
+    """Every slice holds a whole number of native chunks and re-chunks back to
+    exactly those chunks (issue #3282).
+
+    This is the invariant the rest of the retain path is built on: the chunks
+    stored for a document must depend only on its body, never on how transport
+    split it. Delta retain and the streaming recovery pass both match stored
+    chunks by content hash, so a slice cutting mid-chunk silently re-extracts
+    unchanged history; ``chunk_index`` bookkeeping assumes whole chunks too.
+    """
+    chunk_size = 3000
+    native_chunks = chunk_text(body, chunk_size)
+    assert len(native_chunks) > 3, "test payload must span several native chunks"
+
+    split = _split_contents_into_sub_batches(
+        [{"content": body, "document_id": "doc-align"}],
+        tokens_per_batch=1_500,
+        chunk_size=chunk_size,
+    )
+
+    assert len(split.sub_batches) > 1, "payload should have been sliced"
+    rechunked: list[str] = []
+    for sub_batch, count in zip(split.sub_batches, split.chunk_counts):
+        slice_chunks = chunk_text(sub_batch[0]["content"], chunk_size)
+        assert len(slice_chunks) == count, "chunk_counts must match what the slice re-chunks to"
+        rechunked.extend(slice_chunks)
+
+    assert rechunked == native_chunks, "slices did not reproduce the document's native chunks"
+
+
+def test_split_slice_never_cuts_a_native_chunk_under_a_tiny_budget():
+    """A budget below one native chunk cannot shrink the slice past that chunk.
+
+    ``retain_chunk_size`` is the real bound on a slice; honouring a smaller
+    token budget would mean cutting mid-chunk, which is exactly what breaks
+    hash-based chunk reuse (issue #3282).
+    """
+    body = "The quick brown fox jumps over the lazy dog. " * 1_000
+    native_chunks = chunk_text(body, 3000)
+
+    split = _split_contents_into_sub_batches(
+        [{"content": body, "document_id": "doc-tiny-budget"}],
+        tokens_per_batch=10,
+        chunk_size=3000,
+    )
+
+    assert [b[0]["content"] for b in split.sub_batches] == native_chunks
+    assert split.chunk_counts == [1] * len(native_chunks)
+
+
 def test_split_small_batch_returns_single_sub_batch():
     """A batch under the budget stays as a single sub-batch."""
     tokens_per_batch = 10_000
@@ -112,7 +185,7 @@ def test_split_small_batch_returns_single_sub_batch():
         {"content": "Bob loves Python", "document_id": "doc-2"},
     ]
 
-    split = _split_contents_into_sub_batches(contents, tokens_per_batch)
+    split = _split_contents_into_sub_batches(contents, tokens_per_batch, chunk_size=3000)
 
     assert len(split.sub_batches) == 1
     assert split.sub_batches[0] == contents

--- a/hindsight-api-slim/tests/test_delta_oversized_replacement.py
+++ b/hindsight-api-slim/tests/test_delta_oversized_replacement.py
@@ -1,0 +1,262 @@
+"""
+Regression tests for https://github.com/vectorize-io/hindsight/issues/3282
+
+When a replacement body for an existing ``document_id`` exceeds
+``retain_batch_tokens``, ``retain_batch_async`` slices it into sub-batches
+*before* the orchestrator gets a chance to classify the whole replacement
+against the stored chunks. Delta retain only runs on the first sub-batch (and
+only sees that slice), so a one-section edit plus an appended tail re-extracts
+the entire unchanged history instead of just the changed/new native chunks.
+
+The control test pins the behaviour with a transport budget large enough to
+keep the replacement in one piece (delta works there today); the repro test
+lowers only ``retain_batch_tokens`` and asserts the same document edit still
+skips the unchanged chunks.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from hindsight_api.config import clear_config_cache
+from hindsight_api.engine.memory_engine import count_tokens
+from hindsight_api.engine.retain import fact_extraction, orchestrator
+
+# Sections are separated by blank lines and each is just under
+# retain_chunk_size (3000 chars), so the chunker emits exactly one native chunk
+# per section. That keeps the chunk boundaries stable across versions: the edit
+# below is length-preserving, so only the edited section's chunk changes.
+_SECTION_REPEATS = 117  # ~2.5 KB per section
+_BASE_SECTIONS = 10
+_APPENDED_SECTIONS = 3
+
+# Transport budget for the replacement retain. The splitter slices an oversized
+# item at ``3 * retain_batch_tokens`` chars, so this is deliberately below the
+# native chunk size: the slices cut across native chunk boundaries.
+_OVERSIZED_BATCH_TOKENS = 300
+
+
+def _ts() -> float:
+    return datetime.now(timezone.utc).timestamp()
+
+
+def _section(idx: int, *, edited: bool = False) -> str:
+    marker = f"MARKER{idx:02d}"
+    payload = "bbbbb" if edited else "aaaaa"
+    return f"Section {idx:02d} {marker}. Payload {payload}. " + f"{marker} filler word here. " * _SECTION_REPEATS
+
+
+def _body(*, edited_idx: int | None = None, appended: int = 0) -> str:
+    sections = [_section(i, edited=(i == edited_idx)) for i in range(_BASE_SECTIONS)]
+    sections += [_section(100 + j) for j in range(appended)]
+    return "\n\n".join(sections)
+
+
+def _unchanged_markers(edited_idx: int) -> list[str]:
+    return [f"MARKER{i:02d}" for i in range(_BASE_SECTIONS) if i != edited_idx]
+
+
+class _ExtractionSpy:
+    """Records the content fed to LLM fact extraction on each call."""
+
+    def __init__(self) -> None:
+        self.texts: list[str] = []
+
+    def install(self, monkeypatch) -> None:
+        original = fact_extraction.extract_facts_from_contents
+
+        async def _spy(contents, *args, **kwargs):
+            self.texts.extend(c.content for c in contents)
+            return await original(contents, *args, **kwargs)
+
+        monkeypatch.setattr(fact_extraction, "extract_facts_from_contents", _spy)
+
+    def markers_seen(self, markers: list[str]) -> list[str]:
+        blob = "\n".join(self.texts)
+        return [m for m in markers if m in blob]
+
+    @property
+    def extracted_tokens(self) -> int:
+        return sum(count_tokens(t) for t in self.texts)
+
+
+@pytest.fixture(autouse=True)
+def _fast_retain_env(monkeypatch):
+    # Keep the tests focused on the retain path.
+    monkeypatch.setenv("HINDSIGHT_API_ENABLE_AUTO_CONSOLIDATION", "false")
+    monkeypatch.setenv("HINDSIGHT_API_ENABLE_OBSERVATIONS", "false")
+    clear_config_cache()
+    yield
+    clear_config_cache()
+
+
+async def _retain_v1_then_v2(
+    memory,
+    request_context,
+    bank_id: str,
+    document_id: str,
+    *,
+    replacement_batch_tokens: int | None,
+    monkeypatch,
+    spy: _ExtractionSpy,
+    edited_idx: int,
+) -> str:
+    """Retain the base body, then the edited+appended replacement.
+
+    ``replacement_batch_tokens`` is applied only to the second retain, matching
+    the issue's reproduction steps. Returns the replacement body.
+    """
+    v1 = _body()
+    await memory.retain_async(
+        bank_id=bank_id,
+        content=v1,
+        context="notes",
+        document_id=document_id,
+        request_context=request_context,
+    )
+
+    v2 = _body(edited_idx=edited_idx, appended=_APPENDED_SECTIONS)
+
+    if replacement_batch_tokens is not None:
+        monkeypatch.setenv("HINDSIGHT_API_RETAIN_BATCH_TOKENS", str(replacement_batch_tokens))
+        clear_config_cache()
+
+    # Only spy on the replacement — the first retain legitimately extracts everything.
+    spy.install(monkeypatch)
+
+    await memory.retain_async(
+        bank_id=bank_id,
+        content=v2,
+        context="notes",
+        document_id=document_id,
+        request_context=request_context,
+    )
+    return v2
+
+
+@pytest.mark.asyncio
+async def test_replacement_within_batch_budget_skips_unchanged_chunks(memory, request_context, monkeypatch):
+    """Control: with the whole replacement inside the transport budget, delta
+    retain re-extracts only the edited section and the appended tail."""
+    bank_id = f"test_3282_control_{_ts()}"
+    document_id = "doc-3282-control"
+    edited_idx = 1
+    spy = _ExtractionSpy()
+
+    try:
+        await _retain_v1_then_v2(
+            memory,
+            request_context,
+            bank_id,
+            document_id,
+            replacement_batch_tokens=100_000,  # whole replacement fits — no splitting
+            monkeypatch=monkeypatch,
+            spy=spy,
+            edited_idx=edited_idx,
+        )
+
+        re_extracted = spy.markers_seen(_unchanged_markers(edited_idx))
+        assert re_extracted == [], f"unchanged sections were re-extracted: {re_extracted}"
+        assert spy.markers_seen([f"MARKER{edited_idx:02d}", "MARKER100"]), (
+            "the edited section and the appended tail should have been extracted"
+        )
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_oversized_replacement_still_skips_unchanged_chunks(memory, request_context, monkeypatch):
+    """Repro for #3282: the same edit must not re-extract unchanged history just
+    because the complete replacement exceeds ``retain_batch_tokens``.
+
+    The budget is set below both the full replacement and the aggregate token
+    count of the changed/new chunks, so the transport split cannot be satisfied
+    by the delta chunk list either — delta classification must still run against
+    the complete body first.
+    """
+    bank_id = f"test_3282_oversized_{_ts()}"
+    document_id = "doc-3282-oversized"
+    edited_idx = 1
+    spy = _ExtractionSpy()
+    batch_tokens = _OVERSIZED_BATCH_TOKENS
+
+    try:
+        v2 = await _retain_v1_then_v2(
+            memory,
+            request_context,
+            bank_id,
+            document_id,
+            replacement_batch_tokens=batch_tokens,
+            monkeypatch=monkeypatch,
+            spy=spy,
+            edited_idx=edited_idx,
+        )
+
+        # Sanity-check the premise of the repro: the replacement really is over
+        # the transport budget, and so is the changed/new chunk aggregate.
+        assert count_tokens(v2) > batch_tokens
+        changed_chunk_tokens = count_tokens(_section(edited_idx, edited=True)) + sum(
+            count_tokens(_section(100 + j)) for j in range(_APPENDED_SECTIONS)
+        )
+        assert changed_chunk_tokens > batch_tokens
+
+        re_extracted = spy.markers_seen(_unchanged_markers(edited_idx))
+        assert re_extracted == [], (
+            f"unchanged sections {re_extracted} were re-extracted: the oversized "
+            f"replacement bypassed delta retain (issue #3282). Extraction saw "
+            f"{spy.extracted_tokens:,} tokens; only the changed/new chunks "
+            f"(~{changed_chunk_tokens:,} tokens) should have reached it."
+        )
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_oversized_replacement_screens_document_body_once(memory, request_context, monkeypatch):
+    """Companion to #3282: the split fallback must not re-run Memory Defense over
+    the whole document for every sub-batch.
+
+    Each sub-batch carries ``document_body_override`` (the COMPLETE body, so
+    ``documents.original_text`` isn't clobbered with a slice), and the retain
+    path redaction-scans that override before persisting it. With N sub-batches
+    the full body is scanned N times even though only one of them wins the
+    document row.
+    """
+    bank_id = f"test_3282_defense_{_ts()}"
+    document_id = "doc-3282-defense"
+    edited_idx = 1
+    spy = _ExtractionSpy()
+
+    full_body_scans: list[int] = []
+    original_redaction = orchestrator.apply_redaction
+
+    def _counting_redaction(text: str, *args, **kwargs):
+        full_body_scans.append(len(text))
+        return original_redaction(text, *args, **kwargs)
+
+    try:
+        await memory.update_bank_config(
+            bank_id,
+            {"memory_defense": {"enabled": True, "rules": [{"on": "sensitive_data", "action": "redact"}]}},
+            request_context=request_context,
+        )
+        monkeypatch.setattr(orchestrator, "apply_redaction", _counting_redaction)
+
+        v2 = await _retain_v1_then_v2(
+            memory,
+            request_context,
+            bank_id,
+            document_id,
+            replacement_batch_tokens=_OVERSIZED_BATCH_TOKENS,
+            monkeypatch=monkeypatch,
+            spy=spy,
+            edited_idx=edited_idx,
+        )
+
+        replacement_scans = [n for n in full_body_scans if n == len(v2)]
+        assert len(replacement_scans) <= 1, (
+            f"the complete {len(v2):,}-char body was Memory Defense scanned "
+            f"{len(replacement_scans)} times — once per fallback sub-batch (issue #3282)"
+        )
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_large_document_replacement.py
+++ b/hindsight-api-slim/tests/test_large_document_replacement.py
@@ -168,21 +168,28 @@ async def test_append_after_zero_fact_header_slice_skips_unchanged_history(
     bank_id = f"test_large_append_zero_fact_header_{_ts()}"
     document_id = "chat-session-zero-fact-header"
     header = "# Stable Chat Session\nSession id: session-1\nCreated at: 2026-07-09T00:00:00Z"
+    # Long enough to span several native chunks: slices are cut on chunk
+    # boundaries, so the history has to exceed a few retain_chunk_size windows
+    # for this test to see more than a couple of sub-batches.
     history = "\n".join(
         f"[role: user] turn {turn}: "
         f"{'UNCHANGED_HEAD' if turn == 0 else 'UNCHANGED_MIDDLE' if turn == 30 else 'historical'} "
         "alpha bravo charlie delta echo foxtrot golf hotel india juliet"
-        for turn in range(60)
+        for turn in range(160)
     )
     initial_body = f"{header}\n\n{history}"
     tail_marker = "NEW_APPEND_ONLY_TAIL"
     appended_body = f"{initial_body}\n[role: user] turn 60: {tail_marker} alpha bravo charlie delta"
 
+    # Slices are cut on native chunk boundaries, so a tiny token budget yields
+    # one sub-batch per chunk of the body — the header lands alone in the first
+    # one, followed by the history slices this test replays.
     split = _split_contents_into_sub_batches(
         [{"content": initial_body, "document_id": document_id}],
         100,
+        chunk_size=3000,
     )
-    assert len(split.sub_batches) > 3
+    assert len(split.sub_batches) > 2
     assert "[role:" not in split.sub_batches[0][0]["content"]
 
     extracted_contents: list[str] = []


### PR DESCRIPTION
Fixes #3282.

## The defect

`retain_batch_async` slices an oversized item at `tokens_per_batch * 3` chars — a chars-per-token fudge that has nothing to do with the boundaries the rest of the retain path works in. Everything downstream reuses stored work by **chunk content hash**: delta retain, the streaming recovery pass, and `chunk_index` bookkeeping.

So a slice that happened to line up with native chunks reused them, and one that cut mid-chunk matched nothing. A replacement with one edited section plus an appended tail then re-extracted the entire unchanged history. That is why the bug only shows when `3 * retain_batch_tokens < retain_chunk_size` — above that ratio the slices accidentally align, which is why earlier work in this area (#1571 / #1838 / #1888) looked like it had settled the matter.

## The fix

Slice on the bank's own `chunk_text(chunk_size, structured_chunk_size)` boundaries, packing whole chunks up to the token budget, and **verify** each slice re-chunks back to exactly the chunks it holds (candidate joins: merged JSON array → `\n\n` → `\n`; otherwise fall back to one sub-batch per chunk, which `chunk_text`'s idempotency guarantees — #2301).

That makes one invariant hold by construction instead of by luck:

> the chunks stored for a document depend only on its body, never on how transport split it.

**Deliberate behaviour change:** a slice honours `retain_batch_tokens` only down to one native chunk. Below that, `retain_chunk_size` is the real bound — cutting finer is the defect, not the budget. The chunking parameters have no default, so a caller cannot silently fall back to the global 3000 and reintroduce the misalignment.

Two follow-ons fall out of the same invariant:

* The split reports `chunk_counts`, so the caller stops re-deriving them right before handing each sub-batch over — a workaround that existed only because the orchestrator pops `content` while streaming (#1888).
* `document_body_override` is Memory Defense screened **once**, by the engine that produces it, rather than by every slice that carries it. In the regression scenario a 42 KB body split into 26 sub-batches was rescanned 26 times. The orchestrator's four re-screen sites are gone and the "overrides arrive pre-screened" invariant is documented at both ends.

## Tests

* `test_delta_oversized_replacement.py` — the issue's reproduction (fails on `main`: all 9 unchanged sections re-extracted, 7,808 tokens through extraction against ~3,324 for the changed/new chunks), a control showing the same edit inside the budget already reused chunks, and the single-screening companion.
* `test_batch_chunking.py` — unit tests pinning the alignment invariant across prose, JSON conversation and JSONL payloads, plus one asserting a tiny budget cannot cut a native chunk.
* `test_large_document_replacement.py` — the #2930 test encoded the old slice granularity (`>3` sub-batches at a 100-token budget); its history payload now spans several native chunks so it still exercises several slices. Every behavioural assertion is unchanged.

109 tests pass across the delta / sub-batch / large-document / batch-chunking / memory-defense suites; `./scripts/hooks/lint.sh` and `ty check` are clean.
