### PR TITLE
fix(coding-agents): seed bank missions once, then leave them to the user (#2492)

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
@@ -411,7 +411,11 @@ describe("HindsightClient.configureBank template import", () => {
 
     const importPosts = calls.filter((k) => k.method === "POST" && k.url.endsWith("/import"));
     expect(importPosts).toHaveLength(1);
-    expect(calls[0]).toBe(importPosts[0]); // config first — page seeding needs the bank to exist
+    // Config before the knowledge base — page seeding needs the bank to exist. (The very first
+    // call is the GET /config probe that decides whether the missions are still ours to seed.)
+    expect(calls.indexOf(importPosts[0])).toBeLessThan(
+      calls.findIndex((k) => k.url.includes("/knowledge-base/"))
+    );
 
     const body = importPosts[0].body;
     expect(body.version).toBe("1");
@@ -447,5 +451,96 @@ describe("HindsightClient.configureBank template import", () => {
     expect(calls[0].url.endsWith("/import")).toBe(false);
     expect(calls[1].method).toBe("POST");
     expect(calls[1].url.endsWith("/import")).toBe(true);
+  });
+});
+
+describe("HindsightClient.configureBank — missions are seeded once (#2492)", () => {
+  const routes = (overrides: Record<string, unknown> | undefined, ok = true) => [
+    {
+      match: (m: string, u: string) => m === "GET" && u.endsWith("/knowledge-base/tree"),
+      json: { roots: [] },
+    },
+    {
+      match: (m: string, u: string) => m === "GET" && u.endsWith("/config"),
+      json: { bank_id: "repo-a", config: {}, overrides },
+      ok,
+    },
+  ];
+
+  const run = async (calls: any[], routeList: any[]) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: any) => {
+        const method = init?.method;
+        calls.push({ url, method, body: init?.body ? JSON.parse(init.body) : undefined });
+        const route = routeList.find((r) => r.match(method, url));
+        return {
+          ok: route?.ok ?? true,
+          status: route?.ok === false ? 404 : 200,
+          json: async () => route?.json ?? { ok: true },
+        } as any;
+      })
+    );
+    await new HindsightClient({ apiUrl: "http://x", bank: "repo-a" }).configureBank();
+    return calls.find((k) => k.method === "POST" && k.url.endsWith("/import")).body;
+  };
+
+  it("seeds the full template — missions included — on a bank with no mission overrides", async () => {
+    const body = await run([], routes({}));
+    expect(typeof body.bank.reflect_mission).toBe("string");
+    expect(body.bank.retain_strategies).toBeDefined();
+  });
+
+  it("leaves the missions alone once the bank carries its own", async () => {
+    // The user rewrote reflect_mission in the control plane; a later seed pass must not stamp the
+    // default back over it — the whole of #2492.
+    const body = await run([], routes({ reflect_mission: "MY OWN MISSION" }));
+    expect(body.bank.reflect_mission).toBeUndefined();
+    expect(body.bank.retain_mission).toBeUndefined();
+    expect(body.bank.observations_mission).toBeUndefined();
+  });
+
+  it("still re-applies the strategies and labels the plugin writes through", async () => {
+    // Not preferences: a bank missing `conversation` would reject the session write-back.
+    const body = await run([], routes({ retain_mission: "mine" }));
+    expect(Object.keys(body.bank.retain_strategies)).toEqual(
+      expect.arrayContaining(["git", "gitlog", "conversation", "document"])
+    );
+    expect(body.bank.entity_labels).toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: "knowledge" })])
+    );
+  });
+
+  it("treats a blank override as unset", async () => {
+    const body = await run([], routes({ reflect_mission: "   " }));
+    expect(typeof body.bank.reflect_mission).toBe("string");
+  });
+
+  it("seeds when the bank-config API is unavailable — nothing to preserve there", async () => {
+    // With that API off a user cannot set per-bank missions at all, so there is no edit to protect.
+    const body = await run([], routes(undefined, false));
+    expect(typeof body.bank.reflect_mission).toBe("string");
+  });
+
+  it("re-seeds the missions after an explicit reset", async () => {
+    const calls: any[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: any) => {
+        calls.push({
+          url,
+          method: init?.method,
+          body: init?.body ? JSON.parse(init.body) : undefined,
+        });
+        return { ok: true, status: 200, json: async () => ({ roots: [] }) } as any;
+      })
+    );
+    await new HindsightClient({ apiUrl: "http://x", bank: "repo-a" }).configureBank({
+      reset: true,
+    });
+    const body = calls.find((k) => k.method === "POST" && k.url.endsWith("/import")).body;
+    expect(typeof body.bank.reflect_mission).toBe("string");
+    // reset deletes the bank, so there is nothing to probe
+    expect(calls.some((k) => k.method === "GET" && k.url.endsWith("/config"))).toBe(false);
   });
 });

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -5,7 +5,13 @@
  * (missions + git/chat retain strategies), retains memories, reflects, drains async operations, and
  * creates knowledge pages. Nothing here knows about opencode/claude-code/etc.
  */
-import { CODING_BANK_TEMPLATE, PAGE_MAX_TOKENS, PAGE_TRIGGER, PAGES } from "./missions";
+import {
+  CODING_BANK_STRUCTURE,
+  CODING_BANK_TEMPLATE,
+  PAGE_MAX_TOKENS,
+  PAGE_TRIGGER,
+  PAGES,
+} from "./missions";
 import { semverGte, sleep } from "./util";
 
 /** One node of GET /knowledge-base/tree. Only the fields this client reads. */
@@ -51,6 +57,9 @@ export class KnowledgePagesUnavailableError extends Error {
 }
 
 const TERMINAL = new Set(["completed", "failed", "cancelled", "error"]);
+
+/** Bank-level missions the template seeds once and then leaves alone (#2492). */
+const MISSION_FIELDS = ["reflect_mission", "retain_mission", "observations_mission"] as const;
 
 export class HindsightClient {
   readonly apiUrl: string;
@@ -190,12 +199,44 @@ export class HindsightClient {
       await this.req("DELETE", this.bankUrl());
       this.log(`[bank] reset ${this.bank}`);
     }
-    await this.req("POST", this.bankUrl("/import"), CODING_BANK_TEMPLATE);
+    // Seed the missions ONCE. After that they belong to whoever set them — see CODING_BANK_STRUCTURE.
+    const seeded = opts.reset ? false : await this.hasBankMissions();
+    await this.req(
+      "POST",
+      this.bankUrl("/import"),
+      seeded ? CODING_BANK_STRUCTURE : CODING_BANK_TEMPLATE
+    );
     this.log(
-      `[bank] template applied to ${this.bank}: missions, entity_labels {knowledge}, ` +
-        `strategies {git, gitlog, conversation, document}`
+      seeded
+        ? `[bank] structure applied to ${this.bank}: entity_labels {knowledge}, ` +
+            `strategies {git, gitlog, conversation, document} — missions left as configured`
+        : `[bank] template applied to ${this.bank}: missions, entity_labels {knowledge}, ` +
+            `strategies {git, gitlog, conversation, document}`
     );
     await this.seedPages();
+  }
+
+  /**
+   * Whether this bank already carries bank-level mission overrides — ours from an earlier seed, or
+   * the user's own edit. Either way they are not ours to overwrite.
+   *
+   * Reads the bank-scoped OVERRIDES, not the resolved config, so inherited global defaults don't
+   * read as "already set". A missing bank, or a deployment with the bank-config API switched off,
+   * answers false: there is nothing to preserve, and without that API a user cannot set per-bank
+   * missions in the first place.
+   */
+  private async hasBankMissions(): Promise<boolean> {
+    try {
+      const r = await this.req("GET", this.bankUrl("/config"));
+      if (!r.ok) return false;
+      const j = (await r.json()) as { overrides?: Record<string, unknown> };
+      return MISSION_FIELDS.some((f) => {
+        const v = j.overrides?.[f];
+        return typeof v === "string" && v.trim() !== "";
+      });
+    } catch {
+      return false;
+    }
   }
 
   /** Delete one document (cascades its memory units/links). Used by deepen's self-cleanup. */

--- a/hindsight-integrations/coding-agents/src/core/missions.ts
+++ b/hindsight-integrations/coding-agents/src/core/missions.ts
@@ -267,3 +267,22 @@ export const CODING_BANK_TEMPLATE = {
     entities_allow_free_form: true,
   },
 } as const;
+
+/**
+ * The subset re-applied to a bank that is ALREADY configured — everything above minus the missions.
+ *
+ * The full template seeds a bank once. After that the missions are the user's: someone who rewrites
+ * `reflect_mission` in the control plane means it, and re-importing the manifest on every seed pass
+ * silently stamped the defaults back over it (#2492 — the same regression #1270 fixed for OpenClaw).
+ *
+ * The retain strategies and entity labels stay, because they are not preferences: this plugin writes
+ * documents under `git` / `gitlog` / `conversation` / `document`, and a bank missing one of those
+ * would reject the write. A newer plugin adding a strategy needs it to land on existing banks too.
+ */
+export const CODING_BANK_STRUCTURE = {
+  version: "1",
+  bank: {
+    retain_strategies: RETAIN_STRATEGIES,
+    entity_labels: [KNOWLEDGE_LABELS],
+  },
+} as const;


### PR DESCRIPTION
Closes #2492 — third of the superseded-plugin issues that needed real work here rather than a migration note.

## Confirmed present

`configureBank` POSTs the full `CODING_BANK_TEMPLATE` to `/banks/{id}/import`:

```ts
bank: { reflect_mission: …, observations_mission: …, retain_mission: …, retain_strategies, entity_labels, … }
```

and the server applies it unconditionally — `http.py`: `if config_updates: await memory.update_bank_config(...)`, with no only-if-unset guard. The seed engine (`deepen`) runs on **every session start**, so a mission rewritten in the control plane was stamped back to the plugin's default on the next session. Same regression #1270 fixed for OpenClaw, here by the same route — the template was carried over, the guard wasn't.

## The rule now

**Seed once; after that the missions are the user's.**

Before importing, the client reads the bank-scoped `overrides` from `GET /banks/{id}/config` — deliberately the overrides, not the resolved config, so an inherited global default doesn't read as "already set". If any of `reflect_mission` / `retain_mission` / `observations_mission` is set there — ours from an earlier pass, or the user's own — it imports `CODING_BANK_STRUCTURE`, which omits them. Omitted fields are untouched server-side: `get_config_updates` keeps only non-None values.

**Strategies and entity labels are still re-applied every time.** Those aren't preferences: the plugin writes documents under `git` / `gitlog` / `conversation` / `document`, a bank missing one would reject the write, and a newer plugin version adding a strategy needs it to reach existing banks.

Two cases still seed on purpose: `configureBank({reset: true})`, because the bank was just deleted; and a deployment with the bank-config API switched off, where a user cannot set per-bank missions at all, so there is no edit to protect.

## Test

**409 passed**, 19 skipped. `tsc --noEmit` and `./scripts/hooks/lint.sh` clean.

Six new cases: full template on a bank with no overrides; missions omitted once the bank carries its own; strategies and labels re-applied regardless; a blank override treated as unset; seeding when the config API is unavailable; and re-seeding after an explicit reset (with no probe, since the bank is gone).

The pre-existing import test needed one change — it asserted the import was the very first call, and the probe now precedes it. It asserts the ordering that actually matters instead: the import lands before any knowledge-base call, because page seeding needs the bank to exist.

## Note

Per-*strategy* missions (inside `retain_strategies`) are still re-applied, since they're part of the extraction contract the plugin writes through. If someone wants those editable too, that's a separate call — this PR covers the bank-level missions #2492 names.