### PR TITLE
fix(transfer): mint a fresh internal_id on whole-bank import (#3270)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
@@ -532,6 +532,16 @@ async def import_bank(
                 if "bank_id" in row:
                     row["bank_id"] = bank_id
 
+    # `internal_id` is a globally-unique (banks_internal_id_unique) local identifier
+    # used only for per-bank index naming — it is NOT part of the bank's logical
+    # state and nothing in the archive references it. Drop it so the column DEFAULT
+    # (gen_random_uuid) mints a fresh one on insert. Keeping the source value makes
+    # the banks INSERT collide with the source bank on a same-instance re-import,
+    # where `ON CONFLICT DO NOTHING` then silently skips the parent row and every
+    # child (mental_models, …) trips its bank_id foreign key. See #3270.
+    for row in parsed.bank_rows.get("banks", []):
+        row.pop("internal_id", None)
+
     async with acquire_with_retry(backend) as conn:
         # Refuse to import into an existing bank — this restores a whole bank, it
         # does not merge. Merging would silently mix the archive's config/mental

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -664,6 +664,54 @@ async def test_bank_export_import_exact_roundtrip(memory, request_context):
 
 
 @pytest.mark.asyncio
+async def test_bank_import_into_new_id_on_same_instance(memory, request_context):
+    """Export a bank and import it RIGHT BACK into a new id on the same instance
+    (source bank left in place). The banks row carries a globally-unique
+    ``internal_id``; if that were kept, the copy's banks INSERT would collide with
+    the still-present source and ``ON CONFLICT DO NOTHING`` would skip the parent
+    row, so the mental_models insert would trip fk_mental_models_bank_id. Import
+    must mint a fresh internal_id so the copy lands cleanly. Regression for #3270."""
+    source = _unique_bank("bank_src")
+    target = _unique_bank("bank_copy")
+    try:
+        await _retain(memory, source, "Alice works at Google.", request_context, "doc-1")
+        await memory.create_mental_model(
+            source,
+            name="Work model",
+            source_query="where do people work",
+            content="User tracks where people work.",
+            mental_model_id="mm-1",
+            request_context=request_context,
+        )
+
+        backend = await memory._get_backend()
+        async with acquire_with_retry(backend) as conn:
+            source_internal_id = await conn.fetchval(
+                f"SELECT internal_id FROM {fq_table('banks')} WHERE bank_id = $1", source
+            )
+
+        from hindsight_api.engine.transfer import export_bank
+
+        async with acquire_with_retry(backend) as conn:
+            archive = await export_bank(conn, source)
+        # Source bank is left in place — this is the same-instance "make a copy" flow.
+        result = await memory.import_bank_async(archive, request_context, target_bank_id=target)
+        assert result.bank_id == target
+        assert result.mental_models_imported == 1
+
+        async with acquire_with_retry(backend) as conn:
+            target_internal_id = await conn.fetchval(
+                f"SELECT internal_id FROM {fq_table('banks')} WHERE bank_id = $1", target
+            )
+        # The copy exists (parent row landed) and got a fresh, non-colliding id.
+        assert target_internal_id is not None
+        assert target_internal_id != source_internal_id
+    finally:
+        await memory.delete_bank(source, request_context=request_context)
+        await memory.delete_bank(target, request_context=request_context)
+
+
+@pytest.mark.asyncio
 async def test_bank_roundtrip_carries_mental_model_history(memory, request_context):
     """Mental-model refresh history survives export/import. Mental models keep a
     stable (id, bank_id), so the dedicated mental_model_history rows are carried


### PR DESCRIPTION
Fixes #3270.

## Problem

`hindsight-admin export-bank -b memory` then `import-bank -a memory.zip --target-bank test` on the same instance fails with:

```
ForeignKeyViolationError: insert or update on table "mental_models"
violates foreign key constraint "fk_mental_models_bank_id"
DETAIL:  Key (bank_id)=(test) is not present in table "banks".
```

It's not really about mental models — the `banks` **parent** row silently never gets inserted.

## Root cause

The `banks` table has a globally-unique `internal_id` UUID column (`banks_internal_id_unique`, used only for per-bank vector-index naming). The whole-bank export dumps the row with `SELECT *`, so it carries `internal_id`. On import, the remap rewrites only `bank_id`, leaving the source's `internal_id` in place.

When you export and import back into a **new id on the same instance**, the source bank is still present, so its `internal_id` still exists. The copy's `banks` INSERT hits the unique constraint and `ON CONFLICT DO NOTHING` silently skips the parent row. Then every child (`mental_models`, `directives`, `webhooks`) inserted with `bank_id='test'` trips its `bank_id` foreign key — exactly the reported error. The "target bank already exists" guard doesn't catch it because `test` genuinely doesn't exist; the collision is on `internal_id`, not `bank_id`.

**Cross-instance migration was never affected** — `internal_id` is a random UUID, so it doesn't collide on a fresh target. Only the same-instance "make a copy" flow broke, which is why the existing round-trip tests (all delete-then-restore, or import into a fresh context) missed it.

## Fix

Drop `internal_id` from the `banks` row before restore so the column `DEFAULT gen_random_uuid()` mints a fresh one. It's a local identifier nothing in the archive references, and `create_bank_vector_indexes` already reads it back from the DB after the insert, so it picks up the new value automatically.

## Test

Adds `test_bank_import_into_new_id_on_same_instance` — exports a bank with a mental model and imports it into a new id **without deleting the source**, asserting the copy lands and gets a fresh, non-colliding `internal_id`. Verified it fails (FK violation) without the fix and passes with it; the existing exact-roundtrip test still passes.
