### PR TITLE
fix(obsidian): scope sync index to bank and API target (#3257)

### DIFF
--- a/hindsight-integrations/obsidian/README.md
+++ b/hindsight-integrations/obsidian/README.md
@@ -85,7 +85,7 @@ hindsight-obsidian-sync reconcile --vault ~/Vaults/Brain --bank my-vault --watch
 
 `--api-url` / `--api-token` fall back to `HINDSIGHT_API_URL` / `HINDSIGHT_API_TOKEN`. Other flags: `--include <folder>` / `--exclude <folder>` (repeatable), `--vault-name <name>` (defaults to the vault dir name), `--prefix-doc-id` (prefix document ids with the vault name for multi-vault banks), `--index <file>`, and `--help`.
 
-The sync index (the CLI's equivalent of the plugin's `data.json`) defaults to `~/.hindsight/obsidian/<vault>.json` — deliberately **outside** the vault so Obsidian Sync never propagates it.
+The sync index (the CLI's equivalent of the plugin's `data.json`) defaults to a **per-target** file under `~/.hindsight/obsidian/` — `<vault>-<bank>-<fingerprint>.json`, deliberately **outside** the vault so Obsidian Sync never propagates it. The index is bound to the destination it was built against (API origin, bank, vault path, and the `--vault-name`/`--prefix-doc-id` document-id namespace); pointing a saved index at a different bank or API — whether via the default path or an explicit `--index` — **fails closed** with an actionable message rather than silently skipping files or mis-attributing deletes to a bank it never wrote to. Changing `--include`/`--exclude` on the _same_ destination is fine (it reuses the index and prunes newly-excluded notes it owns there).
 
 > **Running the CLI and the plugin against the same bank + vault?** Keep their scope config identical (`--include`/`--exclude`, `--vault-name`, `--prefix-doc-id` matching the plugin's settings). They each keep their own index, and a reconcile prunes only what its own index tracks — so mismatched scope on the two frontends could let one prune documents the other owns.
 

--- a/hindsight-integrations/obsidian/package-lock.json
+++ b/hindsight-integrations/obsidian/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectorize-io/hindsight-obsidian",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectorize-io/hindsight-obsidian",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.3"

--- a/hindsight-integrations/obsidian/src/node/cli.ts
+++ b/hindsight-integrations/obsidian/src/node/cli.ts
@@ -20,7 +20,13 @@ import { SyncEngine, type ReconcileSummary, type SyncConfig } from "../sync";
 import type { Transport } from "../transport";
 import { fetchTransport } from "./fetch-transport";
 import { FsVault } from "./fs-vault";
-import { defaultIndexPath, loadIndex, makePersist } from "./json-index";
+import {
+  canonicalApiOrigin,
+  defaultIndexPath,
+  type IndexIdentity,
+  loadIndex,
+  makePersist,
+} from "./json-index";
 
 export interface CliOptions {
   /** Absolute path to the vault root. */
@@ -34,6 +40,8 @@ export interface CliOptions {
   prefixDocId: boolean;
   indexPath: string;
   watch: boolean;
+  /** Destination the sync index is bound to (issue #3257). */
+  identity: IndexIdentity;
 }
 
 const USAGE = `hindsight-obsidian-sync — ingest an Obsidian vault into Hindsight (headless).
@@ -50,7 +58,8 @@ Options:
   --exclude <folder>    Skip this folder (repeatable)
   --vault-name <name>   Vault name for tags/ids (default: the vault dir name)
   --prefix-doc-id       Prefix document ids with the vault name (multi-vault banks)
-  --index <file>        Sync-index JSON path (default: ~/.hindsight/obsidian/<vault>.json)
+  --index <file>        Sync-index JSON path (default: a per-target file under
+                        ~/.hindsight/obsidian/, scoped to bank + API + vault)
   --watch               Keep running and sync changes as they happen
   --help                Show this help
 `;
@@ -96,6 +105,14 @@ export function parseCliArgs(argv: string[]): CliOptions {
   const apiUrl = values["api-url"] || process.env.HINDSIGHT_API_URL || "";
   if (!apiUrl) throw new UsageError("--api-url is required (or set HINDSIGHT_API_URL)");
 
+  const identity: IndexIdentity = {
+    apiOrigin: canonicalApiOrigin(apiUrl),
+    bankId: values.bank,
+    vaultPath: vault,
+    vaultName,
+    prefixDocId: values["prefix-doc-id"] ?? false,
+  };
+
   return {
     vault,
     bank: values.bank,
@@ -105,8 +122,9 @@ export function parseCliArgs(argv: string[]): CliOptions {
     exclude: values.exclude ?? [],
     vaultName,
     prefixDocId: values["prefix-doc-id"] ?? false,
-    indexPath: values.index || defaultIndexPath(vaultName),
+    indexPath: values.index || defaultIndexPath(identity),
     watch: values.watch ?? false,
+    identity,
   };
 }
 
@@ -130,13 +148,13 @@ export async function buildEngine(
 ): Promise<{ engine: SyncEngine; vault: FsVault }> {
   const vault = new FsVault(opts.vault);
   const client = new HindsightClient(opts.apiUrl, opts.apiToken, transport);
-  const index = await loadIndex(opts.indexPath);
+  const index = await loadIndex(opts.indexPath, opts.identity);
   const engine = new SyncEngine(
     client,
     vault,
     buildConfig(opts),
     index,
-    makePersist(opts.indexPath)
+    makePersist(opts.indexPath, opts.identity)
   );
   return { engine, vault };
 }

--- a/hindsight-integrations/obsidian/src/node/json-index.ts
+++ b/hindsight-integrations/obsidian/src/node/json-index.ts
@@ -3,48 +3,173 @@
  * `data.json`. Kept out of the vault by default (see {@link defaultIndexPath})
  * so Obsidian Sync never propagates it and it can't collide with the plugin's
  * own index on another machine.
+ *
+ * The index is *bound* to the destination it was built against — API origin,
+ * bank, vault, and the document-id namespace (`vaultName` + `prefixDocId`).
+ * Reusing a vault-name-only index across banks/targets would silently classify
+ * the old target's files as "already synced" against the new one (leaving it
+ * incomplete) and could authorize prune DELETEs against a bank this ingester
+ * never wrote to. So the default path is target-scoped and {@link loadIndex}
+ * fails closed when the persisted destination doesn't match (issue #3257).
+ *
+ * Include/exclude scope is deliberately *not* bound: on the same destination,
+ * narrowing scope legitimately prunes the newly-excluded docs (this ingester
+ * owns them there). The described cross-target harms all require a destination
+ * change, which is what this binding refuses.
  */
 
+import { createHash } from "node:crypto";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { SyncIndex } from "../sync";
 
+/**
+ * The destination an index is bound to. Two indexes are interchangeable only
+ * when every field here matches; any difference means a distinct target whose
+ * sync state must not be shared. Scope (include/exclude) is intentionally absent
+ * — see the module header.
+ */
+export interface IndexIdentity {
+  /** Canonical, non-secret API origin (protocol + host + port), no path/token. */
+  apiOrigin: string;
+  bankId: string;
+  /** Resolved absolute vault path — the on-disk source of truth. */
+  vaultPath: string;
+  /** With {@link prefixDocId}, part of the document-id namespace. */
+  vaultName: string;
+  prefixDocId: boolean;
+}
+
 interface IndexFile {
+  /** Envelope schema version; bump when the on-disk shape changes. */
+  version: number;
+  /** Destination this index was built against (see {@link IndexIdentity}). */
+  identity: IndexIdentity;
   syncIndex: SyncIndex;
   lastSyncAt: string | null;
 }
 
-/** Default out-of-vault index location: `~/.hindsight/obsidian/<vault>.json`. */
-export function defaultIndexPath(vaultName: string): string {
-  const safe = vaultName.replace(/[^A-Za-z0-9._-]+/g, "_") || "vault";
-  return join(homedir(), ".hindsight", "obsidian", `${safe}.json`);
+const ENVELOPE_VERSION = 1;
+
+/** Raised when an existing index belongs to a different (or unknown) target. */
+export class IndexIdentityError extends Error {}
+
+/** Canonical origin of an API base URL — drops path, query, and any credentials. */
+export function canonicalApiOrigin(apiUrl: string): string {
+  try {
+    return new URL(apiUrl).origin;
+  } catch {
+    // Not a parseable URL (e.g. a bare host in a test); normalize trailing slashes.
+    return apiUrl.replace(/\/+$/, "");
+  }
 }
 
-/** Load a previously-persisted index, or an empty one if absent/unreadable. */
-export async function loadIndex(path: string): Promise<SyncIndex> {
+function sanitize(part: string): string {
+  return part.replace(/[^A-Za-z0-9._-]+/g, "_") || "x";
+}
+
+/**
+ * Short, stable fingerprint of the destination identity. Two targets that differ
+ * in any bound field get different fingerprints, so their default index files
+ * never collide even when the vault name is identical.
+ */
+export function identityFingerprint(identity: IndexIdentity): string {
+  const canonical = JSON.stringify([
+    identity.apiOrigin,
+    identity.bankId,
+    identity.vaultPath,
+    identity.vaultName,
+    identity.prefixDocId,
+  ]);
+  return createHash("sha256").update(canonical).digest("hex").slice(0, 12);
+}
+
+/**
+ * Default out-of-vault index location, target-scoped so a different bank/API/
+ * vault lands in its own file: `~/.hindsight/obsidian/<vault>-<bank>-<fp>.json`.
+ */
+export function defaultIndexPath(identity: IndexIdentity): string {
+  const name = `${sanitize(identity.vaultName)}-${sanitize(identity.bankId)}-${identityFingerprint(identity)}`;
+  return join(homedir(), ".hindsight", "obsidian", `${name}.json`);
+}
+
+/** Fields whose divergence between two identities makes them incompatible. */
+function identityMismatches(want: IndexIdentity, have: IndexIdentity): string[] {
+  const keys: (keyof IndexIdentity)[] = [
+    "apiOrigin",
+    "bankId",
+    "vaultPath",
+    "vaultName",
+    "prefixDocId",
+  ];
+  return keys
+    .filter((key) => want[key] !== have[key])
+    .map((key) => `${key}: ${JSON.stringify(have[key])} → ${JSON.stringify(want[key])}`);
+}
+
+/**
+ * Load a previously-persisted index for {@link identity}, or an empty one if
+ * absent/unreadable. Throws {@link IndexIdentityError} — fail closed — when the
+ * file was built against a different target, or predates identity binding, so
+ * we never silently skip files or mis-attribute deletes across banks.
+ */
+export async function loadIndex(path: string, identity: IndexIdentity): Promise<SyncIndex> {
   let raw: string;
   try {
     raw = await readFile(path, "utf8");
   } catch {
     return {}; // first run — no index yet
   }
+
+  let data: Partial<IndexFile>;
   try {
-    const data = JSON.parse(raw) as Partial<IndexFile>;
-    return data.syncIndex ?? {};
+    data = JSON.parse(raw) as Partial<IndexFile>;
   } catch {
     // A corrupt index means a full re-ingest (hash-skips unchanged) rather than
     // a crash; warn because orphan pruning can't run until the index is rebuilt.
     console.warn(`[hindsight] ignoring unreadable sync index at ${path}; starting fresh`);
     return {};
   }
+
+  if (!data.identity) {
+    // Legacy (pre-binding) index: adopt explicitly rather than silently trust it.
+    throw new IndexIdentityError(
+      `sync index at ${path} predates target binding (no identity metadata) and cannot be safely reused.\n` +
+        `Delete it to re-sync bank "${identity.bankId}" from scratch, or pass --index <fresh path>.`
+    );
+  }
+
+  const diffs = identityMismatches(identity, data.identity);
+  if (diffs.length > 0) {
+    throw new IndexIdentityError(
+      `sync index at ${path} is bound to a different target and cannot be reused:\n` +
+        diffs.map((d) => `  - ${d}`).join("\n") +
+        `\nReusing it would leave the new target incomplete or mis-attribute deletes. ` +
+        `Use a distinct --index path for this target, or delete ${path} to re-sync from scratch.`
+    );
+  }
+
+  return data.syncIndex ?? {};
 }
 
-/** A `persist` callback for {@link SyncEngine} that atomically writes the index. */
-export function makePersist(path: string, nowIso: () => string = () => new Date().toISOString()) {
+/**
+ * A `persist` callback for {@link SyncEngine} that atomically writes the index,
+ * stamping the {@link identity} it belongs to so future loads can validate it.
+ */
+export function makePersist(
+  path: string,
+  identity: IndexIdentity,
+  nowIso: () => string = () => new Date().toISOString()
+) {
   return async (index: SyncIndex): Promise<void> => {
     await mkdir(dirname(path), { recursive: true });
-    const payload: IndexFile = { syncIndex: index, lastSyncAt: nowIso() };
+    const payload: IndexFile = {
+      version: ENVELOPE_VERSION,
+      identity,
+      syncIndex: index,
+      lastSyncAt: nowIso(),
+    };
     const tmp = `${path}.tmp`;
     await writeFile(tmp, `${JSON.stringify(payload, null, 2)}\n`);
     await rename(tmp, path); // atomic replace — never leave a half-written index

--- a/hindsight-integrations/obsidian/tests/node/cli.spec.ts
+++ b/hindsight-integrations/obsidian/tests/node/cli.spec.ts
@@ -32,7 +32,25 @@ describe("parseCliArgs", () => {
     expect(o.exclude).toEqual([]);
     expect(o.prefixDocId).toBe(false);
     expect(o.watch).toBe(false);
-    expect(o.indexPath).toMatch(/\.hindsight[/\\]obsidian[/\\]v\.json$/);
+    // Default index path is target-scoped: <vault>-<bank>-<fingerprint>.json.
+    expect(o.indexPath).toMatch(/\.hindsight[/\\]obsidian[/\\]v-b-[0-9a-f]{12}\.json$/);
+  });
+
+  it("binds the index identity to the resolved destination (not scope)", () => {
+    const o = parseCliArgs([...base, "--exclude", "Archive", "--prefix-doc-id"]);
+    expect(o.identity).toEqual({
+      apiOrigin: "https://h",
+      bankId: "b",
+      vaultPath: o.vault,
+      vaultName: "v",
+      prefixDocId: true,
+    });
+  });
+
+  it("routes different banks to different default index files", () => {
+    const a = parseCliArgs(["--vault", "/v", "--bank", "a", "--api-url", "https://h"]);
+    const b = parseCliArgs(["--vault", "/v", "--bank", "b", "--api-url", "https://h"]);
+    expect(a.indexPath).not.toBe(b.indexPath);
   });
 
   it("collects repeatable --include/--exclude and flags", () => {
@@ -196,5 +214,77 @@ describe("runCli", () => {
     );
     expect(code).toBe(0);
     expect(posted).toEqual(["Keep/a.md"]);
+  });
+
+  it("refuses to reuse one --index file across two banks (issue #3257)", async () => {
+    await writeFile(join(root, "note.md"), "# Note\nremember this");
+    const posts: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (init?.method === "POST") posts.push(url);
+        return { status: 200, text: async () => "{}" } as unknown as Response;
+      })
+    );
+    const index = join(root, "shared.json");
+    const argsFor = (bank: string) => [
+      "--vault",
+      root,
+      "--bank",
+      bank,
+      "--api-url",
+      "https://h",
+      "--index",
+      index,
+    ];
+
+    // First target populates the shared index.
+    expect(await runCli(argsFor("bank-a"), () => {})).toBe(0);
+    expect(posts).toEqual(["https://h/v1/default/banks/bank-a/memories"]);
+
+    // Reusing it against bank-b must fail closed — never silently skip note.md,
+    // and never retain against bank-b off the back of bank-a's index.
+    const err: string[] = [];
+    const code = await runCli(
+      argsFor("bank-b"),
+      () => {},
+      (m) => err.push(m)
+    );
+    expect(code).toBe(1);
+    expect(err.join("\n")).toMatch(/different target|bankId/);
+    // No POST landed on bank-b.
+    expect(posts).toEqual(["https://h/v1/default/banks/bank-a/memories"]);
+  });
+
+  it("refuses a stale --index whose scope changed, preventing cross-target deletes", async () => {
+    await writeFile(join(root, "note.md"), "# Note\nkeep");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ status: 200, text: async () => "{}" }) as unknown as Response)
+    );
+    const index = join(root, "shared.json");
+    const at = (url: string) => [
+      "--vault",
+      root,
+      "--bank",
+      "b",
+      "--api-url",
+      url,
+      "--index",
+      index,
+    ];
+
+    expect(await runCli(at("https://a"), () => {})).toBe(0);
+
+    // Same bank + vault, different API origin → the index no longer owns the target.
+    const err: string[] = [];
+    expect(
+      await runCli(
+        at("https://b"),
+        () => {},
+        (m) => err.push(m)
+      )
+    ).toBe(1);
+    expect(err.join("\n")).toMatch(/apiOrigin|different target/);
   });
 });

--- a/hindsight-integrations/obsidian/tests/node/json-index.spec.ts
+++ b/hindsight-integrations/obsidian/tests/node/json-index.spec.ts
@@ -3,7 +3,15 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SyncIndex } from "../../src/sync";
-import { defaultIndexPath, loadIndex, makePersist } from "../../src/node/json-index";
+import {
+  canonicalApiOrigin,
+  defaultIndexPath,
+  identityFingerprint,
+  type IndexIdentity,
+  IndexIdentityError,
+  loadIndex,
+  makePersist,
+} from "../../src/node/json-index";
 
 let dir: string;
 beforeEach(async () => {
@@ -16,27 +24,43 @@ afterEach(async () => {
 
 const INDEX: SyncIndex = { "a.md": { hash: "sha256:1", mtime: 5, syncedAt: "T0" } };
 
+const IDENTITY: IndexIdentity = {
+  apiOrigin: "http://127.0.0.1:8888",
+  bankId: "bank-a",
+  vaultPath: "/tmp/test-vault",
+  vaultName: "test-vault",
+  prefixDocId: false,
+};
+
+/** IDENTITY with one field overridden, for mismatch tests. */
+const withField = (patch: Partial<IndexIdentity>): IndexIdentity => ({ ...IDENTITY, ...patch });
+
 describe("json-index", () => {
   it("returns an empty index when the file does not exist", async () => {
-    expect(await loadIndex(join(dir, "missing.json"))).toEqual({});
+    expect(await loadIndex(join(dir, "missing.json"), IDENTITY)).toEqual({});
   });
 
   it("round-trips an index through persist + load", async () => {
     const path = join(dir, "sub", "idx.json"); // parent created by persist
-    await makePersist(path, () => "T1")(INDEX);
-    expect(await loadIndex(path)).toEqual(INDEX);
+    await makePersist(path, IDENTITY, () => "T1")(INDEX);
+    expect(await loadIndex(path, IDENTITY)).toEqual(INDEX);
   });
 
-  it("stamps lastSyncAt and nests the index under syncIndex", async () => {
+  it("stamps lastSyncAt + identity and nests the index under syncIndex", async () => {
     const path = join(dir, "idx.json");
-    await makePersist(path, () => "2026-08-04T00:00:00.000Z")(INDEX);
+    await makePersist(path, IDENTITY, () => "2026-08-04T00:00:00.000Z")(INDEX);
     const raw = JSON.parse(await readFile(path, "utf8"));
-    expect(raw).toEqual({ syncIndex: INDEX, lastSyncAt: "2026-08-04T00:00:00.000Z" });
+    expect(raw).toEqual({
+      version: 1,
+      identity: IDENTITY,
+      syncIndex: INDEX,
+      lastSyncAt: "2026-08-04T00:00:00.000Z",
+    });
   });
 
   it("writes atomically (no leftover .tmp file)", async () => {
     const path = join(dir, "idx.json");
-    await makePersist(path, () => "T1")(INDEX);
+    await makePersist(path, IDENTITY, () => "T1")(INDEX);
     const entries = await readdir(dir);
     expect(entries).toContain("idx.json");
     expect(entries.some((e) => e.endsWith(".tmp"))).toBe(false);
@@ -46,12 +70,85 @@ describe("json-index", () => {
     const path = join(dir, "corrupt.json");
     await writeFile(path, "{ not json");
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    expect(await loadIndex(path)).toEqual({});
+    expect(await loadIndex(path, IDENTITY)).toEqual({});
     expect(warn).toHaveBeenCalledOnce();
   });
 
-  it("defaultIndexPath sanitizes the vault name and lives under ~/.hindsight/obsidian", () => {
-    const p = defaultIndexPath("My Vault/2026");
-    expect(p).toMatch(/[/\\]\.hindsight[/\\]obsidian[/\\]My_Vault_2026\.json$/);
+  describe("target binding (issue #3257)", () => {
+    it("reuses the index when the identity is unchanged", async () => {
+      const path = join(dir, "idx.json");
+      await makePersist(path, IDENTITY, () => "T1")(INDEX);
+      expect(await loadIndex(path, IDENTITY)).toEqual(INDEX);
+    });
+
+    it.each<[string, IndexIdentity]>([
+      ["bank", withField({ bankId: "bank-b" })],
+      ["API origin", withField({ apiOrigin: "http://other:8888" })],
+      ["vault path", withField({ vaultPath: "/tmp/other-vault" })],
+      ["vault name", withField({ vaultName: "renamed" })],
+      ["prefixDocId", withField({ prefixDocId: true })],
+    ])("refuses to reuse an index bound to a different %s", async (_label, other) => {
+      const path = join(dir, "idx.json");
+      await makePersist(path, IDENTITY, () => "T1")(INDEX);
+      await expect(loadIndex(path, other)).rejects.toBeInstanceOf(IndexIdentityError);
+    });
+
+    it("reuses the index across an include/exclude change (scope is not bound)", async () => {
+      // Same destination, narrowed scope → the engine legitimately reuses the
+      // index (and would prune newly-excluded docs it owns on that bank).
+      const path = join(dir, "idx.json");
+      await makePersist(path, IDENTITY, () => "T1")(INDEX);
+      expect(await loadIndex(path, IDENTITY)).toEqual(INDEX);
+    });
+
+    it("names the changed field in the refusal message", async () => {
+      const path = join(dir, "idx.json");
+      await makePersist(path, IDENTITY, () => "T1")(INDEX);
+      await expect(loadIndex(path, withField({ bankId: "bank-b" }))).rejects.toThrow(
+        /bankId.*bank-a.*bank-b/s
+      );
+    });
+
+    it("refuses a legacy index that has no identity metadata", async () => {
+      const path = join(dir, "legacy.json");
+      // The pre-3257 envelope: syncIndex + lastSyncAt, no identity.
+      await writeFile(path, JSON.stringify({ syncIndex: INDEX, lastSyncAt: "T0" }));
+      await expect(loadIndex(path, IDENTITY)).rejects.toThrow(/predates target binding/);
+    });
+  });
+
+  describe("defaultIndexPath", () => {
+    it("lives under ~/.hindsight/obsidian and encodes vault + bank + fingerprint", () => {
+      const p = defaultIndexPath(withField({ vaultName: "My Vault/2026", bankId: "bank a" }));
+      expect(p).toMatch(
+        /[/\\]\.hindsight[/\\]obsidian[/\\]My_Vault_2026-bank_a-[0-9a-f]{12}\.json$/
+      );
+    });
+
+    it("gives different targets different default paths (same vault name)", () => {
+      const a = defaultIndexPath(withField({ bankId: "bank-a" }));
+      const b = defaultIndexPath(withField({ bankId: "bank-b" }));
+      expect(a).not.toBe(b);
+    });
+
+    it("is stable for the same destination regardless of scope", () => {
+      // Scope isn't part of the identity, so it can't shift the default path.
+      const p1 = defaultIndexPath(IDENTITY);
+      const p2 = defaultIndexPath({ ...IDENTITY });
+      expect(identityFingerprint(IDENTITY)).toBe(identityFingerprint({ ...IDENTITY }));
+      expect(p1).toBe(p2);
+    });
+  });
+
+  describe("canonicalApiOrigin", () => {
+    it("drops path, query, and credentials", () => {
+      expect(canonicalApiOrigin("https://user:pw@host:8888/v1/default?x=1")).toBe(
+        "https://host:8888"
+      );
+    });
+
+    it("normalizes trailing slashes on an unparseable value", () => {
+      expect(canonicalApiOrigin("not a url///")).toBe("not a url");
+    });
   });
 });

--- a/hindsight-integrations/obsidian/tests/node/reconcile-integration.spec.ts
+++ b/hindsight-integrations/obsidian/tests/node/reconcile-integration.spec.ts
@@ -12,7 +12,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HindsightClient } from "../../src/client";
 import { FsVault } from "../../src/node/fs-vault";
-import { loadIndex, makePersist } from "../../src/node/json-index";
+import { type IndexIdentity, loadIndex, makePersist } from "../../src/node/json-index";
 import {
   SyncEngine,
   type SyncConfig,
@@ -54,20 +54,30 @@ async function writeNote(rel: string, content: string): Promise<void> {
 
 async function makeEngine(config: Partial<SyncConfig> = {}) {
   const client = fakeClient();
-  const index = await loadIndex(indexPath);
+  const cfg: SyncConfig = {
+    bankId: "bank",
+    includeFolders: [],
+    excludeFolders: [],
+    vaultName: "Vault",
+    prefixDocId: false,
+    ...config,
+  };
+  // Destination identity for the index (scope is intentionally not bound, so
+  // narrowing include/exclude across reconciles reuses the same index).
+  const identity: IndexIdentity = {
+    apiOrigin: "http://test",
+    bankId: cfg.bankId,
+    vaultPath: root,
+    vaultName: cfg.vaultName,
+    prefixDocId: cfg.prefixDocId,
+  };
+  const index = await loadIndex(indexPath, identity);
   const engine = new SyncEngine(
     client as unknown as HindsightClient,
     new FsVault(root),
-    {
-      bankId: "bank",
-      includeFolders: [],
-      excludeFolders: [],
-      vaultName: "Vault",
-      prefixDocId: false,
-      ...config,
-    },
+    cfg,
     index,
-    makePersist(indexPath, () => "T0"),
+    makePersist(indexPath, identity, () => "T0"),
     () => "T0"
   );
   return { client, engine };

--- a/hindsight-integrations/obsidian/tests/node/watch.spec.ts
+++ b/hindsight-integrations/obsidian/tests/node/watch.spec.ts
@@ -48,6 +48,13 @@ function options(): CliOptions {
     prefixDocId: false,
     indexPath: join(root, ".idx.json"),
     watch: true,
+    identity: {
+      apiOrigin: "http://unused",
+      bankId: "b",
+      vaultPath: root,
+      vaultName: "V",
+      prefixDocId: false,
+    },
   };
 }
 


### PR DESCRIPTION
Fixes #3257.

## Problem

`hindsight-obsidian-sync` keyed its sync index only on the vault name (`~/.hindsight/obsidian/<vault>.json`), and the on-disk envelope was just `{ syncIndex, lastSyncAt }` — no destination identity. Reusing the default index across a different `--bank` or `--api-url`:

- **Silent incompleteness** — files synced to the old target are seen as `unchanged` (same hash/mtime), so no retain is issued to the new bank and it stays empty while the CLI exits `0`.
- **Prune ownership violation** — a deleted/newly-excluded path from the old target's index could authorize a `DELETE` against the new bank, which this ingester never wrote to.

## Fix

Bind the index to its **destination identity** — canonical API origin (no path/token), `bankId`, resolved vault path, `vaultName`, `prefixDocId`:

- **`defaultIndexPath` is target-scoped**: `~/.hindsight/obsidian/<vault>-<bank>-<fingerprint>.json`, so different targets never share a default file.
- **The envelope records the identity** (`{ version, identity, syncIndex, lastSyncAt }`). `loadIndex(path, identity)` **fails closed** with an actionable `IndexIdentityError` (naming the changed field) when the persisted destination differs, and refuses legacy indexes that carry no identity metadata rather than silently trusting them — both via the default path *and* an explicit `--index`.

### Deliberate scope decision

Include/exclude scope is **not** bound. On the same destination, narrowing scope legitimately reuses the index and prunes the newly-excluded notes it owns there (existing `reconcile-integration` behaviour preserved). Every concrete harm in the issue requires a *destination* change — bank / API origin / vault / doc-id namespace — which is exactly what's now refused.

## Tests

Covers the issue's full regression list:
- Same vault+index, same bank/API → unchanged files still skipped.
- Different bank → refuse (end-to-end via `runCli`; no POST lands on the new bank).
- Different API origin → refuse.
- Per-field mismatch matrix (bank, API origin, vault path, vault name, prefixDocId).
- Legacy index with no identity metadata → refuse.
- Target-scoped default paths; `canonicalApiOrigin` strips credentials/path/query.

All 107 obsidian tests pass; `tsc --noEmit` and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)