### PR TITLE
fix(cli): exit non-zero when configure receives invalid API URL

### DIFF
--- a/hindsight-cli/src/main.rs
+++ b/hindsight-cli/src/main.rs
@@ -2199,11 +2199,10 @@ fn handle_configure(
 
     // Validate the URL
     if !new_api_url.starts_with("http://") && !new_api_url.starts_with("https://") {
-        ui::print_error(&format!(
+        anyhow::bail!(
             "Invalid API URL: {}. Must start with http:// or https://",
             new_api_url
-        ));
-        return Ok(());
+        );
     }
 
     // Use provided api_key, or keep existing one if not provided

--- a/hindsight-cli/tests/cli_profile.rs
+++ b/hindsight-cli/tests/cli_profile.rs
@@ -319,3 +319,40 @@ fn hindsight_profile_env_var_is_honored() {
         + &String::from_utf8_lossy(&out.stdout);
     assert!(err.contains("from-env"), "expected profile URL in output:\n{}", err);
 }
+
+#[test]
+fn configure_rejects_invalid_url_with_nonzero_exit() {
+    let home = unique_tempdir("bad-url");
+    let out = run_with_home(
+        &home,
+        &[
+            "configure",
+            "--api-url",
+            "not-a-valid-url",
+            "--api-key",
+            "test-key",
+        ],
+    );
+
+    assert!(
+        !out.status.success(),
+        "configure with invalid URL should exit non-zero, got success"
+    );
+    assert!(
+        stderr(&out).contains("Invalid API URL"),
+        "expected error message on stderr, got:\n{}",
+        stderr(&out)
+    );
+}
+
+#[test]
+fn configure_accepts_valid_http_and_https_urls() {
+    for url in ["http://localhost:8080", "https://api.example.com"] {
+        let home = unique_tempdir("valid-url");
+        let out = run_with_home(
+            &home,
+            &["configure", "--api-url", url, "--api-key", "test-key"],
+        );
+        assert_success(&out);
+    }
+}


### PR DESCRIPTION
## Summary

`hindsight configure --api-url <invalid>` prints an error message but returns exit code 0. Scripts and CI pipelines relying on the exit status cannot detect the failure.

## Root cause

The URL validation block in `handle_configure()` calls `ui::print_error!` and then `return Ok(())`, so the error is logged but the process exits successfully.

## Fix

Replace the silent success with `anyhow::bail!`, which lets the top-level error handler print the message and exit with status 1 — consistent with every other error path in the CLI.

## Tests

Added two integration tests in `cli_profile.rs`:

- `configure_rejects_invalid_url_with_nonzero_exit` — verifies exit code != 0 and error message on stderr for a URL missing the scheme
- `configure_accepts_valid_http_and_https_urls` — regression: both `http://` and `https://` URLs still save successfully

All 13 tests in `cli_profile` pass:

```
cargo test --manifest-path hindsight-cli/Cargo.toml --test cli_profile
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Scope

Only touches the configure command's URL validation. No change to URL parsing logic, config saving, or any other command.