### PR TITLE
fix(kb): serialize knowledge tree writes

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -15291,6 +15291,19 @@ class MemoryEngine(MemoryEngineInterface):
         if row["kind"] != "folder":
             raise ValueError(f"Parent '{parent_id}' is not a folder")
 
+    async def _kp_lock_bank(self, conn, bank_id: str) -> None:
+        """Serialize structural knowledge-tree writers on the bank row.
+
+        FOR NO KEY UPDATE conflicts with other tree writers but not with the
+        FOR KEY SHARE locks taken by inserts into tables that reference banks.
+        Oracle rewrites it to FOR UPDATE, which does not block indexed-FK child
+        inserts there.
+        """
+        await conn.fetchrow(
+            f"SELECT bank_id FROM {fq_table('banks')} WHERE bank_id = $1 FOR NO KEY UPDATE",
+            bank_id,
+        )
+
     async def create_knowledge_folder(
         self,
         bank_id: str,
@@ -15320,6 +15333,7 @@ class MemoryEngine(MemoryEngineInterface):
         async with acquire_with_retry(backend) as conn:
             async with conn.transaction():
                 await self._ensure_bank_exists(bank_id, request_context, conn=conn)
+                await self._kp_lock_bank(conn, bank_id)
                 await self._kp_assert_folder_parent(conn, bank_id, parent_id)
                 row = await conn.fetchrow(
                     f"""
@@ -15383,6 +15397,7 @@ class MemoryEngine(MemoryEngineInterface):
                 # share a transaction instead of compensating after a partial commit.
                 async with conn.transaction():
                     created = await self._ensure_bank_exists(bank_id, request_context, conn=conn)
+                    await self._kp_lock_bank(conn, bank_id)
                     await self._kp_assert_folder_parent(conn, bank_id, parent_id)
                     mm_row = await self._insert_pinned_mental_model(
                         conn,
@@ -15778,6 +15793,9 @@ class MemoryEngine(MemoryEngineInterface):
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
             async with conn.transaction():
+                # Structural tree writers lock this bank row before reading or
+                # changing the hierarchy, serializing moves with creates/deletes.
+                await self._kp_lock_bank(conn, bank_id)
                 await self._kp_assert_folder_parent(conn, bank_id, new_parent_id)
                 # Cycle guard: walk up from the new parent; if we reach node_id,
                 # the move would create a loop. Done in Python so the check stays
@@ -15828,6 +15846,7 @@ class MemoryEngine(MemoryEngineInterface):
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
             async with conn.transaction():
+                await self._kp_lock_bank(conn, bank_id)
                 all_rows = await conn.fetch(
                     f"SELECT id, parent_id, mental_model_id FROM {fq_table('knowledge_pages')} WHERE bank_id = $1",
                     bank_id,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -15298,6 +15298,14 @@ class MemoryEngine(MemoryEngineInterface):
         FOR KEY SHARE locks taken by inserts into tables that reference banks.
         Oracle rewrites it to FOR UPDATE, which does not block indexed-FK child
         inserts there.
+
+        Correctness relies on READ COMMITTED (the default here): the waiter's
+        snapshot is taken per statement, so the hierarchy it reads *after* this
+        call reflects whatever the previous writer committed.
+
+        A missing bank row takes no lock and is not an error: there is then no
+        tree to serialize, and each caller already surfaces "not found" from its
+        own query (create paths ensure the bank in this same transaction first).
         """
         await conn.fetchrow(
             f"SELECT bank_id FROM {fq_table('banks')} WHERE bank_id = $1 FOR NO KEY UPDATE",
@@ -15808,10 +15816,19 @@ class MemoryEngine(MemoryEngineInterface):
                             bank_id,
                         )
                     }
+                    # `seen` bounds the walk. The lock above stops this process
+                    # from creating a loop, but a tree corrupted before the lock
+                    # existed (or restored from such an export) would otherwise
+                    # spin here forever, holding a connection and an open
+                    # transaction. Refuse the move instead of hanging.
+                    seen: set[str] = set()
                     cursor: str | None = new_parent_id
                     while cursor is not None:
                         if cursor == node_id:
                             raise ValueError("Cannot move a node into its own subtree")
+                        if cursor in seen:
+                            raise ValueError(f"Knowledge tree for bank '{bank_id}' contains a parent cycle")
+                        seen.add(cursor)
                         cursor = parents.get(cursor)
                 row = await conn.fetchrow(
                     f"""
@@ -15857,10 +15874,19 @@ class MemoryEngine(MemoryEngineInterface):
                 if not any(r["id"] == node_id for r in all_rows):
                     return False
                 # BFS the subtree rooted at node_id, collecting page mental models.
+                # `visited` bounds the walk: a tree corrupted before the bank lock
+                # existed (or restored from such an export) contains a parent cycle
+                # the FK does not forbid, and an unguarded walk would spin forever
+                # holding a connection and an open transaction. Visiting each node
+                # once still deletes every reachable node.
                 stack = [node_id]
+                visited: set[str] = set()
                 mm_ids: list[str] = []
                 while stack:
                     current = stack.pop()
+                    if current in visited:
+                        continue
+                    visited.add(current)
                     for child in by_parent.get(current, []):
                         stack.append(child["id"])
                     node_row = next((r for r in all_rows if r["id"] == current), None)

--- a/hindsight-api-slim/tests/test_knowledge_base.py
+++ b/hindsight-api-slim/tests/test_knowledge_base.py
@@ -33,6 +33,67 @@ def _enc(bank_id: str) -> str:
     return urllib.parse.quote(bank_id, safe="")
 
 
+# The statement structural knowledge-tree writers use to serialize on the bank row.
+_BANK_LOCK_SQL = "FOR NO KEY UPDATE"
+
+
+class _BankLockPauser:
+    """Freeze the first structural tree writer for one bank while it holds the lock.
+
+    Wraps the connection the engine acquires and pauses inside the *real* bank-lock
+    query, after it has taken the row lock. A second writer then reaches the same
+    query and cannot get past it until the first commits, so the interleaving under
+    test is driven by events rather than by sleeps and is repeatable.
+
+    Matching is scoped to this bank's id, not just the SQL text: other callers take
+    the same lock on their own bank rows (async-operation submit dedupe, for one),
+    and mistaking one of those for the writer under test would pause an unrelated
+    transaction and desynchronize the test.
+    """
+
+    def __init__(self, bank_id: str) -> None:
+        self.bank_id = bank_id
+        self.first_holds_lock = asyncio.Event()
+        self.second_reached_lock = asyncio.Event()
+        self.release_first = asyncio.Event()
+        self._locks_seen = 0
+
+    def install(self, monkeypatch) -> None:
+        original_acquire = memory_engine_module.acquire_with_retry
+        pauser = self
+
+        class _PausingConnection:
+            def __init__(self, conn):
+                self._conn = conn
+
+            async def fetchrow(self, query, *args, **kwargs):
+                if _BANK_LOCK_SQL in query and args and args[0] == pauser.bank_id:
+                    pauser._locks_seen += 1
+                    if pauser._locks_seen == 1:
+                        row = await self._conn.fetchrow(query, *args, **kwargs)
+                        pauser.first_holds_lock.set()
+                        await pauser.release_first.wait()
+                        return row
+                    pauser.second_reached_lock.set()
+                return await self._conn.fetchrow(query, *args, **kwargs)
+
+            def __getattr__(self, name):
+                return getattr(self._conn, name)
+
+        @asynccontextmanager
+        async def pausing_acquire(backend, *args, **kwargs):
+            async with original_acquire(backend, *args, **kwargs) as conn:
+                yield _PausingConnection(conn)
+
+        monkeypatch.setattr(memory_engine_module, "acquire_with_retry", pausing_acquire)
+
+
+async def _assert_blocked(task: asyncio.Task, label: str) -> None:
+    """Assert the task is still waiting on the bank lock (it can only be released by a commit)."""
+    done, _pending = await asyncio.wait({task}, timeout=0.5)
+    assert not done, f"{label} must block on the bank lock until the first writer commits"
+
+
 class _RecordingValidator(OperationValidatorExtension):
     """A validator that records every bank read/write and rejects one operation.
 
@@ -858,68 +919,154 @@ class TestMoveRenameDelete:
     async def test_concurrent_opposite_moves_are_serialized(self, memory: MemoryEngine, request_context, monkeypatch):
         """The second opposite move must observe the first committed parent link.
 
-        Pause the first request only after its real ``FOR NO KEY UPDATE`` query has
-        acquired the bank lock. The second request then reaches the same query
-        but cannot finish it until the first commits, making this a deterministic
-        regression test rather than a timing-dependent concurrent test.
+        Without the bank lock both moves read the same pre-commit tree, both pass
+        the Python cycle guard, and both commit — leaving ``A.parent = B`` and
+        ``B.parent = A``.
         """
         bank_id = f"test-kb-move-race-{uuid.uuid4().hex[:8]}"
         folder_a = await memory.create_knowledge_folder(bank_id, "A", request_context=request_context)
         folder_b = await memory.create_knowledge_folder(bank_id, "B", request_context=request_context)
-        first_lock_acquired = asyncio.Event()
-        second_lock_attempted = asyncio.Event()
-        release_first_lock = asyncio.Event()
-        original_acquire = memory_engine_module.acquire_with_retry
-        lock_query = "FOR NO KEY UPDATE"
-        lock_query_count = 0
-
-        class _PausingConnection:
-            def __init__(self, conn):
-                self._conn = conn
-
-            async def fetchrow(self, query, *args, **kwargs):
-                nonlocal lock_query_count
-                if lock_query in query:
-                    lock_query_count += 1
-                    if lock_query_count == 1:
-                        row = await self._conn.fetchrow(query, *args, **kwargs)
-                        first_lock_acquired.set()
-                        await release_first_lock.wait()
-                        return row
-                    second_lock_attempted.set()
-                return await self._conn.fetchrow(query, *args, **kwargs)
-
-            async def fetch(self, query, *args, **kwargs):
-                return await self._conn.fetch(query, *args, **kwargs)
-
-            def __getattr__(self, name):
-                return getattr(self._conn, name)
-
-        @asynccontextmanager
-        async def pausing_acquire(backend, *args, **kwargs):
-            async with original_acquire(backend, *args, **kwargs) as conn:
-                yield _PausingConnection(conn)
-
-        monkeypatch.setattr(memory_engine_module, "acquire_with_retry", pausing_acquire)
+        pauser = _BankLockPauser(bank_id)
+        pauser.install(monkeypatch)
         try:
             first = asyncio.create_task(
                 memory.move_knowledge_node(bank_id, folder_a["id"], folder_b["id"], request_context=request_context)
             )
-            await asyncio.wait_for(first_lock_acquired.wait(), timeout=5)
+            await asyncio.wait_for(pauser.first_holds_lock.wait(), timeout=5)
 
             second = asyncio.create_task(
                 memory.move_knowledge_node(bank_id, folder_b["id"], folder_a["id"], request_context=request_context)
             )
-            await asyncio.wait_for(second_lock_attempted.wait(), timeout=5)
-            assert not second.done(), "second move must not finish before the first commits"
+            await asyncio.wait_for(pauser.second_reached_lock.wait(), timeout=5)
+            await _assert_blocked(second, "the second move")
 
-            release_first_lock.set()
+            pauser.release_first.set()
             first_result = await first
             assert first_result["parent_id"] == folder_b["id"]
             with pytest.raises(ValueError, match="own subtree"):
                 await second
         finally:
-            release_first_lock.set()
+            pauser.release_first.set()
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_move_serializes_behind_a_concurrent_delete(self, memory: MemoryEngine, request_context, monkeypatch):
+        """A move into a folder another request is deleting waits for that delete.
+
+        Delete is a structural writer too, so it takes the same lock. The move
+        then validates its destination against the committed tree and refuses
+        cleanly, instead of validating a stale parent and hitting a raw foreign
+        key violation on the UPDATE.
+        """
+        bank_id = f"test-kb-move-delete-race-{uuid.uuid4().hex[:8]}"
+        folder_a = await memory.create_knowledge_folder(bank_id, "A", request_context=request_context)
+        folder_b = await memory.create_knowledge_folder(bank_id, "B", request_context=request_context)
+        pauser = _BankLockPauser(bank_id)
+        pauser.install(monkeypatch)
+        try:
+            deleting = asyncio.create_task(
+                memory.delete_knowledge_node(bank_id, folder_b["id"], request_context=request_context)
+            )
+            await asyncio.wait_for(pauser.first_holds_lock.wait(), timeout=5)
+
+            moving = asyncio.create_task(
+                memory.move_knowledge_node(bank_id, folder_a["id"], folder_b["id"], request_context=request_context)
+            )
+            await asyncio.wait_for(pauser.second_reached_lock.wait(), timeout=5)
+            await _assert_blocked(moving, "the move")
+
+            pauser.release_first.set()
+            assert await deleting is True
+            with pytest.raises(ValueError, match="not found"):
+                await moving
+        finally:
+            pauser.release_first.set()
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_create_serializes_behind_a_concurrent_delete(
+        self, memory: MemoryEngine, request_context, monkeypatch
+    ):
+        """Creating into a folder another request is deleting waits for that delete.
+
+        Create is the third structural writer, so it takes the same lock and
+        validates its parent against the committed tree — a clean rejection
+        rather than an insert against a parent that is already gone.
+        """
+        bank_id = f"test-kb-create-delete-race-{uuid.uuid4().hex[:8]}"
+        folder = await memory.create_knowledge_folder(bank_id, "Doomed", request_context=request_context)
+        pauser = _BankLockPauser(bank_id)
+        pauser.install(monkeypatch)
+        try:
+            deleting = asyncio.create_task(
+                memory.delete_knowledge_node(bank_id, folder["id"], request_context=request_context)
+            )
+            await asyncio.wait_for(pauser.first_holds_lock.wait(), timeout=5)
+
+            creating = asyncio.create_task(
+                memory.create_knowledge_folder(
+                    bank_id, "Child", parent_id=folder["id"], request_context=request_context
+                )
+            )
+            await asyncio.wait_for(pauser.second_reached_lock.wait(), timeout=5)
+            await _assert_blocked(creating, "the create")
+
+            pauser.release_first.set()
+            assert await deleting is True
+            with pytest.raises(ValueError, match="not found"):
+                await creating
+        finally:
+            pauser.release_first.set()
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_tree_walks_terminate_on_a_pre_existing_cycle(self, memory: MemoryEngine, request_context):
+        """A tree corrupted before the bank lock existed must not hang a request.
+
+        The lock stops this process from committing a parent loop, but a bank
+        corrupted by the old race — or restored from an export of one — still
+        carries it, and nothing in the schema forbids it. Both Python tree walks
+        are bounded, so such a bank fails or deletes instead of spinning forever
+        inside an open transaction.
+        """
+        bank_id = f"test-kb-cycle-{uuid.uuid4().hex[:8]}"
+        folder_a = await memory.create_knowledge_folder(bank_id, "A", request_context=request_context)
+        folder_b = await memory.create_knowledge_folder(bank_id, "B", request_context=request_context)
+        folder_c = await memory.create_knowledge_folder(bank_id, "C", request_context=request_context)
+        try:
+            # Raw SQL because the engine API can no longer produce this state —
+            # forging the loop is the whole point. A -> B -> A.
+            async with memory._pool.acquire() as conn:
+                await conn.execute(
+                    "UPDATE knowledge_pages SET parent_id = $2 WHERE bank_id = $1 AND id = $3",
+                    bank_id,
+                    folder_b["id"],
+                    folder_a["id"],
+                )
+                await conn.execute(
+                    "UPDATE knowledge_pages SET parent_id = $2 WHERE bank_id = $1 AND id = $3",
+                    bank_id,
+                    folder_a["id"],
+                    folder_b["id"],
+                )
+
+            # The ancestor walk never reaches C, so only the cycle guard ends it.
+            with pytest.raises(ValueError, match="cycle"):
+                await asyncio.wait_for(
+                    memory.move_knowledge_node(
+                        bank_id, folder_c["id"], folder_a["id"], request_context=request_context
+                    ),
+                    timeout=10,
+                )
+
+            # The subtree walk visits each node once and deletes what it reached.
+            assert (
+                await asyncio.wait_for(
+                    memory.delete_knowledge_node(bank_id, folder_a["id"], request_context=request_context),
+                    timeout=10,
+                )
+                is True
+            )
+            remaining = {n["id"] for n in await memory.list_knowledge_nodes(bank_id, request_context=request_context)}
+            assert remaining == {folder_c["id"]}
+        finally:
             await memory.delete_bank(bank_id, request_context=request_context)
 
     async def test_delete_folder_cascades(self, api_client, kb_bank, memory, request_context):

--- a/hindsight-api-slim/tests/test_knowledge_base.py
+++ b/hindsight-api-slim/tests/test_knowledge_base.py
@@ -5,8 +5,10 @@ tree, markdown rendering, move/rename, and cascade-delete behaviour can be asser
 without consolidation.
 """
 
+import asyncio
 import urllib.parse
 import uuid
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Any, NoReturn
 
@@ -14,6 +16,7 @@ import asyncpg
 import pytest
 import pytest_asyncio
 
+import hindsight_api.engine.memory_engine as memory_engine_module
 from hindsight_api.engine.db import DatabaseConnection
 from hindsight_api.engine.memory_engine import MemoryEngine, _may_need_refresh
 from hindsight_api.extensions import (
@@ -851,6 +854,73 @@ class TestMoveRenameDelete:
             json={"parent_id": ids.sub},
         )
         assert resp.status_code == 400
+
+    async def test_concurrent_opposite_moves_are_serialized(self, memory: MemoryEngine, request_context, monkeypatch):
+        """The second opposite move must observe the first committed parent link.
+
+        Pause the first request only after its real ``FOR NO KEY UPDATE`` query has
+        acquired the bank lock. The second request then reaches the same query
+        but cannot finish it until the first commits, making this a deterministic
+        regression test rather than a timing-dependent concurrent test.
+        """
+        bank_id = f"test-kb-move-race-{uuid.uuid4().hex[:8]}"
+        folder_a = await memory.create_knowledge_folder(bank_id, "A", request_context=request_context)
+        folder_b = await memory.create_knowledge_folder(bank_id, "B", request_context=request_context)
+        first_lock_acquired = asyncio.Event()
+        second_lock_attempted = asyncio.Event()
+        release_first_lock = asyncio.Event()
+        original_acquire = memory_engine_module.acquire_with_retry
+        lock_query = "FOR NO KEY UPDATE"
+        lock_query_count = 0
+
+        class _PausingConnection:
+            def __init__(self, conn):
+                self._conn = conn
+
+            async def fetchrow(self, query, *args, **kwargs):
+                nonlocal lock_query_count
+                if lock_query in query:
+                    lock_query_count += 1
+                    if lock_query_count == 1:
+                        row = await self._conn.fetchrow(query, *args, **kwargs)
+                        first_lock_acquired.set()
+                        await release_first_lock.wait()
+                        return row
+                    second_lock_attempted.set()
+                return await self._conn.fetchrow(query, *args, **kwargs)
+
+            async def fetch(self, query, *args, **kwargs):
+                return await self._conn.fetch(query, *args, **kwargs)
+
+            def __getattr__(self, name):
+                return getattr(self._conn, name)
+
+        @asynccontextmanager
+        async def pausing_acquire(backend, *args, **kwargs):
+            async with original_acquire(backend, *args, **kwargs) as conn:
+                yield _PausingConnection(conn)
+
+        monkeypatch.setattr(memory_engine_module, "acquire_with_retry", pausing_acquire)
+        try:
+            first = asyncio.create_task(
+                memory.move_knowledge_node(bank_id, folder_a["id"], folder_b["id"], request_context=request_context)
+            )
+            await asyncio.wait_for(first_lock_acquired.wait(), timeout=5)
+
+            second = asyncio.create_task(
+                memory.move_knowledge_node(bank_id, folder_b["id"], folder_a["id"], request_context=request_context)
+            )
+            await asyncio.wait_for(second_lock_attempted.wait(), timeout=5)
+            assert not second.done(), "second move must not finish before the first commits"
+
+            release_first_lock.set()
+            first_result = await first
+            assert first_result["parent_id"] == folder_b["id"]
+            with pytest.raises(ValueError, match="own subtree"):
+                await second
+        finally:
+            release_first_lock.set()
+            await memory.delete_bank(bank_id, request_context=request_context)
 
     async def test_delete_folder_cascades(self, api_client, kb_bank, memory, request_context):
         bank_id, ids = kb_bank


### PR DESCRIPTION
## Summary

Serialize knowledge-base structural writes at the bank level so create, delete, and move operations cannot validate or rewrite the hierarchy from incompatible snapshots. This prevents concurrent opposite moves from both passing cycle detection and committing a parent loop.

## Problem

Knowledge-base hierarchy checks previously ran without a shared serialization point. Two transactions moving `A` under `B` and `B` under `A` could both read the same pre-commit tree, independently pass the existing cycle guard, and then commit a cycle. Create and delete also change the same hierarchy, so serializing move alone would leave the structural-write invariant incomplete.

## Design

Add `_kp_lock_bank()` and acquire a row lock on the owning bank before structural hierarchy reads or writes. Folder creation, page-node insertion, move, and delete all use the same lock, so structural writers for one bank execute against one committed tree state. Writers for different banks remain independent.

The lock uses `FOR NO KEY UPDATE` rather than `FOR UPDATE`. It still conflicts with another structural writer taking the same lock, but it does not conflict with the `FOR KEY SHARE` locks PostgreSQL takes for inserts into tables that reference the bank. This preserves writer serialization without unnecessarily blocking unrelated bank-scoped inserts or introducing the foreign-key lock interaction caused by the stronger lock. The Oracle adapter already rewrites this form to supported `FOR UPDATE` syntax.

Move takes the bank lock before validating the destination parent and reading the parent map. Delete takes the same lock before reading and removing a subtree. Create takes it before validating the parent and inserting the new hierarchy row. Non-structural operations such as rename do not take this lock.

## Concurrency behavior

| Step | First move: A under B | Second move: B under A |
| --- | --- | --- |
| Acquire bank lock | Proceeds | Waits on the same bank row |
| Read hierarchy | Sees both nodes at their original parents | Runs after the first transaction commits |
| Validate cycle | Passes | Sees `A.parent_id = B` and rejects the move |
| Write | Commits `A.parent_id = B` | Does not commit a cycle |

## Test coverage

Add a deterministic regression test that pauses the first request after it acquires the real bank-row lock, verifies the second request reaches the same lock and cannot finish early, then confirms the first move succeeds and the second move is rejected. The test uses events rather than sleeps, making the required interleaving explicit and repeatable.

## Validation

- `./scripts/hooks/lint.sh`
- `uv run pytest tests/test_knowledge_base.py -q -n 0` (40 passed)

## Scope and tradeoffs

The serialization scope is one bank row, so structural writes within the same bank are intentionally serialized. This is coarser than locking individual paths, but it keeps a uniform lock order across create, delete, and move, makes the tree invariant straightforward to audit, and avoids locking every knowledge node.

This change is intentionally limited to preventing concurrent structural writes from creating a parent loop. It does not add defensive traversal for trees already corrupted before the fix, change page-creation failure compensation, or alter existing exception semantics.