### PR TITLE
fix(claude-code,codex): expose retain turn interval via env

### DIFF
--- a/hindsight-integrations/claude-code/README.md
+++ b/hindsight-integrations/claude-code/README.md
@@ -244,7 +244,7 @@ Auto-retain runs after Claude responds. It extracts the conversation transcript 
 |---------|---------|---------|-------------|
 | `autoRetain` | `HINDSIGHT_AUTO_RETAIN` | `true` | Master switch for auto-retain. Set to `false` to disable memory storage entirely. |
 | `retainMode` | `HINDSIGHT_RETAIN_MODE` | `"full-session"` | Retention strategy. `"full-session"` sends the initial transcript once, then only new messages in chunk documents; compaction starts a fresh chunk. |
-| `retainEveryNTurns` | — | `10` | How often to retain. `1` = every turn; `10` = every 10th turn. Higher values reduce API calls but delay memory capture. Values > 1 enable **chunked retention** with a sliding window. |
+| `retainEveryNTurns` | `HINDSIGHT_RETAIN_EVERY_N_TURNS` | `10` | How often to retain. `1` = every turn; `10` = every 10th turn. Higher values reduce API calls but delay memory capture. Values > 1 enable **chunked retention** with a sliding window. |
 | `retainOverlapTurns` | — | `2` | When chunked retention fires, this many extra turns from the previous chunk are included for continuity. Total window size = `retainEveryNTurns + retainOverlapTurns`. |
 | `retainRoles` | — | `["user", "assistant"]` | Which message roles to include in the retained transcript. |
 | `retainToolCalls` | — | `true` | Whether to include tool calls (function invocations and results) in the retained transcript. Captures structured actions like file reads, searches, and code edits. |

--- a/hindsight-integrations/claude-code/scripts/lib/config.py
+++ b/hindsight-integrations/claude-code/scripts/lib/config.py
@@ -75,6 +75,7 @@ ENV_OVERRIDES = {
     "HINDSIGHT_AUTO_RECALL": ("autoRecall", bool),
     "HINDSIGHT_AUTO_RETAIN": ("autoRetain", bool),
     "HINDSIGHT_RETAIN_MODE": ("retainMode", str),
+    "HINDSIGHT_RETAIN_EVERY_N_TURNS": ("retainEveryNTurns", int),
     "HINDSIGHT_RECALL_BUDGET": ("recallBudget", str),
     "HINDSIGHT_RECALL_MAX_TOKENS": ("recallMaxTokens", int),
     "HINDSIGHT_RECALL_MAX_QUERY_CHARS": ("recallMaxQueryChars", int),

--- a/hindsight-integrations/claude-code/tests/test_config.py
+++ b/hindsight-integrations/claude-code/tests/test_config.py
@@ -70,6 +70,20 @@ class TestLoadConfig:
         cfg = load_config()
         assert cfg["apiPort"] == 9999
 
+    def test_retain_every_n_turns_env_override_is_int(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+        monkeypatch.setenv("HINDSIGHT_RETAIN_EVERY_N_TURNS", "3")
+        cfg = load_config()
+        assert cfg["retainEveryNTurns"] == 3
+        assert isinstance(cfg["retainEveryNTurns"], int)
+
+    def test_invalid_retain_every_n_turns_env_is_ignored(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+        (tmp_path / "settings.json").write_text(json.dumps({"retainEveryNTurns": 4}))
+        monkeypatch.setenv("HINDSIGHT_RETAIN_EVERY_N_TURNS", "invalid")
+        cfg = load_config()
+        assert cfg["retainEveryNTurns"] == 4
+
     def test_request_timeout_default_none(self, tmp_path, monkeypatch):
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
         cfg = load_config()

--- a/hindsight-integrations/codex/README.md
+++ b/hindsight-integrations/codex/README.md
@@ -101,6 +101,7 @@ export HINDSIGHT_API_URL=https://api.hindsight.vectorize.io
 export HINDSIGHT_API_TOKEN=your-api-key
 export HINDSIGHT_BANK_ID=my-project
 export HINDSIGHT_RECALL_TIMEOUT=30
+export HINDSIGHT_RETAIN_EVERY_N_TURNS=1
 export HINDSIGHT_DEBUG=true
 ```
 

--- a/hindsight-integrations/codex/scripts/lib/config.py
+++ b/hindsight-integrations/codex/scripts/lib/config.py
@@ -66,6 +66,7 @@ ENV_OVERRIDES = {
     "HINDSIGHT_AUTO_RECALL": ("autoRecall", bool),
     "HINDSIGHT_AUTO_RETAIN": ("autoRetain", bool),
     "HINDSIGHT_RETAIN_MODE": ("retainMode", str),
+    "HINDSIGHT_RETAIN_EVERY_N_TURNS": ("retainEveryNTurns", int),
     "HINDSIGHT_RECALL_BUDGET": ("recallBudget", str),
     "HINDSIGHT_RECALL_MAX_TOKENS": ("recallMaxTokens", int),
     "HINDSIGHT_RECALL_TIMEOUT": ("recallTimeout", int),

--- a/hindsight-integrations/codex/tests/test_config.py
+++ b/hindsight-integrations/codex/tests/test_config.py
@@ -1,0 +1,26 @@
+"""Tests for lib/config.py environment overrides."""
+
+import os
+
+import pytest
+from lib.config import load_config
+
+
+class TestConfigEnvOverrides:
+    @pytest.fixture(autouse=True)
+    def _isolate_config(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        for key in list(os.environ):
+            if key.startswith("HINDSIGHT_"):
+                monkeypatch.delenv(key, raising=False)
+
+    def test_retain_every_n_turns_env_override_is_int(self, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_RETAIN_EVERY_N_TURNS", "3")
+        cfg = load_config()
+        assert cfg["retainEveryNTurns"] == 3
+        assert isinstance(cfg["retainEveryNTurns"], int)
+
+    def test_invalid_retain_every_n_turns_env_is_ignored(self, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_RETAIN_EVERY_N_TURNS", "invalid")
+        cfg = load_config()
+        assert cfg["retainEveryNTurns"] == 10


### PR DESCRIPTION
Both the Claude Code and Codex integrations default `retainEveryNTurns` to `10`, and neither lists it in `ENV_OVERRIDES` — unlike neighbouring keys such as `HINDSIGHT_AUTO_RETAIN`. On a long-lived ACP host that makes retention unreachable rather than merely infrequent.

## The gap

`retain.py` gates on the cadence and returns early:

```python
retain_every_n = max(1, config.get("retainEveryNTurns", 1))
# Respect retainEveryNTurns in both modes, unless force=True (SessionEnd final retain)
if retain_every_n > 1 and not force:
    turn_count = increment_turn_count(session_id)
    if turn_count % retain_every_n != 0:
        return
```

The only escape for skipped turns is the `force=True` final retain on `SessionEnd`. That assumption holds for an interactive CLI, where the session ends and batching is a sensible cost trade. It does not hold for a host that keeps one session alive per channel or room: `SessionEnd` may never arrive, so every turn below the cadence threshold is skipped and never flushed.

The skip returns successfully and logs only at debug level, so nothing surfaces as an error. An operator discovers the missing writes only by querying the bank.

## Evidence

Observed on an ACP host with per-channel sessions. `autoRetain` was enabled via `HINDSIGHT_AUTO_RETAIN=true`, the hooks fired on `SessionStart`, `UserPromptSubmit` and `Stop` with the intended bank id in the environment, and no error appeared anywhere — yet the bank received zero memory units across several sessions. Setting `retainEveryNTurns` to `1` (at the time, by patching this same table locally) made retention work immediately, with the units landing in the expected bank.

Because the key was not env-overridable, the only workaround was editing the plugin config file — which lives in a cache directory and is lost on upgrade.

## What changed

- `HINDSIGHT_RETAIN_EVERY_N_TURNS` added to `ENV_OVERRIDES` in both integrations, typed `int`, matching the existing integer overrides. Invalid values are ignored exactly as the other integer keys already behave.
- README env tables updated in both integrations.
- Tests covering the conversion and the graceful discard of an invalid value.

The default stays `10`; this only makes it reachable without a config file, so persistent-session hosts can set `1`.

## Note

`hindsight-integrations/claude-code/tests/test_run_mcp.py::TestMcpServerWorkingDirectory::test_exec_runs_from_plugin_data_dir_when_project_env_is_unreadable` fails on this branch. It also fails on an unmodified `main` checkout, and the files it touches are untouched here — it is unrelated to this change.