### PR TITLE
fix(coding-agents): bound automatic reflect budget

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/hook.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hook.test.ts
@@ -152,7 +152,7 @@ describe("buildHookOutput", () => {
     expect(client.reflect).toHaveBeenCalledTimes(1);
   });
 
-  it("caps the reflect timeout at 25000ms even when config asks for more", async () => {
+  it("uses a bounded low-budget reflect and caps its timeout at 25000ms", async () => {
     const cfg = resolveConfig({}); // reflectTimeoutMs default 120000
     const client = makeClient();
     await buildHookOutput({
@@ -163,7 +163,7 @@ describe("buildHookOutput", () => {
       cacheFile,
     });
     expect(client.reflect).toHaveBeenCalledWith(buildReflectQuery("the prompt"), {
-      budget: "high",
+      budget: "low",
       timeoutMs: 25000,
     });
   });
@@ -179,7 +179,7 @@ describe("buildHookOutput", () => {
       cacheFile,
     });
     expect(client.reflect).toHaveBeenCalledWith(buildReflectQuery("the prompt"), {
-      budget: "high",
+      budget: "low",
       timeoutMs: 5000,
     });
   });

--- a/hindsight-integrations/coding-agents/src/core/hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/hook.ts
@@ -112,7 +112,10 @@ export async function buildHookOutput(args: {
     const t0 = Date.now();
     try {
       reflectAnswer = await client.reflect(buildReflectQuery(prompt), {
-        budget: "high",
+        // Automatic reflection runs inside a hard 25s hook window. Hindsight's low budget is the
+        // supported default for bounded reflect calls; callers that explicitly invoke the MCP
+        // tool still get the deeper high-budget path.
+        budget: "low",
         timeoutMs: Math.min(cfg.reflectTimeoutMs, HOOK_REFLECT_CAP_MS),
       });
       diag(harness, reflectAnswer ? "reflect_ok" : "reflect_empty", {


### PR DESCRIPTION
## Summary

- Use Hindsight’s supported low reflect budget for the automatic first-prompt hook.
- Keep explicit `hindsight_reflect` MCP calls on the existing high-budget path.
- Preserve the 25-second client cap below the 30-second host hook timeout.

## Root cause

The automatic hook requested `budget: high` while enforcing a hard 25-second deadline. High-budget reflect may perform several LLM/tool iterations and can legitimately exceed that window. In a live comparison against the same self-hosted endpoint, a high-budget reflect took 35.169 seconds, while the equivalent low-budget control completed in 6.580 seconds. Concurrent page refreshes can worsen tail latency, but an idle control also exceeded 25 seconds, so increasing workers or changing the database would not fix the contract mismatch.

## Validation

- Focused hook and MCP tests: 37/37 passed.
- Full Coding Agents suite: 430/430 passed across 41 files.
- TypeScript `--noEmit`: passed.
- Production build: passed.
- Bundle inspection confirms the Codex hook uses low while the MCP tool remains high.

No timeout, hook configuration, server, database, provider, dependency, or schema change.