### PR TITLE
fix(coding-agents): drop harness transport wrappers from retained turns (#3023)

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/transcript-util.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript-util.ts
@@ -7,10 +7,18 @@ export const TOOL_TEXT_CAP = 2000;
 
 /** Injected context — stripped from retained text so a write-back never re-ingests its own
  *  injected memory (a retain→reflect feedback loop). Covers every block the hooks inject, PLUS
- *  the host's own hook-transport wrappers (codex surfaces hook stdout/errors as `<hook_prompt>`
- *  user messages — transport noise, not the user's work). Tag-structural, not content-guessing. */
+ *  the host's own hook-transport wrappers, which arrive as ordinary USER messages and would
+ *  otherwise be extracted as things the user said (#3023):
+ *    <hook_prompt>        codex surfaces hook stdout/errors this way
+ *    <task-notification>  Claude Code reports a background task's outcome — task id, tool-use id,
+ *                         status; measured at 39 of these across 400 local transcripts, each one
+ *                         the entire message
+ *    <system-reminder>    same class; today it only rides inside `tool_result` blocks, which the
+ *                         Claude reader already drops, so this is insurance against it moving
+ *  Tag-structural, not content-guessing. The block is removed and any surrounding text KEPT — a
+ *  message that is nothing but a wrapper then renders empty and is dropped as a no-content turn. */
 const MEMORY_TAG_RE =
-  /<(hook_prompt|hindsight_memory|hindsight_memories|hindsight_bank|relevant_memories|user_feedback|hindsight_knowledge|hindsight_knowledge_refresh)\b[\s\S]*?<\/\1>/g;
+  /<(hook_prompt|task-notification|system-reminder|hindsight_memory|hindsight_memories|hindsight_bank|relevant_memories|user_feedback|hindsight_knowledge|hindsight_knowledge_refresh)\b[\s\S]*?<\/\1>/g;
 
 export function stripInjectedMemory(s: string): string {
   return s.replace(MEMORY_TAG_RE, "");

--- a/hindsight-integrations/coding-agents/src/core/transcript.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript.test.ts
@@ -166,6 +166,68 @@ describe("readClaudeTranscript", () => {
     expect(result[0].content).not.toContain("hindsight_memories");
   });
 
+  it("drops a <task-notification>: the harness's background-task plumbing, not the user's words", () => {
+    // Claude Code delivers these as an ordinary type:"user" message with a string body and no
+    // isMeta flag, so nothing else filters them and extraction saw task ids and status lines as
+    // things the user said. Measured at 39 across 400 local transcripts, each the whole message
+    // (#3023 — which named skill bodies and <system-reminder>; both are already handled, this is
+    // the case that actually survived).
+    writeFileSync(
+      file,
+      JSON.stringify({
+        type: "user",
+        message: {
+          role: "user",
+          content:
+            "<task-notification>\n<task-id>b46ca19nr</task-id>\n" +
+            "<tool-use-id>toolu_0127NeaVZbdiAsbacNvasB78</tool-use-id>\n" +
+            "<status>stopped</status>\n<summary>No completion record</summary>\n</task-notification>",
+        },
+      })
+    );
+
+    expect(readClaudeTranscript(file)).toEqual([]); // renders empty -> no turn at all
+  });
+
+  it("keeps what the user wrote around a harness wrapper", () => {
+    // The stripper removes the BLOCK, never the message: replacing the whole turn with the tag's
+    // contents is what made the old plugin's strip_channel_envelope discard real user text (#3124).
+    writeFileSync(
+      file,
+      JSON.stringify({
+        type: "user",
+        message: {
+          role: "user",
+          content: "before <task-notification><status>done</status></task-notification> after",
+        },
+      })
+    );
+
+    const result = readClaudeTranscript(file);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe("before  after");
+    expect(result[0].content).not.toContain("status");
+  });
+
+  it("drops a <system-reminder> block if the harness ever delivers one as user text", () => {
+    // Today these ride inside tool_result blocks, which this reader already drops entirely; the
+    // rule is tag-structural so it holds if that placement changes.
+    writeFileSync(
+      file,
+      JSON.stringify({
+        type: "user",
+        message: {
+          role: "user",
+          content: "<system-reminder>plan mode is active</system-reminder>\nship the fix",
+        },
+      })
+    );
+
+    const result = readClaudeTranscript(file);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe("ship the fix");
+  });
+
   it("strips the reflect hook's <hindsight_memory> injection block (buildSystemInjection output)", () => {
     // The exact block the UserPromptSubmit hook injects — wrapper tags, preamble, attribution
     // text and the surfaced memory itself must ALL be gone from retained text, or the session


### PR DESCRIPTION
Closes #3023.

## What I found

The issue names two cases. Measured against 400 real Claude Code transcripts on this machine, **both are already handled here** — and a third one, which it doesn't name, is live:

| #3023 claim | in coding-agents | why |
|---|---|---|
| skill bodies retained as user conversation | **no** | Claude Code marks them `isMeta: true` (8/8 in the sample); the reader drops isMeta lines |
| `<system-reminder>` retained | **no** | they arrive inside `tool_result` blocks, which the reader drops entirely |
| `<task-notification>` retained | **YES** | 39 in 400 transcripts, delivered as plain `type:"user"`, `isMeta:false`, string body |

So the harness's background-task plumbing — task id, tool-use id, status, summary — was being fed to fact extraction as things the user said.

## Reproduction

Running the real `readClaudeTranscript` over a real transcript, before:

```
retained turns: 243
turns that are a harness task-notification: 1   (519 chars, role "user")
"<task-notification>\n<task-id>b46ca19nr</task-id>\n<tool-use-id>toolu_0127…</tool-use-id>\n<status>stopped</status>…"
```

After:

```
before: 243 turns, 1 harness-noise turn
after:  242 turns, 0 harness-noise turns
real turns preserved: true
```

## The fix

One tag added to `MEMORY_TAG_RE`, which already covered codex's `<hook_prompt>` for exactly this reason — its comment calls them "the host's own hook-transport wrappers… transport noise, not the user's work". `<task-notification>` is that category for Claude Code.

`<system-reminder>` joins it as well. Not reachable today (dropped `tool_result`), but it is the same class and the rule is tag-structural rather than content-guessing, so listing it costs nothing and survives the harness moving where it puts them.

Stripping removes the **block** and keeps surrounding text: a message that is nothing but a wrapper renders empty and is dropped as a no-content turn, while a real message that merely mentions one keeps the user's words. That is deliberately the opposite of the old plugin's unanchored `strip_channel_envelope`, which replaced the whole message with the tag's inner text (#3124).

## Test

**433 passed**, 19 skipped. `tsc --noEmit` and `./scripts/hooks/lint.sh` clean.

Three new cases: a notification-only message producing no turn at all; a message with a wrapper embedded in real text keeping the text; and a `<system-reminder>` delivered as user text being stripped.