### PR TITLE
fix(memories): list_banks NameError on per-bank capability check

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
@@ -464,7 +464,7 @@ async def list_banks(pool) -> list:
             last_doc = row["last_document_at"]
 
             fact_count = row["fact_count"]
-            if not _store.writes_memory_rows_in_sql_for(bank_id):
+            if not _store.writes_memory_rows_in_sql_for(row["bank_id"]):
                 fact_count = sum(
                     (await _store.count_memories(conn=conn, fq_table=fq_table, bank_id=row["bank_id"])).values()
                 )

--- a/hindsight-api-slim/tests/test_list_banks_non_sql_store.py
+++ b/hindsight-api-slim/tests/test_list_banks_non_sql_store.py
@@ -1,0 +1,67 @@
+"""Regression test: list_banks must consult the per-bank capability with the
+*current row's* bank id, and source fact_count from the store when that bank
+keeps its memories outside SQL.
+
+Bug (introduced with per-bank store capabilities, #3350): list_banks called
+``_store.writes_memory_rows_in_sql_for(bank_id)`` with a bare ``bank_id`` name
+that is not in scope inside the per-row loop (the row's id is ``row["bank_id"]``).
+Because the argument is evaluated before the call, this raised
+``NameError: name 'bank_id' is not defined`` for *every* org on the very first
+bank — i.e. GET /banks 500'd outright — regardless of the store's capability.
+
+This test swaps in a store that reports ``writes_memory_rows_in_sql_for -> False``
+(the non-SQL branch the feature added), and asserts list_banks (a) does not raise,
+(b) calls the capability + count_memories with the correct per-bank id, and
+(c) surfaces the store's live count as fact_count.
+
+Runs via: uv run pytest tests/test_list_banks_non_sql_store.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import hindsight_api.engine.memories as memories_mod
+from hindsight_api.models import RequestContext
+
+
+class _NonSqlStore:
+    """A store that keeps memory rows outside SQL: list_banks must count via the store."""
+
+    def __init__(self):
+        self.capability_calls: list[str] = []
+        self.count_calls: list[str] = []
+
+    def writes_memory_rows_in_sql_for(self, bank_id: str) -> bool:
+        self.capability_calls.append(bank_id)
+        return False
+
+    async def count_memories(self, *, conn, fq_table, bank_id: str) -> dict:
+        self.count_calls.append(bank_id)
+        return {"world": 7}
+
+
+@pytest.mark.asyncio
+async def test_list_banks_counts_via_store_for_non_sql_bank(memory, monkeypatch):
+    bank_id = "list_banks_non_sql_bank"
+    request_context = RequestContext(api_key=None, api_key_id=None, tenant_id=None, internal=False)
+
+    store = _NonSqlStore()
+    monkeypatch.setattr(memories_mod, "get_memories", lambda: store)
+
+    try:
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        # Must not raise NameError; must reach the store's non-SQL count path.
+        banks = await memory.list_banks(request_context=request_context)
+
+        entry = next((b for b in banks if b["bank_id"] == bank_id), None)
+        assert entry is not None, f"bank {bank_id!r} not present in list_banks output"
+
+        # The capability + count were consulted with the row's real bank id.
+        assert bank_id in store.capability_calls
+        assert bank_id in store.count_calls
+        # fact_count came from the store (sum of the per-type counts), not the empty SQL join.
+        assert entry["fact_count"] == 7
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## Problem

`GET /v1/default/banks` returns **HTTP 500** for every org:

```
NameError: name 'bank_id' is not defined
  File ".../engine/retain/bank_utils.py", line 467, in list_banks
    if not _store.writes_memory_rows_in_sql_for(bank_id):
```

Introduced with per-bank store capabilities (#3350). Inside `list_banks`, the per-row loop
variable is `row["bank_id"]` — there is no bare `bank_id` in scope. Because the argument is
evaluated *before* the call, this raises for **every** org on the very first bank, regardless of
what the store's capability would have returned. The line immediately below already uses
`row["bank_id"]` correctly.

Found live: routing a dev org's memories to an out-of-SQL store (memlake), the bank list 500'd
while single-bank reads worked.

## Fix

One line: pass `row["bank_id"]`.

## Test

Adds `tests/test_list_banks_non_sql_store.py`: swaps in a store reporting
`writes_memory_rows_in_sql_for -> False` and asserts `list_banks` (a) doesn't raise, (b) consults
the capability + `count_memories` with the correct per-bank id, and (c) sources `fact_count` from
the store. That non-SQL branch is exactly where the bug lived and was previously untested.