### PR TITLE
fix(coding-agents): drop Claude Code's compaction summary from retained turns (#3379)

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/retain-cursor.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-cursor.ts
@@ -11,9 +11,12 @@
  * whenever that cannot be established:
  *
  *   - no cursor          first write-back of the session, or the cache was evicted.
- *   - fingerprint drift  the transcript was REWRITTEN rather than extended (Claude Code compaction,
- *                        a truncated/rotated rollout), so what we already sent is no longer a prefix
- *                        of what we hold and an append would splice two different conversations.
+ *   - fingerprint drift  the transcript was REWRITTEN rather than extended (an edited or redacted
+ *                        turn, a truncated/rotated rollout), so what we already sent is no longer a
+ *                        prefix of what we hold and an append would splice two conversations.
+ *                        NOT Claude Code compaction, which this used to cite: that appends a
+ *                        summary record and leaves every earlier record in place (#3379), so the
+ *                        prefix stays intact and the append path keeps working.
  *   - dirty              the previous retain failed, or its outcome is unknown (the client aborts at
  *                        15s while the server may well have committed it). Appending on top of an
  *                        unknown state is the one way to DUPLICATE turns inside the document, so we

--- a/hindsight-integrations/coding-agents/src/core/transcript.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript.test.ts
@@ -166,6 +166,36 @@ describe("readClaudeTranscript", () => {
     expect(result[0].content).not.toContain("hindsight_memories");
   });
 
+  it("drops the compaction summary — Claude Code's recap, not the user's words", () => {
+    // Written when the context window fills, as a plain type:"user" record with no isMeta flag.
+    // Measured at 29 records / 474,016 chars across local transcripts, averaging 16KB each, every
+    // one retained as if the user had typed it — and each one summarising turns already retained,
+    // since compaction APPENDS to the transcript rather than rewriting it (#3379).
+    writeFileSync(
+      file,
+      [
+        JSON.stringify({
+          type: "user",
+          isCompactSummary: true,
+          message: {
+            role: "user",
+            content:
+              "This session is being continued from a previous conversation that ran out of " +
+              "context. The summary below covers <analysis>…</analysis>",
+          },
+        }),
+        JSON.stringify({
+          type: "user",
+          message: { role: "user", content: "now add the retry backoff" },
+        }),
+      ].join("\n")
+    );
+
+    const result = readClaudeTranscript(file);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe("now add the retry backoff");
+  });
+
   it("drops a <task-notification>: the harness's background-task plumbing, not the user's words", () => {
     // Claude Code delivers these as an ordinary type:"user" message with a string body and no
     // isMeta flag, so nothing else filters them and extraction saw task ids and status lines as

--- a/hindsight-integrations/coding-agents/src/core/transcript.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript.ts
@@ -6,7 +6,8 @@
  * no arguments, no outputs. That keeps WHICH files/commands the session touched without burying the
  * decisions in mechanical noise; `tool_result` blocks are dropped entirely.
  *
- * Drops non-message lines (`last-prompt`, `mode`, `summary`, …), `isMeta` lines, `isSidechain`
+ * Drops non-message lines (`last-prompt`, `mode`, `summary`, …), `isMeta` lines, compaction
+ * summaries (`isCompactSummary`), `isSidechain`
  * (subagent/Task) lines, `thinking` blocks, and turns that render to nothing. Injected recall
  * context (`<hindsight_memories>` / `<hindsight_bank>` / `<relevant_memories>`) is stripped so the
  * write-back can't feed recalled memory back into the bank (a retain→recall feedback loop). A
@@ -29,6 +30,7 @@ interface TranscriptLine {
   type?: string;
   isMeta?: boolean;
   isSidechain?: boolean;
+  isCompactSummary?: boolean;
   timestamp?: string;
   message?: {
     content?: string | ContentBlock[];
@@ -95,6 +97,12 @@ export function readClaudeTranscript(path: string): TransportTurn[] {
     if (line.type !== "user" && line.type !== "assistant") continue;
     if (line.isMeta === true) continue;
     if (line.isSidechain === true) continue;
+    // Claude Code's own recap of the conversation so far, written when the context window fills.
+    // It arrives as a plain type:"user" record with NO isMeta flag, so nothing else filters it and
+    // a ~16KB machine-written summary was retained as something the user said. It is also a
+    // summary of turns ALREADY retained — compaction appends to the transcript rather than
+    // rewriting it — so keeping it extracts the same decisions twice (#3379).
+    if (line.isCompactSummary === true) continue;
     if (typeof line.message !== "object" || line.message === null) continue;
 
     // `type` is validated as "user" | "assistant" above; drive role from it (not the redundant


### PR DESCRIPTION
Came out of investigating #3379, which asked for a `PreCompact` hook so context isn't lost when Claude Code compacts. **The premise doesn't hold, and the investigation found the opposite problem.**

## Compaction appends; it doesn't rewrite

On a real session (11,144 records, compacted twice):

```
compact-summary records at line(s): [3312, 6630]
records before the first marker: 3,312   <- still on disk
records after: 7,831
```

The transcript JSONL is append-only. Compaction shrinks the *agent's* context window and appends an `isCompactSummary` record; nothing is removed from the file we read. And `Stop` fires after **every assistant response**, not at session end, so everything up to the last response was already retained before compaction ran. There is no window where content lives only in the agent's context.

## What is actually wrong: we retain too much

That summary record is `type: "user"` with **no `isMeta` flag**, so nothing filtered it and Claude Code's machine-written recap was retained as something the user said:

```
retained turns: 2,886
turns that are the compaction summary: 2   (53,643 chars)
  role=user chars=21,483 :: "This session is being continued from a previous conversation…"
  role=user chars=32,160 :: "This session is being continued from a previous conversation…"
```

Across local transcripts: **29 records, 474,016 characters, ~16KB each.** Same class as the `<task-notification>` fix in #3378, but roughly 30x larger per instance — and worse than misattribution, it is a summary of turns *already retained*, so the same decisions get extracted a second time from the recap.

Dropped alongside `isMeta` and `isSidechain`.

## Verification

Against the session that surfaced it, baseline built from v0.2.0:

```
before (v0.2.0): 2886 turns, 2 summaries (53,643 chars)
after:           2884 turns, 0 summaries
turns removed: 2 | expected: 2
every other turn identical: true
```

(My first run of this compared against a stale bundle and showed 168 turns removed — worth mentioning because it is exactly the kind of false verification that reads as success. Rebuilding the baseline from current main gave the exact figure above.)

## Also corrected

`retain-cursor.ts` cited Claude Code compaction as an example of a transcript being *rewritten* rather than extended. It isn't — the prefix stays intact, so the append path keeps working straight through a compaction. The guard is unchanged; only the example it named was wrong.

## Test

**434 passed**, 19 skipped. `tsc --noEmit` and lint clean. One new regression: a compaction summary followed by a real user turn retains only the user's turn.