### PR TITLE
fix(retain): sweep observations when delta retain deletes chunks

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/chunk_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/chunk_storage.py
@@ -14,6 +14,9 @@ from .types import ChunkMetadata
 
 logger = logging.getLogger(__name__)
 
+# Page size for walking the facts a chunk owns out of a store that keeps memories outside SQL.
+_OUTGOING_PAGE = 500
+
 
 def compute_chunk_hash(chunk_text: str) -> str:
     """Compute SHA256 hash of chunk text for delta comparison."""
@@ -55,7 +58,54 @@ async def load_existing_chunks(conn, bank_id: str, document_id: str) -> list[Exi
     ]
 
 
-async def delete_chunks_by_ids(conn, chunk_ids: list[str], bank_id: str | None = None, txn=None) -> None:
+async def memory_ids_for_chunks(conn, bank_id: str, chunk_ids: list[str]) -> list[str]:
+    """Ids of the facts these chunks own, asked of whichever store holds them.
+
+    The SQL store keeps ``chunk_id`` as a column; a store that keeps memories outside SQL
+    carries it in the metadata bag (the same key its ``delete_where`` predicate matches on),
+    so the two are read differently. Only ``experience``/``world`` units are returned:
+    observations are not chunk-scoped, and feeding one back as a *source* id would be
+    meaningless. Paged to exhaustion — every id is about to be deleted, and a chunk whose
+    facts overflow one page must not keep half of them.
+    """
+    from ..memories import META_CHUNK_ID, get_memories
+
+    store = get_memories()
+    if store.writes_memory_rows_in_sql:
+        rows = await conn.fetch(
+            f"""
+            SELECT id
+            FROM {fq_table("memory_units")}
+            WHERE bank_id = $1
+              AND chunk_id = ANY($2::text[])
+              AND fact_type IN ('experience', 'world')
+            """,
+            bank_id,
+            chunk_ids,
+        )
+        return [str(row["id"]) for row in rows]
+
+    unit_ids: list[str] = []
+    for chunk_id in chunk_ids:
+        page_token = ""
+        while True:
+            page = await store.scan_memories(
+                conn=conn,
+                fq_table=fq_table,
+                bank_id=bank_id,
+                fact_types=["experience", "world"],
+                metadata_equals={META_CHUNK_ID: chunk_id},
+                limit=_OUTGOING_PAGE,
+                page_token=page_token,
+            )
+            unit_ids.extend(m.unit_id for m in page.memories)
+            page_token = page.next_page_token
+            if not page_token:
+                break
+    return unit_ids
+
+
+async def delete_chunks_by_ids(conn, chunk_ids: list[str], bank_id: str | None = None, txn=None, ops=None) -> int:
     """
     Delete specific chunks by their IDs.
 
@@ -66,9 +116,29 @@ async def delete_chunks_by_ids(conn, chunk_ids: list[str], bank_id: str | None =
     the store's tombstones must ride the same txn as the replacement writes so they commit
     (become visible) together — otherwise an aborted re-ingest could drop the old memories
     without landing the new ones.
+
+    ``ops`` is the backend-specific DataAccessOps the observation sweep below needs to choose
+    the PG (native array) vs Oracle (junction table) read path — pass ``pool.ops``.
+
+    Returns the number of observations invalidated by the sweep, so the caller can log it.
     """
     if not chunk_ids:
-        return
+        return 0
+
+    # Delete the observations derived from the facts these chunks own, BEFORE the facts
+    # themselves go. Nothing can reach those observations afterwards: consolidation batches
+    # are built from facts, so an observation whose sources are all deleted is never selected
+    # into a batch again, and it stays valid and recallable — stale knowledge from the previous
+    # version of the document surviving the replace (issue #3294). The full-replace path does
+    # this in ``handle_document_tracking``; the delta path deletes facts through this cascade
+    # instead, which is why the sweep has to live here rather than at one of the call sites.
+    invalidated = 0
+    if bank_id:
+        outgoing_unit_ids = await memory_ids_for_chunks(conn, bank_id, chunk_ids)
+        if outgoing_unit_ids:
+            from .fact_storage import delete_stale_observations_for_memories
+
+            invalidated = await delete_stale_observations_for_memories(conn, bank_id, outgoing_unit_ids, ops=ops)
 
     # The chunks->memory_units FK cascade below does not reach a store that keeps memories
     # outside SQL (its memory_units is empty), so drop the memories carrying each deleted
@@ -128,6 +198,7 @@ async def delete_chunks_by_ids(conn, chunk_ids: list[str], bank_id: str | None =
         """,
         chunk_ids,
     )
+    return invalidated
 
 
 async def store_chunks_batch(

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -270,6 +270,14 @@ async def handle_document_tracking(
                     f"[RETAIN] Document {document_id} re-ingested: invalidated "
                     f"{invalidated} observation(s) derived from {len(existing_unit_ids)} outgoing memory_units"
                 )
+            else:
+                # Logged even at zero: "the sweep matched nothing" and "the sweep never ran"
+                # are the two candidates whenever orphan observations are reported, and
+                # without this line they look identical from the outside (issue #3294).
+                logger.debug(
+                    f"[RETAIN] Document {document_id} re-ingested: no observations derived from "
+                    f"{len(existing_unit_ids)} outgoing memory_units"
+                )
             # Capture link-recompute victims BEFORE the cascade. Same staleness
             # applies on upsert as on explicit delete: surviving units in OTHER
             # documents that linked to these doomed units are about to lose

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -2573,10 +2573,13 @@ async def _try_delta_retain(
                     for idx in changed_indices + removed_indices
                     if idx in existing_by_index
                 ]
-                await chunk_storage.delete_chunks_by_ids(conn, chunks_to_delete, bank_id, txn=_group_txn)
+                invalidated_obs = await chunk_storage.delete_chunks_by_ids(
+                    conn, chunks_to_delete, bank_id, txn=_group_txn, ops=pool.ops
+                )
                 log_buffer.append(
                     f"  Deleted {len(chunks_to_delete)} chunks "
-                    f"({len(changed_indices)} changed + {len(removed_indices)} removed) "
+                    f"({len(changed_indices)} changed + {len(removed_indices)} removed), "
+                    f"invalidated {invalidated_obs} observation(s) "
                     f"in {time.time() - step_start:.3f}s"
                 )
 

--- a/hindsight-api-slim/tests/test_delta_retain_orphan_observations.py
+++ b/hindsight-api-slim/tests/test_delta_retain_orphan_observations.py
@@ -1,0 +1,266 @@
+"""End-to-end regression for issue #3294: delta retain must not orphan observations.
+
+The reporter's sequence, driven through the public engine API rather than by calling
+the storage helpers directly:
+
+    retain(document) -> consolidate -> retain(same document_id, edited) -> consolidate
+
+Before the fix, the second retain took the delta path, which deletes the changed
+chunks and lets the FK cascade drop their facts — with no observation sweep in
+between. The observations derived from those facts stayed behind, still valid and
+still recallable, pointing at ``source_memory_ids`` that no longer resolved. Nothing
+could reach them afterwards: consolidation batches are built from facts, so an
+observation whose sources are all gone is never selected into a batch again.
+
+These tests assert the invariant the lifecycle documents ("removing a document: all
+observations derived from the document's memories are deleted") on the paths delta
+retain actually takes: an edit, a removal, and a no-op re-ingest. A rewrite of *every*
+chunk is deliberately not covered here — with no unchanged chunk left, delta declines
+and the full-replace path (already covered in ``test_observation_invalidation.py``)
+handles it.
+"""
+
+import uuid
+
+import pytest
+
+from hindsight_api import RequestContext
+from hindsight_api.config import _get_raw_config
+from hindsight_api.engine.memories import FactRecord, get_memories
+from hindsight_api.engine.memory_engine import MemoryEngine, fq_table
+
+# Delta retain works per chunk, so the document has to be big enough to produce several
+# (chunk size is 3000 chars) and at least one of them must come out unchanged — with no
+# unchanged chunk delta declines and falls back to a full replace. Keeping the FIRST
+# block byte-identical across a re-ingest is what guarantees that: chunking is greedy
+# from the start of the text, so an edit after chunk 0's boundary cannot move it.
+_BLOCK_A = " ".join(
+    f"Alice shipped the Alpha{i} milestone at Google in the search infrastructure group." for i in range(40)
+)
+_BLOCK_B = " ".join(f"Bob reviewed the Beta{i} rollout at Microsoft in the Azure networking group." for i in range(40))
+_BLOCK_B_EDITED = " ".join(
+    f"Bob reviewed the Beta{i} rollout at Amazon in the AWS networking group." for i in range(40)
+)
+
+_DOCUMENT_V1 = f"{_BLOCK_A} {_BLOCK_B}"
+_DOCUMENT_V2_PARTIAL_EDIT = f"{_BLOCK_A} {_BLOCK_B_EDITED}"
+
+
+@pytest.fixture(autouse=True)
+def enable_observations():
+    config = _get_raw_config()
+    original = config.enable_observations
+    config.enable_observations = True
+    yield
+    config.enable_observations = original
+
+
+async def _scan(memory: MemoryEngine, bank_id: str, fact_types: list[str]) -> list[FactRecord]:
+    """Every stored memory of these types, read through whichever store holds them."""
+    store = get_memories()
+    pool = await memory._get_pool()
+    async with pool.acquire() as conn:
+        page = await store.scan_memories(
+            conn=conn,
+            fq_table=fq_table,
+            bank_id=bank_id,
+            fact_types=fact_types,
+            limit=1_000_000,
+        )
+    return list(page.memories)
+
+
+async def _facts(memory: MemoryEngine, bank_id: str) -> list[FactRecord]:
+    return await _scan(memory, bank_id, ["experience", "world"])
+
+
+async def _observations(memory: MemoryEngine, bank_id: str) -> list[FactRecord]:
+    return await _scan(memory, bank_id, ["observation"])
+
+
+def _broken_source_refs(observations: list[FactRecord], live_fact_ids: set[str]) -> list[tuple[str, list[str]]]:
+    """The reporter's diagnostic: observations whose sources no longer resolve.
+
+    Returns ``(observation_id, unresolvable_source_ids)`` per affected row — what the
+    bug report counted as "broken references" on their bank.
+    """
+    broken = []
+    for obs in observations:
+        missing = [sid for sid in obs.source_memory_ids if sid not in live_fact_ids]
+        if missing:
+            broken.append((obs.unit_id, missing))
+    return broken
+
+
+async def _assert_no_orphans(memory: MemoryEngine, bank_id: str, when: str) -> None:
+    facts = await _facts(memory, bank_id)
+    observations = await _observations(memory, bank_id)
+    broken = _broken_source_refs(observations, {f.unit_id for f in facts})
+    assert broken == [], (
+        f"{when}: {len(broken)} of {len(observations)} observation(s) reference deleted source "
+        f"memories (issue #3294 — delta retain cascaded the facts away without sweeping the "
+        f"observations derived from them): {broken[:5]}"
+    )
+
+
+async def _retain_document(
+    memory: MemoryEngine, bank_id: str, document_id: str, content: str, request_context: RequestContext
+) -> None:
+    await memory.retain_async(
+        bank_id=bank_id,
+        content=content,
+        context="team roster",
+        document_id=document_id,
+        request_context=request_context,
+    )
+
+
+def _facts_by_chunk(facts: list[FactRecord]) -> dict[str, set[str]]:
+    by_chunk: dict[str, set[str]] = {}
+    for fact in facts:
+        if fact.chunk_id:
+            by_chunk.setdefault(fact.chunk_id, set()).add(fact.unit_id)
+    return by_chunk
+
+
+@pytest.mark.asyncio
+async def test_delta_retain_partial_edit_leaves_no_orphan_observations(
+    memory: MemoryEngine, request_context: RequestContext
+):
+    """Editing the tail of a consolidated document orphans nothing.
+
+    Also pins the precision of the sweep: the untouched first chunk keeps its facts
+    AND the observations derived only from them, so a small edit does not
+    re-consolidate the whole document — the case delta retain exists for.
+    """
+    bank_id = f"test_delta_orphan_partial_{uuid.uuid4().hex[:8]}"
+    document_id = "roster-doc"
+
+    try:
+        await _retain_document(memory, bank_id, document_id, _DOCUMENT_V1, request_context)
+        await memory.run_consolidation(bank_id=bank_id, request_context=request_context)
+
+        facts_v1 = await _facts(memory, bank_id)
+        observations_v1 = await _observations(memory, bank_id)
+        by_chunk_v1 = _facts_by_chunk(facts_v1)
+        assert len(by_chunk_v1) >= 2, f"Setup: the document should span several chunks, got {list(by_chunk_v1)}"
+        assert observations_v1, "Setup: consolidation should have produced observations to orphan"
+        await _assert_no_orphans(memory, bank_id, "after the first retain")
+
+        first_chunk = sorted(by_chunk_v1)[0]
+        kept_fact_ids = by_chunk_v1[first_chunk]
+        edited_fact_ids = {fid for chunk, ids in by_chunk_v1.items() if chunk != first_chunk for fid in ids}
+        assert kept_fact_ids and edited_fact_ids
+
+        obs_over_edited = {o.unit_id for o in observations_v1 if edited_fact_ids.intersection(o.source_memory_ids)}
+        obs_only_over_kept = {
+            o.unit_id
+            for o in observations_v1
+            if o.source_memory_ids and set(o.source_memory_ids).issubset(kept_fact_ids)
+        }
+        assert obs_over_edited, "Setup: the chunks being edited should have observations derived from them"
+        assert obs_only_over_kept, "Setup: the unchanged chunk should have observations of its own"
+
+        # Re-ingest with only the tail changed — this is the delta path.
+        await _retain_document(memory, bank_id, document_id, _DOCUMENT_V2_PARTIAL_EDIT, request_context)
+
+        surviving_fact_ids = {f.unit_id for f in await _facts(memory, bank_id)}
+        # Delta really applied: the unchanged chunk's facts were preserved rather than
+        # re-extracted under new ids (a full replace would have changed all of them).
+        assert kept_fact_ids.issubset(surviving_fact_ids), (
+            "Unchanged chunk's facts should survive the delta re-ingest — if they did not, this "
+            "test fell back to the full-replace path and no longer covers the bug"
+        )
+        assert not edited_fact_ids.intersection(surviving_fact_ids), "The edited chunks' facts should be gone"
+
+        await _assert_no_orphans(memory, bank_id, "after the delta re-ingest")
+
+        observation_ids_v2 = {o.unit_id for o in await _observations(memory, bank_id)}
+        assert not observation_ids_v2.intersection(obs_over_edited), (
+            "Observations derived from the edited chunks' facts should have been invalidated"
+        )
+        assert obs_only_over_kept.issubset(observation_ids_v2), (
+            "Observations derived only from the unchanged chunk must survive a partial edit"
+        )
+
+        # And the follow-up consolidation the reporter ran — still no orphans.
+        await memory.run_consolidation(bank_id=bank_id, request_context=request_context)
+        await _assert_no_orphans(memory, bank_id, "after re-consolidating the edited document")
+
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_delta_retain_removed_chunks_leave_no_orphan_observations(
+    memory: MemoryEngine, request_context: RequestContext
+):
+    """Shortening a document orphans nothing either.
+
+    Delta deletes removed chunks through the same call as changed ones, so this
+    covers the ``removed_indices`` half of that list — a document that shrinks loses
+    facts without any replacement being extracted for them.
+    """
+    bank_id = f"test_delta_orphan_shrink_{uuid.uuid4().hex[:8]}"
+    document_id = "roster-doc"
+
+    try:
+        await _retain_document(memory, bank_id, document_id, _DOCUMENT_V1, request_context)
+        await memory.run_consolidation(bank_id=bank_id, request_context=request_context)
+
+        facts_v1 = await _facts(memory, bank_id)
+        observations_v1 = await _observations(memory, bank_id)
+        by_chunk_v1 = _facts_by_chunk(facts_v1)
+        assert len(by_chunk_v1) >= 2, f"Setup: the document should span several chunks, got {list(by_chunk_v1)}"
+        assert observations_v1, "Setup: consolidation should have produced observations to orphan"
+
+        first_chunk = sorted(by_chunk_v1)[0]
+        kept_fact_ids = by_chunk_v1[first_chunk]
+        dropped_fact_ids = {fid for chunk, ids in by_chunk_v1.items() if chunk != first_chunk for fid in ids}
+        obs_over_dropped = {o.unit_id for o in observations_v1 if dropped_fact_ids.intersection(o.source_memory_ids)}
+        assert obs_over_dropped, "Setup: the chunks being dropped should have observations derived from them"
+
+        # Re-ingest only the first block: every later chunk is removed outright.
+        await _retain_document(memory, bank_id, document_id, _BLOCK_A, request_context)
+
+        surviving_fact_ids = {f.unit_id for f in await _facts(memory, bank_id)}
+        assert kept_fact_ids.issubset(surviving_fact_ids), (
+            "The retained chunk's facts should survive — if they did not, this test fell back "
+            "to the full-replace path and no longer covers the bug"
+        )
+        assert not dropped_fact_ids.intersection(surviving_fact_ids), "The removed chunks' facts should be gone"
+
+        await _assert_no_orphans(memory, bank_id, "after shrinking the document")
+        assert not {o.unit_id for o in await _observations(memory, bank_id)}.intersection(obs_over_dropped), (
+            "Observations derived from the removed chunks' facts should have been invalidated"
+        )
+
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_delta_retain_unchanged_content_keeps_observations(memory: MemoryEngine, request_context: RequestContext):
+    """Re-submitting identical content deletes no chunk, so it sweeps no observation
+    and requeues nothing for consolidation."""
+    bank_id = f"test_delta_orphan_noop_{uuid.uuid4().hex[:8]}"
+    document_id = "roster-doc"
+
+    try:
+        await _retain_document(memory, bank_id, document_id, _DOCUMENT_V1, request_context)
+        await memory.run_consolidation(bank_id=bank_id, request_context=request_context)
+        observation_ids_v1 = {o.unit_id for o in await _observations(memory, bank_id)}
+        assert observation_ids_v1
+
+        await _retain_document(memory, bank_id, document_id, _DOCUMENT_V1, request_context)
+
+        assert {o.unit_id for o in await _observations(memory, bank_id)} == observation_ids_v1, (
+            "A no-op delta re-ingest must not touch existing observations"
+        )
+        assert all(f.consolidated_at is not None for f in await _facts(memory, bank_id)), (
+            "A no-op delta re-ingest must not requeue facts for consolidation"
+        )
+        await _assert_no_orphans(memory, bank_id, "after a no-op re-ingest")
+
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_observation_invalidation.py
+++ b/hindsight-api-slim/tests/test_observation_invalidation.py
@@ -33,6 +33,7 @@ async def _insert_memory(
     text: str,
     fact_type: str = "experience",
     document_id: str | None = None,
+    chunk_id: str | None = None,
 ) -> uuid.UUID:
     """Seed one memory through the store, bypassing the LLM retain pipeline.
 
@@ -47,7 +48,7 @@ async def _insert_memory(
         tags=[],
         context=None,
         document_id=document_id,
-        chunk_id=None,
+        chunk_id=chunk_id,
         metadata=None,
         observation_scopes=None,
         entities=[],
@@ -431,6 +432,187 @@ class TestDocumentUpsertObservationCleanup:
             # The two doc-scoped memories are gone via FK cascade.
             doc_mem_count = await _count_surviving(conn, bank_id, [doc_mem_a, doc_mem_b])
             assert doc_mem_count == 0
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+# ---------------------------------------------------------------------------
+# Tests: delta retain chunk delete (regression for orphan observations, #3294)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_chunked_document(memory: MemoryEngine, conn, bank_id: str, chunk_texts: list[str]) -> tuple[str, list]:
+    """One document with ``len(chunk_texts)`` chunks, each owning one fact.
+
+    Returns the document id and, per chunk, the (chunk_id, fact_id) it owns.
+    """
+    doc_id = str(uuid.uuid4())
+    await conn.execute(
+        """
+        INSERT INTO documents (id, bank_id, original_text, content_hash, created_at, updated_at)
+        VALUES ($1, $2, $3, 'hash-old', NOW(), NOW())
+        """,
+        doc_id,
+        bank_id,
+        "\n\n".join(chunk_texts),
+    )
+    seeded = []
+    for idx, text in enumerate(chunk_texts):
+        chunk_id = f"{bank_id}_{doc_id}_{idx}"
+        await conn.execute(
+            """
+            INSERT INTO chunks (chunk_id, document_id, bank_id, chunk_index, chunk_text, content_hash)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            """,
+            chunk_id,
+            doc_id,
+            bank_id,
+            idx,
+            text,
+            f"chunk-hash-{idx}",
+        )
+        fact_id = await _insert_memory(memory, conn, bank_id, text, "experience", document_id=doc_id, chunk_id=chunk_id)
+        seeded.append((chunk_id, fact_id))
+    return doc_id, seeded
+
+
+class TestDeltaChunkDeleteObservationCleanup:
+    """Regression: delta retain drops facts by deleting their chunks, and that
+    cascade must invalidate the observations derived from them.
+
+    ``handle_document_tracking`` (full replace) sweeps observations before its
+    delete, but the delta path never calls it — it upserts the document row and
+    deletes the changed/removed chunks directly, cascading to memory_units. Every
+    delta re-ingest therefore used to leave the observations of the changed chunks
+    behind, valid and recallable, pointing at ids that no longer exist. Nothing
+    could reach them afterwards: consolidation batches are built from facts, so an
+    observation whose sources are all gone is never selected into a batch again.
+    """
+
+    @pytest.mark.asyncio
+    async def test_chunk_delete_removes_observations_from_outgoing_memories(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """The observation of a deleted chunk's fact goes with it; its surviving
+        co-source is requeued for re-consolidation."""
+        from hindsight_api.engine.retain.chunk_storage import delete_chunks_by_ids
+
+        bank_id = f"test-delta-obs-cleanup-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+        pool = await memory._get_pool()
+
+        async with pool.acquire() as conn:
+            _doc_id, seeded = await _seed_chunked_document(
+                memory, conn, bank_id, ["Alice works at Google.", "Bob works at Microsoft."]
+            )
+            (outgoing_chunk, outgoing_fact), (_kept_chunk, kept_fact) = seeded
+            standalone_fact = await _insert_memory(memory, conn, bank_id, "Carol works at Netflix.")
+            obs_id = await _insert_observation(
+                memory,
+                conn,
+                bank_id,
+                "The team is spread across Google, Microsoft and Netflix.",
+                [outgoing_fact, kept_fact, standalone_fact],
+            )
+
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                invalidated = await delete_chunks_by_ids(conn, [outgoing_chunk], bank_id, ops=memory._backend.ops)
+
+        assert invalidated == 1, "delete_chunks_by_ids should report the observation it invalidated"
+
+        async with pool.acquire() as conn:
+            assert str(obs_id) not in await _get_observation_ids(conn, bank_id), (
+                "Observation derived from the deleted chunk's fact should have been invalidated "
+                "(regression #3294: the delta path cascaded the fact away and left the orphan)"
+            )
+            assert await _count_surviving(conn, bank_id, [outgoing_fact]) == 0, "The chunk's fact is gone"
+            # Both surviving co-sources lost an observation, so both are due for re-consolidation.
+            for survivor in (kept_fact, standalone_fact):
+                assert await _get_consolidated_at(conn, survivor, bank_id) is None, (
+                    "Surviving co-source should be reset for re-consolidation"
+                )
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_chunk_delete_keeps_observations_of_unchanged_chunks(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """Precision: an observation sourced only from chunks that stay is untouched.
+
+        A sweep keyed on the document rather than on the deleted chunks would take
+        this one too — and needlessly requeue the whole document for consolidation
+        on every small edit, which is exactly the case delta retain exists for.
+        """
+        from hindsight_api.engine.retain.chunk_storage import delete_chunks_by_ids
+
+        bank_id = f"test-delta-obs-keep-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+        pool = await memory._get_pool()
+
+        async with pool.acquire() as conn:
+            _doc_id, seeded = await _seed_chunked_document(
+                memory, conn, bank_id, ["Alice works at Google.", "Bob works at Microsoft."]
+            )
+            (outgoing_chunk, _outgoing_fact), (_kept_chunk, kept_fact) = seeded
+            kept_obs = await _insert_observation(memory, conn, bank_id, "Bob is at Microsoft.", [kept_fact])
+
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                invalidated = await delete_chunks_by_ids(conn, [outgoing_chunk], bank_id, ops=memory._backend.ops)
+
+        assert invalidated == 0, "No observation of the surviving chunk should have been touched"
+
+        async with pool.acquire() as conn:
+            assert str(kept_obs) in await _get_observation_ids(conn, bank_id), (
+                "Observation of an unchanged chunk must survive the delta delete"
+            )
+            assert await _get_consolidated_at(conn, kept_fact, bank_id) is not None, (
+                "An untouched fact must not be requeued for consolidation"
+            )
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_chunk_delete_sweeps_every_deleted_chunk(self, memory: MemoryEngine, request_context: RequestContext):
+        """Multiple chunks in one call: each one's observations are swept.
+
+        The reporter's bank lost the observations of a whole document at once
+        (25 fully orphaned from a single replace), so the sweep must cover the
+        entire ``chunks_to_delete`` list, not just the first entry.
+        """
+        from hindsight_api.engine.retain.chunk_storage import delete_chunks_by_ids
+
+        bank_id = f"test-delta-obs-multi-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+        pool = await memory._get_pool()
+
+        async with pool.acquire() as conn:
+            _doc_id, seeded = await _seed_chunked_document(
+                memory,
+                conn,
+                bank_id,
+                ["Alice works at Google.", "Bob works at Microsoft.", "Dan works at Apple."],
+            )
+            observations = [
+                await _insert_observation(memory, conn, bank_id, f"Observation of chunk {i}.", [fact])
+                for i, (_chunk, fact) in enumerate(seeded)
+            ]
+
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                invalidated = await delete_chunks_by_ids(
+                    conn, [chunk for chunk, _fact in seeded], bank_id, ops=memory._backend.ops
+                )
+
+        assert invalidated == 3
+
+        async with pool.acquire() as conn:
+            remaining = await _get_observation_ids(conn, bank_id)
+            assert [o for o in observations if str(o) in remaining] == [], (
+                "Every deleted chunk's observations should be swept, not just the first chunk's"
+            )
 
         await memory.delete_bank(bank_id, request_context=request_context)
 


### PR DESCRIPTION
## Problem

A document re-ingest that takes the **delta path** leaves orphan observations: rows that stay valid and recallable while their `source_memory_ids` point at `memory_units` that no longer exist. Stale knowledge from the previous version of a document survives the replace.

The observation sweep lives in `fact_storage.handle_document_tracking`, which only the **full-replace** path calls. Delta retain never goes through it — it upserts the document row ("Update document metadata (no delete)") and deletes the changed/removed chunks directly, cascading to their `memory_units`:

```python
# orchestrator.py, _run_delta_db_work
chunks_to_delete = [...]
await chunk_storage.delete_chunks_by_ids(conn, chunks_to_delete, bank_id, txn=_group_txn)
```

`delete_chunks_by_ids` is the only production path that deletes chunks, and it swept nothing. So this is systematic, not timing-dependent: a small edit to an existing document is exactly the case delta retain exists for.

The rows are unreachable once created. Consolidation batches are built from facts, so an observation whose sources are all gone is never selected into a batch again, and no runtime path removes it — `clear_observations` is bank-wide, `DELETE /memories/{id}/observations` needs a live source, `consolidation/recover` explicitly deletes no observations, graph maintenance prunes entities. The only cleanup shipped is the Alembic backsweep, which runs once at upgrade.

Reported and diagnosed by @fhiltscher in #3294, who measured 25 fully orphaned and 22 partially orphaned observations from a **single serial replace** (32 facts, no concurrency, consolidation allowed to finish).

## Fix

Sweep in `delete_chunks_by_ids`, before the cascade. It goes at that choke point rather than at the call site so no future caller can cascade facts away without it — the function already owns the cross-store side of the delete for the same reason.

- `memory_ids_for_chunks` reads the facts the outgoing chunks own from whichever store holds them: a column on the SQL store, the metadata bag (same key `delete_where` matches on) for a store that keeps memories outside SQL, paged to exhaustion.
- The sweep is keyed on the **deleted chunks**, not the document, so editing one chunk leaves the other chunks' observations alone instead of requeueing the whole document for consolidation.
- `delete_chunks_by_ids` returns the count it invalidated, and the delta log line now carries it **unconditionally**:

  ```
  Deleted 1 chunks (1 changed + 0 removed), invalidated 15 observation(s) in 0.012s
  ```

  This was the reporter's other request: `fact_storage` logged only when `invalidated` was non-zero, so "the sweep matched nothing" and "the sweep never ran" looked identical from the outside — and the diagnostically interesting case was exactly the silent one. The zero case in the full-replace path is now logged at debug for the same reason.

## Tests

`tests/test_delta_retain_orphan_observations.py` — end-to-end through the public engine API, reproducing the reporter's sequence (`retain → consolidate → retain(edited) → consolidate`) and asserting their own diagnostic: every observation's `source_memory_ids` must resolve.

- **partial edit** — one chunk edited, rest unchanged. Verified to fail on a clean tree with the reported symptom: `after the delta re-ingest: 15 of 38 observation(s) reference deleted source memories`. Also pins precision: the untouched chunk keeps its facts *and* the observations derived only from them.
- **removed chunks** — document shrinks, covering the `removed_indices` half of `chunks_to_delete`. Fails pre-fix: `after shrinking the document: 15 of 29 observation(s) reference deleted source memories`.
- **no-op re-ingest** — identical content sweeps nothing and requeues nothing.

A rewrite of *every* chunk is deliberately not covered there: with no unchanged chunk, delta declines (`no unchanged chunks … falling back to full retain`) and the full-replace path handles it — already covered by `test_upsert_document_removes_observations_from_outgoing_memories`.

`tests/test_observation_invalidation.py::TestDeltaChunkDeleteObservationCleanup` — three focused tests at the storage layer: the outgoing fact's observation goes and its surviving co-sources are requeued; an observation of an unchanged chunk survives untouched and is *not* requeued; every chunk in a multi-chunk delete is swept, not just the first.

Each delta test was confirmed to fail without the source change. Full runs: `test_observation_invalidation.py`, `test_delta_retain.py`, `test_delta_retain_duplicates.py`, `test_chunk_storage_delete_ordering.py`, `test_delta_retain_orphan_observations.py` (61 passed), plus `test_retain.py`, `test_consolidation.py`, `test_batch_chunking.py`, `test_async_batch_retain.py` (187 passed, 1 xfailed). `./scripts/hooks/lint.sh` and `ty check` pass.

## Supersedes

- Closes #3302 (@koriyoshi2041) — same diagnosis and same call site. This version adds the store-agnostic lookup, the unconditional diagnostic, and regression coverage through the real retain pipeline rather than the storage helper alone.
- #3295 was withdrawn by its author: it closed a theoretical window in the full-replace path, which is not where these orphans came from.

## Not in scope

- **Existing residue.** Banks already affected keep their orphans — there is still no runtime repair path. Worth a follow-up (a backsweep migration, or teaching `consolidation/recover` to drop them).
- **Relink victims.** The full-replace path calls `enqueue_relink_victims` for the doomed units; the delta path does not, before or after this PR. Same class of staleness, different symptom — filed separately rather than widened into this fix.

Fixes #3294.
