### PR TITLE
docs: correct the Azure OpenAI base URL

### DIFF
--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -27,7 +27,9 @@ Used for fact extraction, entity resolution, mental model consolidation, and ans
 Also supports **any OpenAI-compatible API** (e.g., Azure OpenAI, Together AI, Fireworks) and **100+ providers via LiteLLM** (e.g., AWS Bedrock, Azure OpenAI, Together AI).
 
 :::tip OpenAI-Compatible Providers
-Hindsight works with any provider that exposes an OpenAI-compatible API (e.g., Azure OpenAI). Simply set `HINDSIGHT_API_LLM_PROVIDER=openai` and configure `HINDSIGHT_API_LLM_BASE_URL` to point to your provider's endpoint.
+Hindsight works with any provider that exposes an OpenAI-compatible API. Set `HINDSIGHT_API_LLM_PROVIDER=openai` and point `HINDSIGHT_API_LLM_BASE_URL` at the endpoint that serves `/chat/completions` — for most providers that is the URL ending in `/v1`, **not** the account or resource root.
+
+**Azure OpenAI does not serve the API at the resource root**, so `https://<resource>.openai.azure.com` on its own returns `404 Resource not found`. See [Azure OpenAI Setup](#azure-openai-setup) for the two URL shapes that work.
 
 The `openai` provider talks to the **Chat Completions API** (`/v1/chat/completions`). For the newer **Responses API** (`/v1/responses`), use `HINDSIGHT_API_LLM_PROVIDER=openai-responses` — see the tip below. Both accept a custom `HINDSIGHT_API_LLM_BASE_URL`, so an OpenAI-compatible endpoint that exposes `/v1/responses` works the same way as a Chat Completions one.
 
@@ -573,6 +575,56 @@ each starting from its own copy of a single login's output: a copy stops
 working as soon as another replica refreshes, and the login has to be repeated.
 A single shared writable volume is the supported shape; if you cannot provide
 one, run one replica on this provider and give the others an API-key lane.
+
+---
+
+### Azure OpenAI Setup
+
+Azure OpenAI is reached through the **`openai`** provider — there is no `azure`
+provider, and setting one fails at startup with
+`Invalid LLM provider: azure`.
+
+The one thing that trips people up is the base URL. Azure does not serve the
+OpenAI API at the resource root, so the endpoint shown in the Azure portal is
+not usable on its own:
+
+| `HINDSIGHT_API_LLM_BASE_URL` | Result |
+|---|---|
+| `https://<resource>.openai.azure.com` | `404 Resource not found` |
+| `https://<resource>.openai.azure.com/openai/deployments/<deployment>` | `404 Resource not found` (no `api-version`) |
+| `https://<resource>.openai.azure.com/openai/v1` | works |
+| `https://<resource>.openai.azure.com/openai/deployments/<deployment>?api-version=<version>` | works |
+
+**Recommended — the v1 surface:**
+
+```bash
+export HINDSIGHT_API_LLM_PROVIDER=openai
+export HINDSIGHT_API_LLM_API_KEY=<azure-openai-resource-key>
+export HINDSIGHT_API_LLM_MODEL=<deployment-name>
+export HINDSIGHT_API_LLM_BASE_URL=https://<resource>.openai.azure.com/openai/v1
+```
+
+**Or the deployment-scoped form.** Keep the `api-version` query string — Hindsight
+parses it out of the base URL and passes it to the SDK:
+
+```bash
+export HINDSIGHT_API_LLM_BASE_URL=https://<resource>.openai.azure.com/openai/deployments/<deployment>?api-version=2025-01-01-preview
+```
+
+**Important notes:**
+- `HINDSIGHT_API_LLM_MODEL` is your **deployment name**, not the model name. A
+  `gpt-4o` deployed as `my-gpt4o` is configured as `my-gpt4o`.
+- The key is the Azure OpenAI **resource** key (`az cognitiveservices account
+  keys list -n <resource> -g <group>`). An API Management subscription key is a
+  different credential: with APIM in front, the base URL must be the APIM route
+  and APIM has to forward the `api-key` header. Test against the Azure endpoint
+  directly first to isolate which layer is failing.
+- Gateways and proxies must preserve the same path shape (`/openai/v1` or
+  `/openai/deployments/...?api-version=`).
+- Azure accepts the `prompt_cache_key` field that
+  [`HINDSIGHT_API_LLM_CACHE_AFFINITY`](./configuration#llm-provider) sends under
+  `auto`, on every `api-version` from `2024-02-01` onward, so the default needs
+  no adjustment for Azure.
 
 ---
 

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -50,7 +50,9 @@ Also supports **any OpenAI-compatible API** (e.g., Azure OpenAI, Together AI, Fi
 
 > **💡 OpenAI-Compatible Providers**
 >
-Hindsight works with any provider that exposes an OpenAI-compatible API (e.g., Azure OpenAI). Simply set `HINDSIGHT_API_LLM_PROVIDER=openai` and configure `HINDSIGHT_API_LLM_BASE_URL` to point to your provider's endpoint.
+Hindsight works with any provider that exposes an OpenAI-compatible API. Set `HINDSIGHT_API_LLM_PROVIDER=openai` and point `HINDSIGHT_API_LLM_BASE_URL` at the endpoint that serves `/chat/completions` — for most providers that is the URL ending in `/v1`, **not** the account or resource root.
+
+**Azure OpenAI does not serve the API at the resource root**, so `https://<resource>.openai.azure.com` on its own returns `404 Resource not found`. See [Azure OpenAI Setup](#azure-openai-setup) for the two URL shapes that work.
 
 The `openai` provider talks to the **Chat Completions API** (`/v1/chat/completions`). For the newer **Responses API** (`/v1/responses`), use `HINDSIGHT_API_LLM_PROVIDER=openai-responses` — see the tip below. Both accept a custom `HINDSIGHT_API_LLM_BASE_URL`, so an OpenAI-compatible endpoint that exposes `/v1/responses` works the same way as a Chat Completions one.
 
@@ -633,6 +635,56 @@ each starting from its own copy of a single login's output: a copy stops
 working as soon as another replica refreshes, and the login has to be repeated.
 A single shared writable volume is the supported shape; if you cannot provide
 one, run one replica on this provider and give the others an API-key lane.
+
+---
+
+### Azure OpenAI Setup
+
+Azure OpenAI is reached through the **`openai`** provider — there is no `azure`
+provider, and setting one fails at startup with
+`Invalid LLM provider: azure`.
+
+The one thing that trips people up is the base URL. Azure does not serve the
+OpenAI API at the resource root, so the endpoint shown in the Azure portal is
+not usable on its own:
+
+| `HINDSIGHT_API_LLM_BASE_URL` | Result |
+|---|---|
+| `https://<resource>.openai.azure.com` | `404 Resource not found` |
+| `https://<resource>.openai.azure.com/openai/deployments/<deployment>` | `404 Resource not found` (no `api-version`) |
+| `https://<resource>.openai.azure.com/openai/v1` | works |
+| `https://<resource>.openai.azure.com/openai/deployments/<deployment>?api-version=<version>` | works |
+
+**Recommended — the v1 surface:**
+
+```bash
+export HINDSIGHT_API_LLM_PROVIDER=openai
+export HINDSIGHT_API_LLM_API_KEY=<azure-openai-resource-key>
+export HINDSIGHT_API_LLM_MODEL=<deployment-name>
+export HINDSIGHT_API_LLM_BASE_URL=https://<resource>.openai.azure.com/openai/v1
+```
+
+**Or the deployment-scoped form.** Keep the `api-version` query string — Hindsight
+parses it out of the base URL and passes it to the SDK:
+
+```bash
+export HINDSIGHT_API_LLM_BASE_URL=https://<resource>.openai.azure.com/openai/deployments/<deployment>?api-version=2025-01-01-preview
+```
+
+**Important notes:**
+- `HINDSIGHT_API_LLM_MODEL` is your **deployment name**, not the model name. A
+  `gpt-4o` deployed as `my-gpt4o` is configured as `my-gpt4o`.
+- The key is the Azure OpenAI **resource** key (`az cognitiveservices account
+  keys list -n <resource> -g <group>`). An API Management subscription key is a
+  different credential: with APIM in front, the base URL must be the APIM route
+  and APIM has to forward the `api-key` header. Test against the Azure endpoint
+  directly first to isolate which layer is failing.
+- Gateways and proxies must preserve the same path shape (`/openai/v1` or
+  `/openai/deployments/...?api-version=`).
+- Azure accepts the `prompt_cache_key` field that
+  [`HINDSIGHT_API_LLM_CACHE_AFFINITY`](./configuration#llm-provider) sends under
+  `auto`, on every `api-version` from `2024-02-01` onward, so the default needs
+  no adjustment for Azure.
 
 ---
 


### PR DESCRIPTION
Reported in #3377, verified against a live Azure OpenAI resource rather than reasoned about.

## The problem

The OpenAI-compatible tip told users to point `HINDSIGHT_API_LLM_BASE_URL` at "your provider's endpoint". For Azure that reads as the resource root, and Azure does not serve the API there — which is exactly the connection error in the issue.

Measured against a real Azure resource (`gpt-5-mini` deployment):

| `HINDSIGHT_API_LLM_BASE_URL` | Result |
|---|---|
| `https://<res>.openai.azure.com` | 404 Resource not found |
| `https://<res>.openai.azure.com/openai/deployments/<dep>` | 404 (no `api-version`) |
| `https://<res>.openai.azure.com/openai/v1` | works |
| `.../openai/deployments/<dep>?api-version=2025-01-01-preview` | works |

## The change

Rewrites the misleading tip and adds an **Azure OpenAI Setup** section with both working shapes, plus the three things that actually bite:

- `HINDSIGHT_API_LLM_MODEL` is the **deployment** name, not the model name
- the key is the Azure **resource** key — an APIM subscription key is a different setup
- gateways must preserve the path shape

It also records that Azure accepts the `prompt_cache_key` field that `cache_affinity=auto` sends (#3271) on every `api-version` from `2024-02-01` onward — tested directly — so that default needs no Azure carve-out. That was an explicitly untested risk when #3271 merged; it is now closed.

## Verification

`npm run build` in `hindsight-docs` succeeds and the new `#azure-openai-setup` anchor resolves (the two broken anchors it reports are pre-existing, on a 0.5.5 blog post). Docs-skill mirror regenerated. Versioned docs left alone, matching the convention of recent docs fixes.

## Not included

The reporter also flagged that `pip install hindsight-copilot` fails. That is real and separate — the package is **not on PyPI** (`https://pypi.org/simple/hindsight-copilot/` returns 404) even though `integrations/github-copilot/v0.1.0` was tagged in July, so the publish never landed. The fix there is to publish the package, not to reword the docs, so it is deliberately out of scope for this PR. (`hindsight-copilot-cli` is a different, genuinely published package and is unaffected.)
