### PR TITLE
fix(reflect): decouple page max_tokens from the provider output cap (#3365)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,13 @@ HINDSIGHT_API_LLM_BASE_URL=https://api.openai.com/v1
 # the same model in us-east-1 accepts response_format and needs nothing here.
 # HINDSIGHT_API_LLM_STRUCTURED_OUTPUT_FORCED_TOOL=false
 
+# Transport-level output cap for reflect's final synthesis call. Unset = uncapped:
+# the model runs to a natural stop and the reflect/mental-model max_tokens governs
+# visible length via a prompt directive + a post-hoc rewrite (not by truncating the
+# provider call, which on thinking models is eaten by reasoning tokens and cuts pages
+# off mid-word). Set an integer only to enforce a hard cost ceiling on the call.
+# HINDSIGHT_API_REFLECT_MAX_COMPLETION_TOKENS=16000
+
 # Diagnostic: on any LLM 4xx, log the exact assembled request ([LLM_4XX_DUMP]) --
 # serialized request config (message bodies stripped) + capped per-message previews.
 # For debugging otherwise-unreproducible rejected calls. Off by default.

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -792,6 +792,7 @@ ENV_REFLECT_MAX_CONTEXT_TOKENS = "HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS"
 ENV_REFLECT_WALL_TIMEOUT = "HINDSIGHT_API_REFLECT_WALL_TIMEOUT"
 ENV_REFLECT_MISSION = "HINDSIGHT_API_REFLECT_MISSION"
 ENV_REFLECT_SOURCE_FACTS_MAX_TOKENS = "HINDSIGHT_API_REFLECT_SOURCE_FACTS_MAX_TOKENS"
+ENV_REFLECT_MAX_COMPLETION_TOKENS = "HINDSIGHT_API_REFLECT_MAX_COMPLETION_TOKENS"
 ENV_RECALL_INCLUDE_CHUNKS = "HINDSIGHT_API_RECALL_INCLUDE_CHUNKS"
 ENV_RECALL_MAX_TOKENS = "HINDSIGHT_API_RECALL_MAX_TOKENS"
 ENV_RECALL_CHUNKS_MAX_TOKENS = "HINDSIGHT_API_RECALL_CHUNKS_MAX_TOKENS"
@@ -1323,6 +1324,14 @@ DEFAULT_REFLECT_PROMPT_CACHE_ENABLED = True
 DEFAULT_REFLECT_MAX_CONTEXT_TOKENS = 100_000  # Max accumulated context tokens before forcing final prompt
 DEFAULT_REFLECT_WALL_TIMEOUT = 300  # Wall-clock timeout in seconds for the entire reflect operation (5 minutes)
 DEFAULT_REFLECT_SOURCE_FACTS_MAX_TOKENS = -1  # Token budget for source facts in search_observations (-1 = disabled)
+# Transport-level output cap (max_completion_tokens) for reflect's final synthesis.
+# None = uncapped: the model runs to a natural stop and the desired page length is
+# governed by a prompt directive + the post-hoc rewrite, NOT by truncating the
+# provider call. This decouples the mental-model/reflect ``max_tokens`` (a page-length
+# target) from the raw provider budget, which on thinking models is consumed by
+# reasoning tokens and would otherwise cut pages off mid-word (#3365). Set an integer
+# only if you want a hard cost ceiling on the synthesis call.
+DEFAULT_REFLECT_MAX_COMPLETION_TOKENS: int | None = None
 DEFAULT_RECALL_INCLUDE_CHUNKS = True  # Whether internal recall (e.g. mental model refresh) returns raw chunks
 DEFAULT_RECALL_MAX_TOKENS = 2048  # Token budget for facts returned by internal recall
 DEFAULT_RECALL_CHUNKS_MAX_TOKENS = 1000  # Token budget for raw chunks returned by internal recall
@@ -2520,6 +2529,7 @@ class HindsightConfig:
     reflect_max_context_tokens: int
     reflect_wall_timeout: int
     reflect_prompt_cache_enabled: bool
+    reflect_max_completion_tokens: int | None
 
     # OpenTelemetry tracing configuration
     otel_traces_enabled: bool
@@ -3784,6 +3794,11 @@ class HindsightConfig:
             reflect_mission=os.getenv(ENV_REFLECT_MISSION) or None,
             reflect_source_facts_max_tokens=int(
                 os.getenv(ENV_REFLECT_SOURCE_FACTS_MAX_TOKENS, str(DEFAULT_REFLECT_SOURCE_FACTS_MAX_TOKENS))
+            ),
+            reflect_max_completion_tokens=(
+                int(os.getenv(ENV_REFLECT_MAX_COMPLETION_TOKENS))
+                if os.getenv(ENV_REFLECT_MAX_COMPLETION_TOKENS)
+                else DEFAULT_REFLECT_MAX_COMPLETION_TOKENS
             ),
             enable_temporal_retrieval=os.getenv(
                 ENV_ENABLE_TEMPORAL_RETRIEVAL, str(DEFAULT_ENABLE_TEMPORAL_RETRIEVAL)

--- a/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
@@ -510,6 +510,21 @@ class GeminiLLM(LLMInterface):
                 if hasattr(response, "candidates") and response.candidates:
                     if hasattr(response.candidates[0], "finish_reason"):
                         finish_reason = str(response.candidates[0].finish_reason)
+
+                # Surface silent truncation. A non-empty response that stopped on
+                # MAX_TOKENS was cut off (often mid-word) yet still returns as a
+                # success — on thinking models the reasoning tokens can consume the
+                # whole max_output_tokens budget, leaving the visible answer
+                # truncated (#3365). Make it visible in the logs rather than let a
+                # half-written page look healthy.
+                if finish_reason and "MAX_TOKENS" in finish_reason and content:
+                    logger.warning(
+                        "Gemini response truncated at max_output_tokens "
+                        f"(scope={scope}, model={self.model}, max_output_tokens={max_completion_tokens}, "
+                        f"output_tokens={output_tokens}, thoughts_tokens={thoughts_tokens}). The visible "
+                        "output was cut off; raise the cap or leave it unset for reasoning models."
+                    )
+
                 span_recorder = get_span_recorder()
                 from hindsight_api.tracing import _serialize_for_span
 

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -462,7 +462,12 @@ async def _run_reflect_agent_inner(
         expand_fn: Tool callback for expand (memory_ids, depth) -> result
         context: Optional additional context
         max_iterations: Maximum number of iterations before forcing response
-        max_tokens: Maximum tokens for the final response
+        max_tokens: Desired *visible* length of the final answer. Communicated to
+            the model as a soft directive and enforced by the post-hoc rewrite --
+            NOT passed as the provider's ``max_completion_tokens``, which on
+            thinking models is consumed by reasoning tokens and would truncate the
+            answer mid-word (#3365). The transport-level cost cap is a separate,
+            uncapped-by-default config (``reflect_max_completion_tokens``).
         response_schema: Optional JSON Schema for structured output in final response
         directives: Optional list of directive mental models to inject as hard rules
 
@@ -470,6 +475,13 @@ async def _run_reflect_agent_inner(
         ReflectAgentResult with final answer and metadata
     """
     start_time = time.time()
+
+    # Transport-level output cap for the synthesis calls. Decoupled from
+    # ``max_tokens`` (a page-length target enforced via prompt + rewrite): None by
+    # default so reasoning models run to a natural stop instead of truncating the
+    # visible page mid-word (#3365). An operator can set a hard cost ceiling via
+    # HINDSIGHT_API_REFLECT_MAX_COMPLETION_TOKENS.
+    synthesis_max_completion_tokens = get_config().reflect_max_completion_tokens
 
     # Build directives_applied for the trace
     directives_applied = _build_directives_applied(directives)
@@ -657,7 +669,12 @@ async def _run_reflect_agent_inner(
         if is_last:
             # Force text response on last iteration - no tools
             prompt = build_final_prompt(
-                query, context_history, bank_profile, context, max_context_tokens=max_context_tokens
+                query,
+                context_history,
+                bank_profile,
+                context,
+                max_context_tokens=max_context_tokens,
+                max_tokens=max_tokens,
             )
             llm_start = time.time()
             response, usage = await llm_config.call(
@@ -671,7 +688,7 @@ async def _run_reflect_agent_inner(
                     {"role": "user", "content": prompt},
                 ],
                 scope="reflect",
-                max_completion_tokens=max_tokens,
+                max_completion_tokens=synthesis_max_completion_tokens,
                 return_usage=True,
             )
             llm_duration = int((time.time() - llm_start) * 1000)
@@ -722,7 +739,12 @@ async def _run_reflect_agent_inner(
                 f"~{estimated_tokens} tokens >= {max_context_tokens} limit. Forcing final synthesis."
             )
             prompt = build_final_prompt(
-                query, context_history, bank_profile, context, max_context_tokens=max_context_tokens
+                query,
+                context_history,
+                bank_profile,
+                context,
+                max_context_tokens=max_context_tokens,
+                max_tokens=max_tokens,
             )
             llm_start = time.time()
             response, usage = await llm_config.call(
@@ -736,7 +758,7 @@ async def _run_reflect_agent_inner(
                     {"role": "user", "content": prompt},
                 ],
                 scope="reflect",
-                max_completion_tokens=max_tokens,
+                max_completion_tokens=synthesis_max_completion_tokens,
                 return_usage=True,
             )
             llm_duration = int((time.time() - llm_start) * 1000)
@@ -865,7 +887,12 @@ async def _run_reflect_agent_inner(
             elif not has_gathered_evidence and iteration < max_iterations - 1 and consecutive_errors < 2:
                 continue
             prompt = build_final_prompt(
-                query, context_history, bank_profile, context, max_context_tokens=max_context_tokens
+                query,
+                context_history,
+                bank_profile,
+                context,
+                max_context_tokens=max_context_tokens,
+                max_tokens=max_tokens,
             )
             llm_start = time.time()
             response, usage = await llm_config.call(
@@ -879,7 +906,7 @@ async def _run_reflect_agent_inner(
                     {"role": "user", "content": prompt},
                 ],
                 scope="reflect",
-                max_completion_tokens=max_tokens,
+                max_completion_tokens=synthesis_max_completion_tokens,
                 return_usage=True,
             )
             llm_duration = int((time.time() - llm_start) * 1000)
@@ -943,7 +970,12 @@ async def _run_reflect_agent_inner(
             # Model tool-called earlier and is now stopping: fall through to a clean
             # forced final synthesis (tools disabled, prose expected).
             prompt = build_final_prompt(
-                query, context_history, bank_profile, context, max_context_tokens=max_context_tokens
+                query,
+                context_history,
+                bank_profile,
+                context,
+                max_context_tokens=max_context_tokens,
+                max_tokens=max_tokens,
             )
             llm_start = time.time()
             response, usage = await llm_config.call(
@@ -957,7 +989,7 @@ async def _run_reflect_agent_inner(
                     {"role": "user", "content": prompt},
                 ],
                 scope="reflect",
-                max_completion_tokens=max_tokens,
+                max_completion_tokens=synthesis_max_completion_tokens,
                 return_usage=True,
             )
             llm_duration = int((time.time() - llm_start) * 1000)
@@ -1287,6 +1319,10 @@ async def _process_done_tool(
     final_usage = usage
     if llm_config and max_tokens is not None and count_cl100k_tokens(answer) > max_tokens:
         rewrite_start = time.time()
+        # The token budget is enforced via the prompt, not a hard provider cap:
+        # on thinking models a hard cap is eaten by reasoning tokens and would
+        # truncate the rewrite mid-word (#3365). Cost is bounded by the separate
+        # reflect_max_completion_tokens config (uncapped by default).
         rewritten, rewrite_usage = await llm_config.call(
             messages=[
                 {
@@ -1303,7 +1339,7 @@ async def _process_done_tool(
                 },
             ],
             scope="reflect",
-            max_completion_tokens=max_tokens,
+            max_completion_tokens=get_config().reflect_max_completion_tokens,
             return_usage=True,
         )
         answer = rewritten.strip()

--- a/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
@@ -449,8 +449,18 @@ def build_final_prompt(
     bank_profile: dict,
     additional_context: str | None = None,
     max_context_tokens: int = 100_000,
+    max_tokens: int | None = None,
 ) -> str:
-    """Build the final prompt when forcing a text response (no tools)."""
+    """Build the final prompt when forcing a text response (no tools).
+
+    ``max_tokens`` is the desired *visible* length of the answer (e.g. a mental
+    model page's ``max_tokens``). It is communicated here as a soft directive
+    rather than enforced by truncating the provider call: on thinking models the
+    provider budget is consumed by reasoning tokens, so a hard cap cuts the page
+    off mid-word (#3365). The hard length guarantee is the post-hoc rewrite in
+    the agent; this directive just steers the model toward the target so the
+    rewrite rarely has to fire.
+    """
     parts = []
 
     # Bank identity
@@ -521,6 +531,15 @@ def build_final_prompt(
         '"I\'ll search..." or "Let me analyze...". Do NOT explain your reasoning process. '
         "Just provide the direct synthesized answer."
     )
+
+    if max_tokens is not None:
+        parts.append(
+            "\n## Length\n"
+            f"Aim for a complete, self-contained answer of approximately {max_tokens} tokens. "
+            "Finishing cleanly matters more than length: end on a complete sentence and NEVER stop "
+            "mid-word, mid-list, or mid-code-fence. If you near the budget, wrap up gracefully rather "
+            "than cutting off."
+        )
 
     return "\n".join(parts)
 

--- a/hindsight-api-slim/tests/test_reflect_agent.py
+++ b/hindsight-api-slim/tests/test_reflect_agent.py
@@ -314,7 +314,13 @@ class TestReflectAgentMocked:
         )
 
         assert result.text == "Fallback answer from final iteration"
-        assert mock_llm.call.await_args.kwargs["max_completion_tokens"] == 8
+        # The page budget is now enforced via the rewrite PROMPT, not a hard
+        # transport cap: max_completion_tokens is left uncapped (None) by default
+        # so thinking models don't truncate the rewrite mid-word (#3365), while the
+        # target still reaches the model through the prompt.
+        assert mock_llm.call.await_args.kwargs["max_completion_tokens"] is None
+        rewrite_user_msg = mock_llm.call.await_args.kwargs["messages"][1]["content"]
+        assert "Target budget: 8 tokens" in rewrite_user_msg
         assert result.usage.total_tokens == 150
         assert result.llm_trace[-1].scope == "final_rewrite"
 
@@ -746,8 +752,13 @@ class TestReflectAgentMocked:
         # Answer comes from the clean forced-final call, not the turn-1 free text.
         assert result.text == "Synthesized final answer."
         assert mock_llm.call.await_count == 1
-        # The forced-final synthesis respects the token cap directly on the call.
-        assert mock_llm.call.await_args.kwargs["max_completion_tokens"] == cap
+        # The forced-final synthesis no longer hard-caps the transport at the page
+        # budget (that truncates thinking models mid-word, #3365): the call is
+        # uncapped by default and the page length reaches the model as a prompt
+        # directive instead.
+        assert mock_llm.call.await_args.kwargs["max_completion_tokens"] is None
+        final_prompt = mock_llm.call.await_args.kwargs["messages"][1]["content"]
+        assert f"approximately {cap} tokens" in final_prompt
 
     @pytest.mark.asyncio
     async def test_max_iterations_reached(self, mock_llm, mock_functions):

--- a/hindsight-api-slim/tests/test_reflect_page_length_decoupling.py
+++ b/hindsight-api-slim/tests/test_reflect_page_length_decoupling.py
@@ -1,0 +1,172 @@
+"""Reflect/mental-model ``max_tokens`` is a page-length target, not a transport cap (#3365).
+
+On thinking models the provider's output budget is consumed by reasoning tokens,
+so passing the page ``max_tokens`` straight through as ``max_completion_tokens``
+truncates the visible answer mid-word. These tests pin the decoupled contract:
+
+- ``build_final_prompt`` communicates the length as a prompt directive.
+- ``reflect_max_completion_tokens`` config is uncapped (None) by default and
+  overridable via env.
+- The forced synthesis passes the *config* cap (None by default), never the page
+  budget.
+- ``GeminiLLM`` logs a warning instead of silently returning MAX_TOKENS-truncated
+  text.
+"""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from hindsight_api.config import HindsightConfig, clear_config_cache
+from hindsight_api.engine.reflect.agent import run_reflect_agent
+from hindsight_api.engine.reflect.prompts import build_final_prompt
+
+BANK = {"name": "TestBank", "mission": "Testing"}
+
+
+# --------------------------------------------------------------------------- #
+# Prompt directive
+# --------------------------------------------------------------------------- #
+def test_build_final_prompt_includes_length_directive():
+    prompt = build_final_prompt("q", [], BANK, max_tokens=3072)
+    assert "## Length" in prompt
+    assert "approximately 3072 tokens" in prompt
+    # The whole point: steer toward a clean stop, never a hard mid-word cut.
+    assert "NEVER stop" in prompt
+
+
+def test_build_final_prompt_omits_length_directive_when_unset():
+    prompt = build_final_prompt("q", [], BANK)
+    assert "## Length" not in prompt
+
+
+# --------------------------------------------------------------------------- #
+# Config
+# --------------------------------------------------------------------------- #
+def test_reflect_max_completion_tokens_defaults_to_none(monkeypatch):
+    monkeypatch.delenv("HINDSIGHT_API_REFLECT_MAX_COMPLETION_TOKENS", raising=False)
+    config = HindsightConfig.from_env()
+    assert config.reflect_max_completion_tokens is None
+
+
+def test_reflect_max_completion_tokens_env_override(monkeypatch):
+    monkeypatch.setenv("HINDSIGHT_API_REFLECT_MAX_COMPLETION_TOKENS", "16000")
+    config = HindsightConfig.from_env()
+    assert config.reflect_max_completion_tokens == 16000
+
+
+# --------------------------------------------------------------------------- #
+# Forced synthesis honors the config cap, not the page budget
+# --------------------------------------------------------------------------- #
+def _mock_llm(final_answer: str = "Synthesized final answer."):
+    from hindsight_api.engine.response_models import TokenUsage
+
+    llm = MagicMock()
+    llm.provider = "gemini"
+    llm.model = "gemini-2.5-flash"
+    llm.call = AsyncMock(return_value=(final_answer, TokenUsage(input_tokens=40, output_tokens=12, total_tokens=52)))
+    return llm
+
+
+def _mock_functions():
+    return {
+        "search_mental_models_fn": AsyncMock(
+            return_value={"mental_models": [{"id": "mm-1", "name": "Prefs", "content": "Fresh.", "is_stale": False}]}
+        ),
+        "search_observations_fn": AsyncMock(return_value={"observations": []}),
+        "recall_fn": AsyncMock(return_value={"memories": []}),
+        "expand_fn": AsyncMock(return_value={"memories": []}),
+    }
+
+
+def _stop_after_evidence(llm):
+    """Turn 0 tool-calls, turn 1 stops with plain text -> forced final synthesis."""
+    from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult
+
+    llm.call_with_tools = AsyncMock(
+        side_effect=[
+            LLMToolCallResult(
+                tool_calls=[LLMToolCall(id="1", name="search_mental_models", arguments={"query": "q"})],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(tool_calls=[], content="I have enough.", finish_reason="stop"),
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_forced_synthesis_uncapped_by_default(monkeypatch):
+    monkeypatch.delenv("HINDSIGHT_API_REFLECT_MAX_COMPLETION_TOKENS", raising=False)
+    clear_config_cache()
+    try:
+        llm = _mock_llm()
+        _stop_after_evidence(llm)
+        result = await run_reflect_agent(
+            llm_config=llm,
+            bank_id="b",
+            query="q",
+            bank_profile=BANK,
+            has_mental_models=True,
+            budget="low",
+            max_tokens=64,
+            **_mock_functions(),
+        )
+        assert result.text == "Synthesized final answer."
+        # Uncapped transport; page length reached the model via the prompt.
+        assert llm.call.await_args.kwargs["max_completion_tokens"] is None
+        assert "approximately 64 tokens" in llm.call.await_args.kwargs["messages"][1]["content"]
+    finally:
+        clear_config_cache()
+
+
+@pytest.mark.asyncio
+async def test_forced_synthesis_uses_config_cap_when_set(monkeypatch):
+    monkeypatch.setenv("HINDSIGHT_API_REFLECT_MAX_COMPLETION_TOKENS", "12345")
+    clear_config_cache()
+    try:
+        llm = _mock_llm()
+        _stop_after_evidence(llm)
+        await run_reflect_agent(
+            llm_config=llm,
+            bank_id="b",
+            query="q",
+            bank_profile=BANK,
+            has_mental_models=True,
+            budget="low",
+            max_tokens=64,
+            **_mock_functions(),
+        )
+        # The transport cap is the operator-set ceiling, still independent of the
+        # page budget (64).
+        assert llm.call.await_args.kwargs["max_completion_tokens"] == 12345
+    finally:
+        clear_config_cache()
+
+
+# --------------------------------------------------------------------------- #
+# Gemini surfaces MAX_TOKENS truncation instead of a silent success
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_gemini_warns_on_max_tokens_truncation(caplog):
+    pytest.importorskip("google.genai")
+    from hindsight_api.engine.llm_wrapper import LLMConfig
+
+    with patch("google.genai.Client", return_value=MagicMock()):
+        llm = LLMConfig(provider="gemini", api_key="fake-key", base_url="", model="gemini-2.5-flash")
+
+    response = MagicMock()
+    response.text = "A page that was cut off mid-wor"
+    candidate = MagicMock()
+    candidate.finish_reason = "FinishReason.MAX_TOKENS"
+    response.candidates = [candidate]
+    response.usage_metadata = MagicMock(
+        prompt_token_count=10, candidates_token_count=20, cached_content_token_count=0, thoughts_token_count=480
+    )
+    llm._provider_impl._client.aio.models.generate_content = AsyncMock(return_value=response)
+
+    with caplog.at_level(logging.WARNING):
+        out = await llm._provider_impl.call([{"role": "user", "content": "write a page"}], max_completion_tokens=500)
+
+    assert out == "A page that was cut off mid-wor"
+    assert any("truncated at max_output_tokens" in r.message for r in caplog.records)

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -521,6 +521,7 @@ Different memory operations have different requirements. **Retain** (fact extrac
 | `HINDSIGHT_API_REFLECT_LLM_REASONING_EFFORT` | Reasoning effort for reflect operations | Falls back to `HINDSIGHT_API_LLM_REASONING_EFFORT` |
 | `HINDSIGHT_API_REFLECT_LLM_EXTRA_BODY` | Extra request-body params (JSON dict) for reflect operations | Falls back to `HINDSIGHT_API_LLM_EXTRA_BODY` |
 | `HINDSIGHT_API_REFLECT_LLM_CACHE_AFFINITY` | Prompt-cache affinity mode for reflect operations | Falls back to `HINDSIGHT_API_LLM_CACHE_AFFINITY` |
+| `HINDSIGHT_API_REFLECT_MAX_COMPLETION_TOKENS` | Transport-level output cap (`max_completion_tokens`) for reflect's final synthesis call. Unset means uncapped: the model runs to a natural stop and the reflect/mental-model `max_tokens` governs *visible* length via a prompt directive plus a post-hoc rewrite, not by truncating the provider call. On thinking models the raw provider budget is consumed by reasoning tokens, so a hard cap here would cut pages off mid-word. Set an integer only to enforce a hard cost ceiling on the synthesis call. | Unset (uncapped) |
 | `HINDSIGHT_API_CONSOLIDATION_LLM_PROVIDER` | LLM provider for observation consolidation | Falls back to `HINDSIGHT_API_LLM_PROVIDER` |
 | `HINDSIGHT_API_CONSOLIDATION_LLM_API_KEY` | API key for consolidation LLM | Falls back to `HINDSIGHT_API_LLM_API_KEY` |
 | `HINDSIGHT_API_CONSOLIDATION_LLM_MODEL` | Model for consolidation operations | Falls back to `HINDSIGHT_API_LLM_MODEL` |

--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -46,6 +46,14 @@ Recommended for reasoning models (gpt-5.x, o-series) that use tools. It also hon
 See [Configuration](./configuration#llm-provider) for setup examples.
 :::
 
+:::info Reasoning/thinking models and `max_tokens`
+On a thinking model (Gemini 2.5+/3.x, GPT-5/o-series, Grok reasoning, Claude extended thinking) the provider's output budget covers **reasoning tokens plus visible output** — the reasoning is billed against the same `max_output_tokens`/`max_completion_tokens` cap. A small cap can therefore be fully consumed by reasoning, leaving the visible answer truncated mid-word.
+
+Hindsight keeps the reflect/mental-model `max_tokens` meaning **visible page length**: it is applied as a prompt-level target plus a post-hoc rewrite, **not** as a hard cap on the provider call. Reflect's synthesis call is uncapped by default so reasoning never starves the answer. If you want a hard cost ceiling on that call, set `HINDSIGHT_API_REFLECT_MAX_COMPLETION_TOKENS` — but leave enough headroom above your page length for reasoning, or thinking models will truncate again.
+
+When a Gemini call does hit its cap, Hindsight logs a `truncated at max_output_tokens` warning instead of returning the half-written text as a silent success.
+:::
+
 :::tip AWS Bedrock
 Set `HINDSIGHT_API_LLM_PROVIDER=bedrock` to use AWS Bedrock models directly. Model names use Bedrock model IDs (e.g., `us.amazon.nova-2-lite-v1:0`). No API key is required — authentication uses AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION_NAME`) or IAM roles. For 50% cost savings on throughput, set `HINDSIGHT_API_LLM_BEDROCK_SERVICE_TIER=flex` (see [Configuration](./configuration#llm-provider)).
 

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -54,6 +54,13 @@ HINDSIGHT_API_LLM_BASE_URL=https://api.openai.com/v1
 # the same model in us-east-1 accepts response_format and needs nothing here.
 # HINDSIGHT_API_LLM_STRUCTURED_OUTPUT_FORCED_TOOL=false
 
+# Transport-level output cap for reflect's final synthesis call. Unset = uncapped:
+# the model runs to a natural stop and the reflect/mental-model max_tokens governs
+# visible length via a prompt directive + a post-hoc rewrite (not by truncating the
+# provider call, which on thinking models is eaten by reasoning tokens and cuts pages
+# off mid-word). Set an integer only to enforce a hard cost ceiling on the call.
+# HINDSIGHT_API_REFLECT_MAX_COMPLETION_TOKENS=16000
+
 # Diagnostic: on any LLM 4xx, log the exact assembled request ([LLM_4XX_DUMP]) --
 # serialized request config (message bodies stripped) + capped per-message previews.
 # For debugging otherwise-unreproducible rejected calls. Off by default.

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -521,6 +521,7 @@ Different memory operations have different requirements. **Retain** (fact extrac
 | `HINDSIGHT_API_REFLECT_LLM_REASONING_EFFORT` | Reasoning effort for reflect operations | Falls back to `HINDSIGHT_API_LLM_REASONING_EFFORT` |
 | `HINDSIGHT_API_REFLECT_LLM_EXTRA_BODY` | Extra request-body params (JSON dict) for reflect operations | Falls back to `HINDSIGHT_API_LLM_EXTRA_BODY` |
 | `HINDSIGHT_API_REFLECT_LLM_CACHE_AFFINITY` | Prompt-cache affinity mode for reflect operations | Falls back to `HINDSIGHT_API_LLM_CACHE_AFFINITY` |
+| `HINDSIGHT_API_REFLECT_MAX_COMPLETION_TOKENS` | Transport-level output cap (`max_completion_tokens`) for reflect's final synthesis call. Unset means uncapped: the model runs to a natural stop and the reflect/mental-model `max_tokens` governs *visible* length via a prompt directive plus a post-hoc rewrite, not by truncating the provider call. On thinking models the raw provider budget is consumed by reasoning tokens, so a hard cap here would cut pages off mid-word. Set an integer only to enforce a hard cost ceiling on the synthesis call. | Unset (uncapped) |
 | `HINDSIGHT_API_CONSOLIDATION_LLM_PROVIDER` | LLM provider for observation consolidation | Falls back to `HINDSIGHT_API_LLM_PROVIDER` |
 | `HINDSIGHT_API_CONSOLIDATION_LLM_API_KEY` | API key for consolidation LLM | Falls back to `HINDSIGHT_API_LLM_API_KEY` |
 | `HINDSIGHT_API_CONSOLIDATION_LLM_MODEL` | Model for consolidation operations | Falls back to `HINDSIGHT_API_LLM_MODEL` |

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -66,6 +66,13 @@ Why it exists: some reasoning models — e.g. `gpt-5.6-terra` — **reject `reas
 Recommended for reasoning models (gpt-5.x, o-series) that use tools. It also honors a custom `HINDSIGHT_API_LLM_BASE_URL`, so any OpenAI-compatible endpoint exposing `/v1/responses` (gateways, Azure-style deployments) can be used just like the Chat Completions path.
 
 See [Configuration](./configuration#llm-provider) for setup examples.
+> **ℹ️ Reasoning/thinking models and `max_tokens`**
+>
+On a thinking model (Gemini 2.5+/3.x, GPT-5/o-series, Grok reasoning, Claude extended thinking) the provider's output budget covers **reasoning tokens plus visible output** — the reasoning is billed against the same `max_output_tokens`/`max_completion_tokens` cap. A small cap can therefore be fully consumed by reasoning, leaving the visible answer truncated mid-word.
+
+Hindsight keeps the reflect/mental-model `max_tokens` meaning **visible page length**: it is applied as a prompt-level target plus a post-hoc rewrite, **not** as a hard cap on the provider call. Reflect's synthesis call is uncapped by default so reasoning never starves the answer. If you want a hard cost ceiling on that call, set `HINDSIGHT_API_REFLECT_MAX_COMPLETION_TOKENS` — but leave enough headroom above your page length for reasoning, or thinking models will truncate again.
+
+When a Gemini call does hit its cap, Hindsight logs a `truncated at max_output_tokens` warning instead of returning the half-written text as a silent success.
 > **💡 AWS Bedrock**
 >
 Set `HINDSIGHT_API_LLM_PROVIDER=bedrock` to use AWS Bedrock models directly. Model names use Bedrock model IDs (e.g., `us.amazon.nova-2-lite-v1:0`). No API key is required — authentication uses AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION_NAME`) or IAM roles. For 50% cost savings on throughput, set `HINDSIGHT_API_LLM_BEDROCK_SERVICE_TIER=flex` (see [Configuration](./configuration#llm-provider)).


### PR DESCRIPTION
## Summary

Fixes #3365. On thinking models (Gemini 2.5+/3.x, GPT-5/o-series, Grok reasoning, Claude extended thinking) the provider's output budget covers **reasoning tokens plus visible output**. Reflect passed the mental-model/reflect `max_tokens` straight through as `max_completion_tokens`, so reasoning could consume the whole budget and the page was cut off **mid-word** — and it returned as `success`, so a truncated page was indistinguishable from a healthy one.

I reproduced this live against `gemini-2.5-flash` (`google-genai` 1.53.0): at `max_output_tokens=3072` the response finished with `MAX_TOKENS`, thinking ate 1904 tokens, and the visible text ended mid-word. With the cap unset the same prompt finished with `STOP` and returned the complete page.

## Approach

`max_tokens` on a reflect/mental-model page means **visible page length**, not a raw provider budget. So decouple the two:

- **`max_tokens` → a page-length target**, communicated to the model via a prompt directive in `build_final_prompt` and enforced by the existing post-hoc rewrite (`_process_done_tool_call`). It is no longer passed as the provider `max_completion_tokens`.
- **`max_completion_tokens` → a separate transport cost cap**, new config `HINDSIGHT_API_REFLECT_MAX_COMPLETION_TOKENS`, **uncapped by default** so reasoning never starves the answer. Set an integer only for a hard cost ceiling.

This fixes the truncation for **every** provider — no model-specific "is this a thinking model" detection — and self-heals the recursive rewrite call (which also carried the hard cap). The reflect tool-calling loop was already uncapped; only the final synthesis + rewrite carried the page cap.

Also: **Gemini now logs a `truncated at max_output_tokens` warning** on a non-empty `MAX_TOKENS` response instead of returning half-written text as a silent success (the OpenAI path already raised `OutputTooLongError`; Gemini swallowed it).

## Not addressed (out of scope)

- The issue's secondary note that `max_tokens` can't be edited on an existing page (PUT→405, POST→500) is a separate API-surface gap.
- xAI/grok has the same cap-includes-reasoning shape; this change fixes the reflect path for it too via the decoupling, but its provider warning isn't added here.

## Testing

- Live repro before/after against `gemini-2.5-flash` (mid-word `MAX_TOKENS` → clean `STOP`).
- New `tests/test_reflect_page_length_decoupling.py`: prompt directive present/absent, config default (None) + env override, forced synthesis uncapped-by-default, config-cap honored when set, Gemini truncation warning.
- Updated two `test_reflect_agent.py` tests to the decoupled contract (rewrite + forced synthesis now uncapped, length reaches the model via the prompt).
- `lint.sh`, `ruff`, `ty check` all green.
