### PR TITLE
fix(retain): stop concurrent appends to one document from losing turns

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/d9c1a7b4e2f6_async_operations_serialization_key.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/d9c1a7b4e2f6_async_operations_serialization_key.py
@@ -1,0 +1,95 @@
+"""Add async_operations.serialization_key for per-document retain serialization.
+
+``update_mode="append"`` is a read-modify-write over the whole document: the
+retain reads ``documents.original_text``, concatenates the new content onto it,
+and reprocesses the result. Two appends to one document whose read→write
+windows overlap therefore lose an update — the loser's turn is content nobody
+else has.
+
+The orchestrator now detects that at write time and fails the loser instead of
+committing over it, but detection alone turns lost data into wasted extraction.
+This column lets the worker's claim query keep a document to one in-flight
+retain at a time, so the conflict is avoided rather than paid for: a second
+retain for the same document simply is not claimed until the first finishes,
+and the waiting operation holds no worker slot while it waits.
+
+It carries the single document an operation targets (NULL when it targets none
+or several), so the claim predicate can compare it without digging into
+``task_payload`` — a shape both dialects index cheaply and which the Oracle
+rewrite of the claim SQL can handle.
+
+The partial index covers only live rows: claims never look at terminal
+operations, and retain queues are dominated by completed history.
+
+Revision ID: d9c1a7b4e2f6
+Revises: b3e8d1c6f4a9
+Create Date: 2026-08-11
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import context, op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "d9c1a7b4e2f6"
+down_revision: str | Sequence[str] | None = "b3e8d1c6f4a9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_INDEX = "idx_async_operations_serialization_key"
+
+
+def _pg_schema_prefix() -> str:
+    """Schema-qualifier for raw SQL on PG (multi-tenant search_path)."""
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def _pg_upgrade() -> None:
+    schema = context.config.get_main_option("target_schema")
+    op.add_column(
+        "async_operations",
+        sa.Column("serialization_key", sa.Text(), nullable=True),
+        schema=schema or None,
+    )
+    prefix = _pg_schema_prefix()
+    op.execute(
+        f"CREATE INDEX IF NOT EXISTS {_INDEX} ON {prefix}async_operations "
+        f"(bank_id, serialization_key) "
+        f"WHERE serialization_key IS NOT NULL AND status IN ('pending', 'processing')"
+    )
+
+
+def _pg_downgrade() -> None:
+    schema = context.config.get_main_option("target_schema")
+    prefix = _pg_schema_prefix()
+    op.execute(f"DROP INDEX IF EXISTS {prefix}{_INDEX}")
+    op.drop_column("async_operations", "serialization_key", schema=schema or None)
+
+
+def _oracle_upgrade() -> None:
+    op.add_column("async_operations", sa.Column("serialization_key", sa.String(4000), nullable=True))
+    # Oracle has no partial indexes. A function-based index on the same
+    # predicate gets the equivalent selectivity: terminal rows collapse to NULL
+    # and Oracle does not store all-NULL entries, so the index only holds the
+    # live rows the claim query looks at.
+    op.get_bind().exec_driver_sql(
+        f"CREATE INDEX {_INDEX} ON async_operations ("
+        f"  CASE WHEN status IN ('pending', 'processing') THEN bank_id END,"
+        f"  CASE WHEN status IN ('pending', 'processing') THEN serialization_key END)"
+    )
+
+
+def _oracle_downgrade() -> None:
+    op.get_bind().exec_driver_sql(f"DROP INDEX {_INDEX}")
+    op.drop_column("async_operations", "serialization_key")
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade, oracle=_oracle_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade, oracle=_oracle_downgrade)

--- a/hindsight-api-slim/hindsight_api/engine/db/ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops.py
@@ -25,6 +25,59 @@ from .base import DatabaseConnection
 from .result import ResultRow
 
 
+def document_serialization_sql(table: str, alias: str) -> str:
+    """SQL predicate keeping one document to a single in-flight retain.
+
+    A retain that targets exactly one document carries it in
+    ``serialization_key``. Appending to a document is a read-modify-write over
+    its whole text, so two concurrent retains for one document can only produce
+    a lost update or a wasted extraction — never more throughput. This
+    predicate makes the queue reflect that: a candidate is claimable only when
+    no peer for the same document is already ``processing``, and only when it
+    is the oldest claimable pending peer for that document.
+
+    Ordering, not just exclusion, is the point. Appends are cumulative, so the
+    order they commit in is the order the document ends up in; claiming them by
+    ``(created_at, operation_id)`` makes that the submission order. It also
+    stops a single claim batch from taking several peers at once, which
+    excluding busy documents alone would not prevent.
+
+    Rows with a NULL ``serialization_key`` — multi-document batches, and every
+    non-retain operation — are unaffected, and documents are independent of one
+    another, so this costs no parallelism across a busy bank: only the retains
+    that were racing each other for one document are put in a line.
+
+    A peer wedged in 'processing' holds its document until claim recovery
+    releases it, the same caveat ``graph_maintenance_bank_serialization_sql``
+    carries and the same general gap.
+
+    The candidate row is always 'pending' and the 'pending' branch is
+    strictly-older, so the subquery can never match the candidate itself. The
+    fragment carries no SQL comments on purpose — it is rewritten for Oracle by
+    regex (``db/oracle.py``).
+
+    Args:
+        table: Fully-qualified async_operations table.
+        alias: Alias of the outer candidate row in the calling query.
+    """
+    return f"""
+        ({alias}.serialization_key IS NULL OR NOT EXISTS (
+            SELECT 1 FROM {table} doc_peer
+            WHERE doc_peer.bank_id = {alias}.bank_id
+              AND doc_peer.serialization_key = {alias}.serialization_key
+              AND (
+                  doc_peer.status = 'processing'
+                  OR (doc_peer.status = 'pending'
+                      AND doc_peer.task_payload IS NOT NULL
+                      AND (doc_peer.next_retry_at IS NULL OR doc_peer.next_retry_at <= NOW())
+                      AND (doc_peer.created_at < {alias}.created_at
+                           OR (doc_peer.created_at = {alias}.created_at
+                               AND doc_peer.operation_id < {alias}.operation_id)))
+              )
+        ))
+    """
+
+
 def graph_maintenance_bank_serialization_sql(table: str, alias: str) -> str:
     """SQL predicate serialising ``graph_maintenance`` claims per bank (#3230).
 
@@ -665,7 +718,9 @@ class DataAccessOps(ABC):
 
         Implementations must apply :func:`graph_maintenance_bank_serialization_sql`
         to every query that can return a ``graph_maintenance`` row, so at most one
-        such row per bank is ever in flight.
+        such row per bank is ever in flight, and :func:`document_serialization_sql`
+        to every query that can return a ``retain`` row, so at most one retain per
+        document is ever in flight.
 
         Args:
             consolidation_bank_priority: Per-bank priority for consolidation scheduling.
@@ -675,8 +730,48 @@ class DataAccessOps(ABC):
                 When set, consolidation tasks are claimed in priority tiers.
                 None preserves current behavior (pure created_at ordering).
 
-        Returns claimed rows with operation_id, operation_type, task_payload, retry_count.
-        The caller is responsible for building ClaimedTask objects.
+        Returns claimed rows with operation_id, operation_type, task_payload,
+        retry_count, bank_id and serialization_key. The caller is responsible for
+        building ClaimedTask objects.
+        """
+        ...
+
+    @abstractmethod
+    async def fetch_foldable_retain_peers(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        bank_id: str,
+        serialization_key: str,
+        limit: int,
+    ) -> list[ResultRow]:
+        """Lock the pending retains queued behind a just-claimed one, in order.
+
+        Called inside the claim transaction, so the rows come back locked and
+        the caller can fold some of them into the claimed execution and leave
+        the rest pending simply by not marking them (their locks release with
+        the transaction).
+
+        ``SKIP LOCKED`` matters here for liveness, not just speed: a peer some
+        other worker is already looking at must never stall this claim.
+
+        Returns rows with operation_id, task_payload and retry_count, ordered by
+        ``(created_at, operation_id)`` — the order the fold planner requires.
+        """
+        ...
+
+    @abstractmethod
+    async def mark_operations_processing(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        worker_id: str,
+        operation_ids: list,
+    ) -> None:
+        """Claim the given pending operations for ``worker_id``.
+
+        Used to fold peers into an execution that has already been claimed;
+        runs in the same transaction that locked them.
         """
         ...
 

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -15,6 +15,7 @@ from .ops import (
     LinkExpansionRows,
     TagListingParts,
     UpdatedWindow,
+    document_serialization_sql,
     graph_maintenance_bank_serialization_sql,
 )
 from .result import DictResultRow as ResultRow
@@ -1144,7 +1145,7 @@ class OracleOps(DataAccessOps):
             if exclude_ids:
                 return await conn.fetch(
                     f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count
+                    SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
                     FROM {table}
                     WHERE status = 'pending'
                       AND task_payload IS NOT NULL
@@ -1163,7 +1164,7 @@ class OracleOps(DataAccessOps):
             else:
                 return await conn.fetch(
                     f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count
+                    SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
                     FROM {table}
                     WHERE status = 'pending'
                       AND task_payload IS NOT NULL
@@ -1181,7 +1182,7 @@ class OracleOps(DataAccessOps):
             if exclude_ids:
                 return await conn.fetch(
                     f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count
+                    SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
                     FROM {table}
                     WHERE status = 'pending'
                       AND task_payload IS NOT NULL
@@ -1198,7 +1199,7 @@ class OracleOps(DataAccessOps):
             else:
                 return await conn.fetch(
                     f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count
+                    SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
                     FROM {table}
                     WHERE status = 'pending'
                       AND task_payload IS NOT NULL
@@ -1239,7 +1240,7 @@ class OracleOps(DataAccessOps):
         extra = " AND ".join(conditions)
         return await conn.fetch(
             f"""
-            SELECT operation_id, operation_type, task_payload, retry_count
+            SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
             FROM {table}
             WHERE status = 'pending'
               AND task_payload IS NOT NULL
@@ -1286,7 +1287,7 @@ class OracleOps(DataAccessOps):
         extra_clause = (" AND " + " AND ".join(conditions)) if conditions else ""
         return await conn.fetch(
             f"""
-            SELECT operation_id, operation_type, task_payload, retry_count
+            SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
             FROM {table}
             WHERE status = 'pending'
               AND task_payload IS NOT NULL
@@ -1338,13 +1339,14 @@ class OracleOps(DataAccessOps):
             else:
                 rows = await conn.fetch(
                     f"""
-                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count
+                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
                     FROM {table} o
                     WHERE o.status = 'pending'
                       AND o.task_payload IS NOT NULL
                       AND o.operation_type = $1
                       AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
                       AND {graph_maintenance_bank_serialization_sql(table, "o")}
+                      AND {document_serialization_sql(table, "o")}
                     ORDER BY o.created_at
                     LIMIT $2
                     FOR UPDATE SKIP LOCKED
@@ -1366,7 +1368,7 @@ class OracleOps(DataAccessOps):
             if claimed_ids:
                 rows = await conn.fetch(
                     f"""
-                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count
+                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
                     FROM {table} o
                     WHERE o.status = 'pending'
                       AND o.task_payload IS NOT NULL
@@ -1374,6 +1376,7 @@ class OracleOps(DataAccessOps):
                       AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
                       AND o.operation_id != ALL($1::uuid[])
                       AND {graph_maintenance_bank_serialization_sql(table, "o")}
+                      AND {document_serialization_sql(table, "o")}
                     ORDER BY o.created_at
                     LIMIT $2
                     FOR UPDATE SKIP LOCKED
@@ -1384,13 +1387,14 @@ class OracleOps(DataAccessOps):
             else:
                 rows = await conn.fetch(
                     f"""
-                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count
+                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
                     FROM {table} o
                     WHERE o.status = 'pending'
                       AND o.task_payload IS NOT NULL
                       AND o.operation_type != 'consolidation'
                       AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
                       AND {graph_maintenance_bank_serialization_sql(table, "o")}
+                      AND {document_serialization_sql(table, "o")}
                     ORDER BY o.created_at
                     LIMIT $1
                     FOR UPDATE SKIP LOCKED
@@ -1431,6 +1435,19 @@ class OracleOps(DataAccessOps):
 
         # Mark all claimed rows as processing
         operation_ids = [row["operation_id"] for row in all_rows]
+        await self.mark_operations_processing(conn, table, worker_id, operation_ids)
+
+        return all_rows
+
+    async def mark_operations_processing(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        worker_id: str,
+        operation_ids: list,
+    ) -> None:
+        if not operation_ids:
+            return
         await conn.execute(
             f"""
             UPDATE {table}
@@ -1441,4 +1458,34 @@ class OracleOps(DataAccessOps):
             operation_ids,
         )
 
-        return all_rows
+    async def fetch_foldable_retain_peers(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        bank_id: str,
+        serialization_key: str,
+        limit: int,
+    ) -> list[ResultRow]:
+        if limit <= 0:
+            return []
+        # Same ``LIMIT $n ... FOR UPDATE SKIP LOCKED`` shape the claim queries
+        # above use, which the Oracle SQL translation layer rewrites into the
+        # row-limited form Oracle accepts (a bare one raises ORA-02014).
+        return await conn.fetch(
+            f"""
+            SELECT operation_id, task_payload, retry_count
+            FROM {table}
+            WHERE status = 'pending'
+              AND task_payload IS NOT NULL
+              AND operation_type = 'retain'
+              AND bank_id = $1
+              AND serialization_key = $2
+              AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+            ORDER BY created_at, operation_id
+            LIMIT $3
+            FOR UPDATE SKIP LOCKED
+            """,
+            bank_id,
+            serialization_key,
+            limit,
+        )

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -13,6 +13,7 @@ from .ops import (
     LinkExpansionRows,
     TagListingParts,
     UpdatedWindow,
+    document_serialization_sql,
     graph_maintenance_bank_serialization_sql,
 )
 from .result import ResultRow
@@ -1234,7 +1235,7 @@ class PostgreSQLOps(DataAccessOps):
             if exclude_ids:
                 return await conn.fetch(
                     f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count
+                    SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
                     FROM {table}
                     WHERE status = 'pending'
                       AND task_payload IS NOT NULL
@@ -1253,7 +1254,7 @@ class PostgreSQLOps(DataAccessOps):
             else:
                 return await conn.fetch(
                     f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count
+                    SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
                     FROM {table}
                     WHERE status = 'pending'
                       AND task_payload IS NOT NULL
@@ -1271,7 +1272,7 @@ class PostgreSQLOps(DataAccessOps):
             if exclude_ids:
                 return await conn.fetch(
                     f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count
+                    SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
                     FROM {table}
                     WHERE status = 'pending'
                       AND task_payload IS NOT NULL
@@ -1288,7 +1289,7 @@ class PostgreSQLOps(DataAccessOps):
             else:
                 return await conn.fetch(
                     f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count
+                    SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
                     FROM {table}
                     WHERE status = 'pending'
                       AND task_payload IS NOT NULL
@@ -1329,7 +1330,7 @@ class PostgreSQLOps(DataAccessOps):
         extra = " AND ".join(conditions)
         return await conn.fetch(
             f"""
-            SELECT operation_id, operation_type, task_payload, retry_count
+            SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
             FROM {table}
             WHERE status = 'pending'
               AND task_payload IS NOT NULL
@@ -1376,7 +1377,7 @@ class PostgreSQLOps(DataAccessOps):
         extra_clause = (" AND " + " AND ".join(conditions)) if conditions else ""
         return await conn.fetch(
             f"""
-            SELECT operation_id, operation_type, task_payload, retry_count
+            SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
             FROM {table}
             WHERE status = 'pending'
               AND task_payload IS NOT NULL
@@ -1427,13 +1428,14 @@ class PostgreSQLOps(DataAccessOps):
             else:
                 rows = await conn.fetch(
                     f"""
-                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count
+                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
                     FROM {table} o
                     WHERE o.status = 'pending'
                       AND o.task_payload IS NOT NULL
                       AND o.operation_type = $1
                       AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
                       AND {graph_maintenance_bank_serialization_sql(table, "o")}
+                      AND {document_serialization_sql(table, "o")}
                     ORDER BY o.created_at
                     LIMIT $2
                     FOR UPDATE SKIP LOCKED
@@ -1455,7 +1457,7 @@ class PostgreSQLOps(DataAccessOps):
             if claimed_ids:
                 rows = await conn.fetch(
                     f"""
-                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count
+                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
                     FROM {table} o
                     WHERE o.status = 'pending'
                       AND o.task_payload IS NOT NULL
@@ -1463,6 +1465,7 @@ class PostgreSQLOps(DataAccessOps):
                       AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
                       AND o.operation_id != ALL($1::uuid[])
                       AND {graph_maintenance_bank_serialization_sql(table, "o")}
+                      AND {document_serialization_sql(table, "o")}
                     ORDER BY o.created_at
                     LIMIT $2
                     FOR UPDATE SKIP LOCKED
@@ -1473,13 +1476,14 @@ class PostgreSQLOps(DataAccessOps):
             else:
                 rows = await conn.fetch(
                     f"""
-                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count
+                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
                     FROM {table} o
                     WHERE o.status = 'pending'
                       AND o.task_payload IS NOT NULL
                       AND o.operation_type != 'consolidation'
                       AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
                       AND {graph_maintenance_bank_serialization_sql(table, "o")}
+                      AND {document_serialization_sql(table, "o")}
                     ORDER BY o.created_at
                     LIMIT $1
                     FOR UPDATE SKIP LOCKED
@@ -1520,6 +1524,19 @@ class PostgreSQLOps(DataAccessOps):
 
         # Mark all claimed rows as processing
         operation_ids = [row["operation_id"] for row in all_rows]
+        await self.mark_operations_processing(conn, table, worker_id, operation_ids)
+
+        return all_rows
+
+    async def mark_operations_processing(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        worker_id: str,
+        operation_ids: list,
+    ) -> None:
+        if not operation_ids:
+            return
         await conn.execute(
             f"""
             UPDATE {table}
@@ -1530,4 +1547,31 @@ class PostgreSQLOps(DataAccessOps):
             operation_ids,
         )
 
-        return all_rows
+    async def fetch_foldable_retain_peers(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        bank_id: str,
+        serialization_key: str,
+        limit: int,
+    ) -> list[ResultRow]:
+        if limit <= 0:
+            return []
+        return await conn.fetch(
+            f"""
+            SELECT operation_id, task_payload, retry_count
+            FROM {table}
+            WHERE status = 'pending'
+              AND task_payload IS NOT NULL
+              AND operation_type = 'retain'
+              AND bank_id = $1
+              AND serialization_key = $2
+              AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+            ORDER BY created_at, operation_id
+            LIMIT $3
+            FOR UPDATE SKIP LOCKED
+            """,
+            bank_id,
+            serialization_key,
+            limit,
+        )

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -17,6 +17,7 @@ import functools
 import inspect
 import json
 import logging
+import random
 import sys
 import time
 import uuid
@@ -450,6 +451,7 @@ from .response_models import (
 )
 from .response_models import RecallResult as RecallResultModel
 from .retain import bank_utils, embedding_utils
+from .retain.fold import FoldMemberRef
 from .retain.types import RetainContentDict
 from .search.reranking import CrossEncoderReranker, apply_combined_scoring
 from .search.tags import TagGroup, TagsMatch, build_tag_groups_where_clause, build_tags_where_clause
@@ -2188,6 +2190,9 @@ class MemoryEngine(MemoryEngineInterface):
             request_context=context,
             operation_id=operation_id,
             strategy=strategy,
+            # Present when the claim folded other queued retains for this
+            # document into this task; drives one post-retain hook per member.
+            fold_members=FoldMemberRef.list_from_payload(task_dict.get("_fold_members")),
             outbox_callback_factory=self._build_retain_outbox_callback_factory(
                 bank_id=bank_id,
                 operation_id=operation_id,
@@ -2355,8 +2360,9 @@ class MemoryEngine(MemoryEngineInterface):
                 await conn.execute(
                     f"""
                     INSERT INTO {fq_table("async_operations")}
-                    (operation_id, bank_id, operation_type, result_metadata, status, task_payload)
-                    VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+                    (operation_id, bank_id, operation_type, result_metadata, status,
+                     task_payload, serialization_key)
+                    VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7)
                     """,
                     retain_operation_id,
                     bank_id,
@@ -2364,6 +2370,9 @@ class MemoryEngine(MemoryEngineInterface):
                     json.dumps({}),
                     "pending",
                     payload_json,
+                    # A converted file always retains into exactly one document,
+                    # so it queues behind any other retain for that document.
+                    document_id,
                 )
 
                 if operation_id:
@@ -4205,6 +4214,7 @@ class MemoryEngine(MemoryEngineInterface):
         outbox_callback: RetainOutboxCallback | None = None,
         outbox_callback_factory: RetainOutboxCallbackFactory | None = None,
         strategy: str | None = None,
+        fold_members: list[FoldMemberRef] | None = None,
     ):
         """
         Store multiple content items as memory units in ONE batch operation.
@@ -4226,6 +4236,11 @@ class MemoryEngine(MemoryEngineInterface):
                         Applies the same document_id to ALL content items that don't specify their own.
             fact_type_override: Override fact type for all facts ('world', 'experience')
             return_usage: If True, returns tuple of (unit_ids, TokenUsage). Default False for backward compatibility.
+            fold_members: Set by the worker when several queued retains for one
+                document were coalesced into this call (see ``engine.retain.fold``).
+                One entry per submitted operation, in submission order, with its
+                ``operation_id`` and the number of ``contents`` items it supplied —
+                the slices that let the post-retain hook fire once per operation.
 
         Returns:
             If return_usage=False: List of lists of unit IDs (one list per content item)
@@ -4438,28 +4453,21 @@ class MemoryEngine(MemoryEngineInterface):
 
         # Call post-operation hook if validator is configured
         if self._operation_validator:
-            from hindsight_api.extensions import RetainResult
-
-            result_ctx = RetainResult(
+            for result_ctx in self._build_retain_hook_results(
                 bank_id=bank_id,
-                contents=contents_copy,
+                contents_copy=contents_copy,
                 request_context=request_context,
                 document_id=document_id,
                 fact_type_override=fact_type_override,
                 unit_ids=result,
-                success=True,
-                error=None,
-                llm_input_tokens=total_usage.input_tokens,
-                llm_output_tokens=total_usage.output_tokens,
-                llm_total_tokens=total_usage.total_tokens,
-                llm_cached_input_tokens=getattr(total_usage, "cached_tokens", 0) or 0,
-                llm_thoughts_tokens=getattr(total_usage, "thoughts_tokens", 0) or 0,
-                processed_content_tokens=total_processed_content_tokens,
-            )
-            try:
-                await self._operation_validator.on_retain_complete(result_ctx)
-            except Exception as e:
-                logger.warning(f"Post-retain hook error (non-fatal): {e}")
+                total_usage=total_usage,
+                total_processed_content_tokens=total_processed_content_tokens,
+                fold_members=fold_members,
+            ):
+                try:
+                    await self._operation_validator.on_retain_complete(result_ctx)
+                except Exception as e:
+                    logger.warning(f"Post-retain hook error (non-fatal): {e}")
 
         # Same async side effects every fact insert triggers (retain or import).
         await self._submit_post_insert_maintenance(bank_id, request_context)
@@ -4467,6 +4475,82 @@ class MemoryEngine(MemoryEngineInterface):
         if return_usage:
             return result, total_usage
         return result
+
+    def _build_retain_hook_results(
+        self,
+        *,
+        bank_id: str,
+        contents_copy: list[dict],
+        request_context: "RequestContext",
+        document_id: str | None,
+        fact_type_override: str | None,
+        unit_ids: list[list[str]],
+        total_usage: "TokenUsage",
+        total_processed_content_tokens: int | None,
+        fold_members: list[FoldMemberRef] | None,
+    ) -> list["RetainResult"]:
+        """Build the post-retain hook payload(s) for one execution.
+
+        An ordinary retain produces exactly one result, unchanged.
+
+        A folded execution ran several submitted operations as one document, so
+        it produces one result per member, in submission order, each carrying
+        that member's own content slice and the ids it was folded with. The
+        execution's token usage lands entirely on the first member and is zero
+        on the rest: the members were extracted together and there is no honest
+        per-member split, but the total across the fold is exactly what the
+        execution spent — the invariant metering extensions depend on.
+        """
+        from hindsight_api.extensions import RetainResult
+
+        cached = getattr(total_usage, "cached_tokens", 0) or 0
+        thoughts = getattr(total_usage, "thoughts_tokens", 0) or 0
+
+        def _result(
+            contents: list[dict],
+            *,
+            units: list[list[str]],
+            carries_usage: bool,
+            folded_with: list[str] | None,
+        ) -> RetainResult:
+            return RetainResult(
+                bank_id=bank_id,
+                contents=contents,
+                request_context=request_context,
+                document_id=document_id,
+                fact_type_override=fact_type_override,
+                unit_ids=units,
+                success=True,
+                error=None,
+                llm_input_tokens=total_usage.input_tokens if carries_usage else 0,
+                llm_output_tokens=total_usage.output_tokens if carries_usage else 0,
+                llm_total_tokens=total_usage.total_tokens if carries_usage else 0,
+                llm_cached_input_tokens=cached if carries_usage else 0,
+                llm_thoughts_tokens=thoughts if carries_usage else 0,
+                processed_content_tokens=total_processed_content_tokens if carries_usage else 0,
+                folded_with=folded_with,
+            )
+
+        if not fold_members or len(fold_members) < 2:
+            return [_result(contents_copy, units=unit_ids, carries_usage=True, folded_with=None)]
+
+        member_ids = [member.operation_id for member in fold_members]
+        results: list[RetainResult] = []
+        offset = 0
+        for position, member in enumerate(fold_members):
+            count = member.items_count
+            # unit_ids is one entry per submitted content item, in the same
+            # order the fold merged them, so each member's slice lines up.
+            results.append(
+                _result(
+                    contents_copy[offset : offset + count],
+                    units=unit_ids[offset : offset + count],
+                    carries_usage=position == 0,
+                    folded_with=[op_id for op_id in member_ids if op_id != member_ids[position]],
+                )
+            )
+            offset += count
+        return results
 
     async def _submit_post_insert_maintenance(
         self,
@@ -4804,9 +4888,6 @@ class MemoryEngine(MemoryEngineInterface):
             See ``RetainResult.processed_content_tokens`` for the semantics of
             the third element.
         """
-        # Use the new modular orchestrator
-        from .retain import orchestrator
-
         await self._get_backend()
 
         # Resolve bank-specific config for this operation
@@ -4827,7 +4908,7 @@ class MemoryEngine(MemoryEngineInterface):
         # Create parent span for retain operation
         with create_operation_span("retain", bank_id):
             retain_llm = self._retain_llm_config.with_config(resolved_config, bank_id=bank_id, operation="retain")
-            result = await orchestrator.retain_batch(
+            result = await self._retain_batch_with_append_retry(
                 pool=self._backend,
                 embeddings_model=self.embeddings,
                 llm_config=retain_llm,
@@ -4862,6 +4943,63 @@ class MemoryEngine(MemoryEngineInterface):
             # never adds latency to the retain response.
             self._llm_recorder.attach_memory_ids(trace_context_of(retain_llm), created=created_ids)
             return result
+
+    # How many times an append re-reads the document and redoes itself after
+    # losing the race to a concurrent append. Contention this deep means the
+    # queue-level serialization is not doing its job (or the caller is racing
+    # itself on the sync path); failing then is better than looping, because
+    # the operation-level retry re-runs the whole submission anyway.
+    _APPEND_CONFLICT_ATTEMPTS = 3
+
+    async def _retain_batch_with_append_retry(self, **kwargs) -> tuple[list[list[str]], "TokenUsage", int | None]:
+        """Run ``orchestrator.retain_batch``, redoing an append that lost its race.
+
+        ``update_mode="append"`` reads the stored document, concatenates onto it
+        and reprocesses; the orchestrator raises ``ConcurrentAppendConflict``
+        rather than committing when that base moved underneath it. Redoing the
+        call re-reads the newer text and re-appends the same submission on top,
+        so no turn is lost. Delta retain makes the redo cheap: every chunk of
+        the prior document still matches by content hash, leaving only this
+        submission's own new chunks to extract.
+
+        Non-append retains never raise it, so they run exactly once.
+        """
+        from .retain import orchestrator
+        from .retain.types import ConcurrentAppendConflict
+
+        submitted: list[RetainContentDict] = kwargs["contents_dicts"]
+        is_append = any(item.get("update_mode") == "append" for item in submitted)
+        if not is_append:
+            # Only appends can raise the conflict, so replace-mode retains skip
+            # both the retry bookkeeping and the snapshot copy below.
+            return await orchestrator.retain_batch(**kwargs)
+
+        # retain_batch consumes its input: it releases the (potentially
+        # multi-MB) content strings as they are chunked so the pipeline doesn't
+        # pin them. A retry therefore has to start from a pristine copy, not
+        # from the drained list the failed attempt left behind. The copy is of
+        # the caller's submission only — the stored document text an append
+        # concatenates onto is read inside retain_batch and never copied here.
+        pristine = copy.deepcopy(submitted)
+        doc_label = next((item.get("document_id") for item in submitted if item.get("document_id")), None)
+
+        for attempt in range(1, self._APPEND_CONFLICT_ATTEMPTS + 1):
+            try:
+                return await orchestrator.retain_batch(**kwargs)
+            except ConcurrentAppendConflict:
+                if attempt == self._APPEND_CONFLICT_ATTEMPTS:
+                    logger.warning(
+                        f"Append to document {doc_label} lost its race "
+                        f"{attempt} times; failing so the operation is retried"
+                    )
+                    raise
+                # Jittered so simultaneous losers don't line up and collide again.
+                await asyncio.sleep(random.uniform(0.05, 0.25) * attempt)
+                logger.info(
+                    f"Append to document {doc_label} lost its race (attempt {attempt}) — redoing on the newer document"
+                )
+                kwargs["contents_dicts"] = copy.deepcopy(pristine)
+        raise AssertionError("unreachable: append retry loop always returns or raises")
 
     async def export_documents_async(
         self,
@@ -16087,8 +16225,10 @@ class MemoryEngine(MemoryEngineInterface):
 
                         await conn.execute(
                             f"""
-                            INSERT INTO {fq_table("async_operations")} (operation_id, bank_id, operation_type, result_metadata, status, task_payload)
-                            VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+                            INSERT INTO {fq_table("async_operations")}
+                                (operation_id, bank_id, operation_type, result_metadata, status,
+                                 task_payload, serialization_key)
+                            VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7)
                             """,
                             child_operation_id,
                             bank_id,
@@ -16096,6 +16236,11 @@ class MemoryEngine(MemoryEngineInterface):
                             json.dumps(child_metadata.to_dict(), default=_json_default),
                             "pending",
                             json.dumps(full_payload, default=_json_default),
+                            # Serialize (and coalesce) this child against other
+                            # retains for the same document. Only a child that
+                            # targets exactly one document has a document to be
+                            # serialized on; NULL leaves it claimable freely.
+                            child_metadata.document_id,
                         )
                         deferred_child_payloads.append(full_payload)
         except Exception as e:

--- a/hindsight-api-slim/hindsight_api/engine/retain/fold.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fold.py
@@ -1,0 +1,182 @@
+"""Coalescing several queued retains for one document into a single execution.
+
+Appends to one document are serialized by the claim predicate
+(``document_serialization_sql``), which is what makes them correct — but on its
+own it also makes them slow: a client that buffers 50 turns offline and flushes
+them would run 50 sequential retains, each re-reading and reprocessing the
+document. Folding collapses that burst into one execution over the concatenated
+turns.
+
+The folding happens at **claim** time, over rows the claim transaction already
+holds ``FOR UPDATE``, and it never rewrites an operation's ``task_payload``.
+That is the whole reason this is tractable:
+
+* Rows are immutable after insert, so there is no submit-vs-claim race to
+  reason about — the alternative (merging new content into a pending row at
+  submit time) races the worker reading that row and reintroduces exactly the
+  lost-update bug this is meant to fix.
+* Operation identity survives. Each submission keeps its own ``operation_id``,
+  status, and post-retain hook, so nothing downstream of the queue — polling,
+  webhooks, cancellation, metering — has to learn about folding.
+
+Because of that, folding is a pure optimization: delete it and the system is
+still correct, only slower. A bug here can cost latency or LLM spend; it cannot
+lose a turn, because ``ConcurrentAppendConflict`` and the claim predicate carry
+correctness independently.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Peers folded into one execution on a first attempt. Bounded so a document
+# that has accumulated a long backlog still commits in reasonable steps rather
+# than one enormous transaction; the remainder is claimed on the next cycle.
+DEFAULT_MAX_FOLD_PEERS = 16
+
+
+@dataclass
+class FoldMember:
+    """One submitted operation participating in a folded execution."""
+
+    operation_id: str
+    contents: list[dict[str, Any]]
+    tenant_id: str | None = None
+    api_key_id: str | None = None
+
+
+@dataclass
+class FoldMemberRef:
+    """A fold member as it survives the trip through the task payload.
+
+    The fold is decided at claim time and consumed by the engine, with the task
+    payload (JSON) in between — so this is the boundary type: the payload
+    carries plain dicts and they are parsed back into this the moment the engine
+    reads them, rather than being passed around as loose dicts.
+
+    Only what the engine needs downstream: which operation, and how many content
+    items it contributed, which is what slices the execution's results back
+    apart for the per-operation post-retain hooks.
+    """
+
+    operation_id: str
+    items_count: int
+
+    def to_payload(self) -> dict[str, Any]:
+        return {"operation_id": self.operation_id, "items_count": self.items_count}
+
+    @classmethod
+    def from_payload(cls, raw: dict[str, Any]) -> "FoldMemberRef":
+        return cls(operation_id=str(raw["operation_id"]), items_count=int(raw["items_count"]))
+
+    @classmethod
+    def list_from_payload(cls, raw: list[dict[str, Any]] | None) -> list["FoldMemberRef"] | None:
+        return None if raw is None else [cls.from_payload(item) for item in raw]
+
+
+@dataclass
+class FoldPlan:
+    """Which queued peers join this execution, and which stay pending."""
+
+    members: list[FoldMember] = field(default_factory=list)
+    """The primary operation first, then the peers folded into it, in submission order."""
+
+    deferred: list[str] = field(default_factory=list)
+    """Operation ids left pending for a later claim, with the reason logged."""
+
+    @property
+    def peer_ids(self) -> list[str]:
+        """Ids of the folded peers — everything but the primary."""
+        return [m.operation_id for m in self.members[1:]]
+
+
+def max_fold_peers_for_retry(retry_count: int, base: int = DEFAULT_MAX_FOLD_PEERS) -> int:
+    """Fold width for an operation on its ``retry_count``-th attempt.
+
+    A folded execution is all-or-nothing: one poisonous turn (content that makes
+    extraction fail every time) would otherwise take every turn folded with it
+    down on every retry, and those turns would be re-folded with it again on the
+    next attempt — a burst of good content held hostage by one bad item.
+
+    Halving the width per retry makes the fold converge on the poison: by the
+    time the operation has failed a few times it runs alone, fails alone, and
+    is dead-lettered alone while its neighbours proceed. Expressed as a rule
+    rather than a special case, so there is no "is this the bad one" heuristic
+    to get wrong.
+    """
+    if retry_count <= 0:
+        return base
+    return max(0, base >> retry_count)
+
+
+def plan_retain_fold(
+    primary: FoldMember,
+    peers: list[FoldMember],
+    *,
+    max_peers: int,
+    token_budget: int,
+    count_tokens,
+) -> FoldPlan:
+    """Choose the contiguous run of ``peers`` that folds into ``primary``.
+
+    ``peers`` must already be ordered by ``(created_at, operation_id)`` — the
+    order the claim query imposes and the order the document accumulates in.
+
+    Folding stops at the **first** peer that cannot join, and takes nothing
+    after it. Appends are cumulative, so skipping one and taking the next would
+    commit turns out of order; a contiguous prefix is the only shape that keeps
+    the document's text in submission order. Peers left behind stay pending and
+    are claimed on a later cycle, still in order.
+
+    A peer cannot join when:
+
+    * it would push the execution past ``token_budget``. Beyond that the engine
+      splits the work into sub-batches, and several sub-batches carrying
+      different bodies for one document defeat the streaming ownership check
+      (#3282) — so the fold stays inside a single orchestrator pass by
+      construction. The primary alone is always allowed through, however large.
+    * it belongs to a different tenant or API key. Token usage is attributed to
+      the members of a fold, so mixing credentials inside one execution would
+      bill one caller for another's extraction.
+    * ``max_peers`` is already reached.
+    """
+    plan = FoldPlan(members=[primary])
+    if max_peers <= 0:
+        plan.deferred = [p.operation_id for p in peers]
+        return plan
+
+    used = sum(count_tokens(item.get("content", "")) for item in primary.contents)
+
+    for index, peer in enumerate(peers):
+        if len(plan.members) > max_peers:
+            plan.deferred = [p.operation_id for p in peers[index:]]
+            break
+        if peer.tenant_id != primary.tenant_id or peer.api_key_id != primary.api_key_id:
+            logger.debug(
+                "Not folding %s: different tenant/api key from the primary operation",
+                peer.operation_id,
+            )
+            plan.deferred = [p.operation_id for p in peers[index:]]
+            break
+        peer_tokens = sum(count_tokens(item.get("content", "")) for item in peer.contents)
+        if used + peer_tokens > token_budget:
+            plan.deferred = [p.operation_id for p in peers[index:]]
+            break
+        used += peer_tokens
+        plan.members.append(peer)
+
+    return plan
+
+
+def merge_fold_contents(members: list[FoldMember]) -> list[dict[str, Any]]:
+    """Flatten a fold's submissions into the content list for one execution.
+
+    Order is the members' order, which is submission order — the document ends
+    up carrying the turns exactly as the callers sent them.
+    """
+    merged: list[dict[str, Any]] = []
+    for member in members:
+        merged.extend(member.contents)
+    return merged

--- a/hindsight-api-slim/hindsight_api/engine/retain/fold.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fold.py
@@ -45,6 +45,43 @@ class FoldMember:
     contents: list[dict[str, Any]]
     tenant_id: str | None = None
     api_key_id: str | None = None
+    document_tags: list[str] | None = None
+    strategy: str | None = None
+    has_file_metadata: bool = False
+    """Whether the submission carries ``_file_metadata`` (a converted upload)."""
+
+    @property
+    def is_append_only(self) -> bool:
+        """Whether every item this operation submitted appends to its document.
+
+        Only appends are foldable, because only appends are cumulative — see
+        :func:`plan_retain_fold`.
+        """
+        return bool(self.contents) and all(item.get("update_mode") == "append" for item in self.contents)
+
+
+def _can_join(primary: FoldMember, peer: FoldMember) -> str | None:
+    """Why ``peer`` cannot join ``primary``'s execution, or None if it can.
+
+    Everything an execution applies once, from the primary's payload, has to
+    match — otherwise folding would silently apply the primary's value to the
+    peer's content.
+    """
+    if not peer.is_append_only:
+        return "not an append"
+    if peer.has_file_metadata:
+        return "carries file metadata"
+    if peer.tenant_id != primary.tenant_id or peer.api_key_id != primary.api_key_id:
+        # Usage is attributed to the members of a fold, so mixing credentials
+        # inside one execution would bill one caller for another's extraction.
+        return "different tenant/api key"
+    if sorted(peer.document_tags or []) != sorted(primary.document_tags or []):
+        # The execution applies the primary's document_tags to the whole
+        # document; folding a differently-tagged peer would drop its tags.
+        return "different document_tags"
+    if peer.strategy != primary.strategy:
+        return "different strategy"
+    return None
 
 
 @dataclass
@@ -130,6 +167,14 @@ def plan_retain_fold(
     the document's text in submission order. Peers left behind stay pending and
     are claimed on a later cycle, still in order.
 
+    **Only appends fold.** Appends are cumulative: running two of them as one
+    execution over the concatenated turns produces the same document as running
+    them in sequence. Replace is not — it means "this body supersedes what is
+    stored", so folding two replaces would store ``body1 + body2`` where the
+    correct answer is ``body2``, and folding an append behind a replace would
+    turn a document-wiping submission into a concatenation. An operation that
+    is not append-only therefore runs alone, as primary and as peer.
+
     A peer cannot join when:
 
     * it would push the execution past ``token_budget``. Beyond that the engine
@@ -137,13 +182,16 @@ def plan_retain_fold(
       different bodies for one document defeat the streaming ownership check
       (#3282) — so the fold stays inside a single orchestrator pass by
       construction. The primary alone is always allowed through, however large.
-    * it belongs to a different tenant or API key. Token usage is attributed to
-      the members of a fold, so mixing credentials inside one execution would
-      bill one caller for another's extraction.
+    * ``_can_join`` rejects it: not an append, carrying file metadata, or
+      differing in anything the execution applies once from the primary's
+      payload (tenant, API key, document_tags, strategy).
     * ``max_peers`` is already reached.
     """
     plan = FoldPlan(members=[primary])
-    if max_peers <= 0:
+    if max_peers <= 0 or not primary.is_append_only or primary.has_file_metadata:
+        # A non-append primary is not a fold base at all: whatever queued behind
+        # it must wait for it to finish and then be re-evaluated against the
+        # document it leaves behind.
         plan.deferred = [p.operation_id for p in peers]
         return plan
 
@@ -153,11 +201,9 @@ def plan_retain_fold(
         if len(plan.members) > max_peers:
             plan.deferred = [p.operation_id for p in peers[index:]]
             break
-        if peer.tenant_id != primary.tenant_id or peer.api_key_id != primary.api_key_id:
-            logger.debug(
-                "Not folding %s: different tenant/api key from the primary operation",
-                peer.operation_id,
-            )
+        rejection = _can_join(primary, peer)
+        if rejection is not None:
+            logger.debug("Not folding %s: %s", peer.operation_id, rejection)
             plan.deferred = [p.operation_id for p in peers[index:]]
             break
         peer_tokens = sum(count_tokens(item.get("content", "")) for item in peer.contents)

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -275,6 +275,7 @@ from . import (
 from .types import (
     CausalRelation,
     ChunkMetadata,
+    ConcurrentAppendConflict,
     ExtractedFact,
     Phase1Result,
     ProcessedFact,
@@ -284,6 +285,11 @@ from .types import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Sentinel append base: the append read found no document row at all. Distinct
+# from None (not an append) and from any real content_hash, so the write gate
+# can tell "nobody had written this document yet" apart from "we didn't look".
+_APPEND_BASE_ABSENT = "__absent__"
 
 RetainOutboxCallback = Callable[[asyncpg.Connection], Awaitable[None]]
 RetainOutboxCallbackFactory = Callable[[list[RetainContentDict]], RetainOutboxCallback | None]
@@ -973,9 +979,23 @@ async def retain_batch(
             update_mode = item_mode
             break
 
-    if update_mode == "append" and effective_doc_id and is_first_batch:
+    # The document version this append was built on. Captured with the text it
+    # reads so the write path can prove nothing else appended in between — see
+    # ``ConcurrentAppendConflict`` and the gate in ``_streaming_retain_batch``.
+    # ``_APPEND_BASE_ABSENT`` distinguishes "read a document that wasn't there"
+    # from "not an append", which None alone cannot express.
+    append_base_hash: str | None = None
+    is_append = update_mode == "append" and bool(effective_doc_id) and is_first_batch
+
+    if is_append:
         async with acquire_with_retry(pool) as conn:
-            existing_text = await fact_storage.get_document_content(conn, bank_id, effective_doc_id)
+            base_row = await conn.fetchrow(
+                f"SELECT original_text, content_hash FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2",
+                effective_doc_id,
+                bank_id,
+            )
+        existing_text = base_row["original_text"] if base_row else None
+        append_base_hash = base_row["content_hash"] if base_row else _APPEND_BASE_ABSENT
         if existing_text:
             # Prepend existing text as a new content item at the beginning
             existing_content: RetainContentDict = {"content": existing_text}
@@ -1041,6 +1061,20 @@ async def retain_batch(
     if doc_row and doc_row["updated_at"]:
         doc_updated = doc_row["updated_at"].timestamp()
         if doc_updated > start_time:
+            # Under replace semantics dropping this request is right: a newer
+            # submission of the same document already superseded it. Under
+            # append semantics it is data loss — our content is a turn the
+            # winner never saw — so raise and let the caller retry on top of
+            # the newer document instead.
+            if is_append:
+                log_buffer.append(
+                    f"[append] Document {effective_doc_id} advanced before extraction — "
+                    f"retrying this append on the newer document"
+                )
+                logger.info("\n" + "\n".join(log_buffer) + "\n")
+                raise ConcurrentAppendConflict(
+                    f"Document {effective_doc_id} was updated by a concurrent retain after this append read its content"
+                )
             log_buffer.append(
                 f"[stale] Skipping retain: document {effective_doc_id} was updated at "
                 f"{doc_row['updated_at'].isoformat()} (after this request started at "
@@ -1074,6 +1108,7 @@ async def retain_batch(
             outbox_callback,
             db_semaphore,
             document_body_override=document_body_override,
+            append_base_hash=append_base_hash,
         )
         if delta_result is not None:
             return delta_result
@@ -1138,6 +1173,7 @@ async def retain_batch(
         document_body_override=document_body_override,
         chunk_index_offset=chunk_index_offset,
         progress_callback=progress_callback,
+        append_base_hash=append_base_hash,
     )
 
 
@@ -1331,6 +1367,7 @@ async def _streaming_retain_batch(
     document_body_override: str | None = None,
     chunk_index_offset: int = 0,
     progress_callback: "Callable[..., Awaitable[None]] | None" = None,
+    append_base_hash: str | None = None,
 ) -> tuple[list[list[str]], TokenUsage]:
     """
     Process a large document in streaming mini-batches to bound memory usage.
@@ -1462,6 +1499,34 @@ async def _streaming_retain_batch(
     # over the document (content_hash mismatch). The consumer checks this and
     # stops processing further batches.
     pipeline_aborted: list[bool] = [False]
+
+    def _assert_append_base_unchanged(existing_hash: str | None) -> None:
+        """Fail the append if the document moved since it read its base text.
+
+        Called under the document row lock, on the write that establishes
+        ownership. ``append_base_hash`` is the ``content_hash`` the append read
+        alongside the text it concatenated onto; the row can only still carry
+        that hash if no one else committed in between. A freshly created row
+        reads back ``'__pending__'``, which is the expected value exactly when
+        the append found no document at all.
+
+        No-op for replace-mode retains (``append_base_hash is None``), whose
+        last-writer-wins semantics make a moved document the correct outcome
+        rather than a conflict.
+        """
+        if append_base_hash is None or existing_hash is None:
+            return
+        expected = "__pending__" if append_base_hash == _APPEND_BASE_ABSENT else append_base_hash
+        if existing_hash == expected:
+            return
+        log_buffer.append(
+            f"[append] Document {effective_doc_id} moved between the append read and this "
+            f"write (expected {expected[:12]}, found {existing_hash[:12]}) — retrying on the newer document"
+        )
+        logger.info("\n" + "\n".join(log_buffer) + "\n")
+        raise ConcurrentAppendConflict(
+            f"Document {effective_doc_id} was updated by a concurrent retain while this append was extracting"
+        )
 
     # ---- LLM Producer ----
     # Fires all chunk extractions as concurrent tasks (bounded by the LLM
@@ -1678,19 +1743,17 @@ async def _streaming_retain_batch(
                 _edge_txn = None
                 async with acquire_with_retry(pool) as conn:
                     async with conn.transaction():
-                        await conn.execute(
-                            f"INSERT INTO {fq_table('documents')} (id, bank_id, original_text, content_hash) "
-                            f"VALUES ($1, $2, '', '__pending__') "
-                            f"ON CONFLICT (id, bank_id) DO NOTHING",
+                        # Same create-and-lock the fact-bearing path uses. Routed
+                        # through the ops layer so this branch takes the row lock
+                        # on Oracle too, and so the append gate below sees the
+                        # pre-existing hash rather than discarding it.
+                        existing_hash = await pool.ops.lock_document_for_write(
+                            conn,
+                            fq_table("documents"),
                             effective_doc_id,
                             bank_id,
                         )
-                        await conn.fetchval(
-                            f"SELECT content_hash FROM {fq_table('documents')} "
-                            f"WHERE id = $1 AND bank_id = $2 FOR UPDATE",
-                            effective_doc_id,
-                            bank_id,
-                        )
+                        _assert_append_base_unchanged(existing_hash)
                         if is_recovery:
                             await fact_storage.upsert_document_metadata(
                                 conn,
@@ -1801,6 +1864,12 @@ async def _streaming_retain_batch(
                         bank_id,
                     )
 
+                    # Append compare-and-swap, under the row lock and before any
+                    # write-group opens: an append that lost its read-modify-write
+                    # race must abort here rather than commit over the winner.
+                    if not doc_tracking_done[0]:
+                        _assert_append_base_unchanged(existing_hash)
+
                     # Open the cross-store write-group txn INSIDE this batch's transaction,
                     # before the first-batch replace deletes any outgoing memories: the delete
                     # and this batch's writes must ride the same txn so they commit together.
@@ -1856,12 +1925,21 @@ async def _streaming_retain_batch(
                                 f"concurrent request (hash mismatch) — aborting remaining batches"
                             )
                             logger.info("\n" + "\n".join(log_buffer) + "\n")
-                            # Signal the consumer to stop processing further batches
-                            pipeline_aborted[0] = True
                             # Abort the write-group we just opened rather than leaving it for the
                             # recovery sweep — we wrote nothing this batch and are bailing. No-op for
                             # the Postgres store (begin_txn returned None).
                             await _provider.decide_txn(_group_txn, commit=False)
+                            # Discarding the rest is only acceptable under replace
+                            # semantics, where the winner's content supersedes ours.
+                            # An append's remaining batches carry content nobody
+                            # else has, so raise and redo the whole append instead.
+                            if append_base_hash is not None:
+                                raise ConcurrentAppendConflict(
+                                    f"Document {effective_doc_id} was taken over by a concurrent "
+                                    f"retain while this append was storing its batches"
+                                )
+                            # Signal the consumer to stop processing further batches
+                            pipeline_aborted[0] = True
                             return
 
                     # Store chunks with correct global indices
@@ -2263,6 +2341,7 @@ async def _try_delta_retain(
     db_semaphore: "asyncio.Semaphore | None" = None,
     *,
     document_body_override: str | None = None,
+    append_base_hash: str | None = None,
 ) -> tuple[list[list[str]], TokenUsage, int | None] | None:
     """
     Attempt delta retain for a document upsert. Returns result tuple if delta
@@ -2306,6 +2385,19 @@ async def _try_delta_retain(
         # between these reads, the hash precondition on metadata-only writes (or
         # the extraction freshness recheck below) forces a streaming fallback.
         existing_chunks = await chunk_storage.load_existing_chunks(conn, bank_id, effective_doc_id)
+
+    # For an append, the document this delta plans against must still be the one
+    # whose text the append concatenated onto. Every write below is gated on
+    # ``doc_hash_at_load``, so a document that already moved would let the delta
+    # commit content assembled from a stale base — losing the turn that moved it.
+    # Cheapest possible place to notice: before any chunking or extraction.
+    if append_base_hash is not None:
+        expected_base = "__pending__" if append_base_hash == _APPEND_BASE_ABSENT else append_base_hash
+        if doc_hash_at_load is not None and doc_hash_at_load != expected_base:
+            raise ConcurrentAppendConflict(
+                f"Document {effective_doc_id} was updated by a concurrent retain "
+                f"between this append's read and its delta plan"
+            )
 
     if not existing_chunks:
         return None
@@ -2488,7 +2580,14 @@ async def _try_delta_retain(
     result_unit_ids: list[list[str]] = []
     log_buffer_pre_db = len(log_buffer)
 
-    async def _run_delta_db_work() -> None:
+    async def _run_delta_db_work() -> bool:
+        """Write this delta. Returns False when the document moved underneath it.
+
+        The caller must translate False into "fall back to the streaming path" —
+        this used to be declared ``-> None`` with a bare ``return None`` on the
+        abort branch, so the guard logged that it was falling back while the
+        delta actually committed on top of the concurrent writer.
+        """
         nonlocal result_unit_ids
         del log_buffer[log_buffer_pre_db:]
         for pf in processed_facts:
@@ -2521,8 +2620,9 @@ async def _try_delta_retain(
                         f"since chunks were loaded — aborting delta, falling back to full retain"
                     )
                     logger.info("\n" + "\n".join(log_buffer) + "\n")
-                    # Return None to fall back to streaming (which has full FOR UPDATE protection)
-                    return None
+                    # Fall back to streaming, which re-locks the document and (for
+                    # an append) verifies the base this content was built on.
+                    return False
 
                 # Update document metadata (no delete)
                 step_start = time.time()
@@ -2679,11 +2779,18 @@ async def _try_delta_retain(
         except Exception:
             logger.warning("Entity stats flush failed — retrieval unaffected", exc_info=True)
 
+        return True
+
     if db_semaphore is not None:
         async with db_semaphore:
-            await _run_delta_db_work()
+            delta_committed = await _run_delta_db_work()
     else:
-        await _run_delta_db_work()
+        delta_committed = await _run_delta_db_work()
+    if not delta_committed:
+        # The document moved while this delta was extracting. Nothing was
+        # written; the streaming path redoes the work under its own lock, and
+        # for an append its base check turns the loss into a retry.
+        return None
     await _record_retain_document_outcome(pool, bank_id, effective_doc_id, sum(len(ids) for ids in result_unit_ids))
     # Count content + context tokens that actually went through extraction.
     # ``delta_contents`` holds the per-chunk RetainContent items for the

--- a/hindsight-api-slim/hindsight_api/engine/retain/types.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/types.py
@@ -348,3 +348,19 @@ class RetainBatch:
 
     # Results (populated after storage)
     unit_ids_by_content: list[list[str]] = field(default_factory=list)
+
+
+class ConcurrentAppendConflict(Exception):
+    """An append-mode retain lost its read-modify-write race for a document.
+
+    ``update_mode="append"`` reads ``documents.original_text``, concatenates the
+    new content onto it, and reprocesses the result. That read and the write
+    that follows it are separated by LLM extraction, so a second append
+    committing in between would make this request overwrite a turn it never
+    saw. Every write path that can observe the document having moved raises
+    this instead of dropping the submission, so a lost race costs a retry
+    rather than the caller's content.
+
+    Retryable by construction: the retry re-reads the (now newer) stored text
+    and re-appends the same submission on top of it.
+    """

--- a/hindsight-api-slim/hindsight_api/extensions/operation_validator.py
+++ b/hindsight-api-slim/hindsight_api/extensions/operation_validator.py
@@ -245,6 +245,17 @@ class RetainResult:
     # when the customer's client resubmits growing payloads to the same
     # document_id (e.g. a session transcript appended to on each turn).
     processed_content_tokens: int | None = None
+    # Operation ids of every submission that ran as one execution with this
+    # one, when several queued retains for a document were coalesced (see
+    # ``engine.retain.fold``). None for an ordinary, unfolded retain.
+    #
+    # A fold fires this hook once per member, in submission order, so an
+    # extension still sees every operation it was given. The execution's LLM
+    # usage cannot be attributed per member — the members were extracted as one
+    # document — so it is reported in full on the FIRST member and as zero on
+    # the rest. Summing across a fold therefore yields exactly the tokens the
+    # execution spent, the same total an unfolded run would have reported.
+    folded_with: list[str] | None = None
 
 
 @dataclass

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -622,6 +622,12 @@ class WorkerPoller:
                     contents=data.get("contents", []),
                     tenant_id=data.get("_tenant_id"),
                     api_key_id=data.get("_api_key_id"),
+                    document_tags=data.get("document_tags"),
+                    strategy=data.get("strategy"),
+                    # A converted upload attaches its storage key to the document
+                    # afterwards, and that step only fires for a single-item
+                    # retain — so such an operation must never be folded.
+                    has_file_metadata=data.get("_file_metadata") is not None,
                 )
 
             primary = _member(row["operation_id"], row["task_payload"])

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -15,7 +15,7 @@ import logging
 import time
 from collections import Counter
 from collections.abc import Awaitable, Callable, Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from ..config import get_config
@@ -157,6 +157,18 @@ class ClaimedTask:
     operation_id: str
     task_dict: dict[str, Any]
     schema: str | None
+    folded_operation_ids: list[str] = field(default_factory=list)
+    """Peers coalesced into this execution (see ``engine.retain.fold``).
+
+    They were claimed by the same transaction that claimed ``operation_id`` and
+    run as part of its execution, so they must reach a terminal state with it —
+    never separately, and never not at all.
+    """
+
+    @property
+    def all_operation_ids(self) -> list[str]:
+        """Every operation this execution is responsible for completing."""
+        return [self.operation_id, *self.folded_operation_ids]
 
 
 @dataclass
@@ -552,14 +564,137 @@ class WorkerPoller:
                     db_op_type = row["operation_type"]
                     if db_op_type:
                         task_dict["operation_type"] = db_op_type
+                    folded = await self._fold_retain_peers(conn, table, row, task_dict)
                     result.append(
                         ClaimedTask(
                             operation_id=str(row["operation_id"]),
                             task_dict=task_dict,
                             schema=schema,
+                            folded_operation_ids=folded,
                         )
                     )
                 return result
+
+    async def _fold_retain_peers(self, conn, table: str, row, task_dict: dict[str, Any]) -> list[str]:
+        """Coalesce the retains queued behind ``row`` into its execution.
+
+        Runs inside the claim transaction, so the peers are locked, claimed and
+        handed over atomically with the row they join — there is no window in
+        which a peer is folded but not claimed, or claimed but not executed.
+
+        Peers this does not take stay pending and are claimed on a later cycle.
+        Purely an optimization: on any failure the execution proceeds unfolded,
+        one operation at a time, which is exactly the pre-folding behaviour.
+        """
+        from ..engine.retain.fold import (
+            FoldMember,
+            FoldMemberRef,
+            max_fold_peers_for_retry,
+            merge_fold_contents,
+            plan_retain_fold,
+        )
+
+        serialization_key = row["serialization_key"]
+        if not serialization_key or row["operation_type"] != "retain":
+            return []
+        max_peers = max_fold_peers_for_retry(row["retry_count"] or 0)
+        if max_peers <= 0:
+            return []
+
+        try:
+            from ..config import get_config
+            from ..engine.memory_engine import count_tokens
+
+            peer_rows = await self._backend.ops.fetch_foldable_retain_peers(
+                conn,
+                table,
+                row["bank_id"],
+                serialization_key,
+                max_peers,
+            )
+            if not peer_rows:
+                return []
+
+            def _member(operation_id, payload) -> FoldMember:
+                data = json.loads(payload) if isinstance(payload, str) else payload
+                return FoldMember(
+                    operation_id=str(operation_id),
+                    contents=data.get("contents", []),
+                    tenant_id=data.get("_tenant_id"),
+                    api_key_id=data.get("_api_key_id"),
+                )
+
+            primary = _member(row["operation_id"], row["task_payload"])
+            peers = [_member(p["operation_id"], p["task_payload"]) for p in peer_rows]
+            plan = plan_retain_fold(
+                primary,
+                peers,
+                max_peers=max_peers,
+                token_budget=get_config().retain_batch_tokens,
+                count_tokens=count_tokens,
+            )
+            if not plan.peer_ids:
+                return []
+
+            # Everything that can fail happens before the peers are claimed, so
+            # a failure can only leave them pending — never claimed by an
+            # execution that then doesn't carry them.
+            folded_ids = set(plan.peer_ids)
+            merged_contents = merge_fold_contents(plan.members)
+            fold_members = [
+                FoldMemberRef(operation_id=m.operation_id, items_count=len(m.contents)).to_payload()
+                for m in plan.members
+            ]
+            await self._backend.ops.mark_operations_processing(
+                conn,
+                table,
+                self._worker_id,
+                [p["operation_id"] for p in peer_rows if str(p["operation_id"]) in folded_ids],
+            )
+            task_dict["contents"] = merged_contents
+            task_dict["_fold_members"] = fold_members
+            logger.info(
+                f"Folded {len(plan.peer_ids)} queued retain(s) for document "
+                f"{serialization_key} into operation {row['operation_id']}"
+                + (f" ({len(plan.deferred)} left pending)" if plan.deferred else "")
+            )
+            return plan.peer_ids
+        except Exception:
+            logger.warning(
+                f"Retain fold for document {serialization_key} failed — "
+                f"running operation {row['operation_id']} on its own",
+                exc_info=True,
+            )
+            return []
+
+    # -- Fold-aware terminal transitions -----------------------------------
+    #
+    # A folded execution is responsible for every operation the claim
+    # transaction handed it, not just the row it was keyed on. Routing all
+    # terminal transitions through these wrappers is what makes that structural:
+    # each one fans out over ``task.all_operation_ids``, so no branch can leave
+    # a folded peer stuck in 'processing' by only remembering the primary.
+    #
+    # Every member gets the same outcome, because a fold is one execution:
+    # they either all committed or none did. Retry and deferral put the whole
+    # group back to pending, so it is re-claimed (and re-folded, more narrowly
+    # each time) together.
+
+    async def _mark_all_completed(self, task: ClaimedTask) -> None:
+        for operation_id in task.all_operation_ids:
+            await self._mark_completed(operation_id, task.schema)
+
+    async def _mark_all_failed(self, task: ClaimedTask, error_message: str) -> None:
+        for operation_id in task.all_operation_ids:
+            await self._mark_failed(operation_id, error_message, task.schema)
+
+    async def _defer_all(self, task: ClaimedTask, exec_date, reason: str) -> None:
+        for operation_id in task.all_operation_ids:
+            await self._defer_operation(operation_id, exec_date, reason, task.schema)
+
+    async def _schedule_retry_all(self, task: ClaimedTask, retry_at, reason: str) -> None:
+        for operation_id in task.all_operation_ids:
+            await self._schedule_retry(operation_id, retry_at, reason, task.schema)
 
     async def _mark_completed(self, operation_id: str, schema: str | None):
         """Mark a processing task as completed, then propagate to parent if needed."""
@@ -830,7 +965,7 @@ class WorkerPoller:
                 task.task_dict["_schema"] = task.schema
             await self._run_executor(task, task_type)
             logger.debug(f"Task {task.operation_id} execution finished")
-            await self._mark_completed(task.operation_id, task.schema)
+            await self._mark_all_completed(task)
             terminal_success = True
         except _WallTimeoutExceeded as e:
             # The executor has already been cancelled; all that's left is to say so
@@ -845,21 +980,21 @@ class WorkerPoller:
                 f"if this is a legitimately long operation, or set it to 0 to disable the limit."
             )
             logger.error(f"Task {task.operation_id} timed out: {message}")
-            await self._mark_failed(task.operation_id, message, task.schema)
+            await self._mark_all_failed(task, message)
             terminal_success = False
         except DeferOperation as e:
             # Deferral is not a terminal outcome — do not record a completion.
-            await self._defer_operation(task.operation_id, e.exec_date, e.reason, task.schema)
+            await self._defer_all(task, e.exec_date, e.reason)
         except RetryTaskAt as e:
             # Retry is not a terminal outcome — do not record a completion.
-            await self._schedule_retry(task.operation_id, e.retry_at, str(e), task.schema)
+            await self._schedule_retry_all(task, e.retry_at, str(e))
         except Exception as e:
             # exc_info rather than print_exc(): the stderr copy carries no task id
             # and is the first thing lost to log rotation (issue #3218).
             error_message = format_task_error(e)
             logger.error(f"Task {task.operation_id} failed: {error_message}", exc_info=True)
             try:
-                await self._mark_failed(task.operation_id, error_message, task.schema)
+                await self._mark_all_failed(task, error_message)
             except Exception:
                 # Marking a task failed is itself a DB write, and it can fail
                 # (pool exhausted, connection reset, statement timeout). Without
@@ -868,10 +1003,11 @@ class WorkerPoller:
                 # recover_own_tasks only runs at startup, and no dead-worker logic
                 # applies because the worker is alive. See issue #3228.
                 logger.exception(f"Could not mark task {task.operation_id} failed; reconciling it for re-claim")
-                try:
-                    await self._reclaim_own_processing_tasks(task.schema, operation_id=task.operation_id)
-                except Exception:
-                    logger.exception(f"Could not reconcile task {task.operation_id}; it stays 'processing'")
+                for operation_id in task.all_operation_ids:
+                    try:
+                        await self._reclaim_own_processing_tasks(task.schema, operation_id=operation_id)
+                    except Exception:
+                        logger.exception(f"Could not reconcile task {operation_id}; it stays 'processing'")
             terminal_success = False
 
         # Record the metric outside the executor's exception scope so a metrics

--- a/hindsight-api-slim/tests/test_retain_document_serialization.py
+++ b/hindsight-api-slim/tests/test_retain_document_serialization.py
@@ -63,12 +63,28 @@ def _fake_count_tokens(text: str) -> int:
 # ---------------------------------------------------------------------------
 
 
-def _member(op_id: str, content: str, *, tenant: str | None = "t1", api_key: str | None = "k1") -> FoldMember:
+def _member(
+    op_id: str,
+    content: str,
+    *,
+    tenant: str | None = "t1",
+    api_key: str | None = "k1",
+    update_mode: str | None = "append",
+    document_tags: list[str] | None = None,
+    strategy: str | None = None,
+    has_file_metadata: bool = False,
+) -> FoldMember:
+    item: dict = {"content": content, "document_id": "doc"}
+    if update_mode is not None:
+        item["update_mode"] = update_mode
     return FoldMember(
         operation_id=op_id,
-        contents=[{"content": content, "document_id": "doc", "update_mode": "append"}],
+        contents=[item],
         tenant_id=tenant,
         api_key_id=api_key,
+        document_tags=document_tags,
+        strategy=strategy,
+        has_file_metadata=has_file_metadata,
     )
 
 
@@ -128,6 +144,109 @@ def test_fold_respects_max_peers():
     assert plan.deferred == ["op4", "op5", "op6", "op7"]
 
 
+def test_replace_mode_never_folds():
+    """Replace is not cumulative: folding two of them would concatenate bodies
+    where the second should supersede the first."""
+    plan = plan_retain_fold(
+        _member("op1", "first body", update_mode="replace"),
+        [_member("op2", "second body", update_mode="replace")],
+        max_peers=8,
+        token_budget=1000,
+        count_tokens=_fake_count_tokens,
+    )
+
+    assert plan.peer_ids == [], "a replace must run alone"
+    assert plan.deferred == ["op2"]
+
+
+def test_append_primary_does_not_swallow_a_replace_peer():
+    """A replace queued behind an append must keep its wipe-and-store semantics."""
+    plan = plan_retain_fold(
+        _member("op1", "a turn"),
+        [_member("op2", "a fresh body", update_mode="replace"), _member("op3", "another turn")],
+        max_peers=8,
+        token_budget=1000,
+        count_tokens=_fake_count_tokens,
+    )
+
+    assert plan.peer_ids == []
+    assert plan.deferred == ["op2", "op3"]
+
+
+def test_item_without_update_mode_is_not_foldable():
+    """Absent update_mode means replace (the default) — not foldable."""
+    plan = plan_retain_fold(
+        _member("op1", "a turn"),
+        [_member("op2", "plain item", update_mode=None)],
+        max_peers=8,
+        token_budget=1000,
+        count_tokens=_fake_count_tokens,
+    )
+
+    assert plan.peer_ids == []
+
+
+def test_fold_requires_matching_document_tags():
+    """The execution applies the primary's tags to the document, so a
+    differently-tagged peer would silently lose its own."""
+    plan = plan_retain_fold(
+        _member("op1", "one", document_tags=["a"]),
+        [_member("op2", "two", document_tags=["a", "b"])],
+        max_peers=8,
+        token_budget=1000,
+        count_tokens=_fake_count_tokens,
+    )
+
+    assert plan.peer_ids == []
+    assert plan.deferred == ["op2"]
+
+
+def test_fold_ignores_document_tag_ordering():
+    plan = plan_retain_fold(
+        _member("op1", "one", document_tags=["a", "b"]),
+        [_member("op2", "two", document_tags=["b", "a"])],
+        max_peers=8,
+        token_budget=1000,
+        count_tokens=_fake_count_tokens,
+    )
+
+    assert plan.peer_ids == ["op2"]
+
+
+def test_fold_requires_matching_strategy():
+    plan = plan_retain_fold(
+        _member("op1", "one", strategy="fast"),
+        [_member("op2", "two", strategy="thorough")],
+        max_peers=8,
+        token_budget=1000,
+        count_tokens=_fake_count_tokens,
+    )
+
+    assert plan.peer_ids == []
+
+
+def test_file_backed_retain_never_folds():
+    """A converted upload attaches its storage key afterwards, and that step
+    only runs for a single-item retain."""
+    as_primary = plan_retain_fold(
+        _member("op1", "converted", has_file_metadata=True),
+        [_member("op2", "a turn")],
+        max_peers=8,
+        token_budget=1000,
+        count_tokens=_fake_count_tokens,
+    )
+    assert as_primary.peer_ids == []
+
+    as_peer = plan_retain_fold(
+        _member("op1", "a turn"),
+        [_member("op2", "converted", has_file_metadata=True)],
+        max_peers=8,
+        token_budget=1000,
+        count_tokens=_fake_count_tokens,
+    )
+    assert as_peer.peer_ids == []
+
+
 def test_fold_width_narrows_with_retries_until_the_poison_runs_alone():
     assert max_fold_peers_for_retry(0) == DEFAULT_MAX_FOLD_PEERS
     assert max_fold_peers_for_retry(1) == DEFAULT_MAX_FOLD_PEERS // 2
@@ -177,6 +296,15 @@ async def backend(pg0_db_url):
 
 
 async def _insert_retain_op(pool, bank_id: str, document_id: str | None, *, contents: list[dict]) -> str:
+    """Queue a pending append-mode retain, as submit_async_retain would.
+
+    Append mode because that is the shape folding applies to at all — a replace
+    is not cumulative and runs alone (see plan_retain_fold).
+    """
+    contents = [
+        {**item, "document_id": item.get("document_id", document_id), "update_mode": "append"} if document_id else item
+        for item in contents
+    ]
     operation_id = uuid.uuid4()
     payload = {
         "type": "batch_retain",

--- a/hindsight-api-slim/tests/test_retain_document_serialization.py
+++ b/hindsight-api-slim/tests/test_retain_document_serialization.py
@@ -1,0 +1,638 @@
+"""Per-document retain serialization, claim-time folding, and the append CAS.
+
+Three layers guard concurrent appends to one document, and they are tested at
+the level each one lives at:
+
+* the **claim predicate** and the **fold**, at the queue — deterministic SQL
+  behaviour, no LLM and no retain pipeline involved;
+* the **fold planner**, as pure functions;
+* the **append compare-and-swap**, end-to-end through the real retain pipeline,
+  because the whole point of it is what happens across an extraction.
+
+The end-to-end race test is the regression test for the original bug: three
+concurrent appends to one document used to leave only one of them stored, with
+all three reporting success.
+"""
+
+import asyncio
+import hashlib
+import json
+import logging
+import struct
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+
+from hindsight_api.engine.db.postgresql import PostgreSQLBackend
+from hindsight_api.engine.embeddings import Embeddings
+from hindsight_api.engine.memory_engine import MemoryEngine
+from hindsight_api.engine.retain.fold import (
+    DEFAULT_MAX_FOLD_PEERS,
+    FoldMember,
+    FoldMemberRef,
+    max_fold_peers_for_retry,
+    merge_fold_contents,
+    plan_retain_fold,
+)
+from hindsight_api.engine.task_backend import SyncTaskBackend
+from hindsight_api.extensions.operation_validator import (
+    OperationValidatorExtension,
+    RetainResult,
+    ValidationResult,
+)
+
+logger = logging.getLogger(__name__)
+
+_DIM = 384
+
+
+def _ts() -> float:
+    return datetime.now(timezone.utc).timestamp()
+
+
+def _fake_count_tokens(text: str) -> int:
+    """One 'token' per character — keeps budget assertions readable."""
+    return len(text)
+
+
+# ---------------------------------------------------------------------------
+# Fold planner (pure)
+# ---------------------------------------------------------------------------
+
+
+def _member(op_id: str, content: str, *, tenant: str | None = "t1", api_key: str | None = "k1") -> FoldMember:
+    return FoldMember(
+        operation_id=op_id,
+        contents=[{"content": content, "document_id": "doc", "update_mode": "append"}],
+        tenant_id=tenant,
+        api_key_id=api_key,
+    )
+
+
+def test_fold_takes_peers_in_submission_order():
+    plan = plan_retain_fold(
+        _member("op1", "one"),
+        [_member("op2", "two"), _member("op3", "three")],
+        max_peers=8,
+        token_budget=1000,
+        count_tokens=_fake_count_tokens,
+    )
+
+    assert plan.peer_ids == ["op2", "op3"]
+    assert [c["content"] for c in merge_fold_contents(plan.members)] == ["one", "two", "three"]
+    assert plan.deferred == []
+
+
+def test_fold_stops_at_the_token_budget():
+    """The fold must fit one orchestrator pass — see plan_retain_fold."""
+    plan = plan_retain_fold(
+        _member("op1", "a" * 10),
+        [_member("op2", "b" * 10), _member("op3", "c" * 10)],
+        max_peers=8,
+        token_budget=25,
+        count_tokens=_fake_count_tokens,
+    )
+
+    assert plan.peer_ids == ["op2"]
+    assert plan.deferred == ["op3"]
+
+
+def test_fold_never_skips_a_turn_to_reach_a_later_one():
+    """A disqualified peer stops the fold — taking op3 would reorder the document."""
+    plan = plan_retain_fold(
+        _member("op1", "one"),
+        [_member("op2", "two", api_key="other-key"), _member("op3", "three")],
+        max_peers=8,
+        token_budget=1000,
+        count_tokens=_fake_count_tokens,
+    )
+
+    assert plan.peer_ids == []
+    assert plan.deferred == ["op2", "op3"]
+
+
+def test_fold_respects_max_peers():
+    peers = [_member(f"op{i}", "x") for i in range(2, 8)]
+    plan = plan_retain_fold(
+        _member("op1", "x"),
+        peers,
+        max_peers=2,
+        token_budget=1000,
+        count_tokens=_fake_count_tokens,
+    )
+
+    assert plan.peer_ids == ["op2", "op3"]
+    assert plan.deferred == ["op4", "op5", "op6", "op7"]
+
+
+def test_fold_width_narrows_with_retries_until_the_poison_runs_alone():
+    assert max_fold_peers_for_retry(0) == DEFAULT_MAX_FOLD_PEERS
+    assert max_fold_peers_for_retry(1) == DEFAULT_MAX_FOLD_PEERS // 2
+    assert max_fold_peers_for_retry(2) == DEFAULT_MAX_FOLD_PEERS // 4
+    # Deep enough into the retries, an operation stops taking anything with it.
+    assert max_fold_peers_for_retry(99) == 0
+
+
+def test_fold_with_zero_width_defers_every_peer():
+    plan = plan_retain_fold(
+        _member("op1", "one"),
+        [_member("op2", "two")],
+        max_peers=0,
+        token_budget=1000,
+        count_tokens=_fake_count_tokens,
+    )
+
+    assert plan.peer_ids == []
+    assert plan.deferred == ["op2"]
+
+
+def test_oversized_primary_still_runs_alone():
+    """A single submission over budget must not be stuck forever unclaimable."""
+    plan = plan_retain_fold(
+        _member("op1", "a" * 500),
+        [_member("op2", "b")],
+        max_peers=8,
+        token_budget=100,
+        count_tokens=_fake_count_tokens,
+    )
+
+    assert plan.members[0].operation_id == "op1"
+    assert plan.peer_ids == []
+
+
+# ---------------------------------------------------------------------------
+# Claim predicate + fold (against the database)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def backend(pg0_db_url):
+    pool = PostgreSQLBackend()
+    await pool.initialize(pg0_db_url, min_size=1, max_size=5)
+    yield pool
+    await pool.shutdown()
+
+
+async def _insert_retain_op(pool, bank_id: str, document_id: str | None, *, contents: list[dict]) -> str:
+    operation_id = uuid.uuid4()
+    payload = {
+        "type": "batch_retain",
+        "operation_id": str(operation_id),
+        "bank_id": bank_id,
+        "contents": contents,
+        "_tenant_id": "tenant-a",
+        "_api_key_id": "key-a",
+    }
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO async_operations
+                (operation_id, bank_id, operation_type, result_metadata, status,
+                 task_payload, serialization_key, created_at)
+            VALUES ($1, $2, 'retain', '{}'::jsonb, 'pending', $3::jsonb, $4, now())
+            """,
+            operation_id,
+            bank_id,
+            json.dumps(payload),
+            document_id,
+        )
+    # created_at ties would make claim order ambiguous; space the rows out.
+    await asyncio.sleep(0.01)
+    return str(operation_id)
+
+
+def _own(rows, bank_id: str) -> list[str]:
+    """Claimed operation ids belonging to this test's bank.
+
+    The claim query is queue-wide by design and the test database is shared
+    with every other module's pending work, so assertions have to be scoped.
+    """
+    return [str(r["operation_id"]) for r in rows if r["bank_id"] == bank_id]
+
+
+class _Rollback(Exception):
+    """Unwinds a test's claim transaction so the shared queue is left untouched."""
+
+
+# Claim limits large enough that the shared test queue's depth can never push
+# this module's rows out of the ORDER BY created_at window. What is under test
+# is which rows are *claimable*, not how many a worker takes per cycle.
+_UNBOUNDED_CLAIM = 1000
+
+
+async def _claiming(backend, body):
+    """Run ``body(conn)`` inside a claim transaction, then roll it back.
+
+    Claiming is queue-wide by design: ``claim_tasks`` takes whatever is
+    claimable, which in a shared test database includes operations other test
+    modules are relying on. Rolling back means these tests can exercise the real
+    claim SQL — the point of them — without actually stealing that work.
+    """
+    captured = {}
+    try:
+        async with backend.acquire() as conn:
+            async with conn.transaction():
+                captured["value"] = await body(conn)
+                raise _Rollback
+    except _Rollback:
+        pass
+    return captured["value"]
+
+
+@pytest_asyncio.fixture
+async def bank(backend):
+    bank_id = f"test_serialization_{_ts()}"
+    async with backend.acquire() as conn:
+        await conn.execute("INSERT INTO banks (bank_id) VALUES ($1) ON CONFLICT DO NOTHING", bank_id)
+    yield bank_id
+    async with backend.acquire() as conn:
+        await conn.execute("DELETE FROM async_operations WHERE bank_id = $1", bank_id)
+        await conn.execute("DELETE FROM banks WHERE bank_id = $1", bank_id)
+
+
+@pytest.mark.asyncio
+async def test_claim_takes_only_one_retain_per_document(backend, bank):
+    """Three queued appends to one document: only the oldest is claimable."""
+    first = await _insert_retain_op(backend, bank, "doc-a", contents=[{"content": "one"}])
+    await _insert_retain_op(backend, bank, "doc-a", contents=[{"content": "two"}])
+    await _insert_retain_op(backend, bank, "doc-a", contents=[{"content": "three"}])
+
+    rows = await _claiming(
+        backend, lambda conn: backend.ops.claim_tasks(conn, "async_operations", "w1", {}, _UNBOUNDED_CLAIM)
+    )
+
+    claimed = _own(rows, bank)
+    assert claimed == [first], f"expected only the oldest same-document retain, got {claimed}"
+
+
+@pytest.mark.asyncio
+async def test_claim_does_not_serialize_across_documents(backend, bank):
+    """Different documents are independent — a busy one must not block the fleet."""
+    a = await _insert_retain_op(backend, bank, "doc-a", contents=[{"content": "a1"}])
+    b = await _insert_retain_op(backend, bank, "doc-b", contents=[{"content": "b1"}])
+    c = await _insert_retain_op(backend, bank, None, contents=[{"content": "c1"}])
+
+    rows = await _claiming(
+        backend, lambda conn: backend.ops.claim_tasks(conn, "async_operations", "w1", {}, _UNBOUNDED_CLAIM)
+    )
+
+    assert set(_own(rows, bank)) == {a, b, c}
+
+
+@pytest.mark.asyncio
+async def test_claim_waits_for_a_processing_peer(backend, bank):
+    """A document with a retain in flight yields nothing, even after a restart."""
+    first = await _insert_retain_op(backend, bank, "doc-a", contents=[{"content": "one"}])
+    await _insert_retain_op(backend, bank, "doc-a", contents=[{"content": "two"}])
+    async with backend.acquire() as conn:
+        await conn.execute(
+            "UPDATE async_operations SET status = 'processing' WHERE operation_id = $1",
+            uuid.UUID(first),
+        )
+
+    rows = await _claiming(
+        backend, lambda conn: backend.ops.claim_tasks(conn, "async_operations", "w2", {}, _UNBOUNDED_CLAIM)
+    )
+
+    assert _own(rows, bank) == [], "a document with a retain in flight must yield nothing"
+
+
+@pytest.mark.asyncio
+async def test_fetch_foldable_peers_returns_submission_order(backend, bank):
+    first = await _insert_retain_op(backend, bank, "doc-a", contents=[{"content": "one"}])
+    second = await _insert_retain_op(backend, bank, "doc-a", contents=[{"content": "two"}])
+    third = await _insert_retain_op(backend, bank, "doc-a", contents=[{"content": "three"}])
+    await _insert_retain_op(backend, bank, "doc-b", contents=[{"content": "other"}])
+
+    rows = await _claiming(
+        backend,
+        lambda conn: backend.ops.fetch_foldable_retain_peers(conn, "async_operations", bank, "doc-a", _UNBOUNDED_CLAIM),
+    )
+
+    ids = [str(r["operation_id"]) for r in rows]
+    assert ids == [first, second, third], "peers must come back in (created_at, operation_id) order"
+
+
+def _poller(backend, worker_id: str):
+    from hindsight_api.extensions.builtin.tenant import DefaultTenantExtension
+    from hindsight_api.worker.poller import WorkerPoller
+
+    return WorkerPoller(
+        backend=backend,
+        worker_id=worker_id,
+        executor=lambda _: None,
+        tenant_extension=DefaultTenantExtension(config={}),
+    )
+
+
+@dataclass
+class _ClaimOutcome:
+    """What a rolled-back claim observed for one bank."""
+
+    tasks: list[tuple]
+    statuses: list
+
+
+async def _claim_own(backend, bank_id: str, worker_id: str) -> "_ClaimOutcome":
+    """Claim, fold, and assert on this bank's rows without committing the claim.
+
+    Drives the poller's real claim path (``claim_tasks`` then
+    ``_fold_retain_peers``) rather than reimplementing it, so what is asserted
+    is what a worker actually does — and rolls it back, so other modules'
+    queued work is left alone.
+    """
+    poller = _poller(backend, worker_id)
+    observed: dict = {}
+
+    async def _body(conn):
+        rows = await backend.ops.claim_tasks(conn, "async_operations", worker_id, {}, _UNBOUNDED_CLAIM)
+        tasks = []
+        for row in rows:
+            if row["bank_id"] != bank_id:
+                continue
+            payload = row["task_payload"]
+            task_dict = json.loads(payload) if isinstance(payload, str) else payload
+            folded = await poller._fold_retain_peers(conn, "async_operations", row, task_dict)
+            tasks.append((str(row["operation_id"]), folded, task_dict))
+        # Read the claim's effect back inside the same transaction, before the
+        # rollback: this is the state a committed claim would leave behind.
+        observed["statuses"] = await conn.fetch(
+            "SELECT operation_id, status, worker_id FROM async_operations WHERE bank_id = $1",
+            bank_id,
+        )
+        return tasks
+
+    tasks = await _claiming(backend, _body)
+    return _ClaimOutcome(tasks=tasks, statuses=observed["statuses"])
+
+
+@pytest.mark.asyncio
+async def test_claim_folds_queued_peers_into_one_execution(backend, bank):
+    """The whole backlog for a document is claimed and merged as one task."""
+    first = await _insert_retain_op(backend, bank, "doc-a", contents=[{"content": "turn one"}])
+    second = await _insert_retain_op(backend, bank, "doc-a", contents=[{"content": "turn two"}])
+    third = await _insert_retain_op(backend, bank, "doc-a", contents=[{"content": "turn three"}])
+
+    claimed = await _claim_own(backend, bank, "w-fold")
+
+    assert len(claimed.tasks) == 1, "the fold must produce a single execution"
+    operation_id, folded, task_dict = claimed.tasks[0]
+    assert operation_id == first
+    assert folded == [second, third]
+    assert [c["content"] for c in task_dict["contents"]] == ["turn one", "turn two", "turn three"]
+    assert [m["operation_id"] for m in task_dict["_fold_members"]] == [first, second, third]
+
+    # Invariant: every folded member is claimed by this worker, none left pending.
+    assert {r["status"] for r in claimed.statuses} == {"processing"}
+    assert {r["worker_id"] for r in claimed.statuses} == {"w-fold"}
+
+
+@pytest.mark.asyncio
+async def test_fold_stops_at_a_foreign_document(backend, bank):
+    """Only peers for the same document join; another document is untouched."""
+    first = await _insert_retain_op(backend, bank, "doc-a", contents=[{"content": "a1"}])
+    second = await _insert_retain_op(backend, bank, "doc-a", contents=[{"content": "a2"}])
+    other = await _insert_retain_op(backend, bank, "doc-b", contents=[{"content": "b1"}])
+
+    claimed = await _claim_own(backend, bank, "w-fold2")
+
+    folds = {op_id: folded for op_id, folded, _ in claimed.tasks}
+    assert folds[first] == [second]
+    assert folds[other] == []
+
+
+# ---------------------------------------------------------------------------
+# Append compare-and-swap (end to end)
+# ---------------------------------------------------------------------------
+
+
+class _StubEmbeddings(Embeddings):
+    """Deterministic, torch-free embeddings — same text, same vector.
+
+    The local sentence-transformers model segfaults under heavy in-process
+    async concurrency (a torch limitation, not a product issue: in production
+    embeddings are served out-of-process), and these tests only care about what
+    ends up stored.
+    """
+
+    @property
+    def provider_name(self) -> str:
+        return "stub"
+
+    @property
+    def dimension(self) -> int:
+        return _DIM
+
+    async def initialize(self) -> None:
+        return None
+
+    def encode(self, texts: list[str]) -> list[list[float]]:
+        out = []
+        for text in texts:
+            seed = hashlib.sha256(text.encode("utf-8")).digest()
+            vals: list[float] = []
+            i = 0
+            while len(vals) < _DIM:
+                block = hashlib.sha256(seed + struct.pack("<I", i)).digest()
+                for j in range(0, len(block), 4):
+                    if len(vals) >= _DIM:
+                        break
+                    (u,) = struct.unpack("<I", block[j : j + 4])
+                    vals.append((u % 100000) / 100000.0)
+                i += 1
+            out.append(vals)
+        return out
+
+
+@pytest_asyncio.fixture
+async def memory_stub_emb(pg0_db_url, cross_encoder, query_analyzer):
+    mem = MemoryEngine(
+        db_url=pg0_db_url,
+        memory_llm_provider="mock",
+        memory_llm_api_key="",
+        memory_llm_model="mock",
+        embeddings=_StubEmbeddings(),
+        cross_encoder=cross_encoder,
+        query_analyzer=query_analyzer,
+        pool_min_size=1,
+        pool_max_size=20,
+        run_migrations=False,
+        task_backend=SyncTaskBackend(),
+    )
+    await mem.initialize()
+    # Auto-consolidation dominates wall-clock here and is irrelevant to what
+    # these tests assert.
+    mem._config_resolver._global_config.enable_auto_consolidation = False
+    yield mem
+    await asyncio.sleep(1)
+    try:
+        if mem._pool and not mem._pool._closing:
+            await mem.close()
+    except Exception:
+        pass
+
+
+async def _append(memory, request_context, bank_id: str, document_id: str, body: str) -> None:
+    await memory.retain_batch_async(
+        bank_id=bank_id,
+        contents=[{"content": body, "document_id": document_id, "update_mode": "append"}],
+        request_context=request_context,
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_appends_keep_every_turn(memory_stub_emb, request_context):
+    """Regression: parallel appends used to drop all but one turn.
+
+    Each append reads the stored document, concatenates onto it and reprocesses.
+    Before the compare-and-swap, three appends that all read the same base each
+    replaced the document with their own version — the last writer won, the
+    other two turns were deleted, and all three calls returned success.
+    """
+    bank_id = f"test_append_race_{_ts()}"
+    document_id = "conversation"
+
+    await _append(memory_stub_emb, request_context, bank_id, document_id, "TURN_ONE Alice works at Google.")
+
+    await asyncio.gather(
+        _append(memory_stub_emb, request_context, bank_id, document_id, "TURN_TWO Bob works at Microsoft."),
+        _append(memory_stub_emb, request_context, bank_id, document_id, "TURN_THREE Carol works at Amazon."),
+        _append(memory_stub_emb, request_context, bank_id, document_id, "TURN_FOUR Dave works at Meta."),
+    )
+
+    doc = await memory_stub_emb.get_document(document_id, bank_id, request_context=request_context)
+    text = doc["original_text"] or ""
+    missing = [marker for marker in ("TURN_ONE", "TURN_TWO", "TURN_THREE", "TURN_FOUR") if marker not in text]
+    assert not missing, f"appends lost {missing}; document is {text!r}"
+
+    # The turns must also survive as memories, not just as document text: the
+    # losing writers used to cascade-delete the winner's units.
+    async with memory_stub_emb._pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT text FROM memory_units WHERE bank_id = $1 AND document_id = $2",
+            bank_id,
+            document_id,
+        )
+    stored = " ".join(r["text"] for r in rows)
+    assert "TURN_ONE" in stored and "TURN_FOUR" in stored
+
+
+@pytest.mark.asyncio
+async def test_sequential_appends_are_unaffected(memory_stub_emb, request_context):
+    """The compare-and-swap must not cost the uncontended path anything."""
+    bank_id = f"test_append_sequential_{_ts()}"
+    document_id = "conversation"
+
+    for marker in ("ONE", "TWO", "THREE"):
+        await _append(memory_stub_emb, request_context, bank_id, document_id, f"TURN_{marker} content here.")
+
+    doc = await memory_stub_emb.get_document(document_id, bank_id, request_context=request_context)
+    text = doc["original_text"] or ""
+    assert all(f"TURN_{m}" in text for m in ("ONE", "TWO", "THREE"))
+    assert text.index("TURN_ONE") < text.index("TURN_TWO") < text.index("TURN_THREE")
+
+
+# ---------------------------------------------------------------------------
+# Post-retain hooks across a folded execution
+# ---------------------------------------------------------------------------
+
+
+class _RecordingValidator(OperationValidatorExtension):
+    """Minimal stand-in for a metering extension — records what it is told.
+
+    A real subclass rather than a duck-typed stub: the engine calls the
+    pre-operation validators too, so a bare recorder would never be reached.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(config={})
+        self.results: list[RetainResult] = []
+
+    async def validate_retain(self, ctx) -> ValidationResult:
+        return ValidationResult.accept()
+
+    async def validate_recall(self, ctx) -> ValidationResult:
+        return ValidationResult.accept()
+
+    async def validate_reflect(self, ctx) -> ValidationResult:
+        return ValidationResult.accept()
+
+    async def on_retain_complete(self, result: RetainResult) -> None:
+        self.results.append(result)
+
+
+@pytest.mark.asyncio
+async def test_folded_execution_reports_one_hook_per_operation(memory_stub_emb, request_context):
+    """A fold must not make submissions invisible to metering, or double-count them.
+
+    Each folded operation gets its own hook with its own content slice, and the
+    LLM usage summed across the fold equals what the single execution spent —
+    the same total the callers would have seen retaining one at a time.
+    """
+    validator = _RecordingValidator()
+    memory_stub_emb._operation_validator = validator
+    try:
+        bank_id = f"test_fold_hooks_{_ts()}"
+        document_id = "conversation"
+        fold_members = [
+            FoldMemberRef(operation_id="op-1", items_count=1),
+            FoldMemberRef(operation_id="op-2", items_count=1),
+            FoldMemberRef(operation_id="op-3", items_count=1),
+        ]
+
+        _, usage = await memory_stub_emb.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {"content": "TURN_ONE Alice works at Google.", "document_id": document_id},
+                {"content": "TURN_TWO Bob works at Microsoft.", "document_id": document_id},
+                {"content": "TURN_THREE Carol works at Amazon.", "document_id": document_id},
+            ],
+            request_context=request_context,
+            return_usage=True,
+            fold_members=fold_members,
+        )
+    finally:
+        memory_stub_emb._operation_validator = None
+
+    assert len(validator.results) == 3, "one post-retain hook per folded operation"
+
+    # Totals are preserved: the fold reports exactly the execution's usage.
+    assert sum(r.llm_total_tokens for r in validator.results) == usage.total_tokens
+    assert sum(r.llm_input_tokens for r in validator.results) == usage.input_tokens
+    assert sum(r.llm_output_tokens for r in validator.results) == usage.output_tokens
+
+    # ...carried by the first member, with the rest at zero (see RetainResult.folded_with).
+    assert validator.results[0].llm_total_tokens == usage.total_tokens
+    assert all(r.llm_total_tokens == 0 for r in validator.results[1:])
+
+    # Every member knows the operations it ran with, itself excluded.
+    assert validator.results[0].folded_with == ["op-2", "op-3"]
+    assert validator.results[1].folded_with == ["op-1", "op-3"]
+    assert validator.results[2].folded_with == ["op-1", "op-2"]
+
+    # Each member sees only the content it submitted.
+    assert [r.contents[0]["content"][:8] for r in validator.results] == ["TURN_ONE", "TURN_TWO", "TURN_THR"]
+
+
+@pytest.mark.asyncio
+async def test_unfolded_retain_reports_one_hook_with_full_usage(memory_stub_emb, request_context):
+    """The ordinary path is untouched: one hook, all the usage, no folded_with."""
+    validator = _RecordingValidator()
+    memory_stub_emb._operation_validator = validator
+    try:
+        bank_id = f"test_unfolded_hooks_{_ts()}"
+        _, usage = await memory_stub_emb.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": "Alice works at Google.", "document_id": "doc"}],
+            request_context=request_context,
+            return_usage=True,
+        )
+    finally:
+        memory_stub_emb._operation_validator = None
+
+    assert len(validator.results) == 1
+    assert validator.results[0].llm_total_tokens == usage.total_tokens
+    assert validator.results[0].folded_with is None

--- a/hindsight-api-slim/tests/test_retain_document_serialization.py
+++ b/hindsight-api-slim/tests/test_retain_document_serialization.py
@@ -329,10 +329,19 @@ def _poller(backend, worker_id: str):
 
 
 @dataclass
+class _ClaimedRetain:
+    """One claimed retain and the peers folded into it."""
+
+    operation_id: str
+    folded_operation_ids: list[str]
+    task_dict: dict
+
+
+@dataclass
 class _ClaimOutcome:
     """What a rolled-back claim observed for one bank."""
 
-    tasks: list[tuple]
+    tasks: list[_ClaimedRetain]
     statuses: list
 
 
@@ -356,7 +365,13 @@ async def _claim_own(backend, bank_id: str, worker_id: str) -> "_ClaimOutcome":
             payload = row["task_payload"]
             task_dict = json.loads(payload) if isinstance(payload, str) else payload
             folded = await poller._fold_retain_peers(conn, "async_operations", row, task_dict)
-            tasks.append((str(row["operation_id"]), folded, task_dict))
+            tasks.append(
+                _ClaimedRetain(
+                    operation_id=str(row["operation_id"]),
+                    folded_operation_ids=folded,
+                    task_dict=task_dict,
+                )
+            )
         # Read the claim's effect back inside the same transaction, before the
         # rollback: this is the state a committed claim would leave behind.
         observed["statuses"] = await conn.fetch(
@@ -379,11 +394,11 @@ async def test_claim_folds_queued_peers_into_one_execution(backend, bank):
     claimed = await _claim_own(backend, bank, "w-fold")
 
     assert len(claimed.tasks) == 1, "the fold must produce a single execution"
-    operation_id, folded, task_dict = claimed.tasks[0]
-    assert operation_id == first
-    assert folded == [second, third]
-    assert [c["content"] for c in task_dict["contents"]] == ["turn one", "turn two", "turn three"]
-    assert [m["operation_id"] for m in task_dict["_fold_members"]] == [first, second, third]
+    claim = claimed.tasks[0]
+    assert claim.operation_id == first
+    assert claim.folded_operation_ids == [second, third]
+    assert [c["content"] for c in claim.task_dict["contents"]] == ["turn one", "turn two", "turn three"]
+    assert [m["operation_id"] for m in claim.task_dict["_fold_members"]] == [first, second, third]
 
     # Invariant: every folded member is claimed by this worker, none left pending.
     assert {r["status"] for r in claimed.statuses} == {"processing"}
@@ -399,7 +414,7 @@ async def test_fold_stops_at_a_foreign_document(backend, bank):
 
     claimed = await _claim_own(backend, bank, "w-fold2")
 
-    folds = {op_id: folded for op_id, folded, _ in claimed.tasks}
+    folds = {claim.operation_id: claim.folded_operation_ids for claim in claimed.tasks}
     assert folds[first] == [second]
     assert folds[other] == []
 


### PR DESCRIPTION
## The bug

`update_mode="append"` is a read-modify-write over the whole document: the retain reads `documents.original_text`, concatenates the new content onto it, and reprocesses the result — with LLM extraction sitting between the read and the write. Nothing made that atomic, so concurrent appends to one document raced, and the losers were dropped **silently**, with every caller getting a success.

Reproduced on `main` — three parallel appends after a seeded turn:

```
outcomes:      ['t2:ok', 't3:ok', 't4:ok']          ← all three "succeeded"
document:      TURN_ONE ... TURN_FOUR               ← TWO and THREE gone
memory_units:  TURN_ONE, TURN_FOUR                  ← their units cascade-deleted too
```

This is now the standard integration shape: a session gets one stable `document_id` and each turn is appended from an independent process (see `openclaw`'s session-scoped document, `index.ts`), plus queue flushes replaying buffered turns.

Every existing guard was written for *replace* semantics, where "someone newer won, drop mine" is correct. For append it is data loss — the dropped turn is content nobody else has.

## The fix

Three layers, each carrying a different guarantee.

**1. Append compare-and-swap** — correctness. The append records the `content_hash` it built on and verifies it under the document row lock, before the write that establishes ownership. A moved base raises `ConcurrentAppendConflict`; the append is redone on the newer text (3 attempts, jittered) rather than committing over the winner. The paths that used to discard content — the stale-request skip and the streaming takeover — now raise for appends and are untouched for replace.

**2. Per-document claim serialization** — avoids the conflict rather than paying for it. New `async_operations.serialization_key` plus `document_serialization_sql`, the same predicate shape `graph_maintenance_bank_serialization_sql` already uses per bank. One in-flight retain per document; a waiting operation holds **no worker slot** (it simply isn't claimed), and different documents stay fully parallel — so a 12-worker fleet keeps saturating.

**3. Claim-time coalescing** — performance. A backlog for one document is claimed and run as a single execution, so a client flushing 50 buffered turns costs one pass instead of 50 sequential ones.

The coalescing is deliberately shaped to be low-risk:

- It folds **at claim time, over immutable rows** the claim transaction already holds `FOR UPDATE` — it never rewrites a pending operation's `task_payload`. The submit-time alternative races the worker reading that row and would reintroduce the very lost-update bug being fixed.
- **Operation identity survives.** Each submission keeps its own `operation_id`, status and post-retain hook, so nothing downstream of the queue — polling, webhooks, cancellation, metering — has to learn about folding.
- It is a **pure optimization**: delete it and the system is still correct, only slower. Layers 1 and 2 carry correctness independently, so a folding bug can cost latency or LLM spend but cannot lose a turn.

Fold width halves per `retry_count`, so a poisonous turn converges on running — and failing — alone instead of holding good turns hostage.

## Fold eligibility

Folding is sound only for **appends**, because only appends are cumulative: running two as one execution over the concatenated turns gives the same document as running them in sequence. Replace means "this body supersedes what is stored", so a fold must never take one — two folded replaces would store `body1 + body2` where the answer is `body2`, and an append folded behind a replace would turn a document-wiping submission into a concatenation. Anything that is not append-only runs alone, as primary and as peer (including items with no `update_mode`, since the default is replace).

A peer also has to match the primary on everything the execution applies **once** from the primary's payload — tenant, API key, `document_tags` (compared order-insensitively), `strategy` — or folding would apply the primary's value to the peer's content and silently drop the peer's. File-backed retains are excluded on both sides: a converted upload attaches its storage key afterwards, and that step only fires for a single-item retain.

A rejected peer defers everything behind it. Taking a later peer past a rejected one would commit turns out of order.

## Post-retain hooks

A folded execution fires the hook **once per member**, in submission order, each with its own content slice and a `folded_with` list. The execution's usage lands on the first member and zero on the rest, so `sum(llm_total_tokens)` across a fold is exactly what the execution spent — the same total the callers would have seen retaining one at a time. Asserted directly in `test_folded_execution_reports_one_hook_per_operation`.

## Also fixed

`_run_delta_db_work` signalled its concurrency abort with a bare `return None` from a function declared `-> None`, and the caller discarded the value. The delta concurrency guard has therefore been logging *"aborting delta, falling back to full retain"* while actually committing on top of the concurrent writer. Distinct latent bug, found while tracing this one.

## Relationship to #3363 / #3386

#3363 said of the queued path: *"Keep the guard there, or serialise children per document first."* Layer 2 is that serialization. #3386 (now on main) made the sync path fold shared `document_id` items; a claim-time fold hands `retain_batch_async` exactly that shape, so this rides #3386's grouping rather than duplicating it. The queued-path submit guard is left as-is — out of scope here.

## Tests

- `test_concurrent_appends_keep_every_turn` — the regression test; fails on `main`, passes here.
- Claim predicate and fold, deterministic at the queue layer (no LLM): one retain per document, no cross-document serialization, waits for a processing peer, folds in submission order, every member claimed.
- Fold planner as pure functions: submission order, token budget, never skipping a turn to reach a later one, `max_peers`, retry narrowing.
- Hook totals, folded and unfolded.

303 passed across the retain / delta / worker / batch / extensions / file-retain / backup-restore suites on a clean database. `lint.sh` and `ty` clean.

## Notes for review

- The CAS is scoped to the first sub-batch (where the append read happens). A multi-sub-batch append that loses later still raises rather than dropping — it just fails the operation and relies on the worker's retry instead of the in-process redo.
- The fold is capped by `retain_batch_tokens` so a folded execution stays within a single orchestrator pass; splitting one document across differently-bodied sub-batches trips the streaming ownership check (#3282).
- A peer wedged in `processing` holds its document until claim recovery releases it — the same caveat the graph-maintenance predicate already carries, not new here.
