### PR TITLE
fix(stats): drop permanently failed memories from pending_consolidation

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1985,7 +1985,14 @@ class BankStatsResponse(BaseModel):
             "mental-model read can confirm."
         ),
     )
-    pending_consolidation: int = Field(default=0, description="Number of memories not yet processed into observations")
+    pending_consolidation: int = Field(
+        default=0,
+        description=(
+            "Number of source memories (world/experience) still queued for consolidation into "
+            "observations. Excludes memories whose consolidation permanently failed — those are "
+            "counted only in failed_consolidation — so this drains to 0 when the consolidator catches up."
+        ),
+    )
     failed_consolidation: int = Field(
         default=0,
         description="Number of source memories (world/experience) whose consolidation permanently failed and can be retried via the consolidation recovery endpoint.",

--- a/hindsight-api-slim/hindsight_api/engine/memories/pg/counts.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/pg/counts.py
@@ -17,6 +17,13 @@ from typing import Any
 async def consolidation_freshness(*, conn, fq_table: Callable[[str], str], bank_id: str) -> dict[str, Any]:
     """Last consolidation time, the pending / failed fact counts, and the write watermark, in one scan.
 
+    ``pending`` and ``failed`` are disjoint: pending carries the consolidator's
+    own candidate predicate (``consolidated_at IS NULL AND consolidation_failed_at
+    IS NULL``, see ``reads.find_unconsolidated``), so it reads as "work the
+    consolidator will still do" and drains to zero. A fact the LLM could not
+    handle is counted once, under ``failed``, and only leaves that bucket via the
+    consolidation-recovery endpoint.
+
     All four come from a single pass so keeping ``failed`` — part of the
     published contract — costs nothing over reflect()'s ``pending`` read, and
     ``last_memory_write_at`` (the newest ``updated_at`` anywhere in the bank)
@@ -29,7 +36,11 @@ async def consolidation_freshness(*, conn, fq_table: Callable[[str], str], bank_
         SELECT
             MAX(consolidated_at) AS last_consolidated_at,
             MAX(updated_at) AS last_memory_write_at,
-            COUNT(*) FILTER (WHERE consolidated_at IS NULL AND fact_type IN ('experience', 'world')) AS pending,
+            COUNT(*) FILTER (
+                WHERE consolidated_at IS NULL
+                  AND consolidation_failed_at IS NULL
+                  AND fact_type IN ('experience', 'world')
+            ) AS pending,
             COUNT(*) FILTER (WHERE consolidation_failed_at IS NOT NULL AND fact_type IN ('experience', 'world')) AS failed
         FROM {fq_table("memory_units")}
         WHERE bank_id = $1

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -11805,6 +11805,9 @@ class MemoryEngine(MemoryEngineInterface):
             # Consolidation freshness (last-consolidated, pending, failed) lives on the memories,
             # so a store that keeps them outside SQL must answer this — the memory_units query
             # returns 0/None for it. Same {last_consolidated_at, pending, failed} shape either way.
+            # `pending` and `failed` are disjoint here exactly as in
+            # memories.pg.counts.consolidation_freshness: pending carries the consolidator's
+            # candidate predicate, so a permanently failed fact is counted only as failed.
             from .memories import get_memories
 
             _store = get_memories()
@@ -11814,7 +11817,11 @@ class MemoryEngine(MemoryEngineInterface):
                     SELECT
                         MAX(consolidated_at) as last_consolidated_at,
                         MAX(updated_at) as last_memory_write_at,
-                        COUNT(*) FILTER (WHERE consolidated_at IS NULL AND fact_type IN ('experience', 'world')) as pending,
+                        COUNT(*) FILTER (
+                            WHERE consolidated_at IS NULL
+                              AND consolidation_failed_at IS NULL
+                              AND fact_type IN ('experience', 'world')
+                        ) as pending,
                         COUNT(*) FILTER (WHERE consolidation_failed_at IS NOT NULL AND fact_type IN ('experience', 'world')) as failed
                     FROM {fq_table("memory_units")}
                     WHERE bank_id = $1

--- a/hindsight-api-slim/hindsight_api/metrics.py
+++ b/hindsight-api-slim/hindsight_api/metrics.py
@@ -954,7 +954,8 @@ class MetricsCollector(MetricsCollectorBase):
         self.meter.create_observable_gauge(
             name="hindsight.consolidation.backlog",
             callbacks=[get_consolidation_backlog],
-            description="Source memories (experience/world) not yet consolidated into observations",
+            description="Source memories (experience/world) still queued for consolidation into "
+            "observations; excludes permanently failed ones, which are in hindsight.consolidation.failed",
             unit="{memories}",
         )
         self.meter.create_observable_gauge(
@@ -1043,6 +1044,14 @@ class MetricsCollector(MetricsCollectorBase):
                 #   idx_memory_units_consolidation_failed  WHERE consolidation_failed_at IS NOT NULL ...
                 # GROUP BY bank_id still composes — bank_id is each index's lead column.
                 #
+                # The backlog gauge is disjoint from the failed gauge: it carries the
+                # consolidator's own `consolidation_failed_at IS NULL` (see
+                # reads.find_unconsolidated), so a permanently failed fact does not hold
+                # the backlog above zero forever and "backlog > 0 for N minutes" stays an
+                # alertable condition. That extra term is not in the partial index's
+                # predicate, so it is a cheap recheck on the rows the index already
+                # returned — the failed set is tiny by construction.
+                #
                 # The backlog count runs with seqscan disabled in a scoped
                 # transaction. The partial index matches its predicate, but
                 # `consolidated_at IS NULL` is true for a large fraction of the
@@ -1059,7 +1068,8 @@ class MetricsCollector(MetricsCollectorBase):
                         rows = await conn.fetch(
                             f"SELECT {bank_sel}COUNT(*) AS count "
                             f'FROM "{schema}".memory_units '
-                            "WHERE consolidated_at IS NULL AND fact_type IN ('experience', 'world')"
+                            "WHERE consolidated_at IS NULL AND consolidation_failed_at IS NULL "
+                            "AND fact_type IN ('experience', 'world')"
                             f"{bank_grp}"
                         )
                     for row in rows:

--- a/hindsight-api-slim/tests/test_backlog_metrics.py
+++ b/hindsight-api-slim/tests/test_backlog_metrics.py
@@ -129,7 +129,13 @@ async def test_refresh_backlog_uses_index_matched_predicates_not_filter_scan():
     mem_queries = [s for s in captured if "memory_units" in s and "COUNT(*)" in s]
     assert len(mem_queries) == 2  # split, not a single two-FILTER aggregate
     assert all("FILTER" not in s for s in mem_queries)
-    assert any("consolidated_at IS NULL AND fact_type IN ('experience', 'world')" in s for s in mem_queries)
+    # The backlog query excludes the permanently failed memories the consolidator
+    # will never pick up again, so the two gauges are disjoint and the backlog can
+    # reach zero (they are counted by the second query instead).
+    assert any(
+        "consolidated_at IS NULL AND consolidation_failed_at IS NULL AND fact_type IN ('experience', 'world')" in s
+        for s in mem_queries
+    )
     assert any("consolidation_failed_at IS NOT NULL AND fact_type IN ('experience', 'world')" in s for s in mem_queries)
 
     ops_sql = next(s for s in captured if "async_operations" in s and "GROUP BY" in s)

--- a/hindsight-api-slim/tests/test_bank_stats.py
+++ b/hindsight-api-slim/tests/test_bank_stats.py
@@ -229,8 +229,38 @@ async def test_bank_stats_reports_failed_consolidation(api_client, memory, test_
         stats = response.json()
 
         assert stats["failed_consolidation"] == 2
-        # The two failed memories also count as "not-yet-consolidated".
-        assert stats["pending_consolidation"] >= 3
+        # Pending is the work the consolidator will still do, so the two failed
+        # memories are counted only as failed — the buckets are disjoint.
+        assert stats["pending_consolidation"] == 1
+    finally:
+        await api_client.delete(f"/v1/default/banks/{test_bank_id}")
+
+
+@pytest.mark.asyncio
+async def test_pending_consolidation_matches_pending_memory_list(api_client, memory, test_bank_id):
+    """pending_consolidation must agree with ?consolidation_state=pending.
+
+    Both are meant to answer "what is left to consolidate"; when the stats gauge
+    counted permanently failed memories too, it sat above the list total by
+    exactly failed_consolidation and never reached zero.
+    """
+    try:
+        await _insert_memory(memory, test_bank_id, "Still queued 1.", failed=False)
+        await _insert_memory(memory, test_bank_id, "Still queued 2.", failed=False)
+        await _insert_memory(memory, test_bank_id, "Given up on.", failed=True)
+
+        stats_response = await api_client.get(f"/v1/default/banks/{test_bank_id}/stats")
+        assert stats_response.status_code == 200
+        stats = stats_response.json()
+
+        list_response = await api_client.get(
+            f"/v1/default/banks/{test_bank_id}/memories/list",
+            params={"consolidation_state": "pending", "limit": 1},
+        )
+        assert list_response.status_code == 200
+
+        assert stats["pending_consolidation"] == list_response.json()["total"] == 2
+        assert stats["failed_consolidation"] == 1
     finally:
         await api_client.delete(f"/v1/default/banks/{test_bank_id}")
 
@@ -321,8 +351,9 @@ async def test_get_bank_freshness_returns_only_consolidation_fields(memory, test
             "pending_consolidation",
             "failed_consolidation",
         }
-        assert freshness["pending_consolidation"] >= 2
-        assert freshness["failed_consolidation"] >= 1
+        # Same disjoint buckets as /stats: the failed memory is not also pending.
+        assert freshness["pending_consolidation"] == 1
+        assert freshness["failed_consolidation"] == 1
     finally:
         await memory._bank_stats_cache.clear()
         async with memory._pool.acquire() as conn:

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -5107,7 +5107,10 @@ components:
           type: string
         pending_consolidation:
           default: 0
-          description: Number of memories not yet processed into observations
+          description: Number of source memories (world/experience) still queued for
+            consolidation into observations. Excludes memories whose consolidation
+            permanently failed — those are counted only in failed_consolidation —
+            so this drains to 0 when the consolidator catches up.
           title: Pending Consolidation
           type: integer
         failed_consolidation:

--- a/hindsight-clients/go/model_bank_stats_response.go
+++ b/hindsight-clients/go/model_bank_stats_response.go
@@ -35,7 +35,7 @@ type BankStatsResponse struct {
 	OperationsByStatus map[string]int32 `json:"operations_by_status,omitempty"`
 	LastConsolidatedAt NullableString `json:"last_consolidated_at,omitempty"`
 	LastMemoryWriteAt NullableString `json:"last_memory_write_at,omitempty"`
-	// Number of memories not yet processed into observations
+	// Number of source memories (world/experience) still queued for consolidation into observations. Excludes memories whose consolidation permanently failed — those are counted only in failed_consolidation — so this drains to 0 when the consolidator catches up.
 	PendingConsolidation *int32 `json:"pending_consolidation,omitempty"`
 	// Number of source memories (world/experience) whose consolidation permanently failed and can be retried via the consolidation recovery endpoint.
 	FailedConsolidation *int32 `json:"failed_consolidation,omitempty"`

--- a/hindsight-clients/python/hindsight_client_api/models/bank_stats_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/bank_stats_response.py
@@ -39,7 +39,7 @@ class BankStatsResponse(BaseModel):
     operations_by_status: Optional[Dict[str, StrictInt]] = Field(default=None, description="Async operations grouped by status (pending, processing, completed, failed, cancelled).")
     last_consolidated_at: Optional[StrictStr] = None
     last_memory_write_at: Optional[StrictStr] = None
-    pending_consolidation: Optional[StrictInt] = Field(default=0, description="Number of memories not yet processed into observations")
+    pending_consolidation: Optional[StrictInt] = Field(default=0, description="Number of source memories (world/experience) still queued for consolidation into observations. Excludes memories whose consolidation permanently failed — those are counted only in failed_consolidation — so this drains to 0 when the consolidator catches up.")
     failed_consolidation: Optional[StrictInt] = Field(default=0, description="Number of source memories (world/experience) whose consolidation permanently failed and can be retried via the consolidation recovery endpoint.")
     total_observations: Optional[StrictInt] = Field(default=0, description="Total number of observations")
     __properties: ClassVar[List[str]] = ["bank_id", "total_nodes", "total_links", "total_documents", "nodes_by_fact_type", "links_by_link_type", "links_by_fact_type", "links_breakdown", "pending_operations", "failed_operations", "operations_by_status", "last_consolidated_at", "last_memory_write_at", "pending_consolidation", "failed_consolidation", "total_observations"]

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -426,7 +426,7 @@ export type BankStatsResponse = {
   /**
    * Pending Consolidation
    *
-   * Number of memories not yet processed into observations
+   * Number of source memories (world/experience) still queued for consolidation into observations. Excludes memories whose consolidation permanently failed — those are counted only in failed_consolidation — so this drains to 0 when the consolidator catches up.
    */
   pending_consolidation?: number;
   /**

--- a/hindsight-control-plane/src/components/bank-stats-view.tsx
+++ b/hindsight-control-plane/src/components/bank-stats-view.tsx
@@ -1115,7 +1115,13 @@ export function BankStatsView() {
 
   if (!stats) return null;
 
-  const consolidatedDone = Math.max(0, stats.total_nodes - stats.pending_consolidation);
+  // Done / pending / failed are shown side by side and must not overlap: the API's
+  // pending_consolidation already excludes permanently failed memories, so those are
+  // subtracted here too rather than being counted as done.
+  const consolidatedDone = Math.max(
+    0,
+    stats.total_nodes - stats.pending_consolidation - (stats.failed_consolidation ?? 0)
+  );
 
   return (
     <div className="space-y-8">

--- a/hindsight-dev/benchmarks/common/benchmark_runner.py
+++ b/hindsight-dev/benchmarks/common/benchmark_runner.py
@@ -560,8 +560,13 @@ class BenchmarkRunner:
         """
         Get the count of memories pending consolidation.
 
+        Mirrors the consolidator's own candidate predicate (and the API's
+        pending_consolidation): memories stamped consolidation_failed_at are never
+        retried, so counting them here would keep _wait_for_consolidation spinning
+        until its timeout.
+
         Returns:
-            Number of memories not yet processed by the consolidation job
+            Number of memories still queued for the consolidation job
         """
         pool = await self.memory._get_pool()
         from hindsight_api.engine.memory_engine import fq_table
@@ -571,7 +576,10 @@ class BenchmarkRunner:
                 f"""
                 SELECT COUNT(*) as count
                 FROM {fq_table("memory_units")}
-                WHERE bank_id = $1 AND consolidated_at IS NULL AND fact_type IN ('experience', 'world')
+                WHERE bank_id = $1
+                  AND consolidated_at IS NULL
+                  AND consolidation_failed_at IS NULL
+                  AND fact_type IN ('experience', 'world')
                 """,
                 bank_id,
             )

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -7414,7 +7414,7 @@
           "pending_consolidation": {
             "type": "integer",
             "title": "Pending Consolidation",
-            "description": "Number of memories not yet processed into observations",
+            "description": "Number of source memories (world/experience) still queued for consolidation into observations. Excludes memories whose consolidation permanently failed \u2014 those are counted only in failed_consolidation \u2014 so this drains to 0 when the consolidator catches up.",
             "default": 0
           },
           "failed_consolidation": {

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -7414,7 +7414,7 @@
           "pending_consolidation": {
             "type": "integer",
             "title": "Pending Consolidation",
-            "description": "Number of memories not yet processed into observations",
+            "description": "Number of source memories (world/experience) still queued for consolidation into observations. Excludes memories whose consolidation permanently failed \u2014 those are counted only in failed_consolidation \u2014 so this drains to 0 when the consolidator catches up.",
             "default": 0
           },
           "failed_consolidation": {


### PR DESCRIPTION
Fixes #3362.

## The bug

`pending_consolidation` counted every fact with `consolidated_at IS NULL`, including the ones stamped `consolidation_failed_at` that the consolidator's own candidate query (`reads.find_unconsolidated`) skips on purpose. The gauge had a floor no amount of work could clear — it sat above `?consolidation_state=pending` by exactly `failed_consolidation`, indefinitely — so an operator could not tell a real backlog from an abandoned residue.

`pending` now carries the consolidator's predicate. The two buckets are disjoint: a fact the LLM could not handle is counted once, under `failed`, and leaves that bucket only via `POST /consolidation/recover`.

## The same predicate was missing in five more places

- **`get_bank_stats` keeps a second copy of the freshness SQL** for the `writes_memory_rows_in_sql` path — fixing only `counts.py` would have left the default Postgres path wrong.
- **`hindsight.consolidation.backlog`** had the same floor, which made "backlog > 0 for N minutes" unalertable on any bank holding a residue.
- **reflect's `tool_search_observations`** derives `is_stale` / `freshness` from this count (`stale` at ≥10), so a residue told the model the observations were stale on every reflect call, for ever. Fixed transitively via `get_bank_freshness`.
- **The control plane's consolidation card** computed `done = total - pending`, which would have counted the failed rows as done once pending got strict; it now subtracts both, so done / pending / failed no longer overlap.
- **The benchmark runner** waits for this count to reach 0, so one permanently failed fact burned the full 3000s timeout.

Everything else that answers "what is left to consolidate" already excluded them — the memories list filter, `count_unconsolidated`, and the `banks_needing_consolidation()` maintenance routine — so scheduling was never spinning on the residue.

The issue also names `components/data-view.tsx`; that surface no longer exists on `main`, so only the stats card needed the render fix.

## Notes

- `pending_consolidation`'s OpenAPI description said "not yet processed into observations", which is what invited the superset reading. It now states the exclusion; specs and clients are regenerated.
- The extra `consolidation_failed_at IS NULL` term is not in `idx_memory_units_unconsolidated`'s predicate, so it is a recheck on rows the index already returned. The failed set is tiny by construction, and the metrics query keeps its `SET LOCAL enable_seqscan = off` nudge.

## Testing

- New regression test asserts `pending_consolidation == GET /memories/list?consolidation_state=pending → total` — the exact equality the issue reported as broken — plus `failed_consolidation` counted separately.
- `test_bank_stats_reports_failed_consolidation` and `test_get_bank_freshness_...` now assert the strict counts instead of `>=`.
- `test_backlog_metrics.py` asserts the gauge SQL carries the exclusion.
- Local: those three stats tests, `test_consolidation_failure_recovery.py` + `test_maintenance_routines.py` (31 passed), and `test_backlog_metrics.py` (7 passed) all pass; lint clean.
