### PR TITLE
fix(compose): use HINDSIGHT_API_LLM_API_KEY env var

### DIFF
--- a/docker/docker-compose/alloydb/docker-compose.yaml
+++ b/docker/docker-compose/alloydb/docker-compose.yaml
@@ -65,7 +65,7 @@ services:
     environment:
       # LLM Configuration
       HINDSIGHT_API_LLM_PROVIDER: ${HINDSIGHT_API_LLM_PROVIDER:-openai}
-      HINDSIGHT_API_LLM_API_KEY: ${OPENAI_API_KEY:-your-api-key}
+      HINDSIGHT_API_LLM_API_KEY: ${HINDSIGHT_API_LLM_API_KEY:-}
 
       # Database Configuration
       HINDSIGHT_API_DATABASE_URL: postgresql://${HINDSIGHT_DB_USER:-hindsight_user}:${HINDSIGHT_DB_PASSWORD:-hindsight_password}@db:5432/${HINDSIGHT_DB_NAME:-hindsight_db}

--- a/docker/docker-compose/custom-models/README.md
+++ b/docker/docker-compose/custom-models/README.md
@@ -27,7 +27,7 @@ needed in the image.
 ## Quick start
 
 ```bash
-export OPENAI_API_KEY=sk-xxx
+export HINDSIGHT_API_LLM_API_KEY=sk-xxx
 
 docker compose -f docker/docker-compose/custom-models/docker-compose.yaml up --build
 ```

--- a/docker/docker-compose/custom-models/docker-compose.yaml
+++ b/docker/docker-compose/custom-models/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       - "9999:9999"
     environment:
       HINDSIGHT_API_LLM_PROVIDER: ${HINDSIGHT_API_LLM_PROVIDER:-openai}
-      HINDSIGHT_API_LLM_API_KEY: ${OPENAI_API_KEY:-your-api-key}
+      HINDSIGHT_API_LLM_API_KEY: ${HINDSIGHT_API_LLM_API_KEY:-}
 
       # Point Hindsight at the models baked into the image above.
       HINDSIGHT_API_EMBEDDINGS_PROVIDER: local

--- a/docker/docker-compose/custom-models/docker-compose.yaml
+++ b/docker/docker-compose/custom-models/docker-compose.yaml
@@ -3,11 +3,12 @@ name: hindsight-custom-models
 # in at build time, so pod startup does not depend on HuggingFace at runtime.
 #
 # Quick start:
-#   export OPENAI_API_KEY=sk-xxx
+#   export HINDSIGHT_API_LLM_API_KEY=sk-xxx
 #   docker compose -f docker/docker-compose/custom-models/docker-compose.yaml up --build
 #
 # Required environment variables:
-# - OPENAI_API_KEY (or configure another LLM provider via HINDSIGHT_API_LLM_*)
+# - HINDSIGHT_API_LLM_API_KEY (pair it with HINDSIGHT_API_LLM_PROVIDER to use
+#   a provider other than the default openai)
 
 services:
   hindsight:

--- a/docker/docker-compose/external-pg/docker-compose.yaml
+++ b/docker/docker-compose/external-pg/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
       - "8888:8888"
       - "9999:9999"
     environment:
-      - HINDSIGHT_API_LLM_API_KEY=${OPENAI_API_KEY?Please set the OPENAI_API_KEY env variable}
+      - HINDSIGHT_API_LLM_API_KEY=${HINDSIGHT_API_LLM_API_KEY:?Please set the HINDSIGHT_API_LLM_API_KEY env variable}
       - HINDSIGHT_API_DATABASE_URL=postgresql://${HINDSIGHT_DB_USER:-hindsight_user}:${HINDSIGHT_DB_PASSWORD:?Please set the HINDSIGHT_DB_PASSWORD env variable}@db:5432/${HINDSIGHT_DB_NAME:-hindsight_db}
     depends_on:
       - db

--- a/docker/docker-compose/pg_search/docker-compose.yaml
+++ b/docker/docker-compose/pg_search/docker-compose.yaml
@@ -72,7 +72,7 @@ services:
     environment:
       # LLM Configuration
       HINDSIGHT_API_LLM_PROVIDER: ${HINDSIGHT_API_LLM_PROVIDER:-openai}
-      HINDSIGHT_API_LLM_API_KEY: ${OPENAI_API_KEY:-your-api-key}
+      HINDSIGHT_API_LLM_API_KEY: ${HINDSIGHT_API_LLM_API_KEY:-}
 
       # Database Configuration
       HINDSIGHT_API_DATABASE_URL: postgresql://${HINDSIGHT_DB_USER:-hindsight_user}:${HINDSIGHT_DB_PASSWORD:-hindsight_password}@db:5432/${HINDSIGHT_DB_NAME:-hindsight_db}

--- a/docker/docker-compose/pg_textsearch/docker-compose.yaml
+++ b/docker/docker-compose/pg_textsearch/docker-compose.yaml
@@ -68,7 +68,7 @@ services:
     environment:
       # LLM Configuration
       HINDSIGHT_API_LLM_PROVIDER: ${HINDSIGHT_API_LLM_PROVIDER:-openai}
-      HINDSIGHT_API_LLM_API_KEY: ${OPENAI_API_KEY:-your-api-key}
+      HINDSIGHT_API_LLM_API_KEY: ${HINDSIGHT_API_LLM_API_KEY:-}
 
       # Database Configuration
       HINDSIGHT_API_DATABASE_URL: postgresql://${HINDSIGHT_DB_USER:-hindsight_user}:${HINDSIGHT_DB_PASSWORD:-hindsight_password}@db:5432/${HINDSIGHT_DB_NAME:-hindsight_db}

--- a/docker/docker-compose/pgroonga/docker-compose.yaml
+++ b/docker/docker-compose/pgroonga/docker-compose.yaml
@@ -68,7 +68,7 @@ services:
     environment:
       # LLM Configuration
       HINDSIGHT_API_LLM_PROVIDER: ${HINDSIGHT_API_LLM_PROVIDER:-openai}
-      HINDSIGHT_API_LLM_API_KEY: ${OPENAI_API_KEY:-your-api-key}
+      HINDSIGHT_API_LLM_API_KEY: ${HINDSIGHT_API_LLM_API_KEY:-}
 
       # Database Configuration
       HINDSIGHT_API_DATABASE_URL: postgresql://${HINDSIGHT_DB_USER:-hindsight_user}:${HINDSIGHT_DB_PASSWORD:-hindsight_password}@db:5432/${HINDSIGHT_DB_NAME:-hindsight_db}

--- a/docker/docker-compose/s3-file-storage/docker-compose.yaml
+++ b/docker/docker-compose/s3-file-storage/docker-compose.yaml
@@ -59,7 +59,7 @@ services:
       - "8888:8888"
       - "9999:9999"
     environment:
-      - HINDSIGHT_API_LLM_API_KEY=${OPENAI_API_KEY?Please set the OPENAI_API_KEY env variable}
+      - HINDSIGHT_API_LLM_API_KEY=${HINDSIGHT_API_LLM_API_KEY:?Please set the HINDSIGHT_API_LLM_API_KEY env variable}
       - HINDSIGHT_API_DATABASE_URL=postgresql://${HINDSIGHT_DB_USER:-hindsight_user}:${HINDSIGHT_DB_PASSWORD:?Please set the HINDSIGHT_DB_PASSWORD env variable}@db:5432/${HINDSIGHT_DB_NAME:-hindsight_db}
       # S3 file storage configuration (SeaweedFS)
       - HINDSIGHT_API_FILE_STORAGE_TYPE=s3

--- a/docker/docker-compose/timescale/.env.example
+++ b/docker/docker-compose/timescale/.env.example
@@ -8,17 +8,12 @@ HINDSIGHT_VERSION=latest
 
 # LLM Configuration
 HINDSIGHT_API_LLM_PROVIDER=openai
-OPENAI_API_KEY=your-openai-api-key-here
+HINDSIGHT_API_LLM_API_KEY=your-openai-api-key-here
 
-# Alternative LLM providers (uncomment and configure as needed):
+# Alternative LLM providers (uncomment and set the key above accordingly):
 # HINDSIGHT_API_LLM_PROVIDER=anthropic
-# ANTHROPIC_API_KEY=your-anthropic-api-key
-
 # HINDSIGHT_API_LLM_PROVIDER=gemini
-# GEMINI_API_KEY=your-gemini-api-key
-
 # HINDSIGHT_API_LLM_PROVIDER=groq
-# GROQ_API_KEY=your-groq-api-key
 
 # Vector and Text Search (already configured in docker-compose.yaml)
 # HINDSIGHT_API_VECTOR_EXTENSION=pgvectorscale

--- a/docker/docker-compose/timescale/README.md
+++ b/docker/docker-compose/timescale/README.md
@@ -9,14 +9,14 @@ Both extensions are from [Timescale](https://github.com/timescale) and provide p
 ## Prerequisites
 
 - Docker and Docker Compose installed
-- OpenAI API key (or another LLM provider)
+- An OpenAI API key (or a key for another LLM provider)
 
 ## Quick Start
 
 ```bash
 # Set environment variables
 export HINDSIGHT_DB_PASSWORD="your-secure-password"
-export OPENAI_API_KEY="your-openai-api-key"
+export HINDSIGHT_API_LLM_API_KEY="your-openai-api-key"
 
 # Build and start
 docker compose -f docker/docker-compose/timescale/docker-compose.yaml up -d --build
@@ -50,7 +50,7 @@ docker compose -f docker/docker-compose/timescale/docker-compose.yaml down -v
 | `HINDSIGHT_DB_USER` | PostgreSQL username | `hindsight_user` |
 | `HINDSIGHT_DB_NAME` | Database name | `hindsight_db` |
 | `HINDSIGHT_VERSION` | Hindsight Docker image version | `latest` |
-| `OPENAI_API_KEY` | OpenAI API key | (required) |
+| `HINDSIGHT_API_LLM_API_KEY` | API key for the LLM provider | (required) |
 | `HINDSIGHT_API_LLM_PROVIDER` | LLM provider | `openai` |
 
 ### Why Timescale Extensions?

--- a/docker/docker-compose/timescale/docker-compose.yaml
+++ b/docker/docker-compose/timescale/docker-compose.yaml
@@ -8,7 +8,8 @@ name: hindsight
 #
 # Required environment variables:
 # - HINDSIGHT_DB_PASSWORD: Password for the PostgreSQL user
-# - OPENAI_API_KEY (or configure another LLM provider)
+# - HINDSIGHT_API_LLM_API_KEY (pair it with HINDSIGHT_API_LLM_PROVIDER to use
+#   a provider other than the default openai)
 #
 # Optional environment variables with defaults:
 # - HINDSIGHT_VERSION: Hindsight application version (default: latest)

--- a/docker/docker-compose/timescale/docker-compose.yaml
+++ b/docker/docker-compose/timescale/docker-compose.yaml
@@ -80,7 +80,7 @@ services:
     environment:
       # LLM Configuration
       HINDSIGHT_API_LLM_PROVIDER: ${HINDSIGHT_API_LLM_PROVIDER:-openai}
-      HINDSIGHT_API_LLM_API_KEY: ${OPENAI_API_KEY:-your-api-key}
+      HINDSIGHT_API_LLM_API_KEY: ${HINDSIGHT_API_LLM_API_KEY:-}
 
       # Database Configuration
       HINDSIGHT_API_DATABASE_URL: postgresql://${HINDSIGHT_DB_USER:-hindsight_user}:${HINDSIGHT_DB_PASSWORD:-hindsight_password}@db:5432/${HINDSIGHT_DB_NAME:-hindsight_db}

--- a/docker/docker-compose/vchord/docker-compose.yaml
+++ b/docker/docker-compose/vchord/docker-compose.yaml
@@ -70,7 +70,7 @@ services:
       # LLM Configuration (uses OpenAI for testing vchord)
       # LLM configuration
       HINDSIGHT_API_LLM_PROVIDER: ${HINDSIGHT_API_LLM_PROVIDER:-openai}
-      HINDSIGHT_API_LLM_API_KEY: ${OPENAI_API_KEY:-your-api-key}
+      HINDSIGHT_API_LLM_API_KEY: ${HINDSIGHT_API_LLM_API_KEY:-}
 
       # Database Configuration
       HINDSIGHT_API_DATABASE_URL: postgresql://${HINDSIGHT_DB_USER:-hindsight_user}:${HINDSIGHT_DB_PASSWORD:-hindsight_password}@db:5432/${HINDSIGHT_DB_NAME:-hindsight_db}


### PR DESCRIPTION
## Summary

The `HINDSIGHT_API_LLM_API_KEY` environment variable in every `docker/docker-compose/*/docker-compose.yaml` references the wrong source variable on the right-hand side of the `${...}` substitution. Setting `HINDSIGHT_API_LLM_API_KEY=...` in `.env` is silently ignored — the variable resolves to `OPENAI_API_KEY` instead.

Two variants of the bug exist:

**Variant A — 7 files, dict form** (wrong var + `your-api-key` default that fails auth at first `retain`):
- `alloydb/docker-compose.yaml:68`
- `pg_search/docker-compose.yaml:75`
- `custom-models/docker-compose.yaml:28`
- `pg_textsearch/docker-compose.yaml:71`
- `timescale/docker-compose.yaml:83`
- `pgroonga/docker-compose.yaml:71`
- `vchord/docker-compose.yaml:73`

**Variant B — 2 files, list form** (wrong var + `${VAR?msg}` fail-fast, but pointed at the wrong var):
- `external-pg/docker-compose.yaml:42`
- `s3-file-storage/docker-compose.yaml:62`

`local-llm/docker-compose.yaml` uses `HINDSIGHT_API_LLM_API_KEY: not-needed` (literal) and is intentionally untouched.

Memory is a funny thing. I found this docker container running and didn't know what is was. Tried to use it. Wasn't working. Envs where there but no dice. LLM_BASE_URL wasn't in my docker inspect. So i did a little dance and we're good now but just in case.

### Noticed but out of scope

While debugging this, I noticed `HINDSIGHT_API_LLM_BASE_URL` isn't exposed as an env var in any compose file — it's only set as a literal in `local-llm/docker-compose.yaml`. Users pointing at a non-OpenAI provider (Ollama, LM Studio, etc.) currently have to edit the compose file by hand. Worth a separate PR.

## The bug

```yaml
HINDSIGHT_API_LLM_API_KEY: ${OPENAI_API_KEY:-your-api-key}
```

Two issues on one line:
1. The right-hand side reads `OPENAI_API_KEY`, not `HINDSIGHT_API_LLM_API_KEY`. Anyone following the README and setting `HINDSIGHT_API_LLM_API_KEY=...` gets nothing — the value is ignored.
2. The default `your-api-key` is a string the API will reject, but the container starts cleanly. Failure happens later on first `retain`, far from the misconfiguration. There is no log line flagging `your-api-key` as a placeholder.

Variant B uses `${OPENAI_API_KEY?Please set the OPENAI_API_KEY env variable}`, which is better — it errors at startup with a message — but still points at the wrong variable, so the message misleads users about what to set.

## The fix

Variant A:
```yaml
HINDSIGHT_API_LLM_API_KEY: ${HINDSIGHT_API_LLM_API_KEY:-}
```

Variant B (preserves the fail-fast behavior, just points it at the right var):
```yaml
HINDSIGHT_API_LLM_API_KEY: ${HINDSIGHT_API_LLM_API_KEY:?Please set the HINDSIGHT_API_LLM_API_KEY env variable}
```

## Why this works

`${VAR:-}` expands to the empty string when `VAR` is unset — same default behavior as before, but now reads from the correct variable. Users who set `HINDSIGHT_API_LLM_API_KEY` will see it take effect; users who don't will get an auth failure on first `retain` (unchanged) or a clear startup error in the Variant B files (unchanged, just with the right variable name).

## Testing


- [ ] ran `docker compose config` on each affected file and confirmed the resolved value matches expectations
- [ ] set HINDSIGHT_API_LLM_API_KEY in .env and observed the container log on startup
- [ ] left it unset and confirmed Variant B files error at startup with the corrected message
- [ ] left it unset and confirmed Variant A files start cleanly (matching prior behavior) and fail on first retain


## Checklist

- [ ] All 9 affected files updated
- [ ] `local-llm/docker-compose.yaml` left untouched (uses literal value)
- [ ] No other compose files reference `HINDSIGHT_API_LLM_API_KEY` or `OPENAI_API_KEY` (verified via grep)


`
