### PR TITLE
fix: pass EXTRA_BODY through to LlamaCppLLM + detect GFM tables without leading/trailing pipes

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -513,6 +513,7 @@ def create_llm_provider(
             base_url=base_url,
             model=model,
             reasoning_effort=reasoning_effort,
+            extra_body=extra_body,
             model_path=config.llamacpp_model_path,
             gpu_layers=config.llamacpp_gpu_layers,
             context_size=config.llamacpp_context_size,

--- a/hindsight-api-slim/hindsight_api/engine/providers/llamacpp_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/llamacpp_llm.py
@@ -274,6 +274,7 @@ class LlamaCppLLM(LLMInterface):
         base_url: str,
         model: str,
         reasoning_effort: str = "low",
+        extra_body: dict[str, Any] | None = None,
         model_path: str | None = None,
         gpu_layers: int = -1,
         context_size: int = 8192,
@@ -295,6 +296,7 @@ class LlamaCppLLM(LLMInterface):
         self._chat_format = chat_format
         self._no_grammar = no_grammar
         self._extra_args = extra_args
+        self._extra_body = extra_body
         self._server: LlamaCppServer | None = None
         self._delegate: Any = None  # OpenAICompatibleLLM, created after server starts
         self._initialized = False
@@ -337,6 +339,7 @@ class LlamaCppLLM(LLMInterface):
             base_url=self._server.base_url,
             model=self.model,
             reasoning_effort=self.reasoning_effort,
+            extra_body=self._extra_body,
         )
 
         self._initialized = True

--- a/hindsight-api-slim/hindsight_api/engine/reflect/structured_doc.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/structured_doc.py
@@ -333,6 +333,17 @@ def _parse_block(chunk: list[str]) -> Block:
         if has_separator:
             return _parse_table_block(chunk)
 
+    # Lenient fallback: GFM allows omitting leading/trailing pipes, so a table
+    # like "Col1 | Col2\\n--- | ---\\nA | B" won't match the strict pipe-delimited
+    # pattern above. Detect these by requiring a separator line AND at least one
+    # ``|`` in every non-separator line (the column delimiter can't be omitted).
+    if len(chunk) >= 2:
+        sep_indices = [i for i, line in enumerate(chunk) if _TABLE_SEPARATOR_RX.match(line)]
+        if sep_indices:
+            non_sep = [line for i, line in enumerate(chunk) if i not in sep_indices]
+            if non_sep and all("|" in line for line in non_sep):
+                return _parse_table_block(chunk)
+
     return ParagraphBlock(text=" ".join(line.strip() for line in chunk).strip())
 
 

--- a/skills/hindsight-docs/references/sdks/integrations/agent-plugin.md
+++ b/skills/hindsight-docs/references/sdks/integrations/agent-plugin.md
@@ -1,0 +1,14 @@
+
+# Agent Plugins
+
+Portable long-term memory for any [Agent Plugins](https://agent-plugins.org) client, powered by Hindsight.
+
+Agent Plugins is the vendor-neutral open standard for packaging Agent Skills + MCP servers into a single distributable plugin. Hindsight ships one plugin that every compatible client can load.
+
+## Quick Start
+
+1. Get your API key from the Hindsight Cloud dashboard.
+2. Set `HINDSIGHT_API_KEY` and optionally `HINDSIGHT_BANK_ID`.
+3. Install the plugin in your client through its plugin/MCP UI.
+
+Once installed, agents can call `recall`, `retain`, and `reflect` automatically through the bundled skill.


### PR DESCRIPTION
## Summary

Two independent fixes for issues discovered during contribution analysis.

### Fix 1: llamacpp provider silently ignores HINDSIGHT_API_LLM_EXTRA_BODY (closes #3326)

The create_llm_provider() factory accepted extra_body but never passed it to LlamaCppLLM. Every other provider (Bedrock, Fireworks, OpenAI-compatible, LiteLLM, Gemini, Anthropic) receives extra_body — only llamacpp was missing.

**Changes (2 files, +4 lines):**
- llm_wrapper.py: Pass extra_body=extra_body to LlamaCppLLM constructor
- llamacpp_llm.py: Accept extra_body in __init__, store it, forward to OpenAICompatibleLLM delegate

### Fix 2: Delta refresh collapses GFM tables without leading/trailing pipes (closes #3361)

The table parser required pipes at both start AND end of every row. GFM-compliant tables without outer pipes fell through to ParagraphBlock which joins lines with spaces, destroying table structure permanently.

**Changes (1 file, +11 lines):**
- structured_doc.py: Lenient fallback — if chunk has a separator line AND every non-separator line contains |, treat as table