### PR TITLE
fix(embed): make daemon health-check timeout configurable (default 30s, was 2s)

### DIFF
--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -72,6 +72,11 @@ def _parse_non_negative_int(value: str | None, default: int, name: str) -> int:
 # runners than POSIX.
 DAEMON_STARTUP_TIMEOUT = int(os.getenv("HINDSIGHT_EMBED_DAEMON_STARTUP_TIMEOUT", "180"))
 DEFAULT_DAEMON_IDLE_TIMEOUT = 0  # 0 = disabled (no auto-exit)
+# Per-request HTTP timeout for /health probes.  A busy daemon (slow LLM call,
+# large consolidation pass) can take 15+ seconds to free the event loop, so the
+# default is set above typical LLM latency.  Operators whose provider is known
+# to be faster can lower this to detect dead daemons sooner.
+DAEMON_HEALTH_TIMEOUT = _parse_float_env("HINDSIGHT_EMBED_DAEMON_HEALTH_TIMEOUT", 30.0)
 ENV_DAEMON_LOG_MAX_BYTES = "HINDSIGHT_EMBED_DAEMON_LOG_MAX_BYTES"
 ENV_DAEMON_LOG_BACKUP_COUNT = "HINDSIGHT_EMBED_DAEMON_LOG_BACKUP_COUNT"
 DEFAULT_DAEMON_LOG_MAX_BYTES = 10 * 1024 * 1024
@@ -195,7 +200,7 @@ class DaemonEmbedManager(EmbedManager):
         """Check if daemon is running and responsive."""
         daemon_url = self.get_url(profile)
         try:
-            with httpx.Client(timeout=2) as client:
+            with httpx.Client(timeout=DAEMON_HEALTH_TIMEOUT) as client:
                 response = client.get(f"{daemon_url}/health")
                 return response.status_code == 200
         except Exception:
@@ -379,7 +384,7 @@ class DaemonEmbedManager(EmbedManager):
     def _port_health_ok(port: int) -> bool:
         """Return True when the listener on port responds like initialized Hindsight."""
         try:
-            with httpx.Client(timeout=2) as client:
+            with httpx.Client(timeout=DAEMON_HEALTH_TIMEOUT) as client:
                 response = client.get(f"http://127.0.0.1:{port}/health")
                 if response.status_code != 200:
                     return False

--- a/hindsight-embed/hindsight_embed/profile_manager.py
+++ b/hindsight-embed/hindsight_embed/profile_manager.py
@@ -575,7 +575,7 @@ class ProfileManager:
         """
         try:
             with httpx.Client() as client:
-                response = client.get(f"http://127.0.0.1:{port}/health", timeout=1)
+                response = client.get(f"http://127.0.0.1:{port}/health", timeout=2)
                 return response.status_code == 200
         except Exception:
             return False

--- a/skills/hindsight-docs/references/sdks/integrations/agent-plugin.md
+++ b/skills/hindsight-docs/references/sdks/integrations/agent-plugin.md
@@ -1,0 +1,14 @@
+
+# Agent Plugins
+
+Portable long-term memory for any [Agent Plugins](https://agent-plugins.org) client, powered by Hindsight.
+
+Agent Plugins is the vendor-neutral open standard for packaging Agent Skills + MCP servers into a single distributable plugin. Hindsight ships one plugin that every compatible client can load.
+
+## Quick Start
+
+1. Get your API key from the Hindsight Cloud dashboard.
+2. Set `HINDSIGHT_API_KEY` and optionally `HINDSIGHT_BANK_ID`.
+3. Install the plugin in your client through its plugin/MCP UI.
+
+Once installed, agents can call `recall`, `retain`, and `reflect` automatically through the bundled skill.

--- a/skills/hindsight-docs/references/sdks/integrations/agent-plugin.md
+++ b/skills/hindsight-docs/references/sdks/integrations/agent-plugin.md
@@ -1,14 +1,85 @@
 
 # Agent Plugins
 
-Portable long-term memory for any [Agent Plugins](https://agent-plugins.org) client, powered by Hindsight.
+Portable long-term memory for any [Agent Plugins](https://agent-plugins.org) client, powered by [Hindsight](https://vectorize.io/hindsight).
 
-Agent Plugins is the vendor-neutral open standard for packaging Agent Skills + MCP servers into a single distributable plugin. Hindsight ships one plugin that every compatible client can load.
+[Agent Plugins](https://agent-plugins.org) is the vendor-neutral open standard (developed with Amazon, Cursor, Microsoft, OpenAI, and Vercel) for packaging **Agent Skills + MCP servers** into a single distributable plugin. Instead of a separate integration per tool, Hindsight ships **one** plugin that every compatible client can load — at launch: **ChatGPT / Codex, Cursor, GitHub Copilot, Kiro, and VS Code**.
 
 ## Quick Start
 
-1. Get your API key from the Hindsight Cloud dashboard.
-2. Set `HINDSIGHT_API_KEY` and optionally `HINDSIGHT_BANK_ID`.
-3. Install the plugin in your client through its plugin/MCP UI.
+> **💡 Recommended: Hindsight Cloud**
+>
+[Sign up free](https://ui.hindsight.vectorize.io/signup) for a Hindsight Cloud API key — no self-hosting, no local daemon to manage.
+1. Get your `hsk_...` API key from [ui.hindsight.vectorize.io/connect](https://ui.hindsight.vectorize.io/connect).
+2. Set the environment variables the plugin reads:
 
-Once installed, agents can call `recall`, `retain`, and `reflect` automatically through the bundled skill.
+   ```bash
+   export HINDSIGHT_API_KEY="hsk_your_token"
+   export HINDSIGHT_BANK_ID="my-project"   # optional; defaults to "default"
+   ```
+
+3. Install the plugin in your client (through its plugin/MCP UI, or by pointing it at the plugin directory — installation is client-specific per the standard).
+
+Once installed, ask the agent something that depends on past context, or tell it a durable preference — it calls `recall` and `retain` automatically, guided by the bundled skill.
+
+## What's in the plugin
+
+The plugin is a thin, transport-only wrapper — all memory logic stays server-side in Hindsight. It follows the Agent Plugins `1.0.0` layout:
+
+```
+agent-plugin/
+├── plugin.json                       # manifest ($schema + name + metadata)
+├── mcp.json                          # Hindsight MCP server (Streamable HTTP)
+└── skills/
+    └── hindsight-memory/
+        └── SKILL.md                  # teaches the agent when to recall / retain / reflect
+```
+
+- **`mcp.json`** connects the client to Hindsight's built-in [MCP server](../../developer/mcp-server.md) over Streamable HTTP.
+- **`skills/hindsight-memory/SKILL.md`** is loaded into the agent's context so it knows *when* to reach for memory, not just that the tools exist.
+
+## Memory tools
+
+Via the MCP server, the agent gets Hindsight's full memory surface. The three it reaches for most:
+
+| Tool | When | What it does |
+|------|------|--------------|
+| `recall` | Before answering, when past context could help | Semantic + keyword + graph + temporal retrieval over the bank |
+| `retain` | After learning a durable, reusable fact | Stores the fact for future sessions |
+| `reflect` | When a lookup is too shallow and you need synthesized reasoning | Disposition-aware reasoning over everything remembered |
+
+Additional tools (knowledge pages, mental models, documents, tags) are exposed too — see the [MCP Server reference](../../developer/mcp-server.md).
+
+## Configuration
+
+The plugin reads two environment variables, interpolated into `mcp.json`:
+
+| Setting | Env Var | Default | Description |
+|---------|---------|---------|-------------|
+| API key | `HINDSIGHT_API_KEY` | — | Your `hsk_...` key. Sent as `Authorization: Bearer`. Required for Hindsight Cloud. |
+| Memory bank | `HINDSIGHT_BANK_ID` | `default` | Bank to read from and write to (sent as `X-Bank-Id`). Use one bank per user, project, or team for isolation. |
+
+> **📝 Env-var syntax varies by client**
+>
+Most clients substitute `${VAR}`; some (VS Code, Cursor) use `${env:VAR}`. If your client doesn't interpolate, paste the literal key and bank id into `mcp.json`.
+**Self-hosting:** replace the host in `mcp.json` (`https://api.hindsight.vectorize.io`) with your deployment's URL. A local server with the MCP endpoint open needs no API key.
+
+## Explicit tools vs. automatic capture
+
+Agent Plugins `1.0.0` standardizes **Skills + MCP**, not session lifecycle hooks. This plugin therefore delivers **explicit, tool-driven** memory that works identically across every supported client.
+
+For the fully automatic experience — recall injected before every prompt and transcripts retained on session end — use the native, hook-based integration built for your specific tool, such as [Claude Code](claude-code.md) or [Codex](codex.md). Both share the same Hindsight banks, so memory captured by the hook-based integration is recalled through the Agent Plugin, and vice versa.
+
+## Troubleshooting
+
+**No memories recalled**: `recall` returns results only after something has been retained. Retain a fact first, or seed the bank via the [API](../../developer/api/quickstart.md).
+
+**401 Unauthorized**: Check `HINDSIGHT_API_KEY` is set and your client is interpolating it into the `Authorization` header (see the env-var syntax note above).
+
+**Wrong or empty memory**: Confirm `HINDSIGHT_BANK_ID` points at the bank you expect. Different tools writing to different banks won't share memory.
+
+## Learn more
+
+- [Agent Plugins standard](https://agent-plugins.org)
+- [Hindsight MCP Server reference](../../developer/mcp-server.md)
+- [Hindsight Cloud sign-up](https://ui.hindsight.vectorize.io/signup)


### PR DESCRIPTION
## Summary

Fixes #3099: The embed daemon liveness check used a hardcoded **2-second** HTTP timeout on `/health`. When the daemon's asyncio event loop was blocked by a slow LLM call (measured **17.4s** for consolidation against custom providers), `/health` could not respond within 2s. The embed manager then **misclassified the daemon as dead and force-killed + restarted it** — even though it was merely busy.

## Root Cause

Three hardcoded `timeout=2` (and one `timeout=1`) values in the health-check path:

| Location | Old timeout | Impact |
|----------|------------|--------|
| `is_running()` line 198 | `timeout=2` | Kill/restart decision |
| `_port_health_ok()` line 382 | `timeout=2` | Port clearing on startup |
| `profile_manager._check_daemon_running()` line 578 | `timeout=1` | Port scanning |

Any LLM call that blocked the event loop for > 2s triggered a false kill.

## Changes

1. **New env var `HINDSIGHT_EMBED_DAEMON_HEALTH_TIMEOUT`** (default **30.0s**) — configurable, above typical LLM latency.
2. `is_running()` and `_port_health_ok()` use `DAEMON_HEALTH_TIMEOUT` instead of hardcoded 2s.
3. `profile_manager._check_daemon_running()` bumped from 1s to 2s for consistency (less critical path).

## Impact

- Daemons running slow LLM calls (consolidation, large retains) are no longer falsely killed.
- Operators using fast providers can set `HINDSIGHT_EMBED_DAEMON_HEALTH_TIMEOUT=5` to detect dead daemons sooner.
- No change to startup behavior — the grace-period timeout `_wait_for_port_health` is separate.