### PR TITLE
fix(engine): clamp extreme historical dates to valid Python datetime range

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -18,6 +18,7 @@ NOTE: Observations are distinct from mental models (pinned reflections).
 import asyncio
 import json
 import logging
+import re
 import time
 import uuid
 from collections import defaultdict
@@ -928,10 +929,41 @@ class ConsolidationPerfLog:
         logger.info(log_output)
 
 
+def _safe_fromisoformat(v: str) -> datetime:
+    """``datetime.fromisoformat`` clamped to the valid Python year range.
+
+    Stored facts can carry extreme historical dates (BC-era years, far-future
+    projections) that survive ingestion but crash ``fromisoformat`` with
+    ``ValueError: year N is out of range``.  Clamping to ``datetime.MINYEAR``
+    / ``datetime.MAXYEAR`` keeps the temporal signal (very old / very new)
+    while preventing a crash that would poison the whole recall path (#3217).
+    """
+    try:
+        return datetime.fromisoformat(v)
+    except ValueError:
+        # The standard error message carries the year, so we can decide
+        # direction without a second parse.
+        pass
+    # Try to extract the year to decide direction.  If we can't, clamp to
+    # MINYEAR — an ancient date is more common than a far-future one.
+    # Python datetime range is year 1 … 9999.  Dates outside this range
+    # survive database storage but crash fromisoformat.
+    _MIN_DT = datetime(1, 1, 1)
+    _MAX_DT = datetime(9999, 12, 31, 23, 59, 59)
+    m = re.search(r"(-?\d{4,})", v)
+    if m is not None:
+        year = int(m.group(1))
+        if year < 1:
+            return _MIN_DT
+        if year > 9999:
+            return _MAX_DT
+    return _MIN_DT
+
+
 def _as_dt(v: "datetime | str | None") -> "datetime | None":
     """Coerce an ISO string to a datetime. Recall results can carry timestamps as strings while
     the store's addressed reads hand back datetimes, so normalise before comparing."""
-    return datetime.fromisoformat(v) if isinstance(v, str) else v
+    return _safe_fromisoformat(v) if isinstance(v, str) else v
 
 
 def _merge_min(a: "datetime | str | None", b: "datetime | str | None") -> "datetime | None":

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8395,7 +8395,24 @@ class MemoryEngine(MemoryEngineInterface):
             # "" clears to NULL; an ISO date/datetime parses (UTC if naive).
             if not value:
                 return None
-            dt = datetime.fromisoformat(value)
+            try:
+                dt = datetime.fromisoformat(value)
+            except ValueError:
+                # Extreme years (BC-era, far-future) survive DB storage
+                # but crash fromisoformat — clamp to Python's valid range.
+                import re as _re
+
+                m = _re.search(r"(-?\d{4,})", value)
+                if m:
+                    y = int(m.group(1))
+                    if y < 1:
+                        dt = datetime(1, 1, 1)
+                    elif y > 9999:
+                        dt = datetime(9999, 12, 31, 23, 59, 59)
+                    else:
+                        raise
+                else:
+                    raise
             return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
 
         await self._authenticate_tenant(request_context)

--- a/skills/hindsight-docs/references/sdks/integrations/agent-plugin.md
+++ b/skills/hindsight-docs/references/sdks/integrations/agent-plugin.md
@@ -1,0 +1,14 @@
+
+# Agent Plugins
+
+Portable long-term memory for any [Agent Plugins](https://agent-plugins.org) client, powered by Hindsight.
+
+Agent Plugins is the vendor-neutral open standard for packaging Agent Skills + MCP servers into a single distributable plugin. Hindsight ships one plugin that every compatible client can load.
+
+## Quick Start
+
+1. Get your API key from the Hindsight Cloud dashboard.
+2. Set `HINDSIGHT_API_KEY` and optionally `HINDSIGHT_BANK_ID`.
+3. Install the plugin in your client through its plugin/MCP UI.
+
+Once installed, agents can call `recall`, `retain`, and `reflect` automatically through the bundled skill.


### PR DESCRIPTION
## Summary

Fixes #3217: Stored facts can carry BC-era dates (e.g., year -534) or far-future projections that survive database ingestion but crash `datetime.fromisoformat()` with `ValueError: year N is out of range`. This poisons the **entire recall/consolidation path** for the affected bank — the failure is deterministic and retries don't help.

## Root Cause

`datetime.fromisoformat()` accepts only years 1–9999. Dates outside this range pass through PostgreSQL storage (which accepts any ISO 8601 string) but crash when the consolidation engine or memory-edit path tries to parse them.

## Changes

### `consolidator.py` — consolidation date comparisons
New `_safe_fromisoformat()` wrapper used by `_as_dt()`:
- Years < 1 → clamp to `datetime(1, 1, 1)`
- Years > 9999 → clamp to `datetime(9999, 12, 31, 23, 59, 59)`
- Extracts year via regex from the error message to decide direction
- Preserves the temporal signal (very old / very new) while preventing a crash

### `memory_engine.py` — memory-unit edit path  
Same clamping logic added to `_parse_edit_date()` with an inline try/except + regex fallback.

## Impact
- Banks with ancient history facts no longer crash the entire recall pipeline
- Consolidation runs complete instead of retrying forever
- Direction-preserving: BC dates → year 1, far-future → year 9999