### PR TITLE
fix(gemini): leave thinking models room to think within max_output_tokens

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
@@ -46,6 +46,32 @@ except ImportError:
     VERTEXAI_AVAILABLE = False
 
 
+# Floor for the max_output_tokens we actually send on a thinking model.
+# Gemini charges thinking tokens against max_output_tokens along with the visible
+# reply, so a budget sized for the reply alone leaves the model nothing to reply
+# with: the text comes back truncated mid-word, or empty, with finish_reason
+# MAX_TOKENS and no other signal (#3365). The burn scales with task difficulty
+# rather than being a constant, so "budget minus some slack" is not a usable
+# sizing rule and we raise the ceiling instead, leaving the caller's budget to
+# govern the visible answer. Same floor and same reasoning as the reasoning-model
+# branch of OpenAICompatibleLLM.call (#2630); keep the two in step.
+MIN_THINKING_MAX_OUTPUT_TOKENS = 16000
+
+# Model families that answer without reasoning first. This is a denylist because
+# everything Google has shipped since 2.5 thinks by default, so an unrecognized
+# name should get the headroom: being wrong that way only raises a ceiling the
+# model never reaches, while being wrong the other way silently truncates output.
+_NON_THINKING_MODEL_MARKERS = ("gemini-1.", "gemini-2.0")
+
+
+def _max_output_tokens_with_headroom(model: str, max_completion_tokens: int) -> int:
+    """Return the max_output_tokens to send, leaving a thinking model room to think."""
+    model_lower = model.lower()
+    if any(marker in model_lower for marker in _NON_THINKING_MODEL_MARKERS):
+        return max_completion_tokens
+    return max(max_completion_tokens, MIN_THINKING_MAX_OUTPUT_TOKENS)
+
+
 def _to_int(value: Any) -> int:
     """Coerce Gemini's optional/string completion counts to int, defaulting to 0."""
     try:
@@ -409,9 +435,11 @@ class GeminiLLM(LLMInterface):
                 config_kwargs["temperature"] = temperature
             # Gemini's equivalent of OpenAI-style max_completion_tokens is max_output_tokens.
             # Without it the model can produce arbitrarily long responses, ignoring the
-            # caller's intended cap (e.g. mental_models max_tokens during refresh).
+            # caller's intended cap (e.g. mental_models max_tokens during refresh). On a
+            # thinking model that cap also has to cover the reasoning tokens, hence the
+            # headroom.
             if max_completion_tokens is not None:
-                config_kwargs["max_output_tokens"] = max_completion_tokens
+                config_kwargs["max_output_tokens"] = _max_output_tokens_with_headroom(self.model, max_completion_tokens)
             if effective_safety_settings is not None:
                 config_kwargs["safety_settings"] = [
                     genai_types.SafetySetting(category=s["category"], threshold=s["threshold"])
@@ -750,9 +778,10 @@ class GeminiLLM(LLMInterface):
             if temperature is not None:
                 config_kwargs["temperature"] = temperature
             # See note in `call`: Gemini's max_output_tokens is the equivalent of
-            # OpenAI-style max_completion_tokens.
+            # OpenAI-style max_completion_tokens, and on a thinking model it has to
+            # cover the reasoning tokens too.
             if max_completion_tokens is not None:
-                config_kwargs["max_output_tokens"] = max_completion_tokens
+                config_kwargs["max_output_tokens"] = _max_output_tokens_with_headroom(self.model, max_completion_tokens)
 
             # Map OpenAI-style tool_choice to Gemini FunctionCallingConfig
             if tool_choice.mode is LLMToolChoiceMode.REQUIRED:
@@ -1088,7 +1117,7 @@ class GeminiLLM(LLMInterface):
         # Kept for signature compatibility with the shared retain driver.
         logger.info(f"Submitting Gemini batch with {len(requests)} requests")
 
-        jsonl = self._translate_requests(requests)
+        jsonl = self._translate_requests(requests, self.model)
 
         # Upload the JSONL as a Gemini file (mime_type must be "jsonl"; a
         # BytesIO has no path for the SDK to infer it from).
@@ -1177,26 +1206,29 @@ class GeminiLLM(LLMInterface):
     # ----- pure translation/normalization helpers (unit-tested) ----------
 
     @staticmethod
-    def _translate_requests(requests: list[dict[str, Any]]) -> str:
+    def _translate_requests(requests: list[dict[str, Any]], model: str) -> str:
         """OpenAI batch requests -> Gemini batch input JSONL.
 
         Each output line is ``{"key": <custom_id>, "request": <GenerateContentRequest>}``;
-        the model is supplied to ``batches.create`` so it is omitted per-line.
+        the model is supplied to ``batches.create`` so it is omitted per-line, but it is
+        still needed here to size the per-request token budget.
         """
         lines = []
         for req in requests:
-            gemini_request = GeminiLLM._openai_body_to_gemini_request(req.get("body") or {})
+            gemini_request = GeminiLLM._openai_body_to_gemini_request(req.get("body") or {}, model)
             lines.append(json.dumps({"key": req.get("custom_id"), "request": gemini_request}, ensure_ascii=False))
         return "\n".join(lines)
 
     @staticmethod
-    def _openai_body_to_gemini_request(body: dict[str, Any]) -> dict[str, Any]:
+    def _openai_body_to_gemini_request(body: dict[str, Any], model: str) -> dict[str, Any]:
         """OpenAI chat-completions body -> Gemini ``GenerateContentRequest`` JSON.
 
         Mirrors the synchronous ``call`` path: system messages become
         ``systemInstruction``; a ``response_format`` json_schema forces JSON
         output (``responseMimeType``), appends the schema as a textual hint, and
         grammar-enforces via ``responseJsonSchema`` whenever a schema is present.
+        ``model`` is the model the batch will run against, needed to give a
+        thinking model the same token headroom the synchronous path gets.
         """
         system_texts: list[str] = []
         contents: list[dict[str, Any]] = []
@@ -1214,7 +1246,9 @@ class GeminiLLM(LLMInterface):
         if body.get("temperature") is not None:
             generation_config["temperature"] = body["temperature"]
         if body.get("max_completion_tokens") is not None:
-            generation_config["maxOutputTokens"] = body["max_completion_tokens"]
+            generation_config["maxOutputTokens"] = _max_output_tokens_with_headroom(
+                model, body["max_completion_tokens"]
+            )
 
         response_format = body.get("response_format")
         if isinstance(response_format, dict) and response_format.get("type") == "json_schema":

--- a/hindsight-api-slim/tests/test_gemini_batch.py
+++ b/hindsight-api-slim/tests/test_gemini_batch.py
@@ -23,10 +23,14 @@ import pytest
 
 pytest.importorskip("google.genai")
 
-from hindsight_api.engine.providers.gemini_llm import GeminiLLM
+from hindsight_api.engine.providers.gemini_llm import MIN_THINKING_MAX_OUTPUT_TOKENS, GeminiLLM
+
+# The model a batch runs against. It is passed to ``batches.create`` rather than
+# written per-line, but the translation still needs it to size the token budget.
+BATCH_MODEL = "gemini-2.5-flash"
 
 
-def _make_gemini(model: str = "gemini-2.5-flash") -> GeminiLLM:
+def _make_gemini(model: str = BATCH_MODEL) -> GeminiLLM:
     # Patch the genai client constructor so no real credentials/network are used;
     # the batch tests swap in a fake aio client below.
     with patch("hindsight_api.engine.providers.gemini_llm.genai.Client", MagicMock()):
@@ -84,7 +88,7 @@ async def test_vertexai_does_not_support_batch_api():
 
 
 def test_translate_requests_builds_keyed_jsonl():
-    jsonl = GeminiLLM._translate_requests([_openai_request("chunk_0"), _openai_request("chunk_1")])
+    jsonl = GeminiLLM._translate_requests([_openai_request("chunk_0"), _openai_request("chunk_1")], BATCH_MODEL)
     lines = jsonl.split("\n")
     assert len(lines) == 2
     first = json.loads(lines[0])
@@ -93,7 +97,7 @@ def test_translate_requests_builds_keyed_jsonl():
 
 
 def test_body_translation_maps_roles_and_generation_config():
-    req = GeminiLLM._openai_body_to_gemini_request(_openai_request("c")["body"])
+    req = GeminiLLM._openai_body_to_gemini_request(_openai_request("c")["body"], BATCH_MODEL)
 
     # system -> systemInstruction; user -> contents(role=user)
     assert req["contents"] == [{"role": "user", "parts": [{"text": "Paris is the capital of France."}]}]
@@ -101,7 +105,9 @@ def test_body_translation_maps_roles_and_generation_config():
 
     gc = req["generationConfig"]
     assert gc["temperature"] == 0.1
-    assert gc["maxOutputTokens"] == 2048
+    # 2048 was the requested budget; on a thinking model it is raised so the
+    # reasoning tokens do not eat the reply (see test_gemini_thinking_headroom).
+    assert gc["maxOutputTokens"] == MIN_THINKING_MAX_OUTPUT_TOKENS
     assert gc["responseMimeType"] == "application/json"
     # grammar-enforced via responseJsonSchema
     assert gc["responseJsonSchema"] == {"type": "object", "properties": {"facts": {"type": "array"}}}
@@ -115,7 +121,7 @@ def test_body_translation_grammar_enforces_schema_without_strict():
     # (the interactive path already does). Otherwise batch requests at default
     # config (HINDSIGHT_API_LLM_STRICT_SCHEMA=False) only get a textual schema hint
     # and intermittently emit malformed JSON, dropping every fact in the chunk.
-    req = GeminiLLM._openai_body_to_gemini_request(_openai_request("c", strict=False)["body"])
+    req = GeminiLLM._openai_body_to_gemini_request(_openai_request("c", strict=False)["body"], BATCH_MODEL)
     gc = req["generationConfig"]
     assert gc["responseMimeType"] == "application/json"
     assert gc["responseJsonSchema"] == {"type": "object", "properties": {"facts": {"type": "array"}}}
@@ -123,7 +129,7 @@ def test_body_translation_grammar_enforces_schema_without_strict():
 
 def test_assistant_role_maps_to_model():
     body = {"messages": [{"role": "assistant", "content": "prior turn"}]}
-    req = GeminiLLM._openai_body_to_gemini_request(body)
+    req = GeminiLLM._openai_body_to_gemini_request(body, BATCH_MODEL)
     assert req["contents"] == [{"role": "model", "parts": [{"text": "prior turn"}]}]
     assert "systemInstruction" not in req
 

--- a/hindsight-api-slim/tests/test_gemini_thinking_headroom.py
+++ b/hindsight-api-slim/tests/test_gemini_thinking_headroom.py
@@ -1,0 +1,203 @@
+"""Tests for the thinking-token headroom on ``max_output_tokens`` (#3365).
+
+Gemini charges thinking tokens against ``max_output_tokens`` along with the
+visible reply, so passing a caller's budget straight through leaves a thinking
+model nothing to reply with. A mental-model page configured at 3072 came back as
+337 visible tokens ending mid-word, and the refresh still reported success with
+no warnings, so the truncation was invisible. ``OpenAICompatibleLLM`` already
+floors the budget for o1/o3/GPT-5 (#2630); these tests pin the same treatment on
+the Gemini adapter, across all three places it builds a request.
+
+Deterministic: the genai client is mocked and we assert on the config/JSON the
+adapter builds, so no API key and no network are involved.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip("google.genai")
+
+from hindsight_api.engine.providers.gemini_llm import (  # noqa: E402
+    MIN_THINKING_MAX_OUTPUT_TOKENS,
+    GeminiLLM,
+    _max_output_tokens_with_headroom,
+)
+
+# The budget from the issue report: a page sized for 3072 lost ~2735 of it to
+# thinking and rendered a single heading.
+TRUNCATED_PAGE_BUDGET = 3072
+
+
+def _make_gemini_provider(model: str = "gemini-2.5-flash") -> GeminiLLM:
+    """A GeminiLLM whose client is a mock, so nothing leaves the process."""
+    with patch("google.genai.Client") as mock_client_cls:
+        mock_client_cls.return_value = MagicMock()
+        provider = GeminiLLM(provider="gemini", api_key="fake-api-key", base_url="", model=model)
+    provider._client = MagicMock()
+    return provider
+
+
+def _fake_response():
+    response = MagicMock()
+    response.text = "hello"
+    response.candidates = [MagicMock(finish_reason="STOP")]
+    response.usage_metadata = MagicMock(prompt_token_count=5, candidates_token_count=2)
+    return response
+
+
+def _openai_body(max_completion_tokens: int = TRUNCATED_PAGE_BUDGET) -> dict:
+    return {
+        "messages": [{"role": "user", "content": "Paris is the capital of France."}],
+        "max_completion_tokens": max_completion_tokens,
+    }
+
+
+# ─── the sizing rule ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gemini-2.5-flash",
+        "gemini-2.5-flash-lite",
+        "gemini-3.5-flash",
+        "gemini-3.6-flash",
+        "google/gemini-3.1-flash-lite",  # vertexai keeps the vendor prefix
+        "gemini-flash-latest",  # unrecognized alias: assume it thinks
+    ],
+)
+def test_thinking_models_get_headroom(model):
+    assert _max_output_tokens_with_headroom(model, TRUNCATED_PAGE_BUDGET) == MIN_THINKING_MAX_OUTPUT_TOKENS
+
+
+@pytest.mark.parametrize("model", ["gemini-2.0-flash", "gemini-2.0-flash-001", "gemini-1.5-pro"])
+def test_non_thinking_models_are_left_alone(model):
+    """Pre-2.5 models never reason, so their budget already is the visible budget."""
+    assert _max_output_tokens_with_headroom(model, TRUNCATED_PAGE_BUDGET) == TRUNCATED_PAGE_BUDGET
+
+
+def test_budget_above_the_floor_is_never_lowered():
+    """The floor only ever raises: a caller asking for more keeps it."""
+    generous = MIN_THINKING_MAX_OUTPUT_TOKENS * 2
+    assert _max_output_tokens_with_headroom("gemini-3.5-flash", generous) == generous
+
+
+# ─── call() ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_call_sends_headroom_on_a_thinking_model():
+    provider = _make_gemini_provider()
+    provider._client.aio.models.generate_content = AsyncMock(return_value=_fake_response())
+
+    await provider.call(
+        messages=[{"role": "user", "content": "hi"}],
+        max_completion_tokens=TRUNCATED_PAGE_BUDGET,
+        scope="test",
+    )
+
+    config = provider._client.aio.models.generate_content.call_args.kwargs["config"]
+    assert config.max_output_tokens == MIN_THINKING_MAX_OUTPUT_TOKENS
+
+
+@pytest.mark.asyncio
+async def test_call_passes_the_budget_through_on_a_non_thinking_model():
+    provider = _make_gemini_provider(model="gemini-2.0-flash")
+    provider._client.aio.models.generate_content = AsyncMock(return_value=_fake_response())
+
+    await provider.call(
+        messages=[{"role": "user", "content": "hi"}],
+        max_completion_tokens=TRUNCATED_PAGE_BUDGET,
+        scope="test",
+    )
+
+    config = provider._client.aio.models.generate_content.call_args.kwargs["config"]
+    assert config.max_output_tokens == TRUNCATED_PAGE_BUDGET
+
+
+@pytest.mark.asyncio
+async def test_verify_connection_gets_headroom_too():
+    """Startup verification asks for 100 tokens, which a thinking model spends on thinking.
+
+    This is #2630 in Gemini's clothing: the OpenAI-compatible path hit the same wall
+    when its verification budget was exhausted by reasoning. Verification goes through
+    ``call``, so the floor covers it, and this pins that it keeps doing so.
+    """
+    provider = _make_gemini_provider()
+    provider._client.aio.models.generate_content = AsyncMock(return_value=_fake_response())
+
+    await provider.verify_connection()
+
+    config = provider._client.aio.models.generate_content.call_args.kwargs["config"]
+    assert config.max_output_tokens == MIN_THINKING_MAX_OUTPUT_TOKENS
+
+
+@pytest.mark.asyncio
+async def test_call_without_a_budget_sets_no_ceiling():
+    """No caller budget means no max_output_tokens, headroom or not."""
+    provider = _make_gemini_provider()
+    provider._client.aio.models.generate_content = AsyncMock(return_value=_fake_response())
+
+    await provider.call(messages=[{"role": "user", "content": "hi"}], scope="test")
+
+    config = provider._client.aio.models.generate_content.call_args.kwargs["config"]
+    assert config is None or config.max_output_tokens is None
+
+
+# ─── call_with_tools() ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_call_with_tools_sends_headroom_on_a_thinking_model():
+    provider = _make_gemini_provider()
+
+    part = MagicMock()
+    part.text = "answer"
+    part.function_call = None
+    response = MagicMock()
+    response.candidates = [MagicMock(content=MagicMock(parts=[part]))]
+    response.usage_metadata = MagicMock(prompt_token_count=5, candidates_token_count=3)
+    provider._client.aio.models.generate_content = AsyncMock(return_value=response)
+
+    await provider.call_with_tools(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "test_tool",
+                    "description": "A test tool",
+                    "parameters": {"type": "object", "properties": {}, "required": []},
+                },
+            }
+        ],
+        max_completion_tokens=TRUNCATED_PAGE_BUDGET,
+        scope="test",
+    )
+
+    config = provider._client.aio.models.generate_content.call_args.kwargs["config"]
+    assert config.max_output_tokens == MIN_THINKING_MAX_OUTPUT_TOKENS
+
+
+# ─── batch translation ────────────────────────────────────────────────────────
+
+
+def test_batch_request_gets_headroom_on_a_thinking_model():
+    """The batch path builds raw request JSON, so it needs the same sizing."""
+    request = GeminiLLM._openai_body_to_gemini_request(_openai_body(), "gemini-3.5-flash")
+    assert request["generationConfig"]["maxOutputTokens"] == MIN_THINKING_MAX_OUTPUT_TOKENS
+
+
+def test_batch_request_passes_the_budget_through_on_a_non_thinking_model():
+    request = GeminiLLM._openai_body_to_gemini_request(_openai_body(), "gemini-2.0-flash")
+    assert request["generationConfig"]["maxOutputTokens"] == TRUNCATED_PAGE_BUDGET
+
+
+def test_submit_batch_sizes_against_the_configured_model():
+    """submit_batch must hand its own model down; the per-line JSON carries none."""
+    jsonl = GeminiLLM._translate_requests(
+        [{"custom_id": "chunk_0", "body": _openai_body()}],
+        "gemini-3.5-flash",
+    )
+    assert f'"maxOutputTokens": {MIN_THINKING_MAX_OUTPUT_TOKENS}' in jsonl


### PR DESCRIPTION
## Problem

Gemini charges thinking tokens against `max_output_tokens` along with the visible reply, and `GeminiLLM`
passes the caller's budget through unchanged. On a thinking model the reasoning consumes the budget and the
answer stops mid-word, while the refresh still reports `status: success` with empty `warnings`, so a
truncated page is indistinguishable from a healthy one.

## Fix

Raise the ceiling actually sent on 2.5 and newer, so the caller's budget governs the visible answer rather
than the whole generation. This is the floor `OpenAICompatibleLLM.call` already applies for o1/o3/GPT-5,
kept at the same value. Pre-2.5 models pass through untouched. Three request builders had drifted apart, so
`call`, `call_with_tools` and the batch path all needed it; `verify_connection` is covered as a side effect
since its 100-token probe goes through `call`.

## Tests

`tests/test_gemini_thinking_headroom.py`, genai client mocked, no network. Reverting the sizing helper
fails 11 of them across all three builders.

Fixes #3365.
