### PR TITLE
perf(graph): decouple stale-cooccurrence prune from hub-entity degree (#3367)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -523,25 +523,44 @@ class PostgreSQLOps(DataAccessOps):
         # retry wrap in run_graph_maintenance_job stays as a backstop for the
         # residual paths (FK cascade from prune_orphan_entities, Oracle).
         #
-        # The staleness predicate is an INTERSECT of the two entities' unit sets
-        # rather than the equivalent `unit_entities u1 JOIN u2 ON u1.unit_id =
-        # u2.unit_id` self-join (#2473): both INTERSECT branches resolve as Index
-        # Only Scans on idx_unit_entities_entity_unit (entity_id, unit_id), so the
-        # per-pair cost is bounded by the two entities' degrees. The self-join let
-        # the planner pick an anti-join that rescanned a high-degree hub entity's
-        # membership set for every pair — 28-30min on a bank with a ~100K-membership
-        # hub, even when zero rows were stale. Don't "simplify" it back.
+        # Staleness is decided against a SET of currently-live pairs built ONCE
+        # per sweep, not with a per-cooccurrence-row check (#3367). The old form
+        # ran a correlated `NOT EXISTS (… INTERSECT …)` for every row, and each
+        # evaluation re-scanned a hub entity's full membership set — cost scaled
+        # as (cooccurrence rows) × (hub degree), 88-140s on a real bank with a
+        # ~22K-degree hub (and 215s in a 12K-degree repro). #2473 had swapped an
+        # earlier hub-rescanning self-join to that INTERSECT, but only made each
+        # per-row check cheaper — it kept the per-row structure, so the product
+        # blew up again at scale.
+        #
+        # `live` instead groups unit_entities by unit (self-join on unit_id) to
+        # emit every co-occurring (e1<e2) pair in one materialised pass: its cost
+        # is driven by unit degree (entities per unit — small), never by entity
+        # degree, so a hub contributes only its per-unit membership, not a rescan
+        # per edge. The victims anti-join then hashes against it. Scope `live` to
+        # this bank's entities (`u1 -> bank entity`; a unit co-member is in the
+        # same bank): graph maintenance runs per-bank, so an unscoped schema-wide
+        # build would re-derive every bank's pairs on every bank's run —
+        # O(banks × schema) per cycle instead of O(schema). MATERIALIZED keeps
+        # the planner from inlining `live` back into a per-row correlated plan.
         result = await conn.execute(
             f"""
-            WITH victims AS (
+            WITH live AS MATERIALIZED (
+                SELECT u1.entity_id AS e1, u2.entity_id AS e2
+                FROM {entities_table} be
+                JOIN {ue_table} u1 ON u1.entity_id = be.id
+                JOIN {ue_table} u2 ON u2.unit_id = u1.unit_id
+                                  AND u2.entity_id > u1.entity_id
+                WHERE be.bank_id = $1
+            ),
+            victims AS (
                 SELECT c.entity_id_1, c.entity_id_2
                 FROM {ec_table} c
                 JOIN {entities_table} e ON e.id = c.entity_id_1
                 WHERE e.bank_id = $1
                   AND NOT EXISTS (
-                      SELECT unit_id FROM {ue_table} WHERE entity_id = c.entity_id_1
-                      INTERSECT
-                      SELECT unit_id FROM {ue_table} WHERE entity_id = c.entity_id_2
+                      SELECT 1 FROM live l
+                      WHERE l.e1 = c.entity_id_1 AND l.e2 = c.entity_id_2
                   )
                 ORDER BY c.entity_id_1, c.entity_id_2
                 FOR UPDATE OF c

--- a/hindsight-api-slim/tests/test_graph_maintenance.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance.py
@@ -683,6 +683,73 @@ class TestStaleCooccurrencePrune:
             )
             assert still_there == 5
 
+    @pytest.mark.asyncio
+    async def test_prunes_only_the_stale_edge_around_a_hub_and_leaves_other_banks(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """The prune decides staleness against a per-bank SET of live pairs (#3367),
+        not per-cooccurrence-row. Guard the two things that swap could get wrong:
+        a hub's *still-grounded* edges survive while only its genuinely stale edge
+        is pruned, and the bank-scoped ``live`` set never reaches across banks."""
+        bank_id = f"test-gm-hub-{uuid.uuid4().hex[:8]}"
+        other_bank = f"test-gm-oth-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+        await _ensure_bank(memory, other_bank, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            hub = await _insert_entity(conn, bank_id, "hub")
+            spoke_live = await _insert_entity(conn, bank_id, "spoke_live")
+            spoke_stale = await _insert_entity(conn, bank_id, "spoke_stale")
+            # Both edges recorded, but only hub+spoke_live still share a unit.
+            await _insert_cooccurrence(conn, hub, spoke_live, count=3)
+            await _insert_cooccurrence(conn, hub, spoke_stale, count=7)
+            unit_together = await _insert_unit(conn, bank_id, "hub-and-live")
+            await _link_unit_entity(conn, unit_together, hub)
+            await _link_unit_entity(conn, unit_together, spoke_live)
+            # spoke_stale still exists in its own unit (so it is not an orphan),
+            # just no longer alongside the hub.
+            unit_solo = await _insert_unit(conn, bank_id, "stale-solo")
+            await _link_unit_entity(conn, unit_solo, spoke_stale)
+
+            # A different bank with its own stale edge that pruning bank_id must
+            # not touch — the scoped ``live`` build must not consider it grounded
+            # or stale.
+            oth_a = await _insert_entity(conn, other_bank, "oth_a")
+            oth_b = await _insert_entity(conn, other_bank, "oth_b")
+            await _insert_cooccurrence(conn, oth_a, oth_b, count=2)
+            oth_unit_a = await _insert_unit(conn, other_bank, "oth-with-a")
+            oth_unit_b = await _insert_unit(conn, other_bank, "oth-with-b")
+            await _link_unit_entity(conn, oth_unit_a, oth_a)
+            await _link_unit_entity(conn, oth_unit_b, oth_b)
+
+        result = await run_graph_maintenance_job(memory, bank_id, request_context)
+        assert result["stale_cooccurrences_pruned"] == 1
+        assert result["orphan_entities_pruned"] == 0
+
+        async with pool.acquire() as conn:
+            hub_live = sorted([hub, spoke_live])
+            hub_stale = sorted([hub, spoke_stale])
+            oth = sorted([oth_a, oth_b])
+            live_kept = await conn.fetchval(
+                "SELECT COUNT(*) FROM entity_cooccurrences WHERE entity_id_1 = $1 AND entity_id_2 = $2",
+                hub_live[0],
+                hub_live[1],
+            )
+            stale_gone = await conn.fetchval(
+                "SELECT COUNT(*) FROM entity_cooccurrences WHERE entity_id_1 = $1 AND entity_id_2 = $2",
+                hub_stale[0],
+                hub_stale[1],
+            )
+            other_untouched = await conn.fetchval(
+                "SELECT COUNT(*) FROM entity_cooccurrences WHERE entity_id_1 = $1 AND entity_id_2 = $2",
+                oth[0],
+                oth[1],
+            )
+            assert live_kept == 1
+            assert stale_gone == 0
+            assert other_untouched == 1
+
 
 # ---------------------------------------------------------------------------
 # Sanity check on cap values


### PR DESCRIPTION
## Summary

Fixes #3367 — `prune_stale_cooccurrences` (graph maintenance's stale-cooccurrence sweep) scaled with **hub-entity degree**, hitting 88–140s on a real bank with a ~22K-degree hub.

The PG path decided staleness with a correlated `NOT EXISTS (… INTERSECT …)` evaluated **once per cooccurrence row**, and each evaluation re-scanned a hub entity's full membership set — cost `(cooccurrence rows) × (hub degree)`. #2473 had swapped an earlier hub-rescanning self-join to that `INTERSECT`, but only made each per-row check cheaper; it kept the per-row structure, so the product resurfaced once the table/hub grew again.

## Fix

Decide staleness against a **set of currently-live pairs built once per sweep**:

```sql
WITH live AS MATERIALIZED (
    SELECT u1.entity_id AS e1, u2.entity_id AS e2
    FROM entities be
    JOIN unit_entities u1 ON u1.entity_id = be.id
    JOIN unit_entities u2 ON u2.unit_id = u1.unit_id AND u2.entity_id > u1.entity_id
    WHERE be.bank_id = $1
),
victims AS ( … NOT EXISTS (SELECT 1 FROM live …) … ORDER BY … FOR UPDATE OF c )
DELETE …
```

- The unit-grouped self-join's cost is driven by **unit degree** (entities-per-unit — small), never by entity degree, so a hub contributes only its per-unit membership instead of a full rescan per edge.
- `live` is **scoped to the bank's entities**, so a per-bank sweep stays `O(bank)`, not `O(schema)`, across a multi-bank maintenance cycle (graph maintenance runs per bank).
- `MATERIALIZED` keeps the planner from inlining `live` back into a per-row correlated plan.
- The **#2529 ordered-lock** (`ORDER BY entity_id_1, entity_id_2 FOR UPDATE OF c`) is preserved, so the deadlock-avoidance vs. retain's sorted cooccurrence upsert still holds.
- **Oracle already used a set-based form** and is unchanged.

## Measured (reproduced locally)

Seeded a bank the way the issue describes — hub entity degree **12,000**, **14,000** cooccurrence rows (12,000 live hub edges + 2,000 genuinely-stale spoke pairs), on production table shapes/indexes:

| Query | Time | Plan |
|---|---:|---|
| Old (per-pair `INTERSECT`) | **215,329 ms** | `SubPlan HashSetOp Intersect`, **loops=14000**, hub membership re-scanned per row (1.25M buffer hits) |
| New (set-based `live` anti-join) | **~250 ms** | `live` built once, hash anti-join, no per-row subplan |

Both delete the **identical set** (exactly the 2,000 stale pairs; all 12,000 hub pairs kept).

Bank-scoping matters on shared schemas — pruning a small bank next to large ones:

| `live` scope | Time |
|---|---:|
| Schema-wide (Oracle-style) | ~260 ms |
| **Bank-scoped (this PR)** | **~1–10 ms** |

## Tests

- Existing: `test_prunes_cooccurrence_with_no_shared_unit`, `test_keeps_cooccurrence_with_shared_unit`, and the `test_graph_maintenance_deadlock.py` suite (ordered-lock preserved).
- Added: `test_prunes_only_the_stale_edge_around_a_hub_and_leaves_other_banks` — a hub's still-grounded edge survives while only its stale edge is pruned, and a second bank's stale edge is untouched (guards the bank-scoping).
