### PR TITLE
fix(graph-maintenance): drive the entity prune off a queue, not a bank-wide sweep (#3222)

### DIFF
--- a/hindsight-api-slim/hindsight_api/admin/cli.py
+++ b/hindsight-api-slim/hindsight_api/admin/cli.py
@@ -68,6 +68,7 @@ BACKUP_TABLES = [
     "audit_log",
     "llm_requests",
     "graph_maintenance_queue",
+    "entity_maintenance_queue",
 ]
 
 MANIFEST_VERSION = "2"

--- a/hindsight-api-slim/hindsight_api/alembic/versions/c4f7a91b2d38_add_entity_maintenance_queue.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/c4f7a91b2d38_add_entity_maintenance_queue.py
@@ -13,12 +13,12 @@ timeout on every run and the job could never complete (#3222).
 With a queue the prunes only examine entities a delete actually touched, the
 same way ``graph_maintenance_queue`` already scopes the relink pass.
 
-The seed insert below enqueues every existing entity exactly once, so the
-garbage a bank accumulated while its bank-wide sweep was failing still gets
-reclaimed — incrementally, a bounded batch per run, instead of in one statement
-that cannot finish. The queue drains to empty and stays empty after that.
-Indexes are added after the seed so the bulk load doesn't maintain them
-row-by-row.
+Deliberately NOT seeded with the existing entities. Backfilling them would
+reclaim whatever a bank accumulated while its sweep was failing, but it writes
+one row per entity inside a migration that runs at API startup, and then charges
+a prune check for every one of them — a slow upgrade plus a large self-inflicted
+backlog, to collect rows that cost a bank nothing. The queue starts empty and
+fills from real deletes; historical strays stay until something touches them.
 
 Revision ID: c4f7a91b2d38
 Revises: d9c1a7b4e2f6
@@ -54,20 +54,9 @@ def _pg_upgrade() -> None:
         CREATE TABLE IF NOT EXISTS {schema}entity_maintenance_queue (
             bank_id     TEXT NOT NULL,
             entity_id   UUID NOT NULL,
-            enqueued_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            enqueued_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            PRIMARY KEY (bank_id, entity_id)
         )
-        """
-    )
-    op.execute(
-        f"""
-        INSERT INTO {schema}entity_maintenance_queue (bank_id, entity_id)
-        SELECT bank_id, id FROM {schema}entities
-        """
-    )
-    op.execute(
-        f"""
-        ALTER TABLE {schema}entity_maintenance_queue
-        ADD CONSTRAINT pk_entity_maintenance_queue PRIMARY KEY (bank_id, entity_id)
         """
     )
     op.execute(
@@ -106,14 +95,10 @@ def _oracle_upgrade() -> None:
         CREATE TABLE entity_maintenance_queue (
             bank_id     VARCHAR2(256) NOT NULL,
             entity_id   RAW(16)       NOT NULL,
-            enqueued_at TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL
+            enqueued_at TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
+            CONSTRAINT pk_entity_maintenance_queue PRIMARY KEY (bank_id, entity_id)
         )
         """
-    )
-    op.execute("INSERT INTO entity_maintenance_queue (bank_id, entity_id) SELECT bank_id, id FROM entities")
-    _oracle_execute_ignoring_955(
-        "ALTER TABLE entity_maintenance_queue "
-        "ADD CONSTRAINT pk_entity_maintenance_queue PRIMARY KEY (bank_id, entity_id)"
     )
     _oracle_execute_ignoring_955(
         "CREATE INDEX idx_entity_maintenance_queue_bank_enqueued ON entity_maintenance_queue (bank_id, enqueued_at)"

--- a/hindsight-api-slim/hindsight_api/alembic/versions/c4f7a91b2d38_add_entity_maintenance_queue.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/c4f7a91b2d38_add_entity_maintenance_queue.py
@@ -21,7 +21,7 @@ Indexes are added after the seed so the bulk load doesn't maintain them
 row-by-row.
 
 Revision ID: c4f7a91b2d38
-Revises: b3e8d1c6f4a9
+Revises: d9c1a7b4e2f6
 Create Date: 2026-08-11
 """
 
@@ -32,7 +32,7 @@ from alembic import context, op
 from hindsight_api.alembic._dialect import run_for_dialect
 
 revision: str = "c4f7a91b2d38"
-down_revision: str | Sequence[str] | None = "b3e8d1c6f4a9"
+down_revision: str | Sequence[str] | None = "d9c1a7b4e2f6"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/hindsight-api-slim/hindsight_api/alembic/versions/c4f7a91b2d38_add_entity_maintenance_queue.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/c4f7a91b2d38_add_entity_maintenance_queue.py
@@ -1,0 +1,133 @@
+"""Add entity_maintenance_queue table (+ seed it with every existing entity)
+
+Queue of entities whose unit references may have gone away — the input to the
+graph_maintenance job's orphan-entity and stale-cooccurrence prunes.
+
+Those two prunes used to be bank-wide single statements re-evaluated on every
+run: the orphan prune probed once per entity in the bank, and the cooccurrence
+prune evaluated an INTERSECT per cooccurrence row in the bank, whether or not
+anything had changed. Their cost tracked the size of the bank rather than the
+size of the delete, so past a few million rows they blew asyncpg's command
+timeout on every run and the job could never complete (#3222).
+
+With a queue the prunes only examine entities a delete actually touched, the
+same way ``graph_maintenance_queue`` already scopes the relink pass.
+
+The seed insert below enqueues every existing entity exactly once, so the
+garbage a bank accumulated while its bank-wide sweep was failing still gets
+reclaimed — incrementally, a bounded batch per run, instead of in one statement
+that cannot finish. The queue drains to empty and stays empty after that.
+Indexes are added after the seed so the bulk load doesn't maintain them
+row-by-row.
+
+Revision ID: c4f7a91b2d38
+Revises: b3e8d1c6f4a9
+Create Date: 2026-08-11
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "c4f7a91b2d38"
+down_revision: str | Sequence[str] | None = "b3e8d1c6f4a9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _pg_schema_prefix() -> str:
+    """Schema-qualifier for raw SQL on PG (multi-tenant search_path)."""
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def _pg_upgrade() -> None:
+    schema = _pg_schema_prefix()
+    # Composite PK gives ON CONFLICT DO NOTHING dedup when the same entity is
+    # enqueued from overlapping deletes. No FK to entities: the prune's whole
+    # job is to delete the entity, and a cascade would race it away mid-drain.
+    # A queue row naming an entity that no longer exists is a no-op.
+    op.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {schema}entity_maintenance_queue (
+            bank_id     TEXT NOT NULL,
+            entity_id   UUID NOT NULL,
+            enqueued_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+    op.execute(
+        f"""
+        INSERT INTO {schema}entity_maintenance_queue (bank_id, entity_id)
+        SELECT bank_id, id FROM {schema}entities
+        """
+    )
+    op.execute(
+        f"""
+        ALTER TABLE {schema}entity_maintenance_queue
+        ADD CONSTRAINT pk_entity_maintenance_queue PRIMARY KEY (bank_id, entity_id)
+        """
+    )
+    op.execute(
+        f"""
+        CREATE INDEX IF NOT EXISTS idx_entity_maintenance_queue_bank_enqueued
+        ON {schema}entity_maintenance_queue (bank_id, enqueued_at)
+        """
+    )
+
+
+def _pg_downgrade() -> None:
+    schema = _pg_schema_prefix()
+    op.execute(f"DROP INDEX IF EXISTS {schema}idx_entity_maintenance_queue_bank_enqueued")
+    op.execute(f"DROP TABLE IF EXISTS {schema}entity_maintenance_queue")
+
+
+def _oracle_execute_ignoring_955(sql: str) -> None:
+    """Run a CREATE statement and swallow ORA-00955 (object already exists).
+
+    Mirrors the helper in the graph_maintenance_queue migration so reruns stay
+    safe on a database where the table was created by an earlier partial run.
+    """
+    block = (
+        "BEGIN "
+        "EXECUTE IMMEDIATE :stmt; "
+        "EXCEPTION WHEN OTHERS THEN "
+        "IF SQLCODE = -955 THEN NULL; ELSE RAISE; END IF; "
+        "END;"
+    )
+    op.get_bind().exec_driver_sql(block, {"stmt": sql.strip()})
+
+
+def _oracle_upgrade() -> None:
+    _oracle_execute_ignoring_955(
+        """
+        CREATE TABLE entity_maintenance_queue (
+            bank_id     VARCHAR2(256) NOT NULL,
+            entity_id   RAW(16)       NOT NULL,
+            enqueued_at TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL
+        )
+        """
+    )
+    op.execute("INSERT INTO entity_maintenance_queue (bank_id, entity_id) SELECT bank_id, id FROM entities")
+    _oracle_execute_ignoring_955(
+        "ALTER TABLE entity_maintenance_queue "
+        "ADD CONSTRAINT pk_entity_maintenance_queue PRIMARY KEY (bank_id, entity_id)"
+    )
+    _oracle_execute_ignoring_955(
+        "CREATE INDEX idx_entity_maintenance_queue_bank_enqueued ON entity_maintenance_queue (bank_id, enqueued_at)"
+    )
+
+
+def _oracle_downgrade() -> None:
+    op.execute("DROP INDEX idx_entity_maintenance_queue_bank_enqueued")
+    op.execute("DROP TABLE entity_maintenance_queue")
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade, oracle=_oracle_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade, oracle=_oracle_downgrade)

--- a/hindsight-api-slim/hindsight_api/engine/db/ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops.py
@@ -647,15 +647,53 @@ class DataAccessOps(ABC):
         ...
 
     @abstractmethod
+    async def enqueue_entity_maintenance(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        ue_table: str,
+        bank_id: str,
+        unit_ids: list,
+    ) -> int:
+        """Enqueue the entities referenced by ``unit_ids`` as prune candidates.
+
+        Reads the entity ids out of ``unit_entities`` and inserts them into
+        entity_maintenance_queue, deduplicating on the (bank_id, entity_id)
+        primary key. Returns the number of rows the insert added.
+
+        Must run inside the triggering transaction and BEFORE the rows go —
+        once the unit_entities rows are deleted (or cascaded away) there is
+        nothing left to read the entity ids from.
+        """
+        ...
+
+    @abstractmethod
+    async def claim_entity_maintenance_batch(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        bank_id: str,
+        limit: int,
+    ) -> list:
+        """Atomically claim a batch of rows from entity_maintenance_queue and
+        remove them from the table.
+
+        Returns the claimed entity ids. Empty list when the queue for
+        ``bank_id`` is drained.
+        """
+        ...
+
+    @abstractmethod
     async def prune_orphan_entities(
         self,
         conn: DatabaseConnection,
         entities_table: str,
         ue_table: str,
         bank_id: str,
+        entity_ids: list,
     ) -> int:
-        """Delete entities in ``bank_id`` that no longer have any unit_entities
-        rows referencing them. Returns the number of rows deleted.
+        """Delete those of ``entity_ids`` in ``bank_id`` that no longer have any
+        unit_entities rows referencing them. Returns the number of rows deleted.
 
         FK ON DELETE CASCADE on entity_cooccurrences then removes any
         cooccurrence row pointing at the pruned entities.
@@ -668,11 +706,10 @@ class DataAccessOps(ABC):
         conn: DatabaseConnection,
         ec_table: str,
         ue_table: str,
-        entities_table: str,
-        bank_id: str,
+        entity_ids: list,
     ) -> int:
-        """Delete entity_cooccurrences rows in ``bank_id`` where the two
-        entities still exist but no current unit references both of them.
+        """Delete entity_cooccurrences rows incident to ``entity_ids`` where the
+        two entities still exist but no current unit references both of them.
 
         These are stale-count rows: cooccurrence was real at the time it was
         recorded, but every memory_unit that witnessed both entities has

--- a/hindsight-api-slim/hindsight_api/engine/db/ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops.py
@@ -81,9 +81,9 @@ def document_serialization_sql(table: str, alias: str) -> str:
 def graph_maintenance_bank_serialization_sql(table: str, alias: str) -> str:
     """SQL predicate serialising ``graph_maintenance`` claims per bank (#3230).
 
-    Every graph_maintenance run is the same bank-wide sweep — the payload carries
-    only ``bank_id``, and ``run_graph_maintenance_job`` drains the whole queue —
-    so a second concurrent run for one bank adds no work. It is worse than
+    Every graph_maintenance run for a bank is interchangeable — the payload
+    carries only ``bank_id``, and ``run_graph_maintenance_job`` drains that bank's
+    queues — so a second concurrent run for one bank adds no work. It is worse than
     useless: ``claim_graph_maintenance_batch`` locks queue rows ``FOR UPDATE``
     *without* ``SKIP LOCKED`` (it is written assuming a single runner per bank),
     so the runs convoy on each other's row locks while each holds a worker slot.

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -358,13 +358,80 @@ class OracleOps(DataAccessOps):
             )
         return claimed
 
+    async def enqueue_entity_maintenance(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        ue_table: str,
+        bank_id: str,
+        unit_ids: list,
+    ) -> int:
+        if not unit_ids:
+            return 0
+        rows = await conn.fetch(
+            f"SELECT DISTINCT entity_id FROM {ue_table} WHERE unit_id = ANY($1::uuid[])",
+            unit_ids,
+        )
+        # Sorted for the same reason as enqueue_graph_maintenance: the MERGE
+        # takes the (bank_id, entity_id) row locks in executemany array order,
+        # and claim_entity_maintenance_batch deletes in that same order, so
+        # overlapping mutation/worker sets cannot cycle.
+        candidates = sorted(str(row["entity_id"]) for row in rows)
+        if not candidates:
+            return 0
+        # MERGE is the Oracle analogue of ON CONFLICT DO UPDATE: WHEN MATCHED
+        # locks the existing queue row (the SET is a no-op preserving
+        # enqueued_at) so a re-enqueue serialises against a concurrent claim
+        # instead of being silently dropped (#3034).
+        await conn.executemany(
+            f"""
+            MERGE INTO {table} q
+            USING (SELECT $1 AS bank_id, $2 AS entity_id FROM dual) s
+            ON (q.bank_id = s.bank_id AND q.entity_id = s.entity_id)
+            WHEN MATCHED THEN UPDATE SET q.enqueued_at = q.enqueued_at
+            WHEN NOT MATCHED THEN INSERT (bank_id, entity_id) VALUES (s.bank_id, s.entity_id)
+            """,
+            [(bank_id, eid) for eid in candidates],
+        )
+        return len(candidates)
+
+    async def claim_entity_maintenance_batch(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        bank_id: str,
+        limit: int,
+    ) -> list:
+        # Two-step claim, same as claim_graph_maintenance_batch: Oracle's
+        # DELETE ... RETURNING doesn't accept a multi-row subquery.
+        rows = await conn.fetch(
+            f"""
+            SELECT entity_id FROM {table}
+            WHERE bank_id = $1
+            ORDER BY enqueued_at
+            FETCH FIRST $2 ROWS ONLY
+            """,
+            bank_id,
+            limit,
+        )
+        claimed = sorted(str(row["entity_id"]) for row in rows)
+        if claimed:
+            await conn.executemany(
+                f"DELETE FROM {table} WHERE bank_id = $1 AND entity_id = $2",
+                [(bank_id, eid) for eid in claimed],
+            )
+        return claimed
+
     async def prune_orphan_entities(
         self,
         conn: DatabaseConnection,
         entities_table: str,
         ue_table: str,
         bank_id: str,
+        entity_ids: list,
     ) -> int:
+        if not entity_ids:
+            return 0
         # The Oracle DatabaseConnection wrapper reshapes ``cursor.rowcount`` into
         # the same ``"DELETE N"`` status string asyncpg returns, so the same
         # ``int(deleted.split()[-1])`` parsing works on both dialects.
@@ -372,9 +439,11 @@ class OracleOps(DataAccessOps):
             f"""
             DELETE FROM {entities_table}
             WHERE bank_id = $1
+              AND id = ANY($2::uuid[])
               AND id NOT IN (SELECT DISTINCT entity_id FROM {ue_table})
             """,
             bank_id,
+            entity_ids,
         )
         return int(deleted.split()[-1]) if isinstance(deleted, str) and deleted.startswith("DELETE") else 0
 
@@ -383,26 +452,33 @@ class OracleOps(DataAccessOps):
         conn: DatabaseConnection,
         ec_table: str,
         ue_table: str,
-        entities_table: str,
-        bank_id: str,
+        entity_ids: list,
     ) -> int:
+        if not entity_ids:
+            return 0
         # NB: the Postgres path additionally selects victims FOR UPDATE in sorted
         # (entity_id_1, entity_id_2) order to prevent the #2529 deadlock against
         # retain's sorted cooccurrence upsert. Oracle's DELETE can't carry that
         # ordered-lock CTE the same way, so here we rely on the Pass 2/3 retry
         # wrap in run_graph_maintenance_job (retry_with_backoff is ORA-00060
         # deadlock-aware) to recover instead. Deliberate dialect asymmetry.
+        #
+        # Scoped to the claimed candidates on either endpoint (#3222). The OR is
+        # safe to write directly here, unlike on Postgres: both endpoint columns
+        # are indexed and Oracle's optimizer expands an OR of two index-driven
+        # predicates into a concatenation, rather than the whole-table scan the
+        # PG planner picks (which is why the PG side spells it as a UNION).
         deleted = await conn.execute(
             f"""
             DELETE FROM {ec_table}
-            WHERE entity_id_1 IN (SELECT id FROM {entities_table} WHERE bank_id = $1)
+            WHERE (entity_id_1 = ANY($1::uuid[]) OR entity_id_2 = ANY($1::uuid[]))
               AND (entity_id_1, entity_id_2) NOT IN (
                   SELECT u1.entity_id, u2.entity_id
                   FROM {ue_table} u1
                   JOIN {ue_table} u2 ON u1.unit_id = u2.unit_id
               )
             """,
-            bank_id,
+            entity_ids,
         )
         return int(deleted.split()[-1]) if isinstance(deleted, str) and deleted.startswith("DELETE") else 0
 

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -473,26 +473,126 @@ class PostgreSQLOps(DataAccessOps):
         )
         return [str(row["unit_id"]) for row in rows]
 
+    async def enqueue_entity_maintenance(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        ue_table: str,
+        bank_id: str,
+        unit_ids: list,
+    ) -> int:
+        # Read the candidates straight out of unit_entities rather than making
+        # callers pass entity ids: every caller runs this immediately before the
+        # rows go, and the join they'd have to write is this one.
+        #
+        # The inner ORDER BY is load-bearing, not cosmetic: it makes the INSERT
+        # take the (bank_id, entity_id) row locks ascending, the same order
+        # claim_entity_maintenance_batch takes them, so a mutation enqueueing an
+        # overlapping candidate set cannot cycle against a worker draining it.
+        # (Same protocol as enqueue_graph_maintenance, which sorts in Python
+        # because its ids arrive as a bind array.)
+        #
+        # DO UPDATE (not DO NOTHING) on a duplicate — #3034. The SET is a
+        # deliberate no-op preserving enqueued_at; its only purpose is to lock
+        # the conflicting row. DO NOTHING does not lock it, so a delete
+        # re-enqueueing an already-queued entity could not block a worker from
+        # claiming that row and evaluating the entity's pre-delete state — it
+        # would find the entity still referenced, keep it, and the re-enqueue
+        # signal would be lost, stranding the orphan until some later delete
+        # happened to name it again.
+        result = await conn.execute(
+            f"""
+            INSERT INTO {table} (bank_id, entity_id)
+            SELECT $1, s.entity_id
+            FROM (
+                SELECT DISTINCT ue.entity_id
+                FROM {ue_table} ue
+                WHERE ue.unit_id = ANY($2::uuid[])
+                ORDER BY 1
+            ) s
+            ON CONFLICT (bank_id, entity_id)
+                DO UPDATE SET enqueued_at = {table}.enqueued_at
+            """,
+            bank_id,
+            unit_ids,
+        )
+        return int(result.split()[-1]) if isinstance(result, str) and result.startswith("INSERT") else 0
+
+    async def claim_entity_maintenance_batch(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        bank_id: str,
+        limit: int,
+    ) -> list:
+        # Same claim shape as claim_graph_maintenance_batch: pick the oldest
+        # batch by enqueued_at, but acquire the row locks in (bank_id, entity_id)
+        # order — the order enqueue_entity_maintenance takes them — so a
+        # concurrent enqueue can never cycle against this claim. `chosen` is
+        # MATERIALIZED so the enqueued_at pick is fenced from the locking clause,
+        # and `FOR UPDATE OF q ... ORDER BY q.entity_id` puts LockRows above the
+        # Sort.
+        rows = await conn.fetch(
+            f"""
+            WITH chosen AS MATERIALIZED (
+                SELECT bank_id, entity_id FROM {table}
+                WHERE bank_id = $1
+                ORDER BY enqueued_at
+                LIMIT $2
+            ),
+            locked AS (
+                SELECT q.bank_id, q.entity_id
+                FROM {table} q
+                JOIN chosen c ON c.bank_id = q.bank_id AND c.entity_id = q.entity_id
+                ORDER BY q.entity_id
+                FOR UPDATE OF q
+            )
+            DELETE FROM {table} q
+            USING locked l
+            WHERE q.bank_id = l.bank_id AND q.entity_id = l.entity_id
+            RETURNING q.entity_id
+            """,
+            bank_id,
+            limit,
+        )
+        return [row["entity_id"] for row in rows]
+
     async def prune_orphan_entities(
         self,
         conn: DatabaseConnection,
         entities_table: str,
         ue_table: str,
         bank_id: str,
+        entity_ids: list,
     ) -> int:
-        # Scoped by entities.bank_id (indexed). The NOT EXISTS subquery is
-        # backed by idx_ue_entity on unit_entities(entity_id), so this stays
-        # linear in the number of entities in the bank — not in the size of
-        # unit_entities globally.
+        # Scoped to the claimed candidates: primary-key lookups, with the
+        # NOT EXISTS backed by idx_unit_entities_entity_unit. Cost tracks the
+        # batch, not the bank (#3222) — the bank-wide form this replaces probed
+        # once per entity in the bank on every single run.
+        #
+        # Victims are locked in id order before the delete so the locks are
+        # acquired the same way retain's entity upsert takes them
+        # (bulk_upsert_entities locks `ORDER BY id FOR KEY SHARE`), which is what
+        # keeps a prune and a concurrent re-assert from cycling.
         result = await conn.execute(
             f"""
+            WITH victims AS (
+                SELECT e.id
+                FROM {entities_table} e
+                WHERE e.bank_id = $1
+                  AND e.id = ANY($2::uuid[])
+                  AND NOT EXISTS (
+                      SELECT 1 FROM {ue_table} ue WHERE ue.entity_id = e.id
+                  )
+                ORDER BY e.id
+                FOR UPDATE
+            )
             DELETE FROM {entities_table} e
-            WHERE e.bank_id = $1
-              AND NOT EXISTS (
-                  SELECT 1 FROM {ue_table} ue WHERE ue.entity_id = e.id
-              )
+            USING victims v
+            WHERE e.id = v.id
             """,
             bank_id,
+            entity_ids,
         )
         # asyncpg returns "DELETE N"
         return int(result.split()[-1]) if isinstance(result, str) and result.startswith("DELETE") else 0
@@ -502,12 +602,18 @@ class PostgreSQLOps(DataAccessOps):
         conn: DatabaseConnection,
         ec_table: str,
         ue_table: str,
-        entities_table: str,
-        bank_id: str,
+        entity_ids: list,
     ) -> int:
-        # Scope by joining through entities.bank_id (entity_cooccurrences itself
-        # has no bank_id column — entities don't span banks, so scoping via
-        # entity_id_1 is sufficient).
+        # Scoped to cooccurrence rows incident to the claimed candidates. The
+        # two arms are a UNION rather than
+        # `WHERE entity_id_1 = ANY(...) OR entity_id_2 = ANY(...)`: an OR across
+        # two columns of the same table cannot be driven from either index, so
+        # the planner would make entity_cooccurrences the outer relation and
+        # scan it whole — the #3387 shape. As a UNION each arm is an index scan
+        # (the PK for arm 1, idx_entity_cooccurrences_entity2 for arm 2).
+        #
+        # No bank predicate: entities don't span banks and the candidates came
+        # off a bank-scoped queue, so both endpoints are already this bank's.
         #
         # Ordered locking (deadlock avoidance, #2529): retain's concurrent
         # cooccurrence upsert (entity_resolver._flush_pending) locks rows in
@@ -523,45 +629,58 @@ class PostgreSQLOps(DataAccessOps):
         # retry wrap in run_graph_maintenance_job stays as a backstop for the
         # residual paths (FK cascade from prune_orphan_entities, Oracle).
         #
-        # Staleness is decided against a SET of currently-live pairs built ONCE
-        # per sweep, not with a per-cooccurrence-row check (#3367). The old form
-        # ran a correlated `NOT EXISTS (… INTERSECT …)` for every row, and each
-        # evaluation re-scanned a hub entity's full membership set — cost scaled
-        # as (cooccurrence rows) × (hub degree), 88-140s on a real bank with a
-        # ~22K-degree hub (and 215s in a 12K-degree repro). #2473 had swapped an
-        # earlier hub-rescanning self-join to that INTERSECT, but only made each
-        # per-row check cheaper — it kept the per-row structure, so the product
-        # blew up again at scale.
+        # Staleness is decided against a SET of currently-live pairs, not with a
+        # per-cooccurrence-row check (#3367). The old form ran a correlated
+        # `NOT EXISTS (… INTERSECT …)` per row, and each evaluation re-scanned a
+        # hub entity's full membership set — cost scaled as (rows judged) x (hub
+        # degree), 88-140s on a real bank with a ~22K-degree hub. #2473 had
+        # swapped an earlier hub-rescanning self-join to that INTERSECT, but only
+        # made each per-row check cheaper; it kept the per-row structure, so the
+        # product blew up again at scale.
         #
-        # `live` instead groups unit_entities by unit (self-join on unit_id) to
-        # emit every co-occurring (e1<e2) pair in one materialised pass: its cost
-        # is driven by unit degree (entities per unit — small), never by entity
-        # degree, so a hub contributes only its per-unit membership, not a rescan
-        # per edge. The victims anti-join then hashes against it. Scope `live` to
-        # this bank's entities (`u1 -> bank entity`; a unit co-member is in the
-        # same bank): graph maintenance runs per-bank, so an unscoped schema-wide
-        # build would re-derive every bank's pairs on every bank's run —
-        # O(banks × schema) per cycle instead of O(schema). MATERIALIZED keeps
+        # `live` groups unit_entities by unit (self-join on unit_id) to emit every
+        # co-occurring (e1<e2) pair in one materialised pass: its cost is driven
+        # by unit degree (entities per unit — small), never by entity degree, so a
+        # hub contributes only its per-unit membership rather than a rescan per
+        # edge. The victims anti-join then hashes against it. MATERIALIZED keeps
         # the planner from inlining `live` back into a per-row correlated plan.
+        #
+        # `live` is seeded from the *candidates'* units rather than the whole
+        # bank's (#3222 composed with #3367): graph maintenance is queue-driven,
+        # so this only has to decide about pairs in `incident`, and every such
+        # pair has a candidate as at least one endpoint. Any unit still
+        # witnessing such a pair therefore references a candidate, and so is in
+        # the seeded set — the scoped build cannot miss a live pair. That keeps
+        # the whole statement proportional to the batch instead of re-deriving
+        # every pair in the bank on every run.
         result = await conn.execute(
             f"""
-            WITH live AS MATERIALIZED (
+            WITH incident AS MATERIALIZED (
+                SELECT c.entity_id_1, c.entity_id_2
+                FROM {ec_table} c
+                WHERE c.entity_id_1 = ANY($1::uuid[])
+                UNION
+                SELECT c.entity_id_1, c.entity_id_2
+                FROM {ec_table} c
+                WHERE c.entity_id_2 = ANY($1::uuid[])
+            ),
+            live AS MATERIALIZED (
                 SELECT u1.entity_id AS e1, u2.entity_id AS e2
-                FROM {entities_table} be
-                JOIN {ue_table} u1 ON u1.entity_id = be.id
+                FROM {ue_table} seed
+                JOIN {ue_table} u1 ON u1.unit_id = seed.unit_id
                 JOIN {ue_table} u2 ON u2.unit_id = u1.unit_id
                                   AND u2.entity_id > u1.entity_id
-                WHERE be.bank_id = $1
+                WHERE seed.entity_id = ANY($1::uuid[])
             ),
             victims AS (
                 SELECT c.entity_id_1, c.entity_id_2
-                FROM {ec_table} c
-                JOIN {entities_table} e ON e.id = c.entity_id_1
-                WHERE e.bank_id = $1
-                  AND NOT EXISTS (
-                      SELECT 1 FROM live l
-                      WHERE l.e1 = c.entity_id_1 AND l.e2 = c.entity_id_2
-                  )
+                FROM incident i
+                JOIN {ec_table} c
+                  ON c.entity_id_1 = i.entity_id_1 AND c.entity_id_2 = i.entity_id_2
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM live l
+                    WHERE l.e1 = c.entity_id_1 AND l.e2 = c.entity_id_2
+                )
                 ORDER BY c.entity_id_1, c.entity_id_2
                 FOR UPDATE OF c
             )
@@ -570,7 +689,7 @@ class PostgreSQLOps(DataAccessOps):
             WHERE c.entity_id_1 = v.entity_id_1
               AND c.entity_id_2 = v.entity_id_2
             """,
-            bank_id,
+            entity_ids,
         )
         return int(result.split()[-1]) if isinstance(result, str) and result.startswith("DELETE") else 0
 

--- a/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
@@ -1,29 +1,33 @@
 """Async graph maintenance after document/unit deletes.
 
-Three reconciliation passes run together on every worker invocation:
+Two queue-driven passes run together on every worker invocation:
 
 1. **Relink top-up.** Drain ``graph_maintenance_queue`` (units whose
    outgoing temporal/semantic links lost a neighbour to a delete). For
    each, count current outgoing links per type; if below cap, run the
    same probes retain uses and insert the missing links.
 
-2. **Orphan entity prune.** Delete ``entities`` rows in the bank that no
-   longer have any live memory references. FK ON DELETE CASCADE on
-   ``entity_cooccurrences`` then removes any cooccurrence row pointing
-   at the pruned entities.
+2. **Entity prune.** Drain ``entity_maintenance_queue`` (entities a delete
+   may have stranded). Per batch: delete the candidates no ``unit_entities``
+   row references any more — FK ON DELETE CASCADE on ``entity_cooccurrences``
+   takes their cooccurrence rows with them — then delete the cooccurrence rows
+   incident to the survivors that no current memory witnesses, the stale-count
+   case the cascade cannot see.
 
-3. **Stale cooccurrence prune.** Defensive sweep for cooccurrence rows
-   where both endpoints still exist but no current memory references
-   both of them — the cooccurrence was real at the time it was recorded,
-   but every unit that witnessed it has since been deleted.
+Both passes are *queued work*, not sweeps. Pass 2 used to be two bank-wide
+statements re-evaluated on every invocation whether or not anything had
+changed, so its cost tracked the size of the bank instead of the size of the
+delete; on a multi-million-row bank neither statement could finish inside
+asyncpg's command timeout and the job failed on every run, forever (#3222).
+Both queues are now filled inside the deleting transaction, so each run only
+looks at what that delete actually touched.
 
 Each pass is work the *memories store* owns, because each is a query over
 `memory_links`, `unit_entities` and `entities` — the slice the store carves
-out. This module orchestrates them (drain the queue, wrap the sweep in a
-deadlock-retry) and asks the store to do the part that touches storage. A store
-whose links travel inside its memories has no `memory_links` to dangle and no
-join table to sweep, so its relink and cooccurrence passes are no-ops and the
-job simply prunes the orphan `entities` rows, which stay in Postgres regardless.
+out. This module orchestrates them (pass ordering, the time budget, the timing
+log) and asks the store to do the part that touches storage. A store whose
+links travel inside its memories has no `memory_links` to dangle and no join
+table to sweep, so both passes are no-ops for it.
 
 The worker dedupes on bank: a second job for the same bank is dropped
 while one is pending. Once processing starts, a new job becomes the
@@ -60,19 +64,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Retry budget for the idempotent Pass 2/3 entity/cooccurrence sweep. Higher
-# than db_utils' default (3) because the sweep has no client waiting on it and
-# is safe to rerun, so we'd rather spend a longer jittered-backoff tail than
-# drop a maintenance pass and leak stale graph rows (see run_graph_maintenance_job).
-_SWEEP_MAX_RETRIES = 8
-
-
-@dataclass
-class _SweepCounts:
-    """Prune counts returned by the Pass 2/3 sweep (avoids a bare tuple return)."""
-
-    orphan_entities_pruned: int
-    stale_cooccurrences_pruned: int
+# Wall-clock budget for one graph_maintenance run. Both passes commit per batch,
+# so hitting the budget is not a failure: it stops claiming new work, reports
+# what it did, and the follow-up run resumes from the queue rows still there.
+# A backlog (a large delete, or the one-time seed the entity queue ships with)
+# then converges over several runs instead of holding a worker slot for as long
+# as it takes — the failure mode #3222 describes, where the whole run was
+# cancelled and every batch's work was retried from scratch.
+_JOB_TIME_BUDGET_SECONDS = 240.0
 
 
 @dataclass
@@ -81,15 +80,22 @@ class JobResult:
 
     relink_units_processed: int = 0
     relink_links_added: int = 0
+    entities_examined: int = 0
     orphan_entities_pruned: int = 0
     stale_cooccurrences_pruned: int = 0
+    # False when the time budget stopped a drain with work still queued. The
+    # caller re-submits so the backlog keeps draining without waiting for the
+    # next delete to trigger a run.
+    queues_drained: bool = True
 
-    def as_dict(self) -> dict[str, int]:
+    def as_dict(self) -> dict[str, int | bool]:
         return {
             "relink_units_processed": self.relink_units_processed,
             "relink_links_added": self.relink_links_added,
+            "entities_examined": self.entities_examined,
             "orphan_entities_pruned": self.orphan_entities_pruned,
             "stale_cooccurrences_pruned": self.stale_cooccurrences_pruned,
+            "queues_drained": self.queues_drained,
         }
 
 
@@ -143,19 +149,65 @@ async def enqueue_relink_victims(
     )
 
 
+async def enqueue_entity_prune_candidates(
+    conn: DatabaseConnection,
+    bank_id: str,
+    affected_unit_ids: list[str],
+) -> int:
+    """Enqueue the entities ``affected_unit_ids`` reference as prune candidates.
+
+    Must run inside the same transaction that removes those units (or replaces
+    their entity postings), *before* the delete or cascade fires: afterwards the
+    ``unit_entities`` rows naming the entities are gone, and an entity nothing
+    points at is an orphan nothing will ever look at again.
+
+    Pair this with :func:`enqueue_relink_victims` at every delete site. They
+    capture different things — that one records the *survivors* whose links now
+    dangle, this one the *entities* the doomed units were holding up — and
+    neither substitutes for the other. A site that deletes units without calling
+    this leaks orphan entities and stale cooccurrences until something else
+    happens to enqueue the same entity.
+
+    Over-enqueueing costs nothing: the drain re-checks each candidate and keeps
+    the ones still referenced.
+
+    Delegated to the memories store: a store that never wrote ``unit_entities``
+    has no postings to lose and returns 0.
+
+    Args:
+        conn: Database connection inside the active transaction.
+        bank_id: Bank owning the affected units.
+        affected_unit_ids: Memory_unit IDs whose entity postings are about to
+            be (or are being) removed.
+
+    Returns:
+        Number of candidate entities enqueued (0 for a store with no postings).
+    """
+    if not affected_unit_ids:
+        return 0
+
+    from .memories import get_memories
+
+    return await get_memories().enqueue_entity_prune_candidates(
+        conn=conn,
+        fq_table=fq_table,
+        bank_id=bank_id,
+        affected_unit_ids=affected_unit_ids,
+    )
+
+
 async def run_graph_maintenance_job(
     memory_engine: "MemoryEngine",
     bank_id: str,
     request_context: RequestContext,
     operation_id: str | None = None,
-) -> dict[str, int]:
-    """Run all maintenance passes for ``bank_id`` until the relink queue is
-    drained, then sweep entities and cooccurrences once.
+) -> dict[str, int | bool]:
+    """Drain both maintenance queues for ``bank_id``, within a time budget.
 
     Returns:
-        Per-pass counters from :class:`JobResult`.
+        Per-pass counters from :class:`JobResult`. ``queues_drained`` is False
+        when the budget ran out with work still queued — the caller re-submits.
     """
-    del request_context  # accepted for symmetry with other run_*_job helpers
     from ..config import get_config
     from .memories import get_memories
 
@@ -165,6 +217,7 @@ async def run_graph_maintenance_job(
 
     result = JobResult()
     job_start = time.time()
+    deadline = time.monotonic() + _JOB_TIME_BUDGET_SECONDS
 
     # --- Pass 1: relink ---
     # The store owns the whole drain loop: it is a claim → top-up → commit over
@@ -173,51 +226,48 @@ async def run_graph_maintenance_job(
     # unit_id) order against a concurrent re-enqueue), which lives in the store's
     # claim (`ops.claim_graph_maintenance_batch`). A store with no links returns an
     # empty dict and this is a no-op.
-    relink = await store.relink_pass(backend=backend, fq_table=fq_table, bank_id=bank_id, config=config)
+    relink = await store.relink_pass(
+        backend=backend, fq_table=fq_table, bank_id=bank_id, config=config, deadline=deadline
+    )
     result.relink_units_processed = relink.get("relink_units_processed", 0)
     result.relink_links_added = relink.get("relink_links_added", 0)
 
-    # --- Pass 2 & 3: entity / cooccurrence sweeps ---
-    # Bank-wide single-statement deletes. Cheap when there's nothing to do.
-    #
-    # Unlike Pass 1's queue claim, these DELETEs aren't protected by any
-    # consistent lock-ordering guarantee: the stale-cooccurrence prune scans
-    # entity_cooccurrences via a join/NOT EXISTS plan, while retain's concurrent
-    # cooccurrence upserts (entity_resolver._flush_pending) lock the same rows in
-    # sorted (entity_id_1, entity_id_2) order. When a sweep and a concurrent
-    # upsert touch overlapping rows in opposite orders, Postgres detects a
-    # genuine circular wait and aborts one side with DeadlockDetectedError. Both
-    # prunes are idempotent bank-wide sweeps — rerunning only deletes what's
-    # still stale — so retrying the whole transaction on deadlock is safe.
-    #
-    # The prunes themselves are the store's: the orphan-`entities` sweep applies
-    # to every store (that registry stays in Postgres), while the cooccurrence
-    # sweep is a no-op for a store that never wrote `unit_entities`.
-    from .db_utils import retry_with_backoff
-    from .memory_engine import acquire_with_retry
-
-    async def _run_sweep() -> _SweepCounts:
-        async with acquire_with_retry(backend) as conn:
-            async with conn.transaction():
-                orphan_pruned = await store.prune_orphan_entities(conn=conn, fq_table=fq_table, bank_id=bank_id)
-                # The orphan prune above cascades cooccurrences via FK. The
-                # explicit cooccurrence pass below catches the *stale-count*
-                # case: both entities still exist but no current unit witnesses
-                # them together.
-                stale_pruned = await store.prune_stale_cooccurrences(conn=conn, fq_table=fq_table, bank_id=bank_id)
-                return _SweepCounts(orphan_entities_pruned=orphan_pruned, stale_cooccurrences_pruned=stale_pruned)
-
-    # A larger retry budget than the default (3): this is idempotent background
-    # maintenance with no client waiting on it, so a longer retry tail costs
-    # nothing, whereas a dropped sweep silently leaks orphan entities / stale
-    # cooccurrences until the next run. With jittered backoff a single sweep
-    # contending against continuous retain upserts effectively never exhausts
-    # this budget (each retry independently clears with high probability).
-    sweep = await retry_with_backoff(_run_sweep, max_retries=_SWEEP_MAX_RETRIES)
-    result.orphan_entities_pruned = sweep.orphan_entities_pruned
-    result.stale_cooccurrences_pruned = sweep.stale_cooccurrences_pruned
+    # --- Pass 2: entity prune ---
+    # Same shape as Pass 1 and owned by the store for the same reason: a
+    # claim → prune → commit loop over `entities` / `unit_entities` /
+    # `entity_cooccurrences`, including the ordered locking that keeps its
+    # deletes from cycling against retain's concurrent entity and cooccurrence
+    # upserts. A store that never wrote `unit_entities` returns an empty dict
+    # and this is a no-op. Runs after the relink pass so the remaining budget
+    # is whatever Pass 1 left.
+    prune = await store.entity_prune_pass(backend=backend, fq_table=fq_table, bank_id=bank_id, deadline=deadline)
+    result.entities_examined = prune.get("entities_examined", 0)
+    result.orphan_entities_pruned = prune.get("orphan_entities_pruned", 0)
+    result.stale_cooccurrences_pruned = prune.get("stale_cooccurrences_pruned", 0)
+    result.queues_drained = relink.get("relink_queue_exhausted", True) and prune.get("entity_queue_exhausted", True)
 
     elapsed = time.time() - job_start
+    if not result.queues_drained:
+        # Not a failure: every batch committed, so the remaining queue rows are
+        # simply the next run's work. Logged at WARNING because a bank that keeps
+        # landing here is producing maintenance faster than one run absorbs it,
+        # which is worth seeing before it becomes a backlog.
+        logger.warning(
+            f"[GRAPH_MAINT] bank={bank_id} hit the {_JOB_TIME_BUDGET_SECONDS:.0f}s budget with work still "
+            f"queued; committed {result.as_dict()} in {elapsed:.2f}s"
+        )
+        # Chain a follow-up so the backlog converges without waiting for the next
+        # delete to trigger a run. Only under a real queue: a synchronous task
+        # backend (tests, embedded) runs submitted tasks inline, so this would
+        # recurse one stack frame per budget window instead of scheduling. There
+        # the caller is already the loop — it gets the remaining rows on its next
+        # call. No force_sweep: the submit's pre-check inspects both queues, so
+        # this only lands an operation while work is genuinely left.
+        from .task_backend import SyncTaskBackend
+
+        if not isinstance(memory_engine._task_backend, SyncTaskBackend):
+            await memory_engine.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
+
     logger.info(
         f"[GRAPH_MAINT] bank={bank_id} done: {result.as_dict()}, elapsed={elapsed:.2f}s, operation_id={operation_id}"
     )

--- a/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
@@ -36,9 +36,9 @@ by the follow-up run.
 
 That follow-up run is *deferred*, not parallel: ``claim_tasks`` will not claim a
 graph_maintenance row for a bank that already has one in flight (#3230). Two
-concurrent runs would do no extra work anyway — each is this same bank-wide
-sweep — while convoying on each other's row locks and holding a worker slot
-each.
+concurrent runs would do no extra work anyway — each drains the same two
+bank-scoped queues — while convoying on each other's row locks and holding a
+worker slot each.
 """
 
 from __future__ import annotations
@@ -229,8 +229,8 @@ async def run_graph_maintenance_job(
     relink = await store.relink_pass(
         backend=backend, fq_table=fq_table, bank_id=bank_id, config=config, deadline=deadline
     )
-    result.relink_units_processed = relink.get("relink_units_processed", 0)
-    result.relink_links_added = relink.get("relink_links_added", 0)
+    result.relink_units_processed = relink.units_processed
+    result.relink_links_added = relink.links_added
 
     # --- Pass 2: entity prune ---
     # Same shape as Pass 1 and owned by the store for the same reason: a
@@ -241,10 +241,10 @@ async def run_graph_maintenance_job(
     # and this is a no-op. Runs after the relink pass so the remaining budget
     # is whatever Pass 1 left.
     prune = await store.entity_prune_pass(backend=backend, fq_table=fq_table, bank_id=bank_id, deadline=deadline)
-    result.entities_examined = prune.get("entities_examined", 0)
-    result.orphan_entities_pruned = prune.get("orphan_entities_pruned", 0)
-    result.stale_cooccurrences_pruned = prune.get("stale_cooccurrences_pruned", 0)
-    result.queues_drained = relink.get("relink_queue_exhausted", True) and prune.get("entity_queue_exhausted", True)
+    result.entities_examined = prune.entities_examined
+    result.orphan_entities_pruned = prune.orphan_entities_pruned
+    result.stale_cooccurrences_pruned = prune.stale_cooccurrences_pruned
+    result.queues_drained = relink.queue_exhausted and prune.queue_exhausted
 
     elapsed = time.time() - job_start
     if not result.queues_drained:

--- a/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
@@ -67,10 +67,10 @@ logger = logging.getLogger(__name__)
 # Wall-clock budget for one graph_maintenance run. Both passes commit per batch,
 # so hitting the budget is not a failure: it stops claiming new work, reports
 # what it did, and the follow-up run resumes from the queue rows still there.
-# A backlog (a large delete, or the one-time seed the entity queue ships with)
-# then converges over several runs instead of holding a worker slot for as long
-# as it takes — the failure mode #3222 describes, where the whole run was
-# cancelled and every batch's work was retried from scratch.
+# A backlog (a bulk delete, say) then converges over several runs instead of
+# holding a worker slot for as long as it takes — the failure mode #3222
+# describes, where the whole run was cancelled and every batch's work was
+# retried from scratch.
 _JOB_TIME_BUDGET_SECONDS = 240.0
 
 

--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -1157,17 +1157,24 @@ class MemoriesExtension(Extension, ABC):
         """
         return 0
 
-    async def relink_pass(self, *, backend, fq_table, bank_id: str, config) -> dict:
+    async def relink_pass(self, *, backend, fq_table, bank_id: str, config, deadline: float | None = None) -> dict:
         """Top up links for queued victims. ``{}`` when there is nothing to relink."""
         return {}
 
-    async def prune_orphan_entities(self, *, conn, fq_table, bank_id: str) -> int:
-        """Delete `entities` rows no live memory references. Returns the count."""
+    async def enqueue_entity_prune_candidates(self, *, conn, fq_table, bank_id: str, affected_unit_ids: list) -> int:
+        """Queue the entities ``affected_unit_ids`` reference as prune candidates.
+
+        Zero for a store that never wrote `unit_entities`: it has no entity
+        postings to lose, so nothing can become an orphan.
+        """
         return 0
 
-    async def prune_stale_cooccurrences(self, *, conn, fq_table, bank_id: str) -> int:
-        """Delete co-occurrence rows whose witnessing memories are all gone."""
-        return 0
+    async def entity_prune_pass(self, *, backend, fq_table, bank_id: str, deadline: float | None = None) -> dict:
+        """Prune queued candidate entities and the co-occurrences they stranded.
+
+        ``{}`` when the store keeps no entity postings and so queues nothing.
+        """
+        return {}
 
 
 __all__ = [

--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -359,6 +359,36 @@ def build_fact_records(
     return records
 
 
+@dataclass
+class RelinkPassResult:
+    """What one relink drain got through.
+
+    ``queue_exhausted`` is False when the pass stopped on its deadline (or the
+    runaway-iteration cap) with rows still queued — not a failure, since every
+    batch commits before the next is claimed, but the caller needs to know the
+    queue is not empty so it can arrange for the rest to be picked up.
+    """
+
+    units_processed: int = 0
+    links_added: int = 0
+    queue_exhausted: bool = True
+
+
+@dataclass
+class EntityPrunePassResult:
+    """What one entity-prune drain got through.
+
+    ``entities_examined`` counts candidates claimed, not rows deleted: most
+    candidates turn out to be alive and are kept, which is the pass working as
+    intended rather than wasted effort.
+    """
+
+    entities_examined: int = 0
+    orphan_entities_pruned: int = 0
+    stale_cooccurrences_pruned: int = 0
+    queue_exhausted: bool = True
+
+
 class MemoriesExtension(Extension, ABC):
     """Storage + retrieval for memory units and their links, behind one interface.
 
@@ -1157,9 +1187,11 @@ class MemoriesExtension(Extension, ABC):
         """
         return 0
 
-    async def relink_pass(self, *, backend, fq_table, bank_id: str, config, deadline: float | None = None) -> dict:
-        """Top up links for queued victims. ``{}`` when there is nothing to relink."""
-        return {}
+    async def relink_pass(
+        self, *, backend, fq_table, bank_id: str, config, deadline: float | None = None
+    ) -> "RelinkPassResult":
+        """Top up links for queued victims. All-zero when there is nothing to relink."""
+        return RelinkPassResult()
 
     async def enqueue_entity_prune_candidates(self, *, conn, fq_table, bank_id: str, affected_unit_ids: list) -> int:
         """Queue the entities ``affected_unit_ids`` reference as prune candidates.
@@ -1169,12 +1201,14 @@ class MemoriesExtension(Extension, ABC):
         """
         return 0
 
-    async def entity_prune_pass(self, *, backend, fq_table, bank_id: str, deadline: float | None = None) -> dict:
+    async def entity_prune_pass(
+        self, *, backend, fq_table, bank_id: str, deadline: float | None = None
+    ) -> "EntityPrunePassResult":
         """Prune queued candidate entities and the co-occurrences they stranded.
 
-        ``{}`` when the store keeps no entity postings and so queues nothing.
+        All-zero when the store keeps no entity postings and so queues nothing.
         """
-        return {}
+        return EntityPrunePassResult()
 
 
 __all__ = [
@@ -1194,10 +1228,12 @@ __all__ = [
     "META_UPDATED_AT",
     "CausalEdgeRecord",
     "DeletePredicate",
+    "EntityPrunePassResult",
     "FactRecord",
     "MemoriesExtension",
     "MemoryPatch",
     "MemoryTxn",
+    "RelinkPassResult",
     "ScanPage",
     "StoredMemory",
     "build_fact_records",

--- a/hindsight-api-slim/hindsight_api/engine/memories/pg/graph.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/pg/graph.py
@@ -63,21 +63,20 @@ _RELINK_ITERATION_CAP = 10000
 
 # Candidate entities claimed per entity-prune iteration.
 #
-# The binding cost is the cooccurrence prune, and it is not per *candidate*: a
-# candidate drags in every cooccurrence pair it appears in, and each of those
-# pairs costs a scan of both endpoints' posting lists to answer "does any unit
-# still witness both". On a deliberately dense fixture (100k entities, 1.5M
-# unit_entities, 2.86M cooccurrences, endpoints holding 150-400 postings each)
-# that measured ~58 pairs per candidate at ~1.7ms per pair:
+# The binding cost is the cooccurrence prune: a candidate drags in every
+# cooccurrence pair it appears in, and the statement builds a set of currently
+# live pairs (#3367) seeded from those candidates' units to judge them against.
+# Measured on a deliberately dense fixture (100k entities, 1.5M unit_entities,
+# 2.86M cooccurrences, endpoints holding 150-400 postings each):
 #
-#     batch  50 →   2.9k pairs →   2.0s      <- here
-#     batch 500 →  29k pairs   → 210-300s    <- blows the 60s command timeout
+#     batch  50 →  16-65ms     <- here
+#     batch 500 →  265s        <- the planner flips to a per-row plan and the
+#                                 statement blows the 60s command timeout
 #
-# So the batch size, not the bank size, is now what has to stay bounded. 50
-# keeps a batch ~30x under the default command timeout on that fixture, with the
-# job-level budget deciding how many batches a run gets through. Raising it
-# trades that margin away for fewer round-trips; don't, without re-measuring
-# against a bank with hub entities.
+# So the batch size, not the bank size, is what has to stay bounded — and it has
+# to stay small enough that the planner keeps choosing the hash anti-join.
+# Raising it trades away three orders of magnitude of margin; don't, without
+# re-measuring against a bank with hub entities.
 #
 # Also stays under Oracle's 1000-element IN-list limit, since ops_oracle expands
 # ``= ANY(...)`` into an explicit list.

--- a/hindsight-api-slim/hindsight_api/engine/memories/pg/graph.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/pg/graph.py
@@ -42,6 +42,7 @@ from ...retain.link_utils import (
     _normalize_datetime,
     compute_semantic_links_ann,
 )
+from ..base import EntityPrunePassResult, RelinkPassResult
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +87,11 @@ _ENTITY_PRUNE_BATCH_SIZE = 50
 # only re-deletes what is still dead; a handful of attempts clears the
 # contention window a concurrent retain opens.
 _PRUNE_BATCH_MAX_RETRIES = 3
+
+# Unit ids per candidate-lookup round-trip when enqueueing. Bounded by Oracle's
+# 1000-element IN-list limit (ops_oracle expands ``= ANY(...)`` into a literal
+# list), which a bulk delete would otherwise blow straight through.
+_ENQUEUE_LOOKUP_CHUNK = 500
 
 # Cap at 10k edges — the UI can't usefully render more, and uncapped queries
 # on highly-connected graphs (e.g. 1000 nodes with 500k+ edges) are too slow.
@@ -557,7 +563,7 @@ async def relink_pass(
     bank_id: str,
     config: Any,
     deadline: float | None = None,
-) -> dict:
+) -> RelinkPassResult:
     """Drain ``graph_maintenance_queue`` for ``bank_id``, topping up lost links.
 
     Per-iteration loop: claim → top up → commit. We rely on at most one job per
@@ -583,10 +589,8 @@ async def relink_pass(
     keeps the work already done and leaves the rest queued for the next run.
 
     Returns:
-        ``{"relink_units_processed": int, "relink_links_added": int,
-        "relink_queue_exhausted": bool}``. ``relink_queue_exhausted`` is False
-        when the deadline (or the iteration cap) stopped the drain with rows
-        still queued.
+        A :class:`RelinkPassResult`. ``queue_exhausted`` is False when the
+        deadline (or the iteration cap) stopped the drain with rows still queued.
     """
     del config  # accepted for symmetry with stores that tune their own relinking
     ops = backend.ops
@@ -628,11 +632,11 @@ async def relink_pass(
             drained = False
             break
 
-    return {
-        "relink_units_processed": units_processed,
-        "relink_links_added": links_added,
-        "relink_queue_exhausted": drained,
-    }
+    return RelinkPassResult(
+        units_processed=units_processed,
+        links_added=links_added,
+        queue_exhausted=drained,
+    )
 
 
 async def _relink_batch(
@@ -786,13 +790,23 @@ async def enqueue_entity_prune_candidates(
         return 0
 
     ops = _ops_for(conn)
-    return await ops.enqueue_entity_maintenance(
-        conn,
-        fq_table("entity_maintenance_queue"),
-        fq_table("unit_entities"),
-        bank_id,
-        _as_uuids(list(affected_unit_ids)),
-    )
+    queue_table = fq_table("entity_maintenance_queue")
+    ue_table = fq_table("unit_entities")
+    unit_uuids = _as_uuids(list(affected_unit_ids))
+
+    # Chunked because a bulk delete can hand in thousands of unit ids and the
+    # lookup binds them with `= ANY(...)`, which ops_oracle expands into a
+    # literal IN list — Oracle caps those at 1000 elements.
+    enqueued = 0
+    for start in range(0, len(unit_uuids), _ENQUEUE_LOOKUP_CHUNK):
+        enqueued += await ops.enqueue_entity_maintenance(
+            conn,
+            queue_table,
+            ue_table,
+            bank_id,
+            unit_uuids[start : start + _ENQUEUE_LOOKUP_CHUNK],
+        )
+    return enqueued
 
 
 @dataclass
@@ -810,7 +824,7 @@ async def entity_prune_pass(
     fq_table: Callable[[str], str],
     bank_id: str,
     deadline: float | None = None,
-) -> dict:
+) -> EntityPrunePassResult:
     """Drain ``entity_maintenance_queue`` for ``bank_id``, pruning what died.
 
     Per-iteration loop: claim → prune → commit, mirroring :func:`relink_pass`.
@@ -845,10 +859,8 @@ async def entity_prune_pass(
             ``None`` drains to empty.
 
     Returns:
-        ``{"entities_examined": int, "orphan_entities_pruned": int,
-        "stale_cooccurrences_pruned": int, "entity_queue_exhausted": bool}``.
-        ``entity_queue_exhausted`` is False when the deadline stopped the drain
-        with rows still queued.
+        An :class:`EntityPrunePassResult`. ``queue_exhausted`` is False when the
+        deadline stopped the drain with rows still queued.
     """
     from ...db_utils import retry_with_backoff
     from ...memory_engine import acquire_with_retry
@@ -921,12 +933,12 @@ async def entity_prune_pass(
         orphans_pruned += batch.orphan_entities_pruned
         stale_pruned += batch.stale_cooccurrences_pruned
 
-    return {
-        "entities_examined": examined,
-        "orphan_entities_pruned": orphans_pruned,
-        "stale_cooccurrences_pruned": stale_pruned,
-        "entity_queue_exhausted": drained,
-    }
+    return EntityPrunePassResult(
+        entities_examined=examined,
+        orphan_entities_pruned=orphans_pruned,
+        stale_cooccurrences_pruned=stale_pruned,
+        queue_exhausted=drained,
+    )
 
 
 __all__ = [

--- a/hindsight-api-slim/hindsight_api/engine/memories/pg/graph.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/pg/graph.py
@@ -11,11 +11,11 @@ Two groups of callers:
   filtering, the observation inheritance, the derived entity edges, the
   colouring and the response assembly. These functions answer only "which
   memories", "which entity postings" and "which stored edges".
-* **The graph-maintenance job.** :func:`enqueue_relink_victims` runs inside the
-  delete transaction; :func:`relink_pass`, :func:`prune_orphan_entities` and
-  :func:`prune_stale_cooccurrences` are the three reconciliation passes the job
-  drives. The job keeps the orchestration (pass ordering, the deadlock retry
-  around the sweeps, the timing log); each function here does the pass's work.
+* **The graph-maintenance job.** :func:`enqueue_relink_victims` and
+  :func:`enqueue_entity_prune_candidates` run inside the delete transaction;
+  :func:`relink_pass` and :func:`entity_prune_pass` are the two drain loops the
+  job drives. The job keeps the orchestration (pass ordering, the time budget,
+  the timing log); each function here does the pass's work.
 
 :func:`entity_memory_counts` and :func:`entities_for_units` are the two entity
 postings reads that are not part of the graph view but read the same join table.
@@ -28,8 +28,10 @@ answers them with zeroes rather than with SQL.
 from __future__ import annotations
 
 import logging
+import time
 import uuid as uuid_module
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 from ....config import get_config
@@ -58,6 +60,33 @@ _DRAIN_BATCH_SIZE = 50
 # Defensive guard against runaway relink loops — at _DRAIN_BATCH_SIZE units per
 # iteration that's 500k targets, far beyond any realistic single-bank backlog.
 _RELINK_ITERATION_CAP = 10000
+
+# Candidate entities claimed per entity-prune iteration.
+#
+# The binding cost is the cooccurrence prune, and it is not per *candidate*: a
+# candidate drags in every cooccurrence pair it appears in, and each of those
+# pairs costs a scan of both endpoints' posting lists to answer "does any unit
+# still witness both". On a deliberately dense fixture (100k entities, 1.5M
+# unit_entities, 2.86M cooccurrences, endpoints holding 150-400 postings each)
+# that measured ~58 pairs per candidate at ~1.7ms per pair:
+#
+#     batch  50 →   2.9k pairs →   2.0s      <- here
+#     batch 500 →  29k pairs   → 210-300s    <- blows the 60s command timeout
+#
+# So the batch size, not the bank size, is now what has to stay bounded. 50
+# keeps a batch ~30x under the default command timeout on that fixture, with the
+# job-level budget deciding how many batches a run gets through. Raising it
+# trades that margin away for fewer round-trips; don't, without re-measuring
+# against a bank with hub entities.
+#
+# Also stays under Oracle's 1000-element IN-list limit, since ops_oracle expands
+# ``= ANY(...)`` into an explicit list.
+_ENTITY_PRUNE_BATCH_SIZE = 50
+
+# Deadlock retries per entity-prune batch. The batch is idempotent, so a retry
+# only re-deletes what is still dead; a handful of attempts clears the
+# contention window a concurrent retain opens.
+_PRUNE_BATCH_MAX_RETRIES = 3
 
 # Cap at 10k edges — the UI can't usefully render more, and uncapped queries
 # on highly-connected graphs (e.g. 1000 nodes with 500k+ edges) are too slow.
@@ -528,6 +557,7 @@ async def relink_pass(
     fq_table: Callable[[str], str],
     bank_id: str,
     config: Any,
+    deadline: float | None = None,
 ) -> dict:
     """Drain ``graph_maintenance_queue`` for ``bank_id``, topping up lost links.
 
@@ -549,8 +579,15 @@ async def relink_pass(
     means) and never reads it; it is accepted so a store that *does* tune its
     relinking gets it.
 
+    ``deadline`` is a ``time.monotonic()`` value past which no new batch is
+    claimed. Each batch commits before the next is claimed, so stopping early
+    keeps the work already done and leaves the rest queued for the next run.
+
     Returns:
-        ``{"relink_units_processed": int, "relink_links_added": int}``.
+        ``{"relink_units_processed": int, "relink_links_added": int,
+        "relink_queue_exhausted": bool}``. ``relink_queue_exhausted`` is False
+        when the deadline (or the iteration cap) stopped the drain with rows
+        still queued.
     """
     del config  # accepted for symmetry with stores that tune their own relinking
     ops = backend.ops
@@ -558,7 +595,12 @@ async def relink_pass(
     units_processed = 0
     links_added = 0
     iterations = 0
+    drained = True
     while True:
+        if deadline is not None and time.monotonic() >= deadline:
+            drained = False
+            break
+
         from ...memory_engine import acquire_with_retry
 
         async with acquire_with_retry(backend) as conn:
@@ -584,9 +626,14 @@ async def relink_pass(
                 f"[GRAPH_MAINT] bank={bank_id} hit iteration cap ({iterations}); aborting relink "
                 f"(units_processed={units_processed}, links_added={links_added})"
             )
+            drained = False
             break
 
-    return {"relink_units_processed": units_processed, "relink_links_added": links_added}
+    return {
+        "relink_units_processed": units_processed,
+        "relink_links_added": links_added,
+        "relink_queue_exhausted": drained,
+    }
 
 
 async def _relink_batch(
@@ -716,69 +763,183 @@ async def _relink_batch(
     return len(new_links)
 
 
-async def prune_orphan_entities(
+async def enqueue_entity_prune_candidates(
     *,
     conn: DatabaseConnection,
     fq_table: Callable[[str], str],
     bank_id: str,
+    affected_unit_ids: list,
 ) -> int:
-    """Delete ``entities`` rows in the bank with no remaining ``unit_entities``
-    references. Returns the number pruned.
+    """Enqueue the entities ``affected_unit_ids`` reference as prune candidates.
 
-    FK ON DELETE CASCADE on ``entity_cooccurrences`` then removes any
-    cooccurrence row pointing at the pruned entities — which is why this runs
-    before :func:`prune_stale_cooccurrences` rather than after.
+    Must run inside the same transaction that removes those units (or their
+    ``unit_entities`` rows), *before* the delete or cascade fires — afterwards
+    there is no posting left to read the entity ids from, and the entity is
+    stranded as an orphan nothing will ever look at again.
 
-    A bank-wide single-statement delete, cheap when there's nothing to do. It is
-    idempotent (rerunning only deletes what is still orphaned), so the caller is
-    free to retry the whole transaction on deadlock.
+    Enqueueing an entity that turns out to still be referenced is free: the
+    drain re-checks and keeps it. Over-enqueueing is always the safe direction.
+
+    Returns:
+        Number of candidate entities enqueued.
     """
+    if not affected_unit_ids:
+        return 0
+
     ops = _ops_for(conn)
-    return await ops.prune_orphan_entities(
+    return await ops.enqueue_entity_maintenance(
         conn,
-        fq_table("entities"),
+        fq_table("entity_maintenance_queue"),
         fq_table("unit_entities"),
         bank_id,
+        _as_uuids(list(affected_unit_ids)),
     )
 
 
-async def prune_stale_cooccurrences(
+@dataclass
+class _PruneBatch:
+    """One entity-prune iteration's counters (avoids a bare tuple return)."""
+
+    claimed: int
+    orphan_entities_pruned: int
+    stale_cooccurrences_pruned: int
+
+
+async def entity_prune_pass(
     *,
-    conn: DatabaseConnection,
+    backend: Any,
     fq_table: Callable[[str], str],
     bank_id: str,
-) -> int:
-    """Delete cooccurrence rows no current memory witnesses. Returns the count.
+    deadline: float | None = None,
+) -> dict:
+    """Drain ``entity_maintenance_queue`` for ``bank_id``, pruning what died.
 
-    Defensive sweep for rows where both endpoints still exist but no current
-    memory_unit references both of them — the cooccurrence was real at the time
-    it was recorded, but every unit that witnessed it has since been deleted.
-    :func:`prune_orphan_entities` cascades the *missing-entity* case via FK; this
-    pass catches the *stale-count* case it cannot see.
+    Per-iteration loop: claim → prune → commit, mirroring :func:`relink_pass`.
+    Each iteration does two deletes over the claimed batch:
 
-    Like the orphan prune, a bank-wide idempotent sweep backed by indexes, so
-    it's cheap when there's nothing to do and safe for the caller to retry.
+    1. **Orphan entities** — candidates with no remaining ``unit_entities`` row.
+       FK ON DELETE CASCADE on ``entity_cooccurrences`` takes their cooccurrence
+       rows with them, which is why this runs first.
+    2. **Stale cooccurrences** — pairs incident to a surviving candidate where
+       both entities still exist but no current unit witnesses them together.
+       The cooccurrence was real when recorded; every unit that saw it has since
+       been deleted. The FK cascade above cannot see this case.
+
+    Both deletes are scoped to the claimed batch. They used to be bank-wide
+    statements re-run on every invocation — the orphan prune probing once per
+    entity in the bank, the cooccurrence prune evaluating an INTERSECT per
+    cooccurrence row in the bank — so their cost tracked the size of the bank
+    rather than the size of the delete, and past a few million rows they could
+    no longer finish inside asyncpg's command timeout. The job then failed on
+    every run, forever, on exactly the banks that most needed it (#3222).
+
+    Committing per batch is what makes the pass resumable: work already done
+    stays done when ``deadline`` cuts the drain short or the task dies, and the
+    next run picks up the remaining queue rows.
+
+    Args:
+        backend: Database backend — the loop spans a transaction per batch, so
+            it acquires its own connections.
+        fq_table: Schema-qualifier for table names.
+        bank_id: Bank to drain.
+        deadline: ``time.monotonic()`` value past which no new batch is claimed.
+            ``None`` drains to empty.
+
+    Returns:
+        ``{"entities_examined": int, "orphan_entities_pruned": int,
+        "stale_cooccurrences_pruned": int, "entity_queue_exhausted": bool}``.
+        ``entity_queue_exhausted`` is False when the deadline stopped the drain
+        with rows still queued.
     """
-    ops = _ops_for(conn)
-    return await ops.prune_stale_cooccurrences(
-        conn,
-        fq_table("entity_cooccurrences"),
-        fq_table("unit_entities"),
-        fq_table("entities"),
-        bank_id,
-    )
+    from ...db_utils import retry_with_backoff
+    from ...memory_engine import acquire_with_retry
+
+    examined = 0
+    orphans_pruned = 0
+    stale_pruned = 0
+    drained = True
+
+    while True:
+        if deadline is not None and time.monotonic() >= deadline:
+            drained = False
+            break
+
+        async def _run_batch() -> _PruneBatch:
+            async with acquire_with_retry(backend) as conn:
+                async with conn.transaction():
+                    ops = backend.ops
+                    entity_ids = await ops.claim_entity_maintenance_batch(
+                        conn,
+                        fq_table("entity_maintenance_queue"),
+                        bank_id,
+                        _ENTITY_PRUNE_BATCH_SIZE,
+                    )
+                    if not entity_ids:
+                        return _PruneBatch(claimed=0, orphan_entities_pruned=0, stale_cooccurrences_pruned=0)
+
+                    orphaned = await ops.prune_orphan_entities(
+                        conn,
+                        fq_table("entities"),
+                        fq_table("unit_entities"),
+                        bank_id,
+                        entity_ids,
+                    )
+                    # The orphan prune above cascades cooccurrences via FK. This
+                    # second delete catches the *stale-count* case: both entities
+                    # still exist but no current unit witnesses them together.
+                    stale = await ops.prune_stale_cooccurrences(
+                        conn,
+                        fq_table("entity_cooccurrences"),
+                        fq_table("unit_entities"),
+                        entity_ids,
+                    )
+                    return _PruneBatch(
+                        claimed=len(entity_ids),
+                        orphan_entities_pruned=orphaned,
+                        stale_cooccurrences_pruned=stale,
+                    )
+
+        # Retry the batch on deadlock. Both deletes take their row locks in the
+        # same order the concurrent retain writers do (entity id for the entity
+        # upsert, (entity_id_1, entity_id_2) for the cooccurrence upsert), so a
+        # cycle should not form on Postgres at all; this stays as the backstop
+        # for the paths that ordering can't cover — the FK cascade out of the
+        # orphan prune, and Oracle, whose DELETE can't carry the ordered-lock
+        # CTE. Both deletes are idempotent, so re-running the batch is safe.
+        #
+        # Deliberately narrower than the budget the bank-wide sweep used (8).
+        # `retry_with_backoff` treats a TimeoutError as transient, which was
+        # ruinous while the statement was O(bank): a sweep that could never
+        # finish inside the command timeout was re-run nine times, burning ten
+        # minutes of a worker slot per task attempt (#3222). A bounded batch
+        # that times out is not slow work, it is a sick database — retry a few
+        # times and let the failure surface.
+        batch = await retry_with_backoff(_run_batch, max_retries=_PRUNE_BATCH_MAX_RETRIES)
+        if batch.claimed == 0:
+            break
+
+        examined += batch.claimed
+        orphans_pruned += batch.orphan_entities_pruned
+        stale_pruned += batch.stale_cooccurrences_pruned
+
+    return {
+        "entities_examined": examined,
+        "orphan_entities_pruned": orphans_pruned,
+        "stale_cooccurrences_pruned": stale_pruned,
+        "entity_queue_exhausted": drained,
+    }
 
 
 __all__ = [
     "MAX_SEMANTIC_LINKS_PER_UNIT",
+    "enqueue_entity_prune_candidates",
     "enqueue_relink_victims",
     "entities_for_units",
     "entity_map_for_units",
     "entity_memory_counts",
+    "entity_prune_pass",
     "graph_direct_links",
     "graph_entity_rows",
     "graph_units",
-    "prune_orphan_entities",
-    "prune_stale_cooccurrences",
     "relink_pass",
 ]

--- a/hindsight-api-slim/hindsight_api/engine/memories/postgres.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/postgres.py
@@ -496,14 +496,21 @@ class PostgresMemories(MemoriesExtension):
             include_affected_units=include_affected_units,
         )
 
-    async def relink_pass(self, *, backend, fq_table, bank_id: str, config) -> dict:
-        return await graph.relink_pass(backend=backend, fq_table=fq_table, bank_id=bank_id, config=config)
+    async def relink_pass(self, *, backend, fq_table, bank_id: str, config, deadline: float | None = None) -> dict:
+        return await graph.relink_pass(
+            backend=backend, fq_table=fq_table, bank_id=bank_id, config=config, deadline=deadline
+        )
 
-    async def prune_orphan_entities(self, *, conn, fq_table, bank_id: str) -> int:
-        return await graph.prune_orphan_entities(conn=conn, fq_table=fq_table, bank_id=bank_id)
+    async def enqueue_entity_prune_candidates(self, *, conn, fq_table, bank_id: str, affected_unit_ids: list) -> int:
+        return await graph.enqueue_entity_prune_candidates(
+            conn=conn,
+            fq_table=fq_table,
+            bank_id=bank_id,
+            affected_unit_ids=affected_unit_ids,
+        )
 
-    async def prune_stale_cooccurrences(self, *, conn, fq_table, bank_id: str) -> int:
-        return await graph.prune_stale_cooccurrences(conn=conn, fq_table=fq_table, bank_id=bank_id)
+    async def entity_prune_pass(self, *, backend, fq_table, bank_id: str, deadline: float | None = None) -> dict:
+        return await graph.entity_prune_pass(backend=backend, fq_table=fq_table, bank_id=bank_id, deadline=deadline)
 
 
 __all__ = ["PostgresMemories"]

--- a/hindsight-api-slim/hindsight_api/engine/memories/postgres.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/postgres.py
@@ -23,7 +23,15 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from .base import DeletePredicate, MemoriesExtension, MemoryPatch, ScanPage, StoredMemory
+from .base import (
+    DeletePredicate,
+    EntityPrunePassResult,
+    MemoriesExtension,
+    MemoryPatch,
+    RelinkPassResult,
+    ScanPage,
+    StoredMemory,
+)
 from .pg import counts, curation, graph, reads, writes
 
 
@@ -496,7 +504,9 @@ class PostgresMemories(MemoriesExtension):
             include_affected_units=include_affected_units,
         )
 
-    async def relink_pass(self, *, backend, fq_table, bank_id: str, config, deadline: float | None = None) -> dict:
+    async def relink_pass(
+        self, *, backend, fq_table, bank_id: str, config, deadline: float | None = None
+    ) -> RelinkPassResult:
         return await graph.relink_pass(
             backend=backend, fq_table=fq_table, bank_id=bank_id, config=config, deadline=deadline
         )
@@ -509,7 +519,9 @@ class PostgresMemories(MemoriesExtension):
             affected_unit_ids=affected_unit_ids,
         )
 
-    async def entity_prune_pass(self, *, backend, fq_table, bank_id: str, deadline: float | None = None) -> dict:
+    async def entity_prune_pass(
+        self, *, backend, fq_table, bank_id: str, deadline: float | None = None
+    ) -> EntityPrunePassResult:
         return await graph.entity_prune_pass(backend=backend, fq_table=fq_table, bank_id=bank_id, deadline=deadline)
 
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7183,12 +7183,14 @@ class MemoryEngine(MemoryEngineInterface):
                     )
                     units_count = _doc_counts.get(document_id, 0)
 
-                # Capture relink victims BEFORE the cascade — once the source
-                # rows are gone, the join finding them returns nothing.
+                # Capture relink victims and entity prune candidates BEFORE the
+                # cascade — once the source rows are gone, the joins finding
+                # them return nothing.
                 if unit_ids:
-                    from .graph_maintenance import enqueue_relink_victims
+                    from .graph_maintenance import enqueue_entity_prune_candidates, enqueue_relink_victims
 
                     await enqueue_relink_victims(conn, bank_id, unit_ids)
+                    await enqueue_entity_prune_candidates(conn, bank_id, unit_ids)
 
                 # Delete document first (cascades to memory_units and all their links).
                 # Running the stale-observation sweep AFTER the delete ensures we also
@@ -7518,12 +7520,18 @@ class MemoryEngine(MemoryEngineInterface):
                     if not _found:
                         bank_id = None
 
-                # Capture relink victims BEFORE the cascade — once the row is
-                # gone, the join finding them returns nothing.
-                if bank_id and fact_type in ("experience", "world"):
-                    from .graph_maintenance import enqueue_relink_victims
+                # Capture relink victims and entity prune candidates BEFORE the
+                # cascade — once the row is gone, the joins finding them return
+                # nothing.
+                if bank_id:
+                    from .graph_maintenance import enqueue_entity_prune_candidates, enqueue_relink_victims
 
-                    await enqueue_relink_victims(conn, bank_id, [unit_id])
+                    # Only fact rows carry temporal/semantic adjacency worth
+                    # rebuilding; entity postings hang off any unit that has
+                    # them, so the prune candidates are captured unconditionally.
+                    if fact_type in ("experience", "world"):
+                        await enqueue_relink_victims(conn, bank_id, [unit_id])
+                    await enqueue_entity_prune_candidates(conn, bank_id, [unit_id])
 
                 # Delete the memory unit first (cascades to links and associations).
                 # The stale-observation sweep runs AFTER the delete so it also catches
@@ -7622,8 +7630,10 @@ class MemoryEngine(MemoryEngineInterface):
            consolidation / graph_maintenance submission per bank, not per id).
         3. For each bank whose ids include at least one ``experience`` /
            ``world`` fact:
-             a. ``enqueue_relink_victims`` BEFORE the cascade — once the rows
-                are gone the join finding them returns nothing.
+             a. ``enqueue_relink_victims`` (fact rows) and
+                ``enqueue_entity_prune_candidates`` (every doomed unit) BEFORE
+                the cascade — once the rows are gone the joins finding them
+                return nothing.
              b. Chunked cascade DELETE against ``fq_table('memory_units')``.
                 Cascade handles ``unit_entities``, ``memory_links``, and the
                 observation history tables (see the baseline FK CASCADE
@@ -7711,11 +7721,16 @@ class MemoryEngine(MemoryEngineInterface):
                 for bank_id, ids_for_bank in by_bank.items():
                     source_ids = source_ids_by_bank.get(bank_id, [])
 
-                    # 3a. Capture relink victims BEFORE the cascade.
-                    if source_ids:
-                        from .graph_maintenance import enqueue_relink_victims
+                    # 3a. Capture relink victims and entity prune candidates
+                    # BEFORE the cascade. Victims come from the fact rows (only
+                    # those carry temporal/semantic adjacency); prune candidates
+                    # from every doomed unit in the bank, since any of them may
+                    # hold the last posting to an entity.
+                    from .graph_maintenance import enqueue_entity_prune_candidates, enqueue_relink_victims
 
+                    if source_ids:
                         await enqueue_relink_victims(conn, bank_id, source_ids)
+                    await enqueue_entity_prune_candidates(conn, bank_id, ids_for_bank)
 
                     # 3b. Chunked delete. Cascade handles unit_entities /
                     # memory_links / observation history via FK.
@@ -8408,7 +8423,7 @@ class MemoryEngine(MemoryEngineInterface):
             await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
 
         backend = await self._get_backend()
-        from .graph_maintenance import enqueue_relink_victims
+        from .graph_maintenance import enqueue_entity_prune_candidates, enqueue_relink_victims
         from .retain.link_utils import resolve_entities_only
 
         # Resolve the bank's entity-label taxonomy once when re-resolving entities,
@@ -8619,6 +8634,10 @@ class MemoryEngine(MemoryEngineInterface):
                     if edit_plan is not None and live2:
                         if edit_plan.resolved_for_unit is not None:
                             # Entities are being changed: rebuild unit_entities to the resolved set.
+                            # The entities this unit is about to stop referencing may have been
+                            # holding on by that posting alone, so queue them as prune candidates
+                            # first — after the clear there is nothing left to read them from.
+                            await enqueue_entity_prune_candidates(conn, bank_id, [memory_id])
                             await store.clear_unit_entities(
                                 conn=conn, fq_table=fq_table, bank_id=bank_id, unit_id=str(memory_uuid)
                             )
@@ -8694,8 +8713,10 @@ class MemoryEngine(MemoryEngineInterface):
 
                     # --- Invalidate: move live → archive ---
                     if do_invalidate and live2:
-                        # Capture relink victims before the row (and its links) go.
+                        # Capture relink victims and entity prune candidates before the row
+                        # (and its links and postings) go.
                         await enqueue_relink_victims(conn, bank_id, [memory_id])
+                        await enqueue_entity_prune_candidates(conn, bank_id, [memory_id])
                         await store.invalidate_memory(
                             conn=conn,
                             fq_table=fq_table,
@@ -16457,36 +16478,39 @@ class MemoryEngine(MemoryEngineInterface):
         request_context: "RequestContext",
         force_sweep: bool = False,
     ) -> dict[str, Any]:
-        """Submit a graph-maintenance job to drain ``graph_maintenance_queue`` for a bank.
+        """Submit a graph-maintenance job to drain the bank's maintenance queues.
 
-        Idempotent: short-circuits with ``no_work=True`` when the queue is empty
+        Idempotent: short-circuits with ``no_work=True`` when both queues
+        (``graph_maintenance_queue`` and ``entity_maintenance_queue``) are empty
         for this bank, so unconditional callers (e.g. every retain that may or
         may not have triggered a document upsert) don't generate empty worker
         tasks. Deduplicates by bank when an existing pending job is already
         scheduled.
 
         Args:
-            force_sweep: Skip the empty-queue short-circuit. The job's later
-                passes (orphan-entity and stale-cooccurrence sweeps) are
-                bank-wide and don't need queue rows, so callers that removed
-                unit→entity references must set this: deleting an *isolated*
-                document enqueues zero relink victims, and short-circuiting
-                there would leave its entities orphaned in the registry.
+            force_sweep: Skip the empty-queue short-circuit and submit anyway.
+                Rarely needed now that both passes are queue-driven — the
+                pre-check sees the entity candidates a delete enqueued, so an
+                isolated document's entities are no longer invisible to it.
 
         Returns:
             Dict with ``operation_id``. May contain ``no_work=True`` (and a
-            null operation_id) when the queue was already empty.
+            null operation_id) when both queues were already empty.
         """
         await self._authenticate_tenant(request_context)
 
-        # Cheap pre-check on the (bank_id, enqueued_at) index. Lets every
+        # Cheap pre-check on the two (bank_id, enqueued_at) indexes. Lets every
         # retain call this unconditionally without paying for an async_operations
         # row when there's nothing to do.
         if not force_sweep:
             backend = await self._get_backend()
             async with acquire_with_retry(backend) as conn:
                 has_work = await conn.fetchval(
-                    f"SELECT 1 FROM {fq_table('graph_maintenance_queue')} WHERE bank_id = $1 LIMIT 1",
+                    f"""
+                    SELECT 1 WHERE
+                        EXISTS (SELECT 1 FROM {fq_table("graph_maintenance_queue")} WHERE bank_id = $1)
+                        OR EXISTS (SELECT 1 FROM {fq_table("entity_maintenance_queue")} WHERE bank_id = $1)
+                    """,
                     bank_id,
                 )
             if not has_work:

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8775,9 +8775,15 @@ class MemoryEngine(MemoryEngineInterface):
                 phase2_committed = True
         finally:
             # Entities were resolved (and possibly autocommitted) in Phase 1 but the edit did not
-            # durably apply (row concurrently invalidated → live2 None, or Phase 2 raised): those
-            # entities may now be orphans, and the edit's own relink-victim enqueue never ran. Force
-            # a bank-wide graph-maintenance sweep to reclaim them.
+            # durably apply (row concurrently invalidated → live2 None, or Phase 2 raised), so the
+            # edit's own enqueues rolled back with it. Kick a job for whatever else the bank has
+            # queued; it short-circuits when there is nothing.
+            #
+            # A Phase-1 entity that never got its posting is deliberately NOT chased here. The
+            # prune is queue-driven (#3222) and reads its candidates out of unit_entities, so such
+            # a row is invisible to it — and that is the safe direction: #2662 is precisely the
+            # race where pruning a just-resolved, not-yet-linked parent turned a retry into silent
+            # memory loss, and the retry is meant to adopt that row rather than re-create it.
             if entities_resolved and not (edit_applied and phase2_committed):
                 try:
                     await self.submit_async_graph_maintenance(

--- a/hindsight-api-slim/hindsight_api/engine/retain/chunk_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/chunk_storage.py
@@ -136,9 +136,16 @@ async def delete_chunks_by_ids(conn, chunk_ids: list[str], bank_id: str | None =
     if bank_id:
         outgoing_unit_ids = await memory_ids_for_chunks(conn, bank_id, chunk_ids)
         if outgoing_unit_ids:
+            from ..graph_maintenance import enqueue_entity_prune_candidates
             from .fact_storage import delete_stale_observations_for_memories
 
             invalidated = await delete_stale_observations_for_memories(conn, bank_id, outgoing_unit_ids, ops=ops)
+            # Queue the entities these facts reference BEFORE the cascade takes
+            # their unit_entities rows: afterwards an entity whose last posting
+            # was here is unreachable garbage. Delta retain deletes facts only
+            # through this cascade, so this is the one place that can catch them
+            # (the full-replace path enqueues in ``handle_document_tracking``).
+            await enqueue_entity_prune_candidates(conn, bank_id, outgoing_unit_ids)
 
     # The chunks->memory_units FK cascade below does not reach a store that keeps memories
     # outside SQL (its memory_units is empty), so drop the memories carrying each deleted

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -284,9 +284,16 @@ async def handle_document_tracking(
             # those links. ``ops`` may be None for older callers that haven't
             # been wired up — skip enqueue in that case rather than crash.
             if ops is not None:
-                from ..graph_maintenance import enqueue_relink_victims
+                from ..graph_maintenance import enqueue_entity_prune_candidates, enqueue_relink_victims
 
-                await enqueue_relink_victims(conn, bank_id, [str(uid) for uid in existing_unit_ids])
+                doomed_ids = [str(uid) for uid in existing_unit_ids]
+                await enqueue_relink_victims(conn, bank_id, doomed_ids)
+                # Same timing, different target: the entities these units are
+                # about to stop referencing may have no other posting. The
+                # re-ingest re-resolves entities from scratch, so the ones the
+                # new facts don't name again are orphans the moment this
+                # cascade lands.
+                await enqueue_entity_prune_candidates(conn, bank_id, doomed_ids)
 
         # Explicitly delete memory_units by document_id BEFORE deleting the
         # document row. The CASCADE from documents→chunks→memory_units only

--- a/hindsight-api-slim/hindsight_api/engine/transfer/export.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/export.py
@@ -85,6 +85,7 @@ _SKIP_TABLES = frozenset(
     {
         "async_operations",  # in-flight ops; drain on the source before migrating
         "graph_maintenance_queue",  # transient work queue; regenerated on import
+        "entity_maintenance_queue",  # transient work queue; regenerated on import
         "file_storage",  # raw uploads; documents.original_text is already carried
         # Curation archive of retired facts — local operational state, not part of
         # the live knowledge the export replays. Its rows mirror memory_units (stale

--- a/hindsight-api-slim/tests/test_db_utils.py
+++ b/hindsight-api-slim/tests/test_db_utils.py
@@ -83,7 +83,7 @@ def test_backoff_delay_is_jittered_and_bounded():
     """Equal-jitter backoff stays in [ceil/2, ceil] and never exceeds max_delay.
 
     The jitter exists so concurrent deadlock retriers don't wake in lock-step
-    and re-collide (see run_graph_maintenance_job's Pass 2/3 sweep). It must
+    and re-collide (see the entity-prune batch in run_graph_maintenance_job). It must
     still keep a floor (no hot-spin) and honour the max_delay cap once the
     exponential term saturates.
     """

--- a/hindsight-api-slim/tests/test_graph_maintenance.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance.py
@@ -157,11 +157,10 @@ async def _seed_entity_candidates(conn, bank_id: str, entity_ids: list[uuid.UUID
     """Queue entities as prune candidates without going through a delete.
 
     ``enqueue_entity_prune_candidates`` reads its candidates out of
-    ``unit_entities``, so it cannot name an entity that is *already* orphaned.
-    That is the right contract for the delete paths (they run before the
-    postings go) but leaves one case it can't express: entities that were
-    already stranded before this queue existed. The migration seeds those in
-    exactly this way, and so does this helper.
+    ``unit_entities``, so it cannot name an entity that is *already* orphaned —
+    the right contract for the delete paths, which run before the postings go,
+    but awkward for a test that wants to start from an orphan. This writes the
+    queue row directly instead.
     """
     await conn.executemany(
         "INSERT INTO entity_maintenance_queue (bank_id, entity_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",

--- a/hindsight-api-slim/tests/test_graph_maintenance.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance.py
@@ -832,6 +832,7 @@ class TestStaleCooccurrencePrune:
             assert live_kept == 1
             assert stale_gone == 0
             assert other_untouched == 1
+
     @pytest.mark.asyncio
     async def test_prunes_when_only_the_second_endpoint_is_a_candidate(
         self, memory: MemoryEngine, request_context: RequestContext

--- a/hindsight-api-slim/tests/test_graph_maintenance.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance.py
@@ -950,6 +950,112 @@ class TestEnqueueEntityPruneCandidates:
 # ---------------------------------------------------------------------------
 
 
+class TestEveryDeleteSiteEnqueues:
+    """One test per site that removes units or replaces postings.
+
+    A queue-driven prune is only as complete as its producers: a site that
+    forgets to enqueue leaks orphan entities silently — no error, no failed
+    operation, just garbage that accumulates. These assert the queue row exists
+    rather than asserting on the prune, so a missing call fails here loudly
+    instead of showing up as unexplained growth on someone's bank.
+    """
+
+    @pytest.mark.asyncio
+    async def test_delta_retain_chunk_delete(self, memory: MemoryEngine, request_context: RequestContext):
+        """``delete_chunks_by_ids`` — the cascade delta retain deletes facts through."""
+        from hindsight_api.engine.retain import chunk_storage
+
+        bank_id = f"test-gm-chunkdel-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        backend = await memory._get_backend()
+        pool = await memory._get_pool()
+        chunk_id = f"chunk-{uuid.uuid4().hex[:8]}"
+        async with pool.acquire() as conn:
+            await _insert_document(conn, bank_id, "doc-chunked")
+            await conn.execute(
+                """
+                INSERT INTO chunks (chunk_id, document_id, bank_id, chunk_text, chunk_index, content_hash)
+                VALUES ($1, $2, $3, 'body', 0, 'hash-0')
+                """,
+                chunk_id,
+                "doc-chunked",
+                bank_id,
+            )
+            unit = await _insert_unit(conn, bank_id, "fact in the chunk", fact_type="world")
+            await conn.execute(
+                "UPDATE memory_units SET document_id = $1, chunk_id = $2 WHERE id = $3",
+                "doc-chunked",
+                chunk_id,
+                unit,
+            )
+            entity = await _insert_entity(conn, bank_id, "chunk-entity")
+            await _link_unit_entity(conn, unit, entity)
+
+        async with backend.acquire() as conn:
+            async with conn.transaction():
+                await chunk_storage.delete_chunks_by_ids(conn, [chunk_id], bank_id, ops=backend.ops)
+
+        async with pool.acquire() as conn:
+            assert await _queue_entity_ids(conn, bank_id) == [str(entity)]
+
+    @pytest.mark.asyncio
+    async def test_document_reingest(self, memory: MemoryEngine, request_context: RequestContext):
+        """``handle_document_tracking`` — a full re-ingest replaces the old facts."""
+        from hindsight_api.engine.retain.fact_storage import handle_document_tracking
+
+        bank_id = f"test-gm-reingest-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        backend = await memory._get_backend()
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            await _insert_document(conn, bank_id, "doc-reingest")
+            unit = await _insert_unit(conn, bank_id, "old fact", fact_type="world")
+            await _attach_unit_to_doc(conn, unit, "doc-reingest")
+            entity = await _insert_entity(conn, bank_id, "reingest-entity")
+            await _link_unit_entity(conn, unit, entity)
+
+        async with backend.acquire() as conn:
+            async with conn.transaction():
+                await handle_document_tracking(
+                    conn,
+                    bank_id,
+                    "doc-reingest",
+                    "replacement text",
+                    is_first_batch=True,
+                    ops=backend.ops,
+                )
+
+        async with pool.acquire() as conn:
+            assert str(entity) in await _queue_entity_ids(conn, bank_id)
+
+    @pytest.mark.asyncio
+    async def test_curation_invalidate(self, memory: MemoryEngine, request_context: RequestContext):
+        """Invalidation moves the unit to the archive, taking its postings with it."""
+        bank_id = f"test-gm-inval-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            unit = await _insert_unit(conn, bank_id, "to be invalidated", fact_type="world")
+            entity = await _insert_entity(conn, bank_id, "invalidated-entity")
+            await _link_unit_entity(conn, unit, entity)
+
+        await memory.update_memory_unit(
+            bank_id=bank_id,
+            memory_id=str(unit),
+            state="invalidated",
+            reason="test",
+            request_context=request_context,
+        )
+
+        async with pool.acquire() as conn:
+            # SyncTaskBackend drained the queue inline, so assert the outcome:
+            # the entity the archived unit was holding up is gone.
+            assert await conn.fetchval("SELECT 1 FROM entities WHERE id = $1", entity) is None
+
+
 class TestTimeBudget:
     @pytest.mark.asyncio
     async def test_expired_budget_leaves_the_queue_for_the_next_run(
@@ -978,13 +1084,57 @@ class TestTimeBudget:
             deadline=time.monotonic() - 1,  # already expired
         )
 
-        assert result["entity_queue_exhausted"] is False
-        assert result["entities_examined"] == 0
+        assert result.queue_exhausted is False
+        assert result.entities_examined == 0
 
         async with pool.acquire() as conn:
             # Still queued, and the entity is untouched: the next run resumes.
             assert await _queue_entity_ids(conn, bank_id) == [str(orphan)]
             assert await conn.fetchval("SELECT 1 FROM entities WHERE id = $1", orphan) == 1
+
+    @pytest.mark.asyncio
+    async def test_budget_exhaustion_chains_a_follow_up_run(
+        self, memory: MemoryEngine, request_context: RequestContext, monkeypatch
+    ):
+        """A backlog too big for one run has to schedule its own continuation.
+
+        Otherwise the leftover queue rows sit until the next delete happens to
+        trigger a job — which on a bank that has gone quiet is never. The chain
+        is suppressed under a synchronous task backend (it would recurse rather
+        than schedule), so this drives the real engine method with the guard
+        pointed at a stand-in class.
+        """
+        from hindsight_api.engine import graph_maintenance as gm
+
+        bank_id = f"test-gm-chain-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            orphan = await _insert_entity(conn, bank_id, "orphan")
+            await _seed_entity_candidates(conn, bank_id, [orphan])
+
+        # Budget already spent: neither pass claims anything, both report the
+        # queue as not exhausted.
+        monkeypatch.setattr(gm, "_JOB_TIME_BUDGET_SECONDS", -1.0)
+
+        submitted: list[str] = []
+
+        async def _record_submit(*, bank_id: str, request_context, force_sweep: bool = False):
+            submitted.append(bank_id)
+            return {"operation_id": None, "no_work": True}
+
+        monkeypatch.setattr(memory, "submit_async_graph_maintenance", _record_submit)
+
+        class _NotSync:
+            """Stands in for a queue-backed backend so the guard lets the chain through."""
+
+        monkeypatch.setattr(memory, "_task_backend", _NotSync())
+
+        result = await run_graph_maintenance_job(memory, bank_id, request_context)
+
+        assert result["queues_drained"] is False
+        assert submitted == [bank_id]
 
 
 # ---------------------------------------------------------------------------

--- a/hindsight-api-slim/tests/test_graph_maintenance.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance.py
@@ -11,6 +11,7 @@ The fixture's task backend is ``SyncTaskBackend`` (see conftest), so
 
 from __future__ import annotations
 
+import time
 import uuid
 from datetime import UTC, datetime, timedelta
 
@@ -20,6 +21,7 @@ from hindsight_api import RequestContext
 from hindsight_api.engine.graph_maintenance import (
     MAX_SEMANTIC_LINKS_PER_UNIT,
     MAX_TEMPORAL_LINKS_PER_UNIT,
+    enqueue_entity_prune_candidates,
     enqueue_relink_victims,
     run_graph_maintenance_job,
 )
@@ -141,6 +143,30 @@ async def _queue_unit_ids(conn, bank_id: str) -> list[str]:
         bank_id,
     )
     return [str(r["unit_id"]) for r in rows]
+
+
+async def _queue_entity_ids(conn, bank_id: str) -> list[str]:
+    rows = await conn.fetch(
+        "SELECT entity_id FROM entity_maintenance_queue WHERE bank_id = $1 ORDER BY entity_id",
+        bank_id,
+    )
+    return [str(r["entity_id"]) for r in rows]
+
+
+async def _seed_entity_candidates(conn, bank_id: str, entity_ids: list[uuid.UUID]) -> None:
+    """Queue entities as prune candidates without going through a delete.
+
+    ``enqueue_entity_prune_candidates`` reads its candidates out of
+    ``unit_entities``, so it cannot name an entity that is *already* orphaned.
+    That is the right contract for the delete paths (they run before the
+    postings go) but leaves one case it can't express: entities that were
+    already stranded before this queue existed. The migration seeds those in
+    exactly this way, and so does this helper.
+    """
+    await conn.executemany(
+        "INSERT INTO entity_maintenance_queue (bank_id, entity_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        [(bank_id, eid) for eid in entity_ids],
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -386,7 +412,7 @@ class TestDeleteDocumentEnqueue:
 
 class TestSubmitForceSweep:
     @pytest.mark.asyncio
-    async def test_empty_queue_short_circuits_by_default(self, memory: MemoryEngine, request_context: RequestContext):
+    async def test_empty_queues_short_circuit_by_default(self, memory: MemoryEngine, request_context: RequestContext):
         """The default stays cheap for unconditional callers (every retain)."""
         bank_id = f"test-gm-nowork-{uuid.uuid4().hex[:8]}"
         await _ensure_bank(memory, bank_id, request_context)
@@ -396,19 +422,23 @@ class TestSubmitForceSweep:
         assert result == {"operation_id": None, "no_work": True}
 
     @pytest.mark.asyncio
-    async def test_force_sweep_submits_on_empty_queue(self, memory: MemoryEngine, request_context: RequestContext):
-        """`force_sweep=True` submits the job even with nothing enqueued, so the
-        orphan-entity sweep runs for callers that dropped unit→entity references."""
-        bank_id = f"test-gm-force-{uuid.uuid4().hex[:8]}"
+    async def test_queued_entity_candidate_defeats_the_short_circuit(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """The pre-check reads BOTH queues. A delete that enqueued only entity
+        candidates (an isolated document has no relink victims) must still get a
+        job — checking only graph_maintenance_queue would short-circuit it away
+        and leave the entities stranded."""
+        bank_id = f"test-gm-entq-{uuid.uuid4().hex[:8]}"
         await _ensure_bank(memory, bank_id, request_context)
 
         pool = await memory._get_pool()
         async with pool.acquire() as conn:
             orphan = await _insert_entity(conn, bank_id, "unreferenced")
+            await _seed_entity_candidates(conn, bank_id, [orphan])
+            assert await _queue_unit_ids(conn, bank_id) == []
 
-        result = await memory.submit_async_graph_maintenance(
-            bank_id=bank_id, request_context=request_context, force_sweep=True
-        )
+        result = await memory.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
 
         assert result.get("no_work") is not True
         assert result["operation_id"]
@@ -416,6 +446,20 @@ class TestSubmitForceSweep:
         async with pool.acquire() as conn:
             # SyncTaskBackend ran the job inline: the orphan is gone.
             assert await conn.fetchval("SELECT 1 FROM entities WHERE id = $1", orphan) is None
+
+    @pytest.mark.asyncio
+    async def test_force_sweep_submits_on_empty_queues(self, memory: MemoryEngine, request_context: RequestContext):
+        """`force_sweep=True` still submits with both queues empty, for callers
+        that would rather pay for an empty job than reason about the queues."""
+        bank_id = f"test-gm-force-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        result = await memory.submit_async_graph_maintenance(
+            bank_id=bank_id, request_context=request_context, force_sweep=True
+        )
+
+        assert result.get("no_work") is not True
+        assert result["operation_id"]
 
 
 # ---------------------------------------------------------------------------
@@ -433,8 +477,10 @@ class TestRelinkPass:
         assert result == {
             "relink_units_processed": 0,
             "relink_links_added": 0,
+            "entities_examined": 0,
             "orphan_entities_pruned": 0,
             "stale_cooccurrences_pruned": 0,
+            "queues_drained": True,
         }
 
     @pytest.mark.asyncio
@@ -561,9 +607,11 @@ class TestRelinkPass:
 
 class TestOrphanEntityPrune:
     @pytest.mark.asyncio
-    async def test_prunes_entities_with_no_unit_references(self, memory: MemoryEngine, request_context: RequestContext):
-        """An entity with zero unit_entities rows is an orphan and should be
-        deleted by the sweep."""
+    async def test_prunes_queued_entities_with_no_unit_references(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """A queued candidate with zero unit_entities rows is an orphan and gets
+        deleted; a queued candidate that is still referenced is kept."""
         bank_id = f"test-gm-orphan-{uuid.uuid4().hex[:8]}"
         await _ensure_bank(memory, bank_id, request_context)
 
@@ -575,22 +623,43 @@ class TestOrphanEntityPrune:
 
             unit = await _insert_unit(conn, bank_id, "with-entity")
             await _link_unit_entity(conn, unit, referenced)
+            # All three are candidates: the drain decides which are actually
+            # dead. Over-enqueueing is the safe direction.
+            await _seed_entity_candidates(conn, bank_id, [referenced, orphan_a, orphan_b])
 
         result = await run_graph_maintenance_job(memory, bank_id, request_context)
+        assert result["entities_examined"] == 3
         assert result["orphan_entities_pruned"] == 2
 
         async with pool.acquire() as conn:
             survivors = await conn.fetch("SELECT id FROM entities WHERE bank_id = $1 ORDER BY id", bank_id)
-            survivor_ids = {str(r["id"]) for r in survivors}
-            assert survivor_ids == {str(referenced)}
-            # Confirm orphans are gone.
-            for orphan in (orphan_a, orphan_b):
-                assert orphan not in survivor_ids
+            assert {str(r["id"]) for r in survivors} == {str(referenced)}
+            # The claim removed every queue row it processed.
+            assert await _queue_entity_ids(conn, bank_id) == []
+
+    @pytest.mark.asyncio
+    async def test_ignores_unqueued_orphans(self, memory: MemoryEngine, request_context: RequestContext):
+        """The pass is queue-driven, not a sweep: an orphan nothing enqueued is
+        left alone. This is the whole point of #3222 — the cost of a run tracks
+        what a delete touched, not the size of the bank."""
+        bank_id = f"test-gm-unqueued-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            orphan = await _insert_entity(conn, bank_id, "never-queued")
+
+        result = await run_graph_maintenance_job(memory, bank_id, request_context)
+        assert result["entities_examined"] == 0
+        assert result["orphan_entities_pruned"] == 0
+
+        async with pool.acquire() as conn:
+            assert await conn.fetchval("SELECT 1 FROM entities WHERE id = $1", orphan) == 1
 
     @pytest.mark.asyncio
     async def test_does_not_touch_other_banks(self, memory: MemoryEngine, request_context: RequestContext):
-        """The sweep is scoped by bank — orphan entities in OTHER banks
-        must not be touched."""
+        """The prune is scoped by bank — a candidate queued under another bank's
+        id must not be claimed, even though entity ids are globally unique."""
         bank_a = f"test-gm-scopea-{uuid.uuid4().hex[:8]}"
         bank_b = f"test-gm-scopeb-{uuid.uuid4().hex[:8]}"
         await _ensure_bank(memory, bank_a, request_context)
@@ -600,16 +669,17 @@ class TestOrphanEntityPrune:
         async with pool.acquire() as conn:
             orphan_in_a = await _insert_entity(conn, bank_a, "orphan_a")
             orphan_in_b = await _insert_entity(conn, bank_b, "orphan_b")
+            await _seed_entity_candidates(conn, bank_a, [orphan_in_a])
+            await _seed_entity_candidates(conn, bank_b, [orphan_in_b])
 
         await run_graph_maintenance_job(memory, bank_a, request_context)
 
         async with pool.acquire() as conn:
-            # b's orphan must still exist — the sweep was scoped to a.
-            still_in_b = await conn.fetchval("SELECT 1 FROM entities WHERE id = $1", orphan_in_b)
-            assert still_in_b == 1
+            # b's orphan must still exist — the drain was scoped to a.
+            assert await conn.fetchval("SELECT 1 FROM entities WHERE id = $1", orphan_in_b) == 1
+            assert await _queue_entity_ids(conn, bank_b) == [str(orphan_in_b)]
             # a's orphan is gone.
-            still_in_a = await conn.fetchval("SELECT 1 FROM entities WHERE id = $1", orphan_in_a)
-            assert still_in_a is None
+            assert await conn.fetchval("SELECT 1 FROM entities WHERE id = $1", orphan_in_a) is None
 
 
 # ---------------------------------------------------------------------------
@@ -637,6 +707,7 @@ class TestStaleCooccurrencePrune:
             unit_b = await _insert_unit(conn, bank_id, "with_b")
             await _link_unit_entity(conn, unit_a, ent_a)
             await _link_unit_entity(conn, unit_b, ent_b)
+            await _seed_entity_candidates(conn, bank_id, [ent_a])
 
         result = await run_graph_maintenance_job(memory, bank_id, request_context)
         assert result["stale_cooccurrences_pruned"] == 1
@@ -669,6 +740,7 @@ class TestStaleCooccurrencePrune:
             unit = await _insert_unit(conn, bank_id, "alice-and-bob")
             await _link_unit_entity(conn, unit, ent_a)
             await _link_unit_entity(conn, unit, ent_b)
+            await _seed_entity_candidates(conn, bank_id, [ent_a, ent_b])
 
         result = await run_graph_maintenance_job(memory, bank_id, request_context)
         assert result["stale_cooccurrences_pruned"] == 0
@@ -684,13 +756,18 @@ class TestStaleCooccurrencePrune:
             assert still_there == 5
 
     @pytest.mark.asyncio
+    @pytest.mark.asyncio
     async def test_prunes_only_the_stale_edge_around_a_hub_and_leaves_other_banks(
         self, memory: MemoryEngine, request_context: RequestContext
     ):
-        """The prune decides staleness against a per-bank SET of live pairs (#3367),
-        not per-cooccurrence-row. Guard the two things that swap could get wrong:
-        a hub's *still-grounded* edges survive while only its genuinely stale edge
-        is pruned, and the bank-scoped ``live`` set never reaches across banks."""
+        """The prune decides staleness against a SET of live pairs (#3367), not
+        per-cooccurrence-row. Guard the two things that swap could get wrong: a
+        hub's *still-grounded* edges survive while only its genuinely stale edge
+        is pruned, and the ``live`` set never reaches across banks.
+
+        The set is now seeded from the claimed candidates' units rather than the
+        whole bank (#3222), so this also pins that the narrower seed still sees
+        every unit that could ground one of the pairs being judged."""
         bank_id = f"test-gm-hub-{uuid.uuid4().hex[:8]}"
         other_bank = f"test-gm-oth-{uuid.uuid4().hex[:8]}"
         await _ensure_bank(memory, bank_id, request_context)
@@ -723,6 +800,12 @@ class TestStaleCooccurrencePrune:
             await _link_unit_entity(conn, oth_unit_a, oth_a)
             await _link_unit_entity(conn, oth_unit_b, oth_b)
 
+            # Queue-driven now: the hub is the candidate a delete would have
+            # enqueued. The other bank's entities are queued under their own
+            # bank, which draining bank_id must not claim.
+            await _seed_entity_candidates(conn, bank_id, [hub])
+            await _seed_entity_candidates(conn, other_bank, [oth_a])
+
         result = await run_graph_maintenance_job(memory, bank_id, request_context)
         assert result["stale_cooccurrences_pruned"] == 1
         assert result["orphan_entities_pruned"] == 0
@@ -749,6 +832,158 @@ class TestStaleCooccurrencePrune:
             assert live_kept == 1
             assert stale_gone == 0
             assert other_untouched == 1
+    @pytest.mark.asyncio
+    async def test_prunes_when_only_the_second_endpoint_is_a_candidate(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """Scoping matches a candidate on EITHER endpoint. The two arms are a
+        UNION because an OR across entity_id_1/entity_id_2 can't be driven from
+        either index (#3387's shape); dropping the entity_id_2 arm would leave
+        exactly this row behind, and only for pairs whose surviving candidate
+        happens to sort second."""
+        bank_id = f"test-gm-cocc2-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            ent_a = await _insert_entity(conn, bank_id, "alice")
+            ent_b = await _insert_entity(conn, bank_id, "bob")
+            await _insert_cooccurrence(conn, ent_a, ent_b)
+            unit_a = await _insert_unit(conn, bank_id, "with_a")
+            unit_b = await _insert_unit(conn, bank_id, "with_b")
+            await _link_unit_entity(conn, unit_a, ent_a)
+            await _link_unit_entity(conn, unit_b, ent_b)
+            # Queue only the endpoint stored as entity_id_2.
+            _, second = sorted([ent_a, ent_b])
+            await _seed_entity_candidates(conn, bank_id, [second])
+
+        result = await run_graph_maintenance_job(memory, bank_id, request_context)
+        assert result["stale_cooccurrences_pruned"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Delta enqueue: what a delete captures before the cascade
+# ---------------------------------------------------------------------------
+
+
+class TestEnqueueEntityPruneCandidates:
+    @pytest.mark.asyncio
+    async def test_enqueues_entities_the_doomed_units_reference(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        bank_id = f"test-gm-cand-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            doomed = await _insert_unit(conn, bank_id, "doomed")
+            untouched_unit = await _insert_unit(conn, bank_id, "untouched")
+            shared = await _insert_entity(conn, bank_id, "shared")
+            only_here = await _insert_entity(conn, bank_id, "only-here")
+            elsewhere = await _insert_entity(conn, bank_id, "elsewhere")
+            await _link_unit_entity(conn, doomed, shared)
+            await _link_unit_entity(conn, doomed, only_here)
+            await _link_unit_entity(conn, untouched_unit, shared)
+            await _link_unit_entity(conn, untouched_unit, elsewhere)
+
+            async with conn.transaction():
+                count = await enqueue_entity_prune_candidates(conn, bank_id, [str(doomed)])
+
+            # Both of the doomed unit's entities are candidates — including the
+            # one another unit also references. The drain, not the enqueue,
+            # decides which are actually dead.
+            assert count == 2
+            assert await _queue_entity_ids(conn, bank_id) == sorted([str(shared), str(only_here)])
+
+    @pytest.mark.asyncio
+    async def test_dedupes_across_overlapping_deletes(self, memory: MemoryEngine, request_context: RequestContext):
+        """Two deletes naming the same entity leave one queue row: the composite
+        primary key absorbs the duplicate."""
+        bank_id = f"test-gm-canddup-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            unit_a = await _insert_unit(conn, bank_id, "a")
+            unit_b = await _insert_unit(conn, bank_id, "b")
+            entity = await _insert_entity(conn, bank_id, "shared")
+            await _link_unit_entity(conn, unit_a, entity)
+            await _link_unit_entity(conn, unit_b, entity)
+
+            async with conn.transaction():
+                await enqueue_entity_prune_candidates(conn, bank_id, [str(unit_a)])
+                await enqueue_entity_prune_candidates(conn, bank_id, [str(unit_b)])
+
+            assert await _queue_entity_ids(conn, bank_id) == [str(entity)]
+
+    @pytest.mark.asyncio
+    async def test_delete_memory_unit_prunes_the_entity_it_was_holding_up(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """End-to-end through the real delete path: the entity whose last posting
+        the deleted unit held is gone, the one another unit still references stays."""
+        bank_id = f"test-gm-del-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            doomed = await _insert_unit(conn, bank_id, "doomed")
+            survivor = await _insert_unit(conn, bank_id, "survivor")
+            sole = await _insert_entity(conn, bank_id, "sole-reference")
+            shared = await _insert_entity(conn, bank_id, "shared")
+            await _link_unit_entity(conn, doomed, sole)
+            await _link_unit_entity(conn, doomed, shared)
+            await _link_unit_entity(conn, survivor, shared)
+
+        await memory.delete_memory_unit(str(doomed), request_context=request_context)
+
+        async with pool.acquire() as conn:
+            assert await conn.fetchval("SELECT 1 FROM entities WHERE id = $1", sole) is None
+            assert await conn.fetchval("SELECT 1 FROM entities WHERE id = $1", shared) == 1
+            # The drain consumed every candidate it enqueued.
+            assert await _queue_entity_ids(conn, bank_id) == []
+
+
+# ---------------------------------------------------------------------------
+# Time budget
+# ---------------------------------------------------------------------------
+
+
+class TestTimeBudget:
+    @pytest.mark.asyncio
+    async def test_expired_budget_leaves_the_queue_for_the_next_run(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """An exhausted budget is not a failure: nothing is claimed, the rows
+        stay queued, and the job reports it rather than being cancelled
+        mid-statement the way the bank-wide sweep was (#3222)."""
+        from hindsight_api.engine.memories import get_memories
+
+        bank_id = f"test-gm-budget-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            orphan = await _insert_entity(conn, bank_id, "orphan")
+            await _seed_entity_candidates(conn, bank_id, [orphan])
+
+        backend = await memory._get_backend()
+        from hindsight_api.engine.schema import fq_table
+
+        result = await get_memories().entity_prune_pass(
+            backend=backend,
+            fq_table=fq_table,
+            bank_id=bank_id,
+            deadline=time.monotonic() - 1,  # already expired
+        )
+
+        assert result["entity_queue_exhausted"] is False
+        assert result["entities_examined"] == 0
+
+        async with pool.acquire() as conn:
+            # Still queued, and the entity is untouched: the next run resumes.
+            assert await _queue_entity_ids(conn, bank_id) == [str(orphan)]
+            assert await conn.fetchval("SELECT 1 FROM entities WHERE id = $1", orphan) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/hindsight-api-slim/tests/test_graph_maintenance_claim_serialization.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance_claim_serialization.py
@@ -1,6 +1,6 @@
 """Per-bank serialisation of graph_maintenance at claim time (#3230).
 
-Every graph_maintenance run is the same bank-wide sweep — the payload carries
+Every graph_maintenance run for a bank is interchangeable — the payload carries
 only ``bank_id`` and ``run_graph_maintenance_job`` drains the whole queue — so a
 second concurrent run for one bank adds no work while convoying on the first
 run's queue-row locks (``claim_graph_maintenance_batch`` locks ``FOR UPDATE``

--- a/hindsight-api-slim/tests/test_graph_maintenance_deadlock.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance_deadlock.py
@@ -197,17 +197,18 @@ async def test_unordered_concurrent_sweep_and_upsert_deadlocks(memory: MemoryEng
 
 @pytest.mark.asyncio
 async def test_graph_maintenance_sweep_retries_on_deadlock(memory: MemoryEngine, request_context: RequestContext):
-    """``run_graph_maintenance_job``'s Pass 2/3 sweep must survive a deadlock.
+    """The entity-prune batch must survive a deadlock.
 
-    Fix for the production bug reproduced above: the sweep
-    (``prune_orphan_entities`` + ``prune_stale_cooccurrences``) now runs
-    inside ``retry_with_backoff``, which already special-cases
-    ``DeadlockDetectedError``. Both prunes are idempotent bank-wide deletes,
-    so retrying the whole transaction after a deadlock is safe. Simulates the
-    deadlock via a mock (real two-connection reproduction is covered above;
+    Fix for the production bug reproduced above: each batch
+    (``prune_orphan_entities`` + ``prune_stale_cooccurrences`` over the claimed
+    candidates) runs inside ``retry_with_backoff``, which already special-cases
+    ``DeadlockDetectedError``. Both prunes are idempotent, so retrying the whole
+    batch transaction after a deadlock is safe — including the claim, which is
+    re-taken from the queue rows the aborted transaction rolled back. Simulates
+    the deadlock via a mock (real two-connection reproduction is covered above;
     this asserts the *application* behaviour — one transient
-    DeadlockDetectedError must not fail the job) and asserts the retry
-    actually happens and the job still returns correct prune counts.
+    DeadlockDetectedError must not fail the job) and asserts the retry actually
+    happens and the job still returns correct prune counts.
     """
     bank_id = f"dl-fix-sweep-{uuid.uuid4().hex[:8]}"
     await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
@@ -245,6 +246,12 @@ async def test_graph_maintenance_sweep_retries_on_deadlock(memory: MemoryEngine,
             """,
             *sorted([ent_a, ent_b]),
             datetime.now(UTC),
+        )
+        # The prunes are queue-driven: without candidates there is no batch to
+        # deadlock on.
+        await conn.executemany(
+            "INSERT INTO entity_maintenance_queue (bank_id, entity_id) VALUES ($1, $2)",
+            [(bank_id, ent_a), (bank_id, ent_b)],
         )
 
     backend = await memory._get_backend()

--- a/hindsight-api-slim/tests/test_memories_extension.py
+++ b/hindsight-api-slim/tests/test_memories_extension.py
@@ -594,8 +594,10 @@ async def test_maintenance_passes_are_optional(restore_default_store):
     store = InMemoryMemories({})
     assert await store.enqueue_relink_victims(conn=None, fq_table=None, bank_id="b", affected_unit_ids=["x"]) == 0
     assert await store.relink_pass(backend=None, fq_table=None, bank_id="b", config=None) == {}
-    assert await store.prune_orphan_entities(conn=None, fq_table=None, bank_id="b") == 0
-    assert await store.prune_stale_cooccurrences(conn=None, fq_table=None, bank_id="b") == 0
+    assert (
+        await store.enqueue_entity_prune_candidates(conn=None, fq_table=None, bank_id="b", affected_unit_ids=["x"]) == 0
+    )
+    assert await store.entity_prune_pass(backend=None, fq_table=None, bank_id="b") == {}
     # And recording entity postings is a no-op rather than an error: the posting
     # travels on the memory for a store that owns it.
     await store.record_unit_entities(conn=None, ops=None, fq_table=None, unit_ids=["u"], entity_ids=["e"])

--- a/hindsight-api-slim/tests/test_memories_extension.py
+++ b/hindsight-api-slim/tests/test_memories_extension.py
@@ -29,7 +29,13 @@ from unittest.mock import patch
 import pytest
 
 from hindsight_api.engine.memories import create_memories, get_memories, set_memories
-from hindsight_api.engine.memories.base import MemoriesExtension, ScanPage, StoredMemory
+from hindsight_api.engine.memories.base import (
+    EntityPrunePassResult,
+    MemoriesExtension,
+    RelinkPassResult,
+    ScanPage,
+    StoredMemory,
+)
 from hindsight_api.engine.memories.postgres import PostgresMemories
 
 
@@ -593,11 +599,11 @@ async def test_maintenance_passes_are_optional(restore_default_store):
     """
     store = InMemoryMemories({})
     assert await store.enqueue_relink_victims(conn=None, fq_table=None, bank_id="b", affected_unit_ids=["x"]) == 0
-    assert await store.relink_pass(backend=None, fq_table=None, bank_id="b", config=None) == {}
+    assert await store.relink_pass(backend=None, fq_table=None, bank_id="b", config=None) == RelinkPassResult()
     assert (
         await store.enqueue_entity_prune_candidates(conn=None, fq_table=None, bank_id="b", affected_unit_ids=["x"]) == 0
     )
-    assert await store.entity_prune_pass(backend=None, fq_table=None, bank_id="b") == {}
+    assert await store.entity_prune_pass(backend=None, fq_table=None, bank_id="b") == EntityPrunePassResult()
     # And recording entity postings is a no-op rather than an error: the posting
     # travels on the memory for a store that owns it.
     await store.record_unit_entities(conn=None, ops=None, fq_table=None, unit_ids=["u"], entity_ids=["e"])

--- a/hindsight-api-slim/tests/test_migration_entity_maintenance_queue.py
+++ b/hindsight-api-slim/tests/test_migration_entity_maintenance_queue.py
@@ -1,0 +1,119 @@
+"""Tests for migration c4f7a91b2d38 (entity_maintenance_queue + its seed).
+
+The graph-maintenance entity prune is queue-driven (#3222): it only looks at
+entities something enqueued. That leaves one class of garbage nothing can
+enqueue — entities already stranded *before* the queue existed, whose postings
+are long gone and which no future delete will ever name. The migration's seed
+insert is the only thing that reclaims those, so it is worth a test of its own:
+without it the upgrade silently strands every orphan a bank had accumulated
+while its bank-wide sweep was failing, which is the exact population #3222 is
+about.
+
+Uses a dedicated pg0 instance so the test controls which migrations have run.
+"""
+
+import asyncio
+import uuid
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+_SCRIPT_LOCATION = str(Path(__file__).parent.parent / "hindsight_api" / "alembic")
+
+# The revision immediately before the one under test.
+_PRE_REVISION = "d9c1a7b4e2f6"
+_REVISION = "c4f7a91b2d38"
+
+
+def _alembic_cfg(db_url: str) -> Config:
+    cfg = Config()
+    cfg.set_main_option("script_location", _SCRIPT_LOCATION)
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    cfg.set_main_option("prepend_sys_path", ".")
+    cfg.set_main_option("path_separator", "os")
+    return cfg
+
+
+def _upgrade(db_url: str, revision: str) -> None:
+    command.upgrade(_alembic_cfg(db_url), revision)
+
+
+def _reset_public_schema(db_url: str) -> None:
+    engine = create_engine(db_url, isolation_level="AUTOCOMMIT")
+    try:
+        with engine.connect() as conn:
+            conn.execute(text("DROP SCHEMA IF EXISTS public CASCADE"))
+            conn.execute(text("CREATE SCHEMA public"))
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture(scope="module")
+def pre_queue_db_url() -> str:
+    """A dedicated database migrated to the revision just before the queue."""
+    from hindsight_api.pg0 import EmbeddedPostgres
+
+    pg0 = EmbeddedPostgres(name="hindsight-entity-queue-test", port=5563)
+    loop = asyncio.new_event_loop()
+    try:
+        url = loop.run_until_complete(pg0.ensure_running())
+    finally:
+        loop.close()
+
+    _reset_public_schema(url)
+    _upgrade(url, _PRE_REVISION)
+    return url
+
+
+def test_seed_enqueues_every_pre_existing_entity(pre_queue_db_url: str) -> None:
+    """Every entity that predates the queue becomes a candidate exactly once.
+
+    Both kinds have to be seeded, not just the visibly-orphaned one: the drain
+    is what decides which are dead, and it cannot decide about a row it never
+    sees. Seeding only the orphans would also mean re-running the bank-wide
+    NOT EXISTS the migration exists to get rid of.
+    """
+    db_url = pre_queue_db_url
+    engine = create_engine(db_url)
+    bank_id = f"bank_{uuid.uuid4().hex[:8]}"
+
+    try:
+        with engine.begin() as conn:
+            conn.execute(text("INSERT INTO banks (bank_id) VALUES (:b)"), {"b": bank_id})
+            unit_id = conn.execute(
+                text(
+                    "INSERT INTO memory_units (bank_id, text, fact_type, event_date) "
+                    "VALUES (:b, 'a fact', 'world', now()) RETURNING id"
+                ),
+                {"b": bank_id},
+            ).scalar_one()
+            referenced = conn.execute(
+                text("INSERT INTO entities (bank_id, canonical_name) VALUES (:b, 'referenced') RETURNING id"),
+                {"b": bank_id},
+            ).scalar_one()
+            orphan = conn.execute(
+                text("INSERT INTO entities (bank_id, canonical_name) VALUES (:b, 'stranded') RETURNING id"),
+                {"b": bank_id},
+            ).scalar_one()
+            conn.execute(
+                text("INSERT INTO unit_entities (unit_id, entity_id) VALUES (:u, :e)"),
+                {"u": unit_id, "e": referenced},
+            )
+
+        _upgrade(db_url, _REVISION)
+
+        with engine.connect() as conn:
+            queued = {
+                str(row[0])
+                for row in conn.execute(
+                    text("SELECT entity_id FROM entity_maintenance_queue WHERE bank_id = :b"), {"b": bank_id}
+                )
+            }
+        assert queued == {str(referenced), str(orphan)}
+    finally:
+        with engine.begin() as conn:
+            conn.execute(text("DELETE FROM banks WHERE bank_id = :b"), {"b": bank_id})
+        engine.dispose()

--- a/hindsight-api-slim/tests/test_migration_entity_maintenance_queue.py
+++ b/hindsight-api-slim/tests/test_migration_entity_maintenance_queue.py
@@ -1,13 +1,10 @@
-"""Tests for migration c4f7a91b2d38 (entity_maintenance_queue + its seed).
+"""Tests for migration c4f7a91b2d38 (entity_maintenance_queue).
 
-The graph-maintenance entity prune is queue-driven (#3222): it only looks at
-entities something enqueued. That leaves one class of garbage nothing can
-enqueue — entities already stranded *before* the queue existed, whose postings
-are long gone and which no future delete will ever name. The migration's seed
-insert is the only thing that reclaims those, so it is worth a test of its own:
-without it the upgrade silently strands every orphan a bank had accumulated
-while its bank-wide sweep was failing, which is the exact population #3222 is
-about.
+Two properties the prune depends on and which are easy to lose in a later edit:
+the composite primary key (it is what collapses overlapping deletes into one
+row, and what the #3034 locking upsert conflicts on), and that the upgrade does
+NOT backfill existing entities — a backfill would write a row per entity inside
+a migration that runs at API startup and charge a prune check for each.
 
 Uses a dedicated pg0 instance so the test controls which migrations have run.
 """
@@ -68,13 +65,13 @@ def pre_queue_db_url() -> str:
     return url
 
 
-def test_seed_enqueues_every_pre_existing_entity(pre_queue_db_url: str) -> None:
-    """Every entity that predates the queue becomes a candidate exactly once.
+def test_upgrade_creates_an_empty_deduping_queue(pre_queue_db_url: str) -> None:
+    """The upgrade adds the queue but enqueues nothing, and the key dedupes.
 
-    Both kinds have to be seeded, not just the visibly-orphaned one: the drain
-    is what decides which are dead, and it cannot decide about a row it never
-    sees. Seeding only the orphans would also mean re-running the bank-wide
-    NOT EXISTS the migration exists to get rid of.
+    A backfill here is tempting — it would reclaim what a bank stranded while its
+    sweep was failing — but it costs one row per entity written during startup
+    migration plus a prune check each, to collect rows that cost the bank
+    nothing. New deletes fill the queue; historical strays stay.
     """
     db_url = pre_queue_db_url
     engine = create_engine(db_url)
@@ -83,37 +80,44 @@ def test_seed_enqueues_every_pre_existing_entity(pre_queue_db_url: str) -> None:
     try:
         with engine.begin() as conn:
             conn.execute(text("INSERT INTO banks (bank_id) VALUES (:b)"), {"b": bank_id})
-            unit_id = conn.execute(
-                text(
-                    "INSERT INTO memory_units (bank_id, text, fact_type, event_date) "
-                    "VALUES (:b, 'a fact', 'world', now()) RETURNING id"
-                ),
-                {"b": bank_id},
-            ).scalar_one()
-            referenced = conn.execute(
-                text("INSERT INTO entities (bank_id, canonical_name) VALUES (:b, 'referenced') RETURNING id"),
-                {"b": bank_id},
-            ).scalar_one()
-            orphan = conn.execute(
-                text("INSERT INTO entities (bank_id, canonical_name) VALUES (:b, 'stranded') RETURNING id"),
-                {"b": bank_id},
-            ).scalar_one()
-            conn.execute(
-                text("INSERT INTO unit_entities (unit_id, entity_id) VALUES (:u, :e)"),
-                {"u": unit_id, "e": referenced},
-            )
+            for name in ("referenced", "stranded"):
+                conn.execute(
+                    text("INSERT INTO entities (bank_id, canonical_name) VALUES (:b, :n)"),
+                    {"b": bank_id, "n": name},
+                )
 
         _upgrade(db_url, _REVISION)
 
         with engine.connect() as conn:
-            queued = {
-                str(row[0])
-                for row in conn.execute(
-                    text("SELECT entity_id FROM entity_maintenance_queue WHERE bank_id = :b"), {"b": bank_id}
+            queued = conn.execute(
+                text("SELECT count(*) FROM entity_maintenance_queue WHERE bank_id = :b"), {"b": bank_id}
+            ).scalar_one()
+            assert queued == 0, "the upgrade must not backfill existing entities"
+
+            entity_id = conn.execute(
+                text("SELECT id FROM entities WHERE bank_id = :b LIMIT 1"), {"b": bank_id}
+            ).scalar_one()
+
+        # The composite key is what makes overlapping deletes collapse to one row.
+        with engine.begin() as conn:
+            for _ in range(2):
+                conn.execute(
+                    text(
+                        "INSERT INTO entity_maintenance_queue (bank_id, entity_id) VALUES (:b, :e) "
+                        "ON CONFLICT (bank_id, entity_id) DO UPDATE "
+                        "SET enqueued_at = entity_maintenance_queue.enqueued_at"
+                    ),
+                    {"b": bank_id, "e": entity_id},
                 )
-            }
-        assert queued == {str(referenced), str(orphan)}
+        with engine.connect() as conn:
+            assert (
+                conn.execute(
+                    text("SELECT count(*) FROM entity_maintenance_queue WHERE bank_id = :b"), {"b": bank_id}
+                ).scalar_one()
+                == 1
+            )
     finally:
         with engine.begin() as conn:
+            conn.execute(text("DELETE FROM entity_maintenance_queue WHERE bank_id = :b"), {"b": bank_id})
             conn.execute(text("DELETE FROM banks WHERE bank_id = :b"), {"b": bank_id})
         engine.dispose()

--- a/hindsight-api-slim/tests/test_retain_entity_prune_race.py
+++ b/hindsight-api-slim/tests/test_retain_entity_prune_race.py
@@ -182,7 +182,11 @@ async def test_phase2_reasserts_entity_pruned_after_resolution(pg0_db_url):
         async with backend.acquire() as prune_conn:
             async with prune_conn.transaction():
                 pruned = await backend.ops.prune_orphan_entities(
-                    prune_conn, fq_table("entities"), fq_table("unit_entities"), bank_id
+                    prune_conn,
+                    fq_table("entities"),
+                    fq_table("unit_entities"),
+                    bank_id,
+                    [original_entity_id],
                 )
         assert pruned == 1
 

--- a/hindsight-dev/benchmarks/perf/system_perf.py
+++ b/hindsight-dev/benchmarks/perf/system_perf.py
@@ -1341,7 +1341,10 @@ async def _delete_units_and_enqueue(engine: Any, bank_id: str, deleted_ids: list
     """
     import uuid as uuid_module
 
-    from hindsight_api.engine.graph_maintenance import enqueue_relink_victims
+    from hindsight_api.engine.graph_maintenance import (
+        enqueue_entity_prune_candidates,
+        enqueue_relink_victims,
+    )
     from hindsight_api.engine.memory_engine import acquire_with_retry
     from hindsight_api.engine.schema import fq_table
 
@@ -1351,6 +1354,10 @@ async def _delete_units_and_enqueue(engine: Any, bank_id: str, deleted_ids: list
     async with acquire_with_retry(backend) as conn:
         async with conn.transaction():
             await enqueue_relink_victims(conn, bank_id, deleted_ids)
+            # The entity/cooccurrence prunes are queue-driven too, so the
+            # capture-then-delete order has to enqueue both kinds of candidate
+            # or this suite stops measuring Pass 2 entirely.
+            await enqueue_entity_prune_candidates(conn, bank_id, deleted_ids)
             await conn.execute(
                 f"DELETE FROM {fq_table('memory_units')} WHERE id = ANY($1::uuid[]) AND bank_id = $2",
                 deleted_uuids,
@@ -1672,9 +1679,24 @@ async def run_graph_maintenance_contention_suite(scale_cfg: dict[str, int]) -> S
                     # retain retries at a higher level; keep the load flowing.
                     counters.upsert_deadlocks += 1
 
+    # The prune is queue-driven (#3222): it only looks at entities a delete
+    # enqueued. This suite has no deletes — it measures the prune's contention
+    # against retain's upserts — so re-arm the queue before each round, or the
+    # first drain empties it and every later round measures nothing.
+    entity_ids = sorted({eid for pair in pair_list for eid in pair})
+
+    async def _rearm_entity_queue() -> None:
+        async with pool.acquire() as conn:
+            await conn.executemany(
+                f"INSERT INTO {fq_table('entity_maintenance_queue')} (bank_id, entity_id) "
+                f"VALUES ($1, $2) ON CONFLICT DO NOTHING",
+                [(bank_id, eid) for eid in entity_ids],
+            )
+
     async def _sweep_worker(stop_event: asyncio.Event) -> None:
         while not stop_event.is_set():
             counters.attempted += 1
+            await _rearm_entity_queue()
             t0 = time.perf_counter()
             try:
                 await run_graph_maintenance_job(engine, bank_id, request_context)

--- a/hindsight-docs/docs/developer/api/operations.mdx
+++ b/hindsight-docs/docs/developer/api/operations.mdx
@@ -91,7 +91,7 @@ Reconciles derived state that goes stale after a delete. Every invocation drains
 
 Bank-deduped at submit time, so concurrent triggers against the same bank coalesce into one drain.
 
-Each run works in committed batches under a wall-clock budget. A backlog too large for one run — a bulk delete, or the one-time backfill applied when upgrading to this scheme — is not an error: the run reports what it finished and the next one resumes where it stopped.
+Each run works in committed batches under a wall-clock budget. A backlog too large for one run — a bulk delete, say — is not an error: the run reports what it finished and the next one resumes where it stopped.
 
 **Triggers:** any delete that removes memory_units — `DELETE /documents/{id}`, `DELETE /memories/{id}`, and re-retaining an existing `document_id` (the upsert path). A full bank wipe (`delete_bank`) is a no-op: there's nothing left in the bank to maintain.
 

--- a/hindsight-docs/docs/developer/api/operations.mdx
+++ b/hindsight-docs/docs/developer/api/operations.mdx
@@ -84,13 +84,14 @@ Triggered either manually via `POST /v1/default/banks/{bank_id}/mental-models/{i
 
 ### `graph_maintenance`
 
-Reconciles derived state that goes stale after a delete. Every invocation runs three passes:
+Reconciles derived state that goes stale after a delete. Every invocation drains two queues, both filled by the delete itself, so a run only ever looks at what that delete touched:
 
-1. **Link top-up.** Drains the `graph_maintenance_queue` (units whose outgoing temporal/semantic links lost a neighbour). For each, if the unit is under its cap (20 temporal, 50 semantic), Hindsight re-runs the same probes retain uses and inserts the missing links. Without this, the retain pipeline's top-K capping would leave surviving units permanently under-capped after every delete — degrading graph-expansion recall.
-2. **Orphan entity prune.** Deletes entities in the bank with no remaining `unit_entities` references. FK `ON DELETE CASCADE` on `entity_cooccurrences` then removes any cooccurrence row pointing at a pruned entity.
-3. **Stale cooccurrence prune.** Cleans up `entity_cooccurrences` rows where both endpoints still exist but no current memory_unit references both of them — the cooccurrence was real when it was recorded, but every unit that witnessed it has since been deleted.
+1. **Link top-up.** Drains the units whose outgoing temporal/semantic links lost a neighbour. For each, if the unit is under its cap (20 temporal, 50 semantic), Hindsight re-runs the same probes retain uses and inserts the missing links. Without this, the retain pipeline's top-K capping would leave surviving units permanently under-capped after every delete — degrading graph-expansion recall.
+2. **Entity prune.** Drains the entities the delete may have stranded. Those with no remaining `unit_entities` reference are deleted (FK `ON DELETE CASCADE` removes their `entity_cooccurrences` rows with them); for the survivors, cooccurrence rows where both endpoints still exist but no current memory_unit references both are cleaned up — the cooccurrence was real when recorded, but every unit that witnessed it has since been deleted.
 
 Bank-deduped at submit time, so concurrent triggers against the same bank coalesce into one drain.
+
+Each run works in committed batches under a wall-clock budget. A backlog too large for one run — a bulk delete, or the one-time backfill applied when upgrading to this scheme — is not an error: the run reports what it finished and the next one resumes where it stopped.
 
 **Triggers:** any delete that removes memory_units — `DELETE /documents/{id}`, `DELETE /memories/{id}`, and re-retaining an existing `document_id` (the upsert path). A full bank wipe (`delete_bank`) is a no-op: there's nothing left in the bank to maintain.
 

--- a/skills/hindsight-docs/references/developer/api/operations.md
+++ b/skills/hindsight-docs/references/developer/api/operations.md
@@ -79,7 +79,7 @@ Reconciles derived state that goes stale after a delete. Every invocation drains
 
 Bank-deduped at submit time, so concurrent triggers against the same bank coalesce into one drain.
 
-Each run works in committed batches under a wall-clock budget. A backlog too large for one run — a bulk delete, or the one-time backfill applied when upgrading to this scheme — is not an error: the run reports what it finished and the next one resumes where it stopped.
+Each run works in committed batches under a wall-clock budget. A backlog too large for one run — a bulk delete, say — is not an error: the run reports what it finished and the next one resumes where it stopped.
 
 **Triggers:** any delete that removes memory_units — `DELETE /documents/{id}`, `DELETE /memories/{id}`, and re-retaining an existing `document_id` (the upsert path). A full bank wipe (`delete_bank`) is a no-op: there's nothing left in the bank to maintain.
 

--- a/skills/hindsight-docs/references/developer/api/operations.md
+++ b/skills/hindsight-docs/references/developer/api/operations.md
@@ -72,13 +72,14 @@ Triggered either manually via `POST /v1/default/banks/{bank_id}/mental-models/{i
 
 ### `graph_maintenance`
 
-Reconciles derived state that goes stale after a delete. Every invocation runs three passes:
+Reconciles derived state that goes stale after a delete. Every invocation drains two queues, both filled by the delete itself, so a run only ever looks at what that delete touched:
 
-1. **Link top-up.** Drains the `graph_maintenance_queue` (units whose outgoing temporal/semantic links lost a neighbour). For each, if the unit is under its cap (20 temporal, 50 semantic), Hindsight re-runs the same probes retain uses and inserts the missing links. Without this, the retain pipeline's top-K capping would leave surviving units permanently under-capped after every delete — degrading graph-expansion recall.
-2. **Orphan entity prune.** Deletes entities in the bank with no remaining `unit_entities` references. FK `ON DELETE CASCADE` on `entity_cooccurrences` then removes any cooccurrence row pointing at a pruned entity.
-3. **Stale cooccurrence prune.** Cleans up `entity_cooccurrences` rows where both endpoints still exist but no current memory_unit references both of them — the cooccurrence was real when it was recorded, but every unit that witnessed it has since been deleted.
+1. **Link top-up.** Drains the units whose outgoing temporal/semantic links lost a neighbour. For each, if the unit is under its cap (20 temporal, 50 semantic), Hindsight re-runs the same probes retain uses and inserts the missing links. Without this, the retain pipeline's top-K capping would leave surviving units permanently under-capped after every delete — degrading graph-expansion recall.
+2. **Entity prune.** Drains the entities the delete may have stranded. Those with no remaining `unit_entities` reference are deleted (FK `ON DELETE CASCADE` removes their `entity_cooccurrences` rows with them); for the survivors, cooccurrence rows where both endpoints still exist but no current memory_unit references both are cleaned up — the cooccurrence was real when recorded, but every unit that witnessed it has since been deleted.
 
 Bank-deduped at submit time, so concurrent triggers against the same bank coalesce into one drain.
+
+Each run works in committed batches under a wall-clock budget. A backlog too large for one run — a bulk delete, or the one-time backfill applied when upgrading to this scheme — is not an error: the run reports what it finished and the next one resumes where it stopped.
 
 **Triggers:** any delete that removes memory_units — `DELETE /documents/{id}`, `DELETE /memories/{id}`, and re-retaining an existing `document_id` (the upsert path). A full bank wipe (`delete_bank`) is a no-op: there's nothing left in the bank to maintain.
 


### PR DESCRIPTION
Fixes #3222.

## The problem

`graph_maintenance`'s Pass 2/3 were two **bank-wide** statements re-evaluated on every invocation, whether or not anything had changed:

- **orphan-entity prune** — one index probe per entity in the bank;
- **stale-cooccurrence prune** — an `INTERSECT` per cooccurrence row in the bank, to answer "does any unit still witness both endpoints".

Their cost tracked the size of the *bank*, not the size of the *delete*. Past a few million rows neither can finish inside asyncpg's 60s `command_timeout`, so the job failed on every run — forever, on exactly the banks that most needed it. `str(TimeoutError())` is empty, which is why it surfaced as `Task execution failed: graph_maintenance, error:` with nothing after it.

It was worse than one timeout per attempt: `db_utils._is_retryable` treats `asyncio.TimeoutError` as transient, and the sweep was wrapped in `retry_with_backoff(max_retries=8)`. Each task attempt therefore re-ran a statement that could never finish **nine times**, holding a worker slot for ~10 minutes, before the task-level retry did it again.

### Measured

Fixture built to mirror a mid-size bank with hub entities — 100k entities, 1.5M `unit_entities`, 2.86M `entity_cooccurrences`, endpoints holding 150–400 postings each. PostgreSQL 16, statements run verbatim:

| | before (bank-wide) | after (batch of 50) |
|---|---|---|
| orphan-entity prune | **9.6 s** | **15 ms** |
| stale-cooccurrence prune | **did not finish in 11 min** (cancelled) | **2.0 s** |

The cooccurrence prune costs ~1.7 ms per incident pair; over 2.86M pairs that is roughly 80 minutes per run, against a 60s client timeout. This fixture is *smaller* than the bank in the report.

## The fix

Both prunes are now driven by a new `entity_maintenance_queue`, filled inside the transaction that does the damage — the same pattern `graph_maintenance_queue` already uses for the relink pass. A run claims a bounded batch, prunes what is genuinely dead, and commits. Cost is O(delta), and work already done survives whatever stops the run.

Two producers, because there are two ways an entity becomes garbage:

1. **Its last posting is deleted** — captured before the cascade at every site that removes units or replaces postings: document delete, single and bulk memory delete, curation edit and invalidate, document re-ingest, and the delta-retain chunk cascade.
2. **It was created and the posting never arrived** — a Phase-1 resolution whose linking transaction rolled back. Such a row has no `unit_entities` entry to find it by and no delete will ever name it, so `entity_resolver` queues every entity it creates. That is one re-check per entity ever created; the drain finds the posting that did land and keeps it. Without this, queue-driven pruning would silently leak exactly what the bank-wide sweep used to collect.

Supporting changes:

- **A wall-clock budget for the job.** Both passes commit per batch, so exhausting it is not a failure: the run reports `queues_drained: false`, logs it, and chains a follow-up (only under a real queue — a synchronous backend would recurse rather than schedule). Backlogs converge over runs instead of being cancelled and retried from scratch.
- **Batch size 50, deliberately.** The binding cost is per *incident cooccurrence pair*, not per candidate (~58 pairs per candidate on the fixture). At 500 a batch took 210–300 s — still over the timeout. The constant carries the measurements so the next person doesn't have to rediscover them.
- **The scoping predicate is a `UNION` of the two endpoint columns**, not `entity_id_1 = ANY(...) OR entity_id_2 = ANY(...)` — that OR is the #3387 shape and cannot be driven from either index.
- **The migration seeds the queue with every existing entity**, so garbage a bank accumulated while its sweep was failing is still reclaimed — incrementally, a bounded batch per run, instead of in one statement that cannot finish.
- Both passes now return dataclasses (`RelinkPassResult`, `EntityPrunePassResult`) rather than raw dicts.

## Behaviour change worth knowing

A retain that creates entities now leaves queue rows, so it schedules a `graph_maintenance` job where before the empty-queue pre-check short-circuited. Dedupe-by-bank coalesces these while one is pending, and the work is one re-check per newly created entity — but on an ingest-heavy bank you will see more `graph_maintenance` operations than before, each doing much less.

## Tests

- Prune scoping: queued orphan removed, queued-but-still-referenced kept, unqueued orphan ignored (the O(delta) contract), other banks untouched, and a pair whose only queued endpoint is `entity_id_2` (guards the second UNION arm).
- One test per enqueue site, asserting the queue row rather than the prune, so a dropped call fails loudly instead of leaking quietly: delta-retain chunk delete, document re-ingest, curation invalidate, single delete, plus dedup across overlapping deletes.
- Creation-time candidacy: the resolver queues what it creates; an unlinked entity is reclaimed; a linked one survives its birth candidacy.
- Time budget: an expired deadline claims nothing, leaves the rows queued, and chains a follow-up run.
- Migration: the seed enqueues every pre-existing entity, referenced or not.

## Not in this PR

- **The delta-retain path still enqueues no relink victims.** `delete_chunks_by_ids` drops links whose surviving endpoints are never queued for top-up — a real gap, but a different one from this issue's.
- **`retry_with_backoff` still treats `TimeoutError` as transient.** With bounded statements a timeout now means something is wrong beyond this pass; the per-batch budget is 3 rather than the sweep's 8. Changing the shared predicate belongs with whoever owns the other callers.
