### PR TITLE
fix(coding-agents): resolve the project when the working directory is gone (supersedes #3110)

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/bank-missing-dir.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/bank-missing-dir.test.ts
@@ -1,0 +1,72 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { deriveBankId } from "./bank";
+
+/**
+ * Real git, real filesystem — deliberately NOT the mocked child_process of bank.test.ts, because
+ * what is under test is how resolution behaves against paths that do and do not exist.
+ *
+ * A hook runs after the fact, so the directory it reports can already be gone: an ephemeral
+ * worktree removed once the task finished, or a checkout moved mid-session (#3110).
+ */
+describe("project resolution when the working directory is gone", () => {
+  let repo: string;
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), "hs-gone-"));
+    execFileSync("git", ["init", "-q"], { cwd: repo });
+  });
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+    delete process.env.CLAUDE_PROJECT_DIR;
+  });
+
+  it("names the repository rather than the deleted leaf directory", () => {
+    // Never created: this is the state the hook actually observes once the worktree is removed.
+    const gone = join(repo, ".agent", "worktrees", "agent-a33c4d63");
+    expect(deriveBankId({}, gone, "claude-code")).toBe(`coding-agent::${basename(repo)}`);
+  });
+
+  it("keeps the historical answer while the directory still exists", () => {
+    // The walk is a no-op for a live directory, so no existing bank moves.
+    expect(deriveBankId({}, repo, "claude-code")).toBe(`coding-agent::${basename(repo)}`);
+  });
+
+  it("uses an exported project root when the walk lands outside the repository", () => {
+    // A LINKED worktree is a sibling of the repo, not a child, so walking up leaves it entirely;
+    // only the harness's own variable still names the project.
+    process.env.CLAUDE_PROJECT_DIR = repo;
+    const goneSibling = join(tmpdir(), "hs-gone-linked-worktree-never-created");
+    expect(deriveBankId({}, goneSibling, "claude-code")).toBe(`coding-agent::${basename(repo)}`);
+  });
+
+  it("prefers a resolvable directory over the exported root", () => {
+    const other = mkdtempSync(join(tmpdir(), "hs-other-"));
+    execFileSync("git", ["init", "-q"], { cwd: other });
+    process.env.CLAUDE_PROJECT_DIR = other;
+    try {
+      expect(deriveBankId({}, repo, "claude-code")).toBe(`coding-agent::${basename(repo)}`);
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  it("never yields an empty project name", () => {
+    // basename("/") is "", which produced bank ids like `coding-agent::` that name nothing.
+    expect(deriveBankId({}, "/", "claude-code")).toBe("coding-agent::unknown");
+    expect(deriveBankId({ bankIdTemplate: "{project}" }, "/", "claude-code")).toBe("unknown");
+  });
+
+  it("still yields a name for a directory that is not a repository", () => {
+    const plain = mkdtempSync(join(tmpdir(), "hs-plain-"));
+    try {
+      expect(deriveBankId({}, plain, "claude-code")).toBe(`coding-agent::${basename(plain)}`);
+    } finally {
+      rmSync(plain, { recursive: true, force: true });
+    }
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/bank.ts
+++ b/hindsight-integrations/coding-agents/src/core/bank.ts
@@ -21,6 +21,7 @@
  *      is harness-neutral "coding-agent::{gitProject}" so every coding agent shares ONE memory per repo.
  */
 import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join, normalize, sep } from "node:path";
 import { applyTemplate } from "./template";
@@ -64,12 +65,62 @@ export function projectNameOf(directory: string): string {
   return gitProjectName(directory, true);
 }
 
+/**
+ * Project roots a harness exports into its hook process. Only Claude Code is known to export one,
+ * so this is deliberately a list of ONE rather than a guess at nine names — the mechanism that
+ * covers every harness is the ancestor walk in `nearestExistingDir`, not this.
+ *
+ * It earns its place for the case the walk cannot reach: a LINKED worktree (a sibling directory,
+ * not a child of the repo) that has been deleted. Walking up from it lands outside the repository
+ * entirely, while this variable still names it.
+ */
+const PROJECT_ROOT_ENV = ["CLAUDE_PROJECT_DIR"] as const;
+
+/**
+ * The nearest ancestor of `directory` that still exists, or "" if none does.
+ *
+ * A hook runs after the fact, so the directory it reports can already be gone — an ephemeral
+ * worktree removed once the task finished, a checkout moved or deleted mid-session. git can only
+ * answer about a path that exists, so probing the vanished leaf fails and its basename — a
+ * throwaway name like `agent-a33c4d63` — becomes the project identity, scattering memory into
+ * orphan banks (#3110). Walking up finds the repository that contained it. Harness-agnostic: no
+ * harness has to export anything for this to work.
+ *
+ * When the directory does exist this returns it unchanged, so the common path is untouched and no
+ * existing bank moves.
+ */
+function nearestExistingDir(directory: string): string {
+  let current = directory;
+  while (current) {
+    if (existsSync(current)) return current;
+    const parent = dirname(current);
+    if (parent === current) return "";
+    current = parent;
+  }
+  return "";
+}
+
+/** Basename of a directory, or "unknown" — never the empty string. `basename("/")` is "", which
+ *  would otherwise produce a bank id like `coding-agent::` that names nothing. */
+function dirName(directory: string): string {
+  return (directory && basename(directory)) || "unknown";
+}
+
 function gitProjectName(directory: string, resolveWorktrees: boolean): string {
   if (resolveWorktrees) {
-    const root = getProjectRootFromGit(directory);
-    if (root) return basename(root);
+    // The directory itself first (via the walk, which is a no-op when it exists), so anything git
+    // can still resolve keeps its historical answer and no existing bank moves. The exported roots
+    // are a last rescue, not a new source of truth.
+    const candidates = [
+      nearestExistingDir(directory),
+      ...PROJECT_ROOT_ENV.map((v) => process.env[v] || ""),
+    ];
+    for (const candidate of candidates) {
+      const root = candidate ? getProjectRootFromGit(candidate) : null;
+      if (root) return basename(root);
+    }
   }
-  return directory ? basename(directory) : "unknown";
+  return dirName(directory);
 }
 
 /** Longest-prefix match of `directory` against the map's absolute paths (exact or ancestor). */
@@ -98,7 +149,7 @@ export function deriveBankId(config: BankConfig, directory: string, harness = "c
 
   const resolvers: Record<string, () => string> = {
     harness: () => harness,
-    project: () => (directory ? basename(directory) : "unknown"),
+    project: () => dirName(directory),
     gitProject: () => gitProjectName(directory, config.resolveWorktrees ?? true),
     channel: () => process.env.HINDSIGHT_CHANNEL_ID || "default",
     user: () => process.env.HINDSIGHT_USER_ID || "anonymous",

--- a/skills/hindsight-docs/references/sdks/integrations/agent-plugin.md
+++ b/skills/hindsight-docs/references/sdks/integrations/agent-plugin.md
@@ -1,0 +1,85 @@
+
+# Agent Plugins
+
+Portable long-term memory for any [Agent Plugins](https://agent-plugins.org) client, powered by [Hindsight](https://vectorize.io/hindsight).
+
+[Agent Plugins](https://agent-plugins.org) is the vendor-neutral open standard (developed with Amazon, Cursor, Microsoft, OpenAI, and Vercel) for packaging **Agent Skills + MCP servers** into a single distributable plugin. Instead of a separate integration per tool, Hindsight ships **one** plugin that every compatible client can load — at launch: **ChatGPT / Codex, Cursor, GitHub Copilot, Kiro, and VS Code**.
+
+## Quick Start
+
+> **💡 Recommended: Hindsight Cloud**
+>
+[Sign up free](https://ui.hindsight.vectorize.io/signup) for a Hindsight Cloud API key — no self-hosting, no local daemon to manage.
+1. Get your `hsk_...` API key from [ui.hindsight.vectorize.io/connect](https://ui.hindsight.vectorize.io/connect).
+2. Set the environment variables the plugin reads:
+
+   ```bash
+   export HINDSIGHT_API_KEY="hsk_your_token"
+   export HINDSIGHT_BANK_ID="my-project"   # optional; defaults to "default"
+   ```
+
+3. Install the plugin in your client (through its plugin/MCP UI, or by pointing it at the plugin directory — installation is client-specific per the standard).
+
+Once installed, ask the agent something that depends on past context, or tell it a durable preference — it calls `recall` and `retain` automatically, guided by the bundled skill.
+
+## What's in the plugin
+
+The plugin is a thin, transport-only wrapper — all memory logic stays server-side in Hindsight. It follows the Agent Plugins `1.0.0` layout:
+
+```
+agent-plugin/
+├── plugin.json                       # manifest ($schema + name + metadata)
+├── mcp.json                          # Hindsight MCP server (Streamable HTTP)
+└── skills/
+    └── hindsight-memory/
+        └── SKILL.md                  # teaches the agent when to recall / retain / reflect
+```
+
+- **`mcp.json`** connects the client to Hindsight's built-in [MCP server](../../developer/mcp-server.md) over Streamable HTTP.
+- **`skills/hindsight-memory/SKILL.md`** is loaded into the agent's context so it knows *when* to reach for memory, not just that the tools exist.
+
+## Memory tools
+
+Via the MCP server, the agent gets Hindsight's full memory surface. The three it reaches for most:
+
+| Tool | When | What it does |
+|------|------|--------------|
+| `recall` | Before answering, when past context could help | Semantic + keyword + graph + temporal retrieval over the bank |
+| `retain` | After learning a durable, reusable fact | Stores the fact for future sessions |
+| `reflect` | When a lookup is too shallow and you need synthesized reasoning | Disposition-aware reasoning over everything remembered |
+
+Additional tools (knowledge pages, mental models, documents, tags) are exposed too — see the [MCP Server reference](../../developer/mcp-server.md).
+
+## Configuration
+
+The plugin reads two environment variables, interpolated into `mcp.json`:
+
+| Setting | Env Var | Default | Description |
+|---------|---------|---------|-------------|
+| API key | `HINDSIGHT_API_KEY` | — | Your `hsk_...` key. Sent as `Authorization: Bearer`. Required for Hindsight Cloud. |
+| Memory bank | `HINDSIGHT_BANK_ID` | `default` | Bank to read from and write to (sent as `X-Bank-Id`). Use one bank per user, project, or team for isolation. |
+
+> **📝 Env-var syntax varies by client**
+>
+Most clients substitute `${VAR}`; some (VS Code, Cursor) use `${env:VAR}`. If your client doesn't interpolate, paste the literal key and bank id into `mcp.json`.
+**Self-hosting:** replace the host in `mcp.json` (`https://api.hindsight.vectorize.io`) with your deployment's URL. A local server with the MCP endpoint open needs no API key.
+
+## Explicit tools vs. automatic capture
+
+Agent Plugins `1.0.0` standardizes **Skills + MCP**, not session lifecycle hooks. This plugin therefore delivers **explicit, tool-driven** memory that works identically across every supported client.
+
+For the fully automatic experience — recall injected before every prompt and transcripts retained on session end — use the native, hook-based integration built for your specific tool, such as [Claude Code](claude-code.md) or [Codex](codex.md). Both share the same Hindsight banks, so memory captured by the hook-based integration is recalled through the Agent Plugin, and vice versa.
+
+## Troubleshooting
+
+**No memories recalled**: `recall` returns results only after something has been retained. Retain a fact first, or seed the bank via the [API](../../developer/api/quickstart.md).
+
+**401 Unauthorized**: Check `HINDSIGHT_API_KEY` is set and your client is interpolating it into the `Authorization` header (see the env-var syntax note above).
+
+**Wrong or empty memory**: Confirm `HINDSIGHT_BANK_ID` points at the bank you expect. Different tools writing to different banks won't share memory.
+
+## Learn more
+
+- [Agent Plugins standard](https://agent-plugins.org)
+- [Hindsight MCP Server reference](../../developer/mcp-server.md)
+- [Hindsight Cloud sign-up](https://ui.hindsight.vectorize.io/signup)


### PR DESCRIPTION
Ports #3110's idea to the **Coding Agents** plugin, which supersedes the per-agent Claude Code plugin that PR targets.

## The failure

A hook runs after the fact, so the directory it reports can already be deleted — an ephemeral worktree removed once its task finished, or a checkout moved mid-session. `git` can only answer about a path that exists, so the probe fails and `basename` of the vanished path becomes the project identity: a throwaway name like `agent-a33c4d63`, scattering memory into orphan banks.

## The fix, for every harness

@jouve's PR rescues this with `CLAUDE_PROJECT_DIR`. That works, but only for the one harness that exports it — we support eleven, and only Claude Code is known to publish such a variable. Inventing names for the other ten would be registering behaviour nothing implements.

So the primary mechanism here is **harness-agnostic**: walk up to the nearest ancestor that still exists and probe that. It needs nothing from the harness, and it covers the reported shape directly (`<repo>/.agent/worktrees/agent-x` deleted → `<repo>` resolves → the repository's name). For a live directory the walk returns it unchanged, so the common path is untouched and **no existing bank moves**.

`CLAUDE_PROJECT_DIR` is kept as a last rescue for the one case the walk cannot reach: a **linked** worktree is a sibling of the repository, not a child, so walking up from it leaves the repository entirely. Deliberately a list of one, easy to extend if another harness turns out to export an equivalent.

## Also: no more empty project names

`basename("/")` is `""`, which produced bank ids like `coding-agent::` that name nothing — flagged while reviewing #3286 and never fixed. Both `{gitProject}` and `{project}` now fall back to `"unknown"`.

## Test

**453 passed**, 21 skipped; tsc and lint clean.

Six new cases in their own file, using **real git against real directories** rather than the mocked `child_process` of `bank.test.ts` — what is under test is behaviour against paths that do and do not exist, which a mock can't tell you: the deleted leaf resolving to its repository, a live directory keeping its historical answer, the exported root rescuing a deleted linked worktree, a resolvable directory winning over that variable, no empty names, and a plain non-git directory still getting one.