### PR TITLE
fix(search): stop extreme relative date offsets from crashing recall (#3217)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/chinese_temporal_periods.py
+++ b/hindsight-api-slim/hindsight_api/engine/chinese_temporal_periods.py
@@ -114,19 +114,17 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
             return NO_TEMPORAL_CONSTRAINT
         return constraint(start, end)
 
-    def subtract_months(months: int) -> datetime:
-        month_index = reference_date.month - months - 1
-        year = reference_date.year + month_index // 12
-        month = month_index % 12 + 1
-        day = min(reference_date.day, calendar.monthrange(year, month)[1])
-        return reference_date.replace(year=year, month=month, day=day)
+    def subtract_months(months: int) -> datetime | None:
+        return add_months(reference_date, -months)
 
     def month_end(year: int, month: int) -> datetime:
         return datetime(year, month, calendar.monthrange(year, month)[1])
 
-    def add_months(base_date: datetime, months: int) -> datetime:
+    def add_months(base_date: datetime, months: int) -> datetime | None:
         month_index = base_date.month + months - 1
         year = base_date.year + month_index // 12
+        if year < datetime.min.year or year > datetime.max.year:
+            return None
         month = month_index % 12 + 1
         day = min(base_date.day, calendar.monthrange(year, month)[1])
         return base_date.replace(year=year, month=month, day=day)
@@ -373,7 +371,7 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
         sat = start + timedelta(days=5)
         return constraint(sat, sat + timedelta(days=1))
 
-    def relative_month_start(period: str | None) -> datetime:
+    def relative_month_start(period: str | None) -> datetime | None:
         return add_months(reference_date.replace(day=1), relative_period_offset(period))
 
     def exact_day_constraint(year: int, month_text: str, day_text: str) -> DateRange | None:
@@ -418,6 +416,8 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
         if day is None:
             return None
         start = relative_month_start(period)
+        if start is None:
+            return None
         if day > calendar.monthrange(start.year, start.month)[1]:
             return None
         return datetime(start.year, start.month, day)
@@ -472,9 +472,9 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
 
     def relative_offset_datetime(amount: int, unit: str, direction: int) -> datetime | None:
         if unit in ("天", "日"):
-            return reference_date + timedelta(days=direction * amount)
+            return add_days(reference_date, direction * amount)
         if unit in ("周", "星期", "礼拜"):
-            return reference_date + timedelta(weeks=direction * amount)
+            return add_days(reference_date, direction * amount * 7)
         if unit == "月":
             return add_months(reference_date, direction * amount)
         return add_years(reference_date, direction * amount)
@@ -616,6 +616,8 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
     if relative_month_range_match:
         first = relative_month_start(relative_month_range_match.group(1))
         second = relative_month_start(relative_month_range_match.group(2))
+        if first is None or second is None:
+            return NO_TEMPORAL_CONSTRAINT
         start = min(first, second)
         end = max(first, second)
         return constraint(start, month_end(end.year, end.month))
@@ -839,7 +841,7 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
         rf"(?<![上下大小])(上上|大上|上|这|本|当|下下|大下|下){_CHINESE_OPTIONAL_PERIOD_MARKER}月{chinese_since_suffix_pattern}"
     )
     if month_since_match:
-        return since_constraint(relative_month_start(month_since_match.group(1)))
+        return safe_since_constraint(relative_month_start(month_since_match.group(1)))
 
     absolute_year_month_since_match = chinese_search(
         rf"({chinese_year_pattern})\s*年\s*({chinese_month_pattern})\s*月{chinese_since_suffix_pattern}"
@@ -1035,7 +1037,7 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
 
     if chinese_search(r"一年半前"):
         d = subtract_months(18)
-        return constraint(d, d)
+        return safe_constraint(d, d)
 
     if chinese_search(r"([一二两三四五六七八九十]+)年半前"):
         match = chinese_search(r"([一二两三四五六七八九十]+)年半前")
@@ -1043,15 +1045,15 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
             years = parse_chinese_number(match.group(1))
             if years is not None:
                 d = subtract_months(years * 12 + 6)
-                return constraint(d, d)
+                return safe_constraint(d, d)
 
     if chinese_search(r"([0-9]+|[一二两三四五六七八九十]+)个?半月前"):
         match = chinese_search(r"([0-9]+|[一二两三四五六七八九十]+)个?半月前")
         if match is not None:
             months = parse_chinese_number(match.group(1))
             if months is not None:
-                d = subtract_months(months) - timedelta(days=15)
-                return constraint(d, d)
+                d = add_days(subtract_months(months), -15)
+                return safe_constraint(d, d)
 
     if chinese_search(r"半个?月前"):
         d = reference_date - timedelta(days=15)
@@ -1059,7 +1061,7 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
 
     if chinese_search(r"半年前"):
         d = subtract_months(6)
-        return constraint(d, d)
+        return safe_constraint(d, d)
 
     future_year_half_match = chinese_search(
         rf"([0-9]+|[{_CHINESE_NUMERAL_CHARS}]+)年半{chinese_relative_future_suffix_pattern}"
@@ -1068,7 +1070,7 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
         years = parse_chinese_number(future_year_half_match.group(1))
         if years is not None:
             d = add_months(reference_date, years * 12 + 6)
-            return constraint(d, d)
+            return safe_constraint(d, d)
 
     future_half_month_match = chinese_search(
         rf"([0-9]+|[{_CHINESE_NUMERAL_CHARS}]+)个?半月{chinese_relative_future_suffix_pattern}"
@@ -1076,8 +1078,8 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
     if future_half_month_match:
         months = parse_chinese_number(future_half_month_match.group(1))
         if months is not None:
-            d = add_months(reference_date, months) + timedelta(days=15)
-            return constraint(d, d)
+            d = add_days(add_months(reference_date, months), 15)
+            return safe_constraint(d, d)
 
     if chinese_search(rf"半个?月{chinese_relative_future_suffix_pattern}"):
         d = reference_date + timedelta(days=15)
@@ -1085,7 +1087,7 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
 
     if chinese_search(rf"半年{chinese_relative_future_suffix_pattern}"):
         d = add_months(reference_date, 6)
-        return constraint(d, d)
+        return safe_constraint(d, d)
 
     adjacent_fuzzy_future_match = chinese_search(
         r"(?<![一二三四五六七八九十百千万零\d后])"
@@ -1232,14 +1234,14 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
         unit = rolling_past_half_match.group(2)
         if unit == "月":
             return constraint(reference_date - timedelta(days=15), reference_date)
-        return constraint(subtract_months(6), reference_date)
+        return safe_constraint(subtract_months(6), reference_date)
 
     within_half_match = chinese_search(r"半个?(月|年)(?:以内|之内|内)")
     if within_half_match:
         unit = within_half_match.group(1)
         if unit == "月":
             return constraint(reference_date - timedelta(days=15), reference_date)
-        return constraint(subtract_months(6), reference_date)
+        return safe_constraint(subtract_months(6), reference_date)
 
     within_count_match = chinese_search(
         rf"([0-9]+|[{_CHINESE_NUMERAL_CHARS}]+)(个?)(天|日|周|星期|礼拜|月|年)(?:以内|之内|内)"
@@ -1302,7 +1304,7 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
         unit = rolling_future_half_match.group(2)
         if unit == "月":
             return constraint(reference_date, reference_date + timedelta(days=15))
-        return constraint(reference_date, add_months(reference_date, 6))
+        return safe_constraint(reference_date, add_months(reference_date, 6))
 
     absolute_year_quarter_since_match = chinese_search(
         rf"({chinese_year_pattern})\s*年\s*(第?[一二三四1-4])季(?:度)?{chinese_since_suffix_pattern}"
@@ -1439,6 +1441,8 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
     )
     if next_month_phase_since_match:
         start = add_months(reference_date.replace(day=1), 1)
+        if start is None:
+            return NO_TEMPORAL_CONSTRAINT
         return since_from_period(month_phase_period(start.year, start.month, next_month_phase_since_match.group(1)))
 
     second_next_month_phase_since_match = chinese_search(
@@ -1447,6 +1451,8 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
     )
     if second_next_month_phase_since_match:
         start = add_months(reference_date.replace(day=1), 2)
+        if start is None:
+            return NO_TEMPORAL_CONSTRAINT
         return since_from_period(
             month_phase_period(start.year, start.month, second_next_month_phase_since_match.group(2))
         )
@@ -1465,7 +1471,10 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
         rf"({chinese_month_phase_pattern}){chinese_since_suffix_pattern}"
     )
     if second_previous_month_phase_since_match:
-        start = subtract_months(2).replace(day=1)
+        start = subtract_months(2)
+        if start is None:
+            return NO_TEMPORAL_CONSTRAINT
+        start = start.replace(day=1)
         return since_from_period(
             month_phase_period(start.year, start.month, second_previous_month_phase_since_match.group(2))
         )
@@ -1590,6 +1599,8 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
     )
     if next_month_phase_match:
         start = add_months(reference_date.replace(day=1), 1)
+        if start is None:
+            return NO_TEMPORAL_CONSTRAINT
         return month_phase_period(start.year, start.month, next_month_phase_match.group(1))
 
     second_next_month_phase_match = chinese_search(
@@ -1597,6 +1608,8 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
     )
     if second_next_month_phase_match:
         start = add_months(reference_date.replace(day=1), 2)
+        if start is None:
+            return NO_TEMPORAL_CONSTRAINT
         return month_phase_period(start.year, start.month, second_next_month_phase_match.group(2))
 
     previous_month_phase_match = chinese_search(
@@ -1611,7 +1624,10 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
         rf"(?<![上大])(上上|大上){_CHINESE_OPTIONAL_PERIOD_MARKER}月份?\s*({chinese_month_phase_pattern})"
     )
     if second_previous_month_phase_match:
-        start = subtract_months(2).replace(day=1)
+        start = subtract_months(2)
+        if start is None:
+            return NO_TEMPORAL_CONSTRAINT
+        start = start.replace(day=1)
         return month_phase_period(start.year, start.month, second_previous_month_phase_match.group(2))
 
     bare_specific_month_phase_match = chinese_search(
@@ -1730,10 +1746,14 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
         rf"(?<![下大])(下下|大下){_CHINESE_OPTIONAL_PERIOD_MARKER}月(?!{chinese_month_boundary_suffix_pattern})"
     ):
         start = add_months(reference_date.replace(day=1), 2)
+        if start is None:
+            return NO_TEMPORAL_CONSTRAINT
         return constraint(start, month_end(start.year, start.month))
 
     if chinese_search(rf"(?<![下大])下{_CHINESE_OPTIONAL_PERIOD_MARKER}月(?!{chinese_month_boundary_suffix_pattern})"):
         start = add_months(reference_date.replace(day=1), 1)
+        if start is None:
+            return NO_TEMPORAL_CONSTRAINT
         return constraint(start, month_end(start.year, start.month))
 
     if chinese_search(rf"(下一个年度|下一年度|下年度|下一年|明年)(?!{chinese_boundary_suffix_pattern})"):
@@ -1763,7 +1783,10 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
     if chinese_search(
         rf"(?<![上大])(上上|大上){_CHINESE_OPTIONAL_PERIOD_MARKER}月(?!{chinese_month_boundary_suffix_pattern})"
     ):
-        start = subtract_months(2).replace(day=1)
+        start = subtract_months(2)
+        if start is None:
+            return NO_TEMPORAL_CONSTRAINT
+        start = start.replace(day=1)
         return constraint(start, month_end(start.year, start.month))
 
     if chinese_search(rf"前一个?(周|星期|礼拜)(?!{chinese_boundary_suffix_pattern})"):

--- a/hindsight-api-slim/hindsight_api/engine/search/temporal_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/temporal_extraction.py
@@ -52,7 +52,22 @@ def extract_temporal_constraint(
     if analyzer is None:
         analyzer = get_default_analyzer()
 
-    analysis = analyzer.analyze(query, reference_date)
+    # Recall must never fail because temporal analysis choked on the query text.
+    # Consolidation recalls with stored fact text as the query, so a single
+    # pathological phrase (e.g. "十万年前" → year -97974) would otherwise fail
+    # every recall touching that bank, deterministically (issue #3217). Degrade
+    # to "no temporal signal" here — the one entry point the recall path uses —
+    # while analyze() itself stays strict so parser bugs still surface in tests
+    # and to direct callers.
+    try:
+        analysis = analyzer.analyze(query, reference_date)
+    except Exception as e:
+        logger.warning(
+            "Temporal query analysis raised %s (treating as no temporal constraint): %s",
+            type(e).__name__,
+            e,
+        )
+        return None
 
     if analysis.temporal_constraint:
         result = (analysis.temporal_constraint.start_date, analysis.temporal_constraint.end_date)

--- a/hindsight-api-slim/hindsight_api/engine/temporal_periods.py
+++ b/hindsight-api-slim/hindsight_api/engine/temporal_periods.py
@@ -50,7 +50,9 @@ def _month_end(year: int, month: int) -> datetime:
     return datetime(year, month, calendar.monthrange(year, month)[1])
 
 
-def _extract_non_chinese_period(query: str, reference_date: datetime) -> DateRange | None:
+def _extract_non_chinese_period(
+    query: str, reference_date: datetime
+) -> DateRange | NoTemporalConstraintSentinel | None:
     if re.search(r"\b(yesterday|ayer|ieri|hier|gestern|вчера)\b", query, re.IGNORECASE):
         d = reference_date - timedelta(days=1)
         return _constraint(d, d)
@@ -162,6 +164,11 @@ def _extract_non_chinese_period(query: str, reference_date: datetime) -> DateRan
         match = re.search(rf"\b({pattern})\s+(\d{{4}})\b", query, re.IGNORECASE)
         if match:
             year = int(match.group(2))
+            if year < datetime.min.year:
+                # "june 0000" — an explicit but unrepresentable year. Treat it
+                # as no constraint rather than crashing recall or letting the
+                # dateparser fallback invent a different date (issue #3217).
+                return NO_TEMPORAL_CONSTRAINT
             start = datetime(year, month_num, 1)
             return _constraint(start, _month_end(year, month_num))
 

--- a/hindsight-api-slim/tests/test_query_analyzer.py
+++ b/hindsight-api-slim/tests/test_query_analyzer.py
@@ -1063,3 +1063,96 @@ def test_query_analyzer_explicit_date_with_restricted_language(query_analyzer):
 
     assert analysis.temporal_constraint is not None
     assert analysis.temporal_constraint.start_date.date() == datetime(2022, 10, 31).date()
+
+
+# --- issue #3217: extreme relative offsets must never crash temporal analysis ---
+#
+# Consolidation recalls with stored fact text as the query, so a single phrase
+# like "十万年前" (100,000 years ago → year -97974) deterministically failed
+# every recall touching that bank. The offset arithmetic in extract_period runs
+# BEFORE analyze()'s dateparser guard, so these used to escape as
+# ValueError('year N is out of range') / OverflowError and kill the search.
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        # the observed #3217 trio: 2560 / 3000 / 100000 years ago
+        "2560年前的事",
+        "3000年前",
+        "十万年前的人类",
+        # unbounded month offsets (add_months previously unguarded)
+        "三万个月前的事件",
+        "五万个月前",
+        "三万个月后",
+        "过去三万个月",
+        # unbounded day/week offsets (raw timedelta previously overflowed)
+        "一百万天前的历史",
+        "九十九万周前",
+        "一亿天前",
+        # half-year/half-month forms with unbounded parsed amounts
+        "三千年半后",
+        "十万个半月后",
+    ],
+)
+def test_query_analyzer_extreme_relative_offsets_no_crash(query_analyzer, query):
+    """Unrepresentable relative offsets degrade to no constraint (issue #3217)."""
+    reference_date = datetime(2026, 8, 6, 12, 0, 0)
+
+    analysis = query_analyzer.analyze(query, reference_date)
+
+    if analysis.temporal_constraint is not None:
+        # A constraint is acceptable only if it is a real, in-range date
+        # (e.g. "三千年半后" lands in year 5027, which is representable).
+        assert analysis.temporal_constraint.start_date.year >= 1
+
+
+@pytest.mark.parametrize(
+    ("query", "reference_date"),
+    [
+        ("下个月的计划", datetime(9999, 12, 15)),
+        ("下下月", datetime(9999, 11, 15)),
+        ("上上月", datetime(1, 1, 15)),
+        ("半年前", datetime(1, 3, 15)),
+        ("半年后", datetime(9999, 9, 15)),
+        ("一年半前", datetime(1, 6, 15)),
+        ("下月以来", datetime(9999, 12, 15)),
+        ("上个月到下个月", datetime(1, 1, 15)),
+        ("下月中", datetime(9999, 12, 15)),
+    ],
+)
+def test_query_analyzer_month_offsets_at_year_bounds_no_crash(query_analyzer, query, reference_date):
+    """Month arithmetic at datetime year bounds degrades to no constraint."""
+    analysis = query_analyzer.analyze(query, reference_date)
+
+    assert analysis.temporal_constraint is None
+
+
+@pytest.mark.parametrize("query", ["what happened in june 0000", "cosa accadde a gennaio 0000"])
+def test_query_analyzer_year_zero_month_pattern_no_crash(query_analyzer, query):
+    """An explicit month + year 0000 is unrepresentable → no constraint (issue #3217)."""
+    analysis = query_analyzer.analyze(query, datetime(2026, 8, 6, 12, 0, 0))
+
+    assert analysis.temporal_constraint is None
+
+
+def test_extract_temporal_constraint_degrades_on_analyzer_crash():
+    """The recall entry point must survive any analyzer failure (issue #3217).
+
+    analyze() stays strict (see test_query_analyzer_period_valueerror_still_surfaces);
+    the recall choke point is where a parser bug degrades to 'no temporal signal'
+    instead of deterministically failing every recall/consolidation on the bank.
+    """
+    from hindsight_api.engine.query_analyzer import QueryAnalysis, QueryAnalyzer
+    from hindsight_api.engine.search.temporal_extraction import extract_temporal_constraint
+
+    class ExplodingAnalyzer(QueryAnalyzer):
+        def load(self) -> None:
+            pass
+
+        def analyze(self, query: str, reference_date: datetime | None = None) -> QueryAnalysis:
+            raise ValueError("year -534 is out of range")
+
+    result = extract_temporal_constraint("anything", analyzer=ExplodingAnalyzer())
+
+    assert result is None


### PR DESCRIPTION
Fixes #3217.

## Root cause — query-time arithmetic, not stored rows

The three observed failures (`year -534`, `year -974`, `year -97974`) are exactly `now.year − {2560, 3000, 100000}`. They come from **"N years ago" offset arithmetic at query-analysis time**, not from dates stored in the DB:

- Consolidation recalls with **stored fact text as the query**. A fact mentioning e.g. `十万年前` (100,000 years ago) is re-analyzed on every recall, so the failure is deterministic per bank and retries never help.
- `extract_period()` runs **before** `analyze()`'s dateparser guard (#893), so `ValueError('year N is out of range')` / `OverflowError` escaped straight out of recall as `Failed to search memories (...)`, which is what killed consolidation.
- No pathological row can exist in the date columns: Python `datetime` cannot represent pre-year-1 dates, so nothing outside 1–9999 can reach PostgreSQL through asyncpg in the first place (asyncpg decodes BC values with a *different* error — `OverflowError: date value out of range` — and `-97974` is outside even PostgreSQL's representable range). This confirms @koriyoshi2041's analysis that the retain-time clamp proposed in the issue targets a non-existent ingress — no retain changes here.

#2636 already fixed this exact class for `add_years` (which is why the `年前` trio no longer reproduces on main), but sibling paths were left unguarded. All of these crash recall on current main:

```
'三万个月前的事件'  -> ValueError: year -474 is out of range   (add_months)
'过去三万个月'      -> ValueError: year -474 is out of range   (subtract_months)
'一百万天前的历史'  -> OverflowError: date value out of range  (raw timedelta days)
'九十九万周前'      -> OverflowError: date value out of range  (raw timedelta weeks)
'june 0000'         -> ValueError: year 0 is out of range      (non-Chinese month+year)
```

## Fix — three layers

1. **`extract_temporal_constraint()` (the recall choke point)** now degrades *any* analyzer failure to "no temporal signal" with a warning. `analyze()` itself stays strict, so parser bugs still surface in tests and to direct callers (`test_query_analyzer_period_valueerror_still_surfaces` is unchanged). This is the guarantee that one pathological phrase can never poison a bank's recall/consolidation again.
2. **`chinese_temporal_periods`**: `add_months`/`subtract_months` are bounds-checked exactly like #2636's `add_years` (return `None`, plumbed through every call site — `ty` enforces completeness), and day/week offsets go through the overflow-guarded `add_days` instead of raw `timedelta` addition. `subtract_months` collapses into `add_months(reference_date, -months)` (they were the same formula).
3. **`temporal_periods`**: an explicit month + year `0000` match returns `NO_TEMPORAL_CONSTRAINT` instead of crashing `datetime()` (and instead of letting the dateparser fallback invent a different date).

## Tests

- The #3217 trio (`2560年前` / `3000年前` / `十万年前`) pinned as regressions.
- Every hole above: unbounded month/day/week offsets, half-year/half-month forms, month arithmetic at the year-1/9999 bounds (extreme `question_date`), and the year-0000 month pattern.
- A choke-point test asserting `extract_temporal_constraint` survives an analyzer that raises.

`tests/test_query_analyzer.py`: 450 passed (409 existing + new).

## Note on #3403

#3403 attributes the crash to `datetime.fromisoformat()` on stored ISO strings, but `fromisoformat` raises `Invalid isoformat string` (not `year N is out of range`) for negative-year input, `_as_dt` runs *after* recall so its errors can't produce the observed `Failed to search memories (...)` wrapper, and clamping to naive `datetime(1, 1, 1)` would introduce naive-vs-aware `TypeError`s in `_merge_min`/`_merge_max`. That path isn't the reported bug.
