### PR TITLE
retain: don't hold the data-plane connection across a separate-store write

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
+++ b/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
@@ -1242,6 +1242,31 @@ class EntityResolver:
         else:
             return await self._link_units_to_entities_batch_impl(conn, normalized, bank_id)
 
+    async def record_unit_entity_postings(
+        self,
+        unit_entity_pairs: list[tuple[str, str]] | list[tuple[str, str, datetime | None]],
+        bank_id: str | None = None,
+    ):
+        """Store-owned variant of :meth:`link_units_to_entities_batch` that touches NO
+        Postgres connection.
+
+        For a memories store that OWNS its memory rows (an external backend), the unit→entity
+        posting is recorded by the store — ``record_unit_entities`` ignores the ``conn`` — and
+        the co-occurrence update only accumulates in memory for the post-transaction flush.
+        Neither needs a database transaction, so the retain orchestrator can run the posting in
+        its connection-free store phase and never hold the data-plane connection across the
+        object-store write. NOT for the Postgres store, whose posting is a real ``unit_entities``
+        INSERT that requires the connection.
+        """
+        if not unit_entity_pairs:
+            return
+
+        normalized: list[tuple[str, str, datetime | None]] = [
+            (t[0], t[1], t[2] if len(t) >= 3 else None)  # type: ignore[misc]
+            for t in unit_entity_pairs
+        ]
+        return await self._link_units_to_entities_batch_impl(None, normalized, bank_id)
+
     async def _link_units_to_entities_batch_impl(
         self, conn, unit_entity_pairs: list[tuple[str, str, datetime | None]], bank_id: str | None = None
     ):

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -643,7 +643,9 @@ async def _streaming_batch_write_ext(
     # so facts can be tagged with document_id + chunk_id before the metadata rows are written.
     chunk_id_by_index = {}
     if batch_chunk_meta:
-        chunk_id_by_index = {cm.chunk_index: f"{bank_id}_{effective_doc_id}_{cm.chunk_index}" for cm in batch_chunk_meta}
+        chunk_id_by_index = {
+            cm.chunk_index: f"{bank_id}_{effective_doc_id}_{cm.chunk_index}" for cm in batch_chunk_meta
+        }
     for fact, processed_fact in zip(batch_extracted, batch_processed):
         processed_fact.document_id = effective_doc_id
         if batch_chunk_meta and fact.chunk_index is not None:
@@ -742,9 +744,7 @@ async def _streaming_batch_write_ext(
                 # Entity registry reassert (Postgres `entities`): re-create the resolved parents
                 # this txn so a concurrent prune can't leave the postings dangling (#2662).
                 if unit_ids:
-                    await entity_resolver.reassert_entities_batch(
-                        bank_id, phase1.entities.resolved_entities, conn=conn
-                    )
+                    await entity_resolver.reassert_entities_batch(bank_id, phase1.entities.resolved_entities, conn=conn)
 
                 # Transactional-outbox row — must ride this Postgres transaction.
                 if is_last and outbox_callback is not None:
@@ -909,9 +909,7 @@ async def _delta_batch_write_ext(
 
                 # Entity registry reassert (Postgres `entities`) — see the streaming path (#2662).
                 if unit_ids:
-                    await entity_resolver.reassert_entities_batch(
-                        bank_id, phase1.entities.resolved_entities, conn=conn
-                    )
+                    await entity_resolver.reassert_entities_batch(bank_id, phase1.entities.resolved_entities, conn=conn)
 
                 # Transactional-outbox row — must ride this Postgres transaction.
                 if outbox_callback is not None:

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -770,6 +770,167 @@ async def _streaming_batch_write_ext(
     return False, batch_result_ids
 
 
+async def _delta_batch_write_ext(
+    *,
+    provider,
+    ext_txn,
+    pool,
+    bank_id: str,
+    fq_table,
+    entity_resolver,
+    phase1,
+    effective_doc_id: str,
+    config,
+    log_buffer: list[str],
+    processed_facts: list,
+    extracted_facts: list,
+    delta_contents: list,
+    contents_dicts: list,
+    document_tags,
+    document_body_override,
+    doc_hash_at_load,
+    new_chunk_metadata: list,
+    delta_chunk_map: dict,
+    new_chunks_with_contents: dict,
+    existing_by_index: dict,
+    changed_indices: list,
+    removed_indices: list,
+    outbox_callback,
+) -> tuple[bool, list[list[str]]]:
+    """Delta re-retain write for a store that OWNS its memory rows in a SEPARATE system.
+
+    Same connection-management contract as :func:`_streaming_batch_write_ext`: the slow object-store
+    writes (the new facts, then their entity re-write) plus the document-body upload are staged with
+    NO connection held; the connection is taken only for the SHORT transaction that records the
+    document/chunk metadata, the chunk tombstones, and the commit witness. Returns
+    ``(fell_back, result_unit_ids)`` — ``fell_back`` True means the document moved underneath us and
+    the caller must redo the work on the streaming path.
+    """
+    # ---- STORE PHASE (no connection held) ----
+    if document_body_override is not None:
+        combined_content = document_body_override
+    else:
+        combined_content = "\n".join([c.get("content", "") for c in contents_dicts])
+    retain_params, merged_tags = _build_retain_params(contents_dicts, document_tags)
+
+    # Re-upload the document bodies (dedup by hash — only what changed moves). A store write, so it
+    # belongs in the connection-free phase.
+    await _store_document_bodies(
+        bank_id=bank_id,
+        document_id=effective_doc_id,
+        combined_content=combined_content,
+        chunk_texts=[new_chunks_with_contents[i] for i in sorted(new_chunks_with_contents)],
+        merged_tags=merged_tags,
+        config=config,
+    )
+
+    # Deterministic chunk ids for the new/changed chunks (mirrors chunk_storage.store_chunks_batch
+    # after the delta remap), so facts can be tagged before the metadata rows are written.
+    remapped_new_indices = {delta_chunk_map.get(cm.chunk_index, cm.chunk_index) for cm in new_chunk_metadata}
+    for ef, pf in zip(extracted_facts, processed_facts):
+        pf.document_id = effective_doc_id
+        if ef.chunk_index is not None:
+            original_idx = delta_chunk_map.get(ef.chunk_index, ef.chunk_index)
+            if original_idx in remapped_new_indices:
+                pf.chunk_id = f"{bank_id}_{effective_doc_id}_{original_idx}"
+
+    # Stage the memory writes to the store (conn unused), tagged with ext_txn.
+    unit_ids = await fact_storage.insert_facts_batch(None, bank_id, processed_facts, ops=pool.ops, txn=ext_txn)
+    result_unit_ids = _map_results_to_contents(delta_contents, processed_facts, unit_ids if unit_ids else [])
+
+    if unit_ids:
+        resolved_entity_ids = [entity.entity_id for entity in phase1.entities.resolved_entities]
+        remapped_entity_to_unit, _r_u2e, _r_sem = _remap_phase1_results(
+            resolved_entity_ids, phase1.entities.entity_to_unit, phase1.entities.unit_to_entity_ids, [], unit_ids
+        )
+        unit_entity_pairs = [
+            (unit_id, resolved_entity_ids[idx], fact_date)
+            for idx, (unit_id, _local_idx, fact_date) in enumerate(remapped_entity_to_unit)
+        ]
+        await entity_resolver.record_unit_entity_postings(unit_entity_pairs, bank_id=bank_id)
+
+    # ---- CONNECTION PHASE (short transaction: local metadata + tombstones + witness) ----
+    try:
+        async with acquire_with_retry(pool) as conn:
+            async with conn.transaction():
+                # Ownership recheck: the delta diff was computed against a snapshot taken outside
+                # this txn; if the document was replaced since, the diff is stale — fall back.
+                current_hash = await conn.fetchval(
+                    f"SELECT content_hash FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2 FOR UPDATE",
+                    effective_doc_id,
+                    bank_id,
+                )
+                if current_hash is not None and doc_hash_at_load is not None and current_hash != doc_hash_at_load:
+                    log_buffer.append(
+                        f"[delta] Document {effective_doc_id} was modified by concurrent request "
+                        f"since chunks were loaded — aborting delta, falling back to full retain"
+                    )
+                    logger.info("\n" + "\n".join(log_buffer) + "\n")
+                    await provider.decide_txn(ext_txn, commit=False)
+                    return True, result_unit_ids
+
+                await fact_storage.upsert_document_metadata(
+                    conn, bank_id, effective_doc_id, combined_content, retain_params, merged_tags
+                )
+
+                # Tombstone the changed/removed chunks' memories (store delete tagged ext_txn +
+                # Postgres observation invalidation) — same write-group as the new facts above.
+                chunks_to_delete = [
+                    existing_by_index[idx].chunk_id
+                    for idx in changed_indices + removed_indices
+                    if idx in existing_by_index
+                ]
+                await chunk_storage.delete_chunks_by_ids(conn, chunks_to_delete, bank_id, txn=ext_txn, ops=pool.ops)
+
+                # Sync tags/metadata onto unchanged survivors (zero rows for a store-owned backend).
+                await fact_storage.update_memory_units_metadata_and_tags(
+                    conn, bank_id, effective_doc_id, merged_tags, retain_params.get("metadata", {})
+                )
+
+                # New/changed chunk metadata rows.
+                if new_chunk_metadata:
+                    remapped_chunks = [
+                        ChunkMetadata(
+                            chunk_text=cm.chunk_text,
+                            fact_count=cm.fact_count,
+                            content_index=cm.content_index,
+                            chunk_index=delta_chunk_map.get(cm.chunk_index, cm.chunk_index),
+                        )
+                        for cm in new_chunk_metadata
+                    ]
+                    await chunk_storage.store_chunks_batch(
+                        conn,
+                        bank_id,
+                        effective_doc_id,
+                        remapped_chunks,
+                        ops=pool.ops,
+                        store_document_text=getattr(config, "store_document_text", True),
+                    )
+
+                # Entity registry reassert (Postgres `entities`) — see the streaming path (#2662).
+                if unit_ids:
+                    await entity_resolver.reassert_entities_batch(
+                        bank_id, phase1.entities.resolved_entities, conn=conn
+                    )
+
+                # Transactional-outbox row — must ride this Postgres transaction.
+                if outbox_callback is not None:
+                    await outbox_callback(conn)
+
+                # The commit witness.
+                await provider.write_txn_witness(ext_txn, conn=conn, fq_table=fq_table)
+
+            await provider.decide_txn(ext_txn, commit=True)
+    except BaseException:
+        try:
+            await provider.decide_txn(ext_txn, commit=False)
+        except Exception:
+            logger.warning(f"[delta] best-effort abort of ext txn for {effective_doc_id} failed", exc_info=True)
+        raise
+
+    return False, result_unit_ids
+
+
 async def _extract_and_embed(
     contents: list[RetainContent],
     llm_config,
@@ -2840,6 +3001,49 @@ async def _try_delta_retain(
         phase1 = await _pre_resolve_phase1(
             pool, entity_resolver, bank_id, delta_contents, processed_facts, config, log_buffer
         )
+
+        # A store that owns its rows in a separate system uses a distinct connection-management
+        # path (mint_txn returns a handle; Postgres returns None and takes the path below,
+        # unchanged) so the data-plane connection is not held across the object-store write.
+        from ..memories import get_memories
+
+        _ext_provider = get_memories()
+        _ext_txn = await _ext_provider.mint_txn(bank_id=bank_id, mutating=True)
+        if _ext_txn is not None:
+            fell_back, _ids = await _delta_batch_write_ext(
+                provider=_ext_provider,
+                ext_txn=_ext_txn,
+                pool=pool,
+                bank_id=bank_id,
+                fq_table=fq_table,
+                entity_resolver=entity_resolver,
+                phase1=phase1,
+                effective_doc_id=effective_doc_id,
+                config=config,
+                log_buffer=log_buffer,
+                processed_facts=processed_facts,
+                extracted_facts=extracted_facts,
+                delta_contents=delta_contents,
+                contents_dicts=contents_dicts,
+                document_tags=document_tags,
+                document_body_override=document_body_override,
+                doc_hash_at_load=doc_hash_at_load,
+                new_chunk_metadata=new_chunk_metadata,
+                delta_chunk_map=delta_chunk_map,
+                new_chunks_with_contents=new_chunks_with_contents,
+                existing_by_index=existing_by_index,
+                changed_indices=changed_indices,
+                removed_indices=removed_indices,
+                outbox_callback=outbox_callback,
+            )
+            if fell_back:
+                return False
+            result_unit_ids = _ids
+            try:
+                await entity_resolver.flush_pending_stats()
+            except Exception:
+                logger.warning("Entity stats flush failed — retrieval unaffected", exc_info=True)
+            return True
 
         # PHASE 2 — Core Write Transaction (atomic)
         # Lock the document row and verify ownership. Delta loaded existing

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -585,6 +585,22 @@ async def _insert_facts_and_links(
     return result_unit_ids
 
 
+@dataclass
+class _ExtStreamingWriteResult:
+    """Outcome of :func:`_streaming_batch_write_ext`."""
+
+    aborted: bool
+    batch_result_ids: list[list[str]]
+
+
+@dataclass
+class _ExtDeltaWriteResult:
+    """Outcome of :func:`_delta_batch_write_ext`."""
+
+    fell_back: bool
+    result_unit_ids: list[list[str]]
+
+
 async def _streaming_batch_write_ext(
     *,
     provider,
@@ -614,7 +630,7 @@ async def _streaming_batch_write_ext(
     outbox_callback,
     assert_append_base_unchanged,
     p2_start: float,
-) -> tuple[bool, list[list[str]]]:
+) -> _ExtStreamingWriteResult:
     """Streaming batch write for a store that OWNS its memory rows in a SEPARATE system.
 
     Unlike the Postgres path (one long transaction that also carries the memory write), this
@@ -634,9 +650,10 @@ async def _streaming_batch_write_ext(
     (no ``memory_units`` for this org), and causal edges already travel on the memory record —
     writing them to PG ``memory_links`` would violate its deferrable FK to ``memory_units``.
 
-    Returns ``(aborted, batch_result_ids)``. ``aborted`` is True when a later batch lost the
-    document to a concurrent takeover (the staged write is discarded); it may also raise
-    :class:`ConcurrentAppendConflict` for a lost append race, exactly like the Postgres path.
+    ``aborted`` in the result is True when a later batch lost the document to a concurrent
+    takeover (the staged write is discarded); the call may also raise
+    :class:`ConcurrentAppendConflict` for a lost append race, exactly like the Postgres path —
+    the staged writes are discarded on that path too.
     """
     # ---- STORE PHASE (no connection held) ----
     # Chunk ids are a deterministic function of identity (mirrors chunk_storage.store_chunks_batch),
@@ -720,15 +737,16 @@ async def _streaming_batch_write_ext(
                             f"concurrent request (hash mismatch) — aborting remaining batches"
                         )
                         logger.info("\n" + "\n".join(log_buffer) + "\n")
-                        # Discard the staged store writes rather than leave them for the sweep.
-                        await provider.decide_txn(ext_txn, commit=False)
                         if append_base_hash is not None:
+                            # The BaseException handler below discards the staged writes.
                             raise ConcurrentAppendConflict(
                                 f"Document {effective_doc_id} was taken over by a concurrent "
                                 f"retain while this append was storing its batches"
                             )
+                        # Discard the staged store writes rather than leave them for the sweep.
+                        await provider.decide_txn(ext_txn, commit=False)
                         pipeline_aborted[0] = True
-                        return True, batch_result_ids
+                        return _ExtStreamingWriteResult(aborted=True, batch_result_ids=batch_result_ids)
 
                 # Chunk metadata rows (bulky bodies were already stored before this call).
                 if batch_chunk_meta:
@@ -756,18 +774,17 @@ async def _streaming_batch_write_ext(
             # Postgres committed the witness: publish the write-group (object-store marker, no conn).
             await provider.decide_txn(ext_txn, commit=True)
             logger.info(f"[streaming] Phase 2 (ext write txn): {time.time() - p2_start:.3f}s")
-    except ConcurrentAppendConflict:
-        raise
     except BaseException:
-        # The witness never committed → make sure the staged store writes don't linger; the
-        # recovery sweep is the backstop if this best-effort abort also fails.
+        # The witness never committed (this also covers a lost-append ConcurrentAppendConflict)
+        # → make sure the staged store writes don't linger; the recovery sweep is the backstop
+        # if this best-effort abort also fails.
         try:
             await provider.decide_txn(ext_txn, commit=False)
         except Exception:
             logger.warning(f"[streaming] best-effort abort of ext txn for {effective_doc_id} failed", exc_info=True)
         raise
 
-    return False, batch_result_ids
+    return _ExtStreamingWriteResult(aborted=False, batch_result_ids=batch_result_ids)
 
 
 async def _delta_batch_write_ext(
@@ -796,15 +813,15 @@ async def _delta_batch_write_ext(
     changed_indices: list,
     removed_indices: list,
     outbox_callback,
-) -> tuple[bool, list[list[str]]]:
+) -> _ExtDeltaWriteResult:
     """Delta re-retain write for a store that OWNS its memory rows in a SEPARATE system.
 
     Same connection-management contract as :func:`_streaming_batch_write_ext`: the slow object-store
     writes (the new facts, then their entity re-write) plus the document-body upload are staged with
     NO connection held; the connection is taken only for the SHORT transaction that records the
-    document/chunk metadata, the chunk tombstones, and the commit witness. Returns
-    ``(fell_back, result_unit_ids)`` — ``fell_back`` True means the document moved underneath us and
-    the caller must redo the work on the streaming path.
+    document/chunk metadata, the chunk tombstones, and the commit witness. ``fell_back`` True in
+    the result means the document moved underneath us and the caller must redo the work on the
+    streaming path.
     """
     # ---- STORE PHASE (no connection held) ----
     if document_body_override is not None:
@@ -867,7 +884,7 @@ async def _delta_batch_write_ext(
                     )
                     logger.info("\n" + "\n".join(log_buffer) + "\n")
                     await provider.decide_txn(ext_txn, commit=False)
-                    return True, result_unit_ids
+                    return _ExtDeltaWriteResult(fell_back=True, result_unit_ids=result_unit_ids)
 
                 await fact_storage.upsert_document_metadata(
                     conn, bank_id, effective_doc_id, combined_content, retain_params, merged_tags
@@ -926,7 +943,7 @@ async def _delta_batch_write_ext(
             logger.warning(f"[delta] best-effort abort of ext txn for {effective_doc_id} failed", exc_info=True)
         raise
 
-    return False, result_unit_ids
+    return _ExtDeltaWriteResult(fell_back=False, result_unit_ids=result_unit_ids)
 
 
 async def _extract_and_embed(
@@ -2200,7 +2217,7 @@ async def _streaming_retain_batch(
             _ext_provider = get_memories()
             _ext_txn = await _ext_provider.mint_txn(bank_id=bank_id, mutating=True)
             if _ext_txn is not None:
-                aborted, batch_result_ids = await _streaming_batch_write_ext(
+                ext_result = await _streaming_batch_write_ext(
                     provider=_ext_provider,
                     ext_txn=_ext_txn,
                     pool=pool,
@@ -2232,7 +2249,11 @@ async def _streaming_retain_batch(
                 # Doc-tracking consumed combined_content on the first batch; release it (mirrors
                 # the Postgres path's first-batch reset).
                 combined_content = ""
-                if not aborted:
+                if not ext_result.aborted:
+                    # The short txn above committed the transactional-outbox row; record it so
+                    # the post-loop fallback doesn't queue a duplicate delivery.
+                    if is_last and outbox_callback is not None:
+                        outbox_fired[0] = True
                     # Deferred-stats flush + unit collection — mirrors the shared tail the Postgres
                     # path reaches after its connection block exits.
                     try:
@@ -2241,9 +2262,8 @@ async def _streaming_retain_batch(
                         logger.warning(
                             f"Entity stats flush (consumer batch {consumer_batch_idx + 1}) failed", exc_info=True
                         )
-                    if batch_result_ids:
-                        for content_ids in batch_result_ids:
-                            all_unit_ids.extend(content_ids)
+                    for content_ids in ext_result.batch_result_ids:
+                        all_unit_ids.extend(content_ids)
                 return
 
             async with acquire_with_retry(pool) as conn:
@@ -3008,7 +3028,7 @@ async def _try_delta_retain(
         _ext_provider = get_memories()
         _ext_txn = await _ext_provider.mint_txn(bank_id=bank_id, mutating=True)
         if _ext_txn is not None:
-            fell_back, _ids = await _delta_batch_write_ext(
+            delta_result = await _delta_batch_write_ext(
                 provider=_ext_provider,
                 ext_txn=_ext_txn,
                 pool=pool,
@@ -3034,9 +3054,11 @@ async def _try_delta_retain(
                 removed_indices=removed_indices,
                 outbox_callback=outbox_callback,
             )
-            if fell_back:
+            if delta_result.fell_back:
                 return False
-            result_unit_ids = _ids
+            result_unit_ids = delta_result.result_unit_ids
+            log_buffer.append(f"DELTA RETAIN COMPLETE (ext store): {len(processed_facts)} new units")
+            logger.info("\n" + "\n".join(log_buffer) + "\n")
             try:
                 await entity_resolver.flush_pending_stats()
             except Exception:

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -585,6 +585,191 @@ async def _insert_facts_and_links(
     return result_unit_ids
 
 
+async def _streaming_batch_write_ext(
+    *,
+    provider,
+    ext_txn,
+    pool,
+    bank_id: str,
+    fq_table,
+    entity_resolver,
+    phase1,
+    batch_contents: list,
+    batch_extracted: list,
+    batch_processed: list,
+    batch_chunk_meta: list,
+    effective_doc_id: str,
+    config,
+    log_buffer: list[str],
+    is_recovery: bool,
+    is_first_batch: bool,
+    is_last: bool,
+    doc_tracking_done: list[bool],
+    pipeline_aborted: list[bool],
+    append_base_hash,
+    new_content_hash,
+    combined_content: str,
+    retain_params,
+    merged_tags,
+    outbox_callback,
+    assert_append_base_unchanged,
+    p2_start: float,
+) -> tuple[bool, list[list[str]]]:
+    """Streaming batch write for a store that OWNS its memory rows in a SEPARATE system.
+
+    Unlike the Postgres path (one long transaction that also carries the memory write), this
+    NEVER holds the data-plane connection across the object-store write. It runs in two phases:
+
+    1. STORE PHASE — no connection. Mint ids and stage the memory records (facts + causal edges,
+       then a re-write carrying the resolved entity ids) to the object store, each tagged with
+       ``ext_txn`` so they stay INVISIBLE until :meth:`decide_txn`. Co-occurrence only accumulates
+       in memory (flushed post-batch). No Postgres transaction is open.
+    2. CONNECTION PHASE — a SHORT transaction: the document/chunk metadata rows, the entity
+       registry reassert, the transactional-outbox row, and finally the commit witness. On commit
+       the witness is the group's proof; ``decide_txn(commit=True)`` (a connection-free object-store
+       marker) then publishes it. A crash before the witness commits leaves the staged writes for
+       the recovery sweep to abort; a crash after leaves them for the sweep to commit.
+
+    The PG link writers are intentionally skipped: temporal/semantic links would touch zero rows
+    (no ``memory_units`` for this org), and causal edges already travel on the memory record —
+    writing them to PG ``memory_links`` would violate its deferrable FK to ``memory_units``.
+
+    Returns ``(aborted, batch_result_ids)``. ``aborted`` is True when a later batch lost the
+    document to a concurrent takeover (the staged write is discarded); it may also raise
+    :class:`ConcurrentAppendConflict` for a lost append race, exactly like the Postgres path.
+    """
+    # ---- STORE PHASE (no connection held) ----
+    # Chunk ids are a deterministic function of identity (mirrors chunk_storage.store_chunks_batch),
+    # so facts can be tagged with document_id + chunk_id before the metadata rows are written.
+    chunk_id_by_index = {}
+    if batch_chunk_meta:
+        chunk_id_by_index = {cm.chunk_index: f"{bank_id}_{effective_doc_id}_{cm.chunk_index}" for cm in batch_chunk_meta}
+    for fact, processed_fact in zip(batch_extracted, batch_processed):
+        processed_fact.document_id = effective_doc_id
+        if batch_chunk_meta and fact.chunk_index is not None:
+            cid = chunk_id_by_index.get(fact.chunk_index)
+            if cid:
+                processed_fact.chunk_id = cid
+
+    # Stage the memory records to the store (conn unused by a store-owned backend), tagged with
+    # ext_txn. This is the slow object-store write we are keeping OUT of the connection window.
+    unit_ids = await fact_storage.insert_facts_batch(None, bank_id, batch_processed, ops=pool.ops, txn=ext_txn)
+    batch_result_ids = _map_results_to_contents(batch_contents, batch_processed, unit_ids if unit_ids else [])
+
+    if unit_ids:
+        # Remap Phase-1 placeholder ids onto the real unit ids, then re-write each memory with its
+        # entity ids attached — also connection-free for a store-owned backend.
+        resolved_entity_ids = [entity.entity_id for entity in phase1.entities.resolved_entities]
+        remapped_entity_to_unit, _remapped_unit_to_entity_ids, _remapped_semantic = _remap_phase1_results(
+            resolved_entity_ids, phase1.entities.entity_to_unit, phase1.entities.unit_to_entity_ids, [], unit_ids
+        )
+        unit_entity_pairs = [
+            (unit_id, resolved_entity_ids[idx], fact_date)
+            for idx, (unit_id, _local_idx, fact_date) in enumerate(remapped_entity_to_unit)
+        ]
+        await entity_resolver.record_unit_entity_postings(unit_entity_pairs, bank_id=bank_id)
+
+    # ---- CONNECTION PHASE (short transaction: local metadata + commit witness) ----
+    try:
+        async with acquire_with_retry(pool) as conn:
+            async with conn.transaction():
+                # Ownership gate: lock the document row (serializes concurrent same-document
+                # writers) and read its pre-existing hash for the takeover check.
+                existing_hash = await pool.ops.lock_document_for_write(
+                    conn, fq_table("documents"), effective_doc_id, bank_id
+                )
+
+                if not doc_tracking_done[0]:
+                    # Append compare-and-swap under the row lock (same as the Postgres path).
+                    assert_append_base_unchanged(existing_hash)
+                    if is_recovery:
+                        await fact_storage.upsert_document_metadata(
+                            conn,
+                            bank_id,
+                            effective_doc_id,
+                            combined_content,
+                            retain_params,
+                            merged_tags,
+                            store_document_text=getattr(config, "store_document_text", True),
+                        )
+                        log_buffer.append(
+                            f"[streaming] Document {effective_doc_id} updated (recovery, preserving existing chunks)"
+                        )
+                    else:
+                        await fact_storage.handle_document_tracking(
+                            conn,
+                            bank_id,
+                            effective_doc_id,
+                            combined_content,
+                            is_first_batch,
+                            retain_params,
+                            merged_tags,
+                            ops=pool.ops,
+                            store_document_text=getattr(config, "store_document_text", True),
+                            txn=ext_txn,
+                        )
+                        log_buffer.append(f"[streaming] Document {effective_doc_id} tracked (full content)")
+                    doc_tracking_done[0] = True
+                else:
+                    # Later batches: verify we still own the document.
+                    if existing_hash is not None and existing_hash != new_content_hash:
+                        log_buffer.append(
+                            f"[streaming] Document {effective_doc_id} taken over by "
+                            f"concurrent request (hash mismatch) — aborting remaining batches"
+                        )
+                        logger.info("\n" + "\n".join(log_buffer) + "\n")
+                        # Discard the staged store writes rather than leave them for the sweep.
+                        await provider.decide_txn(ext_txn, commit=False)
+                        if append_base_hash is not None:
+                            raise ConcurrentAppendConflict(
+                                f"Document {effective_doc_id} was taken over by a concurrent "
+                                f"retain while this append was storing its batches"
+                            )
+                        pipeline_aborted[0] = True
+                        return True, batch_result_ids
+
+                # Chunk metadata rows (bulky bodies were already stored before this call).
+                if batch_chunk_meta:
+                    await chunk_storage.store_chunks_batch(
+                        conn,
+                        bank_id,
+                        effective_doc_id,
+                        batch_chunk_meta,
+                        ops=pool.ops,
+                        store_document_text=getattr(config, "store_document_text", True),
+                    )
+
+                # Entity registry reassert (Postgres `entities`): re-create the resolved parents
+                # this txn so a concurrent prune can't leave the postings dangling (#2662).
+                if unit_ids:
+                    await entity_resolver.reassert_entities_batch(
+                        bank_id, phase1.entities.resolved_entities, conn=conn
+                    )
+
+                # Transactional-outbox row — must ride this Postgres transaction.
+                if is_last and outbox_callback is not None:
+                    await outbox_callback(conn)
+
+                # The commit witness: its presence at commit is what the recovery sweep consults.
+                await provider.write_txn_witness(ext_txn, conn=conn, fq_table=fq_table)
+
+            # Postgres committed the witness: publish the write-group (object-store marker, no conn).
+            await provider.decide_txn(ext_txn, commit=True)
+            logger.info(f"[streaming] Phase 2 (ext write txn): {time.time() - p2_start:.3f}s")
+    except ConcurrentAppendConflict:
+        raise
+    except BaseException:
+        # The witness never committed → make sure the staged store writes don't linger; the
+        # recovery sweep is the backstop if this best-effort abort also fails.
+        try:
+            await provider.decide_txn(ext_txn, commit=False)
+        except Exception:
+            logger.warning(f"[streaming] best-effort abort of ext txn for {effective_doc_id} failed", exc_info=True)
+        raise
+
+    return False, batch_result_ids
+
+
 async def _extract_and_embed(
     contents: list[RetainContent],
     llm_config,
@@ -1846,6 +2031,62 @@ async def _streaming_retain_batch(
 
             p2_start = time.time()
             batch_result_ids = None
+
+            # A store that owns its memory rows in a SEPARATE system returns a write-group handle
+            # from mint_txn (Postgres returns None). For that store we must NOT hold the data-plane
+            # connection across the object-store write, so we run a distinct connection-management
+            # path. Postgres falls through to the single-transaction path below, unchanged.
+            from ..memories import get_memories
+
+            _ext_provider = get_memories()
+            _ext_txn = await _ext_provider.mint_txn(bank_id=bank_id, mutating=True)
+            if _ext_txn is not None:
+                aborted, batch_result_ids = await _streaming_batch_write_ext(
+                    provider=_ext_provider,
+                    ext_txn=_ext_txn,
+                    pool=pool,
+                    bank_id=bank_id,
+                    fq_table=fq_table,
+                    entity_resolver=entity_resolver,
+                    phase1=phase1,
+                    batch_contents=batch_contents,
+                    batch_extracted=batch_extracted,
+                    batch_processed=batch_processed,
+                    batch_chunk_meta=batch_chunk_meta,
+                    effective_doc_id=effective_doc_id,
+                    config=config,
+                    log_buffer=log_buffer,
+                    is_recovery=is_recovery,
+                    is_first_batch=is_first_batch,
+                    is_last=is_last,
+                    doc_tracking_done=doc_tracking_done,
+                    pipeline_aborted=pipeline_aborted,
+                    append_base_hash=append_base_hash,
+                    new_content_hash=new_content_hash,
+                    combined_content=combined_content,
+                    retain_params=retain_params,
+                    merged_tags=merged_tags,
+                    outbox_callback=outbox_callback,
+                    assert_append_base_unchanged=_assert_append_base_unchanged,
+                    p2_start=p2_start,
+                )
+                # Doc-tracking consumed combined_content on the first batch; release it (mirrors
+                # the Postgres path's first-batch reset).
+                combined_content = ""
+                if not aborted:
+                    # Deferred-stats flush + unit collection — mirrors the shared tail the Postgres
+                    # path reaches after its connection block exits.
+                    try:
+                        await entity_resolver.flush_pending_stats()
+                    except Exception:
+                        logger.warning(
+                            f"Entity stats flush (consumer batch {consumer_batch_idx + 1}) failed", exc_info=True
+                        )
+                    if batch_result_ids:
+                        for content_ids in batch_result_ids:
+                            all_unit_ids.extend(content_ids)
+                return
+
             async with acquire_with_retry(pool) as conn:
                 async with conn.transaction():
                     # --- Document ownership gate ---

--- a/hindsight-api-slim/tests/test_retain_ext_writegroup.py
+++ b/hindsight-api-slim/tests/test_retain_ext_writegroup.py
@@ -16,8 +16,6 @@ object-store write. These tests pin that contract:
 
 from types import SimpleNamespace
 
-import pytest
-
 import hindsight_api.engine.retain.orchestrator as orch
 
 
@@ -39,6 +37,7 @@ class _ConnTracker:
             async def __aenter__(self_inner):
                 tracker.open = True
                 return SimpleNamespace(name="conn", transaction=_txn, fetchval=_fetchval)
+
             async def __aexit__(self_inner, *a):
                 tracker.open = False
                 return False
@@ -50,8 +49,10 @@ def _txn():
     class _T:
         async def __aenter__(self):
             return None
+
         async def __aexit__(self, *a):
             return False
+
     return _T()
 
 
@@ -76,14 +77,14 @@ def _make_common(monkeypatch, tracker, *, calls):
     monkeypatch.setattr(orch.chunk_storage, "store_chunks_batch", _store_chunks_batch)
     monkeypatch.setattr(orch.fact_storage, "handle_document_tracking", _handle_doc_tracking)
     monkeypatch.setattr(orch, "_map_results_to_contents", lambda contents, pf, uids: [list(uids)])
-    monkeypatch.setattr(
-        orch, "_remap_phase1_results", lambda rids, e2u, u2e, sem, uids: ([("u1", 0, None)], {}, [])
-    )
+    monkeypatch.setattr(orch, "_remap_phase1_results", lambda rids, e2u, u2e, sem, uids: ([("u1", 0, None)], {}, []))
     # Any PG link writer being called for an ext org is a bug — make it explode.
     for name in ("create_temporal_links_batch", "create_semantic_links_batch", "create_causal_links_batch"):
         if hasattr(orch.link_creation, name):
+
             def _boom(*a, _n=name, **k):
                 raise AssertionError(f"ext path must not call link_creation.{_n}")
+
             monkeypatch.setattr(orch.link_creation, name, _boom)
 
 
@@ -214,8 +215,14 @@ async def test_outbox_row_rides_the_connection(monkeypatch):
 
     aborted, _ = await orch._streaming_batch_write_ext(
         **_kwargs(
-            tracker, provider, er, doc_tracking_done=[False],
-            existing_hash="__pending__", new_hash="h", outbox=_outbox, is_last=True,
+            tracker,
+            provider,
+            er,
+            doc_tracking_done=[False],
+            existing_hash="__pending__",
+            new_hash="h",
+            outbox=_outbox,
+            is_last=True,
         )
     )
     assert aborted is False
@@ -226,6 +233,7 @@ async def test_outbox_row_rides_the_connection(monkeypatch):
 # --------------------------------------------------------------------------------------------
 # Delta re-retain path
 # --------------------------------------------------------------------------------------------
+
 
 def _make_common_delta(monkeypatch, tracker, *, calls):
     _make_common(monkeypatch, tracker, calls=calls)
@@ -315,9 +323,7 @@ async def test_delta_falls_back_when_document_replaced(monkeypatch):
     _make_common_delta(monkeypatch, tracker, calls=calls)
     provider, er = _Provider(), _EntityResolver(tracker)
 
-    fell_back, _ = await orch._delta_batch_write_ext(
-        **_delta_kwargs(tracker, provider, er, doc_hash_at_load="OLD")
-    )
+    fell_back, _ = await orch._delta_batch_write_ext(**_delta_kwargs(tracker, provider, er, doc_hash_at_load="OLD"))
 
     assert fell_back is True
     # Staged store writes still ran connection-free before the conflict was detected.

--- a/hindsight-api-slim/tests/test_retain_ext_writegroup.py
+++ b/hindsight-api-slim/tests/test_retain_ext_writegroup.py
@@ -16,7 +16,10 @@ object-store write. These tests pin that contract:
 
 from types import SimpleNamespace
 
+import pytest
+
 import hindsight_api.engine.retain.orchestrator as orch
+from hindsight_api.engine.retain.types import ConcurrentAppendConflict
 
 
 class _ConnTracker:
@@ -165,12 +168,12 @@ async def test_store_writes_are_connection_free_and_witness_is_in_txn(monkeypatc
     _make_common(monkeypatch, tracker, calls=calls)
     provider, er = _Provider(), _EntityResolver(tracker)
 
-    aborted, result_ids = await orch._streaming_batch_write_ext(
+    result = await orch._streaming_batch_write_ext(
         **_kwargs(tracker, provider, er, doc_tracking_done=[False], existing_hash="__pending__", new_hash="h")
     )
 
-    assert aborted is False
-    assert result_ids == [["u1"]]
+    assert result.aborted is False
+    assert result.batch_result_ids == [["u1"]]
     # The fact write happened with no connection held.
     assert tracker.store_writes_saw_open == [False]
     # Entity re-posting happened (also connection-free — asserted inside the fake).
@@ -191,15 +194,38 @@ async def test_later_batch_takeover_aborts_and_discards_staged_write(monkeypatch
 
     # Later batch (doc_tracking already done) whose document was taken over: existing hash
     # differs from ours → abort.
-    aborted, _ = await orch._streaming_batch_write_ext(
+    result = await orch._streaming_batch_write_ext(
         **_kwargs(tracker, provider, er, doc_tracking_done=[True], existing_hash="OTHER", new_hash="OURS")
     )
 
-    assert aborted is True
+    assert result.aborted is True
     # Staged store write still happened connection-free before the takeover was detected.
     assert tracker.store_writes_saw_open == [False]
     # The group was explicitly aborted, not committed.
     assert provider.decisions == [False]
+
+
+async def test_lost_append_race_discards_staged_write(monkeypatch):
+    tracker = _ConnTracker()
+    calls = []
+    _make_common(monkeypatch, tracker, calls=calls)
+    provider, er = _Provider(), _EntityResolver(tracker)
+
+    # First batch of an append whose base compare-and-swap fails: the conflict must
+    # propagate AND the already-staged store writes must be discarded, exactly once.
+    kwargs = _kwargs(tracker, provider, er, doc_tracking_done=[False], existing_hash="MOVED", new_hash="h")
+    kwargs["append_base_hash"] = "BASE"
+
+    def _cas_fails(existing_hash):
+        raise ConcurrentAppendConflict("append base changed")
+
+    kwargs["assert_append_base_unchanged"] = _cas_fails
+
+    with pytest.raises(ConcurrentAppendConflict):
+        await orch._streaming_batch_write_ext(**kwargs)
+
+    assert provider.decisions == [False]
+    assert tracker.open is False  # connection released on the way out
 
 
 async def test_outbox_row_rides_the_connection(monkeypatch):
@@ -213,7 +239,7 @@ async def test_outbox_row_rides_the_connection(monkeypatch):
         seen["open"] = tracker.open
         seen["conn"] = conn
 
-    aborted, _ = await orch._streaming_batch_write_ext(
+    result = await orch._streaming_batch_write_ext(
         **_kwargs(
             tracker,
             provider,
@@ -225,7 +251,7 @@ async def test_outbox_row_rides_the_connection(monkeypatch):
             is_last=True,
         )
     )
-    assert aborted is False
+    assert result.aborted is False
     assert seen["open"] is True and seen["conn"] is not None  # outbox wrote inside the txn
     assert provider.decisions == [True]
 
@@ -301,12 +327,12 @@ async def test_delta_store_writes_are_connection_free(monkeypatch):
     # _build_retain_params is a plain module function; keep it real but feed simple dicts.
     provider, er = _Provider(), _EntityResolver(tracker)
 
-    fell_back, ids = await orch._delta_batch_write_ext(
+    result = await orch._delta_batch_write_ext(
         **_delta_kwargs(tracker, provider, er, doc_hash_at_load=None)  # None → hash check can't trip
     )
 
-    assert fell_back is False
-    assert ids == [["u1"]]
+    assert result.fell_back is False
+    assert result.result_unit_ids == [["u1"]]
     # Fact write + body store + entity re-posting all happened connection-free.
     assert tracker.store_writes_saw_open == [False]
     assert ("store_document_bodies", False) in calls
@@ -323,9 +349,9 @@ async def test_delta_falls_back_when_document_replaced(monkeypatch):
     _make_common_delta(monkeypatch, tracker, calls=calls)
     provider, er = _Provider(), _EntityResolver(tracker)
 
-    fell_back, _ = await orch._delta_batch_write_ext(**_delta_kwargs(tracker, provider, er, doc_hash_at_load="OLD"))
+    result = await orch._delta_batch_write_ext(**_delta_kwargs(tracker, provider, er, doc_hash_at_load="OLD"))
 
-    assert fell_back is True
+    assert result.fell_back is True
     # Staged store writes still ran connection-free before the conflict was detected.
     assert tracker.store_writes_saw_open == [False]
     # The group was discarded, not committed.

--- a/hindsight-api-slim/tests/test_retain_ext_writegroup.py
+++ b/hindsight-api-slim/tests/test_retain_ext_writegroup.py
@@ -1,0 +1,219 @@
+"""Connection management for the external-backend retain write-group.
+
+The whole point of ``_streaming_batch_write_ext`` is that a store which owns its memory rows
+in a separate system must NOT hold the data-plane Postgres connection across the (slow)
+object-store write. These tests pin that contract:
+
+* the memory writes (``insert_facts_batch`` + the entity re-posting) happen while NO connection
+  is checked out;
+* the connection is taken only for the short witness transaction (document/chunk metadata,
+  entity-registry reassert, outbox, ``write_txn_witness``);
+* ``decide_txn(commit=True)`` publishes the group after the connection is released;
+* a later-batch takeover discards the staged write via ``decide_txn(commit=False)`` — and the
+  staged write was still connection-free;
+* the Postgres link writers (temporal/semantic/causal) are never invoked for an ext org.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import hindsight_api.engine.retain.orchestrator as orch
+
+
+class _ConnTracker:
+    """Flips ``open`` while a connection is checked out via acquire_with_retry."""
+
+    def __init__(self):
+        self.open = False
+        self.store_writes_saw_open = []  # records `open` at each store-write call
+
+    def acquire(self):
+        tracker = self
+
+        class _CM:
+            async def __aenter__(self_inner):
+                tracker.open = True
+                return SimpleNamespace(name="conn", transaction=_txn)
+            async def __aexit__(self_inner, *a):
+                tracker.open = False
+                return False
+
+        return _CM()
+
+
+def _txn():
+    class _T:
+        async def __aenter__(self):
+            return None
+        async def __aexit__(self, *a):
+            return False
+    return _T()
+
+
+def _make_common(monkeypatch, tracker, *, calls):
+    """Patch the module-level collaborators the helper reaches for."""
+    monkeypatch.setattr(orch, "acquire_with_retry", lambda pool: tracker.acquire())
+
+    async def _insert_facts_batch(conn, bank_id, processed, ops=None, txn=None):
+        calls.append(("insert_facts", conn, tracker.open))
+        tracker.store_writes_saw_open.append(tracker.open)
+        assert conn is None, "ext store write must not receive a connection"
+        return ["u1"]
+
+    async def _store_chunks_batch(conn, bank_id, doc_id, meta, ops=None, store_document_text=True):
+        calls.append(("store_chunks", tracker.open))
+        return {}
+
+    async def _handle_doc_tracking(conn, *a, **k):
+        calls.append(("handle_doc_tracking", tracker.open))
+
+    monkeypatch.setattr(orch.fact_storage, "insert_facts_batch", _insert_facts_batch)
+    monkeypatch.setattr(orch.chunk_storage, "store_chunks_batch", _store_chunks_batch)
+    monkeypatch.setattr(orch.fact_storage, "handle_document_tracking", _handle_doc_tracking)
+    monkeypatch.setattr(orch, "_map_results_to_contents", lambda contents, pf, uids: [list(uids)])
+    monkeypatch.setattr(
+        orch, "_remap_phase1_results", lambda rids, e2u, u2e, sem, uids: ([("u1", 0, None)], {}, [])
+    )
+    # Any PG link writer being called for an ext org is a bug — make it explode.
+    for name in ("create_temporal_links_batch", "create_semantic_links_batch", "create_causal_links_batch"):
+        if hasattr(orch.link_creation, name):
+            def _boom(*a, _n=name, **k):
+                raise AssertionError(f"ext path must not call link_creation.{_n}")
+            monkeypatch.setattr(orch.link_creation, name, _boom)
+
+
+class _Provider:
+    def __init__(self):
+        self.decisions = []
+        self.witnesses = []
+
+    async def write_txn_witness(self, txn, *, conn, fq_table):
+        self.witnesses.append((txn, conn))
+
+    async def decide_txn(self, txn, *, commit):
+        self.decisions.append(commit)
+
+
+class _EntityResolver:
+    def __init__(self, tracker):
+        self._t = tracker
+        self.postings = []
+        self.reasserts = []
+
+    async def record_unit_entity_postings(self, pairs, bank_id=None):
+        # THE contract: the store re-posting runs with no connection held.
+        assert self._t.open is False, "entity posting must run connection-free"
+        self.postings.append(pairs)
+
+    async def reassert_entities_batch(self, bank_id, resolved, conn):
+        assert conn is not None
+        self.reasserts.append(bank_id)
+
+
+def _kwargs(tracker, provider, er, *, doc_tracking_done, existing_hash, new_hash, outbox=None, is_last=False):
+    async def _lock(conn, table, doc_id, bank_id):
+        return existing_hash
+
+    pool = SimpleNamespace(ops=SimpleNamespace(lock_document_for_write=_lock))
+    phase1 = SimpleNamespace(
+        entities=SimpleNamespace(
+            resolved_entities=[SimpleNamespace(entity_id="e1")],
+            entity_to_unit=[(0, 0, None)],
+            unit_to_entity_ids={},
+        )
+    )
+    return dict(
+        provider=provider,
+        ext_txn=SimpleNamespace(txn_id="t1"),
+        pool=pool,
+        bank_id="bank1",
+        fq_table=lambda t: t,
+        entity_resolver=er,
+        phase1=phase1,
+        batch_contents=[{"content": "c"}],
+        batch_extracted=[SimpleNamespace(chunk_index=None)],
+        batch_processed=[SimpleNamespace(document_id=None, chunk_id=None)],
+        batch_chunk_meta=[],
+        effective_doc_id="doc1",
+        config=SimpleNamespace(store_document_text=True),
+        log_buffer=[],
+        is_recovery=False,
+        is_first_batch=True,
+        is_last=is_last,
+        doc_tracking_done=doc_tracking_done,
+        pipeline_aborted=[False],
+        append_base_hash=None,
+        new_content_hash=new_hash,
+        combined_content="body",
+        retain_params=None,
+        merged_tags=[],
+        outbox_callback=outbox,
+        assert_append_base_unchanged=lambda h: None,
+        p2_start=0.0,
+    )
+
+
+async def test_store_writes_are_connection_free_and_witness_is_in_txn(monkeypatch):
+    tracker = _ConnTracker()
+    calls = []
+    _make_common(monkeypatch, tracker, calls=calls)
+    provider, er = _Provider(), _EntityResolver(tracker)
+
+    aborted, result_ids = await orch._streaming_batch_write_ext(
+        **_kwargs(tracker, provider, er, doc_tracking_done=[False], existing_hash="__pending__", new_hash="h")
+    )
+
+    assert aborted is False
+    assert result_ids == [["u1"]]
+    # The fact write happened with no connection held.
+    assert tracker.store_writes_saw_open == [False]
+    # Entity re-posting happened (also connection-free — asserted inside the fake).
+    assert er.postings == [[("u1", "e1", None)]]
+    # Witness written with a real connection, exactly once; commit published after release.
+    assert len(provider.witnesses) == 1 and provider.witnesses[0][1] is not None
+    assert provider.decisions == [True]
+    assert tracker.open is False  # connection released at the end
+    # Entity registry reassert ran inside the txn.
+    assert er.reasserts == ["bank1"]
+
+
+async def test_later_batch_takeover_aborts_and_discards_staged_write(monkeypatch):
+    tracker = _ConnTracker()
+    calls = []
+    _make_common(monkeypatch, tracker, calls=calls)
+    provider, er = _Provider(), _EntityResolver(tracker)
+
+    # Later batch (doc_tracking already done) whose document was taken over: existing hash
+    # differs from ours → abort.
+    aborted, _ = await orch._streaming_batch_write_ext(
+        **_kwargs(tracker, provider, er, doc_tracking_done=[True], existing_hash="OTHER", new_hash="OURS")
+    )
+
+    assert aborted is True
+    # Staged store write still happened connection-free before the takeover was detected.
+    assert tracker.store_writes_saw_open == [False]
+    # The group was explicitly aborted, not committed.
+    assert provider.decisions == [False]
+
+
+async def test_outbox_row_rides_the_connection(monkeypatch):
+    tracker = _ConnTracker()
+    calls = []
+    _make_common(monkeypatch, tracker, calls=calls)
+    provider, er = _Provider(), _EntityResolver(tracker)
+    seen = {}
+
+    async def _outbox(conn):
+        seen["open"] = tracker.open
+        seen["conn"] = conn
+
+    aborted, _ = await orch._streaming_batch_write_ext(
+        **_kwargs(
+            tracker, provider, er, doc_tracking_done=[False],
+            existing_hash="__pending__", new_hash="h", outbox=_outbox, is_last=True,
+        )
+    )
+    assert aborted is False
+    assert seen["open"] is True and seen["conn"] is not None  # outbox wrote inside the txn
+    assert provider.decisions == [True]

--- a/hindsight-api-slim/tests/test_retain_ext_writegroup.py
+++ b/hindsight-api-slim/tests/test_retain_ext_writegroup.py
@@ -24,17 +24,21 @@ import hindsight_api.engine.retain.orchestrator as orch
 class _ConnTracker:
     """Flips ``open`` while a connection is checked out via acquire_with_retry."""
 
-    def __init__(self):
+    def __init__(self, current_hash=None):
         self.open = False
         self.store_writes_saw_open = []  # records `open` at each store-write call
+        self._current_hash = current_hash
 
     def acquire(self):
         tracker = self
 
+        async def _fetchval(*a, **k):
+            return tracker._current_hash
+
         class _CM:
             async def __aenter__(self_inner):
                 tracker.open = True
-                return SimpleNamespace(name="conn", transaction=_txn)
+                return SimpleNamespace(name="conn", transaction=_txn, fetchval=_fetchval)
             async def __aexit__(self_inner, *a):
                 tracker.open = False
                 return False
@@ -217,3 +221,106 @@ async def test_outbox_row_rides_the_connection(monkeypatch):
     assert aborted is False
     assert seen["open"] is True and seen["conn"] is not None  # outbox wrote inside the txn
     assert provider.decisions == [True]
+
+
+# --------------------------------------------------------------------------------------------
+# Delta re-retain path
+# --------------------------------------------------------------------------------------------
+
+def _make_common_delta(monkeypatch, tracker, *, calls):
+    _make_common(monkeypatch, tracker, calls=calls)
+
+    async def _store_document_bodies(*a, **k):
+        calls.append(("store_document_bodies", tracker.open))
+        assert tracker.open is False, "document-body store write must be connection-free"
+
+    async def _upsert_document_metadata(conn, *a, **k):
+        calls.append(("upsert_document_metadata", tracker.open))
+
+    async def _delete_chunks_by_ids(conn, ids, bank_id=None, txn=None, ops=None):
+        calls.append(("delete_chunks", tracker.open))
+        return 0
+
+    async def _update_meta(conn, *a, **k):
+        return 0
+
+    monkeypatch.setattr(orch, "_store_document_bodies", _store_document_bodies)
+    monkeypatch.setattr(orch.fact_storage, "upsert_document_metadata", _upsert_document_metadata)
+    monkeypatch.setattr(orch.chunk_storage, "delete_chunks_by_ids", _delete_chunks_by_ids)
+    monkeypatch.setattr(orch.fact_storage, "update_memory_units_metadata_and_tags", _update_meta)
+
+
+def _delta_kwargs(tracker, provider, er, *, doc_hash_at_load):
+    phase1 = SimpleNamespace(
+        entities=SimpleNamespace(
+            resolved_entities=[SimpleNamespace(entity_id="e1")],
+            entity_to_unit=[(0, 0, None)],
+            unit_to_entity_ids={},
+        )
+    )
+    return dict(
+        provider=provider,
+        ext_txn=SimpleNamespace(txn_id="t1"),
+        pool=SimpleNamespace(ops=SimpleNamespace()),
+        bank_id="bank1",
+        fq_table=lambda t: t,
+        entity_resolver=er,
+        phase1=phase1,
+        effective_doc_id="doc1",
+        config=SimpleNamespace(store_document_text=True),
+        log_buffer=[],
+        processed_facts=[SimpleNamespace(document_id=None, chunk_id=None)],
+        extracted_facts=[SimpleNamespace(chunk_index=None)],
+        delta_contents=[{"content": "c"}],
+        contents_dicts=[{"content": "c"}],
+        document_tags=[],
+        document_body_override=None,
+        doc_hash_at_load=doc_hash_at_load,
+        new_chunk_metadata=[],
+        delta_chunk_map={},
+        new_chunks_with_contents={},
+        existing_by_index={},
+        changed_indices=[],
+        removed_indices=[],
+        outbox_callback=None,
+    )
+
+
+async def test_delta_store_writes_are_connection_free(monkeypatch):
+    tracker = _ConnTracker(current_hash="SAME")
+    calls = []
+    _make_common_delta(monkeypatch, tracker, calls=calls)
+    # _build_retain_params is a plain module function; keep it real but feed simple dicts.
+    provider, er = _Provider(), _EntityResolver(tracker)
+
+    fell_back, ids = await orch._delta_batch_write_ext(
+        **_delta_kwargs(tracker, provider, er, doc_hash_at_load=None)  # None → hash check can't trip
+    )
+
+    assert fell_back is False
+    assert ids == [["u1"]]
+    # Fact write + body store + entity re-posting all happened connection-free.
+    assert tracker.store_writes_saw_open == [False]
+    assert ("store_document_bodies", False) in calls
+    assert er.postings == [[("u1", "e1", None)]]
+    # Witness inside the txn; publish after release.
+    assert len(provider.witnesses) == 1 and provider.witnesses[0][1] is not None
+    assert provider.decisions == [True]
+    assert tracker.open is False
+
+
+async def test_delta_falls_back_when_document_replaced(monkeypatch):
+    tracker = _ConnTracker(current_hash="NEW")  # differs from doc_hash_at_load below
+    calls = []
+    _make_common_delta(monkeypatch, tracker, calls=calls)
+    provider, er = _Provider(), _EntityResolver(tracker)
+
+    fell_back, _ = await orch._delta_batch_write_ext(
+        **_delta_kwargs(tracker, provider, er, doc_hash_at_load="OLD")
+    )
+
+    assert fell_back is True
+    # Staged store writes still ran connection-free before the conflict was detected.
+    assert tracker.store_writes_saw_open == [False]
+    # The group was discarded, not committed.
+    assert provider.decisions == [False]


### PR DESCRIPTION
## Problem

For a memories store that keeps its rows in the caller's own database (Postgres), the retain
write group is naturally one transaction: the memory write *is* a SQL write on the same
connection, so holding the transaction across it costs nothing extra.

For a store that **owns its memory rows in a separate system** (any `MemoriesExtension` whose
`mint_txn()`/`begin_txn()` returns a real write-group handle), the streaming retain batch still
ran inside a single `conn.transaction()` — so the data-plane Postgres connection, and the
`documents` row lock, were **held across the separate-store write**. That write is the slow part
of retain, and the memory is actually written to the store *twice* (facts, then a re-write
carrying the resolved entity ids), so the connection sat idle on I/O for both round-trips. Under
concurrency this starves the data-plane pool: each in-flight retain pins a connection for the
duration of an object-store round-trip rather than for local SQL work.

## Change

Add a **distinct connection-management path** for a store that returns a write-group handle,
selected at the streaming write site by `mint_txn(...) is not None`. **Postgres returns `None`
and takes the existing single-transaction path completely unchanged** (the diff is purely
additive — a new branch plus a helper; zero lines of the Postgres path move).

```
mint()   -> stage the store writes with NO connection held (tagged, invisible until decide)
         -> acquire a connection for a SHORT transaction only:
              { document/chunk metadata rows, entity-registry reassert, outbox row, witness }
         -> decide(commit=True) as a connection-free marker in the separate store
```

Why this is safe: for a separate store, **visibility is controlled by the write-group tag +
`decide_txn`, not by holding the row lock**. The staged writes are durable-but-invisible until
`decide_txn`; the commit witness recorded in the short transaction is the group's commit proof;
and the existing recovery sweep resolves a crash between the writes and the witness (witness
present → commit, absent after grace → abort). So the connection is only needed for the fast
local rows and the one-row witness INSERT.

The Postgres link writers (temporal / semantic / causal) are **skipped for such a store**:
temporal/semantic touch zero rows there (no `memory_units`), and causal edges already travel on
the memory record — writing them to `memory_links` would violate its `DEFERRABLE` FK to
`memory_units` (a latent failure this path avoids).

Adds `EntityResolver.record_unit_entity_postings` — the store-owned entity posting plus the
in-memory co-occurrence accumulation, neither of which needs a connection.

## Tests

`tests/test_retain_ext_writegroup.py` pins the contract with a fake store + a connection
tracker:
- `insert_facts_batch` and the entity re-posting run with **no connection checked out**;
- the witness is written **inside** the short transaction, and `decide(commit=True)` fires only
  **after** the connection is released;
- a later-batch takeover discards the staged write via `decide(commit=False)` — still
  connection-free;
- the outbox row rides the transaction;
- none of the Postgres link writers are invoked.

Existing `test_retain_orchestrator_mapping.py` (Postgres path) stays green. The DB-backed
concurrency/delta/append suites need the `pg0` embedded-Postgres fixture and run in CI.

## Scope / follow-ups (not in this PR)

- The **delta re-retain** write site (`_run_delta_db_work`) has the same conn-hold and should get
  the same treatment; it also adds tombstone store-deletes worth hoisting. Deferred so the pattern
  can be reviewed first (the delta path falls back to streaming on conflict).
- **Collapse the double store-write** for a store-owned backend into a single write carrying the
  entity ids (the currently-unused `index_facts` single-write path), halving the object-store
  writes per retain.

Draft: opening for review of the connection-management pattern before replicating to the delta site.
