### PR TITLE
fix(consolidation): cancel sibling tag groups when a batch fails

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -61,6 +61,44 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+async def _gather_or_cancel(coros: list[Any]) -> list[Any]:
+    """``asyncio.gather`` that leaves no task running behind it.
+
+    Plain ``asyncio.gather`` re-raises the first exception immediately but does
+    NOT cancel its siblings — they keep running detached. In consolidation that
+    is actively harmful: the failure propagates out of ``run_consolidation_job``
+    to the worker, which marks the operation failed and re-queues it with a 5s
+    base backoff, while the orphaned tag groups are still calling the LLM,
+    stamping ``mark_consolidated`` and committing write-groups. The per-scope
+    ``scope_locks`` are local to one dispatch, so nothing serialises an orphan
+    against the retry, and the "batches within a group run serially" invariant
+    that keeps two consolidators out of the same observation scope is broken
+    exactly when it matters.
+
+    So: cancel the outstanding tasks and await them before propagating. A
+    cancelled batch's writes stay invisible (its witness row is never
+    committed) and are resolved by the recovery sweep, which is the same state
+    a crash would leave.
+
+    Deliberately not ``asyncio.TaskGroup``: it wraps failures in an
+    ``ExceptionGroup``, and the worker's ``_is_non_retryable_task_error`` does
+    ``isinstance`` checks on the raised exception — a wrapped
+    ``IntegrityConstraintViolationError`` would be misclassified as retryable
+    and retried forever. This helper re-raises the original exception unchanged.
+    """
+    tasks = [asyncio.ensure_future(c) for c in coros]
+    try:
+        return await asyncio.gather(*tasks)
+    except BaseException:
+        for t in tasks:
+            if not t.done():
+                t.cancel()
+        # Await the cancellations before propagating: returning while they are
+        # still unwinding would reintroduce the very overlap this prevents.
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
+
+
 def _native_search_vector_update(config, param: str) -> str:
     """UPDATE-clause fragment that repopulates ``search_vector`` inline, or ''
     when the backend does not maintain a native tsvector column that way.
@@ -1287,21 +1325,60 @@ async def _run_consolidation_job(
             _txn_provider = get_memories()
             _batch_txn = await _txn_provider.mint_txn(bank_id=bank_id, mutating=True)
 
-            pending: list[list[dict[str, Any]]] = [llm_batch_local]
-            while pending:
-                sub_batch = pending.pop(0)
+            try:
+                pending: list[list[dict[str, Any]]] = [llm_batch_local]
+                while pending:
+                    sub_batch = pending.pop(0)
 
-                # No connection is held across the batch: recall, the main LLM call, the
-                # per-action embeds, and dedup all run connection-free; each helper acquires a
-                # short-lived connection only around its own SQL.
-                obs_tags_list = _resolve_obs_tags_list(sub_batch[0]) if sub_batch else None
+                    # No connection is held across the batch: recall, the main LLM call, the
+                    # per-action embeds, and dedup all run connection-free; each helper acquires a
+                    # short-lived connection only around its own SQL.
+                    obs_tags_list = _resolve_obs_tags_list(sub_batch[0]) if sub_batch else None
 
-                sub_deleted: int = 0
-                sub_llm_failed = False
-                if obs_tags_list:
-                    sub_results: list[dict[str, Any]] = []
-                    for obs_tags in obs_tags_list:
-                        pass_results, pass_deleted, pass_failed = await _process_memory_batch(
+                    sub_deleted: int = 0
+                    sub_llm_failed = False
+                    if obs_tags_list:
+                        sub_results: list[dict[str, Any]] = []
+                        for obs_tags in obs_tags_list:
+                            pass_results, pass_deleted, pass_failed = await _process_memory_batch(
+                                pool=pool,
+                                memory_engine=memory_engine,
+                                llm_config=llm_config,
+                                bank_id=bank_id,
+                                memories=sub_batch,
+                                request_context=request_context,
+                                perf=batch_perf,
+                                config=config,
+                                obs_tags_override=obs_tags,
+                                txn=_batch_txn,
+                            )
+                            sub_deleted += pass_deleted
+                            sub_llm_failed = sub_llm_failed or pass_failed
+                            if not sub_results:
+                                sub_results = pass_results
+                            else:
+                                for i, (existing, new) in enumerate(zip(sub_results, pass_results)):
+                                    if existing.get("action") == "skipped" and new.get("action") != "skipped":
+                                        sub_results[i] = new
+                                    elif existing.get("action") != "skipped" and new.get("action") != "skipped":
+                                        existing_created = existing.get(
+                                            "created", 1 if existing.get("action") == "created" else 0
+                                        )
+                                        existing_updated = existing.get(
+                                            "updated", 1 if existing.get("action") == "updated" else 0
+                                        )
+                                        new_created = new.get("created", 1 if new.get("action") == "created" else 0)
+                                        new_updated = new.get("updated", 1 if new.get("action") == "updated" else 0)
+                                        total = existing_created + existing_updated + new_created + new_updated
+                                        sub_results[i] = {
+                                            "action": "multiple",
+                                            "created": existing_created + new_created,
+                                            "updated": existing_updated + new_updated,
+                                            "merged": 0,
+                                            "total_actions": total,
+                                        }
+                    else:
+                        sub_results, sub_deleted, sub_llm_failed = await _process_memory_batch(
                             pool=pool,
                             memory_engine=memory_engine,
                             llm_config=llm_config,
@@ -1310,96 +1387,74 @@ async def _run_consolidation_job(
                             request_context=request_context,
                             perf=batch_perf,
                             config=config,
-                            obs_tags_override=obs_tags,
                             txn=_batch_txn,
                         )
-                        sub_deleted += pass_deleted
-                        sub_llm_failed = sub_llm_failed or pass_failed
-                        if not sub_results:
-                            sub_results = pass_results
-                        else:
-                            for i, (existing, new) in enumerate(zip(sub_results, pass_results)):
-                                if existing.get("action") == "skipped" and new.get("action") != "skipped":
-                                    sub_results[i] = new
-                                elif existing.get("action") != "skipped" and new.get("action") != "skipped":
-                                    existing_created = existing.get(
-                                        "created", 1 if existing.get("action") == "created" else 0
-                                    )
-                                    existing_updated = existing.get(
-                                        "updated", 1 if existing.get("action") == "updated" else 0
-                                    )
-                                    new_created = new.get("created", 1 if new.get("action") == "created" else 0)
-                                    new_updated = new.get("updated", 1 if new.get("action") == "updated" else 0)
-                                    total = existing_created + existing_updated + new_created + new_updated
-                                    sub_results[i] = {
-                                        "action": "multiple",
-                                        "created": existing_created + new_created,
-                                        "updated": existing_updated + new_updated,
-                                        "merged": 0,
-                                        "total_actions": total,
-                                    }
-                else:
-                    sub_results, sub_deleted, sub_llm_failed = await _process_memory_batch(
-                        pool=pool,
-                        memory_engine=memory_engine,
-                        llm_config=llm_config,
-                        bank_id=bank_id,
-                        memories=sub_batch,
-                        request_context=request_context,
-                        perf=batch_perf,
-                        config=config,
-                        txn=_batch_txn,
-                    )
 
-                all_deleted += sub_deleted
+                    all_deleted += sub_deleted
 
-                if sub_llm_failed and len(sub_batch) > 1:
-                    mid = len(sub_batch) // 2
+                    if sub_llm_failed and len(sub_batch) > 1:
+                        mid = len(sub_batch) // 2
+                        logger.warning(
+                            f"[CONSOLIDATION] bank={bank_id} LLM failed for sub-batch of {len(sub_batch)},"
+                            f" splitting into {mid}/{len(sub_batch) - mid}"
+                        )
+                        pending[0:0] = [sub_batch[:mid], sub_batch[mid:]]
+                    elif sub_llm_failed:
+                        failed_ids.append(sub_batch[0]["id"])
+                        all_results.append({"action": "failed"})
+                        logger.warning(
+                            f"[CONSOLIDATION] bank={bank_id} LLM failed for single memory"
+                            f" {sub_batch[0]['id']}, marking consolidation_failed_at"
+                        )
+                    else:
+                        succeeded_ids.extend(m["id"] for m in sub_batch)
+                        all_results.extend(sub_results)
+
+                # Mark through the store so the flag lands wherever the source facts live — tagged
+                # with this batch's txn, so the marks become visible together with the observations
+                # above. Then record the witness row and commit in this ONE short transaction (no LLM
+                # work inside it): its commit is the batch's fate, and `decide` publishes the group.
+                async with acquire_with_retry(pool) as conn:
+                    store = get_memories()
+                    now = datetime.now(timezone.utc)
+                    if succeeded_ids:
+                        await store.mark_consolidated(
+                            conn=conn,
+                            fq_table=fq_table,
+                            bank_id=bank_id,
+                            unit_ids=[str(mem_id) for mem_id in succeeded_ids],
+                            when=now,
+                            failed=False,
+                            txn=_batch_txn,
+                        )
+                    if failed_ids:
+                        await store.mark_consolidated(
+                            conn=conn,
+                            fq_table=fq_table,
+                            bank_id=bank_id,
+                            unit_ids=[str(mem_id) for mem_id in failed_ids],
+                            when=now,
+                            failed=True,
+                            txn=_batch_txn,
+                        )
+                    async with conn.transaction():
+                        await _txn_provider.write_txn_witness(_batch_txn, conn=conn, fq_table=fq_table)
+            except BaseException:
+                # The witness row was never committed, so this batch's writes are invisible;
+                # discard the write-group rather than leaving it pending for the recovery
+                # sweep. This matters more now that a sibling group's failure cancels this
+                # task mid-batch instead of letting it run to completion. Kept OUTSIDE the
+                # decide(commit=True) below on purpose: once the witness has committed, the
+                # batch's fate is decided and an abort here would discard durable writes.
+                try:
+                    await _txn_provider.decide_txn(_batch_txn, commit=False)
+                except Exception:
                     logger.warning(
-                        f"[CONSOLIDATION] bank={bank_id} LLM failed for sub-batch of {len(sub_batch)},"
-                        f" splitting into {mid}/{len(sub_batch) - mid}"
+                        f"[CONSOLIDATION] bank={bank_id} failed to abort write-group for"
+                        f" llm_batch #{batch_num_local}; recovery sweep will resolve it",
+                        exc_info=True,
                     )
-                    pending[0:0] = [sub_batch[:mid], sub_batch[mid:]]
-                elif sub_llm_failed:
-                    failed_ids.append(sub_batch[0]["id"])
-                    all_results.append({"action": "failed"})
-                    logger.warning(
-                        f"[CONSOLIDATION] bank={bank_id} LLM failed for single memory"
-                        f" {sub_batch[0]['id']}, marking consolidation_failed_at"
-                    )
-                else:
-                    succeeded_ids.extend(m["id"] for m in sub_batch)
-                    all_results.extend(sub_results)
-
-            # Mark through the store so the flag lands wherever the source facts live — tagged
-            # with this batch's txn, so the marks become visible together with the observations
-            # above. Then record the witness row and commit in this ONE short transaction (no LLM
-            # work inside it): its commit is the batch's fate, and `decide` publishes the group.
-            async with acquire_with_retry(pool) as conn:
-                store = get_memories()
-                now = datetime.now(timezone.utc)
-                if succeeded_ids:
-                    await store.mark_consolidated(
-                        conn=conn,
-                        fq_table=fq_table,
-                        bank_id=bank_id,
-                        unit_ids=[str(mem_id) for mem_id in succeeded_ids],
-                        when=now,
-                        failed=False,
-                        txn=_batch_txn,
-                    )
-                if failed_ids:
-                    await store.mark_consolidated(
-                        conn=conn,
-                        fq_table=fq_table,
-                        bank_id=bank_id,
-                        unit_ids=[str(mem_id) for mem_id in failed_ids],
-                        when=now,
-                        failed=True,
-                        txn=_batch_txn,
-                    )
-                async with conn.transaction():
-                    await _txn_provider.write_txn_witness(_batch_txn, conn=conn, fq_table=fq_table)
+                raise
             # Postgres committed the witness: publish the batch's write-group. On a crash before
             # here the writes stay invisible and the recovery sweep resolves them (spec §5).
             await _txn_provider.decide_txn(_batch_txn, commit=True)
@@ -1561,7 +1616,7 @@ async def _run_consolidation_job(
                             await stack.enter_async_context(scope_locks[s])
                         return await _process_tag_group(group_batches)
 
-            group_results = await asyncio.gather(*(_run_group(g, s) for g, s in zip(numbered_groups, group_scopes)))
+            group_results = await _gather_or_cancel([_run_group(g, s) for g, s in zip(numbered_groups, group_scopes)])
             batch_results: list[_BatchDeltas] = [d for gd in group_results for d in gd]
             any_cancelled = any(d.cancelled for d in batch_results)
         else:
@@ -1820,8 +1875,6 @@ async def _process_memory_batch(
             consolidation where a single memory can contribute to observations
             scoped at different tag levels (e.g., user-level vs session-level).
     """
-    import asyncio
-
     # Map the source memories this batch consumes onto the consolidation trace.
     record_source_memory_ids([str(m["id"]) for m in memories])
 
@@ -1839,7 +1892,11 @@ async def _process_memory_batch(
         )
         for m in memories
     ]
-    per_fact_recalls = await asyncio.gather(*recall_tasks)
+    # A failed recall must fail the batch rather than degrade to "no related
+    # observations": proceeding with an empty candidate set would hide an
+    # existing twin from the LLM and turn an UPDATE into a duplicate CREATE.
+    # The batch's memories stay unconsolidated and are picked up on retry.
+    per_fact_recalls = await _gather_or_cancel(recall_tasks)
     if perf:
         perf.record_timing("recall", time.time() - t0)
 

--- a/hindsight-api-slim/tests/test_consolidation_failure_isolation.py
+++ b/hindsight-api-slim/tests/test_consolidation_failure_isolation.py
@@ -1,0 +1,321 @@
+"""Failure isolation for the consolidation dispatcher.
+
+A DB failure inside one tag group's recall aborts the consolidation operation,
+which the worker retries with a 5s base backoff. Plain ``asyncio.gather`` does
+not cancel the sibling groups when it re-raises, so before this was fixed those
+groups kept running detached — still calling the LLM, still stamping
+``mark_consolidated`` and committing write-groups — while the retry was already
+under way. The per-scope ``scope_locks`` are local to one dispatch, so nothing
+serialised an orphan against the retry and two consolidators could write the
+same observation scope concurrently.
+
+These tests pin:
+
+1. ``_gather_or_cancel`` cancels and awaits its siblings, and re-raises the
+   ORIGINAL exception (not an ``ExceptionGroup``) so the worker's
+   ``_is_non_retryable_task_error`` classification still works.
+2. End to end: a failing recall in one tag group cancels the other groups
+   before they write, and the job does not wait for them.
+3. A batch that fails between ``mint_txn`` and the witness commit discards its
+   write-group instead of leaving it pending for the recovery sweep.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import uuid
+from unittest.mock import MagicMock, patch
+
+import asyncpg
+import pytest
+
+from hindsight_api.config import _get_raw_config
+from hindsight_api.engine.consolidation import consolidator as consolidator_module
+from hindsight_api.engine.consolidation.consolidator import (
+    _ConsolidationBatchResponse,
+    _CreateAction,
+    _gather_or_cancel,
+    run_consolidation_job,
+)
+from hindsight_api.engine.memory_engine import MemoryEngine, _is_non_retryable_task_error
+from hindsight_api.engine.providers.mock_llm import MockLLM
+from hindsight_api.engine.response_models import RecallResult
+
+
+class _RecallTimeout(Exception):
+    """Stands in for a database command timeout raised inside a recall."""
+
+
+# ---------------------------------------------------------------------------
+# _gather_or_cancel unit tests (no database)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gather_or_cancel_returns_results_in_order():
+    async def one(value: int) -> int:
+        await asyncio.sleep(0)
+        return value
+
+    assert await _gather_or_cancel([one(1), one(2), one(3)]) == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_gather_or_cancel_cancels_siblings_before_returning():
+    """The sibling must be cancelled AND awaited before the exception surfaces.
+
+    ``sibling_finished`` would be True under plain ``asyncio.gather``, which
+    leaves the sibling running past the raise.
+    """
+    started = asyncio.Event()
+    sibling_finished = False
+    sibling_cancelled = False
+
+    async def sibling():
+        nonlocal sibling_finished, sibling_cancelled
+        started.set()
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            sibling_cancelled = True
+            raise
+        sibling_finished = True
+
+    async def boom():
+        await started.wait()
+        raise _RecallTimeout("simulated DB command timeout")
+
+    with pytest.raises(_RecallTimeout):
+        await _gather_or_cancel([boom(), sibling()])
+
+    assert sibling_cancelled is True
+    assert sibling_finished is False
+
+
+@pytest.mark.asyncio
+async def test_gather_or_cancel_reraises_original_exception_unwrapped():
+    """An ExceptionGroup here (i.e. asyncio.TaskGroup) would break retry
+    classification: the worker isinstance-checks the raised exception, so a
+    wrapped integrity violation would be retried forever instead of dropped."""
+
+    async def boom():
+        raise asyncpg.exceptions.UniqueViolationError("duplicate key")
+
+    async def idle():
+        await asyncio.sleep(30)
+
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError) as exc_info:
+        await _gather_or_cancel([boom(), idle()])
+
+    assert not isinstance(exc_info.value, BaseExceptionGroup)
+    assert _is_non_retryable_task_error(exc_info.value) is True
+
+
+# ---------------------------------------------------------------------------
+# End-to-end fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def enable_observations():
+    config = _get_raw_config()
+    original = config.enable_observations
+    config.enable_observations = True
+    yield
+    config.enable_observations = original
+
+
+def _override_config(memory: MemoryEngine, **overrides):
+    raw = _get_raw_config()
+    fake = type(raw)(**{**{f: getattr(raw, f) for f in raw.__dataclass_fields__}, **overrides})
+    return patch.object(memory._config_resolver, "resolve_full_config", return_value=fake)
+
+
+def _mock_llm_one_obs_per_fact():
+    """MockLLM wrapper emitting one CREATE per fact id found in the prompt."""
+    mock_llm = MockLLM(provider="mock", api_key="", base_url="", model="mock-model")
+
+    def callback(messages, scope):
+        if scope != "consolidation":
+            return _ConsolidationBatchResponse()
+        prompt = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+        fact_ids = re.findall(r"\[([0-9a-f-]{36})\]", prompt)
+        creates = [_CreateAction(text=f"Observation about fact {fid[:8]}", source_fact_ids=[fid]) for fid in fact_ids]
+        return _ConsolidationBatchResponse(creates=creates)
+
+    mock_llm.set_response_callback(callback)
+    wrapper = MagicMock()
+    wrapper.with_config.return_value = mock_llm
+    return wrapper
+
+
+async def _insert_memory(conn, bank_id: str, text: str, tags: list[str]) -> uuid.UUID:
+    mem_id = uuid.uuid4()
+    await conn.execute(
+        """
+        INSERT INTO memory_units (id, bank_id, text, fact_type, tags, observation_scopes, created_at)
+        VALUES ($1, $2, $3, 'experience', $4, $5::jsonb, now())
+        """,
+        mem_id,
+        bank_id,
+        text,
+        tags,
+        json.dumps(None),
+    )
+    return mem_id
+
+
+async def _count_observations(memory: MemoryEngine, bank_id: str) -> int:
+    async with memory._pool.acquire() as conn:
+        return await conn.fetchval(
+            "SELECT count(*) FROM memory_units WHERE bank_id = $1 AND fact_type = 'observation'",
+            bank_id,
+        )
+
+
+class _TxnSpy:
+    """Delegates to the real memories store while recording txn decisions."""
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.decisions: list[bool] = []
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+    async def decide_txn(self, txn, *, commit: bool):
+        self.decisions.append(commit)
+        return await self._inner.decide_txn(txn, commit=commit)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recall_failure_cancels_sibling_tag_groups(memory: MemoryEngine, request_context):
+    """One group's recall times out → the other two groups are cancelled before
+    they write, and the job propagates the original error without waiting for
+    them."""
+    bank_id = f"test-cancel-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice likes tea", ["boom"])
+            await _insert_memory(conn, bank_id, "Bob bikes daily", ["user:bob"])
+            await _insert_memory(conn, bank_id, "Carol reads books", ["user:carol"])
+
+        siblings_parked = asyncio.Event()
+        parked_count = 0
+        cancelled_scopes: list[frozenset[str]] = []
+
+        async def fake_recall(*, tags=None, **_kwargs):
+            nonlocal parked_count
+            tag_set = frozenset(tags or [])
+            if "boom" in tag_set:
+                # Fail only once both siblings are parked, so the assertion below
+                # is about cancellation rather than about which group won a race.
+                await siblings_parked.wait()
+                raise _RecallTimeout("simulated DB command timeout")
+            parked_count += 1
+            if parked_count >= 2:
+                siblings_parked.set()
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                cancelled_scopes.append(tag_set)
+                raise
+            return RecallResult(results=[])
+
+        original_llm = memory._consolidation_llm_config
+        memory._consolidation_llm_config = _mock_llm_one_obs_per_fact()
+        try:
+            with (
+                _override_config(memory, consolidation_llm_parallelism=3, consolidation_llm_batch_size=1),
+                patch.object(memory, "submit_async_consolidation"),
+                patch.object(consolidator_module, "_find_related_observations", fake_recall),
+            ):
+                started = asyncio.get_running_loop().time()
+                with pytest.raises(_RecallTimeout):
+                    await run_consolidation_job(memory_engine=memory, bank_id=bank_id, request_context=request_context)
+                elapsed = asyncio.get_running_loop().time() - started
+        finally:
+            memory._consolidation_llm_config = original_llm
+
+        # Both sibling groups were cancelled, not left running detached.
+        assert sorted(cancelled_scopes, key=sorted) == [frozenset({"user:bob"}), frozenset({"user:carol"})]
+        # And the job did not block on their 30s sleep.
+        assert elapsed < 10
+
+        # Nothing was written: the cancelled groups never reached their commit,
+        # and no orphan lands a write after the operation has already failed.
+        await asyncio.sleep(0.2)
+        assert await _count_observations(memory, bank_id) == 0
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_failed_batch_aborts_its_write_group(memory: MemoryEngine, request_context):
+    """A batch that raises before its witness commit decides its write-group
+    abort, rather than leaving it pending for the recovery sweep."""
+    bank_id = f"test-abort-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice likes tea", ["user:alice"])
+
+        async def fake_recall(**_kwargs):
+            raise _RecallTimeout("simulated DB command timeout")
+
+        spy = _TxnSpy(consolidator_module.get_memories())
+        original_llm = memory._consolidation_llm_config
+        memory._consolidation_llm_config = _mock_llm_one_obs_per_fact()
+        try:
+            with (
+                _override_config(memory, consolidation_llm_parallelism=1, consolidation_llm_batch_size=1),
+                patch.object(memory, "submit_async_consolidation"),
+                patch.object(consolidator_module, "get_memories", return_value=spy),
+                patch.object(consolidator_module, "_find_related_observations", fake_recall),
+            ):
+                with pytest.raises(_RecallTimeout):
+                    await run_consolidation_job(memory_engine=memory, bank_id=bank_id, request_context=request_context)
+        finally:
+            memory._consolidation_llm_config = original_llm
+
+        assert spy.decisions == [False]
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_successful_batch_still_commits_its_write_group(memory: MemoryEngine, request_context):
+    """Guard on the abort path: the happy path must still decide commit=True."""
+    bank_id = f"test-commit-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice likes tea", ["user:alice"])
+
+        spy = _TxnSpy(consolidator_module.get_memories())
+        original_llm = memory._consolidation_llm_config
+        memory._consolidation_llm_config = _mock_llm_one_obs_per_fact()
+        try:
+            with (
+                _override_config(memory, consolidation_llm_parallelism=1, consolidation_llm_batch_size=1),
+                patch.object(memory, "submit_async_consolidation"),
+                patch.object(consolidator_module, "get_memories", return_value=spy),
+            ):
+                result = await run_consolidation_job(
+                    memory_engine=memory, bank_id=bank_id, request_context=request_context
+                )
+        finally:
+            memory._consolidation_llm_config = original_llm
+
+        assert result["status"] == "completed"
+        assert spy.decisions == [True]
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## Problem

`_run_consolidation_job` dispatches its tag groups with a plain `asyncio.gather`:

```python
group_results = await asyncio.gather(*(_run_group(g, s) for g, s in zip(numbered_groups, group_scopes)))
```

`asyncio.gather` re-raises the first exception **immediately but does not cancel its siblings** — they keep running detached. So when one group's recall hits the database command timeout:

1. the exception propagates out of `run_consolidation_job` → `_handle_consolidation`, which documents it as "propagates to execute_task for retry";
2. the worker marks the operation failed and re-queues it — `_CONSOLIDATION_RETRY_BACKOFF_BASE_SECONDS = 5`, so the retry is 5 seconds out;
3. meanwhile the other tag groups are **still running**: still calling the LLM, still stamping `mark_consolidated`, still committing write-groups, still writing `_write_operation_progress` for an operation that has already failed.

An LLM batch takes 4–13s and batches inside a group run serially, so the orphans are very likely still alive when the retry starts. The `scope_locks` that enforce per-scope mutual exclusion are a local `defaultdict` created inside one dispatch, so nothing serialises an orphan against the retried run — and the invariant in the code, *"batches within a group share a tag set and observation scope, so they MUST run serially"*, is broken exactly when it matters. Two consolidators recalling the same scope concurrently can both miss an existing observation and both CREATE.

`_process_memory_batch` has no exception handling at all, so any DB error inside the per-fact recall gather takes this path.

## Fix

Both consolidation gathers now go through `_gather_or_cancel`, which cancels the outstanding tasks and **awaits them** before propagating. A cancelled batch's writes stay invisible — its witness row is never committed — which is the same state a crash leaves.

Deliberately **not** `asyncio.TaskGroup`: it wraps failures in an `ExceptionGroup`, and the worker's `_is_non_retryable_task_error` does `isinstance` checks on the raised exception. A wrapped `IntegrityConstraintViolationError` would be misclassified as retryable and retried forever. The helper re-raises the original exception unchanged, and there's a test pinning that.

Two related points:

- **Write-group abort.** Cancelling a batch mid-flight leaves its minted write-group undecided, so the failure path now calls `decide_txn(commit=False)` instead of leaving it pending for the recovery sweep. Before this PR an orphan ran to completion and decided its own txn, so this is fallout from the cancellation change rather than a separate fix. The abort sits *outside* `decide(commit=True)` on purpose: once the witness has committed, the batch's fate is settled and an abort there would discard durable writes.
- **The per-fact recall gather still fails its batch.** Degrading a failed recall to "no related observations" would hide an existing twin from the LLM and turn an UPDATE into a duplicate CREATE. Those memories simply stay unconsolidated and are picked up on the retry.

## Tests

`tests/test_consolidation_failure_isolation.py`:

- `_gather_or_cancel` unit tests — siblings are cancelled *and awaited* before the exception surfaces; the original exception type survives unwrapped and still classifies as non-retryable.
- End to end (`consolidation_llm_parallelism=3`, three disjoint tag groups): one group's recall raises once the other two are parked; both siblings observe `CancelledError`, the job doesn't wait on their 30s sleep, and no observations are written — including after a settle delay, which is what would catch an orphan landing a late write.
- The write-group abort and the happy-path commit are both pinned via a spy on `decide_txn`.

Verified these fail without the fix: reverting just the two call sites gives `cancelled_scopes == []`, and neutralising the abort call gives `spy.decisions == []`.

## Notes for review

- The consolidator diff looks large but is mostly re-indentation from wrapping the batch body in `try:` — review with `?w=1` and it's ~20 real lines.
- `test_subbatch_multichunk_coverage.py` (2) and `test_op_cancellation.py::test_retain_stops_between_sub_batches_when_cancelled` fail on `origin/main` without this change too — pre-existing, unrelated to this PR.

Found while investigating #3301 (closed as not reproducible); this is the piece of that report that turned a single slow query into a stalled bank.
