### PR TITLE
feat(coding-agents): apply retain attribution to all ingestion paths

### DIFF
--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -310,8 +310,8 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `bankIdTemplate`        | `"coding-agent::{gitProject}"`       | dynamic bank id format; the default makes every agent share one bank per repo                                                                                                                                                       |
 | `mapPathToBank`         | —                                    | absolute path → bank; **longest prefix wins**; overrides everything                                                                                                                                                                 |
 | `resolveWorktrees`      | `true`                               | `{gitProject}`: linked worktrees share the main repo's bank                                                                                                                                                                         |
-| `retainTags`            | —                                    | extra tags on every session write-back, e.g. `["project:{gitProject}"]` — see **Recording where a memory came from** below                                                                                                          |
-| `retainMetadata`        | —                                    | extra metadata on every session write-back, e.g. `{"repo": "{gitProject}"}`                                                                                                                                                         |
+| `retainTags`            | —                                    | extra tags on every document written by the integration, e.g. `["project:{gitProject}"]` — see **Recording where a memory came from** below                                                                                         |
+| `retainMetadata`        | —                                    | extra metadata on every document written by the integration, e.g. `{"repo": "{gitProject}"}`                                                                                                                                        |
 | `disabled`              | `false`                              | hard off-switch (inert plugin/hook — a no-memory baseline)                                                                                                                                                                          |
 | `reflectTimeoutMs`      | `120000`                             | session-reflect timeout (hook harnesses additionally cap it at 25s to fit the host's hook window); on timeout the session runs without reflect (recorded)                                                                           |
 | `pageRefreshEveryTurns` | `10`                                 | refetch the knowledge pages and re-inject the page roster + tool guide every N user turns                                                                                                                                           |
@@ -397,8 +397,9 @@ all share one memory per repo — use `"{harness}-{gitProject}"` to split per ag
 
 With a bank per repo, the bank _is_ the answer to "where did this come from". On a deliberately
 **shared** bank — one bank holding cross-project knowledge so facts recall everywhere — it isn't:
-every memory looks alike. `retainTags` and `retainMetadata` stamp that provenance onto each session
-write-back:
+every memory looks alike. `retainTags` and `retainMetadata` stamp that provenance onto conversations,
+git history and diffs, survey lifecycle documents, initiative markers, and documents saved through
+`hindsight_ingest_document`:
 
 ```jsonc
 {
@@ -412,6 +413,7 @@ Recalls can then filter by `project:<repo>`, and every document shows which repo
 of. Both accept the same placeholders as `bankIdTemplate` — `{gitProject}`, `{project}`,
 `{harness}`, `{channel}`, `{user}` — plus `{bankId}`, `{sessionId}` and `{timestamp}`.
 `{gitProject}` is worktree-aware here too, so every linked worktree of a repo stamps one name.
+`{sessionId}` resolves to `unknown` for documents that do not originate from an agent session.
 
 The plugin's own `source:` and `harness:` tags are reserved: entries in those namespaces are ignored
 with a warning, so a document's agent attribution always reflects the agent that actually wrote it.

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -303,8 +303,8 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `bankIdTemplate`        | `"coding-agent::{gitProject}"`       | dynamic bank id format; the default makes every agent share one bank per repo                                                                                                                                                       |
 | `mapPathToBank`         | —                                    | absolute path → bank; **longest prefix wins**; overrides everything                                                                                                                                                                 |
 | `resolveWorktrees`      | `true`                               | `{gitProject}`: linked worktrees share the main repo's bank                                                                                                                                                                         |
-| `retainTags`            | —                                    | extra tags on every session write-back, e.g. `["project:{gitProject}"]` — see **Recording where a memory came from** below                                                                                                          |
-| `retainMetadata`        | —                                    | extra metadata on every session write-back, e.g. `{"repo": "{gitProject}"}`                                                                                                                                                         |
+| `retainTags`            | —                                    | extra tags on every document written by the integration, e.g. `["project:{gitProject}"]` — see **Recording where a memory came from** below                                                                                         |
+| `retainMetadata`        | —                                    | extra metadata on every document written by the integration, e.g. `{"repo": "{gitProject}"}`                                                                                                                                        |
 | `disabled`              | `false`                              | hard off-switch (inert plugin/hook — a no-memory baseline)                                                                                                                                                                          |
 | `reflectTimeoutMs`      | `120000`                             | session-reflect timeout (hook harnesses additionally cap it at 25s to fit the host's hook window); on timeout the session runs without reflect (recorded)                                                                           |
 | `pageRefreshEveryTurns` | `10`                                 | refetch the knowledge pages and re-inject the page roster + tool guide every N user turns                                                                                                                                           |
@@ -390,8 +390,9 @@ all share one memory per repo — use `"{harness}-{gitProject}"` to split per ag
 
 With a bank per repo, the bank _is_ the answer to "where did this come from". On a deliberately
 **shared** bank — one bank holding cross-project knowledge so facts recall everywhere — it isn't:
-every memory looks alike. `retainTags` and `retainMetadata` stamp that provenance onto each session
-write-back:
+every memory looks alike. `retainTags` and `retainMetadata` stamp that provenance onto conversations,
+git history and diffs, survey lifecycle documents, initiative markers, and documents saved through
+`hindsight_ingest_document`:
 
 ```jsonc
 {
@@ -405,6 +406,7 @@ Recalls can then filter by `project:<repo>`, and every document shows which repo
 of. Both accept the same placeholders as `bankIdTemplate` — `{gitProject}`, `{project}`,
 `{harness}`, `{channel}`, `{user}` — plus `{bankId}`, `{sessionId}` and `{timestamp}`.
 `{gitProject}` is worktree-aware here too, so every linked worktree of a repo stamps one name.
+`{sessionId}` resolves to `unknown` for documents that do not originate from an agent session.
 
 The plugin's own `source:` and `harness:` tags are reserved: entries in those namespaces are ignored
 with a warning, so a document's agent attribution always reflects the agent that actually wrote it.

--- a/hindsight-integrations/coding-agents/src/core/chat.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { HindsightClient } from "./hindsight";
-import { renderSessionJsonl, retainLiveSession, type TransportTurn } from "./chat";
+import { ingestChats, renderSessionJsonl, retainLiveSession, type TransportTurn } from "./chat";
 import { memoryCursorStore, type RetainCursorStore } from "./retain-cursor";
 
 describe("renderSessionJsonl", () => {
@@ -74,6 +74,34 @@ describe("retainLiveSession", () => {
       source: "chat",
       session_id: "s2",
       ref_id: "conversation:s2",
+    });
+  });
+});
+
+describe("ingestChats", () => {
+  it("applies per-session retain attribution while preserving built-in chat identity", async () => {
+    const retain = vi.fn().mockResolvedValue(undefined);
+    const client = { retain } as unknown as HindsightClient;
+
+    await ingestChats(
+      client,
+      [{ id: "s-import", turns: [{ role: "user", text: "remember this" }] }],
+      {
+        stampFor: (sessionId) => ({
+          tags: [`project:repo-a`, `session:${sessionId}`],
+          metadata: { project: "repo-a", source: "configured" },
+        }),
+      }
+    );
+
+    expect(retain).toHaveBeenCalledTimes(1);
+    const [, , , tags, , opts] = retain.mock.calls[0];
+    expect(tags).toEqual(["project:repo-a", "session:s-import", "source:chat"]);
+    expect(opts.metadata).toMatchObject({
+      project: "repo-a",
+      source: "chat",
+      chat: "s-import",
+      ref_id: "chat:s-import",
     });
   });
 });

--- a/hindsight-integrations/coding-agents/src/core/chat.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.ts
@@ -38,7 +38,11 @@ export function renderSessionJsonl(refId: string, turns: TransportTurn[], baseTs
 export async function ingestChats(
   client: HindsightClient,
   sessions: ChatSession[],
-  opts: { concurrency?: number; log?: (m: string) => void } = {}
+  opts: {
+    concurrency?: number;
+    log?: (m: string) => void;
+    stampFor?: (sessionId: string) => RetainStamp;
+  } = {}
 ): Promise<number> {
   const log = opts.log ?? (() => {});
   if (!sessions.length) {
@@ -53,6 +57,7 @@ export async function ingestChats(
     opts.concurrency ?? 8,
     async (s, i) => {
       const id = s.id || `s${i}`;
+      const stamp = opts.stampFor?.(id);
       // each turn gets an ABSOLUTE timestamp: its own if provided, else synthesized from the real clock,
       // staggered per session + 1 min/turn to preserve ordering. List order is CHRONOLOGICAL (a later
       // chat can amend an earlier one), so the LAST session is the newest — the previous `NOW - i*1h`
@@ -72,11 +77,16 @@ export async function ingestChats(
         turns.map((x) => JSON.stringify(x)).join("\n"),
         "developer chat",
         `chat:${id}`,
-        ["source:chat"],
+        [...new Set([...(stamp?.tags ?? []), "source:chat"])],
         "conversation",
         {
           timestamp: baseIso,
-          metadata: { source: "chat", chat: id, ref_id: `chat:${id}` },
+          metadata: {
+            ...stamp?.metadata,
+            source: "chat",
+            chat: id,
+            ref_id: `chat:${id}`,
+          },
         }
       );
     },

--- a/hindsight-integrations/coding-agents/src/core/git.gitlog.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/git.gitlog.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HindsightClient } from "./hindsight";
-import { gitLogText, ingestGitLog, repoNameOf } from "./git";
+import { gitLogText, ingestGitLog, repoNameOf, retainCommit } from "./git";
 
 let dir: string;
 
@@ -74,5 +74,40 @@ describe("ingestGitLog", () => {
 
     expect(retainSpy).not.toHaveBeenCalled();
     expect(failures).toBe(0);
+  });
+
+  it("applies retain attribution to aggregated git history", async () => {
+    execFileSync("git", ["-C", dir, "commit", "--allow-empty", "-m", "feat: attributed"]);
+    const retain = vi.fn().mockResolvedValue(undefined);
+    const client = { retain, opIds: [] } as unknown as HindsightClient;
+
+    await ingestGitLog(client, dir, {
+      limit: 10,
+      stampFor: () => ({ tags: ["project:repo-a"], metadata: { project: "repo-a" } }),
+    });
+
+    expect(retain.mock.calls[0][3]).toEqual(
+      expect.arrayContaining(["project:repo-a", "source:git", "source:git-log"])
+    );
+    expect(retain.mock.calls[0][5]).toEqual({ metadata: { project: "repo-a" } });
+  });
+
+  it("applies retain attribution to full commit documents with built-ins authoritative", async () => {
+    execFileSync("git", ["-C", dir, "commit", "--allow-empty", "-m", "feat: full diff"]);
+    const sha = execFileSync("git", ["-C", dir, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+    const retain = vi.fn().mockResolvedValue(undefined);
+    const client = { retain, opIds: [] } as unknown as HindsightClient;
+
+    await retainCommit(client, dir, sha, repoNameOf(dir), {
+      tags: ["project:repo-a"],
+      metadata: { project: "repo-a", source: "configured" },
+    });
+
+    expect(retain.mock.calls[0][3]).toEqual(["project:repo-a", "source:git"]);
+    expect(retain.mock.calls[0][5].metadata).toMatchObject({
+      project: "repo-a",
+      source: "git",
+      commit: sha,
+    });
   });
 });

--- a/hindsight-integrations/coding-agents/src/core/git.ts
+++ b/hindsight-integrations/coding-agents/src/core/git.ts
@@ -9,6 +9,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { projectNameOf } from "./bank";
 import type { HindsightClient } from "./hindsight";
+import type { RetainStamp } from "./retain-stamp";
 import { pool } from "./util";
 
 const US = "\x1f";
@@ -68,7 +69,8 @@ export async function retainCommit(
   client: HindsightClient,
   repo: string,
   sha: string,
-  repoName: string
+  repoName: string,
+  stamp?: RetainStamp
 ): Promise<void> {
   const [h, an, ae, aISO, cISO, subj, body] = git(
     repo,
@@ -83,26 +85,39 @@ export async function retainCommit(
     `REF-ID: git:${sha.slice(0, 12)}\n` +
     `Git commit ${sha.slice(0, 12)} in the ${repoName} repository (${an}, ${aISO}).\n\n` +
     `Message:\n${msg}\n\nDiff:\n${diff}`;
-  await client.retain(content, `git commit in ${repoName}`, `git:${sha}`, ["source:git"], "git", {
-    timestamp: aISO, // the memory's timestamp is the commit's author date
-    metadata: {
-      source: "git",
-      repo: repoName,
-      commit: h,
-      short_sha: sha.slice(0, 12),
-      author: an,
-      author_email: ae,
-      authored_at: aISO,
-      committed_at: cISO,
-      subject: subj,
-    },
-  });
+  await client.retain(
+    content,
+    `git commit in ${repoName}`,
+    `git:${sha}`,
+    [...new Set([...(stamp?.tags ?? []), "source:git"])],
+    "git",
+    {
+      timestamp: aISO, // the memory's timestamp is the commit's author date
+      metadata: {
+        ...stamp?.metadata,
+        source: "git",
+        repo: repoName,
+        commit: h,
+        short_sha: sha.slice(0, 12),
+        author: an,
+        author_email: ae,
+        authored_at: aISO,
+        committed_at: cISO,
+        subject: subj,
+      },
+    }
+  );
 }
 
 export async function ingestGit(
   client: HindsightClient,
   repo: string,
-  opts: { limit?: number; concurrency?: number; log?: (m: string) => void } = {}
+  opts: {
+    limit?: number;
+    concurrency?: number;
+    log?: (m: string) => void;
+    stampFor?: () => RetainStamp;
+  } = {}
 ): Promise<number> {
   const log = opts.log ?? (() => {});
   // NEWEST-first: recent commits (the project's own decision commits) extract before the ancient
@@ -116,7 +131,7 @@ export async function ingestGit(
     shas,
     opts.concurrency ?? 8,
     async (sha) => {
-      await retainCommit(client, repo, sha, repoName);
+      await retainCommit(client, repo, sha, repoName, opts.stampFor?.());
     },
     (i, e) => {
       failures++;
@@ -173,7 +188,7 @@ export function gitLogText(repo: string, limit: number): string {
 export async function ingestGitLog(
   client: HindsightClient,
   repo: string,
-  opts: { limit: number; log?: (m: string) => void } = { limit: 300 }
+  opts: { limit: number; log?: (m: string) => void; stampFor?: () => RetainStamp } = { limit: 300 }
 ): Promise<number> {
   const log = opts.log ?? (() => {});
   const text = gitLogText(repo, opts.limit);
@@ -188,13 +203,33 @@ export async function ingestGitLog(
     // The gitlog-head:<sha> tag makes freshness a single tag query: the deepen engine re-upserts
     // this document (same id — replaces, never duplicates) only when HEAD has moved past it.
     const head = gitHeadSha(repo);
-    await client.retain(
-      text,
-      `git commit-message history (last ${n}) for ${repoName}`,
-      `gitlog:${repoName}`,
-      ["source:git", "source:git-log", ...(head ? [`gitlog-head:${head}`] : [])],
-      "gitlog"
-    );
+    const stamp = opts.stampFor?.();
+    const tags = [
+      ...new Set([
+        ...(stamp?.tags ?? []),
+        "source:git",
+        "source:git-log",
+        ...(head ? [`gitlog-head:${head}`] : []),
+      ]),
+    ];
+    if (Object.keys(stamp?.metadata ?? {}).length) {
+      await client.retain(
+        text,
+        `git commit-message history (last ${n}) for ${repoName}`,
+        `gitlog:${repoName}`,
+        tags,
+        "gitlog",
+        { metadata: stamp?.metadata }
+      );
+    } else {
+      await client.retain(
+        text,
+        `git commit-message history (last ${n}) for ${repoName}`,
+        `gitlog:${repoName}`,
+        tags,
+        "gitlog"
+      );
+    }
     log(`[gitlog] done: ${n} commit messages ingested as 1 document under strategy 'gitlog'`);
     return 0;
   } catch (e) {

--- a/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
@@ -398,6 +398,34 @@ describe("HindsightClient.captureInitiative", () => {
     expect(item.tags).toEqual(["knowledge:feature-work", "relatedPageId:initiative-x"]);
     expect(item.content).toContain("Enhancement to an existing initiative");
   });
+
+  it("applies retain attribution to initiative markers", async () => {
+    const calls: any[] = [];
+    stubFetchRouted(calls, [
+      {
+        match: (m, u) => m === "POST" && u.endsWith("/memories"),
+        json: { operation_id: "op-1" },
+      },
+    ]);
+    const c = new HindsightClient({ apiUrl: "http://x", bank: "repo-a" });
+    await c.captureInitiative({
+      title: "Attributed initiative",
+      summary: "Keep its project provenance.",
+      relatesToPageId: "initiative-x",
+      stamp: {
+        tags: ["project:repo-a"],
+        metadata: { project: "repo-a", source: "configured" },
+      },
+    });
+
+    const item = calls.find((k) => k.url.endsWith("/memories")).body.items[0];
+    expect(item.tags).toEqual([
+      "project:repo-a",
+      "knowledge:feature-work",
+      "relatedPageId:initiative-x",
+    ]);
+    expect(item.metadata).toEqual({ project: "repo-a", source: "configured" });
+  });
 });
 
 describe("HindsightClient.configureBank template import", () => {

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -13,6 +13,7 @@ import {
   PAGES,
 } from "./missions";
 import { semverGte, sleep } from "./util";
+import type { RetainStamp } from "./retain-stamp";
 
 /** One node of GET /knowledge-base/tree. Only the fields this client reads. */
 export interface KnowledgeNode {
@@ -492,6 +493,7 @@ export class HindsightClient {
     title: string;
     summary: string;
     relatesToPageId?: string;
+    stamp?: RetainStamp;
   }): Promise<{ page_id: string }> {
     // `/knowledge-base/pages` mints its OWN page id (kp-…); we can't set it. So for a new initiative
     // we create the page first and adopt the server-assigned id — that id is what the return value
@@ -522,13 +524,20 @@ export class HindsightClient {
     const content = `${verb}: ${args.title}. ${args.summary}`;
     // Unique marker document id (NOT pageId) so repeated captures accrue instead of replacing.
     const markerId = `initiative-marker-${this.slugify(args.title)}-${Date.now()}`;
-    await this.retain(
-      content,
-      "initiative marker",
-      markerId,
-      ["knowledge:feature-work", `relatedPageId:${pageId}`],
-      "document"
-    );
+    const tags = [
+      ...new Set([
+        ...(args.stamp?.tags ?? []),
+        "knowledge:feature-work",
+        `relatedPageId:${pageId}`,
+      ]),
+    ];
+    if (Object.keys(args.stamp?.metadata ?? {}).length) {
+      await this.retain(content, "initiative marker", markerId, tags, "document", {
+        metadata: args.stamp?.metadata,
+      });
+    } else {
+      await this.retain(content, "initiative marker", markerId, tags, "document");
+    }
     return { page_id: pageId };
   }
 

--- a/hindsight-integrations/coding-agents/src/core/knowledge-tools.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/knowledge-tools.test.ts
@@ -226,6 +226,37 @@ describe("buildKnowledgeTools", () => {
     });
   });
 
+  it("applies retain attribution to initiative capture and manual document ingestion", async () => {
+    const client = stubClient();
+    const stampFor = vi.fn(() => ({
+      tags: ["project:repo-a"],
+      metadata: { project: "repo-a" },
+    }));
+    const tools = buildKnowledgeTools(client, "repo-a", { harness: "codex", stampFor });
+
+    await findTool(tools, "hindsight_capture_initiative").handler({
+      title: "New thing",
+      summary: "why",
+    });
+    expect(client.captureInitiative).toHaveBeenCalledWith({
+      title: "New thing",
+      summary: "why",
+      relatesToPageId: undefined,
+      stamp: { tags: ["project:repo-a"], metadata: { project: "repo-a" } },
+    });
+
+    await findTool(tools, "hindsight_ingest_document").handler({ title: "Notes", content: "x" });
+    expect(client.retain).toHaveBeenCalledWith(
+      "x",
+      "ingested document",
+      "notes",
+      ["project:repo-a", "source:upload", "harness:codex"],
+      "document",
+      { metadata: { project: "repo-a", harness: "codex" } }
+    );
+    expect(stampFor).toHaveBeenCalledTimes(2);
+  });
+
   it("hindsight_ingest_document slugifies the title and calls client.retain(...) with the 'document' strategy", async () => {
     const client = stubClient();
     const tools = buildKnowledgeTools(client, "repo-a");

--- a/hindsight-integrations/coding-agents/src/core/knowledge-tools.ts
+++ b/hindsight-integrations/coding-agents/src/core/knowledge-tools.ts
@@ -20,6 +20,7 @@ import type { ZodRawShape } from "zod";
 import type { HindsightClient } from "./hindsight";
 import { syncStatus } from "./status";
 import { loadConfig } from "./config";
+import type { RetainStamp } from "./retain-stamp";
 
 export interface ToolResult {
   // Index signature so this structurally satisfies the MCP SDK's CallToolResult (which carries
@@ -61,7 +62,7 @@ function guarded(fn: (args: any) => Promise<unknown>): (args: any) => Promise<To
 export function buildKnowledgeTools(
   client: HindsightClient,
   bankId: string,
-  opts: { repoDir?: string; harness?: string } = {}
+  opts: { repoDir?: string; harness?: string; stampFor?: () => RetainStamp } = {}
 ): ToolSpec[] {
   return [
     {
@@ -201,7 +202,12 @@ export function buildKnowledgeTools(
         relates_to_page_id: z.string().optional(),
       },
       handler: guarded(async ({ title, summary, relates_to_page_id }) =>
-        client.captureInitiative({ title, summary, relatesToPageId: relates_to_page_id })
+        client.captureInitiative({
+          title,
+          summary,
+          relatesToPageId: relates_to_page_id,
+          ...(opts.stampFor ? { stamp: opts.stampFor() } : {}),
+        })
       ),
     },
     {
@@ -221,13 +227,24 @@ export function buildKnowledgeTools(
             .toLowerCase()
             .replace(/[^a-z0-9]+/g, "-")
             .replace(/^-+|-+$/g, "") || "doc";
+        const stamp = opts.stampFor?.();
+        const metadata = {
+          ...stamp?.metadata,
+          ...(opts.harness ? { harness: opts.harness } : {}),
+        };
         await client.retain(
           content,
           "ingested document",
           docId,
-          ["source:upload", ...(opts.harness ? [`harness:${opts.harness}`] : [])],
+          [
+            ...new Set([
+              ...(stamp?.tags ?? []),
+              "source:upload",
+              ...(opts.harness ? [`harness:${opts.harness}`] : []),
+            ]),
+          ],
           "document",
-          { metadata: opts.harness ? { harness: opts.harness } : undefined }
+          Object.keys(metadata).length ? { metadata } : {}
         );
         return { ok: true, doc_id: docId };
       }),

--- a/hindsight-integrations/coding-agents/src/core/retain-stamp.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-stamp.test.ts
@@ -56,6 +56,12 @@ describe("buildRetainStamp", () => {
     expect(tags).toEqual(["h:codex", "b:shared-bank", "s:sess-1", "u:nico", "c:team"]);
   });
 
+  it("resolves {sessionId} to unknown for non-session documents", () => {
+    expect(
+      buildRetainStamp({ retainTags: ["session:{sessionId}"] }, ctx({ sessionId: undefined })).tags
+    ).toEqual(["session:unknown"]);
+  });
+
   it("resolves {project} from the directory basename, without git", () => {
     const { tags } = buildRetainStamp({ retainTags: ["p:{project}"] }, ctx());
     expect(tags).toEqual([`p:${repo.split("/").pop()}`]);

--- a/hindsight-integrations/coding-agents/src/core/retain-stamp.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-stamp.ts
@@ -33,7 +33,8 @@ export interface RetainStampContext {
   directory: string;
   harness: string;
   bankId: string;
-  sessionId: string;
+  /** Agent session when the document comes from one; absent for non-session documents. */
+  sessionId?: string;
 }
 
 export interface RetainStamp {
@@ -54,7 +55,7 @@ function resolversFor(ctx: RetainStampContext): Resolvers {
     project: () => (ctx.directory ? basename(ctx.directory) : "unknown"),
     harness: () => ctx.harness,
     bankId: () => ctx.bankId,
-    sessionId: () => ctx.sessionId,
+    sessionId: () => ctx.sessionId ?? "unknown",
     timestamp: () => new Date().toISOString(),
     channel: () => process.env.HINDSIGHT_CHANNEL_ID || "default",
     user: () => process.env.HINDSIGHT_USER_ID || "anonymous",

--- a/hindsight-integrations/coding-agents/src/core/runtime.ts
+++ b/hindsight-integrations/coding-agents/src/core/runtime.ts
@@ -73,7 +73,16 @@ export class RuntimeCore {
 
   /** The hindsight_* knowledge + recall tools, bound to this bank, for the harness to register natively. */
   toolSpecs(): ToolSpec[] {
-    return buildKnowledgeTools(this.client, this.bankId, { harness: this.harness });
+    return buildKnowledgeTools(this.client, this.bankId, {
+      repoDir: this.projectDir,
+      harness: this.harness,
+      stampFor: () =>
+        buildRetainStamp(this.cfg, {
+          directory: this.projectDir,
+          harness: this.harness,
+          bankId: this.bankId,
+        }),
+    });
   }
 
   get writeBackEnabled(): boolean {

--- a/hindsight-integrations/coding-agents/src/core/session-start.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.test.ts
@@ -286,6 +286,9 @@ describe("buildSessionStartContext — periodic re-survey (bank-stored commit co
     `survey-baseline:${sha}`,
     ["source:survey-baseline"],
     "survey", // survey-lifecycle strategy (marker rule: zero extraction)
+    // Opts are always passed now; with no retainMetadata configured the stamp is empty, and
+    // `retain` only sets metadata when truthy, so nothing reaches the API.
+    { metadata: undefined },
   ];
 
   it(">= threshold since the latest reachable baseline -> re-surveys + records a new baseline", async () => {

--- a/hindsight-integrations/coding-agents/src/core/session-start.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.test.ts
@@ -309,6 +309,34 @@ describe("buildSessionStartContext — periodic re-survey (bank-stored commit co
     expect(retain).toHaveBeenCalledWith(...marker("newsha"));
   });
 
+  it("applies retain attribution to survey baseline markers", async () => {
+    const retain = vi.fn();
+    await buildSessionStartContext({
+      cwd: "/repo",
+      bankId: "bank-1",
+      cfg: resolveConfig({
+        surveyRefreshCommits: 20,
+        retainTags: ["project:{project}"],
+        retainMetadata: { bank: "{bankId}" },
+      }),
+      client: warmClient(["survey-baseline:oldsha"], retain),
+      hasGit: () => true,
+      startSeed: vi.fn(),
+      startSurvey: vi.fn(),
+      headSha: () => "newsha",
+      commitsSince: () => 25,
+    });
+
+    expect(retain).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      "survey-baseline:newsha",
+      ["project:repo", "source:survey-baseline"],
+      "survey",
+      { metadata: { bank: "bank-1" } }
+    );
+  });
+
   it("< threshold -> no re-survey, no new baseline", async () => {
     const startSurvey = vi.fn();
     const retain = vi.fn();

--- a/hindsight-integrations/coding-agents/src/core/session-start.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.ts
@@ -174,22 +174,15 @@ export async function buildSessionStartContext(args: {
         `(Internal marker: no memories are extracted from this document.)`;
       const tags = [...new Set([...stamp.tags, SURVEY_BASELINE_TAG])];
       // Fire-and-forget; Promise.resolve tolerates a non-Promise return (e.g. a test spy).
-      const retained = Object.keys(stamp.metadata).length
-        ? client.retain(
-            content,
-            "hindsight codebase-survey baseline",
-            `${SURVEY_BASELINE_PREFIX}${sha}`,
-            tags,
-            "survey",
-            { metadata: stamp.metadata }
-          )
-        : client.retain(
-            content,
-            "hindsight codebase-survey baseline",
-            `${SURVEY_BASELINE_PREFIX}${sha}`,
-            tags,
-            "survey"
-          );
+      const retained = client.retain(
+        content,
+        "hindsight codebase-survey baseline",
+        `${SURVEY_BASELINE_PREFIX}${sha}`,
+        tags,
+        "survey",
+        // `retain` only sets metadata when it is truthy, so an empty stamp sends none.
+        { metadata: Object.keys(stamp.metadata).length ? stamp.metadata : undefined }
+      );
       void Promise.resolve(retained).catch(() => {});
     } catch {
       /* best-effort — a failed baseline write never breaks SessionStart */

--- a/hindsight-integrations/coding-agents/src/core/session-start.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.ts
@@ -33,6 +33,7 @@ import { diag } from "./diag";
 import { setLogLevel } from "./log";
 import { parsePageList, buildKnowledgePreamble, type PageRef } from "./knowledge-injection";
 import type { ClientOpts, RetainOpts } from "./hindsight";
+import { buildRetainStamp } from "./retain-stamp";
 import { HindsightClient } from "./hindsight";
 import { sessionCacheFile, writeSessionCache } from "./session-cache";
 
@@ -156,6 +157,7 @@ export async function buildSessionStartContext(args: {
   const startSurvey = args.startSurvey ?? startCodebaseSurvey;
   const resolveHeadSha = args.headSha ?? gitHeadSha;
   const countCommitsSince = args.commitsSince ?? commitsSince;
+  const retainStamp = () => buildRetainStamp(cfg, { directory: cwd, harness, bankId });
 
   // Codebase-survey baseline (Option A): the bank is the only state, so the HEAD at the last survey
   // is recorded IN the bank as a tiny `survey-baseline:<sha>` marker doc (tag source:survey-baseline;
@@ -166,17 +168,29 @@ export async function buildSessionStartContext(args: {
   const recordSurveyBaseline = (sha: string): void => {
     if (!client.retain) return; // minimal client (some tests) — nothing to record
     try {
+      const stamp = retainStamp();
+      const content =
+        `🛰️ Hindsight is researching this codebase — survey started at commit ${sha.slice(0, 12)}. ` +
+        `(Internal marker: no memories are extracted from this document.)`;
+      const tags = [...new Set([...stamp.tags, SURVEY_BASELINE_TAG])];
       // Fire-and-forget; Promise.resolve tolerates a non-Promise return (e.g. a test spy).
-      void Promise.resolve(
-        client.retain(
-          `🛰️ Hindsight is researching this codebase — survey started at commit ${sha.slice(0, 12)}. ` +
-            `(Internal marker: no memories are extracted from this document.)`,
-          "hindsight codebase-survey baseline",
-          `${SURVEY_BASELINE_PREFIX}${sha}`,
-          [SURVEY_BASELINE_TAG],
-          "survey"
-        )
-      ).catch(() => {});
+      const retained = Object.keys(stamp.metadata).length
+        ? client.retain(
+            content,
+            "hindsight codebase-survey baseline",
+            `${SURVEY_BASELINE_PREFIX}${sha}`,
+            tags,
+            "survey",
+            { metadata: stamp.metadata }
+          )
+        : client.retain(
+            content,
+            "hindsight codebase-survey baseline",
+            `${SURVEY_BASELINE_PREFIX}${sha}`,
+            tags,
+            "survey"
+          );
+      void Promise.resolve(retained).catch(() => {});
     } catch {
       /* best-effort — a failed baseline write never breaks SessionStart */
     }

--- a/hindsight-integrations/coding-agents/src/deepen.ts
+++ b/hindsight-integrations/coding-agents/src/deepen.ts
@@ -257,24 +257,17 @@ async function main() {
             `✅ Codebase survey completed — baseline commit ${best.sha.slice(0, 12)}. ` +
             `(Internal marker: no memories are extracted from this document.)`;
           const tags = [...new Set([...stamp.tags, "source:survey-baseline", "survey-state:done"])];
-          if (Object.keys(stamp.metadata).length) {
-            await client.retain(
-              content,
-              "hindsight codebase-survey baseline",
-              best.id,
-              tags,
-              "survey",
-              { metadata: stamp.metadata }
-            );
-          } else {
-            await client.retain(
-              content,
-              "hindsight codebase-survey baseline",
-              best.id,
-              tags,
-              "survey"
-            );
-          }
+          await client.retain(
+            content,
+            "hindsight codebase-survey baseline",
+            best.id,
+            tags,
+            "survey",
+            {
+              // `retain` only sets metadata when it is truthy, so an empty stamp sends none.
+              metadata: Object.keys(stamp.metadata).length ? stamp.metadata : undefined,
+            }
+          );
           log(`[survey] marker ${best.id} flipped to completed`);
         }
       }

--- a/hindsight-integrations/coding-agents/src/deepen.ts
+++ b/hindsight-integrations/coding-agents/src/deepen.ts
@@ -33,6 +33,7 @@ import { DEEPEN_DIFF_TARGET } from "./core/status";
 import { pool } from "./core/util";
 import { getHarness, HARNESS_NAMES } from "./harness/registry";
 import { diag } from "./core/diag";
+import { buildRetainStamp } from "./core/retain-stamp";
 import { log as plog, setLogLevel } from "./core/log";
 
 const DIFF_BATCH = 50; // per-run cap on per-commit diff ingestion (bounded session cost)
@@ -133,6 +134,13 @@ async function main() {
       log,
     });
     log(`deepen -> ${client.apiUrl} bank=${FINAL_BANK} harness=${harness.name}`);
+    const stampFor = (sessionId?: string) =>
+      buildRetainStamp(cfg, {
+        directory: REPO!,
+        harness: HARNESS,
+        bankId: FINAL_BANK!,
+        sessionId,
+      });
 
     await client.configureBank();
     if (client.knowledgePagesSupported === false) {
@@ -151,7 +159,11 @@ async function main() {
     const sessions = all.filter((s, i) => !chatIds.has(`chat:${s.id || `s${i}`}`));
     if (all.length !== sessions.length)
       log(`[chat] ${all.length - sessions.length} conversations already ingested — skipping those`);
-    const chatFails = await ingestChats(client, sessions, { concurrency: CONCURRENCY, log });
+    const chatFails = await ingestChats(client, sessions, {
+      concurrency: CONCURRENCY,
+      log,
+      stampFor,
+    });
 
     // ── git: seeding and syncing are the SAME code — this idempotent pass runs every session,
     // so "keep the bank current" is just "run it again". cfg.gitIngest picks the depth:
@@ -171,7 +183,7 @@ async function main() {
       if (gitlogCurrent) {
         log("[gitlog] current with HEAD — skipping");
       } else {
-        gitFails += await ingestGitLog(client, REPO!, { limit: GITLOG_LIMIT, log });
+        gitFails += await ingestGitLog(client, REPO!, { limit: GITLOG_LIMIT, log, stampFor });
       }
       // Self-cleanup: earlier versions named the gitlog doc per WORKTREE (gitlog:my-repo-wt2 …),
       // duplicating the history in the shared bank. Delete any gitlog doc that isn't the
@@ -208,7 +220,7 @@ async function main() {
             await pool(
               shas,
               CONCURRENCY,
-              (sha) => retainCommit(client, REPO!, sha, repoName),
+              (sha) => retainCommit(client, REPO!, sha, repoName, stampFor()),
               () => {
                 gitFails++;
               }
@@ -240,14 +252,29 @@ async function main() {
           if (behind !== null && (!best || behind < best.behind)) best = { id, sha, behind };
         }
         if (best) {
-          await client.retain(
+          const stamp = stampFor();
+          const content =
             `✅ Codebase survey completed — baseline commit ${best.sha.slice(0, 12)}. ` +
-              `(Internal marker: no memories are extracted from this document.)`,
-            "hindsight codebase-survey baseline",
-            best.id,
-            ["source:survey-baseline", "survey-state:done"],
-            "survey"
-          );
+            `(Internal marker: no memories are extracted from this document.)`;
+          const tags = [...new Set([...stamp.tags, "source:survey-baseline", "survey-state:done"])];
+          if (Object.keys(stamp.metadata).length) {
+            await client.retain(
+              content,
+              "hindsight codebase-survey baseline",
+              best.id,
+              tags,
+              "survey",
+              { metadata: stamp.metadata }
+            );
+          } else {
+            await client.retain(
+              content,
+              "hindsight codebase-survey baseline",
+              best.id,
+              tags,
+              "survey"
+            );
+          }
           log(`[survey] marker ${best.id} flipped to completed`);
         }
       }

--- a/hindsight-integrations/coding-agents/src/mcp-server.ts
+++ b/hindsight-integrations/coding-agents/src/mcp-server.ts
@@ -15,6 +15,7 @@ import { applyBankConfig, loadConfig, type Config } from "./core/config";
 import { deriveBankId } from "./core/bank";
 import { HindsightClient } from "./core/hindsight";
 import { buildKnowledgeTools, type ToolSpec } from "./core/knowledge-tools";
+import { buildRetainStamp } from "./core/retain-stamp";
 
 /**
  * Which tools this server should expose for a given config. Pure + SDK-free so the
@@ -22,10 +23,21 @@ import { buildKnowledgeTools, type ToolSpec } from "./core/knowledge-tools";
  * Hindsight (mirrors the hooks' `cfg.disabled` check) exposes NO tools — the server still
  * connects, it just has nothing registered.
  */
-export function selectTools(cfg: Config, client: HindsightClient, bankId: string): ToolSpec[] {
+export function selectTools(
+  cfg: Config,
+  client: HindsightClient,
+  bankId: string,
+  opts: { cwd?: string; harness?: string } = {}
+): ToolSpec[] {
+  const cwd = opts.cwd ?? process.cwd();
+  const harness = opts.harness ?? cfg.harness;
   return cfg.disabled
     ? []
-    : buildKnowledgeTools(client, bankId, { repoDir: process.cwd(), harness: cfg.harness });
+    : buildKnowledgeTools(client, bankId, {
+        repoDir: cwd,
+        harness,
+        stampFor: () => buildRetainStamp(cfg, { directory: cwd, harness, bankId }),
+      });
 }
 
 async function main() {
@@ -38,7 +50,7 @@ async function main() {
   const client = new HindsightClient({ apiUrl: cfg.apiUrl, apiToken: cfg.apiToken, bank: bankId });
 
   const server = new McpServer({ name: "hindsight", version: "0.1.0" });
-  for (const t of selectTools(cfg, client, bankId)) {
+  for (const t of selectTools(cfg, client, bankId, { cwd, harness })) {
     server.tool(t.name, t.description, t.inputSchema, t.handler);
   }
 

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -305,8 +305,8 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `bankIdTemplate`        | `"coding-agent::{gitProject}"`       | dynamic bank id format; the default makes every agent share one bank per repo                                                                                                                                                       |
 | `mapPathToBank`         | —                                    | absolute path → bank; **longest prefix wins**; overrides everything                                                                                                                                                                 |
 | `resolveWorktrees`      | `true`                               | `{gitProject}`: linked worktrees share the main repo's bank                                                                                                                                                                         |
-| `retainTags`            | —                                    | extra tags on every session write-back, e.g. `["project:{gitProject}"]` — see **Recording where a memory came from** below                                                                                                          |
-| `retainMetadata`        | —                                    | extra metadata on every session write-back, e.g. `{"repo": "{gitProject}"}`                                                                                                                                                         |
+| `retainTags`            | —                                    | extra tags on every document written by the integration, e.g. `["project:{gitProject}"]` — see **Recording where a memory came from** below                                                                                         |
+| `retainMetadata`        | —                                    | extra metadata on every document written by the integration, e.g. `{"repo": "{gitProject}"}`                                                                                                                                        |
 | `disabled`              | `false`                              | hard off-switch (inert plugin/hook — a no-memory baseline)                                                                                                                                                                          |
 | `reflectTimeoutMs`      | `120000`                             | session-reflect timeout (hook harnesses additionally cap it at 25s to fit the host's hook window); on timeout the session runs without reflect (recorded)                                                                           |
 | `pageRefreshEveryTurns` | `10`                                 | refetch the knowledge pages and re-inject the page roster + tool guide every N user turns                                                                                                                                           |
@@ -392,8 +392,9 @@ all share one memory per repo — use `"{harness}-{gitProject}"` to split per ag
 
 With a bank per repo, the bank _is_ the answer to "where did this come from". On a deliberately
 **shared** bank — one bank holding cross-project knowledge so facts recall everywhere — it isn't:
-every memory looks alike. `retainTags` and `retainMetadata` stamp that provenance onto each session
-write-back:
+every memory looks alike. `retainTags` and `retainMetadata` stamp that provenance onto conversations,
+git history and diffs, survey lifecycle documents, initiative markers, and documents saved through
+`hindsight_ingest_document`:
 
 ```jsonc
 {
@@ -407,6 +408,7 @@ Recalls can then filter by `project:<repo>`, and every document shows which repo
 of. Both accept the same placeholders as `bankIdTemplate` — `{gitProject}`, `{project}`,
 `{harness}`, `{channel}`, `{user}` — plus `{bankId}`, `{sessionId}` and `{timestamp}`.
 `{gitProject}` is worktree-aware here too, so every linked worktree of a repo stamps one name.
+`{sessionId}` resolves to `unknown` for documents that do not originate from an agent session.
 
 The plugin's own `source:` and `harness:` tags are reserved: entries in those namespaces are ignored
 with a warning, so a document's agent attribution always reflects the agent that actually wrote it.


### PR DESCRIPTION
Extends the coding-agents integration's existing `retainTags` and `retainMetadata` support to every document it writes, rather than only live session write-back.

This includes:

- Imported conversations
- Aggregated Git history and full commit documents
- Codebase survey lifecycle documents
- Initiative markers
- Documents saved through `hindsight_ingest_document`

Configured attribution is merged with each document's built-in tags and metadata, with built-in source identity remaining authoritative.

## Why

In shared-bank deployments, consistent attribution is needed to identify and filter documents by project or other configured provenance. Partial attribution leaves Git, survey, and manually ingested documents indistinguishable across projects.

##  Notes

This is additive and disabled by default. Existing configurations without `retainTags` or `retainMetadata` retain their current behavior.

## Verification

- 441 coding-agents tests passed
- TypeScript and package build passed
- Declaration generation passed
- Documentation sync passed