### PR TITLE
fix(retain): enqueue relink victims before delta chunk deletion

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/chunk_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/chunk_storage.py
@@ -147,6 +147,16 @@ async def delete_chunks_by_ids(conn, chunk_ids: list[str], bank_id: str | None =
             # (the full-replace path enqueues in ``handle_document_tracking``).
             await enqueue_entity_prune_candidates(conn, bank_id, outgoing_unit_ids)
 
+            # Capture surviving units whose temporal/semantic links point at
+            # the outgoing facts before the link/chunk cascade below removes
+            # the evidence needed to find them. Full document replacement does
+            # the same in ``handle_document_tracking``; without it, a delta
+            # edit leaves survivors permanently below their configured link
+            # caps even though retain submits graph maintenance afterwards.
+            from ..graph_maintenance import enqueue_relink_victims
+
+            await enqueue_relink_victims(conn, bank_id, outgoing_unit_ids)
+
     # The chunks->memory_units FK cascade below does not reach a store that keeps memories
     # outside SQL (its memory_units is empty), so drop the memories carrying each deleted
     # chunk_id through the store — otherwise a delta re-ingest leaves the old ones as duplicates.

--- a/hindsight-api-slim/tests/test_chunk_storage_delete_ordering.py
+++ b/hindsight-api-slim/tests/test_chunk_storage_delete_ordering.py
@@ -164,9 +164,16 @@ async def test_delete_chunks_by_ids_sweeps_links_on_both_endpoints(
             "SELECT from_unit_id, to_unit_id FROM memory_links WHERE bank_id = $1",
             bank_id,
         )
+        queued = await conn.fetch(
+            "SELECT unit_id FROM graph_maintenance_queue WHERE bank_id = $1",
+            bank_id,
+        )
 
     assert {(str(r["from_unit_id"]), str(r["to_unit_id"])) for r in rows} == {(str(kept), str(unrelated))}, (
         "links on both endpoints of the deleted chunk's unit must go; the survivors' link must stay"
+    )
+    assert {str(r["unit_id"]) for r in queued} == {str(unrelated)}, (
+        "a surviving unit whose outgoing link targeted the deleted chunk must be queued for relinking"
     )
 
     await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## Problem

Delta retain deletes changed and removed chunks directly. The cascade drops their memory links, but unlike full document replacement, this path does not enqueue surviving units whose outgoing temporal or semantic links pointed at the deleted facts. Graph maintenance runs afterwards, but by then the links needed to discover those victims are gone.

This is the relink-victim residue called out as out of scope in #3384.

## Fix

Reuse the outgoing fact IDs already collected for observation invalidation and enqueue relink victims before the chunk/link cascade. The store abstraction keeps this a no-op for stores that own links inline.

The existing real-Postgres endpoint-deletion test now also asserts that the surviving source whose outgoing link targeted the deleted chunk is present in `graph_maintenance_queue`.

## Test

- `uv run pytest tests/test_chunk_storage_delete_ordering.py::test_delete_chunks_by_ids_sweeps_links_on_both_endpoints -q -n 0` (1 passed)
- `uv run ruff check hindsight_api/engine/retain/chunk_storage.py tests/test_chunk_storage_delete_ordering.py`
- `uv run ruff format --check hindsight_api/engine/retain/chunk_storage.py tests/test_chunk_storage_delete_ordering.py`
- `git diff --check`

Fixes the relink-victim follow-up noted in #3384.