### PR TITLE
fix: untrack the coding-agents node_modules symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ wheels/
 
 # Node
 node_modules/
+# Without this, the pattern above matches directories only — a node_modules SYMLINK (what you get
+# pointing a scratch worktree at an installed one) is a file, slips past it, and can be committed.
+node_modules
 
 # Environment variables and local config
 .env

--- a/hindsight-integrations/coding-agents/node_modules
+++ b/hindsight-integrations/coding-agents/node_modules
@@ -1,1 +1,0 @@
-/Users/nicoloboschi/dev/hs-coding-plugin-wt/hindsight-integrations/coding-agents/node_modules


### PR DESCRIPTION
My mistake, from #3380 — it has been on main since, and is in the `v0.2.0` and `v0.2.1` tags.

```
120000 blob …  hindsight-integrations/coding-agents/node_modules
  -> /Users/nicoloboschi/dev/hs-coding-plugin-wt/hindsight-integrations/coding-agents/node_modules
```

A tracked symlink pointing at an absolute path on my machine, sitting exactly where the package's `node_modules` belongs. Anyone cloning gets a dangling link there.

**Published packages are unaffected** — npm excludes `node_modules` from packs, and I confirmed it against the real tarball:

```
npm pack @vectorize-io/hindsight-coding-agents@0.2.1
tar -tzf … | grep -c node_modules   →  0
```

So this is repository hygiene, not a shipped defect, and the tags don't need reissuing.

## Why it got in

`.gitignore` had `node_modules/`, which matches **directories only**. A symlink is a file, so it slipped past — and pointing a scratch worktree at an already-installed `node_modules` is the fast way to run this package's tests without a full install, so it was sitting there to be swept up by a `git add <dir>`. Adding the slashless pattern closes it; a sweep for other tracked symlinks found none.

Untracks the file and hardens the pattern.