### PR TITLE
feat(coding-agents): handle 429 on both the request and the poll path

### DIFF
--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -281,7 +281,8 @@ Environment variables are a **fallback**: the file wins wherever it sets a value
 an existing setup changes nothing. `retainTags` takes a comma-separated list
 (`HINDSIGHT_RETAIN_TAGS="project:{gitProject},env:work"`); entries are trimmed and blanks dropped.
 The map-valued settings (`mapPathToBank`, `harnesses`, `banks`, `retainMetadata`) are file-only —
-per-key branching doesn't survive flattening into one variable.
+per-key branching doesn't survive flattening into one variable. `maxParallelRetains` is available
+as `HINDSIGHT_MAX_PARALLEL_RETAINS` for containers and CI.
 
 There is deliberately no repo-carried config file — per-repo bank routing is `mapPathToBank`,
 per-agent differences are `harnesses.<name>`.
@@ -321,6 +322,7 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `surveyModel`           | `haiku`                              | model for the survey — Claude recipe only (`claude -p --model`); other agents use their configured default                                                                                                                          |
 | `surveyBudgetUsd`       | `2`                                  | survey spend cap — Claude recipe only (`claude -p --max-budget-usd`); other agents rely on their read-only sandbox                                                                                                                  |
 | `retainSessions`        | `true`                               | plugin-harness write-back (opencode, Kilo): async upsert of the session transcript every turn, plus an idle flush that captures the reply the per-turn pass can't see (set `false` to opt out; hook harnesses always write on Stop) |
+| `maxParallelRetains`    | `10`                                 | cap on concurrent retain-related requests: drain()'s per-op polls plus deepen's chat/git retain pools. The API rate-limits bursts, not single requests — if you see 429s, lower this rather than raising it                         |
 | `logLevel`              | `"info"`                             | plugin-log verbosity (`"debug"` \| `"info"` \| `"warn"` \| `"error"`); `HINDSIGHT_LOG_LEVEL` env overrides                                                                                                                          |
 | `gitIngest`             | `"message"`                          | git depth for seeding AND staying current (same engine): `"message"` = commit messages only (one doc, re-upserted when HEAD moves); `"full"` = messages + per-commit full diffs (progressive, newest first); `"none"` = git off     |
 | `harnesses.<name>`      | —                                    | per-harness override of any field above                                                                                                                                                                                             |

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -274,7 +274,8 @@ Environment variables are a **fallback**: the file wins wherever it sets a value
 an existing setup changes nothing. `retainTags` takes a comma-separated list
 (`HINDSIGHT_RETAIN_TAGS="project:{gitProject},env:work"`); entries are trimmed and blanks dropped.
 The map-valued settings (`mapPathToBank`, `harnesses`, `banks`, `retainMetadata`) are file-only —
-per-key branching doesn't survive flattening into one variable.
+per-key branching doesn't survive flattening into one variable. `maxParallelRetains` is available
+as `HINDSIGHT_MAX_PARALLEL_RETAINS` for containers and CI.
 
 There is deliberately no repo-carried config file — per-repo bank routing is `mapPathToBank`,
 per-agent differences are `harnesses.<name>`.
@@ -314,6 +315,7 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `surveyModel`           | `haiku`                              | model for the survey — Claude recipe only (`claude -p --model`); other agents use their configured default                                                                                                                          |
 | `surveyBudgetUsd`       | `2`                                  | survey spend cap — Claude recipe only (`claude -p --max-budget-usd`); other agents rely on their read-only sandbox                                                                                                                  |
 | `retainSessions`        | `true`                               | plugin-harness write-back (opencode, Kilo): async upsert of the session transcript every turn, plus an idle flush that captures the reply the per-turn pass can't see (set `false` to opt out; hook harnesses always write on Stop) |
+| `maxParallelRetains`    | `10`                                 | cap on concurrent retain-related requests: drain()'s per-op polls plus deepen's chat/git retain pools. The API rate-limits bursts, not single requests — if you see 429s, lower this rather than raising it                         |
 | `logLevel`              | `"info"`                             | plugin-log verbosity (`"debug"` \| `"info"` \| `"warn"` \| `"error"`); `HINDSIGHT_LOG_LEVEL` env overrides                                                                                                                          |
 | `gitIngest`             | `"message"`                          | git depth for seeding AND staying current (same engine): `"message"` = commit messages only (one doc, re-upserted when HEAD moves); `"full"` = messages + per-commit full diffs (progressive, newest first); `"none"` = git off     |
 | `harnesses.<name>`      | —                                    | per-harness override of any field above                                                                                                                                                                                             |

--- a/hindsight-integrations/coding-agents/src/cline.ts
+++ b/hindsight-integrations/coding-agents/src/cline.ts
@@ -192,6 +192,7 @@ function createRuntime(workspaceRoot: string | undefined): RuntimeCore | undefin
     apiUrl: cfg.apiUrl,
     apiToken: cfg.apiToken,
     bank: resolved.bankId,
+    maxParallelRetains: cfg.maxParallelRetains,
   });
   return new RuntimeCore(client, resolved.bankId, cfg, HARNESS, workspaceRoot || process.cwd());
 }

--- a/hindsight-integrations/coding-agents/src/core/chat.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { HindsightClient } from "./hindsight";
+import { RateLimitedError, type HindsightClient } from "./hindsight";
 import { ingestChats, renderSessionJsonl, retainLiveSession, type TransportTurn } from "./chat";
 import { memoryCursorStore, type RetainCursorStore } from "./retain-cursor";
 
@@ -335,6 +335,66 @@ describe("retainLiveSession — incremental write-back", () => {
       source: "chat",
       session_id: "s1",
     });
+  });
+
+  it("retries a rate-limited write-back instead of dropping it", async () => {
+    const { retain, client } = stubClient();
+    retain.mockRejectedValueOnce(new RateLimitedError(50));
+    const cursors = memoryCursorStore();
+
+    await write(client, turns(3), cursors);
+
+    expect(retain).toHaveBeenCalledTimes(2);
+    // The retry is the SAME payload, so its deterministic operation_id makes it a no-op server-side
+    // if the first attempt actually landed.
+    expect(retain.mock.calls[1][0]).toBe(retain.mock.calls[0][0]);
+    expect(retain.mock.calls[1][5].operationId).toBe(retain.mock.calls[0][5].operationId);
+    expect(cursors.read("s1")?.dirty).toBeFalsy(); // confirmed, not left dirty
+  });
+
+  it("gives up once a newer write-back has taken the cursor", async () => {
+    // Ours is superseded: the newer one carries what we were sending, or replaces the document
+    // outright because our failure left the cursor dirty. Retrying would burn a hook's remaining
+    // time re-sending content already on its way.
+    const { retain, client } = stubClient();
+    const cursors = memoryCursorStore();
+    retain.mockImplementationOnce(async () => {
+      cursors.write("s1", { turns: 99, fingerprint: "someone-else", bank: "b", dirty: true });
+      throw new RateLimitedError(50);
+    });
+
+    await expect(write(client, turns(3), cursors)).rejects.toBeInstanceOf(RateLimitedError);
+    expect(retain).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry when Retry-After exceeds what a hook can wait", async () => {
+    // Waiting less than the server asked would just earn another 429, and waiting the full 60s
+    // risks the harness killing the hook mid-write. Leave it to the next write-back, which
+    // replaces the whole document.
+    const { retain, client } = stubClient();
+    retain.mockRejectedValue(new RateLimitedError(60_000));
+
+    await expect(write(client, turns(3), memoryCursorStore())).rejects.toBeInstanceOf(
+      RateLimitedError
+    );
+    expect(retain).toHaveBeenCalledTimes(1);
+  });
+
+  it("rides out a short rate limit across both attempts", async () => {
+    const { retain, client } = stubClient();
+    retain.mockRejectedValueOnce(new RateLimitedError(20));
+    retain.mockRejectedValueOnce(new RateLimitedError(20));
+
+    await write(client, turns(3), memoryCursorStore());
+    expect(retain).toHaveBeenCalledTimes(3); // attempt + 2 retries, then success
+  });
+
+  it("does not retry a failure that is not a rate limit", async () => {
+    const { retain, client } = stubClient();
+    retain.mockRejectedValue(new Error("500 boom"));
+
+    await expect(write(client, turns(3), memoryCursorStore())).rejects.toThrow("500 boom");
+    expect(retain).toHaveBeenCalledTimes(1);
   });
 
   it("keeps the write-back when the capability probe itself fails", async () => {

--- a/hindsight-integrations/coding-agents/src/core/chat.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.ts
@@ -3,12 +3,12 @@
  * backfill (ingest past sessions) and the live runtime write-back. A leading `system` turn carries
  * the REF-ID tracer; every turn gets an ABSOLUTE timestamp.
  */
-import type { HindsightClient } from "./hindsight";
+import { RateLimitedError, type HindsightClient } from "./hindsight";
 import { fingerprintTurns, planRetain, type RetainCursorStore } from "./retain-cursor";
 import type { RetainStamp } from "./retain-stamp";
 import type { ChatSession } from "./types";
 import { uuidV5 } from "./uuid";
-import { pool } from "./util";
+import { pool, sleep } from "./util";
 
 export interface TransportTurn {
   role: string;
@@ -110,6 +110,52 @@ async function supportsAppend(client: HindsightClient): Promise<boolean> {
 }
 
 /**
+ * Attempts a rate-limited write-back may make, and the most total time it may spend waiting.
+ *
+ * A hook process is on the host's clock — Claude Code allows 60s for a Stop hook, and a cold
+ * daemon can already have eaten most of it — so honouring a long `Retry-After` here would trade a
+ * deferred retain for a killed hook, which is strictly worse. Short limits mean a brief rate limit
+ * is ridden out and a serious one is left to the next write-back, which replaces the whole
+ * document anyway.
+ */
+const RETAIN_RETRY_ATTEMPTS = 2;
+const RETAIN_RETRY_BUDGET_MS = 6000;
+
+/**
+ * Submit a write-back, retrying while the API is rate-limiting us AND our write is still the
+ * newest one for this session.
+ *
+ * Retrying is safe rather than duplicative because the payload carries a deterministic
+ * `operation_id`: an identical resubmission is collapsed into the original operation server-side.
+ *
+ * The staleness check is the important half. If another write-back has claimed the cursor since
+ * ours — a newer turn, another process — then ours is superseded, and the newer one carries
+ * everything we were sending (or replaces the document outright, because our failure left the
+ * cursor dirty). Retrying then would spend a hook's remaining time re-sending content that is
+ * already on its way.
+ */
+async function submitWithRetry(
+  send: () => Promise<void>,
+  isStillNewest: () => boolean
+): Promise<void> {
+  let spent = 0;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await send();
+    } catch (e) {
+      const limited = e instanceof RateLimitedError;
+      if (!limited || attempt >= RETAIN_RETRY_ATTEMPTS || !isStillNewest()) throw e;
+      // Either honour Retry-After or do not retry: waiting less than the server asked would just
+      // earn another 429, so a wait that does not fit the budget means "not on this hook's clock".
+      const wait = e.retryAfterMs || 1000;
+      if (wait > RETAIN_RETRY_BUDGET_MS - spent) throw e;
+      spent += wait;
+      await sleep(wait);
+    }
+  }
+}
+
+/**
  * One write-back at a time per session, keyed by the store the cursors live in.
  *
  * The persistent-plugin runtime fires retains without awaiting them (a turn-driven one and an
@@ -204,33 +250,43 @@ async function writeSession(
   };
   cursors?.write(sessionId, { ...next, dirty: true });
 
-  await client.retain(
-    content,
-    "coding agent session",
-    refId,
-    // Configured tags first, built-ins last and deduped: `source:chat` and `harness:<id>` are what
-    // the documents list filters and draws its agent logo from, so a template cannot displace them.
-    [
-      ...new Set([
-        ...(stamp?.tags ?? []),
-        "source:chat",
-        ...(harness ? [`harness:${harness}`] : []),
-      ]),
-    ],
-    "conversation",
-    {
-      timestamp: startTs,
-      updateMode: plan.mode === "append" ? "append" : undefined,
-      // Identity of THIS payload: a resubmission of the same bytes is collapsed server-side into
-      // the original operation instead of extracting (or appending) twice.
-      operationId: uuidV5(`${client.bank}\n${refId}\n${plan.mode}\n${content}`),
-      metadata: {
-        ...stamp?.metadata, // configured first: the built-ins below win on any key collision
-        source: "chat",
-        session_id: sessionId,
-        ref_id: refId,
-        ...(harness ? { harness } : {}),
-      },
+  const claimed = { ...next, dirty: true };
+  await submitWithRetry(
+    () =>
+      client.retain(
+        content,
+        "coding agent session",
+        refId,
+        // Configured tags first, built-ins last and deduped: `source:chat` and `harness:<id>` are what
+        // the documents list filters and draws its agent logo from, so a template cannot displace them.
+        [
+          ...new Set([
+            ...(stamp?.tags ?? []),
+            "source:chat",
+            ...(harness ? [`harness:${harness}`] : []),
+          ]),
+        ],
+        "conversation",
+        {
+          timestamp: startTs,
+          updateMode: plan.mode === "append" ? "append" : undefined,
+          // Identity of THIS payload: a resubmission of the same bytes is collapsed server-side into
+          // the original operation instead of extracting (or appending) twice.
+          operationId: uuidV5(`${client.bank}\n${refId}\n${plan.mode}\n${content}`),
+          metadata: {
+            ...stamp?.metadata, // configured first: the built-ins below win on any key collision
+            source: "chat",
+            session_id: sessionId,
+            ref_id: refId,
+            ...(harness ? { harness } : {}),
+          },
+        }
+      ),
+    // Still ours to retry only while the cursor holds the claim we wrote above.
+    () => {
+      if (!cursors) return true;
+      const now = cursors.read(sessionId);
+      return now?.turns === claimed.turns && now?.fingerprint === claimed.fingerprint;
     }
   );
   cursors?.write(sessionId, next);

--- a/hindsight-integrations/coding-agents/src/core/config.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.test.ts
@@ -80,6 +80,35 @@ describe("loadConfig layering", () => {
   });
 });
 
+describe("maxParallelRetains", () => {
+  it("defaults to 10 when unset", () => {
+    expect(loadConfig({ harness: "claude-code" }).maxParallelRetains).toBe(10);
+  });
+
+  it("config file value wins over the default", () => {
+    writeJson(globalCfg, { maxParallelRetains: 3 });
+    expect(loadConfig({ path: globalCfg }).maxParallelRetains).toBe(3);
+  });
+
+  const ENV = { ...process.env };
+  afterEach(() => {
+    process.env = { ...ENV };
+  });
+
+  it("reads HINDSIGHT_MAX_PARALLEL_RETAINS as a number", () => {
+    writeJson(globalCfg, {});
+    process.env.HINDSIGHT_MAX_PARALLEL_RETAINS = "6";
+    expect(loadConfig({ path: globalCfg }).maxParallelRetains).toBe(6);
+  });
+
+  it("ignores a malformed env value and falls back to the default", () => {
+    writeJson(globalCfg, {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    process.env.HINDSIGHT_MAX_PARALLEL_RETAINS = "lots";
+    expect(loadConfig({ path: globalCfg }).maxParallelRetains).toBe(10);
+  });
+});
+
 // A project-local .hindsight/coding-agent.json comes from the (untrusted) opened repo. It must not be
 // able to redirect the API endpoint/token or the global bank map — otherwise a malicious repo could
 // exfiltrate the user's token + prompts to its own server just by being opened.

--- a/hindsight-integrations/coding-agents/src/core/config.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.ts
@@ -66,6 +66,11 @@ export interface RawConfig {
   harness?: string; // runtime adapter (default "opencode")
   disabled?: boolean; // hard off-switch — inert plugin, for a no-memory baseline (default false)
   retainSessions?: boolean; // opencode plugin write-back (default true; set false to opt out). Hook harnesses always write back on Stop and ignore this flag.
+  /** Cap on concurrent retain-related requests the client sends to the API (default 10):
+   *  drain()'s per-operation polls and deepen's chat/git retain pools. A single request returning
+   *  200 while bursts get 429s means the server is rate-limiting concurrency, not total volume —
+   *  lower this rather than raising it. */
+  maxParallelRetains?: number;
   reflectTimeoutMs?: number; // session-start reflect timeout (default 120000; hooks cap lower internally)
   autoReflect?: boolean; // inject a one-time reflect synthesis on the session's first prompt (default true; false = the agent reflects only via the hindsight_reflect tool, and the tool guide tells it to do so on new goals)
   pageRefreshEveryTurns?: number; // knowledge-page refresh cadence in user turns (default 10)
@@ -125,6 +130,7 @@ export interface Config {
   harness: string;
   disabled: boolean;
   retainSessions: boolean;
+  maxParallelRetains: number;
   reflectTimeoutMs: number;
   autoReflect: boolean;
   pageRefreshEveryTurns: number;
@@ -170,6 +176,7 @@ export function resolveConfig(raw: RawConfig = {}): Config {
     harness: raw.harness ?? "opencode",
     disabled: raw.disabled ?? false,
     retainSessions: raw.retainSessions ?? true, // opencode: write back by default (parity with hook-harness Stop)
+    maxParallelRetains: raw.maxParallelRetains || 10,
     reflectTimeoutMs: raw.reflectTimeoutMs || 120000,
     autoReflect: raw.autoReflect ?? true,
     pageRefreshEveryTurns: raw.pageRefreshEveryTurns || 10,
@@ -269,6 +276,7 @@ const ENV_KEYS = {
   harness: "HINDSIGHT_HARNESS",
   disabled: "HINDSIGHT_DISABLED",
   retainSessions: "HINDSIGHT_RETAIN_SESSIONS",
+  maxParallelRetains: "HINDSIGHT_MAX_PARALLEL_RETAINS",
   reflectTimeoutMs: "HINDSIGHT_REFLECT_TIMEOUT_MS",
   autoReflect: "HINDSIGHT_AUTO_REFLECT",
   pageRefreshEveryTurns: "HINDSIGHT_PAGE_REFRESH_EVERY_TURNS",
@@ -299,6 +307,7 @@ const ENV_LISTS = new Set<keyof RawConfig>(["retainTags"]);
 const ENV_NUMBERS = new Set<keyof RawConfig>([
   "apiPort",
   "daemonIdleTimeout",
+  "maxParallelRetains",
   "reflectTimeoutMs",
   "pageRefreshEveryTurns",
   "seedLimit",

--- a/hindsight-integrations/coding-agents/src/core/hindsight.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.test.ts
@@ -64,6 +64,23 @@ describe("HindsightClient.drain", () => {
     await p;
   });
 
+  it("caps the backoff however long Retry-After asks for", async () => {
+    // The header is a hint, not a budget we owe the server: an hour-long value would otherwise
+    // park the drain — and the background seed behind it — for that hour.
+    vi.useFakeTimers();
+    const client = new HindsightClient({ apiUrl: "http://x", bank: "b" });
+    const fetchMock = vi.fn(async () => jsonResponse(429, {}, { "Retry-After": "3600" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const p = client.drain(["1"], "test", 300_000);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(60_000); // capped at 60s, not 3600s
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(300_000);
+    await p;
+  });
+
   it("uses the 10s floor when Retry-After is shorter than it", async () => {
     vi.useFakeTimers();
     const client = new HindsightClient({ apiUrl: "http://x", bank: "b" });

--- a/hindsight-integrations/coding-agents/src/core/hindsight.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_MAX_PARALLEL_RETAINS, HindsightClient, retryAfterMs } from "./hindsight";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+function jsonResponse(status: number, body: unknown, headers?: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...(headers ?? {}) },
+  });
+}
+
+describe("HindsightClient.maxParallelRetains", () => {
+  it("defaults to 10 when not provided", () => {
+    const c = new HindsightClient({ apiUrl: "http://x", bank: "b" });
+    expect(c.maxParallelRetains).toBe(DEFAULT_MAX_PARALLEL_RETAINS);
+  });
+
+  it("honours the configured cap", () => {
+    const c = new HindsightClient({ apiUrl: "http://x", bank: "b", maxParallelRetains: 3 });
+    expect(c.maxParallelRetains).toBe(3);
+  });
+});
+
+describe("HindsightClient.drain", () => {
+  it("polls at most maxParallelRetains ops concurrently", async () => {
+    const cap = 2;
+    const client = new HindsightClient({ apiUrl: "http://x", bank: "b", maxParallelRetains: cap });
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const fetchMock = vi.fn(async () => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+      return jsonResponse(200, { status: "completed" });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await client.drain(["1", "2", "3", "4", "5"], "test", 10_000);
+
+    expect(maxInFlight).toBeLessThanOrEqual(cap);
+    expect(maxInFlight).toBe(cap); // 5 ids against a 2-wide pool must actually hit the cap
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+
+  it("backs off by Retry-After when it exceeds the 10s floor", async () => {
+    vi.useFakeTimers();
+    const client = new HindsightClient({ apiUrl: "http://x", bank: "b" });
+    const fetchMock = vi.fn(async () => jsonResponse(429, {}, { "Retry-After": "30" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const p = client.drain(["1"], "test", 60_000);
+    await vi.advanceTimersByTimeAsync(0); // first cycle completes → sleep 30s
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(10_000); // floor elapsed, but the header says 30s
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(20_000); // 30s elapsed → next cycle
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(60_000); // run out the 60-min cap
+    await p;
+  });
+
+  it("uses the 10s floor when Retry-After is shorter than it", async () => {
+    vi.useFakeTimers();
+    const client = new HindsightClient({ apiUrl: "http://x", bank: "b" });
+    const fetchMock = vi.fn(async () => jsonResponse(429, {}, { "Retry-After": "2" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const p = client.drain(["1"], "test", 60_000);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(2_000); // Retry-After=2s would have fired by now
+    expect(fetchMock).toHaveBeenCalledTimes(1); // the 10s floor keeps us waiting
+    await vi.advanceTimersByTimeAsync(8_000);
+    expect(fetchMock).toHaveBeenCalledTimes(2); // floor elapsed → next cycle
+    await vi.advanceTimersByTimeAsync(60_000);
+    await p;
+  });
+
+  it("backs off 10s on a 429 that carries no Retry-After", async () => {
+    vi.useFakeTimers();
+    const client = new HindsightClient({ apiUrl: "http://x", bank: "b" });
+    const fetchMock = vi.fn(async () => jsonResponse(429, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const p = client.drain(["1"], "test", 60_000);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(5_000); // the old 5s cycle would fire here
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(60_000);
+    await p;
+  });
+
+  it("keeps the 5s cycle when ops stay pending without a 429", async () => {
+    vi.useFakeTimers();
+    const client = new HindsightClient({ apiUrl: "http://x", bank: "b" });
+    const fetchMock = vi.fn(async () => jsonResponse(200, { status: "running" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const p = client.drain(["1"], "test", 60_000);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(fetchMock).toHaveBeenCalledTimes(2); // 5s cycle preserved
+    await vi.advanceTimersByTimeAsync(60_000);
+    await p;
+  });
+
+  it("marks non-completed terminal ops as failed and drops them from polling", async () => {
+    const client = new HindsightClient({ apiUrl: "http://x", bank: "b" });
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      const id = String(url).split("/").pop();
+      return id === "1"
+        ? jsonResponse(200, { status: "failed" })
+        : jsonResponse(200, { status: "completed" });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const log = vi.fn();
+    const c = new HindsightClient({ apiUrl: "http://x", bank: "b", log });
+
+    await c.drain(["1", "2"], "test", 10_000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenCalledWith("[wait] test drained — 2 done, 1 failed");
+  });
+});
+
+describe("retryAfterMs", () => {
+  it("parses delta-seconds", () => {
+    expect(retryAfterMs("30")).toBe(30_000);
+    expect(retryAfterMs(" 2 ")).toBe(2_000);
+  });
+
+  it("parses an HTTP-date into a bounded delay", () => {
+    const future = new Date(Date.now() + 60_000).toUTCString();
+    const ms = retryAfterMs(future);
+    expect(ms).toBeGreaterThan(50_000);
+    expect(ms).toBeLessThanOrEqual(60_000);
+  });
+
+  it("returns 0 for absent or unparseable values", () => {
+    expect(retryAfterMs(null)).toBe(0);
+    expect(retryAfterMs(undefined)).toBe(0);
+    expect(retryAfterMs("")).toBe(0);
+    expect(retryAfterMs("soon")).toBe(0);
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -48,6 +48,31 @@ export interface RetainOpts {
  *  could be applied twice without us ever knowing. Hence: no idempotency, no append. */
 export const MIN_IDEMPOTENT_RETAIN_VERSION = "0.8.6";
 
+/**
+ * Raised when the API rate-limits a request (HTTP 429), carrying how long it asked us to wait.
+ *
+ * A plain Error would be indistinguishable from a 500 or a network fault, and those want opposite
+ * treatment: a rate limit is a "not now, ask again" that the caller can honour, while a server
+ * error is not worth hammering. Callers that have somewhere safe to wait retry; the rest fail as
+ * before.
+ */
+export class RateLimitedError extends Error {
+  readonly code = "rate_limited";
+  constructor(readonly retryAfterMs: number) {
+    super(`rate limited; retry after ${Math.round(retryAfterMs / 1000)}s`);
+    this.name = "RateLimitedError";
+  }
+}
+
+/** Parse a `Retry-After` header (delta-seconds or HTTP-date) into ms; 0 when absent or unusable. */
+export function retryAfterMs(header: string | null | undefined): number {
+  if (!header) return 0;
+  const secs = Number(header.trim());
+  if (Number.isFinite(secs) && secs >= 0) return secs * 1000;
+  const at = Date.parse(header);
+  return Number.isNaN(at) ? 0 : Math.max(0, at - Date.now());
+}
+
 /** Raised when the target server predates the knowledge-pages API surface. */
 export class KnowledgePagesUnavailableError extends Error {
   readonly code = "knowledge_pages_unavailable";
@@ -105,6 +130,8 @@ export class HindsightClient {
       body: body ? JSON.stringify(body) : undefined,
       signal: AbortSignal.timeout(15_000),
     });
+    if (r.status === 429 && !tolerate.includes(429))
+      throw new RateLimitedError(retryAfterMs(r.headers.get("retry-after")));
     if (!r.ok && r.status !== 404 && !tolerate.includes(r.status))
       throw new Error(`${method} ${url} -> ${r.status} ${await r.text()}`);
     return r;

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -12,7 +12,7 @@ import {
   PAGE_TRIGGER,
   PAGES,
 } from "./missions";
-import { semverGte, sleep } from "./util";
+import { pool, semverGte, sleep } from "./util";
 import type { RetainStamp } from "./retain-stamp";
 
 /** One node of GET /knowledge-base/tree. Only the fields this client reads. */
@@ -30,6 +30,8 @@ export interface ClientOpts {
   apiToken?: string;
   bank: string;
   log?: (msg: string) => void;
+  /** Cap on concurrent retain-related requests (drain op polls, deepen pools). Default 10. */
+  maxParallelRetains?: number;
 }
 
 export interface RetainOpts {
@@ -84,6 +86,15 @@ export class KnowledgePagesUnavailableError extends Error {
 
 const TERMINAL = new Set(["completed", "failed", "cancelled", "error"]);
 
+/** Default cap on concurrent retain-related requests; configurable via `maxParallelRetains`. */
+export const DEFAULT_MAX_PARALLEL_RETAINS = 10;
+
+/** How long drain() pauses between poll cycles when the API did not rate-limit (429). */
+const POLL_CYCLE_MS = 5000;
+
+/** Minimum backoff after a 429 that carried no (or a shorter) Retry-After. */
+const RETRY_AFTER_FLOOR_MS = 10 * 1000;
+
 /** Bank-level missions the template seeds once and then leaves alone (#2492). */
 const MISSION_FIELDS = ["reflect_mission", "retain_mission", "observations_mission"] as const;
 
@@ -97,12 +108,14 @@ export class HindsightClient {
   /** Tri-state capability probe: unknown until the first append-mode retain, then cached. */
   private idempotentRetain: boolean | undefined;
   private readonly log: (msg: string) => void;
+  readonly maxParallelRetains: number;
 
   constructor(o: ClientOpts) {
     this.apiUrl = o.apiUrl.replace(/\/$/, "");
     this.apiToken = o.apiToken;
     this.bank = o.bank;
     this.log = o.log ?? (() => {});
+    this.maxParallelRetains = o.maxParallelRetains || DEFAULT_MAX_PARALLEL_RETAINS;
   }
 
   private headers(): Record<string, string> {
@@ -288,7 +301,14 @@ export class HindsightClient {
     }
   }
 
-  /** Poll each enqueued operation by id until terminal. LIST only shows active ops, so per-id GET is reliable. */
+  /**
+   * Poll each enqueued operation by id until terminal. LIST only shows active ops, so per-id GET is reliable.
+   *
+   * Concurrency is capped at `maxParallelRetains` (the API rate-limits bursts, not single
+   * requests — a 200 to a lone GET with 429s under `Promise.all` over every pending op). A 429
+   * leaves the op pending and backs the next cycle off by its `Retry-After` (10s floor) instead
+   * of hammering the next cycle 5s later.
+   */
   async drain(ids: string[], label: string, maxMs = 60 * 60 * 1000): Promise<void> {
     if (!ids.length) return;
     this.log(`[wait] draining ${ids.length} ${label} operations …`);
@@ -296,24 +316,33 @@ export class HindsightClient {
     const pending = new Set(ids);
     let failed = 0;
     while (pending.size && Date.now() - start < maxMs) {
-      await Promise.all(
-        [...pending].map(async (id) => {
-          try {
-            const r = await fetch(this.bankUrl(`/operations/${id}`), { headers: this.headers() });
-            if (!r.ok) return;
-            const st = (((await r.json()) as { status?: string }).status || "").toLowerCase();
-            if (TERMINAL.has(st)) {
-              pending.delete(id);
-              if (st !== "completed") failed++;
-            }
-          } catch {
-            /* transient — retry next cycle */
+      // Cycle backoff: default 5s; any 429 in the cycle raises it to the longest Retry-After seen
+      // (floor 10s) so a rate-limited API gets room to recover before the next poll round.
+      let backoffMs = POLL_CYCLE_MS;
+      await pool([...pending], this.maxParallelRetains, async (id) => {
+        try {
+          const r = await fetch(this.bankUrl(`/operations/${id}`), { headers: this.headers() });
+          if (r.status === 429) {
+            backoffMs = Math.max(
+              backoffMs,
+              RETRY_AFTER_FLOOR_MS,
+              retryAfterMs(r.headers.get("retry-after"))
+            );
+            return; // op stays pending — retried after the backoff
           }
-        })
-      );
+          if (!r.ok) return;
+          const st = (((await r.json()) as { status?: string }).status || "").toLowerCase();
+          if (TERMINAL.has(st)) {
+            pending.delete(id);
+            if (st !== "completed") failed++;
+          }
+        } catch {
+          /* transient — retry next cycle */
+        }
+      });
       if (pending.size) {
         this.log(`  … ${pending.size}/${ids.length} ${label} ops pending`);
-        await sleep(5000);
+        await sleep(backoffMs);
       }
     }
     this.log(

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -95,6 +95,17 @@ const POLL_CYCLE_MS = 5000;
 /** Minimum backoff after a 429 that carried no (or a shorter) Retry-After. */
 const RETRY_AFTER_FLOOR_MS = 10 * 1000;
 
+/**
+ * Ceiling on a single backoff, however long `Retry-After` asks for.
+ *
+ * The header is a server's hint, not a budget we owe it: a large value (an incident, a
+ * misconfigured limiter, a proxy inventing one) would otherwise park a drain for as long as it
+ * says — up to the whole `maxMs`, with the background seed frozen behind it. Capping keeps the
+ * signal without handing over the schedule; if the limit still applies, the next poll simply gets
+ * another 429 and backs off again.
+ */
+const RETRY_AFTER_CEILING_MS = 60 * 1000;
+
 /** Bank-level missions the template seeds once and then leaves alone (#2492). */
 const MISSION_FIELDS = ["reflect_mission", "retain_mission", "observations_mission"] as const;
 
@@ -323,10 +334,9 @@ export class HindsightClient {
         try {
           const r = await fetch(this.bankUrl(`/operations/${id}`), { headers: this.headers() });
           if (r.status === 429) {
-            backoffMs = Math.max(
-              backoffMs,
-              RETRY_AFTER_FLOOR_MS,
-              retryAfterMs(r.headers.get("retry-after"))
+            backoffMs = Math.min(
+              RETRY_AFTER_CEILING_MS,
+              Math.max(backoffMs, RETRY_AFTER_FLOOR_MS, retryAfterMs(r.headers.get("retry-after")))
             );
             return; // op stays pending — retried after the backoff
           }

--- a/hindsight-integrations/coding-agents/src/core/hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/hook.ts
@@ -235,7 +235,12 @@ export async function runHook(
     log.debug(spec.harness, "hook skipped: bank disabled via banks override", { bank: bankId });
     return;
   }
-  const client = makeClient({ apiUrl: cfg.apiUrl, apiToken: cfg.apiToken, bank: bankId });
+  const client = makeClient({
+    apiUrl: cfg.apiUrl,
+    apiToken: cfg.apiToken,
+    bank: bankId,
+    maxParallelRetains: cfg.maxParallelRetains,
+  });
   const cacheFile = sessionCacheFile(spec.harness, sessionId || "no-session");
 
   // Safety net on EVERY harness: on the session's FIRST prompt (no cache file yet), fire the

--- a/hindsight-integrations/coding-agents/src/core/retain-hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.ts
@@ -129,7 +129,12 @@ export async function runRetainHook(
   // Deliberately NOT gated on the result — retain proceeds either way, so an unreachable daemon
   // produces the same `retain_failed` diagnostic as an unreachable Cloud/self-hosted server.
   await ensureDaemon(cfg, spec.harness, { waitMs: DAEMON_WAIT_RETAIN_MS });
-  const client = makeClient({ apiUrl: cfg.apiUrl, apiToken: cfg.apiToken, bank: bankId });
+  const client = makeClient({
+    apiUrl: cfg.apiUrl,
+    apiToken: cfg.apiToken,
+    bank: bankId,
+    maxParallelRetains: cfg.maxParallelRetains,
+  });
 
   await buildRetain({
     harness: spec.harness,

--- a/hindsight-integrations/coding-agents/src/core/session-start.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.ts
@@ -353,7 +353,12 @@ export async function runSessionStartHook(
     // detached; we wait only briefly, so an already-running daemon is adopted immediately while a
     // cold one keeps coming up in the background and is picked up by a later turn.
     await ensureDaemon(cfg, harness, { waitMs: DAEMON_WAIT_SESSION_START_MS });
-    const client = makeClient({ apiUrl: cfg.apiUrl, apiToken: cfg.apiToken, bank: bankId });
+    const client = makeClient({
+      apiUrl: cfg.apiUrl,
+      apiToken: cfg.apiToken,
+      bank: bankId,
+      maxParallelRetains: cfg.maxParallelRetains,
+    });
 
     const out = await buildSessionStartContext({ cwd, bankId, cfg, client, harness });
     if (out.deferInitialReflect && sessionId) {

--- a/hindsight-integrations/coding-agents/src/deepen.ts
+++ b/hindsight-integrations/coding-agents/src/deepen.ts
@@ -37,7 +37,6 @@ import { buildRetainStamp } from "./core/retain-stamp";
 import { log as plog, setLogLevel } from "./core/log";
 
 const DIFF_BATCH = 50; // per-run cap on per-commit diff ingestion (bounded session cost)
-const CONCURRENCY = 4;
 const LOCK_STALE_MS = 30 * 60 * 1000;
 
 function arg(name: string, def?: string): string | undefined {
@@ -131,6 +130,7 @@ async function main() {
       apiUrl: API_URL,
       apiToken: API_TOKEN,
       bank: FINAL_BANK!,
+      maxParallelRetains: cfg.maxParallelRetains,
       log,
     });
     log(`deepen -> ${client.apiUrl} bank=${FINAL_BANK} harness=${harness.name}`);
@@ -160,7 +160,7 @@ async function main() {
     if (all.length !== sessions.length)
       log(`[chat] ${all.length - sessions.length} conversations already ingested — skipping those`);
     const chatFails = await ingestChats(client, sessions, {
-      concurrency: CONCURRENCY,
+      concurrency: cfg.maxParallelRetains,
       log,
       stampFor,
     });
@@ -219,7 +219,7 @@ async function main() {
             log(`[deepen] ingesting ${shas.length} commits with full diffs (newest first) …`);
             await pool(
               shas,
-              CONCURRENCY,
+              cfg.maxParallelRetains,
               (sha) => retainCommit(client, REPO!, sha, repoName, stampFor()),
               () => {
                 gitFails++;

--- a/hindsight-integrations/coding-agents/src/harness/plugin-entry.ts
+++ b/hindsight-integrations/coding-agents/src/harness/plugin-entry.ts
@@ -52,6 +52,7 @@ export function createPluginEntry(harness: string): Plugin {
       apiUrl: cfg.apiUrl,
       apiToken: cfg.apiToken,
       bank: bankId,
+      maxParallelRetains: cfg.maxParallelRetains,
     });
     const core = new RuntimeCore(client, bankId, cfg, harness, projectDir || process.cwd());
     // Visible presence via the host's own notice API (POST /tui/show-toast) — never stderr, which

--- a/hindsight-integrations/coding-agents/src/mcp-server.ts
+++ b/hindsight-integrations/coding-agents/src/mcp-server.ts
@@ -47,7 +47,12 @@ async function main() {
   const harness = process.env.HINDSIGHT_MCP_HARNESS || "claude-code";
   const cfg0 = loadConfig({ harness });
   const { cfg, bankId } = applyBankConfig(cfg0, deriveBankId(cfg0, cwd, harness));
-  const client = new HindsightClient({ apiUrl: cfg.apiUrl, apiToken: cfg.apiToken, bank: bankId });
+  const client = new HindsightClient({
+    apiUrl: cfg.apiUrl,
+    apiToken: cfg.apiToken,
+    bank: bankId,
+    maxParallelRetains: cfg.maxParallelRetains,
+  });
 
   const server = new McpServer({ name: "hindsight", version: "0.1.0" });
   for (const t of selectTools(cfg, client, bankId, { cwd, harness })) {

--- a/hindsight-integrations/coding-agents/src/status.ts
+++ b/hindsight-integrations/coding-agents/src/status.ts
@@ -33,6 +33,7 @@ const client = new HindsightClient({
   apiUrl: arg("api-url") ?? cfg.apiUrl,
   apiToken: arg("api-token") ?? cfg.apiToken,
   bank: FINAL_BANK!,
+  maxParallelRetains: cfg.maxParallelRetains,
 });
 
 syncStatus(client, FINAL_BANK!, REPO)

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -276,7 +276,8 @@ Environment variables are a **fallback**: the file wins wherever it sets a value
 an existing setup changes nothing. `retainTags` takes a comma-separated list
 (`HINDSIGHT_RETAIN_TAGS="project:{gitProject},env:work"`); entries are trimmed and blanks dropped.
 The map-valued settings (`mapPathToBank`, `harnesses`, `banks`, `retainMetadata`) are file-only —
-per-key branching doesn't survive flattening into one variable.
+per-key branching doesn't survive flattening into one variable. `maxParallelRetains` is available
+as `HINDSIGHT_MAX_PARALLEL_RETAINS` for containers and CI.
 
 There is deliberately no repo-carried config file — per-repo bank routing is `mapPathToBank`,
 per-agent differences are `harnesses.<name>`.
@@ -316,6 +317,7 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `surveyModel`           | `haiku`                              | model for the survey — Claude recipe only (`claude -p --model`); other agents use their configured default                                                                                                                          |
 | `surveyBudgetUsd`       | `2`                                  | survey spend cap — Claude recipe only (`claude -p --max-budget-usd`); other agents rely on their read-only sandbox                                                                                                                  |
 | `retainSessions`        | `true`                               | plugin-harness write-back (opencode, Kilo): async upsert of the session transcript every turn, plus an idle flush that captures the reply the per-turn pass can't see (set `false` to opt out; hook harnesses always write on Stop) |
+| `maxParallelRetains`    | `10`                                 | cap on concurrent retain-related requests: drain()'s per-op polls plus deepen's chat/git retain pools. The API rate-limits bursts, not single requests — if you see 429s, lower this rather than raising it                         |
 | `logLevel`              | `"info"`                             | plugin-log verbosity (`"debug"` \| `"info"` \| `"warn"` \| `"error"`); `HINDSIGHT_LOG_LEVEL` env overrides                                                                                                                          |
 | `gitIngest`             | `"message"`                          | git depth for seeding AND staying current (same engine): `"message"` = commit messages only (one doc, re-upserted when HEAD moves); `"full"` = messages + per-commit full diffs (progressive, newest first); `"none"` = git off     |
 | `harnesses.<name>`      | —                                    | per-harness override of any field above                                                                                                                                                                                             |


### PR DESCRIPTION
Makes the coding-agents client handle HTTP 429 properly on **both** halves: the requests it sends and the operations it polls.

Carries forward @seppaleinen's #3390, which he closed in favour of folding it in here — his commit is preserved with his authorship, and the diagnosis in it is the reason any of this exists.

## The diagnosis (his)

> a single `GET /operations/<id>` returns 200, so the rate limiter is **burst/concurrency-triggered**, not volume-triggered

Right conclusion from the right evidence, and it identified a genuinely bad loop: `drain()` did `Promise.all` over *every* pending op each cycle, and a 429 fell into `if (!r.ok) return;` — op stays pending, full burst repeats 5s later. The client hammered hardest exactly when the API asked it to stop.

## Polling: bounded and 429-aware (#3390)

- **`maxParallelRetains`** (default 10, `HINDSIGHT_MAX_PARALLEL_RETAINS`) caps concurrent retain-related requests: `drain()`'s per-op polls and deepen's chat/git pools, which previously used a hardcoded `CONCURRENCY = 4` that could not be tuned.
- `drain()` polls through the bounded `pool()` helper instead of `Promise.all`.
- A 429 leaves the op **pending** and backs the next cycle off by `Retry-After` (parsed as delta-seconds or HTTP-date), with a 10s floor.
- The poll uses raw `fetch` rather than `req()`, so the 429 status is observable rather than thrown — easy to get wrong, and it is right.

**One thing I added on review:** the backoff had no ceiling, so `Retry-After: 3600` would park the drain for an hour — up to the whole `maxMs`, with the background seed frozen behind it. Capped at 60s. The header is a hint, not a budget we owe the server; if the limit still applies, the next poll simply gets another 429 and backs off again.

## Submission: retried instead of dropped

`req()` threw a plain `Error` for any non-ok status, so a 429 on `POST /memories` was indistinguishable from a 500. The write-back was abandoned for that turn and nothing backed off. Content survived — the cursor stays dirty, so the next Stop replaces the whole document — but the turn's write did not happen, and on a session's **last** Stop there is no next one.

429 now raises a typed `RateLimitedError` carrying the parsed `Retry-After`, and the session write-back retries on it. Retrying is safe rather than duplicative because the payload already carries a **deterministic `operation_id`**: an identical resubmission is collapsed into the original operation server-side, so retrying after a response we never saw cannot write the same turns twice.

Two conditions bound it, and the first is the point:

**Only while our write is still the newest.** If another write-back has claimed the cursor since ours — a newer turn, another process — ours is superseded: that one carries what we were sending, or replaces the document outright because our failure left the cursor dirty. Retrying then would spend a hook's remaining time re-sending content already on its way.

**Only within a hook's clock.** Claude Code allows 60s for a Stop hook and a cold daemon can already have eaten most of it, so a `Retry-After` that does not fit a 6s budget is not honoured *at all* — waiting less than the server asked would just earn another 429, and waiting the full amount trades a deferred retain for a killed hook. That case is left to the next write-back.

Anything that is not a rate limit still fails immediately.

## Test

**483 passed**, 21 skipped; tsc, lint and docs-sync clean.

His 12 cover the concurrency cap, each `Retry-After` shape, the 5s cycle when nothing is limited, and terminal-op accounting. Mine add the ceiling, and five on the submission path: a rate-limited write-back retried with the identical payload and operation id and the cursor confirmed rather than left dirty; giving up once a newer write-back has taken the cursor; not retrying when `Retry-After` exceeds the budget; riding out a short limit across attempts; and a non-429 failure still failing immediately.
