### PR TITLE
fix(mental-models): trace delta-ops call and decouple its completion cap (#3421)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -13020,8 +13020,9 @@ class MemoryEngine(MemoryEngineInterface):
                 # carries the section_id, op type, and a full block payload
                 # whose ``text`` may quote the original passage. Budget 1.5×
                 # the document cap so the model can express several edits
-                # without truncating mid-string. The cap is also surfaced in
-                # the prompt so the model can self-trim if needed.
+                # without truncating mid-string. This is a *prompt-level*
+                # budget (surfaced so the model can self-trim), NOT the
+                # transport cap — see the call below.
                 doc_max_tokens = stored_max_tokens or 2048
                 delta_max_tokens = max(2048, int(doc_max_tokens * 1.5))
                 user_prompt = build_structured_delta_prompt(
@@ -13031,18 +13032,42 @@ class MemoryEngine(MemoryEngineInterface):
                     source_query=source_query,
                     max_output_tokens=delta_max_tokens,
                 )
+                # Trace the delta call. Unlike the synthesis, this runs on the raw
+                # ``_reflect_llm_config`` outside ``reflect_async``'s trace context,
+                # so its LLM calls were never written to the trace table — the exact
+                # blind spot that made #3421's failures impossible to diagnose after
+                # the fact. Wrapping it here attributes them to the refresh (bank +
+                # operation + mental_model_id), same as every other pipeline call.
+                resolved_config = await self._config_resolver.resolve_full_config(bank_id, request_context)
+                delta_llm = self._reflect_llm_config.with_config(
+                    resolved_config,
+                    bank_id=bank_id,
+                    operation="mental_model_delta_ops",
+                    metadata={"mental_model_id": str(mental_model_id)},
+                )
                 try:
                     # Text-mode call (not structured-output) because Pydantic's
                     # discriminated-union JSON schema isn't accepted by every
                     # provider — Gemini in particular rejects ``oneOf`` /
                     # ``discriminator``. We parse + validate the JSON ourselves
                     # so the same prompt works against any LLM.
-                    raw = await self._reflect_llm_config.call(
+                    #
+                    # The transport cap is the decoupled ``reflect_max_completion_tokens``
+                    # (uncapped by default), NOT ``delta_max_tokens``. On thinking models
+                    # the provider's output budget is spent on reasoning tokens first, so
+                    # capping at the document-sized ``delta_max_tokens`` truncates the ops
+                    # JSON mid-string; at temperature 0 that malformed output is
+                    # deterministic, so ``parse_delta_operation_list`` then fails
+                    # identically on every retry and the model wedges (#3421). This is the
+                    # same decoupling reflect's synthesis got in #3365/#3389 — the
+                    # document-length budget lives in the prompt (``max_output_tokens``
+                    # above), never in the transport cap.
+                    raw = await delta_llm.call(
                         messages=[
                             {"role": "system", "content": STRUCTURED_DELTA_SYSTEM_PROMPT},
                             {"role": "user", "content": user_prompt},
                         ],
-                        max_completion_tokens=delta_max_tokens,
+                        max_completion_tokens=get_config().reflect_max_completion_tokens,
                         temperature=get_config().llm_temperature_consolidation,
                         scope="mental_model_delta_ops",
                     )

--- a/hindsight-api-slim/tests/test_mental_model_delta.py
+++ b/hindsight-api-slim/tests/test_mental_model_delta.py
@@ -612,6 +612,86 @@ class TestDeltaRefreshPlumbing:
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
+    async def test_delta_call_is_traced_and_uses_decoupled_completion_cap(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+        monkeypatch,
+    ):
+        """The structured-delta call is attributed to the refresh trace and its
+        transport cap is the decoupled config, not the document budget (#3421).
+
+        Two regressions in one assertion set:
+
+        - Tracing: the delta call used to run on the raw ``_reflect_llm_config``
+          outside any trace context, so its LLM calls were never written to the
+          trace table — the blind spot that made delta parse failures impossible
+          to diagnose. It must now run inside a ``mental_model_delta_ops`` trace
+          bound to the bank + mental model.
+        - Completion cap: passing the document-sized ``delta_max_tokens`` as the
+          provider's ``max_completion_tokens`` truncated the ops JSON on thinking
+          models (reasoning tokens eat the budget), which at temperature 0 fails
+          the parse deterministically forever. The transport cap must be the
+          decoupled ``reflect_max_completion_tokens`` (uncapped by default),
+          exactly as reflect's synthesis (#3365/#3389).
+        """
+        from hindsight_api.config import get_config
+        from hindsight_api.engine.llm_trace import current_trace_context
+        from hindsight_api.engine.reflect.delta_ops import DeltaOperationList
+
+        bank_id = f"test-delta-trace-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        existing = "# Team\n\nAlice is the lead.\n\n## Members\n\n- Alice — lead\n"
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Team Info",
+            source_query="Tell me about the team",
+            content=existing,
+            trigger={"mode": "delta"},
+            request_context=request_context,
+        )
+
+        # Seed the tracking column (zero ops → no change).
+        patch_reflect(memory, text="ignored — full mode candidate")
+
+        captured: dict[str, Any] = {}
+
+        async def capturing_call(*, messages, **kwargs):
+            ctx = current_trace_context()
+            captured["max_completion_tokens"] = kwargs.get("max_completion_tokens")
+            captured["scope"] = kwargs.get("scope")
+            captured["trace_operation"] = ctx.operation if ctx else None
+            captured["trace_bank_id"] = ctx.bank_id if ctx else None
+            captured["trace_metadata"] = dict(ctx.metadata) if ctx else None
+            return DeltaOperationList()
+
+        # First (seeding) refresh — value captured here is overwritten by the second.
+        monkeypatch.setattr(memory._reflect_llm_config, "call", capturing_call)
+        await memory.refresh_mental_model(bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context)
+
+        # Second refresh with a genuine new fact so the delta call actually fires.
+        patch_reflect(
+            memory,
+            text="Alice is the lead. Bob joined.",
+            facts=[{"id": "obs-bob", "text": "Bob joined the team", "type": "observation", "context": None}],
+        )
+        captured.clear()
+        await memory.refresh_mental_model(bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context)
+
+        assert captured["scope"] == "mental_model_delta_ops"
+        # Transport cap is the decoupled config (None by default), NOT delta_max_tokens
+        # (which would be max(2048, 2048*1.5) == 3072 for the default document budget).
+        assert captured["max_completion_tokens"] == get_config().reflect_max_completion_tokens
+        assert captured["max_completion_tokens"] != 3072
+        # The call ran inside a trace bound to this refresh.
+        assert captured["trace_operation"] == "mental_model_delta_ops"
+        assert captured["trace_bank_id"] == bank_id
+        assert captured["trace_metadata"] == {"mental_model_id": str(mm["id"])}
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
     async def test_delta_prompt_sends_only_new_facts_not_accumulated_history(
         self,
         memory: MemoryEngine,


### PR DESCRIPTION
## Problem

Fixes #3421. A delta-mode mental-model refresh whose structured-delta LLM call fails to parse **wedges permanently**:

1. `parse_delta_operation_list` raises (truncated/malformed JSON, or every op rejected → `DeltaAllOpsInvalidError`) → `mode_fallback_reason = "delta_ops_failed"`.
2. The #3112 window guard (**correctly**) preserves the existing content and refuses to advance `last_refreshed_at`, so no observations are skipped.
3. But the delta call runs at `temperature = llm_temperature_consolidation` (default **0.0**), so the failure is **deterministic**. The next trigger re-reads the *same* window, reproduces the *same* malformed bytes, and fails identically — the "27 repeated errors on `user-preferences`" with no automatic recovery.

We deliberately **do not** fall back to full re-synthesis (the issue's suggested fix): that abandons the whole point of delta mode, and #3112 already rejected it for transient errors. Advancing the watermark on a partial apply is exactly the data loss #3112 exists to prevent. Instead this fixes the two things that actually cause the deterministic parse failure and its invisibility.

## Changes

**1. Decouple the delta transport cap from the document budget.**
The delta call passed the doc-sized `delta_max_tokens` as `max_completion_tokens`. On thinking models the provider's output budget is consumed by reasoning tokens first, truncating the ops JSON mid-string — and at temperature 0 that truncation is deterministic. Now the transport cap is `reflect_max_completion_tokens` (uncapped by default), the same decoupling reflect's synthesis received in #3365 / #3389. `delta_max_tokens` stays as the prompt-level budget hint (`max_output_tokens`), never the transport cap. Operators who want a hard ceiling set `HINDSIGHT_API_REFLECT_MAX_COMPLETION_TOKENS` (applies to synthesis + delta, consistent).

**2. Trace the delta call.**
It ran on the raw `_reflect_llm_config` *outside* `reflect_async`'s trace context, so its LLM calls were never written to the trace table — the blind spot that made #3421's failures impossible to diagnose post-mortem (and why we can't be 100% sure whether truncation or schema-reject fired in the reported incident). It's now wrapped in `with_config(bank_id, operation="mental_model_delta_ops", metadata={mental_model_id})`, so upgrading a wedged deployment will surface the raw failing output.

The intent is to **ship both, upgrade, and let the now-visible traces confirm the failure class** — while the completion-cap fix removes the most likely deterministic cause immediately.

## Test

`test_delta_call_is_traced_and_uses_decoupled_completion_cap` asserts the delta call (a) runs inside a `mental_model_delta_ops` trace bound to the bank + mental model, and (b) uses `reflect_max_completion_tokens` as its transport cap, not `delta_max_tokens`.

Ran `TestDeltaRefreshPlumbing` + dry-run + per-op-concurrency suites (68 passed); ruff + ty clean on changed files.
