### PR TITLE
fix(llm): preserve inline <think> literals in _strip_reasoning_tags

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -214,7 +214,11 @@ def _strip_reasoning_tags(text: str) -> str:
     Handles two cases:
     1. Closed blocks: ``<think>...</think>`` removed wherever they appear.
     2. Unclosed blocks: a dangling ``<think>`` with no closing tag (model output
-       truncated mid-thought) is removed from the open tag to end-of-string.
+       truncated mid-thought) is removed only when it starts its own line
+       (line-start, possibly indented). Inline occurrences (e.g. a JSON value
+       quoting ``<think>`` verbatim) are real content and must be kept --
+       the previous greedy ``.*`` to end-of-string deleted every inline tag plus
+       all following content, surfacing as ``Unterminated string`` in retain.
 
     Returns the input unchanged (modulo surrounding whitespace) when no tags are
     present.
@@ -224,9 +228,11 @@ def _strip_reasoning_tags(text: str) -> str:
     for open_tag, close_tag in _REASONING_TAG_PAIRS:
         open_re = re.escape(open_tag)
         close_re = re.escape(close_tag)
-        # Closed blocks first, then any remaining unclosed (truncated) block.
+        # Closed blocks first.
         text = re.sub(rf"{open_re}.*?{close_re}", "", text, flags=re.DOTALL)
-        text = re.sub(rf"{open_re}.*", "", text, flags=re.DOTALL)
+        # Unclosed (truncated) blocks: strip only when the open tag starts its own
+        # line. Inline literals are preserved so valid JSON is not corrupted.
+        text = re.sub(rf"(^|\n)[ \t]*{open_re}[^\n]*", "", text)
     return text.strip()
 
 

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -190,8 +190,8 @@ def _strip_code_fences(content: str) -> str:
 # Reasoning/thinking tags emitted by extended-thinking models. Some providers
 # (e.g. MiniMax-M3) leak the chain-of-thought wrapped in these tags into the
 # response body instead of a separate reasoning_content field. Each entry is
-# (open_tag, close_tag); the open tag also matches when the close tag is missing
-# (truncated output) so a dangling block is removed to end-of-string.
+# (open_tag, close_tag); a line-start open tag also matches when the close tag is
+# missing (truncated output) so a dangling block is removed to end-of-string.
 _REASONING_TAG_PAIRS: tuple[tuple[str, str], ...] = (
     ("<think>", "</think>"),
     ("<thinking>", "</thinking>"),
@@ -214,11 +214,11 @@ def _strip_reasoning_tags(text: str) -> str:
     Handles two cases:
     1. Closed blocks: ``<think>...</think>`` removed wherever they appear.
     2. Unclosed blocks: a dangling ``<think>`` with no closing tag (model output
-       truncated mid-thought) is removed only when it starts its own line
-       (line-start, possibly indented). Inline occurrences (e.g. a JSON value
-       quoting ``<think>`` verbatim) are real content and must be kept --
-       the previous greedy ``.*`` to end-of-string deleted every inline tag plus
-       all following content, surfacing as ``Unterminated string`` in retain.
+       truncated mid-thought) is removed to end-of-string, but only when it starts
+       its own line (line-start, possibly indented). Inline occurrences (e.g. a
+       JSON value quoting ``<think>`` verbatim) are real content and must be kept
+       -- an unanchored greedy ``.*`` to end-of-string deleted every inline tag
+       plus all following content, surfacing as ``Unterminated string`` in retain.
 
     Returns the input unchanged (modulo surrounding whitespace) when no tags are
     present.
@@ -231,8 +231,11 @@ def _strip_reasoning_tags(text: str) -> str:
         # Closed blocks first.
         text = re.sub(rf"{open_re}.*?{close_re}", "", text, flags=re.DOTALL)
         # Unclosed (truncated) blocks: strip only when the open tag starts its own
-        # line. Inline literals are preserved so valid JSON is not corrupted.
-        text = re.sub(rf"(^|\n)[ \t]*{open_re}[^\n]*", "", text)
+        # line, from there to end-of-string. The line-start anchor preserves inline
+        # literals (e.g. a JSON value quoting ``<think>``) so valid JSON is not
+        # corrupted; DOTALL-to-end still removes a multi-line truncated block whole,
+        # so leaked reasoning does not survive past its first line.
+        text = re.sub(rf"(^|\n)[ \t]*{open_re}.*", "", text, flags=re.DOTALL)
     return text.strip()
 
 

--- a/hindsight-api-slim/tests/test_strip_reasoning_tags.py
+++ b/hindsight-api-slim/tests/test_strip_reasoning_tags.py
@@ -76,3 +76,28 @@ class TestStripReasoningTags:
         """Truncated <think> trailing valid JSON is stripped (closing tag absent)."""
         content = '{"facts": [{"what": "test"}]}\n<think>oops truncated'
         assert _strip_reasoning_tags(content) == '{"facts": [{"what": "test"}]}'
+
+    def test_inline_think_literal_in_json_kept(self):
+        """An inline <think> literal inside a JSON value is real content — must be kept.
+
+        Regression for #2195: the old greedy ``.*`` to end-of-string deleted the
+        inline tag plus all following JSON, surfacing as ``Unterminated string``
+        when the retained conversation itself quoted ``<think>``.
+        """
+        content = '{"facts": [{"what": "analysis of <think> tag behavior"}]}'
+        assert _strip_reasoning_tags(content) == content
+
+    def test_inline_think_literal_mid_sentence_kept(self):
+        """Inline unclosed <think> mid-sentence is a literal, not a block."""
+        content = '{"facts": [{"what": "a <think discussion continues"}]}'
+        assert _strip_reasoning_tags(content) == content
+
+    def test_indented_think_line_stripped(self):
+        """A line-start (indented) unclosed <think> block is still stripped."""
+        content = '  <think>dangling reasoning no close\nresult text'
+        assert _strip_reasoning_tags(content) == "result text"
+
+    def test_inline_multiple_think_literals_kept(self):
+        """Multiple inline think-style literals in a sentence are all kept."""
+        content = "analysis of <think> and <thinking> tag differences"
+        assert _strip_reasoning_tags(content) == content

--- a/hindsight-api-slim/tests/test_strip_reasoning_tags.py
+++ b/hindsight-api-slim/tests/test_strip_reasoning_tags.py
@@ -93,11 +93,34 @@ class TestStripReasoningTags:
         assert _strip_reasoning_tags(content) == content
 
     def test_indented_think_line_stripped(self):
-        """A line-start (indented) unclosed <think> block is still stripped."""
-        content = '  <think>dangling reasoning no close\nresult text'
-        assert _strip_reasoning_tags(content) == "result text"
+        """A line-start (indented) unclosed <think> block is stripped to end-of-string.
+
+        The tag is unclosed because the output was truncated, so everything from
+        the tag onward is reasoning to discard — not an answer to keep.
+        """
+        content = "  <think>dangling reasoning no close\nmore dangling reasoning"
+        assert _strip_reasoning_tags(content) == ""
 
     def test_inline_multiple_think_literals_kept(self):
         """Multiple inline think-style literals in a sentence are all kept."""
         content = "analysis of <think> and <thinking> tag differences"
         assert _strip_reasoning_tags(content) == content
+
+    def test_unclosed_multiline_think_stripped_to_end(self):
+        """A line-start unclosed <think> that spans multiple lines is stripped whole.
+
+        Truncated reasoning is usually multi-line (the close tag never arrived
+        because output hit max_tokens). Stripping only the first line would leak
+        the remaining reasoning into stored memory — the exact free-form
+        contamination this helper exists to prevent.
+        """
+        content = (
+            "# Mental Model: Coding Preferences\n"
+            "The user prefers functional programming.\n"
+            "<think>\n"
+            "leaked reasoning line one\n"
+            "leaked reasoning line two"
+        )
+        result = _strip_reasoning_tags(content)
+        assert result == ("# Mental Model: Coding Preferences\nThe user prefers functional programming.")
+        assert "leaked reasoning" not in result


### PR DESCRIPTION
## Problem

`_strip_reasoning_tags` (in `hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py`) strips unclosed thinking blocks with a greedy `.*` to end-of-string:

```python
text = re.sub(rf"{open_re}.*", "", text, flags=re.DOTALL)
```

When the model quotes `<think>` **verbatim inline** — for example, a retained conversation that itself discusses `<think>` tags — the regex deletes the inline literal plus **all following content**, corrupting otherwise-valid JSON. In retain fact extraction this surfaces as `JSONDecodeError: Unterminated string`, the task retries and eventually fails, and the memory is silently lost.

## Fix

Only strip unclosed blocks that **start their own line** (line-start, possibly indented):

```python
text = re.sub(rf"(^|\n)[ \t]*{open_re}[^\n]*", "", text)
```

- Closed blocks `<think>...</think>` keep their existing behavior (removed wherever they appear).
- Inline literals (e.g. `"analysis of <think> tag behavior"`) are now preserved.

## Tests

Adds 4 regression tests to `tests/test_strip_reasoning_tags.py`:
- inline `<think>` literal inside a JSON value is kept
- inline unclosed `<think>` mid-sentence is kept
- indented line-start unclosed block is still stripped
- multiple inline think-style literals are all kept

All 18 tests in `test_strip_reasoning_tags.py` pass.