### PR TITLE
feat(api): forward allowlisted request headers to extensions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -356,7 +356,9 @@ HINDSIGHT_API_LOG_LEVEL=info
 # TenantExtension / OperationValidatorExtension can read them. Comma-separated,
 # matched case-insensitively. Unset by default: extensions see only the
 # Authorization header. Use this when the bearer token identifies a proxy rather
-# than the caller, and per-caller identity arrives in a separate header.
+# than the caller, and per-caller identity arrives in a separate header. A listed
+# header that arrives more than once is dropped, so only list headers the proxy
+# in front of Hindsight sets itself (stripping any client-supplied copy).
 # HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS=x-user-assertion
 
 # -----------------------------------------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -349,6 +349,17 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_DB_ACQUIRE_WARN_THRESHOLD_MS=1000
 
 # -----------------------------------------------------------------------------
+# Extensions (Optional)
+# -----------------------------------------------------------------------------
+
+# Request headers copied into RequestContext.extra_headers so a custom
+# TenantExtension / OperationValidatorExtension can read them. Comma-separated,
+# matched case-insensitively. Unset by default: extensions see only the
+# Authorization header. Use this when the bearer token identifies a proxy rather
+# than the caller, and per-caller identity arrives in a separate header.
+# HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS=x-user-assertion
+
+# -----------------------------------------------------------------------------
 # Webhooks (Optional)
 # -----------------------------------------------------------------------------
 

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -3978,15 +3978,20 @@ def _register_routes(app: FastAPI):
     # Create audit decorator bound to this app's audit logger
     audited = _make_audited_http(lambda: getattr(app.state, "audit_logger", None))
 
-    def get_request_context(authorization: str | None = Header(default=None)) -> RequestContext:
+    def get_request_context(request: Request, authorization: str | None = Header(default=None)) -> RequestContext:
         """
-        Extract request context from Authorization header.
+        Extract request context from the Authorization header.
 
         Supports:
         - Bearer token: "Bearer <api_key>"
         - Direct API key: "<api_key>"
 
         Returns RequestContext with extracted API key (may be None if no auth header).
+
+        Any header named in HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS is also
+        copied into ``extra_headers`` for extensions to read. That allowlist is
+        empty by default, so no other header reaches extension code unless an
+        operator opts in.
         """
         api_key = None
         if authorization:
@@ -3994,7 +3999,9 @@ def _register_routes(app: FastAPI):
                 api_key = authorization[7:].strip()
             else:
                 api_key = authorization.strip()
-        return RequestContext(api_key=api_key)
+        allowlist = get_config().extension_passthrough_headers
+        extra_headers = {name: request.headers[name] for name in allowlist if name in request.headers}
+        return RequestContext(api_key=api_key, extra_headers=extra_headers)
 
     def precheck_for(operation: PrecheckOperation):
         """

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -21,6 +21,7 @@ from fastapi.responses import JSONResponse
 
 from hindsight_api.api import page_markdown
 from hindsight_api.api.disconnect import ClientDisconnectCancellationMiddleware, get_scope_cancellation_token
+from hindsight_api.api.passthrough_headers import collect_passthrough_headers
 from hindsight_api.cancellation import OperationCancelledError
 from hindsight_api.engine.audit import (
     AuditEntry,
@@ -3999,8 +4000,7 @@ def _register_routes(app: FastAPI):
                 api_key = authorization[7:].strip()
             else:
                 api_key = authorization.strip()
-        allowlist = get_config().extension_passthrough_headers
-        extra_headers = {name: request.headers[name] for name in allowlist if name in request.headers}
+        extra_headers = collect_passthrough_headers(request.headers.raw, get_config().extension_passthrough_headers)
         return RequestContext(api_key=api_key, extra_headers=extra_headers)
 
     def precheck_for(operation: PrecheckOperation):

--- a/hindsight-api-slim/hindsight_api/api/mcp.py
+++ b/hindsight-api-slim/hindsight_api/api/mcp.py
@@ -52,6 +52,11 @@ _current_api_key_id: ContextVar[str | None] = ContextVar("current_api_key_id", d
 # Context variable for MCP pre-authentication flag (set when MCP_AUTH_TOKEN validates)
 _current_mcp_authenticated: ContextVar[bool] = ContextVar("current_mcp_authenticated", default=False)
 
+# Context variable for the headers an operator opted into forwarding to extensions
+# (HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS). Defaults to None rather than {}
+# so no single dict is shared as a default across requests.
+_current_extra_headers: ContextVar[dict[str, str] | None] = ContextVar("current_extra_headers", default=None)
+
 
 def get_current_bank_id() -> str | None:
     """Get the current bank_id from context."""
@@ -76,6 +81,11 @@ def get_current_api_key_id() -> str | None:
 def get_current_mcp_authenticated() -> bool:
     """Get whether the request was pre-authenticated by MCP transport auth."""
     return _current_mcp_authenticated.get()
+
+
+def get_current_extra_headers() -> dict[str, str]:
+    """Get the allowlisted passthrough headers for the current request."""
+    return _current_extra_headers.get() or {}
 
 
 def _build_mcp_tool_descriptions(extra_instructions: str | None) -> tuple[str | None, str | None]:
@@ -159,6 +169,7 @@ def create_mcp_server(memory: MemoryEngine, multi_bank: bool = True) -> FastMCP:
         tenant_id_resolver=get_current_tenant_id,  # Propagate tenant_id for usage metering
         api_key_id_resolver=get_current_api_key_id,  # Propagate api_key_id for usage metering
         mcp_authenticated_resolver=get_current_mcp_authenticated,  # Propagate MCP pre-auth flag
+        extra_headers_resolver=get_current_extra_headers,  # Propagate allowlisted headers to extensions
         include_bank_id_param=multi_bank,
         tools=base_tools,
         retain_description=retain_description,
@@ -378,6 +389,19 @@ class MCPMiddleware:
                 return header_value.decode()
         return None
 
+    def _get_extra_headers(self, scope: dict) -> dict[str, str]:
+        """Collect the headers an operator opted into forwarding to extensions.
+
+        Mirrors the HTTP transport's ``get_request_context``. Empty unless
+        HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS names a header the request
+        actually carries.
+        """
+        allowlist = _get_raw_config().extension_passthrough_headers
+        if not allowlist:
+            return {}
+        present = {name.lower().decode(): value.decode() for name, value in scope.get("headers", [])}
+        return {name: present[name] for name in allowlist if name in present}
+
     async def __call__(self, scope, receive, send):
         if scope["type"] != "http":
             await self.app(scope, receive, send)
@@ -412,6 +436,10 @@ class MCPMiddleware:
             # Support both "Bearer <token>" and direct token
             auth_token = auth_header[7:].strip() if auth_header.startswith("Bearer ") else auth_header.strip()
 
+        # Resolved before authentication so authenticate_mcp() can read a
+        # passthrough header, not just the bearer token.
+        extra_headers = self._get_extra_headers(scope)
+
         # Authenticate: check legacy MCP_AUTH_TOKEN first, then TenantExtension
         tenant_context = None
         auth_tenant_id: str | None = None
@@ -431,7 +459,7 @@ class MCPMiddleware:
         else:
             # Use TenantExtension.authenticate_mcp() for auth
             try:
-                auth_context = RequestContext(api_key=auth_token)
+                auth_context = RequestContext(api_key=auth_token, extra_headers=extra_headers)
                 tenant_context = await self.tenant_extension.authenticate_mcp(auth_context)
                 # Capture tenant_id and api_key_id set by authenticate() for usage metering
                 auth_tenant_id = auth_context.tenant_id
@@ -483,6 +511,8 @@ class MCPMiddleware:
         api_key_id_token = _current_api_key_id.set(auth_api_key_id) if auth_api_key_id else None
         # Store MCP pre-authentication flag to skip tenant re-validation
         mcp_auth_token = _current_mcp_authenticated.set(mcp_pre_authenticated)
+        # Store the allowlisted passthrough headers so per-tool RequestContexts carry them
+        extra_headers_token = _current_extra_headers.set(extra_headers)
         try:
             new_scope = scope.copy()
             new_scope["path"] = new_path
@@ -528,6 +558,7 @@ class MCPMiddleware:
             if api_key_id_token is not None:
                 _current_api_key_id.reset(api_key_id_token)
             _current_mcp_authenticated.reset(mcp_auth_token)
+            _current_extra_headers.reset(extra_headers_token)
             if schema_token is not None:
                 _current_schema.reset(schema_token)
 

--- a/hindsight-api-slim/hindsight_api/api/mcp.py
+++ b/hindsight-api-slim/hindsight_api/api/mcp.py
@@ -9,6 +9,7 @@ from fastmcp import FastMCP
 
 from hindsight_api import MemoryEngine
 from hindsight_api import __version__ as HINDSIGHT_VERSION
+from hindsight_api.api.passthrough_headers import collect_passthrough_headers
 from hindsight_api.config import DEFAULT_MCP_RECALL_DESCRIPTION, DEFAULT_MCP_RETAIN_DESCRIPTION, _get_raw_config
 from hindsight_api.engine.memory_engine import _current_schema
 from hindsight_api.extensions import MCPExtension, load_extension
@@ -84,8 +85,12 @@ def get_current_mcp_authenticated() -> bool:
 
 
 def get_current_extra_headers() -> dict[str, str]:
-    """Get the allowlisted passthrough headers for the current request."""
-    return _current_extra_headers.get() or {}
+    """Get the allowlisted passthrough headers for the current request.
+
+    Returns a copy: every RequestContext built during the request owns its dict,
+    so extension code mutating one cannot alter what the next tool call sees.
+    """
+    return dict(_current_extra_headers.get() or {})
 
 
 def _build_mcp_tool_descriptions(extra_instructions: str | None) -> tuple[str | None, str | None]:
@@ -392,15 +397,12 @@ class MCPMiddleware:
     def _get_extra_headers(self, scope: dict) -> dict[str, str]:
         """Collect the headers an operator opted into forwarding to extensions.
 
-        Mirrors the HTTP transport's ``get_request_context``. Empty unless
+        Shares ``collect_passthrough_headers`` with the HTTP transport, so both
+        agree on decoding and on what a duplicated header means. Empty unless
         HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS names a header the request
         actually carries.
         """
-        allowlist = _get_raw_config().extension_passthrough_headers
-        if not allowlist:
-            return {}
-        present = {name.lower().decode(): value.decode() for name, value in scope.get("headers", [])}
-        return {name: present[name] for name in allowlist if name in present}
+        return collect_passthrough_headers(scope.get("headers", []), _get_raw_config().extension_passthrough_headers)
 
     async def __call__(self, scope, receive, send):
         if scope["type"] != "http":
@@ -437,8 +439,9 @@ class MCPMiddleware:
             auth_token = auth_header[7:].strip() if auth_header.startswith("Bearer ") else auth_header.strip()
 
         # Resolved before authentication so authenticate_mcp() can read a
-        # passthrough header, not just the bearer token.
-        extra_headers = self._get_extra_headers(scope)
+        # passthrough header, not just the bearer token. Named for the request
+        # side: _send_error()'s `extra_headers` below is *response* headers.
+        passthrough_headers = self._get_extra_headers(scope)
 
         # Authenticate: check legacy MCP_AUTH_TOKEN first, then TenantExtension
         tenant_context = None
@@ -459,7 +462,7 @@ class MCPMiddleware:
         else:
             # Use TenantExtension.authenticate_mcp() for auth
             try:
-                auth_context = RequestContext(api_key=auth_token, extra_headers=extra_headers)
+                auth_context = RequestContext(api_key=auth_token, extra_headers=dict(passthrough_headers))
                 tenant_context = await self.tenant_extension.authenticate_mcp(auth_context)
                 # Capture tenant_id and api_key_id set by authenticate() for usage metering
                 auth_tenant_id = auth_context.tenant_id
@@ -512,7 +515,7 @@ class MCPMiddleware:
         # Store MCP pre-authentication flag to skip tenant re-validation
         mcp_auth_token = _current_mcp_authenticated.set(mcp_pre_authenticated)
         # Store the allowlisted passthrough headers so per-tool RequestContexts carry them
-        extra_headers_token = _current_extra_headers.set(extra_headers)
+        extra_headers_token = _current_extra_headers.set(passthrough_headers)
         try:
             new_scope = scope.copy()
             new_scope["path"] = new_path

--- a/hindsight-api-slim/hindsight_api/api/passthrough_headers.py
+++ b/hindsight-api-slim/hindsight_api/api/passthrough_headers.py
@@ -1,0 +1,56 @@
+"""Collection of the request headers an operator forwards to extensions.
+
+Shared by both transports (the HTTP dependency and the MCP ASGI middleware) so
+they cannot disagree about which value an extension sees. Both hand over raw
+ASGI header pairs — Starlette exposes them as ``request.headers.raw``, the MCP
+middleware reads them straight off the ASGI scope — so one implementation covers
+decoding, case-folding and duplicate handling for both.
+"""
+
+import logging
+from collections.abc import Iterable, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+def collect_passthrough_headers(
+    raw_headers: Iterable[tuple[bytes, bytes]],
+    allowlist: Sequence[str],
+) -> dict[str, str]:
+    """Pick the allowlisted headers out of a request, keyed by lower-cased name.
+
+    ``allowlist`` is ``HindsightConfig.extension_passthrough_headers``, already
+    lower-cased at config load; empty (the default) means nothing is forwarded.
+
+    A header sent more than once is dropped rather than resolved. These headers
+    carry identity for the deployments that enable this, and there is no safe
+    universal rule for picking between copies: a proxy may append its trusted
+    value after a client-supplied one or before it. Dropping turns a duplicate
+    into a loud failure in the extension (which sees no header) instead of a
+    silent choice between a real and a spoofed value.
+
+    Values are decoded as latin-1, matching Starlette and the HTTP/1.1 wire
+    encoding, so a header carrying non-UTF-8 bytes cannot fail the request.
+    """
+    if not allowlist:
+        return {}
+
+    wanted = set(allowlist)
+    found: dict[str, list[bytes]] = {}
+    for raw_name, raw_value in raw_headers:
+        name = raw_name.decode("latin-1").lower()
+        if name in wanted:
+            found.setdefault(name, []).append(raw_value)
+
+    collected: dict[str, str] = {}
+    for name, values in found.items():
+        if len(values) > 1:
+            logger.warning(
+                "Header '%s' is in HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS but arrived %d times; "
+                "not forwarding it to extensions (no safe way to choose between the copies)",
+                name,
+                len(values),
+            )
+            continue
+        collected[name] = values[0].decode("latin-1")
+    return collected

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -558,6 +558,12 @@ ENV_LINK_EXPANSION_PER_ENTITY_LIMIT = "HINDSIGHT_API_LINK_EXPANSION_PER_ENTITY_L
 ENV_LINK_EXPANSION_TIMEOUT = "HINDSIGHT_API_LINK_EXPANSION_TIMEOUT"
 ENV_BANK_STATS_CACHE_TTL_SECONDS = "HINDSIGHT_API_BANK_STATS_CACHE_TTL_SECONDS"
 ENV_BANK_STATS_CACHE_MAX_ENTRIES = "HINDSIGHT_API_BANK_STATS_CACHE_MAX_ENTRIES"
+# Request headers copied into RequestContext.extra_headers for extensions to read.
+# Comma-separated, matched case-insensitively. Empty by default: extensions only
+# ever see headers an operator has explicitly opted in, so a custom
+# TenantExtension/OperationValidatorExtension can't be handed request data its
+# author never asked for.
+ENV_EXTENSION_PASSTHROUGH_HEADERS = "HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS"
 
 # OpenTelemetry tracing configuration
 ENV_OTEL_TRACES_ENABLED = "HINDSIGHT_API_OTEL_TRACES_ENABLED"
@@ -2632,6 +2638,12 @@ class HindsightConfig:
     webhook_allowed_hosts: list[str] = field(default_factory=list)
     webhook_expose_response_body: bool = DEFAULT_WEBHOOK_EXPOSE_RESPONSE_BODY
 
+    # Headers forwarded to extensions via RequestContext.extra_headers (static,
+    # server-level only — deliberately NOT per-bank configurable: a tenant must
+    # not be able to widen the set of request headers its own extension code
+    # sees). Stored lower-cased; empty means no header is ever forwarded.
+    extension_passthrough_headers: list[str] = field(default_factory=list)
+
     # Class-level sets for configuration categorization
 
     # CREDENTIAL_FIELDS: Never exposed via API, never configurable per-tenant/bank
@@ -3932,6 +3944,12 @@ class HindsightConfig:
             webhook_expose_response_body=_parse_boolean_env(
                 ENV_WEBHOOK_EXPOSE_RESPONSE_BODY, DEFAULT_WEBHOOK_EXPOSE_RESPONSE_BODY
             ),
+            # Lower-cased here so the transports can match incoming header names
+            # case-insensitively (HTTP header names are case-insensitive) without
+            # re-normalising the allowlist on every request.
+            extension_passthrough_headers=[
+                h.lower() for h in _parse_str_list(os.getenv(ENV_EXTENSION_PASSTHROUGH_HEADERS, ""))
+            ],
         )
         config.validate()
         return config

--- a/hindsight-api-slim/hindsight_api/extensions/tenant.py
+++ b/hindsight-api-slim/hindsight_api/extensions/tenant.py
@@ -67,6 +67,17 @@ class TenantExtension(Extension, ABC):
 
     The returned schema_name is used for fully-qualified table names in queries,
     enabling tenant isolation at the database level.
+
+    By default the only request data reaching authenticate() is the Authorization
+    header, surfaced as RequestContext.api_key. A deployment that authenticates on
+    something else — say a per-caller identity assertion sent alongside a shared
+    bearer token by a proxy — can opt those headers in:
+
+        HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS=x-user-assertion
+
+    They then arrive in RequestContext.extra_headers, keyed by lower-cased name,
+    on both the HTTP and MCP transports. Unset by default, so extensions receive
+    no header data unless an operator asks for it.
     """
 
     @abstractmethod

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -90,9 +90,6 @@ class MCPToolsConfig:
     # How to resolve mcp_authenticated flag (set when MCP_AUTH_TOKEN validates)
     mcp_authenticated_resolver: Callable[[], bool] | None = None
 
-    # How to resolve the allowlisted passthrough headers (set by MCP middleware)
-    extra_headers_resolver: Callable[[], dict[str, str]] | None = None
-
     # Whether to include bank_id as a parameter on tools (for multi-bank support)
     include_bank_id_param: bool = False
 
@@ -102,6 +99,10 @@ class MCPToolsConfig:
     # Custom descriptions (if None, uses defaults)
     retain_description: str | None = None
     recall_description: str | None = None
+
+    # How to resolve the allowlisted passthrough headers (set by MCP middleware).
+    # Appended last so existing positional construction keeps its meaning.
+    extra_headers_resolver: Callable[[], dict[str, str]] | None = None
 
     # Retain behavior
 

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -90,6 +90,9 @@ class MCPToolsConfig:
     # How to resolve mcp_authenticated flag (set when MCP_AUTH_TOKEN validates)
     mcp_authenticated_resolver: Callable[[], bool] | None = None
 
+    # How to resolve the allowlisted passthrough headers (set by MCP middleware)
+    extra_headers_resolver: Callable[[], dict[str, str]] | None = None
+
     # Whether to include bank_id as a parameter on tools (for multi-bank support)
     include_bank_id_param: bool = False
 
@@ -113,8 +116,13 @@ def _get_request_context(config: MCPToolsConfig) -> RequestContext:
     tenant_id = config.tenant_id_resolver() if config.tenant_id_resolver else None
     api_key_id = config.api_key_id_resolver() if config.api_key_id_resolver else None
     mcp_authenticated = config.mcp_authenticated_resolver() if config.mcp_authenticated_resolver else False
+    extra_headers = config.extra_headers_resolver() if config.extra_headers_resolver else {}
     return RequestContext(
-        api_key=api_key, tenant_id=tenant_id, api_key_id=api_key_id, mcp_authenticated=mcp_authenticated
+        api_key=api_key,
+        tenant_id=tenant_id,
+        api_key_id=api_key_id,
+        mcp_authenticated=mcp_authenticated,
+        extra_headers=extra_headers,
     )
 
 

--- a/hindsight-api-slim/hindsight_api/models.py
+++ b/hindsight-api-slim/hindsight_api/models.py
@@ -2,7 +2,7 @@
 SQLAlchemy models for the memory system.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING
 from uuid import UUID as PyUUID
@@ -17,8 +17,9 @@ class RequestContext:
     Context for request authentication and authorization.
 
     This dataclass carries authentication data from HTTP requests to the
-    memory engine operations. It can be extended to include additional
-    context like headers, tokens, user info, etc.
+    memory engine operations. Beyond the Authorization header, a deployment can
+    surface additional request headers to its extensions via ``extra_headers``
+    (see HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS).
     """
 
     api_key: str | None = None
@@ -40,6 +41,14 @@ class RequestContext:
     # consuming CPU/DB resources (issue #2122). None means "never cancelled" —
     # every checkpoint is a no-op.
     cancellation: "CancellationToken | None" = None
+    # Request headers an operator opted into forwarding to extensions, keyed by
+    # lower-cased header name. Populated by the HTTP and MCP transports from the
+    # HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS allowlist; always empty unless
+    # that variable is set, and it never carries a header absent from the
+    # request. Lets a custom TenantExtension read an identity signal that isn't
+    # the Authorization header — e.g. a per-caller assertion sent alongside a
+    # shared bearer token by an authenticating proxy.
+    extra_headers: dict[str, str] = field(default_factory=dict)
 
     def raise_if_cancelled(self) -> None:
         """Abort the current operation if its cancellation token has fired.

--- a/hindsight-api-slim/tests/test_extension_passthrough_headers.py
+++ b/hindsight-api-slim/tests/test_extension_passthrough_headers.py
@@ -4,6 +4,7 @@ Covers config parsing plus the two transports that build a RequestContext from a
 live request: the HTTP dependency and the MCP middleware.
 """
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -146,6 +147,28 @@ class TestHttpTransport:
         assert context.api_key == "shared-key"
         assert context.extra_headers == {ASSERTION_HEADER: "token-abc"}
 
+    def test_duplicated_header_is_not_forwarded(self, recording_client):
+        """A second copy must not be able to override the one the proxy injected."""
+        client, ext = recording_client(ASSERTION_HEADER)
+
+        client.get(
+            "/v1/default/banks",
+            headers=[(ASSERTION_HEADER, "spoofed"), (ASSERTION_HEADER, "trusted")],
+        )
+
+        assert _last_context(ext).extra_headers == {}
+
+    def test_unlisted_header_with_non_utf8_bytes_does_not_break_the_request(self, recording_client):
+        """Header bytes are latin-1 on the wire; a stray one must not fail the request."""
+        client, ext = recording_client(ASSERTION_HEADER)
+
+        client.get(
+            "/v1/default/banks",
+            headers=[(b"user-agent", b"caf\xe9"), (ASSERTION_HEADER.encode(), b"token-abc")],
+        )
+
+        assert _last_context(ext).extra_headers == {ASSERTION_HEADER: "token-abc"}
+
 
 class TestMcpTransport:
     """Header collection in the MCP ASGI middleware."""
@@ -207,6 +230,97 @@ class TestMcpTransport:
 
         assert extra == {ASSERTION_HEADER: "token-abc"}
 
+    def test_duplicated_header_is_not_forwarded(self, memory, set_passthrough):
+        """Same rule as HTTP: neither copy wins, so the two transports cannot disagree."""
+        set_passthrough(ASSERTION_HEADER)
+        middleware = self._middleware(memory)
+
+        extra = middleware._get_extra_headers(self._scope((ASSERTION_HEADER, "spoofed"), (ASSERTION_HEADER, "trusted")))
+
+        assert extra == {}
+
+    def test_unlisted_header_with_non_utf8_bytes_does_not_raise(self, memory, set_passthrough):
+        """ASGI header bytes are not necessarily UTF-8; decoding one must not 500 the request."""
+        set_passthrough(ASSERTION_HEADER)
+        middleware = self._middleware(memory)
+
+        scope = {"headers": [(b"user-agent", b"caf\xe9"), (ASSERTION_HEADER.encode(), b"token-abc")]}
+
+        assert middleware._get_extra_headers(scope) == {ASSERTION_HEADER: "token-abc"}
+
+
+class TestReachesOperationValidator:
+    """The headers survive the whole HTTP path, not just the auth hop."""
+
+    @pytest.mark.asyncio
+    async def test_validator_sees_the_headers(self, memory, set_passthrough):
+        from hindsight_api.api.http import create_app
+        from hindsight_api.extensions import (
+            BankListContext,
+            BankListResult,
+            OperationValidatorExtension,
+            ValidationResult,
+        )
+
+        captured: list[RequestContext] = []
+
+        class CapturingValidator(OperationValidatorExtension):
+            async def validate_retain(self, ctx) -> ValidationResult:
+                return ValidationResult.accept()
+
+            async def validate_recall(self, ctx) -> ValidationResult:
+                return ValidationResult.accept()
+
+            async def validate_reflect(self, ctx) -> ValidationResult:
+                return ValidationResult.accept()
+
+            async def filter_bank_list(self, ctx: BankListContext) -> BankListResult:
+                captured.append(ctx.request_context)
+                return BankListResult(banks=ctx.banks)
+
+        set_passthrough(ASSERTION_HEADER)
+        memory._operation_validator = CapturingValidator({})
+        # An in-loop ASGI client: TestClient drives its own event loop, which the
+        # engine's connection pool (created in this test's loop) cannot serve.
+        transport = httpx.ASGITransport(app=create_app(memory, initialize_memory=False))
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/v1/default/banks", headers={ASSERTION_HEADER: "token-abc"})
+
+        assert response.status_code == 200
+        assert captured, "operation validator was never called"
+        assert captured[-1].extra_headers == {ASSERTION_HEADER: "token-abc"}
+
+
+class TestSharedCollection:
+    """Both transports go through collect_passthrough_headers, so it owns the rules."""
+
+    @staticmethod
+    def _collect(allowlist, *headers: tuple[bytes, bytes]) -> dict[str, str]:
+        from hindsight_api.api.passthrough_headers import collect_passthrough_headers
+
+        return collect_passthrough_headers(list(headers), allowlist)
+
+    def test_empty_allowlist_forwards_nothing(self):
+        assert self._collect([], (b"x-user-assertion", b"token-abc")) == {}
+
+    def test_lower_cases_the_key(self):
+        assert self._collect(["x-user-assertion"], (b"X-User-Assertion", b"token-abc")) == {
+            ASSERTION_HEADER: "token-abc"
+        }
+
+    def test_drops_duplicates_and_keeps_the_rest(self):
+        collected = self._collect(
+            ["x-user-assertion", "x-request-origin"],
+            (b"x-user-assertion", b"spoofed"),
+            (b"x-user-assertion", b"trusted"),
+            (b"x-request-origin", b"gateway"),
+        )
+
+        assert collected == {"x-request-origin": "gateway"}
+
+    def test_decodes_values_as_latin1(self):
+        assert self._collect(["x-user-assertion"], (b"x-user-assertion", b"caf\xe9")) == {ASSERTION_HEADER: "café"}
+
 
 class TestMcpToolsConfig:
     """RequestContext built for MCP tool calls carries the resolved headers."""
@@ -220,6 +334,19 @@ class TestMcpToolsConfig:
         )
 
         assert _get_request_context(config).extra_headers == {ASSERTION_HEADER: "token-abc"}
+
+    def test_each_context_owns_its_dict(self):
+        """One tool call mutating extra_headers must not change what the next one sees."""
+        from hindsight_api.api.mcp import _current_extra_headers, get_current_extra_headers
+
+        token = _current_extra_headers.set({ASSERTION_HEADER: "token-abc"})
+        try:
+            first = get_current_extra_headers()
+            first["injected"] = "nope"
+
+            assert get_current_extra_headers() == {ASSERTION_HEADER: "token-abc"}
+        finally:
+            _current_extra_headers.reset(token)
 
     def test_empty_without_resolver(self):
         from hindsight_api.mcp_tools import MCPToolsConfig, _get_request_context

--- a/hindsight-api-slim/tests/test_extension_passthrough_headers.py
+++ b/hindsight-api-slim/tests/test_extension_passthrough_headers.py
@@ -1,0 +1,229 @@
+"""Tests for HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS.
+
+Covers config parsing plus the two transports that build a RequestContext from a
+live request: the HTTP dependency and the MCP middleware.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hindsight_api.config import HindsightConfig, clear_config_cache
+from hindsight_api.extensions import (
+    AuthenticationError,
+    RequestContext,
+    Tenant,
+    TenantContext,
+    TenantExtension,
+)
+
+ASSERTION_HEADER = "x-user-assertion"
+ENV_VAR = "HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS"
+
+
+class RecordingTenantExtension(TenantExtension):
+    """Captures every RequestContext it authenticates, then rejects the request.
+
+    Rejecting keeps these tests on the auth path only — the request never reaches
+    an engine method, so no database work is needed to observe what the transport
+    put in the context.
+    """
+
+    def __init__(self):
+        super().__init__({})
+        self.contexts: list[RequestContext] = []
+
+    async def authenticate(self, context: RequestContext) -> TenantContext:
+        self.contexts.append(context)
+        raise AuthenticationError("recorded")
+
+    async def list_tenants(self) -> list[Tenant]:
+        return [Tenant(schema="public")]
+
+
+@pytest.fixture
+def set_passthrough(monkeypatch):
+    """Set the allowlist env var and invalidate the cached config around the test."""
+
+    def _set(value: str | None) -> None:
+        if value is None:
+            monkeypatch.delenv(ENV_VAR, raising=False)
+        else:
+            monkeypatch.setenv(ENV_VAR, value)
+        clear_config_cache()
+
+    yield _set
+    clear_config_cache()
+
+
+@pytest.fixture
+def recording_client(memory, set_passthrough):
+    """Build a TestClient whose tenant extension records the request context."""
+    from hindsight_api.api.http import create_app
+
+    def _build(allowlist: str | None) -> tuple[TestClient, RecordingTenantExtension]:
+        set_passthrough(allowlist)
+        ext = RecordingTenantExtension()
+        memory._tenant_extension = ext
+        return TestClient(create_app(memory, initialize_memory=False)), ext
+
+    return _build
+
+
+def _last_context(ext: RecordingTenantExtension) -> RequestContext:
+    assert ext.contexts, "tenant extension was never called"
+    return ext.contexts[-1]
+
+
+class TestConfigParsing:
+    """HindsightConfig parsing of the allowlist."""
+
+    def test_empty_by_default(self, set_passthrough):
+        set_passthrough(None)
+        assert HindsightConfig.from_env().extension_passthrough_headers == []
+
+    def test_parses_and_lowercases_entries(self, set_passthrough):
+        set_passthrough("X-User-Assertion, X-Request-Origin")
+        assert HindsightConfig.from_env().extension_passthrough_headers == [
+            "x-user-assertion",
+            "x-request-origin",
+        ]
+
+    def test_ignores_blank_entries(self, set_passthrough):
+        set_passthrough(" , x-user-assertion , ")
+        assert HindsightConfig.from_env().extension_passthrough_headers == ["x-user-assertion"]
+
+
+class TestHttpTransport:
+    """RequestContext.extra_headers as built by the HTTP dependency."""
+
+    def test_forwards_allowlisted_header(self, recording_client):
+        client, ext = recording_client(ASSERTION_HEADER)
+
+        client.get("/v1/default/banks", headers={ASSERTION_HEADER: "token-abc"})
+
+        assert _last_context(ext).extra_headers == {ASSERTION_HEADER: "token-abc"}
+
+    def test_empty_when_unset(self, recording_client):
+        client, ext = recording_client(None)
+
+        client.get("/v1/default/banks", headers={ASSERTION_HEADER: "token-abc"})
+
+        assert _last_context(ext).extra_headers == {}
+
+    def test_empty_when_header_absent(self, recording_client):
+        client, ext = recording_client(ASSERTION_HEADER)
+
+        client.get("/v1/default/banks")
+
+        assert _last_context(ext).extra_headers == {}
+
+    def test_matches_header_name_case_insensitively(self, recording_client):
+        client, ext = recording_client("X-User-Assertion")
+
+        client.get("/v1/default/banks", headers={"X-USER-ASSERTION": "token-abc"})
+
+        assert _last_context(ext).extra_headers == {ASSERTION_HEADER: "token-abc"}
+
+    def test_does_not_forward_unlisted_headers(self, recording_client):
+        client, ext = recording_client(ASSERTION_HEADER)
+
+        client.get(
+            "/v1/default/banks",
+            headers={ASSERTION_HEADER: "token-abc", "x-secret": "nope"},
+        )
+
+        assert _last_context(ext).extra_headers == {ASSERTION_HEADER: "token-abc"}
+
+    def test_authorization_still_parsed_into_api_key(self, recording_client):
+        client, ext = recording_client(ASSERTION_HEADER)
+
+        client.get(
+            "/v1/default/banks",
+            headers={"Authorization": "Bearer shared-key", ASSERTION_HEADER: "token-abc"},
+        )
+
+        context = _last_context(ext)
+        assert context.api_key == "shared-key"
+        assert context.extra_headers == {ASSERTION_HEADER: "token-abc"}
+
+
+class TestMcpTransport:
+    """Header collection in the MCP ASGI middleware."""
+
+    @staticmethod
+    def _middleware(memory):
+        from hindsight_api.api.mcp import MCPMiddleware
+
+        # Pre-created app slots skip MCP server construction — this only exercises
+        # header collection, which needs no server.
+        return MCPMiddleware(
+            app=None,
+            memory=memory,
+            multi_bank_app=object(),
+            single_bank_app=object(),
+        )
+
+    @staticmethod
+    def _scope(*headers: tuple[str, str]) -> dict:
+        return {"headers": [(name.encode(), value.encode()) for name, value in headers]}
+
+    def test_forwards_allowlisted_header(self, memory, set_passthrough):
+        set_passthrough(ASSERTION_HEADER)
+        middleware = self._middleware(memory)
+
+        extra = middleware._get_extra_headers(self._scope((ASSERTION_HEADER, "token-abc")))
+
+        assert extra == {ASSERTION_HEADER: "token-abc"}
+
+    def test_empty_when_unset(self, memory, set_passthrough):
+        set_passthrough(None)
+        middleware = self._middleware(memory)
+
+        extra = middleware._get_extra_headers(self._scope((ASSERTION_HEADER, "token-abc")))
+
+        assert extra == {}
+
+    def test_empty_when_header_absent(self, memory, set_passthrough):
+        set_passthrough(ASSERTION_HEADER)
+        middleware = self._middleware(memory)
+
+        extra = middleware._get_extra_headers(self._scope(("authorization", "Bearer shared-key")))
+
+        assert extra == {}
+
+    def test_matches_header_name_case_insensitively(self, memory, set_passthrough):
+        set_passthrough("X-User-Assertion")
+        middleware = self._middleware(memory)
+
+        extra = middleware._get_extra_headers(self._scope(("X-USER-ASSERTION", "token-abc")))
+
+        assert extra == {ASSERTION_HEADER: "token-abc"}
+
+    def test_does_not_forward_unlisted_headers(self, memory, set_passthrough):
+        set_passthrough(ASSERTION_HEADER)
+        middleware = self._middleware(memory)
+
+        extra = middleware._get_extra_headers(self._scope((ASSERTION_HEADER, "token-abc"), ("x-secret", "nope")))
+
+        assert extra == {ASSERTION_HEADER: "token-abc"}
+
+
+class TestMcpToolsConfig:
+    """RequestContext built for MCP tool calls carries the resolved headers."""
+
+    def test_resolver_populates_extra_headers(self):
+        from hindsight_api.mcp_tools import MCPToolsConfig, _get_request_context
+
+        config = MCPToolsConfig(
+            bank_id_resolver=lambda: "test-bank",
+            extra_headers_resolver=lambda: {ASSERTION_HEADER: "token-abc"},
+        )
+
+        assert _get_request_context(config).extra_headers == {ASSERTION_HEADER: "token-abc"}
+
+    def test_empty_without_resolver(self):
+        from hindsight_api.mcp_tools import MCPToolsConfig, _get_request_context
+
+        config = MCPToolsConfig(bank_id_resolver=lambda: "test-bank")
+
+        assert _get_request_context(config).extra_headers == {}

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1157,8 +1157,21 @@ Requests without a valid API key receive a `401 Unauthorized` response.
 |----------|-------------|---------|
 | `HINDSIGHT_API_TENANT_EXTENSION` | Dotted path to the loaded tenant extension. Set to `hindsight_api.extensions.builtin.tenant:ApiKeyTenantExtension` to require an API key on every request. | *(none; auth disabled)* |
 | `HINDSIGHT_API_TENANT_API_KEY` | Shared API key checked by the built-in API-key extension. Sent by clients as `Authorization: Bearer <key>`. | *(none)* |
+| `HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS` | Comma-separated request headers copied into `RequestContext.extra_headers` for extensions to read, matched case-insensitively. Empty means extensions see only the `Authorization` header. | *(none)* |
 
 If you are enabling Memory Defense, see `docs/developer/memory-defense/` for the policy schema, detector catalog, and audit trail.
+
+#### Forwarding extra headers to extensions
+
+A custom `TenantExtension` normally only sees the `Authorization` header, as `RequestContext.api_key`. That is not enough when the bearer token identifies the *proxy* rather than the caller — for example behind an authenticating gateway that presents one shared service identity to Hindsight, and carries the per-caller identity in a second header.
+
+List those headers to have them forwarded:
+
+```bash
+export HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS=x-user-assertion,x-request-origin
+```
+
+They arrive in `RequestContext.extra_headers`, keyed by lower-cased name, on both the HTTP and MCP transports, and thread through to `OperationValidatorExtension` hooks with the rest of the request context. Only listed headers that are actually present on the request appear; the setting is unset by default, so extensions receive no header data unless you opt in.
 
 :::tip Custom Authentication
 For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a custom `TenantExtension`. See the [Extensions documentation](./extensions.md) for details.

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1173,6 +1173,8 @@ export HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS=x-user-assertion,x-request-or
 
 They arrive in `RequestContext.extra_headers`, keyed by lower-cased name, on both the HTTP and MCP transports, and thread through to `OperationValidatorExtension` hooks with the rest of the request context. Only listed headers that are actually present on the request appear; the setting is unset by default, so extensions receive no header data unless you opt in.
 
+A listed header that arrives **more than once** is dropped (with a warning) rather than resolved to one of its values, so a duplicate can never silently override the value your proxy injected. Headers forwarded this way are only as trustworthy as the proxy in front of Hindsight: list a header only if that proxy sets it and strips any client-supplied copy. The setting is server-level and cannot be overridden per tenant or bank.
+
 :::tip Custom Authentication
 For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a custom `TenantExtension`. See the [Extensions documentation](./extensions.md) for details.
 :::

--- a/hindsight-docs/docs/developer/extensions.md
+++ b/hindsight-docs/docs/developer/extensions.md
@@ -143,6 +143,30 @@ raise AuthenticationError(
 )
 ```
 
+### Reading additional request headers
+
+`RequestContext` carries the `Authorization` header as `api_key`. To authenticate on a *different* header — for instance when a gateway terminates auth with one shared identity and forwards the per-caller identity separately — name the headers you want forwarded:
+
+```bash
+HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS=x-user-assertion
+```
+
+They are available as `context.extra_headers`, keyed by lower-cased name:
+
+```python
+async def authenticate(self, context: RequestContext) -> TenantContext:
+    assertion = context.extra_headers.get("x-user-assertion")
+    if not assertion:
+        raise AuthenticationError("x-user-assertion header required")
+
+    user_id = verify_assertion(assertion)  # your verification
+    return TenantContext(schema_name=f"tenant_{user_id}")
+```
+
+This works on both the HTTP and MCP transports, and the same `RequestContext` is passed to `OperationValidatorExtension` hooks, so a validator can enforce rules against the identity resolved here.
+
+Only headers you list are forwarded, and only when present on the request. The variable is unset by default, so extensions see no header data unless you opt in.
+
 ### Example: Custom HttpExtension
 
 ```python

--- a/hindsight-docs/docs/developer/extensions.md
+++ b/hindsight-docs/docs/developer/extensions.md
@@ -167,6 +167,12 @@ This works on both the HTTP and MCP transports, and the same `RequestContext` is
 
 Only headers you list are forwarded, and only when present on the request. The variable is unset by default, so extensions see no header data unless you opt in.
 
+A header sent **more than once** is not forwarded at all, and a warning is logged. There is no safe way to choose between the copies — a proxy may append its trusted value either before or after a client-supplied one — so an extension reading it sees nothing and fails the request, rather than silently accepting a value that may be spoofed. Make sure your proxy *replaces* the identity header it injects instead of appending to it.
+
+:::caution Deferred operations
+`extra_headers` describes the request being served. Operations that run later — a queued retain, a scheduled consolidation, a mental-model refresh — are executed by a background worker with no request behind them, so their `RequestContext` carries no headers. Authorize on the header at request time; do not rely on it inside work that continues after the response.
+:::
+
 ### Example: Custom HttpExtension
 
 ```python

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -356,7 +356,9 @@ HINDSIGHT_API_LOG_LEVEL=info
 # TenantExtension / OperationValidatorExtension can read them. Comma-separated,
 # matched case-insensitively. Unset by default: extensions see only the
 # Authorization header. Use this when the bearer token identifies a proxy rather
-# than the caller, and per-caller identity arrives in a separate header.
+# than the caller, and per-caller identity arrives in a separate header. A listed
+# header that arrives more than once is dropped, so only list headers the proxy
+# in front of Hindsight sets itself (stripping any client-supplied copy).
 # HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS=x-user-assertion
 
 # -----------------------------------------------------------------------------

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -349,6 +349,17 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_DB_ACQUIRE_WARN_THRESHOLD_MS=1000
 
 # -----------------------------------------------------------------------------
+# Extensions (Optional)
+# -----------------------------------------------------------------------------
+
+# Request headers copied into RequestContext.extra_headers so a custom
+# TenantExtension / OperationValidatorExtension can read them. Comma-separated,
+# matched case-insensitively. Unset by default: extensions see only the
+# Authorization header. Use this when the bearer token identifies a proxy rather
+# than the caller, and per-caller identity arrives in a separate header.
+# HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS=x-user-assertion
+
+# -----------------------------------------------------------------------------
 # Webhooks (Optional)
 # -----------------------------------------------------------------------------
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1157,8 +1157,23 @@ Requests without a valid API key receive a `401 Unauthorized` response.
 |----------|-------------|---------|
 | `HINDSIGHT_API_TENANT_EXTENSION` | Dotted path to the loaded tenant extension. Set to `hindsight_api.extensions.builtin.tenant:ApiKeyTenantExtension` to require an API key on every request. | *(none; auth disabled)* |
 | `HINDSIGHT_API_TENANT_API_KEY` | Shared API key checked by the built-in API-key extension. Sent by clients as `Authorization: Bearer <key>`. | *(none)* |
+| `HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS` | Comma-separated request headers copied into `RequestContext.extra_headers` for extensions to read, matched case-insensitively. Empty means extensions see only the `Authorization` header. | *(none)* |
 
 If you are enabling Memory Defense, see `docs/developer/memory-defense/` for the policy schema, detector catalog, and audit trail.
+
+#### Forwarding extra headers to extensions
+
+A custom `TenantExtension` normally only sees the `Authorization` header, as `RequestContext.api_key`. That is not enough when the bearer token identifies the *proxy* rather than the caller — for example behind an authenticating gateway that presents one shared service identity to Hindsight, and carries the per-caller identity in a second header.
+
+List those headers to have them forwarded:
+
+```bash
+export HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS=x-user-assertion,x-request-origin
+```
+
+They arrive in `RequestContext.extra_headers`, keyed by lower-cased name, on both the HTTP and MCP transports, and thread through to `OperationValidatorExtension` hooks with the rest of the request context. Only listed headers that are actually present on the request appear; the setting is unset by default, so extensions receive no header data unless you opt in.
+
+A listed header that arrives **more than once** is dropped (with a warning) rather than resolved to one of its values, so a duplicate can never silently override the value your proxy injected. Headers forwarded this way are only as trustworthy as the proxy in front of Hindsight: list a header only if that proxy sets it and strips any client-supplied copy. The setting is server-level and cannot be overridden per tenant or bank.
 
 :::tip Custom Authentication
 For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a custom `TenantExtension`. See the [Extensions documentation](./extensions.md) for details.

--- a/skills/hindsight-docs/references/developer/extensions.md
+++ b/skills/hindsight-docs/references/developer/extensions.md
@@ -143,6 +143,36 @@ raise AuthenticationError(
 )
 ```
 
+### Reading additional request headers
+
+`RequestContext` carries the `Authorization` header as `api_key`. To authenticate on a *different* header — for instance when a gateway terminates auth with one shared identity and forwards the per-caller identity separately — name the headers you want forwarded:
+
+```bash
+HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS=x-user-assertion
+```
+
+They are available as `context.extra_headers`, keyed by lower-cased name:
+
+```python
+async def authenticate(self, context: RequestContext) -> TenantContext:
+    assertion = context.extra_headers.get("x-user-assertion")
+    if not assertion:
+        raise AuthenticationError("x-user-assertion header required")
+
+    user_id = verify_assertion(assertion)  # your verification
+    return TenantContext(schema_name=f"tenant_{user_id}")
+```
+
+This works on both the HTTP and MCP transports, and the same `RequestContext` is passed to `OperationValidatorExtension` hooks, so a validator can enforce rules against the identity resolved here.
+
+Only headers you list are forwarded, and only when present on the request. The variable is unset by default, so extensions see no header data unless you opt in.
+
+A header sent **more than once** is not forwarded at all, and a warning is logged. There is no safe way to choose between the copies — a proxy may append its trusted value either before or after a client-supplied one — so an extension reading it sees nothing and fails the request, rather than silently accepting a value that may be spoofed. Make sure your proxy *replaces* the identity header it injects instead of appending to it.
+
+:::caution Deferred operations
+`extra_headers` describes the request being served. Operations that run later — a queued retain, a scheduled consolidation, a mental-model refresh — are executed by a background worker with no request behind them, so their `RequestContext` carries no headers. Authorize on the header at request time; do not rely on it inside work that continues after the response.
+:::
+
 ### Example: Custom HttpExtension
 
 ```python


### PR DESCRIPTION
## Problem

A custom `TenantExtension` only ever sees the `Authorization` header, surfaced as `RequestContext.api_key`. `get_request_context()` in `api/http.py` reads that one header and nothing else, so no other request data reaches extension code.

That is limiting for deployments behind an authenticating proxy that presents a **single shared identity** to Hindsight — the bearer token identifies the proxy, not the caller. Every request looks identical to the extension, so it cannot attribute actions to the actual caller or enforce per-caller rules, even though the per-caller identity is right there in a second header.

`RequestContext`'s own docstring already anticipated this:

> It can be extended to include additional context like headers, tokens, user info, etc.

This fills that in.

## Change

New env var `HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS`: a comma-separated allowlist of header names copied into a new `RequestContext.extra_headers` field, keyed by lower-cased name.

```bash
HINDSIGHT_API_EXTENSION_PASSTHROUGH_HEADERS=x-user-assertion
```

```python
async def authenticate(self, context: RequestContext) -> TenantContext:
    assertion = context.extra_headers.get("x-user-assertion")
    if not assertion:
        raise AuthenticationError("x-user-assertion header required")
    user_id = verify_assertion(assertion)  # your verification
    return TenantContext(schema_name=f"tenant_{user_id}")
```

Because the same `RequestContext` instance threads through to `OperationValidatorExtension` hooks, a validator can then enforce rules against the identity resolved during auth.

### Opt-in and default-off

Unset (the default) means `extra_headers` stays empty and behaviour is byte-identical to today. This is deliberate rather than forwarding all headers: existing `TenantExtension` / `OperationValidatorExtension` implementations were not written expecting arbitrary request headers to flow into them, and silently starting to pass them would be a regression in the wrong direction.

The setting is server-level only and intentionally **not** in `_CONFIGURABLE_FIELDS`, so a tenant cannot widen the set of headers its own extension code sees. It is modelled on the existing `webhook_allowed_hosts` field, which has the same shape and the same reasoning.

### Both transports

- **HTTP** — `get_request_context()` now takes the `Request` and populates `extra_headers` from the allowlist.
- **MCP** — `MCPMiddleware` collects the same headers from the ASGI scope. They are resolved *before* authentication so `authenticate_mcp()` can read them, and stored in a contextvar (alongside the existing api-key/tenant-id ones) so per-tool-call `RequestContext`s carry them too.

Header names are matched case-insensitively; the allowlist is lower-cased once at config load rather than per request.

## Tests

New `hindsight-api-slim/tests/test_extension_passthrough_headers.py` — 16 tests:

- **Config parsing** — empty by default, lower-casing, blank entries ignored.
- **HTTP transport** — via a recording `TenantExtension`: header forwarded when allowlisted and present; empty when the env var is unset; empty when the header is absent; case-insensitive matching; unlisted headers are *not* forwarded; `Authorization` still parses into `api_key`.
- **MCP transport** — the same five cases against the middleware's header collection.
- **MCP tools** — the resolver populates `extra_headers`, and it is empty without one.

Also updated: `configuration.md`, `extensions.md`, the `RequestContext` and `TenantExtension` docstrings, `.env.example`, and the bundled `hindsight-embed` copy.

## Validation

- New file: 16 passed
- `tests/test_extensions.py`, `tests/test_mcp_tools.py`, `tests/test_extension_passthrough_headers.py`: 264 passed
- `tests/test_http_api_integration.py`: 57 passed (the 2 `*_llm_quality` errors are setup failures from no LLM API key in my environment, unrelated)
- `hindsight-embed/tests/test_env_template.py`: 7 passed
- `uv run ruff check .` and `ruff format --check .` clean; `uv run ty check hindsight_api/` clean

## Notes for reviewers

- **No OpenAPI/client regeneration.** `get_request_context` is an internal dependency — no route signature, request body, or response model changed. Happy to regenerate if you'd rather.
- The MCP test calls `MCPMiddleware._get_extra_headers` directly rather than driving a full `streamable_http_client` session, to keep it fast. Can convert to end-to-end if you prefer.
- I did not factor the two header-collection sites into a shared helper: the inputs differ (Starlette's case-insensitive `Headers` vs raw ASGI byte tuples), and it read as a premature abstraction for two call sites. Easy to change.
