### PR TITLE
fix(engine): scope document statements by bank_id (#3429)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7156,12 +7156,15 @@ class MemoryEngine(MemoryEngineInterface):
                 _store = get_memories()
                 if _store.writes_memory_rows_in_sql_for(bank_id):
                     unit_rows = await conn.fetch(
-                        f"SELECT id FROM {fq_table('memory_units')} WHERE document_id = $1 AND fact_type IN ('experience', 'world')",
+                        f"SELECT id FROM {fq_table('memory_units')} WHERE document_id = $1 AND bank_id = $2 AND fact_type IN ('experience', 'world')",
                         document_id,
+                        bank_id,
                     )
                     unit_ids = [str(row["id"]) for row in unit_rows]
                     units_count = await conn.fetchval(
-                        f"SELECT COUNT(*) FROM {fq_table('memory_units')} WHERE document_id = $1", document_id
+                        f"SELECT COUNT(*) FROM {fq_table('memory_units')} WHERE document_id = $1 AND bank_id = $2",
+                        document_id,
+                        bank_id,
                     )
                 else:
                     src_page = await _store.scan_memories(
@@ -7345,15 +7348,17 @@ class MemoryEngine(MemoryEngineInterface):
                         )
                 elif tags is not None:
                     unit_rows = await conn.fetch(
-                        f"SELECT id FROM {fq_table('memory_units')} WHERE document_id = $1 AND fact_type IN ('experience', 'world')",
+                        f"SELECT id FROM {fq_table('memory_units')} WHERE document_id = $1 AND bank_id = $2 AND fact_type IN ('experience', 'world')",
                         document_id,
+                        bank_id,
                     )
                     unit_ids = [str(row["id"]) for row in unit_rows]
 
                     await conn.execute(
-                        f"UPDATE {fq_table('memory_units')} SET tags = $1 WHERE document_id = $2",
+                        f"UPDATE {fq_table('memory_units')} SET tags = $1 WHERE document_id = $2 AND bank_id = $3",
                         tags,
                         document_id,
+                        bank_id,
                     )
 
                     if unit_ids:

--- a/hindsight-api-slim/tests/test_document_tracking.py
+++ b/hindsight-api-slim/tests/test_document_tracking.py
@@ -122,6 +122,67 @@ async def test_document_deletion(memory, request_context):
         await memory.delete_bank(bank_id, request_context=request_context)
 
 
+async def _retain_shared_document(memory, request_context, banks, document_id):
+    """Give each bank its own copy of the same document_id — legal, `documents` is keyed on (id, bank_id)."""
+    for bank_id in banks:
+        await memory.retain_async(
+            bank_id=bank_id,
+            content="Alice works at Google.",
+            context="Test",
+            document_id=document_id,
+            request_context=request_context,
+        )
+
+
+async def _units(memory, request_context, bank_id, document_id):
+    page = await memory.list_memory_units(bank_id=bank_id, document_id=document_id, request_context=request_context)
+    return page["items"]
+
+
+@pytest.mark.asyncio
+async def test_document_deletion_counts_only_its_own_bank_units(memory, request_context):
+    """`memory_units_deleted` must report the caller's units, not those of every bank sharing the document_id."""
+    stamp = datetime.now(timezone.utc).timestamp()
+    bank_a, bank_b = f"test_del_scope_a_{stamp}", f"test_del_scope_b_{stamp}"
+    document_id = f"shared-document-id-{stamp}"
+
+    try:
+        await _retain_shared_document(memory, request_context, (bank_a, bank_b), document_id)
+        a_count = len(await _units(memory, request_context, bank_a, document_id))
+        assert a_count > 0
+
+        result = await memory.delete_document(document_id, bank_a, request_context=request_context)
+
+        assert result["memory_units_deleted"] == a_count
+        assert len(await _units(memory, request_context, bank_b, document_id)) == a_count
+
+    finally:
+        for bank_id in (bank_a, bank_b):
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_document_tag_update_is_scoped_to_its_bank(memory, request_context):
+    """Re-tagging a document must not re-tag the memory units of another bank sharing the document_id."""
+    stamp = datetime.now(timezone.utc).timestamp()
+    bank_a, bank_b = f"test_tag_scope_a_{stamp}", f"test_tag_scope_b_{stamp}"
+    document_id = f"shared-document-id-{stamp}"
+
+    try:
+        await _retain_shared_document(memory, request_context, (bank_a, bank_b), document_id)
+
+        await memory.update_document(document_id, bank_a, tags=["rewritten"], request_context=request_context)
+
+        for unit in await _units(memory, request_context, bank_a, document_id):
+            assert unit["tags"] == ["rewritten"]
+        for unit in await _units(memory, request_context, bank_b, document_id):
+            assert "rewritten" not in (unit["tags"] or [])
+
+    finally:
+        for bank_id in (bank_a, bank_b):
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+
 @pytest.mark.asyncio
 async def test_memory_without_document(memory, request_context):
     """Test that memories can still be created without document tracking."""


### PR DESCRIPTION
Closes #3429.

`delete_document` and `update_document` filter `memory_units` on `document_id` alone in four statements, although `bank_id` is a parameter of both methods and is used by neighbouring statements:

- `:7159`, `:7164` — read and count the units of every bank sharing the id, so `memory_units_deleted` over-reports and the id list handed to the downstream cleanup carries other banks' ids.
- `:7348` — the same read, on the update path.
- `:7354` — `UPDATE ... SET tags` with no bank predicate: re-tags the memory units of other banks.

Beyond isolation, scoping the reads makes the cost of both endpoints depend on the caller's data rather than on the number of banks sharing the document id — on a bank-per-user deployment, where a role-named document exists in every bank, that cost currently grows with signups.

In both methods, the branch of the same `if` that goes through the non-SQL memories store already passes `bank_id` (`:7167`, `:7330`). This aligns the SQL branch with it.

Deletion itself was not affected: the `DELETE` carries `bank_id`, and `memory_units_document_fkey` is composite `(document_id, bank_id) ON DELETE CASCADE`.

## Tests

Two tests added to `tests/test_document_tracking.py`, each with two banks sharing one `document_id`:

- `test_document_deletion_counts_only_its_own_bank_units`
- `test_document_tag_update_is_scoped_to_its_bank`

Without the change:

```
E   AssertionError: assert 'rewritten' not in (['rewritten'])
E   assert 8 == 4
2 failed
```

With the change: `2 passed`.

## CI note

The Python test jobs are gated on secrets and do not run on fork PRs, so the suite was run locally: 5348 passed, 21 failed. Seven are pre-existing and caused by the absence of an LLM API key (`test_fact_extraction_output_ratio`, `test_retain`) — they fail identically on `main` without this change. The other fourteen only appear under full-suite parallel execution and pass in isolation (`18 passed`); they come from a mock shared across tests and an asyncio lock bound to a different event loop, unrelated to this change.

`ruff check hindsight_api` and `ruff format --check` both pass.
