### PR TITLE
fix(llamacpp): pass extra_body through factory to LlamaCppLLM

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -513,6 +513,7 @@ def create_llm_provider(
             base_url=base_url,
             model=model,
             reasoning_effort=reasoning_effort,
+            extra_body=extra_body,
             model_path=config.llamacpp_model_path,
             gpu_layers=config.llamacpp_gpu_layers,
             context_size=config.llamacpp_context_size,

--- a/hindsight-api-slim/hindsight_api/engine/providers/llamacpp_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/llamacpp_llm.py
@@ -274,6 +274,7 @@ class LlamaCppLLM(LLMInterface):
         base_url: str,
         model: str,
         reasoning_effort: str = "low",
+        extra_body: dict[str, Any] | None = None,
         model_path: str | None = None,
         gpu_layers: int = -1,
         context_size: int = 8192,
@@ -289,6 +290,7 @@ class LlamaCppLLM(LLMInterface):
             model=model or DEFAULT_LLAMACPP_MODEL_ALIAS,
             reasoning_effort=reasoning_effort,
         )
+        self._extra_body = extra_body
         self._model_path_str = model_path
         self._gpu_layers = gpu_layers
         self._context_size = context_size
@@ -337,6 +339,7 @@ class LlamaCppLLM(LLMInterface):
             base_url=self._server.base_url,
             model=self.model,
             reasoning_effort=self.reasoning_effort,
+            extra_body=self._extra_body,
         )
 
         self._initialized = True


### PR DESCRIPTION
## Summary

The `create_llm_provider()` factory accepted `extra_body` from `HINDSIGHT_API_LLM_EXTRA_BODY` but never passed it to `LlamaCppLLM`. Every other provider (Bedrock, Fireworks, OpenAI-compatible, LiteLLM, Gemini, Anthropic) receives `extra_body` — only llamacpp was missing.

Users of local LLMs (Ollama/llama.cpp) had no way to pass provider-native parameters.

## Changes (2 files, +4 lines)

- **llm_wrapper.py**: Pass `extra_body=extra_body` to `LlamaCppLLM` constructor
- **llamacpp_llm.py**: Accept `extra_body` in `__init__`, store as `self._extra_body`, forward to `OpenAICompatibleLLM` delegate in `_ensure_initialized`

Closes #3326