### PR TITLE
feat(coding-agents): optInOnly — run memory only in projects that were opted in

### DIFF
--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -284,6 +284,32 @@ The map-valued settings (`mapPathToBank`, `harnesses`, `banks`, `retainMetadata`
 per-key branching doesn't survive flattening into one variable. `maxParallelRetains` is available
 as `HINDSIGHT_MAX_PARALLEL_RETAINS` for containers and CI.
 
+### Opt-in only
+
+By default every project gets memory — that is what makes the plugin zero-setup. If you would
+rather nothing be remembered until you say so, turn memory off everywhere and name the projects
+that may use it:
+
+```jsonc
+{
+  "optInOnly": true,
+  "optInPaths": ["~/work/client-x", "~/oss"],
+}
+```
+
+Anything outside those paths is **inert**: no bank is created, nothing is retained, no seed runs,
+and the agent behaves exactly as it would without the plugin. Approving costs nothing else —
+`optInPaths` says _which projects_, not _which bank_, so an approved repo keeps its usual
+`coding-agent::{gitProject}` name. Paths are prefixes, so approving `~/work` approves every repo
+under it while each still gets its own bank.
+
+A `mapPathToBank` entry counts as opted in too, since routing a path to a named bank already
+declares that project. A bare `bankId` does not: it names a bank rather than a project, so it
+cannot say which work may be remembered, and a privacy switch has to fail closed.
+
+There is no per-repo opt-in file, for the same reason there is no repo-carried config at all: a
+cloned repository must not be able to turn memory on.
+
 There is deliberately no repo-carried config file — per-repo bank routing is `mapPathToBank`,
 per-agent differences are `harnesses.<name>`.
 
@@ -310,6 +336,8 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `dynamicBankId`         | dynamic iff no `bankId`              | force dynamic (`true`) or static (`false`) resolution                                                                                                                                                                               |
 | `bankIdTemplate`        | `"coding-agent::{gitProject}"`       | dynamic bank id format; the default makes every agent share one bank per repo                                                                                                                                                       |
 | `mapPathToBank`         | —                                    | absolute path → bank; **longest prefix wins**; overrides everything                                                                                                                                                                 |
+| `optInOnly`             | `false`                              | run memory ONLY in opted-in projects — everything else is inert, with no bank created; see Opt-in only                                                                                                              |
+| `optInPaths`            | —                                    | directories opted in, matched as prefixes with `~` expanded; each repo beneath keeps its own dynamic bank                                                                                                                           |
 | `resolveWorktrees`      | `true`                               | `{gitProject}`: linked worktrees share the main repo's bank                                                                                                                                                                         |
 | `retainTags`            | —                                    | extra tags on every document written by the integration, e.g. `["project:{gitProject}"]` — see **Recording where a memory came from** below                                                                                         |
 | `retainMetadata`        | —                                    | extra metadata on every document written by the integration, e.g. `{"repo": "{gitProject}"}`                                                                                                                                        |

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -277,6 +277,32 @@ The map-valued settings (`mapPathToBank`, `harnesses`, `banks`, `retainMetadata`
 per-key branching doesn't survive flattening into one variable. `maxParallelRetains` is available
 as `HINDSIGHT_MAX_PARALLEL_RETAINS` for containers and CI.
 
+### Opt-in only
+
+By default every project gets memory — that is what makes the plugin zero-setup. If you would
+rather nothing be remembered until you say so, turn memory off everywhere and name the projects
+that may use it:
+
+```jsonc
+{
+  "optInOnly": true,
+  "optInPaths": ["~/work/client-x", "~/oss"],
+}
+```
+
+Anything outside those paths is **inert**: no bank is created, nothing is retained, no seed runs,
+and the agent behaves exactly as it would without the plugin. Approving costs nothing else —
+`optInPaths` says _which projects_, not _which bank_, so an approved repo keeps its usual
+`coding-agent::{gitProject}` name. Paths are prefixes, so approving `~/work` approves every repo
+under it while each still gets its own bank.
+
+A `mapPathToBank` entry counts as opted in too, since routing a path to a named bank already
+declares that project. A bare `bankId` does not: it names a bank rather than a project, so it
+cannot say which work may be remembered, and a privacy switch has to fail closed.
+
+There is no per-repo opt-in file, for the same reason there is no repo-carried config at all: a
+cloned repository must not be able to turn memory on.
+
 There is deliberately no repo-carried config file — per-repo bank routing is `mapPathToBank`,
 per-agent differences are `harnesses.<name>`.
 
@@ -303,6 +329,8 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `dynamicBankId`         | dynamic iff no `bankId`              | force dynamic (`true`) or static (`false`) resolution                                                                                                                                                                               |
 | `bankIdTemplate`        | `"coding-agent::{gitProject}"`       | dynamic bank id format; the default makes every agent share one bank per repo                                                                                                                                                       |
 | `mapPathToBank`         | —                                    | absolute path → bank; **longest prefix wins**; overrides everything                                                                                                                                                                 |
+| `optInOnly`             | `false`                              | run memory ONLY in opted-in projects — everything else is inert, with no bank created; see [Opt-in only](#opt-in-only)                                                                                                              |
+| `optInPaths`            | —                                    | directories opted in, matched as prefixes with `~` expanded; each repo beneath keeps its own dynamic bank                                                                                                                           |
 | `resolveWorktrees`      | `true`                               | `{gitProject}`: linked worktrees share the main repo's bank                                                                                                                                                                         |
 | `retainTags`            | —                                    | extra tags on every document written by the integration, e.g. `["project:{gitProject}"]` — see **Recording where a memory came from** below                                                                                         |
 | `retainMetadata`        | —                                    | extra metadata on every document written by the integration, e.g. `{"repo": "{gitProject}"}`                                                                                                                                        |

--- a/hindsight-integrations/coding-agents/src/antigravity-statusline.ts
+++ b/hindsight-integrations/coding-agents/src/antigravity-statusline.ts
@@ -19,7 +19,7 @@ export function buildAntigravityStatusLine(state: AntigravityStatusLineState, cf
   const cwd = state.cwd || state.workspace?.current_dir;
   if (!cwd) return brandWord();
 
-  const resolved = applyBankConfig(cfg, deriveBankId(cfg, cwd, "antigravity-cli"));
+  const resolved = applyBankConfig(cfg, deriveBankId(cfg, cwd, "antigravity-cli"), cwd);
   return resolved.cfg.disabled ? "" : `${brandWord()} · ${resolved.bankId}`;
 }
 

--- a/hindsight-integrations/coding-agents/src/cline.ts
+++ b/hindsight-integrations/coding-agents/src/cline.ts
@@ -185,7 +185,11 @@ export function createClineHooks(
 function createRuntime(workspaceRoot: string | undefined): RuntimeCore | undefined {
   let cfg = loadConfig({ harness: HARNESS });
   if (cfg.disabled) return undefined;
-  const resolved = applyBankConfig(cfg, deriveBankId(cfg, workspaceRoot || process.cwd(), HARNESS));
+  const resolved = applyBankConfig(
+    cfg,
+    deriveBankId(cfg, workspaceRoot || process.cwd(), HARNESS),
+    workspaceRoot || process.cwd()
+  );
   cfg = resolved.cfg;
   if (cfg.disabled) return undefined;
   const client = new HindsightClient({

--- a/hindsight-integrations/coding-agents/src/core/bank.ts
+++ b/hindsight-integrations/coding-agents/src/core/bank.ts
@@ -32,6 +32,8 @@ export interface BankConfig {
   bankIdTemplate?: string;
   mapPathToBank?: Record<string, string>;
   resolveWorktrees?: boolean; // default true: worktrees share the main repo's bank
+  optInOnly?: boolean; // memory runs ONLY where opted in (see isOptedIn)
+  optInPaths?: string[]; // directories opted in, matched as prefixes
 }
 
 const DEFAULT_BANK_NAME = "coding";
@@ -123,18 +125,53 @@ function gitProjectName(directory: string, resolveWorktrees: boolean): string {
   return dirName(directory);
 }
 
+/** A configured directory, `~`-expanded and normalised, without a trailing separator. */
+function configuredDir(dir: string): string {
+  const expanded = dir === "~" || dir.startsWith("~/") ? join(homedir(), dir.slice(1)) : dir;
+  return normalize(expanded).replace(new RegExp(`\\${sep}+$`), "");
+}
+
+/** Whether `directory` IS `configured`, or lives under it. */
+function isWithin(directory: string, configured: string): boolean {
+  return directory === configured || directory.startsWith(configured + sep);
+}
+
 /** Longest-prefix match of `directory` against the map's absolute paths (exact or ancestor). */
 function mapLookup(map: Record<string, string>, directory: string): string | undefined {
   const cwd = normalize(directory);
   let best: { len: number; bank: string } | undefined;
   for (const [dir, bank] of Object.entries(map)) {
-    const expanded = dir === "~" || dir.startsWith("~/") ? join(homedir(), dir.slice(1)) : dir;
-    const p = normalize(expanded).replace(new RegExp(`\\${sep}+$`), "");
-    if (cwd === p || cwd.startsWith(p + sep)) {
+    const p = configuredDir(dir);
+    if (isWithin(cwd, p)) {
       if (!best || p.length > best.len) best = { len: p.length, bank };
     }
   }
   return best?.bank;
+}
+
+/**
+ * Whether memory may run for this directory at all.
+ *
+ * Off by default: without `optInOnly` every project gets memory, which is what makes the plugin
+ * zero-setup. With it, the plugin stays inert — no bank, no retain, no seed — unless the directory
+ * was named on purpose, which means one of:
+ *
+ *   - it is under an `optInPaths` entry (prefix-matched, so approving a directory approves the
+ *     repos beneath it while each keeps its own dynamic bank), or
+ *   - it is under a `mapPathToBank` entry, since routing a path to a named bank is already a
+ *     deliberate declaration of that project.
+ *
+ * A bare `bankId` deliberately does NOT approve anything: it names a bank, not a project, so it
+ * cannot express which work is allowed to be remembered. Under `optInOnly` an unlisted project is
+ * inert even then — a privacy switch has to fail closed.
+ */
+export function isOptedIn(config: BankConfig, directory: string): boolean {
+  if (!config.optInOnly) return true;
+  if (!directory) return false;
+  const cwd = normalize(directory);
+  if ((config.optInPaths ?? []).some((dir) => dir && isWithin(cwd, configuredDir(dir))))
+    return true;
+  return Boolean(config.mapPathToBank && mapLookup(config.mapPathToBank, directory));
 }
 
 /** Derive the bank id for a working directory (see module doc for the resolution order). */

--- a/hindsight-integrations/coding-agents/src/core/config.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.ts
@@ -15,6 +15,7 @@ import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_SEED_LIMIT } from "./seed";
+import { isOptedIn } from "./bank";
 
 /** Default config-file path: ~/.hindsight/coding-agent.json */
 export // HINDSIGHT_CONFIG joins the two env exceptions (diag/log files): it points at THE config file,
@@ -63,6 +64,14 @@ export interface RawConfig {
   //   placeholders: {gitProject} {project} {harness} {channel} {user} (see core/bank.ts)
   mapPathToBank?: Record<string, string>; // absolute path -> bank; longest prefix wins; overrides everything
   resolveWorktrees?: boolean; // {gitProject}: worktrees share the main repo's bank (default true)
+  /** Run memory ONLY in projects that were opted in (default false: every project gets memory,
+   *  which is what makes the plugin zero-setup). With it on, an unlisted project is inert — no
+   *  bank is created, nothing is retained, no seed runs — so unrelated work leaves no trace. */
+  optInOnly?: boolean;
+  /** Directories opted in, matched as PREFIXES with `~` expanded: approving a directory approves
+   *  the repos beneath it, and each still gets its own dynamic bank. A `mapPathToBank` entry counts
+   *  as opted in too, since routing a path to a named bank already declares that project. */
+  optInPaths?: string[];
   harness?: string; // runtime adapter (default "opencode")
   disabled?: boolean; // hard off-switch — inert plugin, for a no-memory baseline (default false)
   retainSessions?: boolean; // opencode plugin write-back (default true; set false to opt out). Hook harnesses always write back on Stop and ignore this flag.
@@ -127,6 +136,8 @@ export interface Config {
   bankIdTemplate?: string;
   mapPathToBank?: Record<string, string>;
   resolveWorktrees?: boolean;
+  optInOnly: boolean;
+  optInPaths: string[];
   harness: string;
   disabled: boolean;
   retainSessions: boolean;
@@ -173,6 +184,11 @@ export function resolveConfig(raw: RawConfig = {}): Config {
     bankIdTemplate: raw.bankIdTemplate,
     mapPathToBank: raw.mapPathToBank,
     resolveWorktrees: raw.resolveWorktrees,
+    optInOnly: raw.optInOnly ?? false,
+    // Same shape as retainTags: a config typo must not become a path that silently approves nothing.
+    optInPaths: Array.isArray(raw.optInPaths)
+      ? raw.optInPaths.filter((p): p is string => typeof p === "string" && p.trim() !== "")
+      : [],
     harness: raw.harness ?? "opencode",
     disabled: raw.disabled ?? false,
     retainSessions: raw.retainSessions ?? true, // opencode: write back by default (parity with hook-harness Stop)
@@ -273,6 +289,8 @@ const ENV_KEYS = {
   dynamicBankId: "HINDSIGHT_DYNAMIC_BANK_ID",
   bankIdTemplate: "HINDSIGHT_BANK_ID_TEMPLATE",
   resolveWorktrees: "HINDSIGHT_RESOLVE_WORKTREES",
+  optInOnly: "HINDSIGHT_OPT_IN_ONLY",
+  optInPaths: "HINDSIGHT_OPT_IN_PATHS",
   harness: "HINDSIGHT_HARNESS",
   disabled: "HINDSIGHT_DISABLED",
   retainSessions: "HINDSIGHT_RETAIN_SESSIONS",
@@ -297,13 +315,14 @@ const ENV_KEYS = {
 const ENV_BOOLEANS = new Set<keyof RawConfig>([
   "dynamicBankId",
   "resolveWorktrees",
+  "optInOnly",
   "disabled",
   "retainSessions",
   "autoReflect",
   "autoSeed",
   "codebaseSurvey",
 ]);
-const ENV_LISTS = new Set<keyof RawConfig>(["retainTags"]);
+const ENV_LISTS = new Set<keyof RawConfig>(["retainTags", "optInPaths"]);
 const ENV_NUMBERS = new Set<keyof RawConfig>([
   "apiPort",
   "daemonIdleTimeout",
@@ -366,6 +385,10 @@ const BANK_OVERRIDE_EXCLUDED = [
   "mapPathToBank",
   "dynamicBankId",
   "resolveWorktrees",
+  // Approval is decided BEFORE the bank is resolved, so a `banks.<id>` section naming these could
+  // only ever arrive too late to matter — strip them rather than let them read as effective.
+  "optInOnly",
+  "optInPaths",
   "harness",
 ] as const;
 
@@ -374,7 +397,18 @@ const BANK_OVERRIDE_EXCLUDED = [
  * that runs AFTER bank resolution, giving per-repo opt-in/out (disable, retainSessions, gitIngest,
  * survey settings, ...) from the ONE global config file.
  */
-export function applyBankConfig(cfg: Config, resolvedId: string): { cfg: Config; bankId: string } {
+export function applyBankConfig(
+  cfg: Config,
+  resolvedId: string,
+  /** The directory the bank was resolved FROM. Supplying it enforces `optInOnly`; every entry
+   *  point already has it to hand, having just passed it to `deriveBankId`. */
+  directory?: string
+): { cfg: Config; bankId: string } {
+  // Rides the `disabled` gate every entry point already checks after bank resolution, rather than
+  // adding a second thing eight call sites must remember — and that gate is known to stop the run
+  // before anything creates a bank.
+  if (directory !== undefined && !isOptedIn(cfg, directory))
+    return { cfg: { ...cfg, disabled: true }, bankId: resolvedId };
   const section = cfg.banks[resolvedId];
   if (!section) return { cfg, bankId: resolvedId };
   const safe: Record<string, unknown> = { ...section };

--- a/hindsight-integrations/coding-agents/src/core/hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/hook.ts
@@ -228,7 +228,7 @@ export async function runHook(
   const out = (context: string | undefined, notice?: string) =>
     process.stdout.write(JSON.stringify(spec.emit(context ?? "", notice, ev)));
 
-  const resolved = applyBankConfig(cfg, deriveBankId(cfg, cwd, spec.harness));
+  const resolved = applyBankConfig(cfg, deriveBankId(cfg, cwd, spec.harness), cwd);
   cfg = resolved.cfg;
   const bankId = resolved.bankId;
   if (cfg.disabled) {

--- a/hindsight-integrations/coding-agents/src/core/opt-in.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/opt-in.test.ts
@@ -1,0 +1,87 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { deriveBankId, isOptedIn } from "./bank";
+import { applyBankConfig, resolveConfig } from "./config";
+
+/**
+ * Opt-in-only: memory runs in declared projects and nowhere else. Real directories, because the
+ * question is entirely about how a working directory relates to what was configured.
+ */
+describe("optInOnly", () => {
+  let root: string;
+  let approved: string;
+  let other: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "hs-optin-"));
+    approved = join(root, "work", "client-x");
+    other = join(root, "scratch", "throwaway");
+    for (const d of [approved, other]) {
+      mkdirSync(d, { recursive: true });
+      execFileSync("git", ["init", "-q"], { cwd: d });
+    }
+  });
+
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it("allows everything when it is off — the zero-setup default is unchanged", () => {
+    const cfg = resolveConfig({});
+    expect(isOptedIn(cfg, approved)).toBe(true);
+    expect(isOptedIn(cfg, other)).toBe(true);
+  });
+
+  it("approves a listed directory and the repos beneath it", () => {
+    const cfg = resolveConfig({ optInOnly: true, optInPaths: [join(root, "work")] });
+    expect(isOptedIn(cfg, approved)).toBe(true);
+    expect(isOptedIn(cfg, join(approved, "src", "deep"))).toBe(true);
+    expect(isOptedIn(cfg, other)).toBe(false);
+  });
+
+  it("leaves an approved project its own dynamic bank — approving names nothing", () => {
+    // The whole point of not reusing mapPathToBank: you approve a tree, each repo still gets its
+    // own bank rather than being merged into one.
+    const cfg = resolveConfig({ optInOnly: true, optInPaths: [join(root, "work")] });
+    expect(deriveBankId(cfg, approved, "codex")).toBe("coding-agent::client-x");
+  });
+
+  it("treats a mapPathToBank entry as opted in", () => {
+    // Routing a path to a named bank is already a deliberate declaration of that project.
+    const cfg = resolveConfig({ optInOnly: true, mapPathToBank: { [approved]: "client-x" } });
+    expect(isOptedIn(cfg, approved)).toBe(true);
+    expect(isOptedIn(cfg, other)).toBe(false);
+  });
+
+  it("does not let a bare bankId approve anything", () => {
+    // It names a bank, not a project, so it cannot say which work may be remembered. A privacy
+    // switch fails closed.
+    const cfg = resolveConfig({ optInOnly: true, bankId: "shared" });
+    expect(isOptedIn(cfg, approved)).toBe(false);
+  });
+
+  it("renders an unlisted project inert through the gate every entry point already checks", () => {
+    const cfg = resolveConfig({ optInOnly: true, optInPaths: [approved] });
+    const inert = applyBankConfig(cfg, deriveBankId(cfg, other, "codex"), other);
+    expect(inert.cfg.disabled).toBe(true);
+
+    const live = applyBankConfig(cfg, deriveBankId(cfg, approved, "codex"), approved);
+    expect(live.cfg.disabled).toBe(false);
+    expect(live.bankId).toBe("coding-agent::client-x");
+  });
+
+  it("stays inert when no directory is known and the switch is on", () => {
+    const cfg = resolveConfig({ optInOnly: true, optInPaths: [approved] });
+    expect(isOptedIn(cfg, "")).toBe(false);
+  });
+
+  it("ignores a banks.<id> section trying to set it — approval is decided before that runs", () => {
+    const cfg = resolveConfig({
+      optInOnly: true,
+      optInPaths: [approved],
+      banks: { "coding-agent::throwaway": { optInOnly: false } as never },
+    });
+    expect(applyBankConfig(cfg, deriveBankId(cfg, other, "codex"), other).cfg.disabled).toBe(true);
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/retain-hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.ts
@@ -119,7 +119,7 @@ export async function runRetainHook(
 
   if (!transcriptPath) return;
 
-  const resolved = applyBankConfig(cfg, deriveBankId(cfg, cwd, spec.harness));
+  const resolved = applyBankConfig(cfg, deriveBankId(cfg, cwd, spec.harness), cwd);
   cfg = resolved.cfg;
   const bankId = resolved.bankId;
   if (cfg.disabled) return;

--- a/hindsight-integrations/coding-agents/src/core/session-start.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.ts
@@ -345,7 +345,7 @@ export async function runSessionStartHook(
     syncCompanionSkill(harness); // keep the installed skill current with the package version
     if (cfg.disabled) return;
 
-    const resolved = applyBankConfig(cfg, deriveBankId(cfg, cwd, harness));
+    const resolved = applyBankConfig(cfg, deriveBankId(cfg, cwd, harness), cwd);
     cfg = resolved.cfg;
     const bankId = resolved.bankId;
     if (cfg.disabled) return; // per-bank opt-out (banks.<id> override)

--- a/hindsight-integrations/coding-agents/src/deepen.ts
+++ b/hindsight-integrations/coding-agents/src/deepen.ts
@@ -49,7 +49,9 @@ const REPO = arg("repo");
 const cfg0 = loadConfig({ harness: arg("harness") ?? undefined, path: arg("config") });
 const BANK =
   arg("bank") ?? (REPO ? deriveBankId(cfg0, REPO, arg("harness") ?? cfg0.harness) : cfg0.bankId);
-const resolved0 = BANK ? applyBankConfig(cfg0, BANK) : { cfg: cfg0, bankId: BANK };
+const resolved0 = BANK
+  ? applyBankConfig(cfg0, BANK, REPO ?? undefined)
+  : { cfg: cfg0, bankId: BANK };
 const cfg = resolved0.cfg;
 const FINAL_BANK = resolved0.bankId ?? BANK;
 if (cfg.disabled) {

--- a/hindsight-integrations/coding-agents/src/harness/plugin-entry.ts
+++ b/hindsight-integrations/coding-agents/src/harness/plugin-entry.ts
@@ -44,7 +44,11 @@ export function createPluginEntry(harness: string): Plugin {
     let cfg = loadConfig({ harness });
     if (cfg.disabled) return {}; // inert: same agent, no memory (baseline parity)
 
-    const resolved = applyBankConfig(cfg, deriveBankId(cfg, projectDir || process.cwd(), harness));
+    const resolved = applyBankConfig(
+      cfg,
+      deriveBankId(cfg, projectDir || process.cwd(), harness),
+      projectDir || process.cwd()
+    );
     cfg = resolved.cfg;
     const bankId = resolved.bankId;
     if (cfg.disabled) return {}; // per-bank opt-out (banks.<id> override)

--- a/hindsight-integrations/coding-agents/src/mcp-server.ts
+++ b/hindsight-integrations/coding-agents/src/mcp-server.ts
@@ -46,7 +46,7 @@ async function main() {
   // resolution mirrors that harness's hooks — config `harnesses.<name>` section + `{harness}` template.
   const harness = process.env.HINDSIGHT_MCP_HARNESS || "claude-code";
   const cfg0 = loadConfig({ harness });
-  const { cfg, bankId } = applyBankConfig(cfg0, deriveBankId(cfg0, cwd, harness));
+  const { cfg, bankId } = applyBankConfig(cfg0, deriveBankId(cfg0, cwd, harness), cwd);
   const client = new HindsightClient({
     apiUrl: cfg.apiUrl,
     apiToken: cfg.apiToken,

--- a/hindsight-integrations/coding-agents/src/prime-agent.ts
+++ b/hindsight-integrations/coding-agents/src/prime-agent.ts
@@ -146,7 +146,7 @@ export function createPrimeAgentHooks(
 function createRuntime(repoPath: string): RuntimeCore | undefined {
   let cfg = loadConfig({ harness: HARNESS });
   if (cfg.disabled) return undefined;
-  const resolved = applyBankConfig(cfg, deriveBankId(cfg, repoPath, HARNESS));
+  const resolved = applyBankConfig(cfg, deriveBankId(cfg, repoPath, HARNESS), repoPath);
   cfg = resolved.cfg;
   if (cfg.disabled) return undefined;
   const client = new HindsightClient({

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -279,6 +279,32 @@ The map-valued settings (`mapPathToBank`, `harnesses`, `banks`, `retainMetadata`
 per-key branching doesn't survive flattening into one variable. `maxParallelRetains` is available
 as `HINDSIGHT_MAX_PARALLEL_RETAINS` for containers and CI.
 
+### Opt-in only
+
+By default every project gets memory — that is what makes the plugin zero-setup. If you would
+rather nothing be remembered until you say so, turn memory off everywhere and name the projects
+that may use it:
+
+```jsonc
+{
+  "optInOnly": true,
+  "optInPaths": ["~/work/client-x", "~/oss"],
+}
+```
+
+Anything outside those paths is **inert**: no bank is created, nothing is retained, no seed runs,
+and the agent behaves exactly as it would without the plugin. Approving costs nothing else —
+`optInPaths` says _which projects_, not _which bank_, so an approved repo keeps its usual
+`coding-agent::{gitProject}` name. Paths are prefixes, so approving `~/work` approves every repo
+under it while each still gets its own bank.
+
+A `mapPathToBank` entry counts as opted in too, since routing a path to a named bank already
+declares that project. A bare `bankId` does not: it names a bank rather than a project, so it
+cannot say which work may be remembered, and a privacy switch has to fail closed.
+
+There is no per-repo opt-in file, for the same reason there is no repo-carried config at all: a
+cloned repository must not be able to turn memory on.
+
 There is deliberately no repo-carried config file — per-repo bank routing is `mapPathToBank`,
 per-agent differences are `harnesses.<name>`.
 
@@ -305,6 +331,8 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `dynamicBankId`         | dynamic iff no `bankId`              | force dynamic (`true`) or static (`false`) resolution                                                                                                                                                                               |
 | `bankIdTemplate`        | `"coding-agent::{gitProject}"`       | dynamic bank id format; the default makes every agent share one bank per repo                                                                                                                                                       |
 | `mapPathToBank`         | —                                    | absolute path → bank; **longest prefix wins**; overrides everything                                                                                                                                                                 |
+| `optInOnly`             | `false`                              | run memory ONLY in opted-in projects — everything else is inert, with no bank created; see Opt-in only                                                                                                              |
+| `optInPaths`            | —                                    | directories opted in, matched as prefixes with `~` expanded; each repo beneath keeps its own dynamic bank                                                                                                                           |
 | `resolveWorktrees`      | `true`                               | `{gitProject}`: linked worktrees share the main repo's bank                                                                                                                                                                         |
 | `retainTags`            | —                                    | extra tags on every document written by the integration, e.g. `["project:{gitProject}"]` — see **Recording where a memory came from** below                                                                                         |
 | `retainMetadata`        | —                                    | extra metadata on every document written by the integration, e.g. `{"repo": "{gitProject}"}`                                                                                                                                        |


### PR DESCRIPTION
Closes #3427.

```jsonc
{
  "optInOnly": true,
  "optInPaths": ["~/work/client-x", "~/oss"]
}
```

Anything outside those paths is **inert** — no bank created, nothing retained, no seed, and the agent behaves exactly as it would without the plugin.

## Approval is separate from routing, on purpose

`optInPaths` says *which projects*, not *which bank*. An approved repo keeps its usual `coding-agent::{gitProject}` name, so approving costs no naming decisions and nothing moves.

That is the whole reason this is **not** built on `mapPathToBank`, which both the reporter and I first reached for. Using routing to express approval forces you to invent a bank id per project, and collapses an approved tree into a single shared bank. Prefix matching means approving `~/work` approves every repo under it while each still gets its own bank.

A `mapPathToBank` entry **does** count as opted in — routing a path to a named bank already declares that project. A bare `bankId` does **not**: it names a bank rather than a project, so it cannot express which work may be remembered, and a privacy switch has to fail closed.

## Enforcement

Through the `disabled` gate every entry point already checks after bank resolution: `applyBankConfig` now takes the directory the bank was resolved from and returns a disabled config when it is not opted in. Nine call sites pass it — each already had it to hand, having just given it to `deriveBankId`.

I chose that path because I had already verified, while testing the workaround for this issue, that this gate stops a run before anything creates a bank. It also avoids adding a second thing every entry point must remember.

## Verified end to end, not just in unit tests

Against a live server with Prime Agent, one config, two repos:

| | result |
|---|---|
| unlisted project | agent answered normally; **no plugin events, no bank** |
| opted-in project | `session_start`, injection, retain — memory active |
| after both | `coding-agent::oi-yes` present, `coding-agent::oi-no` **never created** |

Plus 8 unit tests: the default staying permissive, prefix approval, an approved repo keeping its dynamic bank, `mapPathToBank` counting, a bare `bankId` not counting, the gate rendering an unlisted project inert, an unknown directory failing closed, and a `banks.<id>` section unable to re-enable itself (approval is decided before that section is even selected — the fields are in `BANK_OVERRIDE_EXCLUDED`).

**491 passed**, 21 skipped; tsc, lint and docs-sync clean.

## Not doing: a repo-carried opt-in file

The issue's Idea C (`requireOptIn: "local-config"` + `.hindsight.config.json` in the repo) runs against an explicit decision in the config module: no repo-carried config, because an untrusted repository must not influence memory behaviour. Here it would let a **cloned repo turn memory on**, which is backwards for a privacy control.

## Naming

`optInOnly` rather than a bare `optIn`, because `optIn: true` reads as "opt me in to memory" (turn it on) when it does the opposite — a misread that fails open in a privacy feature.