### PR TITLE
fix(engine): scope document statements by bank_id (#3429)

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -78,6 +78,17 @@ results = await asyncio.gather(*tasks, return_exceptions=True)
 - **Authentication/tenancy is enforced inside each engine method, not assumed by the handler.** Every engine method that touches bank-scoped data must authenticate via `request_context` — typically `await self._authenticate_tenant(request_context)` (often indirectly through `get_bank_profile(...)`) — so the correct tenant schema is resolved before any query runs. Handlers must thread `request_context` through to the engine method; never query a tenant-scoped table assuming the schema is already set.
 - Engine methods return typed models (Pydantic/dataclass), not raw dicts (see Type Safety).
 
+### Bank/Tenant Isolation in Queries
+- **Bank isolation is a hard security invariant: no query may read, count, update, or delete another bank's rows.** Tenant isolation is enforced at the schema level (the resolved `search_path` / `fq_table(...)` qualifier, gated by `_authenticate_tenant`); bank isolation is enforced *within* a schema by a `bank_id` predicate on every statement that touches a multi-bank table.
+- **Every SQL statement against a multi-bank table must be constrained by `bank_id`** — directly in the `WHERE`, or transitively (see below). Multi-bank tables carry a `bank_id` column: `memory_units`, `documents`, `entities`, `entity_links`, `mental_models`, `knowledge_pages`, `memory_links`, `observation_history`, and similar.
+- **The trap: filtering by a caller-supplied, non-globally-unique key without `bank_id`.** Keys like `document_id` and `mental_models.id` are unique only *per bank* (their PK is composite, e.g. `(id, bank_id)`), so the *same* id legally exists in every bank. A statement like `UPDATE memory_units SET tags = $1 WHERE document_id = $2` — no `bank_id` — silently reads/writes **every** bank's rows that share the id. This is the exact defect from #3429/#3430. Adding `AND bank_id = $n` fixes it.
+- **Three ways a statement is legitimately scoped** (accept these; flag anything that fits none):
+  1. **Explicit** `WHERE ... AND bank_id = $n`.
+  2. **Globally-unique single-column PK.** Filtering by a global uuid PK (`memory_units.id`, `entities.id`, `knowledge_pages.id`) or a bank-encoded key (`chunks.chunk_id` is `{bank_id}_{document_id}_{idx}`) cannot collide across banks. Contrast the *composite*-PK ids (`documents.id`/`document_id`, `mental_models.id`) — those are dangerous and MUST carry `bank_id`.
+  3. **Transitive.** Junction tables without a `bank_id` column (`unit_entities`, `entity_cooccurrences`, `observation_sources`) are safe only when reached through globally-unique unit/entity ids that were themselves selected from a bank-scoped query in the same call, and edges are intra-bank by construction. If the id set could contain another bank's ids, it is not scoped.
+- **Watch two smells:** (a) a caller-supplied id used in the `WHERE` with no adjacent `bank_id`, while a *neighbouring* statement in the same method does carry `bank_id` (asymmetry is the tell); (b) a `bank_id` predicate applied only under `if bank_id:` with a `bank_id: str | None = None` default — latent even if all current callers pass one.
+- **Cross-bank by design must rewrite `bank_id` to the destination.** The transfer/import path is the only one that legitimately crosses banks; verify every write pins the *destination* `bank_id` and never inherits a source row's `bank_id`.
+
 ### Database Locking
 - **Never use PostgreSQL advisory locks** (`pg_advisory_lock`, `pg_try_advisory_lock`, `pg_advisory_xact_lock`, `pg_advisory_unlock`, …) in migrations, engine code, or anything else. Hindsight runs against connection poolers and managed/PG-compatible services where advisory locks are unreliable or unsupported: session-level locks silently leak or vanish when a pooler hands the session to another client, and callers can block forever on a lock the server never grants. Reject any new occurrence, including ones that look "safe" because they are transaction-scoped.
 - The pre-existing usage in `hindsight_api/migrations.py` is grandfathered, not a precedent — it is tracked for removal. Don't copy it.
@@ -177,6 +188,17 @@ For each changed handler in `hindsight-api-slim/hindsight_api/api/` (e.g. `http.
 - **Flag any direct DB access in the handler** — `acquire_with_retry`, `conn.fetch` / `fetchrow` / `execute`, raw SQL strings, or `fq_table(...)`. These are a **must fix**: the query must be moved into a `MemoryEngine` method that returns a typed model, and the handler must call that method.
 - **Verify authentication is enforced in the engine** — the handler must delegate to an engine method that authenticates via `request_context` (`_authenticate_tenant`, typically through `get_bank_profile`). A handler that reads/writes tenant-scoped data without an engine method enforcing auth is a **must fix** (tenant data could leak across schemas).
 
+### 7c. Check bank/tenant query scoping
+
+For **every SQL statement added or changed** in the diff (grep the diff for `conn.fetch`, `conn.fetchrow`, `conn.fetchval`, `conn.execute`, `executemany`, and any raw `SELECT`/`INSERT`/`UPDATE`/`DELETE` f-strings, including multi-line ones), verify it cannot touch another bank's rows — see **Bank/Tenant Isolation in Queries** above.
+
+For each statement against a multi-bank table (`memory_units`, `documents`, `entities`, `entity_links`, `mental_models`, `knowledge_pages`, `memory_links`, `observation_history`, …), confirm it is scoped by one of the three legitimate mechanisms:
+1. explicit `AND bank_id = $n`;
+2. a globally-unique single-column PK (`*.id` uuid, or the bank-encoded `chunks.chunk_id`) — **not** a composite-PK id like `documents.id`/`document_id` or `mental_models.id`;
+3. transitively, through a globally-unique id set that was itself selected from a bank-scoped query in the same call.
+
+**Flag as a must fix** any statement filtering a multi-bank table by a caller-supplied, non-globally-unique key (`document_id`, `mental_models.id`, an entity name, …) with **no** `bank_id` predicate — construct the concrete two-bank scenario (two banks share the id; the statement reads/counts/updates/deletes the wrong bank's rows or over-reports) to confirm it's real before flagging. Prime tells: a `bank_id`-carrying sibling statement right next to a `bank_id`-less one; a `WHERE bank_id` guarded by `if bank_id:` with a `None` default; an import/transfer write that inherits a source `bank_id` instead of pinning the destination.
+
 ### 8. Check code comments
 
 For each non-trivial change:
@@ -254,6 +276,7 @@ Present a clear summary organized by severity:
 - Missing tests for new endpoints
 - Direct DB access (raw SQL / `acquire_with_retry` / `fq_table`) in an `api/` handler instead of a `MemoryEngine` method
 - Tenant-scoped data accessed without authentication enforced in the engine (`_authenticate_tenant` / `get_bank_profile`)
+- A SQL statement against a multi-bank table filtered by a caller-supplied, non-globally-unique key without a `bank_id` predicate (cross-bank read/write leak — see step 7c)
 - New integration missing tests, CI job, or release-integration.sh entry
 - Released/added integration missing from `hindsight-docs/src/data/integrations.json`, or a JSON entry with no `docs-integrations/<slug>` page (fails the docs build via `check-integrations.mjs`)
 - New PostgreSQL table missing from `BACKUP_TABLES` in `admin/cli.py` (silent data loss on restore)

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7156,12 +7156,15 @@ class MemoryEngine(MemoryEngineInterface):
                 _store = get_memories()
                 if _store.writes_memory_rows_in_sql_for(bank_id):
                     unit_rows = await conn.fetch(
-                        f"SELECT id FROM {fq_table('memory_units')} WHERE document_id = $1 AND fact_type IN ('experience', 'world')",
+                        f"SELECT id FROM {fq_table('memory_units')} WHERE document_id = $1 AND bank_id = $2 AND fact_type IN ('experience', 'world')",
                         document_id,
+                        bank_id,
                     )
                     unit_ids = [str(row["id"]) for row in unit_rows]
                     units_count = await conn.fetchval(
-                        f"SELECT COUNT(*) FROM {fq_table('memory_units')} WHERE document_id = $1", document_id
+                        f"SELECT COUNT(*) FROM {fq_table('memory_units')} WHERE document_id = $1 AND bank_id = $2",
+                        document_id,
+                        bank_id,
                     )
                 else:
                     src_page = await _store.scan_memories(
@@ -7345,15 +7348,17 @@ class MemoryEngine(MemoryEngineInterface):
                         )
                 elif tags is not None:
                     unit_rows = await conn.fetch(
-                        f"SELECT id FROM {fq_table('memory_units')} WHERE document_id = $1 AND fact_type IN ('experience', 'world')",
+                        f"SELECT id FROM {fq_table('memory_units')} WHERE document_id = $1 AND bank_id = $2 AND fact_type IN ('experience', 'world')",
                         document_id,
+                        bank_id,
                     )
                     unit_ids = [str(row["id"]) for row in unit_rows]
 
                     await conn.execute(
-                        f"UPDATE {fq_table('memory_units')} SET tags = $1 WHERE document_id = $2",
+                        f"UPDATE {fq_table('memory_units')} SET tags = $1 WHERE document_id = $2 AND bank_id = $3",
                         tags,
                         document_id,
+                        bank_id,
                     )
 
                     if unit_ids:

--- a/hindsight-api-slim/tests/test_document_tracking.py
+++ b/hindsight-api-slim/tests/test_document_tracking.py
@@ -122,6 +122,67 @@ async def test_document_deletion(memory, request_context):
         await memory.delete_bank(bank_id, request_context=request_context)
 
 
+async def _retain_shared_document(memory, request_context, banks, document_id):
+    """Give each bank its own copy of the same document_id — legal, `documents` is keyed on (id, bank_id)."""
+    for bank_id in banks:
+        await memory.retain_async(
+            bank_id=bank_id,
+            content="Alice works at Google.",
+            context="Test",
+            document_id=document_id,
+            request_context=request_context,
+        )
+
+
+async def _units(memory, request_context, bank_id, document_id):
+    page = await memory.list_memory_units(bank_id=bank_id, document_id=document_id, request_context=request_context)
+    return page["items"]
+
+
+@pytest.mark.asyncio
+async def test_document_deletion_counts_only_its_own_bank_units(memory, request_context):
+    """`memory_units_deleted` must report the caller's units, not those of every bank sharing the document_id."""
+    stamp = datetime.now(timezone.utc).timestamp()
+    bank_a, bank_b = f"test_del_scope_a_{stamp}", f"test_del_scope_b_{stamp}"
+    document_id = f"shared-document-id-{stamp}"
+
+    try:
+        await _retain_shared_document(memory, request_context, (bank_a, bank_b), document_id)
+        a_count = len(await _units(memory, request_context, bank_a, document_id))
+        assert a_count > 0
+
+        result = await memory.delete_document(document_id, bank_a, request_context=request_context)
+
+        assert result["memory_units_deleted"] == a_count
+        assert len(await _units(memory, request_context, bank_b, document_id)) == a_count
+
+    finally:
+        for bank_id in (bank_a, bank_b):
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_document_tag_update_is_scoped_to_its_bank(memory, request_context):
+    """Re-tagging a document must not re-tag the memory units of another bank sharing the document_id."""
+    stamp = datetime.now(timezone.utc).timestamp()
+    bank_a, bank_b = f"test_tag_scope_a_{stamp}", f"test_tag_scope_b_{stamp}"
+    document_id = f"shared-document-id-{stamp}"
+
+    try:
+        await _retain_shared_document(memory, request_context, (bank_a, bank_b), document_id)
+
+        await memory.update_document(document_id, bank_a, tags=["rewritten"], request_context=request_context)
+
+        for unit in await _units(memory, request_context, bank_a, document_id):
+            assert unit["tags"] == ["rewritten"]
+        for unit in await _units(memory, request_context, bank_b, document_id):
+            assert "rewritten" not in (unit["tags"] or [])
+
+    finally:
+        for bank_id in (bank_a, bank_b):
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+
 @pytest.mark.asyncio
 async def test_memory_without_document(memory, request_context):
     """Test that memories can still be created without document tracking."""


### PR DESCRIPTION
Closes #3429. Supersedes #3430 (carries @raf52's original commit unchanged — authorship preserved — plus a full bank-scoping audit of the surrounding query surface).

## The bug (cross-bank isolation)

`delete_document` and `update_document` filtered `memory_units` on `document_id` **alone** in four statements, even though `bank_id` is a parameter of both methods and is used by neighbouring statements. Because `document_id` is caller-supplied and the `documents`/`memory_units` rows are keyed per bank (the same id legally exists in every bank), those statements reached across the bank boundary:

- `SELECT id … WHERE document_id = $1` and `SELECT COUNT(*) … WHERE document_id = $1` (delete path) — read and count the units of **every** bank sharing the id, so `memory_units_deleted` over-reports and the id list handed to the downstream relink/observation cleanup carries other banks' ids.
- The same read on the update path.
- **`UPDATE memory_units SET tags = $1 WHERE document_id = $2`** — no bank predicate: a cross-bank **write** that re-tags other banks' memory units.

The `else` branch of the same `if` (non-SQL memories store) already passes `bank_id`; this aligns the SQL branch with it. Deletion itself was never affected — the `DELETE` carries `bank_id` and `memory_units_document_fkey` is composite `(document_id, bank_id) ON DELETE CASCADE`.

**Fix:** add `AND bank_id = $n` to all four statements.

## Tests

Two tests in `tests/test_document_tracking.py`, each with two banks sharing one `document_id`:

- `test_document_deletion_counts_only_its_own_bank_units`
- `test_document_tag_update_is_scoped_to_its_bank`

Without the change: `assert 'rewritten' not in (['rewritten'])` and `assert 8 == 4` (2 failed). With the change: 2 passed.

## Bank/tenant scoping audit (the review requested on #3430)

Because this is an isolation defect, I audited the rest of the engine's query surface for the **same vulnerability class** — any SQL against a multi-bank table filtered by a caller-supplied, non-globally-unique key (`document_id`, entity name, mental-model id, …) without a `bank_id` predicate. Coverage:

- `engine/memory_engine.py` (~16k lines) — all reads/writes on `memory_units`, `documents`, `observation_sources`, `entities`, `entity_cooccurrences`, `mental_models`, `knowledge_pages`.
- `retain/*`, `consolidation/consolidator.py`, `memories/pg/*`, `graph_maintenance.py`, `entity_resolver.py`, `causal_links.py`.
- `search/*`, `transfer/{importer,export}.py`, `reflect/*`, `maintenance.py`, `mental_model_refresh.py`, `audit.py`, `source_facts.py`.

**Result: the four statements fixed here are the only instances of the pattern.** Everything else is correctly scoped, by one of three mechanisms:

1. **Explicit** `WHERE bank_id = $n` (the common case, incl. all other `document_id`/`mental_models`/`knowledge_pages` statements).
2. **Globally-unique UUID PK.** `memory_units.id`, `entities.id`, `knowledge_pages.id` are single-column global PKs, and `chunks.chunk_id` is generated as `{bank_id}_{document_id}_{idx}` — a filter by these alone cannot collide across banks. Contrast the genuinely dangerous keys, `documents.id` / `mental_models.id`, whose PK includes `bank_id`.
3. **Transitive** — junction tables without a `bank_id` column (`unit_entities`, `entity_cooccurrences`, `observation_sources`) are always reached through globally-unique unit/entity ids that were themselves selected from a bank-scoped query, and graph edges are intra-bank by construction. `transfer/importer.py` (the one deliberately cross-bank path) rewrites every row's `bank_id` to the destination and constrains every write to it.

Two **non-exploitable** hardening notes (left as-is to keep this PR minimal, filed for follow-up): `memories/pg/graph.py:graph_units` and `memories/pg/curation.py:list_memory_units` add their `bank_id` predicate under `if bank_id:` with a `bank_id: str | None = None` default. Every caller passes a mandatory, non-empty routing `bank_id`, so no cross-bank call is constructible today; making the parameter non-optional would remove the latent footgun.

## CI note

Python test jobs are gated on secrets and skip on fork PRs — that is why #3430's suite ran only locally. This branch is on the main repo, so CI runs the suite here. `ruff check hindsight_api` and `ruff format --check` pass; the four pre-existing `ruff` findings in `tests/test_document_tracking.py` (unused `logging`/`doc_v1`/`doc_v2` in the older `test_document_tracking`) are present on `main` and untouched here.

---

Original fix by @raf52 in #3430; commit carried over verbatim with authorship preserved.
