### PR TITLE
fix(api): correct stale OpenAPI examples

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1450,8 +1450,7 @@ class BankConfigUpdate(BaseModel):
         json_schema_extra={
             "example": {
                 "updates": {
-                    "llm_model": "claude-sonnet-4-5",
-                    "retain_extraction_mode": "verbose",
+                    "retain_extraction_mode": "custom",
                     "retain_custom_instructions": "Extract technical details carefully",
                 }
             }
@@ -1459,8 +1458,8 @@ class BankConfigUpdate(BaseModel):
     )
 
     updates: dict[str, Any] = Field(
-        description="Configuration overrides. Keys can be in Python field format (llm_provider) "
-        "or environment variable format (HINDSIGHT_API_LLM_PROVIDER). "
+        description="Configuration overrides. Keys can be in Python field format (retain_extraction_mode) "
+        "or environment variable format (HINDSIGHT_API_RETAIN_EXTRACTION_MODE). "
         "Only hierarchical fields can be overridden per-bank."
     )
 
@@ -1473,12 +1472,10 @@ class BankConfigResponse(BaseModel):
             "example": {
                 "bank_id": "my-bank",
                 "config": {
-                    "llm_provider": "openai",
-                    "llm_model": "gpt-4",
                     "retain_extraction_mode": "verbose",
+                    "retain_chunk_size": 3000,
                 },
                 "overrides": {
-                    "llm_model": "gpt-4",
                     "retain_extraction_mode": "verbose",
                 },
             }
@@ -3250,6 +3247,7 @@ class OperationsListResponse(BaseModel):
                     {
                         "id": "550e8400-e29b-41d4-a716-446655440000",
                         "task_type": "retain",
+                        "items_count": 5,
                         "created_at": "2024-01-15T10:30:00Z",
                         "status": "pending",
                         "error_message": None,
@@ -3338,7 +3336,7 @@ class OperationStatusResponse(BaseModel):
             "example": {
                 "operation_id": "550e8400-e29b-41d4-a716-446655440000",
                 "status": "completed",
-                "operation_type": "refresh_mental_models",
+                "operation_type": "refresh_mental_model",
                 "created_at": "2024-01-15T10:30:00Z",
                 "updated_at": "2024-01-15T10:31:30Z",
                 "completed_at": "2024-01-15T10:31:30Z",
@@ -3424,15 +3422,19 @@ class VersionResponse(BaseModel):
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
-                "api_version": "0.4.0",
+                "api_version": "0.9.0",
                 "features": {
                     "observations": False,
                     "mcp": True,
                     "worker": True,
                     "bank_config_api": False,
+                    "bank_llm_health": True,
                     "file_upload_api": True,
                     "document_export_api": True,
                     "document_import_api": True,
+                    "audit_log": False,
+                    "llm_trace": False,
+                    "store_document_text": True,
                 },
             }
         }
@@ -7436,8 +7438,9 @@ def _register_routes(app: FastAPI):
         "/v1/default/banks/{bank_id}/config",
         response_model=BankConfigResponse,
         summary="Update bank configuration",
-        description="Update configuration overrides for a bank. Only hierarchical fields can be overridden (LLM settings, retention parameters, etc.). "
-        "Keys can be provided in Python field format (llm_provider) or environment variable format (HINDSIGHT_API_LLM_PROVIDER).",
+        description="Update configuration overrides for a bank. Only hierarchical behavioral settings can be "
+        "overridden (retention parameters, recall settings, etc.). Keys can be provided in Python field format "
+        "(retain_extraction_mode) or environment variable format (HINDSIGHT_API_RETAIN_EXTRACTION_MODE).",
         operation_id="update_bank_config",
         tags=["Banks"],
     )

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -3738,10 +3738,10 @@ paths:
       tags:
       - Banks
     patch:
-      description: "Update configuration overrides for a bank. Only hierarchical fields\
-        \ can be overridden (LLM settings, retention parameters, etc.). Keys can be\
-        \ provided in Python field format (llm_provider) or environment variable format\
-        \ (HINDSIGHT_API_LLM_PROVIDER)."
+      description: "Update configuration overrides for a bank. Only hierarchical behavioral\
+        \ settings can be overridden (retention parameters, recall settings, etc.).\
+        \ Keys can be provided in Python field format (retain_extraction_mode) or\
+        \ environment variable format (HINDSIGHT_API_RETAIN_EXTRACTION_MODE)."
       operationId: update_bank_config
       parameters:
       - explode: false
@@ -4862,11 +4862,9 @@ components:
       example:
         bank_id: my-bank
         config:
-          llm_model: gpt-4
-          llm_provider: openai
+          retain_chunk_size: 3000
           retain_extraction_mode: verbose
         overrides:
-          llm_model: gpt-4
           retain_extraction_mode: verbose
       properties:
         bank_id:
@@ -4891,14 +4889,13 @@ components:
       description: Request model for updating bank configuration.
       example:
         updates:
-          llm_model: claude-sonnet-4-5
           retain_custom_instructions: Extract technical details carefully
-          retain_extraction_mode: verbose
+          retain_extraction_mode: custom
       properties:
         updates:
           additionalProperties: {}
           description: Configuration overrides. Keys can be in Python field format
-            (llm_provider) or environment variable format (HINDSIGHT_API_LLM_PROVIDER).
+            (retain_extraction_mode) or environment variable format (HINDSIGHT_API_RETAIN_EXTRACTION_MODE).
             Only hierarchical fields can be overridden per-bank.
           title: Updates
       required:
@@ -8828,7 +8825,7 @@ components:
         completed_at: 2024-01-15T10:31:30Z
         created_at: 2024-01-15T10:30:00Z
         operation_id: 550e8400-e29b-41d4-a716-446655440000
-        operation_type: refresh_mental_models
+        operation_type: refresh_mental_model
         status: completed
         updated_at: 2024-01-15T10:31:30Z
       properties:
@@ -8892,6 +8889,7 @@ components:
         operations:
         - created_at: 2024-01-15T10:30:00Z
           id: 550e8400-e29b-41d4-a716-446655440000
+          items_count: 5
           status: pending
           task_type: retain
         total: 150
@@ -9999,14 +9997,18 @@ components:
     VersionResponse:
       description: Response model for the version/info endpoint.
       example:
-        api_version: 0.4.0
+        api_version: 0.9.0
         features:
+          audit_log: false
           bank_config_api: false
+          bank_llm_health: true
           document_export_api: true
           document_import_api: true
           file_upload_api: true
+          llm_trace: false
           mcp: true
           observations: false
+          store_document_text: true
           worker: true
       properties:
         api_version:

--- a/hindsight-clients/go/api_banks.go
+++ b/hindsight-clients/go/api_banks.go
@@ -1837,7 +1837,7 @@ func (r ApiUpdateBankConfigRequest) Execute() (*BankConfigResponse, *http.Respon
 /*
 UpdateBankConfig Update bank configuration
 
-Update configuration overrides for a bank. Only hierarchical fields can be overridden (LLM settings, retention parameters, etc.). Keys can be provided in Python field format (llm_provider) or environment variable format (HINDSIGHT_API_LLM_PROVIDER).
+Update configuration overrides for a bank. Only hierarchical behavioral settings can be overridden (retention parameters, recall settings, etc.). Keys can be provided in Python field format (retain_extraction_mode) or environment variable format (HINDSIGHT_API_RETAIN_EXTRACTION_MODE).
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param bankId

--- a/hindsight-clients/go/model_bank_config_update.go
+++ b/hindsight-clients/go/model_bank_config_update.go
@@ -21,7 +21,7 @@ var _ MappedNullable = &BankConfigUpdate{}
 
 // BankConfigUpdate Request model for updating bank configuration.
 type BankConfigUpdate struct {
-	// Configuration overrides. Keys can be in Python field format (llm_provider) or environment variable format (HINDSIGHT_API_LLM_PROVIDER). Only hierarchical fields can be overridden per-bank.
+	// Configuration overrides. Keys can be in Python field format (retain_extraction_mode) or environment variable format (HINDSIGHT_API_RETAIN_EXTRACTION_MODE). Only hierarchical fields can be overridden per-bank.
 	Updates map[string]interface{} `json:"updates"`
 }
 

--- a/hindsight-clients/python/hindsight_client_api/api/banks_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/banks_api.py
@@ -4120,7 +4120,7 @@ class BanksApi:
     ) -> BankConfigResponse:
         """Update bank configuration
 
-        Update configuration overrides for a bank. Only hierarchical fields can be overridden (LLM settings, retention parameters, etc.). Keys can be provided in Python field format (llm_provider) or environment variable format (HINDSIGHT_API_LLM_PROVIDER).
+        Update configuration overrides for a bank. Only hierarchical behavioral settings can be overridden (retention parameters, recall settings, etc.). Keys can be provided in Python field format (retain_extraction_mode) or environment variable format (HINDSIGHT_API_RETAIN_EXTRACTION_MODE).
 
         :param bank_id: (required)
         :type bank_id: str
@@ -4196,7 +4196,7 @@ class BanksApi:
     ) -> ApiResponse[BankConfigResponse]:
         """Update bank configuration
 
-        Update configuration overrides for a bank. Only hierarchical fields can be overridden (LLM settings, retention parameters, etc.). Keys can be provided in Python field format (llm_provider) or environment variable format (HINDSIGHT_API_LLM_PROVIDER).
+        Update configuration overrides for a bank. Only hierarchical behavioral settings can be overridden (retention parameters, recall settings, etc.). Keys can be provided in Python field format (retain_extraction_mode) or environment variable format (HINDSIGHT_API_RETAIN_EXTRACTION_MODE).
 
         :param bank_id: (required)
         :type bank_id: str
@@ -4272,7 +4272,7 @@ class BanksApi:
     ) -> RESTResponseType:
         """Update bank configuration
 
-        Update configuration overrides for a bank. Only hierarchical fields can be overridden (LLM settings, retention parameters, etc.). Keys can be provided in Python field format (llm_provider) or environment variable format (HINDSIGHT_API_LLM_PROVIDER).
+        Update configuration overrides for a bank. Only hierarchical behavioral settings can be overridden (retention parameters, recall settings, etc.). Keys can be provided in Python field format (retain_extraction_mode) or environment variable format (HINDSIGHT_API_RETAIN_EXTRACTION_MODE).
 
         :param bank_id: (required)
         :type bank_id: str

--- a/hindsight-clients/python/hindsight_client_api/models/bank_config_update.py
+++ b/hindsight-clients/python/hindsight_client_api/models/bank_config_update.py
@@ -26,7 +26,7 @@ class BankConfigUpdate(BaseModel):
     """
     Request model for updating bank configuration.
     """ # noqa: E501
-    updates: Dict[str, Any] = Field(description="Configuration overrides. Keys can be in Python field format (llm_provider) or environment variable format (HINDSIGHT_API_LLM_PROVIDER). Only hierarchical fields can be overridden per-bank.")
+    updates: Dict[str, Any] = Field(description="Configuration overrides. Keys can be in Python field format (retain_extraction_mode) or environment variable format (HINDSIGHT_API_RETAIN_EXTRACTION_MODE). Only hierarchical fields can be overridden per-bank.")
     __properties: ClassVar[List[str]] = ["updates"]
 
     model_config = ConfigDict(

--- a/hindsight-clients/typescript/generated/sdk.gen.ts
+++ b/hindsight-clients/typescript/generated/sdk.gen.ts
@@ -1431,7 +1431,7 @@ export const getBankConfig = <ThrowOnError extends boolean = false>(
 /**
  * Update bank configuration
  *
- * Update configuration overrides for a bank. Only hierarchical fields can be overridden (LLM settings, retention parameters, etc.). Keys can be provided in Python field format (llm_provider) or environment variable format (HINDSIGHT_API_LLM_PROVIDER).
+ * Update configuration overrides for a bank. Only hierarchical behavioral settings can be overridden (retention parameters, recall settings, etc.). Keys can be provided in Python field format (retain_extraction_mode) or environment variable format (HINDSIGHT_API_RETAIN_EXTRACTION_MODE).
  */
 export const updateBankConfig = <ThrowOnError extends boolean = false>(
   options: Options<UpdateBankConfigData, ThrowOnError>

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -232,7 +232,7 @@ export type BankConfigUpdate = {
   /**
    * Updates
    *
-   * Configuration overrides. Keys can be in Python field format (llm_provider) or environment variable format (HINDSIGHT_API_LLM_PROVIDER). Only hierarchical fields can be overridden per-bank.
+   * Configuration overrides. Keys can be in Python field format (retain_extraction_mode) or environment variable format (HINDSIGHT_API_RETAIN_EXTRACTION_MODE). Only hierarchical fields can be overridden per-bank.
    */
   updates: {
     [key: string]: unknown;

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -5365,7 +5365,7 @@
           "Banks"
         ],
         "summary": "Update bank configuration",
-        "description": "Update configuration overrides for a bank. Only hierarchical fields can be overridden (LLM settings, retention parameters, etc.). Keys can be provided in Python field format (llm_provider) or environment variable format (HINDSIGHT_API_LLM_PROVIDER).",
+        "description": "Update configuration overrides for a bank. Only hierarchical behavioral settings can be overridden (retention parameters, recall settings, etc.). Keys can be provided in Python field format (retain_extraction_mode) or environment variable format (HINDSIGHT_API_RETAIN_EXTRACTION_MODE).",
         "operationId": "update_bank_config",
         "parameters": [
           {
@@ -7065,12 +7065,10 @@
         "example": {
           "bank_id": "my-bank",
           "config": {
-            "llm_model": "gpt-4",
-            "llm_provider": "openai",
+            "retain_chunk_size": 3000,
             "retain_extraction_mode": "verbose"
           },
           "overrides": {
-            "llm_model": "gpt-4",
             "retain_extraction_mode": "verbose"
           }
         }
@@ -7081,7 +7079,7 @@
             "additionalProperties": true,
             "type": "object",
             "title": "Updates",
-            "description": "Configuration overrides. Keys can be in Python field format (llm_provider) or environment variable format (HINDSIGHT_API_LLM_PROVIDER). Only hierarchical fields can be overridden per-bank."
+            "description": "Configuration overrides. Keys can be in Python field format (retain_extraction_mode) or environment variable format (HINDSIGHT_API_RETAIN_EXTRACTION_MODE). Only hierarchical fields can be overridden per-bank."
           }
         },
         "type": "object",
@@ -7092,9 +7090,8 @@
         "description": "Request model for updating bank configuration.",
         "example": {
           "updates": {
-            "llm_model": "claude-sonnet-4-5",
             "retain_custom_instructions": "Extract technical details carefully",
-            "retain_extraction_mode": "verbose"
+            "retain_extraction_mode": "custom"
           }
         }
       },
@@ -13286,7 +13283,7 @@
           "completed_at": "2024-01-15T10:31:30Z",
           "created_at": "2024-01-15T10:30:00Z",
           "operation_id": "550e8400-e29b-41d4-a716-446655440000",
-          "operation_type": "refresh_mental_models",
+          "operation_type": "refresh_mental_model",
           "status": "completed",
           "updated_at": "2024-01-15T10:31:30Z"
         }
@@ -13335,6 +13332,7 @@
             {
               "created_at": "2024-01-15T10:30:00Z",
               "id": "550e8400-e29b-41d4-a716-446655440000",
+              "items_count": 5,
               "status": "pending",
               "task_type": "retain"
             }
@@ -15476,14 +15474,18 @@
         "title": "VersionResponse",
         "description": "Response model for the version/info endpoint.",
         "example": {
-          "api_version": "0.4.0",
+          "api_version": "0.9.0",
           "features": {
+            "audit_log": false,
             "bank_config_api": false,
+            "bank_llm_health": true,
             "document_export_api": true,
             "document_import_api": true,
             "file_upload_api": true,
+            "llm_trace": false,
             "mcp": true,
             "observations": false,
+            "store_document_text": true,
             "worker": true
           }
         }

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -5365,7 +5365,7 @@
           "Banks"
         ],
         "summary": "Update bank configuration",
-        "description": "Update configuration overrides for a bank. Only hierarchical fields can be overridden (LLM settings, retention parameters, etc.). Keys can be provided in Python field format (llm_provider) or environment variable format (HINDSIGHT_API_LLM_PROVIDER).",
+        "description": "Update configuration overrides for a bank. Only hierarchical behavioral settings can be overridden (retention parameters, recall settings, etc.). Keys can be provided in Python field format (retain_extraction_mode) or environment variable format (HINDSIGHT_API_RETAIN_EXTRACTION_MODE).",
         "operationId": "update_bank_config",
         "parameters": [
           {
@@ -7065,12 +7065,10 @@
         "example": {
           "bank_id": "my-bank",
           "config": {
-            "llm_model": "gpt-4",
-            "llm_provider": "openai",
+            "retain_chunk_size": 3000,
             "retain_extraction_mode": "verbose"
           },
           "overrides": {
-            "llm_model": "gpt-4",
             "retain_extraction_mode": "verbose"
           }
         }
@@ -7081,7 +7079,7 @@
             "additionalProperties": true,
             "type": "object",
             "title": "Updates",
-            "description": "Configuration overrides. Keys can be in Python field format (llm_provider) or environment variable format (HINDSIGHT_API_LLM_PROVIDER). Only hierarchical fields can be overridden per-bank."
+            "description": "Configuration overrides. Keys can be in Python field format (retain_extraction_mode) or environment variable format (HINDSIGHT_API_RETAIN_EXTRACTION_MODE). Only hierarchical fields can be overridden per-bank."
           }
         },
         "type": "object",
@@ -7092,9 +7090,8 @@
         "description": "Request model for updating bank configuration.",
         "example": {
           "updates": {
-            "llm_model": "claude-sonnet-4-5",
             "retain_custom_instructions": "Extract technical details carefully",
-            "retain_extraction_mode": "verbose"
+            "retain_extraction_mode": "custom"
           }
         }
       },
@@ -13286,7 +13283,7 @@
           "completed_at": "2024-01-15T10:31:30Z",
           "created_at": "2024-01-15T10:30:00Z",
           "operation_id": "550e8400-e29b-41d4-a716-446655440000",
-          "operation_type": "refresh_mental_models",
+          "operation_type": "refresh_mental_model",
           "status": "completed",
           "updated_at": "2024-01-15T10:31:30Z"
         }
@@ -13335,6 +13332,7 @@
             {
               "created_at": "2024-01-15T10:30:00Z",
               "id": "550e8400-e29b-41d4-a716-446655440000",
+              "items_count": 5,
               "status": "pending",
               "task_type": "retain"
             }
@@ -15476,14 +15474,18 @@
         "title": "VersionResponse",
         "description": "Response model for the version/info endpoint.",
         "example": {
-          "api_version": "0.4.0",
+          "api_version": "0.9.0",
           "features": {
+            "audit_log": false,
             "bank_config_api": false,
+            "bank_llm_health": true,
             "document_export_api": true,
             "document_import_api": true,
             "file_upload_api": true,
+            "llm_trace": false,
             "mcp": true,
             "observations": false,
+            "store_document_text": true,
             "worker": true
           }
         }


### PR DESCRIPTION
## Summary

Correct stale and misleading OpenAPI examples so they match the bank configuration allowlist, response models, and async operation values used at runtime. Regenerate the OpenAPI documentation, docs skill mirror, and generated client descriptions.

## Fixed issues

| Area | Problem | Fix |
| --- | --- | --- |
| Bank config update example | Used `llm_model`, which is server-level and cannot be overridden per bank | Removed `llm_model` and kept only fields in `_CONFIGURABLE_FIELDS` |
| Custom retain instructions | Paired `retain_custom_instructions` with `retain_extraction_mode: verbose`, which silently ignores the custom instructions | Changed the example mode to `custom` |
| Bank config response example | Claimed `config` and `overrides` could contain `llm_provider` and `llm_model` | Replaced them with configurable retain fields |
| Bank config field description | Used `llm_provider` and `HINDSIGHT_API_LLM_PROVIDER` as accepted key examples even though the API rejects them | Replaced them with `retain_extraction_mode` and `HINDSIGHT_API_RETAIN_EXTRACTION_MODE` |
| Bank config endpoint description | Described LLM settings as per-bank overrides and repeated the invalid provider examples | Limited the description to hierarchical behavioral settings and valid retain examples |
| Operations list response | Omitted the required `items_count` field from each operation | Added `items_count` to the example operation |
| Operation status response | Used the nonexistent plural operation type `refresh_mental_models` | Changed it to the runtime value `refresh_mental_model` |
| Version response | Omitted four required feature flags while still identifying the expanded response as API version `0.4.0` | Added all required feature fields and updated the example version to the current `0.9.0` |
| Generated artifacts | OpenAPI mirrors and generated clients retained stale descriptions and examples | Regenerated the website spec, docs skill mirror, and Python, TypeScript, and Go client artifacts |

## Testing

- `./scripts/generate-openapi.sh`
- `./scripts/generate-bank-template-schema.sh`
- `./scripts/generate-clients.sh`
- `./scripts/generate-docs-skill.sh`
- `./scripts/hooks/lint.sh`
- Verified all 51 model examples pass Pydantic validation
- Verified `tests/test_hierarchical_config.py` passes all 27 tests
- Verified the website and docs skill OpenAPI files are byte-identical
- Verified repeated generation is idempotent
- Completed two consecutive independent adversarial reviews with no findings after the fix