### PR TITLE
fix(files): give each batched file a unique storage key (#3226)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -16439,8 +16439,15 @@ class MemoryEngine(MemoryEngineInterface):
         # Submit individual operation for each file
         operation_ids = []
         for item, file, file_data in files_data:
-            # Generate storage key
-            storage_key = f"banks/{bank_id}/files/{item['document_id']}/{file.filename}"
+            # Generate a per-file storage key that is unique regardless of the
+            # (user-controllable) document_id or filename. Deriving the key from
+            # document_id/filename let two files in one batch collide on the same
+            # key when they shared both; the PG backend's ON CONFLICT DO UPDATE
+            # then overwrote the loser's bytes, and delete-on-conversion of the
+            # first task left the sibling task retrieving a missing key ("File
+            # not found") and failing deterministically on every retry (#3226).
+            # The unguessable uuid segment mirrors the export path convention.
+            storage_key = f"banks/{bank_id}/files/{uuid.uuid4()}/{file.filename}"
 
             # Store file in object storage
             await self._file_storage.store(

--- a/hindsight-api-slim/tests/test_file_retain.py
+++ b/hindsight-api-slim/tests/test_file_retain.py
@@ -208,6 +208,83 @@ async def test_file_retain_multiple_files(memory_no_llm_verify, sample_txt_conte
 
 
 @pytest.mark.asyncio
+async def test_file_retain_batch_generates_unique_storage_keys(memory_no_llm_verify, sample_txt_content):
+    """Regression (#3226): every file in a batch must get its own storage key.
+
+    The key used to be ``banks/<bank>/files/<document_id>/<filename>`` — derived
+    entirely from the (user-controllable) document_id and filename. Two files in
+    one batch sharing both collided on the same key; the PostgreSQL backend's
+    ``ON CONFLICT DO UPDATE`` overwrote the loser's bytes, and delete-on-conversion
+    of the first task left the sibling task retrieving a missing key ("File not
+    found") and failing on every retry. Uploading three same-named files under a
+    shared document_id must now yield three distinct keys, all still resolving
+    under ``banks/<bank>/files/``.
+    """
+    from hindsight_api.engine.memory_engine import get_current_schema
+    from hindsight_api.models import RequestContext
+
+    bank_id = "test_file_unique_key_bank"
+    context = RequestContext(internal=True)
+    await memory_no_llm_verify.get_bank_profile(bank_id, request_context=context)
+
+    class MockFile:
+        def __init__(self, content, filename, content_type):
+            self.content = content
+            self.filename = filename
+            self.content_type = content_type
+
+        async def read(self):
+            return self.content
+
+    # Three files that would have collided under the old scheme: identical
+    # document_id and identical filename, distinct content.
+    file_items = [
+        {
+            "file": MockFile(f"content number {i}".encode(), "same_name.txt", "text/plain"),
+            "document_id": "shared_doc_id",
+            "context": None,
+            "metadata": {},
+            "tags": [],
+            "timestamp": None,
+            "parser": ["markitdown"],
+        }
+        for i in range(3)
+    ]
+
+    result = await memory_no_llm_verify.submit_async_file_retain(
+        bank_id=bank_id,
+        file_items=file_items,
+        document_tags=None,
+        request_context=context,
+    )
+
+    operation_ids = result["operation_ids"]
+    assert len(operation_ids) == 3
+
+    pool = await memory_no_llm_verify._get_pool()
+    schema = get_current_schema()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            f"""
+            SELECT status, task_payload->>'storage_key' AS storage_key
+            FROM {schema}.async_operations
+            WHERE operation_id = ANY($1::uuid[])
+            """,
+            operation_ids,
+        )
+
+    storage_keys = [row["storage_key"] for row in rows]
+    assert len(storage_keys) == 3
+    # The core regression: keys are unique, so no file clobbers another's bytes.
+    assert len(set(storage_keys)) == 3, f"storage keys collided: {storage_keys}"
+    for key in storage_keys:
+        assert key.startswith(f"banks/{bank_id}/files/")
+    # No file was left stranded: every conversion retrieved its own bytes.
+    for row in rows:
+        assert row["status"] == "completed", f"operation not completed: {row['status']}"
+
+
+@pytest.mark.asyncio
 async def test_file_retain_validation_errors(memory_no_llm_verify):
     """Test validation errors."""
     from hindsight_api.api.http import create_app


### PR DESCRIPTION
## Problem

Fixes #3226. In a multi-file conversion batch, files after the first could fail permanently with `File not found: banks/<bank>/files/<A>/<B>`, silently dropping documents.

## Root cause

The per-file storage key was derived entirely from user-controllable values:

```python
storage_key = f"banks/{bank_id}/files/{item['document_id']}/{file.filename}"
```

When two files in one batch shared **both** `document_id` and filename (e.g. re-uploading same-named files under a stable `document_id`), they mapped to the **same** key. The PostgreSQL file-storage backend stores with `ON CONFLICT (storage_key) DO UPDATE`, so the second store overwrote the first's bytes. Then whichever `file_convert_retain` task finished first **deletes** the shared key after conversion, and the sibling task's `retrieve()` fails with `FileNotFoundError` — deterministically, so retries burn out and the document is never ingested.

## Fix

Derive each file's key independently with an unguessable UUID segment, mirroring the export path convention (`banks/{bank_id}/exports/{uuid4()}/…`):

```python
storage_key = f"banks/{bank_id}/files/{uuid.uuid4()}/{file.filename}"
```

The key is only ever read back from stored state (the task payload and the `file_storage_key` column) — never reconstructed — so decoupling it from `document_id`/`filename` is safe. `bank_id` stays the first path segment, so the download endpoint's IDOR guard is unchanged.

## Test

`test_file_retain_batch_generates_unique_storage_keys` uploads three same-named files under a shared `document_id` and asserts all three get distinct keys (still under `banks/<bank>/files/`) and all conversions complete. Verified failing on the old code and passing on the new.
