### PR TITLE
feat(coding-agents): add opt-in project scoping within shared banks

### DIFF
--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -341,6 +341,9 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `resolveWorktrees`      | `true`                               | `{gitProject}`: linked worktrees share the main repo's bank                                                                                                                                                                         |
 | `retainTags`            | —                                    | extra tags on every document written by the integration, e.g. `["project:{gitProject}"]` — see **Recording where a memory came from** below                                                                                         |
 | `retainMetadata`        | —                                    | extra metadata on every document written by the integration, e.g. `{"repo": "{gitProject}"}`                                                                                                                                        |
+| `projectScope`          | `"bank"`                             | `"bank"` keeps existing behavior; `"tags"` scopes ordinary reflect within a shared bank                                                                                                                                             |
+| `projectTagTemplate`    | `"project:{gitProject}"`             | project tag automatically retained and used for scoped reflect                                                                                                                                                                      |
+| `globalTags`            | —                                    | shared tags included alongside the current project during scoped reflect                                                                                                                                                            |
 | `disabled`              | `false`                              | hard off-switch (inert plugin/hook — a no-memory baseline)                                                                                                                                                                          |
 | `reflectTimeoutMs`      | `120000`                             | session-reflect timeout (hook harnesses additionally cap it at 25s to fit the host's hook window); on timeout the session runs without reflect (recorded)                                                                           |
 | `pageRefreshEveryTurns` | `10`                                 | refetch the knowledge pages and re-inject the page roster + tool guide every N user turns                                                                                                                                           |
@@ -447,6 +450,29 @@ of. Both accept the same placeholders as `bankIdTemplate` — `{gitProject}`, `{
 
 The plugin's own `source:` and `harness:` tags are reserved: entries in those namespaces are ignored
 with a warning, so a document's agent attribution always reflects the agent that actually wrote it.
+
+### Project-scoped reflect inside one shared bank
+
+Per-repository banks remain the default. To keep one static bank while making ordinary reflect
+project-specific, opt into strict tag scope:
+
+```jsonc
+{
+  "bankId": "shared",
+  "projectScope": "tags",
+  "projectTagTemplate": "project:{gitProject}",
+  "globalTags": ["scope:global"],
+}
+```
+
+This automatically stamps the project tag on every document written by the integration. Automatic
+reflect and `hindsight_reflect` then search only the current project's tag plus any `globalTags`.
+Untagged and unrelated-project memories are excluded. For an intentional cross-project comparison,
+or while migrating legacy untagged documents, use `hindsight_reflect_all_projects` to query the full
+bank explicitly.
+
+Knowledge Pages remain bank-wide in this mode. Their search endpoint does not currently accept tag
+filters, so project scoping is not presented as covering page search, listing, or page generation.
 
 ## Diagnostics & logging
 

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -334,6 +334,9 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `resolveWorktrees`      | `true`                               | `{gitProject}`: linked worktrees share the main repo's bank                                                                                                                                                                         |
 | `retainTags`            | —                                    | extra tags on every document written by the integration, e.g. `["project:{gitProject}"]` — see **Recording where a memory came from** below                                                                                         |
 | `retainMetadata`        | —                                    | extra metadata on every document written by the integration, e.g. `{"repo": "{gitProject}"}`                                                                                                                                        |
+| `projectScope`          | `"bank"`                             | `"bank"` keeps existing behavior; `"tags"` scopes ordinary reflect within a shared bank                                                                                                                                             |
+| `projectTagTemplate`    | `"project:{gitProject}"`             | project tag automatically retained and used for scoped reflect                                                                                                                                                                      |
+| `globalTags`            | —                                    | shared tags included alongside the current project during scoped reflect                                                                                                                                                            |
 | `disabled`              | `false`                              | hard off-switch (inert plugin/hook — a no-memory baseline)                                                                                                                                                                          |
 | `reflectTimeoutMs`      | `120000`                             | session-reflect timeout (hook harnesses additionally cap it at 25s to fit the host's hook window); on timeout the session runs without reflect (recorded)                                                                           |
 | `pageRefreshEveryTurns` | `10`                                 | refetch the knowledge pages and re-inject the page roster + tool guide every N user turns                                                                                                                                           |
@@ -440,6 +443,29 @@ of. Both accept the same placeholders as `bankIdTemplate` — `{gitProject}`, `{
 
 The plugin's own `source:` and `harness:` tags are reserved: entries in those namespaces are ignored
 with a warning, so a document's agent attribution always reflects the agent that actually wrote it.
+
+### Project-scoped reflect inside one shared bank
+
+Per-repository banks remain the default. To keep one static bank while making ordinary reflect
+project-specific, opt into strict tag scope:
+
+```jsonc
+{
+  "bankId": "shared",
+  "projectScope": "tags",
+  "projectTagTemplate": "project:{gitProject}",
+  "globalTags": ["scope:global"],
+}
+```
+
+This automatically stamps the project tag on every document written by the integration. Automatic
+reflect and `hindsight_reflect` then search only the current project's tag plus any `globalTags`.
+Untagged and unrelated-project memories are excluded. For an intentional cross-project comparison,
+or while migrating legacy untagged documents, use `hindsight_reflect_all_projects` to query the full
+bank explicitly.
+
+Knowledge Pages remain bank-wide in this mode. Their search endpoint does not currently accept tag
+filters, so project scoping is not presented as covering page search, listing, or page generation.
 
 ## Ingestion internals (no CLI)
 

--- a/hindsight-integrations/coding-agents/src/cline.ts
+++ b/hindsight-integrations/coding-agents/src/cline.ts
@@ -9,6 +9,7 @@
 import { applyBankConfig, loadConfig } from "./core/config";
 import { deriveBankId } from "./core/bank";
 import { HindsightClient } from "./core/hindsight";
+import { resolveProjectScope } from "./core/project-scope";
 import { RuntimeCore } from "./core/runtime";
 import type { TransportTurn } from "./core/chat";
 import { diag } from "./core/diag";
@@ -197,6 +198,12 @@ function createRuntime(workspaceRoot: string | undefined): RuntimeCore | undefin
     apiToken: cfg.apiToken,
     bank: resolved.bankId,
     maxParallelRetains: cfg.maxParallelRetains,
+    projectScope: resolveProjectScope(
+      cfg,
+      workspaceRoot || process.cwd(),
+      HARNESS,
+      resolved.bankId
+    ),
   });
   return new RuntimeCore(client, resolved.bankId, cfg, HARNESS, workspaceRoot || process.cwd());
 }

--- a/hindsight-integrations/coding-agents/src/core/config.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.test.ts
@@ -267,6 +267,29 @@ describe("retainTags / retainMetadata", () => {
     expect(cfg.retainTags).toEqual(["ok"]);
     expect(cfg.retainMetadata).toEqual({ good: "x" });
   });
+
+  it("keeps configured tags separate from the derived project scope", () => {
+    expect(resolveConfig({}).projectScope).toBe("bank");
+    const cfg = resolveConfig({
+      projectScope: "tags",
+      projectTagTemplate: "repo:{gitProject}",
+      retainTags: ["kind:transcript"],
+      globalTags: ["scope:global", 42 as unknown as string],
+    });
+    expect(cfg.projectScope).toBe("tags");
+    expect(cfg.retainTags).toEqual(["kind:transcript"]);
+    expect(cfg.globalTags).toEqual(["scope:global"]);
+  });
+
+  it("allows a bank override to disable tag scope without leaving an implicit retain tag", () => {
+    const cfg = resolveConfig({
+      projectScope: "tags",
+      banks: { shared: { projectScope: "bank" } },
+    });
+    const scoped = applyBankConfig(cfg, "shared").cfg;
+    expect(scoped.projectScope).toBe("bank");
+    expect(scoped.retainTags).toEqual([]);
+  });
 });
 
 describe("HINDSIGHT_RETAIN_TAGS", () => {

--- a/hindsight-integrations/coding-agents/src/core/config.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.ts
@@ -105,6 +105,12 @@ export interface RawConfig {
   /** Extra metadata stamped on every session write-back, e.g. {"repo": "{gitProject}"}. Same
    *  placeholders as retainTags; built-in metadata (harness attribution) wins on conflict. */
   retainMetadata?: Record<string, string>;
+  /** Opt into project separation by strict tags inside one shared/static bank. */
+  projectScope?: "bank" | "tags";
+  /** Tag template identifying the current project when projectScope is "tags". */
+  projectTagTemplate?: string;
+  /** Shared tags included alongside the current project during scoped reflect. */
+  globalTags?: string[];
   /** Per-harness overrides of any of the fields above, keyed by harness name ("opencode",
    *  "claude-code", ...). Lets one config file give each agent its own bank/settings. */
   harnesses?: Record<string, Omit<RawConfig, "harnesses">>;
@@ -154,6 +160,9 @@ export interface Config {
   gitIngest: "message" | "full" | "none";
   retainTags: string[];
   retainMetadata: Record<string, string>;
+  projectScope: "bank" | "tags";
+  projectTagTemplate: string;
+  globalTags: string[];
   banks: Record<string, Omit<RawConfig, "banks" | "harnesses"> & { bank?: string }>;
   logLevel: "debug" | "info" | "warn" | "error";
 }
@@ -216,6 +225,11 @@ export function resolveConfig(raw: RawConfig = {}): Config {
             Object.entries(raw.retainMetadata).filter(([, v]) => typeof v === "string")
           )
         : {},
+    projectScope: raw.projectScope === "tags" ? "tags" : "bank",
+    projectTagTemplate: raw.projectTagTemplate || "project:{gitProject}",
+    globalTags: Array.isArray(raw.globalTags)
+      ? raw.globalTags.filter((tag): tag is string => typeof tag === "string" && tag.trim() !== "")
+      : [],
     banks: raw.banks && typeof raw.banks === "object" ? raw.banks : {},
     logLevel: ["debug", "info", "warn", "error"].includes(raw.logLevel as string)
       ? (raw.logLevel as "debug" | "info" | "warn" | "error")

--- a/hindsight-integrations/coding-agents/src/core/hindsight.scope.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.scope.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HindsightClient } from "./hindsight";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("HindsightClient project-scoped reflect", () => {
+  it("scopes ordinary reflect and supports explicit bank-wide reflect", async () => {
+    const bodies: unknown[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        bodies.push(JSON.parse(String(init.body)));
+        return { ok: true, status: 200, json: async () => ({ text: "answer" }) } as Response;
+      })
+    );
+    const client = new HindsightClient({
+      apiUrl: "http://x",
+      bank: "default",
+      projectScope: { projectTag: "project:potcodev", globalTags: ["scope:global"] },
+    });
+    await client.reflect("why?", { budget: "high" });
+    await client.reflect("compare projects", { budget: "high", unscoped: true });
+    expect(bodies[0]).toEqual({
+      query: "why?",
+      budget: "high",
+      tag_groups: [
+        {
+          or: [
+            { tags: ["project:potcodev"], match: "any_strict" },
+            { tags: ["scope:global"], match: "any_strict" },
+          ],
+        },
+      ],
+    });
+    expect(bodies[1]).toEqual({ query: "compare projects", budget: "high" });
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -14,6 +14,7 @@ import {
 } from "./missions";
 import { pool, semverGte, sleep } from "./util";
 import type { RetainStamp } from "./retain-stamp";
+import { scopeTagGroups, type ProjectScope } from "./project-scope";
 
 /** One node of GET /knowledge-base/tree. Only the fields this client reads. */
 export interface KnowledgeNode {
@@ -32,6 +33,7 @@ export interface ClientOpts {
   log?: (msg: string) => void;
   /** Cap on concurrent retain-related requests (drain op polls, deepen pools). Default 10. */
   maxParallelRetains?: number;
+  projectScope?: ProjectScope;
 }
 
 export interface RetainOpts {
@@ -120,6 +122,7 @@ export class HindsightClient {
   private idempotentRetain: boolean | undefined;
   private readonly log: (msg: string) => void;
   readonly maxParallelRetains: number;
+  private readonly projectScope?: ProjectScope;
 
   constructor(o: ClientOpts) {
     this.apiUrl = o.apiUrl.replace(/\/$/, "");
@@ -127,6 +130,7 @@ export class HindsightClient {
     this.bank = o.bank;
     this.log = o.log ?? (() => {});
     this.maxParallelRetains = o.maxParallelRetains || DEFAULT_MAX_PARALLEL_RETAINS;
+    this.projectScope = o.projectScope;
   }
 
   private headers(): Record<string, string> {
@@ -364,7 +368,7 @@ export class HindsightClient {
   /** Reflect: synthesized, root-cause answer over the bank. Bounded so a slow server never hangs a caller. */
   async reflect(
     query: string,
-    opts: { budget?: string; timeoutMs?: number } = {}
+    opts: { budget?: string; timeoutMs?: number; unscoped?: boolean } = {}
   ): Promise<string> {
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), opts.timeoutMs ?? 120000);
@@ -372,7 +376,13 @@ export class HindsightClient {
       const resp = await fetch(this.bankUrl("/reflect"), {
         method: "POST",
         headers: this.headers(),
-        body: JSON.stringify({ query, budget: opts.budget ?? "high" }),
+        body: JSON.stringify({
+          query,
+          budget: opts.budget ?? "high",
+          ...(!opts.unscoped && this.projectScope
+            ? { tag_groups: scopeTagGroups(this.projectScope) }
+            : {}),
+        }),
         signal: ctrl.signal,
       });
       if (!resp.ok) throw new Error(`reflect ${resp.status}`);

--- a/hindsight-integrations/coding-agents/src/core/hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/hook.ts
@@ -30,6 +30,7 @@ import { brandWord } from "./brand";
 import { buildReflectQuery, buildSystemInjection } from "./inject";
 import type { PageRef } from "./knowledge-injection";
 import { buildRosterRefresh, parsePageList } from "./knowledge-injection";
+import { resolveProjectScope } from "./project-scope";
 import {
   readSessionCache,
   sessionCacheFile,
@@ -240,6 +241,7 @@ export async function runHook(
     apiToken: cfg.apiToken,
     bank: bankId,
     maxParallelRetains: cfg.maxParallelRetains,
+    projectScope: resolveProjectScope(cfg, cwd, spec.harness, bankId),
   });
   const cacheFile = sessionCacheFile(spec.harness, sessionId || "no-session");
 

--- a/hindsight-integrations/coding-agents/src/core/knowledge-tools.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/knowledge-tools.test.ts
@@ -195,6 +195,21 @@ describe("buildKnowledgeTools", () => {
     expect(JSON.parse(result.content[0].text)).toBe("the decided rule is X=3");
   });
 
+  it("adds an explicit unscoped reflect tool only in project tag-scope mode", async () => {
+    const client = stubClient({ reflect: vi.fn(async () => "cross-project answer") });
+    expect(buildKnowledgeTools(client, "repo-a").map((tool) => tool.name)).not.toContain(
+      "hindsight_reflect_all_projects"
+    );
+    const tools = buildKnowledgeTools(client, "repo-a", {
+      projectScope: { projectTag: "project:a", globalTags: [] },
+    });
+    await findTool(tools, "hindsight_reflect_all_projects").handler({ query: "compare A and B" });
+    expect(client.reflect).toHaveBeenCalledWith("compare A and B", {
+      budget: "high",
+      unscoped: true,
+    });
+  });
+
   it("hindsight_capture_initiative calls client.captureInitiative({title, summary, relatesToPageId}) and returns the page id", async () => {
     const client = stubClient({
       captureInitiative: vi.fn(async (_a: unknown) => ({ page_id: "initiative-retry-backoff" })),

--- a/hindsight-integrations/coding-agents/src/core/knowledge-tools.ts
+++ b/hindsight-integrations/coding-agents/src/core/knowledge-tools.ts
@@ -21,6 +21,7 @@ import type { HindsightClient } from "./hindsight";
 import { syncStatus } from "./status";
 import { loadConfig } from "./config";
 import type { RetainStamp } from "./retain-stamp";
+import type { ProjectScope } from "./project-scope";
 
 export interface ToolResult {
   // Index signature so this structurally satisfies the MCP SDK's CallToolResult (which carries
@@ -62,9 +63,14 @@ function guarded(fn: (args: any) => Promise<unknown>): (args: any) => Promise<To
 export function buildKnowledgeTools(
   client: HindsightClient,
   bankId: string,
-  opts: { repoDir?: string; harness?: string; stampFor?: () => RetainStamp } = {}
+  opts: {
+    repoDir?: string;
+    harness?: string;
+    stampFor?: () => RetainStamp;
+    projectScope?: ProjectScope;
+  } = {}
 ): ToolSpec[] {
-  return [
+  const tools: ToolSpec[] = [
     {
       name: "hindsight_sync_status",
       description:
@@ -250,4 +256,22 @@ export function buildKnowledgeTools(
       }),
     },
   ];
+  if (opts.projectScope) {
+    tools.splice(
+      tools.findIndex((tool) => tool.name === "hindsight_capture_initiative"),
+      0,
+      {
+        name: "hindsight_reflect_all_projects",
+        description:
+          "Deep memory reasoning across the entire shared bank without the current project's tag " +
+          "scope. Use only for explicit cross-project comparisons or legacy untagged memory; " +
+          "prefer hindsight_reflect for ordinary work in the current project.",
+        inputSchema: { query: z.string().describe("the cross-project question to reason about") },
+        handler: guarded(async ({ query }: { query: string }) =>
+          client.reflect(query, { budget: "high", unscoped: true })
+        ),
+      }
+    );
+  }
+  return tools;
 }

--- a/hindsight-integrations/coding-agents/src/core/project-scope.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/project-scope.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { resolveConfig } from "./config";
+import { buildScopedRetainStamp, resolveProjectScope, scopeTagGroups } from "./project-scope";
+
+describe("project tag scope", () => {
+  it("is disabled by default", () => {
+    expect(resolveProjectScope(resolveConfig({}), "/tmp/p", "codex", "default")).toBeUndefined();
+  });
+
+  it("resolves strict project and optional global tag groups", () => {
+    const scope = resolveProjectScope(
+      resolveConfig({ projectScope: "tags", globalTags: ["scope:global"] }),
+      "/tmp/potcodev",
+      "codex",
+      "default"
+    );
+    expect(scope).toEqual({ projectTag: "project:potcodev", globalTags: ["scope:global"] });
+    expect(scopeTagGroups(scope!)).toEqual([
+      {
+        or: [
+          { tags: ["project:potcodev"], match: "any_strict" },
+          { tags: ["scope:global"], match: "any_strict" },
+        ],
+      },
+    ]);
+  });
+
+  it("adds and deduplicates the project tag only while tag scope is active", () => {
+    const ctx = { directory: "/tmp/potcodev", harness: "codex", bankId: "default" };
+    expect(
+      buildScopedRetainStamp(
+        resolveConfig({ projectScope: "tags", retainTags: ["project:{gitProject}", "env:work"] }),
+        ctx
+      ).tags
+    ).toEqual(["project:potcodev", "env:work"]);
+    expect(buildScopedRetainStamp(resolveConfig({ projectScope: "bank" }), ctx).tags).toEqual([]);
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/project-scope.ts
+++ b/hindsight-integrations/coding-agents/src/core/project-scope.ts
@@ -1,0 +1,35 @@
+import type { Config } from "./config";
+import { buildRetainStamp, type RetainStamp, type RetainStampContext } from "./retain-stamp";
+
+export interface ProjectScope {
+  projectTag: string;
+  globalTags: string[];
+}
+
+export function resolveProjectScope(
+  cfg: Config,
+  cwd: string,
+  harness: string,
+  bankId: string
+): ProjectScope | undefined {
+  if (cfg.projectScope !== "tags") return undefined;
+  const projectTag = buildRetainStamp(
+    { retainTags: [cfg.projectTagTemplate] },
+    { directory: cwd, harness, bankId }
+  ).tags[0];
+  return projectTag ? { projectTag, globalTags: cfg.globalTags } : undefined;
+}
+
+export function scopeTagGroups(scope: ProjectScope): unknown[] {
+  const leaves = [scope.projectTag, ...scope.globalTags].map((tag) => ({
+    tags: [tag],
+    match: "any_strict",
+  }));
+  return leaves.length === 1 ? leaves : [{ or: leaves }];
+}
+
+export function buildScopedRetainStamp(cfg: Config, ctx: RetainStampContext): RetainStamp {
+  const stamp = buildRetainStamp(cfg, ctx);
+  const scope = resolveProjectScope(cfg, ctx.directory, ctx.harness, ctx.bankId);
+  return scope ? { ...stamp, tags: [...new Set([...stamp.tags, scope.projectTag])] } : stamp;
+}

--- a/hindsight-integrations/coding-agents/src/core/retain-hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.ts
@@ -21,7 +21,8 @@ import { log, setLogLevel } from "./log";
 import type { ClientOpts } from "./hindsight";
 import { HindsightClient } from "./hindsight";
 import type { RetainCursorStore } from "./retain-cursor";
-import { buildRetainStamp, type RetainStamp } from "./retain-stamp";
+import type { RetainStamp } from "./retain-stamp";
+import { buildScopedRetainStamp } from "./project-scope";
 import { fileCursorStore } from "./session-cache";
 import { readClaudeTranscript } from "./transcript";
 import type { TransportTurn } from "./chat";
@@ -142,7 +143,7 @@ export async function runRetainHook(
     transcriptPath,
     client,
     readTranscript: spec.readTranscript,
-    stamp: buildRetainStamp(cfg, {
+    stamp: buildScopedRetainStamp(cfg, {
       directory: cwd,
       harness: spec.harness,
       bankId,

--- a/hindsight-integrations/coding-agents/src/core/runtime.ts
+++ b/hindsight-integrations/coding-agents/src/core/runtime.ts
@@ -20,7 +20,7 @@ import type { HindsightClient } from "./hindsight";
 import { buildKnowledgeTools, type ToolSpec } from "./knowledge-tools";
 import { retainLiveSession, type TransportTurn } from "./chat";
 import { memoryCursorStore } from "./retain-cursor";
-import { buildRetainStamp } from "./retain-stamp";
+import { buildScopedRetainStamp, resolveProjectScope } from "./project-scope";
 import { buildSessionStartContext } from "./session-start";
 import { buildHookOutput } from "./hook";
 import { sessionCacheFile, writeSessionCache } from "./session-cache";
@@ -76,8 +76,9 @@ export class RuntimeCore {
     return buildKnowledgeTools(this.client, this.bankId, {
       repoDir: this.projectDir,
       harness: this.harness,
+      projectScope: resolveProjectScope(this.cfg, this.projectDir, this.harness, this.bankId),
       stampFor: () =>
-        buildRetainStamp(this.cfg, {
+        buildScopedRetainStamp(this.cfg, {
           directory: this.projectDir,
           harness: this.harness,
           bankId: this.bankId,
@@ -254,7 +255,7 @@ export class RuntimeCore {
     const t0 = Date.now();
     void retainLiveSession(this.client, sessionId, turns, startTs, this.harness, {
       cursors: this.cursors,
-      stamp: buildRetainStamp(this.cfg, {
+      stamp: buildScopedRetainStamp(this.cfg, {
         directory: this.projectDir,
         harness: this.harness,
         bankId: this.bankId,

--- a/hindsight-integrations/coding-agents/src/core/session-start.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.ts
@@ -33,7 +33,7 @@ import { diag } from "./diag";
 import { setLogLevel } from "./log";
 import { parsePageList, buildKnowledgePreamble, type PageRef } from "./knowledge-injection";
 import type { ClientOpts, RetainOpts } from "./hindsight";
-import { buildRetainStamp } from "./retain-stamp";
+import { buildScopedRetainStamp, resolveProjectScope } from "./project-scope";
 import { HindsightClient } from "./hindsight";
 import { sessionCacheFile, writeSessionCache } from "./session-cache";
 
@@ -157,7 +157,7 @@ export async function buildSessionStartContext(args: {
   const startSurvey = args.startSurvey ?? startCodebaseSurvey;
   const resolveHeadSha = args.headSha ?? gitHeadSha;
   const countCommitsSince = args.commitsSince ?? commitsSince;
-  const retainStamp = () => buildRetainStamp(cfg, { directory: cwd, harness, bankId });
+  const retainStamp = () => buildScopedRetainStamp(cfg, { directory: cwd, harness, bankId });
 
   // Codebase-survey baseline (Option A): the bank is the only state, so the HEAD at the last survey
   // is recorded IN the bank as a tiny `survey-baseline:<sha>` marker doc (tag source:survey-baseline;
@@ -358,6 +358,7 @@ export async function runSessionStartHook(
       apiToken: cfg.apiToken,
       bank: bankId,
       maxParallelRetains: cfg.maxParallelRetains,
+      projectScope: resolveProjectScope(cfg, cwd, harness, bankId),
     });
 
     const out = await buildSessionStartContext({ cwd, bankId, cfg, client, harness });

--- a/hindsight-integrations/coding-agents/src/deepen.ts
+++ b/hindsight-integrations/coding-agents/src/deepen.ts
@@ -33,7 +33,7 @@ import { DEEPEN_DIFF_TARGET } from "./core/status";
 import { pool } from "./core/util";
 import { getHarness, HARNESS_NAMES } from "./harness/registry";
 import { diag } from "./core/diag";
-import { buildRetainStamp } from "./core/retain-stamp";
+import { buildScopedRetainStamp, resolveProjectScope } from "./core/project-scope";
 import { log as plog, setLogLevel } from "./core/log";
 
 const DIFF_BATCH = 50; // per-run cap on per-commit diff ingestion (bounded session cost)
@@ -134,10 +134,11 @@ async function main() {
       bank: FINAL_BANK!,
       maxParallelRetains: cfg.maxParallelRetains,
       log,
+      projectScope: resolveProjectScope(cfg, REPO!, HARNESS, FINAL_BANK!),
     });
     log(`deepen -> ${client.apiUrl} bank=${FINAL_BANK} harness=${harness.name}`);
     const stampFor = (sessionId?: string) =>
-      buildRetainStamp(cfg, {
+      buildScopedRetainStamp(cfg, {
         directory: REPO!,
         harness: HARNESS,
         bankId: FINAL_BANK!,

--- a/hindsight-integrations/coding-agents/src/harness/plugin-entry.ts
+++ b/hindsight-integrations/coding-agents/src/harness/plugin-entry.ts
@@ -15,6 +15,7 @@ import { deriveBankId } from "../core/bank";
 import { applyBankConfig, loadConfig } from "../core/config";
 import { log } from "../core/log";
 import { HindsightClient } from "../core/hindsight";
+import { resolveProjectScope } from "../core/project-scope";
 import { RuntimeCore } from "../core/runtime";
 import { readOpencodeMessages, type OcMessage } from "../core/transcript-opencode";
 import { opencodeAdapter } from "./opencode";
@@ -57,6 +58,7 @@ export function createPluginEntry(harness: string): Plugin {
       apiToken: cfg.apiToken,
       bank: bankId,
       maxParallelRetains: cfg.maxParallelRetains,
+      projectScope: resolveProjectScope(cfg, projectDir || process.cwd(), harness, bankId),
     });
     const core = new RuntimeCore(client, bankId, cfg, harness, projectDir || process.cwd());
     // Visible presence via the host's own notice API (POST /tui/show-toast) — never stderr, which

--- a/hindsight-integrations/coding-agents/src/mcp-server.ts
+++ b/hindsight-integrations/coding-agents/src/mcp-server.ts
@@ -15,7 +15,7 @@ import { applyBankConfig, loadConfig, type Config } from "./core/config";
 import { deriveBankId } from "./core/bank";
 import { HindsightClient } from "./core/hindsight";
 import { buildKnowledgeTools, type ToolSpec } from "./core/knowledge-tools";
-import { buildRetainStamp } from "./core/retain-stamp";
+import { buildScopedRetainStamp, resolveProjectScope } from "./core/project-scope";
 
 /**
  * Which tools this server should expose for a given config. Pure + SDK-free so the
@@ -36,7 +36,8 @@ export function selectTools(
     : buildKnowledgeTools(client, bankId, {
         repoDir: cwd,
         harness,
-        stampFor: () => buildRetainStamp(cfg, { directory: cwd, harness, bankId }),
+        projectScope: resolveProjectScope(cfg, cwd, harness, bankId),
+        stampFor: () => buildScopedRetainStamp(cfg, { directory: cwd, harness, bankId }),
       });
 }
 
@@ -52,6 +53,7 @@ async function main() {
     apiToken: cfg.apiToken,
     bank: bankId,
     maxParallelRetains: cfg.maxParallelRetains,
+    projectScope: resolveProjectScope(cfg, cwd, harness, bankId),
   });
 
   const server = new McpServer({ name: "hindsight", version: "0.1.0" });

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -336,6 +336,9 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `resolveWorktrees`      | `true`                               | `{gitProject}`: linked worktrees share the main repo's bank                                                                                                                                                                         |
 | `retainTags`            | —                                    | extra tags on every document written by the integration, e.g. `["project:{gitProject}"]` — see **Recording where a memory came from** below                                                                                         |
 | `retainMetadata`        | —                                    | extra metadata on every document written by the integration, e.g. `{"repo": "{gitProject}"}`                                                                                                                                        |
+| `projectScope`          | `"bank"`                             | `"bank"` keeps existing behavior; `"tags"` scopes ordinary reflect within a shared bank                                                                                                                                             |
+| `projectTagTemplate`    | `"project:{gitProject}"`             | project tag automatically retained and used for scoped reflect                                                                                                                                                                      |
+| `globalTags`            | —                                    | shared tags included alongside the current project during scoped reflect                                                                                                                                                            |
 | `disabled`              | `false`                              | hard off-switch (inert plugin/hook — a no-memory baseline)                                                                                                                                                                          |
 | `reflectTimeoutMs`      | `120000`                             | session-reflect timeout (hook harnesses additionally cap it at 25s to fit the host's hook window); on timeout the session runs without reflect (recorded)                                                                           |
 | `pageRefreshEveryTurns` | `10`                                 | refetch the knowledge pages and re-inject the page roster + tool guide every N user turns                                                                                                                                           |
@@ -442,6 +445,29 @@ of. Both accept the same placeholders as `bankIdTemplate` — `{gitProject}`, `{
 
 The plugin's own `source:` and `harness:` tags are reserved: entries in those namespaces are ignored
 with a warning, so a document's agent attribution always reflects the agent that actually wrote it.
+
+### Project-scoped reflect inside one shared bank
+
+Per-repository banks remain the default. To keep one static bank while making ordinary reflect
+project-specific, opt into strict tag scope:
+
+```jsonc
+{
+  "bankId": "shared",
+  "projectScope": "tags",
+  "projectTagTemplate": "project:{gitProject}",
+  "globalTags": ["scope:global"]
+}
+```
+
+This automatically stamps the project tag on every document written by the integration. Automatic
+reflect and `hindsight_reflect` then search only the current project's tag plus any `globalTags`.
+Untagged and unrelated-project memories are excluded. For an intentional cross-project comparison,
+or while migrating legacy untagged documents, use `hindsight_reflect_all_projects` to query the full
+bank explicitly.
+
+Knowledge Pages remain bank-wide in this mode. Their search endpoint does not currently accept tag
+filters, so project scoping is not presented as covering page search, listing, or page generation.
 
 ## Diagnostics & logging
 


### PR DESCRIPTION
Adds an opt-in tag-scoped mode for installations that deliberately keep multiple projects in one Hindsight bank.

This complements the new `optInOnly` / per-project routing support rather than replacing it:

- `optInOnly` controls which projects may use memory at all.
- Separate dynamic banks remain the default and provide strong isolation.
- This PR supports the different deployment shape where related opted-in projects intentionally share one established bank, while ordinary retrieval should stay project-local.

It builds on #3418, which supplies consistent ingestion attribution across coding-agent write paths.

## Configuration

```json
{
  "bankId": "team::shared",
  "projectScope": "tags",
  "projectTagTemplate": "project:{gitProject}",
  "globalTags": ["scope:global"]
}