### PR TITLE
fix(reranker): batch FlashRank passages instead of one unbounded forward pass (#3355)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -297,6 +297,10 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_RERANKER_LOCAL_ALLOW_MPS=false
 # For TEI provider:
 # HINDSIGHT_API_RERANKER_TEI_URL=http://localhost:8081
+# For flashrank provider: passages scored per ONNX forward pass. Each pass
+# allocates attention tensors sized batch * heads * seq^2, so raising this
+# raises peak memory quadratically in passage length:
+# HINDSIGHT_API_RERANKER_FLASHRANK_BATCH_SIZE=32
 # Max candidates the cross-encoder reranks per recall (RRF pre-filters the rest):
 # HINDSIGHT_API_RERANKER_MAX_CANDIDATES=300
 # Optionally scale that cap by the recall budget level (the cross-encoder dominates

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -505,6 +505,7 @@ ENV_SEMANTIC_LINK_MIN_SIMILARITY = "HINDSIGHT_API_SEMANTIC_LINK_MIN_SIMILARITY"
 ENV_RERANKER_FLASHRANK_MODEL = "HINDSIGHT_API_RERANKER_FLASHRANK_MODEL"
 ENV_RERANKER_FLASHRANK_CACHE_DIR = "HINDSIGHT_API_RERANKER_FLASHRANK_CACHE_DIR"
 ENV_RERANKER_FLASHRANK_CPU_MEM_ARENA = "HINDSIGHT_API_RERANKER_FLASHRANK_CPU_MEM_ARENA"
+ENV_RERANKER_FLASHRANK_BATCH_SIZE = "HINDSIGHT_API_RERANKER_FLASHRANK_BATCH_SIZE"
 
 # ZeroEntropy configuration (reranker only)
 ENV_RERANKER_ZEROENTROPY_API_KEY = "HINDSIGHT_API_RERANKER_ZEROENTROPY_API_KEY"
@@ -1073,6 +1074,11 @@ def _parse_strategy_boosts(raw: str | None) -> dict[str, str]:
 DEFAULT_RERANKER_FLASHRANK_MODEL = "ms-marco-MiniLM-L-12-v2"  # Best balance of speed and quality
 DEFAULT_RERANKER_FLASHRANK_CACHE_DIR = None  # Use default cache directory
 DEFAULT_RERANKER_FLASHRANK_CPU_MEM_ARENA = False  # Disable ONNX CPU memory arena to bound RSS
+# Passages per FlashRank forward pass. A single pass allocates attention tensors
+# sized batch * heads * seq^2, so an unbatched rerank of a full candidate pool
+# costs gigabytes and can OOM the container (issue #3355). Matches the local
+# reranker's default batch size.
+DEFAULT_RERANKER_FLASHRANK_BATCH_SIZE = 32
 
 DEFAULT_EMBEDDINGS_COHERE_MODEL = "embed-english-v3.0"
 DEFAULT_RERANKER_COHERE_MODEL = "rerank-english-v3.0"
@@ -1880,6 +1886,7 @@ class RerankerMemberConfig:
     flashrank_model: str
     flashrank_cache_dir: str | None
     flashrank_cpu_mem_arena: bool
+    flashrank_batch_size: int
     # litellm (proxy)
     litellm_api_base: str
     litellm_api_key: str | None
@@ -2016,6 +2023,7 @@ def _parse_reranker_members() -> list[RerankerMemberConfig]:
                 flashrank_cpu_mem_arena=_member_bool(
                     base, "FLASHRANK_CPU_MEM_ARENA", DEFAULT_RERANKER_FLASHRANK_CPU_MEM_ARENA
                 ),
+                flashrank_batch_size=_member_int(base, "FLASHRANK_BATCH_SIZE", DEFAULT_RERANKER_FLASHRANK_BATCH_SIZE),
                 litellm_api_base=_member_str(base, "LITELLM_API_BASE", DEFAULT_LITELLM_API_BASE),
                 litellm_api_key=_member_opt_str(base, "LITELLM_API_KEY"),
                 litellm_model=_member_str(base, "LITELLM_MODEL", DEFAULT_RERANKER_LITELLM_MODEL),
@@ -2787,6 +2795,11 @@ class HindsightConfig:
                 ENV_RERANKER_FLASHRANK_CPU_MEM_ARENA, str(DEFAULT_RERANKER_FLASHRANK_CPU_MEM_ARENA)
             ).lower()
             in ("true", "1", "yes"),
+            # Tolerate a set-but-empty value the way _member_int does — an unset
+            # `VAR=` in a compose/env file must fall back, not fail config load.
+            flashrank_batch_size=int(
+                os.environ.get(ENV_RERANKER_FLASHRANK_BATCH_SIZE, "").strip() or DEFAULT_RERANKER_FLASHRANK_BATCH_SIZE
+            ),
             litellm_api_base=self.reranker_litellm_api_base,
             litellm_api_key=self.reranker_litellm_api_key,
             litellm_model=self.reranker_litellm_model,

--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -19,6 +19,7 @@ from ..config import (
     DEFAULT_LITELLM_API_BASE,
     DEFAULT_RERANKER_ALIBABA_MODEL,
     DEFAULT_RERANKER_COHERE_MODEL,
+    DEFAULT_RERANKER_FLASHRANK_BATCH_SIZE,
     DEFAULT_RERANKER_FLASHRANK_CACHE_DIR,
     DEFAULT_RERANKER_FLASHRANK_MODEL,
     DEFAULT_RERANKER_GOOGLE_MODEL,
@@ -872,6 +873,7 @@ class FlashRankCrossEncoder(CrossEncoderModel):
         max_length: int = 512,
         max_concurrent: int = 4,
         cpu_mem_arena: bool = False,
+        batch_size: int = DEFAULT_RERANKER_FLASHRANK_BATCH_SIZE,
     ):
         """
         Initialize FlashRank cross-encoder.
@@ -885,11 +887,16 @@ class FlashRankCrossEncoder(CrossEncoderModel):
                           When True, ONNX pre-allocates a memory arena that never
                           shrinks, causing RSS to grow monotonically. False trades
                           slightly slower per-call allocation for bounded RSS.
+            batch_size: Passages per forward pass. Default: 32. See
+                        ``_predict_sync`` for why this must stay bounded.
         """
         self.model_name = model_name or DEFAULT_RERANKER_FLASHRANK_MODEL
         self.cache_dir = cache_dir or DEFAULT_RERANKER_FLASHRANK_CACHE_DIR
         self.max_length = max_length
         self.cpu_mem_arena = cpu_mem_arena
+        # A non-positive size would mean "one pass for everything", which is the
+        # unbounded behaviour this batching exists to prevent.
+        self.batch_size = max(1, batch_size)
         self._ranker = None
         self._device_type: str = "cpu"  # FlashRank runs on CPU via ONNX Runtime
         FlashRankCrossEncoder._max_concurrent = max_concurrent
@@ -962,7 +969,21 @@ class FlashRankCrossEncoder(CrossEncoderModel):
             logger.info("Reranker: FlashRank provider initialized (using existing executor)")
 
     def _predict_sync(self, pairs: list[tuple[str, str]]) -> list[float]:
-        """Synchronous predict - processes each query group."""
+        """Synchronous predict — each query group, in bounded batches.
+
+        FlashRank scores every passage of a request in one ONNX forward pass, and
+        that pass allocates attention tensors sized ``batch * heads * seq^2``. At
+        the default reranker candidate cap that is gigabytes per call, which OOM-
+        killed containers on large banks (issue #3355): the burst scales with the
+        candidate pool the retrieval arms produce, not with how much work the
+        caller asked for. FlashRank also pads a request to its longest passage, so
+        one long candidate inflates the sequence length for every other one.
+
+        Splitting into ``batch_size`` chunks bounds the peak the same way the
+        local and TEI providers already do. Scores are identical either way —
+        passages are scored independently, so batching changes only the
+        allocation profile.
+        """
         if not pairs:
             return []
 
@@ -979,20 +1000,25 @@ class FlashRankCrossEncoder(CrossEncoderModel):
             all_scores = [0.0] * len(pairs)
 
             for query, indexed_texts in query_groups.items():
-                # Build passages list for FlashRank
-                passages = [{"id": i, "text": text} for i, (_, text) in enumerate(indexed_texts)]
                 global_indices = [idx for idx, _ in indexed_texts]
 
-                # Create rerank request
-                request = RerankRequest(query=query, passages=passages)
-                results = self._ranker.rerank(request)
+                for start in range(0, len(indexed_texts), self.batch_size):
+                    batch = indexed_texts[start : start + self.batch_size]
 
-                # Map scores back to original positions
-                for result in results:
-                    local_idx = result["id"]
-                    score = result["score"]
-                    global_idx = global_indices[local_idx]
-                    all_scores[global_idx] = score
+                    # Build passages list for FlashRank. Ids are batch-local, so
+                    # `start` shifts them back onto the query group's indices.
+                    passages = [{"id": i, "text": text} for i, (_, text) in enumerate(batch)]
+
+                    # Create rerank request
+                    request = RerankRequest(query=query, passages=passages)
+                    results = self._ranker.rerank(request)
+
+                    # Map scores back to original positions
+                    for result in results:
+                        local_idx = result["id"]
+                        score = result["score"]
+                        global_idx = global_indices[start + local_idx]
+                        all_scores[global_idx] = score
 
             return all_scores
         finally:
@@ -1750,6 +1776,7 @@ def create_cross_encoder(member: RerankerMemberConfig) -> CrossEncoderModel:
             model_name=member.flashrank_model,
             cache_dir=member.flashrank_cache_dir,
             cpu_mem_arena=member.flashrank_cpu_mem_arena,
+            batch_size=member.flashrank_batch_size,
         )
     elif provider == "litellm":
         return LiteLLMCrossEncoder(

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -12,6 +12,7 @@ import asyncio
 import io
 import json
 import logging
+import os
 import time
 from collections import Counter
 from collections.abc import Awaitable, Callable, Iterable
@@ -29,6 +30,23 @@ from .stage import StageHolder, bind_holder
 # operation="retain" series the synchronous API path emits. Unknown types
 # pass through unchanged.
 _RETAIN_OP_TYPES = {"retain", "batch_retain", "file_convert_retain"}
+
+
+def _current_rss_bytes() -> int | None:
+    """Current resident set size in bytes, or None if the platform doesn't expose it cheaply.
+
+    Reads ``/proc/self/statm`` (Linux only), whose second field is the resident
+    page count. This is a two-integer parse of a tiny pseudo-file, so it is safe
+    to call on every stats tick. macOS has no equivalent without pulling in a
+    dependency, so callers fall back to reporting the peak alone.
+    """
+    try:
+        with open("/proc/self/statm") as f:
+            resident_pages = int(f.read().split()[1])
+    except (OSError, IndexError, ValueError):
+        return None
+    return resident_pages * os.sysconf("SC_PAGE_SIZE")
+
 
 # How long shutdown waits for cancelled tasks to unwind before it reconciles
 # their operations. Short: the tasks have already been cancelled and the process
@@ -1684,19 +1702,34 @@ class WorkerPoller:
             logger.debug(f"Failed to log progress stats: {e}")
 
     def _format_proc_stats(self) -> str:
-        """Render lightweight process memory stats. Returns 'unavailable' if introspection fails."""
+        """Render lightweight process memory stats. Returns 'unavailable' if introspection fails.
+
+        ``rss_mb`` is the process's *current* resident set. ``peak_rss_mb`` is the
+        high-water mark since start, which only ever climbs.
+
+        Keeping them apart matters: this line used to report ``ru_maxrss`` — the
+        peak — under the bare name ``rss_mb``, so a transient allocation left the
+        field pinned at its peak for the life of the process and every later
+        reading looked like retained memory that had never been freed. That
+        misread a reranker burst as a leak while diagnosing issue #3355.
+        """
         try:
             import resource
-
-            # ru_maxrss is bytes on macOS, kilobytes on Linux. Detect by checking platform.
             import sys
 
             usage = resource.getrusage(resource.RUSAGE_SELF)
-            rss = usage.ru_maxrss
+            peak = usage.ru_maxrss
+            # ru_maxrss is bytes on macOS, kilobytes on Linux.
             if sys.platform != "darwin":
-                rss *= 1024  # Linux reports KB
-            rss_mb = rss / (1024 * 1024)
-            return f"rss_mb={rss_mb:.0f}"
+                peak *= 1024
+            peak_mb = peak / (1024 * 1024)
+
+            current = _current_rss_bytes()
+            if current is None:
+                # No cheap current-RSS source (non-Linux). Report only what we
+                # actually have rather than passing the peak off as current.
+                return f"peak_rss_mb={peak_mb:.0f}"
+            return f"rss_mb={current / (1024 * 1024):.0f} peak_rss_mb={peak_mb:.0f}"
         except Exception as e:
             logger.debug(f"Process stats unavailable: {e}")
             return "unavailable"

--- a/hindsight-api-slim/tests/test_local_cross_encoder.py
+++ b/hindsight-api-slim/tests/test_local_cross_encoder.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hindsight_api.config import DEFAULT_RERANKER_FLASHRANK_BATCH_SIZE
 from hindsight_api.engine import cross_encoder as ce_module
 from hindsight_api.engine.cross_encoder import (
     FlashRankCrossEncoder,
@@ -128,8 +129,8 @@ class TestLocalSTCrossEncoder:
 class TestFlashRankCrossEncoder:
     """Unit tests for the FlashRank ONNX reranker."""
 
-    def _make_encoder(self):
-        encoder = FlashRankCrossEncoder(model_name="ms-marco-MiniLM-L-12-v2")
+    def _make_encoder(self, *, batch_size: int = DEFAULT_RERANKER_FLASHRANK_BATCH_SIZE):
+        encoder = FlashRankCrossEncoder(model_name="ms-marco-MiniLM-L-12-v2", batch_size=batch_size)
         # Bypass initialize() — no model load, no executor needed (we call
         # _predict_sync directly).
         encoder._ranker = MagicMock()
@@ -229,3 +230,82 @@ class TestFlashRankCrossEncoder:
             encoder._predict_sync([])
 
         assert cleanup_calls == []
+
+    def test_predict_sync_splits_into_batches(self):
+        """A candidate pool larger than batch_size must never reach FlashRank as a
+        single request: one forward pass allocates attention tensors sized
+        batch * heads * seq^2, which OOM-killed containers on large banks (#3355).
+        """
+        encoder = self._make_encoder(batch_size=32)
+
+        batch_sizes = []
+
+        def fake_rerank(request):
+            batch_sizes.append(len(request.passages))
+            return [{"id": i, "score": 0.5} for i in range(len(request.passages))]
+
+        encoder._ranker.rerank.side_effect = fake_rerank
+
+        fake_flashrank = MagicMock()
+        fake_flashrank.RerankRequest = lambda query, passages: MagicMock(query=query, passages=passages)
+
+        pairs = [("q", f"doc-{i}") for i in range(300)]
+        with patch.dict("sys.modules", {"flashrank": fake_flashrank}):
+            scores = encoder._predict_sync(pairs)
+
+        assert len(scores) == 300
+        # ceil(300 / 32) == 10 passes, none exceeding the batch size.
+        assert batch_sizes == [32] * 9 + [12]
+
+    def test_predict_sync_batching_preserves_pair_positions(self):
+        """Batch-local FlashRank ids must be shifted back onto the caller's
+        positions, or scores land on the wrong candidates past the first batch."""
+        encoder = self._make_encoder(batch_size=2)
+
+        def fake_rerank(request):
+            # Score by passage text so a misplaced score is detectable, and return
+            # them out of order the way FlashRank does (score-descending).
+            scored = [{"id": i, "score": float(p["text"])} for i, p in enumerate(request.passages)]
+            return sorted(scored, key=lambda r: r["score"], reverse=True)
+
+        encoder._ranker.rerank.side_effect = fake_rerank
+
+        fake_flashrank = MagicMock()
+        fake_flashrank.RerankRequest = lambda query, passages: MagicMock(query=query, passages=passages)
+
+        pairs = [("q", str(i)) for i in range(5)]
+        with patch.dict("sys.modules", {"flashrank": fake_flashrank}):
+            scores = encoder._predict_sync(pairs)
+
+        assert scores == [0.0, 1.0, 2.0, 3.0, 4.0]
+
+    def test_predict_sync_batches_each_query_group_independently(self):
+        """Grouping by query and batching within a group compose: two queries of
+        three passages at batch_size=2 give two passes each, not three overall."""
+        encoder = self._make_encoder(batch_size=2)
+
+        seen = []
+
+        def fake_rerank(request):
+            seen.append((request.query, len(request.passages)))
+            return [{"id": i, "score": 0.5} for i in range(len(request.passages))]
+
+        encoder._ranker.rerank.side_effect = fake_rerank
+
+        fake_flashrank = MagicMock()
+        fake_flashrank.RerankRequest = lambda query, passages: MagicMock(query=query, passages=passages)
+
+        pairs = [("q1", "a"), ("q2", "d"), ("q1", "b"), ("q2", "e"), ("q1", "c"), ("q2", "f")]
+        with patch.dict("sys.modules", {"flashrank": fake_flashrank}):
+            scores = encoder._predict_sync(pairs)
+
+        assert scores == [0.5] * 6
+        assert seen == [("q1", 2), ("q1", 1), ("q2", 2), ("q2", 1)]
+
+    @pytest.mark.parametrize("configured", [0, -1])
+    def test_non_positive_batch_size_clamps_to_one(self, configured):
+        """A misconfigured 0/-1 must not silently restore the unbounded single pass."""
+        assert FlashRankCrossEncoder(batch_size=configured).batch_size == 1
+
+    def test_default_batch_size_matches_config(self):
+        assert FlashRankCrossEncoder().batch_size == DEFAULT_RERANKER_FLASHRANK_BATCH_SIZE

--- a/hindsight-api-slim/tests/test_worker_proc_stats.py
+++ b/hindsight-api-slim/tests/test_worker_proc_stats.py
@@ -1,0 +1,84 @@
+"""Tests for the worker's process-memory stats line.
+
+The distinction these pin down is not cosmetic. ``[WORKER_STATS] ... rss_mb=``
+used to report ``ru_maxrss``, the high-water mark, which never decreases — so a
+single transient allocation pinned the field at its peak for the life of the
+process and every later reading looked like memory that was still held. That is
+exactly how a transient reranker burst was misread as retained heap while
+diagnosing issue #3355.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+from hindsight_api.worker.poller import WorkerPoller, _current_rss_bytes
+
+# _format_proc_stats never touches self, so it can be called unbound against a
+# stand-in rather than building a DB-backed poller.
+_format_proc_stats = WorkerPoller._format_proc_stats
+
+
+def _fake_rusage(peak_native: int) -> MagicMock:
+    """getrusage() result whose ru_maxrss is in the running platform's own units."""
+    return MagicMock(ru_maxrss=peak_native)
+
+
+def _native_peak_units(peak_bytes: int) -> int:
+    """Express a byte count the way ru_maxrss would on this platform."""
+    return peak_bytes if sys.platform == "darwin" else peak_bytes // 1024
+
+
+class TestCurrentRssBytes:
+    def test_returns_positive_size_or_none(self):
+        rss = _current_rss_bytes()
+        if sys.platform == "linux":
+            assert rss is not None and rss > 0
+        else:
+            # No cheap /proc equivalent elsewhere; None is the contract.
+            assert rss is None or rss > 0
+
+    def test_returns_none_when_proc_is_unreadable(self):
+        with patch("builtins.open", side_effect=OSError("no /proc")):
+            assert _current_rss_bytes() is None
+
+    def test_returns_none_on_unparseable_statm(self):
+        handle = MagicMock()
+        handle.read.return_value = "garbage"
+        handle.__enter__ = lambda s: handle
+        handle.__exit__ = lambda *a: False
+        with patch("builtins.open", return_value=handle):
+            assert _current_rss_bytes() is None
+
+
+class TestFormatProcStats:
+    def test_reports_current_and_peak_separately(self):
+        with patch("resource.getrusage", return_value=_fake_rusage(_native_peak_units(8 * 1024**3))):
+            with patch("hindsight_api.worker.poller._current_rss_bytes", return_value=1024**3):
+                out = _format_proc_stats(object())
+
+        assert out == "rss_mb=1024 peak_rss_mb=8192"
+
+    def test_current_rss_is_not_the_peak(self):
+        """The regression itself: a process that burst to 10GB and released it
+        must report ~1GB current, not 10GB."""
+        with patch("resource.getrusage", return_value=_fake_rusage(_native_peak_units(10 * 1024**3))):
+            with patch("hindsight_api.worker.poller._current_rss_bytes", return_value=1024**3):
+                out = _format_proc_stats(object())
+
+        assert "rss_mb=1024 " in out
+        assert "peak_rss_mb=10240" in out
+
+    def test_omits_current_when_platform_cannot_supply_it(self):
+        """Without a current reading we report the peak under its own name rather
+        than passing it off as ``rss_mb``."""
+        with patch("resource.getrusage", return_value=_fake_rusage(_native_peak_units(2 * 1024**3))):
+            with patch("hindsight_api.worker.poller._current_rss_bytes", return_value=None):
+                out = _format_proc_stats(object())
+
+        assert out == "peak_rss_mb=2048"
+        # No bare `rss_mb=` field — only the peak, under its own name.
+        assert "rss_mb=" not in out.replace("peak_rss_mb=", "")
+
+    def test_unavailable_when_introspection_fails(self):
+        with patch("resource.getrusage", side_effect=RuntimeError("no rusage")):
+            assert _format_proc_stats(object()) == "unavailable"

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -955,6 +955,7 @@ ZeroEntropy's `zembed-1` supports Matryoshka dimensions: `2560`, `1280`, `640`, 
 | `HINDSIGHT_API_RERANKER_FLASHRANK_MODEL` | FlashRank model for fast CPU-based reranking | `ms-marco-MiniLM-L-12-v2` |
 | `HINDSIGHT_API_RERANKER_FLASHRANK_CACHE_DIR` | Cache directory for FlashRank models | System default |
 | `HINDSIGHT_API_RERANKER_FLASHRANK_CPU_MEM_ARENA` | Enable ONNX Runtime CPU memory arena for FlashRank. When `true`, ONNX pre-allocates a memory arena that never shrinks, causing RSS to grow monotonically. `false` trades slightly slower per-call allocation for bounded RSS. | `false` |
+| `HINDSIGHT_API_RERANKER_FLASHRANK_BATCH_SIZE` | Passages scored per FlashRank forward pass. Each pass allocates attention tensors sized `batch × heads × seq²`, and FlashRank pads a batch to its longest passage, so raising this raises peak memory sharply on long candidates. Lower it if the reranker is the memory ceiling on a large bank. | `32` |
 | `HINDSIGHT_API_RERANKER_JINA_MLX_MODEL_PATH` | Local path to downloaded `jina-reranker-v3-mlx` model (auto-downloads from HuggingFace if unset) | - |
 
 #### Reranker failover chain

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -297,6 +297,10 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_RERANKER_LOCAL_ALLOW_MPS=false
 # For TEI provider:
 # HINDSIGHT_API_RERANKER_TEI_URL=http://localhost:8081
+# For flashrank provider: passages scored per ONNX forward pass. Each pass
+# allocates attention tensors sized batch * heads * seq^2, so raising this
+# raises peak memory quadratically in passage length:
+# HINDSIGHT_API_RERANKER_FLASHRANK_BATCH_SIZE=32
 # Max candidates the cross-encoder reranks per recall (RRF pre-filters the rest):
 # HINDSIGHT_API_RERANKER_MAX_CANDIDATES=300
 # Optionally scale that cap by the recall budget level (the cross-encoder dominates

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -955,6 +955,7 @@ ZeroEntropy's `zembed-1` supports Matryoshka dimensions: `2560`, `1280`, `640`, 
 | `HINDSIGHT_API_RERANKER_FLASHRANK_MODEL` | FlashRank model for fast CPU-based reranking | `ms-marco-MiniLM-L-12-v2` |
 | `HINDSIGHT_API_RERANKER_FLASHRANK_CACHE_DIR` | Cache directory for FlashRank models | System default |
 | `HINDSIGHT_API_RERANKER_FLASHRANK_CPU_MEM_ARENA` | Enable ONNX Runtime CPU memory arena for FlashRank. When `true`, ONNX pre-allocates a memory arena that never shrinks, causing RSS to grow monotonically. `false` trades slightly slower per-call allocation for bounded RSS. | `false` |
+| `HINDSIGHT_API_RERANKER_FLASHRANK_BATCH_SIZE` | Passages scored per FlashRank forward pass. Each pass allocates attention tensors sized `batch × heads × seq²`, and FlashRank pads a batch to its longest passage, so raising this raises peak memory sharply on long candidates. Lower it if the reranker is the memory ceiling on a large bank. | `32` |
 | `HINDSIGHT_API_RERANKER_JINA_MLX_MODEL_PATH` | Local path to downloaded `jina-reranker-v3-mlx` model (auto-downloads from HuggingFace if unset) | - |
 
 #### Reranker failover chain


### PR DESCRIPTION
Closes #3355.

## The bug

FlashRank scores every passage of a request in **one** ONNX forward pass, and `_predict_sync` handed it the entire candidate pool as a single request:

```python
passages = [{"id": i, "text": text} for i, (_, text) in enumerate(indexed_texts)]
request = RerankRequest(query=query, passages=passages)
```

That pass allocates attention tensors sized `batch × heads × seq²`. For `ms-marco-MiniLM-L-12-v2` at the default `RERANKER_MAX_CANDIDATES=300` and `max_length=512`, a *single* layer's attention-score tensor is ~3.8GB, and softmax holds another of the same shape. The provider also runs on a thread pool with `max_concurrent=4`, so several can overlap.

The two sibling providers already batch — `local` at 32, `tei` at 128. FlashRank was the only path left unbounded, and had no batch-size setting at all.

Two prior changes had worked around the symptom without bounding the batch: `cpu_mem_arena=False` (comment: *"keeping RSS bounded after rerank batches"*) and a `release_local_inference_memory()` in the `finally`.

## Why it presented as a mental-model-refresh bug

The reporter filed this as refresh OOMing the container, but the burst is in `recall_async`, which refresh, consolidation and batch_retain all share. It scales with the **candidate pool the retrieval arms return** — a function of bank size — not with how much work the caller asked for. A consolidation with `total_unconsolidated=1` still issues a recall that fills the pool and pays the full allocation. That is why it looked disproportionate to the workload.

Confirmed on the reporter's 40K-node / 815K-link bank by capping candidates, one variable changed:

| | 300 (default) | 32 |
|---|---|---|
| peak | 10.65 GiB | **2.11 GiB** |
| burst over baseline | ~9.5 GB | **~1.1 GB** |
| container kills | 1 | **0** |
| the recall that killed it | ~60.8 s | **10.0 s** |

The latency side is worth noting on its own: the unbatched pass was a ~6× tax on recall.

## The fix

Split each query group into `batch_size` chunks. Scores are unchanged — passages are scored independently, so batching alters only the allocation profile, not the ranking.

New `HINDSIGHT_API_RERANKER_FLASHRANK_BATCH_SIZE`, default **32** to match the local provider, also settable per failover-chain member (`HINDSIGHT_API_RERANKER_{n}_FLASHRANK_BATCH_SIZE`). Non-positive values clamp to 1 so a misconfiguration can't silently restore the single unbounded pass.

Anyone currently working around this with a lowered `RERANKER_MAX_CANDIDATES` can put it back after upgrading — that cap was cutting recall quality to bound memory, which is no longer the tradeoff.

## Second commit: `WORKER_STATS rss_mb` was the peak, not current RSS

Separate defect, found because it actively misled this investigation. `_format_proc_stats` reported `ru_maxrss` — the high-water mark since process start, which never decreases — under the bare name `rss_mb`. One transient allocation pinned the field at its peak for the life of the process, so every later reading looked like retained memory.

Concretely: a `rss_mb=10506` line with an idle connection pool was read as 10.5GB of live heap, when the process was actually sitting at ~1.08GB and the 10.5GB was a burst that had already been freed. That sent us hunting a leak that didn't exist.

`rss_mb` now reports current RSS from `/proc/self/statm`, with the high-water mark alongside as `peak_rss_mb`. Platforms without `/proc` report `peak_rss_mb` alone rather than passing the peak off as current. The Prometheus gauge in `metrics.py` is untouched — it already labels the same value `rss_max`, which is accurate.

## Tests

`tests/test_local_cross_encoder.py`:
- 300 pairs at `batch_size=32` issue 10 passes of `[32]*9 + [12]` — fails on `main`, which issues one pass of 300
- batch-local FlashRank ids are shifted back onto caller positions (scores land on the wrong candidates past the first batch without it)
- grouping-by-query and batching compose
- non-positive batch size clamps to 1; default matches config

`tests/test_worker_proc_stats.py`:
- current and peak are reported as separate fields
- the regression itself: a process that burst to 10GB and released it reports ~1GB current, 10GB peak
- no bare `rss_mb=` when the platform can't supply a current reading
- `_current_rss_bytes` returns None on unreadable/unparseable `/proc`

## Not in this PR

Three further items surfaced in #3355, none of them this bug:

- `retrieve_all_fact_types_parallel` does `from .temporal_extraction import ...` inside the hot path — a module import on the event loop, once per boot (the one EVENT LOOP BLOCKED trace in the reporter's logs)
- `CONSOLIDATION_RECONCILE_INTERVAL_SECONDS=0` gates *enqueueing*, not execution — the worker poller still claims already-pending work, so the knob doesn't isolate what its name implies. `RETAIN_BATCH_POLL_INTERVAL_SECONDS=0` disables nothing and hot-spins the batch-API poll loop
- refresh operations are re-claimed on every boot, so an OOM mid-refresh becomes a self-sustaining crash loop that needs manual SQL to break

Filing these separately.
