### PR TITLE
Dedupe graph maintenance submits against running jobs, not just pending ones

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
@@ -246,73 +246,98 @@ async def run_graph_maintenance_job(
     result.stale_cooccurrences_pruned = prune.stale_cooccurrences_pruned
     result.queues_drained = relink.queue_exhausted and prune.queue_exhausted
 
-    # Close the hand-off gap. Submit-time dedup treats a *running* job as
-    # covering this bank (see _submit_async_operation's
-    # dedupe_by_bank_includes_processing), which is what stops one job being
-    # queued per triggering operation. The cost is a narrow window: anything
-    # enqueued after Pass 1's final claim — including during the sweeps above,
-    # which are not instant — was deduped against this job and would otherwise
-    # sit in graph_maintenance_queue until some unrelated future operation
-    # happened to trigger another submit. For the last write of an ingest batch
-    # that may be never.
-    #
-    # So re-check before finishing and hand off to a fresh job if anything
-    # landed.
-    #
-    # Gated on this run having drained something. A run that processed nothing
-    # and still sees a non-empty queue has not made progress, and a successor
-    # would repeat that exact outcome — an endless self-resubmitting chain for
-    # the bank. Requiring progress means the chain can only continue while it
-    # is actually consuming the queue, so it terminates. (The normal case
-    # always qualifies: submit_async_graph_maintenance short-circuits on an
-    # empty queue, so a job only starts when there is work to drain.)
-    made_progress = result.relink_units_processed > 0
-    try:
-        backend_check = await memory_engine._get_backend()
-        async with acquire_with_retry(backend_check) as conn:
-            leftover = await conn.fetchval(
-                f"SELECT 1 FROM {fq_table('graph_maintenance_queue')} WHERE bank_id = $1 LIMIT 1",
-                bank_id,
-            )
-        if leftover and not made_progress:
-            logger.warning(
-                f"[GRAPH_MAINT] bank={bank_id} queue still non-empty after a run that drained "
-                f"nothing; not chaining a successor (it would repeat this outcome)"
-            )
-        elif leftover:
-            logger.info(f"[GRAPH_MAINT] bank={bank_id} work arrived during the run; submitting a follow-up job")
-            await memory_engine.submit_async_graph_maintenance(
-                bank_id=bank_id,
-                request_context=request_context,
-                dedupe_excludes_operation_id=operation_id,
-            )
-    except Exception:
-        # Never fail a completed maintenance run over the hand-off. The work is
-        # still queued, and the next triggering operation will pick it up; log
-        # loudly so a persistent failure here is visible rather than silent.
-        logger.exception(f"[GRAPH_MAINT] bank={bank_id} follow-up submit failed")
-
     elapsed = time.time() - job_start
+
+    # --- Hand-off: schedule a successor for any work this run leaves behind ---
+    #
+    # Submit-time dedup now treats a *running* graph-maintenance job as covering
+    # the bank (see _submit_async_operation's dedupe_by_bank_includes_processing).
+    # That is what stops one job being queued per triggering operation, but it
+    # means a submit made while this job runs is suppressed. So this job has to
+    # hand off to a successor for any work it leaves behind, or that work strands
+    # until some unrelated future trigger. Both hand-offs below pass
+    # dedupe_excludes_operation_id: the worker only marks the operation completed
+    # after this body returns, so the row is still 'processing' now and the
+    # widened predicate would otherwise dedup the hand-off against its own row and
+    # silently do nothing.
+    from .memory_engine import acquire_with_retry
+    from .task_backend import SyncTaskBackend
+
     if not result.queues_drained:
-        # Not a failure: every batch committed, so the remaining queue rows are
-        # simply the next run's work. Logged at WARNING because a bank that keeps
-        # landing here is producing maintenance faster than one run absorbs it,
-        # which is worth seeing before it becomes a backlog.
+        # Backlog case: the time budget stopped a drain with work still queued, so
+        # more is provably left. Chain a follow-up so the backlog converges
+        # without waiting for the next delete to trigger a run — on a bank that
+        # has gone quiet that may be never. WARNING because a bank that keeps
+        # landing here is producing maintenance faster than one run absorbs it.
         logger.warning(
             f"[GRAPH_MAINT] bank={bank_id} hit the {_JOB_TIME_BUDGET_SECONDS:.0f}s budget with work still "
             f"queued; committed {result.as_dict()} in {elapsed:.2f}s"
         )
-        # Chain a follow-up so the backlog converges without waiting for the next
-        # delete to trigger a run. Only under a real queue: a synchronous task
-        # backend (tests, embedded) runs submitted tasks inline, so this would
-        # recurse one stack frame per budget window instead of scheduling. There
-        # the caller is already the loop — it gets the remaining rows on its next
-        # call. No force_sweep: the submit's pre-check inspects both queues, so
-        # this only lands an operation while work is genuinely left.
-        from .task_backend import SyncTaskBackend
-
+        # A synchronous task backend (tests, embedded) runs the successor inline,
+        # which would recurse one job per budget window instead of scheduling.
+        # There the caller is already the drain loop and gets the remaining rows
+        # on its next call, so skip the hand-off.
         if not isinstance(memory_engine._task_backend, SyncTaskBackend):
-            await memory_engine.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
+            try:
+                await memory_engine.submit_async_graph_maintenance(
+                    bank_id=bank_id,
+                    request_context=request_context,
+                    dedupe_excludes_operation_id=operation_id,
+                )
+            except Exception:
+                # Never fail a completed maintenance run over the hand-off. The
+                # work is still queued and the next trigger picks it up; log
+                # loudly so a persistent failure here is visible, not silent.
+                logger.exception(f"[GRAPH_MAINT] bank={bank_id} follow-up submit failed")
+    else:
+        # Gap case: both queues drained within budget, but new rows can have
+        # landed in the gap between a pass's final claim and this job being marked
+        # completed. Their submits were deduped against this still-'processing'
+        # job, so nothing is scheduled to pick them up. Re-check both queues —
+        # reusing the portable existence check submit uses for its empty-queue
+        # short-circuit (no Postgres-only LIMIT, and covers the relink and
+        # entity-prune queues) — and hand off anything that landed.
+        #
+        # Gated on this run having made progress. A run that consumed nothing and
+        # still sees queued work would hand off to a successor that repeats the
+        # exact outcome — an endless per-bank chain. Requiring progress means the
+        # chain only continues while it is actually draining, so it terminates.
+        # (The backlog branch above is not gated this way: its contract is to
+        # always continue a budgeted backlog so a quiet bank is never stranded.)
+        #
+        # Not guarded against SyncTaskBackend, unlike the backlog branch: this
+        # branch cannot fire on one. A synchronous backend is single-threaded, so
+        # nothing enqueues concurrently and the queues are empty once the passes
+        # (which never enqueue for themselves) return — leaving no gap to close.
+        made_progress = result.relink_units_processed > 0 or result.entities_examined > 0
+        try:
+            backend_check = await memory_engine._get_backend()
+            async with acquire_with_retry(backend_check) as conn:
+                work_remains = bool(
+                    await conn.fetchval(
+                        f"""
+                        SELECT 1 WHERE
+                            EXISTS (SELECT 1 FROM {fq_table("graph_maintenance_queue")} WHERE bank_id = $1)
+                            OR EXISTS (SELECT 1 FROM {fq_table("entity_maintenance_queue")} WHERE bank_id = $1)
+                        """,
+                        bank_id,
+                    )
+                )
+            if work_remains and not made_progress:
+                logger.warning(
+                    f"[GRAPH_MAINT] bank={bank_id} queue still non-empty after a run that drained "
+                    f"nothing; not chaining a successor (it would repeat this outcome)"
+                )
+            elif work_remains:
+                logger.info(f"[GRAPH_MAINT] bank={bank_id} work arrived during the run; submitting a follow-up job")
+                await memory_engine.submit_async_graph_maintenance(
+                    bank_id=bank_id,
+                    request_context=request_context,
+                    dedupe_excludes_operation_id=operation_id,
+                )
+        except Exception:
+            # As above: the queued work survives, so log rather than fail the run.
+            logger.exception(f"[GRAPH_MAINT] bank={bank_id} follow-up submit failed")
 
     logger.info(
         f"[GRAPH_MAINT] bank={bank_id} done: {result.as_dict()}, elapsed={elapsed:.2f}s, operation_id={operation_id}"

--- a/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
@@ -246,6 +246,48 @@ async def run_graph_maintenance_job(
     result.stale_cooccurrences_pruned = prune.stale_cooccurrences_pruned
     result.queues_drained = relink.queue_exhausted and prune.queue_exhausted
 
+    # Close the hand-off gap. Submit-time dedup treats a *running* job as
+    # covering this bank (see _submit_async_operation's
+    # dedupe_by_bank_includes_processing), which is what stops one job being
+    # queued per triggering operation. The cost is a narrow window: anything
+    # enqueued after Pass 1's final claim — including during the sweeps above,
+    # which are not instant — was deduped against this job and would otherwise
+    # sit in graph_maintenance_queue until some unrelated future operation
+    # happened to trigger another submit. For the last write of an ingest batch
+    # that may be never.
+    #
+    # So re-check before finishing and hand off to a fresh job if anything
+    # landed.
+    #
+    # Gated on this run having drained something. A run that processed nothing
+    # and still sees a non-empty queue has not made progress, and a successor
+    # would repeat that exact outcome — an endless self-resubmitting chain for
+    # the bank. Requiring progress means the chain can only continue while it
+    # is actually consuming the queue, so it terminates. (The normal case
+    # always qualifies: submit_async_graph_maintenance short-circuits on an
+    # empty queue, so a job only starts when there is work to drain.)
+    made_progress = result.relink_units_processed > 0
+    try:
+        backend_check = await memory_engine._get_backend()
+        async with acquire_with_retry(backend_check) as conn:
+            leftover = await conn.fetchval(
+                f"SELECT 1 FROM {fq_table('graph_maintenance_queue')} WHERE bank_id = $1 LIMIT 1",
+                bank_id,
+            )
+        if leftover and not made_progress:
+            logger.warning(
+                f"[GRAPH_MAINT] bank={bank_id} queue still non-empty after a run that drained "
+                f"nothing; not chaining a successor (it would repeat this outcome)"
+            )
+        elif leftover:
+            logger.info(f"[GRAPH_MAINT] bank={bank_id} work arrived during the run; submitting a follow-up job")
+            await memory_engine.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
+    except Exception:
+        # Never fail a completed maintenance run over the hand-off. The work is
+        # still queued, and the next triggering operation will pick it up; log
+        # loudly so a persistent failure here is visible rather than silent.
+        logger.exception(f"[GRAPH_MAINT] bank={bank_id} follow-up submit failed")
+
     elapsed = time.time() - job_start
     if not result.queues_drained:
         # Not a failure: every batch committed, so the remaining queue rows are

--- a/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
@@ -281,7 +281,11 @@ async def run_graph_maintenance_job(
             )
         elif leftover:
             logger.info(f"[GRAPH_MAINT] bank={bank_id} work arrived during the run; submitting a follow-up job")
-            await memory_engine.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
+            await memory_engine.submit_async_graph_maintenance(
+                bank_id=bank_id,
+                request_context=request_context,
+                dedupe_excludes_operation_id=operation_id,
+            )
     except Exception:
         # Never fail a completed maintenance run over the hand-off. The work is
         # still queued, and the next triggering operation will pick it up; log

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -15893,7 +15893,9 @@ class MemoryEngine(MemoryEngineInterface):
             task_type: Task type for the task payload (e.g., 'consolidation', 'batch_retain')
             task_payload: Additional task payload fields (operation_id and bank_id are added automatically)
             result_metadata: Optional metadata to store with the operation record
-            dedupe_by_bank: If True, skip creating a new task if one is already pending for this bank+operation_type
+            dedupe_by_bank: If True, skip creating a new task if one is already queued for this
+                bank+operation_type. Which statuses count as "queued" depends on
+                dedupe_by_bank_includes_processing below.
             dedupe_by_bank_includes_processing: Widen dedupe_by_bank to also match a
                 *processing* job. Only correct for operations whose job drains its
                 own backlog to empty before finishing (see submit_async_graph_maintenance);
@@ -15983,7 +15985,7 @@ class MemoryEngine(MemoryEngineInterface):
                     )
                     pending = await conn.fetch(
                         f"""
-                        SELECT operation_id, task_payload FROM {fq_table("async_operations")}
+                        SELECT operation_id, task_payload, status FROM {fq_table("async_operations")}
                         WHERE bank_id = $1 AND operation_type = $2 AND {status_filter}
                         """,
                         bank_id,
@@ -16024,7 +16026,7 @@ class MemoryEngine(MemoryEngineInterface):
                                         row["operation_id"],
                                     )
                             logger.debug(
-                                f"{operation_type} task already pending for bank_id={bank_id}, "
+                                f"{operation_type} task already {row['status']} for bank_id={bank_id}, "
                                 f"skipping duplicate (existing operation_id={row['operation_id']})"
                             )
                             return {
@@ -16596,8 +16598,9 @@ class MemoryEngine(MemoryEngineInterface):
         (``graph_maintenance_queue`` and ``entity_maintenance_queue``) are empty
         for this bank, so unconditional callers (e.g. every retain that may or
         may not have triggered a document upsert) don't generate empty worker
-        tasks. Deduplicates by bank when an existing pending job is already
-        scheduled.
+        tasks. Deduplicates by bank against a job that is already pending *or*
+        already running — graph maintenance drains its own queue to empty, so a
+        job that is mid-flight still covers work queued after it started.
 
         Args:
             force_sweep: Skip the empty-queue short-circuit and submit anyway.

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -15882,6 +15882,7 @@ class MemoryEngine(MemoryEngineInterface):
         *,
         result_metadata: dict[str, Any] | None = None,
         dedupe_by_bank: bool = False,
+        dedupe_by_bank_includes_processing: bool = False,
         dedupe_in_flight_payload_key: str | None = None,
     ) -> dict[str, Any]:
         """Generic helper to submit an async operation.
@@ -15893,6 +15894,11 @@ class MemoryEngine(MemoryEngineInterface):
             task_payload: Additional task payload fields (operation_id and bank_id are added automatically)
             result_metadata: Optional metadata to store with the operation record
             dedupe_by_bank: If True, skip creating a new task if one is already pending for this bank+operation_type
+            dedupe_by_bank_includes_processing: Widen dedupe_by_bank to also match a
+                *processing* job. Only correct for operations whose job drains its
+                own backlog to empty before finishing (see submit_async_graph_maintenance);
+                for watermark-based jobs like consolidation it would drop work that
+                arrived after the running job took its watermark.
             dedupe_in_flight_payload_key: If set, skip creating a new task when a pending or processing
                 operation of this type exists whose task_payload carries the same value for this key
                 (e.g. 'mental_model_id'). Narrower than dedupe_by_bank, which dedupes per bank.
@@ -15957,13 +15963,28 @@ class MemoryEngine(MemoryEngineInterface):
                     raise OperationValidationError(f"Bank '{bank_id}' not found", status_code=404)
 
                 if dedupe_by_bank:
-                    # Only check 'pending', not 'processing': a processing task uses a
-                    # watermark from when it started, so memories added after that need
-                    # a fresh run regardless.
+                    # Which statuses count as "already covered".
+                    #
+                    # 'pending' only, by default: a *processing* watermark-based task
+                    # (consolidation) fixed its watermark when it started, so memories
+                    # added after that need a fresh run regardless.
+                    #
+                    # Callers whose job drains its own backlog to empty before
+                    # finishing opt into 'processing' as well. Without it, dedup is
+                    # ineffective under load: the single pending row gets claimed
+                    # within milliseconds, the next submit sees no pending row and
+                    # inserts another, and the cycle repeats once per triggering
+                    # operation — producing hundreds of concurrent jobs for one bank
+                    # rather than the one the job body assumes is running.
+                    status_filter = (
+                        "status IN ('pending', 'processing')"
+                        if dedupe_by_bank_includes_processing
+                        else "status = 'pending'"
+                    )
                     pending = await conn.fetch(
                         f"""
                         SELECT operation_id, task_payload FROM {fq_table("async_operations")}
-                        WHERE bank_id = $1 AND operation_type = $2 AND status = 'pending'
+                        WHERE bank_id = $1 AND operation_type = $2 AND {status_filter}
                         """,
                         bank_id,
                         operation_type,
@@ -16629,6 +16650,12 @@ class MemoryEngine(MemoryEngineInterface):
             task_type="graph_maintenance",
             task_payload=task_payload,
             dedupe_by_bank=True,
+            # Safe here (unlike consolidation): run_graph_maintenance_job loops
+            # until graph_maintenance_queue is empty for the bank, so a running
+            # job already covers rows enqueued while it runs. The job re-submits
+            # itself if anything lands in the gap between its final claim and
+            # completion.
+            dedupe_by_bank_includes_processing=True,
         )
 
     async def submit_async_refresh_mental_model(

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -15883,6 +15883,7 @@ class MemoryEngine(MemoryEngineInterface):
         result_metadata: dict[str, Any] | None = None,
         dedupe_by_bank: bool = False,
         dedupe_by_bank_includes_processing: bool = False,
+        dedupe_excludes_operation_id: str | None = None,
         dedupe_in_flight_payload_key: str | None = None,
     ) -> dict[str, Any]:
         """Generic helper to submit an async operation.
@@ -15998,6 +15999,17 @@ class MemoryEngine(MemoryEngineInterface):
                     # JSON_VALUE returns NULL for the array-valued observation_scopes.
                     # (Scoped submits never reach here: they pass dedupe_by_bank=False.)
                     for row in pending:
+                        # A job that submits its own successor must not match itself.
+                        # The submitting operation is still 'processing' while its body
+                        # runs (the worker only marks it completed afterwards), so with
+                        # dedupe_by_bank_includes_processing the hand-off would dedupe
+                        # against its own row and silently do nothing. Compared in
+                        # Python rather than SQL because the operation_id cast is not
+                        # portable across the Postgres and Oracle backends.
+                        if dedupe_excludes_operation_id is not None and str(row["operation_id"]) == str(
+                            dedupe_excludes_operation_id
+                        ):
+                            continue
                         row_payload = row["task_payload"]
                         row_dict = json.loads(row_payload) if isinstance(row_payload, str) else (row_payload or {})
                         if row_dict.get("observation_scopes") is None:
@@ -16590,6 +16602,7 @@ class MemoryEngine(MemoryEngineInterface):
         bank_id: str,
         *,
         request_context: "RequestContext",
+        dedupe_excludes_operation_id: str | None = None,
         force_sweep: bool = False,
     ) -> dict[str, Any]:
         """Submit a graph-maintenance job to drain the bank's maintenance queues.
@@ -16659,6 +16672,9 @@ class MemoryEngine(MemoryEngineInterface):
             # itself if anything lands in the gap between its final claim and
             # completion.
             dedupe_by_bank_includes_processing=True,
+            # Set by the job's own hand-off so it does not match its own
+            # still-'processing' row and suppress its successor.
+            dedupe_excludes_operation_id=dedupe_excludes_operation_id,
         )
 
     async def submit_async_refresh_mental_model(

--- a/hindsight-api-slim/tests/test_graph_maintenance.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance.py
@@ -1119,7 +1119,9 @@ class TestTimeBudget:
 
         submitted: list[str] = []
 
-        async def _record_submit(*, bank_id: str, request_context, force_sweep: bool = False):
+        async def _record_submit(
+            *, bank_id: str, request_context, dedupe_excludes_operation_id=None, force_sweep: bool = False
+        ):
             submitted.append(bank_id)
             return {"operation_id": None, "no_work": True}
 

--- a/hindsight-api-slim/tests/test_graph_maintenance_submit_dedup.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance_submit_dedup.py
@@ -24,15 +24,17 @@ import uuid
 
 import pytest
 
+from hindsight_api.engine.memories.base import RelinkPassResult
 from hindsight_api.engine.memory_engine import MemoryEngine
 
 pytestmark = pytest.mark.xdist_group("graph_maintenance_submit_dedup_tests")
 
 
 async def _progress_relink():
-    """Pretend Pass 1 drained rows; the row left in the queue then stands in for
-    work enqueued after the final claim."""
-    return {"relink_units_processed": 3, "relink_links_added": 0}
+    """Pretend Pass 1 drained rows (queue reported exhausted) while a row is left
+    in the queue, standing in for work enqueued after the final claim — the gap
+    the hand-off exists to close."""
+    return RelinkPassResult(units_processed=3, links_added=0, queue_exhausted=True)
 
 
 @pytest.fixture
@@ -249,7 +251,7 @@ async def test_job_does_not_chain_forever_when_it_drains_nothing(memory, request
     await _queue_one(memory, bank_id)
 
     async def _no_progress():
-        return {"relink_units_processed": 0, "relink_links_added": 0}
+        return RelinkPassResult(units_processed=0, links_added=0, queue_exhausted=True)
 
     monkeypatch.setattr(get_memories(), "relink_pass", lambda **_kwargs: _no_progress())
 
@@ -354,7 +356,7 @@ async def test_handoff_survives_the_real_worker_path(memory, request_context, mo
     assert st == "processing"
 
     async def _progress():
-        return {"relink_units_processed": 3, "relink_links_added": 0}
+        return RelinkPassResult(units_processed=3, links_added=0, queue_exhausted=True)
 
     monkeypatch.setattr(get_memories(), "relink_pass", lambda **_k: _progress())
 

--- a/hindsight-api-slim/tests/test_graph_maintenance_submit_dedup.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance_submit_dedup.py
@@ -1,0 +1,266 @@
+"""Submit-time dedup for graph maintenance must also treat a *running* job as
+covering the bank.
+
+`run_graph_maintenance_job` states that it relies on submit-time dedup to keep
+at most one job per bank running, and skips SKIP LOCKED on that basis. That was
+not true: dedup matched only `status = 'pending'`, and a pending row is claimed
+within milliseconds under load. Each subsequent trigger therefore found no
+pending row and inserted another job, so a bank taking sustained writes
+accumulated one maintenance job per write — hundreds of concurrent jobs
+against a single bank, all doing the same bank-wide sweeps.
+
+Consolidation must keep the old behaviour: its job fixes a watermark when it
+starts, so content added afterwards genuinely needs a fresh run. Graph
+maintenance drains its own queue to empty instead, which is what makes matching
+`processing` safe there and not there.
+
+These run against the real Postgres test DB — the dedup is a SQL predicate over
+`async_operations`, so a mock would prove nothing about it.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from hindsight_api.engine.memory_engine import MemoryEngine
+
+pytestmark = pytest.mark.xdist_group("graph_maintenance_submit_dedup_tests")
+
+
+@pytest.fixture
+def no_inline_execution(memory):
+    """Stop SyncTaskBackend running submitted ops inline, so a submitted job
+    stays in whatever status the test puts it in."""
+
+    async def _noop(_payload):
+        return None
+
+    original = memory._task_backend.submit_task
+    memory._task_backend.submit_task = _noop
+    yield
+    memory._task_backend.submit_task = original
+
+
+async def _make_bank(memory: MemoryEngine, request_context) -> str:
+    """async_operations has an FK to banks, so the row has to exist first."""
+    bank_id = f"gm-dedup-{uuid.uuid4().hex[:8]}"
+    await memory._ensure_bank_exists(bank_id, request_context)
+    return bank_id
+
+
+async def _queue_one(memory: MemoryEngine, bank_id: str) -> None:
+    """Put a row in graph_maintenance_queue so the submit short-circuit
+    ('no work → don't enqueue') doesn't fire."""
+    backend = await memory._get_backend()
+    from hindsight_api.engine.memory_engine import acquire_with_retry
+
+    async with acquire_with_retry(backend) as conn:
+        await backend.ops.enqueue_graph_maintenance(conn, "graph_maintenance_queue", bank_id, [uuid.uuid4()])
+
+
+async def _set_status(memory: MemoryEngine, operation_id: str, status: str) -> None:
+    backend = await memory._get_backend()
+    from hindsight_api.engine.memory_engine import acquire_with_retry
+
+    async with acquire_with_retry(backend) as conn:
+        await conn.execute(
+            "UPDATE async_operations SET status = $2 WHERE operation_id = $1::uuid",
+            operation_id,
+            status,
+        )
+
+
+async def _count_ops(memory: MemoryEngine, bank_id: str, operation_type: str) -> int:
+    backend = await memory._get_backend()
+    from hindsight_api.engine.memory_engine import acquire_with_retry
+
+    async with acquire_with_retry(backend) as conn:
+        return await conn.fetchval(
+            "SELECT count(*) FROM async_operations WHERE bank_id = $1 AND operation_type = $2",
+            bank_id,
+            operation_type,
+        )
+
+
+@pytest.mark.asyncio
+async def test_pending_job_dedupes_a_second_submit(memory, request_context, no_inline_execution):
+    """Pre-existing behaviour, pinned so the widened predicate doesn't lose it."""
+    bank_id = await _make_bank(memory, request_context)
+    await _queue_one(memory, bank_id)
+
+    first = await memory.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
+    second = await memory.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
+
+    assert second.get("deduplicated") is True
+    assert second["operation_id"] == first["operation_id"]
+    assert await _count_ops(memory, bank_id, "graph_maintenance") == 1
+
+
+@pytest.mark.asyncio
+async def test_processing_job_dedupes_a_new_submit(memory, request_context, no_inline_execution):
+    """The fix. A claimed (processing) job must suppress further submits.
+
+    Without this the queue grows by one job per triggering write, because the
+    pending row the previous submit created is already gone from 'pending'.
+    """
+    bank_id = await _make_bank(memory, request_context)
+    await _queue_one(memory, bank_id)
+
+    first = await memory.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
+    # A worker claims it.
+    await _set_status(memory, first["operation_id"], "processing")
+
+    second = await memory.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
+
+    assert second.get("deduplicated") is True
+    assert second["operation_id"] == first["operation_id"]
+    assert await _count_ops(memory, bank_id, "graph_maintenance") == 1
+
+
+@pytest.mark.asyncio
+async def test_sustained_triggers_do_not_stack_jobs(memory, request_context, no_inline_execution):
+    """Reproduces the production shape: repeated triggers against a bank whose
+    job is claimed immediately. One job, not one per trigger."""
+    bank_id = await _make_bank(memory, request_context)
+    await _queue_one(memory, bank_id)
+
+    first = await memory.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
+    await _set_status(memory, first["operation_id"], "processing")
+
+    for _ in range(25):
+        await _queue_one(memory, bank_id)
+        await memory.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
+
+    assert await _count_ops(memory, bank_id, "graph_maintenance") == 1
+
+
+@pytest.mark.asyncio
+async def test_completed_job_does_not_dedupe(memory, request_context, no_inline_execution):
+    """Once the job finishes, the next trigger must enqueue again — otherwise
+    work queued after it would never be drained."""
+    bank_id = await _make_bank(memory, request_context)
+    await _queue_one(memory, bank_id)
+
+    first = await memory.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
+    await _set_status(memory, first["operation_id"], "completed")
+
+    second = await memory.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
+
+    assert second.get("deduplicated") is not True
+    assert second["operation_id"] != first["operation_id"]
+    assert await _count_ops(memory, bank_id, "graph_maintenance") == 2
+
+
+@pytest.mark.asyncio
+async def test_consolidation_still_ignores_processing(memory, request_context, no_inline_execution):
+    """The widened predicate is opt-in and must not reach consolidation.
+
+    A running consolidation holds a watermark from when it started, so content
+    added afterwards needs its own run. Deduping against 'processing' here
+    would silently drop that work.
+    """
+    bank_id = await _make_bank(memory, request_context)
+
+    first = await memory.submit_async_consolidation(bank_id=bank_id, request_context=request_context)
+    await _set_status(memory, first["operation_id"], "processing")
+
+    second = await memory.submit_async_consolidation(bank_id=bank_id, request_context=request_context)
+
+    assert second.get("deduplicated") is not True
+    assert second["operation_id"] != first["operation_id"]
+    assert await _count_ops(memory, bank_id, "consolidation") == 2
+
+
+@pytest.mark.asyncio
+async def test_job_hands_off_when_work_lands_during_the_run(memory, request_context, monkeypatch):
+    """Deduping against 'processing' opens a gap: a submit made while the job
+    runs is suppressed, so whatever it queued must be picked up by the job
+    itself or it strands until some unrelated future write.
+
+    Simulated by making Pass 1 a no-op, which leaves the queue row in place
+    exactly as if it had been enqueued after the final claim.
+    """
+    from hindsight_api.engine.graph_maintenance import run_graph_maintenance_job
+    from hindsight_api.engine.memories import get_memories
+
+    bank_id = await _make_bank(memory, request_context)
+    await _queue_one(memory, bank_id)
+
+    store = get_memories()
+    monkeypatch.setattr(store, "relink_pass", lambda **_kwargs: _progress_relink())
+
+    submitted: list[str] = []
+
+    async def _record(bank_id: str, *, request_context):
+        # Record only. Delegating to the real submit would let the sync task
+        # backend run the successor inline, and the assertion would then be
+        # about the whole chain rather than this run's hand-off decision.
+        submitted.append(bank_id)
+        return {"operation_id": None, "no_work": True}
+
+    monkeypatch.setattr(memory, "submit_async_graph_maintenance", _record)
+
+    await run_graph_maintenance_job(memory_engine=memory, bank_id=bank_id, request_context=request_context)
+
+    assert submitted == [bank_id], "job must hand off the work it could not drain"
+
+
+async def _progress_relink():
+    """Pretend Pass 1 drained rows; the row left in the queue then stands in for
+    work enqueued after the final claim."""
+    return {"relink_units_processed": 3, "relink_links_added": 0}
+
+
+@pytest.mark.asyncio
+async def test_job_does_not_hand_off_when_queue_is_empty(memory, request_context, monkeypatch):
+    """The common case must not submit anything — otherwise every maintenance
+    run would enqueue its own successor forever."""
+    from hindsight_api.engine.graph_maintenance import run_graph_maintenance_job
+
+    bank_id = await _make_bank(memory, request_context)  # nothing queued
+
+    submitted: list[str] = []
+
+    async def _record(bank_id: str, *, request_context):
+        submitted.append(bank_id)
+        return {"operation_id": None, "no_work": True}
+
+    monkeypatch.setattr(memory, "submit_async_graph_maintenance", _record)
+
+    await run_graph_maintenance_job(memory_engine=memory, bank_id=bank_id, request_context=request_context)
+
+    assert submitted == [], "no queued work means no successor"
+
+
+@pytest.mark.asyncio
+async def test_job_does_not_chain_forever_when_it_drains_nothing(memory, request_context, monkeypatch):
+    """A run that drains nothing and still sees queued work must NOT hand off.
+
+    The successor would hit the same state and hand off again — an endless
+    per-bank chain. Caught by an earlier version of this test seeing two
+    submissions instead of one.
+    """
+    from hindsight_api.engine.graph_maintenance import run_graph_maintenance_job
+    from hindsight_api.engine.memories import get_memories
+
+    bank_id = await _make_bank(memory, request_context)
+    await _queue_one(memory, bank_id)
+
+    async def _no_progress():
+        return {"relink_units_processed": 0, "relink_links_added": 0}
+
+    monkeypatch.setattr(get_memories(), "relink_pass", lambda **_kwargs: _no_progress())
+
+    submitted: list[str] = []
+
+    async def _record(bank_id: str, *, request_context):
+        submitted.append(bank_id)
+        return {"operation_id": None, "no_work": True}
+
+    monkeypatch.setattr(memory, "submit_async_graph_maintenance", _record)
+
+    await run_graph_maintenance_job(memory_engine=memory, bank_id=bank_id, request_context=request_context)
+
+    assert submitted == [], "a no-progress run must not chain a successor"

--- a/hindsight-api-slim/tests/test_graph_maintenance_submit_dedup.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance_submit_dedup.py
@@ -29,6 +29,12 @@ from hindsight_api.engine.memory_engine import MemoryEngine
 pytestmark = pytest.mark.xdist_group("graph_maintenance_submit_dedup_tests")
 
 
+async def _progress_relink():
+    """Pretend Pass 1 drained rows; the row left in the queue then stands in for
+    work enqueued after the final claim."""
+    return {"relink_units_processed": 3, "relink_links_added": 0}
+
+
 @pytest.fixture
 def no_inline_execution(memory):
     """Stop SyncTaskBackend running submitted ops inline, so a submitted job
@@ -205,12 +211,6 @@ async def test_job_hands_off_when_work_lands_during_the_run(memory, request_cont
     await run_graph_maintenance_job(memory_engine=memory, bank_id=bank_id, request_context=request_context)
 
     assert submitted == [bank_id], "job must hand off the work it could not drain"
-
-
-async def _progress_relink():
-    """Pretend Pass 1 drained rows; the row left in the queue then stands in for
-    work enqueued after the final claim."""
-    return {"relink_units_processed": 3, "relink_links_added": 0}
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_graph_maintenance_submit_dedup.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance_submit_dedup.py
@@ -305,3 +305,68 @@ async def test_handoff_is_not_suppressed_by_the_jobs_own_row(memory, request_con
     assert after == before + 1, (
         f"hand-off produced no successor ({before} -> {after}); the submit matched the job's own 'processing' row"
     )
+
+
+@pytest.mark.asyncio
+async def test_handoff_survives_the_real_worker_path(memory, request_context, monkeypatch):
+    """Same guarantee as the test above, but through the worker's own machinery.
+
+    The sibling test calls run_graph_maintenance_job directly and sets
+    'processing' with a hand-written UPDATE. That leaves the integration
+    unproven: whether the real claim actually marks the row 'processing' before
+    the body runs, and whether execute_task threads operation_id down to the
+    hand-off. Both are load-bearing — if either is false the self-exclusion
+    never applies and the hand-off is silently dead again.
+
+    So this drives the real payload the task backend receives, the real
+    mark_operations_processing claim, and the real execute_task router.
+    Observed: status=processing, operations 1 -> 2 with the exclusion and
+    1 -> 1 without it.
+    """
+    from hindsight_api.engine.memories import get_memories
+    from hindsight_api.engine.memory_engine import acquire_with_retry
+
+    bank_id = f"gm-e2e-{uuid.uuid4().hex[:8]}"
+    await memory._ensure_bank_exists(bank_id, request_context)
+
+    backend = await memory._get_backend()
+    async with acquire_with_retry(backend) as c:
+        await backend.ops.enqueue_graph_maintenance(c, "graph_maintenance_queue", bank_id, [uuid.uuid4()])
+
+    # Capture the REAL task payload the backend would receive, instead of inventing one.
+    captured: list[dict] = []
+
+    async def _capture(payload):
+        captured.append(dict(payload))
+
+    memory._task_backend.submit_task = _capture
+
+    first = await memory.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
+    assert captured, "no task payload was submitted"
+    task_dict = dict(captured[0])
+
+    # Claim it exactly as a worker does — the real status transition.
+    async with acquire_with_retry(backend) as c:
+        await backend.ops.mark_operations_processing(
+            c, "async_operations", "probe-worker", [uuid.UUID(first["operation_id"])]
+        )
+        st = await c.fetchval("SELECT status FROM async_operations WHERE operation_id=$1::uuid", first["operation_id"])
+    assert st == "processing"
+
+    async def _progress():
+        return {"relink_units_processed": 3, "relink_links_added": 0}
+
+    monkeypatch.setattr(get_memories(), "relink_pass", lambda **_k: _progress())
+
+    async def _count():
+        async with acquire_with_retry(backend) as c:
+            return await c.fetchval(
+                "SELECT count(*) FROM async_operations WHERE bank_id=$1 AND operation_type='graph_maintenance'",
+                bank_id,
+            )
+
+    before = await _count()
+    await memory.execute_task(task_dict)  # <-- the real router, not the job body
+    after = await _count()
+
+    assert after == before + 1, f"hand-off produced no successor through the real worker path ({before} -> {after})"

--- a/hindsight-api-slim/tests/test_graph_maintenance_submit_dedup.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance_submit_dedup.py
@@ -199,7 +199,7 @@ async def test_job_hands_off_when_work_lands_during_the_run(memory, request_cont
 
     submitted: list[str] = []
 
-    async def _record(bank_id: str, *, request_context):
+    async def _record(bank_id: str, *, request_context, dedupe_excludes_operation_id=None):
         # Record only. Delegating to the real submit would let the sync task
         # backend run the successor inline, and the assertion would then be
         # about the whole chain rather than this run's hand-off decision.
@@ -223,7 +223,7 @@ async def test_job_does_not_hand_off_when_queue_is_empty(memory, request_context
 
     submitted: list[str] = []
 
-    async def _record(bank_id: str, *, request_context):
+    async def _record(bank_id: str, *, request_context, dedupe_excludes_operation_id=None):
         submitted.append(bank_id)
         return {"operation_id": None, "no_work": True}
 
@@ -255,7 +255,7 @@ async def test_job_does_not_chain_forever_when_it_drains_nothing(memory, request
 
     submitted: list[str] = []
 
-    async def _record(bank_id: str, *, request_context):
+    async def _record(bank_id: str, *, request_context, dedupe_excludes_operation_id=None):
         submitted.append(bank_id)
         return {"operation_id": None, "no_work": True}
 
@@ -264,3 +264,44 @@ async def test_job_does_not_chain_forever_when_it_drains_nothing(memory, request
     await run_graph_maintenance_job(memory_engine=memory, bank_id=bank_id, request_context=request_context)
 
     assert submitted == [], "a no-progress run must not chain a successor"
+
+
+@pytest.mark.asyncio
+async def test_handoff_is_not_suppressed_by_the_jobs_own_row(memory, request_context, monkeypatch, no_inline_execution):
+    """The hand-off must create a real successor operation, not dedupe against itself.
+
+    Widening dedup to match 'processing' introduced a way for the fix to defeat
+    itself: the submitting job is still 'processing' while its body runs (the
+    worker only marks it completed afterwards), so its own hand-off matched its
+    own row and was silently deduplicated away. The hand-off became dead code
+    and the gap it exists to close stayed open.
+
+    The sibling hand-off tests monkeypatch submit_async_graph_maintenance and
+    assert the *call* happens, so they cannot see this. This one drives the real
+    submit and counts operation rows.
+    """
+    from hindsight_api.engine.graph_maintenance import run_graph_maintenance_job
+    from hindsight_api.engine.memories import get_memories
+
+    bank_id = await _make_bank(memory, request_context)
+    await _queue_one(memory, bank_id)
+
+    first = await memory.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
+    await _set_status(memory, first["operation_id"], "processing")
+
+    monkeypatch.setattr(get_memories(), "relink_pass", lambda **_kwargs: _progress_relink())
+
+    before = await _count_ops(memory, bank_id, "graph_maintenance")
+    # operation_id is threaded exactly as the worker does it in
+    # _handle_graph_maintenance; without it the exclusion cannot apply.
+    await run_graph_maintenance_job(
+        memory_engine=memory,
+        bank_id=bank_id,
+        request_context=request_context,
+        operation_id=first["operation_id"],
+    )
+    after = await _count_ops(memory, bank_id, "graph_maintenance")
+
+    assert after == before + 1, (
+        f"hand-off produced no successor ({before} -> {after}); the submit matched the job's own 'processing' row"
+    )


### PR DESCRIPTION
## Problem

`run_graph_maintenance_job` documents that it relies on submit-time dedup to keep at most one job per bank in flight, and skips `SKIP LOCKED` on that basis. That guarantee didn't hold.

Dedup matched only `status = 'pending'`. Under load a pending row is claimed within milliseconds, so the next submit sees no pending row and inserts another job. Every subsequent trigger does the same. A bank taking sustained writes accumulates roughly one maintenance job per triggering write — many concurrent jobs against a single bank, each doing the same bank-wide sweeps, while the job body is written assuming it is the only one running.

## Fix

Widen the dedup predicate to `status IN ('pending', 'processing')`, behind an opt-in flag (`dedupe_by_bank_includes_processing`).

Deduping against a running job means a submit made *while* the job runs is suppressed, so whatever it queued must be picked up by that job or it strands. The job therefore hands off at the end: if the queue is non-empty when it finishes, it submits a successor. That hand-off is gated on `made_progress` — without the gate, a run that drains nothing and still sees queued work would submit a successor that repeats the outcome, an endless per-bank chain.

### The hand-off defeated itself (second commit)

The first version of this branch shipped a hand-off that never ran. The submitting job is still `processing` while its body executes — the worker marks the operation completed only after the body returns — so the hand-off matched **its own row** and was deduplicated away. It was dead code, and the gap it exists to close stayed open.

The original tests could not see this: they monkeypatch `submit_async_graph_maintenance` and assert the *call* happens, not that an operation results.

Fix: the caller can name an operation the dedup scan must ignore (`dedupe_excludes_operation_id`), and the hand-off passes the running job's own id. `run_graph_maintenance_job` already receives it from `_handle_graph_maintenance`, so nothing new is plumbed to the worker. The comparison is done in Python alongside the existing scope check, because the `operation_id` cast is not portable across the Postgres and Oracle backends.

## Why opt-in rather than global

Consolidation self-resubmits when it hits `max_memories_per_round`, and is safe today **only because** it does not match `processing` — its self-resubmit would otherwise be suppressed by its own row, the identical defect. Now that the exclusion mechanism exists, consolidation could adopt the widened predicate with the same one-line change, but that is a behaviour change to a second subsystem and belongs in its own PR.

(An earlier draft of this description justified the flag by claiming consolidation "fixes a watermark at start". That was wrong — the code explicitly picks up memories retained mid-run. The real reason is the self-resubmit above.)

## Implementation note

The status filter is a literal `IN (...)` rather than `= ANY($n)`. The array form is PostgreSQL-only and this path also targets Oracle.

## Validation

`tests/test_graph_maintenance_submit_dedup.py` — 10 tests against a real PostgreSQL instance, not mocks, since the change is a SQL predicate.

**Behaviour covered**
- a pending job still dedupes a second submit (pre-existing behaviour, pinned)
- a **processing** job dedupes a new submit (the fix)
- sustained triggers against a claimed job produce one job, not one per trigger
- a completed job does **not** dedupe, so later work still drains
- consolidation still ignores `processing` (the opt-in must not leak)
- hand-off fires when work lands mid-run; not when the queue is empty; not when the run drained nothing

**The hand-off, proven end-to-end through the real worker path**

The direct-call tests set `processing` with a hand-written `UPDATE`, which leaves the integration unproven — and the integration is where this fix lives. `test_handoff_survives_the_real_worker_path` drives the real task payload the backend receives, the real `ops.mark_operations_processing` claim, and the real `execute_task` router:

| | status after real claim | graph_maintenance operations |
|---|---|---|
| with self-exclusion | `processing` | **1 → 2** |
| without self-exclusion | `processing` | **1 → 1** |

This confirms empirically, rather than by reading the code, that the claim marks the row `processing` before the body runs and that `execute_task` threads `operation_id` down to the hand-off. Both are load-bearing: if either were false the exclusion would never apply and the hand-off would be silently dead again.

**Mutation testing** — each mutant fails the tests that should catch it, and the suite returns to green when reverted:

| mutant | result |
|---|---|
| narrow predicate back to `status = 'pending'` | kills `test_processing_job_dedupes_a_new_submit`, `test_sustained_triggers_do_not_stack_jobs` |
| remove the hand-off self-exclusion | kills both hand-off tests (`1 → 1`) |

**Wider regression** — 245 tests pass across the graph-maintenance, consolidation, operation-status/completion, async-retain and worker test files. `test_consolidation_round_limit` and `test_consolidation_reschedule_after_round` specifically exercise consolidation's self-resubmit path and are unaffected.

**Call-site audit** — both new parameters are keyword-only with `None` defaults. All six `_submit_async_operation` callers and the five non-hand-off `submit_async_graph_maintenance` callers are unchanged; the only behavioural change is the hand-off itself.

## Not verified

- **No deployment.** This has never run against real traffic in any environment.
- **Concurrency untested.** Simultaneous submits from two workers go through a `serialize` path that was read but not exercised. Since the defect being fixed is about concurrent job creation, this is the most significant remaining gap.
- **Oracle untested.** The comparison is Python-side and should be portable, but has not been executed against that backend.
