### PR TITLE
fix(coding-agents): expose automatic reflect failures

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/hook.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hook.test.ts
@@ -67,6 +67,7 @@ describe("buildHookOutput", () => {
     const cached = JSON.parse(readFileSync(cacheFile, "utf8"));
     expect(cached.turns).toBe(1);
     expect(cached.reflectAnswer).toBe("REFLECT_ANSWER");
+    expect(cached.reflectStatus).toBe("success");
   });
 
   it("reflect runs ONCE per session: cached on turn 1, not called again on turn 2", async () => {
@@ -122,7 +123,7 @@ describe("buildHookOutput", () => {
     expect(second.context).toContain("REFLECT_ANSWER");
   });
 
-  it("reflect rejection: caches '' (no retry next turn), no throw, no context at all", async () => {
+  it("reflect rejection: caches an error status, shows a notice, and does not retry", async () => {
     const cfg = resolveConfig({});
     const client = makeClient({
       reflect: vi.fn(async () => {
@@ -138,8 +139,9 @@ describe("buildHookOutput", () => {
     });
     // Reflect failed -> no reflect block; pages are never auto-injected -> nothing to inject.
     expect(t1.context).toBeUndefined();
-    expect(t1.notice).toBeUndefined();
+    expect(t1.notice).toContain("automatic memory synthesis failed");
     expect(JSON.parse(readFileSync(cacheFile, "utf8")).reflectAnswer).toBe("");
+    expect(JSON.parse(readFileSync(cacheFile, "utf8")).reflectStatus).toBe("error");
 
     await buildHookOutput({
       harness: "claude-code",
@@ -150,6 +152,42 @@ describe("buildHookOutput", () => {
     });
     // The failure is cached as "" — reflect is NOT retried on the next turn.
     expect(client.reflect).toHaveBeenCalledTimes(1);
+  });
+
+  it("reflect timeout: caches timeout status and shows a timeout notice", async () => {
+    const cfg = resolveConfig({});
+    const client = makeClient({
+      reflect: vi.fn(async () => {
+        throw new Error("This operation was aborted");
+      }),
+    });
+    const result = await buildHookOutput({
+      harness: "claude-code",
+      prompt: "the prompt",
+      cfg,
+      client,
+      cacheFile,
+    });
+    expect(result.notice).toContain("automatic memory synthesis timed out");
+    expect(JSON.parse(readFileSync(cacheFile, "utf8")).reflectStatus).toBe("timeout");
+  });
+
+  it("classifies timeout from the full error before truncating diagnostics", async () => {
+    const cfg = resolveConfig({});
+    const client = makeClient({
+      reflect: vi.fn(async () => {
+        throw new Error(`${"x".repeat(240)} timeout`);
+      }),
+    });
+    const result = await buildHookOutput({
+      harness: "claude-code",
+      prompt: "the prompt",
+      cfg,
+      client,
+      cacheFile,
+    });
+    expect(result.notice).toContain("automatic memory synthesis timed out");
+    expect(JSON.parse(readFileSync(cacheFile, "utf8")).reflectStatus).toBe("timeout");
   });
 
   it("uses a bounded low-budget reflect and caps its timeout at 25000ms", async () => {

--- a/hindsight-integrations/coding-agents/src/core/hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/hook.ts
@@ -101,13 +101,15 @@ export async function buildHookOutput(args: {
   // autoReflect false = tool-only mode: no injected synthesis; the roster's tool guide instead
   // instructs the agent to call hindsight_reflect itself when a new goal is set.
   let reflectAnswer = cached.reflectAnswer;
+  // Support caches written before reflectStatus existed.
+  let reflectStatus = cached.reflectStatus;
   let reflectRanThisTurn = false;
   const deferInitialReflect = cached.deferInitialReflect === true;
   if (deferInitialReflect) {
     // A new bank has no useful history yet. Do not burn the once-per-session synthesis on prompt
     // one; this marker is deliberately consumed below so prompt two remains eligible to reflect.
     diag(harness, "reflect_deferred_new_bank", { query: prompt.slice(0, 80) });
-  } else if (cfg.autoReflect && reflectAnswer === undefined) {
+  } else if (cfg.autoReflect && reflectAnswer === undefined && reflectStatus === undefined) {
     reflectRanThisTurn = true;
     const t0 = Date.now();
     try {
@@ -118,6 +120,7 @@ export async function buildHookOutput(args: {
         budget: "low",
         timeoutMs: Math.min(cfg.reflectTimeoutMs, HOOK_REFLECT_CAP_MS),
       });
+      reflectStatus = reflectAnswer ? "success" : "error";
       diag(harness, reflectAnswer ? "reflect_ok" : "reflect_empty", {
         ms: Date.now() - t0,
         chars: reflectAnswer.length,
@@ -127,13 +130,16 @@ export async function buildHookOutput(args: {
         answer: reflectAnswer.slice(0, 8000),
       });
     } catch (e) {
-      reflectAnswer = ""; // ran and failed — don't retry every turn; the diag trail records it
+      reflectAnswer = ""; // ran and failed — don't retry every turn; the status records why
+      const fullMessage = String((e as Error)?.message || e);
+      const message = fullMessage.slice(0, 200);
+      reflectStatus = /abort|timeout|deadline/i.test(fullMessage) ? "timeout" : "error";
       log.warn(harness, "reflect failed — session runs without memory", {
-        error: String((e as Error)?.message || e).slice(0, 200),
+        error: message,
       });
       diag(harness, "reflect_failed", {
         ms: Date.now() - t0,
-        error: String((e as Error)?.message || e).slice(0, 200),
+        error: message,
         query: prompt.slice(0, 80),
       });
     }
@@ -163,6 +169,7 @@ export async function buildHookOutput(args: {
   writeSessionCache(cacheFile, {
     turns,
     reflectAnswer,
+    reflectStatus,
     pages: { atTurn: stale ? turns : (cached.pages?.atTurn ?? turns), list: pages },
   } satisfies SessionCache);
 
@@ -193,6 +200,10 @@ export async function buildHookOutput(args: {
     notice =
       `${brandWord()} · goal: recall this repo's past decisions about “${excerpt}”\n` +
       `↳ ${preview.length > 140 ? `${preview.slice(0, 140)}…` : preview}`;
+  } else if (reflectRanThisTurn && reflectStatus) {
+    notice = `${brandWord()} · automatic memory synthesis ${
+      reflectStatus === "timeout" ? "timed out" : "failed"
+    } this turn; continuing without synthesized memory. You can call hindsight_reflect manually if needed.`;
   }
 
   return { context: kept.length ? kept.join("\n\n") : undefined, notice, pagesKnown: pages.length };

--- a/hindsight-integrations/coding-agents/src/core/session-cache.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-cache.ts
@@ -9,7 +9,9 @@ import type { RetainCursor, RetainCursorStore } from "./retain-cursor";
  * bank state. */
 export interface SessionCache {
   turns?: number;
-  reflectAnswer?: string; // present (even "") = reflect already ran this session
+  reflectAnswer?: string;
+  /** Automatic reflect outcome; any defined status means it was attempted this session. */
+  reflectStatus?: "success" | "timeout" | "error";
   /** SessionStart saw a new/empty bank; consume this on prompt one, then allow reflect. */
   deferInitialReflect?: boolean;
   pages?: { atTurn: number; list: PageRef[] };


### PR DESCRIPTION
## Summary

The coding-agents prompt hook can time out during its once-per-session automatic reflect. The current fallback caches an empty string and emits no user-visible signal, so the agent continues without synthesized memory while the user cannot distinguish that from “no relevant memory exists”.

This PR makes that fallback explicit without changing the bounded-hook design.

## Design

- Persist a separate `reflectStatus` in the session cache with `success`, `timeout`, or `error`.
- Keep `reflectAnswer` for the answer payload and retain compatibility with caches written before `reflectStatus` existed.
- Treat any recorded outcome as an attempted automatic reflect, so a failed request is still not retried on every subsequent prompt.
- Emit a notice on the turn that automatic reflect fails, distinguishing timeout from other errors and pointing the agent/user to manual `hindsight_reflect`.
- Classify timeout using the complete provider error, while limiting the logged/diagnostic error text to 200 characters.

## Scope and non-goals

The 25-second cap is unchanged because it must remain below the host hook timeout; increasing it alone could cause uncached re-fires. This PR does not add automatic retry/backoff. It also does not force a generic `thinking: disabled` request parameter, since reasoning controls are provider/model-specific and can affect quality or API compatibility. Provider-specific tuning remains available through `HINDSIGHT_API_REFLECT_LLM_EXTRA_BODY`. Retrieval/reranker performance is a separate optimization.

## Testing

- Added coverage for success, timeout, error, cache state, no-retry behavior, and long error messages.
- `npm test`: 494 tests passed.
- `npm run build`: passed.

Partially addresses #3443