### PR TITLE
fix(release): ship Rust CLI license notices

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -327,17 +327,42 @@ jobs:
       working-directory: hindsight-cli
       run: cargo build --release --target ${{ matrix.target }}
 
+    - name: Install cargo-about
+      if: matrix.asset_name == 'hindsight-linux-amd64'
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-about@0.9.1
+
+    - name: Verify cargo-about
+      if: matrix.asset_name == 'hindsight-linux-amd64'
+      run: cargo about --version
+
+    - name: Generate license manifest
+      if: matrix.asset_name == 'hindsight-linux-amd64'
+      working-directory: hindsight-cli
+      run: mkdir -p ../artifacts && cargo about generate --offline --manifest-path Cargo.toml --config about.toml about.hbs --output-file ../artifacts/THIRD_PARTY_LICENSES.txt
+
+    - name: Verify license files
+      if: matrix.asset_name == 'hindsight-linux-amd64'
+      run: |
+        test -s LICENSE
+        test -s artifacts/THIRD_PARTY_LICENSES.txt
+        grep -Fq "THIRD-PARTY SOFTWARE LICENSES" artifacts/THIRD_PARTY_LICENSES.txt
+
     - name: Prepare artifact
       run: |
         mkdir -p artifacts
         cp hindsight-cli/target/${{ matrix.target }}/release/${{ matrix.artifact_name }} artifacts/${{ matrix.asset_name }}
+        if [ "${{ matrix.asset_name }}" = "hindsight-linux-amd64" ]; then
+          cp LICENSE artifacts/LICENSE
+        fi
         chmod +x artifacts/${{ matrix.asset_name }}
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v7
       with:
         name: rust-cli-${{ matrix.asset_name }}
-        path: artifacts/${{ matrix.asset_name }}
+        path: artifacts/*
         retention-days: 1
 
   release-docker-images:
@@ -601,6 +626,11 @@ jobs:
         cp artifacts/rust-cli-linux-arm64/hindsight-linux-arm64 release-assets/ || true
         cp artifacts/rust-cli-darwin-amd64/hindsight-darwin-amd64 release-assets/ || true
         cp artifacts/rust-cli-darwin-arm64/hindsight-darwin-arm64 release-assets/ || true
+        # Rust CLI license files (shared by all four platform binaries)
+        cp artifacts/rust-cli-linux/LICENSE release-assets/
+        cp artifacts/rust-cli-linux/THIRD_PARTY_LICENSES.txt release-assets/
+        test -s release-assets/LICENSE
+        test -s release-assets/THIRD_PARTY_LICENSES.txt
         # Helm chart
         cp artifacts/helm-chart/*.tgz release-assets/ || true
         ls -la release-assets/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1421,6 +1421,21 @@ jobs:
           hindsight-cli/target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+    - name: Install cargo-about
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-about@0.9.1
+
+    - name: Verify cargo-about
+      run: cargo about --version
+
+    - name: Generate and verify license manifest
+      working-directory: hindsight-cli
+      run: |
+        cargo about generate --offline --manifest-path Cargo.toml --config about.toml about.hbs --output-file /tmp/THIRD_PARTY_LICENSES.txt
+        test -s /tmp/THIRD_PARTY_LICENSES.txt
+        grep -Fq "THIRD-PARTY SOFTWARE LICENSES" /tmp/THIRD_PARTY_LICENSES.txt
+
     - name: Run unit tests
       working-directory: hindsight-cli
       run: cargo test

--- a/hindsight-cli/about.hbs
+++ b/hindsight-cli/about.hbs
@@ -1,0 +1,16 @@
+THIRD-PARTY SOFTWARE LICENSES
+==============================
+
+This file contains the license and copyright notices for the Rust crates
+distributed in the Hindsight CLI binary. The list is generated from
+hindsight-cli/Cargo.lock with cargo-about.
+
+{{#each licenses}}
+-------------------------------------------------------------------------------
+{{{name}}}
+Used by:
+{{#each used_by}}- {{crate.name}} {{crate.version}}{{#if crate.repository}} ({{crate.repository}}){{/if}}
+{{/each}}
+
+{{{text}}}
+{{/each}}

--- a/hindsight-cli/about.toml
+++ b/hindsight-cli/about.toml
@@ -1,0 +1,11 @@
+# License IDs accepted from the Cargo.lock dependency graph.
+accepted = [
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "ISC",
+    "MIT",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]


### PR DESCRIPTION
## Summary

Issue #3446 correctly identified a release-packaging gap: the Rust CLI binaries are statically linked release artifacts, but the workflow previously published only the binaries and did not provide the project license or the dependency license and copyright notices needed for redistribution.

This PR adds a separate `LICENSE` asset for Hindsight's MIT license and a generated `THIRD_PARTY_LICENSES.txt` asset containing the locked Rust dependency graph's crate metadata, copyright notices, and complete license text.

## Design

The manifest is generated from `hindsight-cli/Cargo.lock` using the pinned `cargo-about 0.9.1` release. The PR test workflow runs generation and verification so unsupported license expressions fail during review rather than at tag time. The release workflow generates the shared manifest only in the Linux amd64 matrix job because the dependency graph is platform-independent, then transfers it with the Linux artifact for the final Release job.

`cargo-about 0.9.1` uses the `--offline` flag during generation. This prevents Cargo and license-data lookup from accessing the network and keeps CI output deterministic without relying on the removed `no-clearly-defined` configuration from older cargo-about versions.

The generator configuration explicitly includes the license identifiers present in the dependency graph, including MIT, Apache-2.0, BSD-3-Clause, ISC, MPL-2.0, Unicode-3.0, Unlicense, and Zlib. The repository MIT license remains a separate `LICENSE` asset, while `THIRD_PARTY_LICENSES.txt` is reserved for third-party attribution. The two files are shared by all four platform binaries in the GitHub Release rather than duplicated once per platform.

## Workflow Changes

- Install the pinned `cargo-about 0.9.1` prebuilt release with `taiki-e/install-action`.
- Verify the installed tool version before generating the manifest.
- Generate and verify `THIRD_PARTY_LICENSES.txt` during the Rust CLI PR test.
- Generate the release manifest once from the Linux amd64 job instead of once per platform.
- Upload the complete Linux artifact directory so the shared license files survive artifact transfer.
- Fail the Release preparation if either license file is missing or empty.
- Attach the shared `LICENSE` and `THIRD_PARTY_LICENSES.txt` files to the final GitHub Release.

## Validation

- `cargo-about 0.9.1` generates a 6,773-line, approximately 346 KB manifest successfully.
- The generated manifest includes Hindsight's MIT text and non-MIT dependency licenses such as MPL-2.0.
- The generated output contains no HTML entity escaping.
- `cargo test` passes with 76 unit tests and 24 CLI integration tests.
- `cargo build --release` passes.
- The complete local `test-rust-cli` core flow passes in 16.65 seconds with cached dependencies.
- Both workflow files parse as valid YAML.
- `git diff --check` passes.

Fixes #3446
