### PR TITLE
perf(recall): score observation expansion set-wise, not per candidate row (#3085)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -903,6 +903,17 @@ class PostgreSQLOps(DataAccessOps):
         # The window bounds the observations that come *back*, not the source facts
         # traversed to reach them: an observation is in the window when it was itself
         # written or refreshed there, regardless of how old the facts underneath it are.
+        #
+        # The shared-source count is scored set-wise (`scored`), not per candidate row.
+        # It used to be a correlated subquery — COUNT(DISTINCT s) over
+        # unnest(mu.source_memory_ids) filtered by `= ANY(ca.source_ids)` — which
+        # re-scanned the connected-source array linearly for every element of every
+        # candidate's array. Because consolidation appends to source_memory_ids and
+        # never prunes it (issue #1725), that product grows with the bank's age: at
+        # 5k observations averaging 113 sources against ~3k connected sources it was
+        # ~1.7B element comparisons, 2.6s of one saturated backend (issue #3085).
+        # Unnesting once and hash-joining connected_sources makes the work linear in
+        # the number of source ids instead.
 
         entity_rows = await conn.fetch(
             f"""
@@ -933,19 +944,35 @@ class PostgreSQLOps(DataAccessOps):
             ),
             connected_array AS (
                 SELECT array_agg(source_id) AS source_ids FROM connected_sources
+            ),
+            candidates AS (
+                SELECT
+                    mu.id, mu.text, mu.context, mu.event_date, mu.occurred_start,
+                    mu.occurred_end, mu.mentioned_at,
+                    mu.fact_type, mu.document_id, mu.chunk_id, mu.tags, mu.proof_count,
+                    mu.source_memory_ids
+                FROM {mu_table} mu, connected_array ca
+                WHERE mu.fact_type = 'observation'
+                  AND mu.id != ALL($1::uuid[])
+                  AND ca.source_ids IS NOT NULL
+                  AND mu.source_memory_ids && ca.source_ids
+                  {window.clause("mu")}
+            ),
+            scored AS (
+                SELECT c.id, COUNT(DISTINCT cs.source_id)::float AS score
+                FROM candidates c
+                CROSS JOIN LATERAL unnest(c.source_memory_ids) AS s(source_id)
+                JOIN connected_sources cs ON cs.source_id = s.source_id
+                GROUP BY c.id
             )
             SELECT
-                mu.id, mu.text, mu.context, mu.event_date, mu.occurred_start,
-                mu.occurred_end, mu.mentioned_at,
-                mu.fact_type, mu.document_id, mu.chunk_id, mu.tags, mu.proof_count,
-                (SELECT COUNT(DISTINCT s) FROM unnest(mu.source_memory_ids) s WHERE s = ANY(ca.source_ids))::float AS score
-            FROM {mu_table} mu, connected_array ca
-            WHERE mu.fact_type = 'observation'
-              AND mu.id != ALL($1::uuid[])
-              AND ca.source_ids IS NOT NULL
-              AND mu.source_memory_ids && ca.source_ids
-              {window.clause("mu")}
-            ORDER BY score DESC
+                c.id, c.text, c.context, c.event_date, c.occurred_start,
+                c.occurred_end, c.mentioned_at,
+                c.fact_type, c.document_id, c.chunk_id, c.tags, c.proof_count,
+                sc.score
+            FROM candidates c
+            JOIN scored sc ON sc.id = c.id
+            ORDER BY sc.score DESC
             LIMIT $2
             """,
             seed_ids,

--- a/hindsight-api-slim/tests/test_observation_expansion_scoring.py
+++ b/hindsight-api-slim/tests/test_observation_expansion_scoring.py
@@ -1,0 +1,165 @@
+"""Shared-source scoring for the observation graph arm (issue #3085).
+
+``expand_observations`` ranks candidate observations by how many source facts
+they share with the seeds' entity neighbourhood. That count used to be computed
+by a correlated subquery per candidate row, which made the query's cost grow with
+``len(source_memory_ids)`` — unbounded, because consolidation appends to that
+array and never prunes it (#1725). It is now computed set-wise. These tests pin
+the *semantics* that rewrite has to preserve: the score is the number of distinct
+shared source facts, and it orders the results.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+
+async def _ensure_bank(conn, bank_id: str) -> None:
+    await conn.execute(
+        "INSERT INTO banks (bank_id, name) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        bank_id,
+        bank_id,
+    )
+
+
+async def _insert_unit(
+    conn,
+    table: str,
+    bank_id: str,
+    text: str,
+    fact_type: str,
+    sources: list[uuid.UUID] | None = None,
+) -> uuid.UUID:
+    unit_id = uuid.uuid4()
+    await conn.execute(
+        f"""
+        INSERT INTO {table} (id, bank_id, text, fact_type, source_memory_ids, event_date)
+        VALUES ($1, $2, $3, $4, $5::uuid[], $6)
+        """,
+        unit_id,
+        bank_id,
+        text,
+        fact_type,
+        sources,
+        datetime.now(timezone.utc),
+    )
+    return unit_id
+
+
+@pytest.mark.asyncio
+async def test_score_counts_distinct_shared_sources(memory, request_context):
+    """Score == number of distinct source facts shared with the seed neighbourhood."""
+    from hindsight_api.engine.db.ops import UpdatedWindow
+    from hindsight_api.engine.task_backend import fq_table
+
+    bank_id = f"test_obs_score_{uuid.uuid4().hex[:8]}"
+    try:
+        pool = await memory._get_pool()
+        backend = await memory._get_backend()
+        mu, ue, ml = fq_table("memory_units"), fq_table("unit_entities"), fq_table("memory_links")
+
+        async with pool.acquire() as conn:
+            await _ensure_bank(conn, bank_id)
+            # Four world facts, all sharing one entity so they land in the
+            # seed's connected-source set.
+            facts = [await _insert_unit(conn, mu, bank_id, f"fact {i}", "world") for i in range(4)]
+            entity_id = uuid.uuid4()
+            await conn.execute(
+                f"INSERT INTO {fq_table('entities')} (id, bank_id, canonical_name) VALUES ($1, $2, $3)",
+                entity_id,
+                bank_id,
+                "Acme",
+            )
+            for fid in facts:
+                await conn.execute(
+                    f"INSERT INTO {ue} (unit_id, entity_id) VALUES ($1, $2)",
+                    fid,
+                    entity_id,
+                )
+
+            # The seed observation is built from fact 0 only; the candidates
+            # share a varying number of the *other* facts.
+            seed = await _insert_unit(conn, mu, bank_id, "seed obs", "observation", [facts[0]])
+            three = await _insert_unit(conn, mu, bank_id, "shares three", "observation", facts[1:4])
+            one = await _insert_unit(conn, mu, bank_id, "shares one", "observation", [facts[1]])
+            # Duplicate ids in the array must count once — the old query used
+            # COUNT(DISTINCT ...) and the rewrite must not turn that into COUNT(*).
+            dupes = await _insert_unit(
+                conn, mu, bank_id, "shares one, listed twice", "observation", [facts[2], facts[2]]
+            )
+
+            rows = await backend.ops.expand_observations(
+                conn,
+                mu,
+                ue,
+                ml,
+                [seed],
+                100,
+                200,
+                UpdatedWindow(after=None, before=None, first_param_index=3),
+            )
+
+        scores = {r["id"]: r["score"] for r in rows.entity}
+        assert scores[three] == 3.0
+        assert scores[one] == 1.0
+        assert scores[dupes] == 1.0, "repeated source ids must count once"
+        assert seed not in scores, "the seed itself must not come back as a result"
+
+        ranked = [r["id"] for r in rows.entity]
+        assert ranked[0] == three, "higher shared-source count must rank first"
+    finally:
+        await memory.delete_bank(bank_id=bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_wide_source_arrays_do_not_change_results(memory, request_context):
+    """A long source array is a cost problem, not a correctness one (#3085).
+
+    Two observations sharing the same single source fact must score the same
+    whether their arrays hold 1 id or 200 — the extra ids are simply unrelated.
+    """
+    from hindsight_api.engine.db.ops import UpdatedWindow
+    from hindsight_api.engine.task_backend import fq_table
+
+    bank_id = f"test_obs_wide_{uuid.uuid4().hex[:8]}"
+    try:
+        pool = await memory._get_pool()
+        backend = await memory._get_backend()
+        mu, ue, ml = fq_table("memory_units"), fq_table("unit_entities"), fq_table("memory_links")
+
+        async with pool.acquire() as conn:
+            await _ensure_bank(conn, bank_id)
+            shared = [await _insert_unit(conn, mu, bank_id, f"shared fact {i}", "world") for i in range(2)]
+            entity_id = uuid.uuid4()
+            await conn.execute(
+                f"INSERT INTO {fq_table('entities')} (id, bank_id, canonical_name) VALUES ($1, $2, $3)",
+                entity_id,
+                bank_id,
+                "Acme",
+            )
+            for fid in shared:
+                await conn.execute(f"INSERT INTO {ue} (unit_id, entity_id) VALUES ($1, $2)", fid, entity_id)
+
+            # Unrelated facts: no entity rows, so they never enter connected_sources.
+            padding = [await _insert_unit(conn, mu, bank_id, f"unrelated {i}", "world") for i in range(200)]
+
+            seed = await _insert_unit(conn, mu, bank_id, "seed obs", "observation", [shared[0]])
+            narrow = await _insert_unit(conn, mu, bank_id, "narrow", "observation", [shared[1]])
+            wide = await _insert_unit(conn, mu, bank_id, "wide", "observation", [shared[1], *padding])
+
+            rows = await backend.ops.expand_observations(
+                conn,
+                mu,
+                ue,
+                ml,
+                [seed],
+                100,
+                200,
+                UpdatedWindow(after=None, before=None, first_param_index=3),
+            )
+
+        scores = {r["id"]: r["score"] for r in rows.entity}
+        assert scores[narrow] == scores[wide] == 1.0
+    finally:
+        await memory.delete_bank(bank_id=bank_id, request_context=request_context)

--- a/hindsight-dev/benchmarks/perf/recall_perf.py
+++ b/hindsight-dev/benchmarks/perf/recall_perf.py
@@ -584,14 +584,29 @@ def _build_engine(*, disable_observations: bool = False) -> "Any":
 _BATCH_SIZE = 500
 
 
-async def _insert_synthetic_observations(pool: Any, bank_id: str) -> int:
+async def _insert_synthetic_observations(pool: Any, bank_id: str, sources_per_observation: int = 1) -> int:
     """
     For every non-observation memory unit in *bank_id*, insert one synthetic
     observation with the same text, embedding, and tags, pointing back to that
-    unit as its sole source fact.
+    unit as a source fact.
+
+    ``sources_per_observation`` controls how many source facts each observation
+    carries. This is the dimension the observation graph arm actually scales on:
+    ``expand_observations`` unnests ``source_memory_ids`` for every seed and again
+    for every candidate, so its cost grows with the length of those arrays — not
+    with the observation count. Real banks grow them without bound, because
+    consolidation appends a source id on every merge and never prunes (#1725); a
+    reported bank ran at ~113 sources per observation (#3085). Leaving this at 1
+    (as this fixture did originally) keeps the arm permanently in its cheapest
+    regime and hides that whole class of regression.
+
+    Sources are drawn from a window of neighbouring facts so that source sets
+    *overlap* between observations, which is what makes the `&&` candidate scan
+    and the shared-source scoring do real work.
 
     Returns the number of observations inserted.
     """
+    import random
     import uuid
 
     from hindsight_api.engine.task_backend import fq_table
@@ -612,6 +627,19 @@ async def _insert_synthetic_observations(pool: Any, bank_id: str) -> int:
     if not rows:
         return 0
 
+    fact_ids = [row["id"] for row in rows]
+    n_sources = max(1, min(sources_per_observation, len(fact_ids)))
+    rng = random.Random(42)  # deterministic fixture
+
+    def _sources_for(index: int) -> list:
+        """Own fact plus neighbours, so adjacent observations share source ids."""
+        if n_sources == 1:
+            return [fact_ids[index]]
+        window_size = min(len(fact_ids), n_sources * 3)
+        start = min(max(0, index - window_size // 2), len(fact_ids) - window_size)
+        window = [fid for fid in fact_ids[start : start + window_size] if fid != fact_ids[index]]
+        return [fact_ids[index], *rng.sample(window, n_sources - 1)]
+
     inserted = 0
     for offset in range(0, len(rows), _BATCH_SIZE):
         batch = rows[offset : offset + _BATCH_SIZE]
@@ -623,7 +651,7 @@ async def _insert_synthetic_observations(pool: Any, bank_id: str) -> int:
                 tags, event_date, occurred_start, occurred_end, mentioned_at
             ) VALUES (
                 $1, $2, $3, 'observation', $4::vector,
-                1, ARRAY[$5::uuid],
+                1, $5::uuid[],
                 $6, $7, $8, $9, $10
             )
             ON CONFLICT DO NOTHING
@@ -634,14 +662,14 @@ async def _insert_synthetic_observations(pool: Any, bank_id: str) -> int:
                     bank_id,  # bank_id
                     row["text"],
                     row["embedding"],
-                    row["id"],  # source fact id
+                    _sources_for(offset + i),  # source facts
                     row["tags"] or [],
                     row["event_date"],
                     row["occurred_start"],
                     row["occurred_end"],
                     row["mentioned_at"],
                 )
-                for row in batch
+                for i, row in enumerate(batch)
             ],
         )
         inserted += len(batch)

--- a/hindsight-dev/benchmarks/perf/system_perf.py
+++ b/hindsight-dev/benchmarks/perf/system_perf.py
@@ -68,6 +68,7 @@ SCALES: dict[str, dict[str, int]] = {
         "retain_items": 20,
         "recall_bank_size": 20,
         "recall_iterations": 5,
+        "recall_obs_sources_per_observation": 4,
         "recall_concurrency": 1,
         "consolidation_items": 20,
         "graph_maintenance_bank_size": 20,
@@ -82,6 +83,7 @@ SCALES: dict[str, dict[str, int]] = {
         "retain_items": 200,
         "recall_bank_size": 200,
         "recall_iterations": 20,
+        "recall_obs_sources_per_observation": 8,
         "recall_concurrency": 4,
         "consolidation_items": 200,
         "graph_maintenance_bank_size": 200,
@@ -96,6 +98,7 @@ SCALES: dict[str, dict[str, int]] = {
         "retain_items": 1_000,
         "recall_bank_size": 1_000,
         "recall_iterations": 50,
+        "recall_obs_sources_per_observation": 32,
         "recall_concurrency": 8,
         "consolidation_items": 1_000,
         "graph_maintenance_bank_size": 1_000,
@@ -110,6 +113,12 @@ SCALES: dict[str, dict[str, int]] = {
         "retain_items": 5_000,
         "recall_bank_size": 5_000,
         "recall_iterations": 100,
+        # Source facts per synthetic observation. The observation graph arm's cost
+        # scales with the length of source_memory_ids, which consolidation grows
+        # without bound (#1725) — 113 is the average measured on the bank reported
+        # in #3085. At the fixture's original value of 1 the arm never leaves its
+        # cheapest regime, which is why a 39x blowup went unseen here.
+        "recall_obs_sources_per_observation": 113,
         "recall_concurrency": 16,
         "consolidation_items": 5_000,
         # Past the seqscan→HNSW crossover (~10k units) so this suite exercises
@@ -141,6 +150,7 @@ SCALES: dict[str, dict[str, int]] = {
         "retain_items": 5_000,
         "recall_bank_size": 5_000,
         "recall_iterations": 10,
+        "recall_obs_sources_per_observation": 113,
         "recall_concurrency": 4,
         "consolidation_items": 5_000,
         "graph_maintenance_bank_size": 15_000,
@@ -241,6 +251,10 @@ class RecallResult:
     latency: PercentileStats
     throughput_queries_per_sec: float
     phase_timings: dict[str, PercentileStats] = field(default_factory=dict)
+    # Only set by recall-with-observations: source facts per observation. Published
+    # so a change to the fixture is visible on the dashboard rather than reading as
+    # a latency regression (or masking one).
+    sources_per_observation: int | None = None
 
 
 @dataclass
@@ -846,11 +860,13 @@ async def run_recall_with_observations_suite(scale_cfg: dict[str, int]) -> Suite
     bank_size = scale_cfg["recall_bank_size"]
     iterations = scale_cfg["recall_iterations"]
     concurrency = scale_cfg["recall_concurrency"]
+    sources_per_obs = scale_cfg["recall_obs_sources_per_observation"]
     bank_id = f"perf-recall-obs-{uuid.uuid4().hex[:8]}"
 
     console.print(
         f"\n[bold cyan]Suite: recall-with-observations[/bold cyan]  "
-        f"bank_size={bank_size}  iterations={iterations}  concurrency={concurrency}  bank={bank_id}"
+        f"bank_size={bank_size}  iterations={iterations}  concurrency={concurrency}  "
+        f"sources/obs={sources_per_obs}  bank={bank_id}"
     )
 
     engine = _build_engine()
@@ -859,7 +875,8 @@ async def run_recall_with_observations_suite(scale_cfg: dict[str, int]) -> Suite
     # Use RRF reranker to isolate DB performance from cross-encoder CPU cost
     engine._cross_encoder_reranker = _RRFReranker()
 
-    # Populate bank with facts then insert synthetic observations (1 per fact)
+    # Populate bank with facts then insert synthetic observations (1 per fact,
+    # each carrying `sources_per_obs` source facts — see the scale config)
     await _populate_bank(engine, bank_id, bank_size)
 
     pool = await engine._get_pool()
@@ -870,8 +887,8 @@ async def run_recall_with_observations_suite(scale_cfg: dict[str, int]) -> Suite
         console=console,
     ) as progress:
         progress.add_task("Inserting synthetic observations…")
-        n_obs = await _insert_synthetic_observations(pool, bank_id)
-    console.print(f"  Inserted {n_obs:,} observations")
+        n_obs = await _insert_synthetic_observations(pool, bank_id, sources_per_obs)
+    console.print(f"  Inserted {n_obs:,} observations ({sources_per_obs} source facts each)")
 
     request_context = RequestContext()
     durations: list[float] = []
@@ -931,6 +948,7 @@ async def run_recall_with_observations_suite(scale_cfg: dict[str, int]) -> Suite
         latency=latency_stats,
         throughput_queries_per_sec=round(throughput, 2),
         phase_timings=phase_stats,
+        sources_per_observation=sources_per_obs,
     )
 
     # Print summary


### PR DESCRIPTION
Closes #3085.

## What was actually slow

Not prepared-statement plan caching, and not the `semantic_expanded` CTE. On a repro bank matching the reported shape (10k units, 15k `unit_entities`, 154k links, observations averaging 113 source facts), splitting `expand_observations` into its two queries gives:

- semantic/causal CTE: **6 ms**
- entity CTE: **2,592 ms**

`EXPLAIN (ANALYZE)` puts 2.47s of that 2.60s in one node — the score column:

```sql
(SELECT COUNT(DISTINCT s) FROM unnest(mu.source_memory_ids) s WHERE s = ANY(ca.source_ids))
```

a correlated `SubPlan` with `loops=4980`, 0.497 ms each. Per candidate row it linearly scans that row's 113-element array against a ~3,000-element array and then sorts for the `DISTINCT` — roughly 1.7 billion element comparisons, all CPU in a single backend, which is the "one Postgres process at 90-95% for minutes" symptom from the report. The graph traversal CTEs underneath cost ~5 ms; the `&&` candidate scan ~114 ms.

The cost scales with `len(source_memory_ids)`, and consolidation appends to that array on every merge without ever pruning it (#1725) — so it grows with the bank's age. That is why it shows up on aged production banks and never in tests.

## The change

Score set-wise instead of per row: a `candidates` CTE for the `&&` prefilter, then a `scored` CTE that unnests each candidate's array **once** and hash-joins `connected_sources`.

Output is unchanged — I ran the old and new SQL side by side over the same seeds and compared every `(id, score)` pair: identical across 5 queries × 4,980 rows.

### Numbers

Paired on the same bank, same protocol, graph arm p50:

| sources/observation | before | after | |
|---|---|---|---|
| 1 | 65 ms | 58 ms | 1.1× |
| 10 | 425 ms | 193 ms | 2.2× |
| 50 | 1,338 ms | 230 ms | 5.8× |
| 113 (reported bank) | 2,539 ms | 274 ms | **9.3×** |

Growth across the fan-out range flattens from 39× to 4.7×.

End-to-end `perf-test --scale large --suite recall-with-observations`:

| | before | after |
|---|---|---|
| latency p50 | 11.616 s | 3.502 s |
| latency p95 | 14.174 s | 4.184 s |
| throughput | 1.38 q/s | 4.68 q/s |
| `retrieval_graph` phase | 8.902 s | 1.152 s |

## Why the perf suite never caught it

`_insert_synthetic_observations` gave every synthetic observation exactly **one** source fact — the degenerate value of the only dimension this query scales on. At 1 source the arm sits permanently in its cheapest regime, so a 39× blowup was invisible. (The consolidation suite can't grow it either: its mock LLM emits only `_CreateAction(source_fact_ids=[fid])`, never merges.)

The fixture now takes `sources_per_observation`, wired to a `recall_obs_sources_per_observation` key per scale (113 at `large`, matching the reported bank). Sources are drawn from a neighbour window so source sets **overlap** between observations — otherwise the `&&` scan and the scoring have nothing to do.

**Dashboard note:** `recall-with-observations` will step up when this merges. That is the heavier fixture, not a regression — the same suite on the old SQL measures 11.6 s p50 against 3.5 s here. The fixture value is published in the results JSON (`sources_per_observation`) so the change is visible rather than inferred.

## Scope

Deliberately not in this PR:

- **The `wait_for` + partial-results fallback** that the issue's "Expected Behavior" asks for. `_expand_observations` is still untimed while `_expand_combined` is not. As @ebarkhordar and @jordigilh both noted in the thread, that asymmetry is real but would not have bounded this: the timeout is 10 s and the query finishes in milliseconds. Doing it properly needs an ops-layer split so the semantic/causal half can run alone on expiry — worth its own change.
- **A latency gate.** The deeper reason this went unseen is that the harness has exactly one pass/fail assertion (the #2529 deadlock-escape-rate gate); everything else publishes to a dashboard on a daily cron.
- **Oracle.** `ops_oracle.expand_observations` has the same per-row correlated shape, but against the indexed `observation_sources` junction table rather than array scans — a much weaker version of the same problem.

## Tests

`tests/test_observation_expansion_scoring.py` pins the semantics the rewrite has to preserve: score equals the number of distinct shared source facts, repeated ids count once, higher counts rank first, the seed never returns itself, and a wide source array does not change any score.

## Credit

Diagnosis in the issue thread from @DiscountDarcy (who caught that their own first CTE benchmark was measuring the wrong query), @ebarkhordar (the `command_timeout` / `statement_timeout` correction and the observation that this path is not consolidation-specific — it is any observation-type retrieval, including plain `recall` with no `fact_type`), and @jordigilh (ruling out prepared-statement plan caching via the hardcoded `statement_cache_size=0`, and finding #3367 along the way).
