### PR TITLE
fix(claude-code): pin mcp<2 so the MCP server can start

### DIFF
--- a/hindsight-integrations/claude-code/requirements.txt
+++ b/hindsight-integrations/claude-code/requirements.txt
@@ -1,1 +1,3 @@
-mcp>=1.0.0
+# Pinned below 2.0: `mcp.server.fastmcp`, imported by scripts/mcp_server.py,
+# was removed in mcp 2.0.
+mcp>=1.0.0,<2


### PR DESCRIPTION
## Problem

The Claude Code plugin's MCP server never starts on a freshly created venv.

`hindsight-integrations/claude-code/scripts/mcp_server.py:26` imports:

```python
from mcp.server.fastmcp import FastMCP
```

`mcp.server.fastmcp` was removed in **mcp 2.0**. `requirements.txt` declares
`mcp>=1.0.0` with no upper bound, so `run_mcp.sh` resolves the plugin venv to
`mcp 2.0.0` and the server dies at import time:

```
Traceback (most recent call last):
  File ".../hindsight-memory/0.7.5/scripts/mcp_server.py", line 26, in <module>
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

Claude Code surfaces this only as `hindsight MCP · ✘ failed`.

Two details make it worse:

- The failure happens at module import, **before** `get_api_url()` at
  `mcp_server.py:52`. So none of the plugin's own connection logic runs — the
  API URL resolution, the health probe, and the daemon auto-start are all
  unreachable. In my case a healthy API was already listening on 9077 and the
  plugin still could not use it.
- `run_mcp.sh` only re-runs pip when `import mcp` fails. `import mcp` still
  succeeds on 2.x (only the `server.fastmcp` submodule is gone), so the broken
  venv is never repaired by a warm start. It stays broken until the venv is
  deleted by hand.

## Fix

Pin the dependency below the breaking major:

```
mcp>=1.0.0,<2
```

This is the minimal change. Adopting mcp 2.x properly would mean migrating
`mcp_server.py` off `FastMCP`, which is a much larger change and out of scope
here.

## Verification

Reinstalled the plugin venv with the pin (resolves to `mcp 1.29.0`), then drove
the server over stdio with a real `initialize` + `tools/list` exchange:

```
{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05",
 "capabilities":{...},
 "serverInfo":{"name":"hindsight","version":"1.29.0"}}}
{"jsonrpc":"2.0","id":2,"result":{"tools":[
 {"name":"agent_knowledge_get_current_bank",...},
 {"name":"agent_knowledge_list_pages",...}, ...]}}
```

Before the pin the same invocation produced only the `ModuleNotFoundError`
traceback above.

Environment: macOS 15 (arm64), Python 3.14.2, plugin `hindsight-memory` 0.7.5.

## Scope

`hindsight-integrations/claude-code` is the only integration affected —
`git grep mcp.server.fastmcp` reports exactly one hit, and the `dify` and `omo`
requirements files do not depend on `mcp`.
