### PR TITLE
fix(coding-agents): say when a turn is running without memory

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/diag.ts
+++ b/hindsight-integrations/coding-agents/src/core/diag.ts
@@ -10,11 +10,16 @@
 import { appendFileSync } from "node:fs";
 import { log } from "./log";
 
+/** Where the JSONL trail lands. Exported so a failure notice can name the file to open. */
+export function diagFilePath(): string {
+  return process.env.HINDSIGHT_DIAG_FILE || "/tmp/hindsight-plugin.log";
+}
+
 export function diag(harness: string, event: string, extra: Record<string, unknown> = {}): void {
   log.debug(harness, `diag:${event}`, extra); // debug level shows the full story in ONE file
   try {
     appendFileSync(
-      process.env.HINDSIGHT_DIAG_FILE || "/tmp/hindsight-plugin.log",
+      diagFilePath(),
       JSON.stringify({ ts: new Date().toISOString(), harness, event, ...extra }) + "\n"
     );
   } catch {

--- a/hindsight-integrations/coding-agents/src/core/hook.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hook.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveConfig } from "./config";
 import { buildHookOutput, runHook } from "./hook";
+import { diagFilePath } from "./diag";
 import { buildReflectQuery } from "./inject";
 
 let root: string;
@@ -138,7 +139,9 @@ describe("buildHookOutput", () => {
     });
     // Reflect failed -> no reflect block; pages are never auto-injected -> nothing to inject.
     expect(t1.context).toBeUndefined();
-    expect(t1.notice).toBeUndefined();
+    // ...but the turn is NOT silent: one line pointing at the diag trail (#3443).
+    expect(t1.notice).toContain("no memory this turn");
+    expect(t1.notice).toContain(diagFilePath());
     expect(JSON.parse(readFileSync(cacheFile, "utf8")).reflectAnswer).toBe("");
 
     await buildHookOutput({
@@ -150,6 +153,34 @@ describe("buildHookOutput", () => {
     });
     // The failure is cached as "" — reflect is NOT retried on the next turn.
     expect(client.reflect).toHaveBeenCalledTimes(1);
+  });
+
+  it("the notice fires ONCE — the turn reflect failed, not on later turns", async () => {
+    const cfg = resolveConfig({});
+    const client = makeClient({
+      reflect: vi.fn(async () => {
+        throw new Error("reflect boom");
+      }),
+    });
+    const args = { harness: "claude-code", prompt: UNRELATED_PROMPT, cfg, client, cacheFile };
+    expect((await buildHookOutput(args)).notice).toContain("no memory this turn");
+    // Turn 2 does not re-run reflect, so re-announcing a failure it did not observe would nag.
+    expect((await buildHookOutput(args)).notice).toBeUndefined();
+  });
+
+  it("an EMPTY answer is not a failure: no notice (reflect simply had nothing to say)", async () => {
+    const cfg = resolveConfig({});
+    // The real client returns (data.text || "").trim() — a 200 with no text yields "".
+    const client = makeClient({ reflect: vi.fn(async () => "") });
+    const result = await buildHookOutput({
+      harness: "claude-code",
+      prompt: UNRELATED_PROMPT,
+      cfg,
+      client,
+      cacheFile,
+    });
+    expect(result.notice).toBeUndefined();
+    expect(result.context).toBeUndefined();
   });
 
   it("uses a bounded low-budget reflect and caps its timeout at 25000ms", async () => {

--- a/hindsight-integrations/coding-agents/src/core/hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/hook.ts
@@ -21,7 +21,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { deriveBankId } from "./bank";
 import type { Config } from "./config";
 import { applyBankConfig, loadConfig } from "./config";
-import { diag } from "./diag";
+import { diag, diagFilePath } from "./diag";
 import { log, setLogLevel } from "./log";
 import { startBackgroundSeed } from "./seed";
 import type { ClientOpts } from "./hindsight";
@@ -102,6 +102,10 @@ export async function buildHookOutput(args: {
   // instructs the agent to call hindsight_reflect itself when a new goal is set.
   let reflectAnswer = cached.reflectAnswer;
   let reflectRanThisTurn = false;
+  // Set ONLY by the catch below. An empty answer is not a failure: reflect can legitimately have
+  // nothing to say on a sparse bank (diag records that as reflect_empty), and reporting it as a
+  // failure would tell the user the plugin broke on exactly the sessions where it did not.
+  let reflectFailed = false;
   const deferInitialReflect = cached.deferInitialReflect === true;
   if (deferInitialReflect) {
     // A new bank has no useful history yet. Do not burn the once-per-session synthesis on prompt
@@ -128,6 +132,7 @@ export async function buildHookOutput(args: {
       });
     } catch (e) {
       reflectAnswer = ""; // ran and failed — don't retry every turn; the diag trail records it
+      reflectFailed = true;
       log.warn(harness, "reflect failed — session runs without memory", {
         error: String((e as Error)?.message || e).slice(0, 200),
       });
@@ -193,6 +198,12 @@ export async function buildHookOutput(args: {
     notice =
       `${brandWord()} · goal: recall this repo's past decisions about “${excerpt}”\n` +
       `↳ ${preview.length > 140 ? `${preview.slice(0, 140)}…` : preview}`;
+  } else if (reflectFailed) {
+    // The failure is already in the diag trail and plugin.log, but both are files nobody is
+    // tailing mid-session, so a memory-less session looked exactly like a healthy one (#3443).
+    // One terse line pointing at the trail — not an explanation, and not advice to the agent:
+    // this fires at most once per session, on the turn reflect ran.
+    notice = `${brandWord()} · no memory this turn — see ${diagFilePath()}`;
   }
 
   return { context: kept.length ? kept.join("\n\n") : undefined, notice, pagesKnown: pages.length };


### PR DESCRIPTION
Addresses #3443. Supersedes #3445 (closed).

## The gap is visibility, not recording

When the once-per-session hook reflect fails, the turn proceeds without memory injection and looks exactly like a healthy one. The failure **is** already recorded, twice:

| sink | where |
|---|---|
| `log.warn("reflect failed — session runs without memory")` | `$TMPDIR/hindsight-coding-agent/plugin.log` |
| `diag("reflect_failed", {ms, error, query})` | `/tmp/hindsight-plugin.log` (JSONL) |

Both are `appendFileSync` to a file. Neither touches stdout, stderr, or the session — so in practice the failure is invisible until someone goes looking. The reporter found their two failures only because they opened the diag log for an unrelated reason, and one of them ate the prompt in which they were asking about this very limit.

`diag.ts` already states the goal in its own header — *"so a silently memory-less session can't masquerade as one that worked"*. A file achieves that in a post-mortem, not in the session.

## One line, pointing at the trail

```
Hindsight · no memory this turn — see /tmp/hindsight-plugin.log
```

Deliberately **not** an explanation, and not advice aimed at the agent: the details are in the file it names. It fires at most once per session, on the turn reflect ran — later turns don't re-run reflect, so re-announcing a failure they never observed would just nag. The path is read from the same helper `diag()` writes through, so it names the file actually in use under `HINDSIGHT_DIAG_FILE`.

## An empty answer is not a failure

The flag is set **only in the `catch`**. Reflect can legitimately return nothing on a sparse bank — a 200 with no text, which the client normalizes to `""` and diag already records as its own `reflect_empty` event, distinct from `reflect_ok`.

This is the trap in #3445, which derived the status as `reflectAnswer ? "success" : "error"`. I ran that branch: an empty-but-successful reflect printed *"automatic memory synthesis failed this turn"*. That inverts the issue's own complaint — you still can't tell "reflect broke" from "no relevant memory exists" — and it lands hardest on a fresh bank, which defers reflect on prompt one and then reflects on prompt two while the bank is at its sparsest. A test pins the empty case as silent.

## No new cache state

#3445 persisted a `reflectStatus` field in `SessionCache`. It isn't needed: the notice is only ever emitted on the turn reflect ran, so a local flag covers it, and the re-run gate is already decided by `reflectAnswer !== undefined`. Keeping it out of the cache avoids a second source of truth that can disagree with `reflectAnswer` — which is exactly the disagreement that produced the bug above — plus the pre-existing-cache compatibility question.

**3 files, +50/-3.**

## Reach

`notice` renders as `systemMessage` on claude-code and as a toast on opencode/kilo. Harnesses whose hook schema has no user-visible channel ignore it, as they already do for the existing reflect notice — unchanged by this PR.

## Not addressed here

Reflect overrunning the 25s cap in the first place. The cap stays (it must remain below the harness hook timeout, or the host kills the hook before the result is cached and reflect re-fires uncached every turn). The reporter's measurements attribute the overrun to reasoning tokens; that hint is provider-specific and already reachable server-side through `HINDSIGHT_API_REFLECT_LLM_EXTRA_BODY`, so #3443 should stay open for the latency half.

## Test

495 passed, tsc and prettier clean. Three new/updated cases: the failure turn carries the line and names the diag file, the line does not repeat on turn 2, and an empty answer stays silent.