### PR TITLE
fix(release): keep package-lock.json's version in step with the release

### DIFF
--- a/hindsight-integrations/coding-agents/package-lock.json
+++ b/hindsight-integrations/coding-agents/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectorize-io/hindsight-coding-agents",
-  "version": "0.0.5",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectorize-io/hindsight-coding-agents",
-      "version": "0.0.5",
+      "version": "0.3.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@vectorize-io/hindsight-all": "^0.8.6",

--- a/hindsight-integrations/eve/package-lock.json
+++ b/hindsight-integrations/eve/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectorize-io/hindsight-eve",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectorize-io/hindsight-eve",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/hindsight-integrations/obsidian/package-lock.json
+++ b/hindsight-integrations/obsidian/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectorize-io/hindsight-obsidian",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectorize-io/hindsight-obsidian",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.3"

--- a/hindsight-integrations/openclaw/package-lock.json
+++ b/hindsight-integrations/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectorize-io/hindsight-openclaw",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectorize-io/hindsight-openclaw",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.2.0",

--- a/hindsight-integrations/opencode/package-lock.json
+++ b/hindsight-integrations/opencode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectorize-io/opencode-hindsight",
-  "version": "0.2.6",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectorize-io/opencode-hindsight",
-      "version": "0.2.6",
+      "version": "0.2.8",
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/plugin": "^1.3.13",

--- a/hindsight-integrations/paperclip/package-lock.json
+++ b/hindsight-integrations/paperclip/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectorize-io/hindsight-paperclip",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectorize-io/hindsight-paperclip",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@paperclipai/plugin-sdk": "^2026.403.0"

--- a/scripts/release-integration.sh
+++ b/scripts/release-integration.sh
@@ -153,6 +153,15 @@ elif [ -f "$INTEGRATION_DIR/package.json" ]; then
     print_info "Updating version in $INTEGRATION_DIR/package.json"
     sed -i.bak "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" "$INTEGRATION_DIR/package.json"
     rm "$INTEGRATION_DIR/package.json.bak"
+    # package-lock.json carries the package's own version twice, and the sed above does not touch
+    # it — so every npm release since the lock was committed left it pinned at whatever version it
+    # was born with (coding-agents still said 0.0.5 at v0.3.2). `npm version` rewrites exactly
+    # those two fields and nothing else; `--package-lock-only` was rejected because it re-resolves
+    # dependencies, which would smuggle dependency bumps into a release commit.
+    if [ -f "$INTEGRATION_DIR/package-lock.json" ]; then
+        print_info "Syncing $INTEGRATION_DIR/package-lock.json"
+        (cd "$INTEGRATION_DIR" && npm version "$VERSION" --no-git-tag-version --allow-same-version >/dev/null)
+    fi
 elif [ -f "$INTEGRATION_DIR/.claude-plugin/plugin.json" ]; then
     print_info "Updating version in $INTEGRATION_DIR/.claude-plugin/plugin.json"
     sed -i.bak "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" "$INTEGRATION_DIR/.claude-plugin/plugin.json"


### PR DESCRIPTION
Follow-up to the lock drift spotted while working on #3455.

## What was wrong

The npm branch of `release-integration.sh` sed's `package.json` only, and a lock file carries the package's own version **twice** (root, and `packages[""]`). So every npm integration release since its lock was committed left the lock pinned at the version it was born with:

| integration | package.json | lock |
|---|---|---|
| coding-agents | 0.3.2 | **0.0.5** |
| eve | 0.2.1 | 0.2.0 |
| obsidian | 0.2.1 | 0.2.0 |
| openclaw | 0.10.0 | 0.9.0 |
| opencode | 0.2.8 | 0.2.6 |
| paperclip | 0.3.0 | 0.2.3 |

**Nothing was broken by this.** `npm ci` tolerates the mismatch, which is why CI stayed green, and npm never publishes the lock file, so no published artifact ever carried the wrong number. It is a stale field that misleads anyone reading the tree — coding-agents claiming 0.0.5 at v0.3.2 is what made me look.

## The fix

```bash
if [ -f "$INTEGRATION_DIR/package-lock.json" ]; then
    (cd "$INTEGRATION_DIR" && npm version "$VERSION" --no-git-tag-version --allow-same-version >/dev/null)
fi
```

`npm version` rewrites exactly those two fields. **`npm install --package-lock-only` is the obvious alternative and is the wrong tool here** — it re-resolves the dependency graph, so a release commit could silently carry dependency bumps nobody asked for. Verified on a scratch copy: package.json and both lock fields land on the new version while every dependency entry comes out byte-identical.

The script already stages `hindsight-integrations/$INTEGRATION/`, so the synced lock rides along in the existing `release(...)` commit with no further change.

## Also syncing the six stale locks

Fixing only the script would stop the drift getting *worse* while leaving every current lock wrong. Each diff is the same two lines and no dependency entry moves.

## Verified

`bash -n` on the script, the release step simulated on a scratch copy (versions updated, dependency graph unchanged), and `npm ci` re-run against the synced coding-agents lock — exit 0.