### PR TITLE
fix(ci): fetch crates for all targets before the offline license scan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,6 +337,14 @@ jobs:
       if: matrix.asset_name == 'hindsight-linux-amd64'
       run: cargo about --version
 
+    # The build above only fetches crates for this target; cargo-about resolves
+    # the graph for every target platform, so fetch for all of them (that is what
+    # `cargo fetch` without --target does) before the --offline generate.
+    - name: Fetch crate sources for the license scan
+      if: matrix.asset_name == 'hindsight-linux-amd64'
+      working-directory: hindsight-cli
+      run: cargo fetch
+
     - name: Generate license manifest
       if: matrix.asset_name == 'hindsight-linux-amd64'
       working-directory: hindsight-cli

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1429,6 +1429,15 @@ jobs:
     - name: Verify cargo-about
       run: cargo about --version
 
+    # cargo-about resolves the dependency graph for every target platform, so it
+    # needs crates this host never builds (e.g. the Android-only
+    # android_system_properties). Populate the registry first: `cargo fetch`
+    # without --target downloads for all targets, and Cargo.lock is not checked
+    # in, so nothing is cached from a previous step.
+    - name: Fetch crate sources for the license scan
+      working-directory: hindsight-cli
+      run: cargo fetch
+
     - name: Generate and verify license manifest
       working-directory: hindsight-cli
       run: |


### PR DESCRIPTION
## Problem

The `test-rust-cli` job is red on `main`:

```
cargo about generate --offline
→ `cargo metadata` exited with an error:
     Locking 283 packages to latest compatible versions
     error: failed to download `android_system_properties v0.1.6`
     Caused by: attempting to make an HTTP request, but --offline was specified
```

Two things combine:

1. **cargo-about resolves the dependency graph for every target platform.** `cargo metadata` without `--filter-platform` includes target-gated crates the runner never builds — here `android_system_properties`, an Android-only dependency of `iana-time-zone` (via `chrono`). A Linux build never downloads it, so it is never in the registry cache.
2. **`hindsight-cli/Cargo.lock` is gitignored** (`hindsight-cli/.gitignore:3`), so CI re-resolves from scratch ("Locking 283 packages to latest compatible versions") and no earlier step has populated the cache. In `test.yml` the license step also runs *before* `cargo test`/`cargo build`, so nothing has been fetched at all.

`--offline` then fails on the first crate it cannot find locally. The same command in the `release-rust-cli` job has the same defect — `cargo build --release --target <host>` only fetches host-target crates — so a release tag would have hit it next.

## Fix

Run `cargo fetch` before the offline generate in both jobs. Without `--target`, `cargo fetch` downloads dependencies for **all** target platforms, so the subsequent `cargo about generate --offline` resolves entirely from cache. `--offline` is kept, preserving the determinism intent of #3447 (no ClearlyDefined network lookups).

## Verification

Reproduced and fixed locally with cargo-about 0.9.1 against a clean `CARGO_HOME` and no `Cargo.lock`, mirroring the CI environment:

- Before: `cargo about generate --offline` fails during `cargo metadata` resolution.
- `cargo fetch`: downloads 282 crates including `android_system_properties-0.1.6` — the exact crate CI died on — plus the Windows-only ones.
- After: generation exits clean and both CI assertions hold (output non-empty, 6773 lines; `grep -Fq "THIRD-PARTY SOFTWARE LICENSES"` matches).

## Note (not addressed here)

Because `hindsight-cli/Cargo.lock` is not checked in, every CI run re-resolves to the latest compatible versions, so the generated license manifest is not reproducible run-to-run and dependency updates land in a release without review. Committing the lockfile for the CLI binary would be worth a separate change.
