### PR TITLE
recall: carry entity_ids on results, skip redundant re-fetch in entity_build

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -880,6 +880,19 @@ class MemoriesExtension(Extension, ABC):
         """
 
     @abstractmethod
+    async def resolve_entity_names(self, *, conn, fq_table, bank_id: str, entity_ids: list[str]) -> dict[str, str]:
+        """``{entity_id: canonical_name}`` for the given ids, from the ``entities`` registry.
+
+        The label half of :meth:`entity_map_for_units`, split out so a backend that
+        already carries a unit's entity ids on the recalled result can turn those ids
+        into names without re-fetching the memories — recall then builds the entity map
+        from the result's ids plus this one lookup. Bank-scoped, and ids with no registry
+        row are simply absent from the result. The concrete SQL is the store's, next to
+        :meth:`entity_map_for_units`, because the query dialect belongs to the backend,
+        not this interface.
+        """
+
+    @abstractmethod
     async def any_memory_updated_since(
         self,
         *,

--- a/hindsight-api-slim/hindsight_api/engine/memories/pg/graph.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/pg/graph.py
@@ -479,6 +479,46 @@ async def entity_map_for_units(
     return by_unit
 
 
+async def resolve_entity_names(
+    *,
+    conn: DatabaseConnection,
+    fq_table: Callable[[str], str],
+    bank_id: str,
+    entity_ids: list[str],
+) -> dict[str, str]:
+    """``{entity_id: canonical_name}`` for the given ids, scoped to ``bank_id``.
+
+    The label half of :func:`entity_map_for_units`, for a backend that already
+    carries a unit's entity ids on the recalled result: recall builds the
+    unit->entity map from those ids and needs only the names, so this resolves the
+    ``entities`` registry once without re-fetching any memory. Bank-scoped like the
+    sibling registry reads (the ``entities`` table has a ``bank_id`` column).
+
+    Ids that don't parse as UUIDs are dropped rather than raised — a malformed id
+    on a store's result payload must not turn into a DB error mid-recall — and ids
+    with no registry row (or in another bank) are simply absent from the result.
+    """
+    if not entity_ids:
+        return {}
+    # Bind ``uuid.UUID`` objects for the ``uuid[]`` param (repo convention, see
+    # ``_as_uuids``), but coerce defensively: skip anything unparseable instead of
+    # letting the whole resolve raise.
+    uuids: list = []
+    for raw in {str(e) for e in entity_ids}:
+        try:
+            uuids.append(uuid_module.UUID(raw))
+        except (ValueError, AttributeError, TypeError):
+            continue
+    if not uuids:
+        return {}
+    rows = await conn.fetch(
+        f"SELECT id, canonical_name FROM {fq_table('entities')} WHERE id = ANY($1::uuid[]) AND bank_id = $2",
+        uuids,
+        bank_id,
+    )
+    return {str(row["id"]): row["canonical_name"] for row in rows}
+
+
 # --------------------------------------------------------------- maintenance
 
 
@@ -953,4 +993,5 @@ __all__ = [
     "graph_entity_rows",
     "graph_units",
     "relink_pass",
+    "resolve_entity_names",
 ]

--- a/hindsight-api-slim/hindsight_api/engine/memories/postgres.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/postgres.py
@@ -614,6 +614,9 @@ class PostgresMemories(MemoriesExtension):
     ) -> dict[str, list[dict[str, str]]]:
         return await graph.entity_map_for_units(conn=conn, fq_table=fq_table, bank_id=bank_id, unit_ids=unit_ids)
 
+    async def resolve_entity_names(self, *, conn, fq_table, bank_id: str, entity_ids: list[str]) -> dict[str, str]:
+        return await graph.resolve_entity_names(conn=conn, fq_table=fq_table, bank_id=bank_id, entity_ids=entity_ids)
+
     # ------------------------------------------------------------------ maintenance
 
     async def record_unit_entities(

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -935,6 +935,33 @@ def _is_invalid_embedding_dimension_error(e: Exception) -> bool:
     )
 
 
+def _entity_map_from_results(
+    ids_by_unit: dict[str, list[str]], names: dict[str, str]
+) -> dict[str, list[dict[str, str]]]:
+    """Build the ``{unit_id: [{entity_id, canonical_name}]}`` recall shape from the
+    entity ids a store carried on its results, given a resolved id->name map.
+
+    Mirrors ``entity_map_for_units`` exactly, so both paths produce identical output:
+    an order-preserving per-unit dedupe (a unit can carry the same id twice), ids with
+    no resolved name dropped, and — crucially — a unit that resolves to no entity is
+    omitted entirely rather than mapped to ``[]``, so its fact keeps ``entities=None``
+    downstream instead of an empty list. Pure and connectionless, so it is unit-testable
+    without a store or a database.
+    """
+    out: dict[str, list[dict[str, str]]] = {}
+    for unit_id, ids in ids_by_unit.items():
+        rows: list[dict[str, str]] = []
+        seen: set[str] = set()
+        for entity_id in ids:
+            if entity_id in seen or entity_id not in names:
+                continue
+            seen.add(entity_id)
+            rows.append({"entity_id": entity_id, "canonical_name": names[entity_id]})
+        if rows:
+            out[unit_id] = rows
+    return out
+
+
 def _is_non_retryable_task_error(e: Exception) -> bool:
     """Classify deterministic task failures that should skip worker retry."""
     return (
@@ -6754,13 +6781,37 @@ class MemoryEngine(MemoryEngineInterface):
                 if unit_ids:
                     from .memories import get_memories
 
-                    async with acquire_with_retry(backend) as entity_conn:
-                        # The memory carries its own entity ids; the store resolves
-                        # them to names (observations inherit their sources'), the
-                        # `entities` registry staying in postgres.
-                        fact_entity_map = await get_memories().entity_map_for_units(
-                            conn=entity_conn, fq_table=fq_table, bank_id=bank_id, unit_ids=unit_ids
-                        )
+                    # A backend that resolves the unit->entity posting inline carries
+                    # each result's entity ids on the RetrievalResult (a list, possibly
+                    # empty); Postgres leaves them None and resolves them here. When every
+                    # result carries its ids we avoid re-fetching the memories: build the
+                    # map from the results themselves and resolve names in one Postgres
+                    # lookup — and when no result carries any entity (chunks mode) skip all
+                    # work, acquiring no connection at all.
+                    if all(sr.retrieval.entity_ids is not None for sr in top_scored):
+                        # Normalise ids to str once, here at the boundary: a store may
+                        # hand back UUIDs, and everything downstream (the union, the
+                        # membership test, the map keys) then speaks one type.
+                        ids_by_unit = {sr.id: [str(e) for e in (sr.retrieval.entity_ids or [])] for sr in top_scored}
+                        union = {e for ids in ids_by_unit.values() for e in ids}
+                        names: dict[str, str] = {}
+                        # Acquire a connection only when there is actually a name to
+                        # resolve — when no result carries any entity (chunks mode) we
+                        # touch Postgres not at all.
+                        if union:
+                            async with acquire_with_retry(backend) as entity_conn:
+                                names = await get_memories().resolve_entity_names(
+                                    conn=entity_conn, fq_table=fq_table, bank_id=bank_id, entity_ids=list(union)
+                                )
+                        fact_entity_map = _entity_map_from_results(ids_by_unit, names)
+                    else:
+                        async with acquire_with_retry(backend) as entity_conn:
+                            # The memory carries its own entity ids; the store resolves
+                            # them to names (observations inherit their sources'), the
+                            # `entities` registry staying in postgres.
+                            fact_entity_map = await get_memories().entity_map_for_units(
+                                conn=entity_conn, fq_table=fq_table, bank_id=bank_id, unit_ids=unit_ids
+                            )
 
             # Convert results to MemoryFact objects
             # Build per-result scores (final/reranker/semantic/text) keyed by id.

--- a/hindsight-api-slim/hindsight_api/engine/search/types.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/types.py
@@ -50,6 +50,22 @@ class RetrievalResult:
     metadata: dict[str, str] | None = None  # User-provided metadata
     proof_count: int | None = None  # Number of supporting memories (observations only)
 
+    # Entity postings the backend already resolved for this unit, if any.
+    # ``None`` means "this backend does not carry entity ids on the result" (the default
+    # store, which resolves them later via ``entity_map_for_units``); a list — possibly
+    # empty — means the backend already resolved the unit->entity posting inline, so
+    # recall can build the entity map directly instead of re-fetching the memories.
+    #
+    # CONTRACT: a backend that populates this for an OBSERVATION MUST include the
+    # entities it inherits from its source memories, not only any it carries directly.
+    # Recall builds the entity map straight from this list and does NOT resolve
+    # observation-from-source inheritance itself (the default store, which leaves this
+    # ``None``, resolves that inheritance inside ``entity_map_for_units`` instead). A
+    # backend that owns its index and resolves the inheritance at write time — so the
+    # stored record's entity ids are already the complete set — satisfies this; one that
+    # only stores direct postings must leave this ``None`` for observations.
+    entity_ids: list[str] | None = None
+
     # Retrieval-specific scores (only one will be set depending on retrieval method)
     similarity: float | None = None  # Semantic retrieval
     bm25_score: float | None = None  # BM25 retrieval

--- a/hindsight-api-slim/tests/test_memories_extension.py
+++ b/hindsight-api-slim/tests/test_memories_extension.py
@@ -55,6 +55,12 @@ class InMemoryMemories(MemoriesExtension):
     # It also owns the document/chunk bodies, so the retain and read paths route those through the
     # document methods below — exercising that half of the seam too.
     owns_document_store = True
+    # When True the store carries each unit's entity ids on the recall result (a backend that
+    # resolves the unit->entity posting inline), so recall builds the entity map from the result
+    # and resolves only names via ``resolve_entity_names``. When False the result carries no ids
+    # (the default store) and recall re-fetches via ``entity_map_for_units``. Both must produce
+    # identical output — the parametrized entity tests pin that.
+    carries_entity_ids_on_result = False
 
     def __init__(self, config: dict[str, str] | None = None):
         super().__init__(config or {})
@@ -133,6 +139,9 @@ class InMemoryMemories(MemoriesExtension):
                 tags=list(row.tags) or None,
                 metadata=row.metadata,
                 proof_count=row.proof_count,
+                # A store that resolves the posting inline carries the ids on the result (a list,
+                # possibly empty); otherwise leave it None so recall re-fetches via the map path.
+                entity_ids=list(row.entity_ids) if self.carries_entity_ids_on_result else None,
                 similarity=score if semantic else None,
                 bm25_score=None if semantic else score,
             )
@@ -284,19 +293,32 @@ class InMemoryMemories(MemoriesExtension):
         # matching registry row, so the direct-call tests (conn=None) still get the recall shape.
         wanted = {str(u): list(self.rows[str(u)].entity_ids) for u in unit_ids if str(u) in self.rows}
         all_ids = {e for ids in wanted.values() for e in ids}
-        names: dict[str, str] = {}
-        if conn is not None and all_ids:
-            try:
-                as_uuids = [uuid.UUID(e) for e in all_ids]
-            except (ValueError, AttributeError, TypeError):
-                as_uuids = None
-            if as_uuids:
-                rows = await conn.fetch(
-                    f"SELECT id, canonical_name FROM {fq_table('entities')} WHERE id = ANY($1::uuid[])",
-                    as_uuids,
-                )
-                names = {str(r["id"]): r["canonical_name"] for r in rows}
-        return {uid: [{"entity_id": e, "canonical_name": names.get(e, e)} for e in ids] for uid, ids in wanted.items()}
+        names = await self.resolve_entity_names(conn=conn, fq_table=fq_table, bank_id=bank_id, entity_ids=all_ids)
+        # A unit with no entities is omitted, not mapped to [] — same as the default store, so
+        # its fact keeps entities=None downstream rather than an empty list.
+        return {
+            uid: [{"entity_id": e, "canonical_name": names.get(e, e)} for e in ids]
+            for uid, ids in wanted.items()
+            if ids
+        }
+
+    async def resolve_entity_names(self, *, conn, fq_table, bank_id, entity_ids):
+        # The store owns the memory rows (and their entity ids), but the *names* live in the
+        # shared entity registry, which this store does not stand in for — resolve them through
+        # the connection recall hands us, bank-scoped, exactly as a store that owns its rows (but
+        # not the registry) would. No connection or no ids means no names to resolve.
+        if not entity_ids or conn is None:
+            return {}
+        try:
+            as_uuids = [uuid.UUID(str(e)) for e in set(entity_ids)]
+        except (ValueError, AttributeError, TypeError):
+            return {}
+        rows = await conn.fetch(
+            f"SELECT id, canonical_name FROM {fq_table('entities')} WHERE id = ANY($1::uuid[]) AND bank_id = $2",
+            as_uuids,
+            bank_id,
+        )
+        return {str(r["id"]): r["canonical_name"] for r in rows}
 
     async def any_memory_updated_since(
         self, *, conn, fq_table, bank_id, since, fact_types=None, tags=None, tags_match="any", tag_groups=None
@@ -989,13 +1011,23 @@ async def test_recall_include_source_facts_hydrates_from_store(memory, request_c
     assert by_id[obs_id].source_fact_ids == [src_id]
 
 
-async def test_recall_include_entities_hydrates_names_from_registry(memory, request_context, restore_default_store):
-    """include_entities must resolve the memory's inline entity ids to NAMES from the PG registry.
+@pytest.mark.parametrize("carries_ids_on_result", [False, True], ids=["map-refetch", "ids-on-result"])
+async def test_recall_include_entities_hydrates_names_from_registry(
+    carries_ids_on_result, memory, request_context, restore_default_store
+):
+    """include_entities must resolve the memory's inline entity ids to NAMES from the registry.
 
     The store owns the memory rows (and the entity ids on them), but the entity name registry stays
     in Postgres — so the names can only come back by resolving through it, not from the dict.
+
+    Parametrized over both recall paths, which MUST agree:
+    - ``map-refetch``: the result carries no entity ids, so recall re-fetches the map via
+      ``entity_map_for_units`` (the default store's behaviour);
+    - ``ids-on-result``: the store carries the ids on the result, so recall builds the map from
+      them and resolves only names via ``resolve_entity_names`` — no re-fetch.
     """
     store = InMemoryMemories({})
+    store.carries_entity_ids_on_result = carries_ids_on_result
     set_memories(store)
     bank_id = f"seam-entities-{uuid.uuid4().hex[:8]}"
     fact_id = str(uuid.uuid4())
@@ -1028,6 +1060,84 @@ async def test_recall_include_entities_hydrates_names_from_registry(memory, requ
     finally:
         async with pool.acquire() as conn:
             await conn.execute("DELETE FROM entities WHERE bank_id = $1", bank_id)
+
+
+@pytest.mark.parametrize("carries_ids_on_result", [False, True], ids=["map-refetch", "ids-on-result"])
+async def test_recall_include_entities_omits_entityless_unit(
+    carries_ids_on_result, memory, request_context, restore_default_store
+):
+    """A unit with no entities is OMITTED, not emitted as ``entities=[]`` — in both recall paths.
+
+    One entity-bearing unit and one entity-less unit in the same recall: the bearing unit resolves
+    to its registry name, the entity-less unit comes back with ``entities is None`` (never ``[]``),
+    and the aggregate ``entities`` dict holds only the one real entity. The ``ids-on-result`` fast
+    path and the ``map-refetch`` path must agree exactly.
+    """
+    store = InMemoryMemories({})
+    store.carries_entity_ids_on_result = carries_ids_on_result
+    set_memories(store)
+    bank_id = f"seam-entities-omit-{uuid.uuid4().hex[:8]}"
+    with_entity_id = str(uuid.uuid4())
+    without_entity_id = str(uuid.uuid4())
+
+    pool = await memory._get_pool()
+    async with pool.acquire() as conn:
+        ent_id = await conn.fetchval(
+            "INSERT INTO entities (bank_id, canonical_name, mention_count) VALUES ($1, $2, 1) RETURNING id",
+            bank_id,
+            "Quantum Lab",
+        )
+    store.rows[with_entity_id] = _stored(
+        with_entity_id, "the quantum lab published its results", "world", entity_ids=[str(ent_id)]
+    )
+    store.rows[without_entity_id] = _stored(without_entity_id, "the cafeteria changed its menu", "world", entity_ids=[])
+
+    try:
+        result = await memory.recall_async(
+            bank_id=bank_id,
+            query="lab and cafeteria",
+            fact_type=["world"],
+            max_tokens=4096,
+            include_entities=True,
+            max_entity_tokens=2000,
+            request_context=request_context,
+        )
+        by_id = {str(r.id): r for r in result.results}
+        assert with_entity_id in by_id and without_entity_id in by_id, f"both facts expected; got {list(by_id)}"
+        assert by_id[with_entity_id].entities == ["Quantum Lab"]
+        assert by_id[without_entity_id].entities is None, (
+            f"entity-less unit must be omitted (entities=None), not entities=[]; "
+            f"got {by_id[without_entity_id].entities!r}"
+        )
+        assert result.entities and list(result.entities) == ["Quantum Lab"]
+    finally:
+        async with pool.acquire() as conn:
+            await conn.execute("DELETE FROM entities WHERE bank_id = $1", bank_id)
+
+
+@pytest.mark.parametrize(
+    "ids_by_unit, names, expected",
+    [
+        # entity-less unit is omitted, not mapped to []
+        ({"u1": ["e1"], "u2": []}, {"e1": "Alpha"}, {"u1": [{"entity_id": "e1", "canonical_name": "Alpha"}]}),
+        # a repeated id yields one row, first-seen order preserved
+        (
+            {"u1": ["e1", "e2", "e1"]},
+            {"e1": "Alpha", "e2": "Beta"},
+            {"u1": [{"entity_id": "e1", "canonical_name": "Alpha"}, {"entity_id": "e2", "canonical_name": "Beta"}]},
+        ),
+        # an id with no resolved name is dropped; a unit left with none is omitted
+        ({"u1": ["e1", "eX"], "u2": ["eX"]}, {"e1": "Alpha"}, {"u1": [{"entity_id": "e1", "canonical_name": "Alpha"}]}),
+        # nothing to resolve -> empty map
+        ({"u1": []}, {}, {}),
+    ],
+)
+def test_entity_map_from_results_shape(ids_by_unit, names, expected):
+    """The pure fast-path helper mirrors entity_map_for_units: per-unit order-preserving dedupe,
+    unresolved ids dropped, entity-less units omitted (never ``[]``). DB-free."""
+    from hindsight_api.engine.memory_engine import _entity_map_from_results
+
+    assert _entity_map_from_results(ids_by_unit, names) == expected
 
 
 async def test_recall_all_enrichments_together_through_store(memory, request_context, restore_default_store):


### PR DESCRIPTION
`entity_build` re-fetched every recalled memory (`entity_map_for_units` → `get_memories`) purely to read `entity_ids` — a redundant round-trip for a backend that already returns them in its recall payload. When there are no entities, it is ~34ms of pure waste.

- `RetrievalResult` gains an optional `entity_ids`; a backend that resolves the unit→entity posting at recall time populates it.
- `entity_build`: when results carry `entity_ids`, resolve names directly via the new `MemoriesExtension.resolve_entity_names`; when the union is empty, acquire no connection and skip entirely.
- The default backend leaves `entity_ids` `None`, keeping the existing `entity_map_for_units` path unchanged.

`entity_build` drops from ~34ms to ~0 when there are no entities to resolve; recall results are unchanged. Shape fidelity preserved (entity-less units are omitted from the map, so a fact gets `entities=None`).