### PR TITLE
docs: specify Claude Sonnet benchmark version

### DIFF
--- a/hindsight-docs/blog/2026-08-06-hindsight-0-9-0.md
+++ b/hindsight-docs/blog/2026-08-06-hindsight-0-9-0.md
@@ -76,7 +76,7 @@ The numbers moved immediately, and they've held through every re-architecture si
 
 | Agent (61 tasks, mean of 3 runs each) | Corrections / task, vanilla | With Hindsight | Corrections | Cost | Wall time / task              |
 | ------------------------------------- | --------------------------- | -------------- | ----------- | ---- | ----------------------------- |
-| **Claude Code** · Claude Sonnet       | 0.85                        | **0.36**       | **−57%**    | −24% | 84.7s → **75.1s** (**−11%**)  |
+| **Claude Code** · Claude Sonnet 5     | 0.85                        | **0.36**       | **−57%**    | −24% | 84.7s → **75.1s** (**−11%**)  |
 | **opencode** · Gemini 3.5 Flash       | 1.20                        | **0.80**       | **−33%**    | −13% | 174.2s → **163.3s** (**−6%**) |
 | **Codex CLI** · GPT-5.4 mini          | 1.34                        | **0.47**       | **−65%**    | −52% | 53.6s → **48.6s** (**−9%**)   |
 


### PR DESCRIPTION
Fixes #3467.

The v0.9.0 benchmark table previously labeled the Claude Code model only as "Claude Sonnet", while the public benchmark runner and recorded results identify the tested model specifically as `claude-sonnet-5`.

Why this is identified as Sonnet 5:

- The benchmark runner hard-codes the Claude Code model as `claude-sonnet-5` in [`src/memory_bench/modes/coding.py`](https://github.com/vectorize-io/agent-memory-benchmark/blob/main/src/memory_bench/modes/coding.py).
- The harness uses the same mapping in [`sdebench/harness/run.py`](https://github.com/vectorize-io/agent-memory-benchmark/blob/main/sdebench/harness/run.py).
- The published [`results-manifest.json`](https://github.com/vectorize-io/agent-memory-benchmark/blob/main/results-manifest.json) records `model: "claude-sonnet-5"` for the Claude runs.
- The individual vanilla and Hindsight result files also include `answer_llm: "claude-code:claude-sonnet-5"` and per-task metadata with `model: "claude-sonnet-5"`.

This updates the release blog benchmark table to say "Claude Sonnet 5", making the benchmark configuration unambiguous and reproducible.

Validation: `git diff --check`.