### PR TITLE
Stop whole-schema claim test fixtures deleting other xdist workers' operations

### DIFF
--- a/hindsight-api-slim/tests/test_graph_maintenance_claim_serialization.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance_claim_serialization.py
@@ -18,7 +18,9 @@ so the slot limits under test are exact and not a function of ambient in-flight
 work in the shared test database.
 """
 
+import asyncio
 import json
+import os
 import uuid
 from datetime import UTC, datetime, timedelta
 
@@ -32,16 +34,89 @@ pytestmark = pytest.mark.xdist_group("worker_tests")
 _TABLE = "async_operations"
 
 
+@pytest.fixture(scope="session")
+def isolated_ops_schema(pg0_db_url):
+    """A private, migrated Postgres schema for this file's claim tests.
+
+    ``ops.claim_tasks`` scans the whole schema on the connection's search_path,
+    and tests like ``test_not_starved_by_newer_pending_work`` assert on an *exact*
+    single-slot claim — both are meaningless if another pytest-xdist worker's
+    pending rows are visible. The previous fixture kept itself clean with a global
+    ``DELETE FROM async_operations WHERE status = 'pending'``, which under xdist
+    deleted those other workers' in-flight operations mid-run (e.g. a refresh op
+    sitting ``pending`` for the window between ``_submit_async_operation``
+    committing it and ``SyncTaskBackend`` marking it ``completed``, which then
+    read back as ``not_found`` and flaked an unrelated test).
+
+    So give this file its own schema: "the whole schema" is then only its own
+    rows, and its cleanup can never touch ``public``. One schema per worker,
+    created + migrated once and dropped at session end. ``search_path`` is set on
+    the pool in :func:`backend`, so every table reference here resolves into it.
+    """
+    from hindsight_api.engine.db import create_database_backend
+    from hindsight_api.pg0 import resolve_database_url
+
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    schema = f"gmclaim_iso_{worker}"
+
+    async def _provision() -> str:
+        url = await resolve_database_url(pg0_db_url)
+        b = create_database_backend("postgresql")
+        await b.initialize(url, min_size=1, max_size=2)
+        try:
+            async with b.get_pool().acquire() as conn:
+                # Rebuild from scratch so a schema left by a crashed prior run
+                # can't carry stale state into this session.
+                await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+                await conn.execute(f'CREATE SCHEMA "{schema}"')
+            # run_migrations is sync; call it with the loop running (as elsewhere
+            # in the suite) — it builds banks/async_operations/etc. in the schema.
+            b.run_migrations(url, schema=schema)
+        finally:
+            await b.shutdown()
+        return url
+
+    async def _drop(url: str) -> None:
+        b = create_database_backend("postgresql")
+        await b.initialize(url, min_size=1, max_size=2)
+        try:
+            async with b.get_pool().acquire() as conn:
+                await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        finally:
+            await b.shutdown()
+
+    loop = asyncio.new_event_loop()
+    try:
+        url = loop.run_until_complete(_provision())
+    finally:
+        loop.close()
+
+    yield schema
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(_drop(url))
+    finally:
+        loop.close()
+
+
 @pytest_asyncio.fixture
-async def backend(pg0_db_url):
-    """Create a DatabaseBackend for claim tests."""
+async def backend(pg0_db_url, isolated_ops_schema):
+    """Create a DatabaseBackend whose pool is pinned to this file's private schema."""
     from hindsight_api.engine.db import create_database_backend
     from hindsight_api.pg0 import resolve_database_url
 
     resolved_url = await resolve_database_url(pg0_db_url)
 
+    async def _use_isolated_schema(conn):
+        # init runs once per new connection, setup runs on every acquire (after
+        # asyncpg's release-time RESET ALL), so this pins search_path for the
+        # pool's whole lifetime — every unqualified table resolves into the
+        # private schema, so claims and cleanup never see the shared public one.
+        await conn.execute(f'SET search_path TO "{isolated_ops_schema}", public')
+
     b = create_database_backend("postgresql")
-    await b.initialize(resolved_url, min_size=2, max_size=10, command_timeout=30)
+    await b.initialize(resolved_url, min_size=2, max_size=10, command_timeout=30, init_callback=_use_isolated_schema)
     yield b
     await b.shutdown()
 
@@ -54,11 +129,10 @@ async def pool(backend):
 
 @pytest_asyncio.fixture
 async def clean_operations(pool):
-    """Isolate these tests from other pending work in the shared schema.
+    """Clear leftovers from a prior test in this group.
 
-    Same rationale as test_worker.py's fixture: the claim queries scan the whole
-    schema, so stale pending rows from other tests would be claimed here and
-    consume the (deliberately small) slot limits under test.
+    Safe to be broad now: the pool is pinned to this file's private schema
+    (:func:`isolated_ops_schema`), so this only ever touches its own rows.
     """
     await pool.execute("DELETE FROM async_operations WHERE status = 'pending'")
     yield

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -58,18 +58,29 @@ async def pool(backend):
 
 @pytest_asyncio.fixture
 async def clean_operations(pool):
-    """Clean up async_operations table before and after tests.
+    """Clean up this file's async_operations rows before and after each test.
 
-    We must clean ALL pending operations (not just test-worker-* prefixed ones)
-    because WorkerPoller.claim_batch scans the entire schema for pending tasks.
-    Stale operations left by other tests (e.g. consolidation) cause spurious
-    failures when the poller picks them up unexpectedly.
+    Scoped to the worker-test bank prefixes. This used to be a global
+    ``DELETE FROM async_operations WHERE status = 'pending'`` to keep the
+    whole-schema ``WorkerPoller.claim_batch`` from picking up rows other tests
+    left behind — but under pytest-xdist this file shares the ``public`` schema
+    with every test running in parallel, so that global delete removed *other
+    workers'* in-flight operations mid-run. A refresh op, for instance, sits
+    ``pending`` for the brief window between ``_submit_async_operation``
+    committing it and ``SyncTaskBackend`` marking it ``completed``; deleting it
+    in that window makes ``get_operation_status`` read back ``not_found`` and
+    flakes an unrelated test.
+
+    The claim tests here don't need a globally empty table: they filter claims to
+    their own bank or assert only against ``max_slots``, so foreign pending rows
+    are harmless. (The claim-*serialisation* tests, which do need an exact view,
+    isolate themselves in a private schema instead — see
+    test_graph_maintenance_claim_serialization.py.)
     """
-    await pool.execute("DELETE FROM async_operations WHERE status = 'pending'")
+    scoped_delete = "DELETE FROM async_operations WHERE bank_id LIKE 'test-worker-%' OR bank_id LIKE 'test_worker_%'"
+    await pool.execute(scoped_delete)
     yield
-    await pool.execute(
-        "DELETE FROM async_operations WHERE bank_id LIKE 'test-worker-%' OR bank_id LIKE 'test_worker_%'"
-    )
+    await pool.execute(scoped_delete)
 
 
 def test_metric_operation_label_normalises_retain_variants():


### PR DESCRIPTION
## Problem

`test_completed_refresh_enriches_result_metadata` flaked in CI with:

```
assert status["status"] == "completed"
E   AssertionError: assert 'not_found' == 'completed'
```

The refresh operation row disappeared between being submitted and being read back.

## Root cause — cross-worker contamination on the shared `public` schema

Two fixtures — `clean_operations` in `test_worker.py` and in `test_graph_maintenance_claim_serialization.py` — ran a **global**

```sql
DELETE FROM async_operations WHERE status = 'pending'
```

at setup, because their whole-schema claim/poller logic must not pick up rows other tests left behind (`WorkerPoller.claim_batch` / `ops.claim_tasks` scan the entire schema).

Under `pytest-xdist` these fixtures run **concurrently with every other test on the shared `public` schema**, so the delete removed *other workers'* in-flight operations. `_submit_async_operation` commits an op as `pending` and only **then** does `SyncTaskBackend` mark it `completed`; a global pending-delete landing in that microsecond window deletes the row, and `get_operation_status` reads back `not_found`.

These were the **only two** unscoped global `async_operations` mutations in the suite.

## Fix

Neither fixture actually needs a globally empty table:

- **`test_worker.py`** — its tests filter claims to their own bank or assert only against `max_slots`, so foreign pending rows are harmless. Scope the cleanup to the worker-test bank prefixes (the same predicate its teardown already used).
- **`test_graph_maintenance_claim_serialization.py`** — `test_not_starved_by_newer_pending_work` asserts on an *exact* single-slot (`shared=1`) claim, which genuinely needs a private view of `async_operations`. Give the file its **own migrated Postgres schema** (one per xdist worker, created + dropped per session) and pin the pool's `search_path` to it, so `ops.claim_tasks` and the cleanup only ever see this file's own rows — never `public`.

## Validation

- `test_worker.py::TestWorkerPoller` + `test_graph_maintenance_claim_serialization.py` + the previously-flaky `test_refresh_outcome_metadata.py` pass together under `-n 4`, **stable across repeated stress runs** (13 passed × 3, 25 passed combined).
- Confirmed the isolated schema fully hides rows from `public` and vice-versa.

## Not in scope

The same CI run surfaced two other reds, both **non-deterministic / infra**, not this class of bug:

- **`Core LLM tests` → `test_reflect_split_synthesis::test_facts_from_distinct_chunks_reach_the_answer`** — a real-Gemini LLM-as-judge assertion (`LLM judge: criteria not met`). Inherently non-deterministic by project convention; not fixable by a code change without weakening the test. Passed on the adjacent run.
- **`build-docs` / `LLM acceptance (vertexai)`** — `fetch failed` / generic infra during setup. Passed on the adjacent run.

Left alone deliberately to keep this PR to the one deterministic, fixable root cause.
