### PR TITLE
docs: link Hindsight Academy from the docs navbar and footer

### DIFF
--- a/hindsight-docs/docusaurus.config.ts
+++ b/hindsight-docs/docusaurus.config.ts
@@ -272,6 +272,12 @@ const config: Config = {
           className: 'navbar-item-changelog',
         },
         {
+          href: 'https://learn.hindsight.vectorize.io',
+          position: 'left',
+          label: 'Academy',
+          className: 'navbar-item-academy',
+        },
+        {
           type: 'dropdown',
           label: 'Resources',
           position: 'left',
@@ -386,6 +392,10 @@ const config: Config = {
             {
               label: 'Guides',
               to: '/guides',
+            },
+            {
+              label: 'Academy',
+              href: 'https://learn.hindsight.vectorize.io',
             },
             {
               label: 'Hindsight Cloud',


### PR DESCRIPTION
Adds links to **Hindsight Academy** (`learn.hindsight.vectorize.io`) from the docs site so people can find the human-facing video course hub.

## Changes (`hindsight-docs/docusaurus.config.ts`)
- **Navbar** — new top-level **Academy** item (left, after *Changelog*) → `https://learn.hindsight.vectorize.io`
- **Footer** — **Academy** entry under the *Resources* column → same URL

External link (opens the Academy site). No content or routing changes.
