### PR TITLE
retain: let a store that owns its vector index skip the Postgres ANN pass

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -452,6 +452,22 @@ class MemoriesExtension(Extension, ABC):
         that keeps some banks in a separate backend overrides it. See :meth:`writes_memory_rows_in_sql_for`."""
         return self.owns_document_store
 
+    #: Whether this store derives the semantic (kNN) link graph itself, so retain must NOT run the
+    #: Postgres ANN pass that populates ``memory_links``. Default False: the SQL stores have no
+    #: standing kNN index, so retain computes each committed unit's semantic neighbours with a
+    #: pgvector ANN pass and writes ``memory_links`` rows, which the recall graph arm then reads.
+    #: A store that keeps its own vector index can serve the same neighbours from it (at read time,
+    #: or from links it derived at fold time) — for such a store the Postgres pass is pure waste: it
+    #: scans a ``memory_units`` table that is empty for its banks and writes ``memory_links`` rows
+    #: nothing on its read path consults. Setting this True makes retain skip that pass entirely.
+    derives_semantic_links_internally: bool = False
+
+    def derives_semantic_links_internally_for(self, bank_id: str) -> bool:
+        """Per-bank form of :attr:`derives_semantic_links_internally`. Defaults to the class
+        attribute; a store that owns its vector index for only some banks overrides it. See
+        :meth:`writes_memory_rows_in_sql_for`."""
+        return self.derives_semantic_links_internally
+
     # ------------------------------------------------------------------ lifecycle
 
     async def initialize(self) -> None:

--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -30,9 +30,10 @@ Most operations are a method here, so the call chains route through the interfac
 rather than reimplement it per store; where the two differ, they usually differ by
 what the method does — the Postgres implementation writes join rows and reprocesses
 links, one that owns the store no-ops those passes and does its own thing. A handful
-of call sites still branch on the two capability flags (``writes_memory_rows_in_sql``
-for the inline-SQL fast paths, ``owns_document_store`` for the document/chunk bodies)
-where the shapes are genuinely different; those are the seams, not accidental leaks.
+of call sites still branch on the capability flags (``writes_memory_rows_in_sql`` for
+the inline-SQL fast paths, ``owns_document_store`` for the document/chunk bodies, and
+``derives_semantic_links_internally`` for the retain-time kNN link pass) where the
+shapes are genuinely different; those are the seams, not accidental leaks.
 """
 
 from __future__ import annotations
@@ -438,6 +439,23 @@ class MemoriesExtension(Extension, ABC):
     #: the inline SQL. Cold, never-searched, key-based — see docs/documents-chunks.md.
     owns_document_store: bool = False
 
+    #: Whether this store derives the semantic (kNN) neighbours of a memory itself, so retain must
+    #: NOT compute them in Postgres. Default False: the SQL stores have no standing kNN index, so
+    #: retain runs a pgvector ANN pass over ``memory_units`` and materializes the neighbours as
+    #: ``semantic`` ``memory_links`` rows, which the SQL graph arm reads back at recall time.
+    #: A store that keeps its own vector index can answer the same question from that index (at read
+    #: time, or from links it derived at fold time), so for it the Postgres work is redundant — and
+    #: for a store whose memories don't live in ``memory_units`` at all it is worse than redundant:
+    #: it queries a table that holds none of its rows and writes ``memory_links`` rows nothing on its
+    #: read path consults. Setting this True makes retain skip BOTH halves for this store's banks —
+    #: the ANN query and the ``memory_links`` write, on every retain path (full, delta, import).
+    #:
+    #: Setting it True is a promise, not just an optimization: this store's :meth:`graph_retriever`
+    #: (or :meth:`graph_direct_links`) must serve the semantic neighbours itself, because after the
+    #: skip there are no ``semantic`` rows in ``memory_links`` for these banks for the SQL graph arm
+    #: to find. Leave it False for a store that relies on the Postgres link graph.
+    derives_semantic_links_internally: bool = False
+
     def writes_memory_rows_in_sql_for(self, bank_id: str) -> bool:
         """Per-bank form of :attr:`writes_memory_rows_in_sql`. Defaults to the class attribute, so a
         single-store extension needs no override. A store that keeps different banks in different
@@ -451,16 +469,6 @@ class MemoriesExtension(Extension, ABC):
         """Per-bank form of :attr:`owns_document_store`. Defaults to the class attribute; a store
         that keeps some banks in a separate backend overrides it. See :meth:`writes_memory_rows_in_sql_for`."""
         return self.owns_document_store
-
-    #: Whether this store derives the semantic (kNN) link graph itself, so retain must NOT run the
-    #: Postgres ANN pass that populates ``memory_links``. Default False: the SQL stores have no
-    #: standing kNN index, so retain computes each committed unit's semantic neighbours with a
-    #: pgvector ANN pass and writes ``memory_links`` rows, which the recall graph arm then reads.
-    #: A store that keeps its own vector index can serve the same neighbours from it (at read time,
-    #: or from links it derived at fold time) — for such a store the Postgres pass is pure waste: it
-    #: scans a ``memory_units`` table that is empty for its banks and writes ``memory_links`` rows
-    #: nothing on its read path consults. Setting this True makes retain skip that pass entirely.
-    derives_semantic_links_internally: bool = False
 
     def derives_semantic_links_internally_for(self, bank_id: str) -> bool:
         """Per-bank form of :attr:`derives_semantic_links_internally`. Defaults to the class

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -2657,8 +2657,16 @@ async def _streaming_retain_batch(
     # Final ANN pass: create semantic links for ALL committed units at once.
     # This replaces per-batch within-batch + fire-and-forget ANN with a single
     # efficient pass after all facts are in the database.
+    #
+    # Skipped for a store that derives the semantic graph itself: the pass would
+    # run a pgvector ANN over the SQL memory_units table — empty for such a store,
+    # since its facts live in its own index — and write memory_links rows its read
+    # path never consults. That is a full redundant pass on every retain; the store
+    # serves the same neighbours from its own vector index instead.
     # ---------------------------------------------------------------------------
-    if all_unit_ids and not pipeline_aborted[0]:
+    from ..memories import get_memories
+
+    if all_unit_ids and not pipeline_aborted[0] and not get_memories().derives_semantic_links_internally_for(bank_id):
         ann_start = time.time()
         try:
             await _run_final_semantic_ann(

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -401,7 +401,16 @@ async def _pre_resolve_phase1(
     slow reads, eliminating TimeoutErrors under concurrent load.
     """
     set_stage("retain.phase1.resolve")
+    from ..memories import get_memories
     from .link_utils import compute_semantic_links_ann
+
+    # A store that derives the semantic graph itself answers those neighbours from its own
+    # vector index, so the pgvector query below — and the memory_links rows it feeds — would
+    # be work nothing ever reads. Gated here, in the one place every retain path (full, delta,
+    # import) resolves Phase 1, so no caller can reintroduce the query by forgetting the flag.
+    if not skip_semantic_ann and get_memories().derives_semantic_links_internally_for(bank_id):
+        skip_semantic_ann = True
+        log_buffer.append("  Semantic ANN: skipped (store derives semantic links internally)")
 
     user_entities_per_content = {idx: content.entities for idx, content in enumerate(contents) if content.entities}
 
@@ -511,6 +520,8 @@ async def _insert_facts_and_links(
     memory_links here.
     """
     set_stage("retain.phase2.insert_facts")
+    from ..memories import get_memories
+
     unit_ids = await fact_storage.insert_facts_batch(conn, bank_id, processed_facts, ops=ops, txn=txn)
     step_start = time.time()
     log_buffer.append(f"  Insert facts: {len(unit_ids)} units in {time.time() - step_start:.3f}s")
@@ -544,9 +555,18 @@ async def _insert_facts_and_links(
         temporal_link_count = await link_creation.create_temporal_links_batch(conn, bank_id, unit_ids, ops=ops)
         log_buffer.append(f"  Temporal links: {temporal_link_count} links in {time.time() - step_start:.3f}s")
 
-        # Create semantic links (within-batch + pre-computed ANN from Phase 1)
+        # Create semantic links (within-batch + pre-computed ANN from Phase 1).
+        # A store that derives them internally gets neither half: Phase 1 already skipped the
+        # ANN query for it, while the within-batch similarities are computed in Python — so
+        # without this gate those would still land in memory_links, rows its read path never
+        # consults.
+        skip_links_reason = None
         if skip_semantic_links:
-            log_buffer.append("  Semantic links: skipped (deferred to final ANN pass)")
+            skip_links_reason = "deferred to final ANN pass"
+        elif get_memories().derives_semantic_links_internally_for(bank_id):
+            skip_links_reason = "store derives semantic links internally"
+        if skip_links_reason:
+            log_buffer.append(f"  Semantic links: skipped ({skip_links_reason})")
             semantic_link_count = 0
         else:
             step_start = time.time()
@@ -1561,10 +1581,21 @@ async def _run_final_semantic_ann(
     fact_types from the database, then runs ANN in chunks of _ANN_CHUNK_SIZE
     seeds. This replaces per-batch within-batch + fire-and-forget ANN with
     one efficient pass that sees the full bank.
+
+    A store that derives the semantic graph itself does none of this: it serves those
+    neighbours from its own vector index, so the pass would query ``memory_units`` and
+    write ``memory_links`` rows its read path never consults. For a store whose facts
+    don't live in ``memory_units`` at all it degenerates further — the lookup below finds
+    none of its units and logs "(unexpected)" on every retain.
     """
+    from ..memories import get_memories
     from .link_utils import _bulk_insert_links, compute_semantic_links_ann
 
     if not unit_ids:
+        return
+
+    if get_memories().derives_semantic_links_internally_for(bank_id):
+        log_buffer.append("[streaming] Final ANN: skipped (store derives semantic links internally)")
         return
 
     # Load embeddings and fact_types for all committed units
@@ -2657,16 +2688,10 @@ async def _streaming_retain_batch(
     # Final ANN pass: create semantic links for ALL committed units at once.
     # This replaces per-batch within-batch + fire-and-forget ANN with a single
     # efficient pass after all facts are in the database.
-    #
-    # Skipped for a store that derives the semantic graph itself: the pass would
-    # run a pgvector ANN over the SQL memory_units table — empty for such a store,
-    # since its facts live in its own index — and write memory_links rows its read
-    # path never consults. That is a full redundant pass on every retain; the store
-    # serves the same neighbours from its own vector index instead.
+    # A store that derives the semantic graph itself opts out inside
+    # _run_final_semantic_ann — see the guard there.
     # ---------------------------------------------------------------------------
-    from ..memories import get_memories
-
-    if all_unit_ids and not pipeline_aborted[0] and not get_memories().derives_semantic_links_internally_for(bank_id):
+    if all_unit_ids and not pipeline_aborted[0]:
         ann_start = time.time()
         try:
             await _run_final_semantic_ann(

--- a/hindsight-api-slim/tests/test_memories_extension.py
+++ b/hindsight-api-slim/tests/test_memories_extension.py
@@ -721,6 +721,29 @@ def test_per_bank_capability_defaults_to_the_class_attribute():
     assert mem.owns_document_store_for("any-bank") is True
 
 
+def test_derives_semantic_links_internally_gates_the_ann_pass():
+    """A store that owns its vector index sets ``derives_semantic_links_internally`` True so retain
+    skips the Postgres ANN pass (which would scan an empty ``memory_units`` and write ``memory_links``
+    rows the store's read path never reads). The default stores keep it False and run the pass —
+    their semantic neighbours live in ``memory_links``, read by the SQL graph arm."""
+    pg = PostgresMemories({})
+    assert pg.derives_semantic_links_internally is False
+    assert pg.derives_semantic_links_internally_for("any-bank") is False
+
+    # A store may own its index for only some banks — the _for method answers per bank.
+    class PartlyOwnedIndex(InMemoryMemories):
+        name = "own-index"
+        derives_semantic_links_internally = True
+
+        def derives_semantic_links_internally_for(self, bank_id):
+            return bank_id != "legacy-sql-bank"
+
+    store = PartlyOwnedIndex({})
+    assert store.derives_semantic_links_internally is True
+    assert store.derives_semantic_links_internally_for("vector-bank") is True
+    assert store.derives_semantic_links_internally_for("legacy-sql-bank") is False
+
+
 def test_a_store_answers_capabilities_per_bank():
     """The point of the _for methods: a store that keeps some banks in SQL and others in a
     separate store answers PER BANK, so mixed banks in one process each take the right path."""

--- a/hindsight-api-slim/tests/test_memories_extension.py
+++ b/hindsight-api-slim/tests/test_memories_extension.py
@@ -721,27 +721,14 @@ def test_per_bank_capability_defaults_to_the_class_attribute():
     assert mem.owns_document_store_for("any-bank") is True
 
 
-def test_derives_semantic_links_internally_gates_the_ann_pass():
-    """A store that owns its vector index sets ``derives_semantic_links_internally`` True so retain
-    skips the Postgres ANN pass (which would scan an empty ``memory_units`` and write ``memory_links``
-    rows the store's read path never reads). The default stores keep it False and run the pass —
-    their semantic neighbours live in ``memory_links``, read by the SQL graph arm."""
+def test_derives_semantic_links_internally_defaults_to_false():
+    """The SQL stores keep the retain-time kNN pass: their semantic neighbours live in
+    ``memory_links``, read back by the SQL graph arm. Only a store that opts in — because it
+    serves those neighbours from its own vector index — makes retain skip the pass. The gates
+    themselves are covered in ``test_retain_orchestrator_mapping.py``."""
     pg = PostgresMemories({})
     assert pg.derives_semantic_links_internally is False
     assert pg.derives_semantic_links_internally_for("any-bank") is False
-
-    # A store may own its index for only some banks — the _for method answers per bank.
-    class PartlyOwnedIndex(InMemoryMemories):
-        name = "own-index"
-        derives_semantic_links_internally = True
-
-        def derives_semantic_links_internally_for(self, bank_id):
-            return bank_id != "legacy-sql-bank"
-
-    store = PartlyOwnedIndex({})
-    assert store.derives_semantic_links_internally is True
-    assert store.derives_semantic_links_internally_for("vector-bank") is True
-    assert store.derives_semantic_links_internally_for("legacy-sql-bank") is False
 
 
 def test_a_store_answers_capabilities_per_bank():

--- a/hindsight-api-slim/tests/test_retain_orchestrator_mapping.py
+++ b/hindsight-api-slim/tests/test_retain_orchestrator_mapping.py
@@ -15,8 +15,18 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from hindsight_api.engine.retain import embedding_utils, entity_processing, link_creation, link_utils, orchestrator
+from hindsight_api.engine import memories as memories_mod
+from hindsight_api.engine.memories.postgres import PostgresMemories
+from hindsight_api.engine.retain import (
+    embedding_utils,
+    entity_processing,
+    fact_storage,
+    link_creation,
+    link_utils,
+    orchestrator,
+)
 from hindsight_api.engine.retain.orchestrator import (
+    _insert_facts_and_links,
     _map_results_to_contents,
     _pre_resolve_phase1,
     _process_extracted_facts,
@@ -306,3 +316,158 @@ class TestSemanticLinkThresholdPropagation:
         )
 
         assert captured_thresholds == [0.84]
+
+
+class _SelfIndexedStore(PostgresMemories):
+    """A store that owns its vector index, so it derives the semantic neighbours itself.
+
+    Subclasses the Postgres store because only the capability answer matters here — the gates
+    ask this one question and nothing else on the store is reached.
+    """
+
+    name = "self-indexed"
+    derives_semantic_links_internally = True
+
+    def __init__(self, sql_link_banks: set[str] | None = None):
+        super().__init__({})
+        # Banks this store still leaves to the Postgres link graph (empty = it owns them all).
+        self._sql_link_banks = sql_link_banks or set()
+
+    def derives_semantic_links_internally_for(self, bank_id: str) -> bool:
+        return bank_id not in self._sql_link_banks
+
+
+class TestSelfIndexedStoreSkipsSemanticLinkWork:
+    """A store that derives the semantic graph itself must see NO retain-time kNN work in
+    Postgres — not the ANN probe, and not the ``memory_links`` rows the probe feeds. Both halves
+    are gated at their single choke point so every retain path (full, delta, import) inherits the
+    skip; these tests pin each gate, since a store that opts in has no ``memory_links`` for the
+    SQL graph arm to fall back on."""
+
+    @pytest.mark.asyncio
+    async def test_phase1_skips_the_ann_probe(self, monkeypatch):
+        """Phase 1 is where delta retain and bank import run their ANN probe."""
+        ann_calls: list[str] = []
+
+        @asynccontextmanager
+        async def fake_acquire_with_retry(_pool):
+            yield object()
+
+        async def fake_resolve_entities(*_args, **_kwargs):
+            return EntityResolutionResult(resolved_entities=[], entity_to_unit=[], unit_to_entity_ids={})
+
+        async def fake_compute_semantic_links_ann(_conn, bank_id, *_args, **_kwargs):
+            ann_calls.append(bank_id)
+            return [("unit", "other", "semantic", 0.9, None)]
+
+        # Owns the index for every bank except "legacy-sql-bank" — the answer is per bank.
+        store = _SelfIndexedStore({"legacy-sql-bank"})
+        monkeypatch.setattr(orchestrator, "acquire_with_retry", fake_acquire_with_retry)
+        monkeypatch.setattr(entity_processing, "resolve_entities", fake_resolve_entities)
+        monkeypatch.setattr(link_utils, "compute_semantic_links_ann", fake_compute_semantic_links_ann)
+        monkeypatch.setattr(memories_mod, "get_memories", lambda: store)
+
+        async def run(bank_id: str):
+            return await _pre_resolve_phase1(
+                pool=object(),
+                entity_resolver=object(),
+                bank_id=bank_id,
+                contents=[_make_content()],
+                processed_facts=[_make_processed_fact(0)],
+                config=SimpleNamespace(entity_labels=None, semantic_link_min_similarity=0.82),
+                log_buffer=[],
+            )
+
+        owned = await run("vector-bank")
+        assert ann_calls == []
+        assert owned.semantic_ann_links == []
+
+        # A bank this store leaves in SQL still gets the probe, on the same store instance.
+        legacy = await run("legacy-sql-bank")
+        assert ann_calls == ["legacy-sql-bank"]
+        assert len(legacy.semantic_ann_links) == 1
+
+    @pytest.mark.asyncio
+    async def test_phase2_writes_no_semantic_memory_links(self, monkeypatch):
+        """The within-batch similarities are computed in Python, so skipping the ANN probe alone
+        would still leave ``memory_links`` rows behind. Phase 2 has to skip the write too."""
+        semantic_writes: list[str] = []
+
+        async def fake_insert_facts_batch(*_args, **_kwargs):
+            return ["unit-1"]
+
+        async def fake_create_semantic_links_batch(_conn, bank_id, *_args, **_kwargs):
+            semantic_writes.append(bank_id)
+            return 1
+
+        async def fake_create_temporal_links_batch(*_args, **_kwargs):
+            return 0
+
+        async def fake_create_causal_links_batch(*_args, **_kwargs):
+            return 0
+
+        store = _SelfIndexedStore({"legacy-sql-bank"})
+        monkeypatch.setattr(fact_storage, "insert_facts_batch", fake_insert_facts_batch)
+        monkeypatch.setattr(link_creation, "create_semantic_links_batch", fake_create_semantic_links_batch)
+        monkeypatch.setattr(link_creation, "create_temporal_links_batch", fake_create_temporal_links_batch)
+        monkeypatch.setattr(link_creation, "create_causal_links_batch", fake_create_causal_links_batch)
+        monkeypatch.setattr(memories_mod, "get_memories", lambda: store)
+
+        entity_resolver = SimpleNamespace(
+            reassert_entities_batch=AsyncMock(),
+            link_units_to_entities_batch=AsyncMock(),
+        )
+
+        async def run(bank_id: str):
+            return await _insert_facts_and_links(
+                object(),
+                entity_resolver,
+                bank_id,
+                [_make_content()],
+                [_make_extracted_fact("f", 0)],
+                [_make_processed_fact(0)],
+                SimpleNamespace(semantic_link_min_similarity=0.82),
+                [],
+                resolved_entities=[],
+                entity_to_unit=[],
+                unit_to_entity_ids={},
+                semantic_ann_links=[],
+            )
+
+        assert await run("vector-bank") == [["unit-1"]]
+        assert semantic_writes == []
+
+        # ...and the store's SQL-backed bank keeps the Postgres link graph.
+        assert await run("legacy-sql-bank") == [["unit-1"]]
+        assert semantic_writes == ["legacy-sql-bank"]
+
+    @pytest.mark.asyncio
+    async def test_streaming_final_ann_pass_is_skipped(self, monkeypatch):
+        """Streaming (full) retain defers its links to this post-commit pass, which reaches
+        pgvector directly rather than through Phase 1 — so it carries its own guard. Nothing
+        should be loaded from memory_units either: the guard runs before the lookup."""
+        conn = SimpleNamespace(fetch=AsyncMock(return_value=[]))
+        ann_calls: list[str] = []
+
+        @asynccontextmanager
+        async def fake_acquire_with_retry(_pool):
+            yield conn
+
+        async def fake_compute_semantic_links_ann(*_args, **_kwargs):
+            ann_calls.append("called")
+            return []
+
+        monkeypatch.setattr(orchestrator, "acquire_with_retry", fake_acquire_with_retry)
+        monkeypatch.setattr(link_utils, "compute_semantic_links_ann", fake_compute_semantic_links_ann)
+        monkeypatch.setattr(memories_mod, "get_memories", lambda: _SelfIndexedStore())
+
+        await _run_final_semantic_ann(
+            SimpleNamespace(ops=object()),
+            "vector-bank",
+            ["unit"],
+            threshold=0.84,
+            log_buffer=[],
+        )
+
+        assert ann_calls == []
+        conn.fetch.assert_not_awaited()


### PR DESCRIPTION
## What

Adds a backend-agnostic capability flag, `derives_semantic_links_internally` (with a per-bank `derives_semantic_links_internally_for`), that lets a store which owns its own vector index skip the retain-time Postgres kNN work that populates `memory_links`.

## Why

The default SQL stores have no standing kNN index, so retain finds each unit's semantic neighbours with a pgvector ANN probe and materializes them as `semantic` `memory_links` rows, which the SQL graph arm reads back at recall time.

A store that keeps its own vector index can answer the same question from that index (at read time, or from links it derived at fold time), so the Postgres work is redundant for it — and for a store whose memories don't live in `memory_units` at all it is worse than redundant: it queries a table holding none of its rows and writes `memory_links` rows nothing on its read path consults.

## How

The flag is honoured at three choke points, so **every** retain path — streaming (full), delta, and bank import — inherits the skip and no caller can reintroduce the query by forgetting to pass a flag down:

- `engine/retain/orchestrator.py`
  - `_pre_resolve_phase1` — skips the ANN probe (this is the probe delta retain and bank import run).
  - `_insert_facts_and_links` — skips the `memory_links` write. Necessary on its own: the within-batch similarities are computed in Python, so skipping the probe alone would still leave rows behind.
  - `_run_final_semantic_ann` — skips streaming retain's post-commit pass, which reaches pgvector directly rather than through Phase 1.
- `engine/memories/base.py` — adds the class attr `derives_semantic_links_internally: bool = False` and `derives_semantic_links_internally_for(bank_id)`, mirroring the existing `writes_memory_rows_in_sql_for` / `owns_document_store_for` pattern.

Setting the flag True is a promise, not just an optimization, and the docstring says so: the store's `graph_retriever` / `graph_direct_links` must serve the semantic neighbours itself, because afterwards there are no `semantic` rows in `memory_links` for the SQL graph arm to find.

## Tests

`tests/test_retain_orchestrator_mapping.py` drives all three gates through the orchestrator — each test fails if its gate is removed — and covers the per-bank answer (one store, one bank it owns the index for and one it leaves in SQL). `tests/test_memories_extension.py` keeps the default-False assertion.

Default is `False`, so there is **no behaviour change** for existing stores.
