### PR TITLE
fix(curation): add exact entity resolution for memory edits

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1793,8 +1793,15 @@ class UpdateMemoryRequest(BaseModel):
     )
     entities: list[str] | None = Field(
         default=None,
-        description="Replace the fact's entities. Names are resolved/find-or-created "
-        "the same way retain does; '[]' detaches all entities. Omit to leave unchanged.",
+        description="Replace the fact's entities. By default names use the same fuzzy "
+        "resolution as retain; set entity_resolution_mode to 'exact' to only reuse "
+        "case-insensitively identical names. '[]' detaches all entities. Omit to leave unchanged.",
+    )
+    entity_resolution_mode: Literal["fuzzy", "exact"] = Field(
+        default="fuzzy",
+        description="How to resolve submitted entity names. 'fuzzy' preserves the legacy "
+        "disambiguation behavior; 'exact' only reuses case-insensitively identical names "
+        "and creates unmatched entities.",
     )
     state: str | None = Field(
         default=None,
@@ -4450,6 +4457,7 @@ def _register_routes(app: FastAPI):
                 occurred_end=occurred_end,
                 new_fact_type=request.fact_type,
                 entities=request.entities,
+                entity_resolution_mode=request.entity_resolution_mode,
                 state=request.state,
                 reason=request.reason,
                 request_context=request_context,

--- a/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
+++ b/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
@@ -15,7 +15,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from difflib import SequenceMatcher
-from typing import Any, Final, cast
+from typing import Any, Final, Literal, cast
 
 from .db_utils import acquire_with_retry
 from .memory_engine import fq_table
@@ -414,6 +414,7 @@ class EntityResolver:
         unit_event_date,
         conn=None,
         entity_labels: list | None = None,
+        resolution_mode: Literal["fuzzy", "exact"] = "fuzzy",
     ) -> list[ResolvedEntity]:
         """
         Resolve multiple entities in batch (MUCH faster than sequential).
@@ -427,6 +428,9 @@ class EntityResolver:
             context: Context where entities appear
             unit_event_date: When this unit was created
             conn: Optional connection to use (if None, acquires from pool)
+            resolution_mode: ``fuzzy`` preserves the normal retain behavior;
+                ``exact`` reuses only case-insensitively identical names and
+                creates a new entity for every unmatched name.
 
         Returns:
             Resolved entity identities (id + stored canonical name) in the same
@@ -434,18 +438,101 @@ class EntityResolver:
         """
         if not entities_data:
             return []
+        if resolution_mode not in ("fuzzy", "exact"):
+            raise ValueError(f"Invalid entity resolution mode '{resolution_mode}': expected 'fuzzy' or 'exact'.")
 
         taxonomy_lookup = self._build_labels_lookup(entity_labels)
         labels_cfg = _parse_entity_labels(entity_labels)
         if conn is None:
             async with acquire_with_retry(self.pool) as conn:
+                if resolution_mode == "exact":
+                    return await self._resolve_entities_batch_exact(
+                        conn, bank_id, entities_data, unit_event_date, taxonomy_lookup, labels_cfg
+                    )
                 return await self._resolve_entities_batch_impl(
                     conn, bank_id, entities_data, context, unit_event_date, taxonomy_lookup, labels_cfg
                 )
         else:
+            if resolution_mode == "exact":
+                return await self._resolve_entities_batch_exact(
+                    conn, bank_id, entities_data, unit_event_date, taxonomy_lookup, labels_cfg
+                )
             return await self._resolve_entities_batch_impl(
                 conn, bank_id, entities_data, context, unit_event_date, taxonomy_lookup, labels_cfg
             )
+
+    async def _resolve_entities_batch_exact(
+        self,
+        conn,
+        bank_id: str,
+        entities_data: list[dict],
+        unit_event_date,
+        taxonomy_lookup: set[str] | None = None,
+        labels_cfg=None,
+    ) -> list[ResolvedEntity]:
+        """Resolve explicit curation names without fuzzy identity substitution.
+
+        ``update_memory`` accepts user-authored corrections, so a similar existing
+        entity is not evidence that the caller meant that entity. Exact mode still
+        reuses an existing case-insensitive name, while unmatched names flow through
+        the normal create/upsert path in ``_resolve_from_candidates``.
+        """
+        entity_texts = list(dict.fromkeys(e["text"] for e in entities_data))
+        rows = []
+        is_oracle = self._ops is not None and self._ops.get_entity_resolution_strategy() == "oracle_fuzzy"
+        entities_table = fq_table("entities")
+
+        for entity_text_batch in self._chunked(entity_texts, self.entity_resolution_batch_size):
+            if is_oracle:
+                rows.extend(
+                    await conn.fetch(
+                        f"""
+                        SELECT e.id, e.canonical_name, e.metadata, e.last_seen, e.mention_count,
+                               q.query_text
+                        FROM JSON_TABLE($2, '$[*]' COLUMNS (query_text VARCHAR2(4000) PATH '$')) q
+                        JOIN {entities_table} e ON (
+                            e.bank_id = $1
+                            AND LOWER(e.canonical_name) = LOWER(q.query_text)
+                        )
+                        """,
+                        bank_id,
+                        json.dumps(entity_text_batch),
+                    )
+                )
+            else:
+                rows.extend(
+                    await conn.fetch(
+                        f"""
+                        SELECT e.id, e.canonical_name, e.metadata, e.last_seen, e.mention_count,
+                               q.query_text
+                        FROM unnest($2::text[]) AS q(query_text)
+                        JOIN {entities_table} e ON (
+                            e.bank_id = $1
+                            AND LOWER(e.canonical_name) = LOWER(q.query_text)
+                        )
+                        """,
+                        bank_id,
+                        entity_text_batch,
+                    )
+                )
+
+        all_candidates: dict[str, list] = {text: [] for text in entity_texts}
+        for row in rows:
+            all_candidates[row["query_text"]].append(
+                (row["id"], row["canonical_name"], row["metadata"], row["last_seen"], row["mention_count"])
+            )
+
+        return await self._resolve_from_candidates(
+            conn,
+            bank_id,
+            entities_data,
+            unit_event_date,
+            all_candidates,
+            {},
+            taxonomy_lookup,
+            labels_cfg,
+            resolution_mode="exact",
+        )
 
     async def _resolve_entities_batch_impl(
         self,
@@ -903,6 +990,7 @@ class EntityResolver:
         cooccurrence_map: dict[str, set[str]],
         taxonomy_lookup: set[str] | None = None,
         labels_cfg=None,
+        resolution_mode: Literal["fuzzy", "exact"] = "fuzzy",
     ) -> list[ResolvedEntity]:
         """Shared scoring + upsert logic used by both lookup strategies."""
 
@@ -955,6 +1043,28 @@ class EntityResolver:
                 # Will create new entity
                 entities_to_create.append(
                     _EntityToCreate(idx=idx, name=entity_text, event_date=entity_event_date, is_label=is_label)
+                )
+                continue
+
+            if resolution_mode == "exact":
+                entity_text_lower = entity_text.lower()
+                exact_candidate = next(
+                    (candidate for candidate in candidates if candidate[1].lower() == entity_text_lower),
+                    None,
+                )
+                if exact_candidate is None:
+                    entities_to_create.append(
+                        _EntityToCreate(idx=idx, name=entity_text, event_date=entity_event_date, is_label=is_label)
+                    )
+                    continue
+                resolved_entity = ResolvedEntity(
+                    entity_id=exact_candidate[0],
+                    canonical_name=exact_candidate[1],
+                    entity_kind="label" if is_label else "regular",
+                )
+                resolved[idx] = resolved_entity
+                entities_to_update.append(
+                    _EntityStat(entity_id=resolved_entity.entity_id, event_date=entity_event_date)
                 )
                 continue
 
@@ -1058,7 +1168,11 @@ class EntityResolver:
             # this, resolution only compares against already-persisted rows, so the first sighting
             # of each variant in a batch always creates a distinct entity (issue #3107). Labels are
             # excluded and keep exact grouping.
-            canonical_by_member = self._intrabatch_canonical_map(entities_to_create)
+            # Exact curation mode must not reintroduce fuzzy matching through the
+            # same-batch dedup pass; each unmatched submitted name remains distinct.
+            canonical_by_member = (
+                {} if resolution_mode == "exact" else self._intrabatch_canonical_map(entities_to_create)
+            )
 
             @dataclass
             class _NameGroup:

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8389,6 +8389,7 @@ class MemoryEngine(MemoryEngineInterface):
         occurred_end: str | None = None,
         new_fact_type: str | None = None,
         entities: list[str] | None = None,
+        entity_resolution_mode: Literal["fuzzy", "exact"] = "fuzzy",
         state: str | None = None,
         reason: str | None = None,
         request_context: "RequestContext",
@@ -8401,7 +8402,10 @@ class MemoryEngine(MemoryEngineInterface):
         graph queries therefore need no state predicate.
 
         - **Edit** (``text``/``context``/``occurred_start``/``occurred_end``/
-          ``new_fact_type``/``entities``): correct what the LLM extracted.
+          ``new_fact_type``/``entities``): correct what the LLM extracted. Entity
+          names use fuzzy resolution by default for compatibility; callers doing
+          explicit corrections can pass ``entity_resolution_mode='exact'`` to
+          reuse only case-insensitively identical names or create new entities.
           Re-embeds (text + dates + entities feed the embedding), drops derived
           observations + temporal/semantic links, and re-consolidates. For date/context fields,
           ``""`` clears to NULL and ``None`` leaves unchanged; ``new_fact_type``
@@ -8443,6 +8447,8 @@ class MemoryEngine(MemoryEngineInterface):
             raise ValueError("text must not be empty.")
         if new_fact_type is not None and new_fact_type not in ("world", "experience"):
             raise ValueError(f"Invalid fact_type '{new_fact_type}': expected 'world' or 'experience'.")
+        if entity_resolution_mode not in ("fuzzy", "exact"):
+            raise ValueError(f"Invalid entity resolution mode '{entity_resolution_mode}': expected 'fuzzy' or 'exact'.")
         # Normalize the entity list up front: drop blanks/whitespace and de-dup
         # case-insensitively (the resolver would coalesce these anyway). A
         # provided-but-empty list means "detach all entities"; None means leave
@@ -8568,6 +8574,7 @@ class MemoryEngine(MemoryEngineInterface):
                         [entity_date],
                         [[{"text": name, "type": "CONCEPT"} for name in new_entities]],
                         entity_labels=entity_labels,
+                        resolution_mode=entity_resolution_mode,
                     )
                     resolved_for_unit = entity_resolution.unit_to_entity_ids.get(str(memory_uuid), [])
                     edit_entity_ids = [str(eid) for eid in resolved_for_unit]

--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -6,6 +6,7 @@ import logging
 import re
 import time
 from datetime import UTC
+from typing import Literal
 
 from ..._vector_index import ann_search_tuning_settings, configured_vector_extension
 from ..causal_links import (
@@ -291,6 +292,7 @@ async def resolve_entities_only(
     llm_entities: list[list[dict]],
     log_buffer: list[str] = None,
     entity_labels: list | None = None,
+    resolution_mode: Literal["fuzzy", "exact"] = "fuzzy",
 ) -> EntityResolutionResult:
     """
     Phase 1 of entity processing: resolve entity names to canonical IDs.
@@ -310,6 +312,8 @@ async def resolve_entities_only(
         llm_entities: Per-fact entity lists from LLM extraction
         log_buffer: Optional logging buffer
         entity_labels: Optional entity label taxonomy
+        resolution_mode: ``fuzzy`` preserves retain's normal behavior; ``exact``
+            is for explicit curation names and only reuses exact matches.
 
     Returns:
         EntityResolutionResult carrying the resolved entity identities (id +
@@ -333,6 +337,7 @@ async def resolve_entities_only(
         unit_event_date=None,
         conn=conn,
         entity_labels=entity_labels,
+        resolution_mode=resolution_mode,
     )
     _log(
         log_buffer,

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -9,7 +9,7 @@ import json
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Callable, get_args
+from typing import Any, Callable, Literal, get_args
 
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
@@ -2467,8 +2467,10 @@ def _register_update_memory(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
             Pass any of text / context / occurred_start / occurred_end / fact_type /
             entities. For context and the dates, "" clears the field and omitting it
             leaves it unchanged; entities replaces the fact's entity set ([] detaches
-            all). The memory is re-embedded and its derived observations, links, and
-            graph are recomputed automatically.
+            all). By default entity names use fuzzy resolution; pass
+            entity_resolution_mode="exact" for explicit corrections to only reuse
+            case-insensitively identical names. The memory is re-embedded and its
+            derived observations, links, and graph are recomputed automatically.
 
             Only raw world/experience facts can be edited; observations are derived.
             To retire or restore a fact, use invalidate_memory instead.
@@ -2485,6 +2487,7 @@ def _register_update_memory(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
             occurred_end: str | None = None,
             fact_type: str | None = None,
             entities: list[str] | None = None,
+            entity_resolution_mode: Literal["fuzzy", "exact"] = "fuzzy",
             bank_id: str | None = None,
         ) -> str:
             """
@@ -2506,6 +2509,7 @@ def _register_update_memory(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
                     occurred_end=occurred_end,
                     new_fact_type=fact_type,
                     entities=entities,
+                    entity_resolution_mode=entity_resolution_mode,
                     request_context=_get_request_context(config),
                 )
                 if result is None:
@@ -2531,6 +2535,7 @@ def _register_update_memory(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
             occurred_end: str | None = None,
             fact_type: str | None = None,
             entities: list[str] | None = None,
+            entity_resolution_mode: Literal["fuzzy", "exact"] = "fuzzy",
         ) -> dict:
             """
             Args:
@@ -2550,6 +2555,7 @@ def _register_update_memory(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
                     occurred_end=occurred_end,
                     new_fact_type=fact_type,
                     entities=entities,
+                    entity_resolution_mode=entity_resolution_mode,
                     request_context=_get_request_context(config),
                 )
                 if result is None:

--- a/hindsight-api-slim/tests/test_entity_resolver.py
+++ b/hindsight-api-slim/tests/test_entity_resolver.py
@@ -6,11 +6,13 @@ import itertools
 import json
 import uuid
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from hindsight_api.engine.db import create_database_backend
+from hindsight_api.engine.db.ops_oracle import OracleOps
 from hindsight_api.engine.db.result import DictResultRow as ResultRow
 from hindsight_api.engine.entity_resolver import EntityResolver, _canonical_cooccurrence_pairs
 from hindsight_api.engine.retain.types import ResolvedEntity
@@ -248,6 +250,66 @@ async def test_fuzzy_scoring_never_merges_regular_text_into_label_row():
 
     assert resolved == [ResolvedEntity(entity_id="new-entity-id", canonical_name="topic empathy")]
     ops.bulk_insert_entities.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_exact_resolution_creates_name_instead_of_using_similar_candidate():
+    """Explicit curation names must not be silently replaced by fuzzy candidates."""
+    submitted_name = "Medication X"
+    created_id = "new-medication-id"
+    ops = SimpleNamespace(
+        bulk_insert_entities=AsyncMock(return_value={submitted_name.lower(): created_id}),
+        fetch_missing_entity_ids=AsyncMock(return_value=[]),
+    )
+    resolver = EntityResolver(pool=SimpleNamespace(ops=ops), entity_lookup="full")
+
+    resolved = await resolver._resolve_from_candidates(
+        conn=AsyncMock(),
+        bank_id="bank-1",
+        entities_data=[{"text": submitted_name, "nearby_entities": []}],
+        unit_event_date=None,
+        all_candidates={
+            submitted_name: [("wrong-person-id", "Medication Xtra", {}, None, 100)],
+        },
+        cooccurrence_map={},
+        resolution_mode="exact",
+    )
+
+    assert resolved == [ResolvedEntity(entity_id=created_id, canonical_name=submitted_name)]
+    ops.bulk_insert_entities.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Oracle exact entity resolution — unit tests (mock conn, no live DB)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exact_resolution_uses_oracle_case_insensitive_lookup():
+    """Exact mode must use Oracle JSON_TABLE without fuzzy SQL functions."""
+    resolver = EntityResolver(pool=SimpleNamespace(ops=OracleOps()), entity_lookup="full")
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(return_value=[])
+
+    with patch.object(resolver, "_resolve_from_candidates", new_callable=AsyncMock, return_value=[]) as resolve:
+        await resolver.resolve_entities_batch(
+            bank_id="bank-1",
+            entities_data=[{"text": "Alice", "nearby_entities": []}],
+            context="",
+            unit_event_date=None,
+            conn=conn,
+            resolution_mode="exact",
+        )
+
+    conn.fetch.assert_called_once()
+    query = conn.fetch.call_args.args[0]
+    assert "JSON_TABLE" in query
+    assert "LOWER(e.canonical_name) = LOWER(q.query_text)" in query
+    assert "UTL_MATCH" not in query
+    assert "unnest" not in query.lower()
+    assert conn.fetch.call_args.args[1] == "bank-1"
+    assert json.loads(conn.fetch.call_args.args[2]) == ["Alice"]
+    assert resolve.call_args.kwargs["resolution_mode"] == "exact"
 
 
 # ---------------------------------------------------------------------------

--- a/hindsight-api-slim/tests/test_memory_curation.py
+++ b/hindsight-api-slim/tests/test_memory_curation.py
@@ -469,6 +469,44 @@ class TestEdit:
         await memory.delete_bank(bank_id, request_context=request_context)
 
     @pytest.mark.asyncio
+    async def test_edit_entities_exact_mode_does_not_fuzzy_substitute(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        bank_id = f"test-curation-editent-exact-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            m1 = await _insert_memory(conn, memory, bank_id, "Alice takes Medication X.")
+            similar = await _insert_entity(conn, bank_id, "Medication Xtra")
+
+        with (
+            patch.object(memory, "submit_async_consolidation", new=AsyncMock()),
+            patch.object(memory, "submit_async_graph_maintenance", new=AsyncMock()),
+        ):
+            result = await memory.update_memory_unit(
+                bank_id,
+                str(m1),
+                entities=["Medication X"],
+                entity_resolution_mode="exact",
+                request_context=request_context,
+            )
+
+        assert result is not None
+        assert result["entities"] == ["Medication X"]
+        async with pool.acquire() as conn:
+            entity_rows = await conn.fetch(
+                "SELECT e.id, e.canonical_name FROM unit_entities ue "
+                "JOIN entities e ON e.id = ue.entity_id WHERE ue.unit_id = $1",
+                m1,
+            )
+            assert len(entity_rows) == 1
+            assert entity_rows[0]["canonical_name"] == "Medication X"
+            assert entity_rows[0]["id"] != similar
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
     async def test_edit_empty_entities_detaches_all(self, memory: MemoryEngine, request_context: RequestContext):
         bank_id = f"test-curation-editent0-{uuid.uuid4().hex[:8]}"
         await _ensure_bank(memory, bank_id, request_context)

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -9861,6 +9861,16 @@ components:
             type: string
           nullable: true
           type: array
+        entity_resolution_mode:
+          default: fuzzy
+          description: How to resolve submitted entity names. 'fuzzy' preserves the
+            legacy disambiguation behavior; 'exact' only reuses case-insensitively
+            identical names and creates unmatched entities.
+          enum:
+          - fuzzy
+          - exact
+          title: Entity Resolution Mode
+          type: string
         state:
           nullable: true
           type: string

--- a/hindsight-clients/go/model_update_memory_request.go
+++ b/hindsight-clients/go/model_update_memory_request.go
@@ -25,6 +25,8 @@ type UpdateMemoryRequest struct {
 	OccurredEnd NullableString `json:"occurred_end,omitempty"`
 	FactType NullableString `json:"fact_type,omitempty"`
 	Entities []string `json:"entities,omitempty"`
+	// How to resolve submitted entity names. 'fuzzy' preserves the legacy disambiguation behavior; 'exact' only reuses case-insensitively identical names and creates unmatched entities.
+	EntityResolutionMode *string `json:"entity_resolution_mode,omitempty"`
 	State NullableString `json:"state,omitempty"`
 	Reason NullableString `json:"reason,omitempty"`
 }
@@ -35,6 +37,8 @@ type UpdateMemoryRequest struct {
 // will change when the set of required properties is changed
 func NewUpdateMemoryRequest() *UpdateMemoryRequest {
 	this := UpdateMemoryRequest{}
+	var entityResolutionMode string = "fuzzy"
+	this.EntityResolutionMode = &entityResolutionMode
 	return &this
 }
 
@@ -43,6 +47,8 @@ func NewUpdateMemoryRequest() *UpdateMemoryRequest {
 // but it doesn't guarantee that properties required by API are set
 func NewUpdateMemoryRequestWithDefaults() *UpdateMemoryRequest {
 	this := UpdateMemoryRequest{}
+	var entityResolutionMode string = "fuzzy"
+	this.EntityResolutionMode = &entityResolutionMode
 	return &this
 }
 
@@ -289,6 +295,38 @@ func (o *UpdateMemoryRequest) SetEntities(v []string) {
 	o.Entities = v
 }
 
+// GetEntityResolutionMode returns the EntityResolutionMode field value if set, zero value otherwise.
+func (o *UpdateMemoryRequest) GetEntityResolutionMode() string {
+	if o == nil || IsNil(o.EntityResolutionMode) {
+		var ret string
+		return ret
+	}
+	return *o.EntityResolutionMode
+}
+
+// GetEntityResolutionModeOk returns a tuple with the EntityResolutionMode field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *UpdateMemoryRequest) GetEntityResolutionModeOk() (*string, bool) {
+	if o == nil || IsNil(o.EntityResolutionMode) {
+		return nil, false
+	}
+	return o.EntityResolutionMode, true
+}
+
+// HasEntityResolutionMode returns a boolean if a field has been set.
+func (o *UpdateMemoryRequest) HasEntityResolutionMode() bool {
+	if o != nil && !IsNil(o.EntityResolutionMode) {
+		return true
+	}
+
+	return false
+}
+
+// SetEntityResolutionMode gets a reference to the given string and assigns it to the EntityResolutionMode field.
+func (o *UpdateMemoryRequest) SetEntityResolutionMode(v string) {
+	o.EntityResolutionMode = &v
+}
+
 // GetState returns the State field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *UpdateMemoryRequest) GetState() string {
 	if o == nil || IsNil(o.State.Get()) {
@@ -400,6 +438,9 @@ func (o UpdateMemoryRequest) ToMap() (map[string]interface{}, error) {
 	}
 	if o.Entities != nil {
 		toSerialize["entities"] = o.Entities
+	}
+	if !IsNil(o.EntityResolutionMode) {
+		toSerialize["entity_resolution_mode"] = o.EntityResolutionMode
 	}
 	if o.State.IsSet() {
 		toSerialize["state"] = o.State.Get()

--- a/hindsight-clients/python/hindsight_client_api/models/update_memory_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/update_memory_request.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictStr
+from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
@@ -32,9 +32,20 @@ class UpdateMemoryRequest(BaseModel):
     occurred_end: Optional[StrictStr] = None
     fact_type: Optional[StrictStr] = None
     entities: Optional[List[StrictStr]] = None
+    entity_resolution_mode: Optional[StrictStr] = Field(default='fuzzy', description="How to resolve submitted entity names. 'fuzzy' preserves the legacy disambiguation behavior; 'exact' only reuses case-insensitively identical names and creates unmatched entities.")
     state: Optional[StrictStr] = None
     reason: Optional[StrictStr] = None
-    __properties: ClassVar[List[str]] = ["text", "context", "occurred_start", "occurred_end", "fact_type", "entities", "state", "reason"]
+    __properties: ClassVar[List[str]] = ["text", "context", "occurred_start", "occurred_end", "fact_type", "entities", "entity_resolution_mode", "state", "reason"]
+
+    @field_validator('entity_resolution_mode')
+    def entity_resolution_mode_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in set(['fuzzy', 'exact']):
+            raise ValueError("must be one of enum values ('fuzzy', 'exact')")
+        return value
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -133,6 +144,7 @@ class UpdateMemoryRequest(BaseModel):
             "occurred_end": obj.get("occurred_end"),
             "fact_type": obj.get("fact_type"),
             "entities": obj.get("entities"),
+            "entity_resolution_mode": obj.get("entity_resolution_mode") if obj.get("entity_resolution_mode") is not None else 'fuzzy',
             "state": obj.get("state"),
             "reason": obj.get("reason")
         })

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -4949,9 +4949,15 @@ export type UpdateMemoryRequest = {
   /**
    * Entities
    *
-   * Replace the fact's entities. Names are resolved/find-or-created the same way retain does; '[]' detaches all entities. Omit to leave unchanged.
+   * Replace the fact's entities. By default names use the same fuzzy resolution as retain; set entity_resolution_mode to 'exact' to only reuse case-insensitively identical names. '[]' detaches all entities. Omit to leave unchanged.
    */
   entities?: Array<string> | null;
+  /**
+   * Entity Resolution Mode
+   *
+   * How to resolve submitted entity names. 'fuzzy' preserves the legacy disambiguation behavior; 'exact' only reuses case-insensitively identical names and creates unmatched entities.
+   */
+  entity_resolution_mode?: "fuzzy" | "exact";
   /**
    * State
    *

--- a/hindsight-control-plane/src/app/api/memories/[memoryId]/route.ts
+++ b/hindsight-control-plane/src/app/api/memories/[memoryId]/route.ts
@@ -76,8 +76,17 @@ export async function PATCH(
     }
 
     // Curation fields only; bank_id is a routing param, not part of the body.
-    const { text, context, occurred_start, occurred_end, fact_type, entities, state, reason } =
-      body;
+    const {
+      text,
+      context,
+      occurred_start,
+      occurred_end,
+      fact_type,
+      entities,
+      entity_resolution_mode,
+      state,
+      reason,
+    } = body;
 
     const response = await fetch(
       dataplaneBankUrl(bankId, `/memories/${encodeURIComponent(memoryId)}`),
@@ -91,6 +100,7 @@ export async function PATCH(
           occurred_end,
           fact_type,
           entities,
+          entity_resolution_mode,
           state,
           reason,
         }),

--- a/hindsight-control-plane/src/components/memory-detail-modal.tsx
+++ b/hindsight-control-plane/src/components/memory-detail-modal.tsx
@@ -160,6 +160,7 @@ export function MemoryDetailModal({
         occurredEnd: fields.occurredEnd,
         factType: fields.factType,
         entities: fields.entities,
+        entityResolutionMode: "exact",
       });
       const data = await client.getMemory(memory.id, currentBank);
       setMemory(data);

--- a/hindsight-control-plane/src/components/memory-detail-panel.tsx
+++ b/hindsight-control-plane/src/components/memory-detail-panel.tsx
@@ -276,6 +276,7 @@ export function MemoryDetailPanel({
         occurredEnd: fields.occurredEnd,
         factType: fields.factType,
         entities: fields.entities,
+        entityResolutionMode: "exact",
       });
       const refreshed = await client.getMemory(id, bankId);
       setFullMemory(refreshed);

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -1046,6 +1046,7 @@ export class ControlPlaneClient {
       occurredEnd?: string;
       factType?: "world" | "experience";
       entities?: string[];
+      entityResolutionMode?: "fuzzy" | "exact";
       state?: "valid" | "invalidated";
       reason?: string;
     }
@@ -1057,6 +1058,9 @@ export class ControlPlaneClient {
     if (update.occurredEnd !== undefined) body.occurred_end = update.occurredEnd;
     if (update.factType !== undefined) body.fact_type = update.factType;
     if (update.entities !== undefined) body.entities = update.entities;
+    if (update.entityResolutionMode !== undefined) {
+      body.entity_resolution_mode = update.entityResolutionMode;
+    }
     if (update.state !== undefined) body.state = update.state;
     if (update.reason !== undefined) body.reason = update.reason;
     return this.fetchApi(memoryApi(memoryId, bankId), {

--- a/hindsight-docs/docs/developer/api/memories.mdx
+++ b/hindsight-docs/docs/developer/api/memories.mdx
@@ -126,7 +126,7 @@ You don't need to rebuild anything yourself: an edit **automatically recomputes 
 </TabItem>
 </Tabs>
 
-You can correct the dates, fact type, and entities the same way. For `context`, `occurred_start`, and `occurred_end`, an empty string `""` clears the field and omitting it leaves it unchanged. For `entities`, a list **replaces** the fact's entity set (names are resolved/find-or-created the same way retain does) and `[]` detaches them all; omitting it leaves them unchanged.
+You can correct the dates, fact type, and entities the same way. For `context`, `occurred_start`, and `occurred_end`, an empty string `""` clears the field and omitting it leaves it unchanged. For `entities`, a list **replaces** the fact's entity set and `[]` detaches them all; omitting it leaves them unchanged. Entity names use the legacy fuzzy resolution by default; pass `entity_resolution_mode: "exact"` for explicit corrections to reuse only case-insensitively identical names or create unmatched entities.
 
 <Tabs>
 <TabItem value="python" label="Python">

--- a/hindsight-docs/examples/api/memories.go
+++ b/hindsight-docs/examples/api/memories.go
@@ -85,12 +85,14 @@ func main() {
 
 		// [docs:edit-memory-fields]
 		// Correct dates, fact type, and entities in one call. "" clears a field;
-		// entities replaces the set ([] detaches all); omit to leave unchanged.
+		// entities replaces the set ([] detaches all); omit to leave unchanged. Use
+		// exact resolution for user-authored corrections.
 		client.MemoryAPI.UpdateMemory(ctx, memBankID, memoryID).
 			UpdateMemoryRequest(hindsight.UpdateMemoryRequest{
 				OccurredStart: *hindsight.NewNullableString(hindsight.PtrString("2023-06-01")),
 				FactType:      *hindsight.NewNullableString(hindsight.PtrString("experience")),
 				Entities:      []string{"Alice", "Paris"},
+				EntityResolutionMode: hindsight.PtrString("exact"),
 			}).Execute()
 		// [/docs:edit-memory-fields]
 

--- a/hindsight-docs/examples/api/memories.mjs
+++ b/hindsight-docs/examples/api/memories.mjs
@@ -67,11 +67,13 @@ await patchMemory(memoryId, { text: 'The user visited Paris in 2023.', reason: '
 
 // [docs:edit-memory-fields]
 // Correct dates, fact type, and entities in one call. "" clears a field;
-// entities replaces the set ([] detaches all); omit to leave unchanged.
+// entities replaces the set ([] detaches all); omit to leave unchanged. Use
+// exact resolution for user-authored corrections.
 await patchMemory(memoryId, {
     occurred_start: '2023-06-01',
     fact_type: 'experience',
     entities: ['Alice', 'Paris'],
+    entity_resolution_mode: 'exact',
 });
 // [/docs:edit-memory-fields]
 

--- a/hindsight-docs/examples/api/memories.py
+++ b/hindsight-docs/examples/api/memories.py
@@ -111,6 +111,8 @@ async def main():
     # [docs:edit-memory-fields]
     # Correct dates, fact type, and entities in one call. "" clears a field;
     # entities replaces the set ([] detaches all); omit to leave unchanged.
+    # Use exact entity resolution for user-authored corrections so similar
+    # existing entities are not silently substituted.
     await client.memory.update_memory(
         bank_id=BANK_ID,
         memory_id=memory_id,
@@ -118,6 +120,7 @@ async def main():
             occurred_start="2023-06-01",
             fact_type="experience",
             entities=["Alice", "Paris"],
+            entity_resolution_mode="exact",
         ),
     )
     # [/docs:edit-memory-fields]

--- a/hindsight-docs/examples/api/memories.sh
+++ b/hindsight-docs/examples/api/memories.sh
@@ -46,10 +46,11 @@ if [ -n "$MEMORY_ID" ]; then
 
   # [docs:edit-memory-fields]
   # Correct dates, fact type, and entities in one call. "" clears a field;
-  # entities replaces the set ([] detaches all); omit to leave unchanged.
+  # entities replaces the set ([] detaches all); omit to leave unchanged. Use
+  # exact resolution for user-authored corrections.
   curl -s -X PATCH "$HINDSIGHT_URL/v1/default/banks/$BANK_ID/memories/$MEMORY_ID" \
     -H "Content-Type: application/json" \
-    -d '{"occurred_start": "2023-06-01", "fact_type": "experience", "entities": ["Alice", "Paris"]}'
+    -d '{"occurred_start": "2023-06-01", "fact_type": "experience", "entities": ["Alice", "Paris"], "entity_resolution_mode": "exact"}'
   # [/docs:edit-memory-fields]
 
   # [docs:invalidate-memory]

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -15162,7 +15162,17 @@
               }
             ],
             "title": "Entities",
-            "description": "Replace the fact's entities. Names are resolved/find-or-created the same way retain does; '[]' detaches all entities. Omit to leave unchanged."
+            "description": "Replace the fact's entities. By default names use the same fuzzy resolution as retain; set entity_resolution_mode to 'exact' to only reuse case-insensitively identical names. '[]' detaches all entities. Omit to leave unchanged."
+          },
+          "entity_resolution_mode": {
+            "type": "string",
+            "enum": [
+              "fuzzy",
+              "exact"
+            ],
+            "title": "Entity Resolution Mode",
+            "description": "How to resolve submitted entity names. 'fuzzy' preserves the legacy disambiguation behavior; 'exact' only reuses case-insensitively identical names and creates unmatched entities.",
+            "default": "fuzzy"
           },
           "state": {
             "anyOf": [

--- a/hindsight-docs/versioned_docs/version-0.9/developer/api/memories.mdx
+++ b/hindsight-docs/versioned_docs/version-0.9/developer/api/memories.mdx
@@ -126,7 +126,7 @@ You don't need to rebuild anything yourself: an edit **automatically recomputes 
 </TabItem>
 </Tabs>
 
-You can correct the dates, fact type, and entities the same way. For `context`, `occurred_start`, and `occurred_end`, an empty string `""` clears the field and omitting it leaves it unchanged. For `entities`, a list **replaces** the fact's entity set (names are resolved/find-or-created the same way retain does) and `[]` detaches them all; omitting it leaves them unchanged.
+You can correct the dates, fact type, and entities the same way. For `context`, `occurred_start`, and `occurred_end`, an empty string `""` clears the field and omitting it leaves it unchanged. For `entities`, a list **replaces** the fact's entity set and `[]` detaches them all; omitting it leaves them unchanged. Entity names use the legacy fuzzy resolution by default; pass `entity_resolution_mode: "exact"` for explicit corrections to reuse only case-insensitively identical names or create unmatched entities.
 
 <Tabs>
 <TabItem value="python" label="Python">

--- a/skills/hindsight-docs/references/developer/api/memories.md
+++ b/skills/hindsight-docs/references/developer/api/memories.md
@@ -170,7 +170,7 @@ await patchMemory(memoryId, { text: 'The user visited Paris in 2023.', reason: '
 # Section 'edit-memory' not found in api/memories.go
 ```
 
-You can correct the dates, fact type, and entities the same way. For `context`, `occurred_start`, and `occurred_end`, an empty string `""` clears the field and omitting it leaves it unchanged. For `entities`, a list **replaces** the fact's entity set (names are resolved/find-or-created the same way retain does) and `[]` detaches them all; omitting it leaves them unchanged.
+You can correct the dates, fact type, and entities the same way. For `context`, `occurred_start`, and `occurred_end`, an empty string `""` clears the field and omitting it leaves it unchanged. For `entities`, a list **replaces** the fact's entity set and `[]` detaches them all; omitting it leaves them unchanged. Entity names use the legacy fuzzy resolution by default; pass `entity_resolution_mode: "exact"` for explicit corrections to reuse only case-insensitively identical names or create unmatched entities.
 
 ### Python
 
@@ -182,11 +182,13 @@ You can correct the dates, fact type, and entities the same way. For `context`, 
 
 ```javascript
 // Correct dates, fact type, and entities in one call. "" clears a field;
-// entities replaces the set ([] detaches all); omit to leave unchanged.
+// entities replaces the set ([] detaches all); omit to leave unchanged. Use
+// exact resolution for user-authored corrections.
 await patchMemory(memoryId, {
     occurred_start: '2023-06-01',
     fact_type: 'experience',
     entities: ['Alice', 'Paris'],
+    entity_resolution_mode: 'exact',
 });
 ```
 

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -15162,7 +15162,17 @@
               }
             ],
             "title": "Entities",
-            "description": "Replace the fact's entities. Names are resolved/find-or-created the same way retain does; '[]' detaches all entities. Omit to leave unchanged."
+            "description": "Replace the fact's entities. By default names use the same fuzzy resolution as retain; set entity_resolution_mode to 'exact' to only reuse case-insensitively identical names. '[]' detaches all entities. Omit to leave unchanged."
+          },
+          "entity_resolution_mode": {
+            "type": "string",
+            "enum": [
+              "fuzzy",
+              "exact"
+            ],
+            "title": "Entity Resolution Mode",
+            "description": "How to resolve submitted entity names. 'fuzzy' preserves the legacy disambiguation behavior; 'exact' only reuses case-insensitively identical names and creates unmatched entities.",
+            "default": "fuzzy"
           },
           "state": {
             "anyOf": [


### PR DESCRIPTION
## Problem

`update_memory` uses fuzzy entity matching by default. During a manual or bulk correction, the entity name supplied by the caller can be matched to a different existing entity with a similar name. The request still succeeds, but the corrected memory is attached to the wrong entity. This is the behavior reported in #3479.

## Change

Add an optional `entity_resolution_mode` parameter to `update_memory`. When the parameter is omitted or set to `fuzzy`, the existing fuzzy matching behavior is preserved. When it is set to `exact`, the resolver reuses an existing entity only when its name matches case-insensitively. A name with no exact match creates a new entity. Exact mode also disables fuzzy deduplication between entity names in the same request.

Exact mode is intended for user-authored corrections and other operations where the caller already knows which entity name should be updated. Keeping fuzzy mode as the default preserves compatibility for existing callers.

## Scope

The parameter is supported by the HTTP API and MCP tool and is passed through the memory engine and entity resolver. The OpenAPI specification, generated Python, Go, and TypeScript client models, and current and 0.9 documentation have been updated. Regression tests cover similar existing entities and the curation API.

## Verification

The resolver and curation tests pass (43 tests), as do the HTTP curation tests (4 tests), Python Ruff check and format check, Python `ty check`, OpenAPI compatibility validation, TypeScript client build, generated Python model validation, and `git diff --check`.

Full linting could not run because the Control Plane environment is missing `@eslint/js`. The documentation build could not run because its environment is missing `ajv`. Go client root integration tests require an API server on `localhost:8888`; package compilation and generated tests pass without that server. An unrelated existing client coverage check still reports the missing `reflect.apply_all_directives` wrapper field in Python and TypeScript.

Fixes #3479.
