### PR TITLE
fix(coding-agents): exclude external facts from knowledge pages

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2325,7 +2325,7 @@ class MentalModelListResponse(BaseModel):
 class KnowledgeNode(BaseModel):
     """A node in the knowledge-base tree — a folder or a page.
 
-    Pages carry ``description``/``tags`` from their backing mental model. The
+    Pages carry ``description``/``tags``/``trigger`` from their backing mental model. The
     knowledge base is client-managed (CRUD); ``managed`` lets a client tag a node
     as system-owned vs. hand-authored.
     """
@@ -2338,6 +2338,10 @@ class KnowledgeNode(BaseModel):
     managed: bool = Field(default=False, description="Client-set flag: true = system-owned, false = hand-authored.")
     description: str | None = Field(default=None, description="Page source query (the page's `description`).")
     tags: list[str] = FieldWithDefault(list)
+    trigger: MentalModelTrigger | None = Field(
+        default=None,
+        description="Page refresh trigger, including optional compound tag filters.",
+    )
     timestamp: str | None = Field(default=None, description="Last refresh (page) or last update (folder).")
     is_stale: bool | None = Field(
         default=None,
@@ -2380,10 +2384,15 @@ class UpdateNodeRequest(BaseModel):
     name: str | None = None
     parent_id: str | None = None
     # Page-only options (updated on the backing mental model). Changing
-    # source_query schedules an async refresh so the page rebuilds.
+    # source_query schedules an async refresh so the page rebuilds; trigger changes only
+    # change the refresh scope and do not rebuild content by themselves.
     source_query: str | None = None
     tags: list[str] | None = None
     max_tokens: int | None = None
+    trigger: MentalModelTrigger | None = Field(
+        default=None,
+        description="Page refresh trigger. Omit to leave it unchanged; explicit null is rejected.",
+    )
 
 
 class CreateKnowledgePageResponse(BaseModel):
@@ -2450,6 +2459,7 @@ def _knowledge_node_model(node: dict[str, Any]) -> KnowledgeNode:
         managed=bool(node.get("managed")),
         description=node.get("source_query") if is_page else None,
         tags=list(node.get("tags") or []) if is_page else [],
+        trigger=node.get("trigger") if is_page else None,
         timestamp=(node.get("last_refreshed_at") if is_page else node.get("updated_at")),
         is_stale=node.get("is_stale") if is_page else None,
     )
@@ -5787,7 +5797,7 @@ def _register_routes(app: FastAPI):
         response_model=KnowledgeNode,
         summary="Rename/move a knowledge-base node or update a page's options",
         description="Rename a node (set `name`), move it under another folder (set `parent_id`, null "
-        "for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`). "
+        "for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`, `trigger`). "
         "Changing `source_query` schedules an async refresh so the page rebuilds against the new question.",
         operation_id="update_knowledge_node",
         tags=["Knowledge Base"],
@@ -5802,6 +5812,11 @@ def _register_routes(app: FastAPI):
         try:
             updated: dict[str, Any] | None = None
             did_change = False
+            if "trigger" in body.model_fields_set and body.trigger is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="trigger cannot be null; omit it to leave the trigger unchanged",
+                )
             if body.name is not None:
                 did_change = True
                 updated = await app.state.memory.rename_knowledge_node(
@@ -5816,7 +5831,7 @@ def _register_routes(app: FastAPI):
                 )
             # Page options live on the backing mental model; each applies only when
             # present in the body (so tags=[] clears, distinct from "not provided").
-            page_fields = {"source_query", "tags", "max_tokens"} & body.model_fields_set
+            page_fields = {"source_query", "tags", "max_tokens", "trigger"} & body.model_fields_set
             if page_fields:
                 did_change = True
                 updated = await app.state.memory.update_knowledge_page(
@@ -5825,6 +5840,7 @@ def _register_routes(app: FastAPI):
                     source_query=body.source_query if "source_query" in page_fields else None,
                     tags=body.tags if "tags" in page_fields else None,
                     max_tokens=body.max_tokens if "max_tokens" in page_fields else None,
+                    trigger=body.trigger.model_dump() if "trigger" in page_fields and body.trigger else None,
                     request_context=request_context,
                 )
                 # A new source query means the content is stale — rebuild it.
@@ -5836,7 +5852,8 @@ def _register_routes(app: FastAPI):
                     )
             if not did_change:
                 raise HTTPException(
-                    status_code=400, detail="Provide name, parent_id, source_query, tags, and/or max_tokens to update"
+                    status_code=400,
+                    detail="Provide name, parent_id, source_query, tags, max_tokens, and/or trigger to update",
                 )
             if updated is None:
                 raise HTTPException(status_code=404, detail=f"Knowledge node '{node_id}' not found")

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -13972,6 +13972,16 @@ class MemoryEngine(MemoryEngineInterface):
         if "mm_tags" in row:
             node["tags"] = list(row["mm_tags"] or [])
             node["source_query"] = row["mm_source_query"]
+            # asyncpg has no JSONB codec on the application pool, and Oracle
+            # returns JSON CLOBs as text for aliased columns such as mm_trigger.
+            # Normalize both database representations before the HTTP model sees it.
+            trigger = row["mm_trigger"]
+            if isinstance(trigger, str):
+                try:
+                    trigger = json.loads(trigger)
+                except json.JSONDecodeError:
+                    trigger = None
+            node["trigger"] = trigger
             node["last_refreshed_at"] = row["mm_last_refreshed_at"].isoformat() if row["mm_last_refreshed_at"] else None
         return node
 
@@ -13981,7 +13991,7 @@ class MemoryEngine(MemoryEngineInterface):
     _KP_PAGE_SELECT = (
         "kp.id, kp.bank_id, kp.parent_id, kp.kind, kp.name, kp.mental_model_id, "
         "kp.sort_order, kp.managed, kp.created_at, kp.updated_at, "
-        "mm.tags AS mm_tags, mm.source_query AS mm_source_query, "
+        "mm.tags AS mm_tags, mm.source_query AS mm_source_query, mm.trigger AS mm_trigger, "
         "mm.last_refreshed_at AS mm_last_refreshed_at"
     )
 

--- a/hindsight-api-slim/tests/test_knowledge_base.py
+++ b/hindsight-api-slim/tests/test_knowledge_base.py
@@ -5,6 +5,7 @@ tree, markdown rendering, move/rename, and cascade-delete behaviour can be asser
 without consolidation.
 """
 
+import json
 import urllib.parse
 import uuid
 from datetime import datetime, timedelta, timezone
@@ -28,6 +29,33 @@ from hindsight_api.extensions import (
 
 def _enc(bank_id: str) -> str:
     return urllib.parse.quote(bank_id, safe="")
+
+
+def test_row_to_knowledge_node_decodes_string_trigger() -> None:
+    trigger = {
+        "mode": "delta",
+        "tag_groups": [{"tags": ["knowledge:decision"], "match": "all_strict"}],
+    }
+    row = {
+        "id": "kp-1",
+        "bank_id": "bank-1",
+        "parent_id": None,
+        "kind": "page",
+        "name": "Decisions",
+        "mental_model_id": "mm-1",
+        "sort_order": 0,
+        "managed": False,
+        "created_at": None,
+        "updated_at": None,
+        "mm_tags": ["knowledge:decision"],
+        "mm_source_query": "What decisions were made?",
+        "mm_trigger": json.dumps(trigger),
+        "mm_last_refreshed_at": None,
+    }
+
+    node = MemoryEngine._row_to_knowledge_node(row)
+
+    assert node["trigger"] == trigger
 
 
 class _RecordingValidator(OperationValidatorExtension):
@@ -533,21 +561,53 @@ class TestMoveRenameDelete:
 
     async def test_update_page_options(self, api_client, kb_bank):
         bank_id, ids = kb_bank
+        trigger = {
+            "fact_types": ["world", "experience", "observation"],
+            "refresh_after_consolidation": True,
+            "tag_groups": [
+                {"tags": ["knowledge:decision"], "match": "all_strict"},
+                {"not": {"tags": ["knowledge:external"], "match": "any_strict"}},
+            ],
+        }
         resp = await api_client.patch(
             f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.orders}",
             json={
                 "source_query": "summarize every order fact and its revenue",
                 "tags": ["type:runbook", "sales", "priority"],
                 "max_tokens": 2048,
+                "trigger": trigger,
             },
         )
         assert resp.status_code == 200, resp.text
         node = resp.json()
         assert node["kind"] == "page"
         assert set(node["tags"]) == {"type:runbook", "sales", "priority"}
+        assert node["trigger"]["tag_groups"] == trigger["tag_groups"]
         # source_query persists — it surfaces as the `description` on the page.
         page = (await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/pages/{ids.orders}")).json()
         assert page["description"] == "summarize every order fact and its revenue"
+
+    async def test_update_rejects_explicit_null_trigger(self, api_client, kb_bank):
+        bank_id, ids = kb_bank
+        before = await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/tree")
+        assert before.status_code == 200, before.text
+        before_orders = next(
+            child for root in before.json()["roots"] for child in root.get("children", []) if child["id"] == ids.orders
+        )
+
+        resp = await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.orders}",
+            json={"trigger": None},
+        )
+
+        assert resp.status_code == 400
+        assert "trigger cannot be null" in resp.json()["detail"]
+        after = await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/tree")
+        assert after.status_code == 200, after.text
+        after_orders = next(
+            child for root in after.json()["roots"] for child in root.get("children", []) if child["id"] == ids.orders
+        )
+        assert after_orders["trigger"] == before_orders["trigger"]
 
     async def test_update_requires_a_field(self, api_client, kb_bank):
         bank_id, ids = kb_bank

--- a/hindsight-cli/src/commands/knowledge_base.rs
+++ b/hindsight-cli/src/commands/knowledge_base.rs
@@ -5,7 +5,7 @@
 //! overlap. `hindsight fs` mirrors the same knowledge base read-only onto disk;
 //! these commands are the read/write side.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::api::ApiClient;
 use crate::output::{self, OutputFormat};
@@ -330,6 +330,7 @@ pub fn update(
     source_query: Option<String>,
     tags: Option<Vec<String>>,
     max_tokens: Option<i64>,
+    trigger: Option<String>,
     verbose: bool,
     output_format: OutputFormat,
 ) -> Result<()> {
@@ -338,9 +339,10 @@ pub fn update(
         && source_query.is_none()
         && tags.is_none()
         && max_tokens.is_none()
+        && trigger.is_none()
     {
         anyhow::bail!(
-            "At least one of --name, --parent-id, --source-query, --tags, or --max-tokens must be provided"
+            "At least one of --name, --parent-id, --source-query, --tags, --max-tokens, or --trigger must be provided"
         );
     }
 
@@ -350,12 +352,20 @@ pub fn update(
         None
     };
 
+    let trigger = trigger
+        .map(|value| {
+            serde_json::from_str::<types::MentalModelTriggerInput>(&value)
+                .context("--trigger must be a valid MentalModelTrigger JSON object")
+        })
+        .transpose()?;
+
     let request = types::UpdateNodeRequest {
         name,
         parent_id,
         source_query,
         tags,
         max_tokens,
+        trigger,
     };
 
     let response = client.update_knowledge_node(bank_id, node_id, &request, verbose);

--- a/hindsight-cli/src/main.rs
+++ b/hindsight-cli/src/main.rs
@@ -1220,6 +1220,10 @@ enum KnowledgeBaseCommands {
         /// Pages only: new maximum tokens for generated content
         #[arg(long)]
         max_tokens: Option<i64>,
+
+        /// Pages only: replace the complete refresh trigger as a JSON object
+        #[arg(long, value_name = "JSON")]
+        trigger: Option<String>,
     },
 
     /// Delete a folder or page and its whole subtree
@@ -1969,6 +1973,7 @@ fn run() -> Result<()> {
                 source_query,
                 tags,
                 max_tokens,
+                trigger,
             } => commands::knowledge_base::update(
                 &client,
                 &bank_id,
@@ -1978,6 +1983,7 @@ fn run() -> Result<()> {
                 source_query,
                 tags,
                 max_tokens,
+                trigger,
                 verbose,
                 output_format,
             ),
@@ -2406,7 +2412,7 @@ fn handle_profile(cmd: ProfileCommands, output_format: OutputFormat) -> Result<(
 
 #[cfg(test)]
 mod tests {
-    use super::{Cli, Commands, OperationCommands};
+    use super::{Cli, Commands, KnowledgeBaseCommands, OperationCommands};
     use clap::Parser;
 
     #[test]
@@ -2432,6 +2438,30 @@ mod tests {
                 assert!(yes);
             }
             _ => panic!("expected operation delete command"),
+        }
+    }
+
+    #[test]
+    fn parses_knowledge_page_update_trigger_json() {
+        let cli = Cli::try_parse_from([
+            "hindsight",
+            "knowledge-base",
+            "update",
+            "bank-1",
+            "page-1",
+            "--trigger",
+            r#"{"tag_groups":[{"tags":["knowledge:external"],"match":"any_strict"}]}"#,
+        ])
+        .expect("knowledge-base update trigger should be a valid command");
+
+        match cli.command {
+            Commands::KnowledgeBase(KnowledgeBaseCommands::Update { trigger, .. }) => {
+                assert_eq!(
+                    trigger.as_deref(),
+                    Some(r#"{"tag_groups":[{"tags":["knowledge:external"],"match":"any_strict"}]}"#)
+                );
+            }
+            _ => panic!("expected knowledge-base update command"),
         }
     }
 }

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -1817,8 +1817,8 @@ paths:
     patch:
       description: "Rename a node (set `name`), move it under another folder (set\
         \ `parent_id`, null for the root), and/or update a page's options (`source_query`,\
-        \ `tags`, `max_tokens`). Changing `source_query` schedules an async refresh\
-        \ so the page rebuilds against the new question."
+        \ `tags`, `max_tokens`, `trigger`). Changing `source_query` schedules an async\
+        \ refresh so the page rebuilds against the new question."
       operationId: update_knowledge_node
       parameters:
       - explode: false
@@ -6823,7 +6823,7 @@ components:
       description: |-
         A node in the knowledge-base tree — a folder or a page.
 
-        Pages carry ``description``/``tags`` from their backing mental model. The
+        Pages carry ``description``/``tags``/``trigger`` from their backing mental model. The
         knowledge base is client-managed (CRUD); ``managed`` lets a client tag a node
         as system-owned vs. hand-authored.
       example:
@@ -6836,6 +6836,33 @@ components:
         name: name
         description: description
         id: id
+        trigger:
+          recall_chunks_max_tokens: 1
+          refresh_cron: refresh_cron
+          tag_groups:
+          - match: any_strict
+            tags:
+            - tags
+            - tags
+          - match: any_strict
+            tags:
+            - tags
+            - tags
+          exclude_mental_models: false
+          mode: full
+          refresh_after_consolidation: false
+          fact_types:
+          - world
+          - world
+          response_schema:
+            key: ""
+          exclude_mental_model_ids:
+          - exclude_mental_model_ids
+          - exclude_mental_model_ids
+          include_chunks: true
+          tags_match: any
+          keep_trace: false
+          recall_max_tokens: 6
         is_stale: true
         mental_model_id: mental_model_id
         tags:
@@ -6874,6 +6901,8 @@ components:
           items:
             type: string
           type: array
+        trigger:
+          $ref: '#/components/schemas/MentalModelTrigger-Output'
         timestamp:
           nullable: true
           type: string
@@ -7048,6 +7077,33 @@ components:
           name: name
           description: description
           id: id
+          trigger:
+            recall_chunks_max_tokens: 1
+            refresh_cron: refresh_cron
+            tag_groups:
+            - match: any_strict
+              tags:
+              - tags
+              - tags
+            - match: any_strict
+              tags:
+              - tags
+              - tags
+            exclude_mental_models: false
+            mode: full
+            refresh_after_consolidation: false
+            fact_types:
+            - world
+            - world
+            response_schema:
+              key: ""
+            exclude_mental_model_ids:
+            - exclude_mental_model_ids
+            - exclude_mental_model_ids
+            include_chunks: true
+            tags_match: any
+            keep_trace: false
+            recall_max_tokens: 6
           is_stale: true
           mental_model_id: mental_model_id
           tags:
@@ -7063,6 +7119,33 @@ components:
           name: name
           description: description
           id: id
+          trigger:
+            recall_chunks_max_tokens: 1
+            refresh_cron: refresh_cron
+            tag_groups:
+            - match: any_strict
+              tags:
+              - tags
+              - tags
+            - match: any_strict
+              tags:
+              - tags
+              - tags
+            exclude_mental_models: false
+            mode: full
+            refresh_after_consolidation: false
+            fact_types:
+            - world
+            - world
+            response_schema:
+              key: ""
+            exclude_mental_model_ids:
+            - exclude_mental_model_ids
+            - exclude_mental_model_ids
+            include_chunks: true
+            tags_match: any
+            keep_trace: false
+            recall_max_tokens: 6
           is_stale: true
           mental_model_id: mental_model_id
           tags:
@@ -9908,6 +9991,33 @@ components:
         max_tokens: 0
         parent_id: parent_id
         name: name
+        trigger:
+          recall_chunks_max_tokens: 1
+          refresh_cron: refresh_cron
+          tag_groups:
+          - match: any_strict
+            tags:
+            - tags
+            - tags
+          - match: any_strict
+            tags:
+            - tags
+            - tags
+          exclude_mental_models: false
+          mode: full
+          refresh_after_consolidation: false
+          fact_types:
+          - world
+          - world
+          response_schema:
+            key: ""
+          exclude_mental_model_ids:
+          - exclude_mental_model_ids
+          - exclude_mental_model_ids
+          include_chunks: true
+          tags_match: any
+          keep_trace: false
+          recall_max_tokens: 6
         tags:
         - tags
         - tags
@@ -9929,6 +10039,8 @@ components:
         max_tokens:
           nullable: true
           type: integer
+        trigger:
+          $ref: '#/components/schemas/MentalModelTrigger-Input'
       title: UpdateNodeRequest
     UpdateWebhookRequest:
       description: Request model for updating a webhook. Only provided fields are

--- a/hindsight-clients/go/api_knowledge_base.go
+++ b/hindsight-clients/go/api_knowledge_base.go
@@ -960,7 +960,7 @@ func (r ApiUpdateKnowledgeNodeRequest) Execute() (*KnowledgeNode, *http.Response
 /*
 UpdateKnowledgeNode Rename/move a knowledge-base node or update a page's options
 
-Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.
+Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`, `trigger`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param bankId

--- a/hindsight-clients/go/model_knowledge_node.go
+++ b/hindsight-clients/go/model_knowledge_node.go
@@ -19,7 +19,7 @@ import (
 // checks if the KnowledgeNode type satisfies the MappedNullable interface at compile time
 var _ MappedNullable = &KnowledgeNode{}
 
-// KnowledgeNode A node in the knowledge-base tree — a folder or a page.  Pages carry ``description``/``tags`` from their backing mental model. The knowledge base is client-managed (CRUD); ``managed`` lets a client tag a node as system-owned vs. hand-authored.
+// KnowledgeNode A node in the knowledge-base tree — a folder or a page.  Pages carry ``description``/``tags``/``trigger`` from their backing mental model. The knowledge base is client-managed (CRUD); ``managed`` lets a client tag a node as system-owned vs. hand-authored.
 type KnowledgeNode struct {
 	Id string `json:"id"`
 	Kind string `json:"kind"`
@@ -30,6 +30,7 @@ type KnowledgeNode struct {
 	Managed *bool `json:"managed,omitempty"`
 	Description NullableString `json:"description,omitempty"`
 	Tags []string `json:"tags,omitempty"`
+	Trigger NullableMentalModelTriggerOutput `json:"trigger,omitempty"`
 	Timestamp NullableString `json:"timestamp,omitempty"`
 	IsStale NullableBool `json:"is_stale,omitempty"`
 	Children []KnowledgeNode `json:"children,omitempty"`
@@ -323,6 +324,48 @@ func (o *KnowledgeNode) SetTags(v []string) {
 	o.Tags = v
 }
 
+// GetTrigger returns the Trigger field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *KnowledgeNode) GetTrigger() MentalModelTriggerOutput {
+	if o == nil || IsNil(o.Trigger.Get()) {
+		var ret MentalModelTriggerOutput
+		return ret
+	}
+	return *o.Trigger.Get()
+}
+
+// GetTriggerOk returns a tuple with the Trigger field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *KnowledgeNode) GetTriggerOk() (*MentalModelTriggerOutput, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.Trigger.Get(), o.Trigger.IsSet()
+}
+
+// HasTrigger returns a boolean if a field has been set.
+func (o *KnowledgeNode) HasTrigger() bool {
+	if o != nil && o.Trigger.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetTrigger gets a reference to the given NullableMentalModelTriggerOutput and assigns it to the Trigger field.
+func (o *KnowledgeNode) SetTrigger(v MentalModelTriggerOutput) {
+	o.Trigger.Set(&v)
+}
+// SetTriggerNil sets the value for Trigger to be an explicit nil
+func (o *KnowledgeNode) SetTriggerNil() {
+	o.Trigger.Set(nil)
+}
+
+// UnsetTrigger ensures that no value is present for Trigger, not even an explicit nil
+func (o *KnowledgeNode) UnsetTrigger() {
+	o.Trigger.Unset()
+}
+
 // GetTimestamp returns the Timestamp field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *KnowledgeNode) GetTimestamp() string {
 	if o == nil || IsNil(o.Timestamp.Get()) {
@@ -466,6 +509,9 @@ func (o KnowledgeNode) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.Tags) {
 		toSerialize["tags"] = o.Tags
+	}
+	if o.Trigger.IsSet() {
+		toSerialize["trigger"] = o.Trigger.Get()
 	}
 	if o.Timestamp.IsSet() {
 		toSerialize["timestamp"] = o.Timestamp.Get()

--- a/hindsight-clients/go/model_update_node_request.go
+++ b/hindsight-clients/go/model_update_node_request.go
@@ -24,6 +24,7 @@ type UpdateNodeRequest struct {
 	SourceQuery NullableString `json:"source_query,omitempty"`
 	Tags []string `json:"tags,omitempty"`
 	MaxTokens NullableInt32 `json:"max_tokens,omitempty"`
+	Trigger NullableMentalModelTriggerInput `json:"trigger,omitempty"`
 }
 
 // NewUpdateNodeRequest instantiates a new UpdateNodeRequest object
@@ -244,6 +245,48 @@ func (o *UpdateNodeRequest) UnsetMaxTokens() {
 	o.MaxTokens.Unset()
 }
 
+// GetTrigger returns the Trigger field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *UpdateNodeRequest) GetTrigger() MentalModelTriggerInput {
+	if o == nil || IsNil(o.Trigger.Get()) {
+		var ret MentalModelTriggerInput
+		return ret
+	}
+	return *o.Trigger.Get()
+}
+
+// GetTriggerOk returns a tuple with the Trigger field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UpdateNodeRequest) GetTriggerOk() (*MentalModelTriggerInput, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.Trigger.Get(), o.Trigger.IsSet()
+}
+
+// HasTrigger returns a boolean if a field has been set.
+func (o *UpdateNodeRequest) HasTrigger() bool {
+	if o != nil && o.Trigger.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetTrigger gets a reference to the given NullableMentalModelTriggerInput and assigns it to the Trigger field.
+func (o *UpdateNodeRequest) SetTrigger(v MentalModelTriggerInput) {
+	o.Trigger.Set(&v)
+}
+// SetTriggerNil sets the value for Trigger to be an explicit nil
+func (o *UpdateNodeRequest) SetTriggerNil() {
+	o.Trigger.Set(nil)
+}
+
+// UnsetTrigger ensures that no value is present for Trigger, not even an explicit nil
+func (o *UpdateNodeRequest) UnsetTrigger() {
+	o.Trigger.Unset()
+}
+
 func (o UpdateNodeRequest) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -268,6 +311,9 @@ func (o UpdateNodeRequest) ToMap() (map[string]interface{}, error) {
 	}
 	if o.MaxTokens.IsSet() {
 		toSerialize["max_tokens"] = o.MaxTokens.Get()
+	}
+	if o.Trigger.IsSet() {
+		toSerialize["trigger"] = o.Trigger.Get()
 	}
 	return toSerialize, nil
 }

--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -1193,7 +1193,7 @@ class Hindsight:
 
         trigger_obj = None
         if trigger:
-            trigger_obj = mental_model_trigger_input.MentalModelTriggerInput(**trigger)
+            trigger_obj = mental_model_trigger_input.MentalModelTriggerInput.from_dict(trigger)
 
         request_obj = create_mental_model_request.CreateMentalModelRequest(
             id=id,
@@ -1355,7 +1355,7 @@ class Hindsight:
 
         trigger_obj = None
         if trigger:
-            trigger_obj = mental_model_trigger_input.MentalModelTriggerInput(**trigger)
+            trigger_obj = mental_model_trigger_input.MentalModelTriggerInput.from_dict(trigger)
 
         request_obj = update_mental_model_request.UpdateMentalModelRequest(
             name=name,
@@ -1472,7 +1472,7 @@ class Hindsight:
 
         trigger_obj = None
         if trigger:
-            trigger_obj = mental_model_trigger_input.MentalModelTriggerInput(**trigger)
+            trigger_obj = mental_model_trigger_input.MentalModelTriggerInput.from_dict(trigger)
 
         request_obj = create_page_request.CreatePageRequest(
             name=name,
@@ -1529,6 +1529,7 @@ class Hindsight:
         source_query: str | None = None,
         tags: list[str] | None = None,
         max_tokens: int | None = None,
+        trigger: dict[str, Any] | None = None,
     ):
         """
         Rename/move a knowledge node and/or update a page's options (sync wrapper —
@@ -1545,11 +1546,12 @@ class Hindsight:
             source_query: Pages only — new question. Changing it rebuilds the page.
             tags: Pages only — replaces the page's tags (pass [] to clear)
             max_tokens: Pages only — new content budget
+            trigger: Pages only — refresh scope and trigger settings
 
         Returns:
             KnowledgeNode
         """
-        from hindsight_client_api.models import update_node_request
+        from hindsight_client_api.models import mental_model_trigger_input, update_node_request
 
         # Build the request from only the arguments the caller supplied: the server
         # treats an absent field as "leave alone" but an explicit null parent_id as
@@ -1566,6 +1568,8 @@ class Hindsight:
             fields["tags"] = tags
         if max_tokens is not None:
             fields["max_tokens"] = max_tokens
+        if trigger is not None:
+            fields["trigger"] = mental_model_trigger_input.MentalModelTriggerInput.from_dict(trigger)
 
         request_obj = update_node_request.UpdateNodeRequest(**fields)
 

--- a/hindsight-clients/python/hindsight_client_api/api/knowledge_base_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/knowledge_base_api.py
@@ -2135,7 +2135,7 @@ class KnowledgeBaseApi:
     ) -> KnowledgeNode:
         """Rename/move a knowledge-base node or update a page's options
 
-        Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.
+        Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`, `trigger`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.
 
         :param bank_id: (required)
         :type bank_id: str
@@ -2215,7 +2215,7 @@ class KnowledgeBaseApi:
     ) -> ApiResponse[KnowledgeNode]:
         """Rename/move a knowledge-base node or update a page's options
 
-        Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.
+        Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`, `trigger`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.
 
         :param bank_id: (required)
         :type bank_id: str
@@ -2295,7 +2295,7 @@ class KnowledgeBaseApi:
     ) -> RESTResponseType:
         """Rename/move a knowledge-base node or update a page's options
 
-        Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.
+        Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`, `trigger`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.
 
         :param bank_id: (required)
         :type bank_id: str

--- a/hindsight-clients/python/hindsight_client_api/models/knowledge_node.py
+++ b/hindsight-clients/python/hindsight_client_api/models/knowledge_node.py
@@ -19,12 +19,13 @@ import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
+from hindsight_client_api.models.mental_model_trigger_output import MentalModelTriggerOutput
 from typing import Optional, Set
 from typing_extensions import Self
 
 class KnowledgeNode(BaseModel):
     """
-    A node in the knowledge-base tree — a folder or a page.  Pages carry ``description``/``tags`` from their backing mental model. The knowledge base is client-managed (CRUD); ``managed`` lets a client tag a node as system-owned vs. hand-authored.
+    A node in the knowledge-base tree — a folder or a page.  Pages carry ``description``/``tags``/``trigger`` from their backing mental model. The knowledge base is client-managed (CRUD); ``managed`` lets a client tag a node as system-owned vs. hand-authored.
     """ # noqa: E501
     id: StrictStr
     kind: StrictStr
@@ -34,10 +35,11 @@ class KnowledgeNode(BaseModel):
     managed: Optional[StrictBool] = Field(default=False, description="Client-set flag: true = system-owned, false = hand-authored.")
     description: Optional[StrictStr] = None
     tags: Optional[List[StrictStr]] = None
+    trigger: Optional[MentalModelTriggerOutput] = None
     timestamp: Optional[StrictStr] = None
     is_stale: Optional[StrictBool] = None
     children: Optional[List[KnowledgeNode]] = None
-    __properties: ClassVar[List[str]] = ["id", "kind", "name", "parent_id", "mental_model_id", "managed", "description", "tags", "timestamp", "is_stale", "children"]
+    __properties: ClassVar[List[str]] = ["id", "kind", "name", "parent_id", "mental_model_id", "managed", "description", "tags", "trigger", "timestamp", "is_stale", "children"]
 
     @field_validator('kind')
     def kind_validate_enum(cls, value):
@@ -85,6 +87,9 @@ class KnowledgeNode(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of trigger
+        if self.trigger:
+            _dict['trigger'] = self.trigger.to_dict()
         # override the default output from pydantic by calling `to_dict()` of each item in children (list)
         _items = []
         if self.children:
@@ -106,6 +111,11 @@ class KnowledgeNode(BaseModel):
         # and model_fields_set contains the field
         if self.description is None and "description" in self.model_fields_set:
             _dict['description'] = None
+
+        # set to None if trigger (nullable) is None
+        # and model_fields_set contains the field
+        if self.trigger is None and "trigger" in self.model_fields_set:
+            _dict['trigger'] = None
 
         # set to None if timestamp (nullable) is None
         # and model_fields_set contains the field
@@ -137,6 +147,7 @@ class KnowledgeNode(BaseModel):
             "managed": obj.get("managed") if obj.get("managed") is not None else False,
             "description": obj.get("description"),
             "tags": obj.get("tags"),
+            "trigger": MentalModelTriggerOutput.from_dict(obj["trigger"]) if obj.get("trigger") is not None else None,
             "timestamp": obj.get("timestamp"),
             "is_stale": obj.get("is_stale"),
             "children": [KnowledgeNode.from_dict(_item) for _item in obj["children"]] if obj.get("children") is not None else None

--- a/hindsight-clients/python/hindsight_client_api/models/update_node_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/update_node_request.py
@@ -19,6 +19,7 @@ import json
 
 from pydantic import BaseModel, ConfigDict, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
+from hindsight_client_api.models.mental_model_trigger_input import MentalModelTriggerInput
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -31,7 +32,8 @@ class UpdateNodeRequest(BaseModel):
     source_query: Optional[StrictStr] = None
     tags: Optional[List[StrictStr]] = None
     max_tokens: Optional[StrictInt] = None
-    __properties: ClassVar[List[str]] = ["name", "parent_id", "source_query", "tags", "max_tokens"]
+    trigger: Optional[MentalModelTriggerInput] = None
+    __properties: ClassVar[List[str]] = ["name", "parent_id", "source_query", "tags", "max_tokens", "trigger"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -72,6 +74,9 @@ class UpdateNodeRequest(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of trigger
+        if self.trigger:
+            _dict['trigger'] = self.trigger.to_dict()
         # set to None if name (nullable) is None
         # and model_fields_set contains the field
         if self.name is None and "name" in self.model_fields_set:
@@ -97,6 +102,11 @@ class UpdateNodeRequest(BaseModel):
         if self.max_tokens is None and "max_tokens" in self.model_fields_set:
             _dict['max_tokens'] = None
 
+        # set to None if trigger (nullable) is None
+        # and model_fields_set contains the field
+        if self.trigger is None and "trigger" in self.model_fields_set:
+            _dict['trigger'] = None
+
         return _dict
 
     @classmethod
@@ -113,7 +123,8 @@ class UpdateNodeRequest(BaseModel):
             "parent_id": obj.get("parent_id"),
             "source_query": obj.get("source_query"),
             "tags": obj.get("tags"),
-            "max_tokens": obj.get("max_tokens")
+            "max_tokens": obj.get("max_tokens"),
+            "trigger": MentalModelTriggerInput.from_dict(obj["trigger"]) if obj.get("trigger") is not None else None
         })
         return _obj
 

--- a/hindsight-clients/python/tests/test_knowledge_base_mapping.py
+++ b/hindsight-clients/python/tests/test_knowledge_base_mapping.py
@@ -12,13 +12,13 @@ from unittest.mock import MagicMock
 from hindsight_client import Hindsight
 
 
-def _capture(monkeypatch, client, method, captured):
+def _capture(monkeypatch, client, method, captured, *, api=None):
     async def fake(*args, **kwargs):
         captured["args"] = args
         captured["kwargs"] = kwargs
         return MagicMock()
 
-    monkeypatch.setattr(client._knowledge_base_api, method, fake)
+    monkeypatch.setattr(api or client._knowledge_base_api, method, fake)
 
 
 def test_create_page_maps_every_option(monkeypatch):
@@ -60,6 +60,10 @@ def test_create_page_threads_trigger_fields(monkeypatch):
             "refresh_after_consolidation": True,
             "fact_types": ["observation"],
             "exclude_mental_models": True,
+            "tag_groups": [
+                {"tags": ["knowledge:decision"], "match": "all_strict"},
+                {"not": {"tags": ["knowledge:external"], "match": "any_strict"}},
+            ],
         },
     )
 
@@ -68,6 +72,49 @@ def test_create_page_threads_trigger_fields(monkeypatch):
     assert request.trigger.refresh_after_consolidation is True
     assert request.trigger.fact_types == ["observation"]
     assert request.trigger.exclude_mental_models is True
+    assert request.trigger.tag_groups[0].actual_instance.to_dict() == {
+        "tags": ["knowledge:decision"],
+        "match": "all_strict",
+    }
+    assert request.trigger.tag_groups[1].actual_instance.to_dict() == {
+        "not": {"tags": ["knowledge:external"], "match": "any_strict"}
+    }
+
+
+def test_create_mental_model_maps_nested_trigger(monkeypatch):
+    client = Hindsight(base_url="http://example.invalid")
+    captured: dict[str, object] = {}
+    _capture(monkeypatch, client, "create_mental_model", captured, api=client._mental_models_api)
+
+    client.create_mental_model(
+        "bank-1",
+        name="Decisions",
+        source_query="What decisions were made?",
+        trigger={"tag_groups": [{"tags": ["knowledge:decision"], "match": "all_strict"}]},
+    )
+
+    _, request = captured["args"]
+    assert request.trigger.tag_groups[0].actual_instance.to_dict() == {
+        "tags": ["knowledge:decision"],
+        "match": "all_strict",
+    }
+
+
+def test_update_mental_model_maps_nested_trigger(monkeypatch):
+    client = Hindsight(base_url="http://example.invalid")
+    captured: dict[str, object] = {}
+    _capture(monkeypatch, client, "update_mental_model", captured, api=client._mental_models_api)
+
+    client.update_mental_model(
+        "bank-1",
+        "mm-1",
+        trigger={"tag_groups": [{"not": {"tags": ["knowledge:external"], "match": "any_strict"}}]},
+    )
+
+    _, _, request = captured["args"]
+    assert request.trigger.tag_groups[0].actual_instance.to_dict() == {
+        "not": {"tags": ["knowledge:external"], "match": "any_strict"}
+    }
 
 
 def test_update_node_sends_only_provided_fields(monkeypatch):
@@ -100,12 +147,32 @@ def test_update_node_maps_page_options(monkeypatch):
     captured: dict[str, object] = {}
     _capture(monkeypatch, client, "update_knowledge_node", captured)
 
-    client.update_knowledge_node("bank-1", "kp-1", source_query="New question?", tags=[], max_tokens=2048)
+    client.update_knowledge_node(
+        "bank-1",
+        "kp-1",
+        source_query="New question?",
+        tags=[],
+        max_tokens=2048,
+        trigger={
+            "refresh_after_consolidation": True,
+            "tag_groups": [
+                {"tags": ["knowledge:decision"], "match": "all_strict"},
+                {"not": {"tags": ["knowledge:external"], "match": "any_strict"}},
+            ],
+        },
+    )
 
     _, _, request = captured["args"]
     assert request.source_query == "New question?"
     assert request.tags == []
     assert request.max_tokens == 2048
+    assert request.trigger.tag_groups[0].actual_instance.to_dict() == {
+        "tags": ["knowledge:decision"],
+        "match": "all_strict",
+    }
+    assert request.trigger.tag_groups[1].actual_instance.to_dict() == {
+        "not": {"tags": ["knowledge:external"], "match": "any_strict"}
+    }
 
 
 def test_search_forwards_query_and_limit(monkeypatch):

--- a/hindsight-clients/typescript/generated/sdk.gen.ts
+++ b/hindsight-clients/typescript/generated/sdk.gen.ts
@@ -855,7 +855,7 @@ export const deleteKnowledgeNode = <ThrowOnError extends boolean = false>(
 /**
  * Rename/move a knowledge-base node or update a page's options
  *
- * Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.
+ * Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`, `trigger`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.
  */
 export const updateKnowledgeNode = <ThrowOnError extends boolean = false>(
   options: Options<UpdateKnowledgeNodeData, ThrowOnError>

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -2175,7 +2175,7 @@ export type IncludeOptions = {
  *
  * A node in the knowledge-base tree — a folder or a page.
  *
- * Pages carry ``description``/``tags`` from their backing mental model. The
+ * Pages carry ``description``/``tags``/``trigger`` from their backing mental model. The
  * knowledge base is client-managed (CRUD); ``managed`` lets a client tag a node
  * as system-owned vs. hand-authored.
  */
@@ -2218,6 +2218,10 @@ export type KnowledgeNode = {
    * Tags
    */
   tags?: Array<string>;
+  /**
+   * Page refresh trigger, including optional compound tag filters.
+   */
+  trigger?: MentalModelTriggerOutput | null;
   /**
    * Timestamp
    *
@@ -5029,6 +5033,10 @@ export type UpdateNodeRequest = {
    * Max Tokens
    */
   max_tokens?: number | null;
+  /**
+   * Page refresh trigger. Omit to leave it unchanged; explicit null is rejected.
+   */
+  trigger?: MentalModelTriggerInput | null;
 };
 
 /**

--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -64,6 +64,7 @@ import type {
   KnowledgePageSearchResponse,
   KnowledgeTreeResponse,
   ListDocumentsResponse,
+  MentalModelTriggerInput,
   MentalModelListResponse,
   MentalModelResponse,
   MentalModelDryRunRefreshResult,
@@ -1238,6 +1239,8 @@ export class HindsightClient {
       /** Pages only — replaces the page's tags (pass [] to clear). */
       tags?: string[];
       maxTokens?: number;
+      /** Pages only — refresh scope and trigger settings. */
+      trigger?: MentalModelTriggerInput | null;
       signal?: AbortSignal;
     }
   ): Promise<KnowledgeNode> {
@@ -1250,6 +1253,7 @@ export class HindsightClient {
         ...(options.sourceQuery !== undefined ? { source_query: options.sourceQuery } : {}),
         ...(options.tags !== undefined ? { tags: options.tags } : {}),
         ...(options.maxTokens !== undefined ? { max_tokens: options.maxTokens } : {}),
+        ...(options.trigger !== undefined ? { trigger: options.trigger } : {}),
       },
       signal: options.signal,
     });

--- a/hindsight-clients/typescript/tests/knowledge_base_mapping.test.ts
+++ b/hindsight-clients/typescript/tests/knowledge_base_mapping.test.ts
@@ -112,12 +112,23 @@ describe("updateKnowledgeNode mapping", () => {
       sourceQuery: "New question?",
       tags: [],
       maxTokens: 2048,
+      trigger: {
+        refresh_after_consolidation: true,
+        tag_groups: [
+          { tags: ["knowledge:decision"], match: "all_strict" },
+          { not: { tags: ["knowledge:external"], match: "any_strict" } },
+        ],
+      },
     });
 
     const body = mockedUpdateNode.mock.calls[0][0].body as any;
     expect(body.source_query).toBe("New question?");
     expect(body.tags).toEqual([]);
     expect(body.max_tokens).toBe(2048);
+    expect(body.trigger.tag_groups).toEqual([
+      { tags: ["knowledge:decision"], match: "all_strict" },
+      { not: { tags: ["knowledge:external"], match: "any_strict" } },
+    ]);
   });
 });
 

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -47,6 +47,7 @@ export interface KnowledgeNode {
   managed: boolean;
   description: string | null;
   tags: string[];
+  trigger?: MentalModel["trigger"] | null;
   timestamp: string | null;
   is_stale: boolean | null;
   children: KnowledgeNode[];
@@ -799,6 +800,7 @@ export class ControlPlaneClient {
       source_query?: string;
       tags?: string[];
       max_tokens?: number;
+      trigger?: MentalModel["trigger"] | null;
     }
   ) {
     return this.fetchApi<KnowledgeNode>(

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -2587,7 +2587,7 @@
           "Knowledge Base"
         ],
         "summary": "Rename/move a knowledge-base node or update a page's options",
-        "description": "Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.",
+        "description": "Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`, `trigger`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.",
         "operationId": "update_knowledge_node",
         "parameters": [
           {
@@ -10405,6 +10405,17 @@
             "title": "Tags",
             "default": []
           },
+          "trigger": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MentalModelTrigger-Output"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Page refresh trigger, including optional compound tag filters."
+          },
           "timestamp": {
             "anyOf": [
               {
@@ -10445,7 +10456,7 @@
           "name"
         ],
         "title": "KnowledgeNode",
-        "description": "A node in the knowledge-base tree \u2014 a folder or a page.\n\nPages carry ``description``/``tags`` from their backing mental model. The\nknowledge base is client-managed (CRUD); ``managed`` lets a client tag a node\nas system-owned vs. hand-authored."
+        "description": "A node in the knowledge-base tree \u2014 a folder or a page.\n\nPages carry ``description``/``tags``/``trigger`` from their backing mental model. The\nknowledge base is client-managed (CRUD); ``managed`` lets a client tag a node\nas system-owned vs. hand-authored."
       },
       "KnowledgePageBundleFile": {
         "properties": {
@@ -15339,6 +15350,17 @@
               }
             ],
             "title": "Max Tokens"
+          },
+          "trigger": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MentalModelTrigger-Input"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Page refresh trigger. Omit to leave it unchanged; explicit null is rejected."
           }
         },
         "type": "object",

--- a/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { HindsightClient } from "./hindsight";
-import { PAGE_MAX_TOKENS, PAGES } from "./missions";
+import { PAGE_MAX_TOKENS, PAGES, pageTrigger } from "./missions";
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -22,22 +22,25 @@ function stubFetch(calls: any[], jsonImpl: () => Promise<unknown> = async () => 
  *  or ids stop resolving (search returns kp-… node ids) and seeded pages fall out of the search
  *  corpus (it joins through knowledge_pages). */
 describe("HindsightClient knowledge-page reads", () => {
-  it("recognizes an older server and exposes the missing capability", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => ({
-        ok: false,
-        status: 404,
-        json: async () => ({ detail: "not found" }),
-      })) as any
-    );
-    const c = new HindsightClient({ apiUrl: "http://x", bank: "repo-a" });
-    await expect(c.listPages()).rejects.toMatchObject({ code: "knowledge_pages_unavailable" });
-    expect(c.knowledgePagesSupported).toBe(false);
-    await expect(c.searchKnowledgePages("architecture")).rejects.toMatchObject({
-      code: "knowledge_pages_unavailable",
-    });
-  });
+  it.each([404, 405, 501])(
+    "recognizes an older server (%s) and exposes the missing capability",
+    async (status) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => ({
+          ok: false,
+          status,
+          json: async () => ({ detail: "not found" }),
+        })) as any
+      );
+      const c = new HindsightClient({ apiUrl: "http://x", bank: "repo-a" });
+      await expect(c.listPages()).rejects.toMatchObject({ code: "knowledge_pages_unavailable" });
+      expect(c.knowledgePagesSupported).toBe(false);
+      await expect(c.searchKnowledgePages("architecture")).rejects.toMatchObject({
+        code: "knowledge_pages_unavailable",
+      });
+    }
+  );
 
   it("listPages reads the knowledge-base tree — never /mental-models", async () => {
     const calls: any[] = [];
@@ -174,8 +177,11 @@ describe("HindsightClient.seedPages", () => {
       expect(post.body.tags[0]).toMatch(
         /^knowledge:(feature-work|decision|convention|component|concept)$/
       );
+      const page = PAGES.find((p) => p.name === post.body.name);
+      expect(page).toBeDefined();
+      expect(post.body.source_query).not.toContain("Only include durable knowledge");
       expect(post.body.max_tokens).toBe(PAGE_MAX_TOKENS);
-      expect(post.body.trigger.refresh_after_consolidation).toBe(true);
+      expect(post.body.trigger).toEqual(pageTrigger(page!));
       expect(post.body.parent_id).toBeUndefined(); // seeded at the tree root
     }
     // Nothing on the mental-models surface.
@@ -193,6 +199,7 @@ describe("HindsightClient.seedPages", () => {
             kind: "page",
             name: p.name,
             description: p.source_query,
+            trigger: pageTrigger(p),
           })),
         },
       },
@@ -202,6 +209,101 @@ describe("HindsightClient.seedPages", () => {
     expect(calls).toHaveLength(1); // the tree GET only
     expect(calls.every((k) => k.method === "GET")).toBe(true);
   });
+
+  it("does not PATCH when trigger object keys arrive in a different order", async () => {
+    const calls: any[] = [];
+    const page = PAGES[0];
+    const trigger = pageTrigger(page);
+    const reorderedTrigger = {
+      ...trigger,
+      tag_groups: [
+        { match: "all_strict", tags: [...page.tags] },
+        { not: { match: "any_strict", tags: ["knowledge:external"] } },
+      ],
+    };
+    stubFetchRouted(calls, [
+      {
+        match: (m, u) => m === "GET" && u.endsWith("/knowledge-base/tree"),
+        json: {
+          roots: PAGES.map((p, i) => ({
+            id: `kp-${i}`,
+            kind: "page",
+            name: p.name,
+            description: p.source_query,
+            trigger: p === page ? reorderedTrigger : pageTrigger(p),
+          })),
+        },
+      },
+    ]);
+    const c = new HindsightClient({ apiUrl: "http://x", bank: "repo-a" });
+
+    await c.seedPages();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe("GET");
+  });
+
+  it("PATCHes an existing page whose trigger does not exclude external knowledge", async () => {
+    const calls: any[] = [];
+    const drifted = PAGES[0];
+    stubFetchRouted(calls, [
+      {
+        match: (m, u) => m === "GET" && u.endsWith("/knowledge-base/tree"),
+        json: {
+          roots: PAGES.map((p, i) => ({
+            id: `kp-${i}`,
+            kind: "page",
+            name: p.name,
+            description: p.source_query,
+            trigger: p === drifted ? { refresh_after_consolidation: true } : pageTrigger(p),
+          })),
+        },
+      },
+    ]);
+    const c = new HindsightClient({ apiUrl: "http://x", bank: "repo-a" });
+    await c.seedPages();
+
+    const patches = calls.filter((k) => k.method === "PATCH");
+    expect(patches).toHaveLength(1);
+    expect(patches[0].url).toContain("/knowledge-base/nodes/kp-0");
+    expect(patches[0].body).toEqual({ trigger: pageTrigger(drifted) });
+  });
+
+  it.each([405, 501])(
+    "continues when an older server rejects page upgrades with %s",
+    async (status) => {
+      const calls: any[] = [];
+      const drifted = PAGES[0];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string, init: any) => {
+          const method = init?.method;
+          calls.push({ url, method, body: init?.body ? JSON.parse(init.body) : undefined });
+          if (method === "GET" && url.endsWith("/knowledge-base/tree")) {
+            return {
+              ok: true,
+              status: 200,
+              json: async () => ({
+                roots: PAGES.map((p, i) => ({
+                  id: `kp-${i}`,
+                  kind: "page",
+                  name: p.name,
+                  description: p.source_query,
+                  trigger: p === drifted ? { refresh_after_consolidation: true } : pageTrigger(p),
+                })),
+              }),
+            } as any;
+          }
+          return { ok: false, status, json: async () => ({ detail: "not supported" }) } as any;
+        }) as any
+      );
+      const c = new HindsightClient({ apiUrl: "http://x", bank: "repo-a" });
+
+      await expect(c.seedPages()).resolves.toBeUndefined();
+      expect(c.knowledgePagesSupported).toBe(false);
+      expect(calls.filter((k) => k.method === "PATCH")).toHaveLength(1);
+    }
+  );
 
   it("tolerates a 409 from a concurrent run that seeded the same name first", async () => {
     const calls: any[] = [];
@@ -238,6 +340,7 @@ describe("HindsightClient.seedPages", () => {
             kind: "page",
             name: p.name.toUpperCase(),
             description: p === drifted ? "an older wording of the query" : p.source_query,
+            trigger: pageTrigger(p),
           })),
         },
       },
@@ -253,6 +356,7 @@ describe("HindsightClient.seedPages", () => {
     expect(patches[0].body).toEqual({
       source_query: drifted.source_query,
       tags: drifted.tags,
+      trigger: pageTrigger(drifted),
     });
   });
 });
@@ -456,6 +560,10 @@ describe("HindsightClient.configureBank template import", () => {
     );
     expect(body.bank.entity_labels).toEqual(
       expect.arrayContaining([expect.objectContaining({ key: "knowledge", tag: true })])
+    );
+    const knowledgeLabels = body.bank.entity_labels.find((group: any) => group.key === "knowledge");
+    expect(knowledgeLabels.values).toEqual(
+      expect.arrayContaining([expect.objectContaining({ value: "external" })])
     );
     expect(body.bank.entities_allow_free_form).toBe(true);
 

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -9,9 +9,10 @@ import {
   CODING_BANK_STRUCTURE,
   CODING_BANK_TEMPLATE,
   PAGE_MAX_TOKENS,
-  PAGE_TRIGGER,
   PAGES,
+  pageTrigger,
 } from "./missions";
+import type { KnowledgePageTagGroup, KnowledgePageTrigger } from "./missions";
 import { pool, semverGte, sleep } from "./util";
 import type { RetainStamp } from "./retain-stamp";
 
@@ -22,6 +23,8 @@ export interface KnowledgeNode {
   name: string;
   /** The page's source query (OKF `description`) — what a re-sync compares against. */
   description?: string;
+  /** Refresh filter returned for pages so managed trigger changes can be re-synced idempotently. */
+  trigger?: { tag_groups?: KnowledgePageTagGroup[] };
   children?: KnowledgeNode[];
 }
 
@@ -84,6 +87,9 @@ export class KnowledgePagesUnavailableError extends Error {
   }
 }
 
+/** HTTP statuses used by older deployments when the Knowledge Base surface is absent. */
+const KNOWLEDGE_PAGES_UNAVAILABLE_STATUSES = [405, 501] as const;
+
 const TERMINAL = new Set(["completed", "failed", "cancelled", "error"]);
 
 /** Default cap on concurrent retain-related requests; configurable via `maxParallelRetains`. */
@@ -108,6 +114,26 @@ const RETRY_AFTER_CEILING_MS = 60 * 1000;
 
 /** Bank-level missions the template seeds once and then leaves alone (#2492). */
 const MISSION_FIELDS = ["reflect_mission", "retain_mission", "observations_mission"] as const;
+
+/** Serialize JSON-like values with sorted object keys so API field order cannot cause drift. */
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, nested]) => nested !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right));
+    return `{${entries.map(([key, nested]) => `${JSON.stringify(key)}:${stableJson(nested)}`).join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+/** Only tag_groups are plugin-owned; server-added trigger defaults must not cause perpetual PATCHes. */
+function hasPageTagGroups(
+  existing: KnowledgeNode["trigger"],
+  desired: KnowledgePageTrigger
+): boolean {
+  return stableJson(existing?.tag_groups) === stableJson(desired.tag_groups);
+}
 
 export class HindsightClient {
   readonly apiUrl: string;
@@ -389,7 +415,9 @@ export class HindsightClient {
    */
   async tree(): Promise<KnowledgeNode[]> {
     if (this.knowledgePagesSupported === false) throw new KnowledgePagesUnavailableError();
-    const r = await this.req("GET", this.bankUrl("/knowledge-base/tree"));
+    const r = await this.req("GET", this.bankUrl("/knowledge-base/tree"), undefined, [
+      ...KNOWLEDGE_PAGES_UNAVAILABLE_STATUSES,
+    ]);
     if ([404, 405, 501].includes(r.status)) {
       this.knowledgePagesSupported = false;
       throw new KnowledgePagesUnavailableError();
@@ -497,17 +525,21 @@ export class HindsightClient {
     let updated = 0;
     for (const page of PAGES) {
       const hit = existing.get(page.name.toLowerCase());
+      const trigger = pageTrigger(page);
       const body = {
         name: page.name,
         source_query: page.source_query,
         tags: page.tags,
         max_tokens: PAGE_MAX_TOKENS,
-        trigger: PAGE_TRIGGER,
+        trigger,
       };
       if (!hit) {
         // 409 = another deepen run seeded this name between our tree read and this POST. That is
         // the outcome we wanted anyway, so tolerate it rather than failing the whole run.
-        const r = await this.req("POST", this.bankUrl("/knowledge-base/pages"), body, [409]);
+        const r = await this.req("POST", this.bankUrl("/knowledge-base/pages"), body, [
+          409,
+          ...KNOWLEDGE_PAGES_UNAVAILABLE_STATUSES,
+        ]);
         if ([404, 405, 501].includes(r.status)) {
           this.knowledgePagesSupported = false;
           this.log(
@@ -516,12 +548,23 @@ export class HindsightClient {
           return;
         }
         if (r.status !== 409) created++;
-      } else if (hit.description !== page.source_query) {
-        // Only the source query can drift — the name IS the match key, so it can't.
+      } else if (
+        hit.description !== page.source_query ||
+        (Object.prototype.hasOwnProperty.call(hit, "trigger") &&
+          !hasPageTagGroups(hit.trigger, trigger))
+      ) {
+        // The negative tag filter lives in the trigger, not in source_query: a prompt can guide
+        // synthesis but cannot prevent an external-tagged memory from entering the refresh scope.
+        const patch: Record<string, unknown> = { trigger };
+        if (hit.description !== page.source_query) {
+          patch.source_query = page.source_query;
+          patch.tags = page.tags;
+        }
         const r = await this.req(
           "PATCH",
           this.bankUrl(`/knowledge-base/nodes/${encodeURIComponent(hit.id)}`),
-          { source_query: page.source_query, tags: page.tags }
+          patch,
+          [...KNOWLEDGE_PAGES_UNAVAILABLE_STATUSES]
         );
         if ([404, 405, 501].includes(r.status)) {
           this.knowledgePagesSupported = false;

--- a/hindsight-integrations/coding-agents/src/core/missions.ts
+++ b/hindsight-integrations/coding-agents/src/core/missions.ts
@@ -115,9 +115,9 @@ export const RETAIN_STRATEGIES = {
 // ── passive tier tagging (entity_labels) ───────────────────────────────────────
 // A single hierarchical bank-config group set by `configureBank` at seed time. `tag: true` makes the
 // extractor copy each selected `knowledge:<value>` onto the fact's tags (via `_inject_label_tags`),
-// giving every durable fact a knowledge-tier routing tag the server-side knowledge base (and any
+// giving every durable fact a knowledge-page routing tag the server-side knowledge base (and any
 // tag-filtered query) can select on. The vocabulary is FIXED (not per-feature) because tag matching
-// is exact set-ops with no wildcards.
+// is exact set-ops with no wildcards. `external` is an exclusion marker, not a page tier.
 export interface EntityLabelValue {
   value: string;
   description: string;
@@ -144,7 +144,11 @@ export const KNOWLEDGE_LABELS: EntityLabelGroup = {
     "it is durable, reusable knowledge a developer would still want surfaced in future sessions. " +
     "IMPORTANT: leave this EMPTY for routine, transient, or operational facts — a passing test, a " +
     "one-off command, a status update, a debugging dead-end. MOST facts should get no label here. " +
-    "Assign more than one value only when the fact genuinely fits several.",
+    "Assign more than one value only when the fact genuinely fits several. " +
+    "Use 'external' ONLY when the fact's subject is another project's own implementation or decision. " +
+    "A decision about how THIS project uses, integrates, configures, or depends on another project is " +
+    "still knowledge about THIS project and must use its normal page tier. 'external' is mutually " +
+    "exclusive with the other knowledge values. If the subject is unclear, leave 'external' empty.",
   values: [
     {
       value: "feature-work",
@@ -176,6 +180,13 @@ export const KNOWLEDGE_LABELS: EntityLabelGroup = {
         "A domain concept, key abstraction, or piece of project vocabulary a new contributor must " +
         "understand to work effectively.",
     },
+    {
+      value: "external",
+      description:
+        "The fact is about another project's own codebase, implementation, configuration, or decision. " +
+        "Do not use this merely because this project discusses or depends on that project. Choose this " +
+        "alone, never alongside decision, convention, component, concept, or feature-work.",
+    },
   ],
 };
 
@@ -183,9 +194,9 @@ export const KNOWLEDGE_LABELS: EntityLabelGroup = {
 // CONSOLIDATED from the ingested MEMORY (commit history + past conversations) — NOT mirrored from the
 // current source (which would need constant re-sync). A universal 5-page taxonomy that generalizes to
 // any repo; the curator populates each from history+chats and can spawn per-component sub-pages.
-// A seeded page is a tag-scoped synthesis view: `tags` pins it to one `knowledge:<tier>` label so
-// its synthesis draws from the facts the extractor routed to that tier (exact set-ops — see
-// KNOWLEDGE_LABELS above; names/tiers mirror the label vocabulary).
+// A seeded page is a tag-scoped synthesis view: its trigger requires one `knowledge:<tier>` label and
+// explicitly excludes `knowledge:external`. The flat `tags` field remains the page's display/routing
+// label, while `tag_groups` supplies the negative filter (see KNOWLEDGE_LABELS above).
 export interface KnowledgePage {
   name: string;
   source_query: string;
@@ -243,6 +254,27 @@ export const PAGE_TRIGGER = {
   fact_types: ["world", "experience", "observation"],
   refresh_after_consolidation: true,
 } as const;
+
+export type KnowledgePageTagGroup =
+  | { tags: string[]; match: "all_strict" | "any_strict" }
+  | { not: KnowledgePageTagGroup };
+
+export interface KnowledgePageTrigger {
+  fact_types: readonly ["world", "experience", "observation"];
+  refresh_after_consolidation: true;
+  tag_groups: [KnowledgePageTagGroup, KnowledgePageTagGroup];
+}
+
+/** Build the refresh scope for one page: its tier, excluding facts marked external. */
+export function pageTrigger(page: Pick<KnowledgePage, "tags">): KnowledgePageTrigger {
+  return {
+    ...PAGE_TRIGGER,
+    tag_groups: [
+      { tags: [...page.tags], match: "all_strict" },
+      { not: { tags: ["knowledge:external"], match: "any_strict" } },
+    ],
+  };
+}
 
 // ── the bank template ──────────────────────────────────────────────────────────
 // The bank's CONFIG — missions, retain strategies, entity labels — as a single manifest for

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -2587,7 +2587,7 @@
           "Knowledge Base"
         ],
         "summary": "Rename/move a knowledge-base node or update a page's options",
-        "description": "Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.",
+        "description": "Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`, `trigger`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.",
         "operationId": "update_knowledge_node",
         "parameters": [
           {
@@ -10405,6 +10405,17 @@
             "title": "Tags",
             "default": []
           },
+          "trigger": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MentalModelTrigger-Output"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Page refresh trigger, including optional compound tag filters."
+          },
           "timestamp": {
             "anyOf": [
               {
@@ -10445,7 +10456,7 @@
           "name"
         ],
         "title": "KnowledgeNode",
-        "description": "A node in the knowledge-base tree \u2014 a folder or a page.\n\nPages carry ``description``/``tags`` from their backing mental model. The\nknowledge base is client-managed (CRUD); ``managed`` lets a client tag a node\nas system-owned vs. hand-authored."
+        "description": "A node in the knowledge-base tree \u2014 a folder or a page.\n\nPages carry ``description``/``tags``/``trigger`` from their backing mental model. The\nknowledge base is client-managed (CRUD); ``managed`` lets a client tag a node\nas system-owned vs. hand-authored."
       },
       "KnowledgePageBundleFile": {
         "properties": {
@@ -15339,6 +15350,17 @@
               }
             ],
             "title": "Max Tokens"
+          },
+          "trigger": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MentalModelTrigger-Input"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Page refresh trigger. Omit to leave it unchanged; explicit null is rejected."
           }
         },
         "type": "object",


### PR DESCRIPTION
## Summary

Knowledge Pages can currently summarize a dependency's implementation or decisions as if they belonged to the repository being worked on. This happens because document attribution records where a fact was captured, but does not identify what project the fact is about. This PR adds an explicit external-knowledge classification and prevents those facts from entering the repository's standard Knowledge Pages.

Fixes #3476

## What changed

The coding-agents plugin adds `knowledge:external` to the entity-label vocabulary. The extraction guidance says to use it only when the fact is about another project's own implementation, configuration, or decision. A decision about how the current repository uses or integrates a dependency remains normal project knowledge. The external label is explicitly exclusive with the other `knowledge:*` categories.

Each seeded Knowledge Page now refreshes from its normal category tag and excludes `knowledge:external` with a deterministic compound tag filter. The exclusion is therefore enforced by the refresh query instead of relying on wording in the page's natural-language source query.

Existing pages are upgraded in place. On startup the plugin reads the Knowledge Base tree, matches the fixed root pages by name, and patches a page only when its trigger is missing or different. Page IDs, existing content, and synthesized history are preserved. New pages receive the trigger when they are created, and repeated startup runs are idempotent.

The Knowledge Base API now exposes the page trigger in tree responses and accepts an optional `trigger` field in node PATCH requests. The route forwards that field to the existing backing mental-model update logic. The field is optional, so older clients and older page behavior remain compatible.

The CLI now exposes the same capability as `knowledge-base update BANK NODE --trigger <JSON>`. The argument accepts the complete trigger object, including nested `tag_groups`, and is included in the CLI OpenAPI coverage check.

The Rust SDK does not commit generated source files. Its `build.rs` generates the models from `hindsight-docs/static/openapi.json` at build time, so `KnowledgeNode.trigger`, `UpdateNodeRequest.trigger`, and nested trigger tag groups are available after rebuilding. The service's native MCP has no Knowledge Base CRUD operation, so it has no corresponding parameter to add. The coding-agents MCP also keeps page CRUD internal to the plugin.

The OpenAPI specification and generated Python, TypeScript, and Go clients are updated together with the control-plane types and wrappers.

## Compatibility

The deprecated per-harness plugins continue to use their existing mental-model endpoints and are not changed by this PR. They remain operational, but they do not automatically gain the new external classification. The current unified plugin upgrades pages created by earlier versions of that same plugin when the server exposes the trigger field. Historical facts are not reclassified automatically; newly extracted facts use the new label.

When an older server does not expose the Knowledge Base surface, the plugin treats 404, 405, and 501 responses as an unavailable optional capability. It skips page creation or upgrade and continues with bank configuration and memory operations. Older servers that return a tree without `trigger` are not sent a trigger PATCH, so their existing page behavior is preserved.

## Verification

The coding-agents test suite passed with 504 tests, including 31 Knowledge Page tests. The CLI trigger parsing test passed, the CLI compiled successfully, and the OpenAPI coverage check reported all 89 operations and 115 request parameters covered. Client and documentation generation, repository lint hooks, and whitespace checks passed. The server Knowledge Base integration tests were not run because this temporary worktree does not include `pg0-embedded`, so its test database cannot start.
