### PR TITLE
feat(memories): assert_writable — let a store close a bank to writes

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -4073,6 +4073,19 @@ def _register_routes(app: FastAPI):
             content={"detail": str(exc)},
         )
 
+    # A bank briefly closed to writes — a store migrating it between backends holds it for a few
+    # seconds. 503 + Retry-After rather than a 500: nothing is broken, and the difference decides
+    # whether a client retries or reports a failure to the user.
+    from ..engine.memories.base import StoreWriteUnavailable
+
+    @app.exception_handler(StoreWriteUnavailable)
+    async def store_write_unavailable_handler(request, exc: StoreWriteUnavailable):
+        return JSONResponse(
+            status_code=503,
+            content={"detail": str(exc)},
+            headers={"Retry-After": str(getattr(exc, "retry_after", 30))},
+        )
+
     async def _readiness_response() -> JSONResponse:
         """Shared body of /health and /health/ready: 200 if healthy, 503 if not."""
         health = await app.state.memory.health_check()

--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -63,6 +63,21 @@ class MemoryTxn:
     deliberately empty: only the store that minted a handle interprets it."""
 
 
+class StoreWriteUnavailable(RuntimeError):
+    """The store cannot accept writes for this bank *right now*, but will shortly.
+
+    Distinct from a failure: nothing is wrong, the bank is briefly closed to writes — a store
+    migrating a bank between backends holds it for a few seconds while it takes the final delta
+    and flips. The caller should retry rather than surface an error, which is why the API maps
+    this to 503 with a `Retry-After` rather than a 5xx that reads as a bug.
+
+    Raised from :meth:`MemoriesExtension.assert_writable` and from bank-scoped write methods.
+    """
+
+    #: Seconds a caller should wait before retrying. A cutover freeze is drain + a reconcile.
+    retry_after: int = 30
+
+
 # Keys used in an implementation's opaque metadata bag for the `memory_units`
 # columns it has no first-class model of. These round-trip verbatim: they are
 # stored without interpretation and returned on every hit, which is what lets
@@ -451,6 +466,21 @@ class MemoriesExtension(Extension, ABC):
         """Per-bank form of :attr:`owns_document_store`. Defaults to the class attribute; a store
         that keeps some banks in a separate backend overrides it. See :meth:`writes_memory_rows_in_sql_for`."""
         return self.owns_document_store
+
+    async def assert_writable(self, bank_id: str) -> None:
+        """Refuse the operation if the store cannot take writes for this bank right now.
+
+        Called at the entry to a *multi-store* operation — retain, which writes documents, chunks
+        and entities through paths that are not this interface at all. Every write that does go
+        through a store method is already covered by the method itself; this exists for the ones
+        that are not, so a store can close a bank completely rather than only partly.
+
+        The default is a no-op, so no existing store needs a change. A store that migrates banks
+        between backends raises :class:`StoreWriteUnavailable` while a bank is mid-cutover: the
+        window is seconds, and a retain that started before it and writes after it would land in
+        the store that is about to stop being authoritative.
+        """
+        return None
 
     # ------------------------------------------------------------------ lifecycle
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -1121,6 +1121,15 @@ async def retain_batch(
         didn't dedup (caller should treat as "bill full submitted content").
         See ``RetainResult.processed_content_tokens`` for details.
     """
+    # Before anything is written. A retain is the one operation that writes to BOTH stores —
+    # documents, chunks and entities go to SQL through paths that never touch the memories
+    # interface — so a store that needs a bank closed to writes (a backend cutover) cannot enforce
+    # it from its own methods alone. Checked here, at the single entry every retain passes through,
+    # rather than at each of the writes it fans out into.
+    from ..memories import get_memories
+
+    await get_memories().assert_writable(bank_id)
+
     start_time = time.time()
     total_chars = sum(len(item.get("content", "")) for item in contents_dicts)
 

--- a/hindsight-api-slim/tests/test_memories_extension.py
+++ b/hindsight-api-slim/tests/test_memories_extension.py
@@ -752,6 +752,38 @@ def test_a_store_answers_capabilities_per_bank():
     assert store.writes_memory_rows_in_sql is False
 
 
+def test_assert_writable_defaults_to_allowing_everything():
+    """No existing store needs a change: the default is a no-op, so a store that has never heard
+    of write windows keeps taking every write."""
+    import asyncio
+
+    asyncio.get_event_loop_policy().new_event_loop().run_until_complete(
+        PostgresMemories({}).assert_writable("any-bank")
+    )
+
+
+async def test_retain_refuses_a_bank_the_store_has_closed_to_writes(restore_default_store):
+    """A retain writes documents, chunks and entities through SQL paths that never reach the
+    memories interface, so a store cannot close a bank from its own methods alone. `retain_batch`
+    asks first — and asks BEFORE anything is written, which is what this pins: every other
+    argument here is None, so a guard that ran even one step late would raise something else.
+    """
+    from hindsight_api.engine.memories.base import StoreWriteUnavailable
+    from hindsight_api.engine.retain import orchestrator
+
+    class ClosedForWrites(InMemoryMemories):
+        name = "closed"
+
+        async def assert_writable(self, bank_id):
+            if bank_id == "frozen-bank":
+                raise StoreWriteUnavailable(f"bank {bank_id} is mid-cutover")
+
+    set_memories(ClosedForWrites({}))
+
+    with pytest.raises(StoreWriteUnavailable, match="mid-cutover"):
+        await orchestrator.retain_batch(None, None, None, None, None, "frozen-bank", [{"content": "hello"}], None)
+
+
 # ---------------------------------------------------------------------------
 # Interface conformance: the stub must stay a COMPLETE, signature-compatible
 # implementation of every MemoriesExtension method. This is the guard that keeps


### PR DESCRIPTION
A store that migrates a bank between backends needs the bank closed to writes for the few seconds it takes to copy the final delta and flip.

Refusing inside the store's own methods closes it only **partly**: a retain also writes documents, chunks and entities through SQL paths that never reach the memories interface, so a retain already past its last store write keeps going and lands rows in the store that is about to stop being authoritative.

## The change

- **`base.py`** — `assert_writable(bank_id)`, default a no-op, so no existing store needs a change. Plus `StoreWriteUnavailable`: a "not right now" rather than a failure, carrying a `retry_after`.
- **`orchestrator.py`** — `retain_batch` calls it as its **first statement**, before it touches the pool. One check at the single entry every retain passes through, rather than one at each of the writes it fans out into.
- **`http.py`** — `StoreWriteUnavailable` → **503 with `Retry-After`**. The type is the engine's own, so the mapping needs no knowledge of which store raised it, and 503-rather-than-500 is what decides whether a client retries or reports a failure to a user.

## Tests

- the default allows everything, so every existing store is unaffected;
- a retain against a bank a store has closed raises **before anything is written** — pinned by passing `None` for every other argument, so a guard that ran even one step late would raise something else.

163 pass in `test_memories_extension.py`.

## Why

Used by an out-of-tree store that routes banks between backends: during a switchover a bank is closed to writes for a few seconds while the final delta is copied and the backend flipped. Nothing changes for a store that does not override the hook.