### PR TITLE
docs: rework the topbar, page chrome and skill installer

### DIFF
--- a/hindsight-docs/docusaurus.config.ts
+++ b/hindsight-docs/docusaurus.config.ts
@@ -7,7 +7,7 @@ const umamiWebsiteId = process.env.UMAMI_WEBSITE_ID;
 
 // Announcement bar - supports HTML for links
 // Set to empty string '' to hide the bar
-const ANNOUNCEMENT_BAR = 'Hindsight is State-of-the-Art on Memory for AI Agents | <a href="https://arxiv.org/abs/2512.12818" target="_blank">Read the paper →</a>';
+const ANNOUNCEMENT_BAR = 'Hindsight is State-of-the-Art on Memory for AI Agents <a href="https://arxiv.org/abs/2512.12818" target="_blank">Read the paper →</a>';
 
 const config: Config = {
   title: 'Hindsight',
@@ -98,6 +98,11 @@ const config: Config = {
         docs: {
           sidebarPath: './sidebars.ts',
           routeBasePath: '/',
+          // The sidebar already shows where a page sits, and every doc opens
+          // with its own H1 — the trail only repeated both.
+          // src/theme/DocBreadcrumbs still renders: the original component
+          // returns null on this flag, and the wrapper carries the skill banner.
+          breadcrumbs: false,
           // Whether to include the "current" (Next / unreleased) docs version.
           //
           // Controlled by the single explicit env var INCLUDE_CURRENT_VERSION.
@@ -194,6 +199,7 @@ const config: Config = {
         id: 'integrations',
         path: './docs-integrations',
         routeBasePath: 'sdks/integrations',
+        breadcrumbs: false, // as above — its own docs plugin, its own flag
         // Unversioned plugin: gives the integration pages a sidebar generated
         // from src/data/integrations.json without versioning them.
         sidebarPath: './sidebars-integrations.ts',
@@ -226,6 +232,11 @@ const config: Config = {
         indexBlog: true,
         blogRouteBasePath: '/blog',
         highlightSearchTermsOnTargetPage: false,
+        // The search field lives in the docs sidebar (see
+        // src/theme/DocSidebar/Desktop/Content), so its results panel opens to
+        // the right of the field. Autodetection would infer "right" from the
+        // navbar and push the panel off the left of the window.
+        searchBarPosition: 'left',
       },
     ],
   ],
@@ -256,8 +267,15 @@ const config: Config = {
           type: 'doc',
           docId: 'developer/index',
           position: 'left',
-          label: 'Developer',
+          label: 'Docs',
           className: 'navbar-item-developer',
+        },
+        // Sits directly after "Docs": the version only ever qualifies the docs,
+        // so it reads as part of that item rather than as a sixth destination.
+        {
+          type: 'docsVersionDropdown',
+          position: 'left',
+          className: 'navbar-item-version',
         },
         {
           to: '/integrations',
@@ -336,26 +354,27 @@ const config: Config = {
           ],
         },
         {
-          type: 'docsVersionDropdown',
-          position: 'right',
-          className: 'navbar-item-version',
-        },
-        {
-          href: 'https://ui.hindsight.vectorize.io/signup',
-          position: 'right',
-          label: 'Cloud',
-          className: 'navbar-item-cloud',
-        },
-        {
           href: 'https://github.com/vectorize-io/hindsight',
           position: 'right',
           label: 'GitHub',
           className: 'header-github-link',
         },
+        // Rendered last on the right (after the color-mode toggle) by
+        // src/theme/Navbar/Content — the only call to action up there.
+        {
+          href: 'https://ui.hindsight.vectorize.io/signup',
+          position: 'right',
+          label: 'Sign up',
+          className: 'navbar-item-signup',
+        },
       ],
     },
     footer: {
-      style: 'dark',
+      // Not 'dark': that paints a slab in the theme's dark palette regardless
+      // of the active theme, so on a light page the footer arrived as a black
+      // block. It now continues the page and is separated by a rule alone
+      // (custom.css).
+      style: 'light',
       links: [
         {
           title: 'Documentation',
@@ -414,10 +433,14 @@ const config: Config = {
               label: 'Slack',
               href: 'https://join.slack.com/t/hindsight-space/shared_invite/zt-3nhbm4w29-LeSJ5Ixi6j8PdiYOCPlOgg',
             },
+            {
+              label: 'Vectorize',
+              href: 'https://vectorize.io',
+            },
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} Vectorize, Inc.`,
+      copyright: `Copyright © ${new Date().getFullYear()} <a href="https://vectorize.io">Vectorize, Inc.</a>`,
     },
     prism: {
       theme: prismThemes.github,

--- a/hindsight-docs/src/components/SkillBanner.module.css
+++ b/hindsight-docs/src/components/SkillBanner.module.css
@@ -1,152 +1,161 @@
 .container {
-  margin: 0 0 20px 0;
+  margin: 0 0 1.5rem 0;
   width: 100%;
 }
 
+/* One slim bar rather than the previous block with the command printed in it:
+   the command now lives behind the Install button, so the strip only has to
+   say what it is for. */
 .banner {
-  background: linear-gradient(135deg, #0074d9 0%, #005db0 100%);
-  border-radius: 8px;
-  padding: 10px 14px;
-  color: white;
-  box-shadow: 0 2px 8px rgba(0, 116, 217, 0.12);
-  border: 1px solid rgba(255, 255, 255, 0.1);
   display: flex;
   align-items: center;
-  gap: 12px;
-  transition: box-shadow 0.2s ease;
+  gap: 0.75rem;
+  min-height: 2.75rem;
+  padding: 0.375rem 0.375rem 0.375rem 0.875rem;
+  border: 1px solid var(--skill-banner-border);
+  border-radius: 0.625rem;
+  background: var(--skill-banner-surface);
 }
 
-.banner:hover {
-  box-shadow: 0 4px 12px rgba(0, 116, 217, 0.2);
-}
-
-.icon {
-  font-size: 20px;
-  line-height: 1;
+.prompt {
   flex-shrink: 0;
-}
-
-.content {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 0;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.8125rem;
+  color: var(--ifm-color-primary);
+  opacity: 0.9;
 }
 
 .title {
-  font-weight: 600;
-  font-size: 12px;
-  line-height: 1.4;
-  color: white;
-}
-
-.commandWrapper {
-  margin-top: 2px;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.command {
-  background: rgba(0, 0, 0, 0.25);
-  padding: 6px 8px;
-  border-radius: 4px;
-  font-size: 10px;
-  font-family: 'JetBrains Mono', 'Fira Code', 'SF Mono', Monaco, Consolas, monospace;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  color: #e6f7f8;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   flex: 1;
   min-width: 0;
-}
-
-.copyButton {
-  background: rgba(255, 255, 255, 0.15);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 4px;
-  padding: 6px 8px;
-  color: white;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.2s ease;
-  flex-shrink: 0;
-  height: 28px;
-  width: 28px;
-}
-
-.copyButton:hover {
-  background: rgba(255, 255, 255, 0.25);
-  transform: scale(1.05);
-}
-
-.copyButton:active {
-  transform: scale(0.95);
-}
-
-.copyButton svg {
-  display: block;
-}
-
-.titleRow {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.copyPageButton {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  background: rgba(255, 255, 255, 0.12);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 4px;
-  padding: 3px 7px;
-  color: rgba(255, 255, 255, 0.85);
-  font-size: 10px;
+  font-family: 'Space Grotesk', var(--ifm-font-family-base);
   font-weight: 600;
-  cursor: pointer;
-  white-space: nowrap;
+  font-size: 0.8125rem;
+  color: var(--ifm-font-color-base);
+}
+
+/* Brand marks only — which agents this works with. Nothing to click. */
+.agents {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   flex-shrink: 0;
-  transition: all 0.2s ease;
 }
 
-.copyPageButton:hover {
-  background: rgba(255, 255, 255, 0.22);
-  color: white;
+.agentLogo {
+  width: 1.125rem;
+  height: 1.125rem;
+  object-fit: contain;
+  border-radius: 0.1875rem;
+  opacity: 0.85;
 }
 
-.copyPageButton:active {
-  transform: scale(0.95);
+/* Split control: the action on the left, the page menu behind the chevron. */
+.actions {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  flex-shrink: 0;
+  border: 1px solid var(--skill-banner-border);
+  border-radius: 0.5rem;
+  background: var(--skill-banner-button);
 }
 
-.copyPageButton.copyPageCopied {
-  background: rgba(255, 255, 255, 0.22);
-  color: white;
+.installButton,
+.menuButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0 0.75rem;
+  border: none;
+  background: none;
+  font-family: 'Space Grotesk', var(--ifm-font-family-base);
+  font-weight: 600;
+  font-size: 0.8125rem;
+  line-height: 1;
+  color: var(--ifm-font-color-base);
+  cursor: pointer;
+  transition: background-color 0.15s ease;
 }
 
-/* Dark mode - make it stand out even more */
-html[data-theme='dark'] .banner {
-  box-shadow: 0 4px 12px rgba(0, 116, 217, 0.2),
-              0 0 0 1px rgba(255, 255, 255, 0.15);
+.installButton {
+  height: 1.875rem;
+  border-radius: 0.4375rem 0 0 0.4375rem;
 }
 
-html[data-theme='dark'] .banner:hover {
-  box-shadow: 0 6px 16px rgba(0, 116, 217, 0.3),
-              0 0 0 1px rgba(255, 255, 255, 0.2);
+.menuButton {
+  padding: 0 0.4375rem;
+  border-left: 1px solid var(--skill-banner-border);
+  border-radius: 0 0.4375rem 0.4375rem 0;
 }
 
-/* Light mode adjustments */
-html[data-theme='light'] .banner {
-  box-shadow: 0 4px 12px rgba(0, 116, 217, 0.15),
-              0 2px 4px rgba(0, 0, 0, 0.05);
+.installButton:hover,
+.menuButton:hover,
+.menuButton[aria-expanded='true'] {
+  background-color: var(--skill-banner-button-hover);
 }
 
-html[data-theme='light'] .banner:hover {
-  box-shadow: 0 6px 16px rgba(0, 116, 217, 0.25),
-              0 4px 8px rgba(0, 0, 0, 0.08);
+.installButton svg,
+.menuButton svg {
+  flex-shrink: 0;
+}
+
+.copied {
+  color: var(--ifm-color-primary);
+}
+
+.menu {
+  position: absolute;
+  top: calc(100% + 0.375rem);
+  right: 0;
+  z-index: 10;
+  min-width: 12rem;
+  padding: 0.375rem;
+  border: 1px solid var(--skill-banner-border);
+  border-radius: 0.625rem;
+  background: var(--ifm-background-surface-color);
+  box-shadow: 0 8px 24px -6px rgba(0, 0, 0, 0.35);
+}
+
+.menuItem {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  width: 100%;
+  padding: 0.5rem 0.625rem;
+  border: none;
+  border-radius: 0.375rem;
+  background: none;
+  font-family: var(--ifm-font-family-base);
+  font-size: 0.8125rem;
+  color: var(--ifm-font-color-base);
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.menuItem:hover {
+  background-color: var(--skill-banner-button-hover);
+}
+
+.menuItem svg {
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
+/* Below the docs sidebar breakpoint the strip has to give up the label before
+   it gives up the button. */
+@media (max-width: 600px) {
+  .title {
+    font-size: 0.75rem;
+  }
+
+  .agents {
+    display: none;
+  }
+}
+
+/* A black one-colour mark would vanish against the dark theme. */
+[data-theme='dark'] .agentLogoMono {
+  filter: invert(1);
 }

--- a/hindsight-docs/src/components/SkillBanner.tsx
+++ b/hindsight-docs/src/components/SkillBanner.tsx
@@ -1,5 +1,36 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import styles from './SkillBanner.module.css';
+
+const INSTALL_COMMAND =
+  'npx skills add https://github.com/vectorize-io/hindsight --skill hindsight-docs';
+
+// Brand marks only: one command installs the skill for any of them, so these
+// say "this works with your agent" rather than offering a choice.
+// `mono` marks a one-colour black mark that has to be flipped to stay visible
+// on the dark theme; the others carry their own brand colours.
+const AGENTS = [
+  { name: 'Claude Code', icon: 'img/icons/claude-code.png', mono: false },
+  { name: 'Codex', icon: 'img/icons/codex.svg', mono: true },
+  { name: 'Cursor', icon: 'img/icons/cursor.svg', mono: false },
+];
+
+function PromptIcon(): React.ReactElement {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <polyline points="4 17 10 11 4 5" />
+      <line x1="12" y1="19" x2="20" y2="19" />
+    </svg>
+  );
+}
+
+function CheckIcon(): React.ReactElement {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
 
 function extractMarkdown(element: Element): string {
   let text = '';
@@ -61,89 +92,152 @@ function extractMarkdown(element: Element): string {
   return text;
 }
 
-export default function SkillBanner(): JSX.Element {
+/** Serialises the rendered page back to markdown, title first. */
+function collectPageMarkdown(): { title: string; markdown: string } | null {
+  const contentElement = document.querySelector('.markdown');
+  if (!contentElement) return null;
+  const title = document.querySelector('h1')?.textContent ?? '';
+  const body = Array.from(contentElement.children)
+    .filter(child => !(child.tagName === 'H1' && child.textContent === title))
+    .map(child => extractMarkdown(child))
+    .join('');
+  const markdown = `${title ? `# ${title}\n\n` : ''}${body}`
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+  return { title, markdown };
+}
+
+export default function SkillBanner(): React.ReactElement {
   const [commandCopied, setCommandCopied] = useState(false);
   const [pageCopied, setPageCopied] = useState(false);
-  const command = 'npx skills add https://github.com/vectorize-io/hindsight --skill hindsight-docs';
+  const [menuOpen, setMenuOpen] = useState(false);
+  const actionsRef = useRef<HTMLDivElement>(null);
 
-  const handleCopyCommand = async () => {
+  // Dismiss the menu the way any menu is expected to go away.
+  useEffect(() => {
+    if (!menuOpen) return undefined;
+    const onPointerDown = (event: MouseEvent) => {
+      if (!actionsRef.current?.contains(event.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setMenuOpen(false);
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [menuOpen]);
+
+  const handleCopyCommand = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(command);
+      await navigator.clipboard.writeText(INSTALL_COMMAND);
       setCommandCopied(true);
       setTimeout(() => setCommandCopied(false), 2000);
     } catch (err) {
       console.error('Failed to copy:', err);
     }
-  };
+  }, []);
 
   const handleCopyPage = useCallback(async () => {
     try {
-      const contentElement = document.querySelector('.markdown');
-      if (!contentElement) return;
-      const title = document.querySelector('h1')?.textContent;
-      let markdown = title ? `# ${title}\n\n` : '';
-      const contentToCopy = Array.from(contentElement.children)
-        .filter(child => !(child.tagName === 'H1' && child.textContent === title))
-        .map(child => extractMarkdown(child))
-        .join('');
-      markdown += contentToCopy;
-      markdown = markdown.replace(/\n{3,}/g, '\n\n').trim();
-      await navigator.clipboard.writeText(markdown);
+      const page = collectPageMarkdown();
+      if (!page) return;
+      await navigator.clipboard.writeText(page.markdown);
       setPageCopied(true);
+      setMenuOpen(false);
       setTimeout(() => setPageCopied(false), 2000);
     } catch (error) {
       console.error('Failed to copy page content:', error);
     }
   }, []);
 
+  const handleDownloadPage = useCallback(() => {
+    const page = collectPageMarkdown();
+    if (!page) return;
+    const url = URL.createObjectURL(
+      new Blob([page.markdown], { type: 'text/markdown;charset=utf-8' }),
+    );
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${
+      page.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'page'
+    }.md`;
+    link.click();
+    // Revoked on the next tick, not inline: the download is only queued by the
+    // click, and pulling the URL out from under it in the same frame can cancel
+    // it before it starts.
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+    setMenuOpen(false);
+  }, []);
+
+  const agentIconBase = useBaseUrl('/');
+
   return (
     <div className={styles.container}>
       <div className={styles.banner}>
-        <div className={styles.icon}>🤖</div>
-        <div className={styles.content}>
-          <div className={styles.titleRow}>
-            <div className={styles.title}>
-              Using a coding agent? Run this to install the Hindsight docs skill:
+        <span className={styles.prompt} aria-hidden="true">
+          <PromptIcon />
+        </span>
+        <span className={styles.title}>Building with a coding agent?</span>
+
+        <span className={styles.agents}>
+          {AGENTS.map(agent => (
+            <img
+              key={agent.name}
+              className={`${styles.agentLogo}${agent.mono ? ` ${styles.agentLogoMono}` : ''}`}
+              src={agentIconBase + agent.icon}
+              alt={agent.name}
+              title={`Works with ${agent.name}`}
+              loading="lazy"
+              width={18}
+              height={18}
+            />
+          ))}
+        </span>
+
+        <div className={styles.actions} ref={actionsRef}>
+          <button
+            type="button"
+            className={`${styles.installButton} ${commandCopied ? styles.copied : ''}`}
+            onClick={handleCopyCommand}
+            title={commandCopied ? 'Copied!' : `Copy: ${INSTALL_COMMAND}`}
+          >
+            {commandCopied ? <CheckIcon /> : <PromptIcon />}
+            <span>{commandCopied ? 'Copied!' : 'Install skill'}</span>
+          </button>
+          <button
+            type="button"
+            className={styles.menuButton}
+            onClick={() => setMenuOpen(open => !open)}
+            aria-label="More page actions"
+            aria-haspopup="menu"
+            aria-expanded={menuOpen}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
+          </button>
+
+          {menuOpen && (
+            <div className={styles.menu} role="menu">
+              <button type="button" className={styles.menuItem} role="menuitem" onClick={handleCopyPage}>
+                <PromptIcon />
+                <span>{pageCopied ? 'Copied!' : 'Copy page'}</span>
+              </button>
+              <button type="button" className={styles.menuItem} role="menuitem" onClick={handleDownloadPage}>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                  <polyline points="7 10 12 15 17 10" />
+                  <line x1="12" y1="15" x2="12" y2="3" />
+                </svg>
+                <span>Download page (.md)</span>
+              </button>
             </div>
-            <button
-              className={`${styles.copyPageButton} ${pageCopied ? styles.copyPageCopied : ''}`}
-              onClick={handleCopyPage}
-              aria-label="Export page as markdown"
-              title={pageCopied ? 'Copied!' : 'Export page as markdown'}
-            >
-              {pageCopied ? (
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
-                  <polyline points="20 6 9 17 4 12"></polyline>
-                </svg>
-              ) : (
-                <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-                  <path d="M4 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V2zm2-1a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H6z"/>
-                  <path d="M2 5a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-1h1v1a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h1v1H2z"/>
-                </svg>
-              )}
-              <span>{pageCopied ? 'Copied!' : 'export this page as .md'}</span>
-            </button>
-          </div>
-          <div className={styles.commandWrapper}>
-            <code className={styles.command}>{command}</code>
-            <button
-              className={styles.copyButton}
-              onClick={handleCopyCommand}
-              aria-label="Copy command"
-              title={commandCopied ? 'Copied!' : 'Copy to clipboard'}
-            >
-              {commandCopied ? (
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                  <polyline points="20 6 9 17 4 12"></polyline>
-                </svg>
-              ) : (
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-                </svg>
-              )}
-            </button>
-          </div>
+          )}
         </div>
       </div>
     </div>

--- a/hindsight-docs/src/css/custom.css
+++ b/hindsight-docs/src/css/custom.css
@@ -6,8 +6,35 @@
 :root {
   /* Primary gradient */
   --hindsight-gradient: linear-gradient(135deg, #0074d9 0%, #009296 100%);
+  /* Same ramp left-to-right, for wide-and-short surfaces (buttons, bars) where
+     the 135° version would only show one end of it. */
+  --hindsight-gradient-horizontal: linear-gradient(90deg, #0074d9 0%, #009296 100%);
   --hindsight-gradient-start: #0074d9;
   --hindsight-gradient-end: #009296;
+
+  /* The surface every active navbar item wears. Flat rather than a gradient:
+     active items keep gradient *text*, which needs `background-clip: text` and
+     therefore owns `background` — so the surface is painted with an inset
+     box-shadow instead, and box-shadow takes no gradient. At this alpha the
+     ramp was imperceptible anyway. */
+  --hindsight-active-surface: rgba(0, 116, 217, 0.09);
+
+  /* Skill banner (src/components/SkillBanner) — a quiet strip that reads as
+     tooling attached to the page, not as an alert competing with the title. */
+  --skill-banner-surface: rgba(0, 116, 217, 0.04);
+  --skill-banner-border: rgba(0, 116, 217, 0.22);
+  --skill-banner-button: rgba(255, 255, 255, 0.6);
+  --skill-banner-button-hover: rgba(0, 116, 217, 0.08);
+
+  /* Body copy on docs pages, a step back from headings and bolded terms. */
+  --hindsight-docs-body-color: #3f3f46;
+
+  /* lucide "chevron-down", masked so it takes the element's own color */
+  --hindsight-chevron-down-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>');
+
+  /* lucide "search" for the sidebar field. Infima ships its own, but it is a
+     filled glyph in a fixed near-black that disappears on the dark surface. */
+  --hindsight-search-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%2371717a" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>');
 
   /* Fallback solid colors (midpoint of gradient) */
   --ifm-color-primary: #0074d9;
@@ -30,7 +57,10 @@
 
   /* Spacing */
   --ifm-spacing-horizontal: 1.5rem;
-  --ifm-navbar-height: 4.5rem;
+  /* 4rem, not Infima's 4.5: with 2rem-tall items the taller bar was mostly
+     empty. Everything positioned under the navbar — sidebar offset, sticky
+     TOC — derives from this variable, so they follow. */
+  --ifm-navbar-height: 4rem;
 
   /* Borders */
   --ifm-global-radius: 0.5rem;
@@ -45,6 +75,18 @@
   --ifm-color-primary-lighter: #99cff5;
   --ifm-color-primary-lightest: rgba(51, 150, 232, 0.15);
   --docusaurus-highlighted-code-line-bg: rgba(51, 150, 232, 0.15);
+
+  --hindsight-active-surface: rgba(51, 150, 232, 0.16);
+
+  --skill-banner-surface: rgba(51, 150, 232, 0.06);
+  --skill-banner-border: rgba(51, 150, 232, 0.28);
+  --skill-banner-button: rgba(255, 255, 255, 0.03);
+  --skill-banner-button-hover: rgba(51, 150, 232, 0.14);
+
+  --hindsight-docs-body-color: #b4b4be;
+
+  /* Same magnifier, a step lighter to hold up against the dark field. */
+  --hindsight-search-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%23a1a1aa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>');
 
   --ifm-background-color: #09090b;
   --ifm-background-surface-color: #18181b;
@@ -85,12 +127,19 @@
   gap: 0.25rem;
 }
 
+/* One height and one radius for every item up here, so the hover box, the
+   active surface and the Docs/version group are all the same shape. Flex
+   rather than inline: it centres the dropdown chevrons against their labels
+   without per-item baseline nudging. */
 .navbar__link {
+  display: inline-flex;
+  align-items: center;
+  height: 2rem;
   font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   font-weight: 700;
-  font-size: 0.9rem;
-  padding: 0.625rem 1rem;
-  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  padding: 0 0.75rem;
+  border-radius: 0.625rem;
   transition: background-color 0.15s ease;
 }
 
@@ -108,26 +157,214 @@ svg[aria-label="(opens in new tab)"] {
   background-color: var(--ifm-background-surface-color);
 }
 
+/* Whichever section you are in wears the same badge — gradient text on a
+   tinted surface — whether that is Docs, Integrations, Changelog or Resources.
+   The spread just has to exceed half the widest item for the inset shadow to
+   fill the box. */
 .navbar__link--active {
   background: var(--hindsight-gradient);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
+  box-shadow: inset 0 0 0 100px var(--hindsight-active-surface);
 }
 
 [data-theme='dark'] .navbar__link:hover {
   background-color: #27272a;
 }
 
-/* Desktop navbar - hide hamburger toggle at >= 1400px */
-@media (min-width: 1400px) {
+/* ── Brand block ──────────────────────────────────────────────────────────
+   The logo occupies the sidebar's column, so the rule closing the block
+   continues the sidebar's own edge instead of cutting the navbar at an
+   arbitrary point. Only on pages that actually have a sidebar. */
+.navbar__brand-block {
+  display: flex;
+  align-items: center;
+  align-self: stretch;
+}
+
+@media (min-width: 997px) {
+  html:has(.theme-doc-sidebar-container) .navbar__brand-block {
+    width: calc(var(--doc-sidebar-width) - 1rem);
+    margin-right: 1.5rem;
+    border-right: 1px solid var(--ifm-toc-border-color);
+  }
+}
+
+/* ── Docs + version ───────────────────────────────────────────────────────
+   The version qualifies the docs section rather than pointing anywhere of its
+   own, so the two sit on one surface — "Docs │ 0.9 ⌄" — wrapped together by
+   src/theme/Navbar/Content. That surface *is* the section's active state: it
+   is painted only while you are in the docs, which is also why the pair needs
+   no separate treatment from the other nav links when you are not. */
+.navbar__docs-group {
+  display: inline-flex;
+  align-items: center;
+  height: 2rem;
+  margin-right: 0.5rem;
+  border-radius: 0.625rem;
+}
+
+/* Same surface as any other active item, only spanning the pair. */
+.navbar__docs-group:has(.navbar__link--active) {
+  background: var(--hindsight-active-surface);
+}
+
+/* The group carries the surface, so its links must not paint their own —
+   either the active one (it would stack a second tint inside the first) or a
+   hover box, which would be a shape inside a shape. */
+.navbar__docs-group .navbar__link--active {
+  box-shadow: none;
+}
+
+.navbar__docs-group .navbar__link:hover,
+[data-theme='dark'] .navbar__docs-group .navbar__link:hover {
+  background-color: transparent;
+}
+
+.navbar__docs-group .navbar-item-developer.navbar__link {
+  padding-right: 0.75rem;
+}
+
+.navbar-item-version.navbar__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0 0.875rem 0 0;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--ifm-color-emphasis-800);
+}
+
+/* Hairline between the two halves, sized to the text rather than the surface. */
+.navbar-item-version.navbar__link::before {
+  content: '';
+  width: 1px;
+  height: 0.875rem;
+  margin-right: 0.75rem;
+  background-color: currentColor;
+  opacity: 0.3;
+}
+
+/* Docusaurus marks the version dropdown active alongside the docs link, which
+   would hand it the gradient-clipped (transparent) text of an active item. */
+.navbar-item-version.navbar__link--active {
+  color: var(--ifm-color-emphasis-800);
+  background: none;
+  -webkit-text-fill-color: currentColor;
+}
+
+/* Infima's caret is a solid triangle; a stroked chevron matches the icon set
+   the rest of the navbar uses. */
+.navbar-item-version.navbar__link::after {
+  width: 0.75rem;
+  height: 0.75rem;
+  margin-left: 0.0625rem;
+  border: none;
+  opacity: 0.6;
+  background-color: currentColor;
+  -webkit-mask: var(--hindsight-chevron-down-icon) center / contain no-repeat;
+  mask: var(--hindsight-chevron-down-icon) center / contain no-repeat;
+}
+
+/* Infima nudges its caret with `top: 2px` + `translateY(-50%)`, sized for a
+   0.4em triangle sitting on the text baseline. Our icons are full 0.75rem
+   boxes centred by the flex row, so the nudge only pushes them up. */
+.navbar-item-version.navbar__link::after,
+.navbar-item-resources.navbar__link::after {
+  position: static;
+  top: auto;
+  transform: none;
+}
+
+/* Infima draws dropdown carets as filled triangles; a stroked chevron matches
+   the icon set the rest of the navbar uses. */
+.navbar-item-resources.navbar__link::after {
+  width: 0.75rem;
+  height: 0.75rem;
+  margin-left: 0.125rem;
+  border: none;
+  opacity: 0.6;
+  background-color: currentColor;
+  -webkit-mask: var(--hindsight-chevron-down-icon) center / contain no-repeat;
+  mask: var(--hindsight-chevron-down-icon) center / contain no-repeat;
+}
+
+/* ── Sign-up call to action ───────────────────────────────────────────── */
+.navbar-item-signup.navbar__link {
+  margin-left: 0.75rem;
+  padding: 0 0.875rem;
+  font-size: 0.875rem;
+  color: #ffffff;
+  border-radius: 0.5rem;
+  background: var(--hindsight-gradient-horizontal);
+  transition: filter 0.15s ease;
+}
+
+.navbar-item-signup.navbar__link:hover,
+[data-theme='dark'] .navbar-item-signup.navbar__link:hover {
+  color: #ffffff;
+  background: var(--hindsight-gradient-horizontal);
+  filter: brightness(1.08);
+}
+
+/* As the last item on the right, the button is caught by the navbar's
+   `:last-child { padding-right: 0 }` (a Docusaurus workaround for text links
+   ending flush with the navbar edge) — on a filled button that padding is the
+   gap between the label and the button's own edge, so it is put back here. */
+.navbar__items--right > .navbar-item-signup.navbar__link {
+  position: relative;
+  padding-right: 0.875rem;
+}
+
+/* Separates the icon buttons from the call to action. */
+.navbar__items--right > .navbar-item-signup.navbar__link::before {
+  content: '';
+  position: absolute;
+  left: -0.75rem;
+  height: 1.25rem;
+  border-left: 1px solid var(--ifm-toc-border-color);
+}
+
+/* ── Search ───────────────────────────────────────────────────────────────
+   Search moved into the docs sidebar (src/theme/DocSidebar/Desktop/Content).
+   The navbar keeps its own copy for pages with no sidebar — blog, galleries,
+   the API reference — and stands down wherever the sidebar renders one. */
+@media (min-width: 997px) {
+  html:has(.theme-doc-sidebar-container) .navbar__items--right .navbar__search {
+    display: none;
+  }
+}
+
+/* Docusaurus clips the sidebar column to its own width (for the hideable
+   sidebar animation it does not use here), which would cut the search results
+   panel off at the sidebar's edge. */
+.theme-doc-sidebar-container {
+  clip-path: none;
+}
+
+/* `searchBarPosition: 'left'` is set for the sidebar copy, which would swing
+   this one's results panel off the right of the window. Needs to out-specify
+   the plugin's own `.searchBar.searchBarLeft .dropdownMenu`. */
+nav.navbar .navbar__items--right .navbar__search [class*='dropdownMenu'] {
+  left: auto !important;
+  right: 0 !important;
+}
+
+/* The nav links and the hamburger are alternatives, never both: the switch is
+   at 997px, where Docusaurus itself moves the docs sidebar into the drawer.
+   It used to be 1400px, but the rule meant to hide the links there targeted
+   `.navbar__items--left` — a modifier the left container does not carry — so
+   the links stayed up alongside the hamburger and crowded it. */
+@media (min-width: 997px) {
   .navbar__toggle {
     display: none !important;
   }
 }
 
-/* Mobile navbar - show hamburger, hide desktop items at < 1400px */
-@media (max-width: 1399px) {
+/* Mobile navbar - show hamburger, hide desktop items */
+@media (max-width: 996px) {
   :root {
     --ifm-navbar-height: 3.5rem;
   }
@@ -145,8 +382,12 @@ svg[aria-label="(opens in new tab)"] {
     height: 24px !important;
   }
 
-  /* Hide left navbar links (accessible via hamburger) */
-  .navbar__items--left > .navbar__link {
+  /* Hide the left navbar items — they are in the drawer. Matched on the theme
+     class, since the left container is `theme-layout-navbar-left navbar__items`
+     with no `--left` modifier, and dropdowns wrap their link in `.dropdown`. */
+  .theme-layout-navbar-left > .navbar__link,
+  .theme-layout-navbar-left > .dropdown,
+  .navbar__docs-group {
     display: none !important;
   }
 
@@ -458,15 +699,16 @@ h1[class*="title"] {
   display: inline-block;
 }
 
+/* The rule under a section heading is structure, not decoration: a hairline in
+   the same colour as every other divider on the page, where it used to be a
+   2px brand gradient that pulled the eye to each heading in turn. */
 article h2 {
   font-size: 1.5rem;
   font-weight: 700;
   margin-top: 2rem;
   margin-bottom: 0.75rem;
   padding-bottom: 0.5rem;
-  border-bottom: 2px solid transparent;
-  border-image: var(--hindsight-gradient);
-  border-image-slice: 1;
+  border-bottom: 1px solid var(--ifm-toc-border-color);
 }
 
 article h3 {
@@ -609,13 +851,96 @@ th {
   letter-spacing: 0.025em;
 }
 
-/* Footer */
-.footer {
+/* ── Previous / next ──────────────────────────────────────────────────────
+   Two boxed cards were the loudest thing on the page by the time you reached
+   the end of an article. They are just the two links either side of where you
+   are, so they read as links: no fill, no border, one rule separating them
+   from the content in the same way the footer is separated. */
+.pagination-nav {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
   border-top: 1px solid var(--ifm-toc-border-color);
+  gap: 1rem;
+}
+
+.pagination-nav__link {
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: none;
+  transition: none;
+}
+
+.pagination-nav__link:hover {
+  background: none;
+}
+
+.pagination-nav__sublabel {
+  font-family: 'Space Grotesk', var(--ifm-font-family-base);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-600);
+  margin-bottom: 0.25rem;
+}
+
+.pagination-nav__label {
+  font-family: 'Space Grotesk', var(--ifm-font-family-base);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--hindsight-docs-body-color);
+  transition: color 0.15s ease;
+}
+
+.pagination-nav__link:hover .pagination-nav__label {
+  color: var(--ifm-color-primary);
+}
+
+/* ── Footer ───────────────────────────────────────────────────────────────
+   Continues the page rather than closing it with a slab: same background as
+   the content above, one hairline to separate them, and everything inside a
+   step quieter than body copy. It is a set of links you go looking for, not
+   something that should compete with the last paragraph you just read. */
+.footer {
+  background-color: transparent;
+  border-top: 1px solid var(--ifm-toc-border-color);
+  padding: 2.5rem 0 3rem;
+  font-size: 0.875rem;
 }
 
 .footer__title {
-  font-weight: 700;
+  font-family: 'Space Grotesk', var(--ifm-font-family-base);
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-600);
+  margin-bottom: 0.75rem;
+}
+
+.footer__item {
+  font-size: 0.875rem;
+  line-height: 1.9;
+}
+
+.footer__link-item {
+  color: var(--hindsight-docs-body-color);
+  transition: color 0.15s ease;
+}
+
+.footer__link-item:hover {
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.footer__copyright {
+  font-size: 0.8125rem;
+  color: var(--ifm-color-emphasis-500);
+}
+
+.footer__bottom {
+  margin-top: 2rem;
 }
 
 /* Tabs styling */
@@ -867,12 +1192,13 @@ div[class*="announcementBar"] a {
   color: #ffffff !important;
   text-decoration: none;
   font-weight: 700;
-  padding: 0.2rem 0.6rem;
-  margin-left: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  margin-left: 0.75rem;
   background: rgba(255, 255, 255, 0.2);
-  border-radius: 0.25rem;
+  border-radius: 999px;
   transition: all 0.2s ease;
   font-size: 0.8125rem;
+  white-space: nowrap;
 }
 
 div[class*="announcementBar"] a:hover {
@@ -1238,6 +1564,37 @@ html.docs-wrapper article h3 {
   font-size: 1.2rem;
 }
 
+/* ── Docs typography ──────────────────────────────────────────────────────
+   Reference material, read in passes rather than start to finish: the type is
+   a step smaller and the body a step quieter than the blog's, so scanning for
+   the heading or the bolded term is the easy path. Docs only — the blog keeps
+   the larger, more editorial setting above. */
+html.docs-wrapper article h1 {
+  font-size: 2rem;
+}
+
+html.docs-wrapper article h2 {
+  font-size: 1.25rem;
+  margin-top: 2.25rem;
+}
+
+html.docs-wrapper article h3 {
+  font-size: 1.0625rem;
+}
+
+html.docs-wrapper article p,
+html.docs-wrapper article li,
+html.docs-wrapper article blockquote p {
+  font-size: 0.9375rem;
+  line-height: 1.75;
+  color: var(--hindsight-docs-body-color);
+}
+
+/* The terms a scanner is looking for stay at full contrast against that. */
+html.docs-wrapper article strong {
+  color: var(--ifm-font-color-base);
+}
+
 /* ===== Blog Styling ===== */
 
 /* Blog author text visible in light mode */
@@ -1290,6 +1647,67 @@ html.docs-wrapper article h3 {
 /* Remove right border from doc sidebar */
 .theme-doc-sidebar-container {
   border-right: none !important;
+}
+
+/* ── On this page ─────────────────────────────────────────────────────────
+   The table of contents is a map, not content: at full text contrast a long
+   one competes with the article beside it. Every entry is muted, and the one
+   Docusaurus marks as active — it scroll-spies the headings — is the only
+   thing that carries colour, so the eye finds your position in one look. */
+/* Explicit tones rather than --ifm-color-emphasis-600: in dark mode that token
+   resolves to #ccd0d5, all but body-text bright, so the muting never landed. */
+.table-of-contents__link,
+.table-of-contents__link code {
+  color: #71717a;
+  transition: color 0.15s ease;
+}
+
+[data-theme='dark'] .table-of-contents__link,
+[data-theme='dark'] .table-of-contents__link code {
+  color: #a1a1aa;
+}
+
+.table-of-contents__link:hover,
+.table-of-contents__link:hover code {
+  color: #18181b;
+}
+
+[data-theme='dark'] .table-of-contents__link:hover,
+[data-theme='dark'] .table-of-contents__link:hover code {
+  color: #f4f4f5;
+}
+
+/* Repeated under [data-theme='dark'] so it outweighs the muted rule above,
+   which would otherwise win on specificity and grey out the active entry. */
+.table-of-contents__link--active,
+.table-of-contents__link--active code,
+.table-of-contents__link--active:hover,
+.table-of-contents__link--active:hover code,
+[data-theme='dark'] .table-of-contents__link--active,
+[data-theme='dark'] .table-of-contents__link--active code,
+[data-theme='dark'] .table-of-contents__link--active:hover,
+[data-theme='dark'] .table-of-contents__link--active:hover code {
+  color: var(--ifm-color-primary);
+  font-weight: 600;
+}
+
+/* Marks the active entry against the TOC's own left rule, so its position in
+   the list is readable without relying on colour alone. */
+.table-of-contents .table-of-contents__left-border {
+  border-left-color: var(--ifm-toc-border-color);
+}
+
+.table-of-contents__link--active {
+  position: relative;
+}
+
+.table-of-contents__link--active::before {
+  content: '';
+  position: absolute;
+  left: -1.02rem;
+  top: 0.15rem;
+  bottom: 0.15rem;
+  border-left: 2px solid var(--ifm-color-primary);
 }
 
 /* Blog filter view transitions (BlogListPage wraps filter updates in

--- a/hindsight-docs/src/theme/DocSidebar/Desktop/Content/index.tsx
+++ b/hindsight-docs/src/theme/DocSidebar/Desktop/Content/index.tsx
@@ -1,10 +1,55 @@
-import React from 'react';
+import React, {useEffect, useRef} from 'react';
 import Content from '@theme-original/DocSidebar/Desktop/Content';
 import type ContentType from '@theme/DocSidebar/Desktop/Content';
 import type {WrapperProps} from '@docusaurus/types';
+import SearchBar from '@theme/SearchBar';
+
+import styles from './styles.module.css';
 
 type Props = WrapperProps<typeof ContentType>;
 
+/**
+ * The search plugin hardcodes its placeholder to the "Search" translation and
+ * exposes no option for it. Overriding the string through i18n/en/code.json is
+ * not available to us either: writing any translation file turns on the
+ * translation pipeline for the docs plugin, which then rejects the sidebars
+ * over duplicate entry labels across versions.
+ *
+ * React never rewrites the attribute after mount (the prop it renders is a
+ * constant, so it never diffs), which leaves setting it here as the one place
+ * that holds.
+ */
+function useSearchPlaceholder(text: string) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const input = containerRef.current?.querySelector('input');
+    if (input) {
+      input.placeholder = text;
+    }
+  }, [text]);
+
+  return containerRef;
+}
+
+/**
+ * Puts search at the top of the docs sidebar instead of in the navbar: it
+ * belongs with the navigation it searches, and it buys back the navbar space
+ * the search field used to occupy.
+ *
+ * It stays mounted in the navbar for pages with no sidebar (blog, galleries) —
+ * custom.css hides that copy wherever this one renders, so exactly one search
+ * field is on screen at a time.
+ */
 export default function ContentWrapper(props: Props): JSX.Element {
-  return <Content {...props} />;
+  const searchRef = useSearchPlaceholder('Search docs');
+
+  return (
+    <>
+      <div className={styles.sidebarSearch} ref={searchRef}>
+        <SearchBar />
+      </div>
+      <Content {...props} />
+    </>
+  );
 }

--- a/hindsight-docs/src/theme/DocSidebar/Desktop/Content/styles.module.css
+++ b/hindsight-docs/src/theme/DocSidebar/Desktop/Content/styles.module.css
@@ -1,0 +1,113 @@
+/*
+ * The docs-sidebar search field. custom.css styles the navbar copy as a bare
+ * underlined input with `!important` throughout, so everything here has to
+ * out-specify it — hence the wrapper class in front of each plugin selector.
+ */
+.sidebarSearch {
+  padding: 0.75rem 0.75rem 0.875rem;
+  border-bottom: 1px solid var(--ifm-toc-border-color);
+}
+
+.sidebarSearch :global(.navbar__search) {
+  margin-left: 0; /* custom.css pushes the navbar copy to the right */
+}
+
+.sidebarSearch :global([class*='searchBarContainer']) {
+  margin-left: 0;
+  width: 100%;
+}
+
+/*
+ * On first focus autocomplete.js wraps the input in a shrink-to-fit span, which
+ * would otherwise pull the field in from the sidebar's width to the input's
+ * intrinsic one — the box visibly narrows as you click into it.
+ */
+.sidebarSearch :global([class*='searchBar_']) {
+  display: block;
+  width: 100%;
+  /* custom.css gives this span the navbar field's gradient underline, which as
+     a full-width block draws a second line under the box. */
+  border: none !important;
+  border-image: none !important;
+}
+
+.sidebarSearch :global([class*='searchBarContainer']) input {
+  width: 100%;
+  height: 2.25rem;
+  padding: 0 2.75rem 0 2.125rem !important;
+  font-family: var(--ifm-font-family-base) !important;
+  font-size: 0.8125rem !important;
+  font-weight: 400 !important;
+  border: 1px solid var(--ifm-toc-border-color) !important;
+  border-radius: 0.5rem !important;
+  color: var(--ifm-font-color-base) !important;
+  /* Restores the magnifier that the navbar `background: transparent` kills. */
+  background: var(--ifm-background-surface-color)
+    var(--hindsight-search-icon) no-repeat 0.75rem center / 0.875rem 0.875rem
+    !important;
+  transition: border-color 0.15s ease;
+}
+
+.sidebarSearch :global([class*='searchBarContainer']) input:focus {
+  border-color: var(--ifm-color-primary) !important;
+}
+
+.sidebarSearch :global([class*='searchBarContainer']) input::placeholder {
+  font-family: var(--ifm-font-family-base) !important;
+  font-weight: 400 !important;
+  color: var(--ifm-color-emphasis-500) !important;
+}
+
+/* Same gradient underline, this time on the clear button. */
+.sidebarSearch :global([class*='searchClearButton']) {
+  border: none !important;
+  border-image: none !important;
+  color: var(--ifm-color-emphasis-600) !important;
+}
+
+/*
+ * The ⌘K hint is hidden globally for the navbar copy; here there is room for
+ * it, and it is the only thing advertising the shortcut. The plugin emits one
+ * <kbd> per key — the container carries the box so the pair reads as the one
+ * chord it is.
+ */
+.sidebarSearch :global([class*='searchHintContainer']) {
+  display: flex !important;
+  right: 0.4375rem;
+  top: 50%;
+  transform: translateY(-50%);
+  gap: 0.0625rem;
+  height: 1.25rem;
+  padding: 0 0.375rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 0.25rem;
+  background-color: var(--ifm-color-emphasis-100);
+}
+
+.sidebarSearch
+  :global([class*='searchHintContainer'])
+  :global([class*='searchHint']) {
+  display: inline-flex !important;
+  align-items: center;
+  height: auto;
+  padding: 0;
+  font-family: var(--ifm-font-family-base);
+  font-size: 0.6875rem;
+  line-height: 1;
+  color: var(--ifm-color-emphasis-600);
+  border: none;
+  border-radius: 0;
+  background: none;
+  box-shadow: none;
+}
+
+/*
+ * Anchor the results panel to the sidebar's left edge. The plugin pins it to
+ * `right: 0` with `!important`, which from a 300px column would hang the 560px
+ * panel off the left of the window.
+ */
+.sidebarSearch :global(.navbar__search) :global([class*='dropdownMenu']) {
+  left: 0 !important;
+  right: auto !important;
+  max-width: calc(100vw - var(--doc-sidebar-width) - 2rem);
+}

--- a/hindsight-docs/src/theme/Navbar/Content/index.tsx
+++ b/hindsight-docs/src/theme/Navbar/Content/index.tsx
@@ -20,6 +20,27 @@ function useNavbarItems() {
   return useThemeConfig().navbar.items as NavbarItemConfig[];
 }
 
+// The sign-up button is the one call to action in the navbar, so it renders
+// last on the right — after the icon buttons and past the divider — instead of
+// in the middle of them where its config position would otherwise put it.
+function isCallToAction(item: NavbarItemConfig): boolean {
+  return hasClassName(item, 'navbar-item-signup');
+}
+
+// "Docs" and the version dropdown read as one control — the version qualifies
+// the docs section rather than pointing somewhere of its own. They share a
+// wrapper so custom.css can draw a single surface behind both; splitting the
+// background across two siblings would seam down the middle.
+const DOCS_GROUP_CLASSNAMES = ['navbar-item-developer', 'navbar-item-version'];
+
+function isDocsGroupItem(item: NavbarItemConfig): boolean {
+  return DOCS_GROUP_CLASSNAMES.some((name) => hasClassName(item, name));
+}
+
+function hasClassName(item: NavbarItemConfig, name: string): boolean {
+  return typeof item.className === 'string' && item.className.includes(name);
+}
+
 function NavbarItems({items}: {items: NavbarItemConfig[]}): ReactNode {
   return (
     <>
@@ -71,6 +92,10 @@ function NavbarContentLayout({
 export default function NavbarContent(): ReactNode {
   const items = useNavbarItems();
   const [leftItems, rightItems] = splitNavbarItems(items);
+  const ctaItems = rightItems.filter(isCallToAction);
+  const secondaryRightItems = rightItems.filter((item) => !isCallToAction(item));
+  const docsGroupItems = leftItems.filter(isDocsGroupItem);
+  const otherLeftItems = leftItems.filter((item) => !isDocsGroupItem(item));
 
   const searchBarItem = items.find((item) => item.type === 'search');
 
@@ -80,22 +105,32 @@ export default function NavbarContent(): ReactNode {
         // TODO stop hardcoding items?
         // Always render toggle, CSS controls visibility at 1400px breakpoint
         <>
-          <NavbarMobileSidebarToggle />
-          <NavbarLogo />
-          <NavbarItems items={leftItems} />
+          {/* Brand block: spans the sidebar's column, so the divider closing
+              it continues the sidebar's own edge (see custom.css). */}
+          <div className="navbar__brand-block">
+            <NavbarMobileSidebarToggle />
+            <NavbarLogo />
+          </div>
+          {docsGroupItems.length > 0 && (
+            <div className="navbar__docs-group">
+              <NavbarItems items={docsGroupItems} />
+            </div>
+          )}
+          <NavbarItems items={otherLeftItems} />
         </>
       }
       right={
         // TODO stop hardcoding items?
         // Ask the user to add the respective navbar items => more flexible
         <>
-          <NavbarItems items={rightItems} />
+          <NavbarItems items={secondaryRightItems} />
           <NavbarColorModeToggle className={styles.colorModeToggle} />
           {!searchBarItem && (
             <NavbarSearch>
               <SearchBar />
             </NavbarSearch>
           )}
+          <NavbarItems items={ctaItems} />
         </>
       }
     />

--- a/hindsight-docs/src/theme/NavbarItem/DefaultNavbarItem/index.tsx
+++ b/hindsight-docs/src/theme/NavbarItem/DefaultNavbarItem/index.tsx
@@ -31,8 +31,14 @@ const ICON_MAP: Record<string, IconType> = {
 type Props = WrapperProps<typeof DefaultNavbarItemType>;
 
 export default function DefaultNavbarItemWrapper(props: Props): JSX.Element {
-  const isExternal = typeof props.href === 'string' && props.href.startsWith('http');
-  const isGithub = (props.className as string | undefined)?.includes('header-github-link');
+  const className = props.className as string | undefined;
+  // The sign-up button is styled as a solid CTA — the "leaving the site" arrow
+  // every other external item gets would only clutter it.
+  const isExternal =
+    typeof props.href === 'string' &&
+    props.href.startsWith('http') &&
+    !className?.includes('navbar-item-signup');
+  const isGithub = className?.includes('header-github-link');
   const iconKey = props.customProps?.icon as string | undefined;
   const IconComponent = iconKey ? ICON_MAP[iconKey] : undefined;
 

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -10,7 +10,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "0.9.0"
+    "version": "0.9.1"
   },
   "paths": {
     "/health": {


### PR DESCRIPTION
Reworks the docs topbar and the page chrome around it, from mockups.

### Navbar

- **"Developer" → "Docs"**, with the version dropdown moved beside it as a single control — `Docs │ 0.9 ⌄` on one surface. The version qualifies the docs section rather than pointing anywhere of its own, so it reads as part of that item instead of a sixth destination. The two share a wrapper (`src/theme/Navbar/Content`) because splitting a background across two siblings seams down the middle.
- **One active state for every item.** Whichever section you are in wears the same badge: gradient text on a tinted surface. The surface is an inset `box-shadow` rather than a background, because active items need `background` for `background-clip: text`.
- **"Cloud" → "Sign up"**, a filled button rendered last on the right past a divider.
- **More compact**: 2rem items on a 4rem bar, down from 42px items on 4.5rem.
- Dropdown carets become stroked chevrons, replacing Infima's filled triangles.

### Search

Moves from the navbar into the docs sidebar, where it sits with the navigation it searches, with the `⌘K` hint shown. The navbar keeps its copy for pages that have no sidebar (blog, galleries, API reference) and stands down wherever the sidebar renders one, so exactly one search field is on screen at a time.

### Responsive fix

The nav links and the hamburger used to render together between 997px and 1400px, crowding each other. The rule meant to hide the links targeted `.navbar__items--left` — a modifier the left container does not carry — so it never matched. They are now alternatives at 997px, matching where Docusaurus moves the docs sidebar into the drawer.

### Page chrome

- **Breadcrumbs off.** The sidebar already shows position and every doc opens with its H1. Disabled per docs plugin, not by deleting the `DocBreadcrumbs` wrapper — that wrapper also renders the skill banner, and the original component returns null on the flag.
- **Table of contents muted**, so only the entry the scroll-spy marks carries colour.
- **Prev/next and the footer** drop their boxed-card and dark-slab treatments for the same hairline-and-muted-text language. The footer was `style: 'dark'`, which paints the dark palette regardless of theme — so on a light page it arrived as a black block. It also now links Vectorize.
- **Docs typography** is a step smaller and quieter than the blog's (scoped to `html.docs-wrapper`, so the blog's editorial setting is untouched), and `h2` trades its 2px brand gradient for a plain rule.

### Skill installer

One slim strip: a prompt, the agents it works with, and an **Install skill** button that copies the `npx skills add` command, with **Copy page** and **Download page (.md)** behind the chevron. The Codex mark ships with no `fill`, so it is inverted on the dark theme rather than rendering black on black.

### Notes for review

- `skills/hindsight-docs/references/openapi.json` is **unrelated to this change** — a pre-existing `0.9.0` → `0.9.1` drift from the v0.9.1 release. The `generate-docs-skill` pre-commit hook refuses to commit until it is staged.
- Verified at 1600 / 1200 / 1100px in both themes, plus the production build and lint. The ≤996px drawer layout was **not** visually verified — the browser tooling on my machine stopped working partway through (see the responsive fix above for what was confirmed at 1100px).
