### PR TITLE
fix(retain): entity postings and witness coverage inside a write-group

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
+++ b/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
@@ -1246,6 +1246,7 @@ class EntityResolver:
         self,
         unit_entity_pairs: list[tuple[str, str]] | list[tuple[str, str, datetime | None]],
         bank_id: str | None = None,
+        txn=None,
     ):
         """Store-owned variant of :meth:`link_units_to_entities_batch` that touches NO
         Postgres connection.
@@ -1257,6 +1258,10 @@ class EntityResolver:
         its connection-free store phase and never hold the data-plane connection across the
         object-store write. NOT for the Postgres store, whose posting is a real ``unit_entities``
         INSERT that requires the connection.
+
+        ``txn`` is the caller's write-group handle. For a store that keeps the posting on the
+        memory, this re-writes rows the same write-group just created, so it belongs to that
+        group — see :meth:`MemoriesExtension.record_unit_entities`.
         """
         if not unit_entity_pairs:
             return
@@ -1265,10 +1270,10 @@ class EntityResolver:
             (t[0], t[1], t[2] if len(t) >= 3 else None)  # type: ignore[misc]
             for t in unit_entity_pairs
         ]
-        return await self._link_units_to_entities_batch_impl(None, normalized, bank_id)
+        return await self._link_units_to_entities_batch_impl(None, normalized, bank_id, txn=txn)
 
     async def _link_units_to_entities_batch_impl(
-        self, conn, unit_entity_pairs: list[tuple[str, str, datetime | None]], bank_id: str | None = None
+        self, conn, unit_entity_pairs: list[tuple[str, str, datetime | None]], bank_id: str | None = None, txn=None
     ):
         # Sorted bulk insert to prevent deadlocks from inconsistent lock ordering
         # across concurrent transactions on the unit_entities unique index.
@@ -1289,6 +1294,7 @@ class EntityResolver:
             bank_id=bank_id,
             unit_ids=unit_ids,
             entity_ids=entity_ids,
+            txn=txn,
         )
 
         # Build maps keyed by unit_id:

--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -1205,7 +1205,15 @@ class MemoriesExtension(Extension, ABC):
     # join table to sweep, so those passes are no-ops for it.
 
     async def record_unit_entities(
-        self, *, conn, ops, fq_table, bank_id: str | None = None, unit_ids: list[Any], entity_ids: list[Any]
+        self,
+        *,
+        conn,
+        ops,
+        fq_table,
+        bank_id: str | None = None,
+        unit_ids: list[Any],
+        entity_ids: list[Any],
+        txn: "MemoryTxn | None" = None,
     ) -> None:
         """Record the unit→entity postings for a batch of memories.
 
@@ -1216,6 +1224,14 @@ class MemoriesExtension(Extension, ABC):
         the memory (rather than in a global join table) needs to know which
         namespace the units live in — the Postgres join is keyed by global unit id
         and ignores it.
+
+        ``txn`` is the caller's write-group handle. For a store that keeps the
+        posting ON the memory this call is a re-write of rows the same write-group
+        already created, so it belongs to that group: passing the handle keeps the
+        two writes atomic together and — for a store that records what its groups
+        wrote — keeps this write inside the group's accounting. Ignored by the
+        Postgres store, whose posting is an ordinary row in the caller's own
+        transaction.
         """
 
     async def enqueue_relink_victims(

--- a/hindsight-api-slim/hindsight_api/engine/memories/postgres.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/postgres.py
@@ -620,9 +620,19 @@ class PostgresMemories(MemoriesExtension):
     # ------------------------------------------------------------------ maintenance
 
     async def record_unit_entities(
-        self, *, conn, ops, fq_table, bank_id: str | None = None, unit_ids: list[Any], entity_ids: list[Any]
+        self,
+        *,
+        conn,
+        ops,
+        fq_table,
+        bank_id: str | None = None,
+        unit_ids: list[Any],
+        entity_ids: list[Any],
+        txn=None,
     ) -> None:
-        # The join is keyed by global unit id, so bank_id is not needed here.
+        # The join is keyed by global unit id, so bank_id is not needed here. `txn` is inert: this
+        # posting is an ordinary INSERT in the caller's own transaction, which is already the unit
+        # of atomicity — there is no second store to coordinate with.
         await ops.bulk_insert_unit_entities(conn, fq_table("unit_entities"), unit_ids, entity_ids)
 
     async def enqueue_relink_victims(

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7267,6 +7267,10 @@ class MemoryEngine(MemoryEngineInterface):
                     # This is the EXPLICIT deletion — distinct from the re-ingest facts-delete above.
                     if _store.owns_document_store_for(bank_id):
                         await _store.delete_document_record(bank_id=bank_id, document_id=document_id, txn=_del_txn)
+                    # Re-record the witness now that the group's writes have happened, so the row
+                    # carries what they actually wrote. `begin_txn` recorded it before any write
+                    # existed; the upsert widens rather than replaces.
+                    await _store.write_txn_witness(_del_txn, conn=conn, fq_table=fq_table)
 
                 # Invalidate observations referencing these (now-deleted) memories
                 if unit_ids:
@@ -7599,6 +7603,10 @@ class MemoryEngine(MemoryEngineInterface):
                         # Tag the store tombstone so it commits atomically with this transaction.
                         _del_txn = await _store.begin_txn(conn=conn, fq_table=fq_table, bank_id=bank_id, mutating=True)
                         await _store.delete_facts(bank_id, [unit_id], txn=_del_txn)
+                        # Re-record the witness now that the group's write has happened, so the row
+                        # carries what it actually wrote. `begin_txn` recorded it before any write
+                        # existed; the upsert widens rather than replaces.
+                        await _store.write_txn_witness(_del_txn, conn=conn, fq_table=fq_table)
 
                 # Invalidate observations referencing this (now-deleted) source memory
                 if bank_id and fact_type in ("experience", "world"):
@@ -8819,6 +8827,12 @@ class MemoryEngine(MemoryEngineInterface):
                                 )
                         need_consolidation = True
                         need_graph = True
+
+                    # Last thing inside the transaction: re-record the witness now that the
+                    # group's writes have happened, so the row carries what they actually wrote.
+                    # `begin_txn` above recorded it before any write existed; the upsert widens
+                    # rather than replaces.
+                    await store.write_txn_witness(_curation_txn, conn=conn, fq_table=fq_table)
 
                 # Postgres committed the curation change: publish the store's write-group. On a
                 # crash before here the writes stay invisible and the recovery sweep resolves them.

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -686,7 +686,7 @@ async def _streaming_batch_write_ext(
             (unit_id, resolved_entity_ids[idx], fact_date)
             for idx, (unit_id, _local_idx, fact_date) in enumerate(remapped_entity_to_unit)
         ]
-        await entity_resolver.record_unit_entity_postings(unit_entity_pairs, bank_id=bank_id)
+        await entity_resolver.record_unit_entity_postings(unit_entity_pairs, bank_id=bank_id, txn=ext_txn)
 
     # ---- CONNECTION PHASE (short transaction: local metadata + commit witness) ----
     try:
@@ -864,7 +864,7 @@ async def _delta_batch_write_ext(
             (unit_id, resolved_entity_ids[idx], fact_date)
             for idx, (unit_id, _local_idx, fact_date) in enumerate(remapped_entity_to_unit)
         ]
-        await entity_resolver.record_unit_entity_postings(unit_entity_pairs, bank_id=bank_id)
+        await entity_resolver.record_unit_entity_postings(unit_entity_pairs, bank_id=bank_id, txn=ext_txn)
 
     # ---- CONNECTION PHASE (short transaction: local metadata + tombstones + witness) ----
     try:
@@ -2152,6 +2152,10 @@ async def _streaming_retain_batch(
                                 store_document_text=getattr(config, "store_document_text", True),
                                 txn=_edge_txn,
                             )
+                            # Re-record the witness now that the group's writes have happened, so
+                            # the row carries what they actually wrote. `begin_txn` recorded it
+                            # before any write existed; the upsert widens rather than replaces.
+                            await _edge_provider.write_txn_witness(_edge_txn, conn=conn, fq_table=fq_table)
                         doc_tracking_done[0] = True
                         # Memory: combined_content has been persisted; release
                         # it now so the rest of the consumer loop doesn't pin
@@ -2416,6 +2420,11 @@ async def _streaming_retain_batch(
                         txn=_group_txn,
                     )
 
+                    # Last thing inside the transaction: re-record the witness now that this
+                    # batch's writes have happened, so the row carries what they actually wrote.
+                    # `begin_txn` above recorded it before any write existed; the upsert widens.
+                    await _provider.write_txn_witness(_group_txn, conn=conn, fq_table=fq_table)
+
                 # Postgres committed this batch: publish its write-group. If it had aborted,
                 # this is skipped and the recovery sweep resolves the undecided txn (spec §5).
                 await _provider.decide_txn(_group_txn, commit=True)
@@ -2594,6 +2603,10 @@ async def _streaming_retain_batch(
                             store_document_text=getattr(config, "store_document_text", True),
                             txn=_edge_txn,
                         )
+                        # Re-record the witness now that the group's writes have happened, so the
+                        # row carries what they actually wrote. `begin_txn` recorded it before any
+                        # write existed; the upsert widens rather than replaces.
+                        await _edge_provider.write_txn_witness(_edge_txn, conn=conn, fq_table=fq_table)
                     doc_tracking_done[0] = True
                     # Memory: combined_content has been persisted and won't be
                     # read again — release the per-document text now.
@@ -3229,6 +3242,12 @@ async def _try_delta_retain(
                     ops=pool.ops,
                     txn=_group_txn,
                 )
+
+                # Last thing inside the transaction: re-record the witness now that the group's
+                # writes have happened, so the row carries what they actually wrote. `begin_txn`
+                # above recorded it before any write existed; the upsert widens rather than
+                # replaces.
+                await _provider.write_txn_witness(_group_txn, conn=conn, fq_table=fq_table)
 
             # Postgres has committed: publish the write-group so its writes become visible.
             # If the transaction had aborted instead, this line is skipped and the recovery

--- a/hindsight-api-slim/tests/test_retain_ext_writegroup.py
+++ b/hindsight-api-slim/tests/test_retain_ext_writegroup.py
@@ -109,10 +109,10 @@ class _EntityResolver:
         self.postings = []
         self.reasserts = []
 
-    async def record_unit_entity_postings(self, pairs, bank_id=None):
+    async def record_unit_entity_postings(self, pairs, bank_id=None, txn=None):
         # THE contract: the store re-posting runs with no connection held.
         assert self._t.open is False, "entity posting must run connection-free"
-        self.postings.append(pairs)
+        self.postings.append((pairs, txn))
 
     async def reassert_entities_batch(self, bank_id, resolved, conn):
         assert conn is not None
@@ -168,16 +168,18 @@ async def test_store_writes_are_connection_free_and_witness_is_in_txn(monkeypatc
     _make_common(monkeypatch, tracker, calls=calls)
     provider, er = _Provider(), _EntityResolver(tracker)
 
-    result = await orch._streaming_batch_write_ext(
-        **_kwargs(tracker, provider, er, doc_tracking_done=[False], existing_hash="__pending__", new_hash="h")
-    )
+    kw = _kwargs(tracker, provider, er, doc_tracking_done=[False], existing_hash="__pending__", new_hash="h")
+    result = await orch._streaming_batch_write_ext(**kw)
 
     assert result.aborted is False
     assert result.batch_result_ids == [["u1"]]
     # The fact write happened with no connection held.
     assert tracker.store_writes_saw_open == [False]
-    # Entity re-posting happened (also connection-free — asserted inside the fake).
-    assert er.postings == [[("u1", "e1", None)]]
+    # Entity re-posting happened (also connection-free — asserted inside the fake), and it rode
+    # the SAME write-group as the fact write. It re-writes the rows that write just created, so a
+    # store that records what its groups wrote must see it as part of the group — otherwise the
+    # posting lands outside the group's accounting and a later replay of the group loses it.
+    assert er.postings == [([("u1", "e1", None)], kw["ext_txn"])]
     # Witness written with a real connection, exactly once; commit published after release.
     assert len(provider.witnesses) == 1 and provider.witnesses[0][1] is not None
     assert provider.decisions == [True]
@@ -327,16 +329,16 @@ async def test_delta_store_writes_are_connection_free(monkeypatch):
     # _build_retain_params is a plain module function; keep it real but feed simple dicts.
     provider, er = _Provider(), _EntityResolver(tracker)
 
-    result = await orch._delta_batch_write_ext(
-        **_delta_kwargs(tracker, provider, er, doc_hash_at_load=None)  # None → hash check can't trip
-    )
+    kw = _delta_kwargs(tracker, provider, er, doc_hash_at_load=None)  # None → hash check can't trip
+    result = await orch._delta_batch_write_ext(**kw)
 
     assert result.fell_back is False
     assert result.result_unit_ids == [["u1"]]
     # Fact write + body store + entity re-posting all happened connection-free.
     assert tracker.store_writes_saw_open == [False]
     assert ("store_document_bodies", False) in calls
-    assert er.postings == [[("u1", "e1", None)]]
+    # ...and the posting rode the same write-group as the fact write (see the streaming test).
+    assert er.postings == [([("u1", "e1", None)], kw["ext_txn"])]
     # Witness inside the txn; publish after release.
     assert len(provider.witnesses) == 1 and provider.witnesses[0][1] is not None
     assert provider.decisions == [True]


### PR DESCRIPTION
Two silent defects on the external-store (write-group) retain path. Neither surfaces as an error, a
latency change, or a moved count.

## 1. Entity postings were dropped entirely

Retain resolves entities only after the memory ids exist, so `record_unit_entities` is a **second
write over rows the same write-group just wrote**. A store with deferred visibility keeps those rows
invisible until the group is decided — so a store implementation that reads them back before
rewriting gets nothing, and every unit→entity posting is lost.

The memories themselves land, so the bank looks healthy. Only the entity graph is quietly empty.

`docs/` for the cross-store protocol already warned about exactly this ("inside steps 3–5 the
provider cannot query the memories it just wrote... do not introduce it"). It was introduced anyway,
which is the argument for a regression test rather than another sentence in the doc.

**Fix:** thread the caller's `txn` through `record_unit_entity_postings` → `record_unit_entities`,
so the store can recognise the write as part of the group and rebuild the rows from what it already
staged instead of querying for rows it has hidden. The fix is deliberately *not* "make the read
work" — that is the thing the caveat forbids.

Inert for the Postgres store: its posting is an ordinary INSERT in the caller's own transaction,
which is already the unit of atomicity. `txn` is accepted and ignored there.

## 2. Seven `begin_txn` sites never re-recorded their witness

`begin_txn` writes the witness row *before any write has happened*, so a store that records what
each group wrote sees an empty group. Retain's two main paths (`_streaming_batch_write_ext`,
`_delta_batch_write_ext`) already re-recorded it before commit. These did not:

| site | path |
|---|---|
| `orchestrator` streaming group txn | per-batch streaming write |
| `orchestrator` delta group txn | delta re-ingest |
| `orchestrator` ×2 document-tracking | 0-fact / no-fact re-ingest replace-delete |
| `memory_engine` document delete | standalone `delete_document` |
| `memory_engine` unit delete | standalone delete-unit |
| `memory_engine` curation | edit / invalidate / revert |

Each now calls `write_txn_witness` as the last statement inside its transaction. That call is an
idempotent widening upsert — calling it twice is the intended usage, which is why this is additive
and safe.

## Verification

Placement was checked **structurally rather than by eye** — an AST pass asserting that every
`begin_txn` and `write_txn_witness` is lexically inside its `conn.transaction()`, and that every
commit-decide is outside it. (The three `decide_txn` calls that remain inside a transaction are all
`commit=False` abort paths, which is correct.)

- `tests/test_retain_ext_writegroup.py` now asserts the posting rides the same write-group as the
  fact write, on both the streaming and delta paths.
- `tests/` slice for retain/entity/curation/memories: 513 passed. The 3 failures and 335 errors in
  that slice are environmental (missing `sentence-transformers`, `pg0-embedded`, LLM API keys) and
  reproduce identically on an unmodified checkout.
- `ruff check`, `ruff format --check`, `ty check hindsight_api`: all clean.

## Deploy ordering

`hindsight_api` now calls `record_unit_entities(..., txn=...)`. The base class and the Postgres store
both accept it, but **an out-of-tree store extension that overrides `record_unit_entities` without a
`txn` parameter will raise `TypeError` on every retain.** Ship the extension update first, or
together.
