### PR TITLE
fix(consolidation): keep source dates when observations merge

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     from asyncpg import Connection
 
     from ...api.http import RequestContext
+    from ..memories.base import StoredMemory
     from ..memory_engine import MemoryEngine
     from ..response_models import MemoryFact, RecallResult
 
@@ -221,6 +222,45 @@ def _dedup_active(config: Any) -> bool:
     return get_config().database_backend != "oracle"
 
 
+@dataclass(frozen=True)
+class _TemporalBounds:
+    """The temporal columns an observation inherits from the facts behind it.
+
+    Merging two observations (or an observation and a fresh set of source facts) must widen
+    these, never replace them: ``event_date``/``occurred_start`` keep the earliest known value
+    and ``occurred_end``/``mentioned_at`` the latest, with a missing value on either side
+    ignored. That is exactly the ``_aggregate_source_fields`` rule, and the Python mirror of the
+    ``LEAST(col, COALESCE(x, col))`` / ``GREATEST(col, COALESCE(x, col))`` the SQL paths apply.
+    """
+
+    event_date: "datetime | None" = None
+    occurred_start: "datetime | None" = None
+    occurred_end: "datetime | None" = None
+    mentioned_at: "datetime | None" = None
+
+    @classmethod
+    def of(cls, row: "StoredMemory | _SourceAggregation") -> "_TemporalBounds":
+        """The bounds carried by a stored memory or by an aggregation over source facts.
+
+        Deliberately not a recall ``MemoryFact``: that model has no ``event_date`` at all and
+        keeps the rest as ISO strings, so it has to be read field by field where it is used.
+        """
+        return cls(
+            event_date=row.event_date,
+            occurred_start=row.occurred_start,
+            occurred_end=row.occurred_end,
+            mentioned_at=row.mentioned_at,
+        )
+
+    def merged_with(self, other: "_TemporalBounds") -> "_TemporalBounds":
+        return _TemporalBounds(
+            event_date=_merge_min(self.event_date, other.event_date),
+            occurred_start=_merge_min(self.occurred_start, other.occurred_start),
+            occurred_end=_merge_max(self.occurred_end, other.occurred_end),
+            mentioned_at=_merge_max(self.mentioned_at, other.mentioned_at),
+        )
+
+
 @dataclass
 class _DedupOutcome:
     """Result of probing one observation against its in-scope neighbours.
@@ -322,6 +362,7 @@ async def _dedup_reconcile_create(
     create_text: str,
     create_source_ids: list[uuid.UUID],
     tags: list[str] | None,
+    source_bounds: _TemporalBounds,
     txn=None,
 ) -> str | None:
     """Semantic dedup for a single CREATE (create-time, focused 1-by-1).
@@ -329,6 +370,10 @@ async def _dedup_reconcile_create(
     On "merge", folds the new source facts + the synthesized text into the existing
     observation and returns its id (caller skips the CREATE). Returns None when there is
     no near twin or the LLM keeps them distinct.
+
+    ``source_bounds`` are the dates the skipped CREATE would have been stamped with. They are
+    folded into the twin too: this path bypasses the CREATE writer, so without them the twin
+    would cite dated source facts while reporting the dates of its original sources only (#3477).
 
     The probe/embed/LLM adjudication runs with no connection held; the fold takes a
     short-lived connection and re-checks source liveness inside the fold transaction.
@@ -362,6 +407,10 @@ async def _dedup_reconcile_create(
                     SET text = $1,
                         source_memory_ids = (SELECT array_agg(DISTINCT e) FROM unnest(source_memory_ids || $2::uuid[]) e),
                         proof_count = (SELECT count(DISTINCT e) FROM unnest(source_memory_ids || $2::uuid[]) e),
+                        event_date = LEAST(event_date, COALESCE($5, event_date)),
+                        occurred_start = LEAST(occurred_start, COALESCE($6, occurred_start)),
+                        occurred_end = GREATEST(occurred_end, COALESCE($7, occurred_end)),
+                        mentioned_at = GREATEST(mentioned_at, COALESCE($8, mentioned_at)),
                         updated_at = now(){search_vector_clause}
                     WHERE id = $3::uuid AND text = $4
                     RETURNING id
@@ -370,6 +419,10 @@ async def _dedup_reconcile_create(
                     live_source_ids,
                     uuid.UUID(outcome.best_id),
                     outcome.best_text,
+                    source_bounds.event_date,
+                    source_bounds.occurred_start,
+                    source_bounds.occurred_end,
+                    source_bounds.mentioned_at,
                 )
                 if folded is None:
                     # The twin vanished (or was rewritten) during the connection-free LLM window.
@@ -382,7 +435,15 @@ async def _dedup_reconcile_create(
                     return None
             else:
                 await _reconcile_merge_via_store(
-                    store, conn, memory_engine, bank_id, outcome.best_id, outcome.merged_text, live_source_ids, txn=txn
+                    store,
+                    conn,
+                    memory_engine,
+                    bank_id,
+                    outcome.best_id,
+                    outcome.merged_text,
+                    live_source_ids,
+                    source_bounds,
+                    txn=txn,
                 )
     return outcome.best_id
 
@@ -426,7 +487,8 @@ async def _dedup_reconcile_update(
     # Fold the updated observation's live sources into the twin (keeping the twin's embedding, as
     # in the create path) then delete the now-redundant updated row. The all_strict/any tag match
     # guarantees twin and updated share scope, so dropping the updated row's tags loses no
-    # visibility. Temporal fields follow the surviving twin (minimal scope; matches create).
+    # visibility. Temporal fields are the UNION of both rows' bounds: the updated row is about to
+    # be deleted, so anything only it knew about would otherwise be lost with it (#3477).
     # The fold + delete share one short transaction so the twin gains the sources exactly as the
     # redundant row is removed; the slow adjudication above already ran connection-free.
     store = get_memories()
@@ -469,6 +531,10 @@ async def _dedup_reconcile_update(
                         proof_count = (
                             SELECT count(DISTINCT e) FROM unnest(t.source_memory_ids || $6::uuid[]) e
                         ),
+                        event_date = LEAST(t.event_date, COALESCE(u.event_date, t.event_date)),
+                        occurred_start = LEAST(t.occurred_start, COALESCE(u.occurred_start, t.occurred_start)),
+                        occurred_end = GREATEST(t.occurred_end, COALESCE(u.occurred_end, t.occurred_end)),
+                        mentioned_at = GREATEST(t.mentioned_at, COALESCE(u.mentioned_at, t.mentioned_at)),
                         updated_at = now(){search_vector_clause}
                     FROM {fq_table("memory_units")} u
                     WHERE t.id = $2::uuid AND u.id = $3::uuid AND t.text = $4 AND u.text = $5
@@ -494,7 +560,15 @@ async def _dedup_reconcile_update(
                 if not live_u_sources:
                     return
                 await _reconcile_merge_via_store(
-                    store, conn, memory_engine, bank_id, outcome.best_id, outcome.merged_text, live_u_sources, txn=txn
+                    store,
+                    conn,
+                    memory_engine,
+                    bank_id,
+                    outcome.best_id,
+                    outcome.merged_text,
+                    live_u_sources,
+                    _TemporalBounds.of(updated_obs[0]),
+                    txn=txn,
                 )
             await _execute_delete_action(conn, bank_id, updated_id, txn=txn)
     logger.info(
@@ -1001,17 +1075,22 @@ async def _reconcile_merge_via_store(
     observation_id: str,
     merged_text: str,
     add_source_ids: list,
+    add_bounds: _TemporalBounds,
     txn=None,
 ) -> None:
     """Dedup merge for a store that owns its rows: fold the extra source facts and the merged text
     into the twin observation and re-upsert it, preserving its other fields. Re-embeds the merged
     text because ``get_memories`` does not return the stored vector (the SQL path reuses it in
-    place instead)."""
+    place instead).
+
+    ``add_bounds`` are the folded-in side's dates, widened onto the twin exactly as the SQL
+    path's LEAST/GREATEST does."""
     current = await store.get_memories(conn=conn, fq_table=fq_table, bank_id=bank_id, unit_ids=[observation_id])
     cur = current[0] if current else None
     if cur is None:
         return
     merged_sources = list(dict.fromkeys([*(cur.source_memory_ids or []), *(str(s) for s in add_source_ids)]))
+    merged_bounds = _TemporalBounds.of(cur).merged_with(add_bounds)
     embeddings = await embedding_utils.generate_embeddings_batch(memory_engine.embeddings, [merged_text])
     await store.upsert_observation(
         conn=conn,
@@ -1025,10 +1104,10 @@ async def _reconcile_merge_via_store(
             tags=list(cur.tags or []),
             proof_count=len(merged_sources),
             source_memory_ids=merged_sources,
-            event_date=cur.event_date,
-            occurred_start=cur.occurred_start,
-            occurred_end=cur.occurred_end,
-            mentioned_at=cur.mentioned_at,
+            event_date=merged_bounds.event_date,
+            occurred_start=merged_bounds.occurred_start,
+            occurred_end=merged_bounds.occurred_end,
+            mentioned_at=merged_bounds.mentioned_at,
             created_at=cur.created_at,
         ),
     )
@@ -2134,9 +2213,7 @@ async def _process_memory_batch(
             new_text=update.text,
             observations=union_observations,
             source_fact_tags=agg.tags,
-            source_occurred_start=agg.occurred_start,
-            source_occurred_end=agg.occurred_end,
-            source_mentioned_at=agg.mentioned_at,
+            source_bounds=_TemporalBounds.of(agg),
             perf=perf,
             txn=txn,
         )
@@ -2204,6 +2281,7 @@ async def _process_memory_batch(
                 create.text,
                 create_source_ids,
                 agg.tags,
+                _TemporalBounds.of(agg),
                 txn=txn,
             )
             if merged_into is not None:
@@ -2338,17 +2416,15 @@ async def _execute_update_action(
     new_text: str,
     observations: list["MemoryFact"],
     source_fact_tags: list[str] | None = None,
-    source_occurred_start: datetime | None = None,
-    source_occurred_end: datetime | None = None,
-    source_mentioned_at: datetime | None = None,
+    source_bounds: _TemporalBounds = _TemporalBounds(),
     perf: ConsolidationPerfLog | None = None,
     txn=None,
 ) -> str | None:
     """
     Update an existing observation.
 
-    Extends source_memory_ids with all contributing memories, updates temporal fields
-    (LEAST for occurred_start, GREATEST for occurred_end / mentioned_at), and merges tags.
+    Extends source_memory_ids with all contributing memories, widens the observation's temporal
+    bounds by ``source_bounds`` (see :class:`_TemporalBounds`), and merges tags.
 
     The embedding is computed off-connection (a slow embedder must never pin a pooled
     connection); the liveness check + UPDATE + history + observation_sources sync then run
@@ -2425,11 +2501,12 @@ async def _execute_update_action(
                         embedding = $2::vector,
                         source_memory_ids = $3,
                         proof_count = $4,
-                        tags = $9,
+                        tags = $10,
                         updated_at = now(),
-                        occurred_start = LEAST(occurred_start, COALESCE($6, occurred_start)),
-                        occurred_end = GREATEST(occurred_end, COALESCE($7, occurred_end)),
-                        mentioned_at = GREATEST(mentioned_at, COALESCE($8, mentioned_at)){search_vector_clause}
+                        event_date = LEAST(event_date, COALESCE($6, event_date)),
+                        occurred_start = LEAST(occurred_start, COALESCE($7, occurred_start)),
+                        occurred_end = GREATEST(occurred_end, COALESCE($8, occurred_end)),
+                        mentioned_at = GREATEST(mentioned_at, COALESCE($9, mentioned_at)){search_vector_clause}
                     WHERE id = $5
                     """,
                     new_text,
@@ -2437,9 +2514,10 @@ async def _execute_update_action(
                     source_ids,
                     len(source_ids),
                     uuid.UUID(observation_id),
-                    source_occurred_start,
-                    source_occurred_end,
-                    source_mentioned_at,
+                    source_bounds.event_date,
+                    source_bounds.occurred_start,
+                    source_bounds.occurred_end,
+                    source_bounds.mentioned_at,
                     merged_tags,
                 )
                 # The source-liveness checks above guard the *source* memories; the
@@ -2457,12 +2535,24 @@ async def _execute_update_action(
                     return None
             else:
                 # Upsert overwrites the whole observation, so start from its current state (fetched
-                # from the store) and apply the same merge the SQL does — LEAST/GREATEST on the times
-                # — while preserving fields the update never touches (event_date, created_at).
+                # from the store) and apply the same merge the SQL does — LEAST/GREATEST on the
+                # times — while preserving fields the update never touches (created_at).
                 current = await store.get_memories(
                     conn=conn, fq_table=fq_table, bank_id=bank_id, unit_ids=[observation_id]
                 )
                 cur = current[0] if current else None
+                # Widen the row the store still holds. If it has vanished, fall back to the
+                # pre-update recall snapshot — ISO strings, and no event_date on that model.
+                current_bounds = (
+                    _TemporalBounds.of(cur)
+                    if cur
+                    else _TemporalBounds(
+                        occurred_start=_as_dt(model.occurred_start),
+                        occurred_end=_as_dt(model.occurred_end),
+                        mentioned_at=_as_dt(model.mentioned_at),
+                    )
+                )
+                merged_bounds = current_bounds.merged_with(source_bounds)
                 await store.upsert_observation(
                     conn=conn,
                     bank_id=bank_id,
@@ -2475,10 +2565,10 @@ async def _execute_update_action(
                         tags=merged_tags,
                         proof_count=len(source_ids),
                         source_memory_ids=[str(s) for s in source_ids],
-                        event_date=cur.event_date if cur else None,
-                        occurred_start=_merge_min(model.occurred_start, source_occurred_start),
-                        occurred_end=_merge_max(model.occurred_end, source_occurred_end),
-                        mentioned_at=_merge_max(model.mentioned_at, source_mentioned_at),
+                        event_date=merged_bounds.event_date,
+                        occurred_start=merged_bounds.occurred_start,
+                        occurred_end=merged_bounds.occurred_end,
+                        mentioned_at=merged_bounds.mentioned_at,
                         created_at=cur.created_at if cur else None,
                     ),
                 )

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -230,7 +230,14 @@ class _TemporalBounds:
     these, never replace them: ``event_date``/``occurred_start`` keep the earliest known value
     and ``occurred_end``/``mentioned_at`` the latest, with a missing value on either side
     ignored. That is exactly the ``_aggregate_source_fields`` rule, and the Python mirror of the
-    ``LEAST(col, COALESCE(x, col))`` / ``GREATEST(col, COALESCE(x, col))`` the SQL paths apply.
+    ``LEAST``/``GREATEST`` the SQL paths apply.
+
+    The SQL spelling differs by reach, deliberately. The dedup folds only ever run on PostgreSQL
+    (``_dedup_active`` disables dedup on Oracle) and use the plain
+    ``LEAST(col, COALESCE(x, col))``, which is enough there because PostgreSQL ignores NULL
+    arguments. ``_execute_update_action`` also runs on Oracle, where LEAST/GREATEST return NULL
+    if any argument is NULL, so it wraps the whole expression in one more COALESCE — see the
+    comment there.
     """
 
     event_date: "datetime | None" = None
@@ -2494,6 +2501,15 @@ async def _execute_update_action(
 
             t0 = time.time()
             if store.writes_memory_rows_in_sql_for(bank_id):
+                # Unlike the dedup folds this statement also runs on Oracle, where LEAST/GREATEST
+                # return NULL as soon as ANY argument is NULL (PostgreSQL ignores NULL arguments).
+                # The inner COALESCE covers a NULL *parameter*; the outer one covers a NULL
+                # *column* — an observation with no occurred interval yet, which is precisely the
+                # #3477 case. Without it Oracle would compute LEAST(NULL, <source date>) = NULL and
+                # silently drop the date it was told to inherit. Keep the inner
+                # ``COALESCE($n, col)`` spelled exactly like this: the Oracle driver shim keys its
+                # TIMESTAMP-TZ input-size hint off that pattern (db/oracle.py::_apply_clob_input_sizes),
+                # and a NULL parameter binds as VARCHAR2 (ORA-00932) without it.
                 updated_rows = await conn.execute_rows_affected(
                     f"""
                     UPDATE {fq_table("memory_units")}
@@ -2503,10 +2519,10 @@ async def _execute_update_action(
                         proof_count = $4,
                         tags = $10,
                         updated_at = now(),
-                        event_date = LEAST(event_date, COALESCE($6, event_date)),
-                        occurred_start = LEAST(occurred_start, COALESCE($7, occurred_start)),
-                        occurred_end = GREATEST(occurred_end, COALESCE($8, occurred_end)),
-                        mentioned_at = GREATEST(mentioned_at, COALESCE($9, mentioned_at)){search_vector_clause}
+                        event_date = COALESCE(LEAST(event_date, COALESCE($6, event_date)), $6),
+                        occurred_start = COALESCE(LEAST(occurred_start, COALESCE($7, occurred_start)), $7),
+                        occurred_end = COALESCE(GREATEST(occurred_end, COALESCE($8, occurred_end)), $8),
+                        mentioned_at = COALESCE(GREATEST(mentioned_at, COALESCE($9, mentioned_at)), $9){search_vector_clause}
                     WHERE id = $5
                     """,
                     new_text,

--- a/hindsight-api-slim/tests/conftest.py
+++ b/hindsight-api-slim/tests/conftest.py
@@ -359,8 +359,16 @@ def oracle_db_url(_oracle_admin_dsn):
                 f'CREATE USER {test_user} IDENTIFIED BY "{test_pass}" DEFAULT TABLESPACE USERS QUOTA UNLIMITED ON USERS'
             )
         except oracledb.DatabaseError as e:
-            if hasattr(e.args[0], "code") and e.args[0].code == 1920:
+            code = getattr(e.args[0], "code", None)
+            if code == 1920:
                 # ORA-01920: user name conflicts with another user or role name
+                pass
+            elif code == 1031:
+                # ORA-01031: we are not an admin. CI provisions the user with a
+                # privileged account before pytest runs and then points
+                # ORACLE_TEST_DSN at that same unprivileged user, so this bootstrap
+                # cannot (and need not) create it. Assume it exists — if it does
+                # not, run_migrations below fails with a plain login error.
                 pass
             else:
                 raise

--- a/hindsight-api-slim/tests/test_consolidation_dedup.py
+++ b/hindsight-api-slim/tests/test_consolidation_dedup.py
@@ -10,6 +10,7 @@ import types
 import uuid
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from unittest.mock import DEFAULT, AsyncMock, patch
 
 import pytest
@@ -23,9 +24,18 @@ from hindsight_api.engine.consolidation.consolidator import (
     _DedupDecision,
     _duplicate_create_target,
     _norm_obs_text,
+    _TemporalBounds,
 )
 from hindsight_api.engine.memories import RecallArms
 from hindsight_api.engine.search.types import RetrievalResult
+
+#: Dates the skipped CREATE would have been stamped with; the fold must carry them onto the twin.
+_SOURCE_BOUNDS = _TemporalBounds(
+    event_date=datetime(2024, 1, 2, tzinfo=timezone.utc),
+    occurred_start=datetime(2023, 1, 2, tzinfo=timezone.utc),
+    occurred_end=datetime(2024, 1, 3, tzinfo=timezone.utc),
+    mentioned_at=datetime(2024, 1, 4, tzinfo=timezone.utc),
+)
 
 
 @dataclass
@@ -195,6 +205,7 @@ def _ctx(threshold: float = 0.97):
         create_text="YouTube content in Uzbek is very rich.",
         create_source_ids=[uuid.uuid4()],
         tags=["t1"],
+        source_bounds=_SOURCE_BOUNDS,
     )
     return kwargs, conn, llm
 
@@ -335,6 +346,15 @@ async def test_dedup_llm_merge_folds_into_twin() -> None:
     assert args[1] == "Uzbek content on YouTube is very rich."  # merged text persisted
     assert args[2] == kwargs["create_source_ids"]  # new (live) source facts folded in
     assert args[3] == uuid.UUID(_TWIN_ID)  # onto the twin row
+    # ...along with the dates the skipped CREATE carried, so the twin's interval widens (#3477).
+    # What the SQL *does* with them is covered against a real database in
+    # test_consolidation_temporal_merge.py — a mocked connection cannot check that.
+    assert args[5:] == (
+        _SOURCE_BOUNDS.event_date,
+        _SOURCE_BOUNDS.occurred_start,
+        _SOURCE_BOUNDS.occurred_end,
+        _SOURCE_BOUNDS.mentioned_at,
+    )
 
 
 async def test_dedup_llm_merge_sanitizes_text_before_write() -> None:

--- a/hindsight-api-slim/tests/test_consolidation_temporal_merge.py
+++ b/hindsight-api-slim/tests/test_consolidation_temporal_merge.py
@@ -1,0 +1,355 @@
+"""Observation merges must never narrow an observation's temporal bounds (#3477).
+
+Every path that folds evidence into an existing observation — the ordinary UPDATE, the
+CREATE-time semantic dedup fold, the UPDATE-time dedup fold — has to widen
+``event_date``/``occurred_start`` to the earliest known value and
+``occurred_end``/``mentioned_at`` to the latest. Before the fix the dedup folds rewrote only
+text/sources, so an observation could cite dated source facts while reporting no event
+interval at all.
+
+The SQL-executing tests here run against a real database on purpose: the merge lives in SQL,
+and asserting on a mocked connection cannot tell a working statement from one PostgreSQL
+refuses to plan.
+"""
+
+import types
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from hindsight_api.config import _get_raw_config
+from hindsight_api.engine.consolidation import consolidator
+from hindsight_api.engine.consolidation.consolidator import (
+    _aggregate_source_fields,
+    _DedupDecision,
+    _DedupOutcome,
+    _execute_create_action,
+    _execute_update_action,
+    _TemporalBounds,
+    run_consolidation_job,
+)
+from hindsight_api.engine.memory_engine import MemoryEngine
+from hindsight_api.engine.response_models import MemoryFact
+
+EARLY = datetime(2020, 3, 1, tzinfo=timezone.utc)
+LATE = datetime(2021, 7, 4, 12, 30, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def observations_enabled():
+    """Observations on, and a loose dedup gate so the near-duplicate CREATE reaches the fold."""
+    config = _get_raw_config()
+    previous_observations = config.enable_observations
+    previous_threshold = config.consolidation_dedup_threshold
+    config.enable_observations = True
+    config.consolidation_dedup_threshold = 0.5
+    yield config
+    config.enable_observations = previous_observations
+    config.consolidation_dedup_threshold = previous_threshold
+
+
+async def _retain_fact(
+    memory: MemoryEngine,
+    request_context,
+    config,
+    bank_id: str,
+    content: str,
+    marker: str,
+    bounds: _TemporalBounds = _TemporalBounds(),
+) -> uuid.UUID:
+    """Retain ``content`` and return the id of the resulting fact containing ``marker``.
+
+    The mock extractor also emits facts for the extraction prompt's own boilerplate; those are
+    marked consolidated so only the fact under test can join a later consolidation job. Retain
+    runs with observations off so the caller controls when consolidation happens.
+    """
+    previous = config.enable_observations
+    config.enable_observations = False
+    try:
+        await memory.retain_async(bank_id=bank_id, content=content, request_context=request_context)
+    finally:
+        config.enable_observations = previous
+
+    async with memory._pool.acquire() as conn:
+        await conn.execute(
+            """
+            UPDATE memory_units SET consolidated_at = now()
+             WHERE bank_id = $1 AND fact_type <> 'observation' AND consolidated_at IS NULL
+               AND text NOT LIKE $2
+            """,
+            bank_id,
+            f"%{marker}%",
+        )
+        fact_id = await conn.fetchval(
+            """
+            UPDATE memory_units
+               SET event_date = $2, occurred_start = $3, occurred_end = $4, mentioned_at = $5
+             WHERE bank_id = $1 AND fact_type <> 'observation' AND consolidated_at IS NULL
+            RETURNING id
+            """,
+            bank_id,
+            bounds.event_date,
+            bounds.occurred_start,
+            bounds.occurred_end,
+            bounds.mentioned_at,
+        )
+    assert fact_id is not None, f"retain produced no unconsolidated fact matching {marker!r}"
+    return fact_id
+
+
+async def _seed_undated_observation(
+    memory: MemoryEngine, bank_id: str, source_fact_id: uuid.UUID, text: str
+) -> uuid.UUID:
+    """Create an observation the way undated source facts do: stamped with a consolidation-time
+    ``event_date``/``mentioned_at`` and no occurred interval at all."""
+    action = await _execute_create_action(
+        pool=await memory._get_backend(),
+        memory_engine=memory,
+        bank_id=bank_id,
+        source_memory_ids=[source_fact_id],
+        text=text,
+    )
+    assert action == "created"
+    async with memory._pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT id, occurred_start FROM memory_units WHERE bank_id = $1 AND fact_type = 'observation'",
+            bank_id,
+        )
+    assert row["occurred_start"] is None
+    return row["id"]
+
+
+async def _observations(memory: MemoryEngine, bank_id: str) -> list:
+    async with memory._pool.acquire() as conn:
+        return await conn.fetch(
+            """
+            SELECT id, text, event_date, occurred_start, occurred_end, mentioned_at, source_memory_ids
+              FROM memory_units WHERE bank_id = $1 AND fact_type = 'observation' ORDER BY created_at
+            """,
+            bank_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_dedup_create_fold_widens_bounds_of_the_twin(memory: MemoryEngine, request_context, observations_enabled):
+    """#3477: a CREATE folded into a near-twin must hand over its source facts' dates.
+
+    Without this the twin ends up citing a dated source fact while still reporting
+    ``occurred_start``/``occurred_end`` as NULL — the exact shape reported in the issue.
+    """
+    bank_id = f"test-temporal-fold-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    undated_fact = await _retain_fact(
+        memory, request_context, observations_enabled, bank_id, "Alice moved to Berlin for work.", "Alice"
+    )
+    observation_id = await _seed_undated_observation(memory, bank_id, undated_fact, "Alice moved to Berlin for work.")
+
+    dated_fact = await _retain_fact(
+        memory,
+        request_context,
+        observations_enabled,
+        bank_id,
+        "Alice relocated to Berlin for a new job.",
+        "relocated",
+        _TemporalBounds(event_date=EARLY, occurred_start=EARLY, occurred_end=LATE, mentioned_at=LATE),
+    )
+
+    # The adjudicating LLM votes "merge", so this CREATE folds into the twin instead of inserting.
+    with patch.object(
+        consolidator,
+        "_dedup_decision_from_response",
+        lambda _response: _DedupDecision(action="merge", text="Alice moved to Berlin for a new job.", reason="test"),
+    ):
+        await run_consolidation_job(memory_engine=memory, bank_id=bank_id, request_context=request_context)
+
+    rows = await _observations(memory, bank_id)
+    assert len(rows) == 1, f"the CREATE should have folded into the twin, not inserted: {[dict(r) for r in rows]}"
+    folded = rows[0]
+    assert folded["id"] == observation_id
+    assert dated_fact in folded["source_memory_ids"], "the dated fact must be cited by the survivor"
+    assert folded["occurred_start"] == EARLY
+    assert folded["occurred_end"] == LATE
+    assert folded["event_date"] == EARLY, "the source's earlier event_date must win over the stamped one"
+    assert folded["mentioned_at"] > LATE, "mentioned_at keeps the later of the two (the stamped one)"
+
+    await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_update_widens_bounds_from_its_source_facts(memory: MemoryEngine, request_context, observations_enabled):
+    """The ordinary UPDATE path inherits every temporal field from its sources, event_date included."""
+    bank_id = f"test-temporal-update-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    undated_fact = await _retain_fact(
+        memory, request_context, observations_enabled, bank_id, "Bob plays the cello.", "cello"
+    )
+    observation_id = await _seed_undated_observation(memory, bank_id, undated_fact, "Bob plays the cello.")
+    stamped = (await _observations(memory, bank_id))[0]
+
+    dated_fact = await _retain_fact(
+        memory,
+        request_context,
+        observations_enabled,
+        bank_id,
+        "Bob joined a string quartet.",
+        "quartet",
+        _TemporalBounds(event_date=EARLY, occurred_start=EARLY, occurred_end=LATE, mentioned_at=LATE),
+    )
+
+    embedding = await _execute_update_action(
+        pool=await memory._get_backend(),
+        memory_engine=memory,
+        bank_id=bank_id,
+        source_memory_ids=[dated_fact],
+        observation_id=str(observation_id),
+        new_text="Bob plays the cello in a string quartet.",
+        observations=[
+            MemoryFact(
+                id=str(observation_id),
+                text=stamped["text"],
+                fact_type="observation",
+                source_fact_ids=[str(undated_fact)],
+                tags=[],
+            )
+        ],
+        source_bounds=_TemporalBounds(event_date=EARLY, occurred_start=EARLY, occurred_end=LATE, mentioned_at=LATE),
+    )
+    assert embedding is not None, "the update must have landed"
+
+    updated = (await _observations(memory, bank_id))[0]
+    assert updated["occurred_start"] == EARLY
+    assert updated["occurred_end"] == LATE
+    assert updated["event_date"] == EARLY, "event_date must follow the sources, not stay at creation time"
+    assert updated["mentioned_at"] == stamped["mentioned_at"], "the stamped mention is later than the source's"
+
+    await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_dedup_update_fold_unions_the_bounds_of_both_rows(
+    memory: MemoryEngine, request_context, observations_enabled
+):
+    """The UPDATE-time fold deletes the folded-from row, so the survivor must absorb its dates."""
+    bank_id = f"test-temporal-updfold-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    twin_fact = await _retain_fact(
+        memory, request_context, observations_enabled, bank_id, "Carla ran the Rome marathon.", "marathon"
+    )
+    updated_fact = await _retain_fact(
+        memory, request_context, observations_enabled, bank_id, "Carla trains every morning.", "trains"
+    )
+
+    twin_text = "Carla ran the Rome marathon."
+    updated_text = "Carla trains every morning and ran the Rome marathon."
+    await _execute_create_action(
+        pool=await memory._get_backend(),
+        memory_engine=memory,
+        bank_id=bank_id,
+        source_memory_ids=[twin_fact],
+        text=twin_text,
+        occurred_start=EARLY,
+    )
+    await _execute_create_action(
+        pool=await memory._get_backend(),
+        memory_engine=memory,
+        bank_id=bank_id,
+        source_memory_ids=[updated_fact],
+        text=updated_text,
+        occurred_end=LATE,
+    )
+    rows = {row["text"]: row for row in await _observations(memory, bank_id)}
+    twin_id, updated_id = rows[twin_text]["id"], rows[updated_text]["id"]
+    assert rows[twin_text]["occurred_end"] is None and rows[updated_text]["occurred_start"] is None
+
+    # The re-embedded UPDATE drifted onto the twin and the LLM votes "merge".
+    with patch.object(
+        consolidator,
+        "_dedup_adjudicate",
+        AsyncMock(
+            return_value=_DedupOutcome(
+                best_id=str(twin_id), merged_text=twin_text, should_merge=True, best_text=twin_text
+            )
+        ),
+    ):
+        await consolidator._dedup_reconcile_update(
+            await memory._get_backend(),
+            memory,
+            bank_id,
+            observations_enabled,
+            None,
+            str(updated_id),
+            updated_text,
+            None,
+            [],
+        )
+
+    survivors = await _observations(memory, bank_id)
+    assert [row["id"] for row in survivors] == [twin_id], "the folded-from row must be gone"
+    assert survivors[0]["occurred_start"] == EARLY, "the twin keeps its own start"
+    assert survivors[0]["occurred_end"] == LATE, "and absorbs the deleted row's end"
+    assert updated_fact in survivors[0]["source_memory_ids"]
+
+    await memory.delete_bank(bank_id, request_context=request_context)
+
+
+def test_temporal_bounds_merge_keeps_the_widest_known_interval():
+    """min/max per field, with a missing value on either side ignored."""
+    merged = _TemporalBounds(event_date=LATE, occurred_start=LATE, occurred_end=EARLY).merged_with(
+        _TemporalBounds(event_date=EARLY, occurred_end=LATE, mentioned_at=LATE)
+    )
+    assert merged == _TemporalBounds(event_date=EARLY, occurred_start=LATE, occurred_end=LATE, mentioned_at=LATE)
+    assert _TemporalBounds().merged_with(_TemporalBounds()) == _TemporalBounds()
+
+
+def test_temporal_bounds_of_reads_a_source_aggregation():
+    """``_aggregate_source_fields`` is where an observation's dates come from, so its result has
+    to hand over all four fields unchanged."""
+    aggregation = _aggregate_source_fields(
+        [
+            {"event_date": LATE, "occurred_start": LATE, "occurred_end": LATE, "mentioned_at": EARLY},
+            {"event_date": EARLY, "occurred_start": EARLY, "occurred_end": None, "mentioned_at": LATE},
+        ]
+    )
+    assert _TemporalBounds.of(aggregation) == _TemporalBounds(
+        event_date=EARLY, occurred_start=EARLY, occurred_end=LATE, mentioned_at=LATE
+    )
+
+
+@pytest.mark.asyncio
+async def test_store_owned_fold_merges_bounds_like_the_sql_path():
+    """A memories store that owns its rows re-upserts the whole observation, so the fold has to
+    apply the same widening in Python."""
+    stored = types.SimpleNamespace(
+        source_memory_ids=["existing"],
+        tags=["t1"],
+        created_at=EARLY,
+        event_date=LATE,
+        occurred_start=LATE,
+        occurred_end=EARLY,
+        mentioned_at=EARLY,
+    )
+    store = types.SimpleNamespace(get_memories=AsyncMock(return_value=[stored]), upsert_observation=AsyncMock())
+
+    with patch.object(consolidator.embedding_utils, "generate_embeddings_batch", AsyncMock(return_value=[[0.1, 0.2]])):
+        await consolidator._reconcile_merge_via_store(
+            store,
+            conn=object(),
+            memory_engine=types.SimpleNamespace(embeddings=object()),
+            bank_id="bank-1",
+            observation_id=str(uuid.uuid4()),
+            merged_text="merged",
+            add_source_ids=[uuid.uuid4()],
+            add_bounds=_TemporalBounds(event_date=EARLY, occurred_end=LATE, mentioned_at=LATE),
+        )
+
+    record = store.upsert_observation.await_args.kwargs["record"]
+    assert record.event_date == EARLY
+    assert record.occurred_start == LATE
+    assert record.occurred_end == LATE
+    assert record.mentioned_at == LATE
+    assert record.created_at == EARLY, "fields the fold does not own are preserved"

--- a/hindsight-api-slim/tests/test_consolidation_temporal_merge.py
+++ b/hindsight-api-slim/tests/test_consolidation_temporal_merge.py
@@ -82,11 +82,15 @@ async def _retain_fact(
             bank_id,
             f"%{marker}%",
         )
-        fact_id = await conn.fetchval(
+        # Repeat the marker predicate rather than leaning on the sweep above: if the extractor
+        # ever emits two facts for this content, stamping both and returning an arbitrary one
+        # would make the caller's source-id assertions flaky rather than fail here.
+        stamped = await conn.fetch(
             """
             UPDATE memory_units
                SET event_date = $2, occurred_start = $3, occurred_end = $4, mentioned_at = $5
              WHERE bank_id = $1 AND fact_type <> 'observation' AND consolidated_at IS NULL
+               AND text LIKE $6
             RETURNING id
             """,
             bank_id,
@@ -94,9 +98,10 @@ async def _retain_fact(
             bounds.occurred_start,
             bounds.occurred_end,
             bounds.mentioned_at,
+            f"%{marker}%",
         )
-    assert fact_id is not None, f"retain produced no unconsolidated fact matching {marker!r}"
-    return fact_id
+    assert len(stamped) == 1, f"expected exactly one unconsolidated fact matching {marker!r}, got {len(stamped)}"
+    return stamped[0]["id"]
 
 
 async def _seed_undated_observation(

--- a/hindsight-api-slim/tests/test_oracle_integration.py
+++ b/hindsight-api-slim/tests/test_oracle_integration.py
@@ -1154,6 +1154,97 @@ class TestOracleSpecific:
         run_migrations(oracle_db_url)
         run_migrations(oracle_db_url)
 
+    @pytest.mark.asyncio
+    async def test_observation_update_widens_null_bounds(
+        self, oracle_memory: MemoryEngine, request_context: RequestContext
+    ):
+        """#3477 on Oracle: an observation with NO occurred interval must inherit its source's.
+
+        Oracle's LEAST/GREATEST return NULL as soon as any argument is NULL, where PostgreSQL
+        ignores NULL arguments. A plain ``LEAST(occurred_start, COALESCE(:n, occurred_start))``
+        therefore evaluates to NULL for an observation that has no interval yet — silently
+        dropping the very dates it was told to inherit — while the identical statement is
+        correct on PostgreSQL. The PG-side coverage lives in test_consolidation_temporal_merge.py;
+        only this test can catch the dialect difference.
+        """
+        from hindsight_api.config import _get_raw_config
+        from hindsight_api.engine.consolidation.consolidator import (
+            _execute_create_action,
+            _execute_update_action,
+            _TemporalBounds,
+        )
+        from hindsight_api.engine.response_models import MemoryFact
+
+        early = datetime(2020, 3, 1, tzinfo=timezone.utc)
+        late = datetime(2021, 7, 4, 12, 30, tzinfo=timezone.utc)
+        bank_id = _bank_id("obsbounds")
+        config = _get_raw_config()
+        previous_observations = config.enable_observations
+        config.enable_observations = False  # the test drives consolidation itself
+        try:
+            await oracle_memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+            await oracle_memory.retain_async(
+                bank_id=bank_id,
+                content="Dana learned to sail.",
+                request_context=request_context,
+            )
+
+            backend = await oracle_memory._get_backend()
+            async with backend.acquire() as conn:
+                source_id = await conn.fetchval(
+                    "SELECT id FROM memory_units WHERE bank_id = $1 AND fact_type <> 'observation'",
+                    bank_id,
+                )
+            assert source_id is not None, "retain produced no fact to build an observation from"
+
+            # An observation built from an undated fact: event_date/mentioned_at are stamped at
+            # creation time, occurred_start/occurred_end stay NULL.
+            action = await _execute_create_action(
+                pool=backend,
+                memory_engine=oracle_memory,
+                bank_id=bank_id,
+                source_memory_ids=[source_id],
+                text="Dana learned to sail.",
+            )
+            assert action == "created"
+            async with backend.acquire() as conn:
+                seeded = await conn.fetchrow(
+                    "SELECT id, occurred_start, occurred_end FROM memory_units "
+                    "WHERE bank_id = $1 AND fact_type = 'observation'",
+                    bank_id,
+                )
+            assert seeded["occurred_start"] is None and seeded["occurred_end"] is None
+
+            await _execute_update_action(
+                pool=backend,
+                memory_engine=oracle_memory,
+                bank_id=bank_id,
+                source_memory_ids=[source_id],
+                observation_id=str(seeded["id"]),
+                new_text="Dana learned to sail on the Adriatic.",
+                observations=[
+                    MemoryFact(
+                        id=str(seeded["id"]),
+                        text="Dana learned to sail.",
+                        fact_type="observation",
+                        source_fact_ids=[str(source_id)],
+                        tags=[],
+                    )
+                ],
+                source_bounds=_TemporalBounds(occurred_start=early, occurred_end=late),
+            )
+
+            async with backend.acquire() as conn:
+                updated = await conn.fetchrow(
+                    "SELECT occurred_start, occurred_end FROM memory_units WHERE id = $1",
+                    seeded["id"],
+                )
+            assert updated["occurred_start"] == early, "a NULL occurred_start must take the source's date"
+            assert updated["occurred_end"] == late, "a NULL occurred_end must take the source's date"
+        finally:
+            config.enable_observations = previous_observations
+            await _safe_cleanup(oracle_memory, bank_id, request_context)
+
 
 # ===================================================================
 # Tier 6 — Edge Cases & Robustness

--- a/hindsight-api-slim/tests/test_oracle_integration.py
+++ b/hindsight-api-slim/tests/test_oracle_integration.py
@@ -35,6 +35,18 @@ def _bank_id(prefix: str = "oracle") -> str:
     return f"test-{prefix}-{uuid.uuid4().hex[:8]}"
 
 
+def _as_utc(value: datetime | None) -> datetime | None:
+    """Attach UTC to a timestamp oracledb handed back naive.
+
+    Values are written as UTC-aware, but the driver reads some timestamp columns back
+    without a tzinfo, and a naive/aware comparison is silently False rather than an error.
+    Normalise before comparing instants.
+    """
+    if value is None or value.tzinfo is not None:
+        return value
+    return value.replace(tzinfo=timezone.utc)
+
+
 async def _safe_cleanup(memory: MemoryEngine, bank_id: str, request_context: RequestContext) -> None:
     """Delete a bank, suppressing deadlock/lock errors in test teardown.
 
@@ -1239,8 +1251,8 @@ class TestOracleSpecific:
                     "SELECT occurred_start, occurred_end FROM memory_units WHERE id = $1",
                     seeded["id"],
                 )
-            assert updated["occurred_start"] == early, "a NULL occurred_start must take the source's date"
-            assert updated["occurred_end"] == late, "a NULL occurred_end must take the source's date"
+            assert _as_utc(updated["occurred_start"]) == early, "a NULL occurred_start must take the source's date"
+            assert _as_utc(updated["occurred_end"]) == late, "a NULL occurred_end must take the source's date"
         finally:
             config.enable_observations = previous_observations
             await _safe_cleanup(oracle_memory, bank_id, request_context)


### PR DESCRIPTION
## Summary

Fixes #3477: an observation could cite dated source facts while reporting `occurred_start` and `occurred_end` as `null`.

Reproduced end-to-end against a real database. The cause is the semantic-dedup **folds**, not the ordinary write paths:

- **CREATE fold** (`_dedup_reconcile_create`) — when a CREATE is merged into a near-duplicate twin instead of being inserted, the fold `UPDATE` rewrote only `text`, `source_memory_ids`, `proof_count` and `updated_at`. The dates the skipped CREATE was going to be stamped with were dropped, so the twin gained a dated source fact and kept its own (often empty) interval. Dedup is on by default (`consolidation_dedup_threshold` 0.97), so this is the default path.
- **UPDATE fold** (`_dedup_reconcile_update`) — same fold, and here the folded-from row is then **deleted**, so anything only it knew about was lost outright.
- **Ordinary UPDATE** (`_execute_update_action`) — this one already merged `occurred_start`/`occurred_end`/`mentioned_at` correctly (`LEAST`/`GREATEST` ignore NULLs in Postgres), but never touched `event_date`, leaving it at whatever the observation was stamped with when it was created. Now it carries `event_date` too, so all four fields follow the same rule everywhere.

The rule is the one `_aggregate_source_fields` already documents and CREATE already applies: `event_date`/`occurred_start` keep the **earliest** known value, `occurred_end`/`mentioned_at` the **latest**, and a missing value on either side is ignored. A merge can only ever widen an observation's interval. `_TemporalBounds` names that contract in one place; the SQL paths express it with `LEAST`/`GREATEST`.

**The SQL spelling differs by which dialects the statement can reach.** The two dedup folds are PostgreSQL-only by construction (`_dedup_active` disables dedup on Oracle) and use the plain `LEAST(col, COALESCE($n, col))` — enough there, because PostgreSQL ignores NULL arguments to `LEAST`/`GREATEST`. `_execute_update_action` also runs on Oracle, where those functions return NULL as soon as **any** argument is NULL. `COALESCE($n, col)` only guards a NULL *parameter*; it does nothing for a NULL *column*, so on Oracle an observation with no occurred interval yet computed `LEAST(NULL, <source date>)` = NULL and silently dropped the date it was told to inherit — precisely the #3477 shape. That statement therefore wraps each assignment in one more COALESCE: `COALESCE(LEAST(col, COALESCE($n, col)), $n)`. It is provably a no-op on PostgreSQL (the outer COALESCE fires only when `LEAST` yields NULL, which there requires both operands to be NULL, and the fallback is then NULL too), and the inner `COALESCE($n, col)` is kept spelled exactly as before because the Oracle driver shim keys its TIMESTAMP-TZ input-size hint off that pattern (`db/oracle.py::_apply_clob_input_sizes`).

## Verification

`tests/test_consolidation_temporal_merge.py` covers each merge path. **The three SQL-executing tests run against a real database on purpose** — the merge lives in SQL, and a mocked connection cannot tell a working statement from one PostgreSQL refuses to plan. Each was confirmed to fail when its merge clause is removed:

| test | path | executes |
|---|---|---|
| `test_dedup_create_fold_widens_bounds_of_the_twin` | full `run_consolidation_job`, dedup fold | real SQL |
| `test_update_widens_bounds_from_its_source_facts` | ordinary observation UPDATE | real SQL |
| `test_dedup_update_fold_unions_the_bounds_of_both_rows` | UPDATE-time fold + delete | real SQL |
| `test_temporal_bounds_merge_keeps_the_widest_known_interval` | the min/max/NULL contract | unit |
| `test_temporal_bounds_of_reads_a_source_aggregation` | source aggregation → bounds | unit |
| `test_store_owned_fold_merges_bounds_like_the_sql_path` | external-store fold (no SQL) | unit |
| `test_observation_update_widens_null_bounds` | the same UPDATE **on Oracle**, NULL column | real SQL (Oracle) |

The Oracle one is in `test_oracle_integration.py` and needs the `oracle-tests` PR label to run (`test-api-oracle` is gated behind it); the label is on this PR. It is the only test that can catch the dialect difference above — the PostgreSQL statement is correct either way.

The first one is the issue's exact scenario: an undated observation, a dated source fact whose CREATE folds into it, and the survivor must come out with the source's interval.

Also ran the whole `hindsight-api-slim` suite locally (non-LLM markers): the consolidation/observation/temporal modules are green, and the handful of unrelated failures left reproduce identically on unmodified `main`. Plus `./scripts/hooks/lint.sh`, `check-unused.sh` and `ty`.

## Note on #3482

#3482 diagnosed this first and proposed the same min/max contract — credited as co-author. It is superseded rather than merged: its SQL uses `CASE WHEN $n IS NULL … ELSE LEAST(col, $n)`, which gives PostgreSQL nothing to infer the parameter type from, so two of its three statements fail to prepare (`asyncpg.exceptions.AmbiguousParameterError`) — including the ordinary observation UPDATE, which would break every consolidation update. Its tests assert on SQL substrings against a mocked connection, and `test-api` is skipped on fork PRs, so nothing caught it. That is the reason the tests here execute the statements for real.

Fixes #3477

