### PR TITLE
perf(postgres): preserve hash join in observation scoring

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -938,9 +938,11 @@ class PostgreSQLOps(DataAccessOps):
                     ORDER BY ue_target.unit_id DESC
                     LIMIT {per_entity_limit}
                 ) t
-                WHERE NOT EXISTS (
-                    SELECT 1 FROM seed_sources ss WHERE ss.source_id = t.unit_id
-                )
+                -- Keep this as a set difference rather than a NOT EXISTS anti-join.
+                -- PostgreSQL can estimate the anti-join at one row and then turn the
+                -- set-wise scoring join below back into a quadratic nested loop.
+                EXCEPT
+                SELECT source_id FROM seed_sources
             ),
             connected_array AS (
                 SELECT array_agg(source_id) AS source_ids FROM connected_sources

--- a/hindsight-api-slim/tests/test_observation_expansion_scoring.py
+++ b/hindsight-api-slim/tests/test_observation_expansion_scoring.py
@@ -11,6 +11,7 @@ shared source facts, and it orders the results.
 
 import uuid
 from datetime import datetime, timezone
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -45,6 +46,34 @@ async def _insert_unit(
         datetime.now(timezone.utc),
     )
     return unit_id
+
+
+@pytest.mark.asyncio
+async def test_connected_sources_uses_set_difference():
+    """Keep the planner-safe set difference in the observation entity query."""
+    from hindsight_api.engine.db.ops import UpdatedWindow
+    from hindsight_api.engine.db.ops_postgresql import PostgreSQLOps
+
+    conn = AsyncMock()
+    conn.fetch.side_effect = [[], []]
+
+    await PostgreSQLOps().expand_observations(
+        conn,
+        "memory_units",
+        "unit_entities",
+        "memory_links",
+        [uuid.uuid4()],
+        300,
+        200,
+        UpdatedWindow(after=None, before=None, first_param_index=3),
+    )
+
+    entity_query = conn.fetch.await_args_list[0].args[0]
+    connected_sources = entity_query.partition("connected_sources AS (")[2].partition(
+        "),\n            connected_array AS"
+    )[0]
+    assert "EXCEPT" in connected_sources
+    assert "WHERE NOT EXISTS" not in connected_sources
 
 
 @pytest.mark.asyncio
@@ -83,6 +112,9 @@ async def test_score_counts_distinct_shared_sources(memory, request_context):
             seed = await _insert_unit(conn, mu, bank_id, "seed obs", "observation", [facts[0]])
             three = await _insert_unit(conn, mu, bank_id, "shares three", "observation", facts[1:4])
             one = await _insert_unit(conn, mu, bank_id, "shares one", "observation", [facts[1]])
+            includes_seed_source = await _insert_unit(
+                conn, mu, bank_id, "shares one plus the seed source", "observation", facts[:2]
+            )
             # Duplicate ids in the array must count once — the old query used
             # COUNT(DISTINCT ...) and the rewrite must not turn that into COUNT(*).
             dupes = await _insert_unit(
@@ -103,6 +135,7 @@ async def test_score_counts_distinct_shared_sources(memory, request_context):
         scores = {r["id"]: r["score"] for r in rows.entity}
         assert scores[three] == 3.0
         assert scores[one] == 1.0
+        assert scores[includes_seed_source] == 1.0, "the seed's own source must not contribute to the score"
         assert scores[dupes] == 1.0, "repeated source ids must count once"
         assert seed not in scores, "the seed itself must not come back as a result"
 


### PR DESCRIPTION
## Summary

- replace the planner-sensitive correlated seed-source anti-join in PostgreSQL observation expansion with an equivalent `EXCEPT` set difference
- preserve the existing per-entity fanout limit, seed-source exclusion, retrieval breadth, and scoring behavior
- add a regression test for the SQL shape and strengthen seed-source scoring coverage

Fixes #3510.

## Problem

On a sufficiently connected PostgreSQL-backed observation graph, `connected_sources` can be underestimated as one row. PostgreSQL then chooses it as the outer side of a nested-loop join and performs millions of rejected comparisons while scoring otherwise set-wise candidates.

A representative warm-cache plan performed about 8.56 million rejected comparisons and took about 4.4 seconds in this path.

## Approach

The previous form used `SELECT DISTINCT ... WHERE NOT EXISTS (...)`. This change expresses the same distinct seed-source exclusion as `EXCEPT`:

```sql
SELECT DISTINCT t.unit_id AS source_id
...
EXCEPT
SELECT source_id FROM seed_sources
```

The left-side `DISTINCT` is intentionally retained to keep the source change minimal. The per-entity lateral `ORDER BY ... LIMIT` remains in the same position, before seed-source removal.

## Results

Across three additional realistic seed sets, the original and rewritten SQL returned identical complete top-300 `id -> score` mappings:

| Case | Original | `EXCEPT` | Speedup |
|---|---:|---:|---:|
| 1 | 1.753s | 0.026s | 67.1x |
| 2 | 1.299s | 0.021s | 62.8x |
| 3 | 2.069s | 0.030s | 69.8x |

Median: **1.753s -> 0.026s (67.4x)**.

A packaged PostgreSQL full-stack A/B on the same synthetic graph-linked database also returned identical ordered result IDs, entities, chunks, source facts, and non-final score inputs. Tiny final-score drift was reproduced on repeated requests against the same image and came from request-time freshness, not the SQL rewrite. Restart persistence and rollback to the unmodified 0.9.1 image were also exercised successfully.

## Testing

- `uv run pytest tests/test_observation_expansion_scoring.py -q -n0` — 3 passed
- selected non-LLM observation/link-expansion suite — 8 passed
- repository lint hook: `./scripts/hooks/lint.sh`
- Ruff formatting check
- `uv run ty check hindsight_api`
- packaged Hindsight 0.9.1 + PostgreSQL retain/recall smoke test
- real client/plugin retain and recall through the packaged image
- clean restart and rollback/restore smoke tests

The complete external-LLM test suite was not run locally; the focused and selected suites above exclude tests requiring an external LLM provider.
