### PR TITLE
[CLI] Add a `--trigger-mode full|delta` flag to `mental-models update`

### DIFF
--- a/hindsight-cli/.openapi-coverage.toml
+++ b/hindsight-cli/.openapi-coverage.toml
@@ -149,4 +149,4 @@ trigger = "Exposed as --mode / --fact-types on `knowledge-base create-page`; the
 trigger = "Exposed as --trigger-refresh-after-consolidation on `mental-model create` (other nested trigger fields like fact_types/tag_groups are not exposed yet)."
 
 [fields.update_mental_model]
-trigger = "Exposed as --trigger-refresh-after-consolidation on `mental-model update` (other nested trigger fields like fact_types/tag_groups are not exposed yet)."
+trigger = "Exposed as --trigger-refresh-after-consolidation and --trigger-mode on `mental-model update` (other nested trigger fields like fact_types/tag_groups are not exposed yet)."

--- a/hindsight-cli/.openapi-coverage.toml
+++ b/hindsight-cli/.openapi-coverage.toml
@@ -155,4 +155,4 @@ trigger = "Changing an existing page's refresh policy (cron vs after-consolidati
 trigger = "Exposed as --trigger-refresh-after-consolidation on `mental-model create` (other nested trigger fields like fact_types/tag_groups are not exposed yet)."
 
 [fields.update_mental_model]
-trigger = "Exposed as --trigger-refresh-after-consolidation on `mental-model update` (other nested trigger fields like fact_types/tag_groups are not exposed yet)."
+trigger = "Exposed as --trigger-refresh-after-consolidation and --trigger-mode on `mental-model update` (other nested trigger fields like fact_types/tag_groups are not exposed yet)."

--- a/hindsight-cli/.openapi-coverage.toml
+++ b/hindsight-cli/.openapi-coverage.toml
@@ -155,4 +155,4 @@ trigger = "Changing an existing page's refresh policy (cron vs after-consolidati
 trigger = "Exposed as --trigger-refresh-after-consolidation on `mental-model create` (other nested trigger fields like fact_types/tag_groups are not exposed yet)."
 
 [fields.update_mental_model]
-trigger = "Exposed as --trigger-refresh-after-consolidation and --trigger-mode on `mental-model update` (other nested trigger fields like fact_types/tag_groups are not exposed yet)."
+trigger = "Exposed as --trigger-mode, --trigger-refresh-after-consolidation, --trigger-refresh-cron, --trigger-min-refresh-interval-seconds, --trigger-tags-match, --trigger-keep-trace and --trigger-exclude-mental-models on `mental-model update`; the update merges these over the model's stored trigger, so the remaining nested fields (fact_types, tag_groups, response_schema, recall_* budgets) are left untouched and stay API-only."

--- a/hindsight-cli/.openapi-coverage.toml
+++ b/hindsight-cli/.openapi-coverage.toml
@@ -152,7 +152,7 @@ trigger = "Exposed as --mode / --fact-types on `knowledge-base create-page`; the
 trigger = "Changing an existing page's refresh policy (cron vs after-consolidation) is page-level tuning done via the API, SDKs, or control plane; `knowledge-base update-node` leaves the page's current trigger alone."
 
 [fields.create_mental_model]
-trigger = "Exposed as --trigger-refresh-after-consolidation on `mental-model create` (other nested trigger fields like fact_types/tag_groups are not exposed yet)."
+trigger = "Exposed as --trigger-mode, --trigger-refresh-after-consolidation and --tags-match on `mental-model create` (other nested trigger fields like fact_types/tag_groups are not exposed yet)."
 
 [fields.update_mental_model]
 trigger = "Exposed as --trigger-mode, --trigger-refresh-after-consolidation, --trigger-refresh-cron, --trigger-min-refresh-interval-seconds, --trigger-tags-match, --trigger-keep-trace and --trigger-exclude-mental-models on `mental-model update`; the update merges these over the model's stored trigger, so the remaining nested fields (fact_types, tag_groups, response_schema, recall_* budgets) are left untouched and stay API-only."

--- a/hindsight-cli/src/commands/mental_model.rs
+++ b/hindsight-cli/src/commands/mental_model.rs
@@ -23,6 +23,47 @@ fn parse_tags_match(value: &str) -> Result<types::TagsMatch> {
     })
 }
 
+/// Parse a --trigger-mode value into the generated refresh-mode enum
+fn parse_trigger_mode(value: &str) -> Result<types::Mode> {
+    Ok(match value.to_lowercase().as_str() {
+        "full" => types::Mode::Full,
+        "delta" => types::Mode::Delta,
+        other => anyhow::bail!("invalid --trigger-mode '{other}': expected one of full, delta"),
+    })
+}
+
+/// Build the trigger override sent on update when at least one trigger flag
+/// was passed. `None` (no trigger flags) leaves the stored trigger config
+/// untouched on the server. When an override IS sent, the server replaces the
+/// whole trigger, so fields the user did not specify fall back to their
+/// defaults.
+fn build_trigger_override(
+    trigger_mode: Option<&str>,
+    trigger_refresh_after_consolidation: Option<bool>,
+) -> Result<Option<types::MentalModelTriggerInput>> {
+    if trigger_mode.is_none() && trigger_refresh_after_consolidation.is_none() {
+        return Ok(None);
+    }
+    Ok(Some(types::MentalModelTriggerInput {
+        mode: trigger_mode
+            .map(parse_trigger_mode)
+            .transpose()?
+            .unwrap_or(types::Mode::Full),
+        refresh_after_consolidation: trigger_refresh_after_consolidation.unwrap_or(false),
+        refresh_cron: None,
+        exclude_mental_models: false,
+        exclude_mental_model_ids: None,
+        fact_types: None,
+        tag_groups: None,
+        tags_match: None,
+        include_chunks: None,
+        recall_max_tokens: None,
+        recall_chunks_max_tokens: None,
+        response_schema: None,
+        keep_trace: false,
+    }))
+}
+
 /// List mental models for a bank
 pub fn list(
     client: &ApiClient,
@@ -194,6 +235,7 @@ pub fn update(
     max_tokens: Option<i64>,
     tags: Option<Vec<String>>,
     trigger_refresh_after_consolidation: Option<bool>,
+    trigger_mode: Option<&str>,
     verbose: bool,
     output_format: OutputFormat,
 ) -> Result<()> {
@@ -202,10 +244,11 @@ pub fn update(
         && max_tokens.is_none()
         && tags.is_none()
         && trigger_refresh_after_consolidation.is_none()
+        && trigger_mode.is_none()
     {
         anyhow::bail!(
-            "At least one of --name, --source-query, --max-tokens, --tags, or \
-             --trigger-refresh-after-consolidation must be provided"
+            "At least one of --name, --source-query, --max-tokens, --tags, \
+             --trigger-mode, or --trigger-refresh-after-consolidation must be provided"
         );
     }
 
@@ -215,23 +258,11 @@ pub fn update(
         None
     };
 
-    // Only build a trigger override when the user actually passed the flag;
-    // sending None leaves the existing trigger config untouched on the server.
-    let trigger = trigger_refresh_after_consolidation.map(|refresh| types::MentalModelTriggerInput {
-        mode: types::Mode::Full,
-        refresh_after_consolidation: refresh,
-        refresh_cron: None,
-        exclude_mental_models: false,
-        exclude_mental_model_ids: None,
-        fact_types: None,
-        tag_groups: None,
-        tags_match: None,
-        include_chunks: None,
-        recall_max_tokens: None,
-        recall_chunks_max_tokens: None,
-        response_schema: None,
-        keep_trace: false,
-    });
+    // Only build a trigger override when the user actually passed a trigger
+    // flag; sending None leaves the existing trigger config untouched on the
+    // server. When an override IS sent, the server replaces the whole trigger,
+    // so fields the user did not specify fall back to their defaults.
+    let trigger = build_trigger_override(trigger_mode, trigger_refresh_after_consolidation)?;
 
     let request = types::UpdateMentalModelRequest {
         name,
@@ -532,5 +563,99 @@ mod tests {
     fn parse_tags_match_rejects_unknown() {
         let err = parse_tags_match("most").unwrap_err().to_string();
         assert!(err.contains("invalid --tags-match 'most'"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn parse_trigger_mode_accepts_both_modes() {
+        assert_eq!(parse_trigger_mode("full").unwrap(), types::Mode::Full);
+        assert_eq!(parse_trigger_mode("delta").unwrap(), types::Mode::Delta);
+    }
+
+    #[test]
+    fn parse_trigger_mode_is_case_insensitive() {
+        assert_eq!(parse_trigger_mode("DELTA").unwrap(), types::Mode::Delta);
+    }
+
+    #[test]
+    fn parse_trigger_mode_rejects_unknown() {
+        let err = parse_trigger_mode("incremental").unwrap_err().to_string();
+        assert!(
+            err.contains("invalid --trigger-mode 'incremental'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn build_trigger_override_none_when_no_flags() {
+        assert!(build_trigger_override(None, None).unwrap().is_none());
+    }
+
+    #[test]
+    fn build_trigger_override_mode_only() {
+        let trigger = build_trigger_override(Some("delta"), None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(trigger.mode, types::Mode::Delta);
+        assert!(!trigger.refresh_after_consolidation);
+    }
+
+    #[test]
+    fn build_trigger_override_refresh_only_defaults_to_full_mode() {
+        let trigger = build_trigger_override(None, Some(true)).unwrap().unwrap();
+        assert_eq!(trigger.mode, types::Mode::Full);
+        assert!(trigger.refresh_after_consolidation);
+
+        // Explicit false must stay distinguishable from omission.
+        let trigger = build_trigger_override(None, Some(false)).unwrap().unwrap();
+        assert_eq!(trigger.mode, types::Mode::Full);
+        assert!(!trigger.refresh_after_consolidation);
+    }
+
+    #[test]
+    fn build_trigger_override_both_flags() {
+        let trigger = build_trigger_override(Some("FULL"), Some(true))
+            .unwrap()
+            .unwrap();
+        assert_eq!(trigger.mode, types::Mode::Full);
+        assert!(trigger.refresh_after_consolidation);
+    }
+
+    #[test]
+    fn build_trigger_override_propagates_parse_error() {
+        let err = build_trigger_override(Some("incremental"), None)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("invalid --trigger-mode 'incremental'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn update_request_serializes_delta_trigger() {
+        let request = types::UpdateMentalModelRequest {
+            name: None,
+            source_query: None,
+            max_tokens: None,
+            tags: None,
+            trigger: build_trigger_override(Some("delta"), Some(true)).unwrap(),
+        };
+        let value = serde_json::to_value(&request).unwrap();
+        assert_eq!(value["trigger"]["mode"], "delta");
+        assert_eq!(value["trigger"]["refresh_after_consolidation"], true);
+    }
+
+    #[test]
+    fn update_request_omits_trigger_when_no_flags() {
+        let request = types::UpdateMentalModelRequest {
+            name: Some("renamed".to_string()),
+            source_query: None,
+            max_tokens: None,
+            tags: None,
+            trigger: build_trigger_override(None, None).unwrap(),
+        };
+        let value = serde_json::to_value(&request).unwrap();
+        assert_eq!(value["name"], "renamed");
+        assert!(value.get("trigger").is_none() || value["trigger"].is_null());
     }
 }

--- a/hindsight-cli/src/commands/mental_model.rs
+++ b/hindsight-cli/src/commands/mental_model.rs
@@ -32,24 +32,42 @@ fn parse_trigger_mode(value: &str) -> Result<types::Mode> {
     })
 }
 
-/// Build the trigger override sent on update when at least one trigger flag
-/// was passed. `None` (no trigger flags) leaves the stored trigger config
-/// untouched on the server. When an override IS sent, the server replaces the
-/// whole trigger, so fields the user did not specify fall back to their
-/// defaults.
-fn build_trigger_override(
-    trigger_mode: Option<&str>,
-    trigger_refresh_after_consolidation: Option<bool>,
-) -> Result<Option<types::MentalModelTriggerInput>> {
-    if trigger_mode.is_none() && trigger_refresh_after_consolidation.is_none() {
-        return Ok(None);
+/// The trigger settings `mental-model update` can change, exactly as the user
+/// passed them. `None` means "not passed": that setting keeps whatever the
+/// server has stored.
+#[derive(Debug, Default)]
+pub struct TriggerUpdate {
+    pub mode: Option<String>,
+    pub refresh_after_consolidation: Option<bool>,
+    pub refresh_cron: Option<String>,
+    pub min_refresh_interval_seconds: Option<u64>,
+    pub tags_match: Option<String>,
+    pub keep_trace: Option<bool>,
+    pub exclude_mental_models: Option<bool>,
+}
+
+impl TriggerUpdate {
+    /// True when the user passed no trigger flag at all, so the update must not
+    /// send a trigger and the server keeps the stored one untouched.
+    fn is_empty(&self) -> bool {
+        self.mode.is_none()
+            && self.refresh_after_consolidation.is_none()
+            && self.refresh_cron.is_none()
+            && self.min_refresh_interval_seconds.is_none()
+            && self.tags_match.is_none()
+            && self.keep_trace.is_none()
+            && self.exclude_mental_models.is_none()
     }
-    Ok(Some(types::MentalModelTriggerInput {
-        mode: trigger_mode
-            .map(parse_trigger_mode)
-            .transpose()?
-            .unwrap_or(types::Mode::Full),
-        refresh_after_consolidation: trigger_refresh_after_consolidation.unwrap_or(false),
+}
+
+/// A trigger carrying nothing but the API's own defaults.
+///
+/// Used as the base when a mental model has no stored trigger yet, so the
+/// user's flags land on the same values the server would have applied.
+fn default_trigger_input() -> types::MentalModelTriggerInput {
+    types::MentalModelTriggerInput {
+        mode: types::Mode::Full,
+        refresh_after_consolidation: false,
         refresh_cron: None,
         min_refresh_interval_seconds: None,
         exclude_mental_models: false,
@@ -62,7 +80,107 @@ fn build_trigger_override(
         recall_chunks_max_tokens: None,
         response_schema: None,
         keep_trace: false,
-    }))
+    }
+}
+
+/// Re-shape the trigger the server reports into the input type an update sends.
+///
+/// The two are the same field set; they are distinct generated types only
+/// because the OpenAPI schema splits request and response models.
+fn stored_trigger_as_input(
+    stored: &types::MentalModelTriggerOutput,
+) -> types::MentalModelTriggerInput {
+    types::MentalModelTriggerInput {
+        mode: stored.mode,
+        refresh_after_consolidation: stored.refresh_after_consolidation,
+        refresh_cron: stored.refresh_cron.clone(),
+        min_refresh_interval_seconds: stored.min_refresh_interval_seconds,
+        exclude_mental_models: stored.exclude_mental_models,
+        exclude_mental_model_ids: stored.exclude_mental_model_ids.clone(),
+        fact_types: stored.fact_types.clone(),
+        tag_groups: stored.tag_groups.clone(),
+        tags_match: stored.tags_match,
+        include_chunks: stored.include_chunks,
+        recall_max_tokens: stored.recall_max_tokens,
+        recall_chunks_max_tokens: stored.recall_chunks_max_tokens,
+        response_schema: stored.response_schema.clone(),
+        keep_trace: stored.keep_trace,
+    }
+}
+
+/// Apply the flags the user passed on top of the mental model's current trigger.
+///
+/// The server patches a supplied trigger over the stored one, but it can only
+/// see which fields were *sent*, and the generated input type serializes its
+/// non-`Option` fields (`mode`, `refresh_after_consolidation`,
+/// `exclude_mental_models`, `keep_trace`) unconditionally. Sending a
+/// freshly-built trigger therefore carried this type's own defaults into every
+/// update and silently reset those four — switching a model to delta mode, say,
+/// also turned off its trace capture. Starting from the stored trigger keeps
+/// every field the user did not name.
+///
+/// An empty string clears `--trigger-refresh-cron` / `--trigger-tags-match`
+/// back to "unset", which is how a cron schedule is removed.
+fn apply_trigger_update(
+    base: types::MentalModelTriggerInput,
+    update: &TriggerUpdate,
+) -> Result<types::MentalModelTriggerInput> {
+    let mut trigger = base;
+
+    if let Some(mode) = update.mode.as_deref() {
+        trigger.mode = parse_trigger_mode(mode)?;
+    }
+    if let Some(refresh) = update.refresh_after_consolidation {
+        trigger.refresh_after_consolidation = refresh;
+    }
+    if let Some(cron) = update.refresh_cron.as_deref() {
+        trigger.refresh_cron = if cron.trim().is_empty() {
+            None
+        } else {
+            Some(cron.to_string())
+        };
+    }
+    if let Some(interval) = update.min_refresh_interval_seconds {
+        trigger.min_refresh_interval_seconds = Some(interval);
+    }
+    if let Some(tags_match) = update.tags_match.as_deref() {
+        trigger.tags_match = if tags_match.trim().is_empty() {
+            None
+        } else {
+            Some(parse_tags_match(tags_match)?)
+        };
+    }
+    if let Some(keep_trace) = update.keep_trace {
+        trigger.keep_trace = keep_trace;
+    }
+    if let Some(exclude) = update.exclude_mental_models {
+        trigger.exclude_mental_models = exclude;
+    }
+
+    // The two refresh triggers are mutually exclusive, and the merged trigger
+    // can carry both even though neither the stored one nor the flags did: a
+    // model that refreshes after consolidation, moved onto a schedule. Setting
+    // one drops an unstated other, mirroring what the server's _merge_trigger
+    // does for a partial trigger — a request that named only a cron would
+    // otherwise be rejected by the API's own validator with a bare 422.
+    let cron_set = update.refresh_cron.is_some();
+    let consolidation_set = update.refresh_after_consolidation.is_some();
+    if trigger.refresh_after_consolidation && trigger.refresh_cron.is_some() {
+        if cron_set && !consolidation_set {
+            trigger.refresh_after_consolidation = false;
+        } else if consolidation_set && !cron_set {
+            trigger.refresh_cron = None;
+        } else {
+            // Both named in one command: only the user can say which they meant.
+            anyhow::bail!(
+                "--trigger-refresh-cron and --trigger-refresh-after-consolidation true \
+                 are mutually exclusive: a mental model refreshes either after \
+                 consolidation or on a cron schedule, not both"
+            );
+        }
+    }
+
+    Ok(trigger)
 }
 
 /// List mental models for a bank
@@ -179,20 +297,9 @@ pub fn create(
     // otherwise.
     let trigger = if trigger_refresh_after_consolidation || tags_match.is_some() {
         Some(types::MentalModelTriggerInput {
-            mode: types::Mode::Full,
             refresh_after_consolidation: trigger_refresh_after_consolidation,
-            refresh_cron: None,
-            min_refresh_interval_seconds: None,
-            exclude_mental_models: false,
-            exclude_mental_model_ids: None,
-            fact_types: None,
-            tag_groups: None,
             tags_match,
-            include_chunks: None,
-            recall_max_tokens: None,
-            recall_chunks_max_tokens: None,
-            response_schema: None,
-            keep_trace: false,
+            ..default_trigger_input()
         })
     } else {
         None
@@ -239,8 +346,7 @@ pub fn update(
     source_query: Option<String>,
     max_tokens: Option<i64>,
     tags: Option<Vec<String>>,
-    trigger_refresh_after_consolidation: Option<bool>,
-    trigger_mode: Option<&str>,
+    trigger_update: &TriggerUpdate,
     verbose: bool,
     output_format: OutputFormat,
 ) -> Result<()> {
@@ -248,26 +354,35 @@ pub fn update(
         && source_query.is_none()
         && max_tokens.is_none()
         && tags.is_none()
-        && trigger_refresh_after_consolidation.is_none()
-        && trigger_mode.is_none()
+        && trigger_update.is_empty()
     {
         anyhow::bail!(
-            "At least one of --name, --source-query, --max-tokens, --tags, \
-             --trigger-mode, or --trigger-refresh-after-consolidation must be provided"
+            "At least one of --name, --source-query, --max-tokens, --tags, or a \
+             --trigger-* flag must be provided"
         );
     }
+
+    // A trigger change is applied on top of the model's current trigger, so the
+    // settings the user did not name survive: see apply_trigger_update for why
+    // the stored trigger has to be read back rather than defaulted. No trigger
+    // flag means no read and no trigger in the request at all.
+    let trigger = if trigger_update.is_empty() {
+        None
+    } else {
+        let current = client.get_mental_model(bank_id, mental_model_id, verbose)?;
+        let base = current
+            .trigger
+            .as_ref()
+            .map(stored_trigger_as_input)
+            .unwrap_or_else(default_trigger_input);
+        Some(apply_trigger_update(base, trigger_update)?)
+    };
 
     let spinner = if output_format == OutputFormat::Pretty {
         Some(ui::create_spinner("Updating mental model..."))
     } else {
         None
     };
-
-    // Only build a trigger override when the user actually passed a trigger
-    // flag; sending None leaves the existing trigger config untouched on the
-    // server. When an override IS sent, the server replaces the whole trigger,
-    // so fields the user did not specify fall back to their defaults.
-    let trigger = build_trigger_override(trigger_mode, trigger_refresh_after_consolidation)?;
 
     let request = types::UpdateMentalModelRequest {
         name,
@@ -633,64 +748,199 @@ mod tests {
         );
     }
 
-    #[test]
-    fn build_trigger_override_none_when_no_flags() {
-        assert!(build_trigger_override(None, None).unwrap().is_none());
+    /// A trigger with a non-default value in every field the CLI does not
+    /// expose, standing in for whatever the server has stored.
+    fn stored_trigger() -> types::MentalModelTriggerOutput {
+        types::MentalModelTriggerOutput {
+            mode: types::Mode::Delta,
+            refresh_after_consolidation: true,
+            refresh_cron: None,
+            min_refresh_interval_seconds: Some(900),
+            exclude_mental_models: true,
+            exclude_mental_model_ids: Some(vec!["mm-other".to_string()]),
+            fact_types: Some(vec![types::FactTypesItem::Observation]),
+            tag_groups: None,
+            tags_match: Some(types::TagsMatch::AnyStrict),
+            include_chunks: Some(true),
+            recall_max_tokens: Some(4096),
+            recall_chunks_max_tokens: Some(2048),
+            response_schema: None,
+            keep_trace: true,
+        }
     }
 
     #[test]
-    fn build_trigger_override_mode_only() {
-        let trigger = build_trigger_override(Some("delta"), None)
-            .unwrap()
-            .unwrap();
+    fn trigger_update_is_empty_only_without_flags() {
+        assert!(TriggerUpdate::default().is_empty());
+        assert!(!TriggerUpdate {
+            keep_trace: Some(false),
+            ..Default::default()
+        }
+        .is_empty());
+    }
+
+    #[test]
+    fn stored_trigger_round_trips_into_the_input_type() {
+        let input = stored_trigger_as_input(&stored_trigger());
+        let value = serde_json::to_value(&input).unwrap();
+        assert_eq!(value["mode"], "delta");
+        assert_eq!(value["refresh_after_consolidation"], true);
+        assert_eq!(value["min_refresh_interval_seconds"], 900);
+        assert_eq!(value["exclude_mental_models"], true);
+        assert_eq!(value["exclude_mental_model_ids"][0], "mm-other");
+        assert_eq!(value["fact_types"][0], "observation");
+        assert_eq!(value["tags_match"], "any_strict");
+        assert_eq!(value["include_chunks"], true);
+        assert_eq!(value["recall_max_tokens"], 4096);
+        assert_eq!(value["recall_chunks_max_tokens"], 2048);
+        assert_eq!(value["keep_trace"], true);
+    }
+
+    /// The regression this command had: changing one trigger setting must not
+    /// reset the four fields the generated type always serializes.
+    #[test]
+    fn apply_trigger_update_keeps_unnamed_fields() {
+        let update = TriggerUpdate {
+            mode: Some("full".to_string()),
+            ..Default::default()
+        };
+        let trigger = apply_trigger_update(stored_trigger_as_input(&stored_trigger()), &update)
+            .expect("mode-only update applies");
+
+        assert_eq!(trigger.mode, types::Mode::Full);
+        assert!(trigger.refresh_after_consolidation);
+        assert!(trigger.exclude_mental_models);
+        assert!(trigger.keep_trace);
+        assert_eq!(trigger.min_refresh_interval_seconds, Some(900));
+        assert_eq!(trigger.tags_match, Some(types::TagsMatch::AnyStrict));
+        assert_eq!(trigger.recall_max_tokens, Some(4096));
+    }
+
+    #[test]
+    fn apply_trigger_update_sets_every_exposed_field() {
+        let update = TriggerUpdate {
+            mode: Some("DELTA".to_string()),
+            refresh_after_consolidation: Some(false),
+            refresh_cron: Some("0 3 * * *".to_string()),
+            min_refresh_interval_seconds: Some(0),
+            tags_match: Some("exact".to_string()),
+            keep_trace: Some(false),
+            exclude_mental_models: Some(false),
+        };
+        let trigger =
+            apply_trigger_update(default_trigger_input(), &update).expect("update applies");
+
         assert_eq!(trigger.mode, types::Mode::Delta);
         assert!(!trigger.refresh_after_consolidation);
+        assert_eq!(trigger.refresh_cron.as_deref(), Some("0 3 * * *"));
+        assert_eq!(trigger.min_refresh_interval_seconds, Some(0));
+        assert_eq!(trigger.tags_match, Some(types::TagsMatch::Exact));
+        assert!(!trigger.keep_trace);
+        assert!(!trigger.exclude_mental_models);
     }
 
     #[test]
-    fn build_trigger_override_refresh_only_defaults_to_full_mode() {
-        let trigger = build_trigger_override(None, Some(true)).unwrap().unwrap();
-        assert_eq!(trigger.mode, types::Mode::Full);
-        assert!(trigger.refresh_after_consolidation);
+    fn apply_trigger_update_clears_cron_and_tags_match_on_empty_string() {
+        let base = types::MentalModelTriggerInput {
+            refresh_cron: Some("0 3 * * *".to_string()),
+            tags_match: Some(types::TagsMatch::All),
+            ..default_trigger_input()
+        };
+        let update = TriggerUpdate {
+            refresh_cron: Some(String::new()),
+            tags_match: Some("  ".to_string()),
+            ..Default::default()
+        };
+        let trigger = apply_trigger_update(base, &update).expect("clearing applies");
 
-        // Explicit false must stay distinguishable from omission.
-        let trigger = build_trigger_override(None, Some(false)).unwrap().unwrap();
-        assert_eq!(trigger.mode, types::Mode::Full);
+        assert!(trigger.refresh_cron.is_none());
+        assert!(trigger.tags_match.is_none());
+    }
+
+    /// The stored trigger already refreshes after consolidation, so a cron
+    /// lands on a combination the API rejects. Setting one drops an unstated
+    /// other, as the server does when it merges a partial trigger.
+    #[test]
+    fn apply_trigger_update_cron_clears_stored_consolidation() {
+        let trigger = apply_trigger_update(
+            stored_trigger_as_input(&stored_trigger()),
+            &TriggerUpdate {
+                refresh_cron: Some("0 3 * * *".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("cron-only update applies");
+
+        assert_eq!(trigger.refresh_cron.as_deref(), Some("0 3 * * *"));
         assert!(!trigger.refresh_after_consolidation);
     }
 
     #[test]
-    fn build_trigger_override_both_flags() {
-        let trigger = build_trigger_override(Some("FULL"), Some(true))
-            .unwrap()
-            .unwrap();
-        assert_eq!(trigger.mode, types::Mode::Full);
+    fn apply_trigger_update_consolidation_clears_stored_cron() {
+        let base = types::MentalModelTriggerInput {
+            refresh_cron: Some("0 3 * * *".to_string()),
+            ..default_trigger_input()
+        };
+        let trigger = apply_trigger_update(
+            base,
+            &TriggerUpdate {
+                refresh_after_consolidation: Some(true),
+                ..Default::default()
+            },
+        )
+        .expect("consolidation-only update applies");
+
         assert!(trigger.refresh_after_consolidation);
+        assert!(trigger.refresh_cron.is_none());
     }
 
     #[test]
-    fn build_trigger_override_propagates_parse_error() {
-        let err = build_trigger_override(Some("incremental"), None)
-            .unwrap_err()
-            .to_string();
+    fn apply_trigger_update_rejects_both_refresh_flags_at_once() {
+        let err = apply_trigger_update(
+            default_trigger_input(),
+            &TriggerUpdate {
+                refresh_cron: Some("0 3 * * *".to_string()),
+                refresh_after_consolidation: Some(true),
+                ..Default::default()
+            },
+        )
+        .unwrap_err()
+        .to_string();
         assert!(
-            err.contains("invalid --trigger-mode 'incremental'"),
+            err.contains("mutually exclusive"),
             "unexpected error: {err}"
         );
     }
 
     #[test]
-    fn update_request_serializes_delta_trigger() {
-        let request = types::UpdateMentalModelRequest {
-            name: None,
-            source_query: None,
-            max_tokens: None,
-            tags: None,
-            trigger: build_trigger_override(Some("delta"), Some(true)).unwrap(),
-        };
-        let value = serde_json::to_value(&request).unwrap();
-        assert_eq!(value["trigger"]["mode"], "delta");
-        assert_eq!(value["trigger"]["refresh_after_consolidation"], true);
+    fn apply_trigger_update_propagates_parse_errors() {
+        let err = apply_trigger_update(
+            default_trigger_input(),
+            &TriggerUpdate {
+                mode: Some("incremental".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("invalid --trigger-mode 'incremental'"),
+            "unexpected error: {err}"
+        );
+
+        let err = apply_trigger_update(
+            default_trigger_input(),
+            &TriggerUpdate {
+                tags_match: Some("most".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("invalid --tags-match 'most'"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -700,7 +950,7 @@ mod tests {
             source_query: None,
             max_tokens: None,
             tags: None,
-            trigger: build_trigger_override(None, None).unwrap(),
+            trigger: None,
         };
         let value = serde_json::to_value(&request).unwrap();
         assert_eq!(value["name"], "renamed");

--- a/hindsight-cli/src/commands/mental_model.rs
+++ b/hindsight-cli/src/commands/mental_model.rs
@@ -23,6 +23,48 @@ fn parse_tags_match(value: &str) -> Result<types::TagsMatch> {
     })
 }
 
+/// Parse a --trigger-mode value into the generated refresh-mode enum
+fn parse_trigger_mode(value: &str) -> Result<types::Mode> {
+    Ok(match value.to_lowercase().as_str() {
+        "full" => types::Mode::Full,
+        "delta" => types::Mode::Delta,
+        other => anyhow::bail!("invalid --trigger-mode '{other}': expected one of full, delta"),
+    })
+}
+
+/// Build the trigger override sent on update when at least one trigger flag
+/// was passed. `None` (no trigger flags) leaves the stored trigger config
+/// untouched on the server. When an override IS sent, the server replaces the
+/// whole trigger, so fields the user did not specify fall back to their
+/// defaults.
+fn build_trigger_override(
+    trigger_mode: Option<&str>,
+    trigger_refresh_after_consolidation: Option<bool>,
+) -> Result<Option<types::MentalModelTriggerInput>> {
+    if trigger_mode.is_none() && trigger_refresh_after_consolidation.is_none() {
+        return Ok(None);
+    }
+    Ok(Some(types::MentalModelTriggerInput {
+        mode: trigger_mode
+            .map(parse_trigger_mode)
+            .transpose()?
+            .unwrap_or(types::Mode::Full),
+        refresh_after_consolidation: trigger_refresh_after_consolidation.unwrap_or(false),
+        refresh_cron: None,
+        min_refresh_interval_seconds: None,
+        exclude_mental_models: false,
+        exclude_mental_model_ids: None,
+        fact_types: None,
+        tag_groups: None,
+        tags_match: None,
+        include_chunks: None,
+        recall_max_tokens: None,
+        recall_chunks_max_tokens: None,
+        response_schema: None,
+        keep_trace: false,
+    }))
+}
+
 /// List mental models for a bank
 pub fn list(
     client: &ApiClient,
@@ -198,6 +240,7 @@ pub fn update(
     max_tokens: Option<i64>,
     tags: Option<Vec<String>>,
     trigger_refresh_after_consolidation: Option<bool>,
+    trigger_mode: Option<&str>,
     verbose: bool,
     output_format: OutputFormat,
 ) -> Result<()> {
@@ -206,10 +249,11 @@ pub fn update(
         && max_tokens.is_none()
         && tags.is_none()
         && trigger_refresh_after_consolidation.is_none()
+        && trigger_mode.is_none()
     {
         anyhow::bail!(
-            "At least one of --name, --source-query, --max-tokens, --tags, or \
-             --trigger-refresh-after-consolidation must be provided"
+            "At least one of --name, --source-query, --max-tokens, --tags, \
+             --trigger-mode, or --trigger-refresh-after-consolidation must be provided"
         );
     }
 
@@ -219,25 +263,11 @@ pub fn update(
         None
     };
 
-    // Only build a trigger override when the user actually passed the flag;
-    // sending None leaves the existing trigger config untouched on the server.
-    let trigger =
-        trigger_refresh_after_consolidation.map(|refresh| types::MentalModelTriggerInput {
-            mode: types::Mode::Full,
-            refresh_after_consolidation: refresh,
-            refresh_cron: None,
-            min_refresh_interval_seconds: None,
-            exclude_mental_models: false,
-            exclude_mental_model_ids: None,
-            fact_types: None,
-            tag_groups: None,
-            tags_match: None,
-            include_chunks: None,
-            recall_max_tokens: None,
-            recall_chunks_max_tokens: None,
-            response_schema: None,
-            keep_trace: false,
-        });
+    // Only build a trigger override when the user actually passed a trigger
+    // flag; sending None leaves the existing trigger config untouched on the
+    // server. When an override IS sent, the server replaces the whole trigger,
+    // so fields the user did not specify fall back to their defaults.
+    let trigger = build_trigger_override(trigger_mode, trigger_refresh_after_consolidation)?;
 
     let request = types::UpdateMentalModelRequest {
         name,
@@ -581,5 +611,99 @@ mod tests {
             err.contains("invalid --tags-match 'most'"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn parse_trigger_mode_accepts_both_modes() {
+        assert_eq!(parse_trigger_mode("full").unwrap(), types::Mode::Full);
+        assert_eq!(parse_trigger_mode("delta").unwrap(), types::Mode::Delta);
+    }
+
+    #[test]
+    fn parse_trigger_mode_is_case_insensitive() {
+        assert_eq!(parse_trigger_mode("DELTA").unwrap(), types::Mode::Delta);
+    }
+
+    #[test]
+    fn parse_trigger_mode_rejects_unknown() {
+        let err = parse_trigger_mode("incremental").unwrap_err().to_string();
+        assert!(
+            err.contains("invalid --trigger-mode 'incremental'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn build_trigger_override_none_when_no_flags() {
+        assert!(build_trigger_override(None, None).unwrap().is_none());
+    }
+
+    #[test]
+    fn build_trigger_override_mode_only() {
+        let trigger = build_trigger_override(Some("delta"), None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(trigger.mode, types::Mode::Delta);
+        assert!(!trigger.refresh_after_consolidation);
+    }
+
+    #[test]
+    fn build_trigger_override_refresh_only_defaults_to_full_mode() {
+        let trigger = build_trigger_override(None, Some(true)).unwrap().unwrap();
+        assert_eq!(trigger.mode, types::Mode::Full);
+        assert!(trigger.refresh_after_consolidation);
+
+        // Explicit false must stay distinguishable from omission.
+        let trigger = build_trigger_override(None, Some(false)).unwrap().unwrap();
+        assert_eq!(trigger.mode, types::Mode::Full);
+        assert!(!trigger.refresh_after_consolidation);
+    }
+
+    #[test]
+    fn build_trigger_override_both_flags() {
+        let trigger = build_trigger_override(Some("FULL"), Some(true))
+            .unwrap()
+            .unwrap();
+        assert_eq!(trigger.mode, types::Mode::Full);
+        assert!(trigger.refresh_after_consolidation);
+    }
+
+    #[test]
+    fn build_trigger_override_propagates_parse_error() {
+        let err = build_trigger_override(Some("incremental"), None)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("invalid --trigger-mode 'incremental'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn update_request_serializes_delta_trigger() {
+        let request = types::UpdateMentalModelRequest {
+            name: None,
+            source_query: None,
+            max_tokens: None,
+            tags: None,
+            trigger: build_trigger_override(Some("delta"), Some(true)).unwrap(),
+        };
+        let value = serde_json::to_value(&request).unwrap();
+        assert_eq!(value["trigger"]["mode"], "delta");
+        assert_eq!(value["trigger"]["refresh_after_consolidation"], true);
+    }
+
+    #[test]
+    fn update_request_omits_trigger_when_no_flags() {
+        let request = types::UpdateMentalModelRequest {
+            name: Some("renamed".to_string()),
+            source_query: None,
+            max_tokens: None,
+            tags: None,
+            trigger: build_trigger_override(None, None).unwrap(),
+        };
+        let value = serde_json::to_value(&request).unwrap();
+        assert_eq!(value["name"], "renamed");
+        assert!(value.get("trigger").is_none() || value["trigger"].is_null());
     }
 }

--- a/hindsight-cli/src/commands/mental_model.rs
+++ b/hindsight-cli/src/commands/mental_model.rs
@@ -281,6 +281,7 @@ pub fn create(
     max_tokens: i64,
     tags_match: Option<&str>,
     trigger_refresh_after_consolidation: bool,
+    trigger_mode: Option<&str>,
     verbose: bool,
     output_format: OutputFormat,
 ) -> Result<()> {
@@ -292,11 +293,14 @@ pub fn create(
 
     let tags_match = tags_match.map(parse_tags_match).transpose()?;
 
+    let mode = trigger_mode.map(parse_trigger_mode).transpose()?;
+
     // Only send a trigger when the user opted into one of its fields, so the
     // server's default behaviour (all_strict for tagged models) is preserved
     // otherwise.
-    let trigger = if trigger_refresh_after_consolidation || tags_match.is_some() {
+    let trigger = if trigger_refresh_after_consolidation || tags_match.is_some() || mode.is_some() {
         Some(types::MentalModelTriggerInput {
+            mode: mode.unwrap_or(types::Mode::Full),
             refresh_after_consolidation: trigger_refresh_after_consolidation,
             tags_match,
             ..default_trigger_input()

--- a/hindsight-cli/src/main.rs
+++ b/hindsight-cli/src/main.rs
@@ -1073,6 +1073,12 @@ enum MentalModelCommands {
         /// Enable/disable automatic refresh after observations consolidation
         #[arg(long)]
         trigger_refresh_after_consolidation: Option<bool>,
+
+        /// Refresh mode: full or delta. Passing a trigger flag replaces the
+        /// stored trigger configuration: trigger settings you do not pass
+        /// reset to their API defaults.
+        #[arg(long)]
+        trigger_mode: Option<String>,
     },
 
     /// Delete a mental model
@@ -1851,6 +1857,7 @@ fn run() -> Result<()> {
                 max_tokens,
                 tags,
                 trigger_refresh_after_consolidation,
+                trigger_mode,
             } => commands::mental_model::update(
                 &client,
                 &bank_id,
@@ -1860,6 +1867,7 @@ fn run() -> Result<()> {
                 max_tokens,
                 tags,
                 trigger_refresh_after_consolidation,
+                trigger_mode.as_deref(),
                 verbose,
                 output_format,
             ),

--- a/hindsight-cli/src/main.rs
+++ b/hindsight-cli/src/main.rs
@@ -1082,11 +1082,34 @@ enum MentalModelCommands {
         #[arg(long)]
         trigger_refresh_after_consolidation: Option<bool>,
 
-        /// Refresh mode: full or delta. Passing a trigger flag replaces the
-        /// stored trigger configuration: trigger settings you do not pass
-        /// reset to their API defaults.
+        /// Refresh mode: full or delta. Trigger settings you do not pass keep
+        /// their stored values.
         #[arg(long)]
         trigger_mode: Option<String>,
+
+        /// Cron expression (UTC, 5-field, e.g. '0 3 * * *') for scheduled
+        /// refreshes. Setting one turns off refresh-after-consolidation, which
+        /// it is mutually exclusive with. Empty string removes the schedule
+        #[arg(long)]
+        trigger_refresh_cron: Option<String>,
+
+        /// Minimum seconds between two automatic refreshes (0 disables the floor)
+        #[arg(long)]
+        trigger_min_refresh_interval_seconds: Option<u64>,
+
+        /// How the model's tags filter memories during refresh: any, all,
+        /// any_strict, all_strict, exact. Pass an empty string to fall back to
+        /// the server default
+        #[arg(long)]
+        trigger_tags_match: Option<String>,
+
+        /// Record how each refresh reached its result under reflect_response.trace
+        #[arg(long)]
+        trigger_keep_trace: Option<bool>,
+
+        /// Exclude all mental models from the reflect loop during refresh
+        #[arg(long)]
+        trigger_exclude_mental_models: Option<bool>,
     },
 
     /// Delete a mental model
@@ -1870,6 +1893,11 @@ fn run() -> Result<()> {
                 tags,
                 trigger_refresh_after_consolidation,
                 trigger_mode,
+                trigger_refresh_cron,
+                trigger_min_refresh_interval_seconds,
+                trigger_tags_match,
+                trigger_keep_trace,
+                trigger_exclude_mental_models,
             } => commands::mental_model::update(
                 &client,
                 &bank_id,
@@ -1878,8 +1906,15 @@ fn run() -> Result<()> {
                 source_query,
                 max_tokens,
                 tags,
-                trigger_refresh_after_consolidation,
-                trigger_mode.as_deref(),
+                &commands::mental_model::TriggerUpdate {
+                    mode: trigger_mode,
+                    refresh_after_consolidation: trigger_refresh_after_consolidation,
+                    refresh_cron: trigger_refresh_cron,
+                    min_refresh_interval_seconds: trigger_min_refresh_interval_seconds,
+                    tags_match: trigger_tags_match,
+                    keep_trace: trigger_keep_trace,
+                    exclude_mental_models: trigger_exclude_mental_models,
+                },
                 verbose,
                 output_format,
             ),

--- a/hindsight-cli/src/main.rs
+++ b/hindsight-cli/src/main.rs
@@ -1052,6 +1052,11 @@ enum MentalModelCommands {
         /// Refresh this mental model automatically after observations consolidation
         #[arg(long)]
         trigger_refresh_after_consolidation: bool,
+
+        /// Refresh mode: full (default) regenerates the content from scratch on
+        /// each refresh, delta edits the existing content in place
+        #[arg(long)]
+        trigger_mode: Option<String>,
     },
 
     /// Update a mental model
@@ -1871,6 +1876,7 @@ fn run() -> Result<()> {
                 max_tokens,
                 tags_match,
                 trigger_refresh_after_consolidation,
+                trigger_mode,
             } => commands::mental_model::create(
                 &client,
                 &bank_id,
@@ -1881,6 +1887,7 @@ fn run() -> Result<()> {
                 max_tokens,
                 tags_match.as_deref(),
                 trigger_refresh_after_consolidation,
+                trigger_mode.as_deref(),
                 verbose,
                 output_format,
             ),

--- a/hindsight-cli/src/main.rs
+++ b/hindsight-cli/src/main.rs
@@ -1081,6 +1081,12 @@ enum MentalModelCommands {
         /// Enable/disable automatic refresh after observations consolidation
         #[arg(long)]
         trigger_refresh_after_consolidation: Option<bool>,
+
+        /// Refresh mode: full or delta. Passing a trigger flag replaces the
+        /// stored trigger configuration: trigger settings you do not pass
+        /// reset to their API defaults.
+        #[arg(long)]
+        trigger_mode: Option<String>,
     },
 
     /// Delete a mental model
@@ -1863,6 +1869,7 @@ fn run() -> Result<()> {
                 max_tokens,
                 tags,
                 trigger_refresh_after_consolidation,
+                trigger_mode,
             } => commands::mental_model::update(
                 &client,
                 &bank_id,
@@ -1872,6 +1879,7 @@ fn run() -> Result<()> {
                 max_tokens,
                 tags,
                 trigger_refresh_after_consolidation,
+                trigger_mode.as_deref(),
                 verbose,
                 output_format,
             ),

--- a/hindsight-cli/tests/cli_integration.rs
+++ b/hindsight-cli/tests/cli_integration.rs
@@ -742,6 +742,140 @@ fn test_mental_model_update() {
 }
 
 #[test]
+fn test_mental_model_update_trigger_mode() {
+    skip_if_no_server!();
+
+    let bank_id = test_bank_id("mm-trigger-mode");
+
+    // Create the bank first
+    let output = run_hindsight(&["bank", "create", &bank_id, "--name", "Test Bank"]);
+    assert!(
+        output.status.success(),
+        "bank create failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Create a mental model
+    let output = run_hindsight(&[
+        "mental-model",
+        "create",
+        &bank_id,
+        "Test Trigger Mode Model",
+        "What are the key facts?",
+    ]);
+    assert!(
+        output.status.success(),
+        "mental-model create failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // List to get the ID
+    let output = run_hindsight(&["mental-model", "list", &bank_id, "-o", "json"]);
+    assert!(
+        output.status.success(),
+        "mental-model list failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let result: serde_json::Value = serde_json::from_str(&String::from_utf8_lossy(&output.stdout))
+        .expect("list output is valid JSON");
+    let id = result
+        .get("items")
+        .and_then(|v| v.as_array())
+        .expect("list response has items")
+        .iter()
+        .find(|item| item.get("name").and_then(|v| v.as_str()) == Some("Test Trigger Mode Model"))
+        .expect("created mental model appears in list")
+        .get("id")
+        .and_then(|v| v.as_str())
+        .expect("mental model has an id")
+        .to_string();
+
+    // Assert the mode currently stored on the server via `get -o json`.
+    let assert_stored_mode = |expected: &str| {
+        let output = run_hindsight(&["mental-model", "get", &bank_id, &id, "-o", "json"]);
+        assert!(
+            output.status.success(),
+            "mental-model get failed: stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let result: serde_json::Value =
+            serde_json::from_str(&String::from_utf8_lossy(&output.stdout))
+                .expect("get output is valid JSON");
+        assert_eq!(
+            result
+                .get("trigger")
+                .and_then(|t| t.get("mode"))
+                .and_then(|v| v.as_str()),
+            Some(expected),
+            "stored trigger mode should be {expected}: {result}"
+        );
+    };
+
+    // Switch the trigger to delta and verify it round-trips.
+    let output = run_hindsight(&[
+        "mental-model",
+        "update",
+        &bank_id,
+        &id,
+        "--trigger-mode",
+        "delta",
+    ]);
+    assert!(
+        output.status.success(),
+        "update --trigger-mode delta failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_stored_mode("delta");
+
+    // And back to full.
+    let output = run_hindsight(&[
+        "mental-model",
+        "update",
+        &bank_id,
+        &id,
+        "--trigger-mode",
+        "full",
+    ]);
+    assert!(
+        output.status.success(),
+        "update --trigger-mode full failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_stored_mode("full");
+
+    // Unknown modes must fail loudly.
+    let output = run_hindsight(&[
+        "mental-model",
+        "update",
+        &bank_id,
+        &id,
+        "--trigger-mode",
+        "incremental",
+    ]);
+    assert!(
+        !output.status.success(),
+        "update --trigger-mode incremental should fail"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid --trigger-mode 'incremental'"),
+        "unexpected stderr: {}",
+        stderr
+    );
+
+    // Clean up
+    let output = run_hindsight(&["bank", "delete", &bank_id, "-y"]);
+    assert!(
+        output.status.success(),
+        "bank delete failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn test_mental_model_refresh() {
     skip_if_no_server!();
 

--- a/hindsight-cli/tests/cli_integration.rs
+++ b/hindsight-cli/tests/cli_integration.rs
@@ -776,8 +776,8 @@ fn test_mental_model_update_trigger_settings() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    // Create a mental model that refreshes after consolidation, so the update
-    // below has a non-default trigger setting to preserve.
+    // Create a delta mental model that also refreshes after consolidation, so
+    // the update below has non-default trigger settings to preserve.
     let output = run_hindsight(&[
         "mental-model",
         "create",
@@ -785,6 +785,8 @@ fn test_mental_model_update_trigger_settings() {
         "Test Trigger Mode Model",
         "What are the key facts?",
         "--trigger-refresh-after-consolidation",
+        "--trigger-mode",
+        "delta",
     ]);
     assert!(
         output.status.success(),
@@ -837,19 +839,21 @@ fn test_mental_model_update_trigger_settings() {
         run_hindsight(&argv)
     };
 
-    assert_eq!(stored_trigger()["refresh_after_consolidation"], true);
+    let trigger = stored_trigger();
+    assert_eq!(trigger["refresh_after_consolidation"], true);
+    assert_eq!(trigger["mode"], "delta", "create honours --trigger-mode");
 
-    // Switch the trigger to delta. The settings not named on the command line
-    // must survive: sending a freshly-built trigger used to reset them.
-    let output = update(&["--trigger-mode", "delta"]);
+    // Switch the trigger back to full. The settings not named on the command
+    // line must survive: sending a freshly-built trigger used to reset them.
+    let output = update(&["--trigger-mode", "full"]);
     assert!(
         output.status.success(),
-        "update --trigger-mode delta failed: stdout={}, stderr={}",
+        "update --trigger-mode full failed: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
     let trigger = stored_trigger();
-    assert_eq!(trigger["mode"], "delta");
+    assert_eq!(trigger["mode"], "full");
     assert_eq!(
         trigger["refresh_after_consolidation"], true,
         "changing the mode must not reset refresh_after_consolidation: {trigger}"
@@ -874,7 +878,7 @@ fn test_mental_model_update_trigger_settings() {
     assert_eq!(trigger["keep_trace"], true);
     assert_eq!(trigger["min_refresh_interval_seconds"], 900);
     assert_eq!(trigger["tags_match"], "any_strict");
-    assert_eq!(trigger["mode"], "delta", "mode must survive: {trigger}");
+    assert_eq!(trigger["mode"], "full", "mode must survive: {trigger}");
 
     // Moving the model onto a schedule clears the auto-refresh it was created
     // with — the two are mutually exclusive — and keeps everything else.

--- a/hindsight-cli/tests/cli_integration.rs
+++ b/hindsight-cli/tests/cli_integration.rs
@@ -763,7 +763,7 @@ fn test_mental_model_update() {
 }
 
 #[test]
-fn test_mental_model_update_trigger_mode() {
+fn test_mental_model_update_trigger_settings() {
     skip_if_no_server!();
 
     let bank_id = test_bank_id("mm-trigger-mode");
@@ -776,13 +776,15 @@ fn test_mental_model_update_trigger_mode() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    // Create a mental model
+    // Create a mental model that refreshes after consolidation, so the update
+    // below has a non-default trigger setting to preserve.
     let output = run_hindsight(&[
         "mental-model",
         "create",
         &bank_id,
         "Test Trigger Mode Model",
         "What are the key facts?",
+        "--trigger-refresh-after-consolidation",
     ]);
     assert!(
         output.status.success(),
@@ -812,8 +814,8 @@ fn test_mental_model_update_trigger_mode() {
         .expect("mental model has an id")
         .to_string();
 
-    // Assert the mode currently stored on the server via `get -o json`.
-    let assert_stored_mode = |expected: &str| {
+    // Read the trigger the server currently stores via `get -o json`.
+    let stored_trigger = || {
         let output = run_hindsight(&["mental-model", "get", &bank_id, &id, "-o", "json"]);
         assert!(
             output.status.success(),
@@ -823,59 +825,100 @@ fn test_mental_model_update_trigger_mode() {
         let result: serde_json::Value =
             serde_json::from_str(&String::from_utf8_lossy(&output.stdout))
                 .expect("get output is valid JSON");
-        assert_eq!(
-            result
-                .get("trigger")
-                .and_then(|t| t.get("mode"))
-                .and_then(|v| v.as_str()),
-            Some(expected),
-            "stored trigger mode should be {expected}: {result}"
-        );
+        result
+            .get("trigger")
+            .cloned()
+            .expect("mental model has a trigger")
     };
 
-    // Switch the trigger to delta and verify it round-trips.
-    let output = run_hindsight(&[
-        "mental-model",
-        "update",
-        &bank_id,
-        &id,
-        "--trigger-mode",
-        "delta",
-    ]);
+    let update = |args: &[&str]| {
+        let mut argv = vec!["mental-model", "update", &bank_id, &id];
+        argv.extend_from_slice(args);
+        run_hindsight(&argv)
+    };
+
+    assert_eq!(stored_trigger()["refresh_after_consolidation"], true);
+
+    // Switch the trigger to delta. The settings not named on the command line
+    // must survive: sending a freshly-built trigger used to reset them.
+    let output = update(&["--trigger-mode", "delta"]);
     assert!(
         output.status.success(),
         "update --trigger-mode delta failed: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    assert_stored_mode("delta");
+    let trigger = stored_trigger();
+    assert_eq!(trigger["mode"], "delta");
+    assert_eq!(
+        trigger["refresh_after_consolidation"], true,
+        "changing the mode must not reset refresh_after_consolidation: {trigger}"
+    );
 
-    // And back to full.
-    let output = run_hindsight(&[
-        "mental-model",
-        "update",
-        &bank_id,
-        &id,
-        "--trigger-mode",
-        "full",
+    // The other exposed settings round-trip, and leave the mode alone.
+    let output = update(&[
+        "--trigger-keep-trace",
+        "true",
+        "--trigger-min-refresh-interval-seconds",
+        "900",
+        "--trigger-tags-match",
+        "any_strict",
     ]);
     assert!(
         output.status.success(),
-        "update --trigger-mode full failed: stdout={}, stderr={}",
+        "update trigger settings failed: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    assert_stored_mode("full");
+    let trigger = stored_trigger();
+    assert_eq!(trigger["keep_trace"], true);
+    assert_eq!(trigger["min_refresh_interval_seconds"], 900);
+    assert_eq!(trigger["tags_match"], "any_strict");
+    assert_eq!(trigger["mode"], "delta", "mode must survive: {trigger}");
+
+    // Moving the model onto a schedule clears the auto-refresh it was created
+    // with — the two are mutually exclusive — and keeps everything else.
+    let output = update(&["--trigger-refresh-cron", "0 3 * * *"]);
+    assert!(
+        output.status.success(),
+        "update --trigger-refresh-cron failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let trigger = stored_trigger();
+    assert_eq!(trigger["refresh_cron"], "0 3 * * *");
+    assert_eq!(trigger["refresh_after_consolidation"], false);
+    assert_eq!(trigger["keep_trace"], true, "keep_trace must survive");
+
+    // Asking for both at once is the one contradiction only the user can settle.
+    let output = update(&[
+        "--trigger-refresh-cron",
+        "0 4 * * *",
+        "--trigger-refresh-after-consolidation",
+        "true",
+    ]);
+    assert!(
+        !output.status.success(),
+        "both refresh flags at once should fail"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("mutually exclusive"),
+        "unexpected stderr: {stderr}"
+    );
+
+    // An empty string clears the schedule again.
+    let output = update(&["--trigger-refresh-cron", ""]);
+    assert!(
+        output.status.success(),
+        "clearing --trigger-refresh-cron failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(stored_trigger()["refresh_cron"].is_null());
 
     // Unknown modes must fail loudly.
-    let output = run_hindsight(&[
-        "mental-model",
-        "update",
-        &bank_id,
-        &id,
-        "--trigger-mode",
-        "incremental",
-    ]);
+    let output = update(&["--trigger-mode", "incremental"]);
     assert!(
         !output.status.success(),
         "update --trigger-mode incremental should fail"
@@ -883,8 +926,7 @@ fn test_mental_model_update_trigger_mode() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("invalid --trigger-mode 'incremental'"),
-        "unexpected stderr: {}",
-        stderr
+        "unexpected stderr: {stderr}"
     );
 
     // Clean up

--- a/hindsight-cli/tests/cli_integration.rs
+++ b/hindsight-cli/tests/cli_integration.rs
@@ -763,6 +763,140 @@ fn test_mental_model_update() {
 }
 
 #[test]
+fn test_mental_model_update_trigger_mode() {
+    skip_if_no_server!();
+
+    let bank_id = test_bank_id("mm-trigger-mode");
+
+    // Create the bank first
+    let output = run_hindsight(&["bank", "create", &bank_id, "--name", "Test Bank"]);
+    assert!(
+        output.status.success(),
+        "bank create failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Create a mental model
+    let output = run_hindsight(&[
+        "mental-model",
+        "create",
+        &bank_id,
+        "Test Trigger Mode Model",
+        "What are the key facts?",
+    ]);
+    assert!(
+        output.status.success(),
+        "mental-model create failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // List to get the ID
+    let output = run_hindsight(&["mental-model", "list", &bank_id, "-o", "json"]);
+    assert!(
+        output.status.success(),
+        "mental-model list failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let result: serde_json::Value = serde_json::from_str(&String::from_utf8_lossy(&output.stdout))
+        .expect("list output is valid JSON");
+    let id = result
+        .get("items")
+        .and_then(|v| v.as_array())
+        .expect("list response has items")
+        .iter()
+        .find(|item| item.get("name").and_then(|v| v.as_str()) == Some("Test Trigger Mode Model"))
+        .expect("created mental model appears in list")
+        .get("id")
+        .and_then(|v| v.as_str())
+        .expect("mental model has an id")
+        .to_string();
+
+    // Assert the mode currently stored on the server via `get -o json`.
+    let assert_stored_mode = |expected: &str| {
+        let output = run_hindsight(&["mental-model", "get", &bank_id, &id, "-o", "json"]);
+        assert!(
+            output.status.success(),
+            "mental-model get failed: stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let result: serde_json::Value =
+            serde_json::from_str(&String::from_utf8_lossy(&output.stdout))
+                .expect("get output is valid JSON");
+        assert_eq!(
+            result
+                .get("trigger")
+                .and_then(|t| t.get("mode"))
+                .and_then(|v| v.as_str()),
+            Some(expected),
+            "stored trigger mode should be {expected}: {result}"
+        );
+    };
+
+    // Switch the trigger to delta and verify it round-trips.
+    let output = run_hindsight(&[
+        "mental-model",
+        "update",
+        &bank_id,
+        &id,
+        "--trigger-mode",
+        "delta",
+    ]);
+    assert!(
+        output.status.success(),
+        "update --trigger-mode delta failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_stored_mode("delta");
+
+    // And back to full.
+    let output = run_hindsight(&[
+        "mental-model",
+        "update",
+        &bank_id,
+        &id,
+        "--trigger-mode",
+        "full",
+    ]);
+    assert!(
+        output.status.success(),
+        "update --trigger-mode full failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_stored_mode("full");
+
+    // Unknown modes must fail loudly.
+    let output = run_hindsight(&[
+        "mental-model",
+        "update",
+        &bank_id,
+        &id,
+        "--trigger-mode",
+        "incremental",
+    ]);
+    assert!(
+        !output.status.success(),
+        "update --trigger-mode incremental should fail"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid --trigger-mode 'incremental'"),
+        "unexpected stderr: {}",
+        stderr
+    );
+
+    // Clean up
+    let output = run_hindsight(&["bank", "delete", &bank_id, "-y"]);
+    assert!(
+        output.status.success(),
+        "bank delete failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn test_mental_model_refresh() {
     skip_if_no_server!();
 


### PR DESCRIPTION
This PR adds `--trigger-mode full|delta` to `hindsight mental-model update` (and now `create`), propagating it to the `trigger.mode` field of the `PATCH` endpoint.

The new flag composes with the existing `--trigger-refresh-after-consolidation`.

This PR also adds some test coverage for trigger override construction and serialization, a live round-trip integration test, and updates the OpenAPI coverage note.

---

**Update (maintainer, rebased onto main):** the original note here said that passing a trigger flag replaces the stored trigger configuration. That is no longer true of the API — `PATCH /mental-models/{id}` patches a supplied trigger over the stored one, and reads which fields were "named" from the ones the request actually carried (#3506/#3549).

The CLI still reset them, for a reason specific to the generated Rust client: `MentalModelTriggerInput` serializes its four non-`Option` fields unconditionally (`mode`, `refresh_after_consolidation`, `exclude_mental_models`, `keep_trace`), so a freshly-built trigger looked to the server like an explicit request for this type's defaults. Switching a model to delta mode also turned off its trace capture and its mental-model exclusion; toggling refresh-after-consolidation reset it to full mode.

Two commits on top of the original:

- **`fix(cli): merge mental-model update trigger flags over the stored trigger`** — the update reads the model's current trigger and applies only the flags the user passed on top of it, so every setting they did not name survives. The `Option`-typed fields (recall budgets, `fact_types`, `tag_groups`, `response_schema`) were already safe via `skip_serializing_if`; now the rest are too. Setting one refresh trigger drops an unstated other, mirroring the server's own `_merge_trigger`, so naming only a cron does not produce a combination the API rejects; naming both in one command is the one case the user has to settle.

  Also exposes the remaining scalar trigger settings: `--trigger-refresh-cron`, `--trigger-min-refresh-interval-seconds`, `--trigger-tags-match`, `--trigger-keep-trace`, `--trigger-exclude-mental-models`. An empty string clears the cron schedule or the tags-match override.

- **`feat(cli): add --trigger-mode to mental-model create`** — the flag existed only on `update`, so a delta model had to be created full and switched afterwards, with the first refresh in between running as a from-scratch build.

The same bug class in the Python SDK wrapper (where the generated model's defaults ride along on every request) is fixed separately in #3913.

https://claude.ai/code/session_01WbaYxouCERUv9djo3GnnA2
