### PR TITLE
fix: preserve Voyage asymmetric embedding semantics

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -1312,6 +1312,8 @@ class LiteLLMSDKEmbeddings(Embeddings):
                 embed_kwargs["dimensions"] = self.output_dimensions
                 if self.model.startswith("openai/"):
                     embed_kwargs["allowed_openai_params"] = ["dimensions"]
+            if self.model.startswith("voyage/"):
+                embed_kwargs["input_type"] = "document"
 
             # Use async embedding method (standard in litellm)
             response = await self._litellm.aembedding(**embed_kwargs)
@@ -1328,6 +1330,22 @@ class LiteLLMSDKEmbeddings(Embeddings):
         logger.info(f"Embeddings: LiteLLM SDK provider initialized (model: {self.model}, dim: {self._dimension})")
 
     def encode(self, texts: list[str]) -> list[list[float]]:
+        """Generate embeddings with provider-default semantics."""
+        return self._encode_with_input_type(texts)
+
+    def encode_query(self, texts: list[str]) -> list[list[float]]:
+        """Generate query-side embeddings for asymmetric Voyage retrieval."""
+        input_type = "query" if self.model.startswith("voyage/") else None
+        return self._encode_with_input_type(texts, input_type)
+
+    def encode_documents(self, texts: list[str]) -> list[list[float]]:
+        """Generate document-side embeddings for asymmetric Voyage retrieval."""
+        input_type = "document" if self.model.startswith("voyage/") else None
+        return self._encode_with_input_type(texts, input_type)
+
+    def _encode_with_input_type(
+        self, texts: list[str], input_type: Literal["query", "document"] | None = None
+    ) -> list[list[float]]:
         """
         Generate embeddings using the LiteLLM SDK.
 
@@ -1365,6 +1383,8 @@ class LiteLLMSDKEmbeddings(Embeddings):
                     embed_kwargs["dimensions"] = self.output_dimensions
                     if self.model.startswith("openai/"):
                         embed_kwargs["allowed_openai_params"] = ["dimensions"]
+                if input_type is not None:
+                    embed_kwargs["input_type"] = input_type
 
                 # Use sync embedding (litellm doesn't have async in thread-safe way)
                 response = self._litellm.embedding(**embed_kwargs)

--- a/hindsight-api-slim/tests/test_litellm_sdk_embeddings.py
+++ b/hindsight-api-slim/tests/test_litellm_sdk_embeddings.py
@@ -105,6 +105,50 @@ class TestLiteLLMSDKEmbeddings:
             call_kwargs = mock_litellm.aembedding.call_args.kwargs
             assert "api_key" not in call_kwargs
 
+    async def test_voyage_initialization_uses_document_input_type(self, mock_litellm):
+        with patch(
+            "builtins.__import__",
+            side_effect=lambda name, *args: mock_litellm if name == "litellm" else __import__(name, *args),
+        ):
+            emb = LiteLLMSDKEmbeddings(
+                api_key="test_key",
+                model="voyage/voyage-4-large",
+                output_dimensions=2048,
+                encoding_format=None,
+            )
+            await emb.initialize()
+
+        call_kwargs = mock_litellm.aembedding.call_args.kwargs
+        assert call_kwargs["input_type"] == "document"
+        assert call_kwargs["dimensions"] == 2048
+        assert "encoding_format" not in call_kwargs
+
+    async def test_voyage_query_and_document_input_types(self, mock_litellm):
+        emb = LiteLLMSDKEmbeddings(
+            api_key="test_key",
+            model="voyage/voyage-4-large",
+            output_dimensions=2048,
+            encoding_format=None,
+        )
+        emb._litellm = mock_litellm
+        emb._dimension = 2048
+        mock_litellm.embedding.return_value.data = [{"embedding": [0.5] * 2048, "index": 0}]
+
+        emb.encode_documents(["document"])
+        assert mock_litellm.embedding.call_args.kwargs["input_type"] == "document"
+
+        emb.encode_query(["query"])
+        assert mock_litellm.embedding.call_args.kwargs["input_type"] == "query"
+
+    async def test_non_voyage_query_keeps_provider_default(self, mock_litellm):
+        emb = LiteLLMSDKEmbeddings(api_key="test_key", model="cohere/embed-english-v3.0")
+        emb._litellm = mock_litellm
+        emb._dimension = 768
+        mock_litellm.embedding.return_value.data = [{"embedding": [0.5] * 768, "index": 0}]
+
+        emb.encode_query(["query"])
+        assert "input_type" not in mock_litellm.embedding.call_args.kwargs
+
     async def test_encode_without_api_key(self, mock_litellm):
         """Test encode omits api_key when not set (IAM/ambient credentials)."""
         emb = LiteLLMSDKEmbeddings(


### PR DESCRIPTION
## Summary

- send `input_type="document"` when initializing Voyage embeddings and embedding stored content
- send `input_type="query"` when embedding recall queries
- preserve provider-default behavior for `encode()` and every non-Voyage LiteLLM provider
- add regression coverage for initialization, query/document routing, and non-Voyage compatibility

## Why

Hindsight already exposes Voyage models through `litellm-sdk`, but the adapter currently omits Voyage's asymmetric retrieval `input_type`.

Voyage's retrieval contract embeds corpus content as `document` and search text as `query`. Passing those roles through Hindsight keeps stored vectors and recall queries in the intended retrieval spaces instead of relying on the provider's general-purpose default.

## Validation

- `uv run python -m pytest -n 0 tests/test_litellm_sdk_embeddings.py -q` (`29 passed, 3 skipped`)
- `uv run ruff check hindsight_api/engine/embeddings.py tests/test_litellm_sdk_embeddings.py`
- `uv run ruff format --check hindsight_api/engine/embeddings.py tests/test_litellm_sdk_embeddings.py`
- `./scripts/hooks/lint.sh`
- end-to-end retain, recall, worker, and reranking validation in a 2048-dimensional Voyage deployment

## Risk and impact

The behavioral change is restricted to LiteLLM model names beginning with `voyage/`. Other providers continue to omit `input_type`, and direct `encode()` callers retain provider-default behavior.

Deployments that already indexed content with a Voyage model while `input_type` was omitted should rebuild those stored embeddings when adopting this change, so document and query vectors consistently use the asymmetric retrieval contract.

## Scope

Two files only:

- `hindsight-api-slim/hindsight_api/engine/embeddings.py`
- `hindsight-api-slim/tests/test_litellm_sdk_embeddings.py`

No schema, configuration, dependency, generated-client, or public API changes.

## Rollout

No database migration is included. New Voyage embeddings use the correct role automatically after upgrade. Existing Voyage-backed indexes should be re-embedded as noted above.

## Reviewer focus

Please verify that:

- initialization and stored content use `document`
- recall queries use `query`
- `encode()` and non-Voyage providers stay unchanged

PR #3090 also touches these two files for retry and timeout behavior. It is not a duplicate, but whichever change lands second may need a focused rebase.