### PR TITLE
fix(embed): use family-agnostic localhost probe and port helpers (#3527)

### DIFF
--- a/hindsight-embed/hindsight_embed/cli.py
+++ b/hindsight-embed/hindsight_embed/cli.py
@@ -785,7 +785,7 @@ def do_ui(args, config: dict, logger):
             status_text = Text()
             status_text.append("UI is running\n\n", style="green bold")
             status_text.append("  URL: ", style="dim")
-            status_text.append(f"http://127.0.0.1:{effective_port}\n", style="cyan")
+            status_text.append(f"http://localhost:{effective_port}\n", style="cyan")
             status_text.append("  Logs: ", style="dim")
             status_text.append(f"{paths.ui_log}", style="")
 

--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -320,9 +320,11 @@ class DaemonEmbedManager(EmbedManager):
         """Check if a port is in use using a socket connection (cross-platform)."""
         import socket
 
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            sock.settimeout(1)
-            return sock.connect_ex(("127.0.0.1", port)) == 0
+        try:
+            with socket.create_connection(("localhost", port), timeout=1):
+                return True
+        except OSError:
+            return False
 
     @staticmethod
     def _find_pid_on_port(port: int) -> int | None:
@@ -342,8 +344,9 @@ class DaemonEmbedManager(EmbedManager):
                 )
                 if result.returncode == 0:
                     for line in result.stdout.splitlines():
-                        if f"127.0.0.1:{port}" in line and "LISTENING" in line:
-                            return int(line.strip().split()[-1])
+                        parts = line.split()
+                        if len(parts) >= 5 and parts[3] == "LISTENING" and parts[1].rsplit(":", 1)[-1] == str(port):
+                            return int(parts[4])
             else:
                 # Use lsof on macOS/Linux
                 result = subprocess.run(
@@ -779,13 +782,12 @@ class DaemonEmbedManager(EmbedManager):
         if ui_port is None:
             paths = self._profile_manager.resolve_profile_paths(profile)
             ui_port = paths.ui_port
-        host = hostname or "0.0.0.0"
+        host = hostname or "localhost"
         return f"http://{host}:{ui_port}"
 
     def is_ui_running(self, profile: str, ui_port: int | None = None) -> bool:
         """Check if the UI is running and responsive."""
-        # Always health-check on 127.0.0.1 regardless of bind hostname
-        ui_url = self.get_ui_url(profile, ui_port, hostname="127.0.0.1")
+        ui_url = self.get_ui_url(profile, ui_port)
         try:
             with httpx.Client(timeout=2) as client:
                 response = client.get(f"{ui_url}/api/health")
@@ -875,7 +877,7 @@ class DaemonEmbedManager(EmbedManager):
                 while time.time() - start_time < 30:
                     if self.is_ui_running(profile, ui_port):
                         self._record_ui_port(paths, ui_port)
-                        log_lines.append(f"✓ UI started at http://127.0.0.1:{ui_port}")
+                        log_lines.append(f"✓ UI started at http://localhost:{ui_port}")
                         log_lines.append(f"Logs: {ui_log}")
                         content = Text("\n".join(log_lines), style="dim")
                         success_title = (

--- a/hindsight-embed/tests/test_ui_health_probe.py
+++ b/hindsight-embed/tests/test_ui_health_probe.py
@@ -1,0 +1,136 @@
+import http.server
+import socket
+import socketserver
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
+
+
+class HealthHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/api/health":
+            self.send_response(200)
+            self.send_header("Content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"status":"ok"}')
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args):
+        pass
+
+
+class V6OnlyServer(socketserver.TCPServer):
+    address_family = socket.AF_INET6
+    allow_reuse_address = True
+
+    def server_bind(self):
+        self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+        super().server_bind()
+
+
+class V4OnlyServer(socketserver.TCPServer):
+    address_family = socket.AF_INET
+    allow_reuse_address = True
+
+
+@pytest.fixture
+def v6_ui_server():
+    if not socket.has_ipv6:
+        pytest.skip("IPv6 not supported by Python build")
+
+    try:
+        server = V6OnlyServer(("::1", 0), HealthHandler)
+    except OSError:
+        pytest.skip("IPv6 loopback interface unavailable")
+
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    port = server.server_address[1]
+    yield port
+    server.shutdown()
+    server.server_close()
+    thread.join()
+
+
+@pytest.fixture
+def v4_ui_server():
+    try:
+        server = V4OnlyServer(("127.0.0.1", 0), HealthHandler)
+    except OSError:
+        pytest.skip("IPv4 loopback interface unavailable")
+
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    port = server.server_address[1]
+    yield port
+    server.shutdown()
+    server.server_close()
+    thread.join()
+
+
+def test_is_ui_running_v6_only(v6_ui_server):
+    manager = DaemonEmbedManager()
+    assert manager.is_ui_running("", ui_port=v6_ui_server) is True
+
+
+def test_is_ui_running_v4_only(v4_ui_server):
+    manager = DaemonEmbedManager()
+    assert manager.is_ui_running("", ui_port=v4_ui_server) is True
+
+
+def test_is_ui_running_nothing_listening():
+    # Find an unused port
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        closed_port = s.getsockname()[1]
+
+    manager = DaemonEmbedManager()
+    start_time = time.time()
+    res = manager.is_ui_running("", ui_port=closed_port)
+    elapsed = time.time() - start_time
+
+    assert res is False
+    assert elapsed < 5.0
+
+
+@pytest.mark.parametrize(
+    "netstat_output, expected_pid",
+    [
+        (
+            "  TCP    [::1]:9177    [::]:0    LISTENING    4321",
+            4321,
+        ),
+        (
+            "  TCP    127.0.0.1:9177    0.0.0.0:0    LISTENING    1234",
+            1234,
+        ),
+        (
+            "  Active Connections",
+            None,
+        ),
+        (
+            "  Proto  Local Address          Foreign Address        State           PID",
+            None,
+        ),
+        (
+            "  TCP    127.0.0.1:54321    127.0.0.1:9177    ESTABLISHED    9999",
+            None,
+        ),
+    ],
+)
+def test_find_pid_on_port_windows_parsing(netstat_output, expected_pid):
+    manager = DaemonEmbedManager()
+    with patch("platform.system", return_value="Windows"):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = f"{netstat_output}\n"
+            mock_run.return_value.returncode = 0
+            pid = manager._find_pid_on_port(9177)
+            assert pid == expected_pid


### PR DESCRIPTION
## Description

`hindsight-embed ui start` and `ui status` report failure when the control plane binds IPv6 (`[::1]`) under `--hostname localhost` or in dual-stack environments. The UI health probe previously hardcoded IPv4 `127.0.0.1`, which is refused when Next.js binds IPv6-only `::1`.

## Root Cause

- `daemon_embed_manager.py:is_ui_running` hardcoded `127.0.0.1` for `/api/health`.
- `_is_port_in_use` used an `AF_INET`-only socket, treating live IPv6 listeners as free ports.
- `_find_pid_on_port` filtered Windows `netstat` output for `127.0.0.1:{port}` substring.

## Fix

1. `get_ui_url`: Default host fallback to `localhost` instead of `0.0.0.0`.
2. `is_ui_running`: Remove hardcoded `127.0.0.1` override; probe `localhost` so `httpx` resolves both IPv4 and IPv6 families via `getaddrinfo`.
3. `_is_port_in_use`: Use stdlib `socket.create_connection(("localhost", port), timeout=1)` for dual-stack support.
4. `_find_pid_on_port`: Replace substring check with bounds-checked netstat column parsing.
5. Printed URLs: Update CLI messages to `http://localhost:{port}`.

## Testing

Added `hindsight-embed/tests/test_ui_health_probe.py` covering:
- IPv6-only (`::1`) health probe response (failing before fix, passing now)
- IPv4-only (`127.0.0.1`) health probe response
- Closed port fail-fast (<5s)
- Windows netstat parsing for `[::1]:port` and `127.0.0.1:port`

All 169 unit & integration tests pass cleanly:
```
============================= 169 passed in 22.22s =============================
```

Fixes #3527