### PR TITLE
fix(engine): drop null metadata values at retain and recall (#3209)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/metadata_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/metadata_utils.py
@@ -1,0 +1,35 @@
+"""Canonical handling of user-supplied memory metadata (issue #3209).
+
+Metadata is accepted as arbitrary JSON at ingest (file retain, the MCP tools and
+direct engine calls all take ``dict[str, Any]``) but is stored in a JSONB column
+and read back through models that declare ``dict[str, str]``. A JSON ``null``
+value therefore sailed through the write path and then failed validation on
+every read that returned the affected rows.
+
+Both ends normalize through the helpers here so the rule lives in one place:
+
+* ``drop_null_values`` — the write contract. Null-valued keys are dropped;
+  every other value is stored as given (the read contract stringifies).
+* ``as_string_metadata`` — the read contract. Null-valued keys are dropped and
+  the rest are coerced to strings, so rows written before this normalization
+  existed stay readable without a data migration.
+"""
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def drop_null_values(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return ``metadata`` without its null-valued keys (empty dict for no metadata)."""
+    if not metadata:
+        return {}
+    return {k: v for k, v in metadata.items() if v is not None}
+
+
+def as_string_metadata(metadata: Mapping[str, Any] | None) -> dict[str, str]:
+    """Coerce a stored metadata bag to the ``dict[str, str]`` read contract.
+
+    Drops null-valued keys and stringifies the rest (JSONB round-trips integers
+    as integers, e.g. ``{"original_id": 348}``).
+    """
+    return {str(k): str(v) for k, v in drop_null_values(metadata).items()}

--- a/hindsight-api-slim/hindsight_api/engine/response_models.py
+++ b/hindsight-api-slim/hindsight_api/engine/response_models.py
@@ -10,6 +10,8 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from .metadata_utils import as_string_metadata
+
 VALID_RECALL_FACT_TYPES = frozenset(["world", "experience", "observation"])
 
 
@@ -260,6 +262,9 @@ class MemoryFact(BaseModel):
         Also coerces non-string dict values (e.g., integer IDs stored in JSONB)
         to strings, preventing ValidationError when consolidation encounters
         metadata like {"original_id": 348} instead of {"original_id": "348"}.
+        Null-valued keys are dropped rather than stringified to "None" (issue
+        #3209), so rows written before retain normalized its input stay
+        readable without a data migration.
         """
         if v is None:
             return None
@@ -268,10 +273,7 @@ class MemoryFact(BaseModel):
 
             v = json.loads(v)
         if isinstance(v, dict):
-            # Drop null-valued keys (issue #3209): retain accepts arbitrary
-            # JSON metadata, and a stored null fails dict[str, str] validation
-            # on every read path that returns MemoryFact.
-            return {str(k): str(val) for k, val in v.items() if val is not None}
+            return as_string_metadata(v)
         return v
 
     chunk_id: str | None = Field(

--- a/hindsight-api-slim/hindsight_api/engine/response_models.py
+++ b/hindsight-api-slim/hindsight_api/engine/response_models.py
@@ -268,7 +268,10 @@ class MemoryFact(BaseModel):
 
             v = json.loads(v)
         if isinstance(v, dict):
-            return {str(k): str(val) for k, val in v.items()}
+            # Drop null-valued keys (issue #3209): retain accepts arbitrary
+            # JSON metadata, and a stored null fails dict[str, str] validation
+            # on every read path that returns MemoryFact.
+            return {str(k): str(val) for k, val in v.items() if val is not None}
         return v
 
     chunk_id: str | None = Field(

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from ...config import _get_raw_config
 from ..memory_engine import fq_table
+from ..metadata_utils import drop_null_values
 from .bank_utils import DEFAULT_DISPOSITION, create_bank_vector_indexes
 from .fact_extraction import _sanitize_text
 from .types import ProcessedFact
@@ -423,6 +424,12 @@ async def update_memory_units_metadata_and_tags(
     current document tags and metadata so its optimized result matches a full
     replace.
 
+    ``metadata`` arrives as the raw retain_params bag (the document row keeps
+    the caller's input verbatim), so null-valued keys are dropped here — the
+    same normalization ``RetainContent`` applies to freshly extracted facts
+    (issue #3209). Without it a re-retain would leave surviving units carrying
+    nulls while the units around them do not.
+
     Returns:
         Number of memory units updated.
     """
@@ -449,7 +456,7 @@ async def update_memory_units_metadata_and_tags(
         bank_id,
         document_id,
         tags or [],
-        json.dumps(metadata or {}),
+        json.dumps(drop_null_values(metadata)),
     )
     # result is a status string like "UPDATE 5"
     try:

--- a/hindsight-api-slim/hindsight_api/engine/retain/types.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/types.py
@@ -66,6 +66,14 @@ class RetainContent:
         None  # Observation scopes
     )
 
+    def __post_init__(self) -> None:
+        # Drop null-valued metadata keys (issue #3209): the retain API accepts
+        # arbitrary JSON metadata, and a null value stored verbatim poisons the
+        # read path, which validates MemoryFact.metadata as dict[str, str].
+        # Non-string values are preserved; the read path coerces them.
+        if self.metadata:
+            self.metadata = {k: v for k, v in self.metadata.items() if v is not None}
+
 
 @dataclass
 class ChunkMetadata:

--- a/hindsight-api-slim/hindsight_api/engine/retain/types.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/types.py
@@ -11,6 +11,8 @@ from datetime import datetime
 from typing import Literal, TypedDict
 from uuid import UUID
 
+from ..metadata_utils import drop_null_values
+
 logger = logging.getLogger(__name__)
 
 
@@ -70,9 +72,10 @@ class RetainContent:
         # Drop null-valued metadata keys (issue #3209): the retain API accepts
         # arbitrary JSON metadata, and a null value stored verbatim poisons the
         # read path, which validates MemoryFact.metadata as dict[str, str].
-        # Non-string values are preserved; the read path coerces them.
-        if self.metadata:
-            self.metadata = {k: v for k, v in self.metadata.items() if v is not None}
+        # Non-string values are preserved; the read path coerces them. An
+        # explicit ``"metadata": null`` in the request normalizes to {} so the
+        # field always matches its declared type.
+        self.metadata = drop_null_values(self.metadata)
 
 
 @dataclass

--- a/hindsight-api-slim/hindsight_api/engine/transfer/export.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/export.py
@@ -24,6 +24,7 @@ import anyio.to_thread
 
 from ..causal_links import CAUSAL_LINK_TYPES
 from ..db_utils import acquire_with_retry
+from ..metadata_utils import as_string_metadata
 from ..schema import fq_table
 from .schema import (
     CARRIED_HISTORY_TABLES,
@@ -595,7 +596,10 @@ async def _load_facts(conn: Any, bank_id: str, doc_ids: list[str], include_lifec
             occurred_start=row["occurred_start"],
             occurred_end=row["occurred_end"],
             mentioned_at=row["mentioned_at"],
-            metadata=_as_jsonb(row["metadata"]) or {},
+            # Same dict[str, str] contract as the recall path: a legacy row
+            # holding a JSON null or a raw integer must not fail the export
+            # that would let an operator move the bank (issue #3209).
+            metadata=as_string_metadata(_as_jsonb(row["metadata"])),
             tags=list(row["tags"] or []),
             observation_scopes=_as_jsonb(row["observation_scopes"]),
             chunk_index=_chunk_index_from_chunk_id(row["chunk_id"]),

--- a/hindsight-api-slim/tests/test_delta_retain.py
+++ b/hindsight-api-slim/tests/test_delta_retain.py
@@ -498,6 +498,82 @@ async def test_delta_retain_metadata_consistent_for_unchanged_units(memory, requ
 
 
 @pytest.mark.asyncio
+async def test_delta_retain_drops_null_metadata_values(memory, request_context):
+    """A null-valued metadata key must never reach memory_units (issue #3209).
+
+    Retain normalizes it away for freshly extracted facts; both delta paths must
+    apply the same normalization to the units they preserve — the metadata-only
+    re-retain, and the survivor sync of a partial delta. Otherwise a re-retain
+    leaves surviving units carrying nulls while the units beside them do not.
+    The document row keeps the caller's input verbatim.
+    """
+    bank_id = f"test_delta_null_meta_{_ts()}"
+    document_id = "null-metadata-doc"
+    # The chunker splits on ``retain_chunk_size`` (default 3000), so v1 is padded
+    # past several chunk boundaries and v2 only appends: every chunk but the last
+    # is byte-identical, which is what makes the third retain a partial delta
+    # with unchanged survivors rather than a whole-document replace.
+    v1 = "Alice works at Google." + " The project budget is fine." * 400
+    v2 = v1 + " Bob works at Microsoft."
+
+    async def _unit_metadata() -> dict[str, dict]:
+        """The document's memory units, keyed by unit id, so a later call can
+        tell units that survived a delta from ones re-extracted from scratch."""
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT id, metadata FROM memory_units WHERE bank_id = $1 AND document_id = $2",
+                bank_id,
+                document_id,
+            )
+        assert rows, "expected memory units for the document"
+        units = {}
+        for row in rows:
+            metadata = row["metadata"]
+            if isinstance(metadata, str):
+                metadata = json.loads(metadata)
+            units[str(row["id"])] = metadata
+        return units
+
+    async def _retain(content: str, source: str) -> None:
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {
+                    "content": content,
+                    "document_id": document_id,
+                    "metadata": {"source": source, "ocr_engine": None},
+                }
+            ],
+            request_context=request_context,
+        )
+
+    try:
+        # Full retain: the null is dropped on the freshly extracted facts.
+        await _retain(v1, "email")
+        assert all(metadata == {"source": "email"} for metadata in (await _unit_metadata()).values())
+
+        # Same content, new metadata — the metadata-only delta path.
+        await _retain(v1, "crm")
+        before = await _unit_metadata()
+        assert all(metadata == {"source": "crm"} for metadata in before.values())
+
+        # The document keeps what the caller sent, nulls included.
+        doc = await memory.get_document(document_id, bank_id, request_context=request_context)
+        assert doc is not None
+        assert doc["document_metadata"] == {"source": "crm", "ocr_engine": None}
+
+        # Appended content — a partial delta: unchanged chunks keep their units
+        # and get their metadata synced, new chunks are extracted fresh.
+        await _retain(v2, "crm2")
+        after = await _unit_metadata()
+        assert before.keys() & after.keys(), "expected surviving units from the unchanged chunk"
+        assert all(metadata == {"source": "crm2"} for metadata in after.values())
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
 async def test_delta_retain_tags_propagated_to_existing_units(memory, request_context):
     """
     When tags change during an upsert with unchanged content, the new tags

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -392,6 +392,36 @@ async def test_export_bank_contents(memory, request_context):
         await memory.delete_bank(bank, request_context=request_context)
 
 
+@pytest.mark.asyncio
+async def test_export_tolerates_legacy_null_and_numeric_fact_metadata(memory, request_context):
+    """A bank holding legacy metadata must still be exportable (issue #3209).
+
+    Rows written before retain normalized its input can hold a JSON null or a
+    raw integer in memory_units.metadata. TransferFact.metadata is dict[str, str],
+    so exporting such a bank used to fail validation — locking an operator out of
+    the one operation (backup / move) that gets them off the bad data. Export
+    applies the same read contract as recall: nulls dropped, the rest stringified.
+    """
+    bank = _unique_bank("export_legacy_metadata")
+    try:
+        await _retain(memory, bank, "Carol lives in Paris.", request_context, "doc-1")
+        backend = await memory._get_backend()
+        async with acquire_with_retry(backend) as conn:
+            updated = await conn.execute(
+                f"UPDATE {fq_table('memory_units')} SET metadata = $2::jsonb WHERE bank_id = $1",
+                bank,
+                json.dumps({"ocr_engine": None, "original_id": 348}),
+            )
+        assert updated != "UPDATE 0"
+
+        parsed = parse_archive(await memory.export_documents_async(bank, request_context))
+        exported = [fact.metadata for doc in parsed.documents for fact in doc.facts]
+        assert exported
+        assert all(metadata == {"original_id": "348"} for metadata in exported)
+    finally:
+        await memory.delete_bank(bank, request_context=request_context)
+
+
 def _as_json(value):
     """Normalize a jsonb column value (str or already-decoded) to a Python object."""
     return json.loads(value) if isinstance(value, str) else value

--- a/hindsight-api-slim/tests/test_response_models.py
+++ b/hindsight-api-slim/tests/test_response_models.py
@@ -29,3 +29,17 @@ class TestMemoryFactMetadataCoercion:
 
     def test_none_metadata_stays_none(self):
         assert MemoryFact(**_BASE, metadata=None).metadata is None
+
+    def test_null_value_is_omitted(self):
+        # #3209: JSONB metadata may contain null values; they must not fail
+        # dict[str, str] validation (previously coerced to the string "None").
+        fact = MemoryFact(**_BASE, metadata={"ocr_engine": None, "source": "slack"})
+        assert fact.metadata == {"source": "slack"}
+
+    def test_null_value_in_jsonb_string_is_omitted(self):
+        fact = MemoryFact(**_BASE, metadata='{"ocr_engine": null, "n": 3}')
+        assert fact.metadata == {"n": "3"}
+
+    def test_all_null_values_become_empty_dict(self):
+        fact = MemoryFact(**_BASE, metadata={"ocr_engine": None})
+        assert fact.metadata == {}

--- a/hindsight-api-slim/tests/test_retain_metadata_normalization.py
+++ b/hindsight-api-slim/tests/test_retain_metadata_normalization.py
@@ -1,0 +1,33 @@
+"""Retain ingestion must not store null metadata values (issue #3209).
+
+The retain API accepts arbitrary JSON metadata; a null value (e.g.
+{"ocr_engine": null}) stored verbatim poisons the read path, which validates
+MemoryFact.metadata as dict[str, str] and made every recall fail for the
+affected rows. RetainContent drops null-valued keys at construction, so
+facts extracted from it (metadata=content.metadata in fact_extraction) stay
+canonical on the write side; the read path drops nulls again for legacy rows.
+Non-string values are preserved as-is here and coerced by the read path.
+"""
+
+from hindsight_api.engine.retain.orchestrator import _build_contents
+from hindsight_api.engine.retain.types import RetainContent
+
+
+def test_retain_content_drops_null_metadata_values():
+    content = RetainContent(content="hi", metadata={"ocr_engine": None, "source": "slack"})
+    assert content.metadata == {"source": "slack"}
+
+
+def test_retain_content_keeps_non_null_values_as_given():
+    content = RetainContent(content="hi", metadata={"n": 5, "source": "slack"})
+    assert content.metadata == {"n": 5, "source": "slack"}
+
+
+def test_build_contents_normalizes_null_metadata_from_api():
+    """The ingestion path accepts JSON null metadata; stored facts must not
+    carry null values (regression for the reported retain-with-null case)."""
+    contents = _build_contents(
+        [{"content": "hi", "metadata": {"ocr_engine": None, "n": 5, "source": "slack"}}],
+        None,
+    )
+    assert contents[0].metadata == {"n": 5, "source": "slack"}

--- a/hindsight-api-slim/tests/test_retain_metadata_normalization.py
+++ b/hindsight-api-slim/tests/test_retain_metadata_normalization.py
@@ -3,14 +3,31 @@
 The retain API accepts arbitrary JSON metadata; a null value (e.g.
 {"ocr_engine": null}) stored verbatim poisons the read path, which validates
 MemoryFact.metadata as dict[str, str] and made every recall fail for the
-affected rows. RetainContent drops null-valued keys at construction, so
-facts extracted from it (metadata=content.metadata in fact_extraction) stay
-canonical on the write side; the read path drops nulls again for legacy rows.
+affected rows. RetainContent drops null-valued keys at construction, so facts
+extracted from it (metadata=content.metadata in fact_extraction) stay canonical
+on the write side; the read path drops nulls again for legacy rows.
 Non-string values are preserved as-is here and coerced by the read path.
+
+The delta paths, which sync document metadata onto units they preserve rather
+than re-extracting them, are covered on a real database by
+test_delta_retain.py::test_delta_retain_drops_null_metadata_values.
 """
 
+from hindsight_api.engine.metadata_utils import as_string_metadata, drop_null_values
 from hindsight_api.engine.retain.orchestrator import _build_contents
 from hindsight_api.engine.retain.types import RetainContent
+
+
+def test_drop_null_values_keeps_everything_else_untouched():
+    assert drop_null_values({"a": None, "b": "x", "c": 5, "d": ""}) == {"b": "x", "c": 5, "d": ""}
+
+
+def test_drop_null_values_normalizes_absent_metadata_to_empty_dict():
+    assert drop_null_values(None) == {}
+
+
+def test_as_string_metadata_drops_nulls_and_stringifies_the_rest():
+    assert as_string_metadata({"a": None, "n": 348}) == {"n": "348"}
 
 
 def test_retain_content_drops_null_metadata_values():
@@ -21,6 +38,12 @@ def test_retain_content_drops_null_metadata_values():
 def test_retain_content_keeps_non_null_values_as_given():
     content = RetainContent(content="hi", metadata={"n": 5, "source": "slack"})
     assert content.metadata == {"n": 5, "source": "slack"}
+
+
+def test_retain_content_normalizes_null_metadata_to_empty_dict():
+    """``"metadata": null`` in the request reaches the dataclass as None; the
+    field is declared dict[str, str], so it must not stay None."""
+    assert RetainContent(content="hi", metadata=None).metadata == {}
 
 
 def test_build_contents_normalizes_null_metadata_from_api():

--- a/hindsight-docs/docs/developer/api/retain.mdx
+++ b/hindsight-docs/docs/developer/api/retain.mdx
@@ -111,6 +111,8 @@ Providing context consistently is one of the highest-leverage things you can do 
 
 Arbitrary key-value string pairs that provide context about this item. For example: `{"source": "slack", "channel": "engineering", "thread_id": "T123"}`. Metadata is included in the fact extraction prompt, so the LLM can use it as additional context when extracting facts — for instance, knowing the document title or source can improve accuracy. It is also stored on each memory unit and returned with every recalled memory, letting you do client-side filtering or static enrichment without extra lookups — for example, linking a memory back to its source URL, thread ID, or any application-specific identifier.
 
+Values are stored and returned as strings. A key whose value is `null` is dropped rather than stored, so it will not come back on the recalled memory — send an empty string if you need the key to survive.
+
 ### document_id
 
 A caller-supplied string that groups one or more items under a logical document. This field is the key to making retain **idempotent**.

--- a/skills/hindsight-docs/references/developer/api/retain.md
+++ b/skills/hindsight-docs/references/developer/api/retain.md
@@ -178,6 +178,8 @@ hindsight memory retain my-bank "Alice got promoted" \
 
 Arbitrary key-value string pairs that provide context about this item. For example: `{"source": "slack", "channel": "engineering", "thread_id": "T123"}`. Metadata is included in the fact extraction prompt, so the LLM can use it as additional context when extracting facts — for instance, knowing the document title or source can improve accuracy. It is also stored on each memory unit and returned with every recalled memory, letting you do client-side filtering or static enrichment without extra lookups — for example, linking a memory back to its source URL, thread ID, or any application-specific identifier.
 
+Values are stored and returned as strings. A key whose value is `null` is dropped rather than stored, so it will not come back on the recalled memory — send an empty string if you need the key to survive.
+
 ### document_id
 
 A caller-supplied string that groups one or more items under a logical document. This field is the key to making retain **idempotent**.


### PR DESCRIPTION
Closes #3209

## Problem

`MemoryFact.metadata` is typed `dict[str, str] | None`, but retain accepts
arbitrary user-supplied JSON metadata. A null value (e.g.
`{"ocr_engine": null}`) was stored verbatim, and every read path that returns
`MemoryFact` — recall, consolidation, mental-model refresh — then failed
Pydantic validation (`Input should be a valid string`), permanently wedging
the affected bank.

## Change

Normalize on both ends, per the plan in the issue:

- **Write path** — `RetainContent.__post_init__` drops null-valued metadata
  keys at construction, so facts extracted from it (`metadata=content.metadata`
  in `fact_extraction`) are stored canonically. Single chokepoint: covers the
  main retain path, delta retain, recovery, and transfer import. Document
  metadata in `retain_params` is untouched (built from the raw request dicts).
- **Read path** — `MemoryFact.parse_metadata` drops null-valued keys instead
  of coercing them to the string `"None"`, so already-stored legacy rows
  become readable again with no data migration. Existing string coercion for
  other non-string values is preserved.

## Verification

- New tests:
  - `tests/test_response_models.py` (read path): null metadata value omitted,
    null inside a JSONB-string is omitted, all-null becomes `{}`.
  - `tests/test_retain_metadata_normalization.py` (write path): `RetainContent`
    drops nulls, keeps non-string values as-is, and `_build_contents` (the API
    ingestion funnel) normalizes a null-metadata request.
- `uv run pytest tests/test_response_models.py tests/test_retain_metadata_normalization.py tests/test_retain_orchestrator_mapping.py -q` → **27 passed**.
- Consumer slice (`test_large_document_replacement.py`,
  `test_retain_entity_prune_race.py`, `test_validation_result_enrichment.py`,
  `test_response_exclude_none.py`): **16 passed**; the 9 errors are all the
  same pre-existing environmental `ImportError: pg0-embedded is required for
  embedded PostgreSQL` (optional `embedded-db` extra not installed in this
  venv), unrelated to this change.
- `ruff check`, `ruff format --check`, and `ty check` pass on all changed files.
