### PR TITLE
fix(mental-models): last_refreshed_at reflects refresh time, not the source watermark

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/a1e2f3b4c5d6_add_mental_model_source_watermark.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/a1e2f3b4c5d6_add_mental_model_source_watermark.py
@@ -1,0 +1,100 @@
+"""Add last_refreshed_source_watermark column to mental_models.
+
+``last_refreshed_at`` has carried two unrelated meanings: the wall-clock time of
+the most recent refresh AND the source-data watermark (the newest in-scope
+memory visible at that refresh). Staleness/"due for refresh" keys off the
+watermark, while time-based client schedulers key off the wall-clock time. When
+a model's source memories are static, the conflated column never advances even
+though refreshes keep rewriting content, so wall-clock schedulers re-refresh
+forever.
+
+This splits the two meanings out. ``last_refreshed_source_watermark`` becomes
+the dedicated source-data watermark; ``last_refreshed_at`` reverts to a true
+wall-clock timestamp. The new column is backfilled from the current
+``last_refreshed_at`` for every existing row — because today ``last_refreshed_at``
+already holds the watermark, this preserves staleness behaviour across the
+migration so nothing mass-refreshes or mass-stops. Nullable so consumers fall
+back to ``last_refreshed_at`` (COALESCE) for any row not yet stamped.
+
+Revision ID: a1e2f3b4c5d6
+Revises: c4f7a91b2d38
+Create Date: 2026-08-16
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "a1e2f3b4c5d6"
+down_revision: str | Sequence[str] | None = "c4f7a91b2d38"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _pg_schema_prefix() -> str:
+    """Schema-qualifier for raw SQL on PG (multi-tenant search_path)."""
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def _pg_upgrade() -> None:
+    schema = _pg_schema_prefix()
+    op.execute(
+        f"""
+        ALTER TABLE {schema}mental_models
+        ADD COLUMN IF NOT EXISTS last_refreshed_source_watermark TIMESTAMP WITH TIME ZONE
+        """
+    )
+    # Backfill from the current last_refreshed_at: it presently holds the
+    # watermark, so copying it preserves each model's staleness decision across
+    # the cutover. Only stamp rows still NULL so a re-run is idempotent.
+    op.execute(
+        f"""
+        UPDATE {schema}mental_models
+        SET last_refreshed_source_watermark = last_refreshed_at
+        WHERE last_refreshed_source_watermark IS NULL
+        """
+    )
+
+
+def _pg_downgrade() -> None:
+    schema = _pg_schema_prefix()
+    op.execute(f"ALTER TABLE {schema}mental_models DROP COLUMN IF EXISTS last_refreshed_source_watermark")
+
+
+def _oracle_upgrade() -> None:
+    # Oracle has no ADD COLUMN IF NOT EXISTS; guard on the data dictionary so a
+    # re-run doesn't fail with ORA-01430 (column already exists).
+    op.get_bind().exec_driver_sql(
+        """
+        DECLARE
+            n NUMBER;
+        BEGIN
+            SELECT COUNT(*) INTO n FROM user_tab_columns
+            WHERE table_name = 'MENTAL_MODELS'
+              AND column_name = 'LAST_REFRESHED_SOURCE_WATERMARK';
+            IF n = 0 THEN
+                EXECUTE IMMEDIATE
+                    'ALTER TABLE mental_models ADD (last_refreshed_source_watermark TIMESTAMP WITH TIME ZONE)';
+            END IF;
+        END;
+        """
+    )
+    op.get_bind().exec_driver_sql(
+        "UPDATE mental_models SET last_refreshed_source_watermark = last_refreshed_at "
+        "WHERE last_refreshed_source_watermark IS NULL"
+    )
+
+
+def _oracle_downgrade() -> None:
+    op.get_bind().exec_driver_sql("ALTER TABLE mental_models DROP COLUMN last_refreshed_source_watermark")
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade, oracle=_oracle_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade, oracle=_oracle_downgrade)

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2293,7 +2293,23 @@ class MentalModelResponse(BaseModel):
     tags: list[str] = FieldWithDefault(list)
     max_tokens: int | None = Field(default=None)
     trigger: MentalModelTrigger | None = Field(default=None)
-    last_refreshed_at: str | None = None
+    last_refreshed_at: str | None = Field(
+        default=None,
+        description=(
+            "Wall-clock time of the most recent refresh that wrote content. Advances on every "
+            "content-writing refresh, even when no new source memories arrived — use this for "
+            "time-based refresh schedulers. Distinct from `last_refreshed_source_watermark`."
+        ),
+    )
+    last_refreshed_source_watermark: str | None = Field(
+        default=None,
+        description=(
+            "Source-data watermark: the newest in-scope memory the last refresh saw. Staleness "
+            "(`is_stale`) keys off this, not `last_refreshed_at`. Stays put when a model's source "
+            "memories are static, so a model whose sources never change settles as not-stale even "
+            "though refreshes keep advancing `last_refreshed_at`. Null for rows not yet stamped."
+        ),
+    )
     created_at: str | None = None
     reflect_response: dict | None = Field(
         default=None,
@@ -2303,10 +2319,11 @@ class MentalModelResponse(BaseModel):
         default=None,
         description=(
             "True when memories matching this mental model's tag/fact_type scope have been written "
-            "since last_refreshed_at. Exact, and costly to compute, so it is populated only by the "
-            "single mental-model read at detail=full — never when listing. For a whole list, compare "
-            "each `last_refreshed_at` against the bank's `last_memory_write_at` from GET /stats: "
-            "at or after it means up to date, older means it may need a refresh."
+            "since last_refreshed_source_watermark. Exact, and costly to compute, so it is populated "
+            "only by the single mental-model read at detail=full — never when listing. For a whole "
+            "list, compare each `last_refreshed_source_watermark` against the bank's "
+            "`last_memory_write_at` from GET /stats: at or after it means up to date, older means it "
+            "may need a refresh."
         ),
     )
 

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -1892,7 +1892,7 @@ async def _trigger_mental_model_refreshes(
         if consolidated_tags:
             candidates = await conn.fetch(
                 f"""
-                SELECT id, name, tags, last_refreshed_at, trigger
+                SELECT id, name, tags, last_refreshed_at, last_refreshed_source_watermark, trigger
                 FROM {fq_table("mental_models")}
                 WHERE bank_id = $1
                   AND (trigger->>'refresh_after_consolidation')::boolean = true
@@ -1907,7 +1907,7 @@ async def _trigger_mental_model_refreshes(
         else:
             candidates = await conn.fetch(
                 f"""
-                SELECT id, name, tags, last_refreshed_at, trigger
+                SELECT id, name, tags, last_refreshed_at, last_refreshed_source_watermark, trigger
                 FROM {fq_table("mental_models")}
                 WHERE bank_id = $1
                   AND (trigger->>'refresh_after_consolidation')::boolean = true

--- a/hindsight-api-slim/hindsight_api/engine/maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/maintenance.py
@@ -484,7 +484,8 @@ class MaintenanceLoop:
                 # the row under the bank's schema context.
                 async with acquire_with_retry(engine._backend, max_retries=1) as conn:
                     mm_row = await conn.fetchrow(
-                        f"SELECT id, tags, trigger, last_refreshed_at FROM {fq_table('mental_models')} "
+                        f"SELECT id, tags, trigger, last_refreshed_at, last_refreshed_source_watermark "
+                        f"FROM {fq_table('mental_models')} "
                         "WHERE bank_id = $1 AND id = $2",
                         bank_id,
                         mm_id,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -12412,7 +12412,7 @@ class MemoryEngine(MemoryEngineInterface):
                 f"""
                 SELECT id, bank_id, name, source_query, content, tags,
                        last_refreshed_at, created_at, reflect_response,
-                       max_tokens, trigger, structured_content
+                       max_tokens, trigger, structured_content, last_refreshed_source_watermark
                 FROM {fq_table("mental_models")}
                 WHERE bank_id = $1 {tag_filter}
                 ORDER BY last_refreshed_at DESC
@@ -12468,7 +12468,7 @@ class MemoryEngine(MemoryEngineInterface):
                 f"""
                 SELECT id, bank_id, name, source_query, content, tags,
                        last_refreshed_at, created_at, reflect_response,
-                       max_tokens, trigger, structured_content
+                       max_tokens, trigger, structured_content, last_refreshed_source_watermark
                 FROM {fq_table("mental_models")}
                 WHERE bank_id = $1 AND id = $2
                 """,
@@ -12586,7 +12586,7 @@ class MemoryEngine(MemoryEngineInterface):
             VALUES ($1, $2, 'pinned', $3, ' ', $4, $5, $6, $7, COALESCE($8, 2048), COALESCE($9, '{{"refresh_after_consolidation": false}}'::jsonb){sv_val})
             RETURNING id, bank_id, name, source_query, content, tags,
                       last_refreshed_at, created_at, reflect_response,
-                      max_tokens, trigger, structured_content
+                      max_tokens, trigger, structured_content, last_refreshed_source_watermark
             """,
             mental_model_id,
             bank_id,
@@ -12710,12 +12710,14 @@ class MemoryEngine(MemoryEngineInterface):
         scope_filter: "_MentalModelScopeFilter",
         refresh_cutoff: datetime,
     ) -> datetime | None:
-        """Watermark to persist after a refresh: the newest in-scope memory visible at
-        the snapshot, clamped so it never regresses below the current ``last_refreshed_at``.
+        """Source watermark to persist after a refresh: the newest in-scope memory
+        visible at the snapshot, clamped so it never regresses below the model's
+        current source watermark (``last_refreshed_source_watermark``, falling back to
+        ``last_refreshed_at`` for rows not yet stamped by the migration backfill).
 
         A still-uncommitted straddling row is excluded from this max, so when it commits
         it stays newer than the watermark and is caught next time. Returns ``None`` when
-        no in-scope memory is visible (leave ``last_refreshed_at`` untouched, so an
+        no in-scope memory is visible (leave the source watermark untouched, so an
         in-flight first row is not skipped). Kept as its own method — like
         ``_mental_model_refresh_cutoff`` — so mock unit tests of the refresh wiring can
         stub it instead of reaching a real pool.
@@ -12725,8 +12727,9 @@ class MemoryEngine(MemoryEngineInterface):
         watermark_params = [*scope_filter.params, refresh_cutoff]
         watermark_where = [*scope_filter.where, f"updated_at <= ${len(watermark_params)}"]
         async with acquire_with_retry(backend) as conn:
-            current_last_refreshed_at = await conn.fetchval(
-                f"SELECT last_refreshed_at FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
+            current_source_watermark = await conn.fetchval(
+                f"SELECT COALESCE(last_refreshed_source_watermark, last_refreshed_at) "
+                f"FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
                 bank_id,
                 mental_model_id,
             )
@@ -12736,8 +12739,8 @@ class MemoryEngine(MemoryEngineInterface):
             )
         if newest_in_scope is None:
             return None
-        if current_last_refreshed_at is not None:
-            return max(newest_in_scope, current_last_refreshed_at)
+        if current_source_watermark is not None:
+            return max(newest_in_scope, current_source_watermark)
         return newest_in_scope
 
     async def _execute_mental_model_refresh(
@@ -12899,12 +12902,20 @@ class MemoryEngine(MemoryEngineInterface):
         # so the agentic loop only retrieves genuinely new information.
         created_after: datetime | None = None
         if use_delta:
-            last_refreshed_at_raw = mental_model.get("last_refreshed_at")
-            if last_refreshed_at_raw is not None:
-                if isinstance(last_refreshed_at_raw, str):
-                    created_after = datetime.fromisoformat(last_refreshed_at_raw)
+            # Delta mode scopes recall to memories newer than the last refresh's
+            # *source watermark* — the newest in-scope memory the previous refresh
+            # actually saw — not the wall-clock last_refreshed_at. Using the wall-clock
+            # time would skip memories that were created between the watermark and the
+            # refresh's completion. Fall back to last_refreshed_at for rows not yet
+            # stamped by the migration backfill.
+            delta_since_raw = mental_model.get("last_refreshed_source_watermark") or mental_model.get(
+                "last_refreshed_at"
+            )
+            if delta_since_raw is not None:
+                if isinstance(delta_since_raw, str):
+                    created_after = datetime.fromisoformat(delta_since_raw)
                 else:
-                    created_after = last_refreshed_at_raw
+                    created_after = delta_since_raw
                 reflect_kwargs["created_after"] = created_after
 
         window = MentalModelRefreshWindow(
@@ -13561,13 +13572,16 @@ class MemoryEngine(MemoryEngineInterface):
             tags: New tags (if changing)
             trigger: New trigger settings (if changing)
             reflect_response: Full reflect API response payload (if changing)
-            refresh_watermark: Watermark persisted by a successful refresh — the newest
-                ``updated_at`` among the in-scope memories visible at the refresh
-                snapshot (not ``now()``), so a row that commits after the snapshot stays
-                newer than the watermark and is not silently dropped. None means "no
-                in-scope memory was visible": on the no-op path ``last_refreshed_at`` is
-                left unchanged (so an in-flight row is not skipped); on the content path
-                it falls back to NOW().
+            refresh_watermark: Source-data watermark persisted by a successful refresh —
+                the newest ``updated_at`` among the in-scope memories visible at the
+                refresh snapshot (not ``now()``), so a row that commits after the snapshot
+                stays newer than the watermark and is not silently dropped. Written to the
+                dedicated ``last_refreshed_source_watermark`` column, which is what
+                staleness keys off. Distinct from ``last_refreshed_at``, which is always
+                the wall-clock time of the refresh. None means "no in-scope memory was
+                visible": the source watermark is left unchanged (so an in-flight row is
+                not skipped). On the content path ``last_refreshed_at`` still advances to
+                NOW() regardless, so time-based schedulers see the refresh happened.
             request_context: Request context for authentication
 
         Returns:
@@ -13643,10 +13657,15 @@ class MemoryEngine(MemoryEngineInterface):
                 params.append(content)
                 content_sql = f"${param_idx}"
                 param_idx += 1
-                if refresh_watermark is None:
-                    updates.append("last_refreshed_at = NOW()")
-                else:
-                    updates.append(f"last_refreshed_at = ${param_idx}")
+                # A content-writing refresh always advances last_refreshed_at to the
+                # wall-clock time of *this* refresh — even when refresh_watermark is
+                # unchanged (static source memories). last_refreshed_at is a wall-clock
+                # timestamp; the source-data watermark lives in its own column so
+                # time-based schedulers stop re-refreshing a model whose sources never
+                # move.
+                updates.append("last_refreshed_at = NOW()")
+                if refresh_watermark is not None:
+                    updates.append(f"last_refreshed_source_watermark = ${param_idx}")
                     params.append(refresh_watermark)
                     param_idx += 1
                 # Snapshot the previous version for history. The actual write goes
@@ -13676,11 +13695,14 @@ class MemoryEngine(MemoryEngineInterface):
                     param_idx += 1
             elif refresh_watermark is not None:
                 # A successful delta refresh can find no topic-relevant facts even though
-                # the coarse staleness query found new rows. Advance the watermark to the
-                # newest in-scope memory we saw (without re-embedding unchanged content or
-                # adding history) so this no-op window stops re-triggering, while any row
-                # that commits later stays newer than the watermark and is still caught.
-                updates.append(f"last_refreshed_at = ${param_idx}")
+                # the coarse staleness query found new rows. Advance the *source
+                # watermark* to the newest in-scope memory we saw (without re-embedding
+                # unchanged content or adding history) so this no-op window stops
+                # re-triggering, while any row that commits later stays newer than the
+                # watermark and is still caught. last_refreshed_at is deliberately left
+                # untouched here: no content was written, so the wall-clock "last
+                # refresh" did not change.
+                updates.append(f"last_refreshed_source_watermark = ${param_idx}")
                 params.append(refresh_watermark)
                 param_idx += 1
 
@@ -13739,7 +13761,7 @@ class MemoryEngine(MemoryEngineInterface):
                 WHERE bank_id = $1 AND id = $2
                 RETURNING id, bank_id, name, source_query, content, tags,
                           last_refreshed_at, created_at, reflect_response,
-                          max_tokens, trigger, structured_content
+                          max_tokens, trigger, structured_content, last_refreshed_source_watermark
             """
 
             row = await conn.fetchrow(query, *params)
@@ -13851,7 +13873,7 @@ class MemoryEngine(MemoryEngineInterface):
                 WHERE bank_id = $1 AND id = $2
                 RETURNING id, bank_id, name, source_query, content, tags,
                           last_refreshed_at, created_at, reflect_response,
-                          max_tokens, trigger, structured_content
+                          max_tokens, trigger, structured_content, last_refreshed_source_watermark
                 """,
                 bank_id,
                 mental_model_id,
@@ -13990,7 +14012,8 @@ class MemoryEngine(MemoryEngineInterface):
         "kp.id, kp.bank_id, kp.parent_id, kp.kind, kp.name, kp.mental_model_id, "
         "kp.sort_order, kp.managed, kp.created_at, kp.updated_at, "
         "mm.tags AS mm_tags, mm.source_query AS mm_source_query, "
-        "mm.last_refreshed_at AS mm_last_refreshed_at"
+        "mm.last_refreshed_at AS mm_last_refreshed_at, "
+        "mm.last_refreshed_source_watermark AS mm_last_refreshed_source_watermark"
     )
 
     def _kp_join(self) -> str:
@@ -14196,7 +14219,10 @@ class MemoryEngine(MemoryEngineInterface):
                 for r in rows:
                     if r["kind"] != "page":
                         continue
-                    by_id[r["id"]]["is_stale"] = _may_need_refresh(r["mm_last_refreshed_at"], watermark)
+                    # Staleness keys off the source-data watermark (fall back to the
+                    # wall-clock last_refreshed_at for rows not yet backfilled).
+                    source_watermark = r["mm_last_refreshed_source_watermark"] or r["mm_last_refreshed_at"]
+                    by_id[r["id"]]["is_stale"] = _may_need_refresh(source_watermark, watermark)
         return nodes
 
     async def get_knowledge_page(
@@ -14618,7 +14644,12 @@ class MemoryEngine(MemoryEngineInterface):
         """Check whether a mental model is out of date.
 
         A mental model is stale when a memory in its **scope** has been ingested after
-        ``last_refreshed_at``. The scope uses the same resolved flat-tag or compound
+        its source watermark — ``last_refreshed_source_watermark``, falling back to
+        ``last_refreshed_at`` for rows not yet stamped by the migration backfill. The
+        source watermark is the newest in-scope memory the last refresh actually saw;
+        keying off it (rather than the wall-clock ``last_refreshed_at``) is what lets a
+        model whose sources are static settle as "not stale" even though refreshes keep
+        advancing ``last_refreshed_at``. The scope uses the same resolved flat-tag or compound
         ``trigger.tag_groups`` filtering as the refresh it gates, plus the
         ``trigger.fact_types`` filter when set. Memories still pending consolidation are
         included because they are already rows in ``memory_units``; no separate
@@ -14637,8 +14668,11 @@ class MemoryEngine(MemoryEngineInterface):
             except (KeyError, TypeError):
                 return None
 
-        last_refreshed_at = _get("last_refreshed_at")
-        if not last_refreshed_at:
+        # Staleness keys off the source-data watermark, not the wall-clock refresh
+        # time. Fall back to last_refreshed_at when the watermark column is absent from
+        # the row or NULL (rows predating the migration backfill, or a narrow SELECT).
+        source_watermark = _get("last_refreshed_source_watermark") or _get("last_refreshed_at")
+        if not source_watermark:
             return True
 
         raw_tags = _get("tags")
@@ -14663,7 +14697,7 @@ class MemoryEngine(MemoryEngineInterface):
             conn=conn,
             fq_table=fq_table,
             bank_id=bank_id,
-            since=last_refreshed_at,
+            since=source_watermark,
             fact_types=fact_types,
             tags=tag_filtering.tags,
             tags_match=tag_filtering.tags_match,
@@ -14683,6 +14717,11 @@ class MemoryEngine(MemoryEngineInterface):
             "name": row["name"],
             "tags": row["tags"] or [],
             "last_refreshed_at": row["last_refreshed_at"].isoformat() if row["last_refreshed_at"] else None,
+            "last_refreshed_source_watermark": (
+                row["last_refreshed_source_watermark"].isoformat()
+                if row.get("last_refreshed_source_watermark")
+                else None
+            ),
             "created_at": row["created_at"].isoformat() if row["created_at"] else None,
         }
         if detail == "metadata":

--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
@@ -150,7 +150,7 @@ async def tool_search_mental_models(
         f"""
         SELECT
             id, name, content,
-            tags, created_at, last_refreshed_at, trigger,
+            tags, created_at, last_refreshed_at, last_refreshed_source_watermark, trigger,
             1 - (embedding <=> $2::vector) as relevance
         FROM {fq_table("mental_models")}
         WHERE bank_id = $1 AND embedding IS NOT NULL {filters}
@@ -167,6 +167,13 @@ async def tool_search_mental_models(
         if last_refreshed_at and last_refreshed_at.tzinfo is None:
             last_refreshed_at = last_refreshed_at.replace(tzinfo=timezone.utc)
 
+        # Staleness keys off the source-data watermark (the newest in-scope memory the
+        # last refresh saw), not the wall-clock refresh time. Fall back to
+        # last_refreshed_at for rows not yet stamped by the migration backfill.
+        source_watermark = row["last_refreshed_source_watermark"] or last_refreshed_at
+        if source_watermark and source_watermark.tzinfo is None:
+            source_watermark = source_watermark.replace(tzinfo=timezone.utc)
+
         # Per-MM staleness: new in-scope memories since last refresh (includes pending).
         # The scoped query has no index to use and scans the bank's memories in full, so
         # skip it for a model the bank-wide watermark already proves current: nothing was
@@ -174,7 +181,7 @@ async def tool_search_mental_models(
         # model still gets the exact answer — the agent trusts a model without a verifying
         # recall() only on `is_stale is False`, so guessing conservatively here would buy
         # LLM turns to save a query. No watermark (absent, or an empty bank) → ask.
-        if last_memory_write_at is not None and not _may_need_refresh(last_refreshed_at, last_memory_write_at):
+        if last_memory_write_at is not None and not _may_need_refresh(source_watermark, last_memory_write_at):
             is_stale = False
         else:
             is_stale = await memory_engine.compute_mental_model_is_stale(conn, bank_id, row)

--- a/hindsight-api-slim/tests/test_mental_model_delta.py
+++ b/hindsight-api-slim/tests/test_mental_model_delta.py
@@ -283,14 +283,16 @@ class TestDeltaRefreshPlumbing:
         patch_llm_call,
         monkeypatch,
     ):
-        """A successful no-op refresh advances ``last_refreshed_at`` to the newest
-        in-scope memory it actually saw — not ``now()``.
+        """A successful no-op refresh advances the source watermark
+        (``last_refreshed_source_watermark``) to the newest in-scope memory it actually
+        saw — not ``now()`` — and leaves the wall-clock ``last_refreshed_at`` untouched
+        (no content was written).
 
-        The scheduled-refresh gate uses ``last_refreshed_at`` as its watermark. If a
-        no-op refresh left it unchanged, one unrelated memory would make every
-        maintenance tick submit another LLM refresh forever. Anchoring the watermark to
-        the newest processed memory stops that storm without jumping ahead of the real
-        data, so a row that commits later stays newer than the watermark (see
+        The scheduled-refresh gate keys off the source watermark. If a no-op refresh left
+        it unchanged, one unrelated memory would make every maintenance tick submit
+        another LLM refresh forever. Anchoring the watermark to the newest processed
+        memory stops that storm without jumping ahead of the real data, so a row that
+        commits later stays newer than the watermark (see
         ``test_delta_refresh_watermark_survives_straddling_commit``).
         """
         bank_id = f"test-delta-watermark-{uuid.uuid4().hex[:8]}"
@@ -361,22 +363,27 @@ class TestDeltaRefreshPlumbing:
 
         async with memory._pool.acquire() as conn:
             mm_row = await conn.fetchrow(
-                "SELECT id, tags, trigger, last_refreshed_at FROM mental_models WHERE bank_id = $1 AND id = $2",
+                "SELECT id, tags, trigger, last_refreshed_at, last_refreshed_source_watermark "
+                "FROM mental_models WHERE bank_id = $1 AND id = $2",
                 bank_id,
                 mm["id"],
             )
             assert mm_row is not None
-            after = mm_row["last_refreshed_at"]
+            after_watermark = mm_row["last_refreshed_source_watermark"]
+            after_last_refreshed_at = mm_row["last_refreshed_at"]
             is_stale = await memory.compute_mental_model_is_stale(conn, bank_id, mm_row)
             history_count = await conn.fetchval(
                 "SELECT COUNT(*) FROM mental_model_history WHERE bank_id = $1 AND mental_model_id = $2",
                 bank_id,
                 mm["id"],
             )
-        # Watermark advanced to the newest in-scope memory actually seen — exactly its
-        # updated_at, not now() — so the settled window no longer re-triggers.
-        assert after == fact_updated_at
-        assert after > before
+        # Source watermark advanced to the newest in-scope memory actually seen — exactly
+        # its updated_at, not now() — so the settled window no longer re-triggers.
+        assert after_watermark == fact_updated_at
+        assert after_watermark > before
+        # A no-op refresh writes no content, so the wall-clock last_refreshed_at is left
+        # exactly where it was (the '1 day ago' the test set up).
+        assert after_last_refreshed_at == before
         assert is_stale is False
         assert history_count == 0
 
@@ -507,7 +514,8 @@ class TestDeltaRefreshPlumbing:
 
         async with memory._pool.acquire() as conn:
             mm_row = await conn.fetchrow(
-                "SELECT id, tags, trigger, last_refreshed_at FROM mental_models WHERE bank_id = $1 AND id = $2",
+                "SELECT id, tags, trigger, last_refreshed_at, last_refreshed_source_watermark "
+                "FROM mental_models WHERE bank_id = $1 AND id = $2",
                 bank_id,
                 mm["id"],
             )
@@ -517,8 +525,8 @@ class TestDeltaRefreshPlumbing:
                 straddle_fact_id,
             )
             assert mm_row is not None
-            after = mm_row["last_refreshed_at"]
-            # Watermark advanced only to the committed baseline the refresh actually saw.
+            after = mm_row["last_refreshed_source_watermark"]
+            # Source watermark advanced only to the committed baseline the refresh actually saw.
             assert after == baseline_updated_at
             # The straddler was stamped before the cutoff (an exact-cutoff/now() watermark
             # would drop it), yet it is newer than max(seen), so the model reads stale.

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -1512,6 +1512,161 @@ class TestMentalModelStaleness:
             await memory.delete_bank(bank_id, request_context=request_context)
 
 
+class TestMentalModelRefreshWatermark:
+    """last_refreshed_at is a wall-clock timestamp; last_refreshed_source_watermark
+    is the source-data watermark. They are decoupled: a content-writing refresh always
+    advances last_refreshed_at (so time-based schedulers see it happened), while
+    staleness keys off the source watermark (so a model whose source memories are
+    static settles as not-stale)."""
+
+    @staticmethod
+    async def _read_ts(memory: MemoryEngine, bank_id: str, mm_id: str) -> tuple:
+        """Return (last_refreshed_at, last_refreshed_source_watermark) straight from the row."""
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                f"SELECT last_refreshed_at, last_refreshed_source_watermark "
+                f"FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                mm_id,
+            )
+        return row["last_refreshed_at"], row["last_refreshed_source_watermark"]
+
+    @staticmethod
+    async def _insert_memory_at(
+        memory: MemoryEngine,
+        bank_id: str,
+        *,
+        at,
+        tags: list[str] | None = None,
+        fact_type: str = "experience",
+    ) -> str:
+        """Insert a memory whose updated_at/created_at are pinned to ``at``."""
+        pool = await memory._get_pool()
+        mem_id = str(uuid.uuid4())
+        async with pool.acquire() as conn:
+            await conn.execute(
+                f"""
+                INSERT INTO {fq_table("memory_units")}
+                    (id, bank_id, text, event_date, fact_type, tags, created_at, updated_at)
+                VALUES ($1, $2, $3, $4, $5, $6::varchar[], $4, $4)
+                """,
+                mem_id,
+                bank_id,
+                "test memory",
+                at,
+                fact_type,
+                tags if tags is not None else [],
+            )
+        return mem_id
+
+    async def test_last_refreshed_at_advances_when_source_watermark_unchanged(
+        self, memory: MemoryEngine, request_context
+    ):
+        """Core regression for the reported bug: a content-writing refresh whose source
+        watermark is unchanged (no new memories) must STILL advance last_refreshed_at to
+        a later wall-clock time. Previously last_refreshed_at was set to the watermark,
+        so it never moved for models with static sources and time-based schedulers
+        re-refreshed forever."""
+        from datetime import datetime, timedelta, timezone
+
+        bank_id = f"test-mm-wm-advance-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id, name="MM", source_query="q", content="c", request_context=request_context
+        )
+
+        # A fixed source watermark that does NOT change between the two refreshes —
+        # i.e. no new in-scope memory arrived.
+        fixed_watermark = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            content="refresh-1",
+            refresh_watermark=fixed_watermark,
+            request_context=request_context,
+        )
+        lra_1, wm_1 = await self._read_ts(memory, bank_id, mm["id"])
+
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            content="refresh-2",
+            refresh_watermark=fixed_watermark,
+            request_context=request_context,
+        )
+        lra_2, wm_2 = await self._read_ts(memory, bank_id, mm["id"])
+
+        # The wall-clock refresh time advanced on the second content-writing refresh...
+        assert lra_2 > lra_1, "last_refreshed_at must advance on every content-writing refresh"
+        # ...even though the source watermark is byte-for-byte unchanged.
+        assert wm_1 == fixed_watermark
+        assert wm_2 == fixed_watermark
+        # last_refreshed_at is a real wall-clock time, not the (much older) watermark.
+        assert lra_2 > fixed_watermark + timedelta(days=365)
+
+        # The serialized API dict exposes BOTH fields, and they carry the two meanings.
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["last_refreshed_source_watermark"] == fixed_watermark.isoformat()
+        assert datetime.fromisoformat(got["last_refreshed_at"]) > fixed_watermark + timedelta(days=365)
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_staleness_keys_off_source_watermark_not_last_refreshed_at(
+        self, memory: MemoryEngine, request_context
+    ):
+        """The "due for refresh?" decision must compare new memories against the source
+        watermark, NOT the wall-clock last_refreshed_at. Guards against re-introducing
+        the opposite regression (never-refresh): a recent last_refreshed_at must not mask
+        a memory that is newer than the source watermark."""
+        from datetime import datetime, timezone
+
+        bank_id = f"test-mm-wm-stale-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id, name="MM", source_query="q", content="c", request_context=request_context
+        )
+
+        # A memory that lands in the middle of 2021.
+        mem_at = datetime(2021, 6, 1, tzinfo=timezone.utc)
+        await self._insert_memory_at(memory, bank_id, at=mem_at)
+
+        # Case 1 — source watermark BEFORE the memory: even though last_refreshed_at is
+        # NOW() (very recent), the model is stale because the source watermark it was
+        # built from predates the memory.
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            content="built-before-memory",
+            refresh_watermark=datetime(2021, 1, 1, tzinfo=timezone.utc),
+            request_context=request_context,
+        )
+        lra, wm = await self._read_ts(memory, bank_id, mm["id"])
+        assert wm == datetime(2021, 1, 1, tzinfo=timezone.utc)
+        assert lra.year >= 2024, "last_refreshed_at is wall-clock NOW(), not the 2021 watermark"
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is True, "a memory newer than the source watermark makes the model stale"
+
+        # Case 2 — source watermark AT/AFTER the memory: last_refreshed_at is unchanged
+        # from case 1 (still recent), but the model is now NOT stale because its source
+        # watermark already covers the memory. This is exactly the case the old code got
+        # wrong: it would keep re-refreshing off the never-advancing timestamp.
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            content="built-after-memory",
+            refresh_watermark=mem_at,
+            request_context=request_context,
+        )
+        _, wm2 = await self._read_ts(memory, bank_id, mm["id"])
+        assert wm2 == mem_at
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is False, "no memory is newer than the source watermark → not stale"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
 @pytest.mark.hs_llm_core
 class TestMentalModelRefreshTagSecurity:
     """Test that mental model refresh respects tag-based security boundaries."""


### PR DESCRIPTION
## Problem
`mental_models.last_refreshed_at` served two purposes at once: the wall-clock time of the last refresh **and** the source-data watermark (the newest in-scope memory) that staleness keys off. When a model's source memories are static, the column never advances even though refreshes keep rewriting content — so any time-based scheduler that reads `last_refreshed_at` to decide "have I already refreshed this?" concludes it never happened and re-refreshes the model indefinitely.

This is a general correctness/fairness issue: under a workload where some models have static sources, those models get refreshed on every scheduler tick.

## Fix
Split the two meanings:
- Add `last_refreshed_source_watermark` (new nullable column) as the dedicated source-data watermark that staleness / "due for refresh" keys off.
- Revert `last_refreshed_at` to a true **wall-clock** timestamp that advances on every content-writing refresh.
- Backfill the new column from the current `last_refreshed_at` (which today holds the watermark), so staleness behaviour is unchanged across the migration. Consumers `COALESCE(last_refreshed_source_watermark, last_refreshed_at)` for rows not yet stamped.

### Changes
- `update_mental_model`: content path always stamps `last_refreshed_at = NOW()` and writes the watermark to the new column; the no-op (no new facts) path advances only the watermark.
- `compute_mental_model_is_stale`, `_may_need_refresh`, `_mental_model_processed_watermark`, and delta `created_after` key off `COALESCE(source_watermark, last_refreshed_at)` — preserving "don't re-refresh when there's no new data".
- Both fields exposed on `MentalModelResponse`; `is_stale` docs point list consumers at the watermark.
- Alembic migration (PG + Oracle) adds + backfills the column.

## Tests
- `last_refreshed_at` advances on a content-writing refresh whose source watermark is unchanged (the reported bug).
- Staleness still keys off the source watermark, so a recent `last_refreshed_at` does not mask a genuinely new memory (guards the inverse never-refresh regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)