### PR TITLE
feat(mental-models): expose refresh operation model id and list total

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2315,6 +2315,15 @@ class MentalModelListResponse(BaseModel):
     """Response model for listing mental models."""
 
     items: list[MentalModelResponse]
+    total: int = Field(
+        description="Total number of mental models matching the filter, ignoring limit/offset.",
+    )
+    limit: int = Field(
+        description="Maximum number of items returned in this page (echoes the request).",
+    )
+    offset: int = Field(
+        description="Number of items skipped before this page (echoes the request).",
+    )
 
 
 # =========================================================================
@@ -3212,6 +3221,10 @@ class OperationResponse(BaseModel):
         default=None,
         description="Last-known progress snapshot for a running operation; null if none was recorded.",
     )
+    mental_model_id: str | None = Field(
+        default=None,
+        description="Mental model this operation refreshed (refresh_mental_model ops only); null otherwise.",
+    )
 
 
 class ConsolidationRequest(BaseModel):
@@ -3373,6 +3386,10 @@ class OperationStatusResponse(BaseModel):
     result_metadata: dict[str, Any] | None = Field(
         default=None,
         description="Internal metadata for debugging. Structure may change without notice. Not for production use.",
+    )
+    mental_model_id: str | None = Field(
+        default=None,
+        description="Mental model this operation refreshed (refresh_mental_model ops only); null otherwise.",
     )
     child_operations: list[ChildOperationStatus] | None = Field(
         default=None, description="Child operations for batch operations (if applicable)"
@@ -5198,7 +5215,18 @@ def _register_routes(app: FastAPI):
                 offset=offset,
                 request_context=request_context,
             )
-            return MentalModelListResponse(items=[MentalModelResponse(**m) for m in mental_models])
+            total = await app.state.memory.count_mental_models(
+                bank_id=bank_id,
+                tags=tags_filter,
+                tags_match=tags_match,
+                request_context=request_context,
+            )
+            return MentalModelListResponse(
+                items=[MentalModelResponse(**m) for m in mental_models],
+                total=total,
+                limit=limit,
+                offset=offset,
+            )
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)
         except (AuthenticationError, HTTPException):

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -12423,6 +12423,61 @@ class MemoryEngine(MemoryEngineInterface):
 
             return [self._row_to_mental_model(row, detail=detail) for row in rows]
 
+    async def count_mental_models(
+        self,
+        bank_id: str,
+        *,
+        tags: list[str] | None = None,
+        tags_match: str = "any",
+        request_context: "RequestContext",
+    ) -> int:
+        """Count pinned mental models for a bank, applying the same tag filter as ``list_mental_models``.
+
+        Unlike ``list_mental_models`` this ignores limit/offset and returns the total number of
+        matching rows, so callers can paginate without under-counting large banks.
+
+        Args:
+            bank_id: Bank identifier
+            tags: Optional tags to filter by
+            tags_match: How to match tags - 'any', 'all', or 'exact'
+            request_context: Request context for authentication
+
+        Returns:
+            Total number of mental models matching the filter.
+        """
+        await self._authenticate_tenant(request_context)
+        if self._operation_validator:
+            from hindsight_api.extensions import BankReadContext, BankReadOperation
+
+            ctx = BankReadContext(
+                bank_id=bank_id, operation=BankReadOperation.LIST_MENTAL_MODELS, request_context=request_context
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        backend = await self._get_backend()
+
+        async with acquire_with_retry(backend) as conn:
+            # Build tag filter — must match list_mental_models exactly so filtered totals line up.
+            tag_filter = ""
+            params: list[Any] = [bank_id]
+            if tags:
+                if tags_match == "all":
+                    tag_filter = " AND tags @> $2::varchar[]"
+                elif tags_match == "exact":
+                    tag_filter = " AND tags = $2::varchar[]"
+                else:  # any
+                    tag_filter = " AND tags && $2::varchar[]"
+                params.append(tags)
+
+            row = await conn.fetchrow(
+                f"""
+                SELECT COUNT(*) AS total
+                FROM {fq_table("mental_models")}
+                WHERE bank_id = $1 {tag_filter}
+                """,
+                *params,
+            )
+            return int(row["total"]) if row else 0
+
     async def get_mental_model(
         self,
         bank_id: str,
@@ -15158,6 +15213,7 @@ class MemoryEngine(MemoryEngineInterface):
                         "retry_count": row["retry_count"] or 0,
                         "next_retry_at": next_retry_at.isoformat() if next_retry_at else None,
                         "progress": result_metadata.get("progress"),
+                        "mental_model_id": result_metadata.get("mental_model_id"),
                     }
                 )
 
@@ -15287,6 +15343,7 @@ class MemoryEngine(MemoryEngineInterface):
                         "next_retry_at": row["next_retry_at"].isoformat() if row["next_retry_at"] else None,
                         "progress": result_metadata.get("progress"),
                         "result_metadata": result_metadata,
+                        "mental_model_id": result_metadata.get("mental_model_id"),
                         "child_operations": child_statuses,
                         "task_payload": task_payload,
                     }
@@ -15304,6 +15361,7 @@ class MemoryEngine(MemoryEngineInterface):
                         "next_retry_at": row["next_retry_at"].isoformat() if row["next_retry_at"] else None,
                         "progress": result_metadata.get("progress"),
                         "result_metadata": result_metadata,
+                        "mental_model_id": result_metadata.get("mental_model_id"),
                         "task_payload": task_payload,
                     }
             else:

--- a/hindsight-api-slim/tests/test_operation_status.py
+++ b/hindsight-api-slim/tests/test_operation_status.py
@@ -58,6 +58,25 @@ async def _insert_operation(pool, bank_id: str, status: str) -> str:
     return str(op_id)
 
 
+async def _insert_refresh_operation(pool, bank_id: str, status: str, mental_model_id: str) -> str:
+    """Insert a refresh_mental_model operation carrying mental_model_id in result_metadata."""
+    import json
+
+    op_id = uuid.uuid4()
+    await pool.execute(
+        """
+        INSERT INTO async_operations
+            (operation_id, bank_id, operation_type, status, task_payload, result_metadata)
+        VALUES ($1, $2, 'refresh_mental_model', $3, '{"test": true}'::jsonb, $4::jsonb)
+        """,
+        op_id,
+        bank_id,
+        status,
+        json.dumps({"mental_model_id": mental_model_id, "name": "Some Model"}),
+    )
+    return str(op_id)
+
+
 @pytest.mark.asyncio
 async def test_list_operations_returns_processing_status(api_client, memory, test_bank_id):
     """GET /operations should return 'processing' status, not collapse it to 'pending'."""
@@ -74,6 +93,35 @@ async def test_list_operations_returns_processing_status(api_client, memory, tes
     statuses_by_id = {op["id"]: op["status"] for op in ops}
     assert statuses_by_id[pending_id] == "pending"
     assert statuses_by_id[processing_id] == "processing"
+
+
+@pytest.mark.asyncio
+async def test_refresh_operation_surfaces_mental_model_id(api_client, memory, test_bank_id):
+    """refresh_mental_model ops should expose mental_model_id (from result_metadata) on both
+    the list and get endpoints; non-refresh ops leave it null."""
+    pool = memory._pool
+    await _ensure_bank(pool, test_bank_id)
+
+    mm_id = str(uuid.uuid4())
+    refresh_id = await _insert_refresh_operation(pool, test_bank_id, "completed", mm_id)
+    retain_id = await _insert_operation(pool, test_bank_id, "completed")
+
+    # List endpoint. Null fields are dropped from the response envelope (ExcludeNoneRoute),
+    # so a non-refresh op simply omits mental_model_id rather than emitting null.
+    response = await api_client.get(f"/v1/default/banks/{test_bank_id}/operations")
+    assert response.status_code == 200
+    ops = {op["id"]: op for op in response.json()["operations"]}
+    assert ops[refresh_id]["mental_model_id"] == mm_id
+    assert ops[retain_id].get("mental_model_id") is None
+
+    # Get endpoint
+    response = await api_client.get(f"/v1/default/banks/{test_bank_id}/operations/{refresh_id}")
+    assert response.status_code == 200
+    assert response.json()["mental_model_id"] == mm_id
+
+    response = await api_client.get(f"/v1/default/banks/{test_bank_id}/operations/{retain_id}")
+    assert response.status_code == 200
+    assert response.json().get("mental_model_id") is None
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_reflections.py
+++ b/hindsight-api-slim/tests/test_reflections.py
@@ -163,6 +163,68 @@ class TestMentalModelsCRUD:
         await memory.delete_bank(bank_id, request_context=request_context)
 
     @pytest.mark.asyncio
+    async def test_count_mental_models(self, memory: MemoryEngine, request_context):
+        """count_mental_models ignores limit/offset and honors the same tag filter as list."""
+        bank_id = f"test-mental-model-count-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+        for i in range(4):
+            await memory.create_mental_model(
+                bank_id=bank_id,
+                name=f"Model {i}",
+                source_query=f"Query {i}",
+                content=f"Content {i}",
+                tags=["shared"] + (["odd"] if i % 2 else []),
+                request_context=request_context,
+            )
+
+        # Total count is not affected by a limit that only lists a page.
+        listed = await memory.list_mental_models(bank_id=bank_id, limit=2, request_context=request_context)
+        assert len(listed) == 2
+        total = await memory.count_mental_models(bank_id=bank_id, request_context=request_context)
+        assert total == 4
+
+        # Tag-filtered count reflects the filter (2 of the 4 have the "odd" tag).
+        odd_total = await memory.count_mental_models(bank_id=bank_id, tags=["odd"], request_context=request_context)
+        assert odd_total == 2
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_list_mental_models_endpoint_returns_total(self, memory: MemoryEngine, api_client, request_context):
+        """GET /mental-models returns total + echoed limit/offset, not just a capped items list."""
+        bank_id = f"test-mm-list-total-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+        for i in range(4):
+            await memory.create_mental_model(
+                bank_id=bank_id,
+                name=f"Model {i}",
+                source_query=f"Query {i}",
+                content=f"Content {i}",
+                tags=["shared"] + (["odd"] if i % 2 else []),
+                request_context=request_context,
+            )
+
+        # A small limit pages the items but total reflects the whole bank.
+        resp = await api_client.get(f"/v1/default/banks/{bank_id}/mental-models?limit=2&offset=1")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert len(body["items"]) == 2
+        assert body["total"] == 4
+        assert body["limit"] == 2
+        assert body["offset"] == 1
+
+        # Tag filter narrows the total.
+        resp = await api_client.get(f"/v1/default/banks/{bank_id}/mental-models?tags=odd&limit=10")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["total"] == 2
+        assert len(body["items"]) == 2
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
     async def test_update_mental_model(self, memory: MemoryEngine, request_context):
         """Test updating a mental model."""
         bank_id = f"test-mental-model-update-{uuid.uuid4().hex[:8]}"


### PR DESCRIPTION
Two small observability improvements around mental models. Independent of each other; no schema changes.

## 1. `mental_model_id` on operation records
`refresh_mental_model` operations return `document_id: null` and no model identifier, so a client can't tell which mental model an operation refreshed (diagnosing refresh behaviour from the operations log is impossible). The id already exists in the operation row's `result_metadata` — this surfaces it as a first-class `mental_model_id` field on `OperationResponse` and `OperationStatusResponse` (null for other task types).

## 2. `total` on `GET /banks/{bank}/mental-models`
The list envelope was `{"items": [...]}` only and silently capped at `limit` (default 100), so a bank with more models than the page size looked fully-listed. Adds `total` (matching-row count, ignoring limit/offset) plus `limit`/`offset` echoes, backed by a new `count_mental_models()` engine method that applies the same tag filter as `list_mental_models`.

## Tests
- A `refresh_mental_model` operation surfaces the correct `mental_model_id`; non-refresh ops don't carry it.
- Listing with a smaller `limit` still reports the full `total`, including a tag-filtered total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)