### PR TITLE
fix(ci): authenticate Hermes compatibility clone

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4644,6 +4644,8 @@ jobs:
       needs.detect-changes.outputs.ci == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v6
@@ -4668,6 +4670,8 @@ jobs:
           ${{ runner.os }}-huggingface-
 
     - name: Run Hermes compatibility test
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       run: ./scripts/test-hermes-compat.sh
 
     - name: Collect embedded daemon logs on failure

--- a/scripts/test-hermes-compat.sh
+++ b/scripts/test-hermes-compat.sh
@@ -147,10 +147,36 @@ echo ""
 # `plugins/` tree on sys.path, which is where the Hindsight memory plugin lives.
 echo "--- [1/5] Resolving hermes-agent@$HERMES_REF + local Hindsight stack ---"
 HERMES_SRC="$WORKDIR/hermes-agent"
+# Use the runner token when available to avoid the low unauthenticated limit on
+# shared CI runner IPs. Environment-based Git config is ephemeral: it is not
+# visible in the command line and is not persisted in the cloned repository.
 # stdout is silenced but stderr is not: a clone that fails on a network blip
 # should say why rather than surface as an opaque failure in the next command.
-git clone --depth 1 --branch "$HERMES_REF" \
-    https://github.com/NousResearch/hermes-agent.git "$HERMES_SRC" >/dev/null
+clone_ok=0
+for attempt in 1 2 3; do
+    if [ -n "${GITHUB_TOKEN:-${GH_TOKEN:-}}" ]; then
+        token="${GITHUB_TOKEN:-${GH_TOKEN}}"
+        GIT_CONFIG_COUNT=1 \
+        GIT_CONFIG_KEY_0="http.https://github.com/.extraheader" \
+        GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$token" | base64 | tr -d '\n')" \
+        git clone --depth 1 --branch "$HERMES_REF" \
+            https://github.com/NousResearch/hermes-agent.git "$HERMES_SRC" >/dev/null && clone_ok=1
+    else
+        git clone --depth 1 --branch "$HERMES_REF" \
+            https://github.com/NousResearch/hermes-agent.git "$HERMES_SRC" >/dev/null && clone_ok=1
+    fi
+    [ "$clone_ok" -eq 1 ] && break
+    rm -rf "$HERMES_SRC"
+    if [ "$attempt" -lt 3 ]; then
+        delay=$((5 * 3 ** (attempt - 1)))
+        echo "    clone failed (attempt $attempt/3); retrying in ${delay}s..." >&2
+        sleep "$delay"
+    fi
+done
+if [ "$clone_ok" -ne 1 ]; then
+    echo "ERROR: could not clone hermes-agent after 3 attempts." >&2
+    exit 1
+fi
 echo "    hermes-agent @ $(git -C "$HERMES_SRC" rev-parse --short HEAD)"
 
 # Pinned rather than taken from .python-version: Hermes caps itself at


### PR DESCRIPTION
## Summary

The Hermes compatibility gate intermittently failed before dependency resolution while fetching the public `NousResearch/hermes-agent` repository:

```text
error: RPC failed; HTTP 429 curl 22 The requested URL returned error: 429
fatal: expected flush after ref listing
```

The `packfile`/`ref listing` message is a secondary Git error from an incomplete response. The failure is caused by GitHub rate limiting Git traffic from shared Actions runner IPs.

## Changes

- Pass the short-lived Actions `${{ github.token }}` to the compatibility step with `contents: read` permission.
- Inject the Git authorization header through `GIT_CONFIG_COUNT` environment variables. This keeps the token out of the process command line and prevents it from being persisted in the cloned repository's `.git/config`.
- Retry the Hermes shallow clone up to three times with exponential backoff (5s, then 15s) for transient rate-limit/network failures.
- Preserve local usage through `GH_TOKEN` and retain unauthenticated behavior when no token is available.

## Security and Compatibility

The workflow token is generated per run, read-only, and requires no manually configured secret. The existing `--depth 1` clone and Hermes ref behavior are unchanged. The original stderr behavior is preserved so GitHub's diagnostic response remains visible in logs.

## Validation

- `bash -n scripts/test-hermes-compat.sh`
- `git diff --check`
