### PR TITLE
fix(coding-agents): answer tools/list when disabled

### DIFF
--- a/hindsight-integrations/coding-agents/src/mcp-server.test.ts
+++ b/hindsight-integrations/coding-agents/src/mcp-server.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
-import { selectTools } from "./mcp-server";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { buildMcpServer, selectTools } from "./mcp-server";
 import { resolveConfig } from "./core/config";
 import type { HindsightClient } from "./core/hindsight";
 
@@ -53,5 +55,23 @@ describe("selectTools", () => {
     const [, , , tags, , opts] = retain.mock.calls[0];
     expect(tags).toContain("harness:codex");
     expect(opts.metadata).toMatchObject({ harness: "codex" });
+  });
+});
+
+describe("buildMcpServer", () => {
+  it("answers tools/list with an empty list when Hindsight is disabled", async () => {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const server = buildMcpServer([]);
+    const client = new Client({ name: "test-client", version: "0.1.0" });
+
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    try {
+      expect(client.getServerCapabilities()).toMatchObject({ tools: { listChanged: false } });
+      await expect(client.listTools()).resolves.toEqual({ tools: [] });
+    } finally {
+      await client.close();
+      await server.close();
+    }
   });
 });

--- a/hindsight-integrations/coding-agents/src/mcp-server.ts
+++ b/hindsight-integrations/coding-agents/src/mcp-server.ts
@@ -11,6 +11,7 @@
 import { fileURLToPath } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { applyBankConfig, loadConfig, type Config } from "./core/config";
 import { deriveBankId } from "./core/bank";
 import { HindsightClient } from "./core/hindsight";
@@ -42,6 +43,27 @@ export function selectTools(
       });
 }
 
+/**
+ * Build the MCP surface for the resolved project.
+ *
+ * An opted-out project intentionally has no Hindsight tools, but some clients probe `tools/list`
+ * without first checking the initialize capabilities. Advertising an empty, queryable tool list
+ * keeps that privacy boundary intact while preventing one optional probe from failing startup.
+ */
+export function buildMcpServer(tools: ToolSpec[]): McpServer {
+  const server = new McpServer({ name: "hindsight", version: "0.1.0" });
+  if (tools.length === 0) {
+    server.server.registerCapabilities({ tools: { listChanged: false } });
+    server.server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [] }));
+    return server;
+  }
+
+  for (const tool of tools) {
+    server.tool(tool.name, tool.description, tool.inputSchema, tool.handler);
+  }
+  return server;
+}
+
 async function main() {
   const cwd = process.env.HINDSIGHT_MCP_PROJECT_CWD || process.cwd();
   // Harness is set per wrapper (Claude default; codex sets HINDSIGHT_MCP_HARNESS=codex) so bank
@@ -57,10 +79,7 @@ async function main() {
     observationScopes: cfg.observationScopes,
   });
 
-  const server = new McpServer({ name: "hindsight", version: "0.1.0" });
-  for (const t of selectTools(cfg, client, bankId, { cwd, harness })) {
-    server.tool(t.name, t.description, t.inputSchema, t.handler);
-  }
+  const server = buildMcpServer(selectTools(cfg, client, bankId, { cwd, harness }));
 
   await server.connect(new StdioServerTransport());
 }


### PR DESCRIPTION
## Summary

Keep opted-out Hindsight MCP servers inert while making their tool-discovery contract valid. This prevents clients that probe `tools/list` from treating an intentionally disabled project as an MCP startup failure.

## Changed

- Build the MCP server through one registration helper.
- When the resolved project exposes no tools, advertise an empty tool capability and answer `tools/list` with `{ "tools": [] }`.
- Add an in-memory MCP client/server regression test for the zero-tool path.

## Risks

Low. Normal tool registration is unchanged; only the existing zero-tool path gains an explicit discovery response.

## Verification

- `npm test` — 530 tests passed.
- `npm run build` — passed.
- `./scripts/hooks/lint.sh` — passed.
- `git diff --check upstream/main...HEAD` — passed.
- Project code review — no findings.

## Complexity

The zero-tool path is constant-time. No API, persistence, or network behavior changes.
