### PR TITLE
fix(mental-models): last_refreshed_at records the refresh, not the source watermark

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/e7c3a91f4b62_add_mental_model_last_memory_seen_at.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/e7c3a91f4b62_add_mental_model_last_memory_seen_at.py
@@ -1,0 +1,99 @@
+"""Add last_memory_seen_at to mental_models, splitting it from last_refreshed_at.
+
+``last_refreshed_at`` carried two meanings at once: the wall-clock time of the
+last refresh, and the source-data watermark (the newest in-scope memory the
+refresh saw) that staleness keys off. A refresh persisted the watermark into it,
+and the watermark is clamped so it never regresses — so on a model whose scope
+gained no new memories the refresh wrote back the value already there. The
+document was rewritten, the timestamp never moved, and a client asking
+"have I already refreshed this?" refreshed it again on every tick.
+
+``last_memory_seen_at`` takes over the watermark meaning; ``last_refreshed_at``
+goes back to being what its name says. The new column is backfilled from
+``last_refreshed_at`` — which today holds the watermark — so staleness decides
+exactly as it did before the migration and no bank mass-refreshes on deploy.
+Nullable, so consumers COALESCE back to ``last_refreshed_at`` for any row a
+refresh has not stamped yet.
+
+Revision ID: e7c3a91f4b62
+Revises: c4f7a91b2d38
+Create Date: 2026-08-17
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "e7c3a91f4b62"
+down_revision: str | Sequence[str] | None = "c4f7a91b2d38"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _pg_schema_prefix() -> str:
+    """Schema-qualifier for raw SQL on PG (multi-tenant search_path)."""
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def _pg_upgrade() -> None:
+    schema = _pg_schema_prefix()
+    op.execute(
+        f"""
+        ALTER TABLE {schema}mental_models
+        ADD COLUMN IF NOT EXISTS last_memory_seen_at TIMESTAMP WITH TIME ZONE
+        """
+    )
+    # last_refreshed_at currently holds the watermark, so copying it carries each
+    # model's staleness decision across the cutover unchanged. Only stamp rows
+    # still NULL, so re-running the migration is a no-op rather than a rollback of
+    # watermarks that refreshes have since advanced.
+    op.execute(
+        f"""
+        UPDATE {schema}mental_models
+        SET last_memory_seen_at = last_refreshed_at
+        WHERE last_memory_seen_at IS NULL
+        """
+    )
+
+
+def _pg_downgrade() -> None:
+    schema = _pg_schema_prefix()
+    op.execute(f"ALTER TABLE {schema}mental_models DROP COLUMN IF EXISTS last_memory_seen_at")
+
+
+def _oracle_upgrade() -> None:
+    # Oracle has no ADD COLUMN IF NOT EXISTS; guard on the data dictionary so a
+    # re-run doesn't fail with ORA-01430 (column already exists).
+    op.get_bind().exec_driver_sql(
+        """
+        DECLARE
+            n NUMBER;
+        BEGIN
+            SELECT COUNT(*) INTO n FROM user_tab_columns
+            WHERE table_name = 'MENTAL_MODELS'
+              AND column_name = 'LAST_MEMORY_SEEN_AT';
+            IF n = 0 THEN
+                EXECUTE IMMEDIATE
+                    'ALTER TABLE mental_models ADD (last_memory_seen_at TIMESTAMP WITH TIME ZONE)';
+            END IF;
+        END;
+        """
+    )
+    op.get_bind().exec_driver_sql(
+        "UPDATE mental_models SET last_memory_seen_at = last_refreshed_at WHERE last_memory_seen_at IS NULL"
+    )
+
+
+def _oracle_downgrade() -> None:
+    op.get_bind().exec_driver_sql("ALTER TABLE mental_models DROP COLUMN last_memory_seen_at")
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade, oracle=_oracle_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade, oracle=_oracle_downgrade)

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -3206,6 +3206,15 @@ class OperationResponse(BaseModel):
         default=None,
         description="Original filename for file-conversion operations (file_convert_retain); null for other task types.",
     )
+    mental_model_id: str | None = Field(
+        default=None,
+        description=(
+            "Mental model this operation acted on (refresh_mental_model); null for other task types. "
+            "Without it the list cannot say which model an operation refreshed — `document_id` is null "
+            "for these, and the list carries no result_metadata. The single-operation read exposes the "
+            "same value under `result_metadata`."
+        ),
+    )
     created_at: str
     updated_at: str | None = Field(
         default=None,

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1990,8 +1990,8 @@ class BankStatsResponse(BaseModel):
         default=None,
         description=(
             "When a memory was last written in this bank — stored, edited, or consolidated (ISO format). "
-            "Null if the bank has no memories. A mental model whose `last_refreshed_at` is at or after this "
-            "is up to date whatever its tags; an older one may need a refresh, which only the single "
+            "Null if the bank has no memories. A mental model whose `last_memory_seen_at` is at or after "
+            "this is up to date whatever its tags; an older one may need a refresh, which only the single "
             "mental-model read can confirm."
         ),
     )
@@ -2293,7 +2293,26 @@ class MentalModelResponse(BaseModel):
     tags: list[str] = FieldWithDefault(list)
     max_tokens: int | None = Field(default=None)
     trigger: MentalModelTrigger | None = Field(default=None)
-    last_refreshed_at: str | None = None
+    last_refreshed_at: str | None = Field(
+        default=None,
+        description=(
+            "When a refresh last finished for this model — wall-clock, in ISO format. Advances on "
+            "every refresh that completes, including one that found nothing new and preserved the "
+            "content, and on a direct edit of `content`. A refresh that failed leaves it alone. "
+            "This is the field to answer 'have I already refreshed this?'; it says nothing about "
+            "whether the model is behind the data, which is `last_memory_seen_at` / `is_stale`."
+        ),
+    )
+    last_memory_seen_at: str | None = Field(
+        default=None,
+        description=(
+            "How far through the bank's memories this model is written — the newest in-scope memory "
+            "the last refresh saw, in ISO format. Stands still when nothing in the model's scope has "
+            "been written, however often it is refreshed. Compare against `last_memory_write_at` "
+            "from GET /stats to flag a whole list cheaply: at or after it means up to date, older "
+            "means it may need a refresh. Null for a model no refresh has stamped yet."
+        ),
+    )
     created_at: str | None = None
     reflect_response: dict | None = Field(
         default=None,
@@ -2303,9 +2322,9 @@ class MentalModelResponse(BaseModel):
         default=None,
         description=(
             "True when memories matching this mental model's tag/fact_type scope have been written "
-            "since last_refreshed_at. Exact, and costly to compute, so it is populated only by the "
+            "since last_memory_seen_at. Exact, and costly to compute, so it is populated only by the "
             "single mental-model read at detail=full — never when listing. For a whole list, compare "
-            "each `last_refreshed_at` against the bank's `last_memory_write_at` from GET /stats: "
+            "each `last_memory_seen_at` against the bank's `last_memory_write_at` from GET /stats: "
             "at or after it means up to date, older means it may need a refresh."
         ),
     )

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -1892,7 +1892,7 @@ async def _trigger_mental_model_refreshes(
         if consolidated_tags:
             candidates = await conn.fetch(
                 f"""
-                SELECT id, name, tags, last_refreshed_at, trigger
+                SELECT id, name, tags, last_refreshed_at, last_memory_seen_at, trigger
                 FROM {fq_table("mental_models")}
                 WHERE bank_id = $1
                   AND (trigger->>'refresh_after_consolidation')::boolean = true
@@ -1907,7 +1907,7 @@ async def _trigger_mental_model_refreshes(
         else:
             candidates = await conn.fetch(
                 f"""
-                SELECT id, name, tags, last_refreshed_at, trigger
+                SELECT id, name, tags, last_refreshed_at, last_memory_seen_at, trigger
                 FROM {fq_table("mental_models")}
                 WHERE bank_id = $1
                   AND (trigger->>'refresh_after_consolidation')::boolean = true

--- a/hindsight-api-slim/hindsight_api/engine/maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/maintenance.py
@@ -484,7 +484,8 @@ class MaintenanceLoop:
                 # the row under the bank's schema context.
                 async with acquire_with_retry(engine._backend, max_retries=1) as conn:
                     mm_row = await conn.fetchrow(
-                        f"SELECT id, tags, trigger, last_refreshed_at FROM {fq_table('mental_models')} "
+                        f"SELECT id, tags, trigger, last_refreshed_at, last_memory_seen_at "
+                        f"FROM {fq_table('mental_models')} "
                         "WHERE bank_id = $1 AND id = $2",
                         bank_id,
                         mm_id,

--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -962,7 +962,7 @@ class MemoriesExtension(Extension, ABC):
         ``last_memory_write_at`` is the newest write time (``updated_at``) across
         the bank's memories, or None for an empty bank. It is the bank-wide
         counterpart of :meth:`any_memory_updated_since`: a mental model whose
-        ``last_refreshed_at`` is at or after it cannot be stale, whatever its
+        ``last_memory_seen_at`` is at or after it cannot be stale, whatever its
         scope — which is how the stats and knowledge-tree surfaces answer "is
         this up to date" for many models without a scoped scan each.
         """

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -15184,6 +15184,9 @@ class MemoryEngine(MemoryEngineInterface):
                         "items_count": result_metadata.get("items_count", 0),
                         "document_id": result_metadata.get("document_id"),
                         "filename": result_metadata.get("original_filename"),
+                        # refresh_mental_model operations have no document_id, so without
+                        # this the log cannot say which model an operation refreshed.
+                        "mental_model_id": result_metadata.get("mental_model_id"),
                         "created_at": row["created_at"].isoformat(),
                         "updated_at": row["updated_at"].isoformat() if row["updated_at"] else None,
                         "status": row["status"],

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -12411,7 +12411,7 @@ class MemoryEngine(MemoryEngineInterface):
             rows = await conn.fetch(
                 f"""
                 SELECT id, bank_id, name, source_query, content, tags,
-                       last_refreshed_at, created_at, reflect_response,
+                       last_refreshed_at, last_memory_seen_at, created_at, reflect_response,
                        max_tokens, trigger, structured_content
                 FROM {fq_table("mental_models")}
                 WHERE bank_id = $1 {tag_filter}
@@ -12467,7 +12467,7 @@ class MemoryEngine(MemoryEngineInterface):
             row = await conn.fetchrow(
                 f"""
                 SELECT id, bank_id, name, source_query, content, tags,
-                       last_refreshed_at, created_at, reflect_response,
+                       last_refreshed_at, last_memory_seen_at, created_at, reflect_response,
                        max_tokens, trigger, structured_content
                 FROM {fq_table("mental_models")}
                 WHERE bank_id = $1 AND id = $2
@@ -12585,7 +12585,7 @@ class MemoryEngine(MemoryEngineInterface):
             (id, bank_id, subtype, name, description, source_query, content, embedding, tags, max_tokens, trigger{sv_col})
             VALUES ($1, $2, 'pinned', $3, ' ', $4, $5, $6, $7, COALESCE($8, 2048), COALESCE($9, '{{"refresh_after_consolidation": false}}'::jsonb){sv_val})
             RETURNING id, bank_id, name, source_query, content, tags,
-                      last_refreshed_at, created_at, reflect_response,
+                      last_refreshed_at, last_memory_seen_at, created_at, reflect_response,
                       max_tokens, trigger, structured_content
             """,
             mental_model_id,
@@ -12711,11 +12711,13 @@ class MemoryEngine(MemoryEngineInterface):
         refresh_cutoff: datetime,
     ) -> datetime | None:
         """Watermark to persist after a refresh: the newest in-scope memory visible at
-        the snapshot, clamped so it never regresses below the current ``last_refreshed_at``.
+        the snapshot, clamped so it never regresses below the model's current
+        ``last_memory_seen_at`` (falling back to ``last_refreshed_at`` for a row no
+        refresh has stamped since the migration backfill).
 
         A still-uncommitted straddling row is excluded from this max, so when it commits
         it stays newer than the watermark and is caught next time. Returns ``None`` when
-        no in-scope memory is visible (leave ``last_refreshed_at`` untouched, so an
+        no in-scope memory is visible (leave ``last_memory_seen_at`` untouched, so an
         in-flight first row is not skipped). Kept as its own method — like
         ``_mental_model_refresh_cutoff`` — so mock unit tests of the refresh wiring can
         stub it instead of reaching a real pool.
@@ -12725,8 +12727,9 @@ class MemoryEngine(MemoryEngineInterface):
         watermark_params = [*scope_filter.params, refresh_cutoff]
         watermark_where = [*scope_filter.where, f"updated_at <= ${len(watermark_params)}"]
         async with acquire_with_retry(backend) as conn:
-            current_last_refreshed_at = await conn.fetchval(
-                f"SELECT last_refreshed_at FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
+            current_memory_seen_at = await conn.fetchval(
+                f"SELECT COALESCE(last_memory_seen_at, last_refreshed_at) "
+                f"FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
                 bank_id,
                 mental_model_id,
             )
@@ -12736,8 +12739,8 @@ class MemoryEngine(MemoryEngineInterface):
             )
         if newest_in_scope is None:
             return None
-        if current_last_refreshed_at is not None:
-            return max(newest_in_scope, current_last_refreshed_at)
+        if current_memory_seen_at is not None:
+            return max(newest_in_scope, current_memory_seen_at)
         return newest_in_scope
 
     async def _execute_mental_model_refresh(
@@ -12899,12 +12902,15 @@ class MemoryEngine(MemoryEngineInterface):
         # so the agentic loop only retrieves genuinely new information.
         created_after: datetime | None = None
         if use_delta:
-            last_refreshed_at_raw = mental_model.get("last_refreshed_at")
-            if last_refreshed_at_raw is not None:
-                if isinstance(last_refreshed_at_raw, str):
-                    created_after = datetime.fromisoformat(last_refreshed_at_raw)
+            # The delta window opens at the newest memory the last refresh saw, not at
+            # the wall-clock time it finished — anything written between the two is
+            # new information this document has never been shown.
+            seen_at_raw = mental_model.get("last_memory_seen_at") or mental_model.get("last_refreshed_at")
+            if seen_at_raw is not None:
+                if isinstance(seen_at_raw, str):
+                    created_after = datetime.fromisoformat(seen_at_raw)
                 else:
-                    created_after = last_refreshed_at_raw
+                    created_after = seen_at_raw
                 reflect_kwargs["created_after"] = created_after
 
         window = MentalModelRefreshWindow(
@@ -13368,6 +13374,9 @@ class MemoryEngine(MemoryEngineInterface):
                     reflect_response=reflect_response_payload,
                     last_refreshed_source_query=run.source_query,
                     refresh_watermark=run.processed_watermark,
+                    # This refresh ran and succeeded; it just had nothing to change.
+                    # A caller polling "did my refresh happen?" must see that.
+                    refresh_completed=True,
                     request_context=request_context,
                 )
 
@@ -13377,10 +13386,11 @@ class MemoryEngine(MemoryEngineInterface):
                 Every failure mode is handled the same way: persist the
                 reflect_response (so the failure is auditable under
                 ``refresh_skipped``) but write no content, no structured document
-                and no watermark — leaving ``last_refreshed_at`` where it was, so a
+                and no watermark — leaving ``last_memory_seen_at`` where it was, so a
                 retry re-reads the same window instead of skipping past the facts
-                this run failed on. Then raise, because a caller that is told
-                nothing assumes the document was refreshed.
+                this run failed on, and leaving ``last_refreshed_at`` where it was,
+                because no refresh finished. Then raise, because a caller that is
+                told nothing assumes the document was refreshed.
                 """
                 logger.warning(f"[MENTAL_MODELS] Refresh for {mental_model_id} failed ({reason}); {detail}")
                 reflect_response_payload["refresh_skipped"] = reason
@@ -13435,6 +13445,7 @@ class MemoryEngine(MemoryEngineInterface):
                 reflect_response=reflect_response_payload,
                 last_refreshed_source_query=run.source_query,
                 refresh_watermark=run.processed_watermark,
+                refresh_completed=True,
                 structured_content=(run.final_structured.model_dump() if run.final_structured is not None else None),
                 request_context=request_context,
             )
@@ -13546,6 +13557,7 @@ class MemoryEngine(MemoryEngineInterface):
         reflect_response: dict[str, Any] | None = None,
         last_refreshed_source_query: str | None = None,
         refresh_watermark: datetime | None = None,
+        refresh_completed: bool = False,
         structured_content: dict[str, Any] | None = None,
         request_context: "RequestContext",
     ) -> dict[str, Any] | None:
@@ -13564,10 +13576,14 @@ class MemoryEngine(MemoryEngineInterface):
             refresh_watermark: Watermark persisted by a successful refresh — the newest
                 ``updated_at`` among the in-scope memories visible at the refresh
                 snapshot (not ``now()``), so a row that commits after the snapshot stays
-                newer than the watermark and is not silently dropped. None means "no
-                in-scope memory was visible": on the no-op path ``last_refreshed_at`` is
-                left unchanged (so an in-flight row is not skipped); on the content path
-                it falls back to NOW().
+                newer than the watermark and is not silently dropped. Written to
+                ``last_memory_seen_at``, which is what staleness keys off. None means
+                "no in-scope memory was visible", and leaves it unchanged so an
+                in-flight first row is not skipped.
+            refresh_completed: True when this write is a refresh that ran to completion,
+                which stamps ``last_refreshed_at = NOW()`` even if the refresh preserved
+                the existing content. A refresh that failed leaves it False, so the
+                timestamp keeps pointing at the last refresh that actually finished.
             request_context: Request context for authentication
 
         Returns:
@@ -13643,12 +13659,6 @@ class MemoryEngine(MemoryEngineInterface):
                 params.append(content)
                 content_sql = f"${param_idx}"
                 param_idx += 1
-                if refresh_watermark is None:
-                    updates.append("last_refreshed_at = NOW()")
-                else:
-                    updates.append(f"last_refreshed_at = ${param_idx}")
-                    params.append(refresh_watermark)
-                    param_idx += 1
                 # Snapshot the previous version for history. The actual write goes
                 # into the dedicated mental_model_history table after the UPDATE
                 # (see _append_mental_model_history); we only store the slim slice
@@ -13674,13 +13684,25 @@ class MemoryEngine(MemoryEngineInterface):
                     updates.append(f"embedding = ${param_idx}")
                     params.append(new_embedding_str)
                     param_idx += 1
-            elif refresh_watermark is not None:
-                # A successful delta refresh can find no topic-relevant facts even though
-                # the coarse staleness query found new rows. Advance the watermark to the
-                # newest in-scope memory we saw (without re-embedding unchanged content or
-                # adding history) so this no-op window stops re-triggering, while any row
-                # that commits later stays newer than the watermark and is still caught.
-                updates.append(f"last_refreshed_at = ${param_idx}")
+
+            # The two timestamps move independently, and conflating them is what made a
+            # refresh look like it never ran (#3531): the watermark is clamped so it
+            # never regresses, so a model whose scope gained no memories had the value
+            # already in the column written straight back over itself while the document
+            # underneath was rewritten.
+            #
+            # last_refreshed_at — wall clock, "when did a refresh last finish". Advances
+            # on every completed refresh, including one that preserved the content
+            # (delta found no new facts: it ran, it just had nothing to change), and on a
+            # direct content edit. A *failed* refresh passes neither, so it stays put.
+            if content is not None or refresh_completed:
+                updates.append("last_refreshed_at = NOW()")
+            # last_memory_seen_at — data watermark, "how far through the bank's memories
+            # this document is written". Staleness keys off it. A row that commits after
+            # the refresh snapshot stays newer than the watermark and is caught next
+            # time, which is why this is the newest memory seen and not NOW().
+            if refresh_watermark is not None:
+                updates.append(f"last_memory_seen_at = ${param_idx}")
                 params.append(refresh_watermark)
                 param_idx += 1
 
@@ -13738,7 +13760,7 @@ class MemoryEngine(MemoryEngineInterface):
                 SET {", ".join(updates)}
                 WHERE bank_id = $1 AND id = $2
                 RETURNING id, bank_id, name, source_query, content, tags,
-                          last_refreshed_at, created_at, reflect_response,
+                          last_refreshed_at, last_memory_seen_at, created_at, reflect_response,
                           max_tokens, trigger, structured_content
             """
 
@@ -13850,7 +13872,7 @@ class MemoryEngine(MemoryEngineInterface):
                     last_refreshed_source_query = NULL{sv_clause}
                 WHERE bank_id = $1 AND id = $2
                 RETURNING id, bank_id, name, source_query, content, tags,
-                          last_refreshed_at, created_at, reflect_response,
+                          last_refreshed_at, last_memory_seen_at, created_at, reflect_response,
                           max_tokens, trigger, structured_content
                 """,
                 bank_id,
@@ -13990,7 +14012,8 @@ class MemoryEngine(MemoryEngineInterface):
         "kp.id, kp.bank_id, kp.parent_id, kp.kind, kp.name, kp.mental_model_id, "
         "kp.sort_order, kp.managed, kp.created_at, kp.updated_at, "
         "mm.tags AS mm_tags, mm.source_query AS mm_source_query, "
-        "mm.last_refreshed_at AS mm_last_refreshed_at"
+        "mm.last_refreshed_at AS mm_last_refreshed_at, "
+        "mm.last_memory_seen_at AS mm_last_memory_seen_at"
     )
 
     def _kp_join(self) -> str:
@@ -14196,7 +14219,10 @@ class MemoryEngine(MemoryEngineInterface):
                 for r in rows:
                     if r["kind"] != "page":
                         continue
-                    by_id[r["id"]]["is_stale"] = _may_need_refresh(r["mm_last_refreshed_at"], watermark)
+                    # Staleness compares the bank's newest write against how far
+                    # through the memories the page is written, not when it last ran.
+                    seen_at = r["mm_last_memory_seen_at"] or r["mm_last_refreshed_at"]
+                    by_id[r["id"]]["is_stale"] = _may_need_refresh(seen_at, watermark)
         return nodes
 
     async def get_knowledge_page(
@@ -14637,8 +14663,14 @@ class MemoryEngine(MemoryEngineInterface):
             except (KeyError, TypeError):
                 return None
 
-        last_refreshed_at = _get("last_refreshed_at")
-        if not last_refreshed_at:
+        # Staleness is a question about data, not about clocks: has a memory in scope
+        # been written since the newest one this document was built from? That is
+        # last_memory_seen_at, never the wall-clock last_refreshed_at — refreshing a
+        # model must not, by itself, make it look current. Fall back to
+        # last_refreshed_at when the watermark is absent (a row no refresh has stamped
+        # since the migration backfill, or a caller that selected neither column).
+        last_memory_seen_at = _get("last_memory_seen_at") or _get("last_refreshed_at")
+        if not last_memory_seen_at:
             return True
 
         raw_tags = _get("tags")
@@ -14663,7 +14695,7 @@ class MemoryEngine(MemoryEngineInterface):
             conn=conn,
             fq_table=fq_table,
             bank_id=bank_id,
-            since=last_refreshed_at,
+            since=last_memory_seen_at,
             fact_types=fact_types,
             tags=tag_filtering.tags,
             tags_match=tag_filtering.tags_match,
@@ -14683,6 +14715,7 @@ class MemoryEngine(MemoryEngineInterface):
             "name": row["name"],
             "tags": row["tags"] or [],
             "last_refreshed_at": row["last_refreshed_at"].isoformat() if row["last_refreshed_at"] else None,
+            "last_memory_seen_at": (row["last_memory_seen_at"].isoformat() if row["last_memory_seen_at"] else None),
             "created_at": row["created_at"].isoformat() if row["created_at"] else None,
         }
         if detail == "metadata":

--- a/hindsight-api-slim/hindsight_api/engine/mental_model_refresh.py
+++ b/hindsight-api-slim/hindsight_api/engine/mental_model_refresh.py
@@ -69,7 +69,8 @@ class MentalModelRefreshWindow(BaseModel):
         default=None,
         description=(
             "Lower bound on memory creation time. Set only in delta mode, where it is the model's "
-            "last_refreshed_at — so a delta refresh only sees memories newer than the last one."
+            "last_memory_seen_at — so a delta refresh only sees memories newer than the newest one "
+            "the previous refresh saw."
         ),
     )
     created_before: datetime = Field(
@@ -81,7 +82,7 @@ class MentalModelRefreshWindow(BaseModel):
     watermark: datetime | None = Field(
         default=None,
         description=(
-            "The last_refreshed_at a real refresh would persist: the newest in-scope memory visible at "
+            "The last_memory_seen_at a real refresh would persist: the newest in-scope memory visible at "
             "the snapshot, not now(). Null means no in-scope memory was visible."
         ),
     )

--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
@@ -150,7 +150,7 @@ async def tool_search_mental_models(
         f"""
         SELECT
             id, name, content,
-            tags, created_at, last_refreshed_at, trigger,
+            tags, created_at, last_refreshed_at, last_memory_seen_at, trigger,
             1 - (embedding <=> $2::vector) as relevance
         FROM {fq_table("mental_models")}
         WHERE bank_id = $1 AND embedding IS NOT NULL {filters}
@@ -167,6 +167,12 @@ async def tool_search_mental_models(
         if last_refreshed_at and last_refreshed_at.tzinfo is None:
             last_refreshed_at = last_refreshed_at.replace(tzinfo=timezone.utc)
 
+        # How far through the bank's memories this model is written — the cheap
+        # bank-wide check below compares against that, not against when it last ran.
+        last_memory_seen_at = row["last_memory_seen_at"] or last_refreshed_at
+        if last_memory_seen_at and last_memory_seen_at.tzinfo is None:
+            last_memory_seen_at = last_memory_seen_at.replace(tzinfo=timezone.utc)
+
         # Per-MM staleness: new in-scope memories since last refresh (includes pending).
         # The scoped query has no index to use and scans the bank's memories in full, so
         # skip it for a model the bank-wide watermark already proves current: nothing was
@@ -174,7 +180,7 @@ async def tool_search_mental_models(
         # model still gets the exact answer — the agent trusts a model without a verifying
         # recall() only on `is_stale is False`, so guessing conservatively here would buy
         # LLM turns to save a query. No watermark (absent, or an empty bank) → ask.
-        if last_memory_write_at is not None and not _may_need_refresh(last_refreshed_at, last_memory_write_at):
+        if last_memory_write_at is not None and not _may_need_refresh(last_memory_seen_at, last_memory_write_at):
             is_stale = False
         else:
             is_stale = await memory_engine.compute_mental_model_is_stale(conn, bank_id, row)

--- a/hindsight-api-slim/tests/test_mcp_tools.py
+++ b/hindsight-api-slim/tests/test_mcp_tools.py
@@ -78,7 +78,9 @@ class TestBuildContentDict:
 # =========================================================================
 
 
-_MENTAL_MODEL_METADATA_FIELDS = frozenset({"id", "bank_id", "name", "tags", "last_refreshed_at", "created_at"})
+_MENTAL_MODEL_METADATA_FIELDS = frozenset(
+    {"id", "bank_id", "name", "tags", "last_refreshed_at", "last_memory_seen_at", "created_at"}
+)
 
 _FULL_MENTAL_MODELS = [
     {
@@ -91,6 +93,7 @@ _FULL_MENTAL_MODELS = [
         "max_tokens": 2048,
         "trigger": {"interval": "daily"},
         "last_refreshed_at": "2026-01-01T00:00:00",
+        "last_memory_seen_at": "2026-01-01T00:00:00",
         "created_at": "2026-01-01T00:00:00",
         "reflect_response": {
             "text": "Prefers Python",
@@ -107,6 +110,7 @@ _FULL_MENTAL_MODELS = [
         "max_tokens": 2048,
         "trigger": None,
         "last_refreshed_at": "2026-01-01T00:00:00",
+        "last_memory_seen_at": "2026-01-01T00:00:00",
         "created_at": "2026-01-01T00:00:00",
         "reflect_response": {"text": "Ship v2", "based_on": {}},
     },

--- a/hindsight-api-slim/tests/test_mental_model_delta.py
+++ b/hindsight-api-slim/tests/test_mental_model_delta.py
@@ -283,15 +283,15 @@ class TestDeltaRefreshPlumbing:
         patch_llm_call,
         monkeypatch,
     ):
-        """A successful no-op refresh advances ``last_refreshed_at`` to the newest
-        in-scope memory it actually saw — not ``now()``.
+        """A successful no-op refresh advances ``last_memory_seen_at`` to the newest
+        in-scope memory it actually saw — not ``now()`` — and records that it ran by
+        stamping ``last_refreshed_at``.
 
-        The scheduled-refresh gate uses ``last_refreshed_at`` as its watermark. If a
-        no-op refresh left it unchanged, one unrelated memory would make every
-        maintenance tick submit another LLM refresh forever. Anchoring the watermark to
-        the newest processed memory stops that storm without jumping ahead of the real
-        data, so a row that commits later stays newer than the watermark (see
-        ``test_delta_refresh_watermark_survives_straddling_commit``).
+        The scheduled-refresh gate keys off the watermark. If a no-op refresh left it
+        unchanged, one unrelated memory would make every maintenance tick submit another
+        LLM refresh forever. Anchoring it to the newest processed memory stops that storm
+        without jumping ahead of the real data, so a row that commits later stays newer
+        than the watermark (see ``test_delta_refresh_watermark_survives_straddling_commit``).
         """
         bank_id = f"test-delta-watermark-{uuid.uuid4().hex[:8]}"
         await memory.get_bank_profile(bank_id, request_context=request_context)
@@ -333,7 +333,8 @@ class TestDeltaRefreshPlumbing:
                 bank_id,
             )
             stale_row = await conn.fetchrow(
-                "SELECT id, tags, trigger, last_refreshed_at FROM mental_models WHERE bank_id = $1 AND id = $2",
+                "SELECT id, tags, trigger, last_refreshed_at, last_memory_seen_at "
+                "FROM mental_models WHERE bank_id = $1 AND id = $2",
                 bank_id,
                 mm["id"],
             )
@@ -361,12 +362,14 @@ class TestDeltaRefreshPlumbing:
 
         async with memory._pool.acquire() as conn:
             mm_row = await conn.fetchrow(
-                "SELECT id, tags, trigger, last_refreshed_at FROM mental_models WHERE bank_id = $1 AND id = $2",
+                "SELECT id, tags, trigger, last_refreshed_at, last_memory_seen_at "
+                "FROM mental_models WHERE bank_id = $1 AND id = $2",
                 bank_id,
                 mm["id"],
             )
             assert mm_row is not None
-            after = mm_row["last_refreshed_at"]
+            after = mm_row["last_memory_seen_at"]
+            refreshed_at = mm_row["last_refreshed_at"]
             is_stale = await memory.compute_mental_model_is_stale(conn, bank_id, mm_row)
             history_count = await conn.fetchval(
                 "SELECT COUNT(*) FROM mental_model_history WHERE bank_id = $1 AND mental_model_id = $2",
@@ -377,6 +380,8 @@ class TestDeltaRefreshPlumbing:
         # updated_at, not now() — so the settled window no longer re-triggers.
         assert after == fact_updated_at
         assert after > before
+        # The refresh ran, so the wall clock says so even though nothing was written.
+        assert refreshed_at > before
         assert is_stale is False
         assert history_count == 0
 
@@ -507,7 +512,8 @@ class TestDeltaRefreshPlumbing:
 
         async with memory._pool.acquire() as conn:
             mm_row = await conn.fetchrow(
-                "SELECT id, tags, trigger, last_refreshed_at FROM mental_models WHERE bank_id = $1 AND id = $2",
+                "SELECT id, tags, trigger, last_refreshed_at, last_memory_seen_at "
+                "FROM mental_models WHERE bank_id = $1 AND id = $2",
                 bank_id,
                 mm["id"],
             )
@@ -517,7 +523,7 @@ class TestDeltaRefreshPlumbing:
                 straddle_fact_id,
             )
             assert mm_row is not None
-            after = mm_row["last_refreshed_at"]
+            after = mm_row["last_memory_seen_at"]
             # Watermark advanced only to the committed baseline the refresh actually saw.
             assert after == baseline_updated_at
             # The straddler was stamped before the cutoff (an exact-cutoff/now() watermark
@@ -876,6 +882,7 @@ class TestDeltaRefreshPlumbing:
         )
         seeded_content = seeded["content"]
         seeded_refreshed_at = seeded["last_refreshed_at"]
+        seeded_memory_seen_at = seeded["last_memory_seen_at"]
 
         # Second refresh: the delta LLM call raises. The candidate is deliberately
         # a plausible-looking document — the danger is that it *is* non-empty, so
@@ -905,8 +912,9 @@ class TestDeltaRefreshPlumbing:
         assert preserved["content"] == seeded_content, (
             "Delta failure overwrote the document with the narrow-window candidate (#3112)"
         )
-        # The watermark must not move: the new fact has to stay inside the window
-        # the retry reads, or it is lost for good.
+        # Neither timestamp moves: the new fact has to stay inside the window the retry
+        # reads, or it is lost for good, and no refresh finished to record.
+        assert preserved["last_memory_seen_at"] == seeded_memory_seen_at
         assert preserved["last_refreshed_at"] == seeded_refreshed_at
         rr = preserved.get("reflect_response") or {}
         assert rr.get("refresh_skipped") == "delta_ops_failed"

--- a/hindsight-api-slim/tests/test_mental_model_scheduled_refresh.py
+++ b/hindsight-api-slim/tests/test_mental_model_scheduled_refresh.py
@@ -106,6 +106,39 @@ async def _count_refresh_ops(memory: MemoryEngine, bank_id: str) -> int:
 
 
 @pytest.mark.asyncio
+async def test_refresh_operations_name_the_model_they_refreshed(memory: MemoryEngine, request_context, monkeypatch):
+    """The operations *list* carries `mental_model_id` for a refresh.
+
+    These operations have no `document_id`, and the list carries no `result_metadata`
+    either, so without it the log cannot say which model an operation refreshed — a bank
+    with hundreds of models is undiagnosable from the list alone. The single-operation
+    read already answers it through `result_metadata`, so it gets no duplicate field.
+    """
+    bank = await _make_bank(memory, request_context)
+    async with memory._pool.acquire() as conn:
+        mm_id = await _insert_mm(conn, bank, refresh_cron="*/5 * * * *", last_refreshed_offset="1 day")
+    _stall_worker(memory, monkeypatch)
+
+    submitted = await memory.submit_async_refresh_mental_model(
+        bank_id=bank, mental_model_id=mm_id, request_context=request_context
+    )
+
+    listed = await memory.list_operations(bank_id=bank, request_context=request_context)
+    refreshes = [op for op in listed["operations"] if op["task_type"] == "refresh_mental_model"]
+    assert len(refreshes) == 1
+    assert refreshes[0]["mental_model_id"] == mm_id
+    # The field this used to be the only handle on is still null for these ops, which is
+    # exactly why mental_model_id is needed.
+    assert refreshes[0]["document_id"] is None
+
+    # The single-operation read answers the same question through result_metadata.
+    status = await memory.get_operation_status(
+        bank_id=bank, operation_id=submitted["operation_id"], request_context=request_context
+    )
+    assert status["result_metadata"]["mental_model_id"] == mm_id
+
+
+@pytest.mark.asyncio
 async def test_refresh_cron_round_trips_through_create_and_get(memory: MemoryEngine, request_context):
     """refresh_cron set on a mental model's trigger persists and reads back."""
     bank = await _make_bank(memory, request_context)

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -1512,6 +1512,168 @@ class TestMentalModelStaleness:
             await memory.delete_bank(bank_id, request_context=request_context)
 
 
+class TestMentalModelRefreshTimestamps:
+    """``last_refreshed_at`` (when a refresh ran) and ``last_memory_seen_at`` (how far
+    through the memories the document is written) move independently.
+
+    Conflating them is #3531: the watermark never regresses, so on a model whose scope
+    gained no memories a refresh wrote the value already in the column back over itself.
+    The document changed, the timestamp did not, and a client asking "have I already
+    refreshed this?" refreshed it again on every tick.
+    """
+
+    @staticmethod
+    async def _read_timestamps(memory: MemoryEngine, bank_id: str, mm_id: str):
+        """The row's two timestamps, straight from the column — not the API's ISO strings."""
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            return await conn.fetchrow(
+                f"SELECT last_refreshed_at, last_memory_seen_at "
+                f"FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                mm_id,
+            )
+
+    async def test_refresh_of_static_scope_still_advances_last_refreshed_at(
+        self, memory: MemoryEngine, request_context
+    ):
+        """The reported bug, reproduced: two refreshes over a scope that gained no
+        memories. The watermark is identical both times — that is correct, the data did
+        not move — but ``last_refreshed_at`` must advance anyway, or a client scheduling
+        its own refreshes sees the model as permanently never-refreshed."""
+        from datetime import datetime, timedelta, timezone
+
+        bank_id = f"test-mm-ts-static-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id, name="MM", source_query="q", content="c", request_context=request_context
+        )
+
+        # The scope is quiet, so every refresh computes the same watermark.
+        watermark = datetime(2026, 8, 15, 20, 16, 58, tzinfo=timezone.utc)
+        for content in ("synthesis v1", "synthesis v2"):
+            await memory.update_mental_model(
+                bank_id=bank_id,
+                mental_model_id=mm["id"],
+                content=content,
+                refresh_watermark=watermark,
+                refresh_completed=True,
+                request_context=request_context,
+            )
+            if content == "synthesis v1":
+                first = await self._read_timestamps(memory, bank_id, mm["id"])
+        second = await self._read_timestamps(memory, bank_id, mm["id"])
+
+        assert second["last_refreshed_at"] > first["last_refreshed_at"], (
+            "a second refresh over an unchanged scope must still record that it ran"
+        )
+        # The watermark is the one that legitimately stands still.
+        assert first["last_memory_seen_at"] == watermark
+        assert second["last_memory_seen_at"] == watermark
+        # last_refreshed_at is a real clock reading, not the watermark it used to hold.
+        assert second["last_refreshed_at"] > watermark + timedelta(days=1)
+
+        api = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert api["last_memory_seen_at"] == watermark.isoformat()
+        assert datetime.fromisoformat(api["last_refreshed_at"]) > watermark + timedelta(days=1)
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_refresh_that_preserves_content_still_advances_last_refreshed_at(
+        self, memory: MemoryEngine, request_context
+    ):
+        """A delta refresh that finds no new facts writes no content but did complete.
+        It stamps the wall clock; only a *failed* refresh leaves it alone."""
+        from datetime import datetime, timezone
+
+        bank_id = f"test-mm-ts-noop-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id, name="MM", source_query="q", content="c", request_context=request_context
+        )
+        before = await self._read_timestamps(memory, bank_id, mm["id"])
+
+        # No content: the content-preserved path a delta refresh takes when the window
+        # held nothing topic-relevant.
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            reflect_response={"text": "no new facts"},
+            refresh_watermark=datetime(2026, 8, 15, tzinfo=timezone.utc),
+            refresh_completed=True,
+            request_context=request_context,
+        )
+        after_noop = await self._read_timestamps(memory, bank_id, mm["id"])
+        assert after_noop["last_refreshed_at"] > before["last_refreshed_at"]
+
+        # A failed refresh persists its reflect_response for audit but claims nothing:
+        # neither timestamp moves, so a retry re-reads the same window.
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            reflect_response={"refresh_skipped": "empty_candidate"},
+            request_context=request_context,
+        )
+        after_failure = await self._read_timestamps(memory, bank_id, mm["id"])
+        assert after_failure["last_refreshed_at"] == after_noop["last_refreshed_at"]
+        assert after_failure["last_memory_seen_at"] == after_noop["last_memory_seen_at"]
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_staleness_keys_off_memories_seen_not_refresh_time(self, memory: MemoryEngine, request_context):
+        """The inverse regression: making ``last_refreshed_at`` a wall clock must not let
+        a recent refresh mask a memory the document has never seen."""
+        from datetime import datetime, timezone
+
+        bank_id = f"test-mm-ts-stale-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id, name="MM", source_query="q", content="c", request_context=request_context
+        )
+
+        memory_at = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            await conn.execute(
+                f"""
+                INSERT INTO {fq_table("memory_units")}
+                    (id, bank_id, text, event_date, fact_type, tags, created_at, updated_at)
+                VALUES ($1, $2, $3, $4, 'experience', $5::varchar[], $4, $4)
+                """,
+                str(uuid.uuid4()),
+                bank_id,
+                "test memory",
+                memory_at,
+                [],
+            )
+
+        # Refreshed just now, but built from memories only up to January: stale.
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            content="built before the memory landed",
+            refresh_watermark=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            refresh_completed=True,
+            request_context=request_context,
+        )
+        api = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert api["is_stale"] is True, "a recent last_refreshed_at must not mask an unseen memory"
+
+        # Same wall clock, watermark now covers the memory: not stale.
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            content="built after the memory landed",
+            refresh_watermark=memory_at,
+            refresh_completed=True,
+            request_context=request_context,
+        )
+        api = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert api["is_stale"] is False
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
 @pytest.mark.hs_llm_core
 class TestMentalModelRefreshTagSecurity:
     """Test that mental model refresh respects tag-based security boundaries."""

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -8797,6 +8797,9 @@ components:
         filename:
           nullable: true
           type: string
+        mental_model_id:
+          nullable: true
+          type: string
         created_at:
           title: Created At
           type: string

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -8088,14 +8088,8 @@ components:
       description: Response model for listing mental models.
       example:
         items:
-        - source_query: source_query
-          max_tokens: 0
-          bank_id: bank_id
-          reflect_response:
-            key: ""
-          name: name
+        - max_tokens: 0
           created_at: created_at
-          id: id
           trigger:
             recall_chunks_max_tokens: 1
             refresh_cron: refresh_cron
@@ -8125,18 +8119,19 @@ components:
             recall_max_tokens: 6
           last_refreshed_at: last_refreshed_at
           is_stale: true
+          last_memory_seen_at: last_memory_seen_at
           content: content
           tags:
           - tags
           - tags
-        - source_query: source_query
-          max_tokens: 0
+          source_query: source_query
           bank_id: bank_id
           reflect_response:
             key: ""
           name: name
-          created_at: created_at
           id: id
+        - max_tokens: 0
+          created_at: created_at
           trigger:
             recall_chunks_max_tokens: 1
             refresh_cron: refresh_cron
@@ -8166,10 +8161,17 @@ components:
             recall_max_tokens: 6
           last_refreshed_at: last_refreshed_at
           is_stale: true
+          last_memory_seen_at: last_memory_seen_at
           content: content
           tags:
           - tags
           - tags
+          source_query: source_query
+          bank_id: bank_id
+          reflect_response:
+            key: ""
+          name: name
+          id: id
       properties:
         items:
           items:
@@ -8317,14 +8319,8 @@ components:
     MentalModelResponse:
       description: Response model for a mental model (stored reflect response).
       example:
-        source_query: source_query
         max_tokens: 0
-        bank_id: bank_id
-        reflect_response:
-          key: ""
-        name: name
         created_at: created_at
-        id: id
         trigger:
           recall_chunks_max_tokens: 1
           refresh_cron: refresh_cron
@@ -8354,10 +8350,17 @@ components:
           recall_max_tokens: 6
         last_refreshed_at: last_refreshed_at
         is_stale: true
+        last_memory_seen_at: last_memory_seen_at
         content: content
         tags:
         - tags
         - tags
+        source_query: source_query
+        bank_id: bank_id
+        reflect_response:
+          key: ""
+        name: name
+        id: id
       properties:
         id:
           title: Id
@@ -8385,6 +8388,9 @@ components:
         trigger:
           $ref: '#/components/schemas/MentalModelTrigger-Output'
         last_refreshed_at:
+          nullable: true
+          type: string
+        last_memory_seen_at:
           nullable: true
           type: string
         created_at:

--- a/hindsight-clients/go/go.mod
+++ b/hindsight-clients/go/go.mod
@@ -2,10 +2,6 @@ module github.com/vectorize-io/hindsight/hindsight-clients/go
 
 go 1.18
 
-require github.com/stretchr/testify v1.11.1
+require github.com/stretchr/testify v1.12.0
 
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
-)
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/hindsight-clients/go/go.sum
+++ b/hindsight-clients/go/go.sum
@@ -1,9 +1,5 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
-github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/stretchr/testify v1.12.0 h1:K6Mr6jO9JICuend/5xzTM03ydSV3vdNRYAdPSukj8uI=
+github.com/stretchr/testify v1.12.0/go.mod h1:bOYBZb5qJ00vPzWfIqBUZPaxK8jWiXc6d3ErP4Ca9Gw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/hindsight-clients/go/model_mental_model_response.go
+++ b/hindsight-clients/go/model_mental_model_response.go
@@ -30,6 +30,7 @@ type MentalModelResponse struct {
 	MaxTokens NullableInt32 `json:"max_tokens,omitempty"`
 	Trigger NullableMentalModelTriggerOutput `json:"trigger,omitempty"`
 	LastRefreshedAt NullableString `json:"last_refreshed_at,omitempty"`
+	LastMemorySeenAt NullableString `json:"last_memory_seen_at,omitempty"`
 	CreatedAt NullableString `json:"created_at,omitempty"`
 	ReflectResponse map[string]interface{} `json:"reflect_response,omitempty"`
 	IsStale NullableBool `json:"is_stale,omitempty"`
@@ -371,6 +372,48 @@ func (o *MentalModelResponse) UnsetLastRefreshedAt() {
 	o.LastRefreshedAt.Unset()
 }
 
+// GetLastMemorySeenAt returns the LastMemorySeenAt field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *MentalModelResponse) GetLastMemorySeenAt() string {
+	if o == nil || IsNil(o.LastMemorySeenAt.Get()) {
+		var ret string
+		return ret
+	}
+	return *o.LastMemorySeenAt.Get()
+}
+
+// GetLastMemorySeenAtOk returns a tuple with the LastMemorySeenAt field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *MentalModelResponse) GetLastMemorySeenAtOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.LastMemorySeenAt.Get(), o.LastMemorySeenAt.IsSet()
+}
+
+// HasLastMemorySeenAt returns a boolean if a field has been set.
+func (o *MentalModelResponse) HasLastMemorySeenAt() bool {
+	if o != nil && o.LastMemorySeenAt.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetLastMemorySeenAt gets a reference to the given NullableString and assigns it to the LastMemorySeenAt field.
+func (o *MentalModelResponse) SetLastMemorySeenAt(v string) {
+	o.LastMemorySeenAt.Set(&v)
+}
+// SetLastMemorySeenAtNil sets the value for LastMemorySeenAt to be an explicit nil
+func (o *MentalModelResponse) SetLastMemorySeenAtNil() {
+	o.LastMemorySeenAt.Set(nil)
+}
+
+// UnsetLastMemorySeenAt ensures that no value is present for LastMemorySeenAt, not even an explicit nil
+func (o *MentalModelResponse) UnsetLastMemorySeenAt() {
+	o.LastMemorySeenAt.Unset()
+}
+
 // GetCreatedAt returns the CreatedAt field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *MentalModelResponse) GetCreatedAt() string {
 	if o == nil || IsNil(o.CreatedAt.Get()) {
@@ -518,6 +561,9 @@ func (o MentalModelResponse) ToMap() (map[string]interface{}, error) {
 	}
 	if o.LastRefreshedAt.IsSet() {
 		toSerialize["last_refreshed_at"] = o.LastRefreshedAt.Get()
+	}
+	if o.LastMemorySeenAt.IsSet() {
+		toSerialize["last_memory_seen_at"] = o.LastMemorySeenAt.Get()
 	}
 	if o.CreatedAt.IsSet() {
 		toSerialize["created_at"] = o.CreatedAt.Get()

--- a/hindsight-clients/go/model_operation_response.go
+++ b/hindsight-clients/go/model_operation_response.go
@@ -26,6 +26,7 @@ type OperationResponse struct {
 	ItemsCount int32 `json:"items_count"`
 	DocumentId NullableString `json:"document_id,omitempty"`
 	Filename NullableString `json:"filename,omitempty"`
+	MentalModelId NullableString `json:"mental_model_id,omitempty"`
 	CreatedAt string `json:"created_at"`
 	UpdatedAt NullableString `json:"updated_at,omitempty"`
 	Status string `json:"status"`
@@ -214,6 +215,48 @@ func (o *OperationResponse) SetFilenameNil() {
 // UnsetFilename ensures that no value is present for Filename, not even an explicit nil
 func (o *OperationResponse) UnsetFilename() {
 	o.Filename.Unset()
+}
+
+// GetMentalModelId returns the MentalModelId field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *OperationResponse) GetMentalModelId() string {
+	if o == nil || IsNil(o.MentalModelId.Get()) {
+		var ret string
+		return ret
+	}
+	return *o.MentalModelId.Get()
+}
+
+// GetMentalModelIdOk returns a tuple with the MentalModelId field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *OperationResponse) GetMentalModelIdOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MentalModelId.Get(), o.MentalModelId.IsSet()
+}
+
+// HasMentalModelId returns a boolean if a field has been set.
+func (o *OperationResponse) HasMentalModelId() bool {
+	if o != nil && o.MentalModelId.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetMentalModelId gets a reference to the given NullableString and assigns it to the MentalModelId field.
+func (o *OperationResponse) SetMentalModelId(v string) {
+	o.MentalModelId.Set(&v)
+}
+// SetMentalModelIdNil sets the value for MentalModelId to be an explicit nil
+func (o *OperationResponse) SetMentalModelIdNil() {
+	o.MentalModelId.Set(nil)
+}
+
+// UnsetMentalModelId ensures that no value is present for MentalModelId, not even an explicit nil
+func (o *OperationResponse) UnsetMentalModelId() {
+	o.MentalModelId.Unset()
 }
 
 // GetCreatedAt returns the CreatedAt field value
@@ -476,6 +519,9 @@ func (o OperationResponse) ToMap() (map[string]interface{}, error) {
 	}
 	if o.Filename.IsSet() {
 		toSerialize["filename"] = o.Filename.Get()
+	}
+	if o.MentalModelId.IsSet() {
+		toSerialize["mental_model_id"] = o.MentalModelId.Get()
 	}
 	toSerialize["created_at"] = o.CreatedAt
 	if o.UpdatedAt.IsSet() {

--- a/hindsight-clients/python/hindsight_client_api/models/mental_model_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/mental_model_response.py
@@ -36,10 +36,11 @@ class MentalModelResponse(BaseModel):
     max_tokens: Optional[StrictInt] = None
     trigger: Optional[MentalModelTriggerOutput] = None
     last_refreshed_at: Optional[StrictStr] = None
+    last_memory_seen_at: Optional[StrictStr] = None
     created_at: Optional[StrictStr] = None
     reflect_response: Optional[Dict[str, Any]] = None
     is_stale: Optional[StrictBool] = None
-    __properties: ClassVar[List[str]] = ["id", "bank_id", "name", "source_query", "content", "tags", "max_tokens", "trigger", "last_refreshed_at", "created_at", "reflect_response", "is_stale"]
+    __properties: ClassVar[List[str]] = ["id", "bank_id", "name", "source_query", "content", "tags", "max_tokens", "trigger", "last_refreshed_at", "last_memory_seen_at", "created_at", "reflect_response", "is_stale"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -108,6 +109,11 @@ class MentalModelResponse(BaseModel):
         if self.last_refreshed_at is None and "last_refreshed_at" in self.model_fields_set:
             _dict['last_refreshed_at'] = None
 
+        # set to None if last_memory_seen_at (nullable) is None
+        # and model_fields_set contains the field
+        if self.last_memory_seen_at is None and "last_memory_seen_at" in self.model_fields_set:
+            _dict['last_memory_seen_at'] = None
+
         # set to None if created_at (nullable) is None
         # and model_fields_set contains the field
         if self.created_at is None and "created_at" in self.model_fields_set:
@@ -144,6 +150,7 @@ class MentalModelResponse(BaseModel):
             "max_tokens": obj.get("max_tokens"),
             "trigger": MentalModelTriggerOutput.from_dict(obj["trigger"]) if obj.get("trigger") is not None else None,
             "last_refreshed_at": obj.get("last_refreshed_at"),
+            "last_memory_seen_at": obj.get("last_memory_seen_at"),
             "created_at": obj.get("created_at"),
             "reflect_response": obj.get("reflect_response"),
             "is_stale": obj.get("is_stale")

--- a/hindsight-clients/python/hindsight_client_api/models/operation_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/operation_response.py
@@ -32,6 +32,7 @@ class OperationResponse(BaseModel):
     items_count: StrictInt
     document_id: Optional[StrictStr] = None
     filename: Optional[StrictStr] = None
+    mental_model_id: Optional[StrictStr] = None
     created_at: StrictStr
     updated_at: Optional[StrictStr] = None
     status: StrictStr
@@ -39,7 +40,7 @@ class OperationResponse(BaseModel):
     retry_count: Optional[StrictInt] = None
     next_retry_at: Optional[StrictStr] = None
     progress: Optional[OperationProgress] = None
-    __properties: ClassVar[List[str]] = ["id", "task_type", "items_count", "document_id", "filename", "created_at", "updated_at", "status", "error_message", "retry_count", "next_retry_at", "progress"]
+    __properties: ClassVar[List[str]] = ["id", "task_type", "items_count", "document_id", "filename", "mental_model_id", "created_at", "updated_at", "status", "error_message", "retry_count", "next_retry_at", "progress"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -93,6 +94,11 @@ class OperationResponse(BaseModel):
         if self.filename is None and "filename" in self.model_fields_set:
             _dict['filename'] = None
 
+        # set to None if mental_model_id (nullable) is None
+        # and model_fields_set contains the field
+        if self.mental_model_id is None and "mental_model_id" in self.model_fields_set:
+            _dict['mental_model_id'] = None
+
         # set to None if updated_at (nullable) is None
         # and model_fields_set contains the field
         if self.updated_at is None and "updated_at" in self.model_fields_set:
@@ -135,6 +141,7 @@ class OperationResponse(BaseModel):
             "items_count": obj.get("items_count"),
             "document_id": obj.get("document_id"),
             "filename": obj.get("filename"),
+            "mental_model_id": obj.get("mental_model_id"),
             "created_at": obj.get("created_at"),
             "updated_at": obj.get("updated_at"),
             "status": obj.get("status"),

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -3855,6 +3855,12 @@ export type OperationResponse = {
    */
   filename?: string | null;
   /**
+   * Mental Model Id
+   *
+   * Mental model this operation acted on (refresh_mental_model); null for other task types. Without it the list cannot say which model an operation refreshed — `document_id` is null for these, and the list carries no result_metadata. The single-operation read exposes the same value under `result_metadata`.
+   */
+  mental_model_id?: string | null;
+  /**
    * Created At
    */
   created_at: string;

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -420,7 +420,7 @@ export type BankStatsResponse = {
   /**
    * Last Memory Write At
    *
-   * When a memory was last written in this bank — stored, edited, or consolidated (ISO format). Null if the bank has no memories. A mental model whose `last_refreshed_at` is at or after this is up to date whatever its tags; an older one may need a refresh, which only the single mental-model read can confirm.
+   * When a memory was last written in this bank — stored, edited, or consolidated (ISO format). Null if the bank has no memories. A mental model whose `last_memory_seen_at` is at or after this is up to date whatever its tags; an older one may need a refresh, which only the single mental-model read can confirm.
    */
   last_memory_write_at?: string | null;
   /**
@@ -3377,7 +3377,7 @@ export type MentalModelRefreshWindow = {
   /**
    * Created After
    *
-   * Lower bound on memory creation time. Set only in delta mode, where it is the model's last_refreshed_at — so a delta refresh only sees memories newer than the last one.
+   * Lower bound on memory creation time. Set only in delta mode, where it is the model's last_memory_seen_at — so a delta refresh only sees memories newer than the newest one the previous refresh saw.
    */
   created_after?: string | null;
   /**
@@ -3389,7 +3389,7 @@ export type MentalModelRefreshWindow = {
   /**
    * Watermark
    *
-   * The last_refreshed_at a real refresh would persist: the newest in-scope memory visible at the snapshot, not now(). Null means no in-scope memory was visible.
+   * The last_memory_seen_at a real refresh would persist: the newest in-scope memory visible at the snapshot, not now(). Null means no in-scope memory was visible.
    */
   watermark?: string | null;
 };
@@ -3433,8 +3433,16 @@ export type MentalModelResponse = {
   trigger?: MentalModelTriggerOutput | null;
   /**
    * Last Refreshed At
+   *
+   * When a refresh last finished for this model — wall-clock, in ISO format. Advances on every refresh that completes, including one that found nothing new and preserved the content, and on a direct edit of `content`. A refresh that failed leaves it alone. This is the field to answer 'have I already refreshed this?'; it says nothing about whether the model is behind the data, which is `last_memory_seen_at` / `is_stale`.
    */
   last_refreshed_at?: string | null;
+  /**
+   * Last Memory Seen At
+   *
+   * How far through the bank's memories this model is written — the newest in-scope memory the last refresh saw, in ISO format. Stands still when nothing in the model's scope has been written, however often it is refreshed. Compare against `last_memory_write_at` from GET /stats to flag a whole list cheaply: at or after it means up to date, older means it may need a refresh. Null for a model no refresh has stamped yet.
+   */
+  last_memory_seen_at?: string | null;
   /**
    * Created At
    */
@@ -3450,7 +3458,7 @@ export type MentalModelResponse = {
   /**
    * Is Stale
    *
-   * True when memories matching this mental model's tag/fact_type scope have been written since last_refreshed_at. Exact, and costly to compute, so it is populated only by the single mental-model read at detail=full — never when listing. For a whole list, compare each `last_refreshed_at` against the bank's `last_memory_write_at` from GET /stats: at or after it means up to date, older means it may need a refresh.
+   * True when memories matching this mental model's tag/fact_type scope have been written since last_memory_seen_at. Exact, and costly to compute, so it is populated only by the single mental-model read at detail=full — never when listing. For a whole list, compare each `last_memory_seen_at` against the bank's `last_memory_write_at` from GET /stats: at or after it means up to date, older means it may need a refresh.
    */
   is_stale?: boolean | null;
 };

--- a/hindsight-control-plane/src/components/bank-stats-view.tsx
+++ b/hindsight-control-plane/src/components/bank-stats-view.tsx
@@ -75,7 +75,10 @@ export interface BankStats {
 }
 
 /** What the mental-models card reads — everything a `detail=metadata` list returns. */
-type MentalModelSummary = Pick<MentalModel, "id" | "name" | "last_refreshed_at">;
+type MentalModelSummary = Pick<
+  MentalModel,
+  "id" | "name" | "last_refreshed_at" | "last_memory_seen_at"
+>;
 
 type Period = "1h" | "12h" | "1d" | "7d" | "30d" | "90d";
 const PERIODS: Period[] = ["1h", "12h", "1d", "7d", "30d", "90d"];
@@ -716,15 +719,20 @@ function MentalModelsCard({
   const t = useTranslations("bankStats");
   const total = models.length;
   // Freshness against the bank's last memory write, not the last consolidation:
-  // a model refreshed at or after it is provably current, whatever its tags.
-  // The other direction is only "may need refresh" — the write could have landed
-  // outside the model's scope, and confirming that costs a scan of the bank's
-  // memories per model, so the exact answer lives on the model's own dialog.
+  // a model that has seen memories at or after it is provably current, whatever
+  // its tags. The other direction is only "may need refresh" — the write could
+  // have landed outside the model's scope, and confirming that costs a scan of the
+  // bank's memories per model, so the exact answer lives on the model's own dialog.
+  //
+  // This compares last_memory_seen_at — how far through the memories the model is
+  // written — never last_refreshed_at, which is only when a refresh last ran and
+  // would report every recently-refreshed model as current even when it is behind.
   const lastWriteTime = lastMemoryWriteAt ? new Date(lastMemoryWriteAt).getTime() : 0;
   const upToDate = models.filter((m) => {
     if (!lastWriteTime) return true;
-    if (!m.last_refreshed_at) return false;
-    return new Date(m.last_refreshed_at).getTime() >= lastWriteTime;
+    const seenAt = m.last_memory_seen_at ?? m.last_refreshed_at;
+    if (!seenAt) return false;
+    return new Date(seenAt).getTime() >= lastWriteTime;
   }).length;
   const mayNeedRefresh = total - upToDate;
 

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -214,6 +214,8 @@ export interface MentalModel {
     keep_trace?: boolean;
   };
   last_refreshed_at: string;
+  /** Newest in-scope memory this model has seen. Staleness compares against this. */
+  last_memory_seen_at: string | null;
   created_at: string;
   reflect_response?: any;
   is_stale?: boolean | null;
@@ -1437,6 +1439,7 @@ export class ControlPlaneClient {
           keep_trace?: boolean;
         };
         last_refreshed_at: string;
+        last_memory_seen_at: string | null;
         created_at: string;
         reflect_response?: {
           text: string;
@@ -1543,6 +1546,7 @@ export class ControlPlaneClient {
         keep_trace?: boolean;
       };
       last_refreshed_at: string;
+      last_memory_seen_at: string | null;
       created_at: string;
       reflect_response?: {
         text: string;

--- a/hindsight-docs/docs/developer/api/mental-models.mdx
+++ b/hindsight-docs/docs/developer/api/mental-models.mdx
@@ -169,7 +169,9 @@ Both automatic triggers run the same check before spending an LLM call: **is the
 
 The `is_stale` flag surfaced to the reflect agent, and the one on a single mental-model read, is computed by the same rule.
 
-Listing surfaces do not pay for it. Reading one model evaluates its scope; listing many would mean one such query each, so `is_stale` is absent from the list response. To flag a whole list, compare each `last_refreshed_at` against the bank's `last_memory_write_at` (from the bank stats endpoint): at or after it means up to date — nothing in the bank changed, so nothing in that model's scope did — while older means it *may* need a refresh. The [knowledge-base tree](./knowledge-pages) uses exactly that rule for its per-page flag.
+Listing surfaces do not pay for it. Reading one model evaluates its scope; listing many would mean one such query each, so `is_stale` is absent from the list response. To flag a whole list, compare each `last_memory_seen_at` against the bank's `last_memory_write_at` (from the bank stats endpoint): at or after it means up to date — nothing in the bank changed, so nothing in that model's scope did — while older means it *may* need a refresh. The [knowledge-base tree](./knowledge-pages) uses exactly that rule for its per-page flag.
+
+**Two timestamps answer two different questions.** `last_refreshed_at` is wall-clock: when a refresh last finished. It advances on every refresh that completes — including one that read the scope, found nothing new, and left the document alone — so a client driving refreshes itself can use it to tell "I already did this one" from "this one still needs a call". `last_memory_seen_at` is a position in the data: the newest in-scope memory the last refresh saw. It stands still while the model's scope is quiet, however many times you refresh, which is what makes it the right side of the staleness comparison. A model with a recent `last_refreshed_at` and an old `last_memory_seen_at` is not a contradiction — it means you refreshed a document that had nothing new to say.
 
 ### What a Refresh Reads
 
@@ -287,7 +289,7 @@ Both **List** and **Get** endpoints accept an optional `detail` query parameter 
 
 | Level | Fields Returned | Use Case |
 |-------|----------------|----------|
-| `metadata` | `id`, `bank_id`, `name`, `tags`, `last_refreshed_at`, `created_at` | Inventory — "what models exist?" |
+| `metadata` | `id`, `bank_id`, `name`, `tags`, `last_refreshed_at`, `last_memory_seen_at`, `created_at` | Inventory — "what models exist?" |
 | `content` | All metadata fields + `source_query`, `content`, `max_tokens`, `trigger` | Agent boot — "what do the models say?" |
 | `full` (default) | All fields including `reflect_response` | Deep inspection — "what evidence backs this model?" |
 
@@ -320,7 +322,8 @@ Use `detail=content` for agent orientation flows. It includes everything the age
 | `bank_id` | string | metadata | Memory bank ID |
 | `name` | string | metadata | Human-readable name |
 | `tags` | list | metadata | Tags for filtering |
-| `last_refreshed_at` | string | metadata | When the mental model was last updated |
+| `last_refreshed_at` | string | metadata | When a refresh last finished — wall-clock. Advances on every completed refresh, including one that found nothing new. Answers "have I already refreshed this?" |
+| `last_memory_seen_at` | string | metadata | The newest in-scope memory the last refresh saw. Answers "is this behind the data?" — compare against `last_memory_write_at` from the stats endpoint |
 | `created_at` | string | metadata | When the mental model was created |
 | `source_query` | string | content | The query used to generate content |
 | `content` | string | content | The generated mental model text |

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -13048,6 +13048,18 @@
             "title": "Filename",
             "description": "Original filename for file-conversion operations (file_convert_retain); null for other task types."
           },
+          "mental_model_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mental Model Id",
+            "description": "Mental model this operation acted on (refresh_mental_model); null for other task types. Without it the list cannot say which model an operation refreshed \u2014 `document_id` is null for these, and the list carries no result_metadata. The single-operation read exposes the same value under `result_metadata`."
+          },
           "created_at": {
             "type": "string",
             "title": "Created At"

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -7406,7 +7406,7 @@
               }
             ],
             "title": "Last Memory Write At",
-            "description": "When a memory was last written in this bank \u2014 stored, edited, or consolidated (ISO format). Null if the bank has no memories. A mental model whose `last_refreshed_at` is at or after this is up to date whatever its tags; an older one may need a refresh, which only the single mental-model read can confirm."
+            "description": "When a memory was last written in this bank \u2014 stored, edited, or consolidated (ISO format). Null if the bank has no memories. A mental model whose `last_memory_seen_at` is at or after this is up to date whatever its tags; an older one may need a refresh, which only the single mental-model read can confirm."
           },
           "pending_consolidation": {
             "type": "integer",
@@ -12229,7 +12229,7 @@
               }
             ],
             "title": "Created After",
-            "description": "Lower bound on memory creation time. Set only in delta mode, where it is the model's last_refreshed_at \u2014 so a delta refresh only sees memories newer than the last one."
+            "description": "Lower bound on memory creation time. Set only in delta mode, where it is the model's last_memory_seen_at \u2014 so a delta refresh only sees memories newer than the newest one the previous refresh saw."
           },
           "created_before": {
             "type": "string",
@@ -12248,7 +12248,7 @@
               }
             ],
             "title": "Watermark",
-            "description": "The last_refreshed_at a real refresh would persist: the newest in-scope memory visible at the snapshot, not now(). Null means no in-scope memory was visible."
+            "description": "The last_memory_seen_at a real refresh would persist: the newest in-scope memory visible at the snapshot, not now(). Null means no in-scope memory was visible."
           }
         },
         "type": "object",
@@ -12333,7 +12333,20 @@
                 "type": "null"
               }
             ],
-            "title": "Last Refreshed At"
+            "title": "Last Refreshed At",
+            "description": "When a refresh last finished for this model \u2014 wall-clock, in ISO format. Advances on every refresh that completes, including one that found nothing new and preserved the content, and on a direct edit of `content`. A refresh that failed leaves it alone. This is the field to answer 'have I already refreshed this?'; it says nothing about whether the model is behind the data, which is `last_memory_seen_at` / `is_stale`."
+          },
+          "last_memory_seen_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Memory Seen At",
+            "description": "How far through the bank's memories this model is written \u2014 the newest in-scope memory the last refresh saw, in ISO format. Stands still when nothing in the model's scope has been written, however often it is refreshed. Compare against `last_memory_write_at` from GET /stats to flag a whole list cheaply: at or after it means up to date, older means it may need a refresh. Null for a model no refresh has stamped yet."
           },
           "created_at": {
             "anyOf": [
@@ -12369,7 +12382,7 @@
               }
             ],
             "title": "Is Stale",
-            "description": "True when memories matching this mental model's tag/fact_type scope have been written since last_refreshed_at. Exact, and costly to compute, so it is populated only by the single mental-model read at detail=full \u2014 never when listing. For a whole list, compare each `last_refreshed_at` against the bank's `last_memory_write_at` from GET /stats: at or after it means up to date, older means it may need a refresh."
+            "description": "True when memories matching this mental model's tag/fact_type scope have been written since last_memory_seen_at. Exact, and costly to compute, so it is populated only by the single mental-model read at detail=full \u2014 never when listing. For a whole list, compare each `last_memory_seen_at` against the bank's `last_memory_write_at` from GET /stats: at or after it means up to date, older means it may need a refresh."
           }
         },
         "type": "object",

--- a/skills/hindsight-docs/references/developer/api/mental-models.md
+++ b/skills/hindsight-docs/references/developer/api/mental-models.md
@@ -216,7 +216,9 @@ Both automatic triggers run the same check before spending an LLM call: **is the
 
 The `is_stale` flag surfaced to the reflect agent, and the one on a single mental-model read, is computed by the same rule.
 
-Listing surfaces do not pay for it. Reading one model evaluates its scope; listing many would mean one such query each, so `is_stale` is absent from the list response. To flag a whole list, compare each `last_refreshed_at` against the bank's `last_memory_write_at` (from the bank stats endpoint): at or after it means up to date — nothing in the bank changed, so nothing in that model's scope did — while older means it *may* need a refresh. The [knowledge-base tree](./knowledge-pages) uses exactly that rule for its per-page flag.
+Listing surfaces do not pay for it. Reading one model evaluates its scope; listing many would mean one such query each, so `is_stale` is absent from the list response. To flag a whole list, compare each `last_memory_seen_at` against the bank's `last_memory_write_at` (from the bank stats endpoint): at or after it means up to date — nothing in the bank changed, so nothing in that model's scope did — while older means it *may* need a refresh. The [knowledge-base tree](./knowledge-pages) uses exactly that rule for its per-page flag.
+
+**Two timestamps answer two different questions.** `last_refreshed_at` is wall-clock: when a refresh last finished. It advances on every refresh that completes — including one that read the scope, found nothing new, and left the document alone — so a client driving refreshes itself can use it to tell "I already did this one" from "this one still needs a call". `last_memory_seen_at` is a position in the data: the newest in-scope memory the last refresh saw. It stands still while the model's scope is quiet, however many times you refresh, which is what makes it the right side of the staleness comparison. A model with a recent `last_refreshed_at` and an old `last_memory_seen_at` is not a contradiction — it means you refreshed a document that had nothing new to say.
 
 ### What a Refresh Reads
 
@@ -396,7 +398,7 @@ Both **List** and **Get** endpoints accept an optional `detail` query parameter 
 
 | Level | Fields Returned | Use Case |
 |-------|----------------|----------|
-| `metadata` | `id`, `bank_id`, `name`, `tags`, `last_refreshed_at`, `created_at` | Inventory — "what models exist?" |
+| `metadata` | `id`, `bank_id`, `name`, `tags`, `last_refreshed_at`, `last_memory_seen_at`, `created_at` | Inventory — "what models exist?" |
 | `content` | All metadata fields + `source_query`, `content`, `max_tokens`, `trigger` | Agent boot — "what do the models say?" |
 | `full` (default) | All fields including `reflect_response` | Deep inspection — "what evidence backs this model?" |
 
@@ -428,7 +430,8 @@ Use `detail=content` for agent orientation flows. It includes everything the age
 | `bank_id` | string | metadata | Memory bank ID |
 | `name` | string | metadata | Human-readable name |
 | `tags` | list | metadata | Tags for filtering |
-| `last_refreshed_at` | string | metadata | When the mental model was last updated |
+| `last_refreshed_at` | string | metadata | When a refresh last finished — wall-clock. Advances on every completed refresh, including one that found nothing new. Answers "have I already refreshed this?" |
+| `last_memory_seen_at` | string | metadata | The newest in-scope memory the last refresh saw. Answers "is this behind the data?" — compare against `last_memory_write_at` from the stats endpoint |
 | `created_at` | string | metadata | When the mental model was created |
 | `source_query` | string | content | The query used to generate content |
 | `content` | string | content | The generated mental model text |

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -13048,6 +13048,18 @@
             "title": "Filename",
             "description": "Original filename for file-conversion operations (file_convert_retain); null for other task types."
           },
+          "mental_model_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mental Model Id",
+            "description": "Mental model this operation acted on (refresh_mental_model); null for other task types. Without it the list cannot say which model an operation refreshed \u2014 `document_id` is null for these, and the list carries no result_metadata. The single-operation read exposes the same value under `result_metadata`."
+          },
           "created_at": {
             "type": "string",
             "title": "Created At"

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -7406,7 +7406,7 @@
               }
             ],
             "title": "Last Memory Write At",
-            "description": "When a memory was last written in this bank \u2014 stored, edited, or consolidated (ISO format). Null if the bank has no memories. A mental model whose `last_refreshed_at` is at or after this is up to date whatever its tags; an older one may need a refresh, which only the single mental-model read can confirm."
+            "description": "When a memory was last written in this bank \u2014 stored, edited, or consolidated (ISO format). Null if the bank has no memories. A mental model whose `last_memory_seen_at` is at or after this is up to date whatever its tags; an older one may need a refresh, which only the single mental-model read can confirm."
           },
           "pending_consolidation": {
             "type": "integer",
@@ -12229,7 +12229,7 @@
               }
             ],
             "title": "Created After",
-            "description": "Lower bound on memory creation time. Set only in delta mode, where it is the model's last_refreshed_at \u2014 so a delta refresh only sees memories newer than the last one."
+            "description": "Lower bound on memory creation time. Set only in delta mode, where it is the model's last_memory_seen_at \u2014 so a delta refresh only sees memories newer than the newest one the previous refresh saw."
           },
           "created_before": {
             "type": "string",
@@ -12248,7 +12248,7 @@
               }
             ],
             "title": "Watermark",
-            "description": "The last_refreshed_at a real refresh would persist: the newest in-scope memory visible at the snapshot, not now(). Null means no in-scope memory was visible."
+            "description": "The last_memory_seen_at a real refresh would persist: the newest in-scope memory visible at the snapshot, not now(). Null means no in-scope memory was visible."
           }
         },
         "type": "object",
@@ -12333,7 +12333,20 @@
                 "type": "null"
               }
             ],
-            "title": "Last Refreshed At"
+            "title": "Last Refreshed At",
+            "description": "When a refresh last finished for this model \u2014 wall-clock, in ISO format. Advances on every refresh that completes, including one that found nothing new and preserved the content, and on a direct edit of `content`. A refresh that failed leaves it alone. This is the field to answer 'have I already refreshed this?'; it says nothing about whether the model is behind the data, which is `last_memory_seen_at` / `is_stale`."
+          },
+          "last_memory_seen_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Memory Seen At",
+            "description": "How far through the bank's memories this model is written \u2014 the newest in-scope memory the last refresh saw, in ISO format. Stands still when nothing in the model's scope has been written, however often it is refreshed. Compare against `last_memory_write_at` from GET /stats to flag a whole list cheaply: at or after it means up to date, older means it may need a refresh. Null for a model no refresh has stamped yet."
           },
           "created_at": {
             "anyOf": [
@@ -12369,7 +12382,7 @@
               }
             ],
             "title": "Is Stale",
-            "description": "True when memories matching this mental model's tag/fact_type scope have been written since last_refreshed_at. Exact, and costly to compute, so it is populated only by the single mental-model read at detail=full \u2014 never when listing. For a whole list, compare each `last_refreshed_at` against the bank's `last_memory_write_at` from GET /stats: at or after it means up to date, older means it may need a refresh."
+            "description": "True when memories matching this mental model's tag/fact_type scope have been written since last_memory_seen_at. Exact, and costly to compute, so it is populated only by the single mental-model read at detail=full \u2014 never when listing. For a whole list, compare each `last_memory_seen_at` against the bank's `last_memory_write_at` from GET /stats: at or after it means up to date, older means it may need a refresh."
           }
         },
         "type": "object",


### PR DESCRIPTION
## The bug

`POST /banks/{bank}/mental-models/{id}/refresh` runs, writes new content, reports `completed` — and leaves `last_refreshed_at` untouched. A reporter drove ~6,000 refreshes/day against an intended ~350, for four days, because their scheduler reads that field to answer *"have I already refreshed this?"* and it never moved.

`update_mental_model` persisted the refresh's **source-data watermark** into `last_refreshed_at`, and `_mental_model_processed_watermark` clamps that watermark so it never regresses:

```python
return max(newest_in_scope, current_last_refreshed_at)
```

On a model whose scope gained no new memories, `newest_in_scope <= current`, so the max **is** the value already in the column. The refresh wrote it straight back over itself. The document changed; the timestamp did not.

That also explains why it looked non-deterministic ("not universal — some models do get a new `last_refreshed_at`, in the same bank, in the same window"): models whose scope *was* being written to had a genuinely newer watermark, so theirs advanced. Nothing to do with consolidation or cron — those were correctly ruled out.

Introduced by #2878, which needed a data watermark and reused the wall-clock column for it.

## The fix

One column cannot answer both *"did a refresh run?"* and *"is this behind the data?"*. Split them:

| Field | Means | Answers |
|---|---|---|
| `last_refreshed_at` | Wall-clock time a refresh completed. **Meaning restored** — the name never changed. | *"Have I already refreshed this?"* |
| `last_memory_seen_at` | **New.** Newest in-scope memory the last refresh saw. | *"Is this behind the data?"* |

The new column takes over the existing value *and* the existing computation, unchanged. Staleness, the delta window, the knowledge-tree flag and the reflect agent's `is_stale` all key off it, so **refresh behaviour is identical** — this is not a change to when models refresh, only to what the timestamps report.

`last_memory_seen_at` deliberately mirrors `last_memory_write_at` on `GET /stats`, so the cheap whole-list rule reads as a sentence: `last_memory_seen_at >= last_memory_write_at` → up to date.

### A completed refresh always stamps the clock

Including a delta refresh that read the scope, found nothing new, and preserved the content — it ran, and a caller polling for it must see that. This matters for exactly the reported workload: a model with static sources is the one whose refresh has nothing to write. A refresh that **failed** still stamps neither, so a retry re-reads the same window.

### Migration

`last_memory_seen_at` is backfilled from `last_refreshed_at` — which today already holds the watermark, so the copy is lossless. **No bank changes staleness on deploy**: nothing mass-refreshes, nothing mass-stops. The column is nullable and consumers `COALESCE` back to `last_refreshed_at` for rows no refresh has stamped yet, so a restored pre-migration backup behaves correctly too. PG + Oracle, both re-runnable.

### Control plane

`bank-stats-view.tsx` implemented the documented "compare `last_refreshed_at` against `last_memory_write_at`" rule. Left alone it would have reported every recently-refreshed model as current — a false-fresh freshness card — so it now reads `last_memory_seen_at`.

## Compatibility — read before releasing

**Schema: additive.** `last_memory_seen_at` is a new optional field. Nothing removed, no type changed, `check-openapi-compatibility` passes, old clients ignore it.

**Semantics: `last_refreshed_at`'s value changes.** This is a deliberate break and needs a note in the release, not a silent ship. A client following the list heuristic documented in v0.9.0 — compare `last_refreshed_at` against `last_memory_write_at` — will start reading models as up to date that aren't, until it switches to `last_memory_seen_at`. False-fresh is the direction that fails quietly, so it should be called out by name.

What makes it the right call rather than a new break:

| Period | `last_refreshed_at` meant |
|---|---|
| inception → 2026-07-21 | wall clock (`NOW()`) |
| v0.8.5 → v0.9.1 (4 weeks, 4 releases) | the source watermark ← #2866 / #2878 |
| this PR | wall clock again |

#2878 needed a data watermark and reused the wall-clock column for it without renaming — that was the break. This reverts it and gives the watermark its own column. The documented compare-rule only landed 2026-08-04 (#3156), so it has been correct for exactly two releases.

The upgrade for anyone affected is one field name, and the replacement ships in the same response.

## Tests

- **The reported bug**, reproduced: two refreshes over a scope that gained no memories. The watermark is identical both times (correct — the data didn't move); `last_refreshed_at` must advance anyway. Fails on `main`.
- A refresh that preserves content stamps the clock; a **failed** one stamps neither.
- **The inverse regression**: a recent `last_refreshed_at` must not mask a memory the document has never seen — staleness still keys off what was seen.
- Updated the delta watermark tests to assert against the column that now carries the watermark.

746 tests pass across the mental-model, delta, dry-run, scheduled-refresh, knowledge-page, consolidation and reflect suites.

## Also from the report: which model did this operation refresh?

`refresh_mental_model` operations return `document_id: null` and carried no model identifier, so the operations log could not say which model an operation acted on. On a bank with 270 models that makes the log useless for diagnosis — which is why this took a live controlled experiment instead of one query.

The id was always there, in `result_metadata` — but the operations *list* exposes no `result_metadata` at all. So the list gains `mental_model_id`, surfaced the same way `document_id` and `filename` already are. The single-operation read already returns `result_metadata` and gets no duplicate field.

## Still not in this PR

**`total` on `GET /banks/{bank}/mental-models`.** The envelope is `{"items": [...]}` with `limit` defaulting to 100 and no count, so a consumer cannot tell "100 models" from "page 1 of 3". One of their clients read 100 of 270 and treated the other 170 as deleted; our own dashboard shows "100 mental models" for that bank for the same reason. Worth its own issue — it changes a widely-consumed envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
