### PR TITLE
fix(api): batch the retention sweep so it stops stalling foreground queries

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/maintenance.py
@@ -28,9 +28,11 @@ thousands of tenants.
 
 The loop runs in *every* API/worker process with no leader election, so a job that
 enqueues work must make that enqueue idempotent or the fleet queues one wave per
-process. Retention and operation cleanup are deletes; the consolidation reconcile
-and the scheduled mental model refresh both dedupe against in-flight operations
-inside the inserting transaction (see ``_submit_async_operation``).
+process. Operation cleanup deletes a bounded batch per schema; the consolidation
+reconcile and the scheduled mental model refresh both dedupe against in-flight
+operations inside the inserting transaction (see ``_submit_async_operation``);
+retention deletes in bounded chunks claimed with SKIP LOCKED, so concurrent
+sweepers split the work instead of colliding (see ``_purge_table_in_batches``).
 """
 
 from __future__ import annotations
@@ -68,6 +70,31 @@ _TXN_RECOVERY_INTERVAL_SECONDS = 300
 # A pending txn is left alone for this long from first sighting before the sweep aborts an
 # unwitnessed one — the writer may still be mid-flight (PendingTxn carries no timestamp).
 _TXN_RECOVERY_GRACE_SECONDS = 300
+
+# ── retention sweep pacing ────────────────────────────────────────────────────
+# Retention used to issue one unbounded `DELETE FROM <table> WHERE started_at <
+# cutoff` per schema. On a table with a real backlog that is a single statement
+# holding row locks for minutes while it reads the whole expired range — and the
+# maintenance loop runs in every API/worker process with no leader election, so
+# every pod issued it at the same hourly boundary. Observed as two concurrent
+# 330s+ deletes pinned on IO.DataFileRead, blocking each other on row locks,
+# saturating RDS I/O and tripling recall latency.
+#
+# The fix is to design the collision out rather than elect one sweeper: each chunk
+# claims its rows with FOR UPDATE SKIP LOCKED, so concurrent sweepers take
+# *disjoint* chunks instead of waiting on each other, and the total work stays the
+# number of expired rows however many pods join in. Chunks are short, index-driven
+# transactions with a pause between them, so no statement holds locks for long and
+# the deletes never monopolise disk I/O.
+_RETENTION_BATCH_SIZE = 2000
+# Ceiling on chunks per table per schema per run: a backstop against looping
+# forever on a table that is filling faster than it drains. A full run therefore
+# removes at most 2M rows per schema, and the next hourly tick continues.
+_RETENTION_MAX_BATCHES = 1000
+# Breather between chunks. Paces one process at ~8k rows/s worst case; several
+# pods sweeping at once multiply that, which is still orders of magnitude gentler
+# than the unbounded delete this replaces.
+_RETENTION_BATCH_PAUSE_SECONDS = 0.25
 
 
 class MaintenanceLoop:
@@ -213,26 +240,86 @@ class MaintenanceLoop:
         if cfg.llm_trace_enabled and cfg.llm_trace_retention_days > 0:
             await self._purge_expired("llm_requests", "started_at", cfg.llm_trace_retention_days)
 
-    async def _purge_expired(self, table: str, ts_col: str, days: int) -> None:
-        """Delete rows older than ``days`` from ``table`` across every tenant schema."""
+    async def _purge_expired(self, table: str, ts_col: str, days: int) -> int:
+        """Delete rows older than ``days`` from ``table`` across every tenant schema.
+
+        Only for the retention tables (``audit_log``, ``llm_requests``): chunking
+        deletes by primary key assumes the ``id`` column both of them carry.
+        Returns the number of rows deleted by *this* process.
+        """
         backend = self._engine._backend
         try:
             async with acquire_with_retry(backend, max_retries=1) as conn:
                 rows = await conn.fetch(
                     f"SELECT * FROM {fq_routine('schemas_with_expired_rows')}($1, $2, $3)", table, ts_col, days
                 )
-                for row in rows:
-                    schema = row[0]
-                    # schema names come from pg_class; quote defensively all the same.
-                    qschema = '"' + schema.replace('"', '""') + '"'
-                    result = await conn.execute(
-                        f"DELETE FROM {qschema}.{table} WHERE {ts_col} < NOW() - make_interval(days => $1)",
-                        days,
-                    )
-                    if result and result != "DELETE 0":
-                        logger.info(f"Retention sweep {schema}.{table}: {result}")
         except Exception as e:
-            logger.warning(f"Retention sweep failed for {table}: {e}")
+            logger.warning(f"Retention sweep discovery failed for {table}: {e}")
+            return 0
+
+        # One cutoff for the whole sweep: a per-chunk NOW() would let the window
+        # creep forward mid-run, which makes "deleted < batch means done" wrong.
+        cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+        total = 0
+        for row in rows:
+            schema = row[0]
+            # schema names come from pg_class; quote defensively all the same.
+            qschema = '"' + schema.replace('"', '""') + '"'
+            try:
+                deleted = await self._purge_table_in_batches(f"{qschema}.{table}", ts_col, cutoff)
+            except Exception as e:
+                logger.warning(f"Retention sweep failed for {schema}.{table}: {e}")
+                continue
+            if deleted:
+                total += deleted
+                logger.info(f"Retention sweep {schema}.{table}: DELETE {deleted}")
+        return total
+
+    async def _purge_table_in_batches(self, table: str, ts_col: str, cutoff: datetime) -> int:
+        """Delete expired rows from one qualified table in bounded chunks.
+
+        Rows are claimed oldest-first off the ``(started_at)`` index with FOR UPDATE
+        SKIP LOCKED, which is what makes a leaderless fleet safe: a chunk never
+        waits on another sweeper (or on a writer still finishing its own row), and
+        two processes sweeping the same table take disjoint chunks rather than
+        redoing each other's work. Each chunk commits on its own, so no transaction
+        holds locks longer than one batch.
+        """
+        backend = self._engine._backend
+        deleted = 0
+        for batch in range(_RETENTION_MAX_BATCHES):
+            if self._stop.is_set():
+                break
+            if batch:
+                await asyncio.sleep(_RETENTION_BATCH_PAUSE_SECONDS)
+            async with acquire_with_retry(backend, max_retries=1) as conn, conn.transaction():
+                removed = await conn.fetchval(
+                    f"""
+                    WITH expired AS (
+                        SELECT id FROM {table}
+                        WHERE {ts_col} < $1
+                        ORDER BY {ts_col}
+                        LIMIT $2
+                        FOR UPDATE SKIP LOCKED
+                    ), removed AS (
+                        DELETE FROM {table} t USING expired e WHERE t.id = e.id RETURNING 1
+                    )
+                    SELECT count(*) FROM removed
+                    """,
+                    cutoff,
+                    _RETENTION_BATCH_SIZE,
+                )
+            deleted += removed
+            # A short chunk means the expired range is drained — or that another
+            # sweeper holds the rest, which is equally a reason to stop.
+            if removed < _RETENTION_BATCH_SIZE:
+                break
+        else:
+            logger.warning(
+                f"Retention sweep hit its per-run batch ceiling on {table} after {deleted} row(s); "
+                "the remainder is left for the next run"
+            )
+        return deleted
 
     # ── terminal operation cleanup ─────────────────────────────────────────
 

--- a/hindsight-api-slim/tests/test_maintenance_loop.py
+++ b/hindsight-api-slim/tests/test_maintenance_loop.py
@@ -111,6 +111,106 @@ async def test_purge_expired_deletes_old_rows_across_schema(memory: MemoryEngine
     assert remaining == 1  # only the recent row survives
 
 
+class TestRetentionSweepPacing:
+    """The retention sweep must never be one long unbounded DELETE, and must stay
+    safe when every process runs it at once.
+
+    The maintenance loop runs in every API/worker process with no leader election,
+    so the previous single `DELETE ... WHERE started_at < cutoff` per schema ran
+    concurrently on every pod: minutes-long statements pinned on disk reads,
+    blocking each other on row locks and starving foreground queries. The sweep now
+    deletes in bounded chunks whose rows are claimed with FOR UPDATE SKIP LOCKED,
+    so concurrent sweepers take disjoint chunks instead of waiting on each other.
+    """
+
+    @staticmethod
+    async def _make_probe_table(memory: MemoryEngine, expired: int, recent: int) -> str:
+        """A throwaway table shaped like the retention tables (id + started_at).
+
+        Purpose-made so the assertions are exact: sweeping the real audit_log would
+        also delete rows other tests left behind in the shared database.
+        """
+        table = f"retention_probe_{uuid.uuid4().hex[:8]}"
+        async with memory._pool.acquire() as conn:
+            await conn.execute(
+                f"CREATE TABLE {table} (id UUID PRIMARY KEY DEFAULT gen_random_uuid(), started_at TIMESTAMPTZ NOT NULL)"
+            )
+            await conn.execute(
+                f"INSERT INTO {table} (started_at) SELECT now() - INTERVAL '10 days' FROM generate_series(1, $1)",
+                expired,
+            )
+            await conn.execute(
+                f"INSERT INTO {table} (started_at) SELECT now() FROM generate_series(1, $1)",
+                recent,
+            )
+        return table
+
+    @staticmethod
+    async def _count(memory: MemoryEngine, table: str) -> int:
+        async with memory._pool.acquire() as conn:
+            return await conn.fetchval(f"SELECT COUNT(*) FROM {table}")
+
+    @staticmethod
+    async def _drop(memory: MemoryEngine, table: str) -> None:
+        async with memory._pool.acquire() as conn:
+            await conn.execute(f"DROP TABLE IF EXISTS {table}")
+
+    @pytest.mark.asyncio
+    async def test_chunked_delete_drains_every_expired_row(self, memory: MemoryEngine, monkeypatch):
+        """Chunking is a pacing device, not a cap: the sweep keeps going until the
+        expired range is gone, and never touches rows inside the window."""
+        import hindsight_api.engine.maintenance as maintenance_mod
+
+        monkeypatch.setattr(maintenance_mod, "_RETENTION_BATCH_SIZE", 2)
+        table = await self._make_probe_table(memory, expired=5, recent=1)
+        try:
+            deleted = await MaintenanceLoop(memory)._purge_expired(table, "started_at", 7)
+
+            assert deleted == 5  # three chunks of 2, 2, 1
+            assert await self._count(memory, table) == 1  # only the row inside the window survives
+        finally:
+            await self._drop(memory, table)
+
+    @pytest.mark.asyncio
+    async def test_per_run_batch_ceiling_bounds_one_sweep(self, memory: MemoryEngine, monkeypatch):
+        """A backlog is drained over several runs rather than in one long statement."""
+        import hindsight_api.engine.maintenance as maintenance_mod
+
+        monkeypatch.setattr(maintenance_mod, "_RETENTION_BATCH_SIZE", 2)
+        monkeypatch.setattr(maintenance_mod, "_RETENTION_MAX_BATCHES", 1)
+        table = await self._make_probe_table(memory, expired=5, recent=1)
+        try:
+            await MaintenanceLoop(memory)._purge_expired(table, "started_at", 7)
+
+            # One chunk of 2 removed; the rest waits for the next run.
+            assert await self._count(memory, table) == 4
+        finally:
+            await self._drop(memory, table)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_sweepers_split_the_work_without_blocking(self, memory: MemoryEngine, monkeypatch):
+        """The point of SKIP LOCKED: with no leader, several pods sweep at once and
+        each row is deleted exactly once — the deletes partition the backlog instead
+        of waiting on each other's row locks."""
+        import asyncio
+
+        import hindsight_api.engine.maintenance as maintenance_mod
+
+        monkeypatch.setattr(maintenance_mod, "_RETENTION_BATCH_SIZE", 2)
+        table = await self._make_probe_table(memory, expired=20, recent=1)
+        try:
+            sweepers = [MaintenanceLoop(memory)._purge_expired(table, "started_at", 7) for _ in range(3)]
+            deleted = await asyncio.wait_for(asyncio.gather(*sweepers), timeout=60)
+
+            # Every expired row accounted for exactly once across the three pods:
+            # a row double-counted would mean a sweeper waited for, then re-deleted,
+            # another's rows; a missing row would mean SKIP LOCKED dropped it.
+            assert sum(deleted) == 20
+            assert await self._count(memory, table) == 1
+        finally:
+            await self._drop(memory, table)
+
+
 class TestOperationCleanupJob:
     """Terminal-operation cleanup runs as a scheduled maintenance job.
 

--- a/hindsight-clients/go/go.mod
+++ b/hindsight-clients/go/go.mod
@@ -2,10 +2,6 @@ module github.com/vectorize-io/hindsight/hindsight-clients/go
 
 go 1.18
 
-require github.com/stretchr/testify v1.11.1
+require github.com/stretchr/testify v1.12.0
 
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
-)
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/hindsight-clients/go/go.sum
+++ b/hindsight-clients/go/go.sum
@@ -1,9 +1,5 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
-github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/stretchr/testify v1.12.0 h1:K6Mr6jO9JICuend/5xzTM03ydSV3vdNRYAdPSukj8uI=
+github.com/stretchr/testify v1.12.0/go.mod h1:bOYBZb5qJ00vPzWfIqBUZPaxK8jWiXc6d3ErP4Ca9Gw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Problem

Reported from production: two `DELETE FROM llm_requests` running concurrently on multiple pods for **330s+**, pinned on `IO.DataFileRead` and blocking each other on row locks — saturating RDS I/O and inflating recall latency from ~0.6s to ~1.8s.

The cause is in `MaintenanceLoop._purge_expired`: the hourly retention sweep issued **one unbounded** `DELETE FROM <schema>.<table> WHERE started_at < NOW() - N days` per tenant schema. The maintenance loop runs in *every* API/worker process with no leader election, so every pod fired that statement on the same hourly boundary.

## Fix

Rather than elect a single sweeper, the collision is designed out:

- **Chunked deletes** — 2000 rows per chunk, oldest first off the `started_at` index, each chunk its own short transaction, 250ms apart. No statement holds row locks for more than one batch, and the sweep never monopolises disk I/O.
- **`FOR UPDATE SKIP LOCKED`** on each chunk's candidate rows. This is what makes a leaderless fleet safe: concurrent sweepers claim **disjoint** chunks instead of waiting on each other, and the total work stays the number of expired rows however many pods join in. A chunk also never waits on a writer still finishing its own row.
- **Per-run chunk ceiling** (1000) so a table filling faster than it drains can't loop forever — the next hourly tick continues where it left off, and the truncation is logged rather than silent.

**No advisory lock and no leader election**, deliberately: Hindsight runs behind connection poolers where advisory locks are unreliable (see the Database Locking rule in `.claude/skills/code-review/SKILL.md` / #2690). `SKIP LOCKED` gives the same protection against concurrent sweepers colliding, without needing exclusivity.

Applies to both retention tables — `llm_requests` and `audit_log`.

## Tests

New `TestRetentionSweepPacing` in `tests/test_maintenance_loop.py`, against a purpose-made probe table so the assertions are exact:

- chunking drains the whole expired range and never touches rows inside the window
- the per-run ceiling really bounds one sweep (backlog drains over several runs)
- **three concurrent sweepers split the work** — every expired row deleted exactly once, none left behind, no blocking

The existing single-schema and multi-tenant retention tests are unchanged and still pass.

```
tests/test_maintenance_loop.py tests/test_maintenance_multitenant.py .. 13 passed
tests/test_maintenance_routines.py tests/test_llm_trace.py ............ 54 passed
```
(the one skipped error is `test_real_llm_retain_and_consolidation_traced`, an `hs_llm_mat` test needing provider credentials)
