### PR TITLE
fix(scripts): preserve go client go.mod/go.sum across regeneration

### DIFF
--- a/scripts/generate-clients.sh
+++ b/scripts/generate-clients.sh
@@ -424,12 +424,19 @@ else
     [ -f "null_test.go" ] && cp null_test.go "$TEMP_DIR/"
     [ -f "trace_test.go" ] && cp trace_test.go "$TEMP_DIR/"
     [ -f "hindsight_client.go" ] && cp hindsight_client.go "$TEMP_DIR/"
+    # go.mod/go.sum are maintained, not regenerated: a fresh `go mod tidy`
+    # resolves unpinned deps (e.g. testify, pulled in by the maintained tests)
+    # to whatever upstream's latest release is, so regeneration output would
+    # change whenever a dependency publishes a new version and break the
+    # verify-generated-files CI check. Preserving them keeps regeneration
+    # deterministic; upgrade deps explicitly with `go get` + `go mod tidy`.
+    [ -f "go.mod" ] && cp go.mod "$TEMP_DIR/"
+    [ -f "go.sum" ] && cp go.sum "$TEMP_DIR/"
 
     # Remove old generated files
     echo "Removing old generated code..."
     rm -f api_*.go model_*.go client.go configuration.go response.go utils.go
     rm -rf docs/ .openapi-generator/
-    rm -f go.mod go.sum
 
     # Generate new client via Docker (--platform linux/amd64 ensures identical output on macOS and Linux CI)
     echo "Generating client from OpenAPI spec..."
@@ -458,6 +465,9 @@ else
     [ -f "$TEMP_DIR/null_test.go" ] && mv "$TEMP_DIR/null_test.go" .
     [ -f "$TEMP_DIR/trace_test.go" ] && mv "$TEMP_DIR/trace_test.go" .
     [ -f "$TEMP_DIR/hindsight_client.go" ] && mv "$TEMP_DIR/hindsight_client.go" .
+    # Overwrites the generator-emitted go.mod/go.sum with the maintained ones.
+    [ -f "$TEMP_DIR/go.mod" ] && mv "$TEMP_DIR/go.mod" .
+    [ -f "$TEMP_DIR/go.sum" ] && mv "$TEMP_DIR/go.sum" .
     rm -rf "$TEMP_DIR"
 
     # Fix known generator issue: api_files.go uses os.File but generator omits "os" import


### PR DESCRIPTION
## Summary

- `scripts/generate-clients.sh` deleted the Go client's `go.mod`/`go.sum` before regeneration and re-resolved them with a fresh `go mod tidy`. Dependencies pulled in by the maintained test files (testify) are not pinned by the generator, so tidy resolved them to upstream's **latest** release.
- As a result, every new testify release changed the regeneration output and broke the `verify-generated-files` check for **all** pull requests (currently happening with testify v1.12.0: recent PRs each had to commit the same `go.mod`/`go.sum` bump to get CI green).
- Fix: treat `go.mod`/`go.sum` as maintained files — stash them alongside `README.md`/`integration_test.go` before wiping generated code and restore them over the generator-emitted ones. `go mod tidy` still runs, but now only adds entries for new imports; dependency upgrades become explicit `go get` + `go mod tidy` commits, same as any normal Go module.

## Test plan

- [x] `bash -n scripts/generate-clients.sh`