### PR TITLE
fix(coding-agents): start the local daemon for plugin harnesses too

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -215,6 +215,48 @@ If any files in `hindsight-integrations/` were added or changed, verify:
 - **Docs gallery + sidebar entry** — the integration must have an entry in `hindsight-docs/src/data/integrations.json`. This file is the **single source of truth** that drives both the integrations gallery and the docs sidebar (the sidebar category is injected from it at render time across all docs versions). The entry needs an internal `/sdks/integrations/<slug>` `link` and a matching page at `hindsight-docs/docs-integrations/<slug>.md(x)`. The `hindsight-docs/scripts/check-integrations.mjs` build step enforces both directions — forward: every internal JSON entry has a doc page; reverse: every released tag (`integrations/<name>/vX.Y.Z`) appears in the JSON (private infra like `cloudflare-oauth-proxy` is in the script's `EXCLUDED` set). Flag any integration that is released (or being released) but missing from `integrations.json`, and any JSON entry without a doc page. Do **not** hand-edit `versioned_sidebars/*.json` to add integration links — they are positional placeholders filled from the JSON.
 - **Code standards** — the integration code must follow all Python style rules (type hints, no raw dicts, no tuple returns, etc.).
 
+### 9a. Check parity across sibling implementations
+
+Whenever the same capability is implemented once per *variant* — one per harness, per language, per
+dialect, per provider — the new or changed variant is where a capability silently goes missing. The
+defect never looks like a bug in the diff: the code that's wrong is the code that **isn't there**,
+and every existing test still passes because the sibling that forgot is by definition the one nobody
+wrote a test for. That is how dsh shipped in daemon mode without ever starting a daemon (#3524):
+`ensureDaemon` sat in the hook-only wrappers, so all five persistent-plugin harnesses lacked it.
+
+Known sibling families in this repo (this is not the whole list — the rule is about the *shape*):
+
+| Family | Where |
+|---|---|
+| Coding-agent harnesses | `hindsight-integrations/coding-agents/src/` (hook harnesses vs. persistent-plugin harnesses: dsh, opencode, Kilo, Cline, Prime Agent) |
+| Wrapper SDK clients | TypeScript + Python wrappers — see step 7a |
+| Alembic migrations | `_pg_upgrade` / `_oracle_upgrade` in every migration |
+| Dataplane ↔ control plane | `api/http.py` params vs `hindsight-control-plane/src/app/api/**` proxy routes + `lib/api.ts` |
+| LLM providers | per-provider branches in `engine/llm_wrapper.py` |
+
+**Procedure — do this by hand; no linter catches it.** When the diff adds a new sibling, or changes
+one sibling of a family:
+
+1. **Enumerate the family.** List every existing sibling (`ls` the directory, grep the registry).
+2. **Diff the capability list, not the code.** For each capability the *other* siblings have —
+   lifecycle hooks called, setup/teardown performed, config flags honoured, opt-outs respected,
+   registry/installer/docs entries — confirm the changed sibling has it, or that its absence is
+   deliberate and commented. Grep is the tool: `grep -rn ensureDaemon src` proves who calls it.
+3. **Prefer hoisting over copying.** If the capability now exists in N places, the fix is usually to
+   move it into the one path every sibling already shares (e.g. `RuntimeCore`, `buildHookOutput`),
+   not to paste an Nth copy that the N+1th sibling will forget again.
+4. **Demand a structural guard, not just a unit test.** A test for the sibling that forgot doesn't
+   exist by construction, so ask for a test that asserts *over the whole family*: enumerate the
+   siblings from the filesystem/registry and assert each satisfies the contract, with an explicit,
+   commented exemption list. Precedents: `registry covers every installable harness`
+   (`harness/registry.test.ts`), `every harness entrypoint reaches a daemon` (`core/daemon.test.ts`),
+   `test_backup_tables_covers_entire_schema`, `test_migration_shape.py`.
+
+Flag a capability present in every sibling but one as a **must fix** — state which siblings have it,
+which doesn't, and what the user-visible symptom is (for #3524: every `hindsight_*` tool call fails
+with ECONNREFUSED and nothing ever starts the daemon). A new sibling family member landing with no
+family-wide guard test is a **should fix**.
+
 ### 10. Check MCP tool registration completeness
 
 If any new MCP tools were added or existing tools renamed in `hindsight-api-slim/hindsight_api/mcp_tools.py`:
@@ -280,6 +322,8 @@ Present a clear summary organized by severity:
 - New integration missing tests, CI job, or release-integration.sh entry
 - Released/added integration missing from `hindsight-docs/src/data/integrations.json`, or a JSON entry with no `docs-integrations/<slug>` page (fails the docs build via `check-integrations.mjs`)
 - New PostgreSQL table missing from `BACKUP_TABLES` in `admin/cli.py` (silent data loss on restore)
+- A capability every sibling implementation has except the one in the diff (see step 9a) — a
+  harness, dialect, provider or language variant that skips a lifecycle step the others perform
 
 **Should fix** — issues that hurt code quality:
 - Dead code / unused imports missed by linter

--- a/hindsight-integrations/coding-agents/src/cline.test.ts
+++ b/hindsight-integrations/coding-agents/src/cline.test.ts
@@ -76,6 +76,28 @@ describe("Cline native plugin adapter", () => {
     CLINE_HOOK_BUDGET_MS + 1_000
   );
 
+  // seedIfCold waits on a cold local daemon (#3524), which outlasts the sandbox's 3s RPC abort by
+  // design — so the SessionStart await has to be bounded exactly like the reflect above.
+  it(
+    "does not let a cold daemon start exceed Cline's sandbox hook budget",
+    async () => {
+      const core = {
+        onPrompt: vi.fn(async () => {}),
+        getInjection: vi.fn(() => undefined),
+        onTranscript: vi.fn(async () => {}),
+      };
+      const hooks = createClineHooks(core as never, "session-1", new Promise<void>(() => {}));
+
+      await expect(
+        hooks.beforeModel({
+          snapshot: { agentId: "agent-1", messages: [message("u-1", "user", "cold daemon")] },
+          request: { messages: [message("u-1", "user", "cold daemon")] },
+        })
+      ).resolves.toBeUndefined();
+    },
+    CLINE_HOOK_BUDGET_MS + 1_000
+  );
+
   it("retains only user-visible text and excludes tool arguments/results", async () => {
     const core = {
       onPrompt: vi.fn(async () => {}),

--- a/hindsight-integrations/coding-agents/src/cline.ts
+++ b/hindsight-integrations/coding-agents/src/cline.ts
@@ -132,7 +132,11 @@ export function createClineHooks(
         // `seedIfCold` sets the shared new-bank marker before the first prompt. Awaiting it here,
         // rather than racing plugin setup, preserves the invariant that a brand-new bank skips its
         // first auto-reflect instead of spending that one synthesis before it has any knowledge.
-        await sessionStart;
+        // Bounded by the same budget as onPrompt below: seedIfCold now also waits for a cold local
+        // daemon (up to DAEMON_WAIT_SESSION_START_MS), and this is the one host that awaits it
+        // inside an RPC the sandbox aborts at 3s. It stays running either way, so a start that
+        // outlasts the budget just lands for a later turn.
+        await settleWithinHookBudget(sessionStart ?? Promise.resolve());
       }
       const user = latestUserMessage(snapshot.messages);
       if (!user) return undefined;

--- a/hindsight-integrations/coding-agents/src/core/daemon.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/daemon.test.ts
@@ -1,3 +1,6 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { resolveConfig } from "./config";
 import { daemonEnv, detectLlm, ensureDaemon, startDaemonDetached } from "./daemon";
@@ -92,6 +95,61 @@ describe("ensureDaemon", () => {
   it("resolves without reporting usability", async () => {
     const cfg = resolveConfig({ apiUrl: "https://cloud.example" });
     expect(await ensureDaemon(cfg, "claude-code", {})).toBeUndefined();
+  });
+});
+
+/**
+ * Daemon parity across harnesses (#3524).
+ *
+ * The ensure points were written for the fresh-process hook harnesses and lived in their hook
+ * wrappers, so every harness added since — the persistent-plugin hosts, which call the shared
+ * lifecycle directly — silently shipped without one. In daemon mode that means every request fails
+ * with ECONNREFUSED and nothing ever starts a daemon; dsh shipped that way in 0.3.4.
+ *
+ * A per-harness unit test can't catch this: the harness that forgets is by definition the one whose
+ * test nobody wrote. So this asserts the shape instead — a module that builds a client is a place a
+ * request originates, and every one of them either ensures a daemon itself or delegates to
+ * something that does. Adding a harness that does neither fails here, and an entrypoint that
+ * genuinely must not start one has to say why in EXEMPT.
+ */
+describe("every harness entrypoint reaches a daemon", () => {
+  const SRC = fileURLToPath(new URL("..", import.meta.url));
+
+  /** Entrypoints that build a client but deliberately do NOT ensure a daemon, and why. */
+  const EXEMPT: Record<string, string> = {
+    "status.ts": "diagnostic — reports what is running; starting one would falsify the report",
+    "deepen.ts": "spawned by the seed, which already ensured the daemon it inherits",
+    "mcp-server.ts": "child of a hook harness whose SessionStart ensured the daemon first",
+    "core/hook.ts":
+      "the prompt path, deliberately: a cold start outlives the hook budget and stalls the turn",
+  };
+
+  function sourceFiles(dir: string, prefix = ""): string[] {
+    return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory())
+        return entry.name === "e2e" ? [] : sourceFiles(join(dir, entry.name), rel);
+      return entry.name.endsWith(".ts") && !entry.name.includes(".test.") ? [rel] : [];
+    });
+  }
+
+  it("has no client-building module that neither ensures a daemon nor delegates to one", () => {
+    const unreached = sourceFiles(SRC).filter((rel) => {
+      if (rel in EXEMPT) return false;
+      const src = readFileSync(join(SRC, rel), "utf8");
+      if (!src.includes("new HindsightClient(")) return false;
+      // RuntimeCore is the persistent-plugin hosts' shared lifecycle; it ensures at both points.
+      return !src.includes("ensureDaemon") && !src.includes("RuntimeCore");
+    });
+    expect(unreached).toEqual([]);
+  });
+
+  // An exemption for a file that no longer builds a client is a stale claim about live code.
+  it("keeps no exemption for a module that stopped building a client", () => {
+    const stale = Object.keys(EXEMPT).filter(
+      (rel) => !readFileSync(join(SRC, rel), "utf8").includes("new HindsightClient(")
+    );
+    expect(stale).toEqual([]);
   });
 });
 

--- a/hindsight-integrations/coding-agents/src/core/daemon.ts
+++ b/hindsight-integrations/coding-agents/src/core/daemon.ts
@@ -19,6 +19,13 @@
  * hook, which has the longest budget and nothing waiting on its result. The prompt path does
  * nothing here at all.
  *
+ * EVERY HARNESS NEEDS BOTH POINTS, not just the fresh-process hook ones. The persistent-plugin
+ * hosts (opencode, Kilo, Cline, Prime Agent, dsh) run no hook binaries, so they reach these through
+ * `RuntimeCore`: `seedIfCold` is their SessionStart and the write-back is their Stop. Missing that
+ * is what #3524 reported — dsh in daemon mode never started a daemon, so every `hindsight_*` call
+ * failed with ECONNREFUSED until the user ran `daemon-start.js` by hand. `daemon.test.ts` now fails
+ * if a harness entrypoint builds a client without reaching one of the two.
+ *
  * A daemon that is down is NOT special-cased anywhere downstream. Once the URL is resolved, every
  * mode uses the identical client and the identical error handling: an unreachable local daemon
  * surfaces as the same connection failure (and the same `retain_failed` diagnostic) as an

--- a/hindsight-integrations/coding-agents/src/core/runtime.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/runtime.test.ts
@@ -1,7 +1,15 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveConfig } from "./config";
 import type { HindsightClient } from "./hindsight";
 import { RuntimeCore } from "./runtime";
+
+// The real ensureDaemon shells out (uvx/cargo probes) and spawns a detached process; only WHERE it
+// is called from is under test here — the deciding itself is covered in daemon.test.ts.
+const daemonSpy = vi.hoisted(() => vi.fn(async () => {}));
+vi.mock("./daemon", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./daemon")>()),
+  ensureDaemon: daemonSpy,
+}));
 
 describe("RuntimeCore", () => {
   it("uses the shared prompt lifecycle and consumes the new-bank reflect deferral once", async () => {
@@ -109,6 +117,54 @@ describe("RuntimeCore session-idle write-back", () => {
     });
     await expect(runtime.onSessionIdle("s5")).resolves.toBeUndefined();
     expect(retained).toHaveLength(0);
+  });
+});
+
+/**
+ * Daemon parity with the hook harnesses (#3524).
+ *
+ * A persistent-plugin host runs no hook binaries, so `runSessionStartHook`/`runRetainHook` — where
+ * the hook harnesses ensure the daemon — never execute for it. dsh in daemon mode therefore never
+ * started one: every `hindsight_*` call failed with ECONNREFUSED until the user ran daemon-start.js
+ * by hand, and again after each idle-out. RuntimeCore is the one place all five plugin hosts
+ * (opencode, Kilo, Cline, Prime Agent, dsh) share, so the two ensure points live here.
+ */
+describe("RuntimeCore daemon lifecycle", () => {
+  const daemonCfg = resolveConfig({ serverMode: "daemon" });
+  const client = {
+    listDocumentIds: vi.fn(async () => new Set<string>()),
+    listPages: vi.fn(async () => ({ items: [] })),
+    retain: vi.fn(async () => {}),
+  } as unknown as HindsightClient;
+
+  beforeEach(() => daemonSpy.mockClear());
+
+  it("starts the daemon at seedIfCold — the plugin hosts' SessionStart", async () => {
+    const core = new RuntimeCore(client, "bank-1", daemonCfg, "dsh", "/repos/one");
+    await core.seedIfCold("/repos/one");
+    expect(daemonSpy).toHaveBeenCalledWith(daemonCfg, "dsh", { waitMs: 12_000 });
+  });
+
+  // The daemon retires itself after daemonIdleTimeout (300s), so a session that thinks longer than
+  // that would lose its whole exchange with no second chance to start one.
+  it("starts the daemon again on write-back — the Stop hook these hosts don't have", async () => {
+    const core = new RuntimeCore(client, "bank-1", daemonCfg, "dsh", "/repos/one");
+    core.setTranscriptSource(async () => [{ role: "user", content: "hi" }] as never);
+    await core.onSessionIdle("s1");
+    await new Promise((r) => setTimeout(r, 0)); // retain is fire-and-forget
+    expect(daemonSpy).toHaveBeenCalledWith(daemonCfg, "dsh", { waitMs: 40_000 });
+    expect(client.retain).toHaveBeenCalled();
+  });
+
+  // Waiting inside the fire-and-forget chain is the point: the host's stop handler awaits
+  // onSessionIdle, and a 40s block there would freeze the UI on a cold daemon.
+  it("never makes the host wait for the daemon on the write path", async () => {
+    let released = () => {};
+    daemonSpy.mockImplementationOnce(() => new Promise<void>((r) => (released = r)));
+    const core = new RuntimeCore(client, "bank-1", daemonCfg, "dsh", "/repos/one");
+    core.setTranscriptSource(async () => [{ role: "user", content: "hi" }] as never);
+    await expect(core.onSessionIdle("s2")).resolves.toBeUndefined();
+    released();
   });
 });
 

--- a/hindsight-integrations/coding-agents/src/core/runtime.ts
+++ b/hindsight-integrations/coding-agents/src/core/runtime.ts
@@ -14,6 +14,7 @@
  * No opencode/claude specifics live here — only the memory logic.
  */
 import type { Config } from "./config";
+import { DAEMON_WAIT_RETAIN_MS, DAEMON_WAIT_SESSION_START_MS, ensureDaemon } from "./daemon";
 import { diag } from "./diag";
 import { describeError, log, setLogLevel } from "./log";
 import type { HindsightClient } from "./hindsight";
@@ -100,6 +101,13 @@ export class RuntimeCore {
     // HINDSIGHT_DISABLE_HOOKS=1 — the tools stay registered (toolSpecs, so the survey can ingest),
     // but seeding/recall/write-back must no-op or the survey would re-seed itself (see core/survey.ts).
     if (process.env.HINDSIGHT_DISABLE_HOOKS) return;
+    // Daemon mode: this is the SessionStart of a persistent-plugin host, so it owns the same
+    // warm-up the hook harnesses do in `runSessionStartHook` — start it before the user has typed
+    // anything, wait only briefly, and let a cold one keep coming up in the background. Without it
+    // these hosts never started a daemon at all and every request failed with ECONNREFUSED (#3524);
+    // `runSessionStartHook` is a hook-only wrapper, so calling `buildSessionStartContext` directly
+    // (as every plugin harness does) skipped the ensure entirely.
+    await ensureDaemon(this.cfg, this.harness, { waitMs: DAEMON_WAIT_SESSION_START_MS });
     try {
       const out = await buildSessionStartContext({
         cwd: repoPath || process.cwd(),
@@ -252,15 +260,24 @@ export class RuntimeCore {
     trigger = "turn"
   ): void {
     const t0 = Date.now();
-    void retainLiveSession(this.client, sessionId, turns, startTs, this.harness, {
-      cursors: this.cursors,
-      stamp: buildRetainStamp(this.cfg, {
-        directory: this.projectDir,
-        harness: this.harness,
-        bankId: this.bankId,
-        sessionId,
-      }),
-    })
+    // Daemon mode: the write path is the last chance to get a daemon up — the Stop-hook role, for
+    // hosts that have no Stop hook. A daemon that idled out mid-session (daemonIdleTimeout) would
+    // otherwise take the whole exchange with it. The wait sits INSIDE the fire-and-forget chain, so
+    // unlike the Stop hook it costs the host nothing: this call already returns before the retain
+    // does. Deliberately not gated on the result — retain proceeds either way, so an unreachable
+    // daemon produces the same `retain_failed` diagnostic as an unreachable Cloud server.
+    void ensureDaemon(this.cfg, this.harness, { waitMs: DAEMON_WAIT_RETAIN_MS })
+      .then(() =>
+        retainLiveSession(this.client, sessionId, turns, startTs, this.harness, {
+          cursors: this.cursors,
+          stamp: buildRetainStamp(this.cfg, {
+            directory: this.projectDir,
+            harness: this.harness,
+            bankId: this.bankId,
+            sessionId,
+          }),
+        })
+      )
       .then(() =>
         diag(this.harness, "retain_ok", {
           ms: Date.now() - t0,


### PR DESCRIPTION
Fixes #3524.

## The gap is wider than dsh

`ensureDaemon` is called from exactly two places, and **both are hook-only wrappers** —
`runSessionStartHook` (`core/session-start.ts`) and `runRetainHook` (`core/retain-hook.ts`).
The shared lifecycle they wrap (`buildSessionStartContext`) does not ensure anything.

So it was never a dsh bug: **every** persistent-plugin harness drives the shared lifecycle
directly and has never started a daemon — `dsh`, `opencode`, `kilo`, `cline-cli`,
`prime-agent`. With `serverMode: "daemon"` all five fail every `hindsight_*` call with
`connect ECONNREFUSED 127.0.0.1:9077` until the user runs `daemon-start.js` by hand, and
again after each `daemonIdleTimeout` retirement.

## Fix

Hoist the two ensure points into `RuntimeCore`, the one path all five hosts share, rather
than pasting a fifth copy that the sixth harness would forget again:

- `seedIfCold` is their SessionStart → `ensureDaemon(..., { waitMs: DAEMON_WAIT_SESSION_START_MS })`
- the private `retain()` is their Stop → the ensure sits **inside** the existing
  fire-and-forget chain, so the 40s cold-start wait costs the host nothing. opencode and dsh
  `await onSessionIdle` in their stop handler; an inline wait would freeze the UI.

One boundary needed adjusting for that: Cline's sandbox aborts every hook RPC at 3s
(`CLINE_HOOK_BUDGET_MS = 2_200`) and `beforeModel` did a bare `await sessionStart`. Now that
`seedIfCold` can wait on a cold daemon, that await goes through the same
`settleWithinHookBudget` race as `onPrompt`. Prime Agent awaits it the same way but has no
host abort, so it is unchanged.

## Guard

A per-harness unit test cannot catch this class of defect — the harness that forgets is by
definition the one whose test nobody wrote. So `core/daemon.test.ts` now asserts over the
whole family: every `src/**.ts` containing `new HindsightClient(` must reach `ensureDaemon`
or `RuntimeCore`, with a commented `EXEMPT` map for the four entrypoints that deliberately
must not start one (`status`, `deepen`, `mcp-server`, the prompt hook), plus a second test
that fails when an exemption goes stale. Same spirit as
`registry covers every installable harness`.

Verified both guards fail when the fix is reverted, and when a stand-in harness that builds
its own client is added.

## Review skill

`.claude/skills/code-review/SKILL.md` gains step **9a — parity across sibling
implementations**: the families in this repo (harnesses, wrapper SDK clients, PG/Oracle
migration halves, dataplane ↔ control-plane routes, LLM providers), and the procedure —
enumerate the family, diff the *capability* list rather than the code, prefer hoisting to
copying, and require a family-wide guard test rather than a test for the sibling that
forgot.

## Not in scope

`mcp-server.ts` is exempt in the guard but has a narrower residual gap: it is long-lived and
its daemon can idle out mid-session with no second ensure. Tracked separately.

## Testing

- `npx vitest run` — 535 passed, 23 skipped
- `npx tsc --noEmit` clean; formatting checked against the pinned prettier 3.7.4
