### PR TITLE
fix(coding-agents): stop forcing a 300s idle timeout on the shared daemon

### DIFF
--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -258,9 +258,9 @@ Nothing to sign up for and nothing to host — memory runs on your machine. The 
   A session that begins before it is ready simply has no memory for a turn or two — a daemon that
   isn't up is treated as an unreachable server, exactly like a Cloud or self-hosted outage, with the
   same error handling and the same diagnostics. Nothing downstream of the URL knows which mode it is.
-- **It shuts down on idle**, after `daemonIdleTimeout` seconds. There is deliberately no
-  stop-on-exit: one daemon is shared, so ending one session must not cut memory out from under
-  another agent still working.
+- **It keeps running** until you stop it. There is deliberately no stop-on-exit: one daemon is
+  shared, so ending one session must not cut memory out from under another agent still working.
+  Set `daemonIdleTimeout` to have it exit after that many seconds of inactivity.
 - **macOS additionally needs a current Rust toolchain.** `litellm` (a transitive dependency of the
   API) publishes wheels only for Linux and Windows, so a Mac compiles it from source through
   maturin and its crates pin a recent `rustc`. Install from [rustup.rs](https://rustup.rs) and keep
@@ -277,7 +277,7 @@ environment carries over unchanged:
 | ------------------- | ------------------------------- | -------------- | ------------------------------------------ |
 | `serverMode`        | `HINDSIGHT_SERVER_MODE`         | `cloud`        | `cloud` \| `self-hosted` \| `daemon`       |
 | `apiPort`           | `HINDSIGHT_API_PORT`            | `9077`         | port the local daemon listens on           |
-| `daemonIdleTimeout` | `HINDSIGHT_DAEMON_IDLE_TIMEOUT` | `300`          | seconds of inactivity before it exits      |
+| `daemonIdleTimeout` | `HINDSIGHT_DAEMON_IDLE_TIMEOUT` | —              | seconds of inactivity before it exits      |
 | `daemonProfile`     | `HINDSIGHT_DAEMON_PROFILE`      | `coding-agent` | which local database it uses               |
 | `embedVersion`      | `HINDSIGHT_EMBED_VERSION`       | `latest`       | which `hindsight-embed` release to run     |
 | `embedPackagePath`  | `HINDSIGHT_EMBED_PACKAGE_PATH`  | —              | run a local checkout instead (development) |

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -251,9 +251,9 @@ Nothing to sign up for and nothing to host — memory runs on your machine. The 
   A session that begins before it is ready simply has no memory for a turn or two — a daemon that
   isn't up is treated as an unreachable server, exactly like a Cloud or self-hosted outage, with the
   same error handling and the same diagnostics. Nothing downstream of the URL knows which mode it is.
-- **It shuts down on idle**, after `daemonIdleTimeout` seconds. There is deliberately no
-  stop-on-exit: one daemon is shared, so ending one session must not cut memory out from under
-  another agent still working.
+- **It keeps running** until you stop it. There is deliberately no stop-on-exit: one daemon is
+  shared, so ending one session must not cut memory out from under another agent still working.
+  Set `daemonIdleTimeout` to have it exit after that many seconds of inactivity.
 - **macOS additionally needs a current Rust toolchain.** `litellm` (a transitive dependency of the
   API) publishes wheels only for Linux and Windows, so a Mac compiles it from source through
   maturin and its crates pin a recent `rustc`. Install from [rustup.rs](https://rustup.rs) and keep
@@ -270,7 +270,7 @@ environment carries over unchanged:
 | ------------------- | ------------------------------- | -------------- | ------------------------------------------ |
 | `serverMode`        | `HINDSIGHT_SERVER_MODE`         | `cloud`        | `cloud` \| `self-hosted` \| `daemon`       |
 | `apiPort`           | `HINDSIGHT_API_PORT`            | `9077`         | port the local daemon listens on           |
-| `daemonIdleTimeout` | `HINDSIGHT_DAEMON_IDLE_TIMEOUT` | `300`          | seconds of inactivity before it exits      |
+| `daemonIdleTimeout` | `HINDSIGHT_DAEMON_IDLE_TIMEOUT` | —              | seconds of inactivity before it exits      |
 | `daemonProfile`     | `HINDSIGHT_DAEMON_PROFILE`      | `coding-agent` | which local database it uses               |
 | `embedVersion`      | `HINDSIGHT_EMBED_VERSION`       | `latest`       | which `hindsight-embed` release to run     |
 | `embedPackagePath`  | `HINDSIGHT_EMBED_PACKAGE_PATH`  | —              | run a local checkout instead (development) |

--- a/hindsight-integrations/coding-agents/src/core/config.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.ts
@@ -26,7 +26,6 @@ const CONFIG_PATH =
 /** Daemon-mode defaults. The port matches the old per-agent Claude Code plugin so a machine that
  *  already ran that daemon keeps using the same one. */
 export const DEFAULT_DAEMON_PORT = 9077;
-export const DEFAULT_DAEMON_IDLE_TIMEOUT = 300;
 export const DEFAULT_DAEMON_PROFILE = "coding-agent";
 
 /** Incremental git-sync settings (see core/sync.ts). */
@@ -46,10 +45,12 @@ export interface RawConfig {
    *  NOT 8888 — that is the conventional port for a server you run yourself, and a daemon must
    *  never squat on it. A healthy server already on this port is adopted rather than restarted. */
   apiPort?: number;
-  /** Daemon mode: seconds of inactivity before the daemon exits (default 300).
-   *  This is how the daemon shuts down. There is deliberately no stop-on-session-end: one daemon
-   *  is shared by every agent and repo on the machine, so ending one session must not cut memory
-   *  out from under another. */
+  /** Daemon mode: seconds of inactivity before the daemon exits. Unset means it never exits on
+   *  its own — `hindsight-embed`'s own default, which every other Hindsight integration also
+   *  ships. This used to default to 300 here, which made the plugin the only thing on the machine
+   *  opting a shared daemon into an auto-exit nobody asked for. There is deliberately no
+   *  stop-on-session-end either: one daemon is shared by every agent and repo on the machine, so
+   *  ending one session must not cut memory out from under another. */
   daemonIdleTimeout?: number;
   /** Daemon mode: `hindsight-embed` profile name, i.e. which local database is used (default
    *  "coding-agent"). Separate profiles keep unrelated setups from sharing memory. */
@@ -127,7 +128,8 @@ export interface Config {
   apiUrl: string;
   apiToken?: string;
   apiPort: number;
-  daemonIdleTimeout: number;
+  /** Undefined = never told the daemon to auto-exit; see RawConfig above. */
+  daemonIdleTimeout?: number;
   daemonProfile: string;
   embedVersion?: string;
   embedPackagePath?: string;
@@ -175,7 +177,7 @@ export function resolveConfig(raw: RawConfig = {}): Config {
         : (raw.apiUrl ?? "https://api.hindsight.vectorize.io"),
     apiToken: raw.apiToken || undefined,
     apiPort,
-    daemonIdleTimeout: raw.daemonIdleTimeout ?? DEFAULT_DAEMON_IDLE_TIMEOUT,
+    daemonIdleTimeout: raw.daemonIdleTimeout,
     daemonProfile: raw.daemonProfile || DEFAULT_DAEMON_PROFILE,
     embedVersion: raw.embedVersion || undefined,
     embedPackagePath: raw.embedPackagePath || undefined,

--- a/hindsight-integrations/coding-agents/src/core/daemon.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/daemon.test.ts
@@ -62,6 +62,13 @@ describe("daemonEnv", () => {
     expect(daemonEnv(cfg, {} as NodeJS.ProcessEnv).HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT).toBe("42");
   });
 
+  // It used to send 300 whether or not anyone asked, quietly retiring a SHARED daemon out from
+  // under an idle session — while every other Hindsight integration ships 0 (never exits).
+  it("says nothing about the idle timeout when it is unset, leaving the daemon its own default", () => {
+    const env = daemonEnv(resolveConfig({ serverMode: "daemon" }), {} as NodeJS.ProcessEnv);
+    expect(env).not.toHaveProperty("HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT");
+  });
+
   // Forwarding the whole HINDSIGHT_API_* namespace means a new server-side knob needs no change
   // here to reach the daemon.
   it("forwards arbitrary HINDSIGHT_API_* settings", () => {

--- a/hindsight-integrations/coding-agents/src/core/daemon.ts
+++ b/hindsight-integrations/coding-agents/src/core/daemon.ts
@@ -26,7 +26,8 @@
  * made daemon mode behave differently from the other two for no benefit.
  *
  * There is no stop. One daemon serves every agent and repo on the machine, so ending one session
- * must not cut memory out from under another; `daemonIdleTimeout` retires it instead.
+ * must not cut memory out from under another. Nothing retires it either, unless the user sets
+ * `daemonIdleTimeout` — see daemonEnv.
  */
 import { execFileSync, spawn as realSpawn } from "node:child_process";
 import { dirname, join } from "node:path";
@@ -149,9 +150,15 @@ export function daemonEnv(
   cfg: Config,
   env: NodeJS.ProcessEnv = process.env
 ): Record<string, string | undefined> {
-  const out: Record<string, string | undefined> = {
-    HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT: String(cfg.daemonIdleTimeout),
-  };
+  const out: Record<string, string | undefined> = {};
+  // Only forward an idle timeout the user actually asked for. This used to default to 300s, which
+  // made the plugin the one thing on the machine opting a SHARED daemon into an auto-exit — every
+  // other Hindsight integration ships 0, and `hindsight-embed`'s own default is 0 (never exits).
+  // Unset means the daemon keeps its own default, so nothing retires it out from under an idle
+  // session.
+  if (cfg.daemonIdleTimeout !== undefined) {
+    out.HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT = String(cfg.daemonIdleTimeout);
+  }
   for (const [key, value] of Object.entries(env)) {
     if (key.startsWith("HINDSIGHT_API_") && value) out[key] = value;
   }

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -253,9 +253,9 @@ Nothing to sign up for and nothing to host — memory runs on your machine. The 
   A session that begins before it is ready simply has no memory for a turn or two — a daemon that
   isn't up is treated as an unreachable server, exactly like a Cloud or self-hosted outage, with the
   same error handling and the same diagnostics. Nothing downstream of the URL knows which mode it is.
-- **It shuts down on idle**, after `daemonIdleTimeout` seconds. There is deliberately no
-  stop-on-exit: one daemon is shared, so ending one session must not cut memory out from under
-  another agent still working.
+- **It keeps running** until you stop it. There is deliberately no stop-on-exit: one daemon is
+  shared, so ending one session must not cut memory out from under another agent still working.
+  Set `daemonIdleTimeout` to have it exit after that many seconds of inactivity.
 - **macOS additionally needs a current Rust toolchain.** `litellm` (a transitive dependency of the
   API) publishes wheels only for Linux and Windows, so a Mac compiles it from source through
   maturin and its crates pin a recent `rustc`. Install from [rustup.rs](https://rustup.rs) and keep
@@ -272,7 +272,7 @@ environment carries over unchanged:
 | ------------------- | ------------------------------- | -------------- | ------------------------------------------ |
 | `serverMode`        | `HINDSIGHT_SERVER_MODE`         | `cloud`        | `cloud` \| `self-hosted` \| `daemon`       |
 | `apiPort`           | `HINDSIGHT_API_PORT`            | `9077`         | port the local daemon listens on           |
-| `daemonIdleTimeout` | `HINDSIGHT_DAEMON_IDLE_TIMEOUT` | `300`          | seconds of inactivity before it exits      |
+| `daemonIdleTimeout` | `HINDSIGHT_DAEMON_IDLE_TIMEOUT` | —              | seconds of inactivity before it exits      |
 | `daemonProfile`     | `HINDSIGHT_DAEMON_PROFILE`      | `coding-agent` | which local database it uses               |
 | `embedVersion`      | `HINDSIGHT_EMBED_VERSION`       | `latest`       | which `hindsight-embed` release to run     |
 | `embedPackagePath`  | `HINDSIGHT_EMBED_PACKAGE_PATH`  | —              | run a local checkout instead (development) |


### PR DESCRIPTION
`daemonEnv` set `HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT` **unconditionally**, from a plugin-side
default of 300 (`core/config.ts`), and `daemon-start.ts` passes that env straight into
`HindsightServer`. So a daemon started by this plugin retires itself after five minutes of
inactivity — easily reached during a build, a test run, or a meeting — and the next `hindsight_*`
call lands on a closed port.

Nothing else on the machine asks for that:

- `hindsight-embed`'s own default is `DEFAULT_DAEMON_IDLE_TIMEOUT = 0` — never auto-exit
  (`daemon_embed_manager.py:74`).
- Every other integration ships `"daemonIdleTimeout": 0` explicitly — claude-code, codex,
  cursor-cli, copilot-cli, zcode, openclaw.
- The daemon being retired is **shared** by every agent and repo on the machine, which is the same
  reason `core/daemon.ts` refuses to stop it at session end.

Unset now means unset: the env var is forwarded only when the user actually configures
`daemonIdleTimeout`, and the daemon keeps its own default otherwise. Setting it still works exactly
as before.

Docs regenerated from the README (`sync-coding-agents-doc.mjs` + `generate-docs-skill.sh`).

## Testing

- New unit test: `daemonEnv` omits the key entirely when the timeout is unset; the existing
  pass-through test (explicit `42`) still passes.
- `npx vitest run` — 530 passed, 23 skipped. `tsc --noEmit` clean, prettier 3.7.4 clean.
