### PR TITLE
docs(api): correct recall fact type descriptions

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -298,7 +298,7 @@ class RecallRequest(BaseModel):
     query: str
     types: list[str] | None = Field(
         default=None,
-        description="List of fact types to recall: 'world', 'experience', 'observation'. Defaults to world and experience if not specified.",
+        description="List of fact types to recall: 'world', 'experience', 'observation'. Defaults to all fact types if not specified.",
     )
     prefer_observations: bool = Field(
         default=False,
@@ -4551,9 +4551,11 @@ def _register_routes(app: FastAPI):
         response_model=RecallResponse,
         summary="Recall memory",
         description="Recall memory using semantic similarity and spreading activation.\n\n"
-        "The type parameter is optional and must be one of:\n"
+        "The `types` parameter is optional and may contain any of:\n"
         "- `world`: General knowledge about people, places, events, and things that happen\n"
-        "- `experience`: Memories about experience, conversations, actions taken, and tasks performed",
+        "- `experience`: Memories about experience, conversations, actions taken, and tasks performed\n"
+        "- `observation`: Consolidated knowledge synthesized from facts\n\n"
+        "If `types` is omitted, all fact types are recalled.",
         operation_id="recall_memories",
         tags=["Memory"],
     )
@@ -4582,7 +4584,7 @@ def _register_routes(app: FastAPI):
             )
 
         try:
-            # Default to world and experience if not specified (exclude observation)
+            # Default to all fact types if not specified
             fact_types = request.types if request.types else list(VALID_RECALL_FACT_TYPES)
 
             # Parse query_timestamp if provided

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -513,9 +513,12 @@ paths:
       description: |-
         Recall memory using semantic similarity and spreading activation.
 
-        The type parameter is optional and must be one of:
+        The `types` parameter is optional and may contain any of:
         - `world`: General knowledge about people, places, events, and things that happen
         - `experience`: Memories about experience, conversations, actions taken, and tasks performed
+        - `observation`: Consolidated knowledge synthesized from facts
+
+        If `types` is omitted, all fact types are recalled.
       operationId: recall_memories
       parameters:
       - explode: false

--- a/hindsight-clients/go/api_memory.go
+++ b/hindsight-clients/go/api_memory.go
@@ -1415,9 +1415,12 @@ RecallMemories Recall memory
 
 Recall memory using semantic similarity and spreading activation.
 
-The type parameter is optional and must be one of:
+The `types` parameter is optional and may contain any of:
 - `world`: General knowledge about people, places, events, and things that happen
 - `experience`: Memories about experience, conversations, actions taken, and tasks performed
+- `observation`: Consolidated knowledge synthesized from facts
+
+If `types` is omitted, all fact types are recalled.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param bankId

--- a/hindsight-clients/python/hindsight_client_api/api/memory_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/memory_api.py
@@ -3025,7 +3025,7 @@ class MemoryApi:
     ) -> RecallResponse:
         """Recall memory
 
-        Recall memory using semantic similarity and spreading activation.  The type parameter is optional and must be one of: - `world`: General knowledge about people, places, events, and things that happen - `experience`: Memories about experience, conversations, actions taken, and tasks performed
+        Recall memory using semantic similarity and spreading activation.  The `types` parameter is optional and may contain any of: - `world`: General knowledge about people, places, events, and things that happen - `experience`: Memories about experience, conversations, actions taken, and tasks performed - `observation`: Consolidated knowledge synthesized from facts  If `types` is omitted, all fact types are recalled.
 
         :param bank_id: (required)
         :type bank_id: str
@@ -3101,7 +3101,7 @@ class MemoryApi:
     ) -> ApiResponse[RecallResponse]:
         """Recall memory
 
-        Recall memory using semantic similarity and spreading activation.  The type parameter is optional and must be one of: - `world`: General knowledge about people, places, events, and things that happen - `experience`: Memories about experience, conversations, actions taken, and tasks performed
+        Recall memory using semantic similarity and spreading activation.  The `types` parameter is optional and may contain any of: - `world`: General knowledge about people, places, events, and things that happen - `experience`: Memories about experience, conversations, actions taken, and tasks performed - `observation`: Consolidated knowledge synthesized from facts  If `types` is omitted, all fact types are recalled.
 
         :param bank_id: (required)
         :type bank_id: str
@@ -3177,7 +3177,7 @@ class MemoryApi:
     ) -> RESTResponseType:
         """Recall memory
 
-        Recall memory using semantic similarity and spreading activation.  The type parameter is optional and must be one of: - `world`: General knowledge about people, places, events, and things that happen - `experience`: Memories about experience, conversations, actions taken, and tasks performed
+        Recall memory using semantic similarity and spreading activation.  The `types` parameter is optional and may contain any of: - `world`: General knowledge about people, places, events, and things that happen - `experience`: Memories about experience, conversations, actions taken, and tasks performed - `observation`: Consolidated knowledge synthesized from facts  If `types` is omitted, all fact types are recalled.
 
         :param bank_id: (required)
         :type bank_id: str

--- a/hindsight-clients/typescript/generated/sdk.gen.ts
+++ b/hindsight-clients/typescript/generated/sdk.gen.ts
@@ -449,9 +449,12 @@ export const getObservationHistory = <ThrowOnError extends boolean = false>(
  *
  * Recall memory using semantic similarity and spreading activation.
  *
- * The type parameter is optional and must be one of:
+ * The `types` parameter is optional and may contain any of:
  * - `world`: General knowledge about people, places, events, and things that happen
  * - `experience`: Memories about experience, conversations, actions taken, and tasks performed
+ * - `observation`: Consolidated knowledge synthesized from facts
+ *
+ * If `types` is omitted, all fact types are recalled.
  */
 export const recallMemories = <ThrowOnError extends boolean = false>(
   options: Options<RecallMemoriesData, ThrowOnError>

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -4011,7 +4011,7 @@ export type RecallRequest = {
   /**
    * Types
    *
-   * List of fact types to recall: 'world', 'experience', 'observation'. Defaults to world and experience if not specified.
+   * List of fact types to recall: 'world', 'experience', 'observation'. Defaults to all fact types if not specified.
    */
   types?: Array<string> | null;
   /**

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -774,7 +774,7 @@
           "Memory"
         ],
         "summary": "Recall memory",
-        "description": "Recall memory using semantic similarity and spreading activation.\n\nThe type parameter is optional and must be one of:\n- `world`: General knowledge about people, places, events, and things that happen\n- `experience`: Memories about experience, conversations, actions taken, and tasks performed",
+        "description": "Recall memory using semantic similarity and spreading activation.\n\nThe `types` parameter is optional and may contain any of:\n- `world`: General knowledge about people, places, events, and things that happen\n- `experience`: Memories about experience, conversations, actions taken, and tasks performed\n- `observation`: Consolidated knowledge synthesized from facts\n\nIf `types` is omitted, all fact types are recalled.",
         "operationId": "recall_memories",
         "parameters": [
           {
@@ -13384,7 +13384,7 @@
               }
             ],
             "title": "Types",
-            "description": "List of fact types to recall: 'world', 'experience', 'observation'. Defaults to world and experience if not specified."
+            "description": "List of fact types to recall: 'world', 'experience', 'observation'. Defaults to all fact types if not specified."
           },
           "prefer_observations": {
             "type": "boolean",

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -774,7 +774,7 @@
           "Memory"
         ],
         "summary": "Recall memory",
-        "description": "Recall memory using semantic similarity and spreading activation.\n\nThe type parameter is optional and must be one of:\n- `world`: General knowledge about people, places, events, and things that happen\n- `experience`: Memories about experience, conversations, actions taken, and tasks performed",
+        "description": "Recall memory using semantic similarity and spreading activation.\n\nThe `types` parameter is optional and may contain any of:\n- `world`: General knowledge about people, places, events, and things that happen\n- `experience`: Memories about experience, conversations, actions taken, and tasks performed\n- `observation`: Consolidated knowledge synthesized from facts\n\nIf `types` is omitted, all fact types are recalled.",
         "operationId": "recall_memories",
         "parameters": [
           {
@@ -13384,7 +13384,7 @@
               }
             ],
             "title": "Types",
-            "description": "List of fact types to recall: 'world', 'experience', 'observation'. Defaults to world and experience if not specified."
+            "description": "List of fact types to recall: 'world', 'experience', 'observation'. Defaults to all fact types if not specified."
           },
           "prefer_observations": {
             "type": "boolean",


### PR DESCRIPTION
## Summary

- Correct the HTTP recall documentation to state that omitted `types` recalls all fact types.
- Document `observation` in the recall endpoint description.
- Regenerate the two OpenAPI references and synchronize Python, TypeScript, and Go client comments.

## Validation

- OpenAPI JSON parses successfully and both copies are identical.
- `ruff check hindsight_api/api/http.py`
- `npm run build` in `hindsight-docs`
