### PR TITLE
fix(knowledge-base): patch a page's trigger instead of replacing it, on create and update

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -5680,7 +5680,11 @@ def _register_routes(app: FastAPI):
                 parent_id=body.parent_id,
                 tags=body.tags if body.tags else None,
                 max_tokens=body.max_tokens,
-                trigger=body.trigger.model_dump() if body.trigger else None,
+                # Only what the client actually set: the engine merges these over the
+                # knowledge-page defaults, and a full dump would drown them in this model's
+                # own field defaults (mode="full", exclude_mental_models=False) — which is
+                # how every page created with a trigger lost its delta refresh (#3506).
+                trigger=body.trigger.model_dump(exclude_unset=True) if body.trigger else None,
                 request_context=request_context,
             )
             if node is None:

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2403,6 +2403,16 @@ class UpdateNodeRequest(BaseModel):
     source_query: str | None = None
     tags: list[str] | None = None
     max_tokens: int | None = None
+    trigger: MentalModelTrigger | None = Field(
+        default=None,
+        description=(
+            "Refresh settings to change. Applied as a patch: only the fields present in this "
+            "object are updated, and the rest keep the page's current values — so moving a page "
+            "onto a schedule does not reset how it refreshes. Setting refresh_cron clears "
+            "refresh_after_consolidation and vice versa, since a page refreshes on one or the "
+            "other, never both."
+        ),
+    )
 
 
 class CreateKnowledgePageResponse(BaseModel):
@@ -5832,8 +5842,10 @@ def _register_routes(app: FastAPI):
         response_model=KnowledgeNode,
         summary="Rename/move a knowledge-base node or update a page's options",
         description="Rename a node (set `name`), move it under another folder (set `parent_id`, null "
-        "for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`). "
-        "Changing `source_query` schedules an async refresh so the page rebuilds against the new question.",
+        "for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`, `trigger`). "
+        "Changing `source_query` schedules an async refresh so the page rebuilds against the new question. "
+        "`trigger` is applied as a patch: the fields you send are updated and the rest keep the page's "
+        "current values.",
         operation_id="update_knowledge_node",
         tags=["Knowledge Base"],
     )
@@ -5861,7 +5873,7 @@ def _register_routes(app: FastAPI):
                 )
             # Page options live on the backing mental model; each applies only when
             # present in the body (so tags=[] clears, distinct from "not provided").
-            page_fields = {"source_query", "tags", "max_tokens"} & body.model_fields_set
+            page_fields = {"source_query", "tags", "max_tokens", "trigger"} & body.model_fields_set
             if page_fields:
                 did_change = True
                 updated = await app.state.memory.update_knowledge_page(
@@ -5870,6 +5882,10 @@ def _register_routes(app: FastAPI):
                     source_query=body.source_query if "source_query" in page_fields else None,
                     tags=body.tags if "tags" in page_fields else None,
                     max_tokens=body.max_tokens if "max_tokens" in page_fields else None,
+                    # Only the trigger fields the client stated: the engine patches them over
+                    # the page's current trigger, and a full dump would carry this model's own
+                    # defaults (mode="full", exclude_mental_models=False) into every update.
+                    trigger=(body.trigger.model_dump(exclude_unset=True) if body.trigger else None),
                     request_context=request_context,
                 )
                 # A new source query means the content is stale — rebuild it.
@@ -5881,7 +5897,8 @@ def _register_routes(app: FastAPI):
                     )
             if not did_change:
                 raise HTTPException(
-                    status_code=400, detail="Provide name, parent_id, source_query, tags, and/or max_tokens to update"
+                    status_code=400,
+                    detail="Provide name, parent_id, source_query, tags, max_tokens, and/or trigger to update",
                 )
             if updated is None:
                 raise HTTPException(status_code=404, detail=f"Knowledge node '{node_id}' not found")

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -13984,27 +13984,45 @@ class MemoryEngine(MemoryEngineInterface):
         "refresh_after_consolidation": True,
     }
 
-    def _merge_page_trigger(self, trigger: dict[str, Any] | None) -> dict[str, Any]:
-        """Layer a client's page trigger over ``KNOWLEDGE_PAGE_DEFAULT_TRIGGER``.
+    def _merge_page_trigger(self, trigger: dict[str, Any] | None, base: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Layer the fields a client actually set over ``base``, so a page trigger patches.
 
-        This used to be all-or-nothing: any supplied trigger REPLACED the defaults
-        outright. Since the API model fills every unset field with its own defaults,
-        a client that wanted one setting — say a cron schedule — silently gave up
-        ``mode: "delta"`` and ``exclude_mental_models``, and its page quietly became
-        a from-scratch rebuild that also reflected over its sibling pages. That is
-        what the coding-agents plugin had been doing to every page it created
-        (#3506). The API layer now sends only the fields the client actually set
-        (``model_dump(exclude_unset=True)``), and they merge here.
+        ``base`` is what the unstated fields keep: ``KNOWLEDGE_PAGE_DEFAULT_TRIGGER``
+        on create, the page's CURRENT trigger on update.
+
+        Both used to be all-or-nothing — a supplied trigger REPLACED whatever was
+        there. Since the API model fills every unset field with its own defaults, a
+        client that wanted one setting (a cron schedule, different fact types)
+        silently gave up ``mode: "delta"`` and ``exclude_mental_models``, and its
+        page quietly became a from-scratch rebuild that also reflected over its
+        sibling pages. That is what the coding-agents plugin had been doing to every
+        page it created (#3506). The API layer now sends only the fields the client
+        actually set (``model_dump(exclude_unset=True)``), and they merge here.
 
         The two refresh triggers stay mutually exclusive, as ``MentalModelTrigger``
-        requires of a stated pair: a client asking for a cron schedule drops the
-        default's ``refresh_after_consolidation`` rather than ending up with both,
-        which no request could have expressed.
+        requires of a stated pair: setting one drops an unstated other rather than
+        producing a combination no request could have expressed. That matters in
+        both directions on update — moving a page onto a cron schedule has to clear
+        the auto-refresh it was created with, and moving it back has to clear the
+        cron.
         """
-        merged = {**self.KNOWLEDGE_PAGE_DEFAULT_TRIGGER, **(trigger or {})}
-        if (trigger or {}).get("refresh_cron") and "refresh_after_consolidation" not in (trigger or {}):
+        supplied = trigger or {}
+        merged = {**(self.KNOWLEDGE_PAGE_DEFAULT_TRIGGER if base is None else base), **supplied}
+        if supplied.get("refresh_cron") and "refresh_after_consolidation" not in supplied:
             merged.pop("refresh_after_consolidation", None)
+        if supplied.get("refresh_after_consolidation") and "refresh_cron" not in supplied:
+            merged.pop("refresh_cron", None)
         return merged
+
+    @staticmethod
+    def _stored_trigger(value: Any) -> dict[str, Any]:
+        """A stored trigger as a dict. JSONB arrives as text on some drivers."""
+        if isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except json.JSONDecodeError:
+                return {}
+        return value if isinstance(value, dict) else {}
 
     # Knowledge pages default to a larger budget than a plain mental model (2048)
     # since they're meant to read as full documents. Applied when the client
@@ -14481,14 +14499,23 @@ class MemoryEngine(MemoryEngineInterface):
             await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
+            # The page's CURRENT trigger comes back with it: a supplied trigger patches
+            # that rather than replacing it (see _merge_page_trigger).
             row = await conn.fetchrow(
-                f"SELECT mental_model_id FROM {fq_table('knowledge_pages')} "
-                f"WHERE bank_id = $1 AND id = $2 AND kind = 'page'",
+                f"SELECT kp.mental_model_id, mm.trigger FROM {fq_table('knowledge_pages')} kp "
+                f"LEFT JOIN {fq_table('mental_models')} mm "
+                f"ON mm.id = kp.mental_model_id AND mm.bank_id = kp.bank_id "
+                f"WHERE kp.bank_id = $1 AND kp.id = $2 AND kp.kind = 'page'",
                 bank_id,
                 page_id,
             )
         if row is None or row["mental_model_id"] is None:
             return None
+        effective_trigger = (
+            self._merge_page_trigger(trigger, base=self._stored_trigger(row["trigger"]))
+            if trigger is not None
+            else None
+        )
         # The write is already authorized above; the backing mental-model update
         # runs without re-invoking the validator.
         with _authorize_nested_operations():
@@ -14498,7 +14525,7 @@ class MemoryEngine(MemoryEngineInterface):
                 source_query=source_query,
                 tags=tags,
                 max_tokens=max_tokens,
-                trigger=trigger,
+                trigger=effective_trigger,
                 request_context=request_context,
             )
         async with acquire_with_retry(backend) as conn:

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -13975,14 +13975,36 @@ class MemoryEngine(MemoryEngineInterface):
     # Default trigger for a knowledge page: a living document synthesized from the
     # bank's consolidated **observations** (not raw facts), refreshed incrementally
     # (delta) after each consolidation, and excluding other mental models so a page
-    # never reflects on sibling pages. Applied when the client doesn't pass its own
-    # ``trigger`` on create; a client can override any of these.
+    # never reflects on sibling pages. A client's own ``trigger`` MERGES over these
+    # (see ``_merge_page_trigger``), so overriding one field keeps the rest.
     KNOWLEDGE_PAGE_DEFAULT_TRIGGER = {
         "mode": "delta",
         "fact_types": ["observation"],
         "exclude_mental_models": True,
         "refresh_after_consolidation": True,
     }
+
+    def _merge_page_trigger(self, trigger: dict[str, Any] | None) -> dict[str, Any]:
+        """Layer a client's page trigger over ``KNOWLEDGE_PAGE_DEFAULT_TRIGGER``.
+
+        This used to be all-or-nothing: any supplied trigger REPLACED the defaults
+        outright. Since the API model fills every unset field with its own defaults,
+        a client that wanted one setting — say a cron schedule — silently gave up
+        ``mode: "delta"`` and ``exclude_mental_models``, and its page quietly became
+        a from-scratch rebuild that also reflected over its sibling pages. That is
+        what the coding-agents plugin had been doing to every page it created
+        (#3506). The API layer now sends only the fields the client actually set
+        (``model_dump(exclude_unset=True)``), and they merge here.
+
+        The two refresh triggers stay mutually exclusive, as ``MentalModelTrigger``
+        requires of a stated pair: a client asking for a cron schedule drops the
+        default's ``refresh_after_consolidation`` rather than ending up with both,
+        which no request could have expressed.
+        """
+        merged = {**self.KNOWLEDGE_PAGE_DEFAULT_TRIGGER, **(trigger or {})}
+        if (trigger or {}).get("refresh_cron") and "refresh_after_consolidation" not in (trigger or {}):
+            merged.pop("refresh_after_consolidation", None)
+        return merged
 
     # Knowledge pages default to a larger budget than a plain mental model (2048)
     # since they're meant to read as full documents. Applied when the client
@@ -14125,7 +14147,7 @@ class MemoryEngine(MemoryEngineInterface):
         mental_model_id = mental_model_id or f"mm-{uuid.uuid4().hex}"
         embedding = await self._generate_mental_model_embedding(name, content)
         effective_max_tokens = max_tokens if max_tokens is not None else self.KNOWLEDGE_PAGE_DEFAULT_MAX_TOKENS
-        effective_trigger = trigger if trigger is not None else dict(self.KNOWLEDGE_PAGE_DEFAULT_TRIGGER)
+        effective_trigger = self._merge_page_trigger(trigger)
         backend = await self._get_backend()
         page_id = f"kp-{uuid.uuid4().hex}"
         try:

--- a/hindsight-api-slim/tests/test_knowledge_base.py
+++ b/hindsight-api-slim/tests/test_knowledge_base.py
@@ -331,6 +331,82 @@ class TestPageDefaults:
         assert mm["max_tokens"] == 1024
         await memory.delete_bank(bank_id, request_context=request_context)
 
+    async def test_partial_trigger_merges_over_the_page_defaults(self, memory: MemoryEngine, request_context):
+        """Overriding one field must not silently give up the rest of the page contract.
+
+        A supplied trigger used to REPLACE the defaults outright, so a client that only
+        wanted different fact types also lost ``mode: "delta"`` and
+        ``exclude_mental_models`` — its page rebuilt itself from scratch on every refresh
+        and reflected over its sibling pages while doing it (#3506).
+        """
+        bank_id = f"test-kb-merge-{uuid.uuid4().hex[:8]}"
+        page = await memory.create_knowledge_page(
+            bank_id,
+            "P",
+            "What is P?",
+            "seed",
+            trigger={"fact_types": ["world", "experience", "observation"]},
+            request_context=request_context,
+        )
+        mm = await memory.get_mental_model(bank_id, page["mental_model_id"], request_context=request_context)
+        assert mm["trigger"] == {
+            "mode": "delta",
+            "fact_types": ["world", "experience", "observation"],
+            "exclude_mental_models": True,
+            "refresh_after_consolidation": True,
+        }
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_cron_trigger_drops_the_default_auto_refresh(self, memory: MemoryEngine, request_context):
+        """The merge must not synthesize a pair no request could have expressed.
+
+        ``MentalModelTrigger`` rejects a body carrying both refresh triggers, so inheriting
+        the default's ``refresh_after_consolidation`` alongside a client's ``refresh_cron``
+        would store a combination the API itself would have refused.
+        """
+        bank_id = f"test-kb-cron-{uuid.uuid4().hex[:8]}"
+        page = await memory.create_knowledge_page(
+            bank_id,
+            "P",
+            "What is P?",
+            "seed",
+            trigger={"refresh_cron": "0 3 * * *"},
+            request_context=request_context,
+        )
+        mm = await memory.get_mental_model(bank_id, page["mental_model_id"], request_context=request_context)
+        assert mm["trigger"]["refresh_cron"] == "0 3 * * *"
+        assert "refresh_after_consolidation" not in mm["trigger"]
+        assert mm["trigger"]["mode"] == "delta"  # still a knowledge page
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_create_endpoint_forwards_only_the_fields_the_client_set(
+        self, api_client, kb_bank, memory, monkeypatch
+    ):
+        """The merge is only meaningful if the HTTP layer stops filling in model defaults.
+
+        ``model_dump()`` on the request model yields every field — mode="full",
+        exclude_mental_models=False — which would override the page defaults on every
+        create that carries a trigger at all.
+        """
+        bank_id, _ = kb_bank
+        captured: dict[str, Any] = {}
+
+        async def fake_create(**kwargs):
+            captured.update(kwargs)
+            return {"id": "kp-fake", "mental_model_id": "mm-fake"}
+
+        async def fake_submit(**kwargs):
+            return {"operation_id": "op-fake"}
+
+        monkeypatch.setattr(memory, "create_knowledge_page", fake_create)
+        monkeypatch.setattr(memory, "submit_async_refresh_mental_model", fake_submit)
+        resp = await api_client.post(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/pages",
+            json={"name": "P", "source_query": "what is P?", "trigger": {"refresh_cron": "0 3 * * *"}},
+        )
+        assert resp.status_code == 201, resp.text
+        assert captured["trigger"] == {"refresh_cron": "0 3 * * *"}
+
 
 class TestGetPage:
     async def test_okf_document(self, api_client, kb_bank):

--- a/hindsight-api-slim/tests/test_knowledge_base.py
+++ b/hindsight-api-slim/tests/test_knowledge_base.py
@@ -379,6 +379,84 @@ class TestPageDefaults:
         assert mm["trigger"]["mode"] == "delta"  # still a knowledge page
         await memory.delete_bank(bank_id, request_context=request_context)
 
+    async def test_update_patches_the_trigger_instead_of_replacing_it(self, memory: MemoryEngine, request_context):
+        """Changing when a page refreshes must not reset how it refreshes.
+
+        ``update_mental_model`` overwrites the whole trigger column, so forwarding a
+        partial one straight through would strip every field the client didn't mention
+        — the create-path defect (#3506) one endpoint over.
+        """
+        bank_id = f"test-kb-upd-{uuid.uuid4().hex[:8]}"
+        page = await memory.create_knowledge_page(bank_id, "P", "What is P?", "seed", request_context=request_context)
+        await memory.update_knowledge_page(
+            bank_id,
+            page["id"],
+            trigger={"refresh_cron": "0 3 * * *"},
+            request_context=request_context,
+        )
+        mm = await memory.get_mental_model(bank_id, page["mental_model_id"], request_context=request_context)
+        assert mm["trigger"]["refresh_cron"] == "0 3 * * *"
+        assert mm["trigger"]["mode"] == "delta"
+        assert mm["trigger"]["fact_types"] == ["observation"]
+        assert mm["trigger"]["exclude_mental_models"] is True
+        # Moving onto a schedule clears the auto-refresh it was created with, in the
+        # direction the create path never had to handle.
+        assert "refresh_after_consolidation" not in mm["trigger"]
+
+        # ...and back again: the stated auto-refresh clears the stored cron.
+        await memory.update_knowledge_page(
+            bank_id,
+            page["id"],
+            trigger={"refresh_after_consolidation": True},
+            request_context=request_context,
+        )
+        mm = await memory.get_mental_model(bank_id, page["mental_model_id"], request_context=request_context)
+        assert mm["trigger"]["refresh_after_consolidation"] is True
+        assert "refresh_cron" not in mm["trigger"]
+        assert mm["trigger"]["mode"] == "delta"
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_update_without_a_trigger_leaves_it_alone(self, memory: MemoryEngine, request_context):
+        bank_id = f"test-kb-keep-{uuid.uuid4().hex[:8]}"
+        page = await memory.create_knowledge_page(
+            bank_id,
+            "P",
+            "What is P?",
+            "seed",
+            trigger={"refresh_cron": "0 3 * * *"},
+            request_context=request_context,
+        )
+        await memory.update_knowledge_page(bank_id, page["id"], max_tokens=2048, request_context=request_context)
+        mm = await memory.get_mental_model(bank_id, page["mental_model_id"], request_context=request_context)
+        assert mm["max_tokens"] == 2048
+        assert mm["trigger"]["refresh_cron"] == "0 3 * * *"
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_update_endpoint_accepts_and_forwards_a_partial_trigger(
+        self, api_client, kb_bank, memory, monkeypatch
+    ):
+        """The PATCH body carries `trigger` at all, and only the fields the client set.
+
+        Both halves are load-bearing: the field was missing from ``UpdateNodeRequest``
+        entirely, so a page's refresh policy could not be changed through the
+        knowledge-base API — and a full dump would carry this model's defaults into
+        every update.
+        """
+        bank_id, ids = kb_bank
+        captured: dict[str, Any] = {}
+
+        async def fake_update(**kwargs):
+            captured.update(kwargs)
+            return {"id": ids.orders, "kind": "page", "name": "Orders", "mental_model_id": ids.orders_mm}
+
+        monkeypatch.setattr(memory, "update_knowledge_page", fake_update)
+        resp = await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.orders}",
+            json={"trigger": {"refresh_cron": "0 4 * * *"}},
+        )
+        assert resp.status_code == 200, resp.text
+        assert captured["trigger"] == {"refresh_cron": "0 4 * * *"}
+
     async def test_create_endpoint_forwards_only_the_fields_the_client_set(
         self, api_client, kb_bank, memory, monkeypatch
     ):

--- a/hindsight-cli/.openapi-coverage.toml
+++ b/hindsight-cli/.openapi-coverage.toml
@@ -145,6 +145,9 @@ items = "Constructed from the single positional content argument on `memory reta
 [fields.create_knowledge_page]
 trigger = "Exposed as --mode / --fact-types on `knowledge-base create-page`; the remaining nested trigger fields (tag_groups, refresh_cron, recall_* budgets) are page-level tuning best done via the API."
 
+[fields.update_knowledge_node]
+trigger = "Changing an existing page's refresh policy (cron vs after-consolidation) is page-level tuning done via the API, SDKs, or control plane; `knowledge-base update-node` leaves the page's current trigger alone."
+
 [fields.create_mental_model]
 trigger = "Exposed as --trigger-refresh-after-consolidation on `mental-model create` (other nested trigger fields like fact_types/tag_groups are not exposed yet)."
 

--- a/hindsight-cli/src/commands/knowledge_base.rs
+++ b/hindsight-cli/src/commands/knowledge_base.rs
@@ -356,6 +356,9 @@ pub fn update(
         source_query,
         tags,
         max_tokens,
+        // A page's refresh policy is not exposed as a CLI flag (see
+        // .openapi-coverage.toml); omitted, it leaves the page's current trigger alone.
+        trigger: None,
     };
 
     let response = client.update_knowledge_node(bank_id, node_id, &request, verbose);

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -1817,8 +1817,10 @@ paths:
     patch:
       description: "Rename a node (set `name`), move it under another folder (set\
         \ `parent_id`, null for the root), and/or update a page's options (`source_query`,\
-        \ `tags`, `max_tokens`). Changing `source_query` schedules an async refresh\
-        \ so the page rebuilds against the new question."
+        \ `tags`, `max_tokens`, `trigger`). Changing `source_query` schedules an async\
+        \ refresh so the page rebuilds against the new question. `trigger` is applied\
+        \ as a patch: the fields you send are updated and the rest keep the page's\
+        \ current values."
       operationId: update_knowledge_node
       parameters:
       - explode: false
@@ -9917,6 +9919,33 @@ components:
         max_tokens: 0
         parent_id: parent_id
         name: name
+        trigger:
+          recall_chunks_max_tokens: 1
+          refresh_cron: refresh_cron
+          tag_groups:
+          - match: any_strict
+            tags:
+            - tags
+            - tags
+          - match: any_strict
+            tags:
+            - tags
+            - tags
+          exclude_mental_models: false
+          mode: full
+          refresh_after_consolidation: false
+          fact_types:
+          - world
+          - world
+          response_schema:
+            key: ""
+          exclude_mental_model_ids:
+          - exclude_mental_model_ids
+          - exclude_mental_model_ids
+          include_chunks: true
+          tags_match: any
+          keep_trace: false
+          recall_max_tokens: 6
         tags:
         - tags
         - tags
@@ -9938,6 +9967,8 @@ components:
         max_tokens:
           nullable: true
           type: integer
+        trigger:
+          $ref: '#/components/schemas/MentalModelTrigger-Input'
       title: UpdateNodeRequest
     UpdateWebhookRequest:
       description: Request model for updating a webhook. Only provided fields are

--- a/hindsight-clients/go/api_knowledge_base.go
+++ b/hindsight-clients/go/api_knowledge_base.go
@@ -960,7 +960,7 @@ func (r ApiUpdateKnowledgeNodeRequest) Execute() (*KnowledgeNode, *http.Response
 /*
 UpdateKnowledgeNode Rename/move a knowledge-base node or update a page's options
 
-Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.
+Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`, `trigger`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question. `trigger` is applied as a patch: the fields you send are updated and the rest keep the page's current values.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param bankId

--- a/hindsight-clients/go/model_update_node_request.go
+++ b/hindsight-clients/go/model_update_node_request.go
@@ -24,6 +24,7 @@ type UpdateNodeRequest struct {
 	SourceQuery NullableString `json:"source_query,omitempty"`
 	Tags []string `json:"tags,omitempty"`
 	MaxTokens NullableInt32 `json:"max_tokens,omitempty"`
+	Trigger NullableMentalModelTriggerInput `json:"trigger,omitempty"`
 }
 
 // NewUpdateNodeRequest instantiates a new UpdateNodeRequest object
@@ -244,6 +245,48 @@ func (o *UpdateNodeRequest) UnsetMaxTokens() {
 	o.MaxTokens.Unset()
 }
 
+// GetTrigger returns the Trigger field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *UpdateNodeRequest) GetTrigger() MentalModelTriggerInput {
+	if o == nil || IsNil(o.Trigger.Get()) {
+		var ret MentalModelTriggerInput
+		return ret
+	}
+	return *o.Trigger.Get()
+}
+
+// GetTriggerOk returns a tuple with the Trigger field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UpdateNodeRequest) GetTriggerOk() (*MentalModelTriggerInput, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.Trigger.Get(), o.Trigger.IsSet()
+}
+
+// HasTrigger returns a boolean if a field has been set.
+func (o *UpdateNodeRequest) HasTrigger() bool {
+	if o != nil && o.Trigger.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetTrigger gets a reference to the given NullableMentalModelTriggerInput and assigns it to the Trigger field.
+func (o *UpdateNodeRequest) SetTrigger(v MentalModelTriggerInput) {
+	o.Trigger.Set(&v)
+}
+// SetTriggerNil sets the value for Trigger to be an explicit nil
+func (o *UpdateNodeRequest) SetTriggerNil() {
+	o.Trigger.Set(nil)
+}
+
+// UnsetTrigger ensures that no value is present for Trigger, not even an explicit nil
+func (o *UpdateNodeRequest) UnsetTrigger() {
+	o.Trigger.Unset()
+}
+
 func (o UpdateNodeRequest) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -268,6 +311,9 @@ func (o UpdateNodeRequest) ToMap() (map[string]interface{}, error) {
 	}
 	if o.MaxTokens.IsSet() {
 		toSerialize["max_tokens"] = o.MaxTokens.Get()
+	}
+	if o.Trigger.IsSet() {
+		toSerialize["trigger"] = o.Trigger.Get()
 	}
 	return toSerialize, nil
 }

--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -1529,6 +1529,7 @@ class Hindsight:
         source_query: str | None = None,
         tags: list[str] | None = None,
         max_tokens: int | None = None,
+        trigger: dict[str, Any] | None = None,
     ):
         """
         Rename/move a knowledge node and/or update a page's options (sync wrapper —
@@ -1545,6 +1546,8 @@ class Hindsight:
             source_query: Pages only — new question. Changing it rebuilds the page.
             tags: Pages only — replaces the page's tags (pass [] to clear)
             max_tokens: Pages only — new content budget
+            trigger: Pages only — refresh settings to change, applied as a patch: the
+                keys you pass are updated and the rest keep the page's current values
 
         Returns:
             KnowledgeNode
@@ -1566,6 +1569,8 @@ class Hindsight:
             fields["tags"] = tags
         if max_tokens is not None:
             fields["max_tokens"] = max_tokens
+        if trigger is not None:
+            fields["trigger"] = trigger
 
         request_obj = update_node_request.UpdateNodeRequest(**fields)
 

--- a/hindsight-clients/python/hindsight_client_api/api/knowledge_base_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/knowledge_base_api.py
@@ -2135,7 +2135,7 @@ class KnowledgeBaseApi:
     ) -> KnowledgeNode:
         """Rename/move a knowledge-base node or update a page's options
 
-        Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.
+        Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`, `trigger`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question. `trigger` is applied as a patch: the fields you send are updated and the rest keep the page's current values.
 
         :param bank_id: (required)
         :type bank_id: str
@@ -2215,7 +2215,7 @@ class KnowledgeBaseApi:
     ) -> ApiResponse[KnowledgeNode]:
         """Rename/move a knowledge-base node or update a page's options
 
-        Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.
+        Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`, `trigger`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question. `trigger` is applied as a patch: the fields you send are updated and the rest keep the page's current values.
 
         :param bank_id: (required)
         :type bank_id: str
@@ -2295,7 +2295,7 @@ class KnowledgeBaseApi:
     ) -> RESTResponseType:
         """Rename/move a knowledge-base node or update a page's options
 
-        Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.
+        Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`, `trigger`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question. `trigger` is applied as a patch: the fields you send are updated and the rest keep the page's current values.
 
         :param bank_id: (required)
         :type bank_id: str

--- a/hindsight-clients/python/hindsight_client_api/models/update_node_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/update_node_request.py
@@ -19,6 +19,7 @@ import json
 
 from pydantic import BaseModel, ConfigDict, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
+from hindsight_client_api.models.mental_model_trigger_input import MentalModelTriggerInput
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -31,7 +32,8 @@ class UpdateNodeRequest(BaseModel):
     source_query: Optional[StrictStr] = None
     tags: Optional[List[StrictStr]] = None
     max_tokens: Optional[StrictInt] = None
-    __properties: ClassVar[List[str]] = ["name", "parent_id", "source_query", "tags", "max_tokens"]
+    trigger: Optional[MentalModelTriggerInput] = None
+    __properties: ClassVar[List[str]] = ["name", "parent_id", "source_query", "tags", "max_tokens", "trigger"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -72,6 +74,9 @@ class UpdateNodeRequest(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of trigger
+        if self.trigger:
+            _dict['trigger'] = self.trigger.to_dict()
         # set to None if name (nullable) is None
         # and model_fields_set contains the field
         if self.name is None and "name" in self.model_fields_set:
@@ -97,6 +102,11 @@ class UpdateNodeRequest(BaseModel):
         if self.max_tokens is None and "max_tokens" in self.model_fields_set:
             _dict['max_tokens'] = None
 
+        # set to None if trigger (nullable) is None
+        # and model_fields_set contains the field
+        if self.trigger is None and "trigger" in self.model_fields_set:
+            _dict['trigger'] = None
+
         return _dict
 
     @classmethod
@@ -113,7 +123,8 @@ class UpdateNodeRequest(BaseModel):
             "parent_id": obj.get("parent_id"),
             "source_query": obj.get("source_query"),
             "tags": obj.get("tags"),
-            "max_tokens": obj.get("max_tokens")
+            "max_tokens": obj.get("max_tokens"),
+            "trigger": MentalModelTriggerInput.from_dict(obj["trigger"]) if obj.get("trigger") is not None else None
         })
         return _obj
 

--- a/hindsight-clients/python/tests/test_knowledge_base_mapping.py
+++ b/hindsight-clients/python/tests/test_knowledge_base_mapping.py
@@ -106,6 +106,22 @@ def test_update_node_maps_page_options(monkeypatch):
     assert request.source_query == "New question?"
     assert request.tags == []
     assert request.max_tokens == 2048
+    assert "trigger" not in request.model_fields_set
+
+
+def test_update_node_forwards_a_partial_trigger(monkeypatch):
+    """The trigger is a PATCH server-side: unsent fields keep the page's current values,
+    so the wrapper must pass exactly what the caller gave it — and a wrapper that dropped
+    the field would leave callers unable to change a refresh policy at all."""
+    client = Hindsight(base_url="http://example.invalid")
+    captured: dict[str, object] = {}
+    _capture(monkeypatch, client, "update_knowledge_node", captured)
+
+    client.update_knowledge_node("bank-1", "kp-1", trigger={"refresh_cron": "0 3 * * *"})
+
+    _, _, request = captured["args"]
+    assert request.trigger.refresh_cron == "0 3 * * *"
+    assert request.trigger.model_fields_set == {"refresh_cron"}
 
 
 def test_search_forwards_query_and_limit(monkeypatch):

--- a/hindsight-clients/typescript/generated/sdk.gen.ts
+++ b/hindsight-clients/typescript/generated/sdk.gen.ts
@@ -855,7 +855,7 @@ export const deleteKnowledgeNode = <ThrowOnError extends boolean = false>(
 /**
  * Rename/move a knowledge-base node or update a page's options
  *
- * Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.
+ * Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`, `trigger`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question. `trigger` is applied as a patch: the fields you send are updated and the rest keep the page's current values.
  */
 export const updateKnowledgeNode = <ThrowOnError extends boolean = false>(
   options: Options<UpdateKnowledgeNodeData, ThrowOnError>

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -5043,6 +5043,10 @@ export type UpdateNodeRequest = {
    * Max Tokens
    */
   max_tokens?: number | null;
+  /**
+   * Refresh settings to change. Applied as a patch: only the fields present in this object are updated, and the rest keep the page's current values — so moving a page onto a schedule does not reset how it refreshes. Setting refresh_cron clears refresh_after_consolidation and vice versa, since a page refreshes on one or the other, never both.
+   */
+  trigger?: MentalModelTriggerInput | null;
 };
 
 /**

--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -66,6 +66,7 @@ import type {
   ListDocumentsResponse,
   MentalModelListResponse,
   MentalModelResponse,
+  MentalModelTriggerInput,
   MentalModelDryRunRefreshResult,
   UpdateDocumentResponse,
   VersionResponse,
@@ -1238,6 +1239,9 @@ export class HindsightClient {
       /** Pages only — replaces the page's tags (pass [] to clear). */
       tags?: string[];
       maxTokens?: number;
+      /** Pages only — refresh settings to change. Applied as a patch: the fields you send are
+       *  updated and the rest keep the page's current values. */
+      trigger?: MentalModelTriggerInput;
       signal?: AbortSignal;
     }
   ): Promise<KnowledgeNode> {
@@ -1250,6 +1254,7 @@ export class HindsightClient {
         ...(options.sourceQuery !== undefined ? { source_query: options.sourceQuery } : {}),
         ...(options.tags !== undefined ? { tags: options.tags } : {}),
         ...(options.maxTokens !== undefined ? { max_tokens: options.maxTokens } : {}),
+        ...(options.trigger !== undefined ? { trigger: options.trigger } : {}),
       },
       signal: options.signal,
     });
@@ -1530,6 +1535,7 @@ export type {
   ListDocumentsResponse,
   MentalModelListResponse,
   MentalModelResponse,
+  MentalModelTriggerInput,
   MentalModelDryRunRefreshResult,
   UpdateDocumentResponse,
   VersionResponse,

--- a/hindsight-clients/typescript/tests/knowledge_base_mapping.test.ts
+++ b/hindsight-clients/typescript/tests/knowledge_base_mapping.test.ts
@@ -119,6 +119,22 @@ describe("updateKnowledgeNode mapping", () => {
     expect(body.tags).toEqual([]);
     expect(body.max_tokens).toBe(2048);
   });
+
+  // The trigger is a PATCH server-side: what isn't sent keeps the page's current value,
+  // so a wrapper that dropped the field would leave callers unable to change a refresh
+  // policy at all — the endpoint carried no trigger before this.
+  test("passes a partial trigger through untouched", async () => {
+    await client.updateKnowledgeNode("bank", "kp-1", { trigger: { refresh_cron: "0 3 * * *" } });
+
+    const body = mockedUpdateNode.mock.calls[0][0].body as any;
+    expect(body.trigger).toEqual({ refresh_cron: "0 3 * * *" });
+  });
+
+  test("omits the trigger entirely when unset", async () => {
+    await client.updateKnowledgeNode("bank", "kp-1", { maxTokens: 2048 });
+
+    expect("trigger" in (mockedUpdateNode.mock.calls[0][0].body as any)).toBe(false);
+  });
 });
 
 describe("searchKnowledgeBase mapping", () => {

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -801,6 +801,15 @@ export class ControlPlaneClient {
       source_query?: string;
       tags?: string[];
       max_tokens?: number;
+      /** Refresh settings to change. Applied as a patch: the fields sent are updated and the
+       *  rest keep the page's current values, so setting a schedule doesn't reset the rest. */
+      trigger?: {
+        mode?: "full" | "delta";
+        refresh_after_consolidation?: boolean;
+        refresh_cron?: string | null;
+        fact_types?: Array<"world" | "experience" | "observation">;
+        exclude_mental_models?: boolean;
+      };
     }
   ) {
     return this.fetchApi<KnowledgeNode>(

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -2587,7 +2587,7 @@
           "Knowledge Base"
         ],
         "summary": "Rename/move a knowledge-base node or update a page's options",
-        "description": "Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.",
+        "description": "Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`, `trigger`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question. `trigger` is applied as a patch: the fields you send are updated and the rest keep the page's current values.",
         "operationId": "update_knowledge_node",
         "parameters": [
           {
@@ -15364,6 +15364,17 @@
               }
             ],
             "title": "Max Tokens"
+          },
+          "trigger": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MentalModelTrigger-Input"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Refresh settings to change. Applied as a patch: only the fields present in this object are updated, and the rest keep the page's current values \u2014 so moving a page onto a schedule does not reset how it refreshes. Setting refresh_cron clears refresh_after_consolidation and vice versa, since a page refreshes on one or the other, never both."
           }
         },
         "type": "object",

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -2587,7 +2587,7 @@
           "Knowledge Base"
         ],
         "summary": "Rename/move a knowledge-base node or update a page's options",
-        "description": "Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question.",
+        "description": "Rename a node (set `name`), move it under another folder (set `parent_id`, null for the root), and/or update a page's options (`source_query`, `tags`, `max_tokens`, `trigger`). Changing `source_query` schedules an async refresh so the page rebuilds against the new question. `trigger` is applied as a patch: the fields you send are updated and the rest keep the page's current values.",
         "operationId": "update_knowledge_node",
         "parameters": [
           {
@@ -15364,6 +15364,17 @@
               }
             ],
             "title": "Max Tokens"
+          },
+          "trigger": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MentalModelTrigger-Input"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Refresh settings to change. Applied as a patch: only the fields present in this object are updated, and the rest keep the page's current values \u2014 so moving a page onto a schedule does not reset how it refreshes. Setting refresh_cron clears refresh_after_consolidation and vice versa, since a page refreshes on one or the other, never both."
           }
         },
         "type": "object",


### PR DESCRIPTION
Creating **or updating** a knowledge page could not change one trigger setting without losing the
rest. Both endpoints now behave the same way: send the fields you want changed, keep the rest.

## Create — the trigger replaced the page defaults

1. `api_create_knowledge_page` did `body.trigger.model_dump()` — no `exclude_unset=True` — so the
   dict handed to the engine carried every field of `MentalModelTrigger` filled with that model's
   own defaults (`mode="full"`, `exclude_mental_models=False`, …).
2. `create_knowledge_page` then did `trigger if trigger is not None else dict(DEFAULT)` — replace,
   not merge.

So a client that wanted one setting also gave up `mode: "delta"` and `exclude_mental_models: true`,
and its page silently became a from-scratch rebuild that reflected over its sibling pages on every
refresh. The engine's own comment already claimed "a client can override any of these", which was
only true all-or-nothing. This is what the coding-agents plugin has been doing to every page it
creates (#3506), and it had no way not to: it legitimately needs to override `fact_types` (its
pages are tag-scoped syntheses over `knowledge:<tier>` labels on world/experience facts, not the
observation-only default).

## Update — the trigger could not be changed at all

`UpdateNodeRequest` carried no `trigger` field and the handler filtered to
`{source_query, tags, max_tokens}`, so a page's refresh policy was **write-once** through the
knowledge-base API. Pages created before this fix were stuck doing full rebuilds forever. The engine
already supported it end to end (`update_knowledge_page(trigger=...)` → `update_mental_model`);
only the HTTP surface didn't expose it.

`UpdateNodeRequest` now carries `trigger`, and it patches over the page's **current** trigger —
not over the defaults. That distinction is load-bearing: `update_mental_model` overwrites the whole
trigger column, so forwarding a partial one straight through would have reintroduced the create-path
defect one endpoint over.

## Exclusivity

`refresh_after_consolidation` and `refresh_cron` are mutually exclusive in `MentalModelTrigger`, so
merging must never produce a pair no request could have expressed. Setting one clears an unstated
other — in **both** directions on update: moving a page onto a schedule clears the auto-refresh it
was created with, and moving it back clears the cron.

## Scope

- The HTTP handler is the only caller of `create_knowledge_page` (page import/restore goes through
  a different path).
- The mental-model create/update endpoints keep full-dump semantics: a plain mental model has no
  page defaults to merge with, so its model defaults *are* the intent.
- Both hand-written wrappers (TS `updateKnowledgeNode`, Python `update_knowledge_node`) take the new
  parameter — they're the surface most consumers actually call — each with a mapping test asserting
  a partial trigger passes through untouched and is absent when unset.

## Testing

`TestPageDefaults` gains five tests: a partial create trigger keeps delta/exclude_mental_models/
auto-refresh; a cron create trigger drops the default auto-refresh; an update patches instead of
replacing (both exclusivity directions); an update without a trigger leaves it alone; and each
endpoint forwards only the fields the client set (catching a dropped `exclude_unset`).

Locally: `./scripts/hooks/lint.sh` passes, both wrapper mapping suites pass (8 Python, 10 TS), and
the merge function was exercised directly over every input shape — create/none, partial, cron,
cron→auto, auto→cron, empty base — including that the class-level default dict is never mutated.
OpenAPI spec, generated clients (Go/Python/TS) and the docs skill are regenerated and committed. The
DB-backed engine tests are left to CI's `test-api` job: the api-slim suite truncates whatever
database the local `.env` points at, which on this machine is the live dev DB.
