### PR TITLE
fix(mental-models): keep at most one queued refresh per model (#3487)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -15988,6 +15988,7 @@ class MemoryEngine(MemoryEngineInterface):
         dedupe_by_bank_includes_processing: bool = False,
         dedupe_excludes_operation_id: str | None = None,
         dedupe_in_flight_payload_key: str | None = None,
+        dedupe_in_flight_includes_processing: bool = True,
     ) -> dict[str, Any]:
         """Generic helper to submit an async operation.
 
@@ -16005,9 +16006,15 @@ class MemoryEngine(MemoryEngineInterface):
                 own backlog to empty before finishing (see submit_async_graph_maintenance);
                 for watermark-based jobs like consolidation it would drop work that
                 arrived after the running job took its watermark.
-            dedupe_in_flight_payload_key: If set, skip creating a new task when a pending or processing
+            dedupe_in_flight_payload_key: If set, skip creating a new task when an already-queued
                 operation of this type exists whose task_payload carries the same value for this key
                 (e.g. 'mental_model_id'). Narrower than dedupe_by_bank, which dedupes per bank.
+                Must be a plain identifier — it is inlined into the JSON accessor so the Oracle
+                rewriter can turn it into JSON_VALUE.
+            dedupe_in_flight_includes_processing: Whether an operation that is already *processing*
+                counts for dedupe_in_flight_payload_key, on top of a pending one. False keeps the
+                guarantee to "at most one pending", which is all that a submit carrying new intent
+                (an explicit refresh after an edit) can safely fold into.
 
         Returns:
             Dict with operation_id and optionally deduplicated=True if an existing task was found
@@ -16148,7 +16155,64 @@ class MemoryEngine(MemoryEngineInterface):
                                 "operation_id": str(row["operation_id"]),
                                 "deduplicated": True,
                             }
-                insert_args = (
+                if dedupe_in_flight_payload_key is not None:
+                    # Sub-bank dedup: skip the INSERT when an operation of this type is
+                    # already queued (and, optionally, already running) for the same
+                    # payload subject — e.g. one mental model (#3210, #3487).
+                    #
+                    # Atomic for the same reason the bank-wide branch above is: the
+                    # bank row is held FOR NO KEY UPDATE for the rest of this
+                    # transaction, so concurrent submits for this bank serialise and
+                    # the loser sees the winner's committed row. (An earlier form
+                    # folded the check into an INSERT ... SELECT ... WHERE NOT EXISTS;
+                    # that is not valid Oracle SQL — a SELECT with no FROM — and its
+                    # bind-parameter JSON key is not rewritten to JSON_VALUE, so every
+                    # deduped submit raised there. The key is inlined below, and
+                    # rejected unless it is a plain identifier, so the rewrite applies
+                    # on both dialects.)
+                    #
+                    # Which statuses count as "already covered" is the caller's call:
+                    # a *pending* op has not started, so it still picks up whatever the
+                    # submitter just changed and folding into it loses nothing, while a
+                    # *processing* op may have read its inputs already.
+                    if not dedupe_in_flight_payload_key.isidentifier():
+                        raise ValueError(
+                            f"dedupe_in_flight_payload_key must be an identifier: {dedupe_in_flight_payload_key!r}"
+                        )
+                    status_filter = (
+                        "status IN ('pending', 'processing')"
+                        if dedupe_in_flight_includes_processing
+                        else "status = 'pending'"
+                    )
+                    subject = task_payload.get(dedupe_in_flight_payload_key)
+                    existing_id = await conn.fetchval(
+                        f"""
+                        SELECT operation_id FROM {fq_table("async_operations")}
+                        WHERE bank_id = $1 AND operation_type = $2
+                          AND {status_filter}
+                          AND task_payload->>'{dedupe_in_flight_payload_key}' = $3
+                        ORDER BY created_at
+                        LIMIT 1
+                        """,
+                        bank_id,
+                        operation_type,
+                        subject,
+                    )
+                    if existing_id is not None:
+                        logger.debug(
+                            f"{operation_type} task already in flight for bank_id={bank_id} "
+                            f"{dedupe_in_flight_payload_key}={subject}, skipping duplicate "
+                            f"(existing operation_id={existing_id})"
+                        )
+                        return {
+                            "operation_id": str(existing_id),
+                            "deduplicated": True,
+                        }
+                await conn.execute(
+                    f"""
+                    INSERT INTO {fq_table("async_operations")} (operation_id, bank_id, operation_type, result_metadata, status, task_payload)
+                    VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+                    """,
                     operation_id,
                     bank_id,
                     operation_type,
@@ -16156,69 +16220,6 @@ class MemoryEngine(MemoryEngineInterface):
                     "pending",
                     json.dumps(full_payload, default=_json_default),
                 )
-                if dedupe_in_flight_payload_key is None:
-                    await conn.execute(
-                        f"""
-                        INSERT INTO {fq_table("async_operations")} (operation_id, bank_id, operation_type, result_metadata, status, task_payload)
-                        VALUES ($1, $2, $3, $4, $5, $6::jsonb)
-                        """,
-                        *insert_args,
-                    )
-                else:
-                    # Sub-bank dedup: the INSERT itself only materialises a row when no
-                    # operation of this type is already queued or running for the same
-                    # payload subject (e.g. one mental model), so the check cannot be
-                    # separated from the write (#3210).
-                    #
-                    # 'processing' counts here, unlike the bank-wide branch above: the
-                    # only caller is the cron-scheduled refresh, whose next tick covers
-                    # anything the in-flight run misses, so a second op would just
-                    # re-check staleness and occupy a claim slot.
-                    #
-                    # PostgreSQL JSON syntax: this path is reached only from the
-                    # maintenance loop, which is PostgreSQL-only. Oracle submits take
-                    # the unconditional branch above.
-                    subject = task_payload.get(dedupe_in_flight_payload_key)
-                    inserted = await conn.fetchval(
-                        f"""
-                        INSERT INTO {fq_table("async_operations")} (operation_id, bank_id, operation_type, result_metadata, status, task_payload)
-                        SELECT $1::uuid, $2, $3, $4::jsonb, $5::text, $6::jsonb
-                        WHERE NOT EXISTS (
-                            SELECT 1 FROM {fq_table("async_operations")}
-                            WHERE bank_id = $2 AND operation_type = $3
-                              AND status IN ('pending', 'processing')
-                              AND task_payload->>$7 = $8
-                        )
-                        RETURNING operation_id
-                        """,
-                        *insert_args,
-                        dedupe_in_flight_payload_key,
-                        subject,
-                    )
-                    if inserted is None:
-                        existing = await conn.fetchval(
-                            f"""
-                            SELECT operation_id FROM {fq_table("async_operations")}
-                            WHERE bank_id = $1 AND operation_type = $2
-                              AND status IN ('pending', 'processing')
-                              AND task_payload->>$3 = $4
-                            ORDER BY created_at
-                            LIMIT 1
-                            """,
-                            bank_id,
-                            operation_type,
-                            dedupe_in_flight_payload_key,
-                            subject,
-                        )
-                        logger.debug(
-                            f"{operation_type} task already in flight for bank_id={bank_id} "
-                            f"{dedupe_in_flight_payload_key}={subject}, skipping duplicate "
-                            f"(existing operation_id={existing})"
-                        )
-                        return {
-                            "operation_id": str(existing),
-                            "deduplicated": True,
-                        }
 
         # For SyncTaskBackend: executes the task immediately.
         # For BrokerTaskBackend: no-op (submit_task's UPDATE skips rows whose
@@ -16796,15 +16797,27 @@ class MemoryEngine(MemoryEngineInterface):
             bank_id: Bank identifier
             mental_model_id: Mental model UUID to refresh
             request_context: Request context for authentication
-            skip_if_in_flight: If True, return the existing operation (with
-                ``deduplicated=True``) instead of queueing a second refresh when one is
-                already pending or processing for this model. Used by the scheduled
-                (cron) refresh, which runs in every process of the fleet and would
-                otherwise queue one wave per process (#3210). Explicit user-triggered
-                refreshes leave it False so an on-demand refresh is never swallowed.
+            skip_if_in_flight: If True, an operation that is already *processing* for this
+                model also suppresses the submit. Used by the automatic triggers — the
+                scheduled (cron) refresh, which runs in every process of the fleet and
+                would otherwise queue one wave per process (#3210), and the
+                after-consolidation flush, which fires once per round (#3411). Explicit
+                user-triggered refreshes leave it False: a refresh that is already running
+                may have read its inputs before the caller's edit, so their intent needs a
+                run of its own.
+
+                A *pending* operation for the model always suppresses the submit,
+                whatever this flag says (#3487). Refreshes carry no per-request options —
+                every queued one does exactly the same work — so a queued-but-unstarted
+                refresh already covers the caller's intent, and letting a second one
+                through only pays for the same recall + LLM call twice. Without that
+                floor, any submit path that forgets this flag piles up unbounded pending
+                copies on a bank whose refresh queue drains slower than it fills.
 
         Returns:
-            Dict with operation_id
+            Dict with operation_id — the surviving operation's when this submit was
+            suppressed, together with ``deduplicated=True``, so the caller can poll
+            that one to completion either way.
         """
         self._raise_if_mental_model_refresh_unavailable()
 
@@ -16849,7 +16862,8 @@ class MemoryEngine(MemoryEngineInterface):
             task_payload=task_payload,
             result_metadata={"mental_model_id": mental_model_id, "name": mental_model["name"]},
             dedupe_by_bank=False,
-            dedupe_in_flight_payload_key="mental_model_id" if skip_if_in_flight else None,
+            dedupe_in_flight_payload_key="mental_model_id",
+            dedupe_in_flight_includes_processing=skip_if_in_flight,
         )
 
     def _raise_if_mental_model_refresh_unavailable(self) -> None:

--- a/hindsight-api-slim/tests/test_mental_model_refresh_pending_dedupe_3487.py
+++ b/hindsight-api-slim/tests/test_mental_model_refresh_pending_dedupe_3487.py
@@ -10,6 +10,7 @@ pile by forgetting to ask for dedupe.
 Deterministic — no LLM: the worker is stalled so submitted operations stay queued.
 """
 
+import asyncio
 import json
 import uuid
 
@@ -126,6 +127,58 @@ async def test_user_triggered_refresh_folds_into_a_queued_one(memory: MemoryEngi
     assert second["deduplicated"] is True
     assert not first.get("deduplicated")
     assert len(await _refresh_ops(memory, bank)) == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_submits_queue_one_refresh(memory: MemoryEngine, request_context, monkeypatch):
+    """Simultaneous submits for the same model still queue exactly one operation.
+
+    The lookup and the INSERT are separate statements, so under READ COMMITTED they
+    would race on their own: each caller's lookup takes its own snapshot, all of them
+    see no queued refresh, and all of them insert. What makes the pair atomic is the
+    bank row, locked FOR NO KEY UPDATE at the top of the same transaction and held to
+    commit — concurrent submits for the bank serialise on it, so each lookup runs
+    against a snapshot that already contains its predecessor's committed row.
+
+    The window is forced open rather than hoped for: every in-flight lookup stalls
+    before returning, so all eight submits would sit between their lookup and their
+    INSERT at the same time. They cannot, because the lock is taken *before* the
+    lookup — the seven losers are still blocked on the bank row while the winner
+    commits. Without it this test inserts eight rows (verified by removing the lock).
+
+    Eight at once, none passing skip_if_in_flight: the guarantee cannot depend on the
+    caller opting in.
+    """
+    bank = await _make_bank(memory, request_context)
+    async with memory._pool.acquire() as conn:
+        mm_id = await _insert_auto_refresh_mm(conn, bank)
+    _stall_worker(memory, monkeypatch)
+
+    original_fetchval = PostgresConnection.fetchval
+
+    async def _stall_in_flight_lookup(self, query, *args, **kwargs):
+        result = await original_fetchval(self, query, *args, **kwargs)
+        if "task_payload->>" in query:
+            await asyncio.sleep(0.2)
+        return result
+
+    monkeypatch.setattr(PostgresConnection, "fetchval", _stall_in_flight_lookup)
+
+    results = await asyncio.gather(
+        *(
+            memory.submit_async_refresh_mental_model(
+                bank_id=bank, mental_model_id=mm_id, request_context=request_context
+            )
+            for _ in range(8)
+        )
+    )
+
+    ops = await _refresh_ops(memory, bank)
+    assert len(ops) == 1
+    # Every loser reports the winner's operation, so all eight callers poll the one
+    # refresh that actually runs.
+    assert {r["operation_id"] for r in results} == {str(ops[0]["operation_id"])}
+    assert sum(1 for r in results if r.get("deduplicated")) == 7
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_mental_model_refresh_pending_dedupe_3487.py
+++ b/hindsight-api-slim/tests/test_mental_model_refresh_pending_dedupe_3487.py
@@ -1,0 +1,189 @@
+"""At most one *pending* refresh operation per (bank, mental model) — issue #3487.
+
+A bank whose refresh queue drains slower than it fills used to accumulate one
+`refresh_mental_model` operation per model per consolidation round: ~12k pending
+operations covering 259 models (~45 identical copies each), every copy a full
+recall + LLM refresh when it eventually ran. The floor is now enforced for every
+submit path rather than opt-in per caller, so no enqueue site can reintroduce the
+pile by forgetting to ask for dedupe.
+
+Deterministic — no LLM: the worker is stalled so submitted operations stay queued.
+"""
+
+import json
+import uuid
+
+import pytest
+
+from hindsight_api.engine.consolidation.consolidator import _trigger_mental_model_refreshes
+from hindsight_api.engine.db.postgresql import PostgresConnection
+from hindsight_api.engine.memory_engine import MemoryEngine
+
+
+async def _make_bank(memory: MemoryEngine, request_context) -> str:
+    bank_id = f"mmdedupe-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    return bank_id
+
+
+async def _insert_auto_refresh_mm(conn, bank_id: str) -> str:
+    """A model that refreshes after consolidation, last refreshed a day ago."""
+    mm_id = f"mm-{uuid.uuid4().hex}"
+    await conn.execute(
+        """
+        INSERT INTO mental_models
+          (id, bank_id, subtype, name, source_query, content, tags, trigger, last_refreshed_at)
+        VALUES ($1, $2, 'pinned', 'auto model', 'what changed', 'body', $3, $4::jsonb,
+                now() - INTERVAL '1 day')
+        """,
+        mm_id,
+        bank_id,
+        [],
+        json.dumps({"refresh_after_consolidation": True}),
+    )
+    return mm_id
+
+
+async def _insert_fact(conn, bank_id: str) -> None:
+    """A memory newer than the model's last refresh, so the model reads as stale."""
+    await conn.execute(
+        "INSERT INTO memory_units (id, bank_id, text, fact_type, tags, created_at, updated_at) "
+        "VALUES ($1, $2, 'a fresh fact', 'experience', $3, now(), now())",
+        uuid.uuid4(),
+        bank_id,
+        [],
+    )
+
+
+def _stall_worker(memory: MemoryEngine, monkeypatch) -> None:
+    """Queue operations without executing them — the slow-draining bank of #3487."""
+
+    async def _never_runs(task_dict):
+        return None
+
+    monkeypatch.setattr(memory._task_backend, "submit_task", _never_runs)
+
+
+async def _refresh_ops(memory: MemoryEngine, bank_id: str) -> list:
+    async with memory._pool.acquire() as conn:
+        return await conn.fetch(
+            "SELECT operation_id, status FROM async_operations "
+            "WHERE bank_id = $1 AND operation_type = 'refresh_mental_model'",
+            bank_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_repeated_flushes_never_queue_a_second_pending_refresh(
+    memory: MemoryEngine, request_context, monkeypatch
+):
+    """Consolidation rounds and explicit refreshes converge on one queued operation.
+
+    Regression for #3487: the after-consolidation flush fires once per round, and the
+    round chain repeats for as long as the backlog lasts. With the operation queued but
+    undrained, every one of those submits — and every explicit refresh landing next to
+    them — must fold into the operation already waiting for this model.
+    """
+    bank = await _make_bank(memory, request_context)
+    async with memory._pool.acquire() as conn:
+        mm_id = await _insert_auto_refresh_mm(conn, bank)
+        await _insert_fact(conn, bank)
+    _stall_worker(memory, monkeypatch)
+
+    for _ in range(5):
+        await _trigger_mental_model_refreshes(memory, bank, request_context)
+        await memory.submit_async_refresh_mental_model(
+            bank_id=bank, mental_model_id=mm_id, request_context=request_context
+        )
+
+    ops = await _refresh_ops(memory, bank)
+    assert len(ops) == 1
+    assert ops[0]["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_user_triggered_refresh_folds_into_a_queued_one(memory: MemoryEngine, request_context, monkeypatch):
+    """An explicit refresh returns the queued operation instead of adding a copy.
+
+    Nothing is lost by folding: a refresh operation carries no per-request options, so
+    the queued one does exactly the work this call is asking for, and it has not started
+    — it still reads whatever the caller just edited. The caller gets that operation's id
+    back and polls it to completion.
+    """
+    bank = await _make_bank(memory, request_context)
+    async with memory._pool.acquire() as conn:
+        mm_id = await _insert_auto_refresh_mm(conn, bank)
+    _stall_worker(memory, monkeypatch)
+
+    first = await memory.submit_async_refresh_mental_model(
+        bank_id=bank, mental_model_id=mm_id, request_context=request_context
+    )
+    second = await memory.submit_async_refresh_mental_model(
+        bank_id=bank, mental_model_id=mm_id, request_context=request_context
+    )
+
+    assert second["operation_id"] == first["operation_id"]
+    assert second["deduplicated"] is True
+    assert not first.get("deduplicated")
+    assert len(await _refresh_ops(memory, bank)) == 1
+
+
+@pytest.mark.asyncio
+async def test_other_models_are_unaffected(memory: MemoryEngine, request_context, monkeypatch):
+    """The floor is per model, not per bank — a second model still gets its own refresh."""
+    bank = await _make_bank(memory, request_context)
+    async with memory._pool.acquire() as conn:
+        first_id = await _insert_auto_refresh_mm(conn, bank)
+        second_id = await _insert_auto_refresh_mm(conn, bank)
+    _stall_worker(memory, monkeypatch)
+
+    for mm_id in (first_id, second_id, first_id, second_id):
+        await memory.submit_async_refresh_mental_model(
+            bank_id=bank, mental_model_id=mm_id, request_context=request_context
+        )
+
+    assert len(await _refresh_ops(memory, bank)) == 2
+
+
+@pytest.mark.asyncio
+async def test_dedupe_statements_survive_the_oracle_rewrite(memory: MemoryEngine, request_context, monkeypatch):
+    """Every statement the deduping submit issues must be valid on Oracle too.
+
+    The dedupe used to live in an ``INSERT ... SELECT ... WHERE NOT EXISTS`` with the
+    JSON key as a bind parameter. Neither survives the Oracle rewriter — a SELECT with
+    no FROM is a syntax error there, and ``->>:7`` is left untouched because only a
+    literal key is mapped to JSON_VALUE — so on Oracle the submit raised instead of
+    deduping, and the after-consolidation flush swallowed the error as a warning.
+    """
+    from hindsight_api.engine.db.oracle import _rewrite_pg_to_oracle
+
+    bank = await _make_bank(memory, request_context)
+    async with memory._pool.acquire() as conn:
+        mm_id = await _insert_auto_refresh_mm(conn, bank)
+    _stall_worker(memory, monkeypatch)
+
+    statements: list[str] = []
+    for method in ("execute", "fetchval"):
+        original = getattr(PostgresConnection, method)
+
+        def _record(self, query, *args, _original=original, **kwargs):
+            statements.append(query)
+            return _original(self, query, *args, **kwargs)
+
+        monkeypatch.setattr(PostgresConnection, method, _record)
+
+    await memory.submit_async_refresh_mental_model(bank_id=bank, mental_model_id=mm_id, request_context=request_context)
+    await memory.submit_async_refresh_mental_model(bank_id=bank, mental_model_id=mm_id, request_context=request_context)
+
+    json_lookups = [s for s in statements if "task_payload->>" in s]
+    assert json_lookups, "the in-flight lookup did not run"
+    for statement in json_lookups:
+        rewritten = _rewrite_pg_to_oracle(statement).query
+        assert "JSON_VALUE(task_payload, '$.mental_model_id')" in rewritten
+        assert "->>" not in rewritten
+
+    inserts = [s for s in statements if "INSERT INTO" in s and "async_operations" in s]
+    assert inserts, "the operation was never inserted"
+    for statement in inserts:
+        # A FROM-less SELECT is what Oracle rejects; the insert must stay a VALUES form.
+        assert "VALUES" in statement

--- a/hindsight-api-slim/tests/test_mental_model_scheduled_refresh.py
+++ b/hindsight-api-slim/tests/test_mental_model_scheduled_refresh.py
@@ -97,6 +97,15 @@ def _stall_worker(memory: MemoryEngine, monkeypatch) -> None:
     monkeypatch.setattr(memory._task_backend, "submit_task", _never_runs)
 
 
+async def _mark_processing(memory: MemoryEngine, operation_id: str) -> None:
+    """Put a queued operation into the state a worker claim leaves it in."""
+    async with memory._pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE async_operations SET status = 'processing' WHERE operation_id = $1",
+            uuid.UUID(operation_id),
+        )
+
+
 async def _count_refresh_ops(memory: MemoryEngine, bank_id: str) -> int:
     async with memory._pool.acquire() as conn:
         return await conn.fetchval(
@@ -247,11 +256,15 @@ async def test_concurrent_scheduled_submits_queue_one_refresh(memory: MemoryEngi
 
 
 @pytest.mark.asyncio
-async def test_user_triggered_refresh_is_not_deduplicated(memory: MemoryEngine, request_context, monkeypatch):
-    """An explicit refresh still queues while a scheduled one is in flight.
+async def test_user_triggered_refresh_still_queues_while_one_is_processing(
+    memory: MemoryEngine, request_context, monkeypatch
+):
+    """An explicit refresh still queues while a scheduled one is *running*.
 
-    The dedup is opt-in for the cron scheduler only: a user asking for a refresh has
-    new intent (e.g. an edited source query) and must not be silently swallowed.
+    Only a running refresh needs a second operation: it may have read the source query
+    before the user edited it, so a user asking for a refresh has new intent that the
+    in-flight run cannot be assumed to cover. (A merely *queued* refresh does cover it —
+    see test_user_triggered_refresh_folds_into_a_queued_one.)
     """
     bank = await _make_bank(memory, request_context)
     async with memory._pool.acquire() as conn:
@@ -261,6 +274,7 @@ async def test_user_triggered_refresh_is_not_deduplicated(memory: MemoryEngine, 
     scheduled = await memory.submit_async_refresh_mental_model(
         bank_id=bank, mental_model_id=mm_id, request_context=request_context, skip_if_in_flight=True
     )
+    await _mark_processing(memory, scheduled["operation_id"])
     manual = await memory.submit_async_refresh_mental_model(
         bank_id=bank, mental_model_id=mm_id, request_context=request_context
     )

--- a/hindsight-docs/docs/developer/api/mental-models.mdx
+++ b/hindsight-docs/docs/developer/api/mental-models.mdx
@@ -357,6 +357,13 @@ Refreshing is useful when:
 - Observations have been updated
 - You want to ensure the mental model reflects current knowledge
 
+**Refreshes coalesce.** A model has at most one refresh waiting at a time: if one is
+already queued and has not started yet, this call returns *that* operation instead of
+queueing an identical second one — the queued refresh reads the model as it stands when
+it runs, so it already covers what you just asked for. Poll the returned `operation_id`
+as usual. A refresh that is already *running* is not reused: it may have read the model
+before your latest change, so a new operation is queued behind it.
+
 ---
 
 ## Troubleshoot a Refresh

--- a/skills/hindsight-docs/references/developer/api/mental-models.md
+++ b/skills/hindsight-docs/references/developer/api/mental-models.md
@@ -477,6 +477,13 @@ Refreshing is useful when:
 - Observations have been updated
 - You want to ensure the mental model reflects current knowledge
 
+**Refreshes coalesce.** A model has at most one refresh waiting at a time: if one is
+already queued and has not started yet, this call returns *that* operation instead of
+queueing an identical second one — the queued refresh reads the model as it stands when
+it runs, so it already covers what you just asked for. Poll the returned `operation_id`
+as usual. A refresh that is already *running* is not reused: it may have read the model
+before your latest change, so a new operation is queued behind it.
+
 ---
 
 ## Troubleshoot a Refresh


### PR DESCRIPTION
Fixes #3487

## What was wrong

A bank whose refresh queue drains slower than it fills accumulated one `refresh_mental_model` operation per model per consolidation round — the report saw 12,461 pending operations covering 259 models (~45 identical copies each), each copy a full recall + LLM refresh when it eventually ran.

The dominant source is already fixed on main: the after-consolidation flush only started asking for the in-flight guard in #3411 (Aug 12), two days before the issue was filed, so the reporting deployment predates it. A repro on current main confirms 5 consolidation flushes queue 1 operation, not 5.

Two holes remained:

1. **The guard was opt-in per call site.** Every enqueue path had to remember `skip_if_in_flight=True`, and the one that forgot is exactly what produced the pile. Nothing structurally enforced "at most one *pending* refresh per `(bank_id, mental_model_id)`".
2. **The dedupe was broken on Oracle.** The check lived in an `INSERT ... SELECT ... WHERE NOT EXISTS` — a FROM-less SELECT there — and carried the JSON key as a bind parameter, which the rewriter leaves untouched (only a *literal* key becomes `JSON_VALUE`). So since #3411 every after-consolidation refresh submit raised on Oracle and was swallowed by the per-model `except Exception` as a warning: those models silently stopped auto-refreshing.

## The fix

- A submit for a model that already has a **queued** refresh always folds into it and returns that operation's id with `deduplicated=True` — for every caller, not just the ones that opt in. Nothing is lost: a refresh carries no per-request options, and a queued operation has not started, so it still reads whatever the caller just edited.
- `skip_if_in_flight` now only widens the guard to an already-**running** refresh. An explicit user refresh still gets its own operation in that case, since the running one may have read the model before their edit — which is what the previous behaviour was actually protecting.
- The check moves out of the INSERT to just in front of it, under the bank-row `FOR NO KEY UPDATE` lock that already serialises submits for the bank (the same pattern `dedupe_by_bank` uses). It stays race-proof under concurrent flushes, and it is now valid on both dialects: the key is inlined (rejected unless a plain identifier) so Oracle rewrites it to `JSON_VALUE`, and the insert stays a `VALUES` form.

Not done: the partial unique index the issue suggests would also reject the deliberate second operation queued behind a *running* refresh.

## Tests

New `test_mental_model_refresh_pending_dedupe_3487.py`:
- repeated consolidation flushes + explicit refreshes converge on one queued operation
- an explicit refresh folds into a queued one and gets its id back
- the floor is per model, not per bank
- every statement the deduping submit issues survives the Oracle rewrite

All four fail without the fix. `test_user_triggered_refresh_is_not_deduplicated` becomes `..._still_queues_while_one_is_processing` for the new contract.

Green locally: the 13 dedupe/cron tests, 56 mental-model + consolidation tests, 379 mental-model/knowledge/template/operation/MCP tests, 140 HTTP-integration tests, and `./scripts/hooks/lint.sh`.

## Docs

The mental-models API page now says refreshes coalesce and what that means for the returned `operation_id` (docs skill regenerated).
