### PR TITLE
docs(recall): say that the created_after/created_before window filters updated_at

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -5398,6 +5398,11 @@ class MemoryEngine(MemoryEngineInterface):
                              This handles varying chunk sizes across documents.
             tags: Optional list of tags for visibility filtering (OR matching - returns
                   memories that have at least one matching tag)
+            created_after: Lower bound on the window, exclusive. Despite the name it bounds
+                  ``updated_at``, not ``created_at``: the window is "memories that changed in
+                  it", so an edited memory re-enters it. That is what the mental-model delta
+                  refresh chases from its watermark (see META_UPDATED_AT in memories/base.py).
+            created_before: Upper bound on the same window, exclusive.
 
         Returns:
             RecallResultModel containing:
@@ -5704,6 +5709,9 @@ class MemoryEngine(MemoryEngineInterface):
     ) -> RecallResultModel:
         """
         Search implementation with modular retrieval and reranking.
+
+        ``created_after`` / ``created_before`` bound ``updated_at``, not ``created_at`` —
+        see the note on :meth:`recall`.
 
         Architecture:
         1. Retrieval: 4-way parallel (semantic, keyword, graph, temporal graph)

--- a/hindsight-api-slim/hindsight_api/engine/mental_model_refresh.py
+++ b/hindsight-api-slim/hindsight_api/engine/mental_model_refresh.py
@@ -68,15 +68,16 @@ class MentalModelRefreshWindow(BaseModel):
     created_after: datetime | None = Field(
         default=None,
         description=(
-            "Lower bound on memory creation time. Set only in delta mode, where it is the model's "
-            "last_memory_seen_at — so a delta refresh only sees memories newer than the newest one "
-            "the previous refresh saw."
+            "Lower bound on when a memory last changed. Set only in delta mode, where it is the "
+            "model's last_memory_seen_at — so a delta refresh only sees memories written or edited "
+            "since the newest one the previous refresh saw."
         ),
     )
     created_before: datetime = Field(
         description=(
-            "Database-time snapshot bounding the refresh. Memories committed after this are not read, "
-            "so they stay newer than the persisted watermark and are caught by the next refresh."
+            "Database-time snapshot bounding the refresh. Memories written or edited after this are "
+            "not read, so they stay newer than the persisted watermark and are caught by the next "
+            "refresh."
         )
     )
     watermark: datetime | None = Field(

--- a/hindsight-api-slim/hindsight_api/engine/search/link_expansion_retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/link_expansion_retrieval.py
@@ -64,23 +64,25 @@ async def _find_semantic_seeds(
     tag_groups_param_start = 6 + (1 if tags else 0)
     groups_clause, groups_params, _ = build_tag_groups_where_clause(tag_groups, tag_groups_param_start)
 
+    # created_after/created_before filter `updated_at`, matching the other recall arms
+    # (see retrieval.py) so a window narrows every arm the same way.
     _next_idx = tag_groups_param_start + len(groups_params)
-    created_range_clause = ""
-    created_range_params: list[Any] = []
+    updated_range_clause = ""
+    updated_range_params: list[Any] = []
     if created_after is not None:
-        created_range_params.append(created_after)
-        created_range_clause += f" AND updated_at > ${_next_idx}"
+        updated_range_params.append(created_after)
+        updated_range_clause += f" AND updated_at > ${_next_idx}"
         _next_idx += 1
     if created_before is not None:
-        created_range_params.append(created_before)
-        created_range_clause += f" AND updated_at < ${_next_idx}"
+        updated_range_params.append(created_before)
+        updated_range_clause += f" AND updated_at < ${_next_idx}"
         _next_idx += 1
 
     params = [query_embedding_str, bank_id, fact_type, threshold, limit]
     if tags:
         params.append(tags)
     params.extend(groups_params)
-    params.extend(created_range_params)
+    params.extend(updated_range_params)
 
     rows = await conn.fetch(
         f"""
@@ -94,7 +96,7 @@ async def _find_semantic_seeds(
           AND (1 - (embedding <=> $1::vector)) >= $4
           {tags_clause}
           {groups_clause}
-          {created_range_clause}
+          {updated_range_clause}
         ORDER BY embedding <=> $1::vector
         LIMIT $5
         """,

--- a/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
@@ -214,19 +214,22 @@ async def retrieve_semantic_bm25_combined_sql(
     tag_groups_param_start = tags_param_idx + (1 if tags else 0)
     groups_clause, groups_params, _ = build_tag_groups_where_clause(tag_groups, tag_groups_param_start)
 
-    # --- created_at time range filter (appended after tags/groups) ---
+    # --- created_after/created_before time range filter (appended after tags/groups) ---
+    # The bounds are named for creation but filter `updated_at` — "memories that changed
+    # in this window", so an edited fact re-enters it. That is what the mental-model delta
+    # refresh needs from its watermark; see META_UPDATED_AT in engine/memories/base.py.
     # Param indices are computed relative to the final params list built below,
     # so we pre-compute the next available index after all preceding params.
     _next_idx = tag_groups_param_start + len(groups_params)
-    created_range_clause = ""
-    created_range_params: list[Any] = []
+    updated_range_clause = ""
+    updated_range_params: list[Any] = []
     if created_after is not None:
-        created_range_params.append(created_after)
-        created_range_clause += f" AND updated_at > ${_next_idx}"
+        updated_range_params.append(created_after)
+        updated_range_clause += f" AND updated_at > ${_next_idx}"
         _next_idx += 1
     if created_before is not None:
-        created_range_params.append(created_before)
-        created_range_clause += f" AND updated_at < ${_next_idx}"
+        updated_range_params.append(created_before)
+        updated_range_clause += f" AND updated_at < ${_next_idx}"
         _next_idx += 1
 
     # --- Semantic UNION ALL arms (one per fact_type) ---
@@ -243,7 +246,7 @@ async def retrieve_semantic_bm25_combined_sql(
             min_similarity=sem_min,
             tags_clause=tags_clause,
             groups_clause=groups_clause,
-            extra_where=created_range_clause,
+            extra_where=updated_range_clause,
         )
         for ft in fact_types
     ]
@@ -297,7 +300,7 @@ async def retrieve_semantic_bm25_combined_sql(
                     text_search_extension=text_ext,
                     bm25_language=config.text_search_extension_native_language,
                     bm25_min_score=bm25_min,
-                    extra_where=created_range_clause,
+                    extra_where=updated_range_clause,
                 )
             )
 
@@ -310,7 +313,7 @@ async def retrieve_semantic_bm25_combined_sql(
     if tags:
         params.append(tags)
     params.extend(groups_params)
-    params.extend(created_range_params)
+    params.extend(updated_range_params)
 
     try:
         rows = await conn.fetch(query, *params)
@@ -329,12 +332,12 @@ async def retrieve_semantic_bm25_combined_sql(
             fb_groups_start = fb_tags_idx + (1 if tags else 0)
             fb_groups_clause, _, _ = build_tag_groups_where_clause(tag_groups, fb_groups_start)
             fb_next_idx = fb_groups_start + len(groups_params)
-            fb_created_clause = ""
+            fb_updated_clause = ""
             if created_after is not None:
-                fb_created_clause += f" AND updated_at > ${fb_next_idx}"
+                fb_updated_clause += f" AND updated_at > ${fb_next_idx}"
                 fb_next_idx += 1
             if created_before is not None:
-                fb_created_clause += f" AND updated_at < ${fb_next_idx}"
+                fb_updated_clause += f" AND updated_at < ${fb_next_idx}"
                 fb_next_idx += 1
             fb_arms = [
                 dialect.build_semantic_arm(
@@ -347,7 +350,7 @@ async def retrieve_semantic_bm25_combined_sql(
                     min_similarity=sem_min,
                     tags_clause=fb_tags_clause,
                     groups_clause=fb_groups_clause,
-                    extra_where=fb_created_clause,
+                    extra_where=fb_updated_clause,
                 )
                 for ft in fact_types
             ]
@@ -356,7 +359,7 @@ async def retrieve_semantic_bm25_combined_sql(
             if tags:
                 fb_params.append(tags)
             fb_params.extend(groups_params)
-            fb_params.extend(created_range_params)
+            fb_params.extend(updated_range_params)
             rows = await conn.fetch(fb_query, *fb_params)
         else:
             raise
@@ -508,24 +511,25 @@ async def retrieve_temporal_combined_sql(
     tag_groups_param_start = 6 + (1 if tags else 0)
     groups_clause, groups_params, _ = build_tag_groups_where_clause(tag_groups, tag_groups_param_start)
 
-    # created_at time range filter (after tags/groups)
+    # created_after/created_before time range filter (after tags/groups) — filters
+    # `updated_at`, as above.
     _next_idx = tag_groups_param_start + len(groups_params)
-    created_range_clause = ""
-    created_range_params: list[Any] = []
+    updated_range_clause = ""
+    updated_range_params: list[Any] = []
     if created_after is not None:
-        created_range_params.append(created_after)
-        created_range_clause += f" AND updated_at > ${_next_idx}"
+        updated_range_params.append(created_after)
+        updated_range_clause += f" AND updated_at > ${_next_idx}"
         _next_idx += 1
     if created_before is not None:
-        created_range_params.append(created_before)
-        created_range_clause += f" AND updated_at < ${_next_idx}"
+        updated_range_params.append(created_before)
+        updated_range_clause += f" AND updated_at < ${_next_idx}"
         _next_idx += 1
 
     params: list = [query_emb_str, bank_id, start_date, end_date, semantic_threshold]
     if tags:
         params.append(tags)
     params.extend(groups_params)
-    params.extend(created_range_params)
+    params.extend(updated_range_params)
 
     # Entry-point selection: similarity-gated, window-filtered, then narrowed for coverage.
     #
@@ -579,7 +583,7 @@ async def retrieve_temporal_combined_sql(
           AND (1 - (embedding <=> $1::vector)) >= $5
           {tags_clause}
           {groups_clause}
-          {created_range_clause}
+          {updated_range_clause}
         ORDER BY embedding <=> $1::vector
         LIMIT {_TEMPORAL_POOL_SIZE}
         )"""

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -8303,9 +8303,9 @@ components:
           nullable: true
           type: string
         created_before:
-          description: "Database-time snapshot bounding the refresh. Memories committed\
-            \ after this are not read, so they stay newer than the persisted watermark\
-            \ and are caught by the next refresh."
+          description: "Database-time snapshot bounding the refresh. Memories written\
+            \ or edited after this are not read, so they stay newer than the persisted\
+            \ watermark and are caught by the next refresh."
           format: date-time
           title: Created Before
           type: string

--- a/hindsight-clients/go/model_mental_model_refresh_window.go
+++ b/hindsight-clients/go/model_mental_model_refresh_window.go
@@ -23,7 +23,7 @@ var _ MappedNullable = &MentalModelRefreshWindow{}
 // MentalModelRefreshWindow The time window a refresh read memories from.
 type MentalModelRefreshWindow struct {
 	CreatedAfter NullableTime `json:"created_after,omitempty"`
-	// Database-time snapshot bounding the refresh. Memories committed after this are not read, so they stay newer than the persisted watermark and are caught by the next refresh.
+	// Database-time snapshot bounding the refresh. Memories written or edited after this are not read, so they stay newer than the persisted watermark and are caught by the next refresh.
 	CreatedBefore time.Time `json:"created_before"`
 	Watermark NullableTime `json:"watermark,omitempty"`
 }

--- a/hindsight-clients/python/hindsight_client_api/models/mental_model_refresh_window.py
+++ b/hindsight-clients/python/hindsight_client_api/models/mental_model_refresh_window.py
@@ -28,7 +28,7 @@ class MentalModelRefreshWindow(BaseModel):
     The time window a refresh read memories from.
     """ # noqa: E501
     created_after: Optional[datetime] = None
-    created_before: datetime = Field(description="Database-time snapshot bounding the refresh. Memories committed after this are not read, so they stay newer than the persisted watermark and are caught by the next refresh.")
+    created_before: datetime = Field(description="Database-time snapshot bounding the refresh. Memories written or edited after this are not read, so they stay newer than the persisted watermark and are caught by the next refresh.")
     watermark: Optional[datetime] = None
     __properties: ClassVar[List[str]] = ["created_after", "created_before", "watermark"]
 

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -3377,13 +3377,13 @@ export type MentalModelRefreshWindow = {
   /**
    * Created After
    *
-   * Lower bound on memory creation time. Set only in delta mode, where it is the model's last_memory_seen_at — so a delta refresh only sees memories newer than the newest one the previous refresh saw.
+   * Lower bound on when a memory last changed. Set only in delta mode, where it is the model's last_memory_seen_at — so a delta refresh only sees memories written or edited since the newest one the previous refresh saw.
    */
   created_after?: string | null;
   /**
    * Created Before
    *
-   * Database-time snapshot bounding the refresh. Memories committed after this are not read, so they stay newer than the persisted watermark and are caught by the next refresh.
+   * Database-time snapshot bounding the refresh. Memories written or edited after this are not read, so they stay newer than the persisted watermark and are caught by the next refresh.
    */
   created_before: string;
   /**

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -12229,13 +12229,13 @@
               }
             ],
             "title": "Created After",
-            "description": "Lower bound on memory creation time. Set only in delta mode, where it is the model's last_memory_seen_at \u2014 so a delta refresh only sees memories newer than the newest one the previous refresh saw."
+            "description": "Lower bound on when a memory last changed. Set only in delta mode, where it is the model's last_memory_seen_at \u2014 so a delta refresh only sees memories written or edited since the newest one the previous refresh saw."
           },
           "created_before": {
             "type": "string",
             "format": "date-time",
             "title": "Created Before",
-            "description": "Database-time snapshot bounding the refresh. Memories committed after this are not read, so they stay newer than the persisted watermark and are caught by the next refresh."
+            "description": "Database-time snapshot bounding the refresh. Memories written or edited after this are not read, so they stay newer than the persisted watermark and are caught by the next refresh."
           },
           "watermark": {
             "anyOf": [

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -12229,13 +12229,13 @@
               }
             ],
             "title": "Created After",
-            "description": "Lower bound on memory creation time. Set only in delta mode, where it is the model's last_memory_seen_at \u2014 so a delta refresh only sees memories newer than the newest one the previous refresh saw."
+            "description": "Lower bound on when a memory last changed. Set only in delta mode, where it is the model's last_memory_seen_at \u2014 so a delta refresh only sees memories written or edited since the newest one the previous refresh saw."
           },
           "created_before": {
             "type": "string",
             "format": "date-time",
             "title": "Created Before",
-            "description": "Database-time snapshot bounding the refresh. Memories committed after this are not read, so they stay newer than the persisted watermark and are caught by the next refresh."
+            "description": "Database-time snapshot bounding the refresh. Memories written or edited after this are not read, so they stay newer than the persisted watermark and are caught by the next refresh."
           },
           "watermark": {
             "anyOf": [


### PR DESCRIPTION
Follow-up to #3502, which surfaced this while auditing who reads `memory_units.updated_at`.

Recall's `created_after` / `created_before` bounds filter **`updated_at`**, not `created_at` — the window is "memories that changed in it", so an edited memory re-enters it. That is deliberate and load-bearing rather than a slip: it is exactly what the mental-model delta refresh chases from its watermark, and `tests/test_recall_time_range.py` already pins the behaviour, down to the case of a fact created at T1 and edited at T3 showing up under `created_after=T2`. Only the names say otherwise, and #3502 widened what stamps the column — so the mismatch now decides slightly more.

**The names stay.** They reach the memories-extension interface (`MemoriesExtension.recall_unified`, `GraphRetriever`) and a published response schema, so renaming would break out-of-tree stores and an API field for a cosmetic win. What changes is that every place a caller reads now says what the bounds mean:

- `MemoryEngine.recall` documents both parameters; the internal search entrypoint points at that note.
- The SQL-building blocks name their locals `updated_range_*`, and the `# --- created_at time range filter ---` comment sitting directly above a clause that emits `AND updated_at > $n` is gone.
- `MentalModelRefreshWindow.created_after` described itself as "Lower bound on memory creation time" — the one *user-visible* wrong statement, since that model is in the published OpenAPI. It now reads "Lower bound on when a memory last changed", `created_before` matches, and the regenerated clients follow.

The parameters are engine-internal beyond that: recall's HTTP surface does not expose them, so no request schema changes.

## Tests

No new tests — this changes no behaviour, and the behaviour is already pinned. Ran `test_recall_time_range`, `test_temporal_recall_selection`, `test_mental_model_dry_run_refresh`, `test_db_abstraction` (151 passed), plus `./scripts/hooks/lint.sh`. Client/docs artifacts regenerated with `generate-openapi.sh` + `generate-clients.sh`; the diff there is description text only, no schema shape.
