### PR TITLE
perf(maintenance): make the cross-tenant sweeps proportionate to tenant count

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -177,6 +177,14 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_OPERATION_RETENTION_DAYS=30  # Prune terminal operation rows, payloads, and metadata after this many days; 0 (the default) keeps them forever.
 # HINDSIGHT_API_OPERATION_CLEANUP_BATCH_SIZE=1000  # Maximum expired terminal rows deleted per tenant schema in each cleanup cycle; must be positive.
 
+# Background maintenance cadences (Optional)
+# Each sweep begins with one cross-tenant discovery call that probes every schema holding the relevant
+# table, in every API/worker process — so its cost scales with tenant count while the work it finds does
+# not. On deployments with thousands of tenants these intervals are the knob to raise.
+# HINDSIGHT_API_RETENTION_SWEEP_INTERVAL_SECONDS=3600  # How often expired audit_log / llm_requests rows are deleted across all tenant schemas. Retention is counted in days, so this only sets how promptly they disappear; 0 disables the sweeps.
+# HINDSIGHT_API_OPERATION_CLEANUP_INTERVAL_SECONDS=900  # How often expired terminal operation rows are pruned; with the batch size above this sets the drain rate for a backlog. 0 disables the job.
+# HINDSIGHT_API_MAINTENANCE_START_JITTER_SECONDS=60  # Upper bound on a random delay before a process runs its FIRST maintenance tick. Every job is due on that tick, so without an offset a fleet started together runs every sweep in every process at once. 0 disables the jitter.
+
 # Vector Extension (Optional - uses pgvector by default)
 # Options: "pgvector" (default), "vchord", "pgvectorscale" (DiskANN)
 # HINDSIGHT_API_VECTOR_EXTENSION=pgvector

--- a/hindsight-api-slim/hindsight_api/alembic/versions/f2a7c9d4b168_add_mental_models_cron_index.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/f2a7c9d4b168_add_mental_models_cron_index.py
@@ -1,0 +1,72 @@
+"""Add a partial index for the cron-scheduled mental model discovery sweep.
+
+``mental_models_with_cron()`` (``f4d1c2b3a5e6``, currently installed by
+``c8b4e2a71f95``) is a cross-tenant discovery routine: it loops over every schema
+holding a ``mental_models`` table and, for each, selects the models carrying a
+non-empty ``trigger->>'refresh_cron'``. No index covers that predicate, so each
+per-schema probe is a **sequential scan** of that tenant's ``mental_models``
+table — paid on every maintenance tick, in every API/worker process, whether or
+not the tenant has a single cron-scheduled model.
+
+Cron-scheduled models are rare by construction (the trigger defaults to
+``{"refresh_after_consolidation": false}``), so at thousands of tenants the sweep
+spends essentially all of its time proving that tenants have nothing to do. A
+partial index whose predicate matches the routine's WHERE clause exactly turns a
+tenant with no cron-scheduled models into an empty index scan.
+
+``bank_id`` is the indexed column so the routine's projection stays on the
+leading column of the index; the predicate is what does the work here.
+
+PostgreSQL only: the maintenance loop and its discovery routines are PG-only
+(the Oracle slot is intentionally absent, mirroring ``f4d1c2b3a5e6``), so an
+Oracle deployment never runs the scan this index exists to avoid.
+
+Revision ID: f2a7c9d4b168
+Revises: c8b4e2a71f95
+Create Date: 2026-08-17
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "f2a7c9d4b168"
+down_revision: str | Sequence[str] | None = "c8b4e2a71f95"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_INDEX = "idx_mental_models_cron"
+
+
+def _pg_schema_prefix() -> str:
+    """Schema-qualifier for PostgreSQL multi-tenant migration runs."""
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def _pg_upgrade() -> None:
+    schema = _pg_schema_prefix()
+    # Plain (non-CONCURRENT) build: mental_models holds one row per mental model,
+    # so this is a sub-second SHARE lock even on large installations — unlike the
+    # async_operations indexes in a8c1e4f7b0d3, which needed CONCURRENTLY.
+    # The predicate is character-for-character the routine's WHERE clause, which
+    # is what lets the planner match the partial index.
+    op.execute(
+        f"CREATE INDEX IF NOT EXISTS {_INDEX} ON {schema}mental_models (bank_id) "
+        "WHERE COALESCE(\"trigger\"->>'refresh_cron', '') <> ''"
+    )
+
+
+def _pg_downgrade() -> None:
+    schema = _pg_schema_prefix()
+    op.execute(f"DROP INDEX IF EXISTS {schema}{_INDEX}")
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade)

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -867,6 +867,9 @@ ENV_LLM_TRACE_MAX_CHARS = "HINDSIGHT_API_LLM_TRACE_MAX_CHARS"
 # Background maintenance settings
 ENV_CONSOLIDATION_RECONCILE_INTERVAL_SECONDS = "HINDSIGHT_API_CONSOLIDATION_RECONCILE_INTERVAL_SECONDS"
 ENV_MENTAL_MODEL_REFRESH_TICK_SECONDS = "HINDSIGHT_API_MENTAL_MODEL_REFRESH_TICK_SECONDS"
+ENV_RETENTION_SWEEP_INTERVAL_SECONDS = "HINDSIGHT_API_RETENTION_SWEEP_INTERVAL_SECONDS"
+ENV_OPERATION_CLEANUP_INTERVAL_SECONDS = "HINDSIGHT_API_OPERATION_CLEANUP_INTERVAL_SECONDS"
+ENV_MAINTENANCE_START_JITTER_SECONDS = "HINDSIGHT_API_MAINTENANCE_START_JITTER_SECONDS"
 
 # Disposition settings
 ENV_DISPOSITION_SKEPTICISM = "HINDSIGHT_API_DISPOSITION_SKEPTICISM"
@@ -1446,7 +1449,30 @@ DEFAULT_CONSOLIDATION_RECONCILE_INTERVAL_SECONDS = 300
 # How often the maintenance loop checks for cron-scheduled mental models that are
 # due for a refresh. This is the *check* cadence; the actual schedule is the
 # per-model cron expression in the mental model's trigger. 0 disables the sweep.
-DEFAULT_MENTAL_MODEL_REFRESH_TICK_SECONDS = 60
+#
+# Discovery is one cross-tenant round-trip that probes every schema holding a
+# mental_models table, so its cost scales with tenant count while the models it
+# looks for are rare. Five minutes keeps that cost proportionate; the floor it
+# imposes on cron granularity (a `* * * * *` schedule fires every 5 minutes, not
+# every minute) is why it stays tunable.
+DEFAULT_MENTAL_MODEL_REFRESH_TICK_SECONDS = 300
+
+# How often the audit_log / llm_requests retention sweeps run. Retention windows
+# are measured in days, so this only sets how promptly expired rows disappear.
+DEFAULT_RETENTION_SWEEP_INTERVAL_SECONDS = 3600
+
+# How often terminal async_operations rows past their retention are pruned. One
+# bounded batch per tenant schema per run, so this also sets the drain rate for a
+# backlog (batch size: HINDSIGHT_API_OPERATION_CLEANUP_BATCH_SIZE). Like the
+# retention sweeps it deletes rows whose retention is counted in days, so a slow
+# cadence costs nothing but avoids a per-tick cross-tenant probe. 0 disables it.
+DEFAULT_OPERATION_CLEANUP_INTERVAL_SECONDS = 900
+
+# Upper bound on the random delay applied before a process runs its first
+# maintenance tick. Every job is due on the first tick, so without this a fleet
+# started together (deploy, rolling restart) runs every sweep in every process at
+# the same instant. 0 disables the jitter (deterministic start).
+DEFAULT_MAINTENANCE_START_JITTER_SECONDS = 60
 
 # Default MCP tool descriptions (can be customized via env vars)
 DEFAULT_MCP_RETAIN_DESCRIPTION = """Store important information to long-term memory.
@@ -2677,6 +2703,14 @@ class HindsightConfig:
     # not be able to widen the set of request headers its own extension code
     # sees). Stored lower-cased; empty means no header is ever forwarded.
     extension_passthrough_headers: list[str] = field(default_factory=list)
+
+    # Background maintenance cadences (static, server-level only). Each sweep's
+    # discovery is one cross-tenant round-trip that probes every schema holding
+    # the relevant table, so its cost scales with tenant count and the cadence is
+    # the lever a large deployment tunes. 0 disables the job.
+    retention_sweep_interval_seconds: int = DEFAULT_RETENTION_SWEEP_INTERVAL_SECONDS
+    operation_cleanup_interval_seconds: int = DEFAULT_OPERATION_CLEANUP_INTERVAL_SECONDS
+    maintenance_start_jitter_seconds: int = DEFAULT_MAINTENANCE_START_JITTER_SECONDS
 
     # Class-level sets for configuration categorization
 
@@ -3963,6 +3997,21 @@ class HindsightConfig:
                     ENV_MENTAL_MODEL_REFRESH_TICK_SECONDS,
                     str(DEFAULT_MENTAL_MODEL_REFRESH_TICK_SECONDS),
                 )
+            ),
+            retention_sweep_interval_seconds=_parse_non_negative_int(
+                ENV_RETENTION_SWEEP_INTERVAL_SECONDS,
+                os.getenv(ENV_RETENTION_SWEEP_INTERVAL_SECONDS),
+                DEFAULT_RETENTION_SWEEP_INTERVAL_SECONDS,
+            ),
+            operation_cleanup_interval_seconds=_parse_non_negative_int(
+                ENV_OPERATION_CLEANUP_INTERVAL_SECONDS,
+                os.getenv(ENV_OPERATION_CLEANUP_INTERVAL_SECONDS),
+                DEFAULT_OPERATION_CLEANUP_INTERVAL_SECONDS,
+            ),
+            maintenance_start_jitter_seconds=_parse_non_negative_int(
+                ENV_MAINTENANCE_START_JITTER_SECONDS,
+                os.getenv(ENV_MAINTENANCE_START_JITTER_SECONDS),
+                DEFAULT_MAINTENANCE_START_JITTER_SECONDS,
             ),
             # Webhook configuration (static, server-level only)
             webhook_url=os.getenv(ENV_WEBHOOK_URL) or DEFAULT_WEBHOOK_URL,

--- a/hindsight-api-slim/hindsight_api/engine/maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/maintenance.py
@@ -3,15 +3,16 @@
 A single periodic loop that drives all of Hindsight's recurring housekeeping
 from one place, so we don't spawn a separate ``asyncio`` task per concern:
 
-- **Retention sweeps** (hourly): delete ``audit_log`` and ``llm_requests`` rows
-  older than their configured retention, across *all* tenant schemas.
+- **Retention sweeps** (configurable, default hourly): delete ``audit_log`` and
+  ``llm_requests`` rows older than their configured retention, across *all*
+  tenant schemas.
 - **Consolidation reconcile** (configurable, default 5 min): re-schedule
   consolidation for banks that have eligible-but-unscheduled facts and no
   in-flight consolidation. This recovers facts that were stranded when a
   consolidation operation failed terminally and left them with
   ``consolidated_at IS NULL AND consolidation_failed_at IS NULL`` and nothing to
   re-trigger them.
-- **Scheduled mental model refresh** (configurable check cadence, default 60s):
+- **Scheduled mental model refresh** (configurable check cadence, default 5 min):
   refresh mental models whose ``trigger.refresh_cron`` schedule is due, but only
   when the model is stale (new memories in its scope since its last refresh), so
   a scheduled tick never burns an LLM call to regenerate identical content. The
@@ -33,12 +34,29 @@ reconcile and the scheduled mental model refresh both dedupe against in-flight
 operations inside the inserting transaction (see ``_submit_async_operation``);
 retention deletes in bounded chunks claimed with SKIP LOCKED, so concurrent
 sweepers split the work instead of colliding (see ``_purge_table_in_batches``).
+
+The *work* is therefore safe to run everywhere. The *discovery* in front of it is
+not free: one round-trip on the wire is still one query per tenant schema inside
+the routine, every process pays it, and its cost scales with tenant count while
+the work it finds does not. Two things keep that proportionate, and both are
+load-bearing rather than incidental:
+
+- **Cadence is config, not a constant.** Every job's interval is a server-level
+  setting. The jobs that delete rows whose retention is measured in *days*
+  (retention, operation cleanup) have no reason to probe every schema every
+  minute.
+- **The first tick is jittered** (``maintenance_start_jitter_seconds``). Every job
+  is due on the first tick, so a fleet started together — a deploy, a rolling
+  restart — would fire every cross-tenant probe in every process at the same
+  instant. SKIP LOCKED keeps that correct but not cheap: the probes are reads, and
+  N of them land at once. Steady state self-staggers; startup does not.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import random
 import time
 from collections.abc import Coroutine
 from datetime import datetime, timedelta, timezone
@@ -56,12 +74,6 @@ logger = logging.getLogger(__name__)
 
 # Short tick so jobs with different cadences share one loop without per-job tasks.
 _TICK_SECONDS = 60
-# Retention sweeps are not time-sensitive; hourly matches the previous per-sweep cadence.
-_RETENTION_INTERVAL_SECONDS = 3600
-# Operation cleanup deletes one bounded batch per schema per run, so its cadence
-# sets the drain rate for a backlog. Kept at one-per-tick (the value it used while
-# it rode the worker's poll loop) so throughput is unchanged by the move.
-_OPERATION_CLEANUP_INTERVAL_SECONDS = 60
 # Cross-store txn recovery (only when the memories store keeps its rows outside SQL): a backstop
 # for a writer that crashed between its external writes and the decide. The happy path decides
 # inline after commit, so this rarely finds work; five minutes bounds how long a crashed txn stalls
@@ -89,7 +101,8 @@ _TXN_RECOVERY_GRACE_SECONDS = 300
 _RETENTION_BATCH_SIZE = 2000
 # Ceiling on chunks per table per schema per run: a backstop against looping
 # forever on a table that is filling faster than it drains. A full run therefore
-# removes at most 2M rows per schema, and the next hourly tick continues.
+# removes at most 2M rows per schema, and the next sweep (whose cadence is
+# HINDSIGHT_API_RETENTION_SWEEP_INTERVAL_SECONDS, default hourly) continues.
 _RETENTION_MAX_BATCHES = 1000
 # Breather between chunks. Paces one process at ~8k rows/s worst case; several
 # pods sweeping at once multiply that, which is still orders of magnitude gentler
@@ -149,10 +162,11 @@ class MaintenanceLoop:
         # Not gated on audit_log_enabled: that is per-bank overridable, so rows
         # can exist even when the deployment default is off. Retention is driven
         # purely by the (server-level) window.
-        audit_on = cfg.audit_log_retention_days > 0
-        llm_on = cfg.llm_trace_enabled and cfg.llm_trace_retention_days > 0
+        sweep_on = cfg.retention_sweep_interval_seconds > 0
+        audit_on = sweep_on and cfg.audit_log_retention_days > 0
+        llm_on = sweep_on and cfg.llm_trace_enabled and cfg.llm_trace_retention_days > 0
         mm_refresh_on = cfg.mental_model_refresh_tick_seconds > 0
-        op_cleanup_on = cfg.operation_retention_days > 0
+        op_cleanup_on = cfg.operation_cleanup_interval_seconds > 0 and cfg.operation_retention_days > 0
         return (
             reconcile_on
             or audit_on
@@ -181,6 +195,8 @@ class MaintenanceLoop:
     # ── loop ───────────────────────────────────────────────────────────────
 
     async def _run(self) -> None:
+        if not await self._wait_start_jitter():
+            return
         while not self._stop.is_set():
             try:
                 await self._tick()
@@ -190,6 +206,26 @@ class MaintenanceLoop:
                 await asyncio.wait_for(self._stop.wait(), timeout=_TICK_SECONDS)
             except asyncio.TimeoutError:
                 pass
+
+    async def _wait_start_jitter(self) -> bool:
+        """Delay the first tick by a random offset. Returns False if stopped while waiting.
+
+        Every job is due the first time ``_is_due`` sees it, so N processes started
+        together would run all of them at the same instant — the one moment where
+        redundant cross-tenant discovery and overlapping DELETEs actually collide.
+        Spreading the *first* tick is enough: from then on each process keeps its
+        own phase.
+        """
+        jitter = get_config().maintenance_start_jitter_seconds
+        if jitter <= 0:
+            return True
+        delay = random.uniform(0, jitter)
+        logger.debug(f"Maintenance loop: delaying first tick by {delay:.1f}s")
+        try:
+            await asyncio.wait_for(self._stop.wait(), timeout=delay)
+        except asyncio.TimeoutError:
+            return True
+        return False
 
     def _is_due(self, job: str, interval_seconds: int) -> bool:
         """True if ``job`` has never run or its interval has elapsed; marks it run now."""
@@ -202,7 +238,8 @@ class MaintenanceLoop:
 
     async def _tick(self) -> None:
         cfg = get_config()
-        if self._is_due("retention", _RETENTION_INTERVAL_SECONDS):
+        retention_interval = cfg.retention_sweep_interval_seconds
+        if retention_interval > 0 and self._is_due("retention", retention_interval):
             await self._run_timed("retention", self._run_retention(cfg))
         interval = cfg.consolidation_reconcile_interval_seconds
         if interval > 0 and self._is_due("reconcile", interval):
@@ -210,7 +247,12 @@ class MaintenanceLoop:
         mm_interval = cfg.mental_model_refresh_tick_seconds
         if mm_interval > 0 and self._is_due("mm_refresh", mm_interval):
             await self._run_timed("scheduled mental model refresh", self._run_scheduled_mm_refresh())
-        if cfg.operation_retention_days > 0 and self._is_due("operation_cleanup", _OPERATION_CLEANUP_INTERVAL_SECONDS):
+        cleanup_interval = cfg.operation_cleanup_interval_seconds
+        if (
+            cleanup_interval > 0
+            and cfg.operation_retention_days > 0
+            and self._is_due("operation_cleanup", cleanup_interval)
+        ):
             await self._run_timed("operation cleanup", self._run_operation_cleanup(cfg))
         if self._cross_store_recovery_enabled() and self._is_due("txn_recovery", _TXN_RECOVERY_INTERVAL_SECONDS):
             await self._run_timed("cross-store txn recovery", self._run_txn_recovery())
@@ -376,7 +418,12 @@ class MaintenanceLoop:
                 async with acquire_with_retry(backend, max_retries=1) as conn:
                     # Delete export archives owned by rows about to be pruned first,
                     # so the file-storage blobs don't outlive their operation row.
-                    await engine.purge_expired_export_archives(conn, table, cutoff)
+                    # Same batch bound as the prune below: the two walk the same
+                    # ordered window so a backlog doesn't re-purge already-deleted
+                    # archives on every cycle.
+                    await engine.purge_expired_export_archives(
+                        conn, table, cutoff, batch_size=cfg.operation_cleanup_batch_size
+                    )
                     async with conn.transaction():
                         deleted = await backend.ops.prune_terminal_operations(
                             conn, table, cutoff, batch_size=cfg.operation_cleanup_batch_size

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -2147,21 +2147,34 @@ class MemoryEngine(MemoryEngineInterface):
         except Exception:
             logger.warning("Failed to delete export archive %s", storage_key, exc_info=True)
 
-    async def purge_expired_export_archives(self, conn: Any, table: str, cutoff: Any) -> int:
+    async def purge_expired_export_archives(self, conn: Any, table: str, cutoff: Any, *, batch_size: int) -> int:
         """Delete stored archives of export operations retention is about to prune.
 
         Mirrors ``prune_terminal_operations``' predicate (terminal status +
-        ``updated_at < cutoff``) so an export's archive is removed in step with its
-        operation row, instead of being orphaned in file storage when the row is
-        pruned. Called by the maintenance sweep before the row prune, on the same
-        (schema-scoped) connection. Returns the number of archives deleted.
+        ``updated_at < cutoff``), ordering and batch bound, so an export's archive
+        is removed in step with its operation row instead of being orphaned in file
+        storage when the row is pruned. Called by the maintenance sweep before the
+        row prune, on the same (schema-scoped) connection. Returns the number of
+        archives deleted.
+
+        The bound is what keeps this proportionate. The prune deletes at most
+        ``batch_size`` rows per run, but an unbounded purge re-selects *every*
+        expired export on every run and re-issues a file-storage delete for each —
+        ``storage_key`` stays in ``result_metadata`` until the row itself is pruned,
+        so there is nothing to mark the blob as already gone. With a backlog that
+        is one redundant round-trip to the blob store per expired export per cycle,
+        per process. Sharing the prune's ``ORDER BY updated_at, operation_id``
+        window makes the two advance together instead.
         """
         rows = await conn.fetch(
             f"""SELECT result_metadata FROM {table}
                 WHERE operation_type = 'export_documents'
                   AND status IN ('completed', 'failed', 'cancelled')
-                  AND updated_at < $1""",
+                  AND updated_at < $1
+                ORDER BY updated_at, operation_id
+                LIMIT $2""",
             cutoff,
+            batch_size,
         )
         purged = 0
         for row in rows:

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -1738,10 +1738,56 @@ async def test_purge_expired_export_archives(memory, request_context):
                 old,
                 uuid.UUID(op_id),
             )
-            purged = await memory.purge_expired_export_archives(conn, fq_table("async_operations"), cutoff)
+            purged = await memory.purge_expired_export_archives(
+                conn, fq_table("async_operations"), cutoff, batch_size=100
+            )
         assert purged >= 1
         with pytest.raises(FileNotFoundError):
             await memory._file_storage.retrieve(storage_key)
+    finally:
+        await memory.delete_bank(bank, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_purge_expired_export_archives_honours_the_batch_bound(memory, request_context):
+    """The purge deletes at most ``batch_size`` archives per call.
+
+    Unbounded, it re-selected every expired export on every cleanup cycle and
+    re-issued a blob delete for each — ``storage_key`` stays in the row until the
+    row itself is pruned, so nothing marks an archive as already handled. The
+    prune next to it is batched, so the purge shares that bound and the two walk
+    the same ``ORDER BY updated_at, operation_id`` window together.
+    """
+    from datetime import timedelta
+
+    bank = _unique_bank("export_purge_bound")
+    try:
+        await memory.get_bank_profile(bank_id=bank, request_context=request_context)
+        backend = await memory._get_backend()
+        # Fabricated rows rather than real exports: the purge counts rows carrying a
+        # storage_key and swallows the blob delete, so no archive needs to exist for
+        # the bound to be observable. Backdated far past any other test's rows so the
+        # ORDER BY puts these first on the shared pg0 database.
+        old = datetime.now(timezone.utc) - timedelta(days=500)
+        cutoff = datetime.now(timezone.utc) - timedelta(days=1)
+        async with acquire_with_retry(backend) as conn:
+            for i in range(2):
+                await conn.execute(
+                    f"""INSERT INTO {fq_table("async_operations")}
+                        (operation_id, bank_id, operation_type, status, task_payload,
+                         result_metadata, updated_at)
+                        VALUES ($1, $2, 'export_documents', 'completed', '{{}}'::jsonb, $3::jsonb, $4)""",
+                    uuid.uuid4(),
+                    bank,
+                    json.dumps({"storage_key": f"banks/{bank}/exports/absent-{i}.zip"}),
+                    old,
+                )
+            # LIMIT 1 caps the result at one row regardless of which expired export
+            # sorts first, so this holds even with other tests' rows in the schema.
+            purged = await memory.purge_expired_export_archives(
+                conn, fq_table("async_operations"), cutoff, batch_size=1
+            )
+        assert purged == 1
     finally:
         await memory.delete_bank(bank, request_context=request_context)
 

--- a/hindsight-api-slim/tests/test_maintenance_loop.py
+++ b/hindsight-api-slim/tests/test_maintenance_loop.py
@@ -20,6 +20,27 @@ def test_start_is_noop_on_oracle(monkeypatch):
     assert loop._task is None
 
 
+def _tick_cfg(**overrides):
+    """A config stub for ``_tick``, with every job disabled unless overridden."""
+    from types import SimpleNamespace
+
+    fields = {
+        "consolidation_reconcile_interval_seconds": 0,
+        "audit_log_enabled": False,
+        "audit_log_retention_days": 0,
+        "llm_trace_enabled": False,
+        "llm_trace_retention_days": 0,
+        "mental_model_refresh_tick_seconds": 0,
+        "retention_sweep_interval_seconds": 3600,
+        "operation_retention_days": 0,
+        "operation_cleanup_interval_seconds": 900,
+        "operation_cleanup_batch_size": 1000,
+        "maintenance_start_jitter_seconds": 0,
+    }
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
 def test_is_due_runs_at_start_then_waits_interval():
     """A job is due on first check (run-at-start), then not until its interval elapses."""
     loop = MaintenanceLoop(engine=None)  # _is_due needs no engine
@@ -30,6 +51,76 @@ def test_is_due_runs_at_start_then_waits_interval():
     # Simulate the interval having elapsed.
     loop._last_run["job"] = time.monotonic() - 4000
     assert loop._is_due("job", 3600) is True
+
+
+@pytest.mark.asyncio
+async def test_retention_sweep_cadence_is_configurable(monkeypatch):
+    """The retention sweep's interval is server config, not a constant, and 0 disables it."""
+    from unittest.mock import AsyncMock
+
+    import hindsight_api.engine.maintenance as maintenance_mod
+
+    cfg = _tick_cfg(audit_log_retention_days=7, retention_sweep_interval_seconds=0)
+    monkeypatch.setattr(maintenance_mod, "get_config", lambda: cfg)
+    loop = MaintenanceLoop(engine=None)
+    loop._run_retention = AsyncMock()
+
+    await loop._tick()
+    loop._run_retention.assert_not_awaited()
+
+    cfg.retention_sweep_interval_seconds = 3600
+    await loop._tick()
+    loop._run_retention.assert_awaited_once()
+
+
+class TestStartJitter:
+    """The first tick is offset by a random delay per process.
+
+    Every job is due the first time ``_is_due`` sees it, so a fleet started
+    together (deploy, rolling restart) would otherwise run every cross-tenant
+    sweep in every process at the same instant.
+    """
+
+    @pytest.mark.asyncio
+    async def test_zero_jitter_starts_immediately(self, monkeypatch):
+        """0 disables the offset, so tests and single-process deployments stay deterministic."""
+        import hindsight_api.engine.maintenance as maintenance_mod
+
+        monkeypatch.setattr(maintenance_mod, "get_config", lambda: _tick_cfg(maintenance_start_jitter_seconds=0))
+        loop = MaintenanceLoop(engine=None)
+
+        assert await loop._wait_start_jitter() is True
+
+    @pytest.mark.asyncio
+    async def test_delay_is_drawn_from_the_configured_window(self, monkeypatch):
+        """The offset is a random draw over [0, jitter], not a fixed sleep — a fixed
+        one would keep the fleet aligned, just later."""
+        import hindsight_api.engine.maintenance as maintenance_mod
+
+        monkeypatch.setattr(maintenance_mod, "get_config", lambda: _tick_cfg(maintenance_start_jitter_seconds=60))
+        draws: list[tuple[float, float]] = []
+
+        def _uniform(low, high):
+            draws.append((low, high))
+            return 0.0
+
+        monkeypatch.setattr(maintenance_mod.random, "uniform", _uniform)
+        loop = MaintenanceLoop(engine=None)
+
+        assert await loop._wait_start_jitter() is True
+        assert draws == [(0, 60)]
+
+    @pytest.mark.asyncio
+    async def test_stop_during_jitter_aborts_the_loop(self, monkeypatch):
+        """A process shut down inside its start offset must not go on to tick."""
+        import hindsight_api.engine.maintenance as maintenance_mod
+
+        monkeypatch.setattr(maintenance_mod, "get_config", lambda: _tick_cfg(maintenance_start_jitter_seconds=60))
+        monkeypatch.setattr(maintenance_mod.random, "uniform", lambda _low, _high: 30.0)
+        loop = MaintenanceLoop(engine=None)
+        loop._stop.set()
+
+        assert await loop._wait_start_jitter() is False
 
 
 async def _make_bank(memory: MemoryEngine, request_context, suffix: str, config_json: str | None = None) -> str:
@@ -88,6 +179,27 @@ async def test_reconcile_submits_eligible_skips_disabled_and_in_flight(
     assert eligible in submitted
     assert disabled not in submitted
     assert in_flight not in submitted
+
+
+@pytest.mark.asyncio
+async def test_cron_discovery_predicate_can_use_the_partial_index(memory: MemoryEngine):
+    """``idx_mental_models_cron``'s predicate must match the discovery routine's WHERE.
+
+    ``mental_models_with_cron()`` probes every tenant schema on every sweep, so a
+    predicate mismatch is expensive and *silent*: the index exists, the sweep still
+    returns the right rows, and every tenant keeps paying a sequential scan of its
+    mental_models table. Disabling seqscan proves the planner considers the index
+    usable for that predicate, which is the property a future edit to either side
+    can regress. It says nothing about which plan wins on cost.
+    """
+    async with memory._pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute("SET LOCAL enable_seqscan = off")
+            rows = await conn.fetch(
+                "EXPLAIN SELECT bank_id, id FROM mental_models WHERE COALESCE(trigger->>'refresh_cron', '') <> ''"
+            )
+    plan = "\n".join(r[0] for r in rows)
+    assert "idx_mental_models_cron" in plan, plan
 
 
 @pytest.mark.asyncio
@@ -322,21 +434,11 @@ class TestOperationCleanupJob:
     @pytest.mark.asyncio
     async def test_tick_schedules_cleanup_only_when_retention_enabled(self, monkeypatch):
         """Retention 0 (the default) disables the job entirely."""
-        from types import SimpleNamespace
         from unittest.mock import AsyncMock
 
         import hindsight_api.engine.maintenance as maintenance_mod
 
-        cfg = SimpleNamespace(
-            consolidation_reconcile_interval_seconds=0,
-            audit_log_enabled=False,
-            audit_log_retention_days=0,
-            llm_trace_enabled=False,
-            llm_trace_retention_days=0,
-            mental_model_refresh_tick_seconds=0,
-            operation_retention_days=0,
-            operation_cleanup_batch_size=1000,
-        )
+        cfg = _tick_cfg(operation_retention_days=0)
         monkeypatch.setattr(maintenance_mod, "get_config", lambda: cfg)
         loop = MaintenanceLoop(engine=None)
         loop._run_operation_cleanup = AsyncMock()
@@ -347,3 +449,39 @@ class TestOperationCleanupJob:
         cfg.operation_retention_days = 30
         await loop._tick()
         loop._run_operation_cleanup.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_cadence_is_configurable(self, monkeypatch):
+        """The interval is server config, not a constant: 0 disables the job even
+        with retention enabled, so a large deployment can turn off the per-tick
+        cross-tenant probe without giving up retention."""
+        from unittest.mock import AsyncMock
+
+        import hindsight_api.engine.maintenance as maintenance_mod
+
+        cfg = _tick_cfg(operation_retention_days=30, operation_cleanup_interval_seconds=0)
+        monkeypatch.setattr(maintenance_mod, "get_config", lambda: cfg)
+        loop = MaintenanceLoop(engine=None)
+        loop._run_operation_cleanup = AsyncMock()
+
+        await loop._tick()
+        loop._run_operation_cleanup.assert_not_awaited()
+
+        cfg.operation_cleanup_interval_seconds = 900
+        await loop._tick()
+        loop._run_operation_cleanup.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_archive_purge_shares_the_prune_batch_bound(self):
+        """The archive purge is bounded by the same batch size as the row prune.
+
+        Unbounded, it re-selects every expired export and re-deletes blobs that are
+        already gone on every cycle — ``storage_key`` survives in the row until the
+        row itself is pruned, so nothing marks the blob as handled.
+        """
+        engine, _backend, _conn = self._make_engine(expired=["public"], tenants=("public",))
+        loop = MaintenanceLoop(engine)
+
+        await loop._run_operation_cleanup(self._cfg(batch=250))
+
+        assert engine.purge_expired_export_archives.await_args.kwargs["batch_size"] == 250

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1713,7 +1713,7 @@ Observations are deduplicated, evidence-grounded knowledge consolidated from mul
 | `HINDSIGHT_API_ENABLE_OBSERVATIONS` | Enable observation consolidation | `true` |
 | `HINDSIGHT_API_ENABLE_AUTO_CONSOLIDATION` | Automatically trigger consolidation after retain, delete, and update operations. When `false`, consolidation only runs when explicitly triggered via the [consolidate endpoint](/developer/api/operations#consolidation). Configurable per bank. | `true` |
 | `HINDSIGHT_API_CONSOLIDATION_RECONCILE_INTERVAL_SECONDS` | Interval for the background sweep that re-schedules consolidation for banks with unconsolidated facts but no consolidation in progress — recovering facts left unscheduled when a consolidation operation failed terminally (e.g. the LLM provider was unavailable). Only applies to banks with auto-consolidation enabled. `0` disables the sweep — but see the note below: that stops work being *scheduled*, not work already queued from *running*. | `300` |
-| `HINDSIGHT_API_MENTAL_MODEL_REFRESH_TICK_SECONDS` | How often the background loop checks for cron-scheduled mental models that are due for a refresh. This is only the *check* cadence; the actual schedule is the per-model `trigger.refresh_cron` expression set on the mental model. A due model is refreshed only when it is stale (new memories in its scope since the last refresh). `0` disables the sweep — but see the note below: that stops work being *scheduled*, not work already queued from *running*. | `60` |
+| `HINDSIGHT_API_MENTAL_MODEL_REFRESH_TICK_SECONDS` | How often the background loop checks for cron-scheduled mental models that are due for a refresh. This is only the *check* cadence; the actual schedule is the per-model `trigger.refresh_cron` expression set on the mental model. A due model is refreshed only when it is stale (new memories in its scope since the last refresh). It also sets a **floor on cron granularity** — at the default, a `* * * * *` schedule fires every 5 minutes, not every minute; lower it if you need finer schedules, at the cost of a more frequent cross-tenant scan (see [Background Maintenance](#background-maintenance)). `0` disables the sweep — but see the note below: that stops work being *scheduled*, not work already queued from *running*. | `300` |
 | `HINDSIGHT_API_ENABLE_OBSERVATION_HISTORY` | Track history of changes to each observation (previous text/tags/dates + timestamp), stored one row per change in the `observation_history` table. Set to `false` to disable entirely — no history rows are written. **This is how you turn the feature off** (not a zero cap). | `true` |
 | `HINDSIGHT_API_OBSERVATION_HISTORY_MAX_ENTRIES` | Max history rows kept per observation. On each update the previous version is inserted into the `observation_history` table and the oldest rows beyond this cap are deleted, so an often-reinforced observation's history can't grow without bound. `0` or a negative value **removes the cap** (unbounded); to turn history off entirely set `HINDSIGHT_API_ENABLE_OBSERVATION_HISTORY=false` instead. | `50` |
 | `HINDSIGHT_API_CONSOLIDATION_MAX_ATTEMPTS` | Outer retry attempts for the consolidation LLM batch call. Each attempt uses the inner retry budget (`HINDSIGHT_API_CONSOLIDATION_LLM_MAX_RETRIES`). Worst-case API calls per batch = `MAX_ATTEMPTS × (LLM_MAX_RETRIES + 1)`. | `3` |
@@ -1901,7 +1901,8 @@ Configuration for background task processing. By default, the API processes task
 | `HINDSIGHT_API_WORKER_HTTP_PORT` | HTTP port for worker metrics/health (worker CLI only) | `8889` |
 | `HINDSIGHT_API_WORKER_MAX_SLOTS` | Maximum concurrent tasks per worker (total across all operation types) | `10` |
 | `HINDSIGHT_API_OPERATION_RETENTION_DAYS` | Static server-wide retention window for completed, failed, and cancelled operation rows, including their task payload and result metadata. `0` (the default) keeps them indefinitely; set a positive number of days to enable automatic pruning. | `0` |
-| `HINDSIGHT_API_OPERATION_CLEANUP_BATCH_SIZE` | Maximum expired terminal operation rows deleted per tenant schema during each cleanup cycle. The cleanup job runs once per maintenance tick, so this also sets the drain rate for a backlog. Must be a positive integer. | `1000` |
+| `HINDSIGHT_API_OPERATION_CLEANUP_BATCH_SIZE` | Maximum expired terminal operation rows deleted per tenant schema during each cleanup cycle. Together with the cleanup interval this sets the drain rate for a backlog. Must be a positive integer. | `1000` |
+| `HINDSIGHT_API_OPERATION_CLEANUP_INTERVAL_SECONDS` | How often the cleanup cycle runs. Each cycle costs one cross-tenant discovery round-trip, so the interval is the main lever on that cost for deployments with many tenants (see [Background Maintenance](#background-maintenance)). `0` disables the job. | `900` |
 | `HINDSIGHT_API_WORKER_CONSOLIDATION_RESERVED_SLOTS` | Reserved (minimum) slots for consolidation within `WORKER_MAX_SLOTS` — a floor that guarantees capacity, **not** a per-type cap (bank-serialization preserved). See the note below. | `2` |
 | `HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY` | Per-bank priority for consolidation scheduling (see note below) | _(unset)_ |
 | `HINDSIGHT_API_WORKER_RETAIN_RESERVED_SLOTS` | Reserved (minimum) slots for retain within `WORKER_MAX_SLOTS`. | `0` |
@@ -2011,6 +2012,38 @@ LLM request tracing records every LLM call Hindsight makes — for retain, refle
 | `HINDSIGHT_API_LLM_TRACE_SCOPES` | Comma-separated allowlist of call scopes to trace (e.g. `retain_extract_facts,reflect`; empty = all scopes) | `""` |
 | `HINDSIGHT_API_LLM_TRACE_RETENTION_DAYS` | Number of days to retain trace rows. `-1` = keep forever. | `1` |
 | `HINDSIGHT_API_LLM_TRACE_MAX_CHARS` | Truncate stored input/output beyond this many characters (keeps the row, stores a truncated preview). | `50000` |
+
+### Background Maintenance {#background-maintenance}
+
+A single periodic loop in every API/worker process drives Hindsight's recurring
+housekeeping: the `audit_log` / `llm_requests` retention sweeps, terminal
+operation cleanup, the consolidation reconcile, and the cron-scheduled mental
+model refresh.
+
+The loop runs in **every** process with no leader election, which is safe by
+construction — the sweeps are idempotent deletes, and the two jobs that enqueue
+work dedupe against in-flight operations inside the inserting transaction. What
+it is not is free at scale: each job starts with a cross-tenant discovery call
+that probes every schema holding the relevant table, and every process pays that
+probe. The cost scales with tenant count while the work it finds does not, so on
+a large multi-tenant deployment **the cadences are the knob that matters**.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HINDSIGHT_API_RETENTION_SWEEP_INTERVAL_SECONDS` | How often expired `audit_log` and `llm_requests` rows are deleted across all tenant schemas. Retention windows are measured in days, so this only affects how promptly expired rows disappear. `0` disables the sweeps. | `3600` |
+| `HINDSIGHT_API_OPERATION_CLEANUP_INTERVAL_SECONDS` | How often expired terminal operation rows are pruned. See [Distributed Workers](#distributed-workers) for the retention window and batch size. `0` disables the job. | `900` |
+| `HINDSIGHT_API_MAINTENANCE_START_JITTER_SECONDS` | Upper bound on a random delay applied before a process runs its **first** maintenance tick. Every job is due on that first tick, so without an offset a fleet started together — a deploy or rolling restart — runs every sweep in every process at the same instant. `0` disables the jitter for a deterministic start. | `60` |
+
+:::tip Tuning for many tenants
+
+At a few hundred tenants the defaults are irrelevant. At tens of thousands, the
+per-tick discovery scan dominates, and the jobs whose retention is counted in
+*days* have no reason to probe every schema every minute. Raise
+`HINDSIGHT_API_OPERATION_CLEANUP_INTERVAL_SECONDS` and
+`HINDSIGHT_API_MENTAL_MODEL_REFRESH_TICK_SECONDS` first — they are the two most
+frequent sweeps — and keep the jitter enabled so restarts don't align the fleet.
+
+:::
 
 ### Programmatic Configuration
 

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -177,6 +177,14 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_OPERATION_RETENTION_DAYS=30  # Prune terminal operation rows, payloads, and metadata after this many days; 0 (the default) keeps them forever.
 # HINDSIGHT_API_OPERATION_CLEANUP_BATCH_SIZE=1000  # Maximum expired terminal rows deleted per tenant schema in each cleanup cycle; must be positive.
 
+# Background maintenance cadences (Optional)
+# Each sweep begins with one cross-tenant discovery call that probes every schema holding the relevant
+# table, in every API/worker process — so its cost scales with tenant count while the work it finds does
+# not. On deployments with thousands of tenants these intervals are the knob to raise.
+# HINDSIGHT_API_RETENTION_SWEEP_INTERVAL_SECONDS=3600  # How often expired audit_log / llm_requests rows are deleted across all tenant schemas. Retention is counted in days, so this only sets how promptly they disappear; 0 disables the sweeps.
+# HINDSIGHT_API_OPERATION_CLEANUP_INTERVAL_SECONDS=900  # How often expired terminal operation rows are pruned; with the batch size above this sets the drain rate for a backlog. 0 disables the job.
+# HINDSIGHT_API_MAINTENANCE_START_JITTER_SECONDS=60  # Upper bound on a random delay before a process runs its FIRST maintenance tick. Every job is due on that tick, so without an offset a fleet started together runs every sweep in every process at once. 0 disables the jitter.
+
 # Vector Extension (Optional - uses pgvector by default)
 # Options: "pgvector" (default), "vchord", "pgvectorscale" (DiskANN)
 # HINDSIGHT_API_VECTOR_EXTENSION=pgvector

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1713,7 +1713,7 @@ Observations are deduplicated, evidence-grounded knowledge consolidated from mul
 | `HINDSIGHT_API_ENABLE_OBSERVATIONS` | Enable observation consolidation | `true` |
 | `HINDSIGHT_API_ENABLE_AUTO_CONSOLIDATION` | Automatically trigger consolidation after retain, delete, and update operations. When `false`, consolidation only runs when explicitly triggered via the [consolidate endpoint](api/operations.md#consolidation). Configurable per bank. | `true` |
 | `HINDSIGHT_API_CONSOLIDATION_RECONCILE_INTERVAL_SECONDS` | Interval for the background sweep that re-schedules consolidation for banks with unconsolidated facts but no consolidation in progress — recovering facts left unscheduled when a consolidation operation failed terminally (e.g. the LLM provider was unavailable). Only applies to banks with auto-consolidation enabled. `0` disables the sweep — but see the note below: that stops work being *scheduled*, not work already queued from *running*. | `300` |
-| `HINDSIGHT_API_MENTAL_MODEL_REFRESH_TICK_SECONDS` | How often the background loop checks for cron-scheduled mental models that are due for a refresh. This is only the *check* cadence; the actual schedule is the per-model `trigger.refresh_cron` expression set on the mental model. A due model is refreshed only when it is stale (new memories in its scope since the last refresh). `0` disables the sweep — but see the note below: that stops work being *scheduled*, not work already queued from *running*. | `60` |
+| `HINDSIGHT_API_MENTAL_MODEL_REFRESH_TICK_SECONDS` | How often the background loop checks for cron-scheduled mental models that are due for a refresh. This is only the *check* cadence; the actual schedule is the per-model `trigger.refresh_cron` expression set on the mental model. A due model is refreshed only when it is stale (new memories in its scope since the last refresh). It also sets a **floor on cron granularity** — at the default, a `* * * * *` schedule fires every 5 minutes, not every minute; lower it if you need finer schedules, at the cost of a more frequent cross-tenant scan (see [Background Maintenance](#background-maintenance)). `0` disables the sweep — but see the note below: that stops work being *scheduled*, not work already queued from *running*. | `300` |
 | `HINDSIGHT_API_ENABLE_OBSERVATION_HISTORY` | Track history of changes to each observation (previous text/tags/dates + timestamp), stored one row per change in the `observation_history` table. Set to `false` to disable entirely — no history rows are written. **This is how you turn the feature off** (not a zero cap). | `true` |
 | `HINDSIGHT_API_OBSERVATION_HISTORY_MAX_ENTRIES` | Max history rows kept per observation. On each update the previous version is inserted into the `observation_history` table and the oldest rows beyond this cap are deleted, so an often-reinforced observation's history can't grow without bound. `0` or a negative value **removes the cap** (unbounded); to turn history off entirely set `HINDSIGHT_API_ENABLE_OBSERVATION_HISTORY=false` instead. | `50` |
 | `HINDSIGHT_API_CONSOLIDATION_MAX_ATTEMPTS` | Outer retry attempts for the consolidation LLM batch call. Each attempt uses the inner retry budget (`HINDSIGHT_API_CONSOLIDATION_LLM_MAX_RETRIES`). Worst-case API calls per batch = `MAX_ATTEMPTS × (LLM_MAX_RETRIES + 1)`. | `3` |
@@ -1901,7 +1901,8 @@ Configuration for background task processing. By default, the API processes task
 | `HINDSIGHT_API_WORKER_HTTP_PORT` | HTTP port for worker metrics/health (worker CLI only) | `8889` |
 | `HINDSIGHT_API_WORKER_MAX_SLOTS` | Maximum concurrent tasks per worker (total across all operation types) | `10` |
 | `HINDSIGHT_API_OPERATION_RETENTION_DAYS` | Static server-wide retention window for completed, failed, and cancelled operation rows, including their task payload and result metadata. `0` (the default) keeps them indefinitely; set a positive number of days to enable automatic pruning. | `0` |
-| `HINDSIGHT_API_OPERATION_CLEANUP_BATCH_SIZE` | Maximum expired terminal operation rows deleted per tenant schema during each cleanup cycle. The cleanup job runs once per maintenance tick, so this also sets the drain rate for a backlog. Must be a positive integer. | `1000` |
+| `HINDSIGHT_API_OPERATION_CLEANUP_BATCH_SIZE` | Maximum expired terminal operation rows deleted per tenant schema during each cleanup cycle. Together with the cleanup interval this sets the drain rate for a backlog. Must be a positive integer. | `1000` |
+| `HINDSIGHT_API_OPERATION_CLEANUP_INTERVAL_SECONDS` | How often the cleanup cycle runs. Each cycle costs one cross-tenant discovery round-trip, so the interval is the main lever on that cost for deployments with many tenants (see [Background Maintenance](#background-maintenance)). `0` disables the job. | `900` |
 | `HINDSIGHT_API_WORKER_CONSOLIDATION_RESERVED_SLOTS` | Reserved (minimum) slots for consolidation within `WORKER_MAX_SLOTS` — a floor that guarantees capacity, **not** a per-type cap (bank-serialization preserved). See the note below. | `2` |
 | `HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY` | Per-bank priority for consolidation scheduling (see note below) | _(unset)_ |
 | `HINDSIGHT_API_WORKER_RETAIN_RESERVED_SLOTS` | Reserved (minimum) slots for retain within `WORKER_MAX_SLOTS`. | `0` |
@@ -2011,6 +2012,38 @@ LLM request tracing records every LLM call Hindsight makes — for retain, refle
 | `HINDSIGHT_API_LLM_TRACE_SCOPES` | Comma-separated allowlist of call scopes to trace (e.g. `retain_extract_facts,reflect`; empty = all scopes) | `""` |
 | `HINDSIGHT_API_LLM_TRACE_RETENTION_DAYS` | Number of days to retain trace rows. `-1` = keep forever. | `1` |
 | `HINDSIGHT_API_LLM_TRACE_MAX_CHARS` | Truncate stored input/output beyond this many characters (keeps the row, stores a truncated preview). | `50000` |
+
+### Background Maintenance {#background-maintenance}
+
+A single periodic loop in every API/worker process drives Hindsight's recurring
+housekeeping: the `audit_log` / `llm_requests` retention sweeps, terminal
+operation cleanup, the consolidation reconcile, and the cron-scheduled mental
+model refresh.
+
+The loop runs in **every** process with no leader election, which is safe by
+construction — the sweeps are idempotent deletes, and the two jobs that enqueue
+work dedupe against in-flight operations inside the inserting transaction. What
+it is not is free at scale: each job starts with a cross-tenant discovery call
+that probes every schema holding the relevant table, and every process pays that
+probe. The cost scales with tenant count while the work it finds does not, so on
+a large multi-tenant deployment **the cadences are the knob that matters**.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HINDSIGHT_API_RETENTION_SWEEP_INTERVAL_SECONDS` | How often expired `audit_log` and `llm_requests` rows are deleted across all tenant schemas. Retention windows are measured in days, so this only affects how promptly expired rows disappear. `0` disables the sweeps. | `3600` |
+| `HINDSIGHT_API_OPERATION_CLEANUP_INTERVAL_SECONDS` | How often expired terminal operation rows are pruned. See [Distributed Workers](#distributed-workers) for the retention window and batch size. `0` disables the job. | `900` |
+| `HINDSIGHT_API_MAINTENANCE_START_JITTER_SECONDS` | Upper bound on a random delay applied before a process runs its **first** maintenance tick. Every job is due on that first tick, so without an offset a fleet started together — a deploy or rolling restart — runs every sweep in every process at the same instant. `0` disables the jitter for a deterministic start. | `60` |
+
+:::tip Tuning for many tenants
+
+At a few hundred tenants the defaults are irrelevant. At tens of thousands, the
+per-tick discovery scan dominates, and the jobs whose retention is counted in
+*days* have no reason to probe every schema every minute. Raise
+`HINDSIGHT_API_OPERATION_CLEANUP_INTERVAL_SECONDS` and
+`HINDSIGHT_API_MENTAL_MODEL_REFRESH_TICK_SECONDS` first — they are the two most
+frequent sweeps — and keep the jitter enabled so restarts don't align the fleet.
+
+:::
 
 ### Programmatic Configuration
 


### PR DESCRIPTION
## Why

The maintenance loop runs in every API/worker process with no leader election. That is **correct** — the sweeps are idempotent deletes, retention claims its chunks with `SKIP LOCKED` (#3539), and the two jobs that enqueue work dedupe inside the inserting transaction (#3210).

What it is not is free. Each job opens with a cross-tenant discovery call, and "one round-trip on the wire" is still **one query per tenant schema** inside the routine — every process pays it, and the cost scales with tenant count while the work it finds does not. At 20k tenants with ~10% having anything to do, the fleet spends nearly all of its maintenance budget proving that tenants have nothing to do.

Rough arithmetic at 20k tenants / 10 processes, per hour, before this PR:

| Job | Cadence | Per-schema probes/hour (fleet) |
|---|---|---|
| `operation_cleanup` | 60s | 12.0M |
| `mm_refresh` | 60s | 12.0M |
| `reconcile` | 300s | 2.4M |
| `retention` | 3600s | 0.4M |

~12M of those were **sequential scans** (see the first change below).

This deliberately does **not** add leader election or a lease. The work is already safe to run everywhere; only the discovery in front of it was disproportionate, and that is fixable without a coordination mechanism. (A lease would also need a new global table, which the schema layout has no concept of today.)

## What changed

**1. Index the cron discovery probe.** `mental_models_with_cron()` filters on `COALESCE(trigger->>'refresh_cron', '') <> ''` with nothing covering it, so every per-schema probe sequentially scans that tenant's `mental_models` table — for models that are rare by construction (`trigger` defaults to `{"refresh_after_consolidation": false}`). The new partial index makes a tenant with no cron-scheduled models an empty index scan. This is the single largest idle-tenant cost in the loop.

**2. Cadences off 60s and into config.** `operation_cleanup` and `mm_refresh` probed every schema every minute in order to delete rows whose retention is counted in *days*. New defaults: 15 min and 5 min. The retention sweep's interval becomes a setting too.

⚠️ **Behaviour change worth a look:** raising the `mm_refresh` check cadence puts a floor on cron granularity — a `* * * * *` schedule now fires every 5 minutes rather than every minute. It stays tunable via `HINDSIGHT_API_MENTAL_MODEL_REFRESH_TICK_SECONDS`, and the docs call this out explicitly. Say the word if you'd rather hold the default at 60s and let large deployments opt in.

**3. Jitter the first tick.** Every job is due the first time `_is_due` sees it, so a deploy or rolling restart fired every cross-tenant probe in every process at the same instant. `SKIP LOCKED` keeps that correct but not cheap — the probes are reads, and N land at once. Steady state self-staggers; startup does not.

**4. Bound the export-archive purge** (arguably a bug fix independent of scale). Unlike the row prune right beside it, `purge_expired_export_archives` had no `LIMIT`: it re-selected *every* expired export each cycle and re-issued a blob delete for each — including ones deleted on the previous cycle, because `storage_key` stays in `result_metadata` until the row itself is pruned. With a backlog that was one redundant round-trip to the blob store per expired export per cycle, per process, against an external service. It now shares the prune's batch bound and `ORDER BY updated_at, operation_id`, so the two advance together.

After (2) and the index from (1), fleet-wide discovery drops from ~26.8M probes/hour to ~600k, and the remainder are index lookups rather than table scans.

## What I deliberately left out

Folding `consolidation_failed_at IS NULL` into `idx_memory_units_unconsolidated`'s predicate. It looked like an easy win, but `metrics.py:1047-1053` already documents the reasoning — the failed set is "tiny by construction", so the extra term is a cheap recheck on rows the index already returned — and narrowing the predicate risks other queries that filter only on `consolidated_at IS NULL`.

## Testing

New tests in `test_maintenance_loop.py` and `test_document_transfer.py`:
- the partial index's predicate is actually usable by the routine's `WHERE` (a mismatch would be silent — index present, sweep correct, every tenant still seq-scanning)
- each cadence is config-driven and `0` disables the job
- the start offset is a random draw over `[0, jitter]`, and a stop inside the offset aborts the loop
- the archive purge receives and honours the prune's batch bound

`ruff`, `ruff format`, `ty` and the pre-commit hooks all pass.

**Note on local test runs:** `test_mental_model_scheduled_refresh.py` (5 tests) and `test_maintenance_routines.py::test_banks_needing_consolidation_skips_schema_locked_by_ddl` fail on my machine — but they fail identically on pristine `origin/main` (verified by checking out `b919b97df` and re-running), so they are pre-existing here and unrelated to this branch. Worth a glance at CI to see whether they're environmental or real.