### PR TITLE
curation + reads: a store that owns entities resolves+mints edit names, and serves its own addressed reads

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -1174,6 +1174,7 @@ class MemoriesExtension(Extension, ABC):
         event_date,
         mentioned_at,
         entity_ids: list[str] | None,
+        entity_names: list[str] | None = None,
         txn=None,
     ) -> None:
         """Apply a curation field edit to a live memory.
@@ -1184,10 +1185,20 @@ class MemoriesExtension(Extension, ABC):
         embedding is *not* written here — the caller re-embeds from the new fields
         and calls :meth:`set_memory_embedding` after.
 
-        ``entity_ids`` is the resolved entity set the memory should now carry; a
-        store that keeps them on the memory writes them here, one that keeps them
-        in a join table has already re-linked them and ignores this. ``None`` means
-        the entity set was not part of this edit.
+        The new entity set for the memory is supplied one of two ways, and a store
+        uses whichever fits how it keeps its registry:
+
+        * ``entity_names`` — the raw names the edit resolved to. A store that owns
+          its entity registry resolves + mints these against its OWN registry
+          (exactly as its :meth:`retain` does) and rewrites the memory's entity
+          ids from the result, so a brand-new entity created by an edit lands in
+          that registry. When it is not ``None`` it is the authoritative set and
+          ``entity_ids`` is ignored.
+        * ``entity_ids`` — the already-resolved set, for a store whose registry is
+          the host's SQL (the host minted them and, for a join-table store, has
+          already re-linked them, so it ignores this).
+
+        Both ``None`` means the entity set was not part of this edit.
         """
         raise NotImplementedError
 

--- a/hindsight-api-slim/hindsight_api/engine/memories/postgres.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/postgres.py
@@ -535,6 +535,7 @@ class PostgresMemories(MemoriesExtension):
         event_date,
         mentioned_at,
         entity_ids: list[str] | None,
+        entity_names: list[str] | None = None,  # noqa: ARG002 — this store's registry is SQL; the host already minted+linked, so entity_ids is authoritative.
         txn=None,
     ) -> None:
         await writes.apply_edit(

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -1388,6 +1388,9 @@ class _MemoryEditPlan:
     # mismatch (a concurrent entity-only edit landed between the phases) triggers a bounded in-txn
     # re-embed so the stored vector stays consistent with the committed entity set.
     names: list[str]
+    # The raw entity names to hand a store that owns its entity registry (it resolves + mints them
+    # itself). None for a SQL-registry store, which uses the pre-resolved ``edit_entity_ids`` instead.
+    entity_names_for_store: list[str] | None = None
     embedding: str | None = None
 
 
@@ -8597,39 +8600,49 @@ class MemoryEngine(MemoryEngineInterface):
                 entity_resolution = None
                 resolved_for_unit = None
                 edit_entity_ids = None
+                entity_names_for_store = None
                 entity_date = None
                 if new_entities is not None:
                     entity_date = new_occ_start or live.mentioned_at
-                    # resolve_entities_only find-or-creates the corrected entities (idempotent) and
-                    # autocommits them on this short connection; the Phase-2 relink writes exactly
-                    # this resolved set, keeping the stored embedding consistent with the links.
                     entities_resolved = True
-                    entity_resolution = await resolve_entities_only(
-                        self.entity_resolver,
-                        conn,
-                        bank_id,
-                        [str(memory_uuid)],
-                        [new_text],
-                        new_context or "",
-                        [entity_date],
-                        [[{"text": name, "type": "CONCEPT"} for name in new_entities]],
-                        entity_labels=entity_labels,
-                    )
-                    resolved_for_unit = entity_resolution.unit_to_entity_ids.get(str(memory_uuid), [])
-                    edit_entity_ids = [str(eid) for eid in resolved_for_unit]
-                    # Canonical names of the newly-resolved set (the entity registry is always in
-                    # SQL, whichever store owns the memory rows), used to build the embedding.
-                    name_rows = (
-                        await conn.fetch(
-                            f"SELECT canonical_name FROM {fq_table('entities')} "
-                            f"WHERE id = ANY($1::uuid[]) AND bank_id = $2 ORDER BY id",
-                            resolved_for_unit,
+                    if store.store_owned_retain_for(bank_id):
+                        # The store owns its entity registry: hand it the raw names and let its
+                        # apply_edit resolve + mint them (exactly as its retain does), so a new
+                        # entity from an edit lands in that registry. Nothing is written to — or
+                        # read from — the SQL entities table; the names ARE the input, and the
+                        # embedding is built from them directly.
+                        names = list(new_entities)
+                        entity_names_for_store = names
+                    else:
+                        # resolve_entities_only find-or-creates the corrected entities (idempotent)
+                        # and autocommits them on this short connection; the Phase-2 relink writes
+                        # exactly this resolved set, keeping the embedding consistent with the links.
+                        entity_resolution = await resolve_entities_only(
+                            self.entity_resolver,
+                            conn,
                             bank_id,
+                            [str(memory_uuid)],
+                            [new_text],
+                            new_context or "",
+                            [entity_date],
+                            [[{"text": name, "type": "CONCEPT"} for name in new_entities]],
+                            entity_labels=entity_labels,
                         )
-                        if resolved_for_unit
-                        else []
-                    )
-                    names = [r["canonical_name"] for r in name_rows]
+                        resolved_for_unit = entity_resolution.unit_to_entity_ids.get(str(memory_uuid), [])
+                        edit_entity_ids = [str(eid) for eid in resolved_for_unit]
+                        # Canonical names of the newly-resolved set (this store's registry is the
+                        # host's SQL), used to build the embedding.
+                        name_rows = (
+                            await conn.fetch(
+                                f"SELECT canonical_name FROM {fq_table('entities')} "
+                                f"WHERE id = ANY($1::uuid[]) AND bank_id = $2 ORDER BY id",
+                                resolved_for_unit,
+                                bank_id,
+                            )
+                            if resolved_for_unit
+                            else []
+                        )
+                        names = [r["canonical_name"] for r in name_rows]
                 else:
                     # Entities untouched: the embedding uses the unit's current linked names.
                     emap = await store.entity_map_for_units(
@@ -8649,6 +8662,7 @@ class MemoryEngine(MemoryEngineInterface):
                     edit_entity_ids=edit_entity_ids,
                     entity_date=entity_date,
                     names=names,
+                    entity_names_for_store=entity_names_for_store,
                 )
 
             # --- Classify the state change (applied in Phase 2). Edit + invalidate can co-occur
@@ -8741,7 +8755,13 @@ class MemoryEngine(MemoryEngineInterface):
 
                     # --- Apply edit (live rows only) ---
                     if edit_plan is not None and live2:
-                        if edit_plan.resolved_for_unit is not None:
+                        if edit_plan.entity_names_for_store is not None:
+                            # The store owns its entity registry: apply_edit below resolves + mints
+                            # these names and rewrites the memory's entity ids. There are no SQL
+                            # postings to clear/relink and no prune queue — the store keeps entity
+                            # ids on the memory itself, so the edit's rewrite replaces the whole set.
+                            edit_embedding = edit_plan.embedding
+                        elif edit_plan.resolved_for_unit is not None:
                             # Entities are being changed: rebuild unit_entities to the resolved set.
                             # The entities this unit is about to stop referencing may have been
                             # holding on by that posting alone, so queue them as prune candidates
@@ -8804,6 +8824,7 @@ class MemoryEngine(MemoryEngineInterface):
                             event_date=edit_plan.new_event_date,
                             mentioned_at=edit_plan.mentioned_at,
                             entity_ids=edit_plan.edit_entity_ids,
+                            entity_names=edit_plan.entity_names_for_store,
                             txn=_curation_txn,
                         )
                         if edit_embedding is not None:


### PR DESCRIPTION
Draft — syncing as work proceeds.

Store-generic throughout: nothing here names a particular backend, and everything keys off the capability probes already on `MemoriesExtension`.

## 1. Curation: a store that owns entities resolves + mints edit names itself

When a curation edit changes the entity set and the store owns its own entity registry, the orchestrator now hands over the raw entity **names** instead of ids minted in Postgres, and `apply_edit` resolves + mints them against the store. A brand-new entity introduced by an edit therefore lands in the store's registry and never in SQL.

## 2. The ADDRESSED reads must come from the store too

The list routes already consult `owns_document_store_for` and read the store. The addressed routes did not — so for such a store the API handed out ids from a list route that its own detail routes then 404'd:

```
GET /banks/{b}/documents             -> 200, 50 items
GET /banks/{b}/documents/{that id}   -> 404 "Document not found"
GET /banks/{b}/entities              -> 200, 31 items
GET /banks/{b}/entities/{that id}    -> 404
GET /banks/{b}/documents/{id}/chunks -> 404  (so no chunk id is discoverable at all)
```

Four reads, each of which could only ever miss for such a store:

| method | was | now |
|---|---|---|
| `get_document` | both branches read `FROM documents`; the else branch's comment asserted "the documents row is still SQL" | reads the record from the store when it owns the document store |
| `list_document_chunks` | verified the doc against SQL, paged SQL `chunks`, overlaid only the text | served from the store, rebuilding ids in retain's `{bank_id}_{document_id}_{index}` shape |
| `get_chunk` | looked the id up in SQL `chunks` | parses the self-describing id and serves from the store |
| `get_entity` | read only SQL `entities` | resolves the one id against the store's registry — addressed, not paged, so O(1) in registry size |

### Known gap, deliberately surfaced rather than hidden

`retain_params` is not carried in the store's document record, so `retain_params`, `document_metadata` and `observation_scopes` come back **null** on `get_document` for such a bank. That is a gap in what the write path persists; returning null beats 404-ing the whole document, and closing it properly is a write-path change.

## Why this was invisible

These paths are only reachable once a deployment actually answers `store_owned_retain_for` — and the deployment layer I was testing against never did, so the store-owned branch had never executed. Every one of these was found within an hour of turning it on.

## Verification

Measured end to end against a real deployment, per endpoint, before and after. The retain win from taking the store-owned path at all:

| | before | after |
|---|---|---|
| batched retain p50 | 8290 ms | **1533 ms** (5.4x) |
| single retain p50 | 5006 ms | **1056 ms** (4.7x) |

Reads already served from the store are unchanged, as expected.