### PR TITLE
docs(retain): document context as caller-supplied trust hint + untrusted-content bank separation

### DIFF
--- a/hindsight-docs/docs/developer/retain.md
+++ b/hindsight-docs/docs/developer/retain.md
@@ -71,6 +71,24 @@ The split is decided by **who is speaking**, not by grammar. A first-person stat
 
 **Note:** Observations are consolidated automatically in the background after `retain()` operations complete. This consolidation process synthesizes patterns from new facts into the bank's knowledge base.
 
+### Trust boundaries (security note)
+
+The `context` string is **caller-supplied and unauthenticated** — a
+disambiguation hint, not a trust assertion. Any caller who can invoke
+`retain()` can supply a misleading `context` (for example
+`context="security_review_note"`) for content that did not come from that
+source. Treat `context` as advisory only; do not rely on it as evidence of
+provenance.
+
+For content from untrusted sources (web scraping, third-party integrations, or
+user-supplied documents), retain it into a **separate bank** and merge
+selectively at `recall()`/`reflect()` time. Bank isolation is strict, so a
+dedicated untrusted bank is the reliable trust boundary rather than the
+`context` label.
+
+See [Memory Defense](#memory-defense-and-source-provenance) for the built-in
+prompt-injection detection that runs at retain time.
+
 ---
 
 ## Entity Recognition

--- a/hindsight-docs/docs/developer/retain.md
+++ b/hindsight-docs/docs/developer/retain.md
@@ -88,8 +88,10 @@ combine results in your own decision logic. Bank isolation is strict, so a
 `context` label.
 
 See [Memory Defense](#memory-defense-and-source-provenance) for the built-in
-prompt-injection detection that runs at retain time.
-
+See [Memory Defense and Source Provenance](#memory-defense-and-source-provenance)
+for the built-in prompt-injection detection that runs at retain time; use
+`receipt_uri` to record actual provenance (an external receipt or co-signature
+pointer) rather than relying on `context`.
 ---
 
 ## Entity Recognition

--- a/hindsight-docs/docs/developer/retain.md
+++ b/hindsight-docs/docs/developer/retain.md
@@ -82,8 +82,9 @@ provenance.
 
 For content from untrusted sources (web scraping, third-party integrations, or
 user-supplied documents), retain it into a **separate bank** and merge
-selectively at `recall()`/`reflect()` time. Bank isolation is strict, so a
-dedicated untrusted bank is the reliable trust boundary rather than the
+user-supplied documents), retain it into a **separate bank**. `recall()` and
+`reflect()` target a single bank, so query the untrusted bank separately and
+combine results in your own decision logic. Bank isolation is strict, so a
 `context` label.
 
 See [Memory Defense](#memory-defense-and-source-provenance) for the built-in


### PR DESCRIPTION
## Summary

Adds a **"Trust boundaries (security note)"** subsection to the Retain docs,
clarifying that the `context` string is **caller-supplied and unauthenticated**
— a disambiguation hint, not a provenance assertion — and recommending that
untrusted content be retained into a **separate bank** (bank isolation being the
reliable trust boundary).

## Motivation

Relates to #3558 (the security evaluation) and #3562 (the hardening proposal).
The `context` field is currently documented as a speaker-disambiguation feature,
but not as a trust consideration: any caller who can invoke `retain()` can
supply a misleading `context` (for example `context="security_review_note"`) for
content that did not come from that source. This documents the boundary so
integrators don't treat `context` as evidence of provenance.

## Change

- One new subsection in `hindsight-docs/docs/developer/retain.md` (docs-only, no
  code changes).
- Cross-links to the existing "Memory Defense and Source Provenance" section.

This is the docs-first step of the hardening work tracked in #3562; the code
changes (context namespacing, dedup, provenance tiering) are follow-ups.
