### PR TITLE
feat(knowledge-base): expose a page's refresh trigger on the tree

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2375,8 +2375,10 @@ class KnowledgeNode(BaseModel):
         default=None,
         description="Pages only: the page's refresh settings — when it rebuilds itself "
         "(`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. "
-        "Absent on folders, which have no backing mental model, and on a page with no trigger "
-        "stored.",
+        "This is the EFFECTIVE policy: a setting the page never stored is reported at its default, "
+        "so compare the fields you care about rather than the whole object against a patch you "
+        "sent. Absent on folders, which have no backing mental model, and on a page with no "
+        "trigger stored.",
     )
     children: list["KnowledgeNode"] = FieldWithDefault(list)
 

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2375,7 +2375,8 @@ class KnowledgeNode(BaseModel):
         default=None,
         description="Pages only: the page's refresh settings — when it rebuilds itself "
         "(`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. "
-        "Null on folders, and on a page with no trigger stored.",
+        "Absent on folders, which have no backing mental model, and on a page with no trigger "
+        "stored.",
     )
     children: list["KnowledgeNode"] = FieldWithDefault(list)
 

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2371,6 +2371,12 @@ class KnowledgeNode(BaseModel):
         "was written, but possibly outside the page's tags. Read the page's mental model for the exact answer. "
         "Shares the bank-stats freshness, so it can lag a just-written memory by up to a minute.",
     )
+    trigger: dict[str, Any] | None = Field(
+        default=None,
+        description="Pages only: the page's refresh settings — when it rebuilds itself "
+        "(`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. "
+        "Null on folders, and on a page with no trigger stored.",
+    )
     children: list["KnowledgeNode"] = FieldWithDefault(list)
 
 
@@ -2487,6 +2493,7 @@ def _knowledge_node_model(node: dict[str, Any]) -> KnowledgeNode:
         tags=list(node.get("tags") or []) if is_page else [],
         timestamp=(node.get("last_refreshed_at") if is_page else node.get("updated_at")),
         is_stale=node.get("is_stale") if is_page else None,
+        trigger=node.get("trigger") if is_page else None,
     )
 
 

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2371,7 +2371,7 @@ class KnowledgeNode(BaseModel):
         "was written, but possibly outside the page's tags. Read the page's mental model for the exact answer. "
         "Shares the bank-stats freshness, so it can lag a just-written memory by up to a minute.",
     )
-    trigger: dict[str, Any] | None = Field(
+    trigger: MentalModelTrigger | None = Field(
         default=None,
         description="Pages only: the page's refresh settings — when it rebuilds itself "
         "(`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. "

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -14119,6 +14119,11 @@ class MemoryEngine(MemoryEngineInterface):
             node["tags"] = list(row["mm_tags"] or [])
             node["source_query"] = row["mm_source_query"]
             node["last_refreshed_at"] = row["mm_last_refreshed_at"].isoformat() if row["mm_last_refreshed_at"] else None
+            # Carried on the read so a client can see WHEN a page refreshes and how much that
+            # costs, and can tell whether its own settings still apply, without walking to the
+            # mental-models API for every page (the knowledge base is the only surface some
+            # clients speak). None when the page has no trigger at all.
+            node["trigger"] = MemoryEngine._stored_trigger(row["mm_trigger"]) or None
         return node
 
     # Column list for plain (non-joined) knowledge_pages reads/RETURNING.
@@ -14128,6 +14133,7 @@ class MemoryEngine(MemoryEngineInterface):
         "kp.id, kp.bank_id, kp.parent_id, kp.kind, kp.name, kp.mental_model_id, "
         "kp.sort_order, kp.managed, kp.created_at, kp.updated_at, "
         "mm.tags AS mm_tags, mm.source_query AS mm_source_query, "
+        "mm.trigger AS mm_trigger, "
         "mm.last_refreshed_at AS mm_last_refreshed_at, "
         "mm.last_memory_seen_at AS mm_last_memory_seen_at"
     )

--- a/hindsight-api-slim/tests/test_knowledge_base.py
+++ b/hindsight-api-slim/tests/test_knowledge_base.py
@@ -202,8 +202,10 @@ class TestTree:
             "exclude_mental_models": True,
             "refresh_after_consolidation": True,
         }
-        # A folder has no backing mental model, so it has no refresh policy either.
-        assert roots["Runbooks"]["trigger"] is None
+        # A folder has no backing mental model, so it has no refresh policy either —
+        # and a null is dropped from the response entirely (ExcludeNoneRoute), the same
+        # way is_stale is absent on folders rather than null.
+        assert roots["Runbooks"].get("trigger") is None
 
     async def test_tree_reflects_a_changed_refresh_policy(self, api_client, memory, kb_bank, request_context):
         """Read-back closes the loop: a client can compare and skip a no-op write."""

--- a/hindsight-api-slim/tests/test_knowledge_base.py
+++ b/hindsight-api-slim/tests/test_knowledge_base.py
@@ -185,6 +185,37 @@ class TestTree:
         # Pages always do.
         assert isinstance(roots["Loose"]["is_stale"], bool)
 
+    async def test_tree_exposes_a_page_refresh_policy(self, api_client, kb_bank):
+        """A page's trigger is readable where the page is.
+
+        It decides when a page rebuilds itself and what that costs, so a client that only speaks
+        the knowledge base — the control plane's tree, the coding-agents plugin — could neither
+        show it nor tell whether its own settings still applied. The alternative was walking to
+        the mental-models API once per page.
+        """
+        bank_id, ids = kb_bank
+        resp = await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/tree")
+        roots = {r["name"]: r for r in resp.json()["roots"]}
+        assert roots["Loose"]["trigger"] == {
+            "mode": "delta",
+            "fact_types": ["observation"],
+            "exclude_mental_models": True,
+            "refresh_after_consolidation": True,
+        }
+        # A folder has no backing mental model, so it has no refresh policy either.
+        assert roots["Runbooks"]["trigger"] is None
+
+    async def test_tree_reflects_a_changed_refresh_policy(self, api_client, memory, kb_bank, request_context):
+        """Read-back closes the loop: a client can compare and skip a no-op write."""
+        bank_id, ids = kb_bank
+        await memory.update_knowledge_page(
+            bank_id, ids.loose, trigger={"refresh_cron": "0 3 * * *"}, request_context=request_context
+        )
+        resp = await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/tree")
+        loose = next(r for r in resp.json()["roots"] if r["name"] == "Loose")
+        assert loose["trigger"]["refresh_cron"] == "0 3 * * *"
+        assert "refresh_after_consolidation" not in loose["trigger"]
+
     async def test_tree_staleness_follows_the_bank_watermark(self, api_client, memory, kb_bank):
         """The tree answers from one bank-wide watermark, not a scan per page.
 

--- a/hindsight-api-slim/tests/test_knowledge_base.py
+++ b/hindsight-api-slim/tests/test_knowledge_base.py
@@ -196,19 +196,27 @@ class TestTree:
         bank_id, ids = kb_bank
         resp = await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/tree")
         roots = {r["name"]: r for r in resp.json()["roots"]}
-        assert roots["Loose"]["trigger"] == {
-            "mode": "delta",
-            "fact_types": ["observation"],
-            "exclude_mental_models": True,
-            "refresh_after_consolidation": True,
-        }
+        # The EFFECTIVE policy, not the stored keys: it serializes as MentalModelTrigger, so a
+        # field nobody set comes back at that model's default (keep_trace=False here). Asserting
+        # the whole dict would pin every future field of that model into this test.
+        trigger = roots["Loose"]["trigger"]
+        assert trigger["mode"] == "delta"
+        assert trigger["fact_types"] == ["observation"]
+        assert trigger["exclude_mental_models"] is True
+        assert trigger["refresh_after_consolidation"] is True
         # A folder has no backing mental model, so it has no refresh policy either —
         # and a null is dropped from the response entirely (ExcludeNoneRoute), the same
         # way is_stale is absent on folders rather than null.
         assert roots["Runbooks"].get("trigger") is None
 
     async def test_tree_reflects_a_changed_refresh_policy(self, api_client, memory, kb_bank, request_context):
-        """Read-back closes the loop: a client can compare and skip a no-op write."""
+        """Read-back closes the loop: a client can compare and skip a no-op write.
+
+        The page was created auto-refreshing; after moving it onto a schedule the tree shows the
+        schedule and auto-refresh off. (That the engine *stores* no ``refresh_after_consolidation``
+        key at all is asserted in TestPageDefaults — through this model it serializes as False,
+        which is the same policy stated a different way.)
+        """
         bank_id, ids = kb_bank
         await memory.update_knowledge_page(
             bank_id, ids.loose, trigger={"refresh_cron": "0 3 * * *"}, request_context=request_context
@@ -216,7 +224,8 @@ class TestTree:
         resp = await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/tree")
         loose = next(r for r in resp.json()["roots"] if r["name"] == "Loose")
         assert loose["trigger"]["refresh_cron"] == "0 3 * * *"
-        assert "refresh_after_consolidation" not in loose["trigger"]
+        assert loose["trigger"]["refresh_after_consolidation"] is False
+        assert loose["trigger"]["mode"] == "delta"  # untouched by the patch
 
     async def test_tree_staleness_follows_the_bank_watermark(self, api_client, memory, kb_bank):
         """The tree answers from one bank-wide watermark, not a scan per page.

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -6859,7 +6859,32 @@ components:
         id: id
         is_stale: true
         trigger:
-          key: ""
+          recall_chunks_max_tokens: 1
+          refresh_cron: refresh_cron
+          tag_groups:
+          - match: any_strict
+            tags:
+            - tags
+            - tags
+          - match: any_strict
+            tags:
+            - tags
+            - tags
+          exclude_mental_models: false
+          mode: full
+          refresh_after_consolidation: false
+          fact_types:
+          - world
+          - world
+          response_schema:
+            key: ""
+          exclude_mental_model_ids:
+          - exclude_mental_model_ids
+          - exclude_mental_model_ids
+          include_chunks: true
+          tags_match: any
+          keep_trace: false
+          recall_max_tokens: 6
         mental_model_id: mental_model_id
         tags:
         - tags
@@ -6904,8 +6929,7 @@ components:
           nullable: true
           type: boolean
         trigger:
-          additionalProperties: {}
-          nullable: true
+          $ref: '#/components/schemas/MentalModelTrigger-Output'
         children:
           default: []
           items:
@@ -7076,7 +7100,32 @@ components:
           id: id
           is_stale: true
           trigger:
-            key: ""
+            recall_chunks_max_tokens: 1
+            refresh_cron: refresh_cron
+            tag_groups:
+            - match: any_strict
+              tags:
+              - tags
+              - tags
+            - match: any_strict
+              tags:
+              - tags
+              - tags
+            exclude_mental_models: false
+            mode: full
+            refresh_after_consolidation: false
+            fact_types:
+            - world
+            - world
+            response_schema:
+              key: ""
+            exclude_mental_model_ids:
+            - exclude_mental_model_ids
+            - exclude_mental_model_ids
+            include_chunks: true
+            tags_match: any
+            keep_trace: false
+            recall_max_tokens: 6
           mental_model_id: mental_model_id
           tags:
           - tags
@@ -7093,7 +7142,32 @@ components:
           id: id
           is_stale: true
           trigger:
-            key: ""
+            recall_chunks_max_tokens: 1
+            refresh_cron: refresh_cron
+            tag_groups:
+            - match: any_strict
+              tags:
+              - tags
+              - tags
+            - match: any_strict
+              tags:
+              - tags
+              - tags
+            exclude_mental_models: false
+            mode: full
+            refresh_after_consolidation: false
+            fact_types:
+            - world
+            - world
+            response_schema:
+              key: ""
+            exclude_mental_model_ids:
+            - exclude_mental_model_ids
+            - exclude_mental_model_ids
+            include_chunks: true
+            tags_match: any
+            keep_trace: false
+            recall_max_tokens: 6
           mental_model_id: mental_model_id
           tags:
           - tags

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -6858,6 +6858,8 @@ components:
         description: description
         id: id
         is_stale: true
+        trigger:
+          key: ""
         mental_model_id: mental_model_id
         tags:
         - tags
@@ -6901,6 +6903,9 @@ components:
         is_stale:
           nullable: true
           type: boolean
+        trigger:
+          additionalProperties: {}
+          nullable: true
         children:
           default: []
           items:
@@ -7070,6 +7075,8 @@ components:
           description: description
           id: id
           is_stale: true
+          trigger:
+            key: ""
           mental_model_id: mental_model_id
           tags:
           - tags
@@ -7085,6 +7092,8 @@ components:
           description: description
           id: id
           is_stale: true
+          trigger:
+            key: ""
           mental_model_id: mental_model_id
           tags:
           - tags

--- a/hindsight-clients/go/model_knowledge_node.go
+++ b/hindsight-clients/go/model_knowledge_node.go
@@ -32,7 +32,7 @@ type KnowledgeNode struct {
 	Tags []string `json:"tags,omitempty"`
 	Timestamp NullableString `json:"timestamp,omitempty"`
 	IsStale NullableBool `json:"is_stale,omitempty"`
-	Trigger map[string]interface{} `json:"trigger,omitempty"`
+	Trigger NullableMentalModelTriggerOutput `json:"trigger,omitempty"`
 	Children []KnowledgeNode `json:"children,omitempty"`
 }
 
@@ -409,36 +409,45 @@ func (o *KnowledgeNode) UnsetIsStale() {
 }
 
 // GetTrigger returns the Trigger field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *KnowledgeNode) GetTrigger() map[string]interface{} {
-	if o == nil {
-		var ret map[string]interface{}
+func (o *KnowledgeNode) GetTrigger() MentalModelTriggerOutput {
+	if o == nil || IsNil(o.Trigger.Get()) {
+		var ret MentalModelTriggerOutput
 		return ret
 	}
-	return o.Trigger
+	return *o.Trigger.Get()
 }
 
 // GetTriggerOk returns a tuple with the Trigger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *KnowledgeNode) GetTriggerOk() (map[string]interface{}, bool) {
-	if o == nil || IsNil(o.Trigger) {
-		return map[string]interface{}{}, false
+func (o *KnowledgeNode) GetTriggerOk() (*MentalModelTriggerOutput, bool) {
+	if o == nil {
+		return nil, false
 	}
-	return o.Trigger, true
+	return o.Trigger.Get(), o.Trigger.IsSet()
 }
 
 // HasTrigger returns a boolean if a field has been set.
 func (o *KnowledgeNode) HasTrigger() bool {
-	if o != nil && !IsNil(o.Trigger) {
+	if o != nil && o.Trigger.IsSet() {
 		return true
 	}
 
 	return false
 }
 
-// SetTrigger gets a reference to the given map[string]interface{} and assigns it to the Trigger field.
-func (o *KnowledgeNode) SetTrigger(v map[string]interface{}) {
-	o.Trigger = v
+// SetTrigger gets a reference to the given NullableMentalModelTriggerOutput and assigns it to the Trigger field.
+func (o *KnowledgeNode) SetTrigger(v MentalModelTriggerOutput) {
+	o.Trigger.Set(&v)
+}
+// SetTriggerNil sets the value for Trigger to be an explicit nil
+func (o *KnowledgeNode) SetTriggerNil() {
+	o.Trigger.Set(nil)
+}
+
+// UnsetTrigger ensures that no value is present for Trigger, not even an explicit nil
+func (o *KnowledgeNode) UnsetTrigger() {
+	o.Trigger.Unset()
 }
 
 // GetChildren returns the Children field value if set, zero value otherwise.
@@ -507,8 +516,8 @@ func (o KnowledgeNode) ToMap() (map[string]interface{}, error) {
 	if o.IsStale.IsSet() {
 		toSerialize["is_stale"] = o.IsStale.Get()
 	}
-	if o.Trigger != nil {
-		toSerialize["trigger"] = o.Trigger
+	if o.Trigger.IsSet() {
+		toSerialize["trigger"] = o.Trigger.Get()
 	}
 	if !IsNil(o.Children) {
 		toSerialize["children"] = o.Children

--- a/hindsight-clients/go/model_knowledge_node.go
+++ b/hindsight-clients/go/model_knowledge_node.go
@@ -32,6 +32,7 @@ type KnowledgeNode struct {
 	Tags []string `json:"tags,omitempty"`
 	Timestamp NullableString `json:"timestamp,omitempty"`
 	IsStale NullableBool `json:"is_stale,omitempty"`
+	Trigger map[string]interface{} `json:"trigger,omitempty"`
 	Children []KnowledgeNode `json:"children,omitempty"`
 }
 
@@ -407,6 +408,39 @@ func (o *KnowledgeNode) UnsetIsStale() {
 	o.IsStale.Unset()
 }
 
+// GetTrigger returns the Trigger field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *KnowledgeNode) GetTrigger() map[string]interface{} {
+	if o == nil {
+		var ret map[string]interface{}
+		return ret
+	}
+	return o.Trigger
+}
+
+// GetTriggerOk returns a tuple with the Trigger field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *KnowledgeNode) GetTriggerOk() (map[string]interface{}, bool) {
+	if o == nil || IsNil(o.Trigger) {
+		return map[string]interface{}{}, false
+	}
+	return o.Trigger, true
+}
+
+// HasTrigger returns a boolean if a field has been set.
+func (o *KnowledgeNode) HasTrigger() bool {
+	if o != nil && !IsNil(o.Trigger) {
+		return true
+	}
+
+	return false
+}
+
+// SetTrigger gets a reference to the given map[string]interface{} and assigns it to the Trigger field.
+func (o *KnowledgeNode) SetTrigger(v map[string]interface{}) {
+	o.Trigger = v
+}
+
 // GetChildren returns the Children field value if set, zero value otherwise.
 func (o *KnowledgeNode) GetChildren() []KnowledgeNode {
 	if o == nil || IsNil(o.Children) {
@@ -472,6 +506,9 @@ func (o KnowledgeNode) ToMap() (map[string]interface{}, error) {
 	}
 	if o.IsStale.IsSet() {
 		toSerialize["is_stale"] = o.IsStale.Get()
+	}
+	if o.Trigger != nil {
+		toSerialize["trigger"] = o.Trigger
 	}
 	if !IsNil(o.Children) {
 		toSerialize["children"] = o.Children

--- a/hindsight-clients/python/hindsight_client_api/models/knowledge_node.py
+++ b/hindsight-clients/python/hindsight_client_api/models/knowledge_node.py
@@ -36,8 +36,9 @@ class KnowledgeNode(BaseModel):
     tags: Optional[List[StrictStr]] = None
     timestamp: Optional[StrictStr] = None
     is_stale: Optional[StrictBool] = None
+    trigger: Optional[Dict[str, Any]] = None
     children: Optional[List[KnowledgeNode]] = None
-    __properties: ClassVar[List[str]] = ["id", "kind", "name", "parent_id", "mental_model_id", "managed", "description", "tags", "timestamp", "is_stale", "children"]
+    __properties: ClassVar[List[str]] = ["id", "kind", "name", "parent_id", "mental_model_id", "managed", "description", "tags", "timestamp", "is_stale", "trigger", "children"]
 
     @field_validator('kind')
     def kind_validate_enum(cls, value):
@@ -117,6 +118,11 @@ class KnowledgeNode(BaseModel):
         if self.is_stale is None and "is_stale" in self.model_fields_set:
             _dict['is_stale'] = None
 
+        # set to None if trigger (nullable) is None
+        # and model_fields_set contains the field
+        if self.trigger is None and "trigger" in self.model_fields_set:
+            _dict['trigger'] = None
+
         return _dict
 
     @classmethod
@@ -139,6 +145,7 @@ class KnowledgeNode(BaseModel):
             "tags": obj.get("tags"),
             "timestamp": obj.get("timestamp"),
             "is_stale": obj.get("is_stale"),
+            "trigger": obj.get("trigger"),
             "children": [KnowledgeNode.from_dict(_item) for _item in obj["children"]] if obj.get("children") is not None else None
         })
         return _obj

--- a/hindsight-clients/python/hindsight_client_api/models/knowledge_node.py
+++ b/hindsight-clients/python/hindsight_client_api/models/knowledge_node.py
@@ -19,6 +19,7 @@ import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
+from hindsight_client_api.models.mental_model_trigger_output import MentalModelTriggerOutput
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -36,7 +37,7 @@ class KnowledgeNode(BaseModel):
     tags: Optional[List[StrictStr]] = None
     timestamp: Optional[StrictStr] = None
     is_stale: Optional[StrictBool] = None
-    trigger: Optional[Dict[str, Any]] = None
+    trigger: Optional[MentalModelTriggerOutput] = None
     children: Optional[List[KnowledgeNode]] = None
     __properties: ClassVar[List[str]] = ["id", "kind", "name", "parent_id", "mental_model_id", "managed", "description", "tags", "timestamp", "is_stale", "trigger", "children"]
 
@@ -86,6 +87,9 @@ class KnowledgeNode(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of trigger
+        if self.trigger:
+            _dict['trigger'] = self.trigger.to_dict()
         # override the default output from pydantic by calling `to_dict()` of each item in children (list)
         _items = []
         if self.children:
@@ -145,7 +149,7 @@ class KnowledgeNode(BaseModel):
             "tags": obj.get("tags"),
             "timestamp": obj.get("timestamp"),
             "is_stale": obj.get("is_stale"),
-            "trigger": obj.get("trigger"),
+            "trigger": MentalModelTriggerOutput.from_dict(obj["trigger"]) if obj.get("trigger") is not None else None,
             "children": [KnowledgeNode.from_dict(_item) for _item in obj["children"]] if obj.get("children") is not None else None
         })
         return _obj

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -2249,6 +2249,14 @@ export type KnowledgeNode = {
    */
   is_stale?: boolean | null;
   /**
+   * Trigger
+   *
+   * Pages only: the page's refresh settings — when it rebuilds itself (`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. Null on folders, and on a page with no trigger stored.
+   */
+  trigger?: {
+    [key: string]: unknown;
+  } | null;
+  /**
    * Children
    */
   children?: Array<KnowledgeNode>;

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -2251,7 +2251,7 @@ export type KnowledgeNode = {
   /**
    * Trigger
    *
-   * Pages only: the page's refresh settings — when it rebuilds itself (`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. Null on folders, and on a page with no trigger stored.
+   * Pages only: the page's refresh settings — when it rebuilds itself (`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. Absent on folders, which have no backing mental model, and on a page with no trigger stored.
    */
   trigger?: {
     [key: string]: unknown;

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -2249,13 +2249,9 @@ export type KnowledgeNode = {
    */
   is_stale?: boolean | null;
   /**
-   * Trigger
-   *
    * Pages only: the page's refresh settings — when it rebuilds itself (`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. Absent on folders, which have no backing mental model, and on a page with no trigger stored.
    */
-  trigger?: {
-    [key: string]: unknown;
-  } | null;
+  trigger?: MentalModelTriggerOutput | null;
   /**
    * Children
    */

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -2249,7 +2249,7 @@ export type KnowledgeNode = {
    */
   is_stale?: boolean | null;
   /**
-   * Pages only: the page's refresh settings — when it rebuilds itself (`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. Absent on folders, which have no backing mental model, and on a page with no trigger stored.
+   * Pages only: the page's refresh settings — when it rebuilds itself (`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. This is the EFFECTIVE policy: a setting the page never stored is reported at its default, so compare the fields you care about rather than the whole object against a patch you sent. Absent on folders, which have no backing mental model, and on a page with no trigger stored.
    */
   trigger?: MentalModelTriggerOutput | null;
   /**

--- a/hindsight-control-plane/src/components/knowledge-base-view.tsx
+++ b/hindsight-control-plane/src/components/knowledge-base-view.tsx
@@ -205,6 +205,7 @@ export function KnowledgeBaseView() {
       tags: [],
       timestamp: null,
       is_stale: null,
+      trigger: null,
       children: roots,
     }),
     [currentBank, roots]

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -49,6 +49,8 @@ export interface KnowledgeNode {
   tags: string[];
   timestamp: string | null;
   is_stale: boolean | null;
+  /** Pages only: when the page rebuilds itself and over which facts. Null on folders. */
+  trigger: MentalModel["trigger"] | null;
   children: KnowledgeNode[];
 }
 

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -10458,7 +10458,7 @@
               }
             ],
             "title": "Trigger",
-            "description": "Pages only: the page's refresh settings \u2014 when it rebuilds itself (`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. Null on folders, and on a page with no trigger stored."
+            "description": "Pages only: the page's refresh settings \u2014 when it rebuilds itself (`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. Absent on folders, which have no backing mental model, and on a page with no trigger stored."
           },
           "children": {
             "items": {

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -10450,14 +10450,12 @@
           "trigger": {
             "anyOf": [
               {
-                "additionalProperties": true,
-                "type": "object"
+                "$ref": "#/components/schemas/MentalModelTrigger-Output"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Trigger",
             "description": "Pages only: the page's refresh settings \u2014 when it rebuilds itself (`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. Absent on folders, which have no backing mental model, and on a page with no trigger stored."
           },
           "children": {

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -10447,6 +10447,19 @@
             "title": "Is Stale",
             "description": "Pages only, populated by the tree endpoint. False means the page is up to date \u2014 nothing in the bank has been written since its last refresh. True means it *may* need a refresh: something was written, but possibly outside the page's tags. Read the page's mental model for the exact answer. Shares the bank-stats freshness, so it can lag a just-written memory by up to a minute."
           },
+          "trigger": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trigger",
+            "description": "Pages only: the page's refresh settings \u2014 when it rebuilds itself (`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. Null on folders, and on a page with no trigger stored."
+          },
           "children": {
             "items": {
               "$ref": "#/components/schemas/KnowledgeNode"

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -10456,7 +10456,7 @@
                 "type": "null"
               }
             ],
-            "description": "Pages only: the page's refresh settings \u2014 when it rebuilds itself (`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. Absent on folders, which have no backing mental model, and on a page with no trigger stored."
+            "description": "Pages only: the page's refresh settings \u2014 when it rebuilds itself (`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. This is the EFFECTIVE policy: a setting the page never stored is reported at its default, so compare the fields you care about rather than the whole object against a patch you sent. Absent on folders, which have no backing mental model, and on a page with no trigger stored."
           },
           "children": {
             "items": {

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -10458,7 +10458,7 @@
               }
             ],
             "title": "Trigger",
-            "description": "Pages only: the page's refresh settings \u2014 when it rebuilds itself (`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. Null on folders, and on a page with no trigger stored."
+            "description": "Pages only: the page's refresh settings \u2014 when it rebuilds itself (`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. Absent on folders, which have no backing mental model, and on a page with no trigger stored."
           },
           "children": {
             "items": {

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -10450,14 +10450,12 @@
           "trigger": {
             "anyOf": [
               {
-                "additionalProperties": true,
-                "type": "object"
+                "$ref": "#/components/schemas/MentalModelTrigger-Output"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Trigger",
             "description": "Pages only: the page's refresh settings \u2014 when it rebuilds itself (`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. Absent on folders, which have no backing mental model, and on a page with no trigger stored."
           },
           "children": {

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -10447,6 +10447,19 @@
             "title": "Is Stale",
             "description": "Pages only, populated by the tree endpoint. False means the page is up to date \u2014 nothing in the bank has been written since its last refresh. True means it *may* need a refresh: something was written, but possibly outside the page's tags. Read the page's mental model for the exact answer. Shares the bank-stats freshness, so it can lag a just-written memory by up to a minute."
           },
+          "trigger": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trigger",
+            "description": "Pages only: the page's refresh settings \u2014 when it rebuilds itself (`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. Null on folders, and on a page with no trigger stored."
+          },
           "children": {
             "items": {
               "$ref": "#/components/schemas/KnowledgeNode"

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -10456,7 +10456,7 @@
                 "type": "null"
               }
             ],
-            "description": "Pages only: the page's refresh settings \u2014 when it rebuilds itself (`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. Absent on folders, which have no backing mental model, and on a page with no trigger stored."
+            "description": "Pages only: the page's refresh settings \u2014 when it rebuilds itself (`refresh_after_consolidation` or `refresh_cron`), in which mode, and over which facts. This is the EFFECTIVE policy: a setting the page never stored is reported at its default, so compare the fields you care about rather than the whole object against a patch you sent. Absent on folders, which have no backing mental model, and on a page with no trigger stored."
           },
           "children": {
             "items": {


### PR DESCRIPTION
A page's `trigger` decides **when** it rebuilds itself and what that costs — and it was write-only.
Nothing in the knowledge-base API returned it, so a client that speaks only that surface (the
control-plane tree, the coding-agents plugin) could neither show a page's refresh policy nor tell
whether its own settings still applied. The only way to read one was the mental-models API, a call
per page, against ids the knowledge base doesn't hand out.

## Change

`_KP_PAGE_SELECT` now carries `mm.trigger` — the join it needs was already there for
`tags`/`source_query`, so this is one more column on a query that already runs — and `KnowledgeNode`
returns it. Null on folders (no backing mental model) and on a page with no trigger stored.

This closes the loop opened by #3549, which made the trigger patchable: a client can now compare
what a page *has* against what it *wants* and skip the write when they already agree, instead of
PATCHing blind on every pass.

## Not included

- `KnowledgePageResponse` (the markdown-document projection behind
  `GET /knowledge-base/pages/{id}`) is unchanged — it renders a document, it isn't the settings
  surface; `KnowledgeNode` is where structure and state already live (`is_stale`, `managed`).
- No control-plane UI yet. `lib/api.ts` carries the field so a view can use it; showing "refreshes
  after each consolidation" / "daily at 03:00" on a page is the obvious next step.

## Testing

Two tests in `TestTree`:
- the tree returns a page's full trigger and `null` for folders;
- after `update_knowledge_page(trigger={"refresh_cron": ...})`, the tree reflects the new policy —
  the read-back that makes compare-then-skip possible.

Locally: `./scripts/hooks/lint.sh` passes, control-plane `tsc` clean for the touched files, OpenAPI
spec + generated clients (Go/Python/TS) + docs skill regenerated and committed. The DB-backed tests
are left to CI's `test-api` job, as the api-slim suite truncates whatever database the local `.env`
points at.
