### PR TITLE
fix(coding-agents): pin the bank to where the session started in a non-git tree

### DIFF
--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -446,7 +446,10 @@ Coding memory is **per repository**. Resolution order for the working directory:
 3. Dynamic — `bankIdTemplate` with placeholders:
    - `{gitProject}` — worktree-aware repo name: `git rev-parse --git-common-dir` resolves every
      linked worktree to the **main** worktree's basename, so all worktrees of a repo share one bank
-     (bare repos use the bare dir name; non-git directories fall back to the dir basename)
+     (bare repos use the bare dir name). **Outside a repo** there is nothing for git to resolve, so
+     it falls back to the basename of the directory the **session started in** — an agent that
+     `cd`s into a subdirectory keeps writing to one bank, and a subdirectory gets its own bank only
+     when you deliberately start a session there
    - `{project}` — plain working-directory basename
    - `{harness}` — the entry point asking (`opencode`, `claude-code`, `codex`, `antigravity-cli`, `cursor-cli`, `copilot-cli`)
    - `{channel}` / `{user}` — `$HINDSIGHT_CHANNEL_ID` / `$HINDSIGHT_USER_ID`

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -439,7 +439,10 @@ Coding memory is **per repository**. Resolution order for the working directory:
 3. Dynamic — `bankIdTemplate` with placeholders:
    - `{gitProject}` — worktree-aware repo name: `git rev-parse --git-common-dir` resolves every
      linked worktree to the **main** worktree's basename, so all worktrees of a repo share one bank
-     (bare repos use the bare dir name; non-git directories fall back to the dir basename)
+     (bare repos use the bare dir name). **Outside a repo** there is nothing for git to resolve, so
+     it falls back to the basename of the directory the **session started in** — an agent that
+     `cd`s into a subdirectory keeps writing to one bank, and a subdirectory gets its own bank only
+     when you deliberately start a session there
    - `{project}` — plain working-directory basename
    - `{harness}` — the entry point asking (`opencode`, `claude-code`, `codex`, `antigravity-cli`, `cursor-cli`, `copilot-cli`)
    - `{channel}` / `{user}` — `$HINDSIGHT_CHANNEL_ID` / `$HINDSIGHT_USER_ID`

--- a/hindsight-integrations/coding-agents/src/antigravity-statusline.ts
+++ b/hindsight-integrations/coding-agents/src/antigravity-statusline.ts
@@ -19,6 +19,11 @@ export function buildAntigravityStatusLine(state: AntigravityStatusLineState, cf
   const cwd = state.cwd || state.workspace?.current_dir;
   if (!cwd) return brandWord();
 
+  // No session root here: the documented state payload carries no conversation id, so there is no
+  // key to look one up by (see core/session-cache.ts). Outside a git repo this can therefore name
+  // the directory the agent navigated to while the hooks keep writing to the session's own bank
+  // (#3563). It is a display-only divergence — this command never calls the API, so nothing is
+  // retained or created under the name shown.
   const resolved = applyBankConfig(cfg, deriveBankId(cfg, cwd, "antigravity-cli"), cwd);
   return resolved.cfg.disabled ? "" : `${brandWord()} · ${resolved.bankId}`;
 }

--- a/hindsight-integrations/coding-agents/src/core/bank-missing-dir.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/bank-missing-dir.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -16,6 +16,7 @@ describe("project resolution when the working directory is gone", () => {
   let repo: string;
 
   beforeEach(() => {
+    delete process.env.CLAUDE_PROJECT_DIR;
     repo = mkdtempSync(join(tmpdir(), "hs-gone-"));
     execFileSync("git", ["init", "-q"], { cwd: repo });
   });
@@ -65,6 +66,73 @@ describe("project resolution when the working directory is gone", () => {
     const plain = mkdtempSync(join(tmpdir(), "hs-plain-"));
     try {
       expect(deriveBankId({}, plain, "claude-code")).toBe(`coding-agent::${basename(plain)}`);
+    } finally {
+      rmSync(plain, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps ONE bank when the agent navigates below a non-repository session root", () => {
+    // #3563: no repo to resolve to, so the bank id used to follow the agent — `analysis` and
+    // `evidence` each became a bank holding part of the SAME conversation.
+    const plain = mkdtempSync(join(tmpdir(), "hs-plain-"));
+    const sub = join(plain, "analysis", "evidence");
+    mkdirSync(sub, { recursive: true });
+    try {
+      for (const cwd of [plain, join(plain, "analysis"), sub]) {
+        expect(deriveBankId({}, cwd, "claude-code", plain)).toBe(
+          `coding-agent::${basename(plain)}`
+        );
+      }
+    } finally {
+      rmSync(plain, { recursive: true, force: true });
+    }
+  });
+
+  it("still names the repository the agent is IN, not the session root", () => {
+    // The session root is a rescue for what git cannot name, never an override: a session started
+    // in a plain directory that then works inside a repo still gets that repo's bank.
+    const plain = mkdtempSync(join(tmpdir(), "hs-plain-"));
+    try {
+      expect(deriveBankId({}, repo, "claude-code", plain)).toBe(`coding-agent::${basename(repo)}`);
+    } finally {
+      rmSync(plain, { recursive: true, force: true });
+    }
+  });
+
+  it("names the session's repository when the agent steps outside it", () => {
+    // Harness-neutral counterpart of the CLAUDE_PROJECT_DIR rescue above: a `cd /tmp` to run
+    // something must not rename the bank after the directory it landed in.
+    const outside = mkdtempSync(join(tmpdir(), "hs-outside-"));
+    try {
+      expect(deriveBankId({}, outside, "codex", repo)).toBe(`coding-agent::${basename(repo)}`);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves {project} on the live working directory", () => {
+    // {project} is documented as the working-directory basename — it is the escape hatch for
+    // anyone who WANTS a bank per directory, so the session root must not reach it.
+    const plain = mkdtempSync(join(tmpdir(), "hs-plain-"));
+    const sub = join(plain, "analysis");
+    mkdirSync(sub);
+    try {
+      expect(deriveBankId({ bankIdTemplate: "{project}" }, sub, "claude-code", plain)).toBe(
+        "analysis"
+      );
+    } finally {
+      rmSync(plain, { recursive: true, force: true });
+    }
+  });
+
+  it("lets mapPathToBank keep overriding the session root", () => {
+    const plain = mkdtempSync(join(tmpdir(), "hs-plain-"));
+    const sub = join(plain, "analysis");
+    mkdirSync(sub);
+    try {
+      expect(deriveBankId({ mapPathToBank: { [sub]: "pinned" } }, sub, "claude-code", plain)).toBe(
+        "pinned"
+      );
     } finally {
       rmSync(plain, { recursive: true, force: true });
     }

--- a/hindsight-integrations/coding-agents/src/core/bank.ts
+++ b/hindsight-integrations/coding-agents/src/core/bank.ts
@@ -12,7 +12,8 @@
  *   2. static — when `dynamicBankId` is false, or left unset WITH an explicit `bankId`
  *      (the benchmark harness and single-bank setups).
  *   3. dynamic — `bankIdTemplate` (default "coding-agent::{gitProject}") with placeholders:
- *        {gitProject}  worktree-aware repo name (all worktrees share it; non-git: dir basename)
+ *        {gitProject}  worktree-aware repo name (all worktrees share it; outside a repo: the
+ *                      basename of the directory the SESSION started in, not the agent's live cwd)
  *        {project}     working-directory basename (no git involved)
  *        {harness}     the entry point asking ("opencode", "claude-code", "codex", "antigravity-cli", ...)
  *        {channel}     $HINDSIGHT_CHANNEL_ID or "default"
@@ -63,8 +64,8 @@ export function getProjectRootFromGit(directory: string): string | null {
 /** Worktree-aware repo name for DOCUMENT IDS (gitlog:<name>, commit context): all worktrees of a
  *  repo must produce the SAME name, or each worktree writes its own gitlog document into the
  *  shared bank (seen in the wild: gitlog:hindsight-wt7 next to gitlog:memory-poc). */
-export function projectNameOf(directory: string): string {
-  return gitProjectName(directory, true);
+export function projectNameOf(directory: string, sessionRoot?: string): string {
+  return gitProjectName(directory, true, sessionRoot);
 }
 
 /**
@@ -74,7 +75,8 @@ export function projectNameOf(directory: string): string {
  *
  * It earns its place for the case the walk cannot reach: a LINKED worktree (a sibling directory,
  * not a child of the repo) that has been deleted. Walking up from it lands outside the repository
- * entirely, while this variable still names it.
+ * entirely, while this variable still names it. The session root passed by the hook runtimes covers
+ * the same case harness-neutrally when a session is what is being resolved.
  */
 const PROJECT_ROOT_ENV = ["CLAUDE_PROJECT_DIR"] as const;
 
@@ -108,13 +110,14 @@ function dirName(directory: string): string {
   return (directory && basename(directory)) || "unknown";
 }
 
-function gitProjectName(directory: string, resolveWorktrees: boolean): string {
+function gitProjectName(directory: string, resolveWorktrees: boolean, sessionRoot = ""): string {
   if (resolveWorktrees) {
     // The directory itself first (via the walk, which is a no-op when it exists), so anything git
-    // can still resolve keeps its historical answer and no existing bank moves. The exported roots
-    // are a last rescue, not a new source of truth.
+    // can still resolve keeps its historical answer and no existing bank moves. The session root
+    // and the exported roots are a last rescue, not a new source of truth.
     const candidates = [
       nearestExistingDir(directory),
+      sessionRoot,
       ...PROJECT_ROOT_ENV.map((v) => process.env[v] || ""),
     ];
     for (const candidate of candidates) {
@@ -122,7 +125,13 @@ function gitProjectName(directory: string, resolveWorktrees: boolean): string {
       if (root) return basename(root);
     }
   }
-  return dirName(directory);
+  // Nothing git can name. `directory` is the agent's LIVE working directory and it moves during
+  // normal work; inside a repo that was harmless because every subdirectory resolved back to the
+  // root above, but a plain directory tree has no root to resolve to, so the bank id followed the
+  // agent and one session was retained into a bank per directory it stepped into (#3563). Name the
+  // directory the session STARTED in instead — a subdirectory earns its own bank by starting a
+  // session there, not by being visited.
+  return dirName(sessionRoot || directory);
 }
 
 /** A configured directory, `~`-expanded and normalised, without a trailing separator. */
@@ -175,7 +184,14 @@ export function isOptedIn(config: BankConfig, directory: string): boolean {
 }
 
 /** Derive the bank id for a working directory (see module doc for the resolution order). */
-export function deriveBankId(config: BankConfig, directory: string, harness = "coding"): string {
+export function deriveBankId(
+  config: BankConfig,
+  directory: string,
+  harness = "coding",
+  /** Where the SESSION started, when the caller knows it (hook runtimes do — see
+   *  `sessionRootDir`). Used only where the live directory yields no project: see gitProjectName. */
+  sessionRoot?: string
+): string {
   const mapped =
     directory && config.mapPathToBank ? mapLookup(config.mapPathToBank, directory) : undefined;
   if (mapped) return mapped;
@@ -187,7 +203,7 @@ export function deriveBankId(config: BankConfig, directory: string, harness = "c
   const resolvers: Record<string, () => string> = {
     harness: () => harness,
     project: () => dirName(directory),
-    gitProject: () => gitProjectName(directory, config.resolveWorktrees ?? true),
+    gitProject: () => gitProjectName(directory, config.resolveWorktrees ?? true, sessionRoot),
     channel: () => process.env.HINDSIGHT_CHANNEL_ID || "default",
     user: () => process.env.HINDSIGHT_USER_ID || "anonymous",
   };

--- a/hindsight-integrations/coding-agents/src/core/hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/hook.ts
@@ -33,6 +33,7 @@ import { buildRosterRefresh, parsePageList } from "./knowledge-injection";
 import {
   readSessionCache,
   sessionCacheFile,
+  sessionRootDir,
   writeSessionCache,
   type SessionCache,
 } from "./session-cache";
@@ -239,7 +240,8 @@ export async function runHook(
   const out = (context: string | undefined, notice?: string) =>
     process.stdout.write(JSON.stringify(spec.emit(context ?? "", notice, ev)));
 
-  const resolved = applyBankConfig(cfg, deriveBankId(cfg, cwd, spec.harness), cwd);
+  const sessionRoot = sessionRootDir(spec.harness, sessionId, cwd);
+  const resolved = applyBankConfig(cfg, deriveBankId(cfg, cwd, spec.harness, sessionRoot), cwd);
   cfg = resolved.cfg;
   const bankId = resolved.bankId;
   if (cfg.disabled) {

--- a/hindsight-integrations/coding-agents/src/core/retain-hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.ts
@@ -22,7 +22,7 @@ import type { ClientOpts } from "./hindsight";
 import { HindsightClient } from "./hindsight";
 import type { RetainCursorStore } from "./retain-cursor";
 import { buildRetainStamp, type RetainStamp } from "./retain-stamp";
-import { fileCursorStore } from "./session-cache";
+import { fileCursorStore, sessionRootDir } from "./session-cache";
 import { readClaudeTranscript } from "./transcript";
 
 /** Headroom left before the host's kill: the response still has to come back after the last wait. */
@@ -133,7 +133,8 @@ export async function runRetainHook(
 
   if (!transcriptPath) return;
 
-  const resolved = applyBankConfig(cfg, deriveBankId(cfg, cwd, spec.harness), cwd);
+  const sessionRoot = sessionRootDir(spec.harness, sessionId, cwd);
+  const resolved = applyBankConfig(cfg, deriveBankId(cfg, cwd, spec.harness, sessionRoot), cwd);
   cfg = resolved.cfg;
   const bankId = resolved.bankId;
   if (cfg.disabled) return;
@@ -159,6 +160,7 @@ export async function runRetainHook(
     retryUntil: hostDeadline,
     stamp: buildRetainStamp(cfg, {
       directory: cwd,
+      sessionRoot,
       harness: spec.harness,
       bankId,
       sessionId: sessionId || "no-session",

--- a/hindsight-integrations/coding-agents/src/core/retain-stamp.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-stamp.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -42,6 +42,24 @@ describe("buildRetainStamp", () => {
     const name = repo.split("/").pop()!;
     expect(tags).toEqual([`project:${name}`]);
     expect(metadata).toEqual({ repo: name });
+  });
+
+  it("resolves {gitProject} from the session root outside a repository", () => {
+    // The stamp must name the project its BANK ID names, and outside a repo the bank id comes from
+    // where the session started rather than the agent's live cwd (#3563).
+    const plain = mkdtempSync(join(tmpdir(), "hs-stamp-plain-"));
+    const sub = join(plain, "analysis");
+    mkdirSync(sub);
+    try {
+      const { tags } = buildRetainStamp(
+        { retainTags: ["project:{gitProject}", "dir:{project}"] },
+        ctx({ directory: sub, sessionRoot: plain })
+      );
+      // {project} stays on the live working directory — it is documented as exactly that.
+      expect(tags).toEqual([`project:${plain.split("/").pop()!}`, "dir:analysis"]);
+    } finally {
+      rmSync(plain, { recursive: true, force: true });
+    }
   });
 
   it("resolves the rest of the vocabulary", () => {

--- a/hindsight-integrations/coding-agents/src/core/retain-stamp.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-stamp.ts
@@ -31,6 +31,9 @@ const RESERVED_TAG_PREFIX = /^(source|harness):/;
 export interface RetainStampContext {
   /** Working directory the retain is being written from — the repo, for {project}/{gitProject}. */
   directory: string;
+  /** Where the session started, when known. {gitProject} must name the same project the bank id
+   *  does, so it falls back to this exactly as bank resolution does (see core/bank.ts). */
+  sessionRoot?: string;
   harness: string;
   bankId: string;
   /** Agent session when the document comes from one; absent for non-session documents. */
@@ -51,7 +54,7 @@ function resolversFor(ctx: RetainStampContext): Resolvers {
   return {
     // Worktree-aware like the bank id, so every linked worktree of a repo stamps the SAME name —
     // otherwise a shared bank ends up with `project:app` and `project:app-wt2` for one repository.
-    gitProject: () => projectNameOf(ctx.directory),
+    gitProject: () => projectNameOf(ctx.directory, ctx.sessionRoot),
     project: () => (ctx.directory ? basename(ctx.directory) : "unknown"),
     harness: () => ctx.harness,
     bankId: () => ctx.bankId,

--- a/hindsight-integrations/coding-agents/src/core/session-cache.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-cache.test.ts
@@ -4,6 +4,7 @@ import {
   fileCursorStore,
   readSessionCache,
   sessionCacheFile,
+  sessionRootDir,
   writeSessionCache,
 } from "./session-cache";
 
@@ -14,6 +15,7 @@ afterEach(() => {
   for (const s of sessions) {
     rmSync(sessionCacheFile(HARNESS, s), { force: true });
     rmSync(sessionCacheFile(HARNESS, s).replace(/\.json$/, ".retain.json"), { force: true });
+    rmSync(sessionCacheFile(HARNESS, s).replace(/\.json$/, ".root"), { force: true });
   }
 });
 
@@ -75,5 +77,36 @@ describe("fileCursorStore", () => {
       expect(seen?.turns).toBe(i);
       expect(seen?.fingerprint).toHaveLength(i * 200);
     }
+  });
+});
+
+describe("sessionRootDir", () => {
+  it("pins the session to the directory it started in, however far the agent navigates", () => {
+    // #3563: each call is a separate hook process, and the cwd it reports is the agent's LIVE one.
+    expect(sessionRootDir(HARNESS, "s1", "/work/incident")).toBe("/work/incident");
+    expect(sessionRootDir(HARNESS, "s1", "/work/incident/analysis")).toBe("/work/incident");
+    expect(sessionRootDir(HARNESS, "s1", "/work/incident/analysis/evidence")).toBe(
+      "/work/incident"
+    );
+  });
+
+  it("keeps roots separate per session", () => {
+    sessionRootDir(HARNESS, "s1", "/work/one");
+    sessionRootDir(HARNESS, "s2", "/work/two");
+    expect(sessionRootDir(HARNESS, "s1", "/elsewhere")).toBe("/work/one");
+    expect(sessionRootDir(HARNESS, "s2", "/elsewhere")).toBe("/work/two");
+  });
+
+  it("survives the prompt hook rewriting the session cache", () => {
+    // Same reason the retain cursor has its own file: the prompt hook writes a fresh object.
+    sessionRootDir(HARNESS, "s1", "/work/one");
+    writeSessionCache(sessionCacheFile(HARNESS, "s1"), { turns: 2 });
+    expect(sessionRootDir(HARNESS, "s1", "/elsewhere")).toBe("/work/one");
+  });
+
+  it("falls back to the live directory without a session id", () => {
+    // Non-hook entry points (statusline, MCP) resolve a directory, not a session.
+    expect(sessionRootDir(HARNESS, undefined, "/work/one")).toBe("/work/one");
+    expect(sessionRootDir(HARNESS, "", "/work/one")).toBe("/work/one");
   });
 });

--- a/hindsight-integrations/coding-agents/src/core/session-cache.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-cache.ts
@@ -60,6 +60,53 @@ export function writeSessionCache(cacheFile: string, cache: SessionCache): void 
   }
 }
 
+/** The session root's own file, deliberately NOT the shared session cache — see sessionRootDir. */
+function sessionRootFile(harness: string, sessionId: string): string {
+  return join(tmpdir(), `hindsight-${harness}`, `${sessionId}.root`);
+}
+
+/**
+ * The directory this session STARTED in: recorded the first time any of its hooks runs — normally
+ * SessionStart — and returned unchanged for the rest of the session.
+ *
+ * Bank resolution needs a directory that does not move. A hook event reports the agent's LIVE
+ * working directory, and an agent `cd`s during ordinary work. Inside a git repo that is harmless
+ * (every subdirectory resolves back to the repo root), but a plain directory tree has no root to
+ * resolve to, so the bank id followed the agent and ONE conversation was retained into a bank per
+ * directory it visited — the same document, its facts split across banks (#3563).
+ *
+ * Deliberately keyed on the session id rather than read from a harness-exported project-root
+ * variable: every hook harness reports a session id, only Claude Code exports a root. Same reason
+ * `nearestExistingDir` walks the tree instead of guessing at nine env var names.
+ *
+ * It lives in its OWN file, like the retain cursor and for the same reason: the prompt hook writes
+ * a fresh session-cache object rather than merging, so a field there would be dropped on every user
+ * prompt — and the very first prompt is where it would first be needed.
+ *
+ * Best-effort throughout. A temp file that cannot be read or written just yields `cwd`, which is
+ * exactly the behaviour before this existed — never an error, never a lost retain.
+ */
+export function sessionRootDir(
+  harness: string,
+  sessionId: string | undefined,
+  cwd: string
+): string {
+  if (!sessionId || !cwd) return cwd;
+  const file = sessionRootFile(harness, sessionId);
+  try {
+    const recorded = readFileSync(file, "utf8").trim();
+    if (recorded) return recorded;
+  } catch {
+    /* not recorded yet — this hook is the session's first */
+  }
+  try {
+    writeFileAtomic(file, cwd);
+  } catch {
+    /* best-effort: an unrecorded root costs stability, never data */
+  }
+  return cwd;
+}
+
 /** The cursor's own file, deliberately NOT the shared session cache — see fileCursorStore. */
 function cursorFile(harness: string, sessionId: string): string {
   return join(tmpdir(), `hindsight-${harness}`, `${sessionId}.retain.json`);

--- a/hindsight-integrations/coding-agents/src/core/session-start.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.ts
@@ -35,7 +35,7 @@ import { parsePageList, buildKnowledgePreamble, type PageRef } from "./knowledge
 import type { ClientOpts, RetainOpts } from "./hindsight";
 import { buildRetainStamp } from "./retain-stamp";
 import { HindsightClient } from "./hindsight";
-import { sessionCacheFile, writeSessionCache } from "./session-cache";
+import { sessionCacheFile, sessionRootDir, writeSessionCache } from "./session-cache";
 
 /** Minimal client shape `buildSessionStartContext` needs. */
 interface SeedContextClient {
@@ -133,6 +133,9 @@ export interface SessionStartHookSpec {
  */
 export async function buildSessionStartContext(args: {
   cwd: string;
+  /** Where the session started — see `sessionRootDir`. Same as `cwd` on a fresh session; they
+   *  differ on a resume, where the bank was resolved from the ORIGINAL root. */
+  sessionRoot?: string;
   bankId: string;
   cfg: Config;
   client: SeedContextClient;
@@ -157,7 +160,9 @@ export async function buildSessionStartContext(args: {
   const startSurvey = args.startSurvey ?? startCodebaseSurvey;
   const resolveHeadSha = args.headSha ?? gitHeadSha;
   const countCommitsSince = args.commitsSince ?? commitsSince;
-  const retainStamp = () => buildRetainStamp(cfg, { directory: cwd, harness, bankId });
+  // sessionRoot as well as cwd, so a stamped {gitProject} names the project the bank id does.
+  const retainStamp = () =>
+    buildRetainStamp(cfg, { directory: cwd, sessionRoot: args.sessionRoot, harness, bankId });
 
   // Codebase-survey baseline (Option A): the bank is the only state, so the HEAD at the last survey
   // is recorded IN the bank as a tiny `survey-baseline:<sha>` marker doc (tag source:survey-baseline;
@@ -345,7 +350,10 @@ export async function runSessionStartHook(
     syncCompanionSkill(harness); // keep the installed skill current with the package version
     if (cfg.disabled) return;
 
-    const resolved = applyBankConfig(cfg, deriveBankId(cfg, cwd, harness), cwd);
+    // Recorded HERE, on the session's first hook, so every later hook of this session resolves the
+    // same bank however far the agent navigates (#3563).
+    const sessionRoot = sessionRootDir(harness, sessionId, cwd);
+    const resolved = applyBankConfig(cfg, deriveBankId(cfg, cwd, harness, sessionRoot), cwd);
     cfg = resolved.cfg;
     const bankId = resolved.bankId;
     if (cfg.disabled) return; // per-bank opt-out (banks.<id> override)
@@ -360,7 +368,7 @@ export async function runSessionStartHook(
       maxParallelRetains: cfg.maxParallelRetains,
     });
 
-    const out = await buildSessionStartContext({ cwd, bankId, cfg, client, harness });
+    const out = await buildSessionStartContext({ cwd, sessionRoot, bankId, cfg, client, harness });
     if (out.deferInitialReflect && sessionId) {
       writeSessionCache(sessionCacheFile(harness, sessionId), { deferInitialReflect: true });
     }

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -441,7 +441,10 @@ Coding memory is **per repository**. Resolution order for the working directory:
 3. Dynamic — `bankIdTemplate` with placeholders:
    - `{gitProject}` — worktree-aware repo name: `git rev-parse --git-common-dir` resolves every
      linked worktree to the **main** worktree's basename, so all worktrees of a repo share one bank
-     (bare repos use the bare dir name; non-git directories fall back to the dir basename)
+     (bare repos use the bare dir name). **Outside a repo** there is nothing for git to resolve, so
+     it falls back to the basename of the directory the **session started in** — an agent that
+     `cd`s into a subdirectory keeps writing to one bank, and a subdirectory gets its own bank only
+     when you deliberately start a session there
    - `{project}` — plain working-directory basename
    - `{harness}` — the entry point asking (`opencode`, `claude-code`, `codex`, `antigravity-cli`, `cursor-cli`, `copilot-cli`)
    - `{channel}` / `{user}` — `$HINDSIGHT_CHANNEL_ID` / `$HINDSIGHT_USER_ID`


### PR DESCRIPTION
Fixes #3563.

## The bug

`gitProjectName` only ever fed its candidates to `getProjectRootFromGit`. Outside a repository both were discarded and it fell through to `dirName(directory)` — the agent's **live** working directory:

```ts
return dirName(directory);   // bank.ts L125
```

Inside a repo that is harmless: every subdirectory resolves back to the root above it. A plain directory tree has no root to resolve to, so the bank id followed the agent as it `cd`d during ordinary work, and one session was retained into a bank per directory it stepped into — the reporter's transcript moved five times and produced `coding-agent::2026-07-22` (18 facts) and `coding-agent::analysis` (37 facts) holding **the same document id**. A recall against either sees part of the history, extraction and consolidation run twice, and nothing warns that the split happened.

This is #3110's pathology on the path `nearestExistingDir` cannot reach — there is no repo to walk up to.

## The fix

The bank is decided by **where the session started**.

The issue offered two options; this takes **B**, for the reason raised in its comment: the resolver is shared by all seven hook harnesses, and `dirName(process.env.CLAUDE_PROJECT_DIR || directory)` would fix only Claude Code. Every hook harness reports a session id (`harness/hook-lifecycle.ts`) and only Claude Code exports a project root, so the session id is the harness-neutral anchor — the same reasoning the existing `PROJECT_ROOT_ENV` comment gives for preferring the ancestor walk over "a guess at nine names".

- **`session-cache.ts`** — `sessionRootDir(harness, sessionId, cwd)` records the first cwd any of a session's hooks reports (normally SessionStart) in `$TMPDIR/hindsight-<harness>/<session>.root`, and returns it unchanged for the rest of the session. Its own file, not a session-cache field, because the prompt hook rewrites that object wholesale — the same reason the retain cursor was split out. Best-effort throughout: an unreadable or unwritable temp file yields `cwd`, i.e. today's behaviour.
- **`bank.ts`** — the session root joins the git-resolution candidates (after the live directory's walk, before the exported roots) and becomes the naming fallback: `dirName(sessionRoot || directory)`.
- Wired into all three hook runtimes — `hook.ts`, `retain-hook.ts`, `session-start.ts` — each after its `cfg.disabled` gate, so a disabled plugin writes no temp file.

### What deliberately does not change

Each is pinned by a test:

- **git resolution still wins first.** A session started in a plain directory that then works inside a repo still gets that repo's bank. The session root is a rescue for what git cannot name, never an override — the L113-115 rule stands.
- **`mapPathToBank` still overrides everything.**
- **`{project}` stays on the live cwd.** It is documented as the working-directory basename and is the escape hatch for anyone who *wants* a bank per directory.

As a side benefit this also gives the non-Claude harnesses the rescue `CLAUDE_PROJECT_DIR` provides today: a `cd /tmp` to run something no longer renames a repo's bank after the directory it landed in.

## Sibling coverage

The persistent-plugin harnesses (dsh, opencode, Kilo, Cline, Prime Agent) need no change — `RuntimeCore` captures `projectDir` once at construction, and `mcp-server.ts` resolves `cwd` once per process. The one place that cannot use a session root is the Antigravity **status line**: its documented state payload carries no conversation id, so there is no key to look one up by. That is now commented at the call site; it is display-only, since that command never calls the API, so nothing is retained or created under the name it shows.

`retainTags` / `retainMetadata` take the session root too, so a stamped `{gitProject}` names the project its bank id does.

## Tests

- `bank-missing-dir.test.ts` — the reported repro (`plain` → `analysis` → `analysis/evidence` all yielding one bank), plus each non-regression boundary above and the harness-neutral `cd`-out-of-repo case on `codex`.
- `session-cache.test.ts` — `sessionRootDir` pins across calls, keeps sessions separate, survives the prompt hook's session-cache rewrite, and falls back to the live directory without a session id.
- `retain-stamp.test.ts` — `{gitProject}` follows the session root while `{project}` does not.

556 passed, 23 skipped. `tsc` clean, `./scripts/hooks/lint.sh` clean, `generate-docs-skill.sh` re-run. README and `docs-integrations/coding-agents.md` updated.
