### PR TITLE
feat(memory-defense): detect international and Chinese PII

### DIFF
--- a/hindsight-api-slim/hindsight_api/extensions/memory_defense.py
+++ b/hindsight-api-slim/hindsight_api/extensions/memory_defense.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 import logging
 import re
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import date
 from enum import Enum
 
 from hindsight_api.extensions.base import Extension
@@ -219,7 +221,53 @@ _REDACTION_PATTERNS: list[tuple[str, str]] = [
     # --- Private keys & generic credentials ---
     ("private_key_pem", r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY( BLOCK)?-----"),
     ("jwt", _ascii_token_pattern(r"eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}")),
-    # --- PII (US-centric defaults; can be tuned per deployment) ---
+    # --- PII ---
+    # These patterns use explicit ASCII lookarounds instead of ``\b`` so a
+    # value immediately next to CJK text is still detected. Name and address
+    # matching is intentionally context-bound to reduce false positives.
+    (
+        "email",
+        r"(?<![A-Za-z0-9._%+-])[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@"
+        r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
+        r"(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+"
+        r"(?![A-Za-z0-9._%+-])",
+    ),
+    (
+        "phone_cn",
+        _ascii_token_pattern(r"(?:(?:\+|00)86[ -]?)?1[3-9](?:[ -]?\d){9}"),
+    ),
+    (
+        "phone_international",
+        _ascii_token_pattern(r"(?:\+[1-9]\d{0,2}|00[1-9]\d{0,2})(?:[ .()-]*\d){6,14}"),
+    ),
+    (
+        "id_cn",
+        _ascii_token_pattern(
+            r"[1-9]\d{5}(?:18|19|20)\d{2}"
+            r"(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])\d{3}[\dXx]"
+        ),
+    ),
+    (
+        "bank_card_cn",
+        _ascii_token_pattern(r"62(?:[ -]?\d){14,17}"),
+    ),
+    (
+        "person_name",
+        _ascii_token_pattern(
+            r"(?i:(?:full[ -]?name|name|contact|recipient|"
+            r"客户姓名|姓名|联系人|收件人)[ \t:：]+"
+            r"(?:[\u4e00-\u9fff]{2,4}|[A-Z][a-z]+(?:[ \t]+[A-Z][a-z]+){0,2}))"
+        ),
+    ),
+    (
+        "address",
+        _ascii_token_pattern(
+            r"(?im:(?:(?:^|(?<=[\r\n]))[ \t]*address[ \t:：]+|"
+            r"(?:home[ -]?address|shipping[ -]?address|postal[ -]?address|"
+            r"收件地址|收货地址|联系地址|(?<![\u4e00-\u9fff])(?:地址|住址))[ \t:：]+)"
+            r"[^\r\n;；。.!！？]{4,160}(?<![ \t,，]))"
+        ),
+    ),
     # NOTE: credit_card regex is intentionally narrowed to 13-19 digits with
     # exact separators to reduce false positives on long product IDs.
     ("credit_card", _ascii_token_pattern(r"(?:\d{4}[ -]?){3}\d{1,4}")),
@@ -230,6 +278,58 @@ _REDACTION_PATTERNS: list[tuple[str, str]] = [
 _COMPILED_REDACTIONS: list[tuple[str, re.Pattern]] = [
     (label, re.compile(pattern)) for label, pattern in _REDACTION_PATTERNS
 ]
+
+_CN_ID_WEIGHTS = (7, 9, 10, 5, 8, 4, 2, 1, 6, 3, 7, 9, 10, 5, 8, 4, 2)
+_CN_ID_CHECK_CODES = "10X98765432"
+
+
+def _is_valid_cn_id(value: str) -> bool:
+    """Validate the birth date and ISO 7064 checksum of a PRC ID number."""
+    normalized = value.upper()
+    try:
+        birth_date = date(int(normalized[6:10]), int(normalized[10:12]), int(normalized[12:14]))
+    except ValueError:
+        return False
+    if birth_date > date.today():
+        return False
+
+    checksum_index = sum(int(digit) * weight for digit, weight in zip(normalized[:17], _CN_ID_WEIGHTS)) % 11
+    return normalized[-1] == _CN_ID_CHECK_CODES[checksum_index]
+
+
+def _is_luhn_valid(value: str) -> bool:
+    """Validate a separated or contiguous payment-card number with Luhn."""
+    digits = [int(char) for char in value if char.isdigit()]
+    total = 0
+    for index, digit in enumerate(reversed(digits)):
+        if index % 2:
+            digit *= 2
+            if digit > 9:
+                digit -= 9
+        total += digit
+    return total % 10 == 0
+
+
+def _is_generic_credit_card_candidate(value: str) -> bool:
+    """Do not let invalid 16-digit UnionPay candidates fall through as credit cards."""
+    digits = "".join(char for char in value if char.isdigit())
+    return not (len(digits) == 16 and digits.startswith("62"))
+
+
+_REDACTION_VALIDATORS: dict[str, Callable[[str], bool]] = {
+    "id_cn": _is_valid_cn_id,
+    "bank_card_cn": _is_luhn_valid,
+    "credit_card": _is_generic_credit_card_candidate,
+}
+_FULLY_MASKED_REDACTION_TYPES = {
+    "email",
+    "phone_cn",
+    "phone_international",
+    "id_cn",
+    "bank_card_cn",
+    "person_name",
+    "address",
+}
 
 
 def apply_redaction(content: str) -> RedactionResult:
@@ -251,7 +351,11 @@ def apply_redaction(content: str) -> RedactionResult:
     matched: list[str] = []
     hits: list[dict] = []
     for label, pattern in _COMPILED_REDACTIONS:
-        raw_hits = pattern.findall(content)
+        validator = _REDACTION_VALIDATORS.get(label)
+        if validator is None:
+            raw_hits = pattern.findall(content)
+        else:
+            raw_hits = [match.group(0) for match in pattern.finditer(content) if validator(match.group(0))]
         if not raw_hits:
             continue
         if label not in matched:
@@ -268,8 +372,15 @@ def apply_redaction(content: str) -> RedactionResult:
                 raw_str = raw
             if not raw_str:
                 continue
-            hits.append({"detector": label, "preview": _fingerprint_value(raw_str)})
-        content = pattern.sub(f"[REDACTED:{label}]", content)
+            preview = "[redacted]" if label in _FULLY_MASKED_REDACTION_TYPES else _fingerprint_value(raw_str)
+            hits.append({"detector": label, "preview": preview})
+        if validator is None:
+            content = pattern.sub(f"[REDACTED:{label}]", content)
+        else:
+            content = pattern.sub(
+                lambda match: f"[REDACTED:{label}]" if validator(match.group(0)) else match.group(0),
+                content,
+            )
     return RedactionResult(content=content, matched_types=matched, hits=hits)
 
 

--- a/hindsight-api-slim/tests/test_memory_defense.py
+++ b/hindsight-api-slim/tests/test_memory_defense.py
@@ -67,11 +67,18 @@ _BOUNDARY_REDACTION_SAMPLES = {
     "telegram_bot": "12345678:" + "A" * 35,
     "shopify_token": "shpat_" + "a" * 32,
     "jwt": "eyJ" + "A" * 10 + ".eyJ" + "A" * 10 + "." + "A" * 10,
+    "phone_cn": "13800138000",
+    "phone_international": "+1 (415) 555-0132",
+    "id_cn": "990000200001010012",
+    "bank_card_cn": "6217000000000000004",
+    "person_name": "姓名：张三",
+    "address": "收件地址：北京市海淀区示例路1号",
     "credit_card": "4111 1111 1111 1111",
     "ssn_us": "123-45-6789",
 }
 
 _NON_BOUNDARY_REDACTION_SAMPLES = {
+    "email": "alice@example.com",
     "aws_secret_key": "aws_secret_access_key=" + "A" * 40,
     "slack_webhook": "https://hooks.slack.com/services/T" + "A" * 8 + "/B" + "A" * 8 + "/" + "A" * 20,
     "db_url_postgres": "postgresql://user:password@localhost/db",
@@ -217,6 +224,91 @@ def test_apply_redaction_multiple_hits_per_pattern() -> None:
     assert len(gh_hits) == 2
     previews = {h["preview"] for h in gh_hits}
     assert previews == {"ghp_...AAAA", "ghp_...BBBB"}
+
+
+@pytest.mark.parametrize(
+    ("label", "content", "sensitive_value"),
+    [
+        ("email", "邮箱：alice@example.com", "alice@example.com"),
+        ("phone_cn", "请联系13800138000", "13800138000"),
+        ("phone_cn", "请联系+86 138-0013-8000", "+86 138-0013-8000"),
+        ("phone_international", "Call +1 (415) 555-0132 for support.", "+1 (415) 555-0132"),
+        ("phone_international", "Call 0044 20 7946 0958 for support.", "0044 20 7946 0958"),
+        ("id_cn", "身份证号：990000200001010012", "990000200001010012"),
+        ("bank_card_cn", "银行卡：6217000000000000004", "6217000000000000004"),
+        ("bank_card_cn", "银行卡：6217000000000006", "6217000000000006"),
+        ("person_name", "姓名：张三", "张三"),
+        ("person_name", "Contact: Alice Smith", "Alice Smith"),
+        ("address", "收件地址：北京市海淀区示例路1号", "北京市海淀区示例路1号"),
+        ("address", "Shipping address: 123 Example Street", "123 Example Street"),
+    ],
+)
+def test_apply_redaction_detects_locale_aware_and_contextual_pii(
+    label: str, content: str, sensitive_value: str
+) -> None:
+    result = apply_redaction(content)
+
+    assert f"[REDACTED:{label}]" in result.content
+    assert result.matched_types == [label]
+    assert sensitive_value not in result.content
+    assert result.hits == [{"detector": label, "preview": "[redacted]"}]
+
+
+@pytest.mark.parametrize(
+    ("content", "sensitive_value"),
+    [
+        (
+            "Shipping address: 123 Main St, Apt 4, Springfield, IL 62704",
+            "123 Main St, Apt 4, Springfield, IL 62704",
+        ),
+        (
+            "收件地址：北京市海淀区中关村大街1号，3单元402室，北京市100080",
+            "北京市海淀区中关村大街1号，3单元402室，北京市100080",
+        ),
+        ("Address: 123 Example Street, Suite 4", "123 Example Street, Suite 4"),
+    ],
+)
+def test_apply_redaction_covers_multi_component_addresses(content: str, sensitive_value: str) -> None:
+    result = apply_redaction(content)
+
+    assert result.content == "[REDACTED:address]"
+    assert result.matched_types == ["address"]
+    assert sensitive_value not in result.content
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "身份证号：990000200002300014",  # invalid calendar date
+        "身份证号：990000200001010013",  # invalid checksum
+        "银行卡：6217000000000000005",  # invalid Luhn checksum
+        "银行卡：6217000000000000",  # invalid 16-digit card must not fall through to credit_card
+    ],
+)
+def test_apply_redaction_rejects_invalid_cn_identity_and_bank_numbers(content: str) -> None:
+    result = apply_redaction(content)
+
+    assert result.content == content
+    assert result.matched_types == []
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "这是普通中文文本，不应被姓名或地址规则匹配。",
+        "地址说明：这里不是收件地址字段。",
+        "username: Alice",
+        "server address: localhost",
+        "IP address: 192.0.2.1",
+        "nameplate and addressable resources are technical terms.",
+        "订单编号 6217000000000000004A 不应被识别为银行卡号。",
+    ],
+)
+def test_apply_redaction_avoids_contextual_pii_false_positives(content: str) -> None:
+    result = apply_redaction(content)
+
+    assert result.content == content
+    assert result.matched_types == []
 
 
 # ---------------------------------------------------------------------------

--- a/hindsight-control-plane/src/messages/de.json
+++ b/hindsight-control-plane/src/messages/de.json
@@ -453,7 +453,7 @@
     "memoryDefenseAction_redact": "Schwärzen",
     "memoryDefenseAction_block": "Blockieren",
     "memoryDefenseSecretLeakTitle": "Geheimnislecks verhindern",
-    "memoryDefenseSecretLeakDescription": "Gespeicherte Inhalte auf Geheimnisse prüfen. 45 Muster für gängige Anbieter-Schlüssel, AWS und persönliche Daten.",
+    "memoryDefenseSecretLeakDescription": "Gespeicherte Inhalte auf Geheimnisse prüfen. 52 Muster für gängige Anbieter-Schlüssel, AWS und persönliche Daten.",
     "memoryDefenseEnterpriseTitle": "Memory Defense Enterprise",
     "memoryDefenseEnterpriseSubtitle": "Mehr erkennen, intelligenter redigieren, alles auditieren — verfügbar in Hindsight Cloud.",
     "memoryDefenseEnterpriseFeatureDetectSecrets": "Erweiterte Geheimnis-Erkennung: 200+ Muster für Anbieter-Schlüssel, AWS, GitHub und CI-Token",

--- a/hindsight-control-plane/src/messages/en.json
+++ b/hindsight-control-plane/src/messages/en.json
@@ -453,7 +453,7 @@
     "memoryDefenseAction_redact": "Redact",
     "memoryDefenseAction_block": "Block",
     "memoryDefenseSecretLeakTitle": "Secret leak prevention",
-    "memoryDefenseSecretLeakDescription": "Scan retained content for secrets. 45 patterns covering common provider keys, AWS, and PII.",
+    "memoryDefenseSecretLeakDescription": "Scan retained content for secrets. 52 patterns covering common provider keys, AWS, and PII.",
     "memoryDefenseEnterpriseTitle": "Memory Defense Enterprise",
     "memoryDefenseEnterpriseSubtitle": "Detect more, redact smarter, and audit everything — available in Hindsight Cloud.",
     "memoryDefenseEnterpriseFeatureDetectSecrets": "Advanced secret detection: 200+ patterns covering provider keys, AWS, GitHub, and CI tokens",

--- a/hindsight-control-plane/src/messages/es.json
+++ b/hindsight-control-plane/src/messages/es.json
@@ -453,7 +453,7 @@
     "memoryDefenseAction_redact": "Redactar",
     "memoryDefenseAction_block": "Bloquear",
     "memoryDefenseSecretLeakTitle": "Prevención de fugas de secretos",
-    "memoryDefenseSecretLeakDescription": "Analiza el contenido retenido en busca de secretos. 45 patrones que cubren claves comunes de proveedores, AWS e información personal.",
+    "memoryDefenseSecretLeakDescription": "Analiza el contenido retenido en busca de secretos. 52 patrones que cubren claves comunes de proveedores, AWS e información personal.",
     "memoryDefenseEnterpriseTitle": "Memory Defense Enterprise",
     "memoryDefenseEnterpriseSubtitle": "Detecta más, redacta más inteligentemente y audita todo: disponible en Hindsight Cloud.",
     "memoryDefenseEnterpriseFeatureDetectSecrets": "Detección avanzada de secretos: más de 200 patrones que cubren claves de proveedores, AWS, GitHub y tokens de CI",

--- a/hindsight-control-plane/src/messages/fr.json
+++ b/hindsight-control-plane/src/messages/fr.json
@@ -453,7 +453,7 @@
     "memoryDefenseAction_redact": "Censurer",
     "memoryDefenseAction_block": "Bloquer",
     "memoryDefenseSecretLeakTitle": "Prévention des fuites de secrets",
-    "memoryDefenseSecretLeakDescription": "Analyse le contenu retenu à la recherche de secrets. 45 motifs couvrant les clés de fournisseurs courants, AWS et les informations personnelles.",
+    "memoryDefenseSecretLeakDescription": "Analyse le contenu retenu à la recherche de secrets. 52 motifs couvrant les clés de fournisseurs courants, AWS et les informations personnelles.",
     "memoryDefenseEnterpriseTitle": "Memory Defense Enterprise",
     "memoryDefenseEnterpriseSubtitle": "Détectez davantage, expurgez plus intelligemment et auditez tout — disponible dans Hindsight Cloud.",
     "memoryDefenseEnterpriseFeatureDetectSecrets": "Détection avancée de secrets : plus de 200 motifs couvrant les clés de fournisseurs, AWS, GitHub et tokens CI",

--- a/hindsight-control-plane/src/messages/ja.json
+++ b/hindsight-control-plane/src/messages/ja.json
@@ -453,7 +453,7 @@
     "memoryDefenseAction_redact": "マスク",
     "memoryDefenseAction_block": "ブロック",
     "memoryDefenseSecretLeakTitle": "シークレット漏洩防止",
-    "memoryDefenseSecretLeakDescription": "保持されたコンテンツのシークレットをスキャンします。一般的なプロバイダーキー、AWS、個人情報をカバーする45パターン。",
+    "memoryDefenseSecretLeakDescription": "保持されたコンテンツのシークレットをスキャンします。一般的なプロバイダーキー、AWS、個人情報をカバーする52パターン。",
     "memoryDefenseEnterpriseTitle": "Memory Defense Enterprise",
     "memoryDefenseEnterpriseSubtitle": "より多くを検出し、よりスマートに編集し、すべてを監査 — Hindsight Cloudで利用可能。",
     "memoryDefenseEnterpriseFeatureDetectSecrets": "高度なシークレット検出:プロバイダーキー、AWS、GitHub、CIトークンをカバーする200以上のパターン",

--- a/hindsight-control-plane/src/messages/ko.json
+++ b/hindsight-control-plane/src/messages/ko.json
@@ -453,7 +453,7 @@
     "memoryDefenseAction_redact": "마스킹",
     "memoryDefenseAction_block": "차단",
     "memoryDefenseSecretLeakTitle": "시크릿 유출 방지",
-    "memoryDefenseSecretLeakDescription": "보존된 콘텐츠에서 시크릿을 검사합니다. 일반적인 공급자 키, AWS, 개인 정보를 포함하는 45개 패턴.",
+    "memoryDefenseSecretLeakDescription": "보존된 콘텐츠에서 시크릿을 검사합니다. 일반적인 공급자 키, AWS, 개인 정보를 포함하는 52개 패턴.",
     "memoryDefenseEnterpriseTitle": "Memory Defense Enterprise",
     "memoryDefenseEnterpriseSubtitle": "더 많이 감지하고, 더 똑똑하게 편집하며, 모든 것을 감사하세요 — Hindsight Cloud에서 사용 가능.",
     "memoryDefenseEnterpriseFeatureDetectSecrets": "고급 시크릿 감지: 공급자 키, AWS, GitHub, CI 토큰을 포함하는 200개 이상의 패턴",

--- a/hindsight-control-plane/src/messages/pt.json
+++ b/hindsight-control-plane/src/messages/pt.json
@@ -453,7 +453,7 @@
     "memoryDefenseAction_redact": "Redigir",
     "memoryDefenseAction_block": "Bloquear",
     "memoryDefenseSecretLeakTitle": "Prevenção de vazamento de segredos",
-    "memoryDefenseSecretLeakDescription": "Verifica o conteúdo retido em busca de segredos. 45 padrões cobrindo chaves comuns de provedores, AWS e informações pessoais.",
+    "memoryDefenseSecretLeakDescription": "Verifica o conteúdo retido em busca de segredos. 52 padrões cobrindo chaves comuns de provedores, AWS e informações pessoais.",
     "memoryDefenseEnterpriseTitle": "Memory Defense Enterprise",
     "memoryDefenseEnterpriseSubtitle": "Detecte mais, edite com mais inteligência e audite tudo: disponível no Hindsight Cloud.",
     "memoryDefenseEnterpriseFeatureDetectSecrets": "Detecção avançada de segredos: mais de 200 padrões cobrindo chaves de provedores, AWS, GitHub e tokens de CI",

--- a/hindsight-control-plane/src/messages/yue-Hant.json
+++ b/hindsight-control-plane/src/messages/yue-Hant.json
@@ -453,7 +453,7 @@
     "memoryDefenseAction_redact": "遮蔽",
     "memoryDefenseAction_block": "封鎖",
     "memoryDefenseSecretLeakTitle": "密鑰外洩防護",
-    "memoryDefenseSecretLeakDescription": "掃描保留內容嘅密鑰。45 種樣式涵蓋常見供應商金鑰、AWS 同個人資料。",
+    "memoryDefenseSecretLeakDescription": "掃描保留內容嘅密鑰。52 種樣式涵蓋常見供應商金鑰、AWS 同個人資料。",
     "memoryDefenseEnterpriseTitle": "Memory Defense Enterprise",
     "memoryDefenseEnterpriseSubtitle": "偵測更多、智能編輯、全面稽核 — Hindsight Cloud 提供。",
     "memoryDefenseEnterpriseFeatureDetectSecrets": "進階密鑰偵測:200+ 種樣式,涵蓋供應商金鑰、AWS、GitHub 同 CI 權杖",

--- a/hindsight-control-plane/src/messages/zh-CN.json
+++ b/hindsight-control-plane/src/messages/zh-CN.json
@@ -453,7 +453,7 @@
     "memoryDefenseAction_redact": "脱敏",
     "memoryDefenseAction_block": "拦截",
     "memoryDefenseSecretLeakTitle": "密钥泄露防护",
-    "memoryDefenseSecretLeakDescription": "扫描保留内容中的密钥。45 种模式,涵盖常见提供商密钥、AWS 和个人信息。",
+    "memoryDefenseSecretLeakDescription": "扫描保留内容中的密钥。52 种模式,涵盖常见提供商密钥、AWS 和个人信息。",
     "memoryDefenseEnterpriseTitle": "Memory Defense Enterprise",
     "memoryDefenseEnterpriseSubtitle": "检测更多、智能编辑、全面审计 — Hindsight Cloud 中提供。",
     "memoryDefenseEnterpriseFeatureDetectSecrets": "高级密钥检测:200+ 模式,涵盖提供商密钥、AWS、GitHub 和 CI 令牌",

--- a/hindsight-control-plane/src/messages/zh-TW.json
+++ b/hindsight-control-plane/src/messages/zh-TW.json
@@ -453,7 +453,7 @@
     "memoryDefenseAction_redact": "去敏",
     "memoryDefenseAction_block": "阻擋",
     "memoryDefenseSecretLeakTitle": "密鑰外洩防護",
-    "memoryDefenseSecretLeakDescription": "掃描保留內容中的密鑰。45 種模式涵蓋常見供應商金鑰、AWS 與個人資訊。",
+    "memoryDefenseSecretLeakDescription": "掃描保留內容中的密鑰。52 種模式涵蓋常見供應商金鑰、AWS 與個人資訊。",
     "memoryDefenseEnterpriseTitle": "Memory Defense Enterprise",
     "memoryDefenseEnterpriseSubtitle": "偵測更多、智能編輯、全面稽核 — Hindsight Cloud 提供。",
     "memoryDefenseEnterpriseFeatureDetectSecrets": "進階密鑰偵測:200+ 種樣式,涵蓋供應商金鑰、AWS、GitHub 與 CI 權杖",

--- a/hindsight-docs/docs/developer/memory-defense/index.md
+++ b/hindsight-docs/docs/developer/memory-defense/index.md
@@ -4,7 +4,7 @@ sidebar_position: 95
 
 # Memory Defense
 
-Hindsight scrubs secrets and PII from retain content using a 45-pattern regex set. Each match is replaced with a `[REDACTED:type]` marker before content reaches memory units or the document body. The feature is configured per bank and disabled by default.
+Hindsight scrubs secrets and PII from retain content using a 52-pattern regex set. Each match is replaced with a `[REDACTED:type]` marker before content reaches memory units or the document body. The feature is configured per bank and disabled by default.
 
 ## How it works
 
@@ -36,7 +36,7 @@ A minimal policy:
 }
 ```
 
-Once that policy is on a bank, every retain to that bank is screened with the 45 redaction patterns documented below.
+Once that policy is on a bank, every retain to that bank is screened with the 52 redaction patterns documented below.
 
 :::note Existing memories are not retroactively scanned
 Enabling Memory Defense on a bank only affects future retain calls. Memories already in the bank are not re-scanned or modified when you add or change a policy. If you need to scrub a bank that already contains unredacted content, you have to re-ingest the affected memories or remove them manually.
@@ -54,7 +54,7 @@ The same redact/block decisions are also recorded as `memory_defense` entries in
 
 ## Patterns covered
 
-The 45 bundled patterns cover the categories below.
+The 52 bundled patterns cover the categories below.
 
 ### AI and LLM providers
 
@@ -136,9 +136,18 @@ The 45 bundled patterns cover the categories below.
 | `private_key_pem` | `-----BEGIN ... PRIVATE KEY-----` PEM blocks |
 | `jwt` | `eyJ<header>.eyJ<payload>.<signature>` |
 
-### PII (US defaults)
+### PII
 
 | Label | Catches |
 |---|---|
+| `email` | Standard email address formats |
+| `phone_cn` | Mainland China mobile numbers, including `+86` and `0086` prefixes |
+| `phone_international` | International numbers with a `+` or `00` country prefix |
+| `id_cn` | Mainland China ID numbers with a valid birth date and checksum |
+| `bank_card_cn` | Mainland China `62`-prefixed bank cards with a valid Luhn checksum |
+| `person_name` | Chinese or English names following an explicit name or contact label |
+| `address` | Postal addresses following an explicit address label |
 | `credit_card` | 13 to 19 digits with regular separators |
 | `ssn_us` | `123-45-6789` shape |
+
+Name and address detection is deliberately context-bound. Unlabelled names and prose that happens to contain location words are not matched, which keeps the default local detector from redacting ordinary conversation text.

--- a/hindsight-docs/versioned_docs/version-0.9/developer/memory-defense/index.md
+++ b/hindsight-docs/versioned_docs/version-0.9/developer/memory-defense/index.md
@@ -4,7 +4,7 @@ sidebar_position: 95
 
 # Memory Defense
 
-Hindsight scrubs secrets and PII from retain content using a 45-pattern regex set. Each match is replaced with a `[REDACTED:type]` marker before content reaches memory units or the document body. The feature is configured per bank and disabled by default.
+Hindsight scrubs secrets and PII from retain content using a 52-pattern regex set. Each match is replaced with a `[REDACTED:type]` marker before content reaches memory units or the document body. The feature is configured per bank and disabled by default.
 
 ## How it works
 
@@ -36,7 +36,7 @@ A minimal policy:
 }
 ```
 
-Once that policy is on a bank, every retain to that bank is screened with the 45 redaction patterns documented below.
+Once that policy is on a bank, every retain to that bank is screened with the 52 redaction patterns documented below.
 
 :::note Existing memories are not retroactively scanned
 Enabling Memory Defense on a bank only affects future retain calls. Memories already in the bank are not re-scanned or modified when you add or change a policy. If you need to scrub a bank that already contains unredacted content, you have to re-ingest the affected memories or remove them manually.
@@ -54,7 +54,7 @@ The same redact/block decisions are also recorded as `memory_defense` entries in
 
 ## Patterns covered
 
-The 45 bundled patterns cover the categories below.
+The 52 bundled patterns cover the categories below.
 
 ### AI and LLM providers
 
@@ -136,9 +136,18 @@ The 45 bundled patterns cover the categories below.
 | `private_key_pem` | `-----BEGIN ... PRIVATE KEY-----` PEM blocks |
 | `jwt` | `eyJ<header>.eyJ<payload>.<signature>` |
 
-### PII (US defaults)
+### PII
 
 | Label | Catches |
 |---|---|
+| `email` | Standard email address formats |
+| `phone_cn` | Mainland China mobile numbers, including `+86` and `0086` prefixes |
+| `phone_international` | International numbers with a `+` or `00` country prefix |
+| `id_cn` | Mainland China ID numbers with a valid birth date and checksum |
+| `bank_card_cn` | Mainland China `62`-prefixed bank cards with a valid Luhn checksum |
+| `person_name` | Chinese or English names following an explicit name or contact label |
+| `address` | Postal addresses following an explicit address label |
 | `credit_card` | 13 to 19 digits with regular separators |
 | `ssn_us` | `123-45-6789` shape |
+
+Name and address detection is deliberately context-bound. Unlabelled names and prose that happens to contain location words are not matched, which keeps the default local detector from redacting ordinary conversation text.

--- a/skills/hindsight-docs/references/developer/memory-defense/index.md
+++ b/skills/hindsight-docs/references/developer/memory-defense/index.md
@@ -4,7 +4,7 @@ sidebar_position: 95
 
 # Memory Defense
 
-Hindsight scrubs secrets and PII from retain content using a 45-pattern regex set. Each match is replaced with a `[REDACTED:type]` marker before content reaches memory units or the document body. The feature is configured per bank and disabled by default.
+Hindsight scrubs secrets and PII from retain content using a 52-pattern regex set. Each match is replaced with a `[REDACTED:type]` marker before content reaches memory units or the document body. The feature is configured per bank and disabled by default.
 
 ## How it works
 
@@ -36,7 +36,7 @@ A minimal policy:
 }
 ```
 
-Once that policy is on a bank, every retain to that bank is screened with the 45 redaction patterns documented below.
+Once that policy is on a bank, every retain to that bank is screened with the 52 redaction patterns documented below.
 
 :::note Existing memories are not retroactively scanned
 Enabling Memory Defense on a bank only affects future retain calls. Memories already in the bank are not re-scanned or modified when you add or change a policy. If you need to scrub a bank that already contains unredacted content, you have to re-ingest the affected memories or remove them manually.
@@ -54,7 +54,7 @@ The same redact/block decisions are also recorded as `memory_defense` entries in
 
 ## Patterns covered
 
-The 45 bundled patterns cover the categories below.
+The 52 bundled patterns cover the categories below.
 
 ### AI and LLM providers
 
@@ -136,9 +136,18 @@ The 45 bundled patterns cover the categories below.
 | `private_key_pem` | `-----BEGIN ... PRIVATE KEY-----` PEM blocks |
 | `jwt` | `eyJ<header>.eyJ<payload>.<signature>` |
 
-### PII (US defaults)
+### PII
 
 | Label | Catches |
 |---|---|
+| `email` | Standard email address formats |
+| `phone_cn` | Mainland China mobile numbers, including `+86` and `0086` prefixes |
+| `phone_international` | International numbers with a `+` or `00` country prefix |
+| `id_cn` | Mainland China ID numbers with a valid birth date and checksum |
+| `bank_card_cn` | Mainland China `62`-prefixed bank cards with a valid Luhn checksum |
+| `person_name` | Chinese or English names following an explicit name or contact label |
+| `address` | Postal addresses following an explicit address label |
 | `credit_card` | 13 to 19 digits with regular separators |
 | `ssn_us` | `123-45-6789` shape |
+
+Name and address detection is deliberately context-bound. Unlabelled names and prose that happens to contain location words are not matched, which keeps the default local detector from redacting ordinary conversation text.


### PR DESCRIPTION
Fixes #3574.
## Summary

- rebase the fix onto the latest upstream `main`
- add redaction patterns for email, Mainland China mobile numbers, international phone numbers, PRC identity numbers, and Mainland China bank cards
- add context-bound Chinese and English person-name and postal-address detection to limit false positives
- cover comma-delimited English and Chinese addresses without truncating persisted PII
- prevent invalid 16-digit `62` candidates from falling through to generic credit-card redaction
- validate PRC birth dates and checksums, validate bank cards with Luhn, and fully mask new PII hit previews
- synchronize all locale catalogs and generated coding-agent documentation

## Testing

- `uv run --no-sync pytest -p no:xdist -o addopts="" tests/test_memory_defense.py -q -k "redaction_samples or redaction_patterns or each_redaction or apply_redaction"` (241 passed, 56 deselected)
- `./scripts/hooks/lint.sh`
- pre-commit hooks
- `node hindsight-docs/scripts/sync-coding-agents-doc.mjs --check`

The DB-backed Memory Defense cases still require a local test database with the current `entities.entity_kind` migration.

