### PR TITLE
fix(engine): give each reranker worker its own CrossEncoder

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -9,6 +9,7 @@ Configuration via environment variables - see hindsight_api.config for all env v
 import asyncio
 import logging
 import threading
+import time
 import warnings
 from abc import ABC, abstractmethod
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -48,8 +49,23 @@ from .tei_retry import tei_retry_delay
 logger = logging.getLogger(__name__)
 
 # Fallback only when the loaded tokenizer does not expose a usable max_length.
-# MiniLM-L-6-v2 reports 512; other CE models may report 256..8192.
+# MiniLM-L-6-v2 reports 512; other CE models may report 256..131072.
 _DEFAULT_CE_MAX_LENGTH = 512
+_CE_MAX_LENGTH_FLOOR = 8
+_CE_MAX_LENGTH_CEILING = 131072
+_OVERFLOW_VALUEERROR_MARKERS = (
+    "Unable to create tensor",
+    "expected sequence of length",
+)
+_QUERY_TRUNCATION_WARN_COOLDOWN_S = 60.0
+_query_truncation_last_warn_at = 0.0
+_bind_tokenizer_lock = threading.Lock()
+
+
+def _is_overflow_value_error(exc: BaseException) -> bool:
+    """True for the known convert_to_tensors / ragged-sequence overflow class."""
+    message = str(exc)
+    return any(marker in message for marker in _OVERFLOW_VALUEERROR_MARKERS)
 
 
 def resolve_ce_max_length(model: Any, default: int = _DEFAULT_CE_MAX_LENGTH) -> int:
@@ -65,8 +81,24 @@ def resolve_ce_max_length(model: Any, default: int = _DEFAULT_CE_MAX_LENGTH) -> 
     for val in candidates:
         if isinstance(val, bool):
             continue
-        if isinstance(val, (int, float)) and 8 <= int(val) <= 8192:
-            return int(val)
+        if not isinstance(val, (int, float)):
+            continue
+        n = int(val)
+        if n < _CE_MAX_LENGTH_FLOOR:
+            logger.warning(
+                "Reranker: model_max_length=%s below floor %s; trying next candidate",
+                n,
+                _CE_MAX_LENGTH_FLOOR,
+            )
+            continue
+        if n > _CE_MAX_LENGTH_CEILING:
+            logger.warning(
+                "Reranker: model_max_length=%s exceeds ceiling %s; clamping",
+                n,
+                _CE_MAX_LENGTH_CEILING,
+            )
+            return _CE_MAX_LENGTH_CEILING
+        return n
     return default
 
 
@@ -118,10 +150,25 @@ def _bind_tokenizer_max_length(model: Any, max_length: int) -> None:
     tok = getattr(model, "tokenizer", None)
     if tok is None or isinstance(tok, TokenizerMaxLengthWrapper):
         return
-    try:
-        model.tokenizer = TokenizerMaxLengthWrapper(tok, max_length)
-    except Exception:
-        pass
+    with _bind_tokenizer_lock:
+        tok = getattr(model, "tokenizer", None)
+        if tok is None or isinstance(tok, TokenizerMaxLengthWrapper):
+            return
+        try:
+            model.tokenizer = TokenizerMaxLengthWrapper(tok, max_length)
+        except Exception as exc:
+            logger.warning("Reranker: could not bind tokenizer wrapper: %s", exc)
+
+
+def _warn_query_truncated(max_length: int) -> None:
+    """Warn on oversized queries, then DEBUG for 60s so a busy reranker cannot flood logs."""
+    global _query_truncation_last_warn_at
+    now = time.monotonic()
+    if now - _query_truncation_last_warn_at < _QUERY_TRUNCATION_WARN_COOLDOWN_S:
+        logger.debug("Reranker: query truncated to tokenizer max_length=%s", max_length)
+        return
+    _query_truncation_last_warn_at = now
+    logger.warning("Reranker: query truncated to tokenizer max_length=%s", max_length)
 
 
 class CrossEncoderModel(ABC):
@@ -450,7 +497,12 @@ class LocalSTCrossEncoder(CrossEncoderModel):
         )
 
     def _scores_from_model(self, model: Any, pairs: list[tuple[str, str]]) -> list[float]:
-        """Score pairs with explicit tokenizer truncation. Never raise on overflow."""
+        """Score pairs with tokenizer truncation.
+
+        Known convert_to_tensors overflow ValueErrors retry one-at-a-time; other
+        ValueErrors (shape, dtype, config) propagate. CUDA OOM / TypeError still
+        raise. Failed pairs score ``-inf`` so they cannot outrank a real score.
+        """
         if not pairs:
             return []
         max_len = resolve_ce_max_length(model)
@@ -462,14 +514,13 @@ class LocalSTCrossEncoder(CrossEncoderModel):
         _bind_tokenizer_max_length(model, max_len)
         query = pairs[0][0] if isinstance(pairs[0], (list, tuple)) and pairs[0] else ""
         if query_exceeds_max_length(getattr(model, "tokenizer", None), str(query), max_len):
-            # One warning per predict() request, not per pair.
-            logger.warning(
-                "Reranker: query truncated to tokenizer max_length=%s",
-                max_len,
-            )
+            # First oversized query in a cooldown window is WARNING; later ones DEBUG.
+            _warn_query_truncated(max_len)
         try:
             scores = model.predict(pairs, batch_size=self.batch_size, show_progress_bar=False)
-        except ValueError:
+        except ValueError as exc:
+            if not _is_overflow_value_error(exc):
+                raise
             # Overflow / convert_to_tensors. Do not log the HF message
             # (operators grep "Unable to create tensor" as a crash class).
             logger.warning(
@@ -480,8 +531,10 @@ class LocalSTCrossEncoder(CrossEncoderModel):
             for pair in pairs:
                 try:
                     one = model.predict([pair], batch_size=1, show_progress_bar=False)
-                except ValueError:
-                    scores.append(0.0)
+                except ValueError as one_exc:
+                    if not _is_overflow_value_error(one_exc):
+                        raise
+                    scores.append(float("-inf"))
                     continue
                 one_list = one.tolist() if hasattr(one, "tolist") else list(one)
                 scores.extend(one_list)

--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -8,9 +8,10 @@ Configuration via environment variables - see hindsight_api.config for all env v
 
 import asyncio
 import logging
+import threading
 import warnings
 from abc import ABC, abstractmethod
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any
 
 import httpx
@@ -104,12 +105,20 @@ class LocalSTCrossEncoder(CrossEncoderModel):
     - Small model (80MB)
     - Trained for passage re-ranking
 
-    Uses a dedicated thread pool to limit concurrent CPU-bound work.
+    Uses a dedicated thread pool to limit concurrent CPU-bound work. Each
+    executor thread owns its own CrossEncoder (tokenizer + weights). Sharing
+    one instance across threads races the HuggingFace fast tokenizer
+    (set_truncation_and_padding + encode_batch) and was observed live as
+    ``Unable to create tensor`` wrapping ``'int' object is not callable``.
     """
 
-    # Shared executor across all instances (one model loaded anyway)
+    # Shared executor across LocalSTCrossEncoder wrappers. The executor is the
+    # only shared mutable object - not the CrossEncoder / tokenizer.
     _executor: ThreadPoolExecutor | None = None
     _max_concurrent: int = 4  # Limit concurrent CPU-bound reranking calls
+    # Serializes first-use CrossEncoder() construction so concurrent worker
+    # threads do not race the HuggingFace cache / torch load path.
+    _load_lock = threading.Lock()
 
     def __init__(
         self,
@@ -153,8 +162,13 @@ class LocalSTCrossEncoder(CrossEncoderModel):
         self.bucket_batching = bucket_batching
         self.batch_size = batch_size
         self.allow_mps = allow_mps
+        # Kept for test doubles that inject a stub; production predict never
+        # reads this. A load failure must not fall back to a shared instance.
         self._model = None
+        self._device: str | None = None
         self._device_type: str = "cpu"
+        self._initialized = False
+        self._thread_models = threading.local()
         LocalSTCrossEncoder._max_concurrent = max_concurrent
 
     @property
@@ -165,33 +179,13 @@ class LocalSTCrossEncoder(CrossEncoderModel):
     def blocking_init(self) -> bool:
         return True
 
-    async def initialize(self) -> None:
-        """Load the cross-encoder model and initialize the executor."""
-        if self._model is not None:
-            return
+    def _apply_xlm_compat_patch(self) -> None:
+        """Restore create_position_ids_from_input_ids for transformers 5.x + XLM-R.
 
-        try:
-            from sentence_transformers import CrossEncoder
-        except ImportError:
-            raise ImportError(
-                "sentence-transformers is required for LocalSTCrossEncoder. "
-                "Install it with: pip install sentence-transformers"
-            )
-
-        logger.info(f"Reranker: initializing local provider with model {self.model_name}")
-
-        # Determine device based on hardware availability. We always set
-        # low_cpu_mem_usage=False to prevent lazy loading (meta tensors) which can
-        # cause issues when accelerate is installed but no GPU is available.
-        # Note: We do NOT use device_map because CrossEncoder internally calls .to(device)
-        # after loading, which conflicts with accelerate's device_map handling.
-        # MPS is opt-in (allow_mps) — see engine/local_device.py for why.
-        device = select_local_device(self.force_cpu, self.allow_mps)
-
-        # Patch transformers 5.x compatibility for models using XLM-RoBERTa
-        # (e.g., jina-reranker-v2-base-multilingual). transformers 5.x removed
-        # create_position_ids_from_input_ids as a module-level function; the custom
-        # code in these models still references it. This monkey-patch restores it.
+        transformers 5.x removed that helper as a module-level function; custom
+        code in models such as jina-reranker-v2-base-multilingual still imports
+        it. Best-effort: a missing transformers install is not an init failure.
+        """
         try:
             import transformers.models.xlm_roberta.modeling_xlm_roberta as xlm_module
             from transformers.models.xlm_roberta.modeling_xlm_roberta import XLMRobertaEmbeddings
@@ -206,67 +200,197 @@ class LocalSTCrossEncoder(CrossEncoderModel):
         except Exception:
             pass
 
-        # Suppress verbose transformers warnings during model loading
-        # This suppresses the "UNEXPECTED" warnings from CrossEncoder which are harmless
-        # but look alarming to users (e.g., "embeddings.position_ids | UNEXPECTED")
+    def _ensure_executor(self) -> ThreadPoolExecutor:
+        """Create the class-level pool once. Does not resize an existing pool.
+
+        max_workers stays whatever the first initialize() observed - changing
+        RERANKER_LOCAL_MAX_CONCURRENT after the executor exists is a process
+        restart, same as before this per-thread change.
+        """
+        if LocalSTCrossEncoder._executor is None:
+            LocalSTCrossEncoder._executor = ThreadPoolExecutor(
+                max_workers=LocalSTCrossEncoder._max_concurrent,
+                thread_name_prefix="reranker",
+            )
+        return LocalSTCrossEncoder._executor
+
+    def _pin_eval_and_device(self, model: Any) -> None:
+        """Run to(device)/eval once at load so predict() is not the first writer.
+
+        Sentence-Transformers CrossEncoder.predict still calls these on every
+        batch; after this they are idempotent writes on a thread-private model.
+        """
+        inner = getattr(model, "model", None)
+        target = inner if inner is not None else model
+        device = getattr(model, "device", None)
+        if device is None:
+            device = self._device
+        to_fn = getattr(target, "to", None)
+        if callable(to_fn) and device is not None:
+            to_fn(device)
+        eval_fn = getattr(target, "eval", None)
+        if callable(eval_fn):
+            eval_fn()
+
+    def _load_model_instance(self) -> Any:
+        """Construct one CrossEncoder for the calling thread. Never returns a shared instance."""
+        try:
+            from sentence_transformers import CrossEncoder
+        except ImportError:
+            raise ImportError(
+                "sentence-transformers is required for LocalSTCrossEncoder. "
+                "Install it with: pip install sentence-transformers"
+            )
+
+        device = self._device
+        if device is None:
+            device = select_local_device(self.force_cpu, self.allow_mps)
+            self._device = device
+
+        # Suppress verbose transformers warnings during model loading.
+        # CrossEncoder emits harmless "UNEXPECTED" / missing-key UserWarnings
+        # (e.g. "embeddings.position_ids | UNEXPECTED") that look like failures.
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning)
             warnings.filterwarnings("ignore", message=".*was not found in model state dict.*")
             warnings.filterwarnings("ignore", message=".*UNEXPECTED.*")
 
-            # Also suppress transformers library logging temporarily
             transformers_logger = logging.getLogger("transformers")
             original_level = transformers_logger.level
             transformers_logger.setLevel(logging.ERROR)
 
             try:
-                self._model = CrossEncoder(
+                # low_cpu_mem_usage=False avoids accelerate meta tensors when no
+                # GPU is present. We do not pass device_map: CrossEncoder calls
+                # .to(device) after load, which conflicts with accelerate.
+                model = CrossEncoder(
                     self.model_name,
                     device=device,
                     model_kwargs={"low_cpu_mem_usage": False},
                     trust_remote_code=self.trust_remote_code,
                 )
             finally:
-                # Restore original logging level
                 transformers_logger.setLevel(original_level)
 
-        self._device_type = resolve_model_device_type(self._model)
-
-        # FP16 inference: convert model weights to half precision.
-        # Empirically validated: 27-36% faster on MPS, quality-identical (20/20 overlap).
-        if self.fp16 and self._device_type != "cpu":
-            self._model.model.half()
-            logger.info("Reranker: FP16 inference enabled")
-
-        # Initialize shared executor (limited workers naturally limits concurrency)
-        if LocalSTCrossEncoder._executor is None:
-            LocalSTCrossEncoder._executor = ThreadPoolExecutor(
-                max_workers=LocalSTCrossEncoder._max_concurrent,
-                thread_name_prefix="reranker",
+        if model is None:
+            raise RuntimeError(
+                f"CrossEncoder({self.model_name!r}) returned None; refusing to share another thread's model"
             )
-            logger.info(f"Reranker: local provider initialized (max_concurrent={LocalSTCrossEncoder._max_concurrent})")
-        else:
-            logger.info("Reranker: local provider initialized (using existing executor)")
+
+        self._device_type = resolve_model_device_type(model)
+        if self.fp16 and self._device_type != "cpu":
+            model.model.half()
+            logger.info("Reranker: FP16 inference enabled")
+        self._pin_eval_and_device(model)
+        return model
+
+    def _get_thread_model(self) -> Any:
+        """Return the CrossEncoder owned by this executor thread, loading if needed.
+
+        Load failures raise. This method never returns another thread's instance
+        and never falls back to ``self._model``.
+        """
+        model = getattr(self._thread_models, "model", None)
+        if model is not None:
+            return model
+
+        thread_name = threading.current_thread().name
+        with LocalSTCrossEncoder._load_lock:
+            model = getattr(self._thread_models, "model", None)
+            if model is not None:
+                return model
+            try:
+                model = self._load_model_instance()
+            except ImportError:
+                raise
+            except Exception as exc:
+                raise RuntimeError(
+                    "Failed to create a per-thread LocalSTCrossEncoder instance "
+                    f"for thread {thread_name!r} (model={self.model_name!r}). "
+                    "Refusing to share another thread's model."
+                ) from exc
+            if model is None:
+                raise RuntimeError(
+                    "Failed to create a per-thread LocalSTCrossEncoder instance "
+                    f"for thread {thread_name!r}: loader returned None. "
+                    "Refusing to share another thread's model."
+                )
+            self._thread_models.model = model
+            return model
+
+    def _warmup_executor_threads(self) -> None:
+        """Force every pool thread to exist and load its own instance.
+
+        ThreadPoolExecutor only creates a worker when a task runs on it.
+        Submitting N tasks without a barrier can run them all on one worker
+        (N loads, 1 thread-local). The barrier makes all N workers start
+        before any load, so initialize() fails fast if any instance cannot
+        be created and first recall does not pay 4 cold loads.
+        """
+        executor = LocalSTCrossEncoder._executor
+        if executor is None:
+            raise RuntimeError("Reranker executor missing during per-thread warmup")
+        # The class-level _max_concurrent is last-writer-wins and does not
+        # resize an existing pool (same as before). Warming N>max_workers
+        # tasks on a smaller pool deadlocks the barrier.
+        n = getattr(executor, "_max_workers", LocalSTCrossEncoder._max_concurrent)
+        barrier = threading.Barrier(n)
+
+        def _warmup() -> None:
+            # Bound so a dead worker cannot hang API startup forever.
+            barrier.wait(timeout=600)
+            self._get_thread_model()
+
+        futures: list[Future[None]] = [executor.submit(_warmup) for _ in range(n)]
+        for fut in futures:
+            fut.result()
+
+    async def initialize(self) -> None:
+        """Prepare the executor and load one CrossEncoder per executor thread."""
+        if self._initialized:
+            return
+
+        logger.info(f"Reranker: initializing local provider with model {self.model_name}")
+        # Device is chosen once; each per-thread CrossEncoder is constructed on it.
+        # MPS is opt-in (allow_mps) - see engine/local_device.py for why.
+        self._device = select_local_device(self.force_cpu, self.allow_mps)
+        self._apply_xlm_compat_patch()
+        created_executor = LocalSTCrossEncoder._executor is None
+        self._ensure_executor()
+        self._warmup_executor_threads()
+        self._initialized = True
+        reused = "" if created_executor else ", using existing executor"
+        logger.info(
+            "Reranker: local provider initialized "
+            f"(max_concurrent={LocalSTCrossEncoder._max_concurrent}, "
+            f"per-thread model instances{reused})"
+        )
+
+    def _scores_from_model(self, model: Any, pairs: list[tuple[str, str]]) -> list[float]:
+        scores = model.predict(pairs, batch_size=self.batch_size, show_progress_bar=False)
+        return scores.tolist() if hasattr(scores, "tolist") else list(scores)
 
     def _predict_sync(self, pairs: list[tuple[str, str]]) -> list[float]:
         """Synchronous prediction wrapper for thread pool execution.
+
+        Both the bucket-batching and plain arms score through the calling
+        thread's private CrossEncoder.
 
         Supports two optimizations (controlled via .env):
         - bucket_batching: sort pairs by token length to reduce padding waste (36-54% speedup)
         - batch_size: explicit batch size for predict() calls (MPS optimal: 32)
         """
-
+        model = self._get_thread_model()
         try:
             if self.bucket_batching and len(pairs) > 1:
                 # Sort pairs by approximate token length to create homogeneous batches.
-                # This eliminates padding waste — short pairs aren't padded to the length
+                # This eliminates padding waste - short pairs aren't padded to the length
                 # of the longest pair in the batch. Quality-identical by construction.
                 lengths = [len(pairs[i][0]) + len(pairs[i][1]) for i in range(len(pairs))]
                 sorted_indices = sorted(range(len(pairs)), key=lambda i: lengths[i])
                 sorted_pairs = [pairs[i] for i in sorted_indices]
 
-                sorted_scores = self._model.predict(sorted_pairs, batch_size=self.batch_size, show_progress_bar=False)
-                sorted_scores = sorted_scores.tolist() if hasattr(sorted_scores, "tolist") else list(sorted_scores)
+                sorted_scores = self._scores_from_model(model, sorted_pairs)
 
                 # Restore original order
                 scores = [0.0] * len(pairs)
@@ -274,8 +398,7 @@ class LocalSTCrossEncoder(CrossEncoderModel):
                     scores[orig_idx] = sorted_scores[new_pos]
                 return scores
 
-            scores = self._model.predict(pairs, batch_size=self.batch_size, show_progress_bar=False)
-            return scores.tolist() if hasattr(scores, "tolist") else list(scores)
+            return self._scores_from_model(model, pairs)
         finally:
             release_local_inference_memory(self._device_type)
 
@@ -284,6 +407,8 @@ class LocalSTCrossEncoder(CrossEncoderModel):
         Score query-document pairs for relevance.
 
         Uses a dedicated thread pool with limited workers to prevent CPU thrashing.
+        Forwards overlap across banks because each worker has its own model;
+        a process-wide predict lock would sum per-bank CE times.
 
         Args:
             pairs: List of (query, document) tuples to score
@@ -291,7 +416,7 @@ class LocalSTCrossEncoder(CrossEncoderModel):
         Returns:
             List of relevance scores (raw logits from the model)
         """
-        if self._model is None:
+        if not self._initialized:
             raise RuntimeError("Reranker not initialized. Call initialize() first.")
 
         # Use dedicated executor - limited workers naturally limits concurrency

--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -47,6 +47,82 @@ from .tei_retry import tei_retry_delay
 
 logger = logging.getLogger(__name__)
 
+# Fallback only when the loaded tokenizer does not expose a usable max_length.
+# MiniLM-L-6-v2 reports 512; other CE models may report 256..8192.
+_DEFAULT_CE_MAX_LENGTH = 512
+
+
+def resolve_ce_max_length(model: Any, default: int = _DEFAULT_CE_MAX_LENGTH) -> int:
+    """Read max_length from the loaded model / tokenizer. Do not hard-code 512."""
+    tok = getattr(model, "tokenizer", None)
+    inner = getattr(tok, "_inner", None)
+    candidates = (
+        getattr(model, "max_length", None),
+        getattr(tok, "model_max_length", None),
+        getattr(tok, "_max_length", None),
+        getattr(inner, "model_max_length", None),
+    )
+    for val in candidates:
+        if isinstance(val, bool):
+            continue
+        if isinstance(val, (int, float)) and 8 <= int(val) <= 8192:
+            return int(val)
+    return default
+
+
+def query_exceeds_max_length(tokenizer: Any, query: str, max_length: int) -> bool:
+    """True when tokenising the query without truncation exceeds max_length."""
+    if tokenizer is None or not query:
+        return False
+    encode = getattr(tokenizer, "encode", None)
+    if not callable(encode):
+        return False
+    try:
+        ids = encode(query, add_special_tokens=False, truncation=False)
+    except TypeError:
+        try:
+            ids = encode(query)
+        except Exception:
+            return False
+    except Exception:
+        return False
+    try:
+        return len(ids) > int(max_length)
+    except TypeError:
+        return False
+
+
+class TokenizerMaxLengthWrapper:
+    """Force padding, truncation, and max_length on every tokenizer() call.
+
+    sentence-transformers 5.2.0 CrossEncoder.predict already passes
+    padding=True and truncation=True but omits max_length. A file-sized
+    query then dies in convert_to_tensors (ValueError: Unable to create tensor).
+    """
+
+    def __init__(self, inner: Any, max_length: int) -> None:
+        self._inner = inner
+        self._max_length = int(max_length)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        kwargs.setdefault("padding", True)
+        kwargs.setdefault("truncation", True)
+        kwargs.setdefault("max_length", self._max_length)
+        return self._inner(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+
+def _bind_tokenizer_max_length(model: Any, max_length: int) -> None:
+    tok = getattr(model, "tokenizer", None)
+    if tok is None or isinstance(tok, TokenizerMaxLengthWrapper):
+        return
+    try:
+        model.tokenizer = TokenizerMaxLengthWrapper(tok, max_length)
+    except Exception:
+        pass
+
 
 class CrossEncoderModel(ABC):
     """
@@ -277,6 +353,13 @@ class LocalSTCrossEncoder(CrossEncoderModel):
                 f"CrossEncoder({self.model_name!r}) returned None; refusing to share another thread's model"
             )
 
+        max_len = resolve_ce_max_length(model)
+        try:
+            model.max_length = max_len
+        except Exception:
+            pass
+        _bind_tokenizer_max_length(model, max_len)
+
         self._device_type = resolve_model_device_type(model)
         if self.fp16 and self._device_type != "cpu":
             model.model.half()
@@ -367,7 +450,42 @@ class LocalSTCrossEncoder(CrossEncoderModel):
         )
 
     def _scores_from_model(self, model: Any, pairs: list[tuple[str, str]]) -> list[float]:
-        scores = model.predict(pairs, batch_size=self.batch_size, show_progress_bar=False)
+        """Score pairs with explicit tokenizer truncation. Never raise on overflow."""
+        if not pairs:
+            return []
+        max_len = resolve_ce_max_length(model)
+        try:
+            if getattr(model, "max_length", None) in (None, 0):
+                model.max_length = max_len
+        except Exception:
+            pass
+        _bind_tokenizer_max_length(model, max_len)
+        query = pairs[0][0] if isinstance(pairs[0], (list, tuple)) and pairs[0] else ""
+        if query_exceeds_max_length(getattr(model, "tokenizer", None), str(query), max_len):
+            # One warning per predict() request, not per pair.
+            logger.warning(
+                "Reranker: query truncated to tokenizer max_length=%s",
+                max_len,
+            )
+        try:
+            scores = model.predict(pairs, batch_size=self.batch_size, show_progress_bar=False)
+        except ValueError:
+            # Overflow / convert_to_tensors. Do not log the HF message
+            # (operators grep "Unable to create tensor" as a crash class).
+            logger.warning(
+                "Reranker: batched predict failed; scoring %d pairs one-at-a-time",
+                len(pairs),
+            )
+            scores = []
+            for pair in pairs:
+                try:
+                    one = model.predict([pair], batch_size=1, show_progress_bar=False)
+                except ValueError:
+                    scores.append(0.0)
+                    continue
+                one_list = one.tolist() if hasattr(one, "tolist") else list(one)
+                scores.extend(one_list)
+            return list(scores)
         return scores.tolist() if hasattr(scores, "tolist") else list(scores)
 
     def _predict_sync(self, pairs: list[tuple[str, str]]) -> list[float]:

--- a/hindsight-api-slim/tests/test_local_cross_encoder.py
+++ b/hindsight-api-slim/tests/test_local_cross_encoder.py
@@ -5,8 +5,17 @@ release helper itself is unit-tested in test_local_device.py.
 
 These tests use mocked models — they do not load real SentenceTransformers or
 FlashRank weights, so they run fast in CI without network access.
+
+The MiniLM stress test at the bottom is skip-by-default (HS_RERANKER_STRESS=1).
 """
 
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -29,7 +38,12 @@ class TestLocalSTCrossEncoder:
             batch_size=batch_size,
         )
         # Bypass initialize() — we don't want to download or load real weights.
-        encoder._model = MagicMock()
+        # Production predict never reads _model; the per-thread loader is stubbed
+        # so existing call-count assertions on this mock still work.
+        mock = MagicMock()
+        encoder._model = mock
+        encoder._initialized = True
+        encoder._load_model_instance = lambda: mock
         return encoder
 
     def test_provider_name(self):
@@ -309,3 +323,312 @@ class TestFlashRankCrossEncoder:
 
     def test_default_batch_size_matches_config(self):
         assert FlashRankCrossEncoder().batch_size == DEFAULT_RERANKER_FLASHRANK_BATCH_SIZE
+
+
+# ---------------------------------------------------------------------------
+# Per-thread CrossEncoder isolation (MB1c2)
+# ---------------------------------------------------------------------------
+
+
+class _TrackingStub:
+    """Stub CrossEncoder that records overlapping predict() on THIS instance."""
+
+    def __init__(self, barrier: threading.Barrier | None = None) -> None:
+        self.barrier = barrier
+        self.inside = 0
+        self.max_inside = 0
+        self.thread_ids: list[int] = []
+        self.predict_calls = 0
+        self.seen_pairs: list[list[tuple[str, str]]] = []
+        self._lock = threading.Lock()
+
+    def predict(
+        self,
+        pairs: list[tuple[str, str]],
+        batch_size: int = 32,
+        show_progress_bar: bool = False,
+    ) -> list[float]:
+        del batch_size, show_progress_bar
+        with self._lock:
+            self.inside += 1
+            self.max_inside = max(self.max_inside, self.inside)
+            self.thread_ids.append(threading.get_ident())
+            self.predict_calls += 1
+            self.seen_pairs.append(list(pairs))
+        if self.barrier is not None:
+            self.barrier.wait(timeout=5)
+            # Stay inside predict long enough that a shared instance would show
+            # overlapping callers if they also waited on this barrier.
+            time.sleep(0.05)
+        with self._lock:
+            self.inside -= 1
+        return [_deterministic_score(q, d) for q, d in pairs]
+
+
+def _deterministic_score(query: str, document: str) -> float:
+    """Stable stand-in for a CE logit so identity tests do not need MiniLM."""
+    return float(len(query) + 2 * len(document) + sum(ord(c) for c in document[:8]))
+
+
+class LegacySharedLocalSTCrossEncoder(LocalSTCrossEncoder):
+    """Pre-MB1c2 LocalSTCrossEncoder: one shared model on every executor thread.
+
+    Used so the attacking test goes RED against the old design (parametrized
+    as ``legacy``) without depending on a git checkout of the previous class.
+    """
+
+    async def initialize(self) -> None:
+        if self._initialized:
+            return
+        self._ensure_executor()
+        # One instance, assigned to _model, used by every worker - the race.
+        self._model = self._load_model_instance()
+        if self._model is None:
+            raise RuntimeError("legacy loader returned None")
+        self._initialized = True
+
+    def _predict_sync(self, pairs: list[tuple[str, str]]) -> list[float]:
+        try:
+            if self.bucket_batching and len(pairs) > 1:
+                lengths = [len(pairs[i][0]) + len(pairs[i][1]) for i in range(len(pairs))]
+                sorted_indices = sorted(range(len(pairs)), key=lambda i: lengths[i])
+                sorted_pairs = [pairs[i] for i in sorted_indices]
+                sorted_scores = self._model.predict(sorted_pairs, batch_size=self.batch_size, show_progress_bar=False)
+                sorted_scores = sorted_scores.tolist() if hasattr(sorted_scores, "tolist") else list(sorted_scores)
+                scores = [0.0] * len(pairs)
+                for new_pos, orig_idx in enumerate(sorted_indices):
+                    scores[orig_idx] = sorted_scores[new_pos]
+                return scores
+            scores = self._model.predict(pairs, batch_size=self.batch_size, show_progress_bar=False)
+            return scores.tolist() if hasattr(scores, "tolist") else list(scores)
+        finally:
+            ce_module.release_local_inference_memory(self._device_type)
+
+
+@pytest.fixture
+def isolated_reranker_executor():
+    """Swap the class-level pool so these tests cannot starve a session fixture."""
+    old_executor = LocalSTCrossEncoder._executor
+    old_max = LocalSTCrossEncoder._max_concurrent
+    pool = ThreadPoolExecutor(max_workers=4, thread_name_prefix="reranker-test")
+    LocalSTCrossEncoder._executor = pool
+    LocalSTCrossEncoder._max_concurrent = 4
+    try:
+        yield pool
+    finally:
+        pool.shutdown(wait=True)
+        LocalSTCrossEncoder._executor = old_executor
+        LocalSTCrossEncoder._max_concurrent = old_max
+
+
+def _install_stub_loader(encoder: LocalSTCrossEncoder, make_stub) -> list[_TrackingStub]:
+    created: list[_TrackingStub] = []
+
+    def _load() -> _TrackingStub:
+        stub = make_stub()
+        created.append(stub)
+        return stub
+
+    encoder._load_model_instance = _load  # type: ignore[method-assign]
+    return created
+
+
+class TestLocalSTPerThreadIsolation:
+    """Attacking concurrency tests for the shared-tokenizer defect."""
+
+    @pytest.mark.parametrize(
+        "impl,expect_exclusive",
+        [
+            ("legacy", False),
+            ("current", True),
+        ],
+    )
+    async def test_concurrent_predict_instance_exclusivity(
+        self, isolated_reranker_executor, impl: str, expect_exclusive: bool
+    ):
+        """Under max_workers=4, the current class never interleaves two threads
+        inside the same instance's predict(). The pre-change (legacy) class
+        does - this parametrization goes RED on exclusive if pointed at the
+        old _predict_sync (one shared _model).
+        """
+        n = 4
+        barrier = threading.Barrier(n)
+        cls = LegacySharedLocalSTCrossEncoder if impl == "legacy" else LocalSTCrossEncoder
+        encoder = cls(model_name="test-model", max_concurrent=n)
+        # If production were reverted to ``self._model.predict``, this one
+        # shared stub is what every thread would enter.
+        shared_fallback = _TrackingStub(barrier=barrier)
+        encoder._model = shared_fallback
+
+        created = _install_stub_loader(encoder, lambda: _TrackingStub(barrier=barrier))
+        await encoder.initialize()
+
+        # One pair-list per concurrent call so each worker is inside predict at once.
+        pairs_by_call = [[(f"q{i}", "x" * (10 + i))] for i in range(n)]
+
+        scores = await asyncio.gather(*[encoder.predict(p) for p in pairs_by_call])
+        assert len(scores) == n
+        for batch in scores:
+            assert len(batch) == 1
+
+        if expect_exclusive:
+            assert len(created) == n, created
+            ids = {id(stub) for stub in created}
+            assert len(ids) == n
+            for stub in created:
+                assert stub.max_inside == 1, f"two threads entered the same per-thread instance: {stub.max_inside}"
+                assert len(set(stub.thread_ids)) == 1
+            # Production must not have used the shared fallback even though
+            # _model was planted (that is the old code path).
+            assert shared_fallback.max_inside == 0
+            assert shared_fallback.predict_calls == 0
+        else:
+            # Legacy: one shared instance, four threads inside predict at once.
+            assert encoder._model is shared_fallback or len(created) == 1
+            raced = shared_fallback if shared_fallback.predict_calls else created[0]
+            assert raced.max_inside > 1, (
+                "legacy shared instance did not interleave; the attacking test cannot prove the old race shape"
+            )
+
+    @pytest.mark.parametrize("bucket_batching", [False, True])
+    async def test_plain_and_bucket_arms_use_per_thread_instance(
+        self, isolated_reranker_executor, bucket_batching: bool
+    ):
+        encoder = LocalSTCrossEncoder(
+            model_name="test-model",
+            max_concurrent=4,
+            bucket_batching=bucket_batching,
+        )
+        created = _install_stub_loader(encoder, _TrackingStub)
+        await encoder.initialize()
+
+        pairs = [
+            ("q", "long document " * 10),
+            ("q", "short"),
+            ("q", "medium doc here"),
+        ]
+        scores = await encoder.predict(pairs)
+        assert len(scores) == 3
+        assert len(created) >= 1
+        used = [s for s in created if s.predict_calls]
+        assert len(used) == 1
+        stub = used[0]
+        assert stub.predict_calls == 1
+        if bucket_batching:
+            received = stub.seen_pairs[0]
+            received_lengths = [len(a) + len(b) for a, b in received]
+            assert received_lengths == sorted(received_lengths)
+            # Caller order is restored even though predict saw sorted pairs.
+            assert scores == [_deterministic_score(q, d) for q, d in pairs]
+        else:
+            assert stub.seen_pairs[0] == pairs
+
+    async def test_scores_match_single_instance_path(self, isolated_reranker_executor):
+        encoder = LocalSTCrossEncoder(model_name="test-model", max_concurrent=4)
+        _install_stub_loader(encoder, _TrackingStub)
+        await encoder.initialize()
+
+        pairs = [("what is rust?", "Rust is a language"), ("what is rust?", "Bananas are fruit")]
+        serial = await encoder.predict(pairs)
+
+        concurrent = await asyncio.gather(*[encoder.predict(pairs) for _ in range(4)])
+        for got in concurrent:
+            assert got == serial
+        # Rank order is the same as a single-instance deterministic scorer.
+        expected = [_deterministic_score(q, d) for q, d in pairs]
+        assert serial == expected
+
+    async def test_load_failure_raises_and_does_not_share(self, isolated_reranker_executor):
+        encoder = LocalSTCrossEncoder(model_name="test-model", max_concurrent=4)
+        shared = MagicMock(name="shared-must-not-be-used")
+        encoder._model = shared
+
+        def boom() -> None:
+            raise RuntimeError("simulated HF load failure")
+
+        encoder._load_model_instance = boom  # type: ignore[method-assign]
+
+        with pytest.raises(RuntimeError, match="per-thread LocalSTCrossEncoder|simulated HF load failure"):
+            await encoder.initialize()
+
+        assert encoder._initialized is False
+        shared.predict.assert_not_called()
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await encoder.predict([("q", "d")])
+        shared.predict.assert_not_called()
+
+    async def test_warmup_matches_existing_pool_size_not_later_max(self):
+        """A later LocalSTCrossEncoder(max_concurrent=4) must not barrier-wait
+        on a pool that was created with 2 workers. That hung initialize()
+        before warmup used executor._max_workers.
+        """
+        old_executor = LocalSTCrossEncoder._executor
+        old_max = LocalSTCrossEncoder._max_concurrent
+        pool = ThreadPoolExecutor(max_workers=2, thread_name_prefix="reranker-small")
+        LocalSTCrossEncoder._executor = pool
+        try:
+            encoder = LocalSTCrossEncoder(model_name="test-model", max_concurrent=4)
+            created = _install_stub_loader(encoder, _TrackingStub)
+            await asyncio.wait_for(encoder.initialize(), timeout=5)
+            assert encoder._initialized is True
+            assert len(created) == 2
+        finally:
+            pool.shutdown(wait=True)
+            LocalSTCrossEncoder._executor = old_executor
+            LocalSTCrossEncoder._max_concurrent = old_max
+
+    async def test_load_none_raises_not_fallback(self, isolated_reranker_executor):
+        encoder = LocalSTCrossEncoder(model_name="test-model", max_concurrent=2)
+        shared = MagicMock(name="shared-none-fallback")
+        encoder._model = shared
+        encoder._load_model_instance = lambda: None  # type: ignore[method-assign]
+
+        with pytest.raises(RuntimeError, match="Refusing to share"):
+            await encoder.initialize()
+        assert encoder._initialized is False
+        shared.predict.assert_not_called()
+
+
+_STRESS_REASON = (
+    "Real MiniLM 4x concurrent stress; run with: "
+    "HS_RERANKER_STRESS=1 uv run pytest "
+    "tests/test_local_cross_encoder.py::TestLocalSTMiniLMStress::test_real_minilm_four_concurrent "
+    "-v -n0 --timeout=600"
+)
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(os.environ.get("HS_RERANKER_STRESS") != "1", reason=_STRESS_REASON)
+class TestLocalSTMiniLMStress:
+    async def test_real_minilm_four_concurrent(self, isolated_reranker_executor):
+        """Four overlapping CrossEncoder.predict calls on the real MiniLM.
+
+        This is a soak, not a guaranteed reproduction of the tokenizer race
+        (planner measurement: 0 errors in ~2.5 min). After the fix it must
+        complete without ValueError/TypeError from the tokenizer.
+        """
+        pytest.importorskip("sentence_transformers")
+
+        encoder = LocalSTCrossEncoder(
+            model_name="cross-encoder/ms-marco-MiniLM-L-6-v2",
+            max_concurrent=4,
+            force_cpu=True,
+            batch_size=64,
+            bucket_batching=True,
+        )
+        await encoder.initialize()
+
+        query = ("BRIEF MB1c2 reranker concurrency query about git hooks. " * 20).strip()
+        docs = [f"memory fact {i} about git hooks and guards. " * 15 for i in range(64)]
+        pairs = [(query, doc) for doc in docs]
+
+        results = await asyncio.gather(*[encoder.predict(pairs) for _ in range(4)])
+        assert len(results) == 4
+        for scores in results:
+            assert len(scores) == 64
+            assert all(isinstance(s, float) for s in scores)
+        # Same input, same model family: values should match within float noise.
+        reference = results[0]
+        for other in results[1:]:
+            for a, b in zip(reference, other, strict=True):
+                assert abs(a - b) < 1e-4

--- a/hindsight-api-slim/tests/test_local_cross_encoder.py
+++ b/hindsight-api-slim/tests/test_local_cross_encoder.py
@@ -23,9 +23,11 @@ import pytest
 from hindsight_api.config import DEFAULT_RERANKER_FLASHRANK_BATCH_SIZE
 from hindsight_api.engine import cross_encoder as ce_module
 from hindsight_api.engine.cross_encoder import (
+    _CE_MAX_LENGTH_CEILING,
     FlashRankCrossEncoder,
     LocalSTCrossEncoder,
     TokenizerMaxLengthWrapper,
+    _bind_tokenizer_max_length,
     query_exceeds_max_length,
     resolve_ce_max_length,
 )
@@ -158,6 +160,7 @@ class TestLocalSTCrossEncoder:
         assert query_exceeds_max_length(tok, "short", 512) is False
 
     async def test_long_query_scores_and_warns_once(self, caplog):
+        ce_module._query_truncation_last_warn_at = 0.0
         encoder = self._make_encoder()
         encoder._model.predict.return_value = [0.4, 0.6]
         encoder._model.max_length = None
@@ -221,6 +224,85 @@ class TestLocalSTCrossEncoder:
         assert kwargs["truncation"] is True
         assert kwargs["padding"] is True
         assert kwargs["max_length"] == 512
+
+    def test_scores_from_model_binds_tokenizer_wrapper(self):
+        encoder = self._make_encoder()
+        encoder._model.predict.return_value = [0.22]
+        tok = MagicMock()
+        tok.model_max_length = 512
+        encoder._model.tokenizer = tok
+        encoder._model.max_length = None
+        encoder._scores_from_model(encoder._model, [("short query", "passage " * 600)])
+        assert isinstance(encoder._model.tokenizer, TokenizerMaxLengthWrapper)
+        assert encoder._model.tokenizer._max_length == 512
+
+    async def test_pair_overflow_scores_negative_inf(self):
+        encoder = self._make_encoder()
+        encoder._model.predict.side_effect = [
+            ValueError("Unable to create tensor: activate truncation and/or padding"),
+            ValueError("Unable to create tensor: activate truncation and/or padding"),
+            [0.7],
+        ]
+        scores = await encoder.predict([("q", "a"), ("q", "b")])
+        assert scores[0] == float("-inf")
+        assert scores[1] == 0.7
+
+    async def test_unexpected_value_error_is_reraised(self):
+        encoder = self._make_encoder()
+        encoder._model.predict.side_effect = ValueError("shape mismatch: expected (2, 512)")
+        with pytest.raises(ValueError, match="shape mismatch"):
+            await encoder.predict([("q", "a")])
+
+    async def test_bind_tokenizer_logs_when_tokenizer_is_read_only(self, caplog):
+        class ReadOnlyTokenizerModel:
+            def __init__(self) -> None:
+                self._tok = MagicMock()
+                self._tok.model_max_length = 512
+                self._tok.encode.return_value = [1, 2, 3]
+                self.predict = MagicMock(return_value=[0.5])
+                self.max_length = None
+
+            @property
+            def tokenizer(self) -> MagicMock:
+                return self._tok
+
+        model = ReadOnlyTokenizerModel()
+        encoder = self._make_encoder()
+        encoder._model = model
+        encoder._load_model_instance = lambda: model
+        with caplog.at_level("WARNING", logger="hindsight_api.engine.cross_encoder"):
+            scores = await encoder.predict([("q", "d")])
+        assert scores == [0.5]
+        assert any("could not bind tokenizer wrapper" in r.getMessage() for r in caplog.records)
+
+    def test_resolve_ce_max_length_clamps_out_of_range(self, caplog):
+        model = MagicMock()
+        model.max_length = None
+        model.tokenizer.model_max_length = 999999
+        with caplog.at_level("WARNING", logger="hindsight_api.engine.cross_encoder"):
+            assert resolve_ce_max_length(model) == _CE_MAX_LENGTH_CEILING
+        assert any("clamping" in r.getMessage() for r in caplog.records)
+        model.tokenizer.model_max_length = 4
+        caplog.clear()
+        with caplog.at_level("WARNING", logger="hindsight_api.engine.cross_encoder"):
+            assert resolve_ce_max_length(model) == 512
+        assert any("below floor" in r.getMessage() for r in caplog.records)
+
+    def test_bind_tokenizer_is_idempotent_under_threads(self):
+        model = MagicMock()
+        inner = MagicMock()
+        model.tokenizer = inner
+
+        def bind() -> None:
+            _bind_tokenizer_max_length(model, 512)
+
+        threads = [threading.Thread(target=bind) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        assert isinstance(model.tokenizer, TokenizerMaxLengthWrapper)
+        assert model.tokenizer._inner is inner
 
 
 class TestFlashRankCrossEncoder:

--- a/hindsight-api-slim/tests/test_local_cross_encoder.py
+++ b/hindsight-api-slim/tests/test_local_cross_encoder.py
@@ -25,6 +25,9 @@ from hindsight_api.engine import cross_encoder as ce_module
 from hindsight_api.engine.cross_encoder import (
     FlashRankCrossEncoder,
     LocalSTCrossEncoder,
+    TokenizerMaxLengthWrapper,
+    query_exceeds_max_length,
+    resolve_ce_max_length,
 )
 
 
@@ -138,6 +141,86 @@ class TestLocalSTCrossEncoder:
                 await encoder.predict([("q", "doc")])
 
         assert cleanup_calls == ["cleanup"]
+
+    def test_resolve_ce_max_length_reads_tokenizer_not_hardcoded(self):
+        model = MagicMock()
+        model.max_length = None
+        model.tokenizer.model_max_length = 384
+        assert resolve_ce_max_length(model) == 384
+        model.tokenizer.model_max_length = 512
+        assert resolve_ce_max_length(model) == 512
+
+    def test_query_exceeds_max_length_uses_tokenizer_encode(self):
+        tok = MagicMock()
+        tok.encode.return_value = [1] * 600
+        assert query_exceeds_max_length(tok, "long query", 512) is True
+        tok.encode.return_value = [1, 2, 3]
+        assert query_exceeds_max_length(tok, "short", 512) is False
+
+    async def test_long_query_scores_and_warns_once(self, caplog):
+        encoder = self._make_encoder()
+        encoder._model.predict.return_value = [0.4, 0.6]
+        encoder._model.max_length = None
+        tok = MagicMock()
+        tok.model_max_length = 512
+        tok.encode.return_value = [1] * 2000
+        encoder._model.tokenizer = tok
+        long_query = "x" * 7500
+        with caplog.at_level("WARNING", logger="hindsight_api.engine.cross_encoder"):
+            scores = await encoder.predict([(long_query, "doc-a"), (long_query, "doc-b")])
+        assert scores == [0.4, 0.6]
+        warnings = [r for r in caplog.records if "query truncated" in r.getMessage()]
+        assert len(warnings) == 1
+        assert "512" in warnings[0].getMessage()
+
+    async def test_long_passage_is_scored(self):
+        encoder = self._make_encoder()
+        encoder._model.predict.return_value = [0.22]
+        encoder._model.max_length = None
+        tok = MagicMock()
+        tok.model_max_length = 512
+        tok.encode.return_value = [1, 2, 3]
+        encoder._model.tokenizer = tok
+        long_passage = "passage " * 600
+        scores = await encoder.predict([("short query", long_passage)])
+        assert scores == [0.22]
+        encoder._model.predict.assert_called_once()
+        called_pairs = encoder._model.predict.call_args.args[0]
+        assert called_pairs[0][1] == long_passage
+
+    async def test_short_pairs_unchanged_and_no_truncation_warning(self, caplog):
+        encoder = self._make_encoder()
+        encoder._model.predict.return_value = [0.9, 0.1]
+        encoder._model.max_length = None
+        tok = MagicMock()
+        tok.model_max_length = 512
+        tok.encode.return_value = [1, 2, 3, 4]
+        encoder._model.tokenizer = tok
+        pairs = [("q", "doc-a"), ("q", "doc-b")]
+        with caplog.at_level("WARNING", logger="hindsight_api.engine.cross_encoder"):
+            scores = await encoder.predict(pairs)
+        assert scores == [0.9, 0.1]
+        assert encoder._model.predict.call_args.args[0] == pairs
+        assert not any("query truncated" in r.getMessage() for r in caplog.records)
+
+    async def test_overflow_value_error_does_not_raise(self):
+        encoder = self._make_encoder()
+        encoder._model.predict.side_effect = [
+            ValueError("Unable to create tensor: activate truncation and/or padding"),
+            [0.3],
+            [0.7],
+        ]
+        scores = await encoder.predict([("q", "a"), ("q", "b")])
+        assert scores == [0.3, 0.7]
+
+    def test_tokenizer_wrapper_injects_truncation_and_max_length(self):
+        inner = MagicMock(return_value={"input_ids": [[1, 2]]})
+        wrapped = TokenizerMaxLengthWrapper(inner, 512)
+        wrapped(["pair"], return_tensors="pt")
+        kwargs = inner.call_args.kwargs
+        assert kwargs["truncation"] is True
+        assert kwargs["padding"] is True
+        assert kwargs["max_length"] == 512
 
 
 class TestFlashRankCrossEncoder:


### PR DESCRIPTION
fix(engine): give each reranker worker its own CrossEncoder

## What

`LocalSTCrossEncoder` shared one SentenceTransformers `CrossEncoder`
(and its HuggingFace fast tokenizer) across a class-level
`ThreadPoolExecutor`. Concurrent `predict()` races
`set_truncation_and_padding` + `encode_batch`.

Observed live on 2026-08-15 15:33:08Z during a 3-bank recall fan-out
as `ValueError: Unable to create tensor` wrapping
`TypeError: 'int' object is not callable` (1 hit / 72 h on that
deployment). This is an engine bug. Multi-bank made the race more
likely (N parallel CE windows); a single-bank host with
`max_concurrent>1` has the same shape.

Each executor thread now owns its own `CrossEncoder`, loaded under a
lock. `to(device)` / `eval()` run once at load. Load failures raise;
there is no fallback to a shared instance. `initialize()` warms every
pool worker so a load failure is a startup error and the first recall
does not pay N cold loads.

`max_workers` is still `HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT`
(default 4). Memory cost was ~+290 MiB private for the 3 extra MiniLM
copies at `max_concurrent=4` (measured on that deployment).

Rebased onto current upstream main. The engine/test tree is the same as
the earlier per-thread fix; the only local correction since then was
dropping an uncommitted private PR-body file before this rebase.

## This does not fix

A later process death (2026-08-16 10:58Z) landed immediately after a
17-candidate CE rerank and is **correlated with, not proven to be
caused by**, long-input CE behaviour (ST 5.2.0 `predict` omits
`max_length`). That is a separate change (tokenizer `max_length` +
pair clip) and should be its own PR. Bundling it here would mix two
failure classes and two review surfaces.

Not a multi-bank change. File separately from the multi-bank recall PR.
Does not change the public reranker provider interface. Does not
change FlashRank batching (#3355 / #3441).

## Bounded CrossEncoder inputs

Local CrossEncoder scoring tokenises every query/passage pair with
explicit `truncation=True` and `max_length` from the loaded tokenizer
(`tokenizer.model_max_length`). 512 is only the fallback when a
stub/model exposes no usable length. Values below 8 are skipped; values
above 131072 clamp (and log).

- First oversized **query** in a 60s window logs WARNING; later ones DEBUG
  so a busy reranker cannot flood logs.
- Known overflow `ValueError` (`Unable to create tensor`, `expected
  sequence of length`) retries one pair at a time. Other ValueErrors
  (shape, dtype, config) propagate. CUDA OOM / TypeError still raise.
- A pair that still overflows scores `-inf` so it cannot outrank a real
  score.
- If the tokenizer wrapper cannot bind (read-only tokenizer), a warning
  is logged and predict still runs.

Single-bank and multi-bank (union CE) share this path. Observed crash
class: `ValueError: Unable to create tensor` on a ~7.5 KB query.

## Tests

`hindsight-api-slim/tests/test_local_cross_encoder.py`:

- Existing mocked predict / bucket-batching / FlashRank tests.
- Isolation: exclusivity vs a legacy shared-model subclass (the
  attacking RED on the old design), score identity, both predict
  arms, load failure, warmup vs a smaller existing pool.
- Optional real-MiniLM soak: `HS_RERANKER_STRESS=1`.
