### PR TITLE
feat(recall): multi-bank recall with score/interleave merge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -333,6 +333,14 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_RERANKER_MAX_CANDIDATES_LOW=0
 # HINDSIGHT_API_RERANKER_MAX_CANDIDATES_MID=0
 # HINDSIGHT_API_RERANKER_MAX_CANDIDATES_HIGH=0
+# Multi-bank union CE: one CrossEncoder pass over the merged pool (not N per-bank
+# CE jobs). Cost is O(union_cap), not O(N_banks). Default 200 keeps per-bank
+# RRF ranks 0-39 at a 5-bank fan-out in the CE batch.
+# HINDSIGHT_API_MULTI_UNION_CAP=200
+# Per-bank RRF head admitted into the union pool before the cap:
+# HINDSIGHT_API_MULTI_PER_BANK_PRE_CAP=50
+# After the CE cut, each bank keeps at least min(floor, its count):
+# HINDSIGHT_API_MULTI_PER_BANK_FLOOR=1
 
 # Reranker failover chain: extra rerankers tried, in order, when the one above
 # fails. Members are numbered from 1 (indices must be contiguous) and every

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -184,6 +184,7 @@ from hindsight_api.engine.response_models import (
     RecallScores,
     TokenUsage,
 )
+from hindsight_api.engine.response_models import RecallResult as CoreRecallResult
 from hindsight_api.engine.search.tags import TagGroup, TagsMatch
 from hindsight_api.engine.structured_output import validate_response_schema
 from hindsight_api.extensions import HttpExtension, OperationValidationError, load_extension
@@ -407,6 +408,7 @@ class RecallResult(BaseModel):
         None  # IDs of source facts (observation type only, when source_facts is enabled)
     )
     scores: RecallScores | None = None  # Per-stage recall scores (final/reranker/semantic/text)
+    bank_id: str | None = None  # Source bank (set by multi-bank recall; null for single-bank)
 
 
 class EntityObservationResponse(BaseModel):
@@ -606,6 +608,120 @@ class RecallResponse(BaseModel):
             "results[].source_fact_ids have no entry in source_facts — the budget ran out, the "
             "references are not dangling. Only set when source facts were requested."
         ),
+    )
+    metadata: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Optional response metadata. Multi-bank recall populates metadata['multi_bank'] with "
+            "merge mode, per-bank status, fallback reason, exact_normalized dedup, and per_bank_cap."
+        ),
+    )
+
+
+class MultiBankRecallRequest(RecallRequest):
+    """Request model for multi-bank recall (additive endpoint).
+
+    Same fields as :class:`RecallRequest`, plus ``bank_ids`` and ``merge``.
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "bank_ids": ["work", "personal"],
+                "query": "What are my open tasks?",
+                "merge": "score",
+                "budget": "mid",
+                "max_tokens": 4096,
+            }
+        }
+    )
+
+    bank_ids: list[str] = Field(
+        description=("Memory banks to query in parallel (max 10). Order is preserved for interleave merge."),
+        min_length=1,
+        max_length=10,
+    )
+    merge: Literal["score", "interleave"] = Field(
+        default="score",
+        description=(
+            "How to order the union of per-bank results. "
+            "'score' (default): sort by normalized cross-encoder score; auto-falls back to "
+            "'interleave' when any bank did not run cross_encoder (enable_reranking=false or "
+            "non-CE reranking). 'interleave': round-robin by per-bank rank."
+        ),
+    )
+
+    @field_validator("bank_ids")
+    @classmethod
+    def validate_bank_ids_nonempty_strings(cls, v: list[str]) -> list[str]:
+        cleaned = [bid.strip() for bid in v if isinstance(bid, str) and bid.strip()]
+        if not cleaned:
+            raise ValueError("bank_ids must contain at least one non-empty bank id")
+        return cleaned
+
+
+def _core_recall_to_http_response(core_result: CoreRecallResult) -> RecallResponse:
+    """Map engine :class:`RecallResult` (core) to the HTTP :class:`RecallResponse`."""
+
+    def _fact_to_result(fact: MemoryFact) -> RecallResult:
+        return RecallResult(
+            id=fact.id,
+            text=fact.text,
+            type=fact.fact_type,
+            entities=fact.entities,
+            context=fact.context,
+            occurred_start=fact.occurred_start,
+            occurred_end=fact.occurred_end,
+            mentioned_at=fact.mentioned_at,
+            document_id=fact.document_id,
+            metadata=fact.metadata,
+            chunk_id=fact.chunk_id,
+            tags=fact.tags,
+            source_fact_ids=fact.source_fact_ids,
+            scores=fact.scores,
+            bank_id=fact.bank_id,
+        )
+
+    recall_results = [_fact_to_result(fact) for fact in core_result.results]
+
+    chunks_response = None
+    if core_result.chunks:
+        chunks_response = {
+            chunk_id: ChunkData(
+                id=chunk_id,
+                text=chunk_info.chunk_text,
+                chunk_index=chunk_info.chunk_index,
+                truncated=chunk_info.truncated,
+            )
+            for chunk_id, chunk_info in core_result.chunks.items()
+        }
+
+    entities_response = None
+    if core_result.entities:
+        entities_response = {
+            name: EntityStateResponse(
+                entity_id=state.entity_id,
+                canonical_name=state.canonical_name,
+                observations=[
+                    EntityObservationResponse(text=obs.text, mentioned_at=obs.mentioned_at)
+                    for obs in state.observations
+                ],
+            )
+            for name, state in core_result.entities.items()
+        }
+
+    source_facts_response = None
+    if core_result.source_facts:
+        source_facts_response = {fact_id: _fact_to_result(fact) for fact_id, fact in core_result.source_facts.items()}
+
+    return RecallResponse(
+        results=recall_results,
+        trace=core_result.trace,
+        entities=entities_response,
+        chunks=chunks_response,
+        source_facts=source_facts_response,
+        source_facts_truncated=core_result.source_facts_truncated,
+        metadata=core_result.metadata,
     )
 
 
@@ -4682,77 +4798,17 @@ def _register_routes(app: FastAPI):
                     bank_id=bank_id,
                 )
 
-            # Convert core MemoryFact objects to API RecallResult objects (excluding internal metrics)
-            def _fact_to_result(fact: "MemoryFact") -> RecallResult:
-                return RecallResult(
-                    id=fact.id,
-                    text=fact.text,
-                    type=fact.fact_type,
-                    entities=fact.entities,
-                    context=fact.context,
-                    occurred_start=fact.occurred_start,
-                    occurred_end=fact.occurred_end,
-                    mentioned_at=fact.mentioned_at,
-                    document_id=fact.document_id,
-                    metadata=fact.metadata,
-                    chunk_id=fact.chunk_id,
-                    tags=fact.tags,
-                    source_fact_ids=fact.source_fact_ids,
-                    scores=fact.scores,
-                )
-
-            recall_results = [_fact_to_result(fact) for fact in core_result.results]
-
-            # Convert chunks from engine to HTTP API format
-            chunks_response = None
-            if core_result.chunks:
-                chunks_response = {}
-                for chunk_id, chunk_info in core_result.chunks.items():
-                    chunks_response[chunk_id] = ChunkData(
-                        id=chunk_id,
-                        text=chunk_info.chunk_text,
-                        chunk_index=chunk_info.chunk_index,
-                        truncated=chunk_info.truncated,
-                    )
-
-            # Convert core EntityState objects to API EntityStateResponse objects
-            entities_response = None
-            if core_result.entities:
-                entities_response = {}
-                for name, state in core_result.entities.items():
-                    entities_response[name] = EntityStateResponse(
-                        entity_id=state.entity_id,
-                        canonical_name=state.canonical_name,
-                        observations=[
-                            EntityObservationResponse(text=obs.text, mentioned_at=obs.mentioned_at)
-                            for obs in state.observations
-                        ],
-                    )
-
-            # Convert source facts dict to API format
-            source_facts_response = None
-            if core_result.source_facts:
-                source_facts_response = {
-                    fact_id: _fact_to_result(fact) for fact_id, fact in core_result.source_facts.items()
-                }
-
-            response = RecallResponse(
-                results=recall_results,
-                trace=core_result.trace,
-                entities=entities_response,
-                chunks=chunks_response,
-                source_facts=source_facts_response,
-                source_facts_truncated=core_result.source_facts_truncated,
-            )
+            response = _core_recall_to_http_response(core_result)
 
             handler_duration = time.time() - handler_start
             recall_duration = time.time() - recall_start
             post_recall = handler_duration - pre_recall - recall_duration
             if handler_duration > 1.0:
+                entities_n = len(response.entities) if response.entities else 0
                 logging.info(
                     f"[RECALL HTTP] bank={bank_id} handler_total={handler_duration:.3f}s "
                     f"pre={pre_recall:.3f}s recall={recall_duration:.3f}s post={post_recall:.3f}s "
-                    f"results={len(recall_results)} entities={len(entities_response) if entities_response else 0}"
+                    f"results={len(response.results)} entities={entities_n}"
                 )
 
             return response
@@ -4778,6 +4834,174 @@ def _register_routes(app: FastAPI):
             error_detail = f"{str(e)}\n\nTraceback:\n{traceback.format_exc()}"
             logger.error(
                 f"[RECALL ERROR] bank={bank_id} handler_duration={handler_duration:.3f}s error={str(e)}\n{error_detail}"
+            )
+            raise HTTPException(status_code=500, detail=str(e))
+
+    @app.post(
+        "/v1/default/memories/recall",
+        response_model=RecallResponse,
+        summary="Recall memory across multiple banks",
+        description=(
+            "Recall across multiple memory banks in parallel and merge results.\n\n"
+            "Merge modes:\n"
+            "- `score` (default): sort the union by each result's normalized cross-encoder score; "
+            "auto-falls back to `interleave` when any bank did not run cross_encoder "
+            "(recorded in `metadata.multi_bank`).\n"
+            "- `interleave`: round-robin by per-bank rank.\n\n"
+            "Partial bank failures return successful banks' results plus per-bank status in metadata. "
+            "Cross-bank dedup is exact/normalized text; each bank is capped at 50 results "
+            "before merge. Each result includes `bank_id` attribution."
+        ),
+        operation_id="recall_memories_multi",
+        tags=["Memory"],
+    )
+    @audited("recall")
+    async def api_recall_multi(
+        request: MultiBankRecallRequest,
+        http_request: Request,
+        request_context: RequestContext = Depends(get_request_context),
+    ):
+        """Multi-bank recall: parallel per-bank recall_async + merge (additive endpoint)."""
+        import time
+
+        handler_start = time.time()
+        metrics = get_metrics_collector()
+        primary_bank = request.bank_ids[0]
+
+        # Same query-length guard as single-bank recall.
+        max_query_tokens = get_config().recall_max_query_tokens
+        encoding = _get_tiktoken_encoding()
+        query_tokens = len(encoding.encode(request.query))
+        if query_tokens > max_query_tokens:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Query too long: {query_tokens} tokens exceeds maximum of {max_query_tokens}. Please shorten your query.",
+            )
+
+        # Precheck every distinct bank (body is already parsed on this path-less route).
+        # Checking only bank_ids[0] would let a caller hide a gated bank behind an allowed one.
+        validator = getattr(app.state.memory, "_operation_validator", None)
+        if validator is not None:
+            from hindsight_api.extensions import PrecheckContext
+
+            await app.state.memory._authenticate_tenant(request_context)
+            cl_header = http_request.headers.get("content-length")
+            content_length: int | None = None
+            if cl_header is not None:
+                try:
+                    parsed = int(cl_header)
+                except ValueError:
+                    parsed = -1
+                if parsed >= 0:
+                    content_length = parsed
+            seen_precheck: set[str] = set()
+            for bid in request.bank_ids:
+                if bid in seen_precheck:
+                    continue
+                seen_precheck.add(bid)
+                precheck_result = await validator.precheck(
+                    PrecheckContext(
+                        operation=PrecheckOperation.RECALL,
+                        bank_id=bid,
+                        request_context=request_context,
+                        content_length=content_length,
+                    )
+                )
+                if not precheck_result.allowed:
+                    raise HTTPException(
+                        status_code=precheck_result.status_code,
+                        detail=precheck_result.reason or "Operation not allowed",
+                    )
+
+        try:
+            fact_types = request.types if request.types else list(VALID_RECALL_FACT_TYPES)
+
+            question_date = None
+            if request.query_timestamp:
+                try:
+                    question_date = datetime.fromisoformat(request.query_timestamp.replace("Z", "+00:00"))
+                except ValueError as e:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Invalid query_timestamp format. Expected ISO format (e.g., '2023-05-30T23:40:00'): {str(e)}",
+                    )
+
+            include_entities = request.include.entities is not None
+            max_entity_tokens = request.include.entities.max_tokens if include_entities else 500
+            include_chunks = request.include.chunks is not None
+            max_chunk_tokens = request.include.chunks.max_tokens if include_chunks else 8192
+            include_source_facts = request.include.source_facts is not None
+            max_source_facts_tokens = request.include.source_facts.max_tokens if include_source_facts else 4096
+            max_source_facts_tokens_per_observation = (
+                request.include.source_facts.max_tokens_per_observation if include_source_facts else -1
+            )
+
+            with metrics.record_operation(
+                "recall",
+                bank_id=primary_bank,
+                source="api",
+                budget=request.budget.value,
+                max_tokens=request.max_tokens,
+            ):
+                core_result = await run_cancellable_on_disconnect(
+                    http_request,
+                    request_context,
+                    app.state.memory.recall_multi_async(
+                        bank_ids=request.bank_ids,
+                        query=request.query,
+                        merge=request.merge,
+                        budget=request.budget,
+                        max_tokens=request.max_tokens,
+                        enable_trace=request.trace,
+                        fact_type=fact_types,
+                        prefer_observations=request.prefer_observations,
+                        question_date=question_date,
+                        include_entities=include_entities,
+                        max_entity_tokens=max_entity_tokens,
+                        include_chunks=include_chunks,
+                        max_chunk_tokens=max_chunk_tokens,
+                        include_source_facts=include_source_facts,
+                        max_source_facts_tokens=max_source_facts_tokens,
+                        max_source_facts_tokens_per_observation=max_source_facts_tokens_per_observation,
+                        request_context=request_context,
+                        tags=request.tags,
+                        tags_match=request.tags_match,
+                        tag_groups=request.tag_groups,
+                        min_scores=request.min_scores,
+                    ),
+                    operation="recall",
+                    bank_id=primary_bank,
+                )
+
+            response = _core_recall_to_http_response(core_result)
+            handler_duration = time.time() - handler_start
+            if handler_duration > 1.0:
+                logging.info(
+                    f"[RECALL MULTI HTTP] banks={request.bank_ids} handler_total={handler_duration:.3f}s "
+                    f"results={len(response.results)}"
+                )
+            return response
+        except HTTPException:
+            raise
+        except OperationValidationError as e:
+            raise HTTPException(status_code=e.status_code, detail=e.reason)
+        except (AuthenticationError, HTTPException):
+            raise
+        except (asyncio.TimeoutError, TimeoutError):
+            handler_duration = time.time() - handler_start
+            logger.error(f"[RECALL MULTI TIMEOUT] banks={request.bank_ids} handler_duration={handler_duration:.3f}s")
+            raise HTTPException(
+                status_code=504,
+                detail="Request timed out while searching memories. Try a shorter or more specific query.",
+            )
+        except Exception as e:
+            import traceback
+
+            handler_duration = time.time() - handler_start
+            error_detail = f"{str(e)}\n\nTraceback:\n{traceback.format_exc()}"
+            logger.error(
+                f"[RECALL MULTI ERROR] banks={request.bank_ids} handler_duration={handler_duration:.3f}s "
+                f"error={str(e)}\n{error_detail}"
             )
             raise HTTPException(status_code=500, detail=str(e))
 

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -22,6 +22,30 @@ from .utils import mask_network_location
 logger = logging.getLogger(__name__)
 
 
+def _clamp_int(raw: object, lo: int, hi: int, default: int, *, name: str = "") -> int:
+    """Parse an int and clamp to [lo, hi].
+
+    Non-int or a value below ``lo`` returns ``default`` (never silent ``lo``).
+    A value above ``hi`` clamps to ``hi``.
+    """
+    label = name or "int"
+    try:
+        value = int(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        logger.warning("%s value %r is not an int; using default %s", label, raw, default)
+        return default
+    if value < lo:
+        logger.warning(
+            "%s value %s is below lo=%s; using default %s",
+            label,
+            value,
+            lo,
+            default,
+        )
+        return default
+    return min(hi, value)
+
+
 def load_dotenv_for_entrypoint() -> None:
     """Load a discovered ``.env`` file for Hindsight's own entry points.
 
@@ -504,6 +528,11 @@ ENV_RERANKER_MAX_CANDIDATES = "HINDSIGHT_API_RERANKER_MAX_CANDIDATES"
 ENV_RERANKER_MAX_CANDIDATES_LOW = "HINDSIGHT_API_RERANKER_MAX_CANDIDATES_LOW"
 ENV_RERANKER_MAX_CANDIDATES_MID = "HINDSIGHT_API_RERANKER_MAX_CANDIDATES_MID"
 ENV_RERANKER_MAX_CANDIDATES_HIGH = "HINDSIGHT_API_RERANKER_MAX_CANDIDATES_HIGH"
+# Multi-bank union CE: one CrossEncoder pass over the merged candidate pool.
+# Cost is O(union_cap), not O(N_banks). Not hierarchical (server-level cost cap).
+ENV_MULTI_UNION_CAP = "HINDSIGHT_API_MULTI_UNION_CAP"
+ENV_MULTI_PER_BANK_PRE_CAP = "HINDSIGHT_API_MULTI_PER_BANK_PRE_CAP"
+ENV_MULTI_PER_BANK_FLOOR = "HINDSIGHT_API_MULTI_PER_BANK_FLOOR"
 ENV_SEMANTIC_MIN_SIMILARITY = "HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY"
 ENV_GRAPH_SEED_MIN_SIMILARITY = "HINDSIGHT_API_GRAPH_SEED_MIN_SIMILARITY"
 ENV_TEMPORAL_SEMANTIC_MIN_SIMILARITY = "HINDSIGHT_API_TEMPORAL_SEMANTIC_MIN_SIMILARITY"
@@ -1018,6 +1047,9 @@ DEFAULT_RERANKER_MAX_CANDIDATES = 300
 DEFAULT_RERANKER_MAX_CANDIDATES_LOW = 0
 DEFAULT_RERANKER_MAX_CANDIDATES_MID = 0
 DEFAULT_RERANKER_MAX_CANDIDATES_HIGH = 0
+DEFAULT_MULTI_UNION_CAP = 200
+DEFAULT_MULTI_PER_BANK_PRE_CAP = 50
+DEFAULT_MULTI_PER_BANK_FLOOR = 1
 DEFAULT_SEMANTIC_MIN_SIMILARITY = 0.3
 DEFAULT_GRAPH_SEED_MIN_SIMILARITY = 0.3
 DEFAULT_TEMPORAL_SEMANTIC_MIN_SIMILARITY = 0.1
@@ -2716,6 +2748,12 @@ class HindsightConfig:
     # sees). Stored lower-cased; empty means no header is ever forwarded.
     extension_passthrough_headers: list[str] = field(default_factory=list)
 
+    # Multi-bank union CE (static, server-level). Defaults keep
+    # HindsightConfig(**kwargs) callers source-compatible.
+    multi_union_cap: int = DEFAULT_MULTI_UNION_CAP
+    multi_per_bank_pre_cap: int = DEFAULT_MULTI_PER_BANK_PRE_CAP
+    multi_per_bank_floor: int = DEFAULT_MULTI_PER_BANK_FLOOR
+
     # Background maintenance cadences (static, server-level only). Each sweep's
     # discovery is one cross-tenant round-trip that probes every schema holding
     # the relevant table, so its cost scales with tenant count and the cadence is
@@ -4051,6 +4089,27 @@ class HindsightConfig:
             extension_passthrough_headers=[
                 h.lower() for h in _parse_str_list(os.getenv(ENV_EXTENSION_PASSTHROUGH_HEADERS, ""))
             ],
+            multi_union_cap=_clamp_int(
+                os.getenv(ENV_MULTI_UNION_CAP, str(DEFAULT_MULTI_UNION_CAP)),
+                1,
+                500,
+                DEFAULT_MULTI_UNION_CAP,
+                name=ENV_MULTI_UNION_CAP,
+            ),
+            multi_per_bank_pre_cap=_clamp_int(
+                os.getenv(ENV_MULTI_PER_BANK_PRE_CAP, str(DEFAULT_MULTI_PER_BANK_PRE_CAP)),
+                1,
+                500,
+                DEFAULT_MULTI_PER_BANK_PRE_CAP,
+                name=ENV_MULTI_PER_BANK_PRE_CAP,
+            ),
+            multi_per_bank_floor=_clamp_int(
+                os.getenv(ENV_MULTI_PER_BANK_FLOOR, str(DEFAULT_MULTI_PER_BANK_FLOOR)),
+                1,
+                20,
+                DEFAULT_MULTI_PER_BANK_FLOOR,
+                name=ENV_MULTI_PER_BANK_FLOOR,
+            ),
         )
         config.validate()
         return config

--- a/hindsight-api-slim/hindsight_api/engine/interface.py
+++ b/hindsight-api-slim/hindsight_api/engine/interface.py
@@ -124,6 +124,53 @@ class MemoryEngineInterface(ABC):
         ...
 
     @abstractmethod
+    async def recall_multi_async(
+        self,
+        bank_ids: list[str],
+        query: str,
+        *,
+        merge: str = "score",
+        budget: "Budget | None" = None,
+        max_tokens: int = 4096,
+        enable_trace: bool = False,
+        fact_type: list[str] | None = None,
+        prefer_observations: bool = True,
+        question_date: datetime | None = None,
+        include_entities: bool = False,
+        max_entity_tokens: int = 500,
+        include_chunks: bool = False,
+        max_chunk_tokens: int = 8192,
+        include_source_facts: bool = False,
+        max_source_facts_tokens: int = 4096,
+        max_source_facts_tokens_per_observation: int = -1,
+        request_context: "RequestContext",
+        tags: list[str] | None = None,
+        tags_match: str = "any",
+        tag_groups: list[Any] | None = None,
+        created_after: datetime | None = None,
+        created_before: datetime | None = None,
+        min_scores: Any | None = None,
+        reranking: str = "cross_encoder",
+    ) -> "RecallResult":
+        """
+        Recall across multiple banks and merge results (thin orchestrator above recall_async).
+
+        Runs one recall_async per bank in parallel (asyncio task per bank). Merge modes:
+        - ``score`` (default): sort union by each result's normalized cross-encoder score;
+          auto-falls back to ``interleave`` when CE is not comparable (config or returned scores).
+        - ``interleave``: round-robin by per-bank rank.
+
+        Ordinary partial bank failures do not fail the call; see response metadata.
+        ``OperationCancelledError`` and tenant ``AuthenticationError`` are re-raised
+        (not soft-failed). Cap: 10 banks. Cross-bank dedup is exact/normalized text;
+        each bank's contribution is capped at 50 before merge.
+
+        Returns:
+            RecallResult with bank_id stamped on each result and multi_bank metadata.
+        """
+        ...
+
+    @abstractmethod
     async def reflect_async(
         self,
         bank_id: str,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -1084,6 +1084,34 @@ def _resolve_reranking(config_dict: dict, reranking: "RecallReranking") -> "Reca
     return reranking
 
 
+def _union_ce_usable(
+    engine: object,
+    *,
+    requested_reranking: "RecallReranking",
+    enable_flags: list[bool],
+) -> bool:
+    """Whether recall_multi_async should run one CE pass over the union.
+
+    False (today's rrf/interleave path) when the caller skipped CE, any bank
+    has enable_reranking=false, or the engine has no usable CrossEncoder
+    (missing, null, or rrf passthrough). Tests that construct MemoryEngine
+    via object.__new__ have no reranker — they stay on the pre-union path.
+    """
+    if requested_reranking != "cross_encoder":
+        return False
+    if not enable_flags or not all(enable_flags):
+        return False
+    reranker = getattr(engine, "_cross_encoder_reranker", None)
+    if reranker is None:
+        return False
+    cross_encoder = getattr(reranker, "cross_encoder", None)
+    if cross_encoder is None:
+        return False
+    if getattr(cross_encoder, "provider_name", None) == "rrf":
+        return False
+    return True
+
+
 def utcnow():
     """Get current UTC time with timezone info."""
     return datetime.now(UTC)
@@ -5780,14 +5808,19 @@ class MemoryEngine(MemoryEngineInterface):
 
         One ``recall_async`` sub-call per bank runs concurrently via ``asyncio.gather``
         (task-per-bank so each keeps its own ``_current_bank_id`` ContextVar binding).
-        Existing ``recall_async`` is not modified.
+        When union CE is eligible, each sub-call uses ``reranking="rrf"`` (retrieval
+        only) and this method runs **one** ``CrossEncoderReranker.rerank`` over the
+        union (default cap 200). Per-bank CE on one shared model made N-bank
+        wall sit between max(single) and sum(singles).
 
         **Merge modes** (``merge``):
         - ``score`` (default): sort the union by each result's normalized cross-encoder
-          score (``scores.reranker``). Auto-falls back to ``interleave`` when any queried
-          bank would not run cross_encoder (``enable_reranking=false`` → rrf, or caller
-          requested ``rrf``/``interleave``). Fallback is recorded in response metadata.
+          score (``scores.reranker``). After union CE those scores are comparable
+          across banks. Auto-falls back to ``interleave`` when CE is disabled/null
+          (``enable_reranking=false``, caller ``rrf``/``interleave``, or passthrough).
+          Fallback is recorded in response metadata.
         - ``interleave``: round-robin by per-bank rank (bankA#1, bankB#1, ...).
+          Still available; within-bank rank is CE order when union CE ran.
 
         **Token budget:** the caller's full ``max_tokens`` is passed to each sub-call;
         the merged list is then cut to ``max_tokens`` (same until-budget semantics as
@@ -5806,20 +5839,27 @@ class MemoryEngine(MemoryEngineInterface):
         so an unauthenticated request fails before N parallel recalls start.
 
         **Dedup:** exact/normalized text across banks (``exact_normalized``), after
-        merge and before the token cut. Per-bank contribution is capped at 50.
-        ``prefer_observations`` defaults True on this orchestrator only (HTTP/MCP
-        request models still default False and pass the caller's value through).
+        merge and before the token cut. Per-bank pre-cap default 50; union cap
+        default 200. ``prefer_observations`` defaults True on this orchestrator only
+        (HTTP/MCP request models still default False and pass the caller's value through).
         """
         from .multi_bank_recall import (
+            DEFAULT_MULTI_UNION_CAP,
+            DEFAULT_PER_BANK_FLOOR,
             DEFAULT_PER_BANK_MERGE_CAP,
             FALLBACK_NO_USABLE_RERANKER_SCORES,
             MAX_MULTI_BANK_RECALL_BANKS,
+            apply_per_bank_floor,
             bank_rank_from_merged,
             build_multi_bank_metadata,
             cross_encoder_eligible,
             has_usable_reranker_scores,
+            memory_facts_to_merged_candidates,
             merge_cap_dedup_cut,
+            select_union_candidates,
+            stamp_union_ce_scores,
             union_merge_dicts,
+            union_per_bank_max_tokens,
         )
 
         if merge not in ("score", "interleave"):
@@ -5895,13 +5935,33 @@ class MemoryEngine(MemoryEngineInterface):
                 merge_applied = "interleave"
                 merge_fallback_reason = reason
 
+        # One CE over the union, not N per-bank CE jobs. Eligible only when the
+        # caller asked for cross_encoder, every bank still has reranking on, and
+        # this engine actually has a non-passthrough CrossEncoder. Missing /
+        # null / rrf-passthrough CE keeps today's per-bank rrf/interleave path.
+        union_ce = _union_ce_usable(self, requested_reranking=reranking, enable_flags=enable_flags)
+        per_bank_reranking: RecallReranking = "rrf" if union_ce else reranking
+        try:
+            union_cfg = get_config()
+            union_cap = int(getattr(union_cfg, "multi_union_cap", DEFAULT_MULTI_UNION_CAP))
+            per_bank_pre_cap = int(getattr(union_cfg, "multi_per_bank_pre_cap", DEFAULT_PER_BANK_MERGE_CAP))
+            per_bank_floor = int(getattr(union_cfg, "multi_per_bank_floor", DEFAULT_PER_BANK_FLOOR))
+        except Exception:
+            union_cap = DEFAULT_MULTI_UNION_CAP
+            per_bank_pre_cap = DEFAULT_PER_BANK_MERGE_CAP
+            per_bank_floor = DEFAULT_PER_BANK_FLOOR
+        union_cap = max(1, union_cap)
+        per_bank_pre_cap = max(1, per_bank_pre_cap)
+        per_bank_floor = max(1, per_bank_floor)
+        subcall_max_tokens = union_per_bank_max_tokens(max_tokens, union_ce=union_ce)
+
         # Fan-out: task-per-bank keeps @_bind_bank_id ContextVar isolation.
         async def _one(bank_id: str) -> RecallResultModel:
             return await self.recall_async(
                 bank_id,
                 query,
                 budget=budget,
-                max_tokens=max_tokens,
+                max_tokens=subcall_max_tokens,
                 enable_trace=enable_trace,
                 fact_type=fact_type,
                 prefer_observations=prefer_observations,
@@ -5922,7 +5982,7 @@ class MemoryEngine(MemoryEngineInterface):
                 min_scores=min_scores,
                 _connection_budget=_connection_budget,
                 _quiet=_quiet,
-                reranking=reranking,
+                reranking=per_bank_reranking,
             )
 
         gathered = await asyncio.gather(
@@ -5974,6 +6034,59 @@ class MemoryEngine(MemoryEngineInterface):
             successful_facts.append((bid, list(outcome.results)))
             successful_outcomes.append((bid, outcome))
 
+        union_ce_applied = False
+        if union_ce and successful_facts:
+            # Cancellation checkpoint: union CE is the expensive stage and runs
+            # in a worker that cannot be interrupted once dispatched.
+            request_context.raise_if_cancelled()
+            try:
+                pool = select_union_candidates(
+                    successful_facts,
+                    per_bank_pre_cap=per_bank_pre_cap,
+                    union_cap=union_cap,
+                    k_floor=per_bank_floor,
+                )
+                tokened = memory_facts_to_merged_candidates(pool.facts)
+                if tokened:
+                    reranker_instance = self._cross_encoder_reranker
+                    await reranker_instance.ensure_initialized()
+                    scored = await reranker_instance.rerank(query, [item.candidate for item in tokened])
+                    score_by_token = {sr.id: sr.cross_encoder_score_normalized for sr in scored}
+                    scored_facts = stamp_union_ce_scores(
+                        [item.fact for item in tokened],
+                        [item.token for item in tokened],
+                        score_by_token,
+                    )
+                    scored_facts = apply_per_bank_floor(
+                        scored_facts,
+                        k_floor=per_bank_floor,
+                        keep=union_cap,
+                        bank_order=pool.bank_order,
+                    )
+                    by_bank: dict[str, list[MemoryFact]] = {bid: [] for bid, _facts in successful_facts}
+                    for fact in scored_facts:
+                        bid = fact.bank_id or ""
+                        by_bank.setdefault(bid, []).append(fact)
+
+                    def _union_score(fact: MemoryFact) -> float:
+                        if fact.scores is None or fact.scores.reranker is None:
+                            return float("-inf")
+                        return float(fact.scores.reranker)
+
+                    for lst in by_bank.values():
+                        lst.sort(key=_union_score, reverse=True)
+                    successful_facts = [(bid, by_bank.get(bid, [])) for bid, _old in successful_facts]
+                    union_ce_applied = True
+            except OperationCancelledError:
+                raise
+            except Exception as e:
+                logger.warning(
+                    "[RECALL MULTI] union CE failed; falling back to rrf/interleave: %s: %r",
+                    type(e).__name__,
+                    e,
+                )
+                union_ce = False
+
         # Post-gather evidence check: pre-flight config said CE was fine, but the
         # returned facts may still lack scores.reranker (RRF passthrough, etc.).
         if merge_applied == "score" and not has_usable_reranker_scores(successful_facts):
@@ -5986,7 +6099,7 @@ class MemoryEngine(MemoryEngineInterface):
             successful_facts,
             merge=merge_applied,
             max_tokens=max_tokens,
-            max_per_bank=DEFAULT_PER_BANK_MERGE_CAP,
+            max_per_bank=per_bank_pre_cap,
         )
         cut = pipeline.facts
         dedup_dropped = pipeline.dropped
@@ -6029,7 +6142,10 @@ class MemoryEngine(MemoryEngineInterface):
                 merge_fallback_reason=merge_fallback_reason,
                 bank_statuses=bank_statuses,
                 dedup_dropped=dedup_dropped,
-                per_bank_cap=DEFAULT_PER_BANK_MERGE_CAP,
+                per_bank_cap=per_bank_pre_cap,
+                union_ce=union_ce_applied,
+                union_cap=union_cap,
+                per_bank_floor=per_bank_floor,
             ),
         )
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -453,6 +453,7 @@ from .mental_model_refresh import (
     RefreshMode,
     RefreshOutcome,
 )
+from .multi_bank_recall import MultiBankMerge
 from .multi_llm import MultiLLMProvider
 from .query_analyzer import QueryAnalyzer
 from .reflect import run_reflect_agent
@@ -990,6 +991,26 @@ def _is_non_retryable_task_error(e: Exception) -> bool:
         or _is_oracledb_integrity_error(e)
         or _is_invalid_embedding_dimension_error(e)
     )
+
+
+def _retry_or_reraise_worker_task(e: Exception, task_dict: dict[str, Any]) -> NoReturn:
+    """Apply the non-consolidation worker retry policy to a task error.
+
+    Raises ``RetryTaskAt`` while ``_retry_count < worker_max_retries``, else
+    re-raises ``e`` so the poller marks the operation failed with the message.
+    Consolidation has its own indefinite-retry / dedup-by-bank path and must
+    not use this helper.
+
+    Retry message uses ``format_task_error`` (main/#3218), not ``str(e)``.
+    """
+    config = get_config()
+    retry_count = task_dict.get("_retry_count", 0)
+    if retry_count < config.worker_max_retries:
+        raise RetryTaskAt(
+            retry_at=datetime.now(UTC) + timedelta(seconds=config.worker_task_retry_backoff_seconds),
+            message=format_task_error(e),
+        )
+    raise e
 
 
 class Budget(str, Enum):
@@ -2732,6 +2753,30 @@ class MemoryEngine(MemoryEngineInterface):
                 # would convert a legitimate defer into a 60-second RetryTaskAt
                 # and lose the "not a failure" semantics entirely.
                 raise
+            except MentalModelRefreshError as e:
+                # Expected fail-safe from #3112/#3182: refresh_mental_model
+                # raises MentalModelRefreshError after _preserve_and_fail leaves
+                # content and watermark untouched so a retry re-reads the same
+                # window. Delta ops are LLM-produced and non-deterministic, so
+                # this is still retryable (same policy as a generic
+                # non-consolidation error).
+                #
+                # Log via logger.error without exc_info: main/#3218 replaced
+                # print_exc() with logger.error(..., exc_info=True) on the
+                # generic path. This designed skip must not emit a traceback
+                # (soak watchers treat Traceback / MentalModelRefreshError as
+                # unhandled). Overlay used logger.warning; we use logger.error
+                # so the skip is visible at the same level as other task
+                # failures, still without a traceback.
+                logger.error(
+                    "Mental model refresh failed (content preserved): "
+                    "task_type=%s mental_model_id=%s bank_id=%s error=%s",
+                    task_type,
+                    task_dict.get("mental_model_id"),
+                    task_dict.get("bank_id"),
+                    e,
+                )
+                _retry_or_reraise_worker_task(e, task_dict)
             except Exception as e:
                 # exc_info, not a bare print_exc(): the traceback is the only pointer
                 # to the offending call site, and under production log volume the
@@ -2812,14 +2857,7 @@ class MemoryEngine(MemoryEngineInterface):
                     # Retry count and backoff come from config (HINDSIGHT_API_WORKER_MAX_RETRIES and
                     # HINDSIGHT_API_WORKER_TASK_RETRY_BACKOFF_SECONDS). Defaults of 3 x 60s give a
                     # 4-minute total window; operators expecting a longer provider outage can raise them.
-                    config = get_config()
-                    retry_count = task_dict.get("_retry_count", 0)
-                    if retry_count < config.worker_max_retries:
-                        raise RetryTaskAt(
-                            retry_at=datetime.now(UTC) + timedelta(seconds=config.worker_task_retry_backoff_seconds),
-                            message=error_message,
-                        )
-                    raise
+                    _retry_or_reraise_worker_task(e, task_dict)
 
     async def _fire_consolidation_webhook(
         self,
@@ -5707,6 +5745,293 @@ class MemoryEngine(MemoryEngineInterface):
             return result
         finally:
             recall_span_context.__exit__(None, None, None)
+
+    async def recall_multi_async(
+        self,
+        bank_ids: list[str],
+        query: str,
+        *,
+        merge: MultiBankMerge = "score",
+        budget: Budget | None = None,
+        max_tokens: int = 4096,
+        enable_trace: bool = False,
+        fact_type: list[str] | None = None,
+        prefer_observations: bool = True,
+        question_date: datetime | None = None,
+        include_entities: bool = False,
+        max_entity_tokens: int = 500,
+        include_chunks: bool = False,
+        max_chunk_tokens: int = 8192,
+        include_source_facts: bool = False,
+        max_source_facts_tokens: int = 4096,
+        max_source_facts_tokens_per_observation: int = -1,
+        request_context: "RequestContext",
+        tags: list[str] | None = None,
+        tags_match: TagsMatch = "any",
+        tag_groups: list[TagGroup] | None = None,
+        created_after: datetime | None = None,
+        created_before: datetime | None = None,
+        min_scores: MinScores | None = None,
+        _connection_budget: int | None = None,
+        _quiet: bool = False,
+        reranking: RecallReranking = "cross_encoder",
+    ) -> RecallResultModel:
+        """Recall across multiple banks and merge (thin orchestrator above ``recall_async``).
+
+        One ``recall_async`` sub-call per bank runs concurrently via ``asyncio.gather``
+        (task-per-bank so each keeps its own ``_current_bank_id`` ContextVar binding).
+        Existing ``recall_async`` is not modified.
+
+        **Merge modes** (``merge``):
+        - ``score`` (default): sort the union by each result's normalized cross-encoder
+          score (``scores.reranker``). Auto-falls back to ``interleave`` when any queried
+          bank would not run cross_encoder (``enable_reranking=false`` → rrf, or caller
+          requested ``rrf``/``interleave``). Fallback is recorded in response metadata.
+        - ``interleave``: round-robin by per-bank rank (bankA#1, bankB#1, ...).
+
+        **Token budget:** the caller's full ``max_tokens`` is passed to each sub-call;
+        the merged list is then cut to ``max_tokens`` (same until-budget semantics as
+        single-bank). Slight over-fetch is the accepted v1 cost.
+
+        **Attribution:** every merged result is stamped with ``bank_id``.
+
+        **Failures:** ordinary bank infrastructure errors do not kill the call — partial
+        results are returned with per-bank status in ``metadata["multi_bank"]["banks"]``
+        (client-visible error text is generic; details are logged server-side).
+        Precedence for hard failures re-raised from the gather: ``OperationCancelledError``
+        first (HTTP 499), then tenant ``AuthenticationError`` (HTTP 401; auth is
+        per-request, not per-bank), then ``OperationValidationError`` (bank-scoped
+        403/422 denials — same mapping as single-bank recall). None of those
+        soft-fail into a 200. The tenant is also authenticated once before fan-out
+        so an unauthenticated request fails before N parallel recalls start.
+
+        **Dedup:** exact/normalized text across banks (``exact_normalized``), after
+        merge and before the token cut. Per-bank contribution is capped at 50.
+        ``prefer_observations`` defaults True on this orchestrator only (HTTP/MCP
+        request models still default False and pass the caller's value through).
+        """
+        from .multi_bank_recall import (
+            DEFAULT_PER_BANK_MERGE_CAP,
+            FALLBACK_NO_USABLE_RERANKER_SCORES,
+            MAX_MULTI_BANK_RECALL_BANKS,
+            bank_rank_from_merged,
+            build_multi_bank_metadata,
+            cross_encoder_eligible,
+            has_usable_reranker_scores,
+            merge_cap_dedup_cut,
+            union_merge_dicts,
+        )
+
+        if merge not in ("score", "interleave"):
+            raise ValueError(f"merge must be 'score' or 'interleave', got {merge!r}")
+
+        # Preserve caller order; de-dupe so a bank is only recalled once.
+        seen: set[str] = set()
+        ordered_bank_ids: list[str] = []
+        for bid in bank_ids:
+            if bid not in seen:
+                seen.add(bid)
+                ordered_bank_ids.append(bid)
+
+        if len(ordered_bank_ids) > MAX_MULTI_BANK_RECALL_BANKS:
+            from hindsight_api.extensions.operation_validator import OperationValidationError
+
+            raise OperationValidationError(
+                f"Too many bank_ids: {len(ordered_bank_ids)} exceeds maximum of "
+                f"{MAX_MULTI_BANK_RECALL_BANKS} parallel banks per multi-bank recall.",
+                status_code=422,
+            )
+
+        if not ordered_bank_ids:
+            return RecallResultModel(
+                results=[],
+                metadata=build_multi_bank_metadata(
+                    merge_requested=merge,
+                    merge_applied=merge,
+                    merge_fallback_reason=None,
+                    bank_statuses={},
+                    # No gather happened on this path, so nothing was deduped.
+                    dedup_dropped=0,
+                    per_bank_cap=DEFAULT_PER_BANK_MERGE_CAP,
+                ),
+            )
+
+        # Tenant auth is request-scoped, not per-bank. Authenticate once before
+        # fan-out so an unauthenticated multi-recall fails the whole request
+        # instead of starting N recalls. Each recall_async still authenticates
+        # (single-bank contract / schema ContextVar); we do not skip that.
+        # Per-bank OperationValidator precheck stays inside recall_async.
+        await self._authenticate_tenant(request_context)
+
+        # Resolve per-bank enable_reranking so score-merge auto-fallback can run
+        # before (or without) depending on result scores. Failed config lookups
+        # are treated as "unknown / not CE-safe" → force interleave for score mode.
+        # Client-visible config_error is generic; details stay in the server log.
+        enable_flags: list[bool] = []
+        config_lookup_failed: set[str] = set()
+        for bid in ordered_bank_ids:
+            try:
+                cfg = await self._config_resolver.get_bank_config(bid, request_context)
+                enable_flags.append(bool(cfg.get("enable_reranking", True)))
+            except Exception as e:
+                enable_flags.append(False)
+                config_lookup_failed.add(bid)
+                logger.warning(
+                    "[RECALL MULTI %s] bank config lookup failed: %s: %r",
+                    bid[:8] if len(bid) >= 8 else bid,
+                    type(e).__name__,
+                    e,
+                )
+
+        merge_requested: MultiBankMerge = merge
+        merge_applied: MultiBankMerge = merge_requested
+        merge_fallback_reason: str | None = None
+        if merge_requested == "score":
+            eligible, reason = cross_encoder_eligible(
+                requested_reranking=reranking,
+                bank_enable_reranking=enable_flags,
+            )
+            if not eligible:
+                merge_applied = "interleave"
+                merge_fallback_reason = reason
+
+        # Fan-out: task-per-bank keeps @_bind_bank_id ContextVar isolation.
+        async def _one(bank_id: str) -> RecallResultModel:
+            return await self.recall_async(
+                bank_id,
+                query,
+                budget=budget,
+                max_tokens=max_tokens,
+                enable_trace=enable_trace,
+                fact_type=fact_type,
+                prefer_observations=prefer_observations,
+                question_date=question_date,
+                include_entities=include_entities,
+                max_entity_tokens=max_entity_tokens,
+                include_chunks=include_chunks,
+                max_chunk_tokens=max_chunk_tokens,
+                include_source_facts=include_source_facts,
+                max_source_facts_tokens=max_source_facts_tokens,
+                max_source_facts_tokens_per_observation=max_source_facts_tokens_per_observation,
+                request_context=request_context,
+                tags=tags,
+                tags_match=tags_match,
+                tag_groups=tag_groups,
+                created_after=created_after,
+                created_before=created_before,
+                min_scores=min_scores,
+                _connection_budget=_connection_budget,
+                _quiet=_quiet,
+                reranking=reranking,
+            )
+
+        gathered = await asyncio.gather(
+            *(_one(bid) for bid in ordered_bank_ids),
+            return_exceptions=True,
+        )
+
+        # Hard failures first — never soft-fail into partial 200 metadata.
+        # Precedence: cancellation (499), then tenant AuthenticationError (401),
+        # then OperationValidationError (403/422). e0a56d80 re-raised OVE only;
+        # AuthenticationError still fell into the generic per-bank soft-fail
+        # (live-measured on the overlay 2026-08-15: multi POST -> 200).
+        from hindsight_api.extensions import AuthenticationError
+        from hindsight_api.extensions.operation_validator import OperationValidationError
+
+        for outcome in gathered:
+            if isinstance(outcome, OperationCancelledError):
+                raise outcome
+        for outcome in gathered:
+            if isinstance(outcome, AuthenticationError):
+                raise outcome
+        for outcome in gathered:
+            if isinstance(outcome, OperationValidationError):
+                raise outcome
+
+        bank_statuses: dict[str, dict] = {}
+        successful_facts: list[tuple[str, list[MemoryFact]]] = []
+        successful_outcomes: list[tuple[str, RecallResultModel]] = []
+        for bid, outcome in zip(ordered_bank_ids, gathered, strict=True):
+            if isinstance(outcome, BaseException):
+                # Soft-fail ordinary infrastructure errors. Client metadata is generic
+                # (no exception class/repr oracle); details stay server-side.
+                logger.warning(
+                    "[RECALL MULTI %s] per-bank recall failed: %s: %r",
+                    bid[:8] if len(bid) >= 8 else bid,
+                    type(outcome).__name__,
+                    outcome,
+                )
+                bank_statuses[bid] = {
+                    "status": "error",
+                    "error": "recall failed for this bank",
+                }
+                if bid in config_lookup_failed:
+                    bank_statuses[bid]["config_error"] = "bank config lookup failed"
+                continue
+            # Successful RecallResultModel — keep full outcome for include_* side dicts.
+            count = len(outcome.results)
+            bank_statuses[bid] = {"status": "ok", "count": count}
+            successful_facts.append((bid, list(outcome.results)))
+            successful_outcomes.append((bid, outcome))
+
+        # Post-gather evidence check: pre-flight config said CE was fine, but the
+        # returned facts may still lack scores.reranker (RRF passthrough, etc.).
+        if merge_applied == "score" and not has_usable_reranker_scores(successful_facts):
+            merge_applied = "interleave"
+            merge_fallback_reason = FALLBACK_NO_USABLE_RERANKER_SCORES
+
+        # cap -> merge -> dedup -> token cut. merge_applied already carries any
+        # FALLBACK_NO_USABLE_RERANKER_SCORES downgrade decided just above.
+        pipeline = merge_cap_dedup_cut(
+            successful_facts,
+            merge=merge_applied,
+            max_tokens=max_tokens,
+            max_per_bank=DEFAULT_PER_BANK_MERGE_CAP,
+        )
+        cut = pipeline.facts
+        dedup_dropped = pipeline.dropped
+
+        # Union-merge entities/chunks/source_facts across successful banks. On key
+        # collision keep the bank whose results ranked higher in the merged order
+        # (chunk ids already embed bank ids, so real collisions are rare).
+        bank_rank = bank_rank_from_merged(cut)
+        entities = union_merge_dicts(
+            [(bid, outcome.entities) for bid, outcome in successful_outcomes],
+            bank_rank=bank_rank,
+        )
+        chunks = union_merge_dicts(
+            [(bid, outcome.chunks) for bid, outcome in successful_outcomes],
+            bank_rank=bank_rank,
+        )
+        source_facts = union_merge_dicts(
+            [(bid, outcome.source_facts) for bid, outcome in successful_outcomes],
+            bank_rank=bank_rank,
+        )
+        # origin/main added source_facts_truncated on single-bank recall. Any
+        # bank that hit the source-facts token budget should surface that on
+        # the union; None when no bank requested / reported the field.
+        truncated_flags = [
+            outcome.source_facts_truncated
+            for _bid, outcome in successful_outcomes
+            if outcome.source_facts_truncated is not None
+        ]
+        source_facts_truncated = any(truncated_flags) if truncated_flags else None
+
+        return RecallResultModel(
+            results=cut,
+            entities=entities,
+            chunks=chunks,
+            source_facts=source_facts,
+            source_facts_truncated=source_facts_truncated,
+            metadata=build_multi_bank_metadata(
+                merge_requested=merge_requested,
+                merge_applied=merge_applied,
+                merge_fallback_reason=merge_fallback_reason,
+                bank_statuses=bank_statuses,
+                dedup_dropped=dedup_dropped,
+                per_bank_cap=DEFAULT_PER_BANK_MERGE_CAP,
+            ),
+        )
 
     async def _search_with_retries(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/multi_bank_recall.py
+++ b/hindsight-api-slim/hindsight_api/engine/multi_bank_recall.py
@@ -1,0 +1,378 @@
+"""Pure helpers for multi-bank recall merge + token budget cut.
+
+The orchestrator (``MemoryEngine.recall_multi_async``) fans out one ``recall_async``
+per bank and then uses these helpers to order and truncate the union.
+
+Pipeline order (orchestrator must compose in this order):
+
+1. Per-bank contribution cap (``cap_per_bank_results``) - anti-flood into the merge pool.
+2. Merge (``score_merge`` or ``interleave_merge`` fallback).
+3. Exact / normalized-text dedup (``dedup_exact_normalized``) - BEFORE token cut.
+4. Token budget cut (``cut_to_token_budget``).
+
+Multi-bank fan-out defaults (orchestrator only; single-bank defaults unchanged):
+
+- ``prefer_observations=True`` via :data:`MULTI_BANK_PREFER_OBSERVATIONS` (narrow
+  semantics - see constant docstring).
+- Full caller ``max_tokens`` per bank (no shared pool; no ``max_tokens / n_banks``).
+
+Limitations still open:
+
+- Score-merge uses each result's existing normalized cross-encoder score
+  (``scores.reranker``); it does not run a second cross-encoder pass over the union.
+- No embedding / near-duplicate collapse (would silently merge distinct facts such
+  as "invalidate" vs "supersede").
+- No cross-bank supersession: a stale fact in bank A can outrank its correction in
+  bank B. Dedup / caps / prefer_observations do not fix that.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Literal, TypeVar
+
+from .response_models import MemoryFact
+from .token_encoding import get_token_encoding
+
+MultiBankMerge = Literal["score", "interleave"]
+
+# Hard cap on parallel bank fan-out (engine + HTTP request model).
+MAX_MULTI_BANK_RECALL_BANKS = 10
+
+# ---------------------------------------------------------------------------
+# Per-bank contribution cap (anti-flood into the merge pool)
+# ---------------------------------------------------------------------------
+#
+# Default rationale:
+# - Stock per-bank ``recall_async`` already ranks/CE-reranks; the multi-bank pool
+#   only needs each bank's *best* head, not its entire returned list.
+# - Typical CE top windows and single-bank result heads sit around ~50 items; keeping
+#   that head per bank preserves ranking quality without letting a large bank
+#   (thousands of facts) dump a long CE-ranked tail into the union.
+# - Worst-case pool before merge/dedup/cut is ``MAX_MULTI_BANK_RECALL_BANKS * M``
+#   (10 * 50 = 500) - large enough not to starve score-merge, small enough to be
+#   an anti-flood measure rather than "pass everything through".
+# - Bank-size asymmetry already OVER-represents small banks (they contribute all
+#   their results while the large bank is ranking/budget-limited). This cap trims
+#   the large bank's flood; it must never starve a bank that has results to zero
+#   (``max_per_bank`` is clamped to >= 1).
+# - Rejected alternatives: ``interleave`` as the anti-flood fix (forces parity and
+#   makes small-bank over-representation worse); ``max_tokens / n_banks`` (starves
+#   both banks' cross-encoder windows).
+DEFAULT_PER_BANK_MERGE_CAP = 50
+
+# Multi-bank fan-out only. Single-bank ``recall_async`` default is unchanged.
+#
+# Real semantics are narrower than the name: when True, the engine drops raw facts
+# whose ids appear in a returned observation's ``source_memory_ids``. It does NOT
+# catch unlinked "same sentence, different fact_type" twins - that is what
+# :func:`dedup_exact_normalized` is for.
+MULTI_BANK_PREFER_OBSERVATIONS = True
+
+# Metadata keys written into ``RecallResult.metadata`` by the orchestrator.
+META_MULTI_BANK = "multi_bank"
+META_MERGE_REQUESTED = "merge_requested"
+META_MERGE_APPLIED = "merge_applied"
+META_MERGE_FALLBACK_REASON = "merge_fallback_reason"
+META_BANKS = "banks"
+META_DEDUP = "dedup"
+META_DEDUP_DROPPED = "dedup_dropped"
+META_PER_BANK_CAP = "per_bank_cap"
+# Was hard-coded ``"none"`` in v1 (no cross-bank dedup). Now exact/normalized text.
+META_DEDUP_V1 = "exact_normalized"
+META_DEDUP_MODE = META_DEDUP_V1  # alias; value is the active mode string
+
+# Distinct post-gather fallback reason when returned facts lack usable CE scores
+# (e.g. RRF passthrough cross-encoder sets scores.reranker=None for every result).
+FALLBACK_NO_USABLE_RERANKER_SCORES = (
+    "no usable cross-encoder scores in returned results (scores.reranker is None); "
+    "score-merge would not order by relevance"
+)
+
+_T = TypeVar("_T")
+
+# Banks with no facts in the merged list still may contribute side dicts
+# (e.g. chunks fetched independently of max_tokens); rank them after all others.
+_SIDE_DICT_UNRANKED = 10**9
+
+
+@dataclass(frozen=True)
+class DedupedFacts:
+    """Facts kept after exact/normalized dedup, plus how many copies were dropped.
+
+    Named type instead of a (facts, dropped) tuple: the project bar forbids
+    multi-item tuple returns even for internal helpers.
+    """
+
+    facts: list[MemoryFact]
+    dropped: int
+
+
+def stamp_bank_id(fact: MemoryFact, bank_id: str) -> MemoryFact:
+    """Return a copy of ``fact`` with ``bank_id`` set (orchestrator attribution)."""
+    return fact.model_copy(update={"bank_id": bank_id})
+
+
+def bank_rank_from_merged(facts: Sequence[MemoryFact]) -> dict[str, int]:
+    """Map each bank_id to its best (earliest) position in the merged result list.
+
+    Lower rank wins on side-dict key collisions. Banks absent from ``facts`` are
+    omitted (callers treat them as unranked).
+    """
+    ranks: dict[str, int] = {}
+    for index, fact in enumerate(facts):
+        bid = fact.bank_id
+        if bid is not None and bid not in ranks:
+            ranks[bid] = index
+    return ranks
+
+
+def union_merge_dicts(
+    bank_dicts: Sequence[tuple[str, Mapping[str, _T] | None]],
+    *,
+    bank_rank: Mapping[str, int],
+) -> dict[str, _T] | None:
+    """Union-merge optional per-bank dicts; on key collision keep the higher-ranked bank.
+
+    ``bank_rank`` maps bank_id → rank (lower is better), typically from
+    :func:`bank_rank_from_merged`. Banks not present in ``bank_rank`` sort last.
+    Returns ``None`` when no bank contributed any entries (mirrors single-bank
+    ``include_*`` omitted behaviour).
+    """
+    winners: dict[str, tuple[int, _T]] = {}
+    for bank_id, mapping in bank_dicts:
+        if not mapping:
+            continue
+        rank = bank_rank.get(bank_id, _SIDE_DICT_UNRANKED)
+        for key, value in mapping.items():
+            previous = winners.get(key)
+            if previous is None or rank < previous[0]:
+                winners[key] = (rank, value)
+    if not winners:
+        return None
+    return {key: pair[1] for key, pair in winners.items()}
+
+
+def _reranker_score(fact: MemoryFact) -> float:
+    """Normalized cross-encoder score used for score-merge; missing → -inf (sort last)."""
+    if fact.scores is None or fact.scores.reranker is None:
+        return float("-inf")
+    return float(fact.scores.reranker)
+
+
+def cap_per_bank_results(
+    bank_results: Sequence[tuple[str, Sequence[MemoryFact]]],
+    *,
+    max_per_bank: int = DEFAULT_PER_BANK_MERGE_CAP,
+) -> list[tuple[str, list[MemoryFact]]]:
+    """Take ``outcome.results[:M]`` per bank before merging (anti-flood).
+
+    ``max_per_bank`` is clamped to at least 1 so a bank that returned results is
+    never starved to zero by the cap alone (an empty bank still contributes nothing).
+
+    Does not re-rank; preserves each bank's existing within-bank order. Apply this
+    *before* :func:`score_merge` / :func:`interleave_merge`.
+    """
+    m = max(1, int(max_per_bank))
+    return [(bank_id, list(facts[:m])) for bank_id, facts in bank_results]
+
+
+def score_merge(bank_results: Sequence[tuple[str, Sequence[MemoryFact]]]) -> list[MemoryFact]:
+    """Sort the union of per-bank results by normalized cross-encoder score descending.
+
+    Tie-break (stable, deterministic): bank list order, then within-bank rank (input
+    order). Each result is stamped with its source ``bank_id``.
+
+    Score-merge is only honest when every contributing bank actually ran
+    cross_encoder reranking (see ``cross_encoder_eligible`` / orchestrator auto-fallback).
+    """
+    tagged: list[tuple[float, int, int, MemoryFact]] = []
+    for bank_idx, (bank_id, facts) in enumerate(bank_results):
+        for rank, fact in enumerate(facts):
+            stamped = stamp_bank_id(fact, bank_id)
+            # Negate score so ascending sort yields highest first; bank_idx/rank break ties.
+            tagged.append((-_reranker_score(stamped), bank_idx, rank, stamped))
+    tagged.sort(key=lambda item: (item[0], item[1], item[2]))
+    return [item[3] for item in tagged]
+
+
+def interleave_merge(bank_results: Sequence[tuple[str, Sequence[MemoryFact]]]) -> list[MemoryFact]:
+    """Round-robin merge by per-bank rank: bankA#1, bankB#1, bankA#2, bankB#2, ...
+
+    Banks appear in the order of ``bank_results``. Empty banks contribute no slots.
+    Each result is stamped with its source ``bank_id``. Guarantees per-bank
+    representation when banks have results (unlike pure score sort).
+
+    Note: interleave is the score-merge *fallback* when CE scores are unusable. It
+    is NOT the anti-flood measure for bank-size asymmetry (that is
+    :func:`cap_per_bank_results`); using interleave as parity-forcing anti-flood
+    was considered and rejected.
+    """
+    stamped_lists: list[list[MemoryFact]] = [
+        [stamp_bank_id(fact, bank_id) for fact in facts] for bank_id, facts in bank_results
+    ]
+    merged: list[MemoryFact] = []
+    max_len = max((len(lst) for lst in stamped_lists), default=0)
+    for rank in range(max_len):
+        for lst in stamped_lists:
+            if rank < len(lst):
+                merged.append(lst[rank])
+    return merged
+
+
+def normalize_dedup_key(text: str | None) -> str:
+    """Normalize fact text for exact cross-bank dedup: casefold + whitespace collapse.
+
+    Whitespace is any Unicode whitespace (``str.split`` with no args). Case uses
+    ``str.casefold`` (stronger than lower for some locales). Punctuation and
+    near-paraphrase differences are intentionally preserved so genuinely distinct
+    facts are not collapsed.
+    """
+    return " ".join((text or "").casefold().split())
+
+
+def dedup_exact_normalized(facts: Sequence[MemoryFact]) -> DedupedFacts:
+    """Drop later duplicates of the same normalized text; keep the higher-ranked copy.
+
+    Higher-ranked = earlier in ``facts`` (call after score/interleave merge so the
+    list is already ordered). Must run *before* :func:`cut_to_token_budget` so
+    dropped duplicates do not consume token budget.
+
+    Exact / normalized only - no embedding or near-duplicate collapse.
+    """
+    seen: set[str] = set()
+    kept: list[MemoryFact] = []
+    dropped = 0
+    for fact in facts:
+        key = normalize_dedup_key(fact.text)
+        if key in seen:
+            dropped += 1
+            continue
+        seen.add(key)
+        kept.append(fact)
+    return DedupedFacts(facts=kept, dropped=dropped)
+
+
+def cut_to_token_budget(facts: Sequence[MemoryFact], max_tokens: int) -> list[MemoryFact]:
+    """Keep results until ``max_tokens`` on the ``text`` field (same semantics as single-bank).
+
+    Stops before including a fact that would exceed the budget. Counts tokens with
+    the shared cl100k_base encoding. ``max_tokens <= 0`` yields an empty list.
+    """
+    if max_tokens <= 0:
+        return []
+    encoding = get_token_encoding()
+    filtered: list[MemoryFact] = []
+    total = 0
+    for fact in facts:
+        text_tokens = len(encoding.encode(fact.text or ""))
+        if total + text_tokens <= max_tokens:
+            filtered.append(fact)
+            total += text_tokens
+        else:
+            break
+    return filtered
+
+
+def merge_cap_dedup_cut(
+    bank_results: Sequence[tuple[str, Sequence[MemoryFact]]],
+    *,
+    merge: MultiBankMerge,
+    max_tokens: int,
+    max_per_bank: int = DEFAULT_PER_BANK_MERGE_CAP,
+) -> DedupedFacts:
+    """Compose the multi-bank post-gather pipeline: cap -> merge -> dedup -> token cut.
+
+    ``DedupedFacts.facts`` is the token-cut list. ``DedupedFacts.dropped`` is how
+    many facts ``dedup_exact_normalized`` removed (counted before the cut).
+    Orchestrators may call the steps individually; this helper encodes the order.
+    """
+    capped = cap_per_bank_results(bank_results, max_per_bank=max_per_bank)
+    if merge == "score":
+        merged = score_merge(capped)
+    else:
+        merged = interleave_merge(capped)
+    deduped = dedup_exact_normalized(merged)
+    return DedupedFacts(
+        facts=cut_to_token_budget(deduped.facts, max_tokens),
+        dropped=deduped.dropped,
+    )
+
+
+def cross_encoder_eligible(
+    *,
+    requested_reranking: str,
+    bank_enable_reranking: Sequence[bool],
+) -> tuple[bool, str | None]:
+    """Whether score-merge is *predicted* valid from config (pre-flight).
+
+    Returns ``(True, None)`` when every bank would resolve to cross_encoder, else
+    ``(False, reason)`` describing why score-merge must fall back to interleave.
+
+    Mirrors ``_resolve_reranking``: only ``cross_encoder`` is downgraded when
+    ``enable_reranking`` is false (to ``rrf``). Caller-requested ``rrf`` / ``interleave``
+    never produce comparable ``scores.reranker`` values.
+
+    This is necessary but not sufficient: the orchestrator also checks
+    :func:`has_usable_reranker_scores` on the actual returned facts (post-gather),
+    because an RRF passthrough cross-encoder still "resolves" to cross_encoder yet
+    writes ``scores.reranker=None`` on every result.
+    """
+    if requested_reranking != "cross_encoder":
+        return (
+            False,
+            f"requested reranking={requested_reranking!r} (score-merge requires cross_encoder)",
+        )
+    if not all(bank_enable_reranking):
+        return (
+            False,
+            "one or more banks have enable_reranking=false (resolved reranking would be rrf)",
+        )
+    return True, None
+
+
+def has_usable_reranker_scores(bank_results: Sequence[tuple[str, Sequence[MemoryFact]]]) -> bool:
+    """True when returned facts include at least one usable ``scores.reranker`` value.
+
+    Empty result sets are treated as usable (nothing to mis-order). If any facts are
+    present, at least one must carry a non-None ``scores.reranker``; otherwise
+    score-merge degenerates to bank-concatenation under a stable sort of all -inf.
+    """
+    saw_fact = False
+    for _bank_id, facts in bank_results:
+        for fact in facts:
+            saw_fact = True
+            if fact.scores is not None and fact.scores.reranker is not None:
+                return True
+    return not saw_fact
+
+
+def build_multi_bank_metadata(
+    *,
+    merge_requested: MultiBankMerge,
+    merge_applied: MultiBankMerge,
+    merge_fallback_reason: str | None,
+    bank_statuses: dict[str, dict],
+    dedup: str = META_DEDUP_MODE,
+    dedup_dropped: int = 0,
+    per_bank_cap: int = DEFAULT_PER_BANK_MERGE_CAP,
+) -> dict:
+    """Assemble the multi-bank block stored on ``RecallResult.metadata``.
+
+    ``dedup`` is the mode string (default :data:`META_DEDUP_MODE` /
+    ``exact_normalized``). ``dedup_dropped`` is how many facts were removed by
+    :func:`dedup_exact_normalized`. ``per_bank_cap`` records the M used for
+    :func:`cap_per_bank_results`.
+    """
+    return {
+        META_MULTI_BANK: {
+            META_MERGE_REQUESTED: merge_requested,
+            META_MERGE_APPLIED: merge_applied,
+            META_MERGE_FALLBACK_REASON: merge_fallback_reason,
+            META_BANKS: bank_statuses,
+            META_DEDUP: dedup,
+            META_DEDUP_DROPPED: int(dedup_dropped),
+            META_PER_BANK_CAP: int(per_bank_cap),
+        }
+    }

--- a/hindsight-api-slim/hindsight_api/engine/multi_bank_recall.py
+++ b/hindsight-api-slim/hindsight_api/engine/multi_bank_recall.py
@@ -1,14 +1,21 @@
 """Pure helpers for multi-bank recall merge + token budget cut.
 
 The orchestrator (``MemoryEngine.recall_multi_async``) fans out one ``recall_async``
-per bank and then uses these helpers to order and truncate the union.
+per bank (``reranking="rrf"`` when union CE will run) and then uses these helpers
+to select a union, apply one CrossEncoder pass, order, and truncate.
 
 Pipeline order (orchestrator must compose in this order):
 
-1. Per-bank contribution cap (``cap_per_bank_results``) - anti-flood into the merge pool.
-2. Merge (``score_merge`` or ``interleave_merge`` fallback).
-3. Exact / normalized-text dedup (``dedup_exact_normalized``) - BEFORE token cut.
-4. Token budget cut (``cut_to_token_budget``).
+1. Per-bank RRF retrieval (no per-bank CE when union CE is eligible).
+2. Per-bank pre-cap + union select (``select_union_candidates``) — floor then
+   interleave fill up to ``union_cap`` (default 200). CE cost is O(union_cap),
+   not O(N_banks).
+3. One ``CrossEncoderReranker.rerank`` over the union (skipped if CE is
+   disabled / null / passthrough — today's rrf/interleave path).
+4. Per-bank floor after the CE cut (``apply_per_bank_floor``).
+5. Merge (``score_merge`` or ``interleave_merge`` fallback).
+6. Exact / normalized-text dedup (``dedup_exact_normalized``) - BEFORE token cut.
+7. Token budget cut (``cut_to_token_budget``).
 
 Multi-bank fan-out defaults (orchestrator only; single-bank defaults unchanged):
 
@@ -18,8 +25,10 @@ Multi-bank fan-out defaults (orchestrator only; single-bank defaults unchanged):
 
 Limitations still open:
 
-- Score-merge uses each result's existing normalized cross-encoder score
-  (``scores.reranker``); it does not run a second cross-encoder pass over the union.
+- Union cap 200: a 5-bank fan-out keeps per-bank RRF ranks 0-39 in the CE
+  pool (``union_cap // n_banks``). A caller ``max_tokens`` of ~2000 applied
+  *before* CE in RRF order drops those deeper ranks; the union path therefore
+  widens the per-bank subcall budget and applies the caller budget after CE.
 - No embedding / near-duplicate collapse (would silently merge distinct facts such
   as "invalidate" vs "supersede").
 - No cross-bank supersession: a stale fact in bank A can outrank its correction in
@@ -30,9 +39,11 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Literal, TypeVar
+from datetime import date, datetime
+from typing import Any, Literal, TypeVar
 
-from .response_models import MemoryFact
+from .response_models import MemoryFact, RecallScores
+from .search.types import MergedCandidate, RetrievalResult
 from .token_encoding import get_token_encoding
 
 MultiBankMerge = Literal["score", "interleave"]
@@ -62,6 +73,16 @@ MAX_MULTI_BANK_RECALL_BANKS = 10
 #   both banks' cross-encoder windows).
 DEFAULT_PER_BANK_MERGE_CAP = 50
 
+# Union CE pool. 200 keeps per-bank RRF ranks 0-39 at N=5 (measured golds
+# lived at ranks 13-37). Cost stays O(cap). Floor default 1 = never drop a
+# bank that returned facts when union_cap >= n_banks (true at defaults:
+# 200 >= 10).
+DEFAULT_MULTI_UNION_CAP = 200
+DEFAULT_PER_BANK_FLOOR = 1
+# When union CE will run, each recall_async subcall uses at least this many
+# tokens so a caller budget of ~2000 cannot drop deep RRF ranks before CE.
+DEFAULT_UNION_SUBCALL_MAX_TOKENS = 100_000
+
 # Multi-bank fan-out only. Single-bank ``recall_async`` default is unchanged.
 #
 # Real semantics are narrower than the name: when True, the engine drops raw facts
@@ -79,6 +100,9 @@ META_BANKS = "banks"
 META_DEDUP = "dedup"
 META_DEDUP_DROPPED = "dedup_dropped"
 META_PER_BANK_CAP = "per_bank_cap"
+META_UNION_CE = "union_ce"
+META_UNION_CAP = "union_cap"
+META_PER_BANK_FLOOR = "per_bank_floor"
 # Was hard-coded ``"none"`` in v1 (no cross-bank dedup). Now exact/normalized text.
 META_DEDUP_V1 = "exact_normalized"
 META_DEDUP_MODE = META_DEDUP_V1  # alias; value is the active mode string
@@ -95,6 +119,23 @@ _T = TypeVar("_T")
 # Banks with no facts in the merged list still may contribute side dicts
 # (e.g. chunks fetched independently of max_tokens); rank them after all others.
 _SIDE_DICT_UNRANKED = 10**9
+
+
+@dataclass(frozen=True)
+class UnionCandidatePool:
+    """Facts selected for the single union CrossEncoder pass, plus bank order."""
+
+    facts: list[MemoryFact]
+    bank_order: list[str]
+
+
+@dataclass(frozen=True)
+class TokenedCandidate:
+    """One MemoryFact paired with a unique CE token and a MergedCandidate."""
+
+    token: str
+    fact: MemoryFact
+    candidate: MergedCandidate
 
 
 @dataclass(frozen=True)
@@ -176,6 +217,190 @@ def cap_per_bank_results(
     """
     m = max(1, int(max_per_bank))
     return [(bank_id, list(facts[:m])) for bank_id, facts in bank_results]
+
+
+def _parse_iso_datetime(value: Any) -> datetime | None:
+    """Accept ISO strings *and* datetime/date (to_dict hands datetimes).
+
+    ``datetime.replace("Z", ...)`` is ``datetime.replace`` (year/month/...)
+    and raises TypeError, which would abort the whole union CE. Strings from
+    MemoryFact.isoformat() are unchanged.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day)
+    text = str(value)
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def union_per_bank_max_tokens(caller_max_tokens: int, *, union_ce: bool) -> int:
+    """Token budget for each recall_async subcall.
+
+    When union CE will run, do not apply the caller's (often 2000) cut in
+    RRF order — that cut drops the deeper ranks that the union pass is
+    meant to rescore. The caller budget is still applied after union CE
+    via merge_cap_dedup_cut.
+    """
+    caller = int(caller_max_tokens)
+    if not union_ce:
+        return caller
+    return max(caller, DEFAULT_UNION_SUBCALL_MAX_TOKENS)
+
+
+def select_union_candidates(
+    bank_results: Sequence[tuple[str, Sequence[MemoryFact]]],
+    *,
+    per_bank_pre_cap: int = DEFAULT_PER_BANK_MERGE_CAP,
+    union_cap: int = DEFAULT_MULTI_UNION_CAP,
+    k_floor: int = DEFAULT_PER_BANK_FLOOR,
+) -> UnionCandidatePool:
+    """Pre-cap each bank, reserve a floor, then interleave-fill up to ``union_cap``.
+
+    Round-robin floor reservation so a CE-weak bank is not dropped before the
+    union CE runs, as long as ``union_cap >= n_banks_with_facts``. When the cap
+    is smaller than the bank count, later banks can be omitted — that is the
+    cap, not a silent starve-to-zero of a bank that fit.
+    """
+    union_cap = max(1, int(union_cap))
+    k_floor = max(1, int(k_floor))
+    pre_capped = cap_per_bank_results(bank_results, max_per_bank=per_bank_pre_cap)
+    stamped: list[tuple[str, list[MemoryFact]]] = [
+        (bank_id, [stamp_bank_id(fact, bank_id) for fact in facts]) for bank_id, facts in pre_capped
+    ]
+    bank_order = [bank_id for bank_id, _facts in stamped]
+    n_with = sum(1 for _bank_id, facts in stamped if facts)
+    fair = min(k_floor, max(1, union_cap // max(1, n_with)))
+
+    taken: dict[str, int] = {bank_id: 0 for bank_id, _facts in stamped}
+    reserved: list[MemoryFact] = []
+    for _round in range(fair):
+        for bank_id, facts in stamped:
+            if len(reserved) >= union_cap:
+                break
+            idx = taken[bank_id]
+            if idx < len(facts) and idx < fair:
+                reserved.append(facts[idx])
+                taken[bank_id] = idx + 1
+        if len(reserved) >= union_cap:
+            break
+
+    leftovers = [(bank_id, facts[taken[bank_id] :]) for bank_id, facts in stamped]
+    if len(reserved) < union_cap:
+        reserved.extend(interleave_merge(leftovers)[: union_cap - len(reserved)])
+    return UnionCandidatePool(facts=reserved[:union_cap], bank_order=bank_order)
+
+
+def apply_per_bank_floor(
+    facts: Sequence[MemoryFact],
+    *,
+    k_floor: int,
+    keep: int,
+    bank_order: Sequence[str],
+) -> list[MemoryFact]:
+    """After CE scoring, keep each bank's top ``min(k_floor, count)`` then fill by CE.
+
+    ``keep`` is the post-CE cut. A CE-weak bank still contributes its floor
+    provided ``keep >= n_banks_with_facts``.
+    """
+    keep = max(0, int(keep))
+    if keep == 0 or not facts:
+        return []
+    k_floor = max(1, int(k_floor))
+
+    by_bank: dict[str, list[MemoryFact]] = {}
+    for fact in facts:
+        bid = fact.bank_id or ""
+        by_bank.setdefault(bid, []).append(fact)
+    for lst in by_bank.values():
+        lst.sort(key=_reranker_score, reverse=True)
+
+    ordered = [bid for bid in bank_order if by_bank.get(bid)]
+    for bid in by_bank:
+        if bid not in ordered:
+            ordered.append(bid)
+    if not ordered:
+        return []
+
+    fair = min(k_floor, max(1, keep // max(1, len(ordered))))
+    protected: list[MemoryFact] = []
+    protected_keys: set[tuple[str, str]] = set()
+    taken: dict[str, int] = {bid: 0 for bid in ordered}
+    for _round in range(fair):
+        for bid in ordered:
+            if len(protected) >= keep:
+                break
+            lst = by_bank[bid]
+            idx = taken[bid]
+            if idx < len(lst) and idx < fair:
+                fact = lst[idx]
+                protected.append(fact)
+                protected_keys.add((bid, fact.id))
+                taken[bid] = idx + 1
+        if len(protected) >= keep:
+            break
+
+    rest = [
+        fact
+        for fact in sorted(facts, key=_reranker_score, reverse=True)
+        if (fact.bank_id or "", fact.id) not in protected_keys
+    ]
+    return (protected + rest)[:keep]
+
+
+def memory_facts_to_merged_candidates(facts: Sequence[MemoryFact]) -> list[TokenedCandidate]:
+    """Build CE inputs. Tokens stay unique when two banks share a fact id."""
+    tokened: list[TokenedCandidate] = []
+    for index, fact in enumerate(facts):
+        token = f"{index}:{fact.bank_id or ''}:{fact.id}"
+        retrieval = RetrievalResult(
+            id=token,
+            text=fact.text,
+            fact_type=fact.fact_type,
+            context=fact.context,
+            occurred_start=_parse_iso_datetime(fact.occurred_start),
+        )
+        tokened.append(
+            TokenedCandidate(
+                token=token,
+                fact=fact,
+                candidate=MergedCandidate(retrieval=retrieval, rrf_score=0.0),
+            )
+        )
+    return tokened
+
+
+def stamp_union_ce_scores(
+    facts: Sequence[MemoryFact],
+    tokens: Sequence[str],
+    score_by_token: Mapping[str, float],
+) -> list[MemoryFact]:
+    """Copy CE-normalized scores onto each fact (comparable across banks)."""
+    stamped: list[MemoryFact] = []
+    for fact, token in zip(facts, tokens, strict=True):
+        score = score_by_token.get(token)
+        if score is None:
+            stamped.append(fact)
+            continue
+        previous = fact.scores
+        stamped.append(
+            fact.model_copy(
+                update={
+                    "scores": RecallScores(
+                        final=float(score),
+                        reranker=float(score),
+                        semantic=previous.semantic if previous is not None else None,
+                        keyword=previous.keyword if previous is not None else None,
+                    )
+                }
+            )
+        )
+    return stamped
 
 
 def score_merge(bank_results: Sequence[tuple[str, Sequence[MemoryFact]]]) -> list[MemoryFact]:
@@ -357,13 +582,17 @@ def build_multi_bank_metadata(
     dedup: str = META_DEDUP_MODE,
     dedup_dropped: int = 0,
     per_bank_cap: int = DEFAULT_PER_BANK_MERGE_CAP,
+    union_ce: bool = False,
+    union_cap: int = DEFAULT_MULTI_UNION_CAP,
+    per_bank_floor: int = DEFAULT_PER_BANK_FLOOR,
 ) -> dict:
     """Assemble the multi-bank block stored on ``RecallResult.metadata``.
 
     ``dedup`` is the mode string (default :data:`META_DEDUP_MODE` /
     ``exact_normalized``). ``dedup_dropped`` is how many facts were removed by
     :func:`dedup_exact_normalized`. ``per_bank_cap`` records the M used for
-    :func:`cap_per_bank_results`.
+    :func:`cap_per_bank_results`. ``union_ce`` is whether one CrossEncoder pass
+    ran over the union (HTTP request schema unchanged; this is response metadata).
     """
     return {
         META_MULTI_BANK: {
@@ -374,5 +603,8 @@ def build_multi_bank_metadata(
             META_DEDUP: dedup,
             META_DEDUP_DROPPED: int(dedup_dropped),
             META_PER_BANK_CAP: int(per_bank_cap),
+            META_UNION_CE: bool(union_ce),
+            META_UNION_CAP: int(union_cap),
+            META_PER_BANK_FLOOR: int(per_bank_floor),
         }
     }

--- a/hindsight-api-slim/hindsight_api/engine/response_models.py
+++ b/hindsight-api-slim/hindsight_api/engine/response_models.py
@@ -283,6 +283,13 @@ class MemoryFact(BaseModel):
         None,
         description="Recall scores from each pipeline stage (final/reranker/semantic/keyword). Not returned for source facts.",
     )
+    bank_id: str | None = Field(
+        None,
+        description=(
+            "Source bank for this fact. Set by multi-bank recall (recall_multi_async); "
+            "None for single-bank recall_async results."
+        ),
+    )
 
 
 class ChunkInfo(BaseModel):
@@ -359,6 +366,13 @@ class RecallResult(BaseModel):
             "Whether the source_facts map was cut short by the token budget. When true, some IDs in "
             "results[].source_fact_ids have no entry in source_facts — the budget ran out, the "
             "references are not dangling. Only set when source facts were requested."
+        ),
+    )
+    metadata: dict[str, Any] | None = Field(
+        None,
+        description=(
+            "Optional response metadata. Multi-bank recall populates metadata['multi_bank'] with "
+            "merge mode, per-bank status, fallback reason, exact_normalized dedup, and per_bank_cap."
         ),
     )
 

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -847,8 +847,7 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
     base_description = config.recall_description or DEFAULT_MCP_RECALL_DESCRIPTION
     if config.recall_description is None:
         description = (
-            base_description
-            + "\n\nMulti-bank: pass bank_ids (2+) to search several banks in parallel; "
+            base_description + "\n\nMulti-bank: pass bank_ids (2+) to search several banks in parallel; "
             "a single bank_ids entry selects that bank; omit to use bank_id/session. "
             "merge='score' (default) orders by cross-encoder score and auto-falls back to "
             "interleave when CE scores are not usable; merge='interleave' round-robins by rank. "
@@ -872,9 +871,7 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
         min_scores: dict | None,
     ) -> dict[str, Any]:
         if tags is not None and tag_groups is not None:
-            raise ValueError(
-                "'tags' and 'tag_groups' are mutually exclusive. Use 'tag_groups' for compound filtering."
-            )
+            raise ValueError("'tags' and 'tag_groups' are mutually exclusive. Use 'tag_groups' for compound filtering.")
         budget_map = {"low": Budget.LOW, "mid": Budget.MID, "high": Budget.HIGH}
         budget_enum = budget_map.get(budget.lower(), Budget.HIGH)
         fact_types = types if types is not None else list(VALID_RECALL_FACT_TYPES)

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -842,7 +842,60 @@ def _register_sync_retain(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsCo
 
 def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig) -> None:
     """Register the recall tool."""
-    description = config.recall_description or DEFAULT_MCP_RECALL_DESCRIPTION
+    # Append multi-bank notes only when the default description is used, so custom
+    # recall_description overrides stay fully under operator control.
+    base_description = config.recall_description or DEFAULT_MCP_RECALL_DESCRIPTION
+    if config.recall_description is None:
+        description = (
+            base_description
+            + "\n\nMulti-bank: pass bank_ids (2+) to search several banks in parallel; "
+            "a single bank_ids entry selects that bank; omit to use bank_id/session. "
+            "merge='score' (default) orders by cross-encoder score and auto-falls back to "
+            "interleave when CE scores are not usable; merge='interleave' round-robins by rank. "
+            "Results include bank_id; metadata.multi_bank reports per-bank status, fallback, "
+            "exact_normalized dedup, and the per-bank cap."
+        )
+    else:
+        description = base_description
+
+    def _build_common_recall_kwargs(
+        *,
+        query: str,
+        max_tokens: int,
+        budget: str,
+        types: list[str] | None,
+        prefer_observations: bool,
+        tags: list[str] | None,
+        tags_match: str,
+        tag_groups: list[dict] | None,
+        query_timestamp: str | None,
+        min_scores: dict | None,
+    ) -> dict[str, Any]:
+        if tags is not None and tag_groups is not None:
+            raise ValueError(
+                "'tags' and 'tag_groups' are mutually exclusive. Use 'tag_groups' for compound filtering."
+            )
+        budget_map = {"low": Budget.LOW, "mid": Budget.MID, "high": Budget.HIGH}
+        budget_enum = budget_map.get(budget.lower(), Budget.HIGH)
+        fact_types = types if types is not None else list(VALID_RECALL_FACT_TYPES)
+        kwargs: dict[str, Any] = {
+            "query": query,
+            "fact_type": fact_types,
+            "prefer_observations": prefer_observations,
+            "budget": budget_enum,
+            "max_tokens": max_tokens,
+            "request_context": _get_request_context(config),
+        }
+        if tags is not None:
+            kwargs["tags"] = tags
+            kwargs["tags_match"] = tags_match
+        if tag_groups is not None:
+            kwargs["tag_groups"] = _TAG_GROUP_LIST_ADAPTER.validate_python(tag_groups)
+        if query_timestamp is not None:
+            kwargs["question_date"] = parse_timestamp(query_timestamp)
+        if min_scores is not None:
+            kwargs["min_scores"] = MinScores.model_validate(min_scores)
+        return kwargs
 
     if config.include_bank_id_param:
 
@@ -859,6 +912,8 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
             query_timestamp: str | None = None,
             min_scores: dict | None = None,
             bank_id: str | None = None,
+            bank_ids: list[str] | None = None,
+            merge: str = "score",
         ) -> str | dict:
             """
             Args:
@@ -883,42 +938,40 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                     All inclusive and AND-ed; omit for no score filtering. The reranker's absolute scores are
                     not calibrated across queries, so only threshold against scores you've calibrated for your
                     own data.
-                bank_id: Optional bank to search in (defaults to session bank). Use for cross-bank operations.
+                bank_id: Optional bank to search in (defaults to session bank). Use for single-bank operations.
+                bank_ids: Optional list of bank ids. 2+ runs multi-bank recall; a single entry selects
+                    that bank for single-bank recall; empty/omitted uses bank_id or the session bank.
+                merge: Multi-bank merge mode — 'score' (default) or 'interleave'. score auto-falls back
+                    to interleave when CE is not comparable across banks.
             """
             try:
-                target_bank = bank_id or config.bank_id_resolver()
-                if target_bank is None:
-                    return "Error: No bank_id configured"
-
-                if tags is not None and tag_groups is not None:
-                    raise ValueError(
-                        "'tags' and 'tag_groups' are mutually exclusive. Use 'tag_groups' for compound filtering."
+                common = _build_common_recall_kwargs(
+                    query=query,
+                    max_tokens=max_tokens,
+                    budget=budget,
+                    types=types,
+                    prefer_observations=prefer_observations,
+                    tags=tags,
+                    tags_match=tags_match,
+                    tag_groups=tag_groups,
+                    query_timestamp=query_timestamp,
+                    min_scores=min_scores,
+                )
+                cleaned_ids = [b for b in (bank_ids or []) if isinstance(b, str) and b.strip()]
+                if len(cleaned_ids) >= 2:
+                    if merge not in ("score", "interleave"):
+                        raise ValueError("merge must be 'score' or 'interleave'")
+                    recall_result = await memory.recall_multi_async(
+                        bank_ids=cleaned_ids,
+                        merge=merge,  # type: ignore[arg-type]
+                        **common,
                     )
-
-                budget_map = {"low": Budget.LOW, "mid": Budget.MID, "high": Budget.HIGH}
-                budget_enum = budget_map.get(budget.lower(), Budget.HIGH)
-                fact_types = types if types is not None else list(VALID_RECALL_FACT_TYPES)
-
-                recall_kwargs: dict[str, Any] = {
-                    "bank_id": target_bank,
-                    "query": query,
-                    "fact_type": fact_types,
-                    "prefer_observations": prefer_observations,
-                    "budget": budget_enum,
-                    "max_tokens": max_tokens,
-                    "request_context": _get_request_context(config),
-                }
-                if tags is not None:
-                    recall_kwargs["tags"] = tags
-                    recall_kwargs["tags_match"] = tags_match
-                if tag_groups is not None:
-                    recall_kwargs["tag_groups"] = _TAG_GROUP_LIST_ADAPTER.validate_python(tag_groups)
-                if query_timestamp is not None:
-                    recall_kwargs["question_date"] = parse_timestamp(query_timestamp)
-                if min_scores is not None:
-                    recall_kwargs["min_scores"] = MinScores.model_validate(min_scores)
-
-                recall_result = await memory.recall_async(**recall_kwargs)
+                else:
+                    # Length-1 bank_ids selects THAT bank; empty falls back to bank_id/session.
+                    target_bank = cleaned_ids[0] if len(cleaned_ids) == 1 else (bank_id or config.bank_id_resolver())
+                    if target_bank is None:
+                        return "Error: No bank_id configured"
+                    recall_result = await memory.recall_async(bank_id=target_bank, **common)
 
                 return recall_result.model_dump_json(indent=2)
             except OperationValidationError as e:
@@ -944,6 +997,8 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
             tag_groups: list[dict] | None = None,
             query_timestamp: str | None = None,
             min_scores: dict | None = None,
+            bank_ids: list[str] | None = None,
+            merge: str = "score",
         ) -> dict:
             """
             Args:
@@ -968,41 +1023,39 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                     All inclusive and AND-ed; omit for no score filtering. The reranker's absolute scores are
                     not calibrated across queries, so only threshold against scores you've calibrated for your
                     own data.
+                bank_ids: Optional list of bank ids. 2+ runs multi-bank recall; a single entry selects
+                    that bank for single-bank recall; empty/omitted uses the session bank.
+                merge: Multi-bank merge mode — 'score' (default) or 'interleave'. score auto-falls back
+                    to interleave when CE is not comparable across banks.
             """
             try:
-                target_bank = config.bank_id_resolver()
-                if target_bank is None:
-                    return {"error": "No bank_id configured", "results": []}
-
-                if tags is not None and tag_groups is not None:
-                    raise ValueError(
-                        "'tags' and 'tag_groups' are mutually exclusive. Use 'tag_groups' for compound filtering."
+                common = _build_common_recall_kwargs(
+                    query=query,
+                    max_tokens=max_tokens,
+                    budget=budget,
+                    types=types,
+                    prefer_observations=prefer_observations,
+                    tags=tags,
+                    tags_match=tags_match,
+                    tag_groups=tag_groups,
+                    query_timestamp=query_timestamp,
+                    min_scores=min_scores,
+                )
+                cleaned_ids = [b for b in (bank_ids or []) if isinstance(b, str) and b.strip()]
+                if len(cleaned_ids) >= 2:
+                    if merge not in ("score", "interleave"):
+                        raise ValueError("merge must be 'score' or 'interleave'")
+                    recall_result = await memory.recall_multi_async(
+                        bank_ids=cleaned_ids,
+                        merge=merge,  # type: ignore[arg-type]
+                        **common,
                     )
-
-                budget_map = {"low": Budget.LOW, "mid": Budget.MID, "high": Budget.HIGH}
-                budget_enum = budget_map.get(budget.lower(), Budget.HIGH)
-                fact_types = types if types is not None else list(VALID_RECALL_FACT_TYPES)
-
-                recall_kwargs: dict[str, Any] = {
-                    "bank_id": target_bank,
-                    "query": query,
-                    "fact_type": fact_types,
-                    "prefer_observations": prefer_observations,
-                    "budget": budget_enum,
-                    "max_tokens": max_tokens,
-                    "request_context": _get_request_context(config),
-                }
-                if tags is not None:
-                    recall_kwargs["tags"] = tags
-                    recall_kwargs["tags_match"] = tags_match
-                if tag_groups is not None:
-                    recall_kwargs["tag_groups"] = _TAG_GROUP_LIST_ADAPTER.validate_python(tag_groups)
-                if query_timestamp is not None:
-                    recall_kwargs["question_date"] = parse_timestamp(query_timestamp)
-                if min_scores is not None:
-                    recall_kwargs["min_scores"] = MinScores.model_validate(min_scores)
-
-                recall_result = await memory.recall_async(**recall_kwargs)
+                else:
+                    # Length-1 bank_ids selects THAT bank; empty falls back to session.
+                    target_bank = cleaned_ids[0] if len(cleaned_ids) == 1 else config.bank_id_resolver()
+                    if target_bank is None:
+                        return {"error": "No bank_id configured", "results": []}
+                    recall_result = await memory.recall_async(bank_id=target_bank, **common)
 
                 return recall_result.model_dump()
             except OperationValidationError as e:

--- a/hindsight-api-slim/pyproject.toml
+++ b/hindsight-api-slim/pyproject.toml
@@ -189,6 +189,7 @@ markers = [
     "hs_llm_core: Core pipeline tests that need a real LLM but only one provider",
     "integration: Live external-API integration tests (require provider credentials; skipped without)",
     "slow: Slow tests (minutes); not run in fast CI",
+    "hs_bench: Synthetic latency benches; skipped unless HS_BENCH=1",
 ]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"

--- a/hindsight-api-slim/tests/bench_multi_bank_union.py
+++ b/hindsight-api-slim/tests/bench_multi_bank_union.py
@@ -1,0 +1,128 @@
+"""Synthetic multi-bank union-CE bench + quality overlap.
+
+The wall-clock bench is skipped unless ``HS_BENCH=1``. The quality test always
+runs: it is the arithmetic/ranking proof, not a live API measurement.
+
+Corpus (fixed, no LLM)::
+
+    query = "multi bank recall"
+    5 banks x 8 facts. Gold facts sit at RRF rank 0 of each bank and share
+    the query tokens. Remaining facts are decoys with no query-token overlap.
+
+    Fake CE score = |query tokens ∩ doc tokens| / |query tokens|.
+    Union cap 200 admits every fact (5*8=40), so union-CE top-5 vs
+    per-bank-CE-then-score-merge top-5 must overlap >= 4/5 (expect 5/5).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+from hindsight_api.engine.multi_bank_recall import (
+    apply_per_bank_floor,
+    score_merge,
+    select_union_candidates,
+    stamp_union_ce_scores,
+)
+from hindsight_api.engine.response_models import MemoryFact, RecallScores
+
+QUERY = "multi bank recall"
+
+GOLDS = {
+    "bank0": "multi bank recall union pass",
+    "bank1": "multi bank recall score merge",
+    "bank2": "multi bank recall one cross encoder",
+    "bank3": "multi bank recall worker isolation",
+    "bank4": "multi bank recall token budget",
+}
+
+
+def _ce_score(query: str, text: str) -> float:
+    q = set(query.lower().split())
+    t = set(text.lower().split())
+    return len(q & t) / max(1, len(q))
+
+
+def _fact(fact_id: str, text: str, *, bank_id: str) -> MemoryFact:
+    return MemoryFact(id=fact_id, text=text, fact_type="world", bank_id=bank_id)
+
+
+def _corpus() -> list[tuple[str, list[MemoryFact]]]:
+    banks: list[tuple[str, list[MemoryFact]]] = []
+    for i in range(5):
+        bid = f"bank{i}"
+        facts = [_fact(f"{bid}-gold", GOLDS[bid], bank_id=bid)]
+        facts.extend(_fact(f"{bid}-d{j}", f"decoy filler sentence {j} about weather", bank_id=bid) for j in range(7))
+        banks.append((bid, facts))
+    return banks
+
+
+def _score_facts(query: str, facts: list[MemoryFact]) -> list[MemoryFact]:
+    scored: list[MemoryFact] = []
+    for fact in facts:
+        value = _ce_score(query, fact.text)
+        scored.append(fact.model_copy(update={"scores": RecallScores(final=value, reranker=value)}))
+    return scored
+
+
+def test_union_ce_top5_overlaps_per_bank_ce() -> None:
+    """Quality: union-CE top-5 vs per-bank-CE top-5 overlap >= 4/5 on the corpus above."""
+    banks = _corpus()
+    per_bank_scored = [(bid, _score_facts(QUERY, facts)) for bid, facts in banks]
+    per_bank_top = [f.id for f in score_merge(per_bank_scored)[:5]]
+
+    pool = select_union_candidates(banks, per_bank_pre_cap=50, union_cap=100, k_floor=1)
+    union_scored = _score_facts(QUERY, pool.facts)
+    union_scored = stamp_union_ce_scores(
+        union_scored,
+        [f"{i}:{f.bank_id}:{f.id}" for i, f in enumerate(union_scored)],
+        {f"{i}:{f.bank_id}:{f.id}": (f.scores.reranker or 0.0) for i, f in enumerate(union_scored)},
+    )
+    floored = apply_per_bank_floor(union_scored, k_floor=1, keep=100, bank_order=[b for b, _ in banks])
+    by_bank: dict[str, list[MemoryFact]] = {}
+    for fact in floored:
+        by_bank.setdefault(fact.bank_id or "", []).append(fact)
+    union_top = [f.id for f in score_merge([(bid, by_bank.get(bid, [])) for bid, _ in banks])[:5]]
+
+    overlap = len(set(per_bank_top) & set(union_top))
+    assert overlap >= 4, (per_bank_top, union_top, overlap)
+
+
+@pytest.mark.hs_bench
+@pytest.mark.skipif(os.environ.get("HS_BENCH") != "1", reason="set HS_BENCH=1 to run the union-CE wall bench")
+def test_union_ce_wall_under_half_per_bank() -> None:
+    """5 banks x 60 candidates; fake CE sleeps per pair. union wall < 0.5 x per-bank wall."""
+    sleep_s = 0.002
+    n_banks = 5
+    n_cands = 60
+
+    def fake_predict(n_pairs: int) -> None:
+        time.sleep(sleep_s * n_pairs)
+
+    banks = [
+        (f"bank{i}", [_fact(f"b{i}-{j}", f"text {i} {j}", bank_id=f"bank{i}") for j in range(n_cands)])
+        for i in range(n_banks)
+    ]
+
+    t0 = time.perf_counter()
+    for _bid, facts in banks:
+        fake_predict(len(facts))
+    per_bank_wall = time.perf_counter() - t0
+
+    t1 = time.perf_counter()
+    pool = select_union_candidates(banks, per_bank_pre_cap=50, union_cap=100, k_floor=1)
+    fake_predict(len(pool.facts))
+    union_wall = time.perf_counter() - t1
+
+    assert len(pool.facts) == 100
+    print(
+        f"HS_BENCH union_ce: union={union_wall:.4f}s per_bank={per_bank_wall:.4f}s "
+        f"ratio={union_wall / per_bank_wall:.3f} sleep={sleep_s} "
+        f"banks={n_banks} cands={n_cands} union_cap=100 pre_cap=50 k_floor=1"
+    )
+    assert union_wall < 0.5 * per_bank_wall, (
+        f"union={union_wall:.3f}s per_bank={per_bank_wall:.3f}s sleep={sleep_s} banks={n_banks} cands={n_cands} cap=100"
+    )

--- a/hindsight-api-slim/tests/test_mcp_tools.py
+++ b/hindsight-api-slim/tests/test_mcp_tools.py
@@ -164,6 +164,12 @@ def mock_memory():
             model_dump_json=lambda indent=None: '{"results": []}', model_dump=lambda: {"results": []}
         )
     )
+    memory.recall_multi_async = AsyncMock(
+        return_value=MagicMock(
+            model_dump_json=lambda indent=None: '{"results": [], "metadata": {"multi_bank": {}}}',
+            model_dump=lambda: {"results": [], "metadata": {"multi_bank": {}}},
+        )
+    )
     memory.reflect_async = AsyncMock(
         return_value=MagicMock(
             model_dump_json=lambda indent=None: '{"text": "reflection"}',
@@ -1173,6 +1179,52 @@ class TestRecallNewParams:
         call_kwargs = mock_memory.recall_async.call_args.kwargs
         assert "tag_groups" in call_kwargs
         assert len(call_kwargs["tag_groups"]) == 1
+
+
+@pytest.mark.asyncio
+class TestRecallMultiBankParams:
+    """bank_ids (2+) routes to recall_multi_async; otherwise single-bank path."""
+
+    async def test_two_plus_bank_ids_calls_multi(self, mock_memory):
+        mcp = _make_mcp_server(mock_memory, {"recall"})
+        await _tools(mcp)["recall"].fn(query="test", bank_ids=["work", "personal"], merge="interleave")
+        mock_memory.recall_multi_async.assert_called_once()
+        mock_memory.recall_async.assert_not_called()
+        kwargs = mock_memory.recall_multi_async.call_args.kwargs
+        assert kwargs["bank_ids"] == ["work", "personal"]
+        assert kwargs["merge"] == "interleave"
+        assert kwargs["query"] == "test"
+
+    async def test_no_bank_ids_stays_single_bank(self, mock_memory):
+        mcp = _make_mcp_server(mock_memory, {"recall"})
+        await _tools(mcp)["recall"].fn(query="test")
+        mock_memory.recall_async.assert_called_once()
+        mock_memory.recall_multi_async.assert_not_called()
+
+    async def test_one_bank_id_selects_that_bank(self, mock_memory):
+        """A single-element bank_ids selects THAT bank (not the session bank)."""
+        mcp = _make_mcp_server(mock_memory, {"recall"})
+        await _tools(mcp)["recall"].fn(query="test", bank_ids=["work"])
+        mock_memory.recall_async.assert_called_once()
+        mock_memory.recall_multi_async.assert_not_called()
+        assert mock_memory.recall_async.call_args.kwargs["bank_id"] == "work"
+
+    async def test_multi_default_merge_is_score(self, mock_memory):
+        mcp = _make_mcp_server(mock_memory, {"recall"})
+        await _tools(mcp)["recall"].fn(query="test", bank_ids=["a", "b"])
+        assert mock_memory.recall_multi_async.call_args.kwargs["merge"] == "score"
+
+    async def test_multi_invalid_merge_returns_error(self, mock_memory):
+        mcp = _make_mcp_server(mock_memory, {"recall"})
+        result = await _tools(mcp)["recall"].fn(query="test", bank_ids=["a", "b"], merge="nope")
+        assert "merge" in result
+        mock_memory.recall_multi_async.assert_not_called()
+
+    async def test_multi_bank_ids_single_bank_mode(self, mock_memory):
+        mcp = _make_mcp_server(mock_memory, {"recall"}, include_bank_id=False)
+        await _tools(mcp)["recall"].fn(query="test", bank_ids=["x", "y"], merge="score")
+        mock_memory.recall_multi_async.assert_called_once()
+        mock_memory.recall_async.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_mcp_tools.py
+++ b/hindsight-api-slim/tests/test_mcp_tools.py
@@ -1209,6 +1209,14 @@ class TestRecallMultiBankParams:
         mock_memory.recall_multi_async.assert_not_called()
         assert mock_memory.recall_async.call_args.kwargs["bank_id"] == "work"
 
+    async def test_singular_bank_id_is_respected_as_explicit(self, mock_memory):
+        """A singular bank_id is explicit: it selects that bank, not the session bank."""
+        mcp = _make_mcp_server(mock_memory, {"recall"})
+        await _tools(mcp)["recall"].fn(query="test", bank_id="explicit-bank")
+        mock_memory.recall_async.assert_called_once()
+        mock_memory.recall_multi_async.assert_not_called()
+        assert mock_memory.recall_async.call_args.kwargs["bank_id"] == "explicit-bank"
+
     async def test_multi_default_merge_is_score(self, mock_memory):
         mcp = _make_mcp_server(mock_memory, {"recall"})
         await _tools(mcp)["recall"].fn(query="test", bank_ids=["a", "b"])

--- a/hindsight-api-slim/tests/test_mental_model_refresh_error_retry.py
+++ b/hindsight-api-slim/tests/test_mental_model_refresh_error_retry.py
@@ -1,0 +1,116 @@
+"""execute_task must handle MentalModelRefreshError without a traceback.
+
+refresh_mental_model raises MentalModelRefreshError from _preserve_and_fail
+(#3112/#3182): content and watermark stay untouched, retry is intended.
+Before this handler the exception fell through execute_task's generic
+``except Exception``, which on the overlay called ``traceback.print_exc()``
+and on main (#3218) logs ``logger.error(..., exc_info=True)``. Either form
+is what the soak watcher treats as unhandled.
+
+These tests isolate execute_task's exception classification by stubbing
+_handle_refresh_mental_model. No DB: omit operation_id so the cancel check
+is skipped.
+
+Port note vs overlay ca2bd211: main already uses logger.error (not print_exc)
+on the generic path. The dedicated MentalModelRefreshError handler logs
+logger.error WITHOUT exc_info, then applies the same RetryTaskAt policy.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from hindsight_api.config import get_config
+from hindsight_api.engine.memory_engine import MemoryEngine, MentalModelRefreshError
+from hindsight_api.worker.exceptions import RetryTaskAt
+
+MM_ID = "mm-test-delta-ops"
+BANK_ID = "bank-test-mmrefresh"
+REFRESH_ERROR = MentalModelRefreshError(
+    f"Refresh failed for mental_model_id={MM_ID}: delta operations did not reach "
+    "the document, and the reflect candidate covers only memories newer than the "
+    "last refresh, so writing it would drop the rest of the document. Previous "
+    "content preserved in DB; reflect_response.refresh_skipped == "
+    "'delta_ops_all_skipped' for audit."
+)
+
+
+def _engine() -> MemoryEngine:
+    engine = object.__new__(MemoryEngine)
+    engine._audit_logger = None
+    return engine
+
+
+def _task(*, retry_count: int) -> dict:
+    return {
+        "type": "refresh_mental_model",
+        "bank_id": BANK_ID,
+        "mental_model_id": MM_ID,
+        "_retry_count": retry_count,
+    }
+
+
+@pytest.mark.asyncio
+async def test_refresh_error_retries_via_logger_error_without_traceback(caplog, capsys):
+    """_retry_count=0 -> RetryTaskAt; no Traceback on stderr; ERROR names the skip."""
+    engine = _engine()
+    with (
+        caplog.at_level(logging.ERROR, logger="hindsight_api.engine.memory_engine"),
+        patch.object(engine, "_handle_refresh_mental_model", side_effect=REFRESH_ERROR),
+        pytest.raises(RetryTaskAt),
+    ):
+        await engine.execute_task(_task(retry_count=0))
+
+    err = capsys.readouterr().err
+    assert "Traceback" not in err
+    error_text = "\n".join(r.message for r in caplog.records if r.levelno == logging.ERROR)
+    assert MM_ID in error_text
+    assert "delta_ops_all_skipped" in error_text
+    assert BANK_ID in error_text
+    assert "refresh_mental_model" in error_text
+    assert "content preserved" in error_text
+    # No traceback attached to the designed-skip record.
+    skip_records = [r for r in caplog.records if "content preserved" in r.getMessage()]
+    assert skip_records
+    assert skip_records[0].exc_info is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_error_propagates_at_retry_cap(capsys):
+    """At _retry_count == worker_max_retries the MentalModelRefreshError escapes."""
+    engine = _engine()
+    cap = get_config().worker_max_retries
+    with patch.object(engine, "_handle_refresh_mental_model", side_effect=REFRESH_ERROR):
+        with pytest.raises(MentalModelRefreshError, match="delta_ops_all_skipped") as excinfo:
+            await engine.execute_task(_task(retry_count=cap))
+    assert not isinstance(excinfo.value, RetryTaskAt)
+    assert "Traceback" not in capsys.readouterr().err
+
+
+@pytest.mark.asyncio
+async def test_generic_runtime_error_on_refresh_still_logs_exc_info(caplog):
+    """A generic RuntimeError on the same path still uses logger.error(..., exc_info=True).
+
+    Overlay asserted print_exc() on stderr. Main/#3218 replaced that with
+    logger.error(..., exc_info=True); silence must not be widened.
+    """
+    engine = _engine()
+    with (
+        caplog.at_level(logging.ERROR, logger="hindsight_api.engine.memory_engine"),
+        patch.object(
+            engine,
+            "_handle_refresh_mental_model",
+            side_effect=RuntimeError("unexpected refresh boom"),
+        ),
+        pytest.raises(RetryTaskAt),
+    ):
+        await engine.execute_task(_task(retry_count=0))
+
+    generic = [r for r in caplog.records if "Task execution failed" in r.getMessage()]
+    assert generic
+    assert generic[0].exc_info is not None
+    assert generic[0].exc_info[0] is RuntimeError
+    assert "unexpected refresh boom" in generic[0].getMessage()

--- a/hindsight-api-slim/tests/test_multi_bank_recall.py
+++ b/hindsight-api-slim/tests/test_multi_bank_recall.py
@@ -17,6 +17,7 @@ No DB / embeddings required — sub-calls are mocked; pure helpers are unit-test
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -25,7 +26,9 @@ import pytest
 from hindsight_api.cancellation import OperationCancelledError
 from hindsight_api.engine.memory_engine import MemoryEngine, _bind_bank_id, get_current_bank_id
 from hindsight_api.engine.multi_bank_recall import (
+    DEFAULT_MULTI_UNION_CAP,
     DEFAULT_PER_BANK_MERGE_CAP,
+    DEFAULT_UNION_SUBCALL_MAX_TOKENS,
     FALLBACK_NO_USABLE_RERANKER_SCORES,
     MAX_MULTI_BANK_RECALL_BANKS,
     META_BANKS,
@@ -38,6 +41,7 @@ from hindsight_api.engine.multi_bank_recall import (
     META_MULTI_BANK,
     META_PER_BANK_CAP,
     MULTI_BANK_PREFER_OBSERVATIONS,
+    _parse_iso_datetime,
     bank_rank_from_merged,
     build_multi_bank_metadata,
     cap_per_bank_results,
@@ -49,8 +53,10 @@ from hindsight_api.engine.multi_bank_recall import (
     merge_cap_dedup_cut,
     normalize_dedup_key,
     score_merge,
+    select_union_candidates,
     stamp_bank_id,
     union_merge_dicts,
+    union_per_bank_max_tokens,
 )
 from hindsight_api.engine.response_models import (
     ChunkInfo,
@@ -258,11 +264,15 @@ def _harness(
     *,
     bank_results: dict[str, list[MemoryFact] | Exception | RecallResult],
     enable_reranking: dict[str, bool] | None = None,
+    reranker: object | None = None,
+    track_reranking: dict[str, str] | None = None,
 ) -> MemoryEngine:
     """Minimal MemoryEngine shell: real recall_multi_async, mocked sub-calls + config."""
     engine = object.__new__(MemoryEngine)
 
     async def fake_recall(bank_id: str, query: str, **kwargs) -> RecallResult:
+        if track_reranking is not None:
+            track_reranking[bank_id] = kwargs.get("reranking", "")
         outcome = bank_results[bank_id]
         if isinstance(outcome, Exception):
             raise outcome
@@ -288,6 +298,8 @@ def _harness(
         return {"enable_reranking": enable_reranking.get(bank_id, True)}
 
     engine._config_resolver = SimpleNamespace(get_bank_config=fake_config)  # type: ignore[attr-defined]
+    if reranker is not None:
+        engine._cross_encoder_reranker = reranker  # type: ignore[attr-defined]
     return engine
 
 
@@ -1159,3 +1171,241 @@ async def test_orchestrator_upfront_tenant_auth_failure_skips_fanout():
             max_tokens=10_000,
         )
     assert called == []
+
+
+# --- LAT2 union CE pinning (RED on 05a022f7: per-bank CE, no union pass) --------
+
+
+class _CountingCrossEncoder:
+    """Deterministic CE: higher score when the document contains ``needle``."""
+
+    provider_name = "local"
+    blocking_init = False
+
+    def __init__(self, needle: str = "GOLD") -> None:
+        self.needle = needle
+        self.predict_calls = 0
+        self.pair_counts: list[int] = []
+
+    async def initialize(self) -> None:
+        return None
+
+    async def predict(self, pairs: list) -> list[float]:
+        self.predict_calls += 1
+        self.pair_counts.append(len(pairs))
+        scores: list[float] = []
+        for _query, doc in pairs:
+            text = doc if isinstance(doc, str) else str(doc)
+            scores.append(0.95 if self.needle in text else 0.05)
+        return scores
+
+
+def _union_reranker(ce: _CountingCrossEncoder):
+    from hindsight_api.engine.search.reranking import CrossEncoderReranker
+
+    reranker = CrossEncoderReranker(cross_encoder=ce)
+    reranker._initialized = True
+    return reranker
+
+
+def test_select_union_candidates_reserves_floor_then_interleaves():
+    """Each bank keeps min(k_floor, count) even when the union cap is tight."""
+    from hindsight_api.engine.multi_bank_recall import select_union_candidates
+
+    bank_a = [_fact(f"a{i}", f"A{i}") for i in range(10)]
+    bank_b = [_fact(f"b{i}", f"B{i}") for i in range(10)]
+    pool = select_union_candidates(
+        [("bank-a", bank_a), ("bank-b", bank_b)],
+        per_bank_pre_cap=50,
+        union_cap=6,
+        k_floor=2,
+    )
+    ids = [f.id for f in pool.facts]
+    assert ids.count("a0") + ids.count("a1") == 2
+    assert ids.count("b0") + ids.count("b1") == 2
+    assert len(pool.facts) == 6
+    assert {f.bank_id for f in pool.facts} == {"bank-a", "bank-b"}
+
+
+def test_apply_per_bank_floor_keeps_ce_weak_bank():
+    """G55 H: a bank whose top candidate is CE-weak still keeps its floor after the CE cut."""
+    from hindsight_api.engine.multi_bank_recall import apply_per_bank_floor
+
+    strong = [stamp_bank_id(_fact(f"a{i}", f"A{i}", reranker=0.9 - i * 0.01), "bank-a") for i in range(8)]
+    weak = [
+        stamp_bank_id(_fact("b0", "weak-best", reranker=0.02), "bank-b"),
+        stamp_bank_id(_fact("b1", "weak-tail", reranker=0.01), "bank-b"),
+    ]
+    cut = apply_per_bank_floor(
+        strong + weak,
+        k_floor=1,
+        keep=5,
+        bank_order=["bank-a", "bank-b"],
+    )
+    ids = [f.id for f in cut]
+    assert "b0" in ids
+    assert "b1" not in ids
+    assert len(cut) == 5
+    assert any(f.bank_id == "bank-b" for f in cut)
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_union_ce_forces_rrf_per_bank_and_scores_once():
+    """Pin: per-bank recall_async must skip CE (reranking=rrf); one union predict."""
+    ce = _CountingCrossEncoder(needle="GOLD")
+    seen: dict[str, str] = {}
+    engine = _harness(
+        bank_results={
+            "bank-a": [_fact("a1", "GOLD from A"), _fact("a2", "noise A")],
+            "bank-b": [_fact("b1", "noise B"), _fact("b2", "GOLD from B")],
+        },
+        reranker=_union_reranker(ce),
+        track_reranking=seen,
+    )
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "which GOLD facts matter",
+        merge="score",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    assert seen == {"bank-a": "rrf", "bank-b": "rrf"}
+    assert ce.predict_calls == 1
+    assert ce.pair_counts == [4]
+    assert [f.id for f in result.results][:2] == ["a1", "b2"]
+    assert result.results[0].scores is not None
+    assert result.results[0].scores.reranker is not None
+    assert result.results[0].scores.reranker > 0.5
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_union_ce_floor_keeps_weak_bank():
+    """One CE pass never loses a bank: CE-weak bank still contributes k_floor."""
+    ce = _CountingCrossEncoder(needle="GOLD")
+    engine = _harness(
+        bank_results={
+            "bank-a": [_fact(f"a{i}", f"GOLD strong {i}") for i in range(8)],
+            "bank-b": [_fact("b0", "only weak fact from B"), _fact("b1", "also weak")],
+        },
+        reranker=_union_reranker(ce),
+    )
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "GOLD",
+        merge="score",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    assert ce.predict_calls == 1
+    banks_present = {f.bank_id for f in result.results}
+    assert "bank-b" in banks_present
+    assert any(f.id == "b0" for f in result.results)
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_skips_union_ce_when_reranker_disabled():
+    """CE null / enable_reranking=false keeps today's rrf/interleave path."""
+    seen: dict[str, str] = {}
+    engine = _harness(
+        bank_results={
+            "bank-a": [_fact("a1", "A1", reranker=0.9)],
+            "bank-b": [_fact("b1", "B1", reranker=None, final=0.1)],
+        },
+        enable_reranking={"bank-a": True, "bank-b": False},
+        track_reranking=seen,
+    )
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "query",
+        merge="score",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    # No union CE: subcalls keep the caller reranking (cross_encoder); merge falls back.
+    assert seen["bank-a"] == "cross_encoder"
+    assert seen["bank-b"] == "cross_encoder"
+    assert result.metadata[META_MULTI_BANK][META_MERGE_APPLIED] == "interleave"
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_skips_union_ce_when_caller_requests_rrf():
+    ce = _CountingCrossEncoder()
+    seen: dict[str, str] = {}
+    engine = _harness(
+        bank_results={
+            "bank-a": [_fact("a1", "A1")],
+            "bank-b": [_fact("b1", "B1")],
+        },
+        reranker=_union_reranker(ce),
+        track_reranking=seen,
+    )
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "query",
+        merge="score",
+        reranking="rrf",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    assert seen == {"bank-a": "rrf", "bank-b": "rrf"}
+    assert ce.predict_calls == 0
+    assert result.metadata[META_MULTI_BANK][META_MERGE_APPLIED] == "interleave"
+
+
+def test_default_union_cap_keeps_deep_rrf_ranks_at_five_banks():
+    assert DEFAULT_MULTI_UNION_CAP == 200
+    assert DEFAULT_UNION_SUBCALL_MAX_TOKENS == 100_000
+    banks: list[tuple[str, list[MemoryFact]]] = []
+    for i in range(5):
+        facts = [_fact(f"b{i}-r{r}", f"bank{i} rank{r}") for r in range(50)]
+        banks.append((f"bank-{i}", facts))
+    banks[0][1][36] = _fact("gold36", "GOLD rrf 36")
+    banks[0][1][37] = _fact("gold37", "GOLD rrf 37")
+    lost = select_union_candidates(banks, per_bank_pre_cap=50, union_cap=150, k_floor=1)
+    lost_ids = [f.id for f in lost.facts]
+    assert "gold36" not in lost_ids
+    assert "gold37" not in lost_ids
+    kept = select_union_candidates(banks, per_bank_pre_cap=50, union_cap=200, k_floor=1)
+    kept_ids = [f.id for f in kept.facts]
+    assert "gold36" in kept_ids
+    assert "gold37" in kept_ids
+
+
+def test_union_subcall_budget_keeps_deep_rrf_when_caller_budget_would_cut():
+    facts = [_fact(f"r{i}", ("matrix " * 80)) for i in range(40)]
+    facts[36] = _fact("gold", "matrix " * 80)
+    cut_caller = cut_to_token_budget(facts, 2000)
+    assert "gold" not in [f.id for f in cut_caller]
+    cut_union = cut_to_token_budget(facts, union_per_bank_max_tokens(2000, union_ce=True))
+    assert "gold" in [f.id for f in cut_union]
+    assert union_per_bank_max_tokens(2000, union_ce=False) == 2000
+
+
+def test_parse_iso_datetime_accepts_datetime_and_date():
+    dt = datetime(2026, 7, 17, 10, 30, 0, tzinfo=timezone.utc)
+    assert _parse_iso_datetime(dt) is dt
+    assert _parse_iso_datetime("2026-07-17T10:30:00Z") is not None
+    assert _parse_iso_datetime(None) is None
+    assert _parse_iso_datetime("not-a-date") is None
+
+
+def test_union_cap_env_zero_uses_default_not_one(monkeypatch):
+    from hindsight_api.config import (
+        DEFAULT_MULTI_UNION_CAP,
+        ENV_MULTI_UNION_CAP,
+        clear_config_cache,
+        get_config,
+    )
+
+    monkeypatch.setenv(ENV_MULTI_UNION_CAP, "0")
+    clear_config_cache()
+    try:
+        cfg = get_config()
+        assert cfg.multi_union_cap == DEFAULT_MULTI_UNION_CAP
+        assert cfg.multi_union_cap != 1
+    finally:
+        clear_config_cache()

--- a/hindsight-api-slim/tests/test_multi_bank_recall.py
+++ b/hindsight-api-slim/tests/test_multi_bank_recall.py
@@ -1,0 +1,1161 @@
+"""Multi-bank recall: pure merge helpers + MemoryEngine.recall_multi_async orchestrator.
+
+Covers the 2026-08-10 multi-bank plan:
+- score-merge order (incl. ties)
+- interleave order
+- auto-fallback to interleave when CE is not comparable
+- token cut on the merged list
+- bank_id attribution
+- partial-failure metadata
+- single-bank equivalence with recall_async
+- empty bank member
+- ContextVar isolation across parallel sub-calls (via @_bind_bank_id on each task)
+
+No DB / embeddings required — sub-calls are mocked; pure helpers are unit-tested directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hindsight_api.cancellation import OperationCancelledError
+from hindsight_api.engine.memory_engine import MemoryEngine, _bind_bank_id, get_current_bank_id
+from hindsight_api.engine.multi_bank_recall import (
+    DEFAULT_PER_BANK_MERGE_CAP,
+    FALLBACK_NO_USABLE_RERANKER_SCORES,
+    MAX_MULTI_BANK_RECALL_BANKS,
+    META_BANKS,
+    META_DEDUP,
+    META_DEDUP_DROPPED,
+    META_DEDUP_V1,
+    META_MERGE_APPLIED,
+    META_MERGE_FALLBACK_REASON,
+    META_MERGE_REQUESTED,
+    META_MULTI_BANK,
+    META_PER_BANK_CAP,
+    MULTI_BANK_PREFER_OBSERVATIONS,
+    bank_rank_from_merged,
+    build_multi_bank_metadata,
+    cap_per_bank_results,
+    cross_encoder_eligible,
+    cut_to_token_budget,
+    dedup_exact_normalized,
+    has_usable_reranker_scores,
+    interleave_merge,
+    merge_cap_dedup_cut,
+    normalize_dedup_key,
+    score_merge,
+    stamp_bank_id,
+    union_merge_dicts,
+)
+from hindsight_api.engine.response_models import (
+    ChunkInfo,
+    EntityState,
+    MemoryFact,
+    RecallResult,
+    RecallScores,
+)
+from hindsight_api.extensions.operation_validator import OperationValidationError
+from hindsight_api.extensions.tenant import AuthenticationError
+from hindsight_api.models import RequestContext
+
+RC = RequestContext(tenant_id="default")
+
+
+def _fact(
+    id: str,
+    text: str,
+    *,
+    reranker: float | None = None,
+    final: float | None = None,
+    bank_id: str | None = None,
+) -> MemoryFact:
+    scores = None
+    if reranker is not None or final is not None:
+        scores = RecallScores(
+            final=final if final is not None else (reranker or 0.0),
+            reranker=reranker,
+        )
+    return MemoryFact(id=id, text=text, fact_type="world", scores=scores, bank_id=bank_id)
+
+
+# --- pure helpers -------------------------------------------------------------
+
+
+def test_score_merge_orders_by_reranker_descending():
+    bank_a = [
+        _fact("a1", "low from A", reranker=0.2),
+        _fact("a2", "high from A", reranker=0.9),
+    ]
+    bank_b = [
+        _fact("b1", "mid from B", reranker=0.5),
+        _fact("b2", "higher from B", reranker=0.8),
+    ]
+    merged = score_merge([("bank-a", bank_a), ("bank-b", bank_b)])
+    assert [f.id for f in merged] == ["a2", "b2", "b1", "a1"]
+    assert [f.bank_id for f in merged] == ["bank-a", "bank-b", "bank-b", "bank-a"]
+
+
+def test_score_merge_ties_break_by_bank_order_then_rank():
+    """Equal reranker scores: earlier bank, then earlier within-bank rank wins."""
+    bank_a = [
+        _fact("a1", "A first", reranker=0.7),
+        _fact("a2", "A second", reranker=0.7),
+    ]
+    bank_b = [
+        _fact("b1", "B first", reranker=0.7),
+    ]
+    merged = score_merge([("bank-a", bank_a), ("bank-b", bank_b)])
+    assert [f.id for f in merged] == ["a1", "a2", "b1"]
+
+
+def test_score_merge_missing_reranker_sorts_last():
+    bank_a = [_fact("a1", "no ce", reranker=None, final=0.9)]
+    bank_b = [_fact("b1", "has ce", reranker=0.1)]
+    merged = score_merge([("bank-a", bank_a), ("bank-b", bank_b)])
+    assert [f.id for f in merged] == ["b1", "a1"]
+
+
+def test_interleave_merge_round_robin_by_rank():
+    bank_a = [
+        _fact("a1", "A1"),
+        _fact("a2", "A2"),
+        _fact("a3", "A3"),
+    ]
+    bank_b = [
+        _fact("b1", "B1"),
+        _fact("b2", "B2"),
+    ]
+    merged = interleave_merge([("bank-a", bank_a), ("bank-b", bank_b)])
+    assert [f.id for f in merged] == ["a1", "b1", "a2", "b2", "a3"]
+    assert all(f.bank_id in ("bank-a", "bank-b") for f in merged)
+
+
+def test_interleave_merge_empty_bank_member():
+    bank_a = [_fact("a1", "only A")]
+    bank_b: list[MemoryFact] = []
+    merged = interleave_merge([("bank-a", bank_a), ("bank-b", bank_b)])
+    assert [f.id for f in merged] == ["a1"]
+    assert merged[0].bank_id == "bank-a"
+
+
+def test_stamp_bank_id_does_not_mutate_original():
+    original = _fact("x", "text")
+    stamped = stamp_bank_id(original, "bank-z")
+    assert stamped.bank_id == "bank-z"
+    assert original.bank_id is None
+
+
+def test_cut_to_token_budget_stops_before_exceeding():
+    from hindsight_api.engine.memory_engine import count_tokens
+
+    f1 = _fact("1", "alpha")
+    f2 = _fact("2", "beta gamma")
+    f3 = _fact("3", "delta")
+    budget = count_tokens(f1.text) + count_tokens(f2.text)
+    cut = cut_to_token_budget([f1, f2, f3], budget)
+    assert [f.id for f in cut] == ["1", "2"]
+    assert sum(count_tokens(f.text) for f in cut) <= budget
+
+    # Budget too small for the first fact → empty (stop-before-exceeding).
+    under_first = max(0, count_tokens(f1.text) - 1)
+    assert cut_to_token_budget([f1, f2], under_first) == []
+
+
+def test_cut_to_token_budget_zero_is_empty():
+    assert cut_to_token_budget([_fact("1", "hello")], 0) == []
+
+
+def test_cross_encoder_eligible_requires_cross_encoder_request():
+    ok, reason = cross_encoder_eligible(
+        requested_reranking="rrf",
+        bank_enable_reranking=[True, True],
+    )
+    assert ok is False
+    assert reason is not None
+    assert "rrf" in reason
+
+
+def test_cross_encoder_eligible_rejects_disabled_reranking_bank():
+    ok, reason = cross_encoder_eligible(
+        requested_reranking="cross_encoder",
+        bank_enable_reranking=[True, False],
+    )
+    assert ok is False
+    assert reason is not None
+    assert "enable_reranking" in reason
+
+
+def test_cross_encoder_eligible_all_ce():
+    ok, reason = cross_encoder_eligible(
+        requested_reranking="cross_encoder",
+        bank_enable_reranking=[True, True],
+    )
+    assert ok is True
+    assert reason is None
+
+
+def test_build_multi_bank_metadata_shape():
+    meta = build_multi_bank_metadata(
+        merge_requested="score",
+        merge_applied="interleave",
+        merge_fallback_reason="test reason",
+        bank_statuses={"a": {"status": "ok", "count": 1}},
+    )
+    block = meta[META_MULTI_BANK]
+    assert block[META_MERGE_REQUESTED] == "score"
+    assert block[META_MERGE_APPLIED] == "interleave"
+    assert block[META_MERGE_FALLBACK_REASON] == "test reason"
+    assert block[META_BANKS]["a"]["status"] == "ok"
+    assert block[META_DEDUP] == META_DEDUP_V1
+    assert block[META_DEDUP] == "exact_normalized"
+    assert block[META_DEDUP_DROPPED] == 0
+    assert block[META_PER_BANK_CAP] == DEFAULT_PER_BANK_MERGE_CAP
+
+
+def test_union_merge_dicts_union_and_collision_by_rank():
+    """On collision keep the bank with the better (lower) rank from the merged order."""
+    merged = [
+        stamp_bank_id(_fact("a1", "top from A", reranker=0.9), "bank-a"),
+        stamp_bank_id(_fact("b1", "from B", reranker=0.5), "bank-b"),
+    ]
+    ranks = bank_rank_from_merged(merged)
+    assert ranks == {"bank-a": 0, "bank-b": 1}
+
+    # Distinct keys union
+    entities = union_merge_dicts(
+        [
+            ("bank-a", {"Alice": EntityState(entity_id="e-a", canonical_name="Alice")}),
+            ("bank-b", {"Bob": EntityState(entity_id="e-b", canonical_name="Bob")}),
+        ],
+        bank_rank=ranks,
+    )
+    assert set(entities) == {"Alice", "Bob"}
+
+    # Collision: same key — bank-a ranks higher so its value wins
+    chunks = union_merge_dicts(
+        [
+            ("bank-a", {"shared": ChunkInfo(chunk_text="from A", chunk_index=0)}),
+            ("bank-b", {"shared": ChunkInfo(chunk_text="from B", chunk_index=0)}),
+        ],
+        bank_rank=ranks,
+    )
+    assert chunks is not None
+    assert chunks["shared"].chunk_text == "from A"
+
+    # None / empty → None
+    assert union_merge_dicts([("bank-a", None), ("bank-b", {})], bank_rank=ranks) is None
+
+
+# --- orchestrator (mocked recall_async) ---------------------------------------
+
+
+def _harness(
+    *,
+    bank_results: dict[str, list[MemoryFact] | Exception | RecallResult],
+    enable_reranking: dict[str, bool] | None = None,
+) -> MemoryEngine:
+    """Minimal MemoryEngine shell: real recall_multi_async, mocked sub-calls + config."""
+    engine = object.__new__(MemoryEngine)
+
+    async def fake_recall(bank_id: str, query: str, **kwargs) -> RecallResult:
+        outcome = bank_results[bank_id]
+        if isinstance(outcome, Exception):
+            raise outcome
+        if isinstance(outcome, RecallResult):
+            return outcome
+        return RecallResult(results=list(outcome))
+
+    engine.recall_async = fake_recall  # type: ignore[method-assign]
+
+    async def fake_auth(request_context: RequestContext) -> str:
+        return "public"
+
+    engine._authenticate_tenant = fake_auth  # type: ignore[method-assign]
+
+    enable_reranking = enable_reranking or {
+        bid: True for bid in bank_results if not isinstance(bank_results[bid], Exception)
+    }
+    # Failed banks may still need config flags
+    for bid in bank_results:
+        enable_reranking.setdefault(bid, True)
+
+    async def fake_config(bank_id: str, request_context):
+        return {"enable_reranking": enable_reranking.get(bank_id, True)}
+
+    engine._config_resolver = SimpleNamespace(get_bank_config=fake_config)  # type: ignore[attr-defined]
+    return engine
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_score_merge_order():
+    engine = _harness(
+        bank_results={
+            "bank-a": [
+                _fact("a1", "low", reranker=0.2),
+                _fact("a2", "high", reranker=0.95),
+            ],
+            "bank-b": [
+                _fact("b1", "mid", reranker=0.6),
+            ],
+        }
+    )
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "query",
+        merge="score",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    assert [f.id for f in result.results] == ["a2", "b1", "a1"]
+    assert result.metadata[META_MULTI_BANK][META_MERGE_APPLIED] == "score"
+    assert result.metadata[META_MULTI_BANK][META_MERGE_FALLBACK_REASON] is None
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_interleave_order():
+    engine = _harness(
+        bank_results={
+            "bank-a": [_fact("a1", "A1"), _fact("a2", "A2")],
+            "bank-b": [_fact("b1", "B1"), _fact("b2", "B2")],
+        }
+    )
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "query",
+        merge="interleave",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    assert [f.id for f in result.results] == ["a1", "b1", "a2", "b2"]
+    assert result.metadata[META_MULTI_BANK][META_MERGE_APPLIED] == "interleave"
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_auto_fallback_when_bank_disables_reranking():
+    engine = _harness(
+        bank_results={
+            "bank-a": [_fact("a1", "A1", reranker=0.9), _fact("a2", "A2", reranker=0.1)],
+            "bank-b": [_fact("b1", "B1", reranker=None, final=0.5)],
+        },
+        enable_reranking={"bank-a": True, "bank-b": False},
+    )
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "query",
+        merge="score",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    mb = result.metadata[META_MULTI_BANK]
+    assert mb[META_MERGE_REQUESTED] == "score"
+    assert mb[META_MERGE_APPLIED] == "interleave"
+    assert mb[META_MERGE_FALLBACK_REASON] is not None
+    # Interleave order, not score order (score would put a1 first and maybe a2 before b1).
+    assert [f.id for f in result.results] == ["a1", "b1", "a2"]
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_auto_fallback_when_requested_rrf():
+    engine = _harness(
+        bank_results={
+            "bank-a": [_fact("a1", "A1")],
+            "bank-b": [_fact("b1", "B1")],
+        }
+    )
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "query",
+        merge="score",
+        reranking="rrf",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    mb = result.metadata[META_MULTI_BANK]
+    assert mb[META_MERGE_APPLIED] == "interleave"
+    assert "rrf" in (mb[META_MERGE_FALLBACK_REASON] or "")
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_token_cut_on_merged_list():
+    from hindsight_api.engine.memory_engine import count_tokens
+
+    # Distinct short texts so ordering is stable and budget math is simple.
+    a1 = _fact("a1", "alpha alpha", reranker=0.9)
+    b1 = _fact("b1", "beta beta beta", reranker=0.8)
+    a2 = _fact("a2", "gamma", reranker=0.7)
+    engine = _harness(bank_results={"bank-a": [a1, a2], "bank-b": [b1]})
+
+    # Fit a1 + b1 but not a2 after score-merge order a1, b1, a2.
+    budget = count_tokens(a1.text) + count_tokens(b1.text)
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "query",
+        merge="score",
+        request_context=RC,
+        max_tokens=budget,
+    )
+    assert [f.id for f in result.results] == ["a1", "b1"]
+    assert sum(count_tokens(f.text) for f in result.results) <= budget
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_bank_id_attribution():
+    engine = _harness(
+        bank_results={
+            "bank-a": [_fact("a1", "from A", reranker=0.5)],
+            "bank-b": [_fact("b1", "from B", reranker=0.6)],
+        }
+    )
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "query",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    by_id = {f.id: f.bank_id for f in result.results}
+    assert by_id == {"b1": "bank-b", "a1": "bank-a"}
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_partial_failure_metadata():
+    engine = _harness(
+        bank_results={
+            "bank-a": [_fact("a1", "ok", reranker=0.5)],
+            "bank-b": RuntimeError("boom"),
+        }
+    )
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "query",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    banks = result.metadata[META_MULTI_BANK][META_BANKS]
+    assert banks["bank-a"]["status"] == "ok"
+    assert banks["bank-a"]["count"] == 1
+    assert banks["bank-b"]["status"] == "error"
+    # Client-visible text is generic — no exception class or message oracle.
+    assert banks["bank-b"]["error"] == "recall failed for this bank"
+    assert "RuntimeError" not in banks["bank-b"]["error"]
+    assert "boom" not in banks["bank-b"]["error"]
+    assert [f.id for f in result.results] == ["a1"]
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_empty_bank_member():
+    engine = _harness(
+        bank_results={
+            "bank-a": [_fact("a1", "only", reranker=0.5)],
+            "bank-empty": [],
+        }
+    )
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-empty"],
+        "query",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    banks = result.metadata[META_MULTI_BANK][META_BANKS]
+    assert banks["bank-empty"] == {"status": "ok", "count": 0}
+    assert [f.id for f in result.results] == ["a1"]
+    assert result.results[0].bank_id == "bank-a"
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_single_bank_equivalence():
+    """Single-bank multi-recall matches recall_async content order (plus bank_id stamp)."""
+    facts = [
+        _fact("s1", "first", reranker=0.9),
+        _fact("s2", "second", reranker=0.5),
+    ]
+    engine = _harness(bank_results={"only": facts})
+
+    single = await engine.recall_async("only", "query", request_context=RC, max_tokens=10_000)
+    multi = await MemoryEngine.recall_multi_async(
+        engine,
+        ["only"],
+        "query",
+        merge="score",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    assert [f.id for f in multi.results] == [f.id for f in single.results]
+    assert [f.text for f in multi.results] == [f.text for f in single.results]
+    assert all(f.bank_id == "only" for f in multi.results)
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_empty_bank_ids_list():
+    engine = _harness(bank_results={})
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        [],
+        "query",
+        request_context=RC,
+    )
+    assert result.results == []
+    assert result.metadata[META_MULTI_BANK][META_BANKS] == {}
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_contextvar_isolation_across_parallel_subcalls():
+    """Each parallel sub-call sees its own bank_id via @_bind_bank_id (task context)."""
+    engine = object.__new__(MemoryEngine)
+    observed: dict[str, str | None] = {}
+    barrier = asyncio.Barrier(2)
+
+    @_bind_bank_id()
+    async def bound_recall(bank_id: str, query: str, **kwargs) -> RecallResult:
+        # Wait so both tasks are concurrent before reading ContextVar.
+        await barrier.wait()
+        observed[bank_id] = get_current_bank_id()
+        return RecallResult(results=[_fact(f"{bank_id}-1", bank_id, reranker=0.5)])
+
+    engine.recall_async = bound_recall  # type: ignore[method-assign]
+
+    async def fake_auth(request_context: RequestContext) -> str:
+        return "public"
+
+    engine._authenticate_tenant = fake_auth  # type: ignore[method-assign]
+    engine._config_resolver = SimpleNamespace(  # type: ignore[attr-defined]
+        get_bank_config=AsyncMock(return_value={"enable_reranking": True})
+    )
+
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-x", "bank-y"],
+        "query",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    assert observed["bank-x"] == "bank-x"
+    assert observed["bank-y"] == "bank-y"
+    assert {f.bank_id for f in result.results} == {"bank-x", "bank-y"}
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_invalid_merge_raises():
+    engine = _harness(bank_results={"a": []})
+    with pytest.raises(ValueError, match="merge must be"):
+        await MemoryEngine.recall_multi_async(
+            engine,
+            ["a"],
+            "query",
+            merge="nope",  # type: ignore[arg-type]
+            request_context=RC,
+        )
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_passes_full_max_tokens_to_each_subcall():
+    """Each sub-call receives the caller's full max_tokens (cut happens after merge)."""
+    seen_max: dict[str, int] = {}
+
+    engine = object.__new__(MemoryEngine)
+
+    async def tracking_recall(bank_id: str, query: str, **kwargs) -> RecallResult:
+        seen_max[bank_id] = kwargs.get("max_tokens", -1)
+        return RecallResult(results=[_fact(f"{bank_id}-1", "x" * 50, reranker=0.5)])
+
+    engine.recall_async = tracking_recall  # type: ignore[method-assign]
+
+    async def fake_auth(request_context: RequestContext) -> str:
+        return "public"
+
+    engine._authenticate_tenant = fake_auth  # type: ignore[method-assign]
+    engine._config_resolver = SimpleNamespace(  # type: ignore[attr-defined]
+        get_bank_config=AsyncMock(return_value={"enable_reranking": True})
+    )
+
+    await MemoryEngine.recall_multi_async(
+        engine,
+        ["b1", "b2"],
+        "query",
+        request_context=RC,
+        max_tokens=1234,
+    )
+    assert seen_max == {"b1": 1234, "b2": 1234}
+
+
+# --- B0: include_* side-dict merge --------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_merges_entities_chunks_source_facts():
+    """include_* payloads from successful banks are union-merged into the response."""
+    engine = _harness(
+        bank_results={
+            "bank-a": RecallResult(
+                results=[_fact("a1", "A top", reranker=0.9)],
+                entities={"Alice": EntityState(entity_id="ea", canonical_name="Alice")},
+                chunks={"a_doc_0": ChunkInfo(chunk_text="chunk A", chunk_index=0)},
+                source_facts={"sf-a": _fact("sf-a", "source from A")},
+            ),
+            "bank-b": RecallResult(
+                results=[_fact("b1", "B mid", reranker=0.5)],
+                entities={"Bob": EntityState(entity_id="eb", canonical_name="Bob")},
+                chunks={"b_doc_0": ChunkInfo(chunk_text="chunk B", chunk_index=0)},
+                source_facts={"sf-b": _fact("sf-b", "source from B")},
+            ),
+        }
+    )
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "query",
+        merge="score",
+        include_entities=True,
+        include_chunks=True,
+        include_source_facts=True,
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    assert result.entities is not None and set(result.entities) == {"Alice", "Bob"}
+    assert result.chunks is not None and set(result.chunks) == {"a_doc_0", "b_doc_0"}
+    assert result.source_facts is not None and set(result.source_facts) == {"sf-a", "sf-b"}
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_side_dict_collision_prefers_higher_ranked_bank():
+    """On key collision, keep the bank whose results ranked higher in the merged list."""
+    # bank-b has the higher CE score → ranks first after score-merge → wins collisions.
+    engine = _harness(
+        bank_results={
+            "bank-a": RecallResult(
+                results=[_fact("a1", "low", reranker=0.2)],
+                entities={"Shared": EntityState(entity_id="from-a", canonical_name="Shared")},
+                chunks={"shared_key": ChunkInfo(chunk_text="from A", chunk_index=0)},
+                source_facts={"sf-shared": _fact("sf-shared", "from A")},
+            ),
+            "bank-b": RecallResult(
+                results=[_fact("b1", "high", reranker=0.95)],
+                entities={"Shared": EntityState(entity_id="from-b", canonical_name="Shared")},
+                chunks={"shared_key": ChunkInfo(chunk_text="from B", chunk_index=0)},
+                source_facts={"sf-shared": _fact("sf-shared", "from B")},
+            ),
+        }
+    )
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "query",
+        merge="score",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    assert [f.id for f in result.results] == ["b1", "a1"]
+    assert result.entities is not None
+    assert result.entities["Shared"].entity_id == "from-b"
+    assert result.chunks is not None
+    assert result.chunks["shared_key"].chunk_text == "from B"
+    assert result.source_facts is not None
+    assert result.source_facts["sf-shared"].text == "from B"
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_include_none_when_subcalls_omit_side_dicts():
+    engine = _harness(
+        bank_results={
+            "bank-a": [_fact("a1", "only", reranker=0.5)],
+            "bank-b": [_fact("b1", "only", reranker=0.4)],
+        }
+    )
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "query",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    assert result.entities is None
+    assert result.chunks is None
+    assert result.source_facts is None
+
+
+# --- Job C audit fixes --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_cancellation_propagates_not_soft_fail():
+    """OperationCancelledError from any sub-call must re-raise, not enter bank metadata."""
+    engine = _harness(
+        bank_results={
+            "bank-a": [_fact("a1", "ok", reranker=0.5)],
+            "bank-b": OperationCancelledError("client disconnected"),
+        }
+    )
+    with pytest.raises(OperationCancelledError, match="client disconnected"):
+        await MemoryEngine.recall_multi_async(
+            engine,
+            ["bank-a", "bank-b"],
+            "query",
+            request_context=RC,
+            max_tokens=10_000,
+        )
+
+
+def test_has_usable_reranker_scores_empty_is_ok():
+    assert has_usable_reranker_scores([("a", []), ("b", [])]) is True
+
+
+def test_has_usable_reranker_scores_all_none_is_false():
+    facts = [
+        ("a", [_fact("a1", "x", reranker=None, final=0.9)]),
+        ("b", [_fact("b1", "y", reranker=None, final=0.8)]),
+    ]
+    assert has_usable_reranker_scores(facts) is False
+
+
+def test_has_usable_reranker_scores_any_usable_is_true():
+    facts = [
+        ("a", [_fact("a1", "x", reranker=None, final=0.9)]),
+        ("b", [_fact("b1", "y", reranker=0.3)]),
+    ]
+    assert has_usable_reranker_scores(facts) is True
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_null_reranker_falls_back_to_interleave_order():
+    """All scores.reranker None + merge=score → interleave applied, real interleave order.
+
+    Without the post-gather check, score-merge would stable-sort all -inf and
+    concatenate banks (a1,a2,b1,b2) while claiming merge_applied='score'.
+    """
+    engine = _harness(
+        bank_results={
+            "bank-a": [
+                _fact("a1", "A1", reranker=None, final=0.9),
+                _fact("a2", "A2", reranker=None, final=0.8),
+            ],
+            "bank-b": [
+                _fact("b1", "B1", reranker=None, final=0.7),
+                _fact("b2", "B2", reranker=None, final=0.6),
+            ],
+        }
+    )
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "query",
+        merge="score",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    mb = result.metadata[META_MULTI_BANK]
+    assert mb[META_MERGE_REQUESTED] == "score"
+    assert mb[META_MERGE_APPLIED] == "interleave"
+    assert mb[META_MERGE_FALLBACK_REASON] == FALLBACK_NO_USABLE_RERANKER_SCORES
+    # Genuine interleave order — not bank concatenation (a1,a2,b1,b2).
+    assert [f.id for f in result.results] == ["a1", "b1", "a2", "b2"]
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_rejects_over_cap_bank_ids():
+    too_many = [f"bank-{i}" for i in range(MAX_MULTI_BANK_RECALL_BANKS + 1)]
+    engine = _harness(bank_results={bid: [] for bid in too_many})
+    with pytest.raises(OperationValidationError) as excinfo:
+        await MemoryEngine.recall_multi_async(
+            engine,
+            too_many,
+            "query",
+            request_context=RC,
+            max_tokens=10_000,
+        )
+    assert excinfo.value.status_code == 422
+    assert str(MAX_MULTI_BANK_RECALL_BANKS) in str(excinfo.value)
+    # Must fail before fan-out — no sub-call attempts required when count is known.
+
+
+# --- Job D auth / metadata fixes ---------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_validation_error_propagates_not_soft_fail():
+    """OperationValidationError (auth denial) must re-raise, not soft-fail into metadata."""
+    engine = _harness(
+        bank_results={
+            "bank-a": [_fact("a1", "ok", reranker=0.5)],
+            "bank-b": OperationValidationError("forbidden for bank-b", status_code=403),
+        }
+    )
+    with pytest.raises(OperationValidationError) as excinfo:
+        await MemoryEngine.recall_multi_async(
+            engine,
+            ["bank-a", "bank-b"],
+            "query",
+            request_context=RC,
+            max_tokens=10_000,
+        )
+    assert excinfo.value.status_code == 403
+    assert "forbidden for bank-b" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_cancel_precedes_validation_error():
+    """When both cancel and validation errors are present, cancellation wins."""
+    engine = _harness(
+        bank_results={
+            "bank-a": OperationCancelledError("client disconnected"),
+            "bank-b": OperationValidationError("forbidden", status_code=403),
+        }
+    )
+    with pytest.raises(OperationCancelledError, match="client disconnected"):
+        await MemoryEngine.recall_multi_async(
+            engine,
+            ["bank-a", "bank-b"],
+            "query",
+            request_context=RC,
+            max_tokens=10_000,
+        )
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_runtime_error_still_soft_fails():
+    """Ordinary infrastructure errors remain soft partial failures (regression guard)."""
+    engine = _harness(
+        bank_results={
+            "bank-a": [_fact("a1", "ok", reranker=0.9)],
+            "bank-b": RuntimeError("db timeout"),
+        }
+    )
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "query",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    banks = result.metadata[META_MULTI_BANK][META_BANKS]
+    assert banks["bank-a"]["status"] == "ok"
+    assert banks["bank-b"]["status"] == "error"
+    assert [f.id for f in result.results] == ["a1"]
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_client_metadata_has_no_exception_oracle():
+    """Client-visible per-bank error must not leak exception class or repr."""
+    engine = _harness(
+        bank_results={
+            "bank-a": [_fact("a1", "ok", reranker=0.5)],
+            "bank-b": RuntimeError("secret internal detail"),
+        }
+    )
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "query",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    err = result.metadata[META_MULTI_BANK][META_BANKS]["bank-b"]["error"]
+    assert err == "recall failed for this bank"
+    assert "RuntimeError" not in err
+    assert "secret" not in err
+    # No exception-style repr leakage in the whole multi_bank block.
+    import json
+
+    blob = json.dumps(result.metadata[META_MULTI_BANK])
+    assert "RuntimeError" not in blob
+    assert "secret internal detail" not in blob
+
+
+# --- Track-A: cap / exact_normalized dedup / prefer_observations / metadata ---
+
+
+def test_normalize_dedup_key_casefold_and_whitespace():
+    assert normalize_dedup_key("  The Sky\nIs  BLUE  ") == "the sky is blue"
+    assert normalize_dedup_key(None) == ""
+    assert normalize_dedup_key("already clean") == "already clean"
+
+
+def test_dedup_exact_normalized_drops_later_duplicate_keeps_first():
+    """Higher-ranked (earlier) copy wins; later exact-normalized twin is dropped."""
+    facts = [
+        _fact("keep", "The sky is blue", reranker=0.9),
+        _fact("drop", "  the   SKY is\tBLUE ", reranker=0.1),
+        _fact("other", "grass is green", reranker=0.5),
+    ]
+    result = dedup_exact_normalized(facts)
+    assert [f.id for f in result.facts] == ["keep", "other"]
+    assert result.dropped == 1
+
+
+def test_cap_per_bank_results_trims_head_and_never_starves():
+    bank_a = [_fact(f"a{i}", f"A{i}", reranker=1.0 - i * 0.01) for i in range(8)]
+    bank_b = [_fact("b0", "only B", reranker=0.5)]
+    capped = cap_per_bank_results([("bank-a", bank_a), ("bank-b", bank_b)], max_per_bank=3)
+    assert [f.id for f in capped[0][1]] == ["a0", "a1", "a2"]
+    assert [f.id for f in capped[1][1]] == ["b0"]
+    # Clamp to >= 1 so a bank with results is never starved by the cap alone.
+    clamped = cap_per_bank_results([("bank-a", bank_a)], max_per_bank=0)
+    assert len(clamped[0][1]) == 1
+
+
+def test_merge_cap_dedup_cut_drops_duplicate_before_token_budget():
+    """A later duplicate must not consume token budget that a unique fact needs."""
+    from hindsight_api.engine.memory_engine import count_tokens
+
+    keep = _fact("keep", "unique-head", reranker=0.9)
+    twin = _fact("twin", "UNIQUE-HEAD", reranker=0.8)
+    tail = _fact("tail", "unique-tail", reranker=0.7)
+    budget = count_tokens(keep.text) + count_tokens(tail.text)
+    pipeline = merge_cap_dedup_cut(
+        [("bank-a", [keep]), ("bank-b", [twin, tail])],
+        merge="score",
+        max_tokens=budget,
+    )
+    assert [f.id for f in pipeline.facts] == ["keep", "tail"]
+    assert pipeline.dropped == 1
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_dedup_drops_exact_normalized_duplicate_across_banks():
+    engine = _harness(
+        bank_results={
+            "bank-a": [_fact("a1", "The sky is blue", reranker=0.95)],
+            "bank-b": [_fact("b1", "  the SKY   is blue", reranker=0.40)],
+        }
+    )
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "query",
+        merge="score",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    assert [f.id for f in result.results] == ["a1"]
+    mb = result.metadata[META_MULTI_BANK]
+    assert mb[META_DEDUP] == "exact_normalized"
+    assert mb[META_DEDUP_DROPPED] == 1
+    assert mb[META_PER_BANK_CAP] == DEFAULT_PER_BANK_MERGE_CAP
+    assert mb[META_BANKS]["bank-a"]["status"] == "ok"
+    assert mb[META_BANKS]["bank-b"]["status"] == "ok"
+    # banks.count is the pre-dedup per-bank contribution.
+    assert mb[META_BANKS]["bank-b"]["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_per_bank_cap_trims_before_merge():
+    bank_a = [_fact(f"a{i}", f"A fact {i}", reranker=0.9 - i * 0.001) for i in range(60)]
+    bank_b = [_fact("b0", "B only", reranker=0.5)]
+    engine = _harness(bank_results={"bank-a": bank_a, "bank-b": bank_b})
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "query",
+        merge="score",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    ids = [f.id for f in result.results]
+    assert "a49" in ids
+    assert "a50" not in ids
+    assert "b0" in ids
+    assert result.metadata[META_MULTI_BANK][META_PER_BANK_CAP] == 50
+    assert result.metadata[META_MULTI_BANK][META_BANKS]["bank-a"]["count"] == 60
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_prefer_observations_default_true_on_fanout_only():
+    """Default True is passed to each recall_async; HTTP/MCP still default False."""
+    import inspect
+
+    seen: dict[str, bool] = {}
+    engine = object.__new__(MemoryEngine)
+
+    async def tracking_recall(bank_id: str, query: str, **kwargs) -> RecallResult:
+        seen[bank_id] = kwargs.get("prefer_observations")
+        return RecallResult(results=[_fact(f"{bank_id}-1", "x", reranker=0.5)])
+
+    engine.recall_async = tracking_recall  # type: ignore[method-assign]
+
+    async def fake_auth(request_context: RequestContext) -> str:
+        return "public"
+
+    engine._authenticate_tenant = fake_auth  # type: ignore[method-assign]
+    engine._config_resolver = SimpleNamespace(  # type: ignore[attr-defined]
+        get_bank_config=AsyncMock(return_value={"enable_reranking": True})
+    )
+
+    await MemoryEngine.recall_multi_async(
+        engine,
+        ["b1", "b2"],
+        "query",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    assert seen == {"b1": True, "b2": True}
+    assert MULTI_BANK_PREFER_OBSERVATIONS is True
+
+    single_default = inspect.signature(MemoryEngine.recall_async).parameters["prefer_observations"].default
+    multi_default = inspect.signature(MemoryEngine.recall_multi_async).parameters["prefer_observations"].default
+    assert single_default is False
+    assert multi_default is True
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_prefer_observations_false_is_passed_through():
+    """Caller False must reach fan-out; merge/dedup still run independently."""
+    seen: dict[str, bool] = {}
+    engine = object.__new__(MemoryEngine)
+
+    async def tracking_recall(bank_id: str, query: str, **kwargs) -> RecallResult:
+        seen[bank_id] = kwargs.get("prefer_observations")
+        text = "Same sentence in both banks" if bank_id == "bank-a" else "same sentence in both banks"
+        return RecallResult(results=[_fact(f"{bank_id}-1", text, reranker=0.9 if bank_id == "bank-a" else 0.4)])
+
+    engine.recall_async = tracking_recall  # type: ignore[method-assign]
+
+    async def fake_auth(request_context: RequestContext) -> str:
+        return "public"
+
+    engine._authenticate_tenant = fake_auth  # type: ignore[method-assign]
+    engine._config_resolver = SimpleNamespace(  # type: ignore[attr-defined]
+        get_bank_config=AsyncMock(return_value={"enable_reranking": True})
+    )
+
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "query",
+        prefer_observations=False,
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    assert seen == {"bank-a": False, "bank-b": False}
+    # Dedup is independent of prefer_observations (fan-out flag only).
+    assert [f.id for f in result.results] == ["bank-a-1"]
+    assert result.metadata[META_MULTI_BANK][META_DEDUP_DROPPED] == 1
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_metadata_keys_present_on_success():
+    engine = _harness(
+        bank_results={
+            "bank-a": [_fact("a1", "ok", reranker=0.5)],
+            "bank-b": [_fact("b1", "also", reranker=0.4)],
+        }
+    )
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "query",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    mb = result.metadata[META_MULTI_BANK]
+    assert set(mb) >= {
+        META_MERGE_REQUESTED,
+        META_MERGE_APPLIED,
+        META_MERGE_FALLBACK_REASON,
+        META_BANKS,
+        META_DEDUP,
+        META_DEDUP_DROPPED,
+        META_PER_BANK_CAP,
+    }
+    assert mb[META_DEDUP] == "exact_normalized"
+    assert mb[META_DEDUP_DROPPED] == 0
+    assert mb[META_PER_BANK_CAP] == 50
+    assert mb[META_BANKS]["bank-a"] == {"status": "ok", "count": 1}
+    assert mb[META_BANKS]["bank-b"] == {"status": "ok", "count": 1}
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_source_facts_truncated_or_across_banks():
+    """origin/main source_facts_truncated: True if any successful bank reported it."""
+    engine = _harness(
+        bank_results={
+            "bank-a": RecallResult(
+                results=[_fact("a1", "A", reranker=0.9)],
+                source_facts={"sf-a": _fact("sf-a", "src A")},
+                source_facts_truncated=False,
+            ),
+            "bank-b": RecallResult(
+                results=[_fact("b1", "B", reranker=0.4)],
+                source_facts={"sf-b": _fact("sf-b", "src B")},
+                source_facts_truncated=True,
+            ),
+        }
+    )
+    result = await MemoryEngine.recall_multi_async(
+        engine,
+        ["bank-a", "bank-b"],
+        "query",
+        request_context=RC,
+        max_tokens=10_000,
+    )
+    assert result.source_facts_truncated is True
+
+
+# --- AuthenticationError hard-fail (94b831d3; not covered by e0a56d80) ---
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_authentication_error_propagates_not_soft_fail():
+    """Tenant AuthenticationError from any sub-call must re-raise, not enter bank metadata.
+
+    Auth is per-request (tenant), not per-bank. e0a56d80 re-raised
+    OperationValidationError only; AuthenticationError fell into the generic
+    soft-fail (live-measured 2026-08-15: multi POST -> 200).
+    """
+    engine = _harness(
+        bank_results={
+            "bank-a": [_fact("a1", "ok", reranker=0.5)],
+            "bank-b": AuthenticationError("Invalid API key"),
+        }
+    )
+    with pytest.raises(AuthenticationError, match="Invalid API key"):
+        await MemoryEngine.recall_multi_async(
+            engine,
+            ["bank-a", "bank-b"],
+            "query",
+            request_context=RC,
+            max_tokens=10_000,
+        )
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_upfront_tenant_auth_failure_skips_fanout():
+    """Unauthenticated multi-recall fails before any per-bank recall_async starts."""
+    engine = _harness(
+        bank_results={
+            "bank-a": [_fact("a1", "ok", reranker=0.5)],
+            "bank-b": [_fact("b1", "ok", reranker=0.4)],
+        }
+    )
+    called: list[str] = []
+    original = engine.recall_async
+
+    async def tracking_recall(bank_id: str, query: str, **kwargs):
+        called.append(bank_id)
+        return await original(bank_id, query, **kwargs)
+
+    engine.recall_async = tracking_recall  # type: ignore[method-assign]
+
+    async def reject_auth(request_context: RequestContext) -> str:
+        raise AuthenticationError("Invalid API key")
+
+    engine._authenticate_tenant = reject_auth  # type: ignore[method-assign]
+    with pytest.raises(AuthenticationError, match="Invalid API key"):
+        await MemoryEngine.recall_multi_async(
+            engine,
+            ["bank-a", "bank-b"],
+            "query",
+            request_context=RC,
+            max_tokens=10_000,
+        )
+    assert called == []

--- a/hindsight-api-slim/tests/test_multi_bank_recall_http.py
+++ b/hindsight-api-slim/tests/test_multi_bank_recall_http.py
@@ -1,0 +1,247 @@
+"""HTTP tests for multi-bank recall (POST /v1/default/memories/recall).
+
+Mocks the engine; no DB required. Mirrors patterns used by other lightweight HTTP tests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from hindsight_api.api import create_app
+from hindsight_api.engine.response_models import (
+    ChunkInfo,
+    EntityState,
+    MemoryFact,
+    RecallResult,
+    RecallScores,
+)
+from hindsight_api.extensions import AuthenticationError, OperationValidationError
+
+
+def _fact(id: str, text: str, *, bank_id: str | None = None, reranker: float = 0.5) -> MemoryFact:
+    return MemoryFact(
+        id=id,
+        text=text,
+        fact_type="world",
+        bank_id=bank_id,
+        scores=RecallScores(final=reranker, reranker=reranker),
+    )
+
+
+@pytest.fixture
+def mock_memory():
+    memory = MagicMock()
+    memory._operation_validator = None
+    memory.audit_logger = None  # disable @audited path (MagicMock is await-hostile)
+    memory._authenticate_tenant = AsyncMock()
+    memory.recall_multi_async = AsyncMock(
+        return_value=RecallResult(
+            results=[
+                _fact("a1", "from A", bank_id="bank-a", reranker=0.9),
+                _fact("b1", "from B", bank_id="bank-b", reranker=0.5),
+            ],
+            entities={"Alice": EntityState(entity_id="e1", canonical_name="Alice")},
+            chunks={"chunk-1": ChunkInfo(chunk_text="chunk text", chunk_index=0)},
+            source_facts={"sf1": _fact("sf1", "source")},
+            metadata={
+                "multi_bank": {
+                    "merge_requested": "score",
+                    "merge_applied": "score",
+                    "merge_fallback_reason": None,
+                    "banks": {
+                        "bank-a": {"status": "ok", "count": 1},
+                        "bank-b": {"status": "ok", "count": 1},
+                    },
+                    "dedup": "exact_normalized",
+                    "dedup_dropped": 0,
+                    "per_bank_cap": 50,
+                }
+            },
+        )
+    )
+    return memory
+
+
+@pytest_asyncio.fixture
+async def api_client(mock_memory):
+    app = create_app(mock_memory, initialize_memory=False)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_multi_bank_recall_endpoint_happy_path(api_client, mock_memory):
+    resp = await api_client.post(
+        "/v1/default/memories/recall",
+        json={
+            "bank_ids": ["bank-a", "bank-b"],
+            "query": "what did we decide?",
+            "merge": "score",
+            "max_tokens": 2048,
+            "include": {"entities": {}, "chunks": {}, "source_facts": {}},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert [r["id"] for r in body["results"]] == ["a1", "b1"]
+    assert body["results"][0]["bank_id"] == "bank-a"
+    assert body["results"][1]["bank_id"] == "bank-b"
+    assert "Alice" in body["entities"]
+    assert "chunk-1" in body["chunks"]
+    assert "sf1" in body["source_facts"]
+    assert body["metadata"]["multi_bank"]["merge_applied"] == "score"
+
+    kwargs = mock_memory.recall_multi_async.call_args.kwargs
+    assert kwargs["bank_ids"] == ["bank-a", "bank-b"]
+    assert kwargs["merge"] == "score"
+    assert kwargs["query"] == "what did we decide?"
+    assert kwargs["max_tokens"] == 2048
+    assert kwargs["include_entities"] is True
+    assert kwargs["include_chunks"] is True
+    assert kwargs["include_source_facts"] is True
+
+
+@pytest.mark.asyncio
+async def test_multi_bank_recall_default_merge_is_score(api_client, mock_memory):
+    resp = await api_client.post(
+        "/v1/default/memories/recall",
+        json={"bank_ids": ["x", "y"], "query": "hello world"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert mock_memory.recall_multi_async.call_args.kwargs["merge"] == "score"
+
+
+@pytest.mark.asyncio
+async def test_multi_bank_recall_rejects_empty_bank_ids(api_client, mock_memory):
+    resp = await api_client.post(
+        "/v1/default/memories/recall",
+        json={"bank_ids": ["  ", ""], "query": "hello world"},
+    )
+    assert resp.status_code == 422
+    mock_memory.recall_multi_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_multi_bank_recall_rejects_over_cap_bank_ids(api_client, mock_memory):
+    """HTTP model max_length=10 rejects 11 bank_ids before the engine is called."""
+    resp = await api_client.post(
+        "/v1/default/memories/recall",
+        json={"bank_ids": [f"b{i}" for i in range(11)], "query": "hello world"},
+    )
+    assert resp.status_code == 422
+    mock_memory.recall_multi_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_multi_bank_recall_rejects_empty_query(api_client, mock_memory):
+    resp = await api_client.post(
+        "/v1/default/memories/recall",
+        json={"bank_ids": ["a", "b"], "query": "   "},
+    )
+    assert resp.status_code == 422
+    mock_memory.recall_multi_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_multi_bank_recall_maps_operation_validation_error(mock_memory):
+    mock_memory.recall_multi_async = AsyncMock(side_effect=OperationValidationError("nope", status_code=403))
+    app = create_app(mock_memory, initialize_memory=False)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/default/memories/recall",
+            json={"bank_ids": ["a", "b"], "query": "hello world"},
+        )
+    assert resp.status_code == 403
+    assert "nope" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_multi_bank_recall_maps_authentication_error(mock_memory):
+    """Same AuthenticationError mapping as single-bank: global handler -> 401."""
+    mock_memory.recall_multi_async = AsyncMock(side_effect=AuthenticationError("Invalid API key"))
+    mock_memory.recall_async = AsyncMock(side_effect=AuthenticationError("Invalid API key"))
+    app = create_app(mock_memory, initialize_memory=False)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        multi = await client.post(
+            "/v1/default/memories/recall",
+            json={"bank_ids": ["a", "b"], "query": "hello world"},
+        )
+        single = await client.post(
+            "/v1/default/banks/a/memories/recall",
+            json={"query": "hello world"},
+        )
+    assert multi.status_code == 401
+    assert single.status_code == 401
+    assert multi.json() == single.json()
+    assert multi.json()["detail"] == "Authentication failed: Invalid API key"
+
+
+@pytest.mark.asyncio
+async def test_multi_bank_precheck_invoked_once_per_distinct_bank(mock_memory):
+    """Precheck must cover every distinct bank_id, not only bank_ids[0]."""
+    from hindsight_api.extensions import ValidationResult
+
+    precheck = AsyncMock(return_value=ValidationResult.accept())
+    validator = MagicMock()
+    validator.precheck = precheck
+    mock_memory._operation_validator = validator
+
+    app = create_app(mock_memory, initialize_memory=False)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/default/memories/recall",
+            # duplicate "allowed" proves de-dupe: 3 entries → 2 precheck calls
+            json={"bank_ids": ["allowed", "gated", "allowed"], "query": "hello world"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert precheck.await_count == 2
+    checked = [c.args[0].bank_id for c in precheck.await_args_list]
+    assert checked == ["allowed", "gated"]
+
+
+@pytest.mark.asyncio
+async def test_multi_bank_precheck_denies_non_primary_bank(mock_memory):
+    """A gated second bank must be rejected even when the first bank is allowed."""
+    from hindsight_api.extensions import ValidationResult
+
+    async def _precheck(ctx):
+        if ctx.bank_id == "gated":
+            return ValidationResult.reject("not allowed on gated", status_code=403)
+        return ValidationResult.accept()
+
+    validator = MagicMock()
+    validator.precheck = AsyncMock(side_effect=_precheck)
+    mock_memory._operation_validator = validator
+
+    app = create_app(mock_memory, initialize_memory=False)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/default/memories/recall",
+            json={"bank_ids": ["allowed", "gated"], "query": "hello world"},
+        )
+    assert resp.status_code == 403
+    assert "gated" in resp.json()["detail"] or "not allowed" in resp.json()["detail"]
+    mock_memory.recall_multi_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_single_bank_recall_path_unchanged(api_client, mock_memory):
+    """Existing single-bank endpoint still calls recall_async, not multi."""
+    mock_memory.recall_async = AsyncMock(return_value=RecallResult(results=[_fact("s1", "solo", bank_id=None)]))
+    resp = await api_client.post(
+        "/v1/default/banks/solo-bank/memories/recall",
+        json={"query": "hello world"},
+    )
+    assert resp.status_code == 200, resp.text
+    mock_memory.recall_async.assert_called_once()
+    mock_memory.recall_multi_async.assert_not_called()
+    assert resp.json()["results"][0]["id"] == "s1"

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1217,6 +1217,9 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | `HINDSIGHT_API_RERANKER_MAX_CANDIDATES_LOW` | Override the reranker candidate cap for `budget=low` recalls (the cross-encoder is the dominant cost of a large recall, so a lower cap trades some depth for latency). `0` falls back to `HINDSIGHT_API_RERANKER_MAX_CANDIDATES`. | `0` |
 | `HINDSIGHT_API_RERANKER_MAX_CANDIDATES_MID` | Override the reranker candidate cap for `budget=mid` recalls. `0` falls back to `HINDSIGHT_API_RERANKER_MAX_CANDIDATES`. | `0` |
 | `HINDSIGHT_API_RERANKER_MAX_CANDIDATES_HIGH` | Override the reranker candidate cap for `budget=high` recalls. `0` falls back to `HINDSIGHT_API_RERANKER_MAX_CANDIDATES`. | `0` |
+| `HINDSIGHT_API_MULTI_UNION_CAP` | Multi-bank recall: max candidates sent to the **one** union CrossEncoder pass. Cost is O(this cap), not O(N_banks). Default 200 keeps per-bank RRF ranks 0-39 at a 5-bank fan-out in the CE batch. Static (not per-bank). | `200` |
+| `HINDSIGHT_API_MULTI_PER_BANK_PRE_CAP` | Multi-bank recall: per-bank RRF head admitted into the union pool before `MULTI_UNION_CAP`. Static. | `50` |
+| `HINDSIGHT_API_MULTI_PER_BANK_FLOOR` | Multi-bank recall: after the union CE cut, each bank keeps at least `min(floor, its count)` so a CE-weak bank is not dropped. Static. | `1` |
 | `HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY` | Minimum cosine similarity a candidate must reach to be returned by the semantic retrieval strategy. Must be between `0` and `1`. | `0.3` |
 | `HINDSIGHT_API_GRAPH_SEED_MIN_SIMILARITY` | Minimum cosine similarity for a memory to seed graph retrieval. This is independent from the main semantic retrieval threshold. Must be between `0` and `1`. | `0.3` |
 | `HINDSIGHT_API_TEMPORAL_SEMANTIC_MIN_SIMILARITY` | Minimum cosine similarity for temporal retrieval entry points and spread neighbors. This is independent from the main semantic retrieval threshold. Must be between `0` and `1`. | `0.1` |

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -333,6 +333,14 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_RERANKER_MAX_CANDIDATES_LOW=0
 # HINDSIGHT_API_RERANKER_MAX_CANDIDATES_MID=0
 # HINDSIGHT_API_RERANKER_MAX_CANDIDATES_HIGH=0
+# Multi-bank union CE: one CrossEncoder pass over the merged pool (not N per-bank
+# CE jobs). Cost is O(union_cap), not O(N_banks). Default 200 keeps per-bank
+# RRF ranks 0-39 at a 5-bank fan-out in the CE batch.
+# HINDSIGHT_API_MULTI_UNION_CAP=200
+# Per-bank RRF head admitted into the union pool before the cap:
+# HINDSIGHT_API_MULTI_PER_BANK_PRE_CAP=50
+# After the CE cut, each bank keeps at least min(floor, its count):
+# HINDSIGHT_API_MULTI_PER_BANK_FLOOR=1
 
 # Reranker failover chain: extra rerankers tried, in order, when the one above
 # fails. Members are numbered from 1 (indices must be contiguous) and every

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1217,6 +1217,9 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | `HINDSIGHT_API_RERANKER_MAX_CANDIDATES_LOW` | Override the reranker candidate cap for `budget=low` recalls (the cross-encoder is the dominant cost of a large recall, so a lower cap trades some depth for latency). `0` falls back to `HINDSIGHT_API_RERANKER_MAX_CANDIDATES`. | `0` |
 | `HINDSIGHT_API_RERANKER_MAX_CANDIDATES_MID` | Override the reranker candidate cap for `budget=mid` recalls. `0` falls back to `HINDSIGHT_API_RERANKER_MAX_CANDIDATES`. | `0` |
 | `HINDSIGHT_API_RERANKER_MAX_CANDIDATES_HIGH` | Override the reranker candidate cap for `budget=high` recalls. `0` falls back to `HINDSIGHT_API_RERANKER_MAX_CANDIDATES`. | `0` |
+| `HINDSIGHT_API_MULTI_UNION_CAP` | Multi-bank recall: max candidates sent to the **one** union CrossEncoder pass. Cost is O(this cap), not O(N_banks). Default 200 keeps per-bank RRF ranks 0-39 at a 5-bank fan-out in the CE batch. Static (not per-bank). | `200` |
+| `HINDSIGHT_API_MULTI_PER_BANK_PRE_CAP` | Multi-bank recall: per-bank RRF head admitted into the union pool before `MULTI_UNION_CAP`. Static. | `50` |
+| `HINDSIGHT_API_MULTI_PER_BANK_FLOOR` | Multi-bank recall: after the union CE cut, each bank keeps at least `min(floor, its count)` so a CE-weak bank is not dropped. Static. | `1` |
 | `HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY` | Minimum cosine similarity a candidate must reach to be returned by the semantic retrieval strategy. Must be between `0` and `1`. | `0.3` |
 | `HINDSIGHT_API_GRAPH_SEED_MIN_SIMILARITY` | Minimum cosine similarity for a memory to seed graph retrieval. This is independent from the main semantic retrieval threshold. Must be between `0` and `1`. | `0.3` |
 | `HINDSIGHT_API_TEMPORAL_SEMANTIC_MIN_SIMILARITY` | Minimum cosine similarity for temporal retrieval entry points and spread neighbors. This is independent from the main semantic retrieval threshold. Must be between `0` and `1`. | `0.1` |


### PR DESCRIPTION
feat(recall): multi-bank recall with score/interleave merge

## What

Adds server-side multi-bank recall so a client that splits memory across
banks does not have to merge rank-relative per-bank scores itself.

- `MemoryEngine.recall_multi_async(bank_ids, query, *, merge=...)` fans out
  one unchanged `recall_async` per bank (`asyncio` task per bank, own
  `@_bind_bank_id` ContextVar).
- `merge="score"` (default) sorts the union by `scores.reranker`.
  Falls back to `merge="interleave"` (round-robin by per-bank rank) when
  CE is not comparable: `enable_reranking=false`, caller asked for
  `rrf`/`interleave`, or returned facts have no usable `scores.reranker`.
- After gather: per-bank cap 50 → merge → exact/normalized text dedup
  (`casefold` + Unicode whitespace collapse, mode `exact_normalized`) →
  token cut. Dedup is not embedding/near-duplicate collapse.
- Additive HTTP route `POST /v1/{tenant}/memories/recall`. Existing
  per-bank route is unchanged. MCP `recall` gains optional `bank_ids` /
  `merge` (2+ = multi; length-1 selects that bank; omit = session/`bank_id`).

`prefer_observations` defaults True on this orchestrator only. HTTP/MCP
request models still default False and pass the caller's value through.
Single-bank `recall_async` is unchanged.

MCP `bank_ids` of length 1 selects that bank. A singular `bank_id` is
also explicit (it is not replaced by the session bank). Tenant
`AuthenticationError` is authenticated once before fan-out and re-raised
as HTTP 401. Per-bank status lives in `metadata.multi_bank`.

## Single-bank vs multi-bank: what runs, and the speed consequence

| | single bank (`bank_ids` omitted, or length 1 / singular `bank_id`) | multi-bank (`bank_ids` length 2..10) |
|---|---|---|
| code path | `recall_async` exactly as before this PR — no new hop | `recall_multi_async`: one unchanged `recall_async` per bank, run concurrently via `asyncio.gather` |
| retrieval | one bank's candidates | N banks' candidates in parallel; each bank capped at `per_bank_cap` (50) before merge |
| reranking | that bank's CrossEncoder pass | ONE CrossEncoder pass over a capped union of all banks' candidates (per-bank pre-cap + floor + interleave fill to `union_cap` 200), so scores are comparable across banks and the CE cost is paid once — see "Union CrossEncoder pass" below |
| merge | none | `merge="score"` by `scores.reranker` (falls back to `interleave` when CE scores are not comparable), then exact-normalized dedup, then the token cut |
| cost | unchanged | wall ≈ slowest bank + one union CE + merge; on our host (local bge-base + MiniLM CE + pgvector, idle): single 0.90–0.94× of before, 3-bank 3.8–3.9 s, 5-bank 4.5–4.7 s (was 4.3–5.3 s / 6.3–7.5 s with per-bank CE) |

Guidance for callers: pass only the banks a query needs — a length-1 `bank_ids` is the single-bank path, byte for byte; multi-bank is for topics that genuinely span banks. Per-bank status (`ok` / `error` with generic text) is in `metadata.multi_bank.banks`, so a slow or failing bank never turns a 200 into a 500.

## Example

Request (tenant `default`, three banks, default score merge):

```http
POST /v1/default/memories/recall
{"query": "how are retains verified", "bank_ids": ["notes", "eng", "ops"], "merge": "score", "max_tokens": 2048}
```

Response (abbreviated): every result carries the bank it came from; the
merge that actually ran, any fallback reason, and per-bank status live in
`metadata.multi_bank`.

```json
{
  "results": [
    {"id": "…", "text": "…", "bank_id": "eng",   "scores": {"reranker": 0.91, "semantic": 0.77}},
    {"id": "…", "text": "…", "bank_id": "notes", "scores": {"reranker": 0.84, "semantic": 0.72}},
    {"id": "…", "text": "…", "bank_id": "ops",   "scores": {"reranker": 0.63, "semantic": 0.70}}
  ],
  "metadata": {
    "multi_bank": {
      "merge_requested": "score",
      "merge_applied": "score",
      "merge_fallback_reason": null,
      "banks": {"notes": {"status": "ok", "count": 12},
                "eng":   {"status": "ok", "count": 9},
                "ops":   {"status": "ok", "count": 4}},
      "dedup": "exact_normalized",
      "dedup_dropped": 1,
      "per_bank_cap": 50
    }
  }
}
```

MCP: `recall(query=..., bank_ids=["notes", "eng"], merge="score")` returns
the same `bank_id`-stamped results and `metadata.multi_bank`; `bank_ids`
of length 1 (or a singular `bank_id`) selects that bank explicitly.

## Error handling (how failures propagate per bank)

- `OperationCancelledError` propagates (same 499 path as single-bank
  `run_cancellable_on_disconnect`).
- Tenant `AuthenticationError` is authenticated once before fan-out and
  re-raised (HTTP 401 via the existing global handler). Must not soft-fail
  into a 200.
- `OperationValidationError` propagates (same status as single-bank).
- Ordinary infrastructure errors soft-fail per bank (generic client text).
- HTTP precheck runs for every distinct `bank_id`. `bank_ids` capped at 10
  (422 at the request model and again in the engine).

## Also in this PR (small, separable)

`execute_task` handles `MentalModelRefreshError` with `logger.error` and
**no** `exc_info`, then the same `RetryTaskAt` policy as other
non-consolidation worker errors. On current main that exception falls
through the generic `except Exception` and logs a traceback; soak
watchers treat that traceback as unhandled. Happy to split this commit
out if preferred.

This is **not** the two-tier refresh work in #3290 and does not depend
on it. It does edit `memory_engine.py` / `http.py`, so it will likely
need a rebase after #3290, #3306, #3372, or #3373.

## Union CrossEncoder pass (folded from #3581)

Multi-bank recall changes only in HOW MANY times the CrossEncoder runs: N per-bank passes (one inside each sub-call) become one pass over a capped union, which makes CE scores comparable across banks and removes the N x rerank cost. Single-bank recall is untouched (no CE change, no new hop).

`recall_multi_async` already fans out one `recall_async` per bank. This
PR stops paying the local CrossEncoder N times.

When union CE is eligible (caller asked for `cross_encoder`, every bank
has `enable_reranking`, engine has a non-passthrough CE):

1. Each subcall uses `reranking="rrf"` (retrieval only).
2. After gather: per-bank pre-cap (default 50) + floor reservation +
   interleave fill up to `union_cap` (default **200**).
3. One `CrossEncoderReranker.rerank` over that union.
4. `apply_per_bank_floor` so a CE-weak bank still keeps
   `min(k_floor, its count)` after the CE cut (default floor 1).
5. Score/interleave merge as today (CE scores are now comparable across
   banks). The caller `max_tokens` is applied **after** that CE pass.

If CE is disabled / null / rrf-passthrough, or the caller requested
`rrf`/`interleave`, today's per-bank path is unchanged.

Per-bank subcalls that will be union-CE scored use a wide token budget
(`max(caller, 100000)`) so a typical caller budget of ~2000 cannot drop
deep RRF ranks before the one CE pass. The caller budget still cuts the
merged list afterwards.

HTTP/MCP request schema is unchanged.

Does **not** change the per-thread
CrossEncoder ownership (that is #3578; the union pass here does not touch
`cross_encoder.py`). Does not pin torch intra-op threads.

### Why (measured, with configuration)

LAT5 (2026-08-17). Configuration: host idle; local embed `BAAI/bge-base`;
local CE `cross-encoder/ms-marco-MiniLM-L-6-v2`; union cap **200**; golds
kept in the CE batch; no `HINDSIGHT_API_RERANKER_TORCH_THREADS` (unset = no
pin); `lt1b_latency_matrix.py --budgets low,mid --reps 5`; 5-bank set +
3-bank (operator-joshf + systems-knowledge + planner-workflow) + singles.

| arm | before (per-bank CE) | after (union CE, U=200, no pin) |
|---|---|---|
| single-bank p50 | baseline | 0.90–0.94× |
| 3-bank p50 low / mid | 4.27 s / 5.34 s | 3.87 s / 3.79 s |
| 5-bank p50 low / mid | 6.29 s / 7.51 s | 4.66 s / 4.48 s |
| quality (top-5 overlap) | — | PASS (median 5/5, min 3/5) |

L5 is this measurement, not a new sweep. LAT3 used cap 150 (rank-25 gold
survival); **200** is the chosen default. Do not re-sweep 120/200/300 now.

A 5-bank fan-out at U=200 keeps per-bank RRF ranks 0–39 in the CE pool.
A caller `max_tokens=2000` applied *before* CE in RRF order dropped
those deeper ranks (the earlier quality drop was absent golds, not a
different score on the same pair).

### Config knobs (static)

| Variable | Default |
|---|---|
| `HINDSIGHT_API_MULTI_UNION_CAP` | 200 |
| `HINDSIGHT_API_MULTI_PER_BANK_PRE_CAP` | 50 |
| `HINDSIGHT_API_MULTI_PER_BANK_FLOOR` | 1 |

Values below 1 (or non-integers) fall back to the default, not to 1.

### Tests (union CE)

- Union CE: rrf-per-bank + one `predict`; floor keeps a CE-weak bank;
  CE-off / caller-`rrf` fallback.
- U=200 keeps RRF ranks 36/37 at 5 banks; U=150 drops them.
- Subcall budget: caller 2000 drops a rank-36 fact; the union budget
  keeps it.
- `_parse_iso_datetime` accepts `datetime`/`date` (a TypeError there
  would abort the whole union CE).
- Env `0` for `MULTI_UNION_CAP` uses the default, not 1.
- `hindsight-api-slim/tests/bench_multi_bank_union.py`: quality overlap
  >= 4/5; `HS_BENCH=1` for the synthetic wall-clock bench.

## Surfaces not updated

HTTP/MCP/OpenAPI/control-plane request models. `MAX_MULTI_BANK_RECALL_BANKS`
is still 10.


OpenAPI, generated clients, control-plane proxy, and the docs site are
untouched — same “regen at release” convention as other recent API PRs.
Happy to add a docs page if wanted.

## Tests

- Score / interleave / fallback / token cut / `bank_id` / `include_*` /
  cancel / fan-out cap / OVE / 401 skip-fanout / dedup / per-bank cap /
  `prefer_observations`: `hindsight-api-slim/tests/test_multi_bank_recall.py`
- HTTP happy path, 422 cap, precheck-all-banks, 401 mapping:
  `hindsight-api-slim/tests/test_multi_bank_recall_http.py`
- MCP `bank_ids` routing: `hindsight-api-slim/tests/test_mcp_tools.py`
  (`TestRecallMultiBankParams`)
- MM refresh skip without traceback:
  `hindsight-api-slim/tests/test_mental_model_refresh_error_retry.py`
