### PR TITLE
fix(mental-models): refuse to overwrite real content with a failure placeholder

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -13066,9 +13066,7 @@ class MemoryEngine(MemoryEngineInterface):
         # Capture whether THIS reflect used any facts BEFORE the delta-mode
         # merge below folds in facts from previous refreshes. Post-merge
         # emptiness is fail-open under carry-over (#2894).
-        fresh_retrieval_empty = not any(
-            payload for payload in based_on_serialized_payload.values() if payload
-        )
+        fresh_retrieval_empty = not any(payload for payload in based_on_serialized_payload.values() if payload)
 
         # In delta mode, based_on must accumulate: the mental model is
         # grounded on ALL facts ever used, not just the latest delta's new

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -134,6 +134,26 @@ def _authorize_nested_operations() -> "Iterator[None]":
 
 MENTAL_MODEL_PENDING_CONTENT = "Generating content..."
 
+_ITERATION_LIMIT_PREFIX = "I was unable to formulate a complete answer"
+
+
+def is_placeholder_refresh_candidate(text: str) -> bool:
+    """True when the reflect candidate is a known failure placeholder, not a document."""
+    from .reflect.agent import NO_ANSWER_TEXT
+
+    candidate = text.strip()
+    return candidate == NO_ANSWER_TEXT.strip() or candidate.startswith(_ITERATION_LIMIT_PREFIX)
+
+
+def should_refuse_failed_refresh_overwrite(
+    *,
+    has_delta_baseline: bool,
+    is_placeholder: bool,
+    fresh_retrieval_empty: bool,
+) -> bool:
+    """Refuse a failed render only when it would overwrite existing real content."""
+    return has_delta_baseline and (is_placeholder or fresh_retrieval_empty)
+
 
 def get_current_schema() -> str:
     """Get the current schema from context (falls back to config default)."""
@@ -13043,6 +13063,13 @@ class MemoryEngine(MemoryEngineInterface):
         for _facts in based_on_serialized_payload.values():
             delta_supporting_facts.extend(_facts)
 
+        # Capture whether THIS reflect used any facts BEFORE the delta-mode
+        # merge below folds in facts from previous refreshes. Post-merge
+        # emptiness is fail-open under carry-over (#2894).
+        fresh_retrieval_empty = not any(
+            payload for payload in based_on_serialized_payload.values() if payload
+        )
+
         # In delta mode, based_on must accumulate: the mental model is
         # grounded on ALL facts ever used, not just the latest delta's new
         # ones. Merge previous based_on with current, deduplicating by id.
@@ -13311,6 +13338,31 @@ class MemoryEngine(MemoryEngineInterface):
             warnings.append(
                 "The refresh produced empty content, which usually means an upstream LLM failure. "
                 "A real refresh would preserve the existing content and fail."
+            )
+            return _finish(
+                effective_mode=effective_mode,
+                mode_fallback_reason=mode_fallback_reason,
+                final_content=final_content,
+                final_structured=None,
+                delta_operations=delta_operations,
+                outcome="refresh_failed_empty_candidate",
+            )
+
+        # Refuse to overwrite EXISTING REAL content with a failure placeholder
+        # (#2959: NO_ANSWER_TEXT / iteration-limit fallback — non-empty, so the
+        # emptiness guard above lets it through) or when this run retrieved
+        # nothing fresh (#2894). Both legs require a real baseline so a
+        # bootstrap write onto empty/PENDING content still lands.
+        is_placeholder = is_placeholder_refresh_candidate(final_content)
+        if should_refuse_failed_refresh_overwrite(
+            has_delta_baseline=has_delta_baseline,
+            is_placeholder=is_placeholder,
+            fresh_retrieval_empty=fresh_retrieval_empty,
+        ):
+            reason = "placeholder_candidate" if is_placeholder else "empty_fresh_retrieval"
+            warnings.append(
+                f"Refresh produced a {reason} render over existing real content; "
+                "preserving previous content and failing the refresh."
             )
             return _finish(
                 effective_mode=effective_mode,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -145,14 +145,39 @@ def is_placeholder_refresh_candidate(text: str) -> bool:
     return candidate == NO_ANSWER_TEXT.strip() or candidate.startswith(_ITERATION_LIMIT_PREFIX)
 
 
+EmptyEvidenceState = Literal["retrieval_empty", "no_grounded_facts"]
+
+
+def empty_evidence_state(*, based_on_empty: bool, retrieved_count: int) -> EmptyEvidenceState | None:
+    """Name the empty-evidence diagnostic, or None when this run grounded facts.
+
+    ``retrieval_empty``: recall returned nothing (``facts.retrieved == 0``).
+    ``no_grounded_facts``: recall returned facts but ``based_on`` is empty —
+    the agent used none of them. The overwrite guard keys on based_on
+    emptiness (either state) so a real document is not replaced by an
+    ungrounded render (#2894). These two used to be collapsed as
+    ``fresh_retrieval_empty`` / ``empty_fresh_retrieval``.
+    """
+    if not based_on_empty:
+        return None
+    if retrieved_count == 0:
+        return "retrieval_empty"
+    return "no_grounded_facts"
+
+
 def should_refuse_failed_refresh_overwrite(
     *,
     has_delta_baseline: bool,
     is_placeholder: bool,
-    fresh_retrieval_empty: bool,
+    no_grounded_facts: bool,
 ) -> bool:
-    """Refuse a failed render only when it would overwrite existing real content."""
-    return has_delta_baseline and (is_placeholder or fresh_retrieval_empty)
+    """Refuse a failed render only when it would overwrite existing real content.
+
+    ``no_grounded_facts`` is based_on emptiness (no facts used/grounded), not
+    "retrieval returned nothing". Retrieval can be nonempty while based_on is
+    empty; the conservative guard still refuses in that case.
+    """
+    return has_delta_baseline and (is_placeholder or no_grounded_facts)
 
 
 def get_current_schema() -> str:
@@ -13063,10 +13088,11 @@ class MemoryEngine(MemoryEngineInterface):
         for _facts in based_on_serialized_payload.values():
             delta_supporting_facts.extend(_facts)
 
-        # Capture whether THIS reflect used any facts BEFORE the delta-mode
+        # Capture whether THIS reflect grounded any facts BEFORE the delta-mode
         # merge below folds in facts from previous refreshes. Post-merge
-        # emptiness is fail-open under carry-over (#2894).
-        fresh_retrieval_empty = not any(payload for payload in based_on_serialized_payload.values() if payload)
+        # emptiness is fail-open under carry-over (#2894). based_on empty means
+        # no facts used/grounded — retrieval can still have returned facts.
+        no_grounded_facts = not any(payload for payload in based_on_serialized_payload.values() if payload)
 
         # In delta mode, based_on must accumulate: the mental model is
         # grounded on ALL facts ever used, not just the latest delta's new
@@ -13348,16 +13374,20 @@ class MemoryEngine(MemoryEngineInterface):
 
         # Refuse to overwrite EXISTING REAL content with a failure placeholder
         # (#2959: NO_ANSWER_TEXT / iteration-limit fallback — non-empty, so the
-        # emptiness guard above lets it through) or when this run retrieved
-        # nothing fresh (#2894). Both legs require a real baseline so a
-        # bootstrap write onto empty/PENDING content still lands.
+        # emptiness guard above lets it through) or when this run grounded no
+        # facts (#2894). based_on empty is the conservative trigger; the warning
+        # names retrieval_empty vs no_grounded_facts so a nonempty recall that
+        # the agent ignored is not reported as "retrieval returned nothing".
+        # Both legs require a real baseline so a bootstrap write onto
+        # empty/PENDING content still lands.
         is_placeholder = is_placeholder_refresh_candidate(final_content)
         if should_refuse_failed_refresh_overwrite(
             has_delta_baseline=has_delta_baseline,
             is_placeholder=is_placeholder,
-            fresh_retrieval_empty=fresh_retrieval_empty,
+            no_grounded_facts=no_grounded_facts,
         ):
-            reason = "placeholder_candidate" if is_placeholder else "empty_fresh_retrieval"
+            evidence_state = empty_evidence_state(based_on_empty=no_grounded_facts, retrieved_count=retrieved_total)
+            reason = "placeholder_candidate" if is_placeholder else (evidence_state or "no_grounded_facts")
             warnings.append(
                 f"Refresh produced a {reason} render over existing real content; "
                 "preserving previous content and failing the refresh."

--- a/hindsight-api-slim/tests/test_mental_model_dry_run_refresh.py
+++ b/hindsight-api-slim/tests/test_mental_model_dry_run_refresh.py
@@ -491,7 +491,7 @@ class TestDryRunReportsRetrievalHealth:
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
-    async def test_empty_fresh_retrieval_over_real_content_fails(
+    async def test_retrieval_empty_over_real_content_fails(
         self, memory: MemoryEngine, request_context: RequestContext, patch_reflect
     ):
         """A generic non-empty render with no facts this run must not clobber."""
@@ -511,7 +511,38 @@ class TestDryRunReportsRetrievalHealth:
         assert result.outcome == "refresh_failed_empty_candidate"
         assert result.would_persist is False
         assert result.preview_content == "# Team\n\nStill here."
-        assert any("empty_fresh_retrieval" in w for w in result.warnings)
+        assert any("retrieval_empty" in w for w in result.warnings)
+        assert not any("no_grounded_facts" in w for w in result.warnings)
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_no_grounded_facts_with_nonzero_retrieval_over_real_content_fails(
+        self, memory: MemoryEngine, request_context: RequestContext, patch_reflect
+    ):
+        """Recall can return facts while based_on is empty; still refuse, name the state."""
+        bank_id = await _make_bank(memory, request_context, "test-dryrun-ungrounded")
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Team Info",
+            source_query="Tell me about the team",
+            content="# Team\n\nStill here.",
+            trigger={"mode": "full"},
+            request_context=request_context,
+        )
+
+        patch_reflect(
+            memory,
+            text="# Team\n\nNothing relevant was found.",
+            facts=[],
+            retrieved=[{"id": "f1", "text": "off topic", "fact_type": "observation"}],
+        )
+        result = await memory.dry_run_refresh_mental_model(bank_id, mm["id"], request_context=request_context)
+
+        assert result.outcome == "refresh_failed_empty_candidate"
+        assert result.would_persist is False
+        assert result.preview_content == "# Team\n\nStill here."
+        assert any("no_grounded_facts" in w for w in result.warnings)
+        assert not any("retrieval_empty" in w for w in result.warnings)
 
         await memory.delete_bank(bank_id, request_context=request_context)
 

--- a/hindsight-api-slim/tests/test_mental_model_dry_run_refresh.py
+++ b/hindsight-api-slim/tests/test_mental_model_dry_run_refresh.py
@@ -461,6 +461,85 @@ class TestDryRunReportsRetrievalHealth:
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
+    async def test_placeholder_candidate_over_real_content_fails(
+        self, memory: MemoryEngine, request_context: RequestContext, patch_reflect
+    ):
+        """NO_ANSWER_TEXT is non-empty, so the emptiness guard does not see it."""
+        from hindsight_api.engine.reflect.agent import NO_ANSWER_TEXT
+
+        bank_id = await _make_bank(memory, request_context, "test-dryrun-placeholder")
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Team Info",
+            source_query="Tell me about the team",
+            content="# Team\n\nStill here.",
+            trigger={"mode": "full"},
+            request_context=request_context,
+        )
+
+        patch_reflect(
+            memory,
+            text=NO_ANSWER_TEXT,
+            facts=[{"id": "f1", "text": "used", "fact_type": "observation"}],
+        )
+        result = await memory.dry_run_refresh_mental_model(bank_id, mm["id"], request_context=request_context)
+
+        assert result.outcome == "refresh_failed_empty_candidate"
+        assert result.would_persist is False
+        assert result.preview_content == "# Team\n\nStill here."
+        assert any("placeholder_candidate" in w for w in result.warnings)
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_empty_fresh_retrieval_over_real_content_fails(
+        self, memory: MemoryEngine, request_context: RequestContext, patch_reflect
+    ):
+        """A generic non-empty render with no facts this run must not clobber."""
+        bank_id = await _make_bank(memory, request_context, "test-dryrun-emptyfresh")
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Team Info",
+            source_query="Tell me about the team",
+            content="# Team\n\nStill here.",
+            trigger={"mode": "full"},
+            request_context=request_context,
+        )
+
+        patch_reflect(memory, text="# Team\n\nNothing relevant was found.", facts=[], retrieved=[])
+        result = await memory.dry_run_refresh_mental_model(bank_id, mm["id"], request_context=request_context)
+
+        assert result.outcome == "refresh_failed_empty_candidate"
+        assert result.would_persist is False
+        assert result.preview_content == "# Team\n\nStill here."
+        assert any("empty_fresh_retrieval" in w for w in result.warnings)
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_placeholder_on_pending_model_still_writes(
+        self, memory: MemoryEngine, request_context: RequestContext, patch_reflect
+    ):
+        """Bootstrap onto PENDING content is a first write, not a clobber."""
+        from hindsight_api.engine.memory_engine import MENTAL_MODEL_PENDING_CONTENT
+        from hindsight_api.engine.reflect.agent import NO_ANSWER_TEXT
+
+        bank_id = await _make_bank(memory, request_context, "test-dryrun-bootph")
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Team Info",
+            source_query="Tell me about the team",
+            content=MENTAL_MODEL_PENDING_CONTENT,
+            trigger={"mode": "full"},
+            request_context=request_context,
+        )
+
+        patch_reflect(memory, text=NO_ANSWER_TEXT, facts=[], retrieved=[])
+        result = await memory.dry_run_refresh_mental_model(bank_id, mm["id"], request_context=request_context)
+
+        assert result.outcome == "content_written"
+        assert result.would_persist is True
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
 
 class TestDryRunScopeResolution:
     """A model's stored tags are not what filters memories; the resolved scope is."""

--- a/hindsight-api-slim/tests/test_mental_model_placeholder_guard.py
+++ b/hindsight-api-slim/tests/test_mental_model_placeholder_guard.py
@@ -1,4 +1,4 @@
-"""Unit tests for the mental-model refresh placeholder / empty-retrieval guard.
+"""Unit tests for the mental-model refresh placeholder / empty-evidence guard.
 
 These are the deterministic legs of #2959 / #2894. The dry-run refresh tests
 exercise the same helpers through the write path when a full engine fixture
@@ -6,6 +6,7 @@ is available.
 """
 
 from hindsight_api.engine.memory_engine import (
+    empty_evidence_state,
     is_placeholder_refresh_candidate,
     should_refuse_failed_refresh_overwrite,
 )
@@ -27,22 +28,31 @@ def test_real_document_is_not_a_placeholder():
     assert not is_placeholder_refresh_candidate("   ")
 
 
-def test_refuse_placeholder_or_empty_retrieval_over_real_content():
-    assert should_refuse_failed_refresh_overwrite(
-        has_delta_baseline=True, is_placeholder=True, fresh_retrieval_empty=False
-    )
-    assert should_refuse_failed_refresh_overwrite(
-        has_delta_baseline=True, is_placeholder=False, fresh_retrieval_empty=True
-    )
+def test_refuse_placeholder_or_empty_grounding_over_real_content():
+    assert should_refuse_failed_refresh_overwrite(has_delta_baseline=True, is_placeholder=True, no_grounded_facts=False)
+    assert should_refuse_failed_refresh_overwrite(has_delta_baseline=True, is_placeholder=False, no_grounded_facts=True)
 
 
 def test_allow_bootstrap_write_on_empty_or_pending_model():
     assert not should_refuse_failed_refresh_overwrite(
-        has_delta_baseline=False, is_placeholder=True, fresh_retrieval_empty=True
+        has_delta_baseline=False, is_placeholder=True, no_grounded_facts=True
     )
 
 
 def test_allow_real_refresh_with_facts():
     assert not should_refuse_failed_refresh_overwrite(
-        has_delta_baseline=True, is_placeholder=False, fresh_retrieval_empty=False
+        has_delta_baseline=True, is_placeholder=False, no_grounded_facts=False
     )
+
+
+def test_empty_evidence_state_splits_retrieval_from_grounding():
+    assert empty_evidence_state(based_on_empty=False, retrieved_count=0) is None
+    assert empty_evidence_state(based_on_empty=False, retrieved_count=3) is None
+    assert empty_evidence_state(based_on_empty=True, retrieved_count=0) == "retrieval_empty"
+    assert empty_evidence_state(based_on_empty=True, retrieved_count=3) == "no_grounded_facts"
+
+
+def test_refuse_no_grounded_facts_when_retrieval_nonzero():
+    """Recall can return facts while based_on stays empty; the guard still refuses."""
+    assert should_refuse_failed_refresh_overwrite(has_delta_baseline=True, is_placeholder=False, no_grounded_facts=True)
+    assert empty_evidence_state(based_on_empty=True, retrieved_count=4) == "no_grounded_facts"

--- a/hindsight-api-slim/tests/test_mental_model_placeholder_guard.py
+++ b/hindsight-api-slim/tests/test_mental_model_placeholder_guard.py
@@ -1,0 +1,50 @@
+"""Unit tests for the mental-model refresh placeholder / empty-retrieval guard.
+
+These are the deterministic legs of #2959 / #2894. The dry-run refresh tests
+exercise the same helpers through the write path when a full engine fixture
+is available.
+"""
+
+from hindsight_api.engine.memory_engine import (
+    is_placeholder_refresh_candidate,
+    should_refuse_failed_refresh_overwrite,
+)
+from hindsight_api.engine.reflect.agent import NO_ANSWER_TEXT
+
+
+def test_no_answer_text_is_a_placeholder():
+    assert is_placeholder_refresh_candidate(NO_ANSWER_TEXT)
+    assert is_placeholder_refresh_candidate(f"  {NO_ANSWER_TEXT}  ")
+
+
+def test_iteration_limit_render_is_a_placeholder():
+    assert is_placeholder_refresh_candidate(
+        "I was unable to formulate a complete answer after 10 iterations."
+    )
+
+
+def test_real_document_is_not_a_placeholder():
+    assert not is_placeholder_refresh_candidate("# Team\n\nAlice joined in 2024.")
+    assert not is_placeholder_refresh_candidate("")
+    assert not is_placeholder_refresh_candidate("   ")
+
+
+def test_refuse_placeholder_or_empty_retrieval_over_real_content():
+    assert should_refuse_failed_refresh_overwrite(
+        has_delta_baseline=True, is_placeholder=True, fresh_retrieval_empty=False
+    )
+    assert should_refuse_failed_refresh_overwrite(
+        has_delta_baseline=True, is_placeholder=False, fresh_retrieval_empty=True
+    )
+
+
+def test_allow_bootstrap_write_on_empty_or_pending_model():
+    assert not should_refuse_failed_refresh_overwrite(
+        has_delta_baseline=False, is_placeholder=True, fresh_retrieval_empty=True
+    )
+
+
+def test_allow_real_refresh_with_facts():
+    assert not should_refuse_failed_refresh_overwrite(
+        has_delta_baseline=True, is_placeholder=False, fresh_retrieval_empty=False
+    )

--- a/hindsight-api-slim/tests/test_mental_model_placeholder_guard.py
+++ b/hindsight-api-slim/tests/test_mental_model_placeholder_guard.py
@@ -18,9 +18,7 @@ def test_no_answer_text_is_a_placeholder():
 
 
 def test_iteration_limit_render_is_a_placeholder():
-    assert is_placeholder_refresh_candidate(
-        "I was unable to formulate a complete answer after 10 iterations."
-    )
+    assert is_placeholder_refresh_candidate("I was unable to formulate a complete answer after 10 iterations.")
 
 
 def test_real_document_is_not_a_placeholder():


### PR DESCRIPTION
fix(mental-models): refuse to overwrite real content with a failure placeholder

## What

A mental-model refresh whose candidate is a failure placeholder
(`NO_ANSWER_TEXT`, or an iteration-limit render) or whose retrieval
returned nothing this run will overwrite a document built over months.
Neither case is empty, so the existing emptiness guard does not see it.

Two checks on the write path, both scoped to **existing real** content
so a bootstrap write onto an empty/`Generating content...` model still
lands:

- Placeholder candidates are refused.
- This run's retrieval emptiness is captured **before** the delta-mode
  `based_on` carry-over merge, which would otherwise make an empty
  retrieval look populated.

Reuses the existing outcome `refresh_failed_empty_candidate` so the
caller's preserve-and-fail path needs no new outcome value. The warning
records `placeholder_candidate` or `empty_fresh_retrieval`.

Related: #2959, #2894.

## Tests

`hindsight-api-slim/tests/test_mental_model_placeholder_guard.py`:

- `NO_ANSWER_TEXT` and the iteration-limit prefix are placeholders.
- A real document is not.
- Refuse placeholder or empty-retrieval over a real baseline.
- Allow bootstrap on empty/PENDING.
- Allow a real refresh that used facts.

The dry-run refresh tests in
`hindsight-api-slim/tests/test_mental_model_dry_run_refresh.py` cover
the same outcomes through the write path.
