### PR TITLE
chore(docs): re-sync the coding-agents page with its README

### DIFF
--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -489,7 +489,8 @@ Every document this integration writes carries provenance tags — `source:chat`
 `knowledge:<kind>`, plus anything from `retainTags`. Those tags say **who wrote** a memory; they are
 what filters recall and draws each document's agent logo, and they stay on the facts.
 
-They are not, however, a good boundary for [observations](/developer/observations). Consolidation's own
+They are not, however, a good boundary for
+[observations](https://hindsight.vectorize.io/developer/observations). Consolidation's own
 default (`combined`) builds one observation set per distinct tag set, so the same repository
 worked on by two agents would grow two parallel sets of beliefs — one per harness — that never
 merge, each blind to the other, at double the consolidation cost. Which agent happened to be typing

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -484,7 +484,8 @@ Every document this integration writes carries provenance tags — `source:chat`
 `knowledge:<kind>`, plus anything from `retainTags`. Those tags say **who wrote** a memory; they are
 what filters recall and draws each document's agent logo, and they stay on the facts.
 
-They are not, however, a good boundary for [observations](../../developer/observations.md). Consolidation's own
+They are not, however, a good boundary for
+[observations](https://hindsight.vectorize.io/developer/observations). Consolidation's own
 default (`combined`) builds one observation set per distinct tag set, so the same repository
 worked on by two agents would grow two parallel sets of beliefs — one per harness — that never
 merge, each blind to the other, at double the consolidation cost. Which agent happened to be typing


### PR DESCRIPTION
`build-docs` has failed on every PR (and the Deploy Docs workflow on `main`) since #3575: that PR edited `hindsight-docs/docs-integrations/coding-agents.md` directly instead of regenerating it, so the relative `/developer/observations` link never went through the generator's absolute-URL rewrite and `sync-coding-agents-doc.mjs --check` fails.

Regenerated with `node hindsight-docs/scripts/sync-coding-agents-doc.mjs` (the pre-commit hook mirrored it into `skills/hindsight-docs/`). `--check` passes locally.

Noticed while merging #3531.