### PR TITLE
docs(coding-agents): regenerate the docs page from the README

### DIFF
--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -489,7 +489,8 @@ Every document this integration writes carries provenance tags — `source:chat`
 `knowledge:<kind>`, plus anything from `retainTags`. Those tags say **who wrote** a memory; they are
 what filters recall and draws each document's agent logo, and they stay on the facts.
 
-They are not, however, a good boundary for [observations](/developer/observations). Consolidation's own
+They are not, however, a good boundary for
+[observations](https://hindsight.vectorize.io/developer/observations). Consolidation's own
 default (`combined`) builds one observation set per distinct tag set, so the same repository
 worked on by two agents would grow two parallel sets of beliefs — one per harness — that never
 merge, each blind to the other, at double the consolidation cost. Which agent happened to be typing

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -484,7 +484,8 @@ Every document this integration writes carries provenance tags — `source:chat`
 `knowledge:<kind>`, plus anything from `retainTags`. Those tags say **who wrote** a memory; they are
 what filters recall and draws each document's agent logo, and they stay on the facts.
 
-They are not, however, a good boundary for [observations](../../developer/observations.md). Consolidation's own
+They are not, however, a good boundary for
+[observations](https://hindsight.vectorize.io/developer/observations). Consolidation's own
 default (`combined`) builds one observation set per distinct tag set, so the same repository
 worked on by two agents would grow two parallel sets of beliefs — one per harness — that never
 merge, each blind to the other, at double the consolidation cost. Which agent happened to be typing


### PR DESCRIPTION
## What

`build-docs` fails on `main` and on every open PR. Step 6 of that job runs

```
node hindsight-docs/scripts/sync-coding-agents-doc.mjs --check
```

which reports `[coding-agents] docs page is out of date with the README`. Steps 1-5 (code parity, integration SEO, integrations) pass, so the failure is this one generated file, not the diffs sitting under it.

The drift is one line. The generator emits the absolute `https://hindsight.vectorize.io/developer/observations`; the checked-in page has the site-relative `/developer/observations`. This PR is the mechanical regeneration the CI message asks for -- 2 insertions, 1 deletion, no hand edits.

## Verification

Run against `edd0d0c5` (current `main`) before and after, LF working tree:

- before: `[coding-agents] docs page is out of date with the README` (exit 1)
- after: `[coding-agents] docs page matches the README` (exit 0)

Re-checked by extracting this commit's blobs into a clean tree and running `--check` there, so the proof is the committed content and not my working copy.

## One judgment call left for you

The generator rewrites absolute URLs on our own domain to site-relative **for assets only**, for the reason its own docstring gives: an absolute URL pins the target to production, so a new asset looks broken locally and in previews. That argument applies to this doc link too -- regenerating moves it the other way, to production-pinned.

Extending the rewrite to doc links on our own domain would keep the page site-relative and still pass `--check`. I did not do that here, because it changes generator behaviour and this PR's purpose is to clear a red that is blocking unrelated review. Happy to follow up with it if you would rather have that shape.
