### PR TITLE
Propagate Ollama num_ctx to unstructured requests

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -839,6 +839,13 @@ class OpenAICompatibleLLM(LLMInterface):
         """Apply provider-specific extra_body defaults while preserving user overrides."""
         if self.provider == "minimax":
             extra_body.setdefault("thinking", {"type": "disabled"})
+        if self.provider == "ollama" and self.ollama_num_ctx is not None:
+            # ``extra_body`` is shallow-copied per call, so copy nested options
+            # before adding the default to avoid mutating the configured payload.
+            options = extra_body.get("options")
+            options = dict(options) if isinstance(options, dict) else {}
+            options.setdefault("num_ctx", self.ollama_num_ctx)
+            extra_body["options"] = options
 
     async def call(
         self,

--- a/hindsight-api-slim/tests/test_llm_wrapper.py
+++ b/hindsight-api-slim/tests/test_llm_wrapper.py
@@ -1,3 +1,6 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 from hindsight_api.engine.llm_wrapper import create_llm_provider, sanitize_llm_output
@@ -194,6 +197,82 @@ async def test_native_ollama_omits_num_ctx_unless_configured(monkeypatch):
     assert "num_ctx" not in calls[0]["json"]["options"]
     assert calls[0]["json"]["options"]["num_batch"] == 512
     assert calls[1]["json"]["options"]["num_ctx"] == 65536
+
+
+def _openai_response(content: str = "ok") -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(finish_reason="stop", message=SimpleNamespace(content=content))],
+        usage=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_ollama_num_ctx_applies_to_unstructured_calls_and_verification():
+    """OpenAI-compatible Ollama calls, including the startup probe, carry num_ctx."""
+    from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+
+    provider = OpenAICompatibleLLM(
+        provider="ollama",
+        api_key="",
+        base_url="",
+        model="llama3.2",
+        ollama_num_ctx=24576,
+    )
+    create = AsyncMock(return_value=_openai_response())
+    provider._client.chat.completions.create = create
+
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        await provider.call(
+            messages=[{"role": "user", "content": "Say 'ok'"}],
+            max_completion_tokens=64,
+            max_retries=0,
+        )
+        await provider.verify_connection()
+
+    assert create.call_args_list[0].kwargs["extra_body"]["options"]["num_ctx"] == 24576
+    assert create.call_args_list[1].kwargs["extra_body"]["options"]["num_ctx"] == 24576
+
+
+@pytest.mark.asyncio
+async def test_ollama_unstructured_num_ctx_preserves_extra_body_precedence_and_unset_behavior():
+    """User options win, while an unset context override remains absent."""
+    from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+
+    configured = OpenAICompatibleLLM(
+        provider="ollama",
+        api_key="",
+        base_url="",
+        model="llama3.2",
+        ollama_num_ctx=24576,
+        extra_body={"options": {"num_ctx": 8192, "temperature": 0.2}},
+    )
+    default = OpenAICompatibleLLM(provider="ollama", api_key="", base_url="", model="llama3.2")
+    copied = OpenAICompatibleLLM(
+        provider="ollama",
+        api_key="",
+        base_url="",
+        model="llama3.2",
+        ollama_num_ctx=24576,
+        extra_body={"options": {"temperature": 0.2}},
+    )
+    configured_create = AsyncMock(return_value=_openai_response())
+    default_create = AsyncMock(return_value=_openai_response())
+    copied_create = AsyncMock(return_value=_openai_response())
+    configured._client.chat.completions.create = configured_create
+    default._client.chat.completions.create = default_create
+    copied._client.chat.completions.create = copied_create
+
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        await configured.call(messages=[{"role": "user", "content": "ping"}], max_retries=0)
+        await default.call(messages=[{"role": "user", "content": "ping"}], max_retries=0)
+        await copied.call(messages=[{"role": "user", "content": "ping"}], max_retries=0)
+
+    configured_options = configured_create.call_args.kwargs["extra_body"]["options"]
+    assert configured_options == {"num_ctx": 8192, "temperature": 0.2}
+    assert configured._config_extra_body == {"options": {"num_ctx": 8192, "temperature": 0.2}}
+    assert "extra_body" not in default_create.call_args.kwargs
+    assert copied_create.call_args.kwargs["extra_body"]["options"] == {"num_ctx": 24576, "temperature": 0.2}
+    assert copied._config_extra_body == {"options": {"temperature": 0.2}}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The OpenAI-compatible Ollama path omitted the configured `ollama_num_ctx` from unstructured requests, including `verify_connection()`, allowing those calls to use Ollama's server-default context instead of the configured value.

## Changes

- Add the configured value to `extra_body.options.num_ctx` for unstructured Ollama calls.
- Preserve an explicit caller-provided `options.num_ctx`, leave unset behavior unchanged, and avoid mutating nested configured options.
- Add regression coverage for ordinary unstructured calls, `verify_connection()`, caller precedence, unset behavior, and the existing native path.

## Verification

- Targeted Ollama regression tests: 3 passed.
- Ruff lint check on both changed files: passed.
- Ruff format check on both changed files: passed.
- `ty` check on the changed production module: passed.
- `git diff --check`: passed.

Addresses #3599.

<!-- oss-autonomy-5dc2e2c63edf48e8595ee18e5dd40321ecf015ad77c42b1362652bee5f31fb45 -->