### PR TITLE
fix(coding-agents): timestamp the aggregated git-log document so its facts get occurrence dates (#3602)

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/git.gitlog.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/git.gitlog.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HindsightClient } from "./hindsight";
-import { gitLogText, ingestGitLog, repoNameOf, retainCommit } from "./git";
+import { gitLogNewestAuthorDate, gitLogText, ingestGitLog, repoNameOf, retainCommit } from "./git";
 
 let dir: string;
 
@@ -38,6 +38,10 @@ describe("gitLogText", () => {
 
   it("returns empty string for a repo with no commits", () => {
     expect(gitLogText(dir, 10)).toBe("");
+  });
+
+  it("gitLogNewestAuthorDate returns null for a repo with no commits", () => {
+    expect(gitLogNewestAuthorDate(dir)).toBeNull();
   });
 });
 
@@ -89,7 +93,24 @@ describe("ingestGitLog", () => {
     expect(retain.mock.calls[0][3]).toEqual(
       expect.arrayContaining(["project:repo-a", "source:git", "source:git-log"])
     );
-    expect(retain.mock.calls[0][5]).toEqual({ metadata: { project: "repo-a" } });
+    expect(retain.mock.calls[0][5]).toMatchObject({ metadata: { project: "repo-a" } });
+  });
+
+  it("timestamps the aggregated document with the newest commit's author date", async () => {
+    execFileSync("git", ["-C", dir, "commit", "--allow-empty", "-m", "feat: older"], {
+      env: { ...process.env, GIT_AUTHOR_DATE: "2024-01-02T03:04:05+00:00" },
+    });
+    execFileSync("git", ["-C", dir, "commit", "--allow-empty", "-m", "feat: newest"], {
+      env: { ...process.env, GIT_AUTHOR_DATE: "2024-03-04T05:06:07+00:00" },
+    });
+    const retain = vi.fn().mockResolvedValue(undefined);
+    const client = { retain, opIds: [] } as unknown as HindsightClient;
+
+    await ingestGitLog(client, dir, { limit: 10 });
+
+    expect(new Date(retain.mock.calls[0][5].timestamp as string).toISOString()).toBe(
+      "2024-03-04T05:06:07.000Z"
+    );
   });
 
   it("applies retain attribution to full commit documents with built-ins authoritative", async () => {

--- a/hindsight-integrations/coding-agents/src/core/git.ts
+++ b/hindsight-integrations/coding-agents/src/core/git.ts
@@ -179,6 +179,21 @@ export function gitLogText(repo: string, limit: number): string {
 }
 
 /**
+ * The author date (strict ISO 8601) of the newest commit `gitLogText` would include — i.e. the newest
+ * non-merge commit reachable from HEAD, matching that function's traversal. This is the aggregated
+ * document's temporal anchor: without it the retain API stamps "now" and the extraction prompt gets
+ * `Event Date: Unknown`, so every extracted fact lands with a null occurred_start/occurred_end.
+ * Null on an empty repo, a non-repo, or any git error — the caller then omits the timestamp.
+ */
+export function gitLogNewestAuthorDate(repo: string): string | null {
+  try {
+    return git(repo, "log", "-n", "1", "--no-merges", "--format=%aI").trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Ingest the aggregated commit-message history (last `opts.limit` commits, no diffs) as ONE document —
  * a single retain/extraction op, orders of magnitude cheaper than per-commit full-diff ingestion. The
  * document_id is `gitlog:<repoName>` so a re-seed replaces it (idempotent) rather than duplicating.
@@ -212,24 +227,22 @@ export async function ingestGitLog(
         ...(head ? [`gitlog-head:${head}`] : []),
       ]),
     ];
-    if (Object.keys(stamp?.metadata ?? {}).length) {
-      await client.retain(
-        text,
-        `git commit-message history (last ${n}) for ${repoName}`,
-        `gitlog:${repoName}`,
-        tags,
-        "gitlog",
-        { metadata: stamp?.metadata }
-      );
-    } else {
-      await client.retain(
-        text,
-        `git commit-message history (last ${n}) for ${repoName}`,
-        `gitlog:${repoName}`,
-        tags,
-        "gitlog"
-      );
-    }
+    await client.retain(
+      text,
+      `git commit-message history (last ${n}) for ${repoName}`,
+      `gitlog:${repoName}`,
+      tags,
+      "gitlog",
+      {
+        // Anchor the document in time on the newest commit it contains, so extraction can date the
+        // facts it pulls out of these messages. Previously no timestamp was passed at all: retain
+        // then stamped "now", the extraction prompt got `Event Date: Unknown`, and every fact landed
+        // with a null occurred_start/occurred_end — invisible to temporal search (#3602).
+        timestamp: gitLogNewestAuthorDate(repo) ?? undefined,
+        // `retain` only sets metadata when it is truthy, so an empty stamp sends none.
+        metadata: Object.keys(stamp?.metadata ?? {}).length ? stamp?.metadata : undefined,
+      }
+    );
     log(`[gitlog] done: ${n} commit messages ingested as 1 document under strategy 'gitlog'`);
     return 0;
   } catch (e) {


### PR DESCRIPTION
Fixes #3602.

## Problem

`ingestGitLog` — the **default** git-ingestion path (`gitIngest: "message"`) shared by every
coding-agent integration — retained the aggregated commit-message document with no `timestamp`.
Retain then stamped "now", the fact-extraction prompt received `Event Date: Unknown`, and every
fact extracted from those commit messages landed with `occurred_start = null` /
`occurred_end = null`: invisible to temporal search, and neutral (0.5) for recency scoring.

The `gitIngest: "full"` path (`retainCommit`) already passed the commit's author date.

## Fix

`ingestGitLog` now anchors the document on the author date of the newest commit it contains.

One deviation from the issue's proposed patch: it suggested `gitHeadSha` + `git show -s --format=%aI`.
That misdates the document whenever HEAD is a **merge** commit, because `gitLogText` builds the
content with `--no-merges` — the merge isn't in the document at all. The new
`gitLogNewestAuthorDate()` helper uses the same `--no-merges` traversal
(`git log -n 1 --no-merges --format=%aI`), so the timestamp is always the date of a commit the
document actually contains. It returns `null` on an empty repo / non-repo / any git error, in which
case the timestamp is omitted exactly as before.

The two duplicated `client.retain(...)` branches (metadata vs. no metadata) collapse into one call
using the `metadata: Object.keys(...).length ? … : undefined` idiom already used in `deepen.ts`.

## Tests

`src/core/git.gitlog.test.ts` (10 passing):

- timestamp equals the newest commit's author date — two commits with pinned `GIT_AUTHOR_DATE`,
  asserts the newer one wins
- `gitLogNewestAuthorDate` returns `null` for a repo with no commits
- the existing attribution assertion relaxed from `toEqual` to `toMatchObject`, since retain opts
  now also carry `timestamp`

## Parity check

Every other retain call site that ingests dated content already passes a timestamp (`retainCommit`,
the chat/transcript paths); the survey-baseline marker deliberately doesn't, since no memories are
extracted from it. `ingestGitLog` was the only gap.

## Risk

Low and additive — `timestamp` only feeds the extraction prompt's `Event Date:` anchor. The
document id is unchanged (`gitlog:<repoName>`), so the next deepen re-upsert replaces the existing
document rather than duplicating it, and picks up the anchor.
