### PR TITLE
fix(coding-agents): name the calling harness in every MCP registration

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/survey.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/survey.test.ts
@@ -76,6 +76,9 @@ describe("startCodebaseSurvey", () => {
     const parsed = JSON.parse(mcpConfigJson);
     expect(parsed.mcpServers.hindsight.args).toEqual(["/x/mcp-server.js"]);
     expect(parsed.mcpServers.hindsight.env.HINDSIGHT_MCP_PROJECT_CWD).toBe("/repo");
+    // #3603: mcp-server.js requires the harness — an inline recipe that omits it used to be served
+    // as claude-code by default, and now refuses to start at all.
+    expect(parsed.mcpServers.hindsight.env.HINDSIGHT_MCP_HARNESS).toBe("claude-code");
 
     expect(options.cwd).toBe("/repo");
     expect(options.detached).toBe(true);
@@ -110,6 +113,9 @@ describe("startCodebaseSurvey", () => {
     expect(argv).toContain(SURVEY_PROMPT);
     expect(argv).toContain(`mcp_servers.hindsight.command="node"`);
     expect(argv).toContain(`mcp_servers.hindsight.args=["/x/mcp-server.js"]`);
+    // Without this the survey's findings were stamped harness:claude-code and landed in Claude
+    // Code's bank even though Codex ran the survey (#3603).
+    expect(argv).toContain(`mcp_servers.hindsight.env.HINDSIGHT_MCP_HARNESS="codex"`);
     expect(argv).toContain(`mcp_servers.hindsight.env.HINDSIGHT_MCP_PROJECT_CWD="/repo"`);
     // No Claude-only flags leak into the codex recipe.
     expect(argv).not.toContain("--model");

--- a/hindsight-integrations/coding-agents/src/core/survey.ts
+++ b/hindsight-integrations/coding-agents/src/core/survey.ts
@@ -205,7 +205,11 @@ function buildSurveyPlan(
           hindsight: {
             command: "node",
             args: [opts.mcpServerPath],
-            env: { HINDSIGHT_MCP_PROJECT_CWD: repoDir },
+            // HINDSIGHT_MCP_HARNESS names the agent whose CLI this recipe drives — the survey's
+            // ingests are its writes. mcp-server.js REQUIRES it (it used to default to
+            // "claude-code", which is how the codex recipe below silently stamped its findings
+            // harness:claude-code and wrote them to Claude Code's bank — #3603).
+            env: { HINDSIGHT_MCP_PROJECT_CWD: repoDir, HINDSIGHT_MCP_HARNESS: "claude-code" },
           },
         },
       });
@@ -250,6 +254,8 @@ function buildSurveyPlan(
           `mcp_servers.hindsight.args=["${opts.mcpServerPath}"]`,
           "-c",
           `mcp_servers.hindsight.env.HINDSIGHT_MCP_PROJECT_CWD="${repoDir}"`,
+          "-c",
+          `mcp_servers.hindsight.env.HINDSIGHT_MCP_HARNESS="codex"`,
           SURVEY_PROMPT,
         ],
         env,

--- a/hindsight-integrations/coding-agents/src/installer.test.ts
+++ b/hindsight-integrations/coding-agents/src/installer.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -119,6 +127,10 @@ describe("claude-code installer", () => {
       "--scope",
       "user",
       "hindsight",
+      // Every host launches the same mcp-server.js, so the registration has to name its harness —
+      // otherwise the server falls back to claude-code and mis-attributes the other hosts' writes.
+      "--env",
+      "HINDSIGHT_MCP_HARNESS=claude-code",
       "--",
       "node",
       join(ctx.dist, "mcp-server.js"),
@@ -179,6 +191,7 @@ describe("codex installer", () => {
     expect(toml).toContain("[features]\nhooks = true");
     expect(toml).toContain("[mcp_servers.hindsight]");
     expect(toml).toContain(join(ctx.dist, "mcp-server.js"));
+    expect(toml).toContain('env = { HINDSIGHT_MCP_HARNESS = "codex" }');
   });
 
   it("does NOT duplicate an existing [features] section (only appends mcp) and backs up the toml", () => {
@@ -203,6 +216,25 @@ describe("codex installer", () => {
     expect(toml.match(/hooks/g)).toHaveLength(1);
     expect(toml.match(/^\[features\]/gm)).toHaveLength(1);
     expect(toml).toContain("[mcp_servers.hindsight]");
+  });
+
+  // Regression: Codex sessions ingested documents tagged `harness:claude-code`. Its registration
+  // carried no HINDSIGHT_MCP_HARNESS, and install skipped whenever a block already existed — so
+  // the stale, harness-less block survived every re-install and the shared mcp-server.js kept
+  // falling back to claude-code for the bank AND the retain stamp.
+  it("re-install REPLACES a harness-less mcp block instead of leaving it stale", () => {
+    const ctx = makeCtx();
+    mkdirSync(join(ctx.home, ".codex"), { recursive: true });
+    writeFileSync(
+      tomlPath(ctx),
+      '[features]\nhooks = true\n\n[mcp_servers.hindsight]\ncommand = "node"\n' +
+        `args = ["${join(ctx.dist, "mcp-server.js")}"]\n\n[ui]\ntheme = "dark"\n`
+    );
+    run(["install", "codex"], ctx);
+    const toml = readFileSync(tomlPath(ctx), "utf8");
+    expect(toml.match(/^\[mcp_servers\.hindsight\]/gm)).toHaveLength(1);
+    expect(toml).toContain('env = { HINDSIGHT_MCP_HARNESS = "codex" }');
+    expect(toml).toContain('[ui]\ntheme = "dark"'); // foreign sections survive the rewrite
   });
 
   it("uninstall removes the mcp_servers.hindsight block and leaves the rest of the toml", () => {
@@ -543,6 +575,7 @@ describe("cursor-cli installer", () => {
     expect(mcp.mcpServers.hindsight).toEqual({
       command: "node",
       args: [join(ctx.dist, "mcp-server.js")],
+      env: { HINDSIGHT_MCP_HARNESS: "cursor-cli" },
     });
   });
 
@@ -585,6 +618,7 @@ describe("grok-build installer", () => {
     expect(config).toContain(join(ctx.dist, "grok-stop-hook.js"));
     expect(config).toContain("[mcp_servers.hindsight]");
     expect(config).toContain(join(ctx.dist, "mcp-server.js"));
+    expect(config).toContain('env = { HINDSIGHT_MCP_HARNESS = "grok-build" }');
     expect(existsSync(join(ctx.home, ".claude"))).toBe(false);
   });
 
@@ -680,6 +714,47 @@ describe("run() CLI behavior", () => {
       "cline-cli",
       "dsh",
     ]);
+  });
+});
+
+/**
+ * Every host launches the SAME `dist/mcp-server.js`, so the command line cannot say who is calling
+ * — only `HINDSIGHT_MCP_HARNESS` can. A registration that omits it silently inherits the server's
+ * claude-code fallback, which is how a Codex `hindsight_ingest_document` was stored tagged
+ * `harness:claude-code` on a machine running both (#3603).
+ *
+ * Swept over INSTALLERS rather than a hand-written list of config paths: the harness that gets this
+ * wrong is by construction the one nobody wrote a test for, so the guard has to find the
+ * registration itself — any file the install wrote that names mcp-server.js, wherever it landed.
+ */
+describe("MCP registrations name the calling harness", () => {
+  /** Every file under `dir`, recursively. */
+  function filesUnder(dir: string): string[] {
+    return readdirSync(dir, { withFileTypes: true }).flatMap((e) =>
+      e.isDirectory() ? filesUnder(join(dir, e.name)) : [join(dir, e.name)]
+    );
+  }
+
+  // These hosts have no MCP registration at all: they load our plugin/extension in-process
+  // (src/kilo.ts, src/dsh.ts, src/prime-agent.ts, dist/index.js for opencode), and that entry
+  // hands its own harness name straight to RuntimeCore.
+  const IN_PROCESS = new Set(["opencode", "kilo", "prime-agent", "dsh"]);
+  const MCP_HOSTS = INSTALLERS.map((i) => i.name).filter((n) => !IN_PROCESS.has(n));
+
+  it.each(MCP_HOSTS)("%s", (harness) => {
+    const ctx = makeCtx();
+    expect(run(["install", harness], ctx)).toBe(0);
+    const registrations = [
+      ...filesUnder(ctx.home)
+        .map((f) => readFileSync(f, "utf8"))
+        // claude-code registers through the `claude` CLI instead of a file we write, so its
+        // registration is the argv we handed the mock.
+        .concat(ctx.claudeMcp.mock.calls.map((c) => c[0].join(" ")))
+        .filter((text) => text.includes("mcp-server.js")),
+    ];
+    expect(registrations.length).toBeGreaterThan(0);
+    for (const text of registrations) expect(text).toContain(`HINDSIGHT_MCP_HARNESS`);
+    for (const text of registrations) expect(text).toContain(harness);
   });
 });
 

--- a/hindsight-integrations/coding-agents/src/installer.ts
+++ b/hindsight-integrations/coding-agents/src/installer.ts
@@ -144,6 +144,21 @@ const cmdHook = (dist: string, file: string, timeout: number) => ({
   hooks: [{ type: "command", command: `node "${join(dist, file)}"`, timeout }],
 });
 
+/**
+ * The MCP registration for a JSON-configured host.
+ *
+ * Every harness launches the SAME `dist/mcp-server.js`, so the command line alone cannot say who
+ * is calling. `HINDSIGHT_MCP_HARNESS` is what the server reads to answer that; without it it falls
+ * back to "claude-code", which is why a Codex `hindsight_ingest_document` landed tagged
+ * `harness:claude-code` (and derived its bank as Claude Code's) on machines running both. Every
+ * registration MUST name its own harness — pass it here, never rely on the fallback.
+ */
+const mcpServerEntry = (dist: string, harness: HookHarnessName | "cline-cli") => ({
+  command: "node",
+  args: [join(dist, "mcp-server.js")],
+  env: { HINDSIGHT_MCP_HARNESS: harness },
+});
+
 /** Install/uninstall consume the same lifecycle declaration as the runtime entrypoints. Keeping
  * event names and command files here would allow a host to run a different lifecycle than it installs. */
 function mergeHarnessHooks(
@@ -369,6 +384,8 @@ const claudeCode: HarnessInstaller = {
         "--scope",
         "user",
         "hindsight",
+        "--env",
+        "HINDSIGHT_MCP_HARNESS=claude-code",
         "--",
         "node",
         join(c.dist, "mcp-server.js"),
@@ -378,7 +395,7 @@ const claudeCode: HarnessInstaller = {
     } else {
       c.log?.(
         `claude-code: could not run \`claude mcp add\` — register the tools manually:\n` +
-          `  claude mcp add --scope user hindsight -- node "${join(c.dist, "mcp-server.js")}"`
+          `  claude mcp add --scope user hindsight --env HINDSIGHT_MCP_HARNESS=claude-code -- node "${join(c.dist, "mcp-server.js")}"`
       );
     }
   },
@@ -408,6 +425,17 @@ function defaultClaudeMcp(args: string[]): boolean {
   }
 }
 
+/**
+ * Our `[mcp_servers.hindsight]` table (plus any sub-table of it): the header line through to the
+ * next table header or EOF. Shared by install — which REPLACES the block — and uninstall.
+ */
+const CODEX_MCP_BLOCK_RE = /^\[mcp_servers\.hindsight(?:\.[^\]]+)?\][^\n]*\n(?:(?!\[)[^\n]*\n?)*/gm;
+
+/** Inline `env`, so CODEX_MCP_BLOCK_RE never has to straddle a `[mcp_servers.hindsight.env]` table. */
+const codexMcpBlock = (dist: string) =>
+  `[mcp_servers.hindsight]\ncommand = "node"\nargs = [${JSON.stringify(join(dist, "mcp-server.js"))}]\n` +
+  `env = { HINDSIGHT_MCP_HARNESS = "codex" }`;
+
 const codex: HarnessInstaller = {
   name: "codex",
   detect: (c) => onPath("codex") || existsSync(join(c.home, ".codex")),
@@ -419,9 +447,13 @@ const codex: HarnessInstaller = {
     writeJson(hooksPath, cfg);
     c.log?.(`codex: hooks merged into ${hooksPath}`);
 
-    // config.toml: append-only, never rewrite (TOML round-tripping is not worth the risk).
+    // config.toml: append-only for anything that is not ours (TOML round-tripping is not worth the
+    // risk). Our OWN mcp block is stripped and rewritten instead of skipped when present: appending
+    // only when absent made this install-once-only, so the harness-less registration that
+    // attributed every Codex write to claude-code could never be repaired by re-running install.
     const tomlPath = join(c.home, ".codex", "config.toml");
-    let toml = existsSync(tomlPath) ? readFileSync(tomlPath, "utf8") : "";
+    const existing = existsSync(tomlPath) ? readFileSync(tomlPath, "utf8") : "";
+    const toml = existing.replace(CODEX_MCP_BLOCK_RE, "");
     const additions: string[] = [];
     // Codex ≥ 0.145 deprecates `codex_hooks` for `[features].hooks`; accept either as "already
     // enabled", write the modern name for new installs.
@@ -434,18 +466,15 @@ const codex: HarnessInstaller = {
         additions.push("[features]\nhooks = true");
       }
     }
-    if (!toml.includes("[mcp_servers.hindsight]")) {
-      additions.push(
-        `[mcp_servers.hindsight]\ncommand = "node"\nargs = ["${join(c.dist, "mcp-server.js")}"]`
-      );
-    }
-    if (additions.length) {
+    additions.push(codexMcpBlock(c.dist));
+    const next = `${toml.replace(/\n*$/, "\n\n")}${additions.join("\n\n")}\n`;
+    if (next !== existing) {
       if (existsSync(tomlPath) && !existsSync(`${tomlPath}.hindsight-backup`)) {
         copyFileSync(tomlPath, `${tomlPath}.hindsight-backup`);
       }
       mkdirSync(dirname(tomlPath), { recursive: true });
-      writeFileSync(tomlPath, `${toml.replace(/\n*$/, "\n\n")}${additions.join("\n\n")}\n`);
-      c.log?.(`codex: appended ${additions.length} section(s) to ${tomlPath}`);
+      writeFileSync(tomlPath, next);
+      c.log?.(`codex: wrote ${additions.length} section(s) to ${tomlPath}`);
     }
     installSkill(c, "codex", join(c.home, ".agents", "skills")); // agentskills-standard shared dir
   },
@@ -462,10 +491,7 @@ const codex: HarnessInstaller = {
     const tomlPath = join(c.home, ".codex", "config.toml");
     if (existsSync(tomlPath)) {
       const toml = readFileSync(tomlPath, "utf8");
-      const cleaned = toml.replace(
-        /\n?\[mcp_servers\.hindsight\]\ncommand = "node"\nargs = \[[^\]]*\]\n?/g,
-        "\n"
-      );
+      const cleaned = toml.replace(CODEX_MCP_BLOCK_RE, "");
       if (cleaned !== toml) writeFileSync(tomlPath, cleaned);
     }
     c.log?.(
@@ -505,11 +531,7 @@ const antigravity: HarnessInstaller = {
     const mcp = readJson(mcpPath);
     mcp.mcpServers = {
       ...(mcp.mcpServers ?? {}),
-      hindsight: {
-        command: "node",
-        args: [join(c.dist, "mcp-server.js")],
-        env: { HINDSIGHT_MCP_HARNESS: "antigravity-cli" },
-      },
+      hindsight: mcpServerEntry(c.dist, "antigravity-cli"),
     };
     writeJson(mcpPath, mcp);
     const settingsPath = join(c.home, ".gemini", "antigravity-cli", "settings.json");
@@ -915,11 +937,7 @@ const devin: HarnessInstaller = {
     const mcp = readJson(mcpPath);
     mcp.mcpServers = {
       ...(mcp.mcpServers ?? {}),
-      hindsight: {
-        command: "node",
-        args: [join(c.dist, "mcp-server.js")],
-        env: { HINDSIGHT_MCP_HARNESS: "devin-cli" },
-      },
+      hindsight: mcpServerEntry(c.dist, "devin-cli"),
     };
     writeJson(mcpPath, mcp);
     c.log?.(`devin-cli: hooks merged into ${configPath}, MCP into ${mcpPath}`);
@@ -959,7 +977,7 @@ const cursor: HarnessInstaller = {
     const mcp = readJson(mcpPath);
     mcp.mcpServers = {
       ...(mcp.mcpServers ?? {}),
-      hindsight: { command: "node", args: [join(c.dist, "mcp-server.js")] },
+      hindsight: mcpServerEntry(c.dist, "cursor-cli"),
     };
     writeJson(mcpPath, mcp);
     c.log?.(`cursor-cli: hooks merged into ${hooksPath}, MCP into ${mcpPath}`);
@@ -1001,7 +1019,7 @@ const copilot: HarnessInstaller = {
     const mcp = readJson(mcpPath);
     mcp.mcpServers = {
       ...(mcp.mcpServers ?? {}),
-      hindsight: { command: "node", args: [join(c.dist, "mcp-server.js")] },
+      hindsight: mcpServerEntry(c.dist, "copilot-cli"),
     };
     writeJson(mcpPath, mcp);
     installSkill(c, "copilot-cli", join(c.home, ".copilot", "skills"));
@@ -1048,7 +1066,8 @@ const grok: HarnessInstaller = {
       `[[hooks.SessionStart]]\n  [[hooks.SessionStart.hooks]]\n  type = \"command\"\n  command = ${command("grok-sessionstart-hook.js")}\n  timeout = 30\n\n` +
       `[[hooks.UserPromptSubmit]]\n  [[hooks.UserPromptSubmit.hooks]]\n  type = \"command\"\n  command = ${command("grok-hook.js")}\n  timeout = 30\n\n` +
       `[[hooks.Stop]]\n  [[hooks.Stop.hooks]]\n  type = \"command\"\n  command = ${command("grok-stop-hook.js")}\n  timeout = 60\n\n` +
-      `[mcp_servers.hindsight]\ncommand = \"node\"\nargs = [${tomlString(join(c.dist, "mcp-server.js"))}]\n${GROK_MARKER_END}\n`;
+      `[mcp_servers.hindsight]\ncommand = \"node\"\nargs = [${tomlString(join(c.dist, "mcp-server.js"))}]\n` +
+      `env = { HINDSIGHT_MCP_HARNESS = \"grok-build\" }\n${GROK_MARKER_END}\n`;
     if (existsSync(path) && !existsSync(`${path}.hindsight-backup`))
       copyFileSync(path, `${path}.hindsight-backup`);
     mkdirSync(dirname(path), { recursive: true });
@@ -1099,11 +1118,7 @@ const cline: HarnessInstaller = {
     const mcp = readJson(mcpPath);
     mcp.mcpServers = {
       ...(mcp.mcpServers ?? {}),
-      hindsight: {
-        command: "node",
-        args: [join(c.dist, "mcp-server.js")],
-        env: { HINDSIGHT_MCP_HARNESS: "cline-cli" },
-      },
+      hindsight: mcpServerEntry(c.dist, "cline-cli"),
     };
     writeJson(mcpPath, mcp);
     installSkill(c, "cline-cli", join(c.home, ".cline", "data", "settings", "skills"));

--- a/hindsight-integrations/coding-agents/src/mcp-server.test.ts
+++ b/hindsight-integrations/coding-agents/src/mcp-server.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { selectTools } from "./mcp-server";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveHarness, selectTools } from "./mcp-server";
 import { resolveConfig } from "./core/config";
 import type { HindsightClient } from "./core/hindsight";
 
@@ -65,5 +68,77 @@ describe("selectTools", () => {
     const [, , , tags, , opts] = retain.mock.calls[0];
     expect(tags).toContain("harness:codex");
     expect(opts.metadata).toMatchObject({ harness: "codex" });
+  });
+});
+
+/**
+ * #3603: this used to fall back to "claude-code" when the registration named no harness. Every
+ * host launches the same binary, so that fallback silently served Codex (and cursor-cli,
+ * copilot-cli, grok-build — none of whose installers set the variable) as Claude Code: their
+ * ingests came back tagged `harness:claude-code` and they resolved Claude Code's bank. Refusing to
+ * start is recoverable by re-running the installer; mis-stamped documents are not.
+ */
+describe("resolveHarness", () => {
+  it("returns the harness its registration declares", () => {
+    expect(resolveHarness({ HINDSIGHT_MCP_HARNESS: "codex" })).toBe("codex");
+  });
+
+  it.each([{}, { HINDSIGHT_MCP_HARNESS: "" }])(
+    "refuses to start on %j rather than guessing",
+    (env) => {
+      expect(() => resolveHarness(env)).toThrow(/HINDSIGHT_MCP_HARNESS is not set/);
+      // The message has to name the way out — the fix is a re-install, not editing a config by hand.
+      expect(() => resolveHarness(env)).toThrow(/install <harness>/);
+    }
+  );
+});
+
+/**
+ * Registration parity across the places that launch this binary (#3603).
+ *
+ * The harness used to default to "claude-code", so a registration that named none was silently
+ * served as Claude Code: four installers and both inline survey recipes wrote one, and Codex
+ * ingests came back tagged `harness:claude-code` in Claude Code's bank. The default is gone — a
+ * nameless registration now refuses to start — but that only converts a silent wrong answer into a
+ * loud one at the site that forgot.
+ *
+ * A per-site test can't catch the next one: the site that forgets is by definition the one whose
+ * test nobody wrote (survey.ts was found by hand, not by the installer sweep). So this asserts the
+ * shape — a module that points something at mcp-server.js is registering it, and every one of them
+ * must also name the harness.
+ */
+describe("every mcp-server.js registration names a harness", () => {
+  const SRC = fileURLToPath(new URL(".", import.meta.url));
+
+  /** Modules that reference the binary WITHOUT registering it, and why. */
+  const EXEMPT: Record<string, string> = {
+    "mcp-server.ts": "the server itself — it READS the variable, it does not register anything",
+  };
+
+  /**
+   * An ASSIGNMENT of the variable, in any of the three dialects a registration is written in:
+   * a JS env object (`HINDSIGHT_MCP_HARNESS: "codex"`), a TOML/`-c` override
+   * (`HINDSIGHT_MCP_HARNESS = "codex"`), or a CLI pair (`HINDSIGHT_MCP_HARNESS=codex`).
+   * Deliberately not a bare-name search: prose about the variable — including the comments this
+   * very fix added next to each registration — would satisfy that and let a site slip through.
+   */
+  const SETS_HARNESS = /HINDSIGHT_MCP_HARNESS\s*[:=]/;
+
+  function sourceFiles(dir: string, prefix = ""): string[] {
+    return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory())
+        return entry.name === "e2e" ? [] : sourceFiles(join(dir, entry.name), rel);
+      return entry.name.endsWith(".ts") && !entry.name.includes(".test.") ? [rel] : [];
+    });
+  }
+
+  it("has no module that points at mcp-server.js without setting HINDSIGHT_MCP_HARNESS", () => {
+    const nameless = sourceFiles(SRC).filter((rel) => {
+      if (rel in EXEMPT) return false;
+      const src = readFileSync(join(SRC, rel), "utf8");
+      return src.includes("mcp-server.js") && !SETS_HARNESS.test(src);
+    });
+    expect(nameless).toEqual([]);
   });
 });

--- a/hindsight-integrations/coding-agents/src/mcp-server.ts
+++ b/hindsight-integrations/coding-agents/src/mcp-server.ts
@@ -3,8 +3,8 @@
  * Native TS MCP (stdio) server exposing the `hindsight_*` knowledge-page + recall + capture tools.
  *
  * Bank resolution MUST mirror the hooks exactly (`resolveHostMemory`, i.e. loadConfig +
- * deriveBankId + the banks section, harness from HINDSIGHT_MCP_HARNESS) so knowledge pages,
- * recall, and retain all land in ONE per-repo bank — this is
+ * deriveBankId + the banks section, harness from the REQUIRED HINDSIGHT_MCP_HARNESS) so knowledge
+ * pages, recall, and retain all land in ONE per-repo bank — this is
  * why this is a native TS server and not a reuse of the Python MCP (whose bank derivation
  * differs). MCP servers launch with the project dir as cwd; the env override is an optional
  * escape hatch (not currently set by the plugin).
@@ -45,15 +45,34 @@ export function selectTools(
       });
 }
 
+/**
+ * The harness this server is running for, from the environment its registration declares.
+ *
+ * REQUIRED, deliberately with no fallback. This used to default to "claude-code", which read as a
+ * safe convenience and was not: every host launches this same binary, so a registration that named
+ * no harness was silently served as Claude Code — Codex ingests came back tagged
+ * `harness:claude-code`, indistinguishable from Claude Code's own, and resolved Claude Code's bank
+ * (#3603). A wrong answer here corrupts stored data; refusing to start is recoverable.
+ */
+export function resolveHarness(env: NodeJS.ProcessEnv = process.env): string {
+  const harness = env.HINDSIGHT_MCP_HARNESS;
+  if (!harness) {
+    throw new Error(
+      "HINDSIGHT_MCP_HARNESS is not set. Every coding agent launches this same mcp-server.js, so " +
+        "only that variable identifies the caller — it decides the harness:<id> stamp on everything " +
+        "ingested and which bank this session resolves. Re-run `npx " +
+        "@vectorize-io/hindsight-coding-agents install <harness>` to repair a registration written " +
+        "before the installer set it."
+    );
+  }
+  return harness;
+}
+
 async function main() {
   const cwd = process.env.HINDSIGHT_MCP_PROJECT_CWD || process.cwd();
-  // Every host launches this same binary, so who is calling is knowable only from the environment
-  // the installer wrote (`HINDSIGHT_MCP_HARNESS`). It decides both the retain stamp — the
-  // `harness:<id>` tag and metadata on anything ingested — and bank resolution (config
-  // `harnesses.<name>` section + `{harness}` template), so it must mirror that harness's hooks.
-  // The "claude-code" fallback only covers registrations written before every installer set the
-  // variable; re-running `install <harness>` repairs those.
-  const harness = process.env.HINDSIGHT_MCP_HARNESS || "claude-code";
+  // Mirrors that harness's hooks: it selects the config `harnesses.<name>` section and feeds the
+  // `{harness}` bank template, so both routes into a repo land in ONE bank.
+  const harness = resolveHarness();
   const { cfg, bankId, client } = resolveHostMemory(harness, cwd);
 
   const server = new McpServer({ name: "hindsight", version: "0.1.0" });

--- a/hindsight-integrations/coding-agents/src/mcp-server.ts
+++ b/hindsight-integrations/coding-agents/src/mcp-server.ts
@@ -3,8 +3,8 @@
  * Native TS MCP (stdio) server exposing the `hindsight_*` knowledge-page + recall + capture tools.
  *
  * Bank resolution MUST mirror the hooks exactly (`resolveHostMemory`, i.e. loadConfig +
- * deriveBankId + the banks section, harness "claude-code") so knowledge pages, recall, and retain
- * all land in ONE per-repo bank — this is
+ * deriveBankId + the banks section, harness from HINDSIGHT_MCP_HARNESS) so knowledge pages,
+ * recall, and retain all land in ONE per-repo bank — this is
  * why this is a native TS server and not a reuse of the Python MCP (whose bank derivation
  * differs). MCP servers launch with the project dir as cwd; the env override is an optional
  * escape hatch (not currently set by the plugin).
@@ -47,8 +47,12 @@ export function selectTools(
 
 async function main() {
   const cwd = process.env.HINDSIGHT_MCP_PROJECT_CWD || process.cwd();
-  // Harness is set per wrapper (Claude default; codex sets HINDSIGHT_MCP_HARNESS=codex) so bank
-  // resolution mirrors that harness's hooks — config `harnesses.<name>` section + `{harness}` template.
+  // Every host launches this same binary, so who is calling is knowable only from the environment
+  // the installer wrote (`HINDSIGHT_MCP_HARNESS`). It decides both the retain stamp — the
+  // `harness:<id>` tag and metadata on anything ingested — and bank resolution (config
+  // `harnesses.<name>` section + `{harness}` template), so it must mirror that harness's hooks.
+  // The "claude-code" fallback only covers registrations written before every installer set the
+  // variable; re-running `install <harness>` repairs those.
   const harness = process.env.HINDSIGHT_MCP_HARNESS || "claude-code";
   const { cfg, bankId, client } = resolveHostMemory(harness, cwd);
 


### PR DESCRIPTION
Fixes #3603.

## The bug

`dist/mcp-server.js` is one binary shared by every coding agent, and `HINDSIGHT_MCP_HARNESS` is the only thing that tells it who launched it. It defaulted to `"claude-code"` — so any registration that named no harness was silently served as Claude Code.

Four installers never set it: **codex, cursor-cli, copilot-cli, grok-build**. Only antigravity-cli, devin-cli and cline-cli did.

That default drives two things, not one:

- the **retain stamp** — the `harness:<id>` tag and `metadata.harness` on anything ingested, which is what the reporter saw: a Codex `hindsight_ingest_document` stored as `harness:claude-code`, indistinguishable from Claude Code's own writes;
- **bank derivation** — `deriveBankId` resolves the `harnesses.<name>` config section and the `{harness}` bank template. The reporter didn't hit this half only because both harnesses were pinned to one fixed bank.

## The fix

**Every registration names its own harness.** JSON hosts go through a shared `mcpServerEntry(dist, harness)`; codex and grok-build get `env = { HINDSIGHT_MCP_HARNESS = "…" }` in their `config.toml` block; claude-code passes `--env HINDSIGHT_MCP_HARNESS=claude-code` to `claude mcp add` so it no longer leans on the fallback either.

**The fallback is gone.** It read as a safe convenience and was not — guessing is what made this invisible in the first place. A nameless registration now refuses to start with an error naming the way out (re-run the installer). A wrong harness corrupts stored data; a refusal is recoverable.

**Codex's install now replaces its `[mcp_servers.hindsight]` block** instead of skipping when one exists. This is what makes the fix reachable for anyone already affected: the old `if (!toml.includes(...))` guard made it install-once-only, so re-running the installer would have left the harness-less block exactly as it was. Uninstall shares the same block matcher, which previously only matched the old 3-line shape.

## A second site, found by the review

Dropping the default surfaced a registration the installer sweep can't see: the codebase survey builds **inline** MCP recipes for its claude-code and codex spawns (`core/survey.ts`), and neither named a harness. So a Codex-run survey was *already* filing its findings as `harness:claude-code` in Claude Code's bank — the same bug, second site — and with the fallback gone it would have failed to start instead. Both recipes now name their agent.

`antigravity-cli` and `opencode` surveys were fine: they use the installed registration (now fixed) and the loaded plugin, which passes its own harness to `RuntimeCore`.

## Upgrade note

Existing installs need `install <harness>` re-run to pick up the variable — the runtime can't distinguish a stale registration from a correct one, which is the whole point. The codex install change is what makes that re-run effective.

## Tests

595 pass (was 576). Two structural guards rather than per-site assertions, because the site that forgets is by construction the one nobody wrote a test for — `survey.ts` was found by hand, not by the installer sweep:

- **installer sweep** — walks `INSTALLERS`, installs each into a temp home, and greps *whatever the install actually wrote* for `mcp-server.js`, requiring every such registration to also name its harness. Verified it fails (`× cursor-cli`) with one registration reverted.
- **source sweep** (modelled on the existing daemon-parity test) — a module that points at `mcp-server.js` is registering it and must *assign* the variable. It matches an assignment, not a mention, on purpose: a bare-name search is satisfied by the comments this fix added next to each registration, which is exactly how `survey.ts` would have slipped through again. Verified it fails for both `core/survey.ts` and `installer.ts` with their assignments stripped.

Plus a direct regression test for the issue's scenario (a pre-existing harness-less codex block is replaced, not left stale), `resolveHarness` unit tests, and the survey recipe assertions.

Also verified: Codex's `env` is *additive* over its curated default env allowlist (`create_env_for_mcp_server`, `codex-rs/rmcp-client/src/utils.rs`), not a replacement, so nothing loses `PATH`/`HOME`; both generated TOML blocks parse and yield the right `env` map.

Lint, `tsc --noEmit`, and `/code-review` clean. No release cut — `@vectorize-io/hindsight-coding-agents` still needs a version bump via `./scripts/release-integration.sh`.
