### PR TITLE
fix(knowledge): cast the mental_models.name bind for vchord writes

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -12749,6 +12749,15 @@ class MemoryEngine(MemoryEngineInterface):
         """Insert a pinned model using the caller's transaction."""
         # VectorChord needs mental_models.search_vector tokenized on write; every
         # other backend either generates it or indexes the source columns.
+        #
+        # $3 is bound twice: to mental_models.name (VARCHAR) and, inside sv_expr,
+        # to tokenize() (TEXT). PostgreSQL infers one type per parameter, so the
+        # two sites make the statement fail at prepare time with "inconsistent
+        # types deduced for parameter $3: text versus character varying". Casting
+        # the column assignment pins the parameter to text; VARCHAR accepts a text
+        # value on assignment. Every write that feeds mental_models.name into
+        # pg_search_vector_expr needs the same cast (see update_mental_model and
+        # rename_knowledge_node).
         sv_expr = pg_search_vector_expr(
             get_config(), text_col="$3", context_col="$5", signals_col=None, native_inline=False
         )
@@ -12758,7 +12767,7 @@ class MemoryEngine(MemoryEngineInterface):
             f"""
             INSERT INTO {fq_table("mental_models")}
             (id, bank_id, subtype, name, description, source_query, content, embedding, tags, max_tokens, trigger{sv_col})
-            VALUES ($1, $2, 'pinned', $3, ' ', $4, $5, $6, $7, COALESCE($8, 2048), COALESCE($9, '{{"refresh_after_consolidation": false}}'::jsonb){sv_val})
+            VALUES ($1, $2, 'pinned', $3::text, ' ', $4, $5, $6, $7, COALESCE($8, 2048), COALESCE($9, '{{"refresh_after_consolidation": false}}'::jsonb){sv_val})
             RETURNING id, bank_id, name, source_query, content, tags,
                       last_refreshed_at, last_memory_seen_at, created_at, reflect_response,
                       max_tokens, trigger, structured_content
@@ -13824,7 +13833,11 @@ class MemoryEngine(MemoryEngineInterface):
             content_sql = "content"
 
             if name is not None:
-                updates.append(f"name = ${param_idx}")
+                # ::text pins the parameter's type — it also feeds the tokenize()
+                # call in sv_expr below, and a bind deduced as both VARCHAR (the
+                # column) and TEXT (the function argument) is rejected at prepare
+                # time. See _insert_pinned_mental_model for the full rationale.
+                updates.append(f"name = ${param_idx}::text")
                 params.append(name)
                 name_sql = f"${param_idx}"
                 param_idx += 1
@@ -14611,6 +14624,9 @@ class MemoryEngine(MemoryEngineInterface):
         # writes share one transaction, so a knowledge_pages name-uniqueness
         # violation rolls the mental-model name back with it. Folders carry no
         # backing model (mental_model_id is NULL), so only the node row is touched.
+        # The mental-model write casts $3 to text because the same bind feeds
+        # sv_expr; see _insert_pinned_mental_model. knowledge_pages.name is already
+        # TEXT, so the node write needs no cast.
         sv_expr = pg_search_vector_expr(
             get_config(), text_col="$3", context_col="content", signals_col=None, native_inline=False
         )
@@ -14632,7 +14648,7 @@ class MemoryEngine(MemoryEngineInterface):
                     await conn.execute(
                         f"""
                         UPDATE {fq_table("mental_models")}
-                        SET name = $3{sv_clause}
+                        SET name = $3::text{sv_clause}
                         WHERE bank_id = $1 AND id = $2
                         """,
                         bank_id,

--- a/hindsight-api-slim/tests/test_knowledge_bm25_dispatch.py
+++ b/hindsight-api-slim/tests/test_knowledge_bm25_dispatch.py
@@ -10,6 +10,7 @@ assert on the generated SQL, the way ``test_multilingual_bm25`` does.
 """
 
 from types import SimpleNamespace
+from typing import Any
 
 from hindsight_api._text_search import mental_models_text_document
 from hindsight_api.engine.db.ops_postgresql import pg_search_vector_expr
@@ -118,3 +119,66 @@ def test_memory_units_default_expr_is_unchanged():
         "'llmlingua2')::bm25_catalog.bm25vector"
     )
     assert pg_search_vector_expr(_cfg("pg_search")) is None
+
+
+# --- write side: the name bind must be cast --------------------------------
+
+
+class _RecordingConn:
+    """Captures the SQL of the one fetchrow the pinned-model insert issues."""
+
+    def __init__(self) -> None:
+        self.sql = ""
+
+    async def fetchrow(self, sql: str, *args: Any) -> dict[str, Any]:
+        self.sql = sql
+        return {}
+
+
+async def _pinned_insert_sql(ext: str, monkeypatch) -> str:
+    """The INSERT that ``_insert_pinned_mental_model`` builds for ``ext``.
+
+    The method reads no attribute off ``self``, so an uninitialised instance is
+    enough to reach the SQL without a database, an embedder, or an LLM.
+    """
+    from hindsight_api.engine import memory_engine as me
+
+    cfg = _cfg(ext)
+    cfg.database_schema = "public"  # fq_table() reads it off the same config
+    monkeypatch.setattr(me, "get_config", lambda: cfg)
+    conn = _RecordingConn()
+    await me.MemoryEngine._insert_pinned_mental_model(
+        object.__new__(me.MemoryEngine),
+        conn,
+        mental_model_id="mm-1",
+        bank_id="b",
+        name="page name",
+        source_query="q",
+        content="c",
+        embedding=None,
+        tags=[],
+        max_tokens=None,
+        trigger=None,
+    )
+    return conn.sql
+
+
+async def test_pinned_insert_casts_the_name_bind(monkeypatch):
+    """$3 lands in a VARCHAR column and in tokenize(), which takes TEXT.
+
+    PostgreSQL infers one type per parameter, so without the cast the statement
+    never reaches execution: prepare fails with "inconsistent types deduced for
+    parameter $3: text versus character varying" and every knowledge-page and
+    pinned mental-model create 500s on vchord.
+    """
+    sql = await _pinned_insert_sql("vchord", monkeypatch)
+    assert "'pinned', $3::text," in sql
+    assert "tokenize(COALESCE($3, '')" in sql
+
+
+async def test_pinned_insert_keeps_the_cast_without_inline_tokenization(monkeypatch):
+    # Backends that leave search_vector alone bind $3 once, so the cast is inert
+    # there — it stays for one statement shape across backends.
+    sql = await _pinned_insert_sql("native", monkeypatch)
+    assert "'pinned', $3::text," in sql
+    assert "search_vector" not in sql


### PR DESCRIPTION
## Problem

With `HINDSIGHT_API_TEXT_SEARCH_EXTENSION=vchord`, every write that sets `mental_models.name` fails with HTTP 500:

```
$ curl -sX POST .../v1/default/banks/$BANK/knowledge-base/pages \
    -H 'content-type: application/json' \
    -d '{"name":"Rejected options","source_query":"..."}'
{"detail":"inconsistent types deduced for parameter $3\nDETAIL:  text versus character varying"}
```

Affected endpoints:

| Endpoint | Engine method |
|---|---|
| `POST /knowledge-base/pages` | `_insert_pinned_mental_model` |
| `POST /mental-models` | `_insert_pinned_mental_model` |
| `PATCH /mental-models/{id}` (with `name`) | `update_mental_model` |
| `PATCH /knowledge-base/nodes/{id}` (page rename) | `rename_knowledge_node` |

In practice this means **knowledge pages cannot be created at all on a vchord deployment**.

## Cause

`mental_models.name` is `VARCHAR`, but the same bind parameter is reused inside the `search_vector` expression that `pg_search_vector_expr` builds, where `tokenize()` takes `TEXT`:

```sql
INSERT INTO mental_models (..., name, ..., search_vector)
VALUES (..., $3, ..., tokenize(COALESCE($3, '') || ' ' || COALESCE($5, ''), 'llmlingua2')::bm25_catalog.bm25vector)
--            ^^ varchar          ^^ text
```

PostgreSQL infers a single type per parameter, so the statement never reaches execution — it is rejected at prepare time. Minimal repro, no Hindsight involved:

```sql
CREATE TEMP TABLE t (a varchar, b text);
PREPARE p AS INSERT INTO t (a, b) VALUES ($1, upper($1));
-- ERROR:  inconsistent types deduced for parameter $1
-- DETAIL:  text versus character varying

PREPARE p AS INSERT INTO t (a, b) VALUES ($1::text, upper(COALESCE($1, '')));
-- PREPARE
```

Only vchord is affected: it is the one backend that writes `search_vector` inline, so it is the only one that binds the name twice. `native` has a `GENERATED` column and `pgroonga` / `pg_search` / `pg_textsearch` index the base columns, so `pg_search_vector_expr(..., native_inline=False)` returns `None` for all of them and the second reference never appears.

## Fix

Cast the column assignment to `::text`. That pins the parameter's type, and `VARCHAR` accepts a text value on assignment. Applied to the three writes that feed `mental_models.name` into `pg_search_vector_expr`:

- `_insert_pinned_mental_model` — `VALUES (..., $3::text, ...)`
- `update_mental_model` — `name = $N::text`
- `rename_knowledge_node` — `SET name = $3::text`

`memory_units.text` / `.context` (`writes.py:apply_edit`) and `knowledge_pages.name` are already `TEXT`, so those statements need no change and none was made.

An alternative fix is a migration widening `mental_models.name` to `TEXT`, which would remove the footgun rather than work around it. Happy to switch if you prefer that — the cast is the smaller, backport-friendly change.

## Tests

`tests/test_knowledge_bm25_dispatch.py` gains two cases that assert on the generated SQL, matching the module's existing approach ("They need no live extension because they assert on the generated SQL"). Reproducing the actual failure needs a live vchord Postgres, which CI does not provision.

Both new tests fail on `main` and pass with the fix:

```
tests/test_knowledge_bm25_dispatch.py::test_pinned_insert_casts_the_name_bind PASSED
tests/test_knowledge_bm25_dispatch.py::test_pinned_insert_keeps_the_cast_without_inline_tokenization PASSED
11 passed
```

`ruff check` / `ruff format --check` / `ty check` clean.

## Verification against a live vchord deployment

Verified on 0.9.1 against `tensorchord/vchord-suite` with `HINDSIGHT_API_TEXT_SEARCH_EXTENSION=vchord`. Before the patch all four endpoints above 500'd; after it, page create returned `201` and completed its background refresh, and both rename paths returned `200`.
