### PR TITLE
fix(coding-agents): recapture an initiative when the plan changes (#3616)

### DIFF
--- a/hindsight-integrations/coding-agents/skill/SKILL.md
+++ b/hindsight-integrations/coding-agents/skill/SKILL.md
@@ -28,7 +28,11 @@ When the user says "store this in hindsight" / "remember this":
 - The **current conversation** is captured automatically at session end — say so; no tool needed.
 - An **external document, notes, or durable findings** → `hindsight_ingest_document(title, content)`.
 - A **new feature/initiative being started** → `hindsight_capture_initiative(title, summary)`,
-  once, right after the plan is agreed and before code is written.
+  right after the plan is agreed and before code is written.
+- A **plan that materially changed** (goal, scope, or rationale — including mid-implementation) →
+  call `hindsight_capture_initiative` again with `relates_to_page_id` set to that initiative's page
+  id, summarising the _current_ intent. Same page, updated plan — never a second page. Trivial
+  course-corrections don't count.
 
 ## Retrieving
 

--- a/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
@@ -495,7 +495,7 @@ describe("HindsightClient.captureInitiative", () => {
     expect(memPost).toBeDefined();
     const item = memPost.body.items[0];
     expect(item.tags).toEqual(["knowledge:feature-work", "relatedPageId:initiative-x"]);
-    expect(item.content).toContain("Enhancement to an existing initiative");
+    expect(item.content).toContain("Update to an existing initiative");
   });
 
   it("applies retain attribution to initiative markers", async () => {

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -652,7 +652,8 @@ export class HindsightClient {
   /**
    * Active-path capture: register a major feature as a per-initiative page + a tagged marker memory.
    * New initiative → creates a page under the Initiatives folder tagged `relatedPageId:<pageId>`.
-   * Enhancement (relatesToPageId) → no new page; only a marker accruing to the existing page.
+   * Update (relatesToPageId) → no new page; only a marker accruing to the existing page, so an
+   * enhancement or a mid-work plan change lands on the initiative it belongs to.
    */
   async captureInitiative(args: {
     title: string;
@@ -685,7 +686,9 @@ export class HindsightClient {
       }
       pageId ||= `initiative-${this.slugify(args.title)}`; // last resort if the response lacked an id
     }
-    const verb = args.relatesToPageId ? "Enhancement to an existing initiative" : "New initiative";
+    // "Update", not "Enhancement": a recapture is just as often a plan change (scope/goal/why
+    // rewritten) as an addition, and this string is what the page synthesis reads.
+    const verb = args.relatesToPageId ? "Update to an existing initiative" : "New initiative";
     const content = `${verb}: ${args.title}. ${args.summary}`;
     // Unique marker document id (NOT pageId) so repeated captures accrue instead of replacing.
     const markerId = `initiative-marker-${this.slugify(args.title)}-${Date.now()}`;

--- a/hindsight-integrations/coding-agents/src/core/knowledge-injection.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/knowledge-injection.test.ts
@@ -34,6 +34,18 @@ describe("buildKnowledgePreamble", () => {
     expect(out).toContain("hindsight_capture_initiative");
     expect(out).toContain("hindsight_ingest_document");
   });
+  it("tells the agent to recapture an initiative when the plan changes mid-work", () => {
+    // Same contract as the MCP tool description (knowledge-tools.ts) — the two must not drift.
+    for (const out of [
+      buildKnowledgePreamble([{ id: "p1", title: "Component map" }]),
+      buildRosterRefresh([]),
+    ]) {
+      expect(out).not.toMatch(/call this ONCE/i);
+      expect(out).toMatch(/call it AGAIN with relates_to_page_id/i);
+      expect(out).toMatch(/goal, scope, or rationale materially changes/i);
+    }
+  });
+
   it("has an empty-state line when there are no pages", () => {
     const out = buildKnowledgePreamble([]);
     expect(out).toMatch(/no knowledge pages yet|still learning/i);

--- a/hindsight-integrations/coding-agents/src/core/knowledge-injection.ts
+++ b/hindsight-integrations/coding-agents/src/core/knowledge-injection.ts
@@ -40,8 +40,10 @@ const TOOL_GUIDE =
   "repo's full memory for the past decision and exact values that explain a behavior or bug (slower — " +
   'use deliberately, and credit results with a blockquote header "> 🧠 **From Hindsight memory** — <summary>").\n' +
   "- hindsight_capture_initiative(title, summary) — right after the user approves a plan or finishes brainstorming a " +
-  "new feature/capability and you are about to start implementing (BEFORE you write any code), call this ONCE to " +
-  "record it as a tracked page. Skip bug fixes, small tweaks, and chores.\n" +
+  "new feature/capability and you are about to start implementing (BEFORE you write any code), call this to " +
+  "record it as a tracked page; then call it AGAIN with relates_to_page_id set to that page whenever the goal, " +
+  "scope, or rationale materially changes mid-work, so the page tracks the current plan and not the opening one. " +
+  "Skip bug fixes, small tweaks, chores, and trivial course-corrections.\n" +
   "- hindsight_ingest_document(title, content) — save an external document or durable notes/findings you want " +
   "remembered (not the current conversation — that is captured automatically at session end).";
 

--- a/hindsight-integrations/coding-agents/src/core/knowledge-tools.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/knowledge-tools.test.ts
@@ -1,6 +1,7 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { buildKnowledgeTools } from "./knowledge-tools";
 import { DEFAULT_REFLECT_TOOL_TIMEOUT_MS } from "./config";
@@ -253,6 +254,37 @@ describe("buildKnowledgeTools", () => {
       relatesToPageId: "initiative-uploader",
     });
     expect(JSON.parse(result.content[0].text)).toEqual({ page_id: "initiative-retry-backoff" });
+  });
+
+  // Regression guard for the "ONCE, EARLY" contract that told agents to capture the opening plan
+  // and never recapture, so mid-work pivots never reached the initiative page.
+  it("hindsight_capture_initiative's description tells the agent to recapture when the plan changes", () => {
+    const tools = buildKnowledgeTools(stubClient(), "repo-a");
+    const desc = findTool(tools, "hindsight_capture_initiative").description;
+    expect(desc).not.toMatch(/ONCE, EARLY/i);
+    expect(desc).toMatch(/call it AGAIN/i);
+    expect(desc).toMatch(/goal, scope, or rationale/i);
+    expect(desc).toMatch(/mid-implementation/i);
+    // The recapture must reuse the existing page, not create a parallel one.
+    expect(desc).toMatch(/relates_to_page_id = that/i);
+    expect(desc).toMatch(/[Nn]ever mint a second page/);
+    // Summary guidance must ask for the current intent, not the originally approved plan.
+    expect(desc).toMatch(/CURRENT intent/);
+    // Trivial course-corrections are still out of scope.
+    expect(desc).toMatch(/trivial course-corrections/i);
+  });
+
+  // The recapture-on-plan-change contract lives in three places an agent can read it from: this
+  // tool description, TOOL_GUIDE (knowledge-injection.ts), and the installed skill. SKILL.md is
+  // copied verbatim by skill-sync, so nothing else would catch it drifting back to "once".
+  it("SKILL.md documents the same recapture-on-plan-change trigger", () => {
+    const md = readFileSync(
+      fileURLToPath(new URL("../../skill/SKILL.md", import.meta.url)),
+      "utf8"
+    );
+    expect(md).toMatch(/plan that materially changed/i);
+    expect(md).toMatch(/`relates_to_page_id`/);
+    expect(md).toMatch(/never a second page/i);
   });
 
   it("hindsight_capture_initiative passes relatesToPageId: undefined for a brand-new initiative", async () => {

--- a/hindsight-integrations/coding-agents/src/core/knowledge-tools.ts
+++ b/hindsight-integrations/coding-agents/src/core/knowledge-tools.ts
@@ -218,15 +218,25 @@ export function buildKnowledgeTools(
       name: "hindsight_capture_initiative",
       description:
         "Record a new feature or initiative as a tracked knowledge page, so future sessions know it " +
-        "exists and can build on it.\n\n" +
-        "WHEN TO CALL: right after the user approves a plan or finishes brainstorming a new feature/" +
-        "capability and you are about to start implementing — BEFORE you write any code. Call it ONCE, EARLY.\n\n" +
-        "WHEN TO SKIP: bug fixes, small tweaks, refactors, and chores are not initiatives — skip " +
-        "them.\n\n" +
-        "- title: short, specific name (e.g. 'Newsletter refinement chat').\n" +
-        "- summary: 2-3 sentences on what you're building and why (the intent, not a code diff).\n" +
-        "- relates_to_page_id: leave empty for a new initiative. Set it only to attach to an " +
-        "initiative that already has a page — pass that page's id from hindsight_list_knowledge_pages.\n\n" +
+        "exists and can build on it — and keep that page tracking the plan as it moves.\n\n" +
+        "WHEN TO CALL:\n" +
+        "- Starting one: right after the user approves a plan or finishes brainstorming a new feature/" +
+        "capability and you are about to start implementing — BEFORE you write any code. Leave " +
+        "relates_to_page_id empty.\n" +
+        "- Plan changed: call it AGAIN — mid-implementation is fine and expected — whenever the goal, " +
+        "scope, or rationale of an initiative you already captured materially changes (an approach is " +
+        "dropped, scope grows or shrinks, the why is rewritten). Pass relates_to_page_id = that " +
+        "initiative's page id so the change lands on the existing page. Never mint a second page for the " +
+        "same initiative.\n\n" +
+        "WHEN TO SKIP: bug fixes, small tweaks, refactors, chores, and trivial course-corrections that " +
+        "leave the goal intact are not initiatives — skip them.\n\n" +
+        "- title: short, specific name (e.g. 'Newsletter refinement chat'). On a recapture, reuse the " +
+        "initiative's existing title.\n" +
+        "- summary: 2-3 sentences on what you're building and why — the CURRENT intent, not the " +
+        "originally approved plan (on a recapture, say what changed and why).\n" +
+        "- relates_to_page_id: leave empty for a new initiative. Set it to an existing initiative's page " +
+        "id — from hindsight_list_knowledge_pages, or the id this tool returned earlier — to record a " +
+        "plan change or an enhancement to it.\n\n" +
         "Returns the page id. The page is generated for you — you never format one yourself.",
       inputSchema: {
         title: z.string(),


### PR DESCRIPTION
Fixes #3616.

## Problem

`hindsight_capture_initiative` is the only agent tool that writes memories tagged `knowledge:feature-work` + `relatedPageId:<pageId>`, and its description told the agent to call it **"ONCE, EARLY"** — right after the plan is approved, before any code is written.

Real feature work keeps moving after that point. Scope grows, an approach gets dropped, the *why* gets rewritten — usually mid-implementation. Nothing in the agent-facing copy told the model to capture again, so the only memory carrying `relatedPageId` stayed the opening plan. Mid-work pivots never reached the initiative page, and that stale marker remained its most specifically tagged source.

The update path already existed: `relates_to_page_id` skips the page create and accrues another marker onto the existing page (unique `initiative-marker-…-<timestamp>` document id, so repeats accumulate rather than replace). It was just described as *"attach to an existing initiative"* — which, next to "ONCE, EARLY", agents don't read as "the plan changed".

## Fix

Prompting/tool-contract only. No server or schema change.

Keeps the early-capture trigger (registering the initiative before it disappears into a transcript is the right call) and adds the recapture trigger to **all three** surfaces an agent can read the contract from, so they cannot drift:

- `src/core/knowledge-tools.ts` — the MCP tool description
- `src/core/knowledge-injection.ts` — `TOOL_GUIDE`, injected at SessionStart and on the ~10-turn roster refresh
- `skill/SKILL.md` — the installed skill

The new contract:

- Call once when the initiative starts, `relates_to_page_id` empty.
- Call **again** with `relates_to_page_id` set to that page when the goal, scope, or rationale materially changes — mid-implementation is fine and expected. Never mint a second page for the same initiative.
- `summary` asks for the **current** intent, not the originally approved plan (on a recapture, what changed and why).
- Still skip bug fixes, tweaks, refactors, chores, and trivial course-corrections that leave the goal intact.

One behaviour change beyond copy: the recapture marker verb moves from `"Enhancement to an existing initiative"` to `"Update to an existing initiative"` (`core/hindsight.ts`). That string is what the page synthesis reads, and a scope pivot is not an addition — labelling it "Enhancement" would bias the page toward reading the change as extra work rather than a redirection.

## Tests

Regression guards on each of the three surfaces assert the recapture trigger is present and `ONCE, EARLY` is gone, so the old contract cannot silently return:

- `knowledge-tools.test.ts` — the tool description (plus a check that SKILL.md, which `skill-sync` copies verbatim and nothing else asserts on, carries the same trigger)
- `knowledge-injection.test.ts` — both the SessionStart preamble and the roster refresh

`npx vitest run` on the touched files: 70 passed. The 3 suite-level failures on this repo (`mcp-server`, `opencode`, `plugin-entry`) are a pre-existing missing `@opencode-ai/plugin` module locally — identical on a clean `origin/main` baseline. `./scripts/hooks/lint.sh` passes.