### PR TITLE
fix(mental-models): store delta documents as verbatim markdown blocks (#3361, #3273)

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/d1e2f3a4b5c6_drop_v1_mental_model_structured_content.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/d1e2f3a4b5c6_drop_v1_mental_model_structured_content.py
@@ -1,0 +1,94 @@
+"""Drop schema-v1 mental model structured_content
+
+``mental_models.structured_content`` held a typed block tree (paragraph /
+bullet_list / ordered_list / code / table) that was *parsed* out of the
+document's markdown. That parse was lossy for every construct the union could
+not express — nested lists, list continuation lines, blockquotes, hard line
+breaks, horizontal rules, HTML, indented code, table alignment, a table row
+missing an outer pipe — and the loss was a fixed point, so a document could
+never recover on its own (#3361).
+
+Schema v2 stores each block as a verbatim markdown fragment instead, so the
+v1 rows are a strictly worse copy of the same document: the row's ``content``
+is the faithful text, and re-deriving the structure from it is lossless. There
+is nothing in a v1 blob worth converting, so this drops them and lets the next
+refresh rebuild the structure from ``content`` — a one-time, lossless import.
+
+``content`` itself is deliberately untouched: it is what users read, and no
+refresh has to run for it to keep working.
+
+Revision ID: d1e2f3a4b5c6
+Revises: c4e8a1b7d2f6
+Create Date: 2026-08-19
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "d1e2f3a4b5c6"
+down_revision: str | Sequence[str] | None = "c4e8a1b7d2f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA_VERSION = "2"
+
+
+def _pg_schema_prefix() -> str:
+    """Schema-qualifier for raw SQL on PG (multi-tenant search_path)."""
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def _pg_upgrade() -> None:
+    schema = _pg_schema_prefix()
+    # ``IS DISTINCT FROM`` so a blob with no ``version`` key (NULL on the left)
+    # is cleared too — an untagged shape is by definition not v2.
+    op.execute(
+        f"""
+        UPDATE {schema}mental_models
+        SET structured_content = NULL
+        WHERE structured_content IS NOT NULL
+          AND (structured_content ->> 'version') IS DISTINCT FROM '{SCHEMA_VERSION}'
+        """
+    )
+
+
+def _pg_downgrade() -> None:
+    # The v1 blobs are gone and are not reconstructible — nor worth
+    # reconstructing: the code that read them no longer exists, and rolling back
+    # leaves every model rebuilding its baseline from ``content``, which is what
+    # a NULL already means.
+    pass
+
+
+def _oracle_upgrade() -> None:
+    # ``structured_content`` is a CLOB with an ``IS JSON`` check, so the version
+    # is read with JSON_VALUE rather than PG's ``->>``. JSON_VALUE returns NULL
+    # both for a missing key and for unparseable JSON; either way it is not v2.
+    op.execute(
+        f"""
+        UPDATE mental_models
+        SET structured_content = NULL
+        WHERE structured_content IS NOT NULL
+          AND (
+              JSON_VALUE(structured_content, '$.version') IS NULL
+              OR JSON_VALUE(structured_content, '$.version') <> '{SCHEMA_VERSION}'
+          )
+        """
+    )
+
+
+def _oracle_downgrade() -> None:
+    # See _pg_downgrade.
+    pass
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade, oracle=_oracle_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade, oracle=_oracle_downgrade)

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -200,14 +200,60 @@ sanitize_llm_output = sanitize_text
 # real provider path (see issue #3172).
 
 
+_JSON_CONTROL_ESCAPES = {"\n": "\\n", "\r": "\\r", "\t": "\\t", "\b": "\\b", "\f": "\\f"}
+
+
+def _escape_control_chars_in_json(text: str) -> str:
+    """Make raw control characters inside JSON string values parseable.
+
+    ``json.loads`` rejects an unescaped control character in a string. Models
+    hit this whenever they write a multi-line value (a markdown table, a list,
+    a code fence) without escaping the line breaks.
+
+    A line break, tab or form feed inside a string is *content*: it is escaped
+    so it survives. Blanking it out instead welds a markdown table onto one
+    line, and the damage is invisible downstream (#3361). Every other control
+    character carries no meaning in text, so it keeps the historical treatment
+    of becoming a space.
+
+    The scan tracks string state because only characters inside a string need
+    escaping; the same byte between tokens is junk either way.
+    """
+    out: list[str] = []
+    in_string = False
+    escape = False
+    for ch in text:
+        if in_string and escape:
+            escape = False
+            out.append(ch)
+            continue
+        if in_string and ch == "\\":
+            escape = True
+            out.append(ch)
+            continue
+        if ch == '"':
+            in_string = not in_string
+            out.append(ch)
+            continue
+        if in_string and ch in _JSON_CONTROL_ESCAPES:
+            out.append(_JSON_CONTROL_ESCAPES[ch])
+            continue
+        if ch <= "\x1f" or ch == "\x7f":
+            out.append(" ")
+            continue
+        out.append(ch)
+    return "".join(out)
+
+
 def parse_llm_json(raw: str) -> Any:
     """
     Robustly parse JSON returned by an LLM.
 
     Handles common LLM output quirks:
     1. Markdown code fences (```json ... ```) — strip them before parsing.
-    2. Embedded control characters (\\x00-\\x1f, \\x7f) — replace with space
-       and retry if the initial parse fails.
+    2. Embedded control characters (\\x00-\\x1f, \\x7f) — escape the ones inside
+       string values (so a raw newline stays a line break), drop the ones
+       between tokens, and retry if the initial parse fails.
     3. Structural malformation (trailing commas, unterminated strings, single
        quotes, invalid ``\\escape`` sequences) — repaired as a last resort via
        ``json_repair`` (#2547/#2544).
@@ -240,8 +286,12 @@ def parse_llm_json(raw: str) -> Any:
         return json.loads(text)
     except json.JSONDecodeError:
         # Some models (e.g. Gemini) embed raw control characters inside JSON
-        # string values. Replacing them with a space usually produces valid JSON.
-        cleaned = re.sub(r"[\x00-\x1f\x7f]", " ", text)
+        # string values. Escape them rather than blank them out: a raw newline
+        # in a string is the model writing a real line break, and replacing it
+        # with a space silently welds a markdown table or list onto one line
+        # (#3361). Control characters *outside* a string are noise and are
+        # dropped, since nothing meaningful can sit between JSON tokens.
+        cleaned = _escape_control_chars_in_json(text)
 
     try:
         return json.loads(cleaned)

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -14275,12 +14275,23 @@ class MemoryEngine(MemoryEngineInterface):
                 # transport cap — see the call below.
                 doc_max_tokens = stored_max_tokens or 2048
                 delta_max_tokens = max(2048, int(doc_max_tokens * 1.5))
+                # The document's own budget. Nothing else measures it on this leg:
+                # a delta refresh only adds, so a page grows every round and drifts
+                # past its configured size with no signal (~20 tokens/round measured,
+                # which crosses the 4096 default after a couple of hundred refreshes).
+                # The model is told where it stands so it can reclaim space from
+                # stale content; truncating here would delete knowledge instead.
+                from .reflect.tokenization import count_cl100k_tokens
+
+                document_tokens = count_cl100k_tokens(current_content)
                 user_prompt = build_structured_delta_prompt(
                     current_document_json=current_doc.model_dump_json(),
                     candidate_markdown=reflect_result.text,
                     supporting_facts=supporting_facts,
                     source_query=source_query,
                     max_output_tokens=delta_max_tokens,
+                    document_tokens=document_tokens,
+                    document_budget=doc_max_tokens,
                 )
                 # Trace the delta call. Unlike the synthesis, this runs on the raw
                 # ``_reflect_llm_config`` outside ``reflect_async``'s trace context,
@@ -14336,6 +14347,18 @@ class MemoryEngine(MemoryEngineInterface):
                         final_structured = apply_outcome.document
                         final_content = render_document(apply_outcome.document)
                         delta_applied = True
+                        # Surfaced rather than enforced: a page that keeps growing past
+                        # its budget is a page whose content needs a decision, and that
+                        # is visible here instead of only in the byte count.
+                        final_tokens = count_cl100k_tokens(final_content)
+                        reflect_response_payload["document_tokens"] = final_tokens
+                        reflect_response_payload["document_budget"] = doc_max_tokens
+                        if final_tokens > doc_max_tokens:
+                            warnings.append(
+                                f"The document is ~{final_tokens} tokens, over its {doc_max_tokens}-token "
+                                "budget. Delta refreshes were asked to reclaim space from superseded "
+                                "content; if it keeps growing, raise max_tokens or narrow the source query."
+                            )
                         logger.info(
                             f"[MENTAL_MODELS] Delta refresh for {mental_model_id}: "
                             f"applied {len(apply_outcome.applied)} op(s), "

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -14098,8 +14098,9 @@ class MemoryEngine(MemoryEngineInterface):
             build_structured_retraction_prompt,
         )
         from .reflect.structured_doc import (
-            parse_markdown,
             render_document,
+            split_markdown,
+            structured_document_from_stored,
         )
 
         final_content = reflect_result.text
@@ -14123,34 +14124,21 @@ class MemoryEngine(MemoryEngineInterface):
             return _op_llm_config
 
         if use_delta:
-            # Use the previously stored structured doc when available; otherwise
-            # parse the existing markdown so the very first delta refresh can
-            # still operate without waiting for a full rebuild.
-            #
-            # A stored doc that fails validation (hand-edited JSON, a shape from an
-            # older schema) is NOT fatal: the markdown in ``content`` is the same
-            # document and ``parse_markdown`` is lenient, so re-deriving the baseline
-            # from it keeps the delta path alive and rebuilds the structured doc as a
-            # side effect. Giving up here would refuse every subsequent refresh
-            # (nothing else repairs the column) over a baseline we can reconstruct.
+            # The stored structure is the baseline. A model that has never been
+            # refreshed in delta mode, or was last written under an older schema,
+            # has its baseline imported once from the stored markdown — a lossless
+            # split on headings and blank lines, not a re-interpretation of the
+            # prose (see ``structured_document_from_stored``). From this refresh on
+            # the structure is authoritative and the markdown is its render.
             current_doc: StructuredDocument | None = None
-            if stored_structured_content is not None:
-                try:
-                    current_doc = StructuredDocument.model_validate(stored_structured_content)
-                except Exception as exc:
-                    logger.warning(
-                        f"[MENTAL_MODELS] Stored structured doc for {mental_model_id} is unusable "
-                        f"({exc}); re-deriving the delta baseline from the stored markdown"
-                    )
-            if current_doc is None:
-                try:
-                    current_doc = parse_markdown(current_content)
-                except Exception as exc:
-                    logger.warning(
-                        f"[MENTAL_MODELS] Could not load structured doc for {mental_model_id} "
-                        f"({exc}); delta has no baseline to edit"
-                    )
-                    mode_fallback_reason = "structured_doc_unreadable"
+            try:
+                current_doc = structured_document_from_stored(stored_structured_content, current_content)
+            except Exception as exc:
+                logger.warning(
+                    f"[MENTAL_MODELS] Could not load structured doc for {mental_model_id} "
+                    f"({exc}); delta has no baseline to edit"
+                )
+                mode_fallback_reason = "structured_doc_unreadable"
 
             if current_doc is not None:
                 supporting_facts = delta_supporting_facts
@@ -14427,17 +14415,31 @@ class MemoryEngine(MemoryEngineInterface):
                 outcome="refresh_failed_delta_not_applied",
             )
 
-        # When delta is not applied (full mode, or delta fallback), parse the
+        # When delta is not applied (full mode, or delta fallback), split the
         # candidate markdown so the next refresh has a structured baseline to
-        # operate against.
+        # operate against, and store the render of that structure as the content.
+        #
+        # Writing the render rather than the raw candidate is what keeps the two
+        # columns in agreement: under v1 the full leg stored the candidate verbatim
+        # while deriving the structure from it lossily, so the first delta refresh
+        # afterwards silently replaced the user-visible markdown with the render of
+        # a degraded structure (#3361). The split is lossless, so this now changes
+        # nothing but whitespace between blocks — and if it ever did more, it would
+        # show up on the refresh that caused it instead of one refresh later.
         if final_structured is None:
             try:
-                final_structured = parse_markdown(final_content)
+                structured = split_markdown(final_content)
+                rendered = render_document(structured)
             except Exception as exc:
+                # Both or neither: a half-applied split would store a structure the
+                # content does not match, which is the very state this replaces.
                 logger.warning(
-                    f"[MENTAL_MODELS] Could not parse final markdown into structured form "
+                    f"[MENTAL_MODELS] Could not split final markdown into structured form "
                     f"for {mental_model_id} ({exc}); leaving structured_content unchanged"
                 )
+            else:
+                final_structured = structured
+                final_content = rendered
 
         # Report by observable effect, not by which branch got here. A delta run
         # whose model emitted *zero* operations lands in the applied path — the

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -13550,7 +13550,17 @@ class MemoryEngine(MemoryEngineInterface):
         max_tokens: int | None,
         trigger: dict[str, Any] | None,
     ) -> ResultRow:
-        """Insert a pinned model using the caller's transaction."""
+        """Insert a pinned model using the caller's transaction.
+
+        ``content`` is stored as the render of its own structure: a mental model
+        created from authored markdown is on the structured schema from the
+        first byte, not from its first delta refresh. Leaving the column NULL
+        here would mean the first refresh silently reshapes a document nobody
+        asked it to touch.
+        """
+        from .reflect.structured_doc import canonical_document
+
+        document = canonical_document(content)
         # VectorChord needs mental_models.search_vector tokenized on write; every
         # other backend either generates it or indexes the source columns.
         #
@@ -13570,8 +13580,10 @@ class MemoryEngine(MemoryEngineInterface):
         row = await conn.fetchrow(
             f"""
             INSERT INTO {fq_table("mental_models")}
-            (id, bank_id, subtype, name, description, source_query, content, embedding, tags, max_tokens, trigger{sv_col})
-            VALUES ($1, $2, 'pinned', $3::text, ' ', $4, $5, $6, $7, COALESCE($8, 2048), COALESCE($9, '{{"refresh_after_consolidation": false}}'::jsonb){sv_val})
+            (id, bank_id, subtype, name, description, source_query, content, embedding, tags, max_tokens,
+             trigger, structured_content{sv_col})
+            VALUES ($1, $2, 'pinned', $3::text, ' ', $4, $5, $6, $7, COALESCE($8, 2048),
+                    COALESCE($9, '{{"refresh_after_consolidation": false}}'::jsonb), $10{sv_val})
             RETURNING id, bank_id, name, source_query, content, tags,
                       last_refreshed_at, last_memory_seen_at, created_at, reflect_response,
                       max_tokens, trigger, structured_content
@@ -13580,11 +13592,12 @@ class MemoryEngine(MemoryEngineInterface):
             bank_id,
             name,
             source_query,
-            content,
+            document.markdown,
             embedding,
             tags or [],
             max_tokens,
             json.dumps(trigger) if trigger else None,
+            json.dumps(document.structure.model_dump()),
         )
         assert row is not None
         return row
@@ -14795,6 +14808,20 @@ class MemoryEngine(MemoryEngineInterface):
                 )
                 await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
         backend = await self._get_backend()
+
+        # A caller that hands over markdown alone (an import, a hand-authored
+        # document) gets its structure derived here, so the two columns can never
+        # be written out of step — the divergence that let a degraded document
+        # reach users one refresh after it was written (#3361). A refresh passes
+        # both (the structure is authoritative there and the markdown is already
+        # its render) and is left exactly as it supplied them. Derived up front so
+        # the embedding, the history snapshot and the UPDATE all see one text.
+        if content is not None and structured_content is None:
+            from .reflect.structured_doc import canonical_document
+
+            document = canonical_document(content)
+            content = document.markdown
+            structured_content = document.structure.model_dump()
 
         # Compute the new embedding BEFORE acquiring a pooled connection: a slow
         # embedder must never pin a DB connection. The embedding text depends only

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -12007,6 +12007,7 @@ class MemoryEngine(MemoryEngineInterface):
         recall_chunks_max_tokens_override: int | None = None,
         created_after: datetime | None = None,
         created_before: datetime | None = None,
+        answer_as_document: bool = False,
         _skip_span: bool = False,
         _operation_label: str = "reflect",
     ) -> ReflectResult:
@@ -12310,6 +12311,7 @@ class MemoryEngine(MemoryEngineInterface):
                         llm_output_language=getattr(resolved_reflect_config, "llm_output_language", None),
                         cancel_check=request_context.raise_if_cancelled,
                         store_document_text=config_dict.get("store_document_text", DEFAULT_STORE_DOCUMENT_TEXT),
+                        answer_as_document=answer_as_document,
                     ),
                     timeout=wall_timeout,
                 )
@@ -12486,6 +12488,7 @@ class MemoryEngine(MemoryEngineInterface):
             # Return response (compatible with existing API)
             result = ReflectResult(
                 text=agent_result.text,
+                document=agent_result.document,
                 based_on=based_on,
                 structured_output=agent_result.structured_output,
                 usage=usage,
@@ -13887,6 +13890,11 @@ class MemoryEngine(MemoryEngineInterface):
             recall_include_chunks=recall_include_chunks_override,
             recall_max_tokens_override=recall_max_tokens_override,
             recall_chunks_max_tokens_override=recall_chunks_max_tokens_override,
+            # The refresh stores a document, so the agent states its structure and
+            # the markdown is rendered from it. The model never writes the markdown
+            # that gets persisted, and nothing has to read markdown back to find
+            # out what the model meant (#3361).
+            answer_as_document=True,
             _skip_span=True,
             # Attribute these LLM calls to the mental-model refresh, not a
             # plain reflect, so traces group under the right operation.
@@ -14441,7 +14449,11 @@ class MemoryEngine(MemoryEngineInterface):
         # show up on the refresh that caused it instead of one refresh later.
         if final_structured is None:
             try:
-                structured = split_markdown(final_content)
+                # The agent emitted the document (``answer_as_document``), so its
+                # structure is used as-is. Splitting is the fallback for a run that
+                # produced plain text instead — an older stub, a provider that
+                # dropped the tool call, or the iteration-limit answer.
+                structured = reflect_result.document or split_markdown(final_content)
                 rendered = render_document(structured)
             except Exception as exc:
                 # Both or neither: a half-applied split would store a structure the

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -28,6 +28,7 @@ from .prompts import (
     split_context_history,
 )
 from .structured_doc import (
+    CanonicalDocument,
     StructuredDocument,
     document_from_sections,
     render_document,
@@ -1172,6 +1173,32 @@ def _tool_call_to_dict(tc: "LLMToolCall") -> dict[str, Any]:
     return d
 
 
+def _document_from_rewrite(rewritten: str, previous_answer: str) -> CanonicalDocument:
+    """Read a shortened document back, falling back to the text if it is not JSON.
+
+    The rewrite is asked for as sections, but it is still model output on a path
+    where failing would throw away a whole reflect. A response that does not parse
+    is treated as the prose it looks like and split, which is lossless — so the
+    worst case is the old behaviour rather than a lost answer.
+    """
+    from hindsight_api.engine.llm_wrapper import parse_llm_json
+
+    text = rewritten.strip()
+    try:
+        payload = parse_llm_json(text)
+    except json.JSONDecodeError:
+        payload = None
+    if isinstance(payload, dict) and payload.get("sections"):
+        document = document_from_sections(payload)
+        rendered = render_document(document).strip()
+        if rendered:
+            return CanonicalDocument(markdown=rendered, structure=document)
+    if not text:
+        # An empty rewrite must not empty the answer; keep what was there.
+        return CanonicalDocument(markdown=previous_answer, structure=split_markdown(previous_answer))
+    return CanonicalDocument(markdown=text, structure=split_markdown(text))
+
+
 async def _process_done_tool(
     done_call: "LLMToolCall",
     available_memory_ids: set[str],
@@ -1215,36 +1242,45 @@ async def _process_done_tool(
     final_usage = usage
     if llm_config and max_tokens is not None and count_cl100k_tokens(answer) > max_tokens:
         rewrite_start = time.time()
-        # The token budget is enforced via the prompt, not a hard provider cap:
-        # on thinking models a hard cap is eaten by reasoning tokens and would
-        # truncate the rewrite mid-word (#3365). Cost is bounded by the separate
-        # reflect_max_completion_tokens config (uncapped by default).
+        # In document mode the trim is asked for as a document too. Asking for
+        # prose here would put the model back in the business of writing the
+        # markdown that gets stored — on the one path where the answer is long
+        # enough that its structure matters most.
+        if document is not None:
+            rewrite_system = (
+                "Shorten the user's document so it fits within the requested token budget. "
+                "Preserve the key facts and the document's structure; drop lower-priority detail. "
+                'Respond ONLY with JSON: {"sections": [{"heading": "...", "level": 2, '
+                '"blocks": ["...", "..."]}]}. A heading carries no "#", and each block is one '
+                "paragraph, list, table or code fence."
+            )
+            rewrite_user = f"Target budget: {max_tokens} tokens.\n\nDocument to shorten:\n{answer}"
+        else:
+            # The token budget is enforced via the prompt, not a hard provider cap:
+            # on thinking models a hard cap is eaten by reasoning tokens and would
+            # truncate the rewrite mid-word (#3365). Cost is bounded by the separate
+            # reflect_max_completion_tokens config (uncapped by default).
+            rewrite_system = (
+                "Rewrite the user's text so it fits within the requested token budget. "
+                "Preserve the key facts and structure; drop lower-priority detail. "
+                "Respond with the rewritten text only, no preamble."
+            )
+            rewrite_user = f"Target budget: {max_tokens} tokens.\n\nText to rewrite:\n{answer}"
+
         rewritten, rewrite_usage = await llm_config.call(
             messages=[
-                {
-                    "role": "system",
-                    "content": (
-                        "Rewrite the user's text so it fits within the requested token budget. "
-                        "Preserve the key facts and structure; drop lower-priority detail. "
-                        "Respond with the rewritten text only, no preamble."
-                    ),
-                },
-                {
-                    "role": "user",
-                    "content": f"Target budget: {max_tokens} tokens.\n\nText to rewrite:\n{answer}",
-                },
+                {"role": "system", "content": rewrite_system},
+                {"role": "user", "content": rewrite_user},
             ],
             scope="reflect",
             max_completion_tokens=get_config().reflect_max_completion_tokens,
             return_usage=True,
         )
-        answer = rewritten.strip()
         if document is not None:
-            # The rewrite is text-level, so the emitted structure no longer
-            # describes the answer. Re-deriving it from the rewritten markdown is
-            # lossless (headings and blank lines only) and keeps the invariant
-            # that the stored text is exactly what the stored structure renders.
-            document = split_markdown(answer)
+            trimmed = _document_from_rewrite(rewritten, answer)
+            document, answer = trimmed.structure, trimmed.markdown
+        else:
+            answer = rewritten.strip()
         final_usage = TokenUsageSummary(
             input_tokens=usage.input_tokens + rewrite_usage.input_tokens,
             output_tokens=usage.output_tokens + rewrite_usage.output_tokens,

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -27,6 +27,12 @@ from .prompts import (
     build_system_prompt_for_tools,
     split_context_history,
 )
+from .structured_doc import (
+    StructuredDocument,
+    document_from_sections,
+    render_document,
+    split_markdown,
+)
 from .tokenization import count_cl100k_tokens
 from .tools_schema import get_reflect_tools
 
@@ -441,6 +447,7 @@ async def _run_reflect_agent_inner(
     llm_output_language: str | None = None,
     cancel_check: Callable[[], None] | None = None,
     store_document_text: bool = True,
+    answer_as_document: bool = False,
     *,
     reflect_id: str,
     provider_impl: Any,
@@ -504,6 +511,7 @@ async def _run_reflect_agent_inner(
         include_observations=include_observations,
         include_recall=include_recall,
         include_expand=include_expand,
+        answer_as_document=answer_as_document,
     )
     # Build set of enabled tool names to guard against LLM hallucinating disabled tool calls
     enabled_tools: frozenset[str] = frozenset(t["function"]["name"] for t in tools if t.get("type") == "function")
@@ -516,6 +524,7 @@ async def _run_reflect_agent_inner(
         has_mental_models=has_mental_models,
         include_observations=include_observations,
         budget=budget,
+        answer_as_document=answer_as_document,
     )
     messages: list[dict[str, Any]] = [
         {"role": "system", "content": system_prompt},
@@ -1186,8 +1195,21 @@ async def _process_done_tool(
     # ``done`` is a structured tool call: trust its ``answer`` field verbatim.
     # Sibling id fields (memory_ids, ...) live in their own arguments and are
     # validated separately below -- they can't bleed into a parsed answer string.
-    answer = args.get("answer", "").strip()
+    #
+    # In document mode the model states the document's structure instead, and the
+    # markdown is rendered from it. The rendered text still flows on as ``text``
+    # so every consumer (structured-output extraction, the length rewrite, the
+    # HTTP response) is unchanged -- what changes is that nobody has to read the
+    # model's markdown back to find out what it meant.
+    document: StructuredDocument | None = None
+    raw_document = args.get("document")
+    if isinstance(raw_document, dict):
+        document = document_from_sections(raw_document)
+        answer = render_document(document).strip()
+    else:
+        answer = args.get("answer", "").strip()
     if not answer:
+        document = None
         answer = NO_ANSWER_TEXT
 
     final_usage = usage
@@ -1217,6 +1239,12 @@ async def _process_done_tool(
             return_usage=True,
         )
         answer = rewritten.strip()
+        if document is not None:
+            # The rewrite is text-level, so the emitted structure no longer
+            # describes the answer. Re-deriving it from the rewritten markdown is
+            # lossless (headings and blank lines only) and keeps the invariant
+            # that the stored text is exactly what the stored structure renders.
+            document = split_markdown(answer)
         final_usage = TokenUsageSummary(
             input_tokens=usage.input_tokens + rewrite_usage.input_tokens,
             output_tokens=usage.output_tokens + rewrite_usage.output_tokens,
@@ -1255,6 +1283,7 @@ async def _process_done_tool(
     log_completion(answer, iterations)
     return ReflectAgentResult(
         text=answer,
+        document=document,
         structured_output=structured_output,
         iterations=iterations,
         tools_called=total_tools_called,
@@ -1469,6 +1498,17 @@ def _summarize_input(tool_name: str, args: dict[str, Any]) -> str:
         depth = args.get("depth", "chunk")
         return f"(memory_ids=[{len(memory_ids)} ids], depth={depth})"
     elif tool_name == "done":
+        raw_document = args.get("document")
+        if isinstance(raw_document, dict):
+            sections = raw_document.get("sections") or []
+            blocks = sum(len(s.get("blocks") or []) for s in sections if isinstance(s, dict))
+            memory_ids = args.get("memory_ids", [])
+            mental_model_ids = args.get("mental_model_ids", [])
+            observation_ids = args.get("observation_ids", [])
+            return (
+                f"(document={len(sections)} sections/{blocks} blocks, mem={len(memory_ids)}, "
+                f"mm={len(mental_model_ids)}, obs={len(observation_ids)})"
+            )
         answer = args.get("answer", "")
         answer_preview = f"'{answer[:30]}...'" if len(answer) > 30 else f"'{answer}'"
         memory_ids = args.get("memory_ids", [])

--- a/hindsight-api-slim/hindsight_api/engine/reflect/delta_ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/delta_ops.py
@@ -1,10 +1,11 @@
 """Delta operations for structured mental models.
 
 The LLM's job during a delta refresh is to emit a list of these operations,
-each targeting an existing section (by id) or referencing a position relative
-to one.  ``apply_operations`` validates and applies each op in turn against a
-copy of the document; invalid ops (unknown ``section_id``, out-of-range
-``block_index``, malformed payloads) are dropped with a debug-friendly reason.
+each targeting an existing section (by id) or a block inside one (by id).
+``apply_operations`` validates and applies each op in turn against a copy of
+the document; invalid ops (unknown ``section_id``, unknown ``block_id``, a
+block that lives in a different section) are dropped with a debug-friendly
+reason.
 
 Sections and blocks not mentioned by any op are physically copied through
 unchanged — there is no LLM-mediated re-emission of unchanged text, so prose
@@ -18,6 +19,14 @@ Why operations and not "output the new structured doc":
 - Operations are auditable: each refresh produces a log of exactly what
   changed, useful for debugging the LLM's behaviour and explaining diffs.
 
+Why blocks are addressed by id and not by index (#3273):
+An index has to be *counted* by the model, and an off-by-one is still in
+range, so it silently overwrites an unrelated block and is recorded as a
+success — no length change for a shrink guard to notice. An id is copied, not
+derived; a wrong one does not resolve and is skipped and reported. Block ids
+travel with the document (see ``structured_doc.Block``), so the model only ever
+has to echo back a string it was given.
+
 Failure modes are by design conservative: an operation list that fails to
 parse against the Pydantic schema, or an LLM that returns invalid ops, results
 in zero changes — the document stays as-is. The structure can only get better
@@ -28,6 +37,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Annotated, Any, Literal, Union
 
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
@@ -38,7 +48,9 @@ from .structured_doc import (
     Block,
     Section,
     StructuredDocument,
+    make_block_id,
     make_unique_id,
+    normalize_block_text,
     slugify_heading,
 )
 
@@ -57,36 +69,37 @@ class AppendBlockOp(_OpBase):
 
     op: Literal["append_block"] = "append_block"
     section_id: str
-    block: Block
+    text: str
 
 
 class InsertBlockOp(_OpBase):
-    """Insert a new block at ``index`` in an existing section.
+    """Insert a new block into an existing section.
 
-    ``index`` may equal ``len(section.blocks)`` (append) but not be greater.
+    ``after_block_id`` names the block the new one follows; ``null`` puts it
+    first. An unknown id is a skip, not an append at a guessed position.
     """
 
     op: Literal["insert_block"] = "insert_block"
     section_id: str
-    index: int = Field(ge=0)
-    block: Block
+    after_block_id: str | None = None
+    text: str
 
 
 class ReplaceBlockOp(_OpBase):
-    """Replace the block at ``index`` of an existing section."""
+    """Replace the text of one block, keeping its position and id."""
 
     op: Literal["replace_block"] = "replace_block"
     section_id: str
-    index: int = Field(ge=0)
-    block: Block
+    block_id: str
+    text: str
 
 
 class RemoveBlockOp(_OpBase):
-    """Remove the block at ``index`` of an existing section."""
+    """Remove one block from a section."""
 
     op: Literal["remove_block"] = "remove_block"
     section_id: str
-    index: int = Field(ge=0)
+    block_id: str
 
 
 class AddSectionOp(_OpBase):
@@ -100,7 +113,7 @@ class AddSectionOp(_OpBase):
     op: Literal["add_section"] = "add_section"
     heading: str
     level: int = Field(default=2, ge=1, le=6)
-    blocks: list[Block] = Field(default_factory=list)
+    blocks: list[str] = Field(default_factory=list)
     after_section_id: str | None = None
     new_id: str | None = None
 
@@ -122,7 +135,7 @@ class ReplaceSectionBlocksOp(_OpBase):
 
     op: Literal["replace_section_blocks"] = "replace_section_blocks"
     section_id: str
-    blocks: list[Block] = Field(default_factory=list)
+    blocks: list[str] = Field(default_factory=list)
 
 
 class RenameSectionOp(_OpBase):
@@ -148,6 +161,10 @@ Operation = Annotated[
 ]
 
 _OPERATION_ADAPTER: TypeAdapter[Operation] = TypeAdapter(Operation)
+
+# Payload fields carrying markdown; kept out of the audit summary so a refresh's
+# operation log stays readable (and small enough to store in reflect_response).
+_BODY_FIELDS = ("text", "blocks")
 
 
 def _validate_operations_list(raw_ops: Any) -> tuple[list[Operation], list[dict[str, Any]]]:
@@ -294,9 +311,37 @@ class AppliedDelta(BaseModel):
 def _op_summary(op: Operation) -> dict[str, Any]:
     """Compact dict suitable for the audit trail."""
     data = op.model_dump()
-    return {k: v for k, v in data.items() if k != "block" and k != "blocks"} | {
-        "op": data["op"],
-    }
+    return {k: v for k, v in data.items() if k not in _BODY_FIELDS} | {"op": data["op"]}
+
+
+# A model that wants one more row in a table sometimes emits the row as its own
+# block instead of replacing the table (observed against a real provider in
+# ``test_document_survives_many_delta_rounds_intact``). Rendered with a blank
+# line before it, a bare row is not a table row — it is a broken fragment. The
+# prompt asks for ``replace_block`` in that case; this is the safety net for
+# when the model does it anyway.
+#
+# Note the narrowness: this never re-reads or reclassifies stored content. It
+# only decides whether a *new* block should join the one before it, and the join
+# is a plain concatenation, so nothing can be reinterpreted or lost.
+_TABLE_ROW_RX = re.compile(r"^\s*\|")
+_TABLE_SEPARATOR_RX = re.compile(r"^\s*\|?[\s:]*-{2,}[\s:|-]*\|?\s*$")
+
+
+def _all_table_rows(text: str) -> bool:
+    lines = text.splitlines()
+    return bool(lines) and all(_TABLE_ROW_RX.match(line) for line in lines)
+
+
+def _is_table(text: str) -> bool:
+    """A table needs a header, a separator row, and pipes on every line."""
+    lines = text.splitlines()
+    return len(lines) >= 2 and _all_table_rows(text) and any(_TABLE_SEPARATOR_RX.match(line) for line in lines)
+
+
+def _is_orphan_table_rows(text: str) -> bool:
+    """Rows with no separator of their own — only meaningful inside a table."""
+    return _all_table_rows(text) and not any(_TABLE_SEPARATOR_RX.match(line) for line in text.splitlines())
 
 
 def apply_operations(
@@ -306,12 +351,16 @@ def apply_operations(
     """Apply a list of operations to a document, returning a new document.
 
     The original document is never mutated. Invalid operations (unknown
-    section, out-of-range index, name collision when adding a section) are
+    section, unknown block, a block that belongs to another section) are
     skipped and recorded in ``skipped`` with a ``reason`` string.
     """
     new_doc = doc.model_copy(deep=True)
     applied: list[dict[str, Any]] = []
     skipped: list[dict[str, Any]] = []
+    # Ids handed out during this batch stay reserved even if the block that
+    # owned one is later removed, so two ops in the same batch can never be
+    # given the same id.
+    reserved_ids: set[str] = set(new_doc.block_ids())
 
     def skip(op: Operation, reason: str) -> None:
         entry = _op_summary(op)
@@ -319,14 +368,61 @@ def apply_operations(
         skipped.append(entry)
         logger.debug(f"[STRUCTURED_DELTA] skipping op {entry}")
 
+    def new_block(text: str) -> Block:
+        normalized = normalize_block_text(text)
+        block_id = make_block_id(normalized, reserved_ids)
+        reserved_ids.add(block_id)
+        return Block(id=block_id, text=normalized)
+
+    def resolve_block(op: Operation, section: Section, block_id: str) -> int | None:
+        index = section.block_index(block_id)
+        if index is not None:
+            return index
+        # Naming a real block in the wrong section is a targeting mistake, not a
+        # licence to edit it: report where it actually lives instead of applying
+        # the edit somewhere the model did not ask for.
+        owner = next((s.id for s in new_doc.sections if s.block_by_id(block_id) is not None), None)
+        if owner is not None:
+            skip(op, f"block_id {block_id} belongs to section {owner}, not {section.id}")
+        else:
+            skip(op, f"unknown block_id: {block_id}")
+        return None
+
+    def merge_orphan_rows(op: Operation, section: Section, position: int) -> bool:
+        """Fold bare table rows into the table they were meant to extend."""
+        if position == 0 or not _is_orphan_table_rows(op.text):
+            return False
+        target = section.blocks[position - 1]
+        if not _is_table(target.text):
+            return False
+        target.text = f"{target.text}\n{normalize_block_text(op.text)}"
+        entry = _op_summary(op)
+        entry["merged_into_block_id"] = target.id
+        applied.append(entry)
+        logger.info(
+            "[STRUCTURED_DELTA] merged orphan table row(s) into block %s of section %s",
+            target.id,
+            section.id,
+        )
+        return True
+
+    def empty_text(op: Operation, text: str) -> bool:
+        if text.strip():
+            return False
+        skip(op, "block text is empty")
+        return True
+
     for op in operations:
         if isinstance(op, AppendBlockOp):
             section = new_doc.section_by_id(op.section_id)
             if section is None:
                 skip(op, f"unknown section_id: {op.section_id}")
                 continue
-            section.blocks.append(op.block)
-            applied.append(_op_summary(op))
+            if empty_text(op, op.text):
+                continue
+            if not merge_orphan_rows(op, section, len(section.blocks)):
+                section.blocks.append(new_block(op.text))
+                applied.append(_op_summary(op))
             continue
 
         if isinstance(op, InsertBlockOp):
@@ -334,14 +430,18 @@ def apply_operations(
             if section is None:
                 skip(op, f"unknown section_id: {op.section_id}")
                 continue
-            if op.index > len(section.blocks):
-                skip(
-                    op,
-                    f"index out of range: {op.index} > {len(section.blocks)}",
-                )
+            if empty_text(op, op.text):
                 continue
-            section.blocks.insert(op.index, op.block)
-            applied.append(_op_summary(op))
+            if op.after_block_id is None:
+                position = 0
+            else:
+                anchor = resolve_block(op, section, op.after_block_id)
+                if anchor is None:
+                    continue
+                position = anchor + 1
+            if not merge_orphan_rows(op, section, position):
+                section.blocks.insert(position, new_block(op.text))
+                applied.append(_op_summary(op))
             continue
 
         if isinstance(op, ReplaceBlockOp):
@@ -349,13 +449,15 @@ def apply_operations(
             if section is None:
                 skip(op, f"unknown section_id: {op.section_id}")
                 continue
-            if op.index >= len(section.blocks):
-                skip(
-                    op,
-                    f"index out of range: {op.index} >= {len(section.blocks)}",
-                )
+            if empty_text(op, op.text):
                 continue
-            section.blocks[op.index] = op.block
+            index = resolve_block(op, section, op.block_id)
+            if index is None:
+                continue
+            # The id is positional identity, not a content hash: keeping it means
+            # an op list that replaces a block and then edits it again still
+            # resolves, and the audit trail follows one block across refreshes.
+            section.blocks[index] = Block(id=op.block_id, text=normalize_block_text(op.text))
             applied.append(_op_summary(op))
             continue
 
@@ -364,13 +466,10 @@ def apply_operations(
             if section is None:
                 skip(op, f"unknown section_id: {op.section_id}")
                 continue
-            if op.index >= len(section.blocks):
-                skip(
-                    op,
-                    f"index out of range: {op.index} >= {len(section.blocks)}",
-                )
+            index = resolve_block(op, section, op.block_id)
+            if index is None:
                 continue
-            section.blocks.pop(op.index)
+            section.blocks.pop(index)
             applied.append(_op_summary(op))
             continue
 
@@ -382,7 +481,7 @@ def apply_operations(
                 id=section_id,
                 heading=op.heading,
                 level=op.level,
-                blocks=list(op.blocks),
+                blocks=[new_block(text) for text in op.blocks if text.strip()],
             )
             if op.after_section_id is None:
                 new_doc.sections.append(new_section)
@@ -411,7 +510,7 @@ def apply_operations(
             if section is None:
                 skip(op, f"unknown section_id: {op.section_id}")
                 continue
-            section.blocks = list(op.blocks)
+            section.blocks = [new_block(text) for text in op.blocks if text.strip()]
             applied.append(_op_summary(op))
             continue
 

--- a/hindsight-api-slim/hindsight_api/engine/reflect/models.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/models.py
@@ -6,6 +6,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
+from .structured_doc import StructuredDocument
+
 
 class ObservationSection(BaseModel):
     """A section within an observation with its supporting memories."""
@@ -110,6 +112,13 @@ class ReflectAgentResult(BaseModel):
     """Result from the reflect agent."""
 
     text: str = Field(description="Final answer text")
+    document: StructuredDocument | None = Field(
+        default=None,
+        description=(
+            "The structured document the agent emitted, when it was asked for one. "
+            "``text`` is its deterministic render — the model never wrote that markdown."
+        ),
+    )
     structured_output: dict[str, Any] | None = Field(
         default=None, description="Structured output parsed according to provided response_schema"
     )

--- a/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
@@ -848,10 +848,11 @@ STRUCTURED_DELTA_SYSTEM_PROMPT = """You are integrating *new information* into a
 You will be given:
 1. TOPIC — the question this document answers. Content that does not help
    answer this question is OFF-TOPIC and should be removed.
-2. CURRENT DOCUMENT (JSON) — the existing structured mental model. Each section
-   has a stable ``id``, a ``heading``, a ``level`` (1..6), and an ordered list
-   of ``blocks``. Blocks are typed: ``paragraph``, ``bullet_list``,
-   ``ordered_list``, ``code``, or ``table``.
+2. CURRENT DOCUMENT (JSON) — the existing structured mental model. It is a list
+   of sections; each section has a stable ``id``, a ``heading``, a ``level``
+   (1..6) and an ordered list of ``blocks``. Each block has a stable ``id`` and
+   a ``text`` field holding one markdown fragment — a paragraph, a list, a
+   table, or a fenced code block.
 3. NEW INFORMATION SYNTHESIS (markdown) — a synthesis showing how the new facts
    relate to the document's topic. Use it to understand context and relevance,
    but do NOT copy its formatting or wording wholesale.
@@ -880,9 +881,11 @@ RULES
   and illustrative ✅/❌ comparisons are MORE valuable than abstract rules.
   When facts contain examples, include them. Never drop an example to make
   room for an abstract restatement of the same point.
-- Operations target sections by ``section_id`` (use the ``id`` field of the
-  section in CURRENT DOCUMENT, NOT the heading). Block operations target
-  blocks by ``index`` (0-based, against the section's current block list).
+- Operations target sections by ``section_id`` and blocks by ``block_id``. Both
+  are the ``id`` values printed in CURRENT DOCUMENT — **copy them exactly**,
+  never invent one, never use a heading in place of an id, and never guess an
+  id for a block you cannot see. An operation naming an id that does not exist
+  is dropped, and its content never reaches the document.
 - **Add** new content with ``append_block``, ``insert_block``, or ``add_section``
   when facts introduce information not yet covered. Prefer extending an
   existing section over creating a new one.
@@ -891,6 +894,10 @@ RULES
   about topics already in the document.
 - **Remove** content with ``remove_block`` or ``remove_section`` ONLY when
   the new facts explicitly contradict or supersede it.
+- Prefer the *smallest* operation that expresses the change: appending or
+  replacing one block leaves every other block byte-identical, while
+  ``replace_section_blocks`` makes you retype the whole section and risks
+  losing detail you did not intend to change.
 - NEVER emit operations whose only effect is to reword unchanged content.
 - NEVER emit operations to "normalize" formatting (numbered → bulleted, casing
   changes, paragraph → list, etc).
@@ -899,46 +906,52 @@ RULES
   in the document (e.g., from a concurrent update).
 
 ALLOWED OPERATIONS (each line shows the JSON shape)
-- ``{"op": "append_block", "section_id": "...", "block": {...}}``
-- ``{"op": "insert_block", "section_id": "...", "index": N, "block": {...}}``
-- ``{"op": "replace_block", "section_id": "...", "index": N, "block": {...}}``
-- ``{"op": "remove_block", "section_id": "...", "index": N}``
-- ``{"op": "add_section", "heading": "...", "level": 2, "blocks": [...], "after_section_id": "..."}``
+- ``{"op": "append_block", "section_id": "...", "text": "..."}``
+- ``{"op": "insert_block", "section_id": "...", "after_block_id": "...", "text": "..."}``
+- ``{"op": "replace_block", "section_id": "...", "block_id": "...", "text": "..."}``
+- ``{"op": "remove_block", "section_id": "...", "block_id": "..."}``
+- ``{"op": "add_section", "heading": "...", "level": 2, "blocks": ["...", "..."], "after_section_id": "..."}``
 - ``{"op": "remove_section", "section_id": "..."}``
-- ``{"op": "replace_section_blocks", "section_id": "...", "blocks": [...]}``
+- ``{"op": "replace_section_blocks", "section_id": "...", "blocks": ["...", "..."]}``
 - ``{"op": "rename_section", "section_id": "...", "new_heading": "..."}``
 
-Block shapes
-- ``{"type": "paragraph", "text": "..."}``
-- ``{"type": "bullet_list", "items": ["...", "..."]}``
-- ``{"type": "ordered_list", "items": ["...", "..."]}``
-- ``{"type": "code", "language": "json", "text": "..."}``
-- ``{"type": "table", "headers": ["col1", "col2"], "rows": [["a", "b"], ["c", "d"]]}``
+BLOCK TEXT RULES
+- Every ``text`` (and every entry of ``blocks``) is ONE markdown fragment:
+  a single paragraph, a single list, a single table, or a single fenced code
+  block. Do not put two paragraphs in one block — emit two operations, or pass
+  two entries in ``blocks``.
+- Write real markdown inside it, with real line breaks encoded as ``\\n``:
+  a list is ``"- one\\n- two"``, a table is
+  ``"| col | col |\\n| --- | --- |\\n| a | b |"``. A table whose rows are not
+  separated by ``\\n`` is not a table.
+- To add a row to an existing table, or an item to an existing list, use
+  ``replace_block`` on that block and re-emit it *with* the addition. A lone
+  table row or bullet appended as its own block is a separate fragment, and a
+  table row on its own is not a table.
+- ``insert_block`` places the new block directly after ``after_block_id``; use
+  ``"after_block_id": null`` to place it first in the section.
 
-OUTPUT FORMAT
-Return ONLY a single JSON object on its own, with no prose before or after,
-no markdown code fences, no commentary. The object must have exactly one
-top-level key, ``operations``, whose value is an array of operation objects
-(empty array when nothing changes).
+JSON STRING RULES (critical)
+- Every string must be valid JSON: escape ``"`` as ``\\"``, backslashes as
+  ``\\\\``, and every line break as ``\\n``. Never put a raw newline inside a
+  JSON string.
+- Return ONLY a single JSON object, with no prose before or after, no markdown
+  code fences, no commentary. The object must have exactly one top-level key,
+  ``operations``, whose value is an array of operation objects (empty array
+  when nothing changes).
+- Do not append extra ``]`` or ``}`` after the closing ``}`` of the root object.
 
 Examples
 - No changes needed → ``{"operations": []}``
-- Add one bullet to an existing "Members" section →
+- Add one bullet list to an existing "Members" section →
   ``{"operations": [{"op": "append_block", "section_id": "members",
-  "block": {"type": "bullet_list", "items": ["Carol — junior engineer"]}}]}``
-- Replace a paragraph that has been corrected by new facts →
+  "text": "- Carol — junior engineer"}]}``
+- Replace a paragraph that new facts have corrected →
   ``{"operations": [{"op": "replace_block", "section_id": "overview",
-  "index": 0, "block": {"type": "paragraph", "text": "Updated summary."}}]}``
+  "block_id": "b3f9a1c2", "text": "Updated summary."}]}``
 - Remove an obsolete block →
-  ``{"operations": [{"op": "remove_block", "section_id": "status", "index": 2}]}``
-
-JSON STRING RULES (critical)
-- Every ``text`` and ``items`` string must be valid JSON: escape ``"`` as ``\\"``,
-  backslashes as ``\\\\``, and newlines as ``\\n``. Do not use raw backticks inside
-  strings unless needed; prefer plain quotes for file paths.
-- ``replace_block``, ``insert_block``, and ``remove_block`` MUST include ``index`` (0-based block position in that section). Use ``replace_section_blocks`` only when replacing every block in a section.
-
-- Do not append extra ``]`` or ``}`` after the closing ``}`` of the root object."""
+  ``{"operations": [{"op": "remove_block", "section_id": "status",
+  "block_id": "b17c4d80"}]}``"""
 
 _STRUCTURED_DELTA_DEFAULT_MAX_INPUT_TOKENS = 24_000
 
@@ -970,7 +983,7 @@ def _fit_structured_delta_prompt_parts(
 
     fixed = (
         f"## Topic\n{source_query}\n\n"
-        f"## CURRENT DOCUMENT (apply ops to this; reference section ids as listed)\n"
+        f"## CURRENT DOCUMENT (apply ops to this; copy section and block ids from it verbatim)\n"
         f"```json\n\n```\n\n"
         f"## NEW INFORMATION SYNTHESIS (context for how new facts relate to the topic)\n"
         f"```markdown\n\n```\n\n"
@@ -1024,9 +1037,9 @@ def build_structured_delta_prompt(
         budget_hint = (
             f"\n\n## Output budget\n"
             f"Your JSON response must fit within ~{max_output_tokens} tokens. If you "
-            "would need more than this to express every change, prefer the highest-"
-            "leverage edits first (a few ``replace_section_blocks`` ops over many "
-            "block-level ops) so the response always parses as valid JSON."
+            "would need more than this to express every change, emit the highest-"
+            "leverage edits first and drop the rest — a truncated response parses as "
+            "nothing and loses every change, while a short one keeps the ones you sent."
         )
 
     task_footer = (
@@ -1054,7 +1067,7 @@ def build_structured_delta_prompt(
 
     return (
         f"## Topic\n{source_query}\n\n"
-        f"## CURRENT DOCUMENT (apply ops to this; reference section ids as listed)\n"
+        f"## CURRENT DOCUMENT (apply ops to this; copy section and block ids from it verbatim)\n"
         f"```json\n{doc_json}\n```\n\n"
         f"## NEW INFORMATION SYNTHESIS (context for how new facts relate to the topic)\n"
         f"```markdown\n{candidate}\n```\n\n"

--- a/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
@@ -413,6 +413,14 @@ def build_system_prompt_for_tools(
                 "- 'blocks' holds the section's content, ONE block per paragraph, list, table or code fence",
                 "- Never put two paragraphs in one block, and never put a heading inside a block",
                 "- Inside a block, write list items and table rows on their own lines as usual",
+                # Stating the structure is a more clerical task than writing prose, and a
+                # model doing clerical work gets terse: measured against the markdown
+                # answer it replaced, the first version of this produced noticeably
+                # shorter documents that judges liked less. Say plainly that the
+                # structure is the shape, not a budget.
+                "- The structure is how the answer is laid out, NOT a reason to say less: give each "
+                "block the same specifics, numbers, names and examples you would write in prose",
+                "- Prefer a section with several blocks over one block that summarises them away",
                 *common_output_rules,
             ]
         )

--- a/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
@@ -1042,6 +1042,8 @@ def build_structured_delta_prompt(
     source_query: str,
     max_output_tokens: int | None = None,
     max_input_tokens: int | None = None,
+    document_tokens: int | None = None,
+    document_budget: int | None = None,
 ) -> str:
     """Build the user prompt for a structured-delta mental model refresh.
 
@@ -1071,6 +1073,34 @@ def build_structured_delta_prompt(
             "leverage edits first and drop the rest — a truncated response parses as "
             "nothing and loses every change, while a short one keeps the ones you sent."
         )
+
+    # The *document's* budget, which is a different thing from the response budget
+    # above and was previously not mentioned to this call at all. A delta refresh
+    # only ever adds, so a long-lived page grows a little on every round and
+    # crosses its configured budget after a few hundred of them with nothing in
+    # the pipeline noticing. Enforcing it by truncation would delete knowledge
+    # nobody asked to delete, so it is stated as a constraint the model satisfies
+    # the same way it does everything else here — with operations, on the content
+    # that has actually gone stale.
+    document_hint = ""
+    if document_budget is not None and document_tokens is not None:
+        if document_tokens >= document_budget:
+            document_hint = (
+                f"\n\n## Document budget (EXCEEDED)\n"
+                f"The document is ~{document_tokens} tokens against a budget of {document_budget}. "
+                "As well as integrating the new facts, make room: remove or merge blocks that are "
+                "superseded, duplicated, or no longer help answer the TOPIC, using remove_block, "
+                "replace_block or replace_section_blocks. Reclaim space from stale content — never "
+                "by dropping the facts you are integrating, and never by summarising a section that "
+                "is still current into a sentence."
+            )
+        elif document_tokens >= int(document_budget * 0.8):
+            document_hint = (
+                f"\n\n## Document budget\n"
+                f"The document is ~{document_tokens} tokens against a budget of {document_budget}. "
+                "It is close to the limit, so prefer replacing stale blocks over appending new ones "
+                "where the new facts update something the document already covers."
+            )
 
     task_footer = (
         "## Task\n"
@@ -1102,7 +1132,7 @@ def build_structured_delta_prompt(
         f"## NEW INFORMATION SYNTHESIS (context for how new facts relate to the topic)\n"
         f"```markdown\n{candidate}\n```\n\n"
         f"## SUPPORTING FACTS (new since last refresh — integrate these)\n{facts_body}"
-        f"{budget_hint}{truncation_note}\n\n"
+        f"{document_hint}{budget_hint}{truncation_note}\n\n"
         f"{task_footer}"
     )
 

--- a/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
@@ -1143,8 +1143,8 @@ You will be given:
 1. TOPIC — the question this document answers.
 2. CURRENT DOCUMENT (JSON) — the existing document. Each section has a stable
    ``id``, a ``heading``, a ``level`` (1..6), and an ordered list of ``blocks``.
-   Blocks are typed: ``paragraph``, ``bullet_list``, ``ordered_list``, ``code``,
-   or ``table``.
+   Each block has a stable ``id`` and a ``text`` field holding one markdown
+   fragment — a paragraph, a list, a table, or a fenced code block.
 3. RETRACTED FACTS — facts this document was built from that have since been
    removed from the memory bank. They are no longer true, no longer supported,
    or were withdrawn. The document may still state them.
@@ -1179,21 +1179,19 @@ RULES
   facts. That is a normal, expected answer.
 
 ALLOWED OPERATIONS (each line shows the JSON shape)
-- ``{"op": "remove_block", "section_id": "...", "index": N}``
+- ``{"op": "remove_block", "section_id": "...", "block_id": "..."}``
 - ``{"op": "remove_section", "section_id": "..."}``
-- ``{"op": "replace_block", "section_id": "...", "index": N, "block": {...}}``
-- ``{"op": "replace_section_blocks", "section_id": "...", "blocks": [...]}``
+- ``{"op": "replace_block", "section_id": "...", "block_id": "...", "text": "..."}``
+- ``{"op": "replace_section_blocks", "section_id": "...", "blocks": ["...", "..."]}``
 
-Block shapes
-- ``{"type": "paragraph", "text": "..."}``
-- ``{"type": "bullet_list", "items": ["...", "..."]}``
-- ``{"type": "ordered_list", "items": ["...", "..."]}``
-- ``{"type": "code", "language": "json", "text": "..."}``
-- ``{"type": "table", "headers": ["col1", "col2"], "rows": [["a", "b"], ["c", "d"]]}``
+Blocks are addressed by ``block_id`` — the ``id`` printed beside each block in
+CURRENT DOCUMENT. Copy it exactly; never invent one, and never use a position.
+An operation naming an id that does not exist is dropped, so a retraction that
+guesses removes nothing.
 
-IMPORTANT: ``remove_block`` operations are applied in the order you emit them, and
-each one shifts the indices of every later block in that section. When removing
-several blocks from the same section, emit them in DESCENDING index order.
+Every ``text`` (and every entry of ``blocks``) is ONE markdown fragment, written
+as it should appear: ``"- one\\n- two"`` for a list,
+``"| col | col |\\n| --- | --- |\\n| a | b |"`` for a table.
 
 OUTPUT FORMAT
 Return ONLY a single JSON object, with no prose before or after, no markdown code
@@ -1202,8 +1200,9 @@ fences, no commentary. The object must have exactly one top-level key,
 nothing changes).
 
 JSON STRING RULES (critical)
-- Every ``text`` and ``items`` string must be valid JSON: escape ``"`` as ``\\"``,
-  backslashes as ``\\\\``, and newlines as ``\\n``.
+- Every string must be valid JSON: escape ``"`` as ``\\"``, backslashes as
+  ``\\\\``, and every line break as ``\\n``. Never put a raw newline inside a
+  JSON string.
 - Do not append extra ``]`` or ``}`` after the closing ``}`` of the root object."""
 
 

--- a/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
@@ -115,6 +115,7 @@ def build_system_prompt_for_tools(
     has_mental_models: bool = False,
     include_observations: bool = True,
     budget: str | None = None,
+    answer_as_document: bool = False,
 ) -> str:
     """
     Build the system prompt for tool-calling reflect agent.
@@ -393,19 +394,40 @@ def build_system_prompt_for_tools(
     steps.append("When ready, call done() with your answer and supporting IDs")
     parts.extend(f"{idx}. {step}" for idx, step in enumerate(steps, 1))
 
-    parts.extend(
-        [
-            "",
-            "## Output Format: Well-Formatted Markdown Answer",
-            "Call done() with a well-formatted markdown 'answer' field.",
-            "- USE markdown formatting for structure (headers, lists, bold, italic, code blocks, tables, etc.)",
-            "- CRITICAL: Add blank lines before and after block elements (tables, code blocks, lists)",
-            "- Format for clarity and readability with proper spacing and hierarchy",
-            "- NEVER include memory IDs, UUIDs, or 'Memory references' in the answer text",
-            "- Put IDs ONLY in the memory_ids/mental_model_ids/observation_ids arrays, not in the answer",
-            "- CRITICAL: This is a NON-CONVERSATIONAL system. NEVER ask follow-up questions, offer further assistance, or suggest next steps. Your answer must be complete and self-contained. The user cannot reply.",
-        ]
-    )
+    common_output_rules = [
+        "- NEVER include memory IDs, UUIDs, or 'Memory references' in the answer text",
+        "- Put IDs ONLY in the memory_ids/mental_model_ids/observation_ids arrays, not in the answer",
+        "- CRITICAL: This is a NON-CONVERSATIONAL system. NEVER ask follow-up questions, offer further assistance, or suggest next steps. Your answer must be complete and self-contained. The user cannot reply.",
+    ]
+    if answer_as_document:
+        # The document is stored as structure and the markdown is rendered from
+        # it, so asking for "a markdown answer" here would be asking for the one
+        # thing the caller does not want (see tools_schema's document tool).
+        parts.extend(
+            [
+                "",
+                "## Output Format: Structured Document",
+                "Call done() with a 'document' field. Do NOT write a markdown document — "
+                "state its structure and the markdown is generated from it.",
+                "- Each section carries its heading text (no '#') and a level; the heading is NOT a block",
+                "- 'blocks' holds the section's content, ONE block per paragraph, list, table or code fence",
+                "- Never put two paragraphs in one block, and never put a heading inside a block",
+                "- Inside a block, write list items and table rows on their own lines as usual",
+                *common_output_rules,
+            ]
+        )
+    else:
+        parts.extend(
+            [
+                "",
+                "## Output Format: Well-Formatted Markdown Answer",
+                "Call done() with a well-formatted markdown 'answer' field.",
+                "- USE markdown formatting for structure (headers, lists, bold, italic, code blocks, tables, etc.)",
+                "- CRITICAL: Add blank lines before and after block elements (tables, code blocks, lists)",
+                "- Format for clarity and readability with proper spacing and hierarchy",
+                *common_output_rules,
+            ]
+        )
 
     # Volatile "now" reference goes here — after all the static instructions and
     # right before the bank-specific/custom data. Everything above is identical

--- a/hindsight-api-slim/hindsight_api/engine/reflect/structured_doc.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/structured_doc.py
@@ -321,6 +321,34 @@ def split_markdown(markdown: str) -> StructuredDocument:
     return StructuredDocument(sections=sections)
 
 
+class CanonicalDocument(BaseModel):
+    """A document and the structure it renders from — the pair that must be stored together.
+
+    ``markdown`` and ``structure`` are two views of one document, and every write
+    of ``mental_models.content`` has to persist both. Storing markdown alone
+    leaves the next delta refresh to reconstruct a structure nobody reviewed;
+    storing a structure that does not render to the stored markdown is the
+    divergence that let a degraded document reach users one refresh after it was
+    created (#3361). Returning them as one value makes it hard to write one and
+    forget the other.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    markdown: str
+    structure: StructuredDocument
+
+
+def canonical_document(markdown: str) -> CanonicalDocument:
+    """Split authored markdown into a structure, and render it back.
+
+    The render is what gets stored, so ``content`` is a view of ``structure``
+    from the first byte rather than from the first refresh. The split is
+    lossless, so this only normalises whitespace *between* blocks.
+    """
+    structure = split_markdown(markdown)
+    return CanonicalDocument(markdown=render_document(structure), structure=structure)
+
+
 def structured_document_from_stored(
     stored: dict | None,
     markdown: str,

--- a/hindsight-api-slim/hindsight_api/engine/reflect/structured_doc.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/structured_doc.py
@@ -9,92 +9,100 @@ content byte-for-byte. The intrinsic mechanism of an LLM is to *generate* the
 next token from a gestalt of the input — not to copy tokens verbatim — so any
 "preserve unchanged content" instruction is fundamentally a soft constraint.
 
-The fix is to give the LLM no opportunity to drift on unchanged content. We
-keep an authoritative structured representation of the document; the markdown
-shown to users is a deterministic render of that structure. Delta refreshes
-emit *operations* against the structure (see ``delta_ops.py``); sections and
-blocks not mentioned by any operation are physically untouched.
+The fix is to give the LLM no opportunity to drift on unchanged content. The
+structured document is the *source of truth*; the markdown stored in
+``mental_models.content`` is a deterministic render of it. Delta refreshes emit
+*operations* against the structure (see ``delta_ops.py``); sections and blocks
+not mentioned by any operation are physically untouched.
 
-Schema (v1)
+Schema (v2)
 -----------
-A document is an ordered list of ``Section``s.  Each section has:
-- ``id``    : stable slug derived from ``heading`` (used as the operation
-              target across refreshes; surviving renames is a separate
-              concern handled by an explicit ``rename`` op).
-- ``heading``: the markdown heading text (without the ``#`` prefix).
-- ``level`` : 1 (``#``) … 6 (``######``).  Default 2.
-- ``blocks``: ordered list of typed blocks — paragraph, bullet_list,
-              ordered_list, code, table.
+A document is an ordered list of ``Section``s. Each section has:
 
-The schema is intentionally narrow: it covers what real mental-model documents
-actually contain (the kind a coding agent writes for itself or a user writes as
-a "skill" doc).  Images and raw HTML are out of scope until needed.
+- ``id``      : stable slug derived from ``heading``, the target of operations
+                across refreshes (renames keep the id, see ``rename_section``).
+- ``heading`` : the heading text without the ``#`` prefix. Empty for the
+                implicit leading section of a document that opens with prose.
+- ``level``   : 1 (``#``) … 6 (``######``). Default 2.
+- ``blocks``  : ordered list of ``Block``s.
+
+A ``Block`` is an id plus a **verbatim markdown fragment** — one paragraph, one
+list, one table, one fenced code block. The fragment is never interpreted: it
+is stored as written and rendered as written.
+
+Why blocks are opaque markdown rather than a typed AST
+------------------------------------------------------
+Schema v1 modelled each block as one of ``paragraph``/``bullet_list``/
+``ordered_list``/``code``/``table`` and *parsed* markdown into that union. Every
+construct the union could not express — nested lists, list-item continuation
+lines, blockquotes, hard line breaks, horizontal rules, HTML, indented code,
+table alignment, a table row missing an outer pipe — collapsed into a paragraph
+whose lines were joined with spaces. The collapse was a fixed point (re-parsing
+the damaged render reproduced it), so a page could never recover: see #3361,
+where stored tables were welded onto one line permanently.
+
+An opaque fragment cannot suffer that class of failure. Nothing parses a table,
+so nothing can flatten one. The only structure we recognise is the one delta
+operations actually address: where sections start (an ATX heading) and where
+blocks start (a blank line). Both are recoverable from the text exactly, which
+makes :func:`split_markdown` lossless — see ``tests/test_structured_doc.py``.
+
+Blocks carry an ``id`` (v1 addressed them by integer index). An index is a
+number the model has to derive by counting, and an off-by-one lands in range
+and silently overwrites an unrelated block (#3273). A wrong id does not
+resolve, so it is skipped and reported instead of applied.
 """
 
 from __future__ import annotations
 
+import hashlib
+import logging
 import re
-from typing import Annotated, Literal, Union
 
 from pydantic import BaseModel, ConfigDict, Field
+
+logger = logging.getLogger(__name__)
 
 # Blocks ---------------------------------------------------------------------
 
 
-class ParagraphBlock(BaseModel):
+class Block(BaseModel):
+    """One markdown fragment — a paragraph, a list, a table, a code fence.
+
+    ``text`` is stored exactly as authored (interior indentation, hard line
+    breaks and table pipes included) and rendered exactly as stored.
+    """
+
     model_config = ConfigDict(extra="forbid")
-    type: Literal["paragraph"] = "paragraph"
+    id: str
     text: str
-
-
-class BulletListBlock(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-    type: Literal["bullet_list"] = "bullet_list"
-    items: list[str] = Field(default_factory=list)
-
-
-class OrderedListBlock(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-    type: Literal["ordered_list"] = "ordered_list"
-    items: list[str] = Field(default_factory=list)
-
-
-class CodeBlock(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-    type: Literal["code"] = "code"
-    language: str = ""
-    text: str
-
-
-class TableBlock(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-    type: Literal["table"] = "table"
-    headers: list[str] = Field(default_factory=list)
-    rows: list[list[str]] = Field(default_factory=list)
-
-
-Block = Annotated[
-    Union[ParagraphBlock, BulletListBlock, OrderedListBlock, CodeBlock, TableBlock],
-    Field(discriminator="type"),
-]
-
-
-# Section / Document ---------------------------------------------------------
 
 
 class Section(BaseModel):
     model_config = ConfigDict(extra="forbid")
     id: str
-    heading: str
+    heading: str = ""
     level: int = Field(default=2, ge=1, le=6)
     blocks: list[Block] = Field(default_factory=list)
+
+    def block_by_id(self, block_id: str) -> Block | None:
+        for b in self.blocks:
+            if b.id == block_id:
+                return b
+        return None
+
+    def block_index(self, block_id: str) -> int | None:
+        for i, b in enumerate(self.blocks):
+            if b.id == block_id:
+                return i
+        return None
 
 
 class StructuredDocument(BaseModel):
     """Top-level structured representation of a mental model."""
 
     model_config = ConfigDict(extra="forbid")
-    version: Literal[1] = 1
+    version: int = 2
     sections: list[Section] = Field(default_factory=list)
 
     def section_by_id(self, section_id: str) -> Section | None:
@@ -109,8 +117,18 @@ class StructuredDocument(BaseModel):
                 return i
         return None
 
+    def block_ids(self) -> set[str]:
+        return {b.id for s in self.sections for b in s.blocks}
 
-# Slug helpers ---------------------------------------------------------------
+
+SCHEMA_VERSION = 2
+
+# The id given to the implicit section holding content that precedes the first
+# heading. Operations can target it like any other section.
+PREAMBLE_SECTION_ID = "preamble"
+
+
+# Id helpers -----------------------------------------------------------------
 
 _SLUG_RX = re.compile(r"[^a-z0-9]+")
 
@@ -135,260 +153,209 @@ def make_unique_id(base: str, existing: set[str]) -> str:
     return f"{base}-{i}"
 
 
+def make_block_id(text: str, existing: set[str]) -> str:
+    """Derive a short, deterministic, document-unique id for a block.
+
+    Content-derived so that splitting the same markdown twice yields the same
+    document (tests and the legacy-import path depend on that), and short
+    enough that a model can copy one into an operation without slipping a
+    character. Ids are *persisted*: once assigned, a block keeps its id even
+    when its text is replaced, so ids never shift under an edit the way an
+    index does.
+    """
+    digest = hashlib.sha1(text.encode("utf-8"), usedforsecurity=False).hexdigest()[:8]
+    return make_unique_id(f"b{digest}", existing)
+
+
 # Renderer -------------------------------------------------------------------
 
 
-def render_block(block: Block) -> str:
-    """Render a single block to markdown. No trailing newline."""
-    if isinstance(block, ParagraphBlock):
-        return block.text.rstrip()
-    if isinstance(block, BulletListBlock):
-        return "\n".join(f"- {item.rstrip()}" for item in block.items)
-    if isinstance(block, OrderedListBlock):
-        return "\n".join(f"{i + 1}. {item.rstrip()}" for i, item in enumerate(block.items))
-    if isinstance(block, CodeBlock):
-        fence_lang = block.language or ""
-        return f"```{fence_lang}\n{block.text}\n```"
-    if isinstance(block, TableBlock):
-        # Width is the widest row, not just the header: a row with more cells
-        # than there are headers would otherwise render cells that GFM drops.
-        width = max(len(block.headers), *(len(row) for row in block.rows), 0)
-        if width == 0:
-            return ""
-        lines = [_render_table_row(block.headers, width)]
-        lines.append("| " + " | ".join("---" for _ in range(width)) + " |")
-        lines.extend(_render_table_row(row, width) for row in block.rows)
-        return "\n".join(lines)
-    raise TypeError(f"Unknown block type: {type(block)!r}")
+def normalize_block_text(text: str) -> str:
+    """Trim blank lines around a fragment without touching its interior.
 
-
-def _escape_table_cell(cell: str) -> str:
-    """Escape a cell so it survives a markdown table round-trip.
-
-    An unescaped ``|`` would start a new column and a newline would start a new
-    row, so both are neutralised: pipes are backslash-escaped (the GFM
-    convention, undone again by :func:`_parse_table_row`) and newlines collapse
-    to a space, since a table cell is a single line by construction.
+    Leading/trailing *blank* lines are separators, not content, and the
+    renderer re-inserts them. Everything inside survives byte-for-byte:
+    ``rstrip()`` here would eat the two trailing spaces that make a markdown
+    hard line break, and ``strip()`` would eat the four-space indent of an
+    indented code block.
     """
-    escaped = cell.replace("\\", "\\\\").replace("|", "\\|")
-    return " ".join(escaped.splitlines()).strip()
-
-
-def _render_table_row(cells: list[str], width: int) -> str:
-    """Render one table row, padded with empty cells to ``width`` columns."""
-    rendered = [_escape_table_cell(cell) for cell in cells]
-    rendered.extend("" for _ in range(width - len(rendered)))
-    return "| " + " | ".join(rendered) + " |"
+    lines = text.split("\n")
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    while lines and not lines[-1].strip():
+        lines.pop()
+    return "\n".join(lines)
 
 
 def render_section(section: Section) -> str:
-    """Render a section: heading + blank line + blocks separated by blank lines."""
-    parts = ["#" * section.level + " " + section.heading.strip()]
-    for block in section.blocks:
-        parts.append("")  # blank line before each block
-        parts.append(render_block(block))
-    return "\n".join(parts)
+    """Render a section: heading (when it has one) then blocks, blank-line separated."""
+    parts: list[str] = []
+    heading = section.heading.strip()
+    if heading:
+        parts.append("#" * section.level + " " + heading)
+    parts.extend(block.text for block in section.blocks if block.text.strip())
+    return "\n\n".join(parts)
 
 
 def render_document(doc: StructuredDocument) -> str:
-    """Render the whole document. Sections separated by a single blank line.
+    """Render the whole document to markdown.
 
-    The output is byte-stable: same structured input always produces the same
-    markdown, modulo the inherent ordering of sections/blocks/items.
+    The output is byte-stable: the same structured input always produces the
+    same markdown, and the render survives a further split/render round trip
+    unchanged (``render(split(render(doc))) == render(doc)``).
     """
-    if not doc.sections:
-        return ""
-    return "\n\n".join(render_section(s) for s in doc.sections) + "\n"
+    rendered = [render_section(s) for s in doc.sections]
+    body = "\n\n".join(part for part in rendered if part)
+    return body + "\n" if body else ""
 
 
-# Parser ---------------------------------------------------------------------
+# Splitter -------------------------------------------------------------------
 #
-# The parser is intentionally lenient: it accepts the markdown produced by
-# our own renderer (round-trip-safe) and the markdown an LLM tends to produce
-# for mental-model documents.  It is *not* a general CommonMark parser — it
-# does not need to be.  When it cannot classify a block it falls back to a
-# paragraph so that no content is silently dropped.
+# This is the ONLY place markdown text is inspected, and it recognises exactly
+# two things: ATX headings (section boundaries) and blank lines (block
+# boundaries), neither of which is honoured inside a fenced code block. Every
+# other byte is carried through untouched. There is deliberately no notion of
+# "understanding" a table, a list or a paragraph here — see the module
+# docstring for why v1's typed parser had to go.
 
-_HEADING_RX = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
-_BULLET_RX = re.compile(r"^\s*[-*+]\s+(.*)$")
-_ORDERED_RX = re.compile(r"^\s*\d+[.)]\s+(.*)$")
-_FENCE_RX = re.compile(r"^```([A-Za-z0-9_+-]*)\s*$")
-_SEPARATOR_RX = re.compile(r"\s*([-*_])\1{2,}\s*")
-_TABLE_ROW_RX = re.compile(r"^\s*\|.*\|\s*$")
-_TABLE_SEPARATOR_RX = re.compile(r"^\s*\|?[\s:]*-{2,}[\s:|-]*\|?\s*$")
+_HEADING_RX = re.compile(r"^(#{1,6})\s+(.*\S)\s*$")
+_FENCE_RX = re.compile(r"^\s*(```+|~~~+)")
 
 
-def _split_blocks(lines: list[str]) -> list[list[str]]:
-    """Group consecutive non-blank lines into block chunks.
-
-    Horizontal-rule lines (`---`, `***`) count as blank.  Our renderer never
-    emits these, but LLM output frequently includes them between sections;
-    treating them as blank avoids parsing them as paragraphs.  Inside a fence
-    they are code, not a separator, so they are kept verbatim.
-    """
-    chunks: list[list[str]] = []
+def _split_into_blocks(lines: list[str], existing_ids: set[str]) -> list[Block]:
+    """Group lines into blocks on blank lines, ignoring blanks inside fences."""
+    blocks: list[Block] = []
     current: list[str] = []
-    in_fence = False
+    fence: str | None = None
+
+    def flush() -> None:
+        text = normalize_block_text("\n".join(current))
+        current.clear()
+        if not text.strip():
+            return
+        block_id = make_block_id(text, existing_ids)
+        existing_ids.add(block_id)
+        blocks.append(Block(id=block_id, text=text))
+
     for line in lines:
-        if _FENCE_RX.match(line):
+        fence_match = _FENCE_RX.match(line)
+        if fence_match:
+            marker = fence_match.group(1)[:3]
+            if fence is None:
+                fence = marker
+            elif marker == fence:
+                fence = None
             current.append(line)
-            in_fence = not in_fence
             continue
-        if in_fence:
-            current.append(line)
+        if fence is None and not line.strip():
+            flush()
             continue
-        if line.strip() == "" or _SEPARATOR_RX.fullmatch(line):
-            if current:
-                chunks.append(current)
-                current = []
-        else:
-            current.append(line)
-    if current:
-        chunks.append(current)
-    return chunks
+        current.append(line)
+    flush()
+    return blocks
 
 
-def _parse_table_row(line: str) -> list[str]:
-    """Split a ``| a | b |`` line into cells, honouring backslash escapes.
+def split_markdown(markdown: str) -> StructuredDocument:
+    """Split markdown into sections and blocks, losslessly.
 
-    Splitting on every ``|`` would tear a cell whose text contains an escaped
-    pipe (``\\|``, what :func:`_escape_table_cell` emits) into two columns, so
-    the line is scanned instead: ``\\|`` and ``\\\\`` unescape to ``|`` and
-    ``\\``, and any other backslash sequence is left verbatim so hand-written
-    content such as ``C:\\path`` survives.
-    """
-    cells: list[str] = []
-    buf: list[str] = []
-    escaped = False
-    for ch in line.strip():
-        if escaped:
-            buf.append(ch if ch in "|\\" else "\\" + ch)
-            escaped = False
-        elif ch == "\\":
-            escaped = True
-        elif ch == "|":
-            cells.append("".join(buf))
-            buf = []
-        else:
-            buf.append(ch)
-    if escaped:
-        buf.append("\\")
-    cells.append("".join(buf))
+    Content that precedes the first heading becomes a leading section with an
+    empty ``heading`` (it renders as bare blocks, so nothing is invented).
+    Section ids are unique slugs of their headings.
 
-    # The leading and trailing pipes of a fully-delimited row produce an empty
-    # cell on each end that is punctuation, not content.
-    if cells and cells[0] == "":
-        cells = cells[1:]
-    if cells and cells[-1] == "":
-        cells = cells[:-1]
-    return [cell.strip() for cell in cells]
-
-
-def _parse_table_block(chunk: list[str]) -> TableBlock:
-    """Parse table lines into a :class:`TableBlock`.
-
-    ``_parse_block`` only routes here when the chunk contains a separator line,
-    so the separator is what splits headers from data. Rows above it other than
-    the first (malformed input: GFM allows exactly one header row) are kept as
-    data rather than dropped — the parser never silently loses content.
-    """
-    rows_raw = [_parse_table_row(line) for line in chunk]
-    separator_idx = next(i for i, line in enumerate(chunk) if _TABLE_SEPARATOR_RX.match(line))
-    if separator_idx == 0:
-        return TableBlock(headers=[], rows=rows_raw[1:])
-    return TableBlock(
-        headers=rows_raw[0],
-        rows=rows_raw[1:separator_idx] + rows_raw[separator_idx + 1 :],
-    )
-
-
-def _parse_block(chunk: list[str]) -> Block:
-    """Parse a single non-empty chunk into a block."""
-    if chunk and _FENCE_RX.match(chunk[0]):
-        m = _FENCE_RX.match(chunk[0])
-        lang = m.group(1) if m else ""
-        body_lines = chunk[1:]
-        if body_lines and _FENCE_RX.match(body_lines[-1]):
-            body_lines = body_lines[:-1]
-        return CodeBlock(language=lang, text="\n".join(body_lines))
-
-    if all(_BULLET_RX.match(line) for line in chunk):
-        items = []
-        for line in chunk:
-            m = _BULLET_RX.match(line)
-            assert m is not None
-            items.append(m.group(1).strip())
-        return BulletListBlock(items=items)
-
-    if all(_ORDERED_RX.match(line) for line in chunk):
-        items = []
-        for line in chunk:
-            m = _ORDERED_RX.match(line)
-            assert m is not None
-            items.append(m.group(1).strip())
-        return OrderedListBlock(items=items)
-
-    if len(chunk) >= 2 and all(_TABLE_ROW_RX.match(line) for line in chunk):
-        has_separator = any(_TABLE_SEPARATOR_RX.match(line) for line in chunk)
-        if has_separator:
-            return _parse_table_block(chunk)
-
-    return ParagraphBlock(text=" ".join(line.strip() for line in chunk).strip())
-
-
-def parse_markdown(markdown: str) -> StructuredDocument:
-    """Best-effort parse of a markdown document into the structured schema.
-
-    Sections are introduced by ATX headings (``#``..``######``).  Anything
-    before the first heading is wrapped into an implicit "Overview" section
-    so we never silently drop user content.  Section IDs are unique slugs of
-    their headings.
+    "Losslessly" means every non-blank line comes back verbatim, in order.
+    Rendering the result normalises only whitespace *between* blocks: runs of
+    blank lines collapse to one, and a heading line loses its surrounding
+    padding. Nothing is reordered, joined, retyped or dropped.
     """
     lines = (markdown or "").splitlines()
 
     sections: list[Section] = []
     used_ids: set[str] = set()
+    block_ids: set[str] = set()
     pending: list[str] = []
     current: Section | None = None
+    fence: str | None = None
 
-    def flush_pending_into(section: Section) -> None:
-        if not pending:
-            return
-        for chunk in _split_blocks(pending):
-            section.blocks.append(_parse_block(chunk))
+    def close(section: Section) -> None:
+        section.blocks.extend(_split_into_blocks(pending, block_ids))
         pending.clear()
+        sections.append(section)
 
     for line in lines:
-        m = _HEADING_RX.match(line)
-        if m:
-            if current is not None:
-                flush_pending_into(current)
-                sections.append(current)
-            elif pending:
-                # Content before the first heading: wrap in implicit section.
-                base = "overview"
-                section_id = make_unique_id(base, used_ids)
-                used_ids.add(section_id)
-                implicit = Section(id=section_id, heading="Overview", level=2)
-                flush_pending_into(implicit)
-                sections.append(implicit)
-            level = len(m.group(1))
-            heading = m.group(2).strip()
-            section_id = make_unique_id(slugify_heading(heading), used_ids)
-            used_ids.add(section_id)
-            current = Section(id=section_id, heading=heading, level=level)
-        else:
+        fence_match = _FENCE_RX.match(line)
+        if fence_match:
+            marker = fence_match.group(1)[:3]
+            if fence is None:
+                fence = marker
+            elif marker == fence:
+                fence = None
             pending.append(line)
+            continue
+
+        heading_match = None if fence is not None else _HEADING_RX.match(line)
+        if heading_match is None:
+            pending.append(line)
+            continue
+
+        if current is not None:
+            close(current)
+        elif any(pending_line.strip() for pending_line in pending):
+            preamble_id = make_unique_id(PREAMBLE_SECTION_ID, used_ids)
+            used_ids.add(preamble_id)
+            close(Section(id=preamble_id, heading="", level=2))
+        else:
+            pending.clear()
+
+        heading = heading_match.group(2).strip()
+        section_id = make_unique_id(slugify_heading(heading), used_ids)
+        used_ids.add(section_id)
+        current = Section(id=section_id, heading=heading, level=len(heading_match.group(1)))
 
     if current is not None:
-        flush_pending_into(current)
-        sections.append(current)
-    elif pending:
-        base = "overview"
-        section_id = make_unique_id(base, used_ids)
-        used_ids.add(section_id)
-        implicit = Section(id=section_id, heading="Overview", level=2)
-        flush_pending_into(implicit)
-        sections.append(implicit)
+        close(current)
+    elif any(pending_line.strip() for pending_line in pending):
+        preamble_id = make_unique_id(PREAMBLE_SECTION_ID, used_ids)
+        used_ids.add(preamble_id)
+        close(Section(id=preamble_id, heading="", level=2))
 
     return StructuredDocument(sections=sections)
+
+
+def structured_document_from_stored(
+    stored: dict | None,
+    markdown: str,
+) -> StructuredDocument:
+    """Load the delta baseline: the stored structure, or the markdown it renders to.
+
+    The stored JSON is authoritative when it validates against the current
+    schema. Anything else is rebuilt from ``markdown`` by :func:`split_markdown`
+    — a lossless import, after which the JSON is the source of truth and the
+    markdown is its render.
+
+    Falling back is the *normal* path for a model that has one, not just a
+    legacy escape hatch: a mental model created with markdown ``content``, or
+    restored from an export, has no structure until its first delta refresh.
+
+    It is also how a schema v1 document is handled. v1 blobs are deliberately
+    not upgraded field-by-field — its typed blocks were parsed out of this same
+    markdown and lost anything the block union could not express (#3361), so the
+    markdown is strictly the better source. Migration ``d1e2f3a4b5c6`` clears
+    them, so after an upgrade a non-v2 blob should only appear while old and new
+    API versions are running side by side; it is logged rather than passed over
+    silently so a persistent one is visible.
+    """
+    if isinstance(stored, dict) and stored:
+        if stored.get("version") != SCHEMA_VERSION:
+            logger.info(
+                f"[STRUCTURED_DOC] stored structure is schema version {stored.get('version')!r}, "
+                f"not {SCHEMA_VERSION}; importing the baseline from the stored markdown instead"
+            )
+        else:
+            try:
+                return StructuredDocument.model_validate(stored)
+            except Exception as exc:  # noqa: BLE001 — any invalid shape falls back to the markdown
+                logger.warning(
+                    f"[STRUCTURED_DOC] stored structure failed validation ({exc}); "
+                    "rebuilding the baseline from the stored markdown"
+                )
+    return split_markdown(markdown)

--- a/hindsight-api-slim/hindsight_api/engine/reflect/structured_doc.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/structured_doc.py
@@ -321,6 +321,56 @@ def split_markdown(markdown: str) -> StructuredDocument:
     return StructuredDocument(sections=sections)
 
 
+def document_from_sections(payload: dict) -> StructuredDocument:
+    """Build a document from the ``done`` tool's emitted sections.
+
+    This is the generation path: the model states the document's structure and
+    the markdown it renders to is derived, so no markdown the model wrote is
+    ever read back to work out what it meant. Ids are assigned here — the model
+    is never asked for one, since a generated document has no prior ids to echo.
+
+    Tolerant by design, because a tool call is still model output: a missing
+    heading, an out-of-range level or a non-string block is coerced rather than
+    rejected. A block holding several blank-line-separated fragments is split
+    into one block each, so the document keeps the granularity delta operations
+    address even when the model packs a whole section into one string.
+    """
+    sections: list[Section] = []
+    used_ids: set[str] = set()
+    block_ids: set[str] = set()
+
+    for raw_section in payload.get("sections") or []:
+        if not isinstance(raw_section, dict):
+            continue
+        heading = str(raw_section.get("heading") or "").strip().lstrip("#").strip()
+        try:
+            level = int(raw_section.get("level") or 2)
+        except (TypeError, ValueError):
+            level = 2
+        level = min(6, max(1, level))
+
+        lines: list[str] = []
+        for raw_block in raw_section.get("blocks") or []:
+            if raw_block is None:
+                continue
+            text = normalize_block_text(str(raw_block))
+            if not text.strip():
+                continue
+            if lines:
+                lines.append("")
+            lines.extend(text.split("\n"))
+
+        blocks = _split_into_blocks(lines, block_ids)
+        if not heading and not blocks:
+            continue
+        base_id = slugify_heading(heading) if heading else PREAMBLE_SECTION_ID
+        section_id = make_unique_id(base_id, used_ids)
+        used_ids.add(section_id)
+        sections.append(Section(id=section_id, heading=heading, level=level, blocks=blocks))
+
+    return StructuredDocument(sections=sections)
+
+
 class CanonicalDocument(BaseModel):
     """A document and the structure it renders from — the pair that must be stored together.
 

--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools_schema.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools_schema.py
@@ -8,6 +8,8 @@ The reflect agent uses a hierarchical retrieval strategy:
 3. recall - Raw facts (world/experience) as ground truth fallback
 """
 
+import copy
+
 # Tool definitions in OpenAI format
 
 TOOL_SEARCH_MENTAL_MODELS = {
@@ -168,6 +170,78 @@ TOOL_DONE_ANSWER = {
 }
 
 
+# Document mode: the answer IS the stored document, so the model emits its
+# structure and the markdown is rendered from it. Nothing the model writes is
+# ever parsed back into structure, which is the whole point — a document that is
+# generated as markdown and read back is a document that can be misread, and was
+# (#3361). See ``structured_doc`` for the schema this mirrors.
+#
+# Deliberately flat: an array of sections, each an array of block strings. No
+# union types, no ``oneOf`` — a tool schema goes to the provider verbatim and not
+# every provider accepts a discriminated union (Gemini rejects ``oneOf``), and a
+# shape the model can fill without thinking is a shape it fills correctly.
+_DONE_DOCUMENT_PROPERTY = {
+    "type": "object",
+    "description": (
+        "Your response as a structured document. The markdown the user reads is rendered "
+        "from this — do NOT write a markdown document yourself."
+    ),
+    "properties": {
+        "sections": {
+            "type": "array",
+            "description": "The document's sections, in order.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "heading": {
+                        "type": "string",
+                        "description": (
+                            "Heading text WITHOUT any leading '#'. Empty string for an "
+                            "opening section that should render with no heading."
+                        ),
+                    },
+                    "level": {
+                        "type": "integer",
+                        "description": "Heading level, 1-6. Use 2 unless the document needs deeper nesting.",
+                    },
+                    "blocks": {
+                        "type": "array",
+                        "description": (
+                            "The section's content, one entry per block: a single paragraph, a single "
+                            "list, a single table, or a single fenced code block. Never put two "
+                            "paragraphs in one entry, and never put a heading in one — headings are the "
+                            "'heading' field. Within an entry, write the content as you would in a "
+                            "document: '- one\n- two' for a list, "
+                            "'| a | b |\n| --- | --- |\n| 1 | 2 |' for a table."
+                        ),
+                        "items": {"type": "string"},
+                    },
+                },
+                "required": ["heading", "level", "blocks"],
+            },
+        }
+    },
+    "required": ["sections"],
+}
+
+
+def _done_tool_for_document(base: dict) -> dict:
+    """Swap a done tool's free-text ``answer`` for a structured ``document``."""
+    tool = copy.deepcopy(base)
+    params = tool["function"]["parameters"]
+    params["properties"].pop("answer", None)
+    params["properties"]["document"] = _DONE_DOCUMENT_PROPERTY
+    params["required"] = ["document"] + [name for name in params.get("required", []) if name != "answer"]
+    tool["function"]["description"] = (
+        "Signal completion with your final answer, as a structured document. Use this when you have "
+        "gathered enough information to answer the question."
+    )
+    return tool
+
+
+TOOL_DONE_DOCUMENT = _done_tool_for_document(TOOL_DONE_ANSWER)
+
+
 def _build_done_tool_with_directives(directive_rules: list[str]) -> dict:
     """
     Build the done tool schema with directive compliance field.
@@ -233,6 +307,7 @@ def get_reflect_tools(
     include_observations: bool = True,
     include_recall: bool = True,
     include_expand: bool = True,
+    answer_as_document: bool = False,
 ) -> list[dict]:
     """
     Get the list of tools for the reflect agent.
@@ -251,6 +326,10 @@ def get_reflect_tools(
         include_expand: Whether to include the expand tool. Disabled when raw
             document/chunk text is not stored, since expand only reads back
             source text and would return empty results.
+        answer_as_document: Have ``done`` take a structured ``document`` instead
+            of a markdown ``answer``. Used when the answer is stored as a
+            document (mental-model refresh) so the model never writes the
+            markdown that gets persisted.
 
     Returns:
         List of tool definitions in OpenAI format
@@ -269,8 +348,9 @@ def get_reflect_tools(
 
     # Use directive-aware done tool if directives are present
     if directive_rules:
-        tools.append(_build_done_tool_with_directives(directive_rules))
+        done_tool = _build_done_tool_with_directives(directive_rules)
     else:
-        tools.append(TOOL_DONE_ANSWER)
+        done_tool = TOOL_DONE_ANSWER
+    tools.append(_done_tool_for_document(done_tool) if answer_as_document else done_tool)
 
     return tools

--- a/hindsight-api-slim/hindsight_api/engine/response_models.py
+++ b/hindsight-api-slim/hindsight_api/engine/response_models.py
@@ -411,6 +411,15 @@ class ReflectResult(BaseModel):
     )
 
     text: str = Field(description="The formulated answer text")
+    document: Any | None = Field(
+        default=None,
+        exclude=True,
+        description=(
+            "Internal: the structured document the agent emitted when the caller asked for one. "
+            "``text`` is its deterministic render. Excluded from the API response — callers read "
+            "the rendered text; the structure is persistence-side state."
+        ),
+    )
     based_on: dict[str, Any] = Field(
         description="Facts used to formulate the answer, organized by type (world, experience, observation, mental-models, directives)"
     )

--- a/hindsight-api-slim/tests/test_delta_operation_parse.py
+++ b/hindsight-api-slim/tests/test_delta_operation_parse.py
@@ -10,15 +10,11 @@ from hindsight_api.engine.reflect.delta_ops import (
     DeltaOperationList,
     parse_delta_operation_list,
 )
-from hindsight_api.engine.reflect.structured_doc import BulletListBlock
 
 
 def test_parse_delta_operation_list_trailing_brackets():
     """glm-style output with extra ]} after the root object."""
-    raw = (
-        '{"operations":[{"op":"append_block","section_id":"members",'
-        '"block":{"type":"bullet_list","items":["knip ignore react-dom"]}}]}]}'
-    )
+    raw = '{"operations":[{"op":"append_block","section_id":"members","text":"- knip ignore react-dom"}]}]}'
     op_list = parse_delta_operation_list(raw)
     assert len(op_list.operations) == 1
     assert isinstance(op_list.operations[0], AppendBlockOp)
@@ -26,41 +22,64 @@ def test_parse_delta_operation_list_trailing_brackets():
 
 def test_parse_delta_operation_list_backticks_in_path():
     raw = (
-        '{"operations":[{"op":"append_block","section_id":"conventions",'
-        '"block":{"type":"bullet_list","items":["hindsight-control-plane/knip.json"]}}]}'
+        '{"operations":[{"op":"append_block","section_id":"conventions","text":"- hindsight-control-plane/knip.json"}]}'
     )
     op_list = parse_delta_operation_list(raw)
     assert len(op_list.operations) == 1
     op = op_list.operations[0]
+    assert isinstance(op, AppendBlockOp)
     assert op.section_id == "conventions"
-    assert op.block.items == ["hindsight-control-plane/knip.json"]
+    assert op.text == "- hindsight-control-plane/knip.json"
 
 
 def test_parse_delta_operation_list_prose_prefix():
-    raw = (
-        'Here is the update:\n{"operations": [{"op": "append_block", '
-        '"section_id": "x", "block": {"type": "paragraph", "text": "ok"}}]}'
-        "\nDone."
-    )
+    raw = 'Here is the update:\n{"operations": [{"op": "append_block", "section_id": "x", "text": "ok"}]}\nDone.'
     op_list = parse_delta_operation_list(raw)
     assert len(op_list.operations) == 1
 
 
+def test_parse_delta_operation_list_multiline_block_text():
+    """A table arrives as one string with escaped newlines and must stay multi-line."""
+    raw = '{"operations": [{"op": "append_block", "section_id": "s", "text": "| a | b |\\n| --- | --- |\\n| 1 | 2 |"}]}'
+    op = parse_delta_operation_list(raw).operations[0]
+    assert isinstance(op, AppendBlockOp)
+    assert op.text.count("\n") == 2
+
+
+def test_parse_delta_operation_list_raw_newline_in_block_text():
+    """A model that forgets to escape its line breaks still yields a real table (#3361).
+
+    The control-character retry in ``parse_llm_json`` used to replace the raw
+    newline with a space, delivering a table already welded onto one line.
+    """
+    raw = '{"operations": [{"op": "append_block", "section_id": "s", "text": "| a | b |\n| --- | --- |\n| 1 | 2 |"}]}'
+    op = parse_delta_operation_list(raw).operations[0]
+    assert isinstance(op, AppendBlockOp)
+    assert op.text.splitlines() == ["| a | b |", "| --- | --- |", "| 1 | 2 |"]
+
+
 def test_parse_delta_operation_list_skips_invalid_op_keeps_valid():
-    """One bad replace_block (missing index) must not discard the whole batch."""
+    """One bad replace_block (missing block_id) must not discard the whole batch."""
     raw = (
         '{"operations": ['
-        '{"op": "append_block", "section_id": "s", '
-        '"block": {"type": "paragraph", "text": "ok"}}, '
-        '{"op": "replace_block", "section_id": "s", '
-        '"block": {"type": "paragraph", "text": "missing index"}}, '
-        '{"op": "append_block", "section_id": "s", '
-        '"block": {"type": "paragraph", "text": "also ok"}}'
+        '{"op": "append_block", "section_id": "s", "text": "ok"}, '
+        '{"op": "replace_block", "section_id": "s", "text": "missing block_id"}, '
+        '{"op": "append_block", "section_id": "s", "text": "also ok"}'
         "]}"
     )
     op_list = parse_delta_operation_list(raw)
     assert len(op_list.operations) == 2
     assert all(isinstance(o, AppendBlockOp) for o in op_list.operations)
+
+
+def test_parse_delta_operation_list_rejects_v1_block_payloads():
+    """The v1 typed-block shape is no longer a valid operation."""
+    raw = (
+        '{"operations": [{"op": "append_block", "section_id": "s", '
+        '"block": {"type": "paragraph", "text": "old shape"}}]}'
+    )
+    with pytest.raises(DeltaAllOpsInvalidError):
+        parse_delta_operation_list(raw)
 
 
 def test_parse_delta_operation_list_empty():
@@ -79,32 +98,17 @@ def test_parse_delta_operation_list_all_invalid_raises():
     silently drop this refresh's new facts."""
     raw = (
         '{"operations": ['
-        '{"op": "replace_block", "section_id": "s", '
-        '"block": {"type": "paragraph", "text": "missing index a"}}, '
-        '{"op": "replace_block", "section_id": "s", '
-        '"block": {"type": "paragraph", "text": "missing index b"}}'
+        '{"op": "replace_block", "section_id": "s", "text": "missing block_id a"}, '
+        '{"op": "replace_block", "section_id": "s", "text": "missing block_id b"}'
         "]}"
     )
     with pytest.raises(DeltaAllOpsInvalidError):
         parse_delta_operation_list(raw)
     # Same payload shape as a dict must behave identically.
     with pytest.raises(DeltaAllOpsInvalidError):
-        parse_delta_operation_list(
-            {
-                "operations": [
-                    {"op": "replace_block", "section_id": "s", "block": {"type": "paragraph", "text": "no index"}},
-                ]
-            }
-        )
+        parse_delta_operation_list({"operations": [{"op": "replace_block", "section_id": "s", "text": "no block_id"}]})
 
 
 def test_parse_delta_operation_list_pydantic_instance():
-    original = DeltaOperationList(
-        operations=[
-            AppendBlockOp(
-                section_id="s",
-                block=BulletListBlock(items=["a"]),
-            )
-        ]
-    )
+    original = DeltaOperationList(operations=[AppendBlockOp(section_id="s", text="- a")])
     assert parse_delta_operation_list(original) is original

--- a/hindsight-api-slim/tests/test_delta_prompt_schema_parity.py
+++ b/hindsight-api-slim/tests/test_delta_prompt_schema_parity.py
@@ -1,0 +1,99 @@
+"""Every prompt that asks for operations must describe the operations we accept.
+
+The op vocabulary is written down twice: once as Pydantic models the applier
+validates against, and once in prose inside each system prompt. Those two drifted
+in exactly the way this kind of duplication always drifts — the delta prompt was
+rewritten for the id-addressed schema while the retraction prompt, added on main
+in parallel, kept telling the model to say ``"index": N``. Nothing failed loudly:
+the ops validated to nothing, every retraction was dropped, and unsaying a
+retracted fact silently stopped working.
+
+A test for the prompt that drifted does not exist by construction — it is the one
+nobody wrote. So this asserts over *every* prompt that carries an operations
+vocabulary, and a new one is caught by being added to a list rather than by
+someone remembering.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from hindsight_api.engine.reflect import prompts
+from hindsight_api.engine.reflect.delta_ops import Operation
+
+# Prompts that instruct a model to emit operations. Add a prompt here when you
+# add one; the point of the list is that forgetting is what this test catches.
+_OPERATION_PROMPTS = {
+    "STRUCTURED_DELTA_SYSTEM_PROMPT": prompts.STRUCTURED_DELTA_SYSTEM_PROMPT,
+    "STRUCTURED_RETRACTION_SYSTEM_PROMPT": prompts.STRUCTURED_RETRACTION_SYSTEM_PROMPT,
+}
+
+_OP_SHAPE_RX = re.compile(r'\{"op":\s*"(\w+)"([^`]*)')
+
+
+def _operation_models() -> dict[str, type]:
+    import typing
+
+    return {m.model_fields["op"].default: m for m in typing.get_args(typing.get_args(Operation)[0])}
+
+
+def _prompt_names() -> list[str]:
+    return sorted(_OPERATION_PROMPTS)
+
+
+@pytest.mark.parametrize("prompt_name", _prompt_names())
+class TestPromptsMatchTheSchema:
+    def test_every_named_op_exists(self, prompt_name: str):
+        """A prompt offering an op we do not implement wastes a whole refresh."""
+        known = set(_operation_models())
+        named = {m.group(1) for m in _OP_SHAPE_RX.finditer(_OPERATION_PROMPTS[prompt_name])}
+        assert named, f"{prompt_name} documents no operations"
+        assert named <= known, f"{prompt_name} offers unknown ops: {sorted(named - known)}"
+
+    def test_no_op_shape_uses_a_field_the_schema_rejects(self, prompt_name: str):
+        """Every field named in a shape must exist on that op's model.
+
+        This is what caught the retraction prompt: ``index`` is not a field on any
+        v2 operation, so a model following that prompt produced ops that failed
+        validation and were dropped.
+        """
+        models = _operation_models()
+        prompt = _OPERATION_PROMPTS[prompt_name]
+        for match in _OP_SHAPE_RX.finditer(prompt):
+            op_name, rest = match.group(1), match.group(2)
+            shape = rest.split("``")[0]
+            fields = set(re.findall(r'"(\w+)":', shape))
+            allowed = set(models[op_name].model_fields)
+            assert fields <= allowed, (
+                f"{prompt_name} tells the model to send {sorted(fields - allowed)} on "
+                f"{op_name!r}; the schema accepts {sorted(allowed)}"
+            )
+
+    def test_blocks_are_never_described_as_typed_objects(self, prompt_name: str):
+        """v1's typed block union is gone; a prompt still describing it teaches
+        the model a payload that cannot validate."""
+        prompt = _OPERATION_PROMPTS[prompt_name]
+        for legacy in ('"type": "paragraph"', '"type": "bullet_list"', '"type": "ordered_list"'):
+            assert legacy not in prompt, f"{prompt_name} still documents the v1 block shape {legacy}"
+
+    def test_block_addressing_is_by_id(self, prompt_name: str):
+        """Positional addressing is the defect in #3273 and is not in the schema."""
+        prompt = _OPERATION_PROMPTS[prompt_name]
+        if "remove_block" in prompt or "replace_block" in prompt:
+            assert "block_id" in prompt, f"{prompt_name} addresses blocks without naming block_id"
+
+
+def test_the_list_covers_every_operations_prompt():
+    """A prompt asking for ``{"operations": [...]}`` that is not in the list above
+    is exactly the prompt this test cannot check — so find it here instead."""
+    unlisted = [
+        name
+        for name in dir(prompts)
+        if name.endswith("_SYSTEM_PROMPT")
+        and isinstance(getattr(prompts, name), str)
+        and '"operations"' in getattr(prompts, name)
+        and name not in _OPERATION_PROMPTS
+    ]
+    assert not unlisted, f"these prompts ask for operations but are not checked: {unlisted}"

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -779,7 +779,7 @@ async def test_bank_roundtrip_carries_mental_model_history(memory, request_conte
         await memory.update_mental_model(bank, mental_model_id="mm-1", content="v3", request_context=request_context)
         # Two refreshes → two snapshots (previous content v1 then v2), newest-first.
         before = await memory.get_mental_model_history(bank, "mm-1", request_context=request_context)
-        assert [h["previous_content"] for h in before] == ["v2", "v1"]
+        assert [h["previous_content"] for h in before] == ["v2\n", "v1\n"]
 
         from hindsight_api.engine.transfer import export_bank
 
@@ -791,7 +791,7 @@ async def test_bank_roundtrip_carries_mental_model_history(memory, request_conte
         assert result.mental_model_history_imported == 2
 
         after = await memory.get_mental_model_history(bank, "mm-1", request_context=request_context)
-        assert [h["previous_content"] for h in after] == ["v2", "v1"]
+        assert [h["previous_content"] for h in after] == ["v2\n", "v1\n"]
     finally:
         await memory.delete_bank(bank, request_context=request_context)
 

--- a/hindsight-api-slim/tests/test_llm_wrapper.py
+++ b/hindsight-api-slim/tests/test_llm_wrapper.py
@@ -268,6 +268,21 @@ def test_parse_llm_json_control_char_scrub_still_works():
     assert parse_llm_json('{"a": "line\x01break"}') == {"a": "line break"}
 
 
+def test_parse_llm_json_preserves_raw_line_breaks_in_strings():
+    """A raw newline in a string is content, not noise (#3361).
+
+    A model writing a markdown table into a JSON string often forgets to escape
+    its line breaks. Blanking them out delivers the table already welded onto
+    one line, and nothing downstream can tell that apart from prose.
+    """
+    from hindsight_api.engine.llm_wrapper import parse_llm_json
+
+    table = "| a | b |\n| --- | --- |\n| 1 | 2 |"
+    assert parse_llm_json('{"text": "%s"}' % table.replace("\n", "\n")) == {"text": table}
+    assert parse_llm_json('{"a": "tab\there"}') == {"a": "tab\there"}
+    assert parse_llm_json('{"a": "back\\\\slash and \\" quote"}') == {"a": 'back\\slash and " quote'}
+
+
 @pytest.mark.parametrize("garbage", ["", "   ", "not json at all !!!", "```json\n```"])
 def test_parse_llm_json_unrecoverable_raises(garbage):
     """Repair that yields an empty result must not masquerade as success — the

--- a/hindsight-api-slim/tests/test_mental_model_delta.py
+++ b/hindsight-api-slim/tests/test_mental_model_delta.py
@@ -21,6 +21,7 @@ This file contains two kinds of tests:
 """
 
 import os
+import re
 import uuid
 from typing import Any
 
@@ -189,8 +190,90 @@ class TestDeltaRefreshPlumbing:
         )
 
         assert refreshed is not None
-        assert refreshed["content"] == "# Team\n\nRegenerated from scratch."
+        assert refreshed["content"] == "# Team\n\nRegenerated from scratch.\n"
         assert len(llm_calls) == 0, "Delta merge LLM call must not happen in full mode"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_stored_content_is_the_render_of_the_stored_structure(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+        patch_llm_call,
+    ):
+        """``content`` is a derived view of ``structured_content``, on both legs.
+
+        Under the v1 schema the full leg stored the LLM candidate verbatim while
+        deriving the structure from it with a lossy parser, so the two columns
+        disagreed by construction and the next delta refresh silently published
+        the degraded one (#3361). They must now agree after every write.
+        """
+        from hindsight_api.engine.reflect.structured_doc import (
+            StructuredDocument,
+            render_document,
+        )
+
+        bank_id = f"test-delta-render-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Team Info",
+            source_query="Tell me about the team",
+            content="# Team\n\nOriginal content.\n",
+            trigger={"mode": "full"},
+            request_context=request_context,
+        )
+
+        # A candidate whose markdown v1's parser could not model: a table with a
+        # row missing its outer pipe, a nested list, and a hard line break.
+        candidate = (
+            "# Team\n\n| Name | Role |\n|---|---|\n| Alice | Lead\n\n- top\n  - nested\n\nline one  \nline two\n"
+        )
+        patch_reflect(
+            memory,
+            text=candidate,
+            facts=[{"id": "obs-1", "text": "Alice leads the team", "type": "observation", "context": None}],
+        )
+        llm_calls = patch_llm_call(memory, returns=[{"op": "append_block", "section_id": "team", "text": "New note."}])
+
+        async def _assert_invariant(where: str) -> dict:
+            stored = await memory.get_mental_model(
+                bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+            )
+            assert stored is not None
+            doc = StructuredDocument.model_validate(stored["structured_content"])
+            assert stored["content"] == render_document(doc), f"{where}: content is not the render"
+            # ...and the constructs v1 flattened are still on their own lines.
+            lines = stored["content"].splitlines()
+            assert "| Alice | Lead" in lines, where
+            assert "  - nested" in lines, where
+            assert "line one  " in lines, where
+            return stored
+
+        # Full leg: the candidate is what gets written.
+        await memory.refresh_mental_model(bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context)
+        await _assert_invariant("full refresh")
+        assert len(llm_calls) == 0, "full mode must not call the delta LLM"
+
+        # Delta leg: the same invariant must hold after an operation is applied
+        # on top of that structure, and the fragile blocks it never named must
+        # come through untouched.
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            trigger={"mode": "delta"},
+            request_context=request_context,
+        )
+        patch_reflect(
+            memory,
+            text="# Team\n\nBob joined.\n",
+            facts=[{"id": "obs-2", "text": "Bob joined the team", "type": "observation", "context": None}],
+        )
+        await memory.refresh_mental_model(bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context)
+        stored = await _assert_invariant("delta refresh")
+        assert len(llm_calls) == 1
+        assert "New note." in stored["content"]
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
@@ -224,7 +307,7 @@ class TestDeltaRefreshPlumbing:
             bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
         )
 
-        assert refreshed["content"] == "# Team\n\nFull fresh synthesis."
+        assert refreshed["content"] == "# Team\n\nFull fresh synthesis.\n"
         assert len(llm_calls) == 0  # delta path skipped entirely
         rr = refreshed.get("reflect_response") or {}
         assert rr.get("delta_applied") is not True
@@ -262,7 +345,7 @@ class TestDeltaRefreshPlumbing:
             bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
         )
 
-        assert refreshed["content"] == "# Backend\n\nFull fresh synthesis."
+        assert refreshed["content"] == "# Backend\n\nFull fresh synthesis.\n"
         assert len(llm_calls) == 0
         assert "created_after" not in reflect_calls[0]
         rr = refreshed.get("reflect_response") or {}
@@ -312,7 +395,7 @@ class TestDeltaRefreshPlumbing:
             bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
         )
 
-        assert refreshed["content"] == "# Customers\n\nBrand new topic."
+        assert refreshed["content"] == "# Customers\n\nBrand new topic.\n"
         assert len(llm_calls) == 0, "Source-query change must bypass the delta merge"
 
         await memory.delete_bank(bank_id, request_context=request_context)
@@ -627,10 +710,7 @@ class TestDeltaRefreshPlumbing:
             {
                 "op": "append_block",
                 "section_id": "members",
-                "block": {
-                    "type": "bullet_list",
-                    "items": ["Bob — junior engineer"],
-                },
+                "text": "- Bob — junior engineer",
             }
         ]
         llm_calls = patch_llm_call(memory, returns=ops)
@@ -811,7 +891,7 @@ class TestDeltaRefreshPlumbing:
             {
                 "op": "append_block",
                 "section_id": "members",
-                "block": {"type": "bullet_list", "items": ["Bob — junior engineer"]},
+                "text": "- Bob — junior engineer",
             }
         ]
         llm_calls = patch_llm_call(memory, returns=ops)
@@ -1010,12 +1090,12 @@ class TestDeltaRefreshPlumbing:
                 {
                     "op": "append_block",
                     "section_id": "does-not-exist",
-                    "block": {"type": "paragraph", "text": "Bob joined the team."},
+                    "text": "Bob joined the team.",
                 },
                 {
                     "op": "append_block",
                     "section_id": "also-missing",
-                    "block": {"type": "paragraph", "text": "Bob sits with Alice."},
+                    "text": "Bob sits with Alice.",
                 },
             ],
         )
@@ -1094,12 +1174,12 @@ class TestDeltaRefreshPlumbing:
                 {
                     "op": "append_block",
                     "section_id": section_id,
-                    "block": {"type": "paragraph", "text": "Bob joined the team."},
+                    "text": "Bob joined the team.",
                 },
                 {
                     "op": "append_block",
                     "section_id": "does-not-exist",
-                    "block": {"type": "paragraph", "text": "Dropped on the floor."},
+                    "text": "Dropped on the floor.",
                 },
             ],
         )
@@ -1204,10 +1284,10 @@ class TestDeltaRefreshPlumbing:
 
         from hindsight_api.engine.reflect import structured_doc
 
-        def unparseable(_markdown: str):
-            raise ValueError("simulated unparseable markdown")
+        def unreadable(_stored, _markdown: str):
+            raise ValueError("simulated unreadable structured document")
 
-        monkeypatch.setattr(structured_doc, "parse_markdown", unparseable)
+        monkeypatch.setattr(structured_doc, "structured_document_from_stored", unreadable)
 
         patch_reflect(
             memory,
@@ -1379,7 +1459,9 @@ async def gemini_memory(memory_no_llm_verify: MemoryEngine):
     """
     if _GEMINI_API_KEY:
         provider = "gemini"
-        model = os.getenv("HINDSIGHT_GEMINI_EVAL_MODEL", "gemini-2.0-flash")
+        # gemini-2.0-flash was retired by the provider (404 NOT_FOUND); this is the
+        # model the repo's own .env and the other Gemini tests use.
+        model = os.getenv("HINDSIGHT_GEMINI_EVAL_MODEL", "gemini-3.1-flash-lite")
         cfg = LLMConfig(provider=provider, api_key=_GEMINI_API_KEY, base_url="", model=model)
     else:
         provider = "openai"
@@ -1561,8 +1643,8 @@ class TestDeltaRefreshGeminiEval:
         appear somewhere in the output.
         """
         from hindsight_api.engine.reflect.structured_doc import (
-            StructuredDocument,
             render_section,
+            split_markdown,
         )
 
         bank_id = f"eval-delta-add-{uuid.uuid4().hex[:8]}"
@@ -1578,17 +1660,10 @@ class TestDeltaRefreshGeminiEval:
             ],
         )
         first_content = seeded["first"]["content"]
-        first_struct = StructuredDocument.model_validate(
-            seeded["first"]["reflect_response"]["delta_operations_applied"]
-            and seeded["first"].get("structured_content")
-            or {"version": 1, "sections": []}
-        )
-        # The first refresh's structured snapshot is what the second refresh
-        # will operate on. Re-fetch via get_mental_model would also work.
-        # For preservation comparison we re-parse first_content.
-        from hindsight_api.engine.reflect.structured_doc import parse_markdown
-
-        before = parse_markdown(first_content)
+        # The stored structure is what the second refresh operates on, and the
+        # stored markdown is its render — so splitting the markdown back gives
+        # the same sections, which is what the preservation check compares.
+        before = split_markdown(first_content)
 
         # Introduce a brand-new fact that fits into "Inputs and Context" or
         # similar — but the model may pick any reasonable section.
@@ -1622,7 +1697,7 @@ class TestDeltaRefreshGeminiEval:
         )
 
         # Every untouched section must render byte-identical to its pre-refresh form.
-        after = parse_markdown(content)
+        after = split_markdown(content)
         before_by_id = {s.id: s for s in before.sections}
         for section in after.sections:
             if section.id in touched_section_ids:
@@ -1726,5 +1801,211 @@ class TestDeltaRefreshGeminiEval:
         )
         # delta_applied should be absent/False because we took the full path.
         assert (refreshed.get("reflect_response") or {}).get("delta_applied") is not True
+
+        await gemini_memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_document_survives_many_delta_rounds_intact(
+        self, gemini_memory: MemoryEngine, request_context: RequestContext
+    ):
+        """Repeated real-LLM delta refreshes must not erode the document.
+
+        This is the failure mode #3361 reported: no single refresh looks wrong,
+        but the markdown degrades a little on each one until a table is one line
+        and the damage is a fixed point. A single-round test cannot see it, so
+        this one runs several rounds against a real model, feeding a genuinely
+        new fact each time, and checks the invariants after every round:
+
+        1. ``content`` is exactly the render of the stored structure.
+        2. Fragile constructs the model never named — a table, a nested list, a
+           fenced code block, a hard line break — survive byte-for-byte.
+        3. Sections no applied operation named are byte-identical to the round
+           before.
+        4. No line ever welds a table separator to other cells (the detector
+           the issue used against production pages).
+        5. The document keeps growing knowledge rather than collapsing.
+        """
+        from hindsight_api.engine.reflect.structured_doc import (
+            StructuredDocument,
+            render_document,
+            render_section,
+            split_markdown,
+        )
+
+        # A separator cell that is not the whole line == a table welded onto one
+        # physical line. Verbatim from the #3361 report.
+        collapsed_table_rx = re.compile(r"\|\s*:?-{2,}:?\s*\|")
+
+        canaries = {
+            "table row": "| `retain` | Store a memory | 12ms |",
+            "table separator": "| --- | --- | --- |",
+            "nested bullet": "  - Nested under retries",
+            "deep bullet": "    - Deeper still, three levels",
+            "code fence line": '    return {"ok": True}',
+            "hard line break": "Latency budget is 200ms  ",
+            "blockquote": "> Never block the request path on consolidation.",
+            "ordered from five": "5. Fifth step, numbering starts at five on purpose",
+        }
+
+        existing_markdown = (
+            "## Purpose\n\n"
+            "Document the API surface, its performance budget, and the delivery rules.\n\n"
+            "## Operations\n\n"
+            "| Operation | Description | Budget |\n"
+            "| --- | --- | --- |\n"
+            "| `retain` | Store a memory | 12ms |\n"
+            "| `recall` | Retrieve memories | 40ms |\n\n"
+            "## Failure Handling\n\n"
+            "- Retry transient errors\n"
+            "  - Nested under retries\n"
+            "    - Deeper still, three levels\n"
+            "- Fail loudly on schema errors\n\n"
+            "## Example\n\n"
+            "```python\n"
+            "def handler(request):\n"
+            "\n"
+            '    return {"ok": True}\n'
+            "```\n\n"
+            "## Constraints\n\n"
+            "Latency budget is 200ms  \n"
+            "measured at the p95.\n\n"
+            "> Never block the request path on consolidation.\n\n"
+            "## Procedure\n\n"
+            "5. Fifth step, numbering starts at five on purpose\n"
+            "6. Sixth step\n"
+        )
+
+        rounds = [
+            "The recall endpoint gained a rerank stage that adds about 15ms.",
+            "Schema errors are now reported with the offending field name.",
+            "A new operation, reflect, answers questions over stored memories.",
+            "The p95 latency budget was raised from 200ms to 250ms.",
+            "Consolidation runs on a background worker every five minutes.",
+        ]
+
+        bank_id = f"eval-delta-stability-{uuid.uuid4().hex[:8]}"
+        seeded = await self._seed(
+            gemini_memory,
+            request_context,
+            bank_id,
+            existing_markdown=existing_markdown,
+            memories=["The API exposes retain and recall operations."],
+        )
+        mental_model_id = seeded["mm"]["id"]
+        previous_content = seeded["first"]["content"]
+
+        def touched_sections(refresh: dict[str, Any]) -> set[str]:
+            applied = (refresh.get("reflect_response") or {}).get("delta_operations_applied") or []
+            ids = {op.get("section_id") for op in applied}
+            ids |= {op.get("assigned_id") for op in applied}
+            return {i for i in ids if i}
+
+        def owning_section(markdown: str, line: str) -> str | None:
+            return next((s.id for s in split_markdown(markdown).sections if line in render_section(s)), None)
+
+        # The seeding refresh is a real delta refresh: the model may deliberately
+        # rewrite sections there too, so the contract is the same as every later
+        # round — a construct in a section no operation named must survive.
+        first_touched = touched_sections(seeded["first"])
+        for name, canary in canaries.items():
+            if owning_section(existing_markdown, canary) in first_touched:
+                continue
+            assert canary in previous_content.splitlines(), (
+                f"{name} was lost by the first refresh, which never named its section "
+                f"(touched: {sorted(first_touched)}):\n{previous_content}"
+            )
+        # Constructs the seed refresh edited away are no longer part of the contract.
+        canaries = {n: c for n, c in canaries.items() if c in previous_content.splitlines()}
+
+        previous_sections = {s.id: render_section(s) for s in split_markdown(previous_content).sections}
+        # Sections no operation has *ever* named must still be byte-identical at
+        # the end of the run, not just between consecutive rounds.
+        never_touched = dict(previous_sections)
+        for section_id in first_touched:
+            never_touched.pop(section_id, None)
+
+        for round_index, new_fact in enumerate(rounds, start=1):
+            await gemini_memory.retain_batch_async(
+                bank_id=bank_id,
+                contents=[{"content": new_fact}],
+                request_context=request_context,
+            )
+            await gemini_memory.wait_for_background_tasks()
+
+            refreshed = await gemini_memory.refresh_mental_model(
+                bank_id=bank_id,
+                mental_model_id=mental_model_id,
+                request_context=request_context,
+            )
+            content = refreshed["content"]
+            where = f"round {round_index} (fact: {new_fact!r})"
+
+            stored = await gemini_memory.get_mental_model(
+                bank_id=bank_id, mental_model_id=mental_model_id, request_context=request_context
+            )
+            assert stored is not None
+            structured = stored.get("structured_content")
+            assert structured is not None, f"{where}: no structure was persisted"
+            doc = StructuredDocument.model_validate(structured)
+            assert content == render_document(doc), (
+                f"{where}: stored markdown is not the render of the stored structure"
+            )
+
+            for line in content.splitlines():
+                if collapsed_table_rx.search(line):
+                    assert line.strip().startswith("|") and set(line.replace("|", "").strip()) <= set("-: "), (
+                        f"{where}: a table was welded onto one line (#3361):\n{line}"
+                    )
+
+            rr = refreshed.get("reflect_response") or {}
+            applied = rr.get("delta_operations_applied") or []
+            touched = touched_sections(refreshed)
+            for section_id in touched:
+                never_touched.pop(section_id, None)
+            print(
+                f"[delta-stability] {where}: applied={len(applied)} "
+                f"skipped={len(rr.get('delta_operations_skipped') or [])} "
+                f"touched={sorted(i for i in touched if i)} bytes={len(content)}"
+            )
+
+            current = split_markdown(content)
+            for section in current.sections:
+                if section.id in touched:
+                    continue
+                before = previous_sections.get(section.id)
+                if before is None:
+                    continue  # a section added this round has no prior form
+                assert render_section(section) == before, (
+                    f"{where}: untouched section {section.id!r} drifted.\n"
+                    f"BEFORE:\n{before}\n\nAFTER:\n{render_section(section)}"
+                )
+
+            previous_lines = previous_content.splitlines()
+            for name, canary in canaries.items():
+                if canary not in previous_lines:
+                    continue  # an earlier round deliberately edited it away
+                if owning_section(previous_content, canary) in touched:
+                    continue  # the model deliberately edited that section
+                assert canary in content.splitlines(), (
+                    f"{where}: {name} disappeared from a section the model never touched.\n{content}"
+                )
+
+            previous_content = content
+            previous_sections = {s.id: render_section(s) for s in current.sections}
+
+        print(f"[delta-stability] final document after {len(rounds)} rounds:\n{previous_content}")
+
+        # The end-to-end contract: a section no operation ever named survives all
+        # five rounds byte-for-byte. Consecutive-round checks alone would miss a
+        # slow erosion that moves a section a little at a time.
+        assert never_touched, (
+            "Every section was edited at least once, so this run proves nothing about "
+            "preservation — the fixture's facts have drifted too close to the seed document."
+        )
+        final_by_id = {s.id: render_section(s) for s in split_markdown(previous_content).sections}
+        for section_id, original in never_touched.items():
+            assert final_by_id.get(section_id) == original, (
+                f"Section {section_id!r} eroded across {len(rounds)} rounds without any "
+                f"operation ever naming it.\nBEFORE:\n{original}\n\nAFTER:\n{final_by_id.get(section_id)}"
+            )
 
         await gemini_memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_mental_model_delta.py
+++ b/hindsight-api-slim/tests/test_mental_model_delta.py
@@ -2223,3 +2223,169 @@ class TestDeltaRefreshGeminiEval:
             )
 
         await gemini_memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_an_over_budget_document_reclaims_space(
+        self, gemini_memory: MemoryEngine, request_context: RequestContext
+    ):
+        """A real model, told the document is over budget, makes room.
+
+        The mechanical half (the budget reaches the prompt, the outcome is
+        recorded) is covered without an LLM. What cannot be mocked is whether a
+        model asked to reclaim space actually removes superseded content instead
+        of appending anyway — which is the whole reason the budget is stated
+        rather than enforced by truncation.
+        """
+        from hindsight_api.engine.reflect.tokenization import count_cl100k_tokens
+
+        bank_id = f"eval-budget-{uuid.uuid4().hex[:8]}"
+        # A document padded with obsolete history: there is plenty here that a
+        # model can drop without losing anything the topic needs.
+        stale_sections = "\n\n".join(
+            f"## Archived note {i}\n\nDuring the {2019 + i} season the team used the legacy pipeline, "
+            f"which was retired years ago and no longer affects how anything works today."
+            for i in range(12)
+        )
+        # Two things that must survive, because "get under budget" must not become
+        # "delete the document": the current cadence, and a checklist that is
+        # nowhere near stale. Space has to come from the archive.
+        current = (
+            "## Current process\n\nReleases are cut on Tuesdays.\n\n"
+            "## Checklist\n\n- Migrations applied\n- Smoke tests green\n- On-call engineer signed off\n"
+        )
+        seeded = await self._seed(
+            gemini_memory,
+            request_context,
+            bank_id,
+            existing_markdown=f"{current}\n{stale_sections}\n",
+            memories=["Releases are cut on Tuesdays and go to staging before production."],
+        )
+        mental_model_id = seeded["mm"]["id"]
+        budget = 200
+        await gemini_memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mental_model_id,
+            max_tokens=budget,
+            request_context=request_context,
+        )
+        before = count_cl100k_tokens(seeded["first"]["content"])
+        assert before > budget, f"the fixture must start over budget, got {before} <= {budget}"
+
+        await gemini_memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": "Releases moved from Tuesdays to Wednesdays."}],
+            request_context=request_context,
+        )
+        await gemini_memory.wait_for_background_tasks()
+
+        refreshed = await gemini_memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mental_model_id, request_context=request_context
+        )
+        after = count_cl100k_tokens(refreshed["content"])
+        rr = refreshed.get("reflect_response") or {}
+        print(f"[budget] {before} -> {after} tokens against a {budget}-token budget")
+
+        assert rr.get("document_budget") == budget
+        assert rr.get("document_tokens") == after
+        # The new fact still lands — reclaiming space must never cost the update.
+        assert "wednesday" in refreshed["content"].lower()
+        # And the document moved toward its budget rather than growing further.
+        assert after < before, (
+            f"an over-budget document grew from {before} to {after} tokens instead of "
+            f"reclaiming space:\n{refreshed['content']}"
+        )
+        # Space came from the archive, not from the document. Getting under budget
+        # by deleting current content would satisfy every check above and be worse
+        # than going over it.
+        content = refreshed["content"].lower()
+        assert "checklist" in content, f"the current checklist was deleted to fit the budget:\n{refreshed['content']}"
+        assert "smoke tests" in content, f"current content was dropped to fit the budget:\n{refreshed['content']}"
+        archived_left = content.count("archived note")
+        assert archived_left < 12, "nothing was reclaimed from the archived sections"
+
+        await gemini_memory.delete_bank(bank_id, request_context=request_context)
+
+
+class TestDocumentBudget:
+    """``max_tokens`` on the delta leg.
+
+    It was enforced in exactly one place — a rewrite of the *synthesis* answer —
+    and in delta mode that answer is only context for the operations call. The
+    document that actually gets stored was never measured against it, and a delta
+    refresh only adds, so a long-lived page drifts past its configured size with
+    nothing noticing. See ``test_mental_model_document_budget.py`` for the prompt
+    that tells the model where it stands.
+    """
+
+    async def test_refresh_records_size_against_budget(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+        patch_llm_call,
+    ):
+        """Every delta refresh reports where the document stands."""
+        bank_id = f"test-mm-budget-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="API Reference",
+            source_query="Document the API",
+            content="## Ops\n\nOriginal.\n",
+            max_tokens=256,
+            trigger={"mode": "delta"},
+            request_context=request_context,
+        )
+        patch_reflect(
+            memory,
+            text="## Ops\n\nCandidate.\n",
+            facts=[{"id": "o1", "text": "a new fact", "type": "observation", "context": None}],
+        )
+        patch_llm_call(memory, returns=[{"op": "append_block", "section_id": "ops", "text": "New note."}])
+
+        refreshed = await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+
+        rr = refreshed.get("reflect_response") or {}
+        assert rr["document_budget"] == 256
+        assert rr["document_tokens"] > 0
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_over_budget_document_is_reported_not_truncated(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+        patch_llm_call,
+    ):
+        """Going over is a warning, never a silent deletion of content."""
+        bank_id = f"test-mm-over-budget-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        long_body = " ".join(f"sentence number {i} about the API." for i in range(200))
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="API Reference",
+            source_query="Document the API",
+            content=f"## Ops\n\n{long_body}\n",
+            max_tokens=256,
+            trigger={"mode": "delta"},
+            request_context=request_context,
+        )
+        patch_reflect(
+            memory,
+            text="## Ops\n\nCandidate.\n",
+            facts=[{"id": "o1", "text": "a new fact", "type": "observation", "context": None}],
+        )
+        patch_llm_call(memory, returns=[{"op": "append_block", "section_id": "ops", "text": "New note."}])
+
+        refreshed = await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+
+        assert "sentence number 199" in refreshed["content"], "content must not be truncated"
+        assert "New note." in refreshed["content"]
+        rr = refreshed.get("reflect_response") or {}
+        assert rr["document_tokens"] > rr["document_budget"]
+
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_mental_model_delta.py
+++ b/hindsight-api-slim/tests/test_mental_model_delta.py
@@ -60,12 +60,15 @@ def patch_reflect(monkeypatch):
         assert len(calls) == 1
     """
 
-    def _install(memory: MemoryEngine, *, text: str, facts: list[dict] | None = None):
+    def _install(memory: MemoryEngine, *, text: str, facts: list[dict] | None = None, document: Any = None):
         calls: list[dict] = []
 
         async def fake_reflect_async(**kwargs):
             calls.append(kwargs)
-            return _canned_reflect_result(text, facts)
+            result = _canned_reflect_result(text, facts)
+            # ``document`` mirrors what the real agent returns in document mode.
+            result.document = document
+            return result
 
         monkeypatch.setattr(memory, "reflect_async", fake_reflect_async)
         return calls
@@ -278,6 +281,123 @@ class TestDeltaRefreshPlumbing:
         doc = StructuredDocument.model_validate(stored["structured_content"])
         assert stored["content"] == render_document(doc)
         assert [s.id for s in doc.sections] == ["new"], "the stale structure must not survive"
+        assert "| 1 | 2 |" in stored["content"].splitlines()
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_full_refresh_stores_the_document_the_agent_emitted(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+    ):
+        """The generation path never reads markdown back.
+
+        In document mode the agent states the document's structure, so the
+        refresh stores that structure verbatim and renders the markdown from it.
+        Splitting only happens when a run produced plain text instead.
+        """
+        from hindsight_api.engine.reflect.structured_doc import (
+            StructuredDocument,
+            document_from_sections,
+            render_document,
+        )
+
+        bank_id = f"test-doc-answer-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="API Reference",
+            source_query="Document the API",
+            content="## Old\n\nOriginal.\n",
+            trigger={"mode": "full"},
+            request_context=request_context,
+        )
+
+        emitted = document_from_sections(
+            {
+                "sections": [
+                    {
+                        "heading": "Operations",
+                        "level": 2,
+                        "blocks": ["| Op | Budget |\n| --- | --- |\n| retain | 12ms |", "- top\n  - nested"],
+                    }
+                ]
+            }
+        )
+        # ``text`` is deliberately something else: if the refresh were still
+        # deriving the document from markdown, it would store this instead.
+        patch_reflect(memory, text="IGNORED MARKDOWN", document=emitted)
+
+        await memory.refresh_mental_model(bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context)
+        stored = await memory.get_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        assert stored is not None
+        assert StructuredDocument.model_validate(stored["structured_content"]) == emitted
+        assert stored["content"] == render_document(emitted)
+        assert "IGNORED MARKDOWN" not in stored["content"]
+        assert "| retain | 12ms |" in stored["content"].splitlines()
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_refresh_asks_the_agent_for_a_document(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+    ):
+        """The refresh must request document mode; markdown mode would reintroduce the parse."""
+        bank_id = f"test-doc-flag-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="API Reference",
+            source_query="Document the API",
+            content="## Old\n\nOriginal.\n",
+            trigger={"mode": "full"},
+            request_context=request_context,
+        )
+        calls = patch_reflect(memory, text="# Team\n\nSomething.\n")
+
+        await memory.refresh_mental_model(bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context)
+
+        assert calls[0]["answer_as_document"] is True
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_plain_text_answer_still_produces_a_document(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+    ):
+        """A run that yields no document (provider dropped the tool call, iteration
+        limit) still gets a structure — split from its text, losslessly."""
+        from hindsight_api.engine.reflect.structured_doc import (
+            StructuredDocument,
+            render_document,
+        )
+
+        bank_id = f"test-doc-fallback-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="API Reference",
+            source_query="Document the API",
+            content="## Old\n\nOriginal.\n",
+            trigger={"mode": "full"},
+            request_context=request_context,
+        )
+        patch_reflect(memory, text="## Ops\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n", document=None)
+
+        await memory.refresh_mental_model(bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context)
+        stored = await memory.get_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        assert stored is not None
+        doc = StructuredDocument.model_validate(stored["structured_content"])
+        assert stored["content"] == render_document(doc)
         assert "| 1 | 2 |" in stored["content"].splitlines()
 
         await memory.delete_bank(bank_id, request_context=request_context)
@@ -1713,9 +1833,16 @@ class TestDeltaRefreshGeminiEval:
             f"second: {second_content[:300]!r}"
         )
         rr = second.get("reflect_response") or {}
-        # The LLM may emit zero ops (best case) or non-effective ops (still no
-        # change to render); both are acceptable so long as the bytes match.
-        assert rr.get("delta_applied") is True
+        # Three outcomes all satisfy "nothing drifted": the delta ran and emitted
+        # zero ops, it emitted non-effective ops, or the window held no new facts
+        # at all and the content was preserved without an LLM call. Which one you
+        # get depends on whether consolidation had produced a new observation by
+        # the time the second refresh ran, so pinning one of them makes the test
+        # flake on timing rather than on behaviour.
+        assert rr.get("delta_applied") is True or rr.get("delta_skipped_reason") == "no_new_facts", (
+            f"expected a clean no-change refresh, got {rr.get('delta_applied')=} "
+            f"{rr.get('delta_skipped_reason')=} {rr.get('refresh_skipped')=}"
+        )
 
         await gemini_memory.delete_bank(bank_id, request_context=request_context)
 

--- a/hindsight-api-slim/tests/test_mental_model_delta.py
+++ b/hindsight-api-slim/tests/test_mental_model_delta.py
@@ -195,6 +195,93 @@ class TestDeltaRefreshPlumbing:
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
+    async def test_creating_a_model_with_markdown_stores_its_structure(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+    ):
+        """A model authored as markdown is on the structured schema immediately.
+
+        Leaving ``structured_content`` NULL until the first delta refresh would
+        mean that refresh silently reshapes a document nobody asked it to touch —
+        and there would be a window where the two columns describe different
+        documents, which is what #3361 was.
+        """
+        from hindsight_api.engine.reflect.structured_doc import (
+            StructuredDocument,
+            render_document,
+        )
+
+        bank_id = f"test-mm-create-structure-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        authored = "## Ops\n\n| Name | Role |\n|---|---|\n| Alice | Lead\n\n- top\n  - nested\n"
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Team Info",
+            source_query="Tell me about the team",
+            content=authored,
+            request_context=request_context,
+        )
+
+        stored = await memory.get_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        assert stored is not None
+        assert stored["structured_content"] is not None, "a created model must carry its structure"
+        doc = StructuredDocument.model_validate(stored["structured_content"])
+        assert stored["content"] == render_document(doc)
+        # The authored markdown survives the split: v1 flattened all three of these.
+        lines = stored["content"].splitlines()
+        assert "| Alice | Lead" in lines
+        assert "  - nested" in lines
+        assert [s.id for s in doc.sections] == ["ops"]
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_updating_content_alone_still_stores_a_matching_structure(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+    ):
+        """``content`` and ``structured_content`` can never be written out of step.
+
+        A caller handing over markdown alone must not leave the previous
+        document's structure behind it — a delta refresh would then edit a
+        document that is no longer what the column says.
+        """
+        from hindsight_api.engine.reflect.structured_doc import (
+            StructuredDocument,
+            render_document,
+        )
+
+        bank_id = f"test-mm-update-structure-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Team Info",
+            source_query="Tell me about the team",
+            content="## Old\n\nOriginal.\n",
+            request_context=request_context,
+        )
+
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            content="## New\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n",
+            request_context=request_context,
+        )
+
+        stored = await memory.get_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        assert stored is not None
+        doc = StructuredDocument.model_validate(stored["structured_content"])
+        assert stored["content"] == render_document(doc)
+        assert [s.id for s in doc.sections] == ["new"], "the stale structure must not survive"
+        assert "| 1 | 2 |" in stored["content"].splitlines()
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
     async def test_stored_content_is_the_render_of_the_stored_structure(
         self,
         memory: MemoryEngine,

--- a/hindsight-api-slim/tests/test_mental_model_document_budget.py
+++ b/hindsight-api-slim/tests/test_mental_model_document_budget.py
@@ -1,0 +1,63 @@
+"""The document's own token budget on the delta leg.
+
+``max_tokens`` was enforced in exactly one place: a rewrite of the *synthesis*
+answer. In delta mode that answer is only context for the operations call, and
+the document that actually gets stored was never measured against the budget at
+all. A delta refresh only ever adds, so a long-lived page grows every round
+(~20 tokens per round, measured over 45 rounds in the document-evolution
+benchmark) and drifts past its configured size with nothing noticing.
+
+Truncating it here would delete knowledge nobody asked to delete, so the budget
+is stated to the model — which reclaims space with the same operations it uses
+for everything else — and the outcome is recorded either way.
+
+These cover the prompt itself; the engine-level tests (that a refresh records the
+size, and that going over is reported rather than truncated) live beside the
+other refresh tests in ``test_mental_model_delta.py``, where their fixtures are.
+"""
+
+from __future__ import annotations
+
+from hindsight_api.engine.reflect.prompts import build_structured_delta_prompt
+
+
+def _prompt(document_tokens: int, document_budget: int) -> str:
+    return build_structured_delta_prompt(
+        current_document_json='{"version": 2, "sections": []}',
+        candidate_markdown="candidate",
+        supporting_facts=[{"id": "o1", "text": "a new fact", "type": "observation"}],
+        source_query="Document the API",
+        document_tokens=document_tokens,
+        document_budget=document_budget,
+    )
+
+
+class TestDocumentBudgetPrompt:
+    def test_silent_when_well_under_budget(self):
+        assert "Document budget" not in _prompt(100, 2048)
+
+    def test_warns_when_close_to_the_budget(self):
+        prompt = _prompt(1700, 2048)
+        assert "## Document budget" in prompt
+        assert "EXCEEDED" not in prompt
+        assert "prefer replacing stale blocks" in prompt
+
+    def test_asks_for_room_when_over_budget(self):
+        prompt = _prompt(2500, 2048)
+        assert "## Document budget (EXCEEDED)" in prompt
+        assert "2500" in prompt and "2048" in prompt
+        assert "remove_block" in prompt
+
+    def test_never_asks_to_drop_the_new_facts(self):
+        prompt = _prompt(2500, 2048)
+        assert "never" in prompt.lower()
+        assert "dropping the facts you are integrating" in prompt
+
+    def test_absent_when_the_caller_does_not_pass_a_budget(self):
+        prompt = build_structured_delta_prompt(
+            current_document_json="{}",
+            candidate_markdown="c",
+            supporting_facts=[],
+            source_query="q",
+        )
+        assert "Document budget" not in prompt

--- a/hindsight-api-slim/tests/test_mental_model_dry_run_refresh.py
+++ b/hindsight-api-slim/tests/test_mental_model_dry_run_refresh.py
@@ -689,7 +689,7 @@ class TestKeepTrace:
             )
 
         stored = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
-        assert stored["content"] == "# Team\n\nStill here."
+        assert stored["content"] == "# Team\n\nStill here.\n"
         trace = (stored.get("reflect_response") or {}).get("trace")
         assert trace is not None
         assert trace["outcome"] == "refresh_failed_empty_candidate"
@@ -742,7 +742,7 @@ class TestDryRunRefreshEndpoint:
         assert "trace" in body
 
         stored = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
-        assert stored["content"] == "# Team\n\nOriginal.", "the endpoint must not persist"
+        assert stored["content"] == "# Team\n\nOriginal.\n", "the endpoint must not persist"
 
         await memory.delete_bank(bank_id, request_context=request_context)
 

--- a/hindsight-api-slim/tests/test_mental_model_dry_run_refresh.py
+++ b/hindsight-api-slim/tests/test_mental_model_dry_run_refresh.py
@@ -131,7 +131,7 @@ class TestDryRunPersistsNothing:
         result = await memory.dry_run_refresh_mental_model(bank_id, mm["id"], request_context=request_context)
 
         assert result is not None
-        assert result.preview_content == "# Team\n\nCompletely rewritten."
+        assert result.preview_content == "# Team\n\nCompletely rewritten.\n"
         assert result.would_persist is True
 
         after = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
@@ -736,7 +736,7 @@ class TestDryRunRefreshEndpoint:
 
         assert response.status_code == 200, response.text
         body = response.json()
-        assert body["preview_content"] == "# Team\n\nRewritten."
+        assert body["preview_content"] == "# Team\n\nRewritten.\n"
         assert body["effective_mode"] == "full"
         assert body["would_persist"] is True
         assert "trace" in body

--- a/hindsight-api-slim/tests/test_mental_model_retractions.py
+++ b/hindsight-api-slim/tests/test_mental_model_retractions.py
@@ -436,6 +436,39 @@ async def test_sweep_defers_to_consolidation_when_facts_are_pending(
 # ---------------------------------------------------------------------------
 
 
+# Blocks are addressed by id, and the ids only exist in the document the model is
+# shown. A canned op therefore cannot name one up front — so it names this marker
+# and the fake resolves it out of the prompt, which is exactly what a real model
+# does. Hardcoding a position instead is the defect the id addressing removed.
+_FIRST_BLOCK = "<first-block-of-section>"
+
+
+def _remove_first_block_of(section_id: str) -> dict[str, Any]:
+    """A retraction op removing that section's first block, resolved at call time."""
+    return {"op": "remove_block", "section_id": section_id, "block_id": _FIRST_BLOCK}
+
+
+def _resolve_block_markers(ops: list[dict[str, Any]], user_prompt: str) -> list[dict[str, Any]]:
+    """Swap ``_FIRST_BLOCK`` for the real id from the document in the prompt."""
+    import json as _json
+    import re as _re
+
+    match = _re.search(r"```json\n(.*?)\n```", user_prompt, _re.DOTALL)
+    document = _json.loads(match.group(1)) if match else {"sections": []}
+    first_block: dict[str, str] = {}
+    for section in document.get("sections", []):
+        blocks = section.get("blocks") or []
+        if blocks:
+            first_block[section["id"]] = blocks[0]["id"]
+
+    resolved: list[dict[str, Any]] = []
+    for op in ops:
+        if op.get("block_id") == _FIRST_BLOCK:
+            op = {**op, "block_id": first_block.get(op["section_id"], "missing-block")}
+        resolved.append(op)
+    return resolved
+
+
 def _patch_op_calls(monkeypatch, memory: MemoryEngine, *, retraction_ops, delta_ops):
     """Route the two op-generating LLM calls by their system prompt.
 
@@ -452,7 +485,7 @@ def _patch_op_calls(monkeypatch, memory: MemoryEngine, *, retraction_ops, delta_
         system = messages[0]["content"]
         is_retraction = system == STRUCTURED_RETRACTION_SYSTEM_PROMPT
         calls.append({"kind": "retraction" if is_retraction else "delta", "messages": messages, **kwargs})
-        ops = retraction_ops if is_retraction else delta_ops
+        ops = _resolve_block_markers(retraction_ops if is_retraction else delta_ops, messages[1]["content"])
         return DeltaOperationList.model_validate({"operations": ops})
 
     monkeypatch.setattr(memory._reflect_llm_config, "call", fake_call)
@@ -488,7 +521,7 @@ async def test_delta_refresh_removes_content_resting_on_a_retracted_fact(
     calls = _patch_op_calls(
         monkeypatch,
         memory,
-        retraction_ops=[{"op": "remove_block", "section_id": "conventions", "index": 0}],
+        retraction_ops=[_remove_first_block_of("conventions")],
         delta_ops=[],
     )
 
@@ -545,7 +578,7 @@ async def test_unsay_runs_even_when_no_new_facts_arrived(
     calls = _patch_op_calls(
         monkeypatch,
         memory,
-        retraction_ops=[{"op": "remove_block", "section_id": "conventions", "index": 0}],
+        retraction_ops=[_remove_first_block_of("conventions")],
         delta_ops=[],
     )
 
@@ -595,7 +628,7 @@ async def test_unsay_is_deferred_while_facts_are_pending_consolidation(
     calls = _patch_op_calls(
         monkeypatch,
         memory,
-        retraction_ops=[{"op": "remove_block", "section_id": "conventions", "index": 0}],
+        retraction_ops=[_remove_first_block_of("conventions")],
         delta_ops=[],
     )
 

--- a/hindsight-api-slim/tests/test_mental_model_structured_output.py
+++ b/hindsight-api-slim/tests/test_mental_model_structured_output.py
@@ -200,7 +200,7 @@ class TestMentalModelStructuredOutput:
 
         # The refresh was aborted, so the prior content is untouched.
         reloaded = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
-        assert reloaded["content"] == "# Doc\n\nOriginal."
+        assert reloaded["content"] == "# Doc\n\nOriginal.\n"
         # …and the failure is auditable, like every other refresh failure: this
         # path used to raise without recording anything, so the only trace of it
         # was a log line.

--- a/hindsight-api-slim/tests/test_mental_model_structured_output.py
+++ b/hindsight-api-slim/tests/test_mental_model_structured_output.py
@@ -93,7 +93,7 @@ class TestMentalModelStructuredOutput:
         # reflect is no longer asked to derive structured_output.
         assert reflect_calls[0].get("response_schema") is None
         # Extraction runs against the final content (== the answer in full mode).
-        assert so_calls == ["# Team\n\nRegenerated answer."]
+        assert so_calls == ["# Team\n\nRegenerated answer.\n"]
         assert refreshed["reflect_response"]["structured_output"] == {"summary": "A team."}
 
     async def test_no_schema_no_structured_output(

--- a/hindsight-api-slim/tests/test_mental_model_trigger_flags.py
+++ b/hindsight-api-slim/tests/test_mental_model_trigger_flags.py
@@ -1,0 +1,250 @@
+"""Every trigger flag, checked on the delta leg.
+
+``max_tokens`` looked wired up — it was read from the model, passed to reflect,
+and enforced by a rewrite — and was still ignored for the document that actually
+got stored, because in delta mode the thing it capped never becomes the document.
+A flag can be honoured on one leg and silently dropped on the other, and reading
+the code is how that was missed the first time.
+
+So each flag here is exercised through a real delta refresh and asserted at its
+destination: retrieval options at the reflect call, document options in the delta
+prompt or the persisted row. Full mode is covered by the surrounding modules;
+this one exists because delta is the leg where a flag goes to die.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+
+from hindsight_api import MemoryEngine, RequestContext
+from tests.test_mental_model_delta import patch_llm_call, patch_reflect  # noqa: F401 — fixtures
+
+pytestmark = pytest.mark.asyncio
+
+_APPEND_OP = [{"op": "append_block", "section_id": "ops", "text": "New note."}]
+_FACTS = [{"id": "o1", "text": "a new fact about the API", "type": "observation", "context": None}]
+
+
+async def _refresh_with_trigger(
+    memory: MemoryEngine,
+    request_context: RequestContext,
+    patch_reflect,
+    patch_llm_call,
+    trigger: dict[str, Any],
+    *,
+    max_tokens: int | None = None,
+) -> dict[str, Any]:
+    """Run one delta refresh and hand back everything worth asserting on."""
+    bank_id = f"test-trigger-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id, request_context=request_context)
+    mm = await memory.create_mental_model(
+        bank_id=bank_id,
+        name="API Reference",
+        source_query="Document the API",
+        content="## Ops\n\nOriginal.\n",
+        tags=["team:core"],
+        max_tokens=max_tokens,
+        trigger={"mode": "delta", **trigger},
+        request_context=request_context,
+    )
+    reflect_calls = patch_reflect(memory, text="## Ops\n\nCandidate.\n", facts=_FACTS)
+    llm_calls = patch_llm_call(memory, returns=_APPEND_OP)
+
+    refreshed = await memory.refresh_mental_model(
+        bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+    )
+    stored = await memory.get_mental_model(bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context)
+    await memory.delete_bank(bank_id, request_context=request_context)
+    return {
+        "refreshed": refreshed,
+        "stored": stored,
+        "reflect_kwargs": reflect_calls[0] if reflect_calls else {},
+        "delta_prompt": llm_calls[0]["messages"][1]["content"] if llm_calls else "",
+        "delta_calls": llm_calls,
+    }
+
+
+class TestRetrievalFlagsReachReflect:
+    """Options that shape what the refresh retrieves.
+
+    These ride on the synthesis call, which runs on both legs — so the contract
+    is that the stored trigger arrives at ``reflect_async`` unchanged.
+    """
+
+    async def test_fact_types(self, memory, request_context, patch_reflect, patch_llm_call):
+        run = await _refresh_with_trigger(
+            memory, request_context, patch_reflect, patch_llm_call, {"fact_types": ["observation"]}
+        )
+        assert run["reflect_kwargs"]["fact_types"] == ["observation"]
+
+    async def test_exclude_mental_models(self, memory, request_context, patch_reflect, patch_llm_call):
+        run = await _refresh_with_trigger(
+            memory, request_context, patch_reflect, patch_llm_call, {"exclude_mental_models": True}
+        )
+        assert run["reflect_kwargs"]["exclude_mental_models"] is True
+
+    async def test_exclude_mental_model_ids(self, memory, request_context, patch_reflect, patch_llm_call):
+        run = await _refresh_with_trigger(
+            memory, request_context, patch_reflect, patch_llm_call, {"exclude_mental_model_ids": ["mm-other"]}
+        )
+        assert "mm-other" in run["reflect_kwargs"]["exclude_mental_model_ids"]
+
+    async def test_a_model_never_feeds_on_itself(self, memory, request_context, patch_reflect, patch_llm_call):
+        """Its own previous version is not evidence for its next one."""
+        run = await _refresh_with_trigger(memory, request_context, patch_reflect, patch_llm_call, {})
+        own_id = run["stored"]["id"]
+        assert own_id in (run["reflect_kwargs"].get("exclude_mental_model_ids") or [])
+
+    async def test_include_chunks(self, memory, request_context, patch_reflect, patch_llm_call):
+        run = await _refresh_with_trigger(
+            memory, request_context, patch_reflect, patch_llm_call, {"include_chunks": True}
+        )
+        assert run["reflect_kwargs"]["recall_include_chunks"] is True
+
+    async def test_recall_max_tokens(self, memory, request_context, patch_reflect, patch_llm_call):
+        run = await _refresh_with_trigger(
+            memory, request_context, patch_reflect, patch_llm_call, {"recall_max_tokens": 1234}
+        )
+        assert run["reflect_kwargs"]["recall_max_tokens_override"] == 1234
+
+    async def test_recall_chunks_max_tokens(self, memory, request_context, patch_reflect, patch_llm_call):
+        run = await _refresh_with_trigger(
+            memory, request_context, patch_reflect, patch_llm_call, {"recall_chunks_max_tokens": 777}
+        )
+        assert run["reflect_kwargs"]["recall_chunks_max_tokens_override"] == 777
+
+    async def test_tags_match_applies_to_the_model_tags(self, memory, request_context, patch_reflect, patch_llm_call):
+        run = await _refresh_with_trigger(memory, request_context, patch_reflect, patch_llm_call, {"tags_match": "all"})
+        assert run["reflect_kwargs"]["tags_match"] == "all"
+        assert "team:core" in (run["reflect_kwargs"].get("tags") or [])
+
+    async def test_tag_groups_override_flat_tags_entirely(self, memory, request_context, patch_reflect, patch_llm_call):
+        """Documented priority, pinned because it looks like a bug from outside.
+
+        Groups carry their own match mode, so a ``tags_match`` set alongside them
+        is deliberately not forwarded — and the model's flat tags are dropped
+        rather than intersected. Anyone reading only the trigger would expect
+        ``tags_match`` to survive; it does not, and that is the rule.
+        """
+        run = await _refresh_with_trigger(
+            memory,
+            request_context,
+            patch_reflect,
+            patch_llm_call,
+            {"tags_match": "all", "tag_groups": [{"tags": ["a", "b"], "match": "any"}]},
+        )
+        assert run["reflect_kwargs"]["tag_groups"]
+        assert run["reflect_kwargs"]["tags"] is None
+        assert run["reflect_kwargs"]["tags_match"] == "any"
+
+    async def test_tagged_model_defaults_to_strict_isolation(
+        self, memory, request_context, patch_reflect, patch_llm_call
+    ):
+        """No tags_match on a tagged model means all_strict, not 'any' — a model
+        scoped to tags must not widen its own scope by default."""
+        run = await _refresh_with_trigger(memory, request_context, patch_reflect, patch_llm_call, {})
+        assert run["reflect_kwargs"]["tags_match"] == "all_strict"
+
+    async def test_model_tags_scope_retrieval(self, memory, request_context, patch_reflect, patch_llm_call):
+        """The model's own tags, not just the trigger's, scope what it reads."""
+        run = await _refresh_with_trigger(memory, request_context, patch_reflect, patch_llm_call, {})
+        assert "team:core" in (run["reflect_kwargs"].get("tags") or [])
+
+
+class TestDocumentFlagsReachTheDeltaLeg:
+    """Options that shape the stored document.
+
+    This is the class that would have caught the ``max_tokens`` gap: in delta
+    mode the document comes from operations, so anything about the document has
+    to reach the operations call or the persist path — being passed to the
+    synthesis is not enough.
+    """
+
+    async def test_max_tokens_reaches_the_delta_prompt(self, memory, request_context, patch_reflect, patch_llm_call):
+        run = await _refresh_with_trigger(memory, request_context, patch_reflect, patch_llm_call, {}, max_tokens=300)
+        rr = run["refreshed"].get("reflect_response") or {}
+        assert rr["document_budget"] == 300
+        assert rr["document_tokens"] > 0
+
+    async def test_response_schema_is_extracted_from_the_delta_result(
+        self, memory, request_context, patch_reflect, patch_llm_call, monkeypatch
+    ):
+        """The projection must come from the document the delta produced."""
+        seen: list[str] = []
+
+        async def fake_structured_output(content_text, schema, llm_config, reflect_id, max_tokens):
+            from hindsight_api.engine.reflect.models import StructuredOutputResult
+
+            seen.append(content_text)
+            return StructuredOutputResult(structured_output={"summary": "ok"})
+
+        monkeypatch.setattr("hindsight_api.engine.reflect.agent._generate_structured_output", fake_structured_output)
+        run = await _refresh_with_trigger(
+            memory,
+            request_context,
+            patch_reflect,
+            patch_llm_call,
+            {"response_schema": {"type": "object", "properties": {"summary": {"type": "string"}}}},
+        )
+        rr = run["refreshed"].get("reflect_response") or {}
+        assert rr["structured_output"] == {"summary": "ok"}
+        # Extracted from the merged document, not from reflect's delta-only answer.
+        assert seen and "New note." in seen[0]
+        assert "Candidate." not in seen[0]
+
+    async def test_keep_trace_records_the_delta_run(self, memory, request_context, patch_reflect, patch_llm_call):
+        run = await _refresh_with_trigger(memory, request_context, patch_reflect, patch_llm_call, {"keep_trace": True})
+        rr = run["refreshed"].get("reflect_response") or {}
+        assert rr.get("trace"), "keep_trace must record the run that produced this version"
+
+    async def test_trace_is_absent_without_keep_trace(self, memory, request_context, patch_reflect, patch_llm_call):
+        run = await _refresh_with_trigger(memory, request_context, patch_reflect, patch_llm_call, {})
+        rr = run["refreshed"].get("reflect_response") or {}
+        assert not rr.get("trace")
+
+    async def test_mode_delta_actually_applied(self, memory, request_context, patch_reflect, patch_llm_call):
+        run = await _refresh_with_trigger(memory, request_context, patch_reflect, patch_llm_call, {})
+        rr = run["refreshed"].get("reflect_response") or {}
+        assert rr["delta_applied"] is True
+        assert len(run["delta_calls"]) == 1
+
+
+class TestTriggerRoundTrip:
+    """A flag that does not survive being stored is not honoured either."""
+
+    async def test_every_flag_survives_create(self, memory, request_context):
+        bank_id = f"test-trigger-rt-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        trigger = {
+            "mode": "delta",
+            "refresh_after_consolidation": True,
+            "refresh_cron": "0 3 * * *",
+            "fact_types": ["observation"],
+            "exclude_mental_models": True,
+            "exclude_mental_model_ids": ["mm-x"],
+            "tags_match": "all",
+            "tag_groups": [{"tags": ["a"], "match": "any"}],
+            "include_chunks": True,
+            "recall_max_tokens": 1234,
+            "recall_chunks_max_tokens": 777,
+            "response_schema": {"type": "object"},
+            "keep_trace": True,
+        }
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="API Reference",
+            source_query="Document the API",
+            content="## Ops\n\nOriginal.\n",
+            trigger=trigger,
+            request_context=request_context,
+        )
+        stored = await memory.get_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        for key, value in trigger.items():
+            assert stored["trigger"].get(key) == value, f"{key} did not survive create"
+
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_mental_model_trigger_flags.py
+++ b/hindsight-api-slim/tests/test_mental_model_trigger_flags.py
@@ -213,7 +213,13 @@ class TestDocumentFlagsReachTheDeltaLeg:
 
 
 class TestTriggerRoundTrip:
-    """A flag that does not survive being stored is not honoured either."""
+    """A flag that does not survive being stored is not honoured either.
+
+    This list is deliberately exhaustive over ``MentalModelTrigger``: it is the
+    cheapest place for a flag added later to be noticed, and the failure it
+    guards against — a field that round-trips as ``None`` — looks like the flag
+    being ignored rather than like a storage bug.
+    """
 
     async def test_every_flag_survives_create(self, memory, request_context):
         bank_id = f"test-trigger-rt-{uuid.uuid4().hex[:8]}"
@@ -232,6 +238,11 @@ class TestTriggerRoundTrip:
             "recall_chunks_max_tokens": 777,
             "response_schema": {"type": "object"},
             "keep_trace": True,
+            # Gates *automatic* refreshes (#3621) rather than shaping one, so it is
+            # honoured in the submit path and covered there; it is here because a
+            # flag that does not survive being stored is not honoured either, and
+            # this list is what keeps the audit complete as flags are added.
+            "min_refresh_interval_seconds": 900,
         }
         mm = await memory.create_mental_model(
             bank_id=bank_id,

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -908,7 +908,7 @@ class TestMentalModelHistory:
 
         history = await memory.get_mental_model_history(bank_id, mm["id"], request_context=request_context)
         assert len(history) == 1
-        assert history[0]["previous_content"] == "Original content"
+        assert history[0]["previous_content"] == "Original content\n"
         assert "changed_at" in history[0]
         assert "previous_reflect_response" in history[0]
 
@@ -958,10 +958,10 @@ class TestMentalModelHistory:
         assert len(history) == 2
         # Most recent first: replacing v2 snapshotted rr_v1's based_on (the only slice
         # the UI consumes). The bulky `text` and `mental_models` fields are dropped.
-        assert history[0]["previous_content"] == "v2"
+        assert history[0]["previous_content"] == "v2\n"
         assert history[0]["previous_reflect_response"] == {"based_on": rr_v1["based_on"]}
         # The first update replaced v1, which had no reflect_response stored yet.
-        assert history[1]["previous_content"] == "v1"
+        assert history[1]["previous_content"] == "v1\n"
         assert history[1]["previous_reflect_response"] is None
 
         await memory.delete_bank(bank_id, request_context=request_context)
@@ -1049,8 +1049,8 @@ class TestMentalModelHistory:
         history = await memory.get_mental_model_history(bank_id, mm["id"], request_context=request_context)
         assert len(history) == 2
         # Most recent first: second update recorded "v2" as previous, first recorded "v1"
-        assert history[0]["previous_content"] == "v2"
-        assert history[1]["previous_content"] == "v1"
+        assert history[0]["previous_content"] == "v2\n"
+        assert history[1]["previous_content"] == "v1\n"
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
@@ -1125,9 +1125,9 @@ class TestMentalModelHistory:
         # Most recent first ordering (per test_history_ordered_most_recent_first):
         # the trimmed window keeps the newest 3 — v5, v4, v3 — and drops v2, v1.
         assert len(history) == 3
-        assert history[0]["previous_content"] == "v5"
-        assert history[1]["previous_content"] == "v4"
-        assert history[2]["previous_content"] == "v3"
+        assert history[0]["previous_content"] == "v5\n"
+        assert history[1]["previous_content"] == "v4\n"
+        assert history[2]["previous_content"] == "v3\n"
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
@@ -2557,7 +2557,7 @@ class TestClearMentalModel:
             content="Some existing content",
             request_context=request_context,
         )
-        assert mm["content"] == "Some existing content"
+        assert mm["content"] == "Some existing content\n"
 
         cleared = await memory.clear_mental_model(
             bank_id=bank_id,

--- a/hindsight-api-slim/tests/test_migration_drop_v1_structured_content.py
+++ b/hindsight-api-slim/tests/test_migration_drop_v1_structured_content.py
@@ -1,0 +1,172 @@
+"""Regression for the schema-v1 ``structured_content`` drop (``d1e2f3a4b5c6``).
+
+``mental_models.structured_content`` used to hold a typed block tree parsed out
+of the document's markdown. That parse flattened every construct the block union
+could not express, permanently (#3361), so a v1 blob is a strictly worse copy of
+the row's own ``content``. The migration therefore deletes v1 blobs rather than
+converting them: the next refresh re-imports the structure from ``content``,
+losslessly.
+
+What this pins:
+- a v1 (or otherwise untagged) blob is cleared;
+- a v2 blob is left exactly as it was — the migration must not touch documents
+  already on the current schema;
+- ``content`` is never modified, on any row. It is what users read, and clearing
+  the structure must not disturb it.
+
+Uses a dedicated pg0 instance (mirrors test_migration_drop_access_count) so it
+controls exactly which migrations have run and never stamps the shared test
+instance.
+"""
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+pytestmark = pytest.mark.xdist_group("migration-drop-v1-structured-content-pg0")
+
+_SCRIPT_LOCATION = str(Path(__file__).parent.parent / "hindsight_api" / "alembic")
+
+_REVISION = "d1e2f3a4b5c6"
+# Revision immediately before the drop.
+_PRE_REVISION = "c4e8a1b7d2f6"
+
+_BANK_ID = "migration-v1-structured"
+
+_V1_BLOB = {
+    "version": 1,
+    "sections": [
+        {
+            "id": "ops",
+            "heading": "Ops",
+            "level": 2,
+            # What v1 stored for a table: one welded paragraph.
+            "blocks": [{"type": "paragraph", "text": "| a | b | |---|---| | 1 | 2 |"}],
+        }
+    ],
+}
+_V2_BLOB = {
+    "version": 2,
+    "sections": [
+        {
+            "id": "ops",
+            "heading": "Ops",
+            "level": 2,
+            "blocks": [{"id": "b1234abcd", "text": "| a | b |\n| --- | --- |\n| 1 | 2 |"}],
+        }
+    ],
+}
+_UNTAGGED_BLOB = {"sections": []}
+
+_CONTENT = "## Ops\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n"
+
+
+def _alembic_cfg(db_url: str) -> Config:
+    cfg = Config()
+    cfg.set_main_option("script_location", _SCRIPT_LOCATION)
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    cfg.set_main_option("prepend_sys_path", ".")
+    cfg.set_main_option("path_separator", "os")
+    return cfg
+
+
+@pytest.fixture(scope="module")
+def migrated_db_url():
+    """pg0 instance seeded at the pre-drop revision, then migrated through it."""
+    from hindsight_api.pg0 import EmbeddedPostgres
+
+    # port=None lets pg0 auto-assign a free port; a hardcoded port is not xdist-safe.
+    pg0 = EmbeddedPostgres(name="hindsight-drop-v1-structured-test", port=None)
+    loop = asyncio.new_event_loop()
+    try:
+        url = loop.run_until_complete(pg0.ensure_running())
+    finally:
+        loop.close()
+
+    cfg = _alembic_cfg(url)
+    command.upgrade(cfg, _PRE_REVISION)
+
+    engine = create_engine(url)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text("INSERT INTO banks (bank_id) VALUES (:b) ON CONFLICT DO NOTHING"),
+                {"b": _BANK_ID},
+            )
+            for mm_id, blob in (
+                ("mm-v1", _V1_BLOB),
+                ("mm-v2", _V2_BLOB),
+                ("mm-untagged", _UNTAGGED_BLOB),
+                ("mm-null", None),
+            ):
+                conn.execute(
+                    text(
+                        "INSERT INTO mental_models "
+                        "(id, bank_id, subtype, name, description, source_query, content, structured_content) "
+                        "VALUES (:id, :bank, 'pinned', :name, '', 'what are the ops?', :content, "
+                        "CAST(:sc AS jsonb))"
+                    ),
+                    {
+                        "id": mm_id,
+                        "bank": _BANK_ID,
+                        "name": mm_id,
+                        "content": _CONTENT,
+                        "sc": json.dumps(blob) if blob is not None else None,
+                    },
+                )
+    finally:
+        engine.dispose()
+
+    command.upgrade(cfg, _REVISION)
+    return url
+
+
+def _row(conn, mm_id: str):
+    return conn.execute(
+        text("SELECT content, structured_content FROM mental_models WHERE id = :id AND bank_id = :bank"),
+        {"id": mm_id, "bank": _BANK_ID},
+    ).one()
+
+
+def test_v1_structure_is_cleared(migrated_db_url):
+    engine = create_engine(migrated_db_url)
+    try:
+        with engine.connect() as conn:
+            assert _row(conn, "mm-v1").structured_content is None
+    finally:
+        engine.dispose()
+
+
+def test_untagged_structure_is_cleared(migrated_db_url):
+    """A blob with no ``version`` key is not v2 either."""
+    engine = create_engine(migrated_db_url)
+    try:
+        with engine.connect() as conn:
+            assert _row(conn, "mm-untagged").structured_content is None
+    finally:
+        engine.dispose()
+
+
+def test_v2_structure_is_untouched(migrated_db_url):
+    engine = create_engine(migrated_db_url)
+    try:
+        with engine.connect() as conn:
+            assert _row(conn, "mm-v2").structured_content == _V2_BLOB
+    finally:
+        engine.dispose()
+
+
+def test_content_is_never_modified(migrated_db_url):
+    """The markdown is the document; clearing a structure must not disturb it."""
+    engine = create_engine(migrated_db_url)
+    try:
+        with engine.connect() as conn:
+            for mm_id in ("mm-v1", "mm-v2", "mm-untagged", "mm-null"):
+                assert _row(conn, mm_id).content == _CONTENT, mm_id
+    finally:
+        engine.dispose()

--- a/hindsight-api-slim/tests/test_migration_drop_v1_structured_content.py
+++ b/hindsight-api-slim/tests/test_migration_drop_v1_structured_content.py
@@ -89,7 +89,12 @@ def migrated_db_url():
         loop.close()
 
     cfg = _alembic_cfg(url)
-    command.upgrade(cfg, _PRE_REVISION)
+    # Bring the schema up first, then seed, then step the *stamp* back over this
+    # revision and re-apply it. A pg0 instance survives between runs, and alembic
+    # will not replay a migration on a DB already stamped past it — seeding into
+    # a stamped DB would leave the rows untouched and the test asserting nothing.
+    # This migration's downgrade is a no-op, so stepping back costs nothing.
+    command.upgrade(cfg, _REVISION)
 
     engine = create_engine(url)
     try:
@@ -98,6 +103,8 @@ def migrated_db_url():
                 text("INSERT INTO banks (bank_id) VALUES (:b) ON CONFLICT DO NOTHING"),
                 {"b": _BANK_ID},
             )
+            # Idempotent seed: the instance persists across runs.
+            conn.execute(text("DELETE FROM mental_models WHERE bank_id = :b"), {"b": _BANK_ID})
             for mm_id, blob in (
                 ("mm-v1", _V1_BLOB),
                 ("mm-v2", _V2_BLOB),
@@ -122,6 +129,7 @@ def migrated_db_url():
     finally:
         engine.dispose()
 
+    command.downgrade(cfg, _PRE_REVISION)
     command.upgrade(cfg, _REVISION)
     return url
 

--- a/hindsight-api-slim/tests/test_reflect_document_answer.py
+++ b/hindsight-api-slim/tests/test_reflect_document_answer.py
@@ -1,0 +1,119 @@
+"""The reflect agent can answer with a document instead of markdown.
+
+A document that is generated as markdown has to be read back to work out its
+structure, and reading markdown back is where #3361 destroyed tables. In
+document mode the model states the structure and the markdown is rendered from
+it, so nothing the model writes is ever parsed to find out what it meant.
+
+These are pure-Python tests of the schema and the parsing of the tool call —
+the mechanics. Whether a real model fills the shape correctly is covered by the
+``hs_llm_core`` refresh evals in ``test_mental_model_delta.py``.
+"""
+
+from __future__ import annotations
+
+from hindsight_api.engine.reflect.structured_doc import (
+    document_from_sections,
+    render_document,
+)
+from hindsight_api.engine.reflect.tools_schema import get_reflect_tools
+
+
+def _done_tool(**kwargs) -> dict:
+    return next(t for t in get_reflect_tools(**kwargs) if t["function"]["name"] == "done")
+
+
+class TestDoneToolSchema:
+    def test_markdown_mode_is_the_default(self):
+        params = _done_tool()["function"]["parameters"]
+        assert "answer" in params["properties"]
+        assert "document" not in params["properties"]
+
+    def test_document_mode_replaces_the_answer_field(self):
+        params = _done_tool(answer_as_document=True)["function"]["parameters"]
+        assert "document" in params["properties"]
+        assert "answer" not in params["properties"], "the model must not have a markdown escape hatch"
+        assert params["required"] == ["document"]
+
+    def test_document_mode_keeps_the_supporting_id_fields(self):
+        params = _done_tool(answer_as_document=True)["function"]["parameters"]
+        for field in ("memory_ids", "mental_model_ids", "observation_ids"):
+            assert field in params["properties"]
+
+    def test_document_mode_composes_with_directives(self):
+        params = _done_tool(directive_rules=["Be concise"], answer_as_document=True)["function"]["parameters"]
+        assert set(params["required"]) == {"document", "directive_compliance"}
+
+    def test_schema_has_no_union_types(self):
+        """A tool schema goes to the provider verbatim, and Gemini rejects ``oneOf``."""
+        rendered = repr(_done_tool(answer_as_document=True))
+        for keyword in ("oneOf", "anyOf", "allOf", "discriminator"):
+            assert keyword not in rendered
+
+    def test_section_shape_is_heading_level_blocks(self):
+        document = _done_tool(answer_as_document=True)["function"]["parameters"]["properties"]["document"]
+        section = document["properties"]["sections"]["items"]
+        assert set(section["required"]) == {"heading", "level", "blocks"}
+        assert section["properties"]["blocks"]["items"]["type"] == "string"
+
+
+class TestDocumentFromSections:
+    def test_renders_headings_and_blocks(self):
+        doc = document_from_sections(
+            {"sections": [{"heading": "Ops", "level": 2, "blocks": ["Intro.", "- one\n- two"]}]}
+        )
+        assert render_document(doc) == "## Ops\n\nIntro.\n\n- one\n- two\n"
+
+    def test_ids_are_assigned(self):
+        doc = document_from_sections({"sections": [{"heading": "Ops", "level": 2, "blocks": ["Intro."]}]})
+        assert doc.sections[0].id == "ops"
+        assert doc.sections[0].blocks[0].id
+
+    def test_table_survives_verbatim(self):
+        table = "| a | b |\n| --- | --- |\n| 1 | 2 |"
+        doc = document_from_sections({"sections": [{"heading": "T", "level": 2, "blocks": [table]}]})
+        assert doc.sections[0].blocks[0].text == table
+
+    def test_a_block_holding_several_fragments_is_split(self):
+        """The model sometimes packs a whole section into one string."""
+        doc = document_from_sections({"sections": [{"heading": "T", "level": 2, "blocks": ["One para.\n\nTwo para."]}]})
+        assert [b.text for b in doc.sections[0].blocks] == ["One para.", "Two para."]
+
+    def test_blank_lines_inside_a_fence_do_not_split(self):
+        fence = "```python\ndef f():\n\n    return 1\n```"
+        doc = document_from_sections({"sections": [{"heading": "T", "level": 2, "blocks": [fence]}]})
+        assert [b.text for b in doc.sections[0].blocks] == [fence]
+
+    def test_heading_hashes_are_stripped(self):
+        doc = document_from_sections({"sections": [{"heading": "## Ops", "level": 2, "blocks": ["x"]}]})
+        assert doc.sections[0].heading == "Ops"
+        assert render_document(doc).startswith("## Ops\n")
+
+    def test_empty_heading_renders_without_one(self):
+        doc = document_from_sections({"sections": [{"heading": "", "level": 2, "blocks": ["lead in"]}]})
+        assert doc.sections[0].id == "preamble"
+        assert render_document(doc) == "lead in\n"
+
+    def test_out_of_range_level_is_clamped(self):
+        doc = document_from_sections({"sections": [{"heading": "T", "level": 99, "blocks": ["x"]}]})
+        assert doc.sections[0].level == 6
+
+    def test_missing_level_defaults_to_two(self):
+        doc = document_from_sections({"sections": [{"heading": "T", "blocks": ["x"]}]})
+        assert doc.sections[0].level == 2
+
+    def test_duplicate_headings_get_unique_ids(self):
+        doc = document_from_sections(
+            {"sections": [{"heading": "T", "level": 2, "blocks": ["a"]}, {"heading": "T", "level": 2, "blocks": ["b"]}]}
+        )
+        assert [s.id for s in doc.sections] == ["t", "t-2"]
+
+    def test_empty_and_malformed_entries_are_dropped(self):
+        doc = document_from_sections(
+            {"sections": [{"heading": "", "level": 2, "blocks": ["   ", None]}, "not a section", {}]}
+        )
+        assert doc.sections == []
+
+    def test_empty_payload_is_an_empty_document(self):
+        assert document_from_sections({}).sections == []
+        assert render_document(document_from_sections({"sections": []})) == ""

--- a/hindsight-api-slim/tests/test_reflect_document_answer.py
+++ b/hindsight-api-slim/tests/test_reflect_document_answer.py
@@ -117,3 +117,49 @@ class TestDocumentFromSections:
     def test_empty_payload_is_an_empty_document(self):
         assert document_from_sections({}).sections == []
         assert render_document(document_from_sections({"sections": []})) == ""
+
+
+class TestOverBudgetRewrite:
+    """A document too long for its budget is trimmed as a document, not as prose.
+
+    The trim is the one place a long answer gets regenerated, so asking for prose
+    there would put the model back in charge of the markdown that gets stored —
+    on exactly the documents whose structure matters most.
+    """
+
+    def test_a_json_rewrite_is_read_back_as_a_document(self):
+        from hindsight_api.engine.reflect.agent import _document_from_rewrite
+
+        rewritten = (
+            '{"sections": [{"heading": "Ops", "level": 2, "blocks": ["| a | b |\\n| --- | --- |\\n| 1 | 2 |"]}]}'
+        )
+        trimmed = _document_from_rewrite(rewritten, "previous")
+        assert [s.heading for s in trimmed.structure.sections] == ["Ops"]
+        assert trimmed.markdown == "## Ops\n\n| a | b |\n| --- | --- |\n| 1 | 2 |"
+
+    def test_markdown_rewrite_falls_back_to_a_lossless_split(self):
+        """A model that ignores the format must not cost us the whole reflect."""
+        from hindsight_api.engine.reflect.agent import _document_from_rewrite
+
+        trimmed = _document_from_rewrite("## Ops\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n", "previous")
+        assert [s.heading for s in trimmed.structure.sections] == ["Ops"]
+        assert "| 1 | 2 |" in trimmed.markdown.splitlines()
+
+    def test_empty_rewrite_keeps_the_previous_answer(self):
+        from hindsight_api.engine.reflect.agent import _document_from_rewrite
+
+        trimmed = _document_from_rewrite("   ", "## Kept\n\nbody\n")
+        assert trimmed.markdown == "## Kept\n\nbody\n"
+        assert [s.heading for s in trimmed.structure.sections] == ["Kept"]
+
+    def test_the_render_always_matches_the_structure(self):
+        from hindsight_api.engine.reflect.agent import _document_from_rewrite
+        from hindsight_api.engine.reflect.structured_doc import render_document
+
+        for rewritten in (
+            '{"sections": [{"heading": "A", "level": 2, "blocks": ["one", "two"]}]}',
+            "## A\n\none\n\ntwo\n",
+            "",
+        ):
+            trimmed = _document_from_rewrite(rewritten, "## Kept\n\nbody\n")
+            assert trimmed.markdown.strip() == render_document(trimmed.structure).strip()

--- a/hindsight-api-slim/tests/test_reflections.py
+++ b/hindsight-api-slim/tests/test_reflections.py
@@ -49,7 +49,7 @@ class TestMentalModelsCRUD:
 
         assert mental_model["name"] == "Team Preferences"
         assert mental_model["source_query"] == "What are the team's communication preferences?"
-        assert mental_model["content"] == "The team prefers async communication via Slack"
+        assert mental_model["content"] == "The team prefers async communication via Slack\n"
         assert mental_model["tags"] == ["team"]
         assert "id" in mental_model
 
@@ -191,7 +191,7 @@ class TestMentalModelsCRUD:
         )
 
         assert updated["name"] == "Updated Name"
-        assert updated["content"] == "Updated Content"
+        assert updated["content"] == "Updated Content\n"
 
         # Cleanup
         await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_refresh_outcome_metadata.py
+++ b/hindsight-api-slim/tests/test_refresh_outcome_metadata.py
@@ -344,19 +344,19 @@ def test_delta_failure_reason_narrows_the_fallback_vocabulary():
 # ---------------------------------------------------------------------------
 
 # The document each scenario starts from. It round-trips through
-# parse_markdown -> render_document unchanged, which is what lets the zero-op
+# split_markdown -> render_document unchanged, which is what lets the zero-op
 # delta case below be byte-identical rather than merely equivalent.
 _BASELINE = "# Team\n\nAlice is the lead.\n"
 
 _VALID_OP = {
     "op": "append_block",
     "section_id": "team",
-    "block": {"type": "paragraph", "text": "Bob joined the team."},
+    "text": "Bob joined the team.",
 }
 _UNKNOWN_SECTION_OP = {
     "op": "append_block",
     "section_id": "does-not-exist",
-    "block": {"type": "paragraph", "text": "Bob joined the team."},
+    "text": "Bob joined the team.",
 }
 _FACTS = [{"id": "obs-new", "text": "Bob joined", "type": "observation", "context": None}]
 _SCHEMA = {"type": "object", "properties": {"summary": {"type": "string"}}}
@@ -512,10 +512,10 @@ async def test_refresh_outcome_matrix(case: _OutcomeCase, memory: MemoryEngine, 
     if case.unparseable_baseline:
         from hindsight_api.engine.reflect import structured_doc
 
-        def unparseable(_markdown: str):
-            raise ValueError("simulated unparseable markdown")
+        def unreadable(_stored, _markdown: str):
+            raise ValueError("simulated unreadable structured document")
 
-        monkeypatch.setattr(structured_doc, "parse_markdown", unparseable)
+        monkeypatch.setattr(structured_doc, "structured_document_from_stored", unreadable)
     if case.structured_output_fails:
         import types
 

--- a/hindsight-api-slim/tests/test_structured_doc.py
+++ b/hindsight-api-slim/tests/test_structured_doc.py
@@ -1,14 +1,18 @@
-"""Unit tests for the structured document schema, renderer, parser, and
+"""Unit tests for the structured document schema, renderer, splitter, and
 delta-operation applicator.
 
 These tests are pure-Python (no DB, no LLM) and run fast. They guard the
 mechanical guarantees that the structured-delta architecture relies on:
 
 - Deterministic rendering (same input → same bytes).
-- Round-trip parse → render is stable for canonical markdown.
-- Section IDs are stable slugs and survive disambiguation.
-- Operations target sections/blocks by id/index and never silently corrupt
-  the document; invalid ops are dropped, not applied half-way.
+- ``split_markdown`` is *lossless*: every non-blank line of the input comes
+  back verbatim and in order, whatever markdown construct it belongs to. This
+  is the guarantee v1's typed parser did not have — it flattened anything it
+  could not classify onto one line, permanently (#3361).
+- Section and block IDs are stable and unique.
+- Operations target sections and blocks by id and never silently corrupt the
+  document: an id that does not resolve is dropped and reported, never applied
+  to whatever happens to be nearby (#3273).
 - Sections and blocks not mentioned by any op come through byte-identical.
 """
 
@@ -19,7 +23,6 @@ import pytest
 from hindsight_api.engine.reflect.delta_ops import (
     AddSectionOp,
     AppendBlockOp,
-    DeltaOperationList,
     InsertBlockOp,
     RemoveBlockOp,
     RemoveSectionOp,
@@ -29,60 +32,65 @@ from hindsight_api.engine.reflect.delta_ops import (
     apply_operations,
 )
 from hindsight_api.engine.reflect.structured_doc import (
-    BulletListBlock,
-    CodeBlock,
-    OrderedListBlock,
-    ParagraphBlock,
+    Block,
     Section,
     StructuredDocument,
-    TableBlock,
+    make_block_id,
     make_unique_id,
-    parse_markdown,
-    render_block,
+    normalize_block_text,
     render_document,
     render_section,
     slugify_heading,
+    split_markdown,
+    structured_document_from_stored,
 )
 
-# Helpers --------------------------------------------------------------------
+# Markdown corpus ------------------------------------------------------------
+#
+# Every construct here was destroyed by the v1 parser (see #3361 and the
+# investigation that preceded this rewrite). They are kept together because the
+# fidelity guarantee is about *all* markdown, not about the handful of shapes
+# the old block union happened to model.
+
+MARKDOWN_CORPUS: dict[str, str] = {
+    "paragraph": "## S\n\nA sentence.\n",
+    "multi_line_paragraph": "## S\n\nA sentence.\nAnother sentence.\n",
+    "hard_line_break": "## S\n\nline one  \nline two\n",
+    "bullets": "## S\n\n- one\n- two\n",
+    "nested_bullets": "## S\n\n- top\n  - child\n    - grandchild\n- second\n",
+    "bullet_continuation": "## S\n\n- item one\n  continued line of item one\n- item two\n",
+    "ordered_from_five": "## S\n\n5. five\n6. six\n",
+    "ordered_paren": "## S\n\n1) one\n2) two\n",
+    "mixed_list": "## S\n\n- bullet\n1. ordered\n",
+    "task_list": "## S\n\n- [ ] todo\n- [x] done\n",
+    "blockquote": "## S\n\n> quoted line one\n> quoted line two\n",
+    "horizontal_rule": "## S\n\npara a\n\n---\n\npara b\n",
+    "setext_heading": "Title\n=====\n\nbody\n",
+    "html_block": "## S\n\n<details>\n<summary>x</summary>\ntext\n</details>\n",
+    "indented_code": "## S\n\n    def f():\n        return 1\n",
+    "fenced_code": '## S\n\n```python\ndef f():\n\n    return {"a": 1}\n```\n',
+    "fenced_code_with_heading": "## S\n\n```\n# not a heading\n```\n",
+    "table": "## S\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n",
+    "table_aligned": "## S\n\n| a | b |\n|:--|--:|\n| 1 | 2 |\n",
+    "table_no_trailing_pipe": "## S\n\n| a | b |\n|---|---|\n| 1 | 2\n",
+    "table_no_leading_pipe": "## S\n\n| a | b |\n|---|---|\na | 1 | 2 |\n",
+    "table_single_dash_separator": "## S\n\n| a | b |\n| - | - |\n| 1 | 2 |\n",
+    "table_pipe_in_cell": "## S\n\n| a | b |\n| --- | --- |\n| `x \\| y` | 2 |\n",
+    "preamble": "Intro prose.\n\n## S\n\nbody\n",
+    "many_sections": "# T\n\nlead\n\n## A\n\na body\n\n### B\n\nb body\n",
+    "unicode": "## 概要\n\n日本語のテキスト。\n",
+}
 
 
-def _team_overview_doc() -> StructuredDocument:
-    return StructuredDocument(
-        sections=[
-            Section(
-                id="team-overview",
-                heading="Team Overview",
-                level=1,
-                blocks=[ParagraphBlock(text="Quick summary of the engineering team.")],
-            ),
-            Section(
-                id="members",
-                heading="Members",
-                level=2,
-                blocks=[
-                    BulletListBlock(
-                        items=[
-                            "**Alice** — team lead, owns planning.",
-                            "**Bob** — senior engineer, mentors juniors.",
-                        ]
-                    )
-                ],
-            ),
-            Section(
-                id="cadence",
-                heading="Cadence",
-                level=2,
-                blocks=[ParagraphBlock(text="Standups happen daily at 9am.")],
-            ),
-        ]
-    )
+def _significant_lines(markdown: str) -> list[str]:
+    """Non-blank lines, right-stripped of nothing — compared verbatim."""
+    return [line for line in markdown.splitlines() if line.strip()]
 
 
-# Slug ----------------------------------------------------------------------
+# Slug / ids -----------------------------------------------------------------
 
 
-class TestSlugify:
+class TestIds:
     def test_basic(self):
         assert slugify_heading("Purpose") == "purpose"
 
@@ -93,7 +101,6 @@ class TestSlugify:
         assert slugify_heading("Inputs / Context !") == "inputs-context"
 
     def test_unicode_falls_back(self):
-        # Non-ASCII chars are stripped; if nothing remains, slug becomes "section".
         assert slugify_heading("???") == "section"
 
     def test_make_unique_id_no_collision(self):
@@ -103,410 +110,495 @@ class TestSlugify:
         assert make_unique_id("rules", {"rules"}) == "rules-2"
         assert make_unique_id("rules", {"rules", "rules-2"}) == "rules-3"
 
+    def test_block_id_is_deterministic(self):
+        assert make_block_id("hello", set()) == make_block_id("hello", set())
 
-# Renderer ------------------------------------------------------------------
+    def test_block_id_differs_by_content(self):
+        assert make_block_id("hello", set()) != make_block_id("goodbye", set())
+
+    def test_block_id_disambiguates_identical_text(self):
+        first = make_block_id("same", set())
+        assert make_block_id("same", {first}) == f"{first}-2"
+
+    def test_identical_blocks_get_distinct_ids(self):
+        doc = split_markdown("## S\n\nrepeated\n\nrepeated\n")
+        ids = [b.id for b in doc.sections[0].blocks]
+        assert len(ids) == len(set(ids)) == 2
+
+
+# Renderer -------------------------------------------------------------------
 
 
 class TestRenderer:
-    def test_paragraph(self):
-        assert render_block(ParagraphBlock(text="hello world")) == "hello world"
+    def test_section_with_heading(self):
+        section = Section(id="s", heading="Title", level=3, blocks=[Block(id="b1", text="body")])
+        assert render_section(section) == "### Title\n\nbody"
 
-    def test_bullet_list(self):
-        block = BulletListBlock(items=["one", "two"])
-        assert render_block(block) == "- one\n- two"
+    def test_section_without_heading_renders_bare_blocks(self):
+        section = Section(id="preamble", heading="", blocks=[Block(id="b1", text="body")])
+        assert render_section(section) == "body"
 
-    def test_ordered_list_uses_sequential_numbering(self):
-        block = OrderedListBlock(items=["one", "two", "three"])
-        assert render_block(block) == "1. one\n2. two\n3. three"
+    def test_blocks_are_blank_line_separated(self):
+        section = Section(
+            id="s",
+            heading="T",
+            blocks=[Block(id="b1", text="one"), Block(id="b2", text="two")],
+        )
+        assert render_section(section) == "## T\n\none\n\ntwo"
 
-    def test_code_block_with_language(self):
-        block = CodeBlock(language="json", text='{"a": 1}')
-        assert render_block(block) == '```json\n{"a": 1}\n```'
-
-    def test_code_block_no_language(self):
-        block = CodeBlock(text="raw text")
-        assert render_block(block) == "```\nraw text\n```"
-
-    def test_table_one_row_per_line(self):
-        block = TableBlock(headers=["Layer", "Role"], rows=[["API", "HTTP"], ["Engine", "Memory"]])
-        assert render_block(block) == ("| Layer | Role |\n| --- | --- |\n| API | HTTP |\n| Engine | Memory |")
-
-    def test_table_escapes_pipes_in_cells(self):
-        block = TableBlock(headers=["col"], rows=[["a | b"]])
-        assert render_block(block) == "| col |\n| --- |\n| a \\| b |"
-
-    def test_table_cell_newline_collapses_to_one_line(self):
-        block = TableBlock(headers=["col"], rows=[["first\nsecond"]])
-        assert render_block(block) == "| col |\n| --- |\n| first second |"
-
-    def test_table_short_row_is_padded(self):
-        block = TableBlock(headers=["a", "b", "c"], rows=[["1"]])
-        assert render_block(block).splitlines()[-1] == "| 1 |  |  |"
-
-    def test_table_row_wider_than_headers_keeps_every_cell(self):
-        block = TableBlock(headers=["a"], rows=[["1", "2"]])
-        assert render_block(block) == "| a |  |\n| --- | --- |\n| 1 | 2 |"
-
-    def test_table_without_headers_still_renders_rows(self):
-        block = TableBlock(headers=[], rows=[["1", "2"]])
-        assert render_block(block) == "|  |  |\n| --- | --- |\n| 1 | 2 |"
-
-    def test_empty_table_renders_empty(self):
-        assert render_block(TableBlock()) == ""
-
-    def test_section_heading_level(self):
-        section = Section(id="purpose", heading="Purpose", level=3, blocks=[ParagraphBlock(text="hi")])
-        assert render_section(section).startswith("### Purpose\n\nhi")
-
-    def test_document_round_trip_is_stable(self):
-        doc = _team_overview_doc()
-        rendered = render_document(doc)
-        # Re-rendering must produce the same bytes.
-        assert render_document(doc) == rendered
-        # Headings, members, cadence all present.
-        assert "# Team Overview" in rendered
-        assert "## Members" in rendered
-        assert "## Cadence" in rendered
-        assert "- **Alice**" in rendered
-        assert "Standups happen daily at 9am" in rendered
-        # Sections separated by exactly one blank line, document ends with newline.
-        assert rendered.endswith("\n")
-        assert "\n\n\n" not in rendered
+    def test_block_text_is_rendered_verbatim(self):
+        table = "| a | b |\n| --- | --- |\n| 1 | 2 |"
+        section = Section(id="s", heading="T", blocks=[Block(id="b1", text=table)])
+        assert table in render_section(section)
 
     def test_empty_document_renders_empty(self):
         assert render_document(StructuredDocument()) == ""
 
+    def test_document_ends_with_single_newline(self):
+        doc = split_markdown("## S\n\nbody\n")
+        assert render_document(doc).endswith("body\n")
 
-# Parser --------------------------------------------------------------------
+    def test_render_is_deterministic(self):
+        doc = split_markdown(MARKDOWN_CORPUS["many_sections"])
+        assert render_document(doc) == render_document(doc)
+
+    def test_empty_blocks_are_not_rendered(self):
+        section = Section(id="s", heading="T", blocks=[Block(id="b1", text="   ")])
+        assert render_section(section) == "## T"
 
 
-class TestParser:
-    def test_simple_document(self):
-        markdown = (
-            "# Team Overview\n\nQuick summary.\n\n## Members\n\n- Alice\n- Bob\n\n## Cadence\n\nStandups daily.\n"
-        )
-        doc = parse_markdown(markdown)
-        assert [s.id for s in doc.sections] == ["team-overview", "members", "cadence"]
-        assert [s.level for s in doc.sections] == [1, 2, 2]
-        assert isinstance(doc.sections[0].blocks[0], ParagraphBlock)
-        assert isinstance(doc.sections[1].blocks[0], BulletListBlock)
-        assert doc.sections[1].blocks[0].items == ["Alice", "Bob"]
+class TestNormalizeBlockText:
+    def test_strips_blank_edges(self):
+        assert normalize_block_text("\n\nbody\n\n") == "body"
 
-    def test_horizontal_rule_treated_as_blank(self):
-        markdown = "## Rules\n\n- one\n\n---\n\n## Stop\n\nstop here.\n"
-        doc = parse_markdown(markdown)
-        assert [s.id for s in doc.sections] == ["rules", "stop"]
-        # Horizontal rule must NOT become a paragraph.
-        assert all(not (isinstance(b, ParagraphBlock) and "---" in b.text) for s in doc.sections for b in s.blocks)
+    def test_keeps_hard_line_break_spaces(self):
+        assert normalize_block_text("line one  \nline two") == "line one  \nline two"
 
-    def test_horizontal_rule_inside_code_fence_is_preserved(self):
-        # `---` is the YAML document separator, so treating it as a section
-        # separator inside a fence merges two documents into one invalid one.
-        markdown = (
-            "## Deploy Manifest\n\n```yaml\napiVersion: v1\nkind: ConfigMap\n---\napiVersion: v1\nkind: Secret\n```\n"
-        )
-        doc = parse_markdown(markdown)
-        block = doc.sections[0].blocks[0]
-        assert isinstance(block, CodeBlock)
-        assert block.text == "apiVersion: v1\nkind: ConfigMap\n---\napiVersion: v1\nkind: Secret"
-        assert render_document(doc) == markdown
+    def test_keeps_leading_indentation(self):
+        assert normalize_block_text("    indented code") == "    indented code"
 
-    def test_rule_spellings_inside_code_fence_are_preserved(self):
-        for rule in ("---", "***", "___", "-----", "  ---"):
-            markdown = f"## Snippet\n\n```text\nbefore\n{rule}\nafter\n```\n"
-            doc = parse_markdown(markdown)
-            block = doc.sections[0].blocks[0]
-            assert isinstance(block, CodeBlock), rule
-            assert block.text == f"before\n{rule}\nafter", rule
 
-    def test_ordered_list(self):
-        markdown = "## Steps\n\n1. one\n2. two\n3. three\n"
-        doc = parse_markdown(markdown)
-        block = doc.sections[0].blocks[0]
-        assert isinstance(block, OrderedListBlock)
-        assert block.items == ["one", "two", "three"]
+# Splitter fidelity ----------------------------------------------------------
 
-    def test_code_block(self):
-        markdown = '## Example\n\n```json\n{"a": 1}\n```\n'
-        doc = parse_markdown(markdown)
-        block = doc.sections[0].blocks[0]
-        assert isinstance(block, CodeBlock)
-        assert block.language == "json"
-        assert block.text == '{"a": 1}'
 
-    def test_implicit_overview_when_content_before_first_heading(self):
-        markdown = "preamble paragraph.\n\n## Members\n\n- Alice\n"
-        doc = parse_markdown(markdown)
-        assert doc.sections[0].id == "overview"
-        assert isinstance(doc.sections[0].blocks[0], ParagraphBlock)
-        assert doc.sections[1].id == "members"
+class TestSplitFidelity:
+    """The core guarantee: splitting never loses or rewrites content."""
+
+    @pytest.mark.parametrize("name", sorted(MARKDOWN_CORPUS))
+    def test_every_significant_line_survives_verbatim(self, name: str):
+        markdown = MARKDOWN_CORPUS[name]
+        rendered = render_document(split_markdown(markdown))
+        assert _significant_lines(rendered) == _significant_lines(markdown)
+
+    @pytest.mark.parametrize("name", sorted(MARKDOWN_CORPUS))
+    def test_render_of_split_is_idempotent(self, name: str):
+        markdown = MARKDOWN_CORPUS[name]
+        once = render_document(split_markdown(markdown))
+        twice = render_document(split_markdown(once))
+        assert once == twice
+
+    @pytest.mark.parametrize("name", sorted(MARKDOWN_CORPUS))
+    def test_canonical_markdown_round_trips_byte_for_byte(self, name: str):
+        """Our own render is a fixed point of the splitter."""
+        markdown = MARKDOWN_CORPUS[name]
+        canonical = render_document(split_markdown(markdown))
+        doc = split_markdown(canonical)
+        assert render_document(doc) == canonical
+        assert [b.text for s in doc.sections for b in s.blocks] == [
+            b.text for s in split_markdown(canonical).sections for b in s.blocks
+        ]
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "table",
+            "table_aligned",
+            "table_no_trailing_pipe",
+            "table_no_leading_pipe",
+            "table_single_dash_separator",
+            "table_pipe_in_cell",
+        ],
+    )
+    def test_tables_keep_one_row_per_line(self, name: str):
+        """#3361: a table — malformed rows included — is never welded onto one line."""
+        markdown = MARKDOWN_CORPUS[name]
+        rendered = render_document(split_markdown(markdown))
+        assert markdown.strip() in rendered
+        # The separator row is still its own physical line.
+        for line in _significant_lines(markdown):
+            assert line in rendered.splitlines()
+
+    def test_table_is_one_block(self):
+        doc = split_markdown(MARKDOWN_CORPUS["table_no_trailing_pipe"])
+        assert len(doc.sections[0].blocks) == 1
+        assert doc.sections[0].blocks[0].text.count("\n") == 2
+
+    def test_nested_list_indentation_survives(self):
+        rendered = render_document(split_markdown(MARKDOWN_CORPUS["nested_bullets"]))
+        assert "  - child" in rendered
+        assert "    - grandchild" in rendered
+
+    def test_ordered_list_numbering_is_not_rewritten(self):
+        rendered = render_document(split_markdown(MARKDOWN_CORPUS["ordered_from_five"]))
+        assert "5. five" in rendered
+        assert "6. six" in rendered
+
+    def test_horizontal_rule_survives(self):
+        rendered = render_document(split_markdown(MARKDOWN_CORPUS["horizontal_rule"]))
+        assert "\n---\n" in rendered
+
+    def test_hard_line_break_spaces_survive(self):
+        rendered = render_document(split_markdown(MARKDOWN_CORPUS["hard_line_break"]))
+        assert "line one  \nline two" in rendered
+
+
+class TestSplitStructure:
+    def test_sections_and_levels(self):
+        doc = split_markdown(MARKDOWN_CORPUS["many_sections"])
+        assert [(s.id, s.level) for s in doc.sections] == [("t", 1), ("a", 2), ("b", 3)]
+
+    def test_content_before_first_heading_becomes_preamble(self):
+        doc = split_markdown(MARKDOWN_CORPUS["preamble"])
+        assert doc.sections[0].id == "preamble"
+        assert doc.sections[0].heading == ""
+        assert doc.sections[0].blocks[0].text == "Intro prose."
+
+    def test_document_without_any_heading_is_all_preamble(self):
+        doc = split_markdown("just prose\n\nand more\n")
+        assert len(doc.sections) == 1
+        assert doc.sections[0].id == "preamble"
+        assert len(doc.sections[0].blocks) == 2
 
     def test_duplicate_headings_get_unique_ids(self):
-        markdown = "## Notes\n\nfirst.\n\n## Notes\n\nsecond.\n"
-        doc = parse_markdown(markdown)
-        assert [s.id for s in doc.sections] == ["notes", "notes-2"]
+        doc = split_markdown("## Rules\n\na\n\n## Rules\n\nb\n")
+        assert [s.id for s in doc.sections] == ["rules", "rules-2"]
 
-    def test_table(self):
-        md = "## Layers\n\n| Layer | Role |\n| --- | --- |\n| API | HTTP |\n| Engine | Memory |\n"
-        block = parse_markdown(md).sections[0].blocks[0]
-        assert isinstance(block, TableBlock)
-        assert block.headers == ["Layer", "Role"]
-        assert block.rows == [["API", "HTTP"], ["Engine", "Memory"]]
+    def test_blank_lines_inside_a_fence_do_not_split_blocks(self):
+        doc = split_markdown(MARKDOWN_CORPUS["fenced_code"])
+        assert len(doc.sections[0].blocks) == 1
+        assert "\n\n    return" in doc.sections[0].blocks[0].text
 
-    def test_table_alignment_colons_are_a_separator(self):
-        md = "## T\n\n| a | b |\n|:---|---:|\n| 1 | 2 |\n"
-        block = parse_markdown(md).sections[0].blocks[0]
-        assert isinstance(block, TableBlock)
-        assert block.headers == ["a", "b"]
-        assert block.rows == [["1", "2"]]
+    def test_heading_inside_a_fence_is_not_a_section(self):
+        doc = split_markdown(MARKDOWN_CORPUS["fenced_code_with_heading"])
+        assert [s.id for s in doc.sections] == ["s"]
+        assert "# not a heading" in doc.sections[0].blocks[0].text
 
-    def test_table_escaped_pipe_stays_in_one_cell(self):
-        md = "## T\n\n| col | expr |\n| --- | --- |\n| a | x \\| y |\n"
-        block = parse_markdown(md).sections[0].blocks[0]
-        assert isinstance(block, TableBlock)
-        assert block.rows == [["a", "x | y"]]
+    def test_tilde_fence_is_honoured(self):
+        doc = split_markdown("## S\n\n~~~\na\n\nb\n~~~\n")
+        assert len(doc.sections[0].blocks) == 1
 
-    def test_table_keeps_other_backslash_sequences_verbatim(self):
-        md = "## T\n\n| col |\n| --- |\n| C:\\path |\n"
-        block = parse_markdown(md).sections[0].blocks[0]
-        assert isinstance(block, TableBlock)
-        assert block.rows == [["C:\\path"]]
+    def test_empty_markdown_yields_no_sections(self):
+        assert split_markdown("").sections == []
+        assert split_markdown("   \n\n  \n").sections == []
 
-    def test_prose_containing_a_pipe_is_not_a_table(self):
-        md = "## T\n\nUse a | b to pipe.\nSecond line.\n"
-        block = parse_markdown(md).sections[0].blocks[0]
-        assert isinstance(block, ParagraphBlock)
+    def test_heading_only_document(self):
+        doc = split_markdown("## Empty\n")
+        assert doc.sections[0].blocks == []
+        assert render_document(doc) == "## Empty\n"
 
-    def test_pipe_rows_without_separator_are_not_a_table(self):
-        md = "## T\n\n| a | b |\n| 1 | 2 |\n"
-        block = parse_markdown(md).sections[0].blocks[0]
-        assert isinstance(block, ParagraphBlock)
+    def test_runs_of_blank_lines_collapse(self):
+        rendered = render_document(split_markdown("## S\n\n\n\na\n\n\n\nb\n"))
+        assert rendered == "## S\n\na\n\nb\n"
 
-    def test_table_round_trip_via_render(self):
-        doc = StructuredDocument(
-            sections=[
-                Section(
-                    id="layers",
-                    heading="Layers",
-                    blocks=[TableBlock(headers=["Layer", "Note"], rows=[["API", "a | b"], ["Engine", ""]])],
-                )
-            ]
-        )
-        markdown = render_document(doc)
-        roundtripped = parse_markdown(markdown)
-        assert roundtripped.sections[0].blocks[0] == doc.sections[0].blocks[0]
-        assert render_document(roundtripped) == markdown
-
-    def test_round_trip_via_render(self):
-        original = _team_overview_doc()
-        markdown = render_document(original)
-        roundtripped = parse_markdown(markdown)
-        # Re-render must match the original render exactly.
-        assert render_document(roundtripped) == markdown
+    def test_split_is_deterministic(self):
+        markdown = MARKDOWN_CORPUS["many_sections"]
+        assert split_markdown(markdown) == split_markdown(markdown)
 
 
-# Operation applicator ------------------------------------------------------
+class TestStructuredDocumentFromStored:
+    def test_valid_v2_is_used_as_is(self):
+        doc = split_markdown("## S\n\nbody\n")
+        loaded = structured_document_from_stored(doc.model_dump(), "## Other\n\nignored\n")
+        assert loaded == doc
+
+    def test_v1_document_is_rebuilt_from_markdown(self):
+        """v1's typed blocks are a lossy projection of the same markdown — drop them."""
+        v1 = {
+            "version": 1,
+            "sections": [
+                {
+                    "id": "s",
+                    "heading": "S",
+                    "level": 2,
+                    "blocks": [{"type": "paragraph", "text": "| a | b | |---|---| | 1 | 2 |"}],
+                }
+            ],
+        }
+        markdown = "## S\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n"
+        loaded = structured_document_from_stored(v1, markdown)
+        assert render_document(loaded) == markdown
+
+    def test_missing_structure_is_rebuilt_from_markdown(self):
+        markdown = "## S\n\nbody\n"
+        assert render_document(structured_document_from_stored(None, markdown)) == markdown
+
+    def test_corrupt_structure_falls_back_to_markdown(self):
+        markdown = "## S\n\nbody\n"
+        loaded = structured_document_from_stored({"version": 2, "sections": "nonsense"}, markdown)
+        assert render_document(loaded) == markdown
+
+    def test_empty_markdown_and_no_structure_is_an_empty_document(self):
+        assert structured_document_from_stored(None, "").sections == []
+
+
+# Operations -----------------------------------------------------------------
+
+
+def _doc() -> StructuredDocument:
+    return split_markdown(
+        "# Team Overview\n\n"
+        "Quick summary of the engineering team.\n\n"
+        "## Members\n\n"
+        "- **Alice** — team lead.\n- **Bob** — senior engineer.\n\n"
+        "## Cadence\n\n"
+        "Standups happen daily at 9am.\n"
+    )
+
+
+def _block_id(doc: StructuredDocument, section_id: str, index: int = 0) -> str:
+    section = doc.section_by_id(section_id)
+    assert section is not None
+    return section.blocks[index].id
 
 
 class TestApplyOperations:
     def test_zero_ops_returns_identical_document(self):
-        doc = _team_overview_doc()
-        result = apply_operations(doc, [])
-        assert result.document.model_dump() == doc.model_dump()
-        assert render_document(result.document) == render_document(doc)
-        assert result.applied == []
-        assert result.changed is False
+        doc = _doc()
+        outcome = apply_operations(doc, [])
+        assert outcome.document == doc
+        assert outcome.applied == []
+        assert not outcome.changed
 
-    def test_unknown_section_op_is_skipped(self):
-        doc = _team_overview_doc()
-        op = AppendBlockOp(section_id="does-not-exist", block=ParagraphBlock(text="x"))
-        result = apply_operations(doc, [op])
-        assert result.applied == []
-        assert len(result.skipped) == 1
-        assert "unknown section_id" in result.skipped[0]["reason"]
-        # Document unchanged.
-        assert render_document(result.document) == render_document(doc)
+    def test_original_document_is_not_mutated(self):
+        doc = _doc()
+        before = render_document(doc)
+        apply_operations(doc, [RemoveSectionOp(section_id="members")])
+        assert render_document(doc) == before
 
-    def test_append_block_to_existing_section(self):
-        doc = _team_overview_doc()
-        op = AppendBlockOp(
-            section_id="members",
-            block=BulletListBlock(items=["**Carol** — junior engineer."]),
+    def test_append_block(self):
+        doc = _doc()
+        outcome = apply_operations(doc, [AppendBlockOp(section_id="cadence", text="Retro on Fridays.")])
+        assert outcome.applied[0]["op"] == "append_block"
+        assert "Retro on Fridays." in render_document(outcome.document)
+
+    def test_append_block_assigns_a_unique_id(self):
+        doc = _doc()
+        outcome = apply_operations(doc, [AppendBlockOp(section_id="cadence", text="New.")])
+        ids = [b.id for s in outcome.document.sections for b in s.blocks]
+        assert len(ids) == len(set(ids))
+
+    def test_insert_block_after_anchor(self):
+        doc = _doc()
+        anchor = _block_id(doc, "members")
+        outcome = apply_operations(
+            doc, [InsertBlockOp(section_id="members", after_block_id=anchor, text="Team is remote.")]
         )
-        result = apply_operations(doc, [op])
-        members = result.document.section_by_id("members")
-        assert members is not None
-        assert len(members.blocks) == 2  # original list + new bullet block
-        # Other sections byte-identical
-        original = doc.model_dump()
-        new = result.document.model_dump()
-        assert new["sections"][0] == original["sections"][0]  # team-overview
-        assert new["sections"][2] == original["sections"][2]  # cadence
+        section = outcome.document.section_by_id("members")
+        assert section is not None
+        assert [b.text for b in section.blocks][1] == "Team is remote."
 
-    def test_insert_block_at_index(self):
-        doc = _team_overview_doc()
-        op = InsertBlockOp(
-            section_id="members",
-            index=0,
-            block=ParagraphBlock(text="Roster as of 2026:"),
+    def test_insert_block_at_start(self):
+        doc = _doc()
+        outcome = apply_operations(doc, [InsertBlockOp(section_id="members", after_block_id=None, text="Roster:")])
+        section = outcome.document.section_by_id("members")
+        assert section is not None
+        assert section.blocks[0].text == "Roster:"
+
+    def test_replace_block_keeps_id_and_position(self):
+        doc = _doc()
+        block_id = _block_id(doc, "cadence")
+        outcome = apply_operations(
+            doc, [ReplaceBlockOp(section_id="cadence", block_id=block_id, text="Standups at 10am.")]
         )
-        result = apply_operations(doc, [op])
-        members = result.document.section_by_id("members")
-        assert isinstance(members.blocks[0], ParagraphBlock)
-        assert members.blocks[0].text.startswith("Roster")
-
-    def test_insert_block_out_of_range_skipped(self):
-        doc = _team_overview_doc()
-        op = InsertBlockOp(section_id="members", index=99, block=ParagraphBlock(text="x"))
-        result = apply_operations(doc, [op])
-        assert result.applied == []
-        assert "index out of range" in result.skipped[0]["reason"]
-
-    def test_replace_block(self):
-        doc = _team_overview_doc()
-        op = ReplaceBlockOp(
-            section_id="cadence",
-            index=0,
-            block=ParagraphBlock(text="Standups happen daily at 10am."),
-        )
-        result = apply_operations(doc, [op])
-        cadence = result.document.section_by_id("cadence")
-        assert isinstance(cadence.blocks[0], ParagraphBlock)
-        assert cadence.blocks[0].text.endswith("10am.")
+        section = outcome.document.section_by_id("cadence")
+        assert section is not None
+        assert section.blocks[0].id == block_id
+        assert section.blocks[0].text == "Standups at 10am."
 
     def test_remove_block(self):
-        doc = _team_overview_doc()
-        op = RemoveBlockOp(section_id="members", index=0)
-        result = apply_operations(doc, [op])
-        members = result.document.section_by_id("members")
-        assert members.blocks == []
+        doc = _doc()
+        block_id = _block_id(doc, "cadence")
+        outcome = apply_operations(doc, [RemoveBlockOp(section_id="cadence", block_id=block_id)])
+        section = outcome.document.section_by_id("cadence")
+        assert section is not None
+        assert section.blocks == []
 
     def test_add_section_at_end(self):
-        doc = _team_overview_doc()
-        op = AddSectionOp(
-            heading="Open Questions",
-            blocks=[ParagraphBlock(text="None right now.")],
-        )
-        result = apply_operations(doc, [op])
-        assert result.document.sections[-1].id == "open-questions"
-        assert result.document.sections[-1].heading == "Open Questions"
+        doc = _doc()
+        outcome = apply_operations(doc, [AddSectionOp(heading="Tools", blocks=["- Linear\n- GitHub"])])
+        assert outcome.document.sections[-1].id == "tools"
+        assert outcome.applied[0]["assigned_id"] == "tools"
 
-    def test_add_section_after_existing(self):
-        doc = _team_overview_doc()
-        op = AddSectionOp(
-            heading="Charter",
-            after_section_id="team-overview",
-            blocks=[ParagraphBlock(text="Mission statement.")],
-        )
-        result = apply_operations(doc, [op])
-        ids = [s.id for s in result.document.sections]
-        assert ids == ["team-overview", "charter", "members", "cadence"]
+    def test_add_section_after_another(self):
+        doc = _doc()
+        outcome = apply_operations(doc, [AddSectionOp(heading="Tools", blocks=["x"], after_section_id="members")])
+        assert [s.id for s in outcome.document.sections] == ["team-overview", "members", "tools", "cadence"]
 
-    def test_add_section_after_unknown_skipped(self):
-        doc = _team_overview_doc()
-        op = AddSectionOp(
-            heading="Charter",
-            after_section_id="nope",
-            blocks=[],
-        )
-        result = apply_operations(doc, [op])
-        assert result.applied == []
-        assert "unknown after_section_id" in result.skipped[0]["reason"]
-
-    def test_add_section_with_id_collision_disambiguates(self):
-        doc = _team_overview_doc()
-        op = AddSectionOp(heading="Members", blocks=[])
-        result = apply_operations(doc, [op])
-        # Two sections with heading "Members": the new one gets "members-2".
-        ids = [s.id for s in result.document.sections]
-        assert "members" in ids
-        assert "members-2" in ids
+    def test_add_section_disambiguates_colliding_id(self):
+        doc = _doc()
+        outcome = apply_operations(doc, [AddSectionOp(heading="Members", blocks=["x"])])
+        assert outcome.applied[0]["assigned_id"] == "members-2"
 
     def test_remove_section(self):
-        doc = _team_overview_doc()
-        op = RemoveSectionOp(section_id="cadence")
-        result = apply_operations(doc, [op])
-        assert [s.id for s in result.document.sections] == ["team-overview", "members"]
+        doc = _doc()
+        outcome = apply_operations(doc, [RemoveSectionOp(section_id="members")])
+        assert outcome.document.section_by_id("members") is None
 
-    def test_replace_section_blocks_preserves_id_and_heading(self):
-        doc = _team_overview_doc()
-        op = ReplaceSectionBlocksOp(
-            section_id="members",
-            blocks=[ParagraphBlock(text="See the org chart.")],
-        )
-        result = apply_operations(doc, [op])
-        members = result.document.section_by_id("members")
-        assert members.heading == "Members"
-        assert members.id == "members"
-        assert len(members.blocks) == 1
-        assert isinstance(members.blocks[0], ParagraphBlock)
+    def test_replace_section_blocks(self):
+        doc = _doc()
+        outcome = apply_operations(doc, [ReplaceSectionBlocksOp(section_id="members", blocks=["- Only Alice now."])])
+        section = outcome.document.section_by_id("members")
+        assert section is not None
+        assert [b.text for b in section.blocks] == ["- Only Alice now."]
 
     def test_rename_section_keeps_id(self):
-        doc = _team_overview_doc()
-        op = RenameSectionOp(section_id="cadence", new_heading="Operating Cadence")
-        result = apply_operations(doc, [op])
-        section = result.document.section_by_id("cadence")
-        assert section.heading == "Operating Cadence"
-        # ID stable so future ops still resolve.
-        assert section.id == "cadence"
+        doc = _doc()
+        outcome = apply_operations(doc, [RenameSectionOp(section_id="members", new_heading="The Team")])
+        section = outcome.document.section_by_id("members")
+        assert section is not None
+        assert section.heading == "The Team"
+        assert "## The Team" in render_document(outcome.document)
 
-    def test_unmodified_sections_byte_identical_in_render(self):
-        """The structural guarantee: sections not touched by any op render
-        identically character-for-character.
-        """
-        doc = _team_overview_doc()
-        op = AppendBlockOp(
-            section_id="members",
-            block=ParagraphBlock(text="New: Carol joined as junior engineer."),
+    def test_multi_line_block_text_survives_an_op(self):
+        doc = _doc()
+        table = "| Name | Role |\n| --- | --- |\n| Alice | Lead |"
+        outcome = apply_operations(doc, [AppendBlockOp(section_id="members", text=table)])
+        assert table in render_document(outcome.document)
+
+
+class TestOperationsAreConservative:
+    def test_unknown_section_is_skipped(self):
+        doc = _doc()
+        outcome = apply_operations(doc, [AppendBlockOp(section_id="nope", text="x")])
+        assert outcome.applied == []
+        assert "unknown section_id" in outcome.skipped[0]["reason"]
+        assert outcome.document == doc
+
+    def test_unknown_block_is_skipped(self):
+        doc = _doc()
+        outcome = apply_operations(doc, [ReplaceBlockOp(section_id="cadence", block_id="bdeadbeef", text="x")])
+        assert outcome.applied == []
+        assert "unknown block_id" in outcome.skipped[0]["reason"]
+        assert outcome.document == doc
+
+    def test_block_id_from_another_section_is_skipped(self):
+        """#3273: a mis-targeted block op must never edit the block it names."""
+        doc = _doc()
+        foreign = _block_id(doc, "members")
+        outcome = apply_operations(doc, [ReplaceBlockOp(section_id="cadence", block_id=foreign, text="WRONG")])
+        assert outcome.applied == []
+        assert "belongs to section members" in outcome.skipped[0]["reason"]
+        assert "WRONG" not in render_document(outcome.document)
+        assert outcome.document == doc
+
+    def test_unknown_insert_anchor_is_skipped_not_appended(self):
+        doc = _doc()
+        outcome = apply_operations(doc, [InsertBlockOp(section_id="cadence", after_block_id="bnope", text="x")])
+        assert outcome.applied == []
+        assert outcome.document == doc
+
+    def test_unknown_after_section_is_skipped(self):
+        doc = _doc()
+        outcome = apply_operations(doc, [AddSectionOp(heading="Tools", blocks=["x"], after_section_id="nope")])
+        assert outcome.applied == []
+        assert outcome.document == doc
+
+    def test_empty_block_text_is_skipped(self):
+        doc = _doc()
+        outcome = apply_operations(doc, [AppendBlockOp(section_id="cadence", text="   ")])
+        assert outcome.applied == []
+        assert "empty" in outcome.skipped[0]["reason"]
+
+    def test_valid_ops_still_apply_when_one_is_skipped(self):
+        doc = _doc()
+        outcome = apply_operations(
+            doc,
+            [
+                AppendBlockOp(section_id="nope", text="dropped"),
+                AppendBlockOp(section_id="cadence", text="kept"),
+            ],
         )
-        result = apply_operations(doc, [op])
-        before_overview = render_section(doc.section_by_id("team-overview"))
-        after_overview = render_section(result.document.section_by_id("team-overview"))
-        before_cadence = render_section(doc.section_by_id("cadence"))
-        after_cadence = render_section(result.document.section_by_id("cadence"))
-        assert before_overview == after_overview
-        assert before_cadence == after_cadence
+        assert len(outcome.applied) == 1
+        assert len(outcome.skipped) == 1
+        assert "kept" in render_document(outcome.document)
+        assert "dropped" not in render_document(outcome.document)
+
+    def test_untouched_sections_are_byte_identical(self):
+        doc = _doc()
+        before = render_section(doc.sections[1])
+        outcome = apply_operations(doc, [AppendBlockOp(section_id="cadence", text="Retro on Fridays.")])
+        assert render_section(outcome.document.sections[1]) == before
+
+    def test_untouched_blocks_are_byte_identical_after_a_sibling_edit(self):
+        doc = split_markdown("## S\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n\nA paragraph.\n")
+        table_before = doc.sections[0].blocks[0].text
+        target = doc.sections[0].blocks[1].id
+        outcome = apply_operations(doc, [ReplaceBlockOp(section_id="s", block_id=target, text="Changed.")])
+        assert outcome.document.sections[0].blocks[0].text == table_before
+
+    def test_op_summary_omits_block_bodies(self):
+        doc = _doc()
+        outcome = apply_operations(doc, [AppendBlockOp(section_id="cadence", text="a very long body")])
+        assert "text" not in outcome.applied[0]
+        assert outcome.applied[0]["section_id"] == "cadence"
 
 
-class TestDeltaOperationListSchema:
-    """Sanity-check that the discriminated-union schema serialises as the LLM
-    will see it: each op has a literal ``op`` string that picks the variant.
+class TestOrphanTableRowMerge:
+    """A bare table row appended as its own block joins the table above it.
+
+    A real model does this when asked to add a row (seen in the multi-round
+    stability eval). Left alone it renders as a blank line followed by a lone
+    ``| ... |``, which is not a table row at all.
     """
 
-    def test_round_trip_via_json(self):
-        ops = DeltaOperationList(
-            operations=[
-                AppendBlockOp(
-                    section_id="members",
-                    block=ParagraphBlock(text="hi"),
-                ),
-                AddSectionOp(
-                    heading="Open Questions",
-                    after_section_id="cadence",
-                    blocks=[ParagraphBlock(text="None.")],
-                ),
-                RemoveSectionOp(section_id="charter"),
-            ]
-        )
-        payload = ops.model_dump_json()
-        roundtripped = DeltaOperationList.model_validate_json(payload)
-        assert len(roundtripped.operations) == 3
+    def _table_doc(self) -> StructuredDocument:
+        return split_markdown("## Ops\n\n| A | B |\n| --- | --- |\n| x | 1 |\n\nProse after.\n")
 
-    def test_invalid_op_field_rejected(self):
-        with pytest.raises(Exception):  # pydantic ValidationError
-            DeltaOperationList.model_validate({"operations": [{"op": "not_a_real_op", "section_id": "x"}]})
+    def test_appended_row_joins_the_table(self):
+        doc = split_markdown("## Ops\n\n| A | B |\n| --- | --- |\n| x | 1 |\n")
+        outcome = apply_operations(doc, [AppendBlockOp(section_id="ops", text="| y | 2 |")])
+        rendered = render_document(outcome.document)
+        assert "| x | 1 |\n| y | 2 |" in rendered
+        assert "\n\n| y | 2 |" not in rendered
 
-    def test_extra_field_rejected(self):
-        with pytest.raises(Exception):
-            DeltaOperationList.model_validate(
-                {
-                    "operations": [
-                        {
-                            "op": "append_block",
-                            "section_id": "members",
-                            "block": {"type": "paragraph", "text": "hi"},
-                            "extra_field": "no",
-                        }
-                    ]
-                }
-            )
+    def test_append_after_a_trailing_paragraph_is_not_merged(self):
+        """Only a row landing directly after the table joins it."""
+        doc = self._table_doc()
+        outcome = apply_operations(doc, [AppendBlockOp(section_id="ops", text="| y | 2 |")])
+        assert len(outcome.document.sections[0].blocks) == 3
+
+    def test_merge_is_recorded_in_the_audit_trail(self):
+        doc = split_markdown("## Ops\n\n| A | B |\n| --- | --- |\n| x | 1 |\n")
+        outcome = apply_operations(doc, [AppendBlockOp(section_id="ops", text="| y | 2 |")])
+        table_id = doc.sections[0].blocks[0].id
+        assert outcome.applied[0]["merged_into_block_id"] == table_id
+        assert len(outcome.document.sections[0].blocks) == 1
+
+    def test_inserted_row_joins_the_table_it_follows(self):
+        doc = self._table_doc()
+        table_id = doc.sections[0].blocks[0].id
+        outcome = apply_operations(doc, [InsertBlockOp(section_id="ops", after_block_id=table_id, text="| y | 2 |")])
+        assert len(outcome.document.sections[0].blocks) == 2
+        assert outcome.document.sections[0].blocks[0].text.endswith("| y | 2 |")
+
+    def test_a_real_table_is_not_merged(self):
+        """A block with its own separator row is a table, not an orphan row."""
+        doc = self._table_doc()
+        outcome = apply_operations(doc, [AppendBlockOp(section_id="ops", text="| C | D |\n| --- | --- |\n| z | 3 |")])
+        assert len(outcome.document.sections[0].blocks) == 3
+
+    def test_prose_is_not_merged(self):
+        doc = self._table_doc()
+        outcome = apply_operations(doc, [AppendBlockOp(section_id="ops", text="Another paragraph.")])
+        assert len(outcome.document.sections[0].blocks) == 3
+
+    def test_row_after_a_non_table_block_is_kept_as_its_own_block(self):
+        doc = split_markdown("## Ops\n\nJust prose.\n")
+        outcome = apply_operations(doc, [AppendBlockOp(section_id="ops", text="| y | 2 |")])
+        assert len(outcome.document.sections[0].blocks) == 2
+        assert outcome.applied[0].get("merged_into_block_id") is None
+
+    def test_row_at_the_start_of_a_section_is_kept(self):
+        doc = self._table_doc()
+        outcome = apply_operations(doc, [InsertBlockOp(section_id="ops", after_block_id=None, text="| y | 2 |")])
+        assert outcome.document.sections[0].blocks[0].text == "| y | 2 |"

--- a/hindsight-control-plane/tsconfig.json
+++ b/hindsight-control-plane/tsconfig.json
@@ -70,7 +70,11 @@
     ".next-9998/types/**/*.ts",
     ".next-9998/dev/types/**/*.ts",
     ".next-9971/types/**/*.ts",
-    ".next-9971/dev/types/**/*.ts"
+    ".next-9971/dev/types/**/*.ts",
+    ".next-51161/types/**/*.ts",
+    ".next-51161/dev/types/**/*.ts",
+    ".next-63772/types/**/*.ts",
+    ".next-63772/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/hindsight-dev/benchmarks/document_evolution/README.md
+++ b/hindsight-dev/benchmarks/document_evolution/README.md
@@ -97,3 +97,37 @@ model under test.
 Each round contributes one fact and declares what must be true afterwards
 (`asserts`), and what must no longer be stated (`supersedes`) when it replaces an
 earlier fact.
+
+Write those claims about the **fact**, not about one phrasing of it. A claim
+demanding that a document call an operation "answers questions" failed against
+documents describing it as "synthesises stored memories" — the same operation,
+in the wording the source fact itself used. A claim a correct document can fail
+measures the corpus, not the pipeline.
+
+## Baseline
+
+`baseline_report.json` holds the run behind PR #3622: `main` (400fd3684) against
+the branch, three repetitions of the three cases, 45 refresh rounds per build,
+identical authored seeds, `gemini-3.1-flash-lite` driving both the pipeline and
+the judge.
+
+| | main | branch |
+|---|---|---|
+| collapsed tables | 3 | 0 |
+| table rows lost | 9 | 0 |
+| nesting lost | 6 | 0 |
+| hard breaks lost | 5 | 0 |
+| damaged rounds | 6 | 0 |
+| drifted sections | 14 | 0 |
+| delta applied | 45/45 | 45/45 |
+| failed rounds / skipped ops | 0 / 0 | 0 / 0 |
+| median ms per refresh | 12935 | 12940 |
+
+Content came out level: 100% recall and zero stale claims on both sides, and a
+pairwise preference of two wins to main, three to the branch, four ties — with
+the branch's documents about 10% shorter, which is the direction the judge's
+length bias pushes against it.
+
+Read the structural column as the result and the content column as a guard: the
+change was made to stop documents being destroyed, and the evidence needed was
+that it does that without making them worse.

--- a/hindsight-dev/benchmarks/document_evolution/README.md
+++ b/hindsight-dev/benchmarks/document_evolution/README.md
@@ -1,0 +1,99 @@
+# Document evolution
+
+Does a living document survive being edited, and is it any good afterwards?
+
+A mental model in delta mode is rewritten by an LLM over and over. Two things can
+go wrong and only one of them is visible in a single refresh:
+
+- the **markdown degrades** — a table welded onto one line, a nested list
+  flattened, a code fence dropped. No single round looks wrong, and because the
+  damage is a fixed point the document never recovers (issue #3361);
+- the **content degrades** — facts arrive but do not land, superseded claims are
+  still stated, detail is replaced by generalities.
+
+This benchmark measures both across several rounds, and compares two builds so a
+change to the pipeline can be shown to be an improvement rather than asserted to
+be one.
+
+## How it works
+
+The harness talks HTTP only, so the same code drives a server built from any
+revision. That is what makes an A/B possible without putting a feature flag in
+the code under test: run it once per build, then compare the two artifacts.
+
+```bash
+# a server per build, each with its own database
+uv run python -m benchmarks.document_evolution run \
+    --api-url http://localhost:8899 --build main   --out results/main.json
+uv run python -m benchmarks.document_evolution run \
+    --api-url http://localhost:9999 --build branch --out results/branch.json
+
+uv run python -m benchmarks.document_evolution compare results/main.json results/branch.json
+```
+
+Every document from every round is stored in the artifact, so the metrics are
+recomputed at comparison time. Sharpening a metric therefore costs nothing —
+apply it to results you already have instead of spending another few hundred LLM
+calls re-measuring.
+
+### Seeding
+
+`--seeding authored` (needs `--db-url`) writes the same starting document into
+both builds. The HTTP API has no way to set a document's text — creation only
+takes a topic — so this reaches past it deliberately: identical input on both
+sides means any divergence afterwards is the pipeline and not the weather.
+
+`--seeding generated` lets each build write its own first version from the same
+memories. Less controlled, but it is what a real page does, and it exercises
+generation rather than only editing.
+
+## What it measures
+
+**Structural, no LLM.** Damage is counted only in sections that no operation
+named. A refresh that rewrites a section it deliberately targeted may
+legitimately restructure it; scoring that as corruption would punish the model
+for doing its job. A section nobody named is different — nothing there was
+supposed to change, so anything missing from it was destroyed by the machinery.
+
+- `collapsed_tables` — a separator cell sharing a line with other cells, the
+  detector from #3361
+- `table_rows_lost`, `nesting_lost`, `hard_breaks_lost`, `fences_lost`,
+  `quotes_lost`, `headings_lost`
+- `drifted_sections` — sections whose bytes changed with no operation naming them
+- `delta_applied_rounds`, `failed_rounds`, `ops_skipped` — pipeline health
+- `median_ms` — wall clock per refresh. Token usage is not reported: the stored
+  `reflect_response` does not carry it, and a column that is always zero reads as
+  "this is free" rather than "this is not measured here".
+
+**Content, judged.** Claims are checked one at a time against the final document,
+so a miss points at a specific fact rather than at a score:
+
+- `recall` — facts that reached the document
+- `stale` — superseded claims the document still makes
+- `preferred` — blind pairwise comparison of the two builds' final documents.
+  Absolute quality scores from an LLM do not calibrate; a forced choice does.
+  Each pair is judged twice with the documents swapped, and a pair that changes
+  its answer is recorded as a tie rather than counted for whichever side happened
+  to go first.
+
+The judge is Gemini by default (`HINDSIGHT_TEST_JUDGE_MODEL`), independent of the
+model under test.
+
+## The corpus
+
+`corpus.py` holds three cases, and the third one is the point:
+
+- **api-reference** — tables, a three-level nested list, a fenced block with an
+  interior blank line, a hard line break, a blockquote, an ordered list that
+  starts at 5.
+- **onboarding-playbook** — prose only, no fragile markdown. This is where
+  "at least as good as before" is measured: a pipeline change that fixes tables
+  but degrades ordinary documents is not an improvement.
+- **release-runbook** — a table whose rows do not all carry both outer pipes.
+  It renders as a table, people write it and models emit it, and it is the exact
+  shape #3361 was reported against. A corpus of only well-formed tables reports
+  the pipeline as healthy, because a well-formed table never triggered the bug.
+
+Each round contributes one fact and declares what must be true afterwards
+(`asserts`), and what must no longer be stated (`supersedes`) when it replaces an
+earlier fact.

--- a/hindsight-dev/benchmarks/document_evolution/__init__.py
+++ b/hindsight-dev/benchmarks/document_evolution/__init__.py
@@ -1,0 +1,1 @@
+"""Document-evolution benchmark: does a living document survive being edited?"""

--- a/hindsight-dev/benchmarks/document_evolution/__main__.py
+++ b/hindsight-dev/benchmarks/document_evolution/__main__.py
@@ -16,6 +16,7 @@ import json
 import statistics
 from pathlib import Path
 
+from pydantic import BaseModel, ConfigDict
 from rich.console import Console
 from rich.table import Table
 
@@ -26,6 +27,30 @@ from .runner import BenchmarkArtifact, CaseRun, run_build
 
 console = Console()
 DEFAULT_RESULTS_DIR = Path(__file__).resolve().parents[1] / "results" / "document_evolution"
+
+
+class StructuralSummary(BaseModel):
+    """The no-LLM half of a build's result, in one typed row.
+
+    Every field counts something lost, so zero is the good value and the report
+    can render the whole model without knowing which metric is which.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    rounds: int = 0
+    collapsed_tables: int = 0
+    table_rows_lost: int = 0
+    nesting_lost: int = 0
+    hard_breaks_lost: int = 0
+    fences_lost: int = 0
+    quotes_lost: int = 0
+    headings_lost: int = 0
+    damaged_rounds: int = 0
+    drifted_sections: int = 0
+    delta_applied_rounds: int = 0
+    failed_rounds: int = 0
+    ops_skipped: int = 0
+    median_ms: float = 0.0
 
 
 class _MeanCoverage:
@@ -45,7 +70,7 @@ def _mean_coverage(results: list) -> _MeanCoverage:
     )
 
 
-def _structural_summary(runs: list[CaseRun]) -> dict[str, float]:
+def _structural_summary(runs: list[CaseRun]) -> StructuralSummary:
     """Damage counts across every round of every run — the no-LLM half.
 
     Recomputed here from the stored documents rather than read off the runner's
@@ -65,23 +90,23 @@ def _structural_summary(runs: list[CaseRun]) -> dict[str, float]:
                 damage_in_untouched_sections(previous.document, current.document, set(current.touched_sections))
             )
     if not rounds:
-        return {}
-    return {
-        "rounds": len(rounds),
-        "collapsed_tables": sum(d.collapsed_tables_introduced for d in damage),
-        "table_rows_lost": sum(d.table_rows_lost for d in damage),
-        "nesting_lost": sum(d.indented_list_lines_lost for d in damage),
-        "hard_breaks_lost": sum(d.hard_break_lines_lost for d in damage),
-        "fences_lost": sum(d.fenced_blocks_lost for d in damage),
-        "quotes_lost": sum(d.blockquote_lines_lost for d in damage),
-        "headings_lost": sum(len(d.headings_lost) for d in damage),
-        "damaged_rounds": sum(d.damaged for d in damage),
-        "drifted_sections": sum(len(r.drifted_sections) for r in rounds),
-        "delta_applied_rounds": sum(r.delta_applied for r in rounds),
-        "failed_rounds": sum(bool(r.error or r.refresh_skipped) for r in rounds),
-        "ops_skipped": sum(r.ops_skipped for r in rounds),
-        "median_ms": statistics.median(r.duration_ms for r in rounds),
-    }
+        return StructuralSummary()
+    return StructuralSummary(
+        rounds=len(rounds),
+        collapsed_tables=sum(d.collapsed_tables_introduced for d in damage),
+        table_rows_lost=sum(d.table_rows_lost for d in damage),
+        nesting_lost=sum(d.indented_list_lines_lost for d in damage),
+        hard_breaks_lost=sum(d.hard_break_lines_lost for d in damage),
+        fences_lost=sum(d.fenced_blocks_lost for d in damage),
+        quotes_lost=sum(d.blockquote_lines_lost for d in damage),
+        headings_lost=sum(len(d.headings_lost) for d in damage),
+        damaged_rounds=sum(d.damaged for d in damage),
+        drifted_sections=sum(len(r.drifted_sections) for r in rounds),
+        delta_applied_rounds=sum(r.delta_applied for r in rounds),
+        failed_rounds=sum(bool(r.error or r.refresh_skipped) for r in rounds),
+        ops_skipped=sum(r.ops_skipped for r in rounds),
+        median_ms=statistics.median(r.duration_ms for r in rounds),
+    )
 
 
 async def _run(args: argparse.Namespace) -> None:
@@ -115,11 +140,11 @@ def _print_structural(artifact: BenchmarkArtifact) -> None:
         summary = _structural_summary([r for r in artifact.runs if r.case == case])
         table.add_row(
             case,
-            str(int(summary["rounds"])),
-            str(int(summary["damaged_rounds"])),
-            str(int(summary["collapsed_tables"])),
-            str(int(summary["table_rows_lost"])),
-            str(int(summary["drifted_sections"])),
+            str(summary.rounds),
+            str(summary.damaged_rounds),
+            str(summary.collapsed_tables),
+            str(summary.table_rows_lost),
+            str(summary.drifted_sections),
         )
     console.print(table)
 
@@ -137,8 +162,10 @@ async def _compare(args: argparse.Namespace) -> None:
     comparison.add_column(right.build, justify="right")
     left_summary = _structural_summary(left.runs)
     right_summary = _structural_summary(right.runs)
-    for key in sorted(set(left_summary) | set(right_summary)):
-        comparison.add_row(key, str(left_summary.get(key, "-")), str(right_summary.get(key, "-")))
+    left_row = left_summary.model_dump()
+    right_row = right_summary.model_dump()
+    for key in sorted(left_row):
+        comparison.add_row(key, str(left_row[key]), str(right_row[key]))
     console.print(comparison)
 
     if args.no_judge:
@@ -217,7 +244,10 @@ async def _compare(args: argparse.Namespace) -> None:
                 {
                     "left": left.build,
                     "right": right.build,
-                    "structural": {left.build: left_summary, right.build: right_summary},
+                    "structural": {
+                        left.build: left_summary.model_dump(),
+                        right.build: right_summary.model_dump(),
+                    },
                     "content": report,
                 },
                 indent=2,

--- a/hindsight-dev/benchmarks/document_evolution/__main__.py
+++ b/hindsight-dev/benchmarks/document_evolution/__main__.py
@@ -1,0 +1,242 @@
+"""CLI: run one build, then compare two runs.
+
+# once per build, against a server running that build
+uv run python -m benchmarks.document_evolution run --api-url http://localhost:8888 --build main --out main.json
+uv run python -m benchmarks.document_evolution run --api-url http://localhost:9999 --build branch --out branch.json
+
+# then, from either build
+uv run python -m benchmarks.document_evolution compare main.json branch.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import statistics
+from pathlib import Path
+
+from rich.console import Console
+from rich.table import Table
+
+from .corpus import CASES, case_by_name
+from .judge import judge_coverage, judge_preference
+from .metrics import ShapeDelta, damage_in_untouched_sections
+from .runner import BenchmarkArtifact, CaseRun, run_build
+
+console = Console()
+DEFAULT_RESULTS_DIR = Path(__file__).resolve().parents[1] / "results" / "document_evolution"
+
+
+class _MeanCoverage:
+    """Coverage averaged over repetitions, in the shape the report reads."""
+
+    def __init__(self, recall: float, staleness: float) -> None:
+        self.recall = recall
+        self.staleness = staleness
+
+
+def _mean_coverage(results: list) -> _MeanCoverage:
+    if not results:
+        return _MeanCoverage(recall=0.0, staleness=0.0)
+    return _MeanCoverage(
+        recall=statistics.mean(r.recall for r in results),
+        staleness=statistics.mean(r.staleness for r in results),
+    )
+
+
+def _structural_summary(runs: list[CaseRun]) -> dict[str, float]:
+    """Damage counts across every round of every run — the no-LLM half.
+
+    Recomputed here from the stored documents rather than read off the runner's
+    per-round fields, so a sharper metric can be applied to results that already
+    exist instead of costing another few hundred LLM calls to re-measure.
+
+    Damage is counted only in sections no operation named. A refresh that
+    rewrites a section it deliberately targeted may legitimately restructure it;
+    scoring that as corruption would punish the model for doing its job.
+    """
+    damage: list[ShapeDelta] = []
+    rounds = []
+    for run in runs:
+        for previous, current in zip(run.rounds, run.rounds[1:], strict=False):
+            rounds.append(current)
+            damage.append(
+                damage_in_untouched_sections(previous.document, current.document, set(current.touched_sections))
+            )
+    if not rounds:
+        return {}
+    return {
+        "rounds": len(rounds),
+        "collapsed_tables": sum(d.collapsed_tables_introduced for d in damage),
+        "table_rows_lost": sum(d.table_rows_lost for d in damage),
+        "nesting_lost": sum(d.indented_list_lines_lost for d in damage),
+        "hard_breaks_lost": sum(d.hard_break_lines_lost for d in damage),
+        "fences_lost": sum(d.fenced_blocks_lost for d in damage),
+        "quotes_lost": sum(d.blockquote_lines_lost for d in damage),
+        "headings_lost": sum(len(d.headings_lost) for d in damage),
+        "damaged_rounds": sum(d.damaged for d in damage),
+        "drifted_sections": sum(len(r.drifted_sections) for r in rounds),
+        "delta_applied_rounds": sum(r.delta_applied for r in rounds),
+        "failed_rounds": sum(bool(r.error or r.refresh_skipped) for r in rounds),
+        "ops_skipped": sum(r.ops_skipped for r in rounds),
+        "median_ms": statistics.median(r.duration_ms for r in rounds),
+    }
+
+
+async def _run(args: argparse.Namespace) -> None:
+    cases = [case_by_name(n) for n in args.case] if args.case else CASES
+    artifact = await run_build(
+        args.api_url,
+        cases,
+        build=args.build,
+        seeding=args.seeding,
+        db_url=args.db_url,
+        repetitions=args.repetitions,
+        settle_seconds=args.settle,
+        keep_banks=args.keep_banks,
+    )
+    out = Path(args.out) if args.out else DEFAULT_RESULTS_DIR / f"{args.build}.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(artifact.model_dump_json(indent=2))
+    console.print(f"[green]wrote[/green] {out}")
+    _print_structural(artifact)
+
+
+def _print_structural(artifact: BenchmarkArtifact) -> None:
+    table = Table(title=f"structural damage — {artifact.build}")
+    table.add_column("case")
+    table.add_column("rounds", justify="right")
+    table.add_column("damaged", justify="right")
+    table.add_column("collapsed tables", justify="right")
+    table.add_column("rows lost", justify="right")
+    table.add_column("drifted sections", justify="right")
+    for case in sorted({r.case for r in artifact.runs}):
+        summary = _structural_summary([r for r in artifact.runs if r.case == case])
+        table.add_row(
+            case,
+            str(int(summary["rounds"])),
+            str(int(summary["damaged_rounds"])),
+            str(int(summary["collapsed_tables"])),
+            str(int(summary["table_rows_lost"])),
+            str(int(summary["drifted_sections"])),
+        )
+    console.print(table)
+
+
+async def _compare(args: argparse.Namespace) -> None:
+    left = BenchmarkArtifact.model_validate_json(Path(args.left).read_text())
+    right = BenchmarkArtifact.model_validate_json(Path(args.right).read_text())
+
+    _print_structural(left)
+    _print_structural(right)
+
+    comparison = Table(title="structural damage, side by side (lower is better)")
+    comparison.add_column("metric")
+    comparison.add_column(left.build, justify="right")
+    comparison.add_column(right.build, justify="right")
+    left_summary = _structural_summary(left.runs)
+    right_summary = _structural_summary(right.runs)
+    for key in sorted(set(left_summary) | set(right_summary)):
+        comparison.add_row(key, str(left_summary.get(key, "-")), str(right_summary.get(key, "-")))
+    console.print(comparison)
+
+    if args.no_judge:
+        return
+
+    verdicts = Table(title="content quality (judged)")
+    verdicts.add_column("case")
+    verdicts.add_column(f"{left.build} recall", justify="right")
+    verdicts.add_column(f"{right.build} recall", justify="right")
+    verdicts.add_column(f"{left.build} stale", justify="right")
+    verdicts.add_column(f"{right.build} stale", justify="right")
+    verdicts.add_column("preferred")
+
+    report: dict[str, dict[str, float | str]] = {}
+    for case_name in sorted({r.case for r in left.runs} & {r.case for r in right.runs}):
+        case = case_by_name(case_name)
+        stated = [r.asserts for r in case.rounds]
+        superseded = [r.supersedes for r in case.rounds if r.supersedes]
+
+        left_runs = [r for r in left.runs if r.case == case_name]
+        right_runs = [r for r in right.runs if r.case == case_name]
+
+        # Every repetition is judged, not just the first: one LLM run is an
+        # anecdote, and coverage is exactly the metric that varies between them.
+        left_covs, right_covs = await asyncio.gather(
+            asyncio.gather(*(judge_coverage(r.final_document, stated, superseded) for r in left_runs)),
+            asyncio.gather(*(judge_coverage(r.final_document, stated, superseded) for r in right_runs)),
+        )
+        left_cov = _mean_coverage(left_covs)
+        right_cov = _mean_coverage(right_covs)
+        preferences = await asyncio.gather(
+            *(
+                judge_preference(case.topic, left.build, lhs.final_document, right.build, rhs.final_document)
+                for lhs, rhs in zip(left_runs, right_runs, strict=False)
+            )
+        )
+        wins = {left.build: 0, right.build: 0, "tie": 0}
+        for preference in preferences:
+            wins[preference.winner] = wins.get(preference.winner, 0) + 1
+        preferred = ", ".join(f"{label}={count}" for label, count in wins.items())
+
+        verdicts.add_row(
+            case_name,
+            f"{left_cov.recall:.0%}",
+            f"{right_cov.recall:.0%}",
+            f"{left_cov.staleness:.0%}",
+            f"{right_cov.staleness:.0%}",
+            preferred,
+        )
+        report[case_name] = {
+            f"{left.build}_recall": left_cov.recall,
+            f"{right.build}_recall": right_cov.recall,
+            f"{left.build}_staleness": left_cov.staleness,
+            f"{right.build}_staleness": right_cov.staleness,
+            "preference": preferred,
+        }
+
+    console.print(verdicts)
+    console.print("[dim]recall: facts that reached the document. stale: superseded claims still stated.[/dim]")
+    if args.out:
+        Path(args.out).write_text(
+            json.dumps(
+                {
+                    "left": left.build,
+                    "right": right.build,
+                    "structural": {left.build: left_summary, right.build: right_summary},
+                    "content": report,
+                },
+                indent=2,
+            )
+        )
+        console.print(f"[green]wrote[/green] {args.out}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="document_evolution", description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run = sub.add_parser("run", help="drive one build through the corpus")
+    run.add_argument("--api-url", required=True)
+    run.add_argument("--build", required=True, help="label for this build, e.g. a git ref")
+    run.add_argument("--case", action="append", help="run only this case (repeatable)")
+    run.add_argument("--seeding", choices=["authored", "generated"], default="generated")
+    run.add_argument("--db-url", help="postgres URL; required for --seeding authored")
+    run.add_argument("--repetitions", type=int, default=1)
+    run.add_argument("--settle", type=float, default=8.0, help="seconds to wait for consolidation")
+    run.add_argument("--keep-banks", action="store_true", help="leave the benchmark banks behind for inspection")
+    run.add_argument("--out")
+
+    compare = sub.add_parser("compare", help="score two runs against each other")
+    compare.add_argument("left")
+    compare.add_argument("right")
+    compare.add_argument("--no-judge", action="store_true", help="structural metrics only, no LLM calls")
+    compare.add_argument("--out")
+
+    args = parser.parse_args()
+    asyncio.run(_run(args) if args.command == "run" else _compare(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/hindsight-dev/benchmarks/document_evolution/__main__.py
+++ b/hindsight-dev/benchmarks/document_evolution/__main__.py
@@ -150,6 +150,10 @@ async def _compare(args: argparse.Namespace) -> None:
     verdicts.add_column(f"{right.build} recall", justify="right")
     verdicts.add_column(f"{left.build} stale", justify="right")
     verdicts.add_column(f"{right.build} stale", justify="right")
+    # Length sits next to preference on purpose: LLM judges favour longer
+    # answers, so a preference that tracks the length column is a confound to
+    # read sceptically rather than a quality signal.
+    verdicts.add_column("mean bytes", justify="right")
     verdicts.add_column("preferred")
 
     report: dict[str, dict[str, float | str]] = {}
@@ -180,12 +184,15 @@ async def _compare(args: argparse.Namespace) -> None:
             wins[preference.winner] = wins.get(preference.winner, 0) + 1
         preferred = ", ".join(f"{label}={count}" for label, count in wins.items())
 
+        left_bytes = statistics.mean(len(r.final_document) for r in left_runs)
+        right_bytes = statistics.mean(len(r.final_document) for r in right_runs)
         verdicts.add_row(
             case_name,
             f"{left_cov.recall:.0%}",
             f"{right_cov.recall:.0%}",
             f"{left_cov.staleness:.0%}",
             f"{right_cov.staleness:.0%}",
+            f"{left_bytes:.0f} / {right_bytes:.0f}",
             preferred,
         )
         report[case_name] = {
@@ -194,10 +201,16 @@ async def _compare(args: argparse.Namespace) -> None:
             f"{left.build}_staleness": left_cov.staleness,
             f"{right.build}_staleness": right_cov.staleness,
             "preference": preferred,
+            f"{left.build}_mean_bytes": left_bytes,
+            f"{right.build}_mean_bytes": right_bytes,
         }
 
     console.print(verdicts)
-    console.print("[dim]recall: facts that reached the document. stale: superseded claims still stated.[/dim]")
+    console.print(
+        "[dim]recall: facts that reached the document. stale: superseded claims still stated. "
+        f"mean bytes: {left.build} / {right.build} — judges favour longer documents, so read a "
+        "preference that tracks this column sceptically.[/dim]"
+    )
     if args.out:
         Path(args.out).write_text(
             json.dumps(

--- a/hindsight-dev/benchmarks/document_evolution/baseline_report.json
+++ b/hindsight-dev/benchmarks/document_evolution/baseline_report.json
@@ -1,0 +1,68 @@
+{
+  "left": "main",
+  "right": "branch-v2",
+  "structural": {
+    "main": {
+      "rounds": 45,
+      "collapsed_tables": 3,
+      "table_rows_lost": 9,
+      "nesting_lost": 6,
+      "hard_breaks_lost": 5,
+      "fences_lost": 0,
+      "quotes_lost": 0,
+      "headings_lost": 0,
+      "damaged_rounds": 6,
+      "drifted_sections": 14,
+      "delta_applied_rounds": 45,
+      "failed_rounds": 0,
+      "ops_skipped": 0,
+      "median_ms": 12935
+    },
+    "branch-v2": {
+      "rounds": 45,
+      "collapsed_tables": 0,
+      "table_rows_lost": 0,
+      "nesting_lost": 0,
+      "hard_breaks_lost": 0,
+      "fences_lost": 0,
+      "quotes_lost": 0,
+      "headings_lost": 0,
+      "damaged_rounds": 0,
+      "drifted_sections": 0,
+      "delta_applied_rounds": 45,
+      "failed_rounds": 0,
+      "ops_skipped": 0,
+      "median_ms": 12940
+    }
+  },
+  "content": {
+    "api-reference": {
+      "main_recall": 1.0,
+      "branch-v2_recall": 1.0,
+      "main_staleness": 0.0,
+      "branch-v2_staleness": 0.0,
+      "preference": "main=1, branch-v2=0, tie=2",
+      "main_mean_bytes": 1368,
+      "branch-v2_mean_bytes": 1165.6666666666667
+    },
+    "onboarding-playbook": {
+      "main_recall": 1.0,
+      "branch-v2_recall": 1.0,
+      "main_staleness": 0.0,
+      "branch-v2_staleness": 0.0,
+      "preference": "main=1, branch-v2=0, tie=2",
+      "main_mean_bytes": 1432.6666666666667,
+      "branch-v2_mean_bytes": 1274.3333333333333
+    },
+    "release-runbook": {
+      "main_recall": 1.0,
+      "branch-v2_recall": 1.0,
+      "main_staleness": 0.0,
+      "branch-v2_staleness": 0.0,
+      "preference": "main=0, branch-v2=3, tie=0",
+      "main_mean_bytes": 1209.6666666666667,
+      "branch-v2_mean_bytes": 1124.3333333333333
+    }
+  },
+  "_about": "Baseline run for PR #3622: main (400fd3684) vs the branch, 3 repetitions of 3 cases, 45 refresh rounds per build, identical authored seeds, gemini-3.1-flash-lite for both the pipeline and the judge. Regenerate with: run once per build, then compare."
+}

--- a/hindsight-dev/benchmarks/document_evolution/corpus.py
+++ b/hindsight-dev/benchmarks/document_evolution/corpus.py
@@ -1,0 +1,255 @@
+"""Seed documents and the fact streams that evolve them.
+
+Each case is a document plus a sequence of rounds. A round contributes one new
+fact and declares what should be true of the document afterwards, so coverage
+can be judged without pinning wording:
+
+- ``asserts`` — a claim the document must support once the round has landed.
+- ``supersedes`` — a claim that must no longer be stated, when the fact replaces
+  an earlier one. This is what catches a document that accretes contradictions.
+
+``fragile`` marks the constructs a markdown round-trip used to destroy. The
+corpus deliberately also carries a case with none of them (``playbook``): the
+release question is not only "is the damage gone" but "is everything else at
+least as good as before", and a document that never contained a table is where
+that is measured.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class Round(BaseModel):
+    """One refresh: a new fact, and what the document must say afterwards."""
+
+    fact: str
+    asserts: str
+    supersedes: str | None = None
+
+
+class Case(BaseModel):
+    """A seed document and the stream of facts that edits it."""
+
+    name: str
+    topic: str = Field(description="The mental model's source_query — what the document answers.")
+    seed_memories: list[str] = Field(
+        description="Retained before the first refresh, so a generated seed has something to say."
+    )
+    seed_document: str = Field(description="Authored seed, used when the run can write it directly.")
+    rounds: list[Round]
+    fragile: bool = Field(description="Whether the seed carries constructs a markdown round-trip can destroy.")
+
+
+API_REFERENCE = Case(
+    name="api-reference",
+    topic="Document the memory API: its operations, latency budgets, failure handling and procedure.",
+    fragile=True,
+    seed_memories=[
+        "The memory API exposes retain and recall operations.",
+        "retain stores a memory and budgets 12ms; recall retrieves memories and budgets 40ms.",
+        "Transient errors are retried; schema errors fail loudly.",
+    ],
+    seed_document="""## Purpose
+
+Reference for the memory API: what each operation does, its latency budget, and how failures are handled.
+
+## Operations
+
+| Operation | Description | Budget |
+| --- | --- | --- |
+| `retain` | Store a memory | 12ms |
+| `recall` | Retrieve memories | 40ms |
+
+## Failure Handling
+
+- Retry transient errors
+  - Nested under retries
+    - Deeper still, three levels
+- Fail loudly on schema errors
+
+## Example
+
+```python
+def handler(request):
+
+    return {"ok": True}
+```
+
+## Constraints
+
+Latency budget is 200ms  
+measured at the p95.
+
+> Never block the request path on consolidation.
+
+## Procedure
+
+5. Fifth step, numbering starts at five on purpose
+6. Sixth step
+""",
+    rounds=[
+        Round(
+            fact="The recall endpoint gained a rerank stage that adds about 15ms, taking its budget to 55ms.",
+            asserts="recall includes a rerank stage and its latency budget is 55ms.",
+            supersedes="recall's budget is 40ms.",
+        ),
+        Round(
+            fact="Schema errors are now reported with the offending field name.",
+            asserts="A schema error names the offending field.",
+        ),
+        Round(
+            fact="A new operation, reflect, answers questions by synthesizing stored memories, budgeting 80ms.",
+            asserts="A reflect operation answers questions over stored memories and budgets 80ms.",
+        ),
+        Round(
+            fact="The p95 latency budget was raised from 200ms to 250ms.",
+            asserts="The p95 latency budget is 250ms.",
+            supersedes="The p95 latency budget is 200ms.",
+        ),
+        Round(
+            fact="Consolidation runs on a background worker every five minutes.",
+            asserts="Consolidation runs on a background worker every five minutes.",
+        ),
+    ],
+)
+
+PLAYBOOK = Case(
+    name="onboarding-playbook",
+    topic="Document how a new engineer is onboarded: who does what, in what order, and when they are done.",
+    fragile=False,
+    seed_memories=[
+        "New engineers are onboarded by an assigned buddy over their first two weeks.",
+        "Onboarding starts with laptop setup and repository access.",
+        "An engineer is considered onboarded once they have shipped one change to production.",
+    ],
+    seed_document="""## Purpose
+
+How a new engineer is brought up to speed in their first two weeks, and who is responsible for each part of it.
+
+## Roles
+
+Every new engineer is assigned a buddy for their first two weeks. The buddy answers questions, reviews their
+first changes, and is the person they ask before asking anyone else.
+
+The hiring manager owns the plan and checks in at the end of each week.
+
+## Sequence
+
+The first day is laptop setup and repository access. The rest of the first week is reading: the architecture
+notes, the deployment runbook, and the last quarter of incident reviews.
+
+In the second week the engineer picks up a small, well-scoped change and ships it with their buddy reviewing.
+
+## Done
+
+An engineer is onboarded once they have shipped one change to production and can describe how it got there.
+""",
+    rounds=[
+        Round(
+            fact="Buddies are now assigned by the team lead a week before the new engineer starts, not on day one.",
+            asserts="The buddy is assigned by the team lead a week before the start date.",
+            supersedes="The buddy is assigned on the engineer's first day.",
+        ),
+        Round(
+            fact="Laptop setup is now handled by IT before the start date, so day one begins with repository access.",
+            asserts="IT completes laptop setup before the start date and day one begins with repository access.",
+            supersedes="The first day is spent on laptop setup.",
+        ),
+        Round(
+            fact="The reading list gained the on-call handbook, which every new engineer must read in week one.",
+            asserts="The week-one reading list includes the on-call handbook.",
+        ),
+        Round(
+            fact="Engineers now pair with their buddy for the first production deploy rather than only being reviewed.",
+            asserts="The engineer pairs with their buddy on the first production deploy.",
+        ),
+        Round(
+            fact="The hiring manager check-in moved from weekly to a single conversation at the end of week two.",
+            asserts="The hiring manager checks in once, at the end of the second week.",
+            supersedes="The hiring manager checks in at the end of every week.",
+        ),
+    ],
+)
+
+# The shape #3361 was reported against, in the position it was reported in.
+#
+# Two details matter and the obvious version of this case has neither. First, the
+# table has a row that does not carry both outer pipes — it renders as a table,
+# people write it and models emit it, and a parser demanding both pipes on every
+# row classified the whole block as prose. Second, it lives in a section the fact
+# stream never concerns. A model editing a malformed table tends to rewrite it
+# correctly, which repairs the damage before it can be measured; the reported
+# failure was in "sections the operations never named", where nothing was
+# supposed to change and so nothing could repair it.
+MALFORMED_TABLE = Case(
+    name="release-runbook",
+    topic="Document the release runbook: the cadence, the checklist, and who signs off.",
+    fragile=True,
+    seed_memories=[
+        "Releases are cut on Tuesdays and go to staging before production.",
+        "A release needs sign-off from the on-call engineer.",
+    ],
+    seed_document="""## Cadence
+
+Releases are cut on Tuesdays. A release that misses Tuesday waits for the next one rather than going out late.
+
+## Sign-off
+
+A release needs sign-off from the on-call engineer before it reaches production.
+
+## Checklist
+
+- Migrations applied
+- Smoke tests green
+- On-call engineer signed off
+
+## Environment reference
+
+Reference only — the release process does not change these.
+
+| Environment | Region | Notes |
+|---|---|---|
+| staging | eu-west-1 | Mirrors production at a tenth of the size |
+| production | eu-west-1 | Live traffic
+
+Contact for access is the platform team  
+via their shared channel.
+
+> Environments are provisioned from infrastructure-as-code; do not edit them by hand.
+""",
+    rounds=[
+        Round(
+            fact="Releases moved from Tuesdays to Wednesdays.",
+            asserts="Releases are cut on Wednesdays.",
+            supersedes="Releases are cut on Tuesdays.",
+        ),
+        Round(
+            fact="Sign-off now needs both the on-call engineer and the release manager.",
+            asserts="Sign-off needs the on-call engineer and the release manager.",
+            supersedes="Sign-off needs only the on-call engineer.",
+        ),
+        Round(
+            fact="The checklist gained a rollback rehearsal, which happens before sign-off.",
+            asserts="A rollback rehearsal happens before sign-off.",
+        ),
+        Round(
+            fact="Smoke tests now run automatically in CI rather than manually.",
+            asserts="Smoke tests run automatically in CI.",
+            supersedes="Smoke tests are run manually.",
+        ),
+        Round(
+            fact="A release that fails its rollback rehearsal is blocked until the rehearsal passes.",
+            asserts="A failed rollback rehearsal blocks the release.",
+        ),
+    ],
+)
+
+CASES: list[Case] = [API_REFERENCE, PLAYBOOK, MALFORMED_TABLE]
+
+
+def case_by_name(name: str) -> Case:
+    for case in CASES:
+        if case.name == name:
+            return case
+    raise KeyError(f"unknown case {name!r}; have {[c.name for c in CASES]}")

--- a/hindsight-dev/benchmarks/document_evolution/corpus.py
+++ b/hindsight-dev/benchmarks/document_evolution/corpus.py
@@ -100,7 +100,12 @@ measured at the p95.
         ),
         Round(
             fact="A new operation, reflect, answers questions by synthesizing stored memories, budgeting 80ms.",
-            asserts="A reflect operation answers questions over stored memories and budgets 80ms.",
+            # Tests the fact, not one phrasing of it. The first version demanded the
+            # document say reflect "answers questions"; documents that described it
+            # as synthesising stored memories — the same operation, the wording the
+            # source fact itself uses — were scored as missing it. A claim that a
+            # correct document can fail measures the corpus, not the pipeline.
+            asserts="There is a reflect operation over stored memories, with a budget of 80ms.",
         ),
         Round(
             fact="The p95 latency budget was raised from 200ms to 250ms.",

--- a/hindsight-dev/benchmarks/document_evolution/judge.py
+++ b/hindsight-dev/benchmarks/document_evolution/judge.py
@@ -116,19 +116,30 @@ _PREFERENCE_SYSTEM = (
 )
 
 
+# A single temperature-0 judge call still flips on a borderline claim — a
+# document saying an operation "synthesizes memories" was once scored as not
+# supporting "answers questions over memories", which is a difference in wording
+# rather than in content. Asking three times and taking the majority costs a few
+# calls and stops one pedantic reading from moving a build's score.
+_CLAIM_VOTES = 3
+
+
 async def judge_coverage(document: str, stated: list[str], superseded: list[str]) -> CoverageResult:
-    """Check every claim against the final document, one call each."""
+    """Check every claim against the final document, by majority of three."""
 
     async def verdict(claim: str) -> ClaimVerdict:
-        payload = await _ask(
-            f"DOCUMENT:\n---\n{document}\n---\n\nCLAIM: {claim}",
-            _CLAIM_SYSTEM,
-        )
-        return ClaimVerdict(
-            claim=claim,
-            supported=bool(payload.get("supported")),
-            reasoning=str(payload.get("reasoning") or ""),
-        )
+        prompt = f"DOCUMENT:\n---\n{document}\n---\n\nCLAIM: {claim}"
+        payloads = await asyncio.gather(*(_ask(prompt, _CLAIM_SYSTEM) for _ in range(_CLAIM_VOTES)))
+        votes = [bool(p.get("supported")) for p in payloads]
+        supported = sum(votes) * 2 > len(votes)
+        # Keep a reasoning from the losing side when the vote was not unanimous:
+        # a split verdict is the interesting one to read.
+        dissent = next((p for p, v in zip(payloads, votes, strict=False) if v is not supported), None)
+        agreeing = next((p for p, v in zip(payloads, votes, strict=False) if v is supported), {})
+        reasoning = str((dissent or agreeing).get("reasoning") or "")
+        if dissent is not None:
+            reasoning = f"[{sum(votes)}/{len(votes)} supported] {reasoning}"
+        return ClaimVerdict(claim=claim, supported=supported, reasoning=reasoning)
 
     stated_verdicts, superseded_verdicts = await asyncio.gather(
         asyncio.gather(*(verdict(c) for c in stated)),

--- a/hindsight-dev/benchmarks/document_evolution/judge.py
+++ b/hindsight-dev/benchmarks/document_evolution/judge.py
@@ -1,0 +1,162 @@
+"""LLM judging for the half of document quality that structure cannot measure.
+
+Two questions, deliberately separate:
+
+- **Coverage** — after all the rounds, does the document actually say what the
+  facts said, and has it stopped saying what they superseded? Judged one claim
+  at a time against the final document, so a miss points at a specific fact.
+- **Preference** — put two builds' final documents side by side and ask which
+  one better serves the topic. Absolute quality scores from an LLM do not
+  calibrate; a blind pairwise choice does. Every pair is judged twice with the
+  documents swapped, and a pair that flips its answer is recorded as a tie
+  rather than silently counted for whichever side happened to go first.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+from pydantic import BaseModel, Field
+
+_JUDGE_PROVIDER = os.getenv("HINDSIGHT_TEST_JUDGE_PROVIDER", "gemini")
+_JUDGE_MODEL = os.getenv("HINDSIGHT_TEST_JUDGE_MODEL", "gemini-3.1-flash-lite")
+_JUDGE_API_KEY = os.getenv(
+    "HINDSIGHT_TEST_JUDGE_API_KEY",
+    os.getenv("GEMINI_API_KEY", os.getenv("HINDSIGHT_API_LLM_API_KEY", "")),
+)
+
+
+class ClaimVerdict(BaseModel):
+    claim: str
+    supported: bool
+    reasoning: str = ""
+
+
+class CoverageResult(BaseModel):
+    """How much of the fact stream survived into the final document."""
+
+    stated: list[ClaimVerdict] = Field(default_factory=list, description="Claims the document should support.")
+    superseded: list[ClaimVerdict] = Field(
+        default_factory=list, description="Claims the document should no longer make."
+    )
+
+    @property
+    def recall(self) -> float:
+        return _ratio(sum(v.supported for v in self.stated), len(self.stated))
+
+    @property
+    def staleness(self) -> float:
+        """Fraction of superseded claims the document still makes. Lower is better."""
+        return _ratio(sum(v.supported for v in self.superseded), len(self.superseded))
+
+
+class PreferenceResult(BaseModel):
+    winner: str = Field(description="A build label, or 'tie'.")
+    reasoning: str = ""
+    flipped: bool = Field(default=False, description="The two orderings disagreed, so this is a tie.")
+
+
+def _ratio(part: int, whole: int) -> float:
+    return part / whole if whole else 1.0
+
+
+_provider_instance = None
+
+
+def _provider():
+    """One judge provider for the whole comparison — it is stateless and reused."""
+    global _provider_instance
+    if _provider_instance is None:
+        from hindsight_api.engine.llm_wrapper import create_llm_provider
+
+        _provider_instance = create_llm_provider(
+            provider=_JUDGE_PROVIDER,
+            api_key=_JUDGE_API_KEY,
+            base_url=os.getenv("HINDSIGHT_TEST_JUDGE_BASE_URL", ""),
+            model=_JUDGE_MODEL,
+            # No reasoning_effort: the default judge is Gemini, which has no such
+            # control and logs a warning for every call when one is set.
+            reasoning_effort="",
+        )
+    return _provider_instance
+
+
+async def _ask(prompt: str, system: str) -> dict:
+    provider = _provider()
+    raw = await provider.call(
+        messages=[{"role": "system", "content": system}, {"role": "user", "content": prompt}],
+        temperature=0,
+        scope="benchmark_judge",
+    )
+    from hindsight_api.engine.llm_wrapper import parse_llm_json
+
+    text = raw if isinstance(raw, str) else str(raw)
+    try:
+        return parse_llm_json(text)
+    except json.JSONDecodeError:
+        return {}
+
+
+_CLAIM_SYSTEM = (
+    "You check whether a document supports a claim. Answer ONLY with JSON: "
+    '{"supported": true|false, "reasoning": "one sentence"}. '
+    "A claim is supported when the document states it or states something that entails it, in any wording. "
+    "It is not supported when the document is silent, vague, or says something incompatible."
+)
+
+_PREFERENCE_SYSTEM = (
+    "You compare two versions of the same reference document and pick the better one. Answer ONLY with JSON: "
+    '{"winner": "A"|"B"|"tie", "reasoning": "one or two sentences"}. '
+    "Judge, in order of importance: (1) does it answer the topic completely and without contradicting itself, "
+    "(2) is specific detail retained rather than flattened into generalities, "
+    "(3) is it well formed — tables that are tables, lists that are lists, code that is fenced, "
+    "(4) is it readable. Ignore length for its own sake. Answer 'tie' only when neither is better."
+)
+
+
+async def judge_coverage(document: str, stated: list[str], superseded: list[str]) -> CoverageResult:
+    """Check every claim against the final document, one call each."""
+
+    async def verdict(claim: str) -> ClaimVerdict:
+        payload = await _ask(
+            f"DOCUMENT:\n---\n{document}\n---\n\nCLAIM: {claim}",
+            _CLAIM_SYSTEM,
+        )
+        return ClaimVerdict(
+            claim=claim,
+            supported=bool(payload.get("supported")),
+            reasoning=str(payload.get("reasoning") or ""),
+        )
+
+    stated_verdicts, superseded_verdicts = await asyncio.gather(
+        asyncio.gather(*(verdict(c) for c in stated)),
+        asyncio.gather(*(verdict(c) for c in superseded)),
+    )
+    return CoverageResult(stated=list(stated_verdicts), superseded=list(superseded_verdicts))
+
+
+async def judge_preference(topic: str, label_a: str, doc_a: str, label_b: str, doc_b: str) -> PreferenceResult:
+    """Blind pairwise comparison, run in both orderings to cancel position bias."""
+
+    async def once(first: str, second: str) -> str:
+        payload = await _ask(
+            f"TOPIC: {topic}\n\nDOCUMENT A:\n---\n{first}\n---\n\nDOCUMENT B:\n---\n{second}\n---",
+            _PREFERENCE_SYSTEM,
+        )
+        return str(payload.get("winner") or "tie").strip().lower()
+
+    forward, backward = await asyncio.gather(once(doc_a, doc_b), once(doc_b, doc_a))
+    # In the backward run the labels are swapped, so "a" there means label_b won.
+    forward_winner = {"a": label_a, "b": label_b}.get(forward, "tie")
+    backward_winner = {"a": label_b, "b": label_a}.get(backward, "tie")
+
+    if forward_winner == backward_winner:
+        return PreferenceResult(winner=forward_winner)
+    if "tie" in (forward_winner, backward_winner):
+        # One ordering was decisive and the other was not: keep the decisive one
+        # rather than throwing away a real signal.
+        decisive = forward_winner if forward_winner != "tie" else backward_winner
+        return PreferenceResult(winner=decisive, reasoning="one ordering was undecided")
+    return PreferenceResult(winner="tie", reasoning="the two orderings disagreed", flipped=True)

--- a/hindsight-dev/benchmarks/document_evolution/metrics.py
+++ b/hindsight-dev/benchmarks/document_evolution/metrics.py
@@ -1,0 +1,189 @@
+"""Deterministic structural metrics for a rendered document.
+
+Everything here is computed from the markdown alone, with no LLM, so the same
+numbers can be produced for any build of the server. This is the half of the
+benchmark that answers "did the document survive being edited" — the other half
+(is it any *good*) needs a judge and lives in ``judge.py``.
+
+The collapsed-table detector is the one from issue #3361: a separator cell that
+shares a physical line with other cells means the table was welded together.
+"""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, Field
+
+_SEPARATOR_CELL_RX = re.compile(r"\|\s*:?-{2,}:?\s*\|")
+_PURE_SEPARATOR_RX = re.compile(r"^\s*\|?[\s:|-]+\|?\s*$")
+_TABLE_LINE_RX = re.compile(r"^\s*\|.*\|?\s*$")
+_FENCE_RX = re.compile(r"^\s*(```|~~~)")
+_INDENTED_LIST_RX = re.compile(r"^\s+[-*+]\s+\S")
+_HEADING_RX = re.compile(r"^(#{1,6})\s+\S")
+_HARD_BREAK_RX = re.compile(r"\S {2,}$")
+
+
+class DocumentShape(BaseModel):
+    """What a document is made of, and whether it is intact."""
+
+    bytes: int
+    lines: int
+    headings: list[str] = Field(default_factory=list)
+    table_rows: int = 0
+    table_blocks: int = 0
+    indented_list_lines: int = 0
+    hard_break_lines: int = 0
+    fenced_blocks: int = 0
+    blockquote_lines: int = 0
+    collapsed_tables: int = Field(
+        default=0,
+        description="Physical lines carrying a table separator plus other cells — a welded table (#3361).",
+    )
+    unbalanced_fence: bool = False
+
+
+def describe(markdown: str) -> DocumentShape:
+    """Measure a document's structure without interpreting its meaning."""
+    lines = markdown.splitlines()
+    shape = DocumentShape(bytes=len(markdown), lines=len(lines))
+
+    in_fence = False
+    prev_was_table = False
+    for line in lines:
+        if _FENCE_RX.match(line):
+            if in_fence:
+                shape.fenced_blocks += 1
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+
+        heading = _HEADING_RX.match(line)
+        if heading:
+            shape.headings.append(line.strip())
+
+        is_table_line = bool(line.strip().startswith("|") and _TABLE_LINE_RX.match(line))
+        if is_table_line:
+            shape.table_rows += 1
+            if not prev_was_table:
+                shape.table_blocks += 1
+        prev_was_table = is_table_line
+
+        if _SEPARATOR_CELL_RX.search(line) and not _PURE_SEPARATOR_RX.match(line):
+            shape.collapsed_tables += 1
+        if _INDENTED_LIST_RX.match(line):
+            shape.indented_list_lines += 1
+        if _HARD_BREAK_RX.search(line):
+            shape.hard_break_lines += 1
+        if line.lstrip().startswith(">"):
+            shape.blockquote_lines += 1
+
+    shape.unbalanced_fence = in_fence
+    return shape
+
+
+class ShapeDelta(BaseModel):
+    """What the structure lost (or gained) between two versions of a document."""
+
+    collapsed_tables_introduced: int = 0
+    table_rows_lost: int = 0
+    indented_list_lines_lost: int = 0
+    hard_break_lines_lost: int = 0
+    fenced_blocks_lost: int = 0
+    blockquote_lines_lost: int = 0
+    headings_lost: list[str] = Field(default_factory=list)
+    became_unbalanced: bool = False
+
+    @property
+    def damaged(self) -> bool:
+        """Any structural loss at all. Content changes are not damage; losing a table is."""
+        return bool(
+            self.collapsed_tables_introduced
+            or self.table_rows_lost
+            or self.indented_list_lines_lost
+            or self.hard_break_lines_lost
+            or self.fenced_blocks_lost
+            or self.blockquote_lines_lost
+            or self.became_unbalanced
+        )
+
+
+def compare_shape(before: DocumentShape, after: DocumentShape) -> ShapeDelta:
+    """Structural loss from ``before`` to ``after``.
+
+    Only losses are reported as damage. A refresh legitimately adds rows, list
+    items and sections; nothing legitimately welds a table onto one line or
+    silently drops a code fence.
+    """
+    return ShapeDelta(
+        collapsed_tables_introduced=max(0, after.collapsed_tables - before.collapsed_tables),
+        table_rows_lost=max(0, before.table_rows - after.table_rows),
+        indented_list_lines_lost=max(0, before.indented_list_lines - after.indented_list_lines),
+        hard_break_lines_lost=max(0, before.hard_break_lines - after.hard_break_lines),
+        fenced_blocks_lost=max(0, before.fenced_blocks - after.fenced_blocks),
+        blockquote_lines_lost=max(0, before.blockquote_lines - after.blockquote_lines),
+        headings_lost=[h for h in before.headings if h not in after.headings],
+        became_unbalanced=after.unbalanced_fence and not before.unbalanced_fence,
+    )
+
+
+def damage_in_untouched_sections(before: str, after: str, touched_headings: set[str]) -> ShapeDelta:
+    """Structural loss restricted to the sections no operation named.
+
+    Whole-document loss is not evidence of a bug: a refresh that deliberately
+    rewrites a section may legitimately turn its nested list into prose, and
+    counting that as damage would score an editorial decision as corruption. A
+    section nobody named is different — nothing there was supposed to change at
+    all, so any structure missing from it was destroyed by the machinery rather
+    than by the model.
+    """
+    before_sections = _sections(before)
+    after_sections = _sections(after)
+    untouched_before = "\n\n".join(body for heading, body in before_sections.items() if heading not in touched_headings)
+    untouched_after = "\n\n".join(
+        body
+        for heading, body in after_sections.items()
+        if heading not in touched_headings and heading in before_sections
+    )
+    return compare_shape(describe(untouched_before), describe(untouched_after))
+
+
+def untouched_sections_drifted(before: str, after: str, touched_headings: set[str]) -> list[str]:
+    """Headings whose body changed although no operation named their section.
+
+    Section identity is the heading text, which is what a reader sees and what
+    survives a rename-free edit. A section the model never named must come
+    through byte-identical; anything else is drift the architecture is supposed
+    to make impossible.
+    """
+    before_sections = _sections(before)
+    after_sections = _sections(after)
+    drifted: list[str] = []
+    for heading, body in before_sections.items():
+        if heading in touched_headings or heading not in after_sections:
+            continue
+        if after_sections[heading] != body:
+            drifted.append(heading)
+    return drifted
+
+
+def _sections(markdown: str) -> dict[str, str]:
+    """Split a document into ``heading -> body``, ignoring headings inside fences."""
+    sections: dict[str, str] = {}
+    current = ""
+    body: list[str] = []
+    in_fence = False
+    for line in markdown.splitlines():
+        if _FENCE_RX.match(line):
+            in_fence = not in_fence
+            body.append(line)
+            continue
+        if not in_fence and _HEADING_RX.match(line):
+            sections[current] = "\n".join(body).strip()
+            current = line.strip()
+            body = []
+            continue
+        body.append(line)
+    sections[current] = "\n".join(body).strip()
+    return sections

--- a/hindsight-dev/benchmarks/document_evolution/runner.py
+++ b/hindsight-dev/benchmarks/document_evolution/runner.py
@@ -1,0 +1,372 @@
+"""Drive one build of the server through a case's rounds and record what happened.
+
+The runner talks HTTP only. That is the point: the same harness runs against a
+server built from any revision, which is how "is the new pipeline better than the
+old one" gets answered without a feature flag inside the code under test. Run it
+once per build, then hand both artifacts to ``compare``.
+
+Seeding has two modes because they answer different questions:
+
+- ``authored`` writes an identical starting document into both builds (needs
+  ``--db-url``, since the HTTP API deliberately has no way to set a document's
+  text). Same input on both sides, so any divergence afterwards is the pipeline.
+- ``generated`` lets each build write its own first version from the same
+  memories. Less controlled, but it is what a real page does, and it exercises
+  the generation path rather than only the editing path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, Field
+
+from .corpus import Case
+from .metrics import DocumentShape, ShapeDelta, compare_shape, describe, untouched_sections_drifted
+
+
+class OperationOutcome(BaseModel):
+    """How an async operation ended."""
+
+    status: str
+    error_message: str | None = None
+    result_metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "completed"
+
+
+class CreatedMentalModel(BaseModel):
+    mental_model_id: str
+    operation_id: str | None = None
+
+
+class RoundResult(BaseModel):
+    """One refresh: what the document became, and what the pipeline did to it."""
+
+    index: int = Field(description="0 is the seed refresh; 1..n are the fact rounds.")
+    fact: str | None
+    document: str
+    shape: DocumentShape
+    delta_from_previous: ShapeDelta
+    drifted_sections: list[str] = Field(
+        default_factory=list, description="Sections that changed although no operation named them."
+    )
+    delta_applied: bool = False
+    delta_skipped_reason: str | None = None
+    refresh_skipped: str | None = None
+    ops_applied: int = 0
+    ops_skipped: int = 0
+    touched_sections: list[str] = Field(default_factory=list)
+    duration_ms: int = Field(
+        default=0,
+        description=(
+            "Wall clock for the refresh. Token usage is deliberately absent: the stored "
+            "reflect_response does not carry it, and a column that is always zero reads as "
+            "'this costs nothing' rather than 'this is not measured here'."
+        ),
+    )
+    error: str | None = None
+
+
+class CaseRun(BaseModel):
+    """Every round of one case against one build."""
+
+    case: str
+    fragile: bool
+    topic: str
+    seeding: str
+    bank_id: str
+    mental_model_id: str
+    rounds: list[RoundResult] = Field(default_factory=list)
+
+    @property
+    def final_document(self) -> str:
+        return self.rounds[-1].document if self.rounds else ""
+
+
+class BenchmarkArtifact(BaseModel):
+    """Everything one build produced — the file ``compare`` reads."""
+
+    build: str = Field(description="Label for the build under test, e.g. a git ref.")
+    api_url: str
+    api_version: str = ""
+    model: str = ""
+    runs: list[CaseRun] = Field(default_factory=list)
+
+
+class _Client:
+    """Thin wrapper over the endpoints this benchmark needs."""
+
+    def __init__(self, api_url: str, timeout: float = 600.0) -> None:
+        self._base = api_url.rstrip("/")
+        self._http = httpx.AsyncClient(timeout=timeout)
+
+    async def close(self) -> None:
+        await self._http.aclose()
+
+    async def _json(self, method: str, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+        response = await self._http.request(method, f"{self._base}{path}", json=payload)
+        response.raise_for_status()
+        return response.json() if response.content else {}
+
+    async def version(self) -> str:
+        return (await self._json("GET", "/version")).get("api_version", "")
+
+    async def ensure_bank(self, bank_id: str) -> None:
+        await self._json("GET", f"/v1/default/banks/{bank_id}/stats")
+
+    async def retain(self, bank_id: str, content: str) -> None:
+        """Retain one memory and wait for it to land.
+
+        A fact whose retain has not completed is not yet in the delta window, so
+        refreshing before it lands measures nothing.
+        """
+        response = await self._json(
+            "POST", f"/v1/default/banks/{bank_id}/memories", {"items": [{"content": content}], "async": True}
+        )
+        operation_ids = list(response.get("operation_ids") or [])
+        if response.get("operation_id"):
+            operation_ids.insert(0, response["operation_id"])
+        for operation_id in operation_ids:
+            await self.await_operation(bank_id, operation_id)
+
+    async def await_operation(self, bank_id: str, operation_id: str, timeout: float = 600.0) -> OperationOutcome:
+        """Block until an async operation settles.
+
+        Every write here — retain, create, refresh — is submitted asynchronously
+        and returns an operation id. Sleeping a fixed interval instead silently
+        benchmarks a document that is still being written: the first version of
+        this runner did exactly that and recorded five rounds of
+        "Generating content..." as though they were real documents.
+        """
+        deadline = time.time() + timeout
+        delay = 0.4
+        while True:
+            operation = await self._json("GET", f"/v1/default/banks/{bank_id}/operations/{operation_id}")
+            status = str(operation.get("status") or "")
+            if status in {"completed", "failed", "cancelled", "not_found"}:
+                return OperationOutcome(
+                    status=status,
+                    error_message=operation.get("error_message"),
+                    result_metadata=operation.get("result_metadata") or {},
+                )
+            if time.time() > deadline:
+                return OperationOutcome(status="timeout", error_message=f"still {status} after {timeout}s")
+            await asyncio.sleep(delay)
+            delay = min(delay * 1.5, 5.0)
+
+    async def create_mental_model(
+        self, bank_id: str, name: str, topic: str, trigger: dict[str, Any]
+    ) -> CreatedMentalModel:
+        created = await self._json(
+            "POST",
+            f"/v1/default/banks/{bank_id}/mental-models",
+            {"name": name, "source_query": topic, "trigger": trigger},
+        )
+        return CreatedMentalModel(mental_model_id=created["mental_model_id"], operation_id=created.get("operation_id"))
+
+    async def refresh(self, bank_id: str, mental_model_id: str) -> OperationOutcome:
+        """Submit a refresh and wait for it — the endpoint is submit-only."""
+        submitted = await self._json("POST", f"/v1/default/banks/{bank_id}/mental-models/{mental_model_id}/refresh", {})
+        operation_id = submitted.get("operation_id")
+        if not operation_id:
+            return OperationOutcome(status="failed", error_message=f"no operation id in {submitted!r}")
+        return await self.await_operation(bank_id, operation_id)
+
+    async def get_mental_model(self, bank_id: str, mental_model_id: str) -> dict[str, Any]:
+        return await self._json("GET", f"/v1/default/banks/{bank_id}/mental-models/{mental_model_id}")
+
+    async def delete_bank(self, bank_id: str) -> None:
+        await self._json("DELETE", f"/v1/default/banks/{bank_id}")
+
+
+async def _write_seed_document(db_url: str, bank_id: str, mental_model_id: str, document: str) -> None:
+    """Install an authored document straight into the row.
+
+    The HTTP API has no way to set a document's text (creation only takes a
+    topic), and the whole point of this mode is that both builds start from
+    exactly the same bytes. ``structured_content`` is cleared so the next refresh
+    imports the document the way an upgraded install would.
+    """
+    import asyncpg
+
+    conn = await asyncpg.connect(db_url)
+    try:
+        await conn.execute(
+            "UPDATE mental_models SET content = $1, structured_content = NULL WHERE id = $2 AND bank_id = $3",
+            document,
+            mental_model_id,
+            bank_id,
+        )
+    finally:
+        await conn.close()
+
+
+# What the API stores while an async build is still running. A round that reads
+# one of these is measuring a placeholder, not a document.
+_PLACEHOLDERS = ("generating content...", "no answer provided.", "")
+
+
+def _is_placeholder(document: str) -> bool:
+    return document.strip().lower() in _PLACEHOLDERS
+
+
+def _touched_headings(document: str, applied_ops: list[dict[str, Any]]) -> list[str]:
+    """Map applied operations back to the headings they named.
+
+    Operations carry section *ids*, which are slugs of headings, and the two
+    builds slug identically — so matching a heading by its slug works across
+    both without either build having to report headings.
+    """
+    import re
+
+    touched_ids = {op.get("section_id") for op in applied_ops} | {op.get("assigned_id") for op in applied_ops}
+    touched_ids = {i for i in touched_ids if i}
+    headings: list[str] = []
+    for line in document.splitlines():
+        match = re.match(r"^(#{1,6})\s+(.*\S)\s*$", line)
+        if not match:
+            continue
+        slug = re.sub(r"[^a-z0-9]+", "-", match.group(2).strip().lower()).strip("-")
+        if slug in touched_ids or any(slug == t or t.startswith(f"{slug}-") for t in touched_ids):
+            headings.append(line.strip())
+    return headings
+
+
+async def run_case(
+    client: _Client,
+    case: Case,
+    *,
+    seeding: str,
+    db_url: str | None,
+    settle_seconds: float,
+) -> CaseRun:
+    """Seed a document, then feed it one fact per round, recording each version."""
+    bank_id = f"docevo-{case.name}-{uuid.uuid4().hex[:8]}"
+    await client.ensure_bank(bank_id)
+    for memory in case.seed_memories:
+        await client.retain(bank_id, memory)
+    # Consolidation runs behind the retain operations and the delta window reads
+    # observations, so give it a moment to produce them before the first refresh.
+    await asyncio.sleep(settle_seconds)
+
+    created = await client.create_mental_model(bank_id, f"{case.name} reference", case.topic, {"mode": "delta"})
+    mental_model_id = created.mental_model_id
+    if created.operation_id:
+        outcome = await client.await_operation(bank_id, created.operation_id)
+        if not outcome.ok:
+            raise RuntimeError(f"creating the mental model {outcome.status}: {outcome.error_message}")
+
+    if seeding == "authored":
+        if not db_url:
+            raise ValueError("authored seeding needs --db-url")
+        await _write_seed_document(db_url, bank_id, mental_model_id, case.seed_document)
+
+    run = CaseRun(
+        case=case.name,
+        fragile=case.fragile,
+        topic=case.topic,
+        seeding=seeding,
+        bank_id=bank_id,
+        mental_model_id=mental_model_id,
+    )
+
+    stored = await client.get_mental_model(bank_id, mental_model_id)
+    previous = stored.get("content") or ""
+    if _is_placeholder(previous):
+        raise RuntimeError(
+            f"the seed document is still a placeholder ({previous.strip()!r}) — the create operation "
+            "reported success but wrote nothing"
+        )
+    run.rounds.append(
+        RoundResult(
+            index=0,
+            fact=None,
+            document=previous,
+            shape=describe(previous),
+            delta_from_previous=ShapeDelta(),
+        )
+    )
+
+    for index, round_spec in enumerate(case.rounds, start=1):
+        await client.retain(bank_id, round_spec.fact)
+        await asyncio.sleep(settle_seconds)
+
+        started = time.time()
+        error: str | None = None
+        try:
+            outcome = await client.refresh(bank_id, mental_model_id)
+            if not outcome.ok:
+                # A refused refresh is a result, not a crash: the document is
+                # preserved and this round is recorded as failed.
+                error = f"{outcome.status}: {outcome.error_message}"
+        except httpx.HTTPStatusError as exc:
+            error = f"{exc.response.status_code}: {exc.response.text[:200]}"
+        duration_ms = int((time.time() - started) * 1000)
+
+        refreshed = await client.get_mental_model(bank_id, mental_model_id)
+        document = refreshed.get("content") or ""
+        reflect_response = refreshed.get("reflect_response") or {}
+        applied = reflect_response.get("delta_operations_applied") or []
+        touched = _touched_headings(previous, applied)
+
+        run.rounds.append(
+            RoundResult(
+                index=index,
+                fact=round_spec.fact,
+                document=document,
+                shape=describe(document),
+                delta_from_previous=compare_shape(describe(previous), describe(document)),
+                drifted_sections=untouched_sections_drifted(previous, document, set(touched)),
+                delta_applied=bool(reflect_response.get("delta_applied")),
+                delta_skipped_reason=reflect_response.get("delta_skipped_reason"),
+                refresh_skipped=reflect_response.get("refresh_skipped"),
+                ops_applied=len(applied),
+                ops_skipped=len(reflect_response.get("delta_operations_skipped") or []),
+                touched_sections=touched,
+                duration_ms=duration_ms,
+                error=error,
+            )
+        )
+        previous = document
+
+    return run
+
+
+async def run_build(
+    api_url: str,
+    cases: list[Case],
+    *,
+    build: str,
+    seeding: str,
+    db_url: str | None,
+    repetitions: int,
+    settle_seconds: float,
+    keep_banks: bool,
+) -> BenchmarkArtifact:
+    """Run every case (``repetitions`` times) against one server."""
+    client = _Client(api_url)
+    try:
+        artifact = BenchmarkArtifact(build=build, api_url=api_url, api_version=await client.version())
+        for repetition in range(repetitions):
+            for case in cases:
+                run = await run_case(client, case, seeding=seeding, db_url=db_url, settle_seconds=settle_seconds)
+                # Repetitions share a case name on purpose: the report aggregates
+                # over them, because one LLM run proves nothing about a model.
+                artifact.runs.append(run)
+                print(
+                    f"[{build}] {case.name} rep {repetition + 1}/{repetitions}: "
+                    f"{len(run.rounds) - 1} rounds, "
+                    f"{sum(r.delta_from_previous.damaged for r in run.rounds)} damaged"
+                )
+                if not keep_banks:
+                    await client.delete_bank(run.bank_id)
+        return artifact
+    finally:
+        await client.close()

--- a/hindsight-dev/benchmarks/document_evolution/runner.py
+++ b/hindsight-dev/benchmarks/document_evolution/runner.py
@@ -363,7 +363,10 @@ async def run_build(
                 print(
                     f"[{build}] {case.name} rep {repetition + 1}/{repetitions}: "
                     f"{len(run.rounds) - 1} rounds, "
-                    f"{sum(r.delta_from_previous.damaged for r in run.rounds)} damaged"
+                    f"{sum(r.delta_from_previous.damaged for r in run.rounds)} damaged",
+                    # A run takes tens of minutes; buffered progress that only
+                    # appears at the end is no progress at all.
+                    flush=True,
                 )
                 if not keep_banks:
                     await client.delete_bank(run.bank_id)

--- a/hindsight-dev/tests/test_document_evolution_metrics.py
+++ b/hindsight-dev/tests/test_document_evolution_metrics.py
@@ -1,0 +1,132 @@
+"""Unit tests for the document-evolution benchmark's damage detector.
+
+The detector decides whether a release is safe, so it gets the same scrutiny as
+the code it measures. Two failure modes would quietly invalidate a comparison: a
+detector that misses the damage it exists to catch, and one that reports an
+edit the model made on purpose as corruption.
+"""
+
+from __future__ import annotations
+
+from benchmarks.document_evolution.metrics import (
+    compare_shape,
+    damage_in_untouched_sections,
+    describe,
+    untouched_sections_drifted,
+)
+
+WELL_FORMED = """## Environments
+
+| Environment | Region |
+| --- | --- |
+| staging | eu-west-1 |
+| production | eu-west-1 |
+
+- top
+  - nested
+
+Contact the platform team  
+via their channel.
+
+> Provisioned from infrastructure-as-code.
+"""
+
+# The same document after a markdown round-trip flattened it: the table is one
+# physical line, the nesting is gone and the hard line break is gone.
+COLLAPSED = """## Environments
+
+| Environment | Region | | --- | --- | | staging | eu-west-1 | | production | eu-west-1 |
+
+- top
+- nested
+
+Contact the platform team via their channel.
+
+> Provisioned from infrastructure-as-code.
+"""
+
+
+class TestDescribe:
+    def test_counts_the_constructs_that_break(self):
+        shape = describe(WELL_FORMED)
+        assert shape.table_rows == 4
+        assert shape.indented_list_lines == 1
+        assert shape.hard_break_lines == 1
+        assert shape.blockquote_lines == 1
+        assert shape.collapsed_tables == 0
+
+    def test_detects_a_welded_table(self):
+        assert describe(COLLAPSED).collapsed_tables == 1
+
+    def test_a_separator_row_alone_is_not_a_collapse(self):
+        assert describe("| a | b |\n| --- | --- |\n| 1 | 2 |\n").collapsed_tables == 0
+
+    def test_aligned_separator_is_not_a_collapse(self):
+        assert describe("| a | b |\n|:---|---:|\n| 1 | 2 |\n").collapsed_tables == 0
+
+    def test_fences_are_counted_and_balanced(self):
+        shape = describe("```python\nx = 1\n```\n")
+        assert shape.fenced_blocks == 1
+        assert not shape.unbalanced_fence
+
+    def test_unbalanced_fence_is_reported(self):
+        assert describe("```python\nx = 1\n").unbalanced_fence
+
+    def test_table_syntax_inside_a_fence_is_not_a_table(self):
+        assert describe("```\n| a | b |\n| --- | --- |\n```\n").table_rows == 0
+
+
+class TestCompareShape:
+    def test_reports_every_loss(self):
+        delta = compare_shape(describe(WELL_FORMED), describe(COLLAPSED))
+        assert delta.collapsed_tables_introduced == 1
+        assert delta.table_rows_lost == 3
+        assert delta.indented_list_lines_lost == 1
+        assert delta.hard_break_lines_lost == 1
+        assert delta.damaged
+
+    def test_growth_is_not_damage(self):
+        grown = WELL_FORMED.replace("| production | eu-west-1 |", "| production | eu-west-1 |\n| canary | eu-west-1 |")
+        assert not compare_shape(describe(WELL_FORMED), describe(grown)).damaged
+
+    def test_identical_documents_are_undamaged(self):
+        assert not compare_shape(describe(WELL_FORMED), describe(WELL_FORMED)).damaged
+
+
+class TestDamageAttribution:
+    """Damage is only damage in a section nobody asked to change."""
+
+    def test_loss_in_an_untouched_section_is_damage(self):
+        assert damage_in_untouched_sections(WELL_FORMED, COLLAPSED, set()).damaged
+
+    def test_loss_in_a_targeted_section_is_an_edit_not_damage(self):
+        delta = damage_in_untouched_sections(WELL_FORMED, COLLAPSED, {"## Environments"})
+        assert not delta.damaged
+
+    def test_damage_elsewhere_still_counts_when_another_section_was_edited(self):
+        before = "## A\n\n| x | y |\n| --- | --- |\n| 1 | 2 |\n\n## B\n\nprose\n"
+        after = "## A\n\n| x | y | | --- | --- | | 1 | 2 |\n\n## B\n\nrewritten prose\n"
+        assert damage_in_untouched_sections(before, after, {"## B"}).damaged
+
+
+class TestDrift:
+    def test_untouched_section_that_changed_is_drift(self):
+        before = "## A\n\none\n\n## B\n\ntwo\n"
+        after = "## A\n\none\n\n## B\n\ntwo changed\n"
+        assert untouched_sections_drifted(before, after, set()) == ["## B"]
+
+    def test_touched_section_that_changed_is_not_drift(self):
+        before = "## A\n\none\n\n## B\n\ntwo\n"
+        after = "## A\n\none\n\n## B\n\ntwo changed\n"
+        assert untouched_sections_drifted(before, after, {"## B"}) == []
+
+    def test_a_removed_section_is_not_reported_as_drift(self):
+        """Removal is a content decision the coverage judge scores, not structural drift."""
+        before = "## A\n\none\n\n## B\n\ntwo\n"
+        after = "## A\n\none\n"
+        assert untouched_sections_drifted(before, after, set()) == []
+
+    def test_added_sections_do_not_disturb_the_others(self):
+        before = "## A\n\none\n"
+        after = "## A\n\none\n\n## New\n\nadded\n"
+        assert untouched_sections_drifted(before, after, set()) == []

--- a/hindsight-docs/docs/developer/api/mental-models.mdx
+++ b/hindsight-docs/docs/developer/api/mental-models.mdx
@@ -230,19 +230,19 @@ Two strategies are available for how a refresh produces the new content:
 
 #### How delta mode works
 
-Hindsight keeps an authoritative **structured** representation of the document — an ordered list of sections, each holding typed blocks (paragraph, bullet list, ordered list, code) — and the markdown you read is a deterministic render of that structure. A delta refresh never asks the LLM to rewrite the document; it asks for operations against that structure:
+Hindsight keeps an authoritative **structured** representation of the document — an ordered list of sections, each holding a list of blocks, where a block is one markdown fragment (a paragraph, a list, a table, a code fence) stored exactly as written. The markdown you read is a deterministic render of that structure. Because a block is never re-interpreted, formatting a refresh didn't touch cannot be rewritten by one — a table stays a table. A delta refresh never asks the LLM to rewrite the document; it asks for operations against that structure:
 
 | Operation | Effect |
 |---|---|
 | `add_section` / `remove_section` | Add or drop a whole section |
 | `rename_section` | Change a section's heading |
 | `replace_section_blocks` | Replace a section's contents wholesale |
-| `append_block` / `insert_block` | Add a block at the end of, or at a position in, a section |
+| `append_block` / `insert_block` | Add a block at the end of, or after a named block in, a section |
 | `replace_block` / `remove_block` | Change or drop one block |
 
 Anything no operation mentions is copied through untouched, so unchanged prose is preserved rather than regenerated and checked. This matters because "preserve the unchanged content" is only a soft constraint on an LLM — generating the next token from a gestalt of the input is what it intrinsically does, so instructed-to-preserve prose drifts over many refreshes.
 
-Failure modes are conservative by design: an operation referencing a section or block that doesn't exist is **dropped** rather than guessed at, and the rest of the operations still apply. The refresh records which ones were dropped and why, so you can see that part of that round's new information didn't make it into the document.
+Sections and blocks are addressed by id, never by position, so an operation cannot land on the wrong one by miscounting. Failure modes are conservative by design: an operation referencing a section or block that doesn't exist — or a block that lives in a different section than the one it names — is **dropped** rather than guessed at, and the rest of the operations still apply. The refresh records which ones were dropped and why, so you can see that part of that round's new information didn't make it into the document.
 
 Delta mode falls back to a full regeneration automatically in two cases:
 1. The mental model has no existing content yet (nothing to anchor edits on).

--- a/scripts/benchmarks/run-document-evolution.sh
+++ b/scripts/benchmarks/run-document-evolution.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Document-evolution benchmark: does a living document survive being edited?
+#
+# Runs against an already-running Hindsight server, so the same harness can
+# drive a server built from any revision — that is how two builds get compared.
+# See hindsight-dev/benchmarks/document_evolution/README.md.
+#
+#   ./scripts/benchmarks/run-document-evolution.sh run --api-url http://localhost:8888 --build main
+#   ./scripts/benchmarks/run-document-evolution.sh compare results/main.json results/branch.json
+set -e
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR/hindsight-dev"
+exec uv run python -m benchmarks.document_evolution "$@"

--- a/skills/hindsight-docs/references/developer/api/mental-models.md
+++ b/skills/hindsight-docs/references/developer/api/mental-models.md
@@ -277,19 +277,19 @@ Two strategies are available for how a refresh produces the new content:
 
 #### How delta mode works
 
-Hindsight keeps an authoritative **structured** representation of the document — an ordered list of sections, each holding typed blocks (paragraph, bullet list, ordered list, code) — and the markdown you read is a deterministic render of that structure. A delta refresh never asks the LLM to rewrite the document; it asks for operations against that structure:
+Hindsight keeps an authoritative **structured** representation of the document — an ordered list of sections, each holding a list of blocks, where a block is one markdown fragment (a paragraph, a list, a table, a code fence) stored exactly as written. The markdown you read is a deterministic render of that structure. Because a block is never re-interpreted, formatting a refresh didn't touch cannot be rewritten by one — a table stays a table. A delta refresh never asks the LLM to rewrite the document; it asks for operations against that structure:
 
 | Operation | Effect |
 |---|---|
 | `add_section` / `remove_section` | Add or drop a whole section |
 | `rename_section` | Change a section's heading |
 | `replace_section_blocks` | Replace a section's contents wholesale |
-| `append_block` / `insert_block` | Add a block at the end of, or at a position in, a section |
+| `append_block` / `insert_block` | Add a block at the end of, or after a named block in, a section |
 | `replace_block` / `remove_block` | Change or drop one block |
 
 Anything no operation mentions is copied through untouched, so unchanged prose is preserved rather than regenerated and checked. This matters because "preserve the unchanged content" is only a soft constraint on an LLM — generating the next token from a gestalt of the input is what it intrinsically does, so instructed-to-preserve prose drifts over many refreshes.
 
-Failure modes are conservative by design: an operation referencing a section or block that doesn't exist is **dropped** rather than guessed at, and the rest of the operations still apply. The refresh records which ones were dropped and why, so you can see that part of that round's new information didn't make it into the document.
+Sections and blocks are addressed by id, never by position, so an operation cannot land on the wrong one by miscounting. Failure modes are conservative by design: an operation referencing a section or block that doesn't exist — or a block that lives in a different section than the one it names — is **dropped** rather than guessed at, and the rest of the operations still apply. The refresh records which ones were dropped and why, so you can see that part of that round's new information didn't make it into the document.
 
 Delta mode falls back to a full regeneration automatically in two cases:
 1. The mental model has no existing content yet (nothing to anchor edits on).


### PR DESCRIPTION
Fixes #3361. Fixes #3273.

## The bug

A knowledge page could come back with a whole table — header, separator, every row — welded onto one line, in sections no delta operation had named, and it never recovered: the collapsed render parsed back to the same paragraph, so every later refresh re-signed the damage.

The delta refresh was blamed, but the damage was done **one refresh earlier**.

`mental_models.structured_content` was only the source of truth on the **delta** leg. The **full** leg stored the LLM candidate markdown verbatim in `content` while deriving the structure from it with `parse_markdown` — a typed-block parser (`paragraph`/`bullet_list`/`ordered_list`/`code`/`table`) that flattened everything its union could not express into `" ".join(lines)`.

I measured the round trip over common markdown: **15 of 16 constructs lost information**, and every loss was a *fixed point* (`render(parse(out)) == out`), which is where "permanently" came from.

| lost | became |
|---|---|
| table with one malformed row | the whole table on one line |
| nested bullets | flat list |
| bullet + continuation line | one joined paragraph |
| ordered list starting at `5.` | renumbered from `1.` |
| hard line break (two spaces) | joined |
| `---` rule, blockquote, HTML, indented code, table alignment, setext heading | dropped or joined |

So `content` and `structured_content` disagreed by construction after every full refresh, and the next delta refresh published the degraded one across the whole document — in sections no operation touched. That is exactly the reported evidence: damage correlates 1:1 with `delta_applied`, every `reflect_response.text` is clean, and the damaged sections were never named by an operation.

## The fix

**Schema v2: a block is an id plus a verbatim markdown fragment.** Nothing parses a table, so nothing can flatten one.

`parse_markdown` is **deleted**. `split_markdown` replaces it and recognises exactly two things, both fence-aware: ATX headings (section boundaries) and blank lines (block boundaries). That makes it lossless, and the tests assert it as a property over a 26-case corpus of precisely the constructs v1 destroyed — every non-blank line returns verbatim and in order.

Splitting is not a legacy path, it is the import boundary: a mental model created with markdown `content`, a document restored from an export, and every full-leg synthesis all enter the structured world through it.

**Blocks are addressed by id, not by index (#3273).** An index has to be *counted* by the model, and an off-by-one is still in range — it silently overwrites an unrelated block and is recorded as a success, with no length change for a shrink guard to notice. An id is copied, not derived; one that does not resolve is skipped and reported, and so is one that names a block living in a *different* section than the operation claims. Operation payloads are now plain markdown strings, so the model no longer emits a typed block union either.

**`content` is now always `render_document(structured_content)`, on both legs**, so the two columns can no longer drift apart.

Also here:

- **`parse_llm_json`** escapes `\n \r \t \b \f` inside JSON string values instead of blanking them. A model writing a markdown table into a string often forgets to escape its line breaks, and the old control-character retry replaced them with spaces — delivering the table already collapsed. Every other control character keeps its previous treatment.
- **Orphan table rows.** A model asked to add a row sometimes emits it as its own block, which renders as a broken fragment. The prompt now asks for `replace_block`, and as a safety net a bare row landing directly after a table is folded into it.
- **Migration `d1e2f3a4b5c6`** clears v1 blobs. They are a lossy projection of the row's own `content`, so there is nothing worth converting: the next refresh re-imports the structure from the markdown, losslessly. `content` is never touched, so nothing has to refresh for a document to keep reading correctly. A non-v2 blob after the migration (rolling deploy) still falls back to the markdown, and now logs.
- The Gemini eval fixture pinned `gemini-2.0-flash`, which the provider has retired (`404 ... no longer available`), so the whole eval class was dead. Bumped to the model the repo's own `.env` uses.

## Verification

**Unit** — 159 tests in `test_structured_doc.py` covering split fidelity, render determinism, id stability, every operation, and the conservative-skip contract, including the #3273 wrong-section case and the #3361 table shapes.

**Real LLM** — `test_document_survives_many_delta_rounds_intact` (`hs_llm_core`) runs **five delta rounds** feeding one genuinely new fact each, asserting after every round that:

1. `content` is exactly the render of the stored structure;
2. no line welds a table separator to other cells (the detector from the issue);
3. sections no applied operation named are byte-identical to the round before;
4. fragile constructs in untouched sections survive verbatim;

plus, at the end, that a section **never** named by any operation across the whole run is unchanged — a slow erosion would pass the per-round check and fail this one.

Run four times: **20 real delta rounds, all green**, one operation applied and zero skipped per round. It is what caught the orphan table row, which no unit test would have.

A representative final document after five rounds — the new `reflect` row merged into the table, nested indentation, the fenced block with its interior blank line, the two-space hard break and the blockquote all intact:

```
## Operations

| Operation | Description | Budget |
| --- | --- | --- |
| `retain` | Store a memory | 12ms |
| `recall` | Retrieve and rerank memories | 55ms |
| `reflect` | Answer questions by synthesizing memories | 80ms |

## Failure Handling

- Retry transient errors
  - Nested under retries
    - Deeper still, three levels
```

**Suite** — full `hindsight-api-slim` suite run; the remaining failures were verified to reproduce on a clean tree (shared pg0 revision mismatch, `recall_min_score`, `loop_watchdog`, `llm_token_metrics`). Lint, vulture and knip clean. OpenAPI regenerates with no diff — `structured_content` is internal and the delta operation payloads are already free-form `list[dict]`, so no client regeneration is needed.

## Compatibility

`ModeFallbackReason` keeps `structured_doc_unreadable`; it is part of the published enum in the generated clients, and removing it would be a breaking API change even though the branch is now nearly unreachable.


---

## Since first review: the LLM no longer writes stored markdown at all

`done()` gained a document mode. Instead of an `answer` string it takes a `document` — sections with a heading, a level and their blocks — and the markdown is rendered from it. In that mode `answer` is **absent from the schema**, so there is no escape hatch back to prose. Splitting markdown is now only an import path: a model created from authored text, a restored export, or a run that produced plain text anyway.

Two related holes closed with it:

- **Creation and update never wrote the structure.** `create_mental_model(content=...)` left `structured_content` NULL, so a model authored as markdown had no structure until its first delta refresh — and that refresh was then the one to derive it, reshaping a document nobody asked it to touch. `update_mental_model(content=...)` was worse: it could set new markdown while leaving the *previous* document's structure in place. Both now go through `canonical_document()`, so `content` is the render of `structured_content` from the first byte.
- **The over-budget trim.** The one path where the model still wrote markdown that got stored now asks for a document too.

## `max_tokens` on the delta leg

It was enforced in exactly one place — a rewrite of the *synthesis* answer — and in delta mode that answer never becomes the document. The stored document was never measured against the budget at all, and a delta refresh only adds: **~20 tokens per round, monotonic**, which crosses the 4096-token knowledge-page default after a couple of hundred refreshes. Knowledge pages refresh after every consolidation.

Truncating would delete knowledge nobody asked to delete, so the budget is stated: the delta call is told where the document stands and, when over, asked to reclaim space with the same operations it uses for everything else — from superseded content, never from the facts it is integrating. Every refresh records `document_tokens` / `document_budget`; going over adds a warning.

Real-LLM eval: told a 434-token document is over a 200-token budget, the model drops the twelve archived sections and keeps the current process and the checklist — 39 tokens, stable across four runs. The assertions check *where* the space came from, because getting under budget by deleting current content would pass a naive shrink check and be worse than going over.

## Release evidence

`hindsight-dev/benchmarks/document_evolution/` compares two builds on how a document survives being edited. It talks HTTP only, so the same harness drives a server built from any revision — no feature flag in the code under test. **45 refresh rounds per build** from identical authored seeds, 3 cases × 3 repetitions, Gemini throughout.

| | main | this branch |
|---|---|---|
| collapsed tables | **3** | **0** |
| table rows lost | 9 | 0 |
| list nesting lost | 6 | 0 |
| hard line breaks lost | 5 | 0 |
| damaged rounds | 6 | 0 |
| **sections drifted with no operation naming them** | **14** | **0** |
| delta applied | 45/45 | 45/45 |
| failed rounds / skipped ops | 0 / 0 | 0 / 0 |
| median ms per refresh | 12935 | 12940 |

Content came out level: 100% recall and zero stale claims on both sides, and a pairwise preference of two wins to main, three to the branch, four ties — with this branch's documents about 10% shorter, which is the direction the judge's length bias pushes against it. `baseline_report.json` records the run.

Two findings from the benchmark landed back in the product: document mode initially made the model **terser** (stating structure is more clerical than writing prose), fixed by saying the structure is the shape of the answer and not a budget for it; and the `max_tokens` gap above, which only became visible once growth was measured over dozens of rounds.
