### PR TITLE
fix(observability): trace the worker process and join the caller's trace

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -8,6 +8,7 @@ the FastAPI application with all API endpoints.
 import asyncio
 import json
 import logging
+import os
 import re
 import uuid
 from collections.abc import Awaitable
@@ -165,7 +166,7 @@ def FieldWithDefault(default_factory: Callable, **kwargs) -> Any:
     return Field(default_factory=default_factory, json_schema_extra=json_extra, **kwargs)
 
 
-from hindsight_api.config import get_config
+from hindsight_api.config import HindsightConfig, StaticConfigProxy, get_config
 from hindsight_api.engine.interface import BankTemplateImportWrite
 from hindsight_api.engine.memory_engine import (
     Budget,
@@ -3783,25 +3784,11 @@ def create_app(
             app.state.prometheus_reader = None
             # Metrics collector is already initialized as no-op by default
 
-        # Initialize OpenTelemetry tracing if enabled
-        if config.otel_traces_enabled:
-            if not config.otel_exporter_otlp_endpoint:
-                logging.warning("OTEL tracing enabled but no endpoint configured. Tracing disabled.")
-            else:
-                from hindsight_api.tracing import create_span_recorder, initialize_tracing
+        # Initialize OpenTelemetry tracing if enabled. Shared with the standalone
+        # worker entrypoint so both processes honour the same configuration.
+        from hindsight_api.tracing import initialize_tracing_from_config
 
-                try:
-                    initialize_tracing(
-                        service_name=config.otel_service_name,
-                        endpoint=config.otel_exporter_otlp_endpoint,
-                        headers=config.otel_exporter_otlp_headers,
-                        deployment_environment=config.otel_deployment_environment,
-                    )
-                    create_span_recorder()
-                    logging.info("OpenTelemetry tracing enabled and configured")
-                except Exception as e:
-                    logging.error(f"Failed to initialize tracing: {e}")
-                    logging.warning("Continuing without tracing")
+        initialize_tracing_from_config(config)
 
         # Startup: Initialize database and memory system (migrations run inside initialize if enabled)
         if initialize_memory:
@@ -3892,6 +3879,11 @@ def create_app(
         # Shutdown: Cleanup memory system
         await memory.close()
         logging.info("Memory system closed")
+
+        # Flush any spans still queued in the BatchSpanProcessor.
+        from hindsight_api.tracing import shutdown_tracing
+
+        shutdown_tracing()
 
     from hindsight_api import __version__
     from hindsight_api.config import get_config
@@ -4060,7 +4052,51 @@ def create_app(
     # is to own the raw ASGI receive channel from outside it (issue #2122).
     app.add_middleware(ClientDisconnectCancellationMiddleware)
 
+    _instrument_app_for_tracing(app, config)
+
     return app
+
+
+def _instrument_app_for_tracing(app: FastAPI, config: HindsightConfig | StaticConfigProxy) -> None:
+    """
+    Make incoming requests continue the caller's trace instead of starting a new one.
+
+    The ASGI instrumentation extracts W3C traceparent/tracestate from the request
+    headers and opens a SERVER span; every span the engine opens while handling
+    that request (hindsight.recall, hindsight.retain, the GenAI child spans, ...)
+    then nests under the caller's trace through the ambient context, with no
+    changes at those call sites (issue #3604). Requests without a traceparent
+    still start their own root trace, so this is backwards compatible.
+
+    Must run here rather than in the lifespan: instrument_app patches
+    Starlette.build_middleware_stack, which is built before the lifespan handler
+    runs. The tracer it captures is a proxy that resolves lazily, so the provider
+    installed later by initialize_tracing_from_config is picked up correctly.
+    """
+    if not config.otel_traces_enabled or not config.otel_exporter_otlp_endpoint:
+        return
+
+    try:
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+        # Probe and metrics scrapes would otherwise dominate the trace stream.
+        # OTEL_PYTHON_FASTAPI_EXCLUDED_URLS, when set, takes precedence.
+        excluded_urls = os.getenv("OTEL_PYTHON_FASTAPI_EXCLUDED_URLS") or "health,metrics"
+        FastAPIInstrumentor.instrument_app(
+            app,
+            excluded_urls=excluded_urls,
+            # Two reasons, both load-bearing. Per-ASGI-message spans triple the
+            # span count per request while saying nothing the request span
+            # doesn't. And excluding "receive" makes the instrumentation pass the
+            # raw receive callable through untouched instead of wrapping it,
+            # which is what keeps ClientDisconnectCancellationMiddleware able to
+            # observe an abandoned request (issue #2122).
+            exclude_spans=["receive", "send"],
+        )
+        logging.info("OpenTelemetry HTTP server instrumentation enabled (trace context propagation)")
+    except Exception as e:
+        logging.error(f"Failed to instrument HTTP server for tracing: {e}")
+        logging.warning("Continuing without incoming trace-context propagation")
 
 
 def _register_routes(app: FastAPI):

--- a/hindsight-api-slim/hindsight_api/tracing.py
+++ b/hindsight-api-slim/hindsight_api/tracing.py
@@ -12,8 +12,9 @@ to Langfuse (or any OTLP-compatible backend) via OTLP HTTP protocol.
 
 import json
 import logging
+import os
 import time
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -21,6 +22,9 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.trace import Status, StatusCode
+
+if TYPE_CHECKING:
+    from .config import HindsightConfig, StaticConfigProxy
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +95,10 @@ class NoOpSpan:
 # Global tracer instance
 _tracer: trace.Tracer | NoOpTracer = NoOpTracer()
 _tracing_enabled: bool = False
+# The SDK provider created by initialize_tracing(). Kept so shutdown_tracing()
+# can flush the BatchSpanProcessor directly instead of going through the global
+# provider, which may be a proxy that never exposes shutdown().
+_provider: TracerProvider | None = None
 
 
 # GenAI semantic convention attribute names (based on v1.37 spec)
@@ -152,13 +160,17 @@ def initialize_tracing(
         headers: Optional headers in format "key1=value1,key2=value2"
         deployment_environment: Deployment environment (e.g., development, staging, production)
     """
-    global _tracer, _tracing_enabled
+    global _tracer, _tracing_enabled, _provider
+
+    # Imported lazily: __version__ is defined at the end of hindsight_api/__init__.py,
+    # after the imports that pull in this module.
+    from hindsight_api import __version__
 
     # Create resource with service information
     resource = Resource.create(
         {
             "service.name": service_name,
-            "service.version": "0.4.8",  # Could import from __version__
+            "service.version": __version__,
             "deployment.environment.name": deployment_environment,
         }
     )
@@ -189,8 +201,91 @@ def initialize_tracing(
     # Get tracer for this application
     _tracer = trace.get_tracer(__name__)
     _tracing_enabled = True
+    _provider = provider
 
     logger.info(f"Tracing initialized: endpoint={otlp_endpoint}, service={service_name}")
+
+
+def initialize_tracing_from_config(
+    config: "HindsightConfig | StaticConfigProxy",
+    *,
+    default_service_name: str | None = None,
+) -> bool:
+    """
+    Bootstrap tracing from a HindsightConfig, for any process entrypoint.
+
+    Both the API (FastAPI lifespan) and the standalone worker call this, so a
+    deployment that sets HINDSIGHT_API_OTEL_* gets traces from every process
+    that does work rather than only from the one serving HTTP (issue #3614).
+
+    Failures are logged and swallowed: tracing must never keep a process from
+    starting.
+
+    Args:
+        config: Resolved Hindsight configuration (raw dataclass or the static proxy).
+        default_service_name: Service name to use when HINDSIGHT_API_OTEL_SERVICE_NAME
+            is not set in the environment. Lets the worker report itself as
+            "hindsight-worker" — matching the name it already reports for metrics —
+            without overriding an operator's explicit choice.
+
+    Returns:
+        True when tracing was initialized, False otherwise.
+    """
+    from .config import ENV_OTEL_SERVICE_NAME
+
+    if not config.otel_traces_enabled:
+        return False
+
+    if not config.otel_exporter_otlp_endpoint:
+        logger.warning("OTEL tracing enabled but no endpoint configured. Tracing disabled.")
+        return False
+
+    # config.otel_service_name has already had the API default applied, so an
+    # unset env var is indistinguishable from one set to that default. Read the
+    # environment directly to tell them apart.
+    service_name = os.getenv(ENV_OTEL_SERVICE_NAME) or default_service_name or config.otel_service_name
+
+    try:
+        initialize_tracing(
+            service_name=service_name,
+            endpoint=config.otel_exporter_otlp_endpoint,
+            headers=config.otel_exporter_otlp_headers,
+            deployment_environment=config.otel_deployment_environment,
+        )
+        create_span_recorder()
+        logger.info("OpenTelemetry tracing enabled and configured")
+        return True
+    except Exception as e:
+        logger.error(f"Failed to initialize tracing: {e}")
+        logger.warning("Continuing without tracing")
+        return False
+
+
+def shutdown_tracing() -> None:
+    """
+    Flush and shut down the tracing pipeline. No-op when tracing was never initialized.
+
+    Spans are batched, so without this a process exiting on SIGTERM drops
+    everything still in the BatchSpanProcessor's queue. That matters most for
+    the worker, where a single consolidation span can be minutes long.
+    """
+    global _tracer, _tracing_enabled, _provider, _span_recorder
+
+    provider = _provider
+    if provider is None:
+        return
+
+    try:
+        provider.shutdown()  # force-flushes the BatchSpanProcessor
+    except Exception as e:
+        logger.warning(f"Failed to shut down tracing cleanly: {e}")
+    finally:
+        _provider = None
+        _tracing_enabled = False
+        _tracer = NoOpTracer()
+        if _span_recorder is not None:
+            unregister_span_recorder(_span_recorder)
+            _span_recorder = None
 
 
 def get_tracer() -> trace.Tracer | NoOpTracer:

--- a/hindsight-api-slim/hindsight_api/worker/main.py
+++ b/hindsight-api-slim/hindsight_api/worker/main.py
@@ -219,6 +219,14 @@ def main():
     # Configure logging
     config.configure_logging()
 
+    # Initialize OpenTelemetry tracing if enabled. The worker runs consolidation,
+    # batch retain and mental-model refresh, so without this the LLM-heaviest half
+    # of a deployment emits no spans at all (issue #3614). Done after logging setup
+    # so the "Tracing initialized" line is visible.
+    from ..tracing import initialize_tracing_from_config
+
+    initialize_tracing_from_config(config, default_service_name="hindsight-worker")
+
     from ..utils import warn_if_container_default_worker_id
 
     warn_if_container_default_worker_id(args.worker_id)
@@ -407,6 +415,13 @@ def main():
 
         # Close memory engine
         await memory.close()
+
+        # Flush queued spans before exiting: a consolidation span can be minutes
+        # long, and everything still batched is lost if the process just exits.
+        from ..tracing import shutdown_tracing
+
+        shutdown_tracing()
+
         print("Worker shutdown complete")
 
     def cleanup():

--- a/hindsight-api-slim/tests/test_tracing.py
+++ b/hindsight-api-slim/tests/test_tracing.py
@@ -406,3 +406,205 @@ def test_operation_span_context_manager(mock_tracer):
     mock_tracer.start_as_current_span.assert_called_once()
     mock_span.__enter__.assert_called_once()
     mock_span.__exit__.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap helper shared by the API and worker entrypoints (issue #3614)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def restore_tracing_globals():
+    """Snapshot and restore tracing module state around a test.
+
+    initialize_tracing_from_config starts a real BatchSpanProcessor thread, so
+    every test that enables tracing has to tear it down again.
+    """
+    import hindsight_api.tracing as tracing_module
+
+    saved = (
+        tracing_module._tracer,
+        tracing_module._tracing_enabled,
+        tracing_module._provider,
+        tracing_module._span_recorder,
+    )
+    try:
+        yield tracing_module
+    finally:
+        tracing_module.shutdown_tracing()
+        (
+            tracing_module._tracer,
+            tracing_module._tracing_enabled,
+            tracing_module._provider,
+            tracing_module._span_recorder,
+        ) = saved
+
+
+def _tracing_config(**overrides):
+    """Build a raw HindsightConfig with tracing knobs set."""
+    import dataclasses
+
+    from hindsight_api.config import _get_raw_config
+
+    defaults = {
+        "otel_traces_enabled": True,
+        "otel_exporter_otlp_endpoint": "http://localhost:4318",
+        "otel_exporter_otlp_headers": None,
+        "otel_service_name": "hindsight-api",
+        "otel_deployment_environment": "test",
+    }
+    return dataclasses.replace(_get_raw_config(), **{**defaults, **overrides})
+
+
+def test_initialize_tracing_from_config_disabled(restore_tracing_globals):
+    """Tracing stays off when the feature flag is off."""
+    tracing_module = restore_tracing_globals
+
+    assert tracing_module.initialize_tracing_from_config(_tracing_config(otel_traces_enabled=False)) is False
+    assert tracing_module.is_tracing_enabled() is False
+
+
+def test_initialize_tracing_from_config_without_endpoint_warns(restore_tracing_globals, caplog):
+    """Enabled but endpoint-less config is reported, not silently ignored."""
+    tracing_module = restore_tracing_globals
+
+    with caplog.at_level("WARNING", logger="hindsight_api.tracing"):
+        result = tracing_module.initialize_tracing_from_config(_tracing_config(otel_exporter_otlp_endpoint=None))
+
+    assert result is False
+    assert tracing_module.is_tracing_enabled() is False
+    assert "no endpoint configured" in caplog.text
+
+
+def test_initialize_tracing_from_config_enables_tracing(restore_tracing_globals):
+    """A fully configured process gets a live tracer and a registered LLM recorder."""
+    tracing_module = restore_tracing_globals
+
+    assert tracing_module.initialize_tracing_from_config(_tracing_config()) is True
+    assert tracing_module.is_tracing_enabled() is True
+    assert tracing_module._span_recorder is not None
+    assert tracing_module._span_recorder in tracing_module.get_span_recorder()._recorders
+
+
+def test_initialize_tracing_from_config_default_service_name(restore_tracing_globals, monkeypatch):
+    """With HINDSIGHT_API_OTEL_SERVICE_NAME unset, the caller's default wins.
+
+    This is what lets the worker report itself as "hindsight-worker" instead of
+    inheriting the API's default service name (issue #3614).
+    """
+    from hindsight_api.config import ENV_OTEL_SERVICE_NAME
+
+    tracing_module = restore_tracing_globals
+    monkeypatch.delenv(ENV_OTEL_SERVICE_NAME, raising=False)
+
+    assert (
+        tracing_module.initialize_tracing_from_config(_tracing_config(), default_service_name="hindsight-worker")
+        is True
+    )
+    assert tracing_module._provider.resource.attributes["service.name"] == "hindsight-worker"
+
+
+def test_initialize_tracing_from_config_env_service_name_wins(restore_tracing_globals, monkeypatch):
+    """An explicitly configured service name overrides the caller's default."""
+    from hindsight_api.config import ENV_OTEL_SERVICE_NAME
+
+    tracing_module = restore_tracing_globals
+    monkeypatch.setenv(ENV_OTEL_SERVICE_NAME, "my-service")
+
+    tracing_module.initialize_tracing_from_config(
+        _tracing_config(otel_service_name="my-service"), default_service_name="hindsight-worker"
+    )
+
+    assert tracing_module._provider.resource.attributes["service.name"] == "my-service"
+
+
+def test_initialize_tracing_from_config_never_raises(restore_tracing_globals, monkeypatch):
+    """A broken exporter must not stop the process from starting."""
+    tracing_module = restore_tracing_globals
+    monkeypatch.setattr(
+        tracing_module,
+        "initialize_tracing",
+        MagicMock(side_effect=RuntimeError("boom")),
+    )
+
+    assert tracing_module.initialize_tracing_from_config(_tracing_config()) is False
+    assert tracing_module.is_tracing_enabled() is False
+
+
+def test_span_resource_reports_the_package_version(restore_tracing_globals):
+    """service.version must track the real package version, not a stale literal."""
+    from hindsight_api import __version__
+
+    tracing_module = restore_tracing_globals
+    tracing_module.initialize_tracing_from_config(_tracing_config())
+
+    assert tracing_module._provider.resource.attributes["service.version"] == __version__
+
+
+def test_shutdown_tracing_flushes_and_resets(restore_tracing_globals):
+    """Shutdown flushes the batch processor and leaves the module inert."""
+    tracing_module = restore_tracing_globals
+    tracing_module.initialize_tracing_from_config(_tracing_config())
+    provider = tracing_module._provider
+    recorder = tracing_module._span_recorder
+
+    with patch.object(provider, "shutdown") as mock_shutdown:
+        tracing_module.shutdown_tracing()
+
+    mock_shutdown.assert_called_once()
+    assert tracing_module.is_tracing_enabled() is False
+    assert tracing_module._provider is None
+    assert recorder not in tracing_module.get_span_recorder()._recorders
+
+
+def test_shutdown_tracing_without_init_is_noop(restore_tracing_globals):
+    """Never-initialized processes can call shutdown unconditionally."""
+    tracing_module = restore_tracing_globals
+    tracing_module._provider = None
+
+    tracing_module.shutdown_tracing()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_api_lifespan_bootstraps_and_flushes_tracing():
+    """The API entrypoint must bootstrap tracing on startup and flush it on shutdown.
+
+    Parity guard with the worker entrypoint (see test_worker_main.py): both
+    processes go through the same helper, and neither may silently stop calling
+    it. Runs the lifespan headless — no DB, no poller — so it stays a fast unit
+    test.
+    """
+    import dataclasses
+    from unittest.mock import AsyncMock
+
+    from hindsight_api.api.http import create_app
+    from hindsight_api.config import _get_raw_config
+
+    config = dataclasses.replace(
+        _get_raw_config(),
+        otel_traces_enabled=True,
+        otel_exporter_otlp_endpoint="http://localhost:4318",
+        worker_enabled=False,
+    )
+    memory = AsyncMock()
+    memory._pool = None
+    memory.audit_logger = None
+    memory._backend.supports_worker_poller = False
+
+    bootstrap_calls = []
+
+    with (
+        patch("hindsight_api.config.get_config", return_value=config),
+        patch("hindsight_api.api.http.get_config", return_value=config),
+        patch(
+            "hindsight_api.tracing.initialize_tracing_from_config",
+            side_effect=lambda cfg, **kwargs: bootstrap_calls.append(cfg) or False,
+        ),
+        patch("hindsight_api.tracing.shutdown_tracing") as mock_shutdown,
+    ):
+        app = create_app(memory, initialize_memory=False)
+        async with app.router.lifespan_context(app):
+            pass
+
+    assert bootstrap_calls == [config]
+    mock_shutdown.assert_called_once()

--- a/hindsight-api-slim/tests/test_tracing_context_propagation.py
+++ b/hindsight-api-slim/tests/test_tracing_context_propagation.py
@@ -1,0 +1,133 @@
+"""Incoming W3C trace-context propagation on the HTTP API (issue #3604).
+
+Before this, every memory operation opened a new root trace, so a caller's
+request and the Hindsight work it triggered were two unrelated traces. The
+FastAPI/ASGI instrumentation installed by ``_instrument_app_for_tracing``
+extracts ``traceparent`` and opens a SERVER span, which the engine's existing
+spans then nest under through the ambient context.
+
+These tests assert the observable contract — what trace the handler runs in —
+rather than the middleware wiring, so they hold whether or not an SDK tracer
+provider happens to be installed in the test process.
+"""
+
+import dataclasses
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from opentelemetry import trace
+
+from hindsight_api.api.http import _instrument_app_for_tracing
+from hindsight_api.config import _get_raw_config
+
+# A well-formed W3C traceparent, from the spec's own example.
+REMOTE_TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736"
+REMOTE_SPAN_ID = "00f067aa0ba902b7"
+TRACEPARENT = f"00-{REMOTE_TRACE_ID}-{REMOTE_SPAN_ID}-01"
+
+
+def _config(**overrides):
+    """Raw config with tracing switched on unless a test says otherwise."""
+    defaults = {
+        "otel_traces_enabled": True,
+        "otel_exporter_otlp_endpoint": "http://localhost:4318",
+    }
+    return dataclasses.replace(_get_raw_config(), **{**defaults, **overrides})
+
+
+def _app_reporting_current_trace(config) -> FastAPI:
+    """An app whose routes report the trace they are executing in."""
+    app = FastAPI()
+
+    def _current_trace_id() -> dict[str, str]:
+        span_context = trace.get_current_span().get_span_context()
+        return {"trace_id": trace.format_trace_id(span_context.trace_id)}
+
+    @app.get("/v1/probe")
+    def probe():
+        return _current_trace_id()
+
+    @app.get("/health")
+    def health():
+        return _current_trace_id()
+
+    _instrument_app_for_tracing(app, config)
+    return app
+
+
+def test_incoming_traceparent_becomes_the_handlers_trace(monkeypatch):
+    """A caller's traceparent is extracted, so Hindsight's work joins its trace."""
+    monkeypatch.delenv("OTEL_PYTHON_FASTAPI_EXCLUDED_URLS", raising=False)
+    app = _app_reporting_current_trace(_config())
+
+    with TestClient(app) as client:
+        response = client.get("/v1/probe", headers={"traceparent": TRACEPARENT})
+
+    assert response.json()["trace_id"] == REMOTE_TRACE_ID
+
+
+def test_request_without_traceparent_starts_its_own_trace(monkeypatch):
+    """Un-instrumented callers are unaffected — the change is backwards compatible."""
+    monkeypatch.delenv("OTEL_PYTHON_FASTAPI_EXCLUDED_URLS", raising=False)
+    app = _app_reporting_current_trace(_config())
+
+    with TestClient(app) as client:
+        response = client.get("/v1/probe")
+
+    assert response.status_code == 200
+    assert response.json()["trace_id"] != REMOTE_TRACE_ID
+
+
+def test_probe_endpoints_are_excluded_from_tracing(monkeypatch):
+    """Health/metrics scrapes must not flood the trace stream."""
+    monkeypatch.delenv("OTEL_PYTHON_FASTAPI_EXCLUDED_URLS", raising=False)
+    app = _app_reporting_current_trace(_config())
+
+    with TestClient(app) as client:
+        response = client.get("/health", headers={"traceparent": TRACEPARENT})
+
+    # Excluded URLs skip the middleware entirely, so the extracted context is
+    # never made current and the handler runs outside any trace.
+    assert response.json()["trace_id"] != REMOTE_TRACE_ID
+
+
+def test_excluded_urls_are_configurable(monkeypatch):
+    """OTEL_PYTHON_FASTAPI_EXCLUDED_URLS overrides the built-in exclusions."""
+    monkeypatch.setenv("OTEL_PYTHON_FASTAPI_EXCLUDED_URLS", "nothing-matches-this")
+    app = _app_reporting_current_trace(_config())
+
+    with TestClient(app) as client:
+        response = client.get("/health", headers={"traceparent": TRACEPARENT})
+
+    assert response.json()["trace_id"] == REMOTE_TRACE_ID
+
+
+def test_app_is_not_instrumented_when_tracing_is_disabled():
+    """No tracing configured means no instrumentation overhead."""
+    app = _app_reporting_current_trace(_config(otel_traces_enabled=False))
+
+    assert getattr(app, "_is_instrumented_by_opentelemetry", False) is False
+
+
+def test_app_is_not_instrumented_without_an_endpoint():
+    """Enabled-but-unexportable tracing leaves the app alone, matching the bootstrap."""
+    app = _app_reporting_current_trace(_config(otel_exporter_otlp_endpoint=None))
+
+    assert getattr(app, "_is_instrumented_by_opentelemetry", False) is False
+
+
+def test_instrumentation_failure_does_not_break_app_creation(monkeypatch):
+    """Instrumentation is best-effort: a failure must not stop the API booting."""
+    import opentelemetry.instrumentation.fastapi as fastapi_instrumentation
+
+    monkeypatch.delenv("OTEL_PYTHON_FASTAPI_EXCLUDED_URLS", raising=False)
+    monkeypatch.setattr(
+        fastapi_instrumentation.FastAPIInstrumentor,
+        "instrument_app",
+        staticmethod(lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom"))),
+    )
+
+    app = _app_reporting_current_trace(_config())  # must not raise
+
+    with TestClient(app) as client:
+        assert client.get("/v1/probe").status_code == 200

--- a/hindsight-api-slim/tests/test_worker_main.py
+++ b/hindsight-api-slim/tests/test_worker_main.py
@@ -33,3 +33,40 @@ def test_install_shutdown_signal_handlers_windows_path():
     installed = _install_shutdown_signal_handlers(loop, handler)
 
     assert installed is False
+
+
+def test_main_bootstraps_tracing_for_the_worker_process(monkeypatch):
+    """The standalone worker must initialize tracing itself.
+
+    initialize_tracing() used to be called only from the FastAPI lifespan, so a
+    `hindsight-worker` process emitted no spans at all — silently, since both
+    tracing chokepoints degrade to no-ops (issue #3614). It also identifies
+    itself as "hindsight-worker" by default, matching the name it already
+    reports for metrics.
+    """
+    import dataclasses
+    import sys
+
+    from hindsight_api import tracing
+    from hindsight_api.config import _get_raw_config
+    from hindsight_api.worker import main as worker_main
+
+    config = dataclasses.replace(_get_raw_config(), worker_id="test-worker")
+    monkeypatch.setattr(config, "configure_logging", lambda: None)
+    monkeypatch.setattr(worker_main, "get_config", lambda: config)
+    monkeypatch.setattr(worker_main, "load_dotenv_for_entrypoint", lambda: None)
+    monkeypatch.setattr(sys, "argv", ["hindsight-worker"])
+
+    bootstrap_calls = []
+
+    def _record(cfg, **kwargs):
+        bootstrap_calls.append(kwargs)
+        return False
+
+    monkeypatch.setattr(tracing, "initialize_tracing_from_config", _record)
+    # Stop before the worker actually runs; we only care about the bootstrap.
+    monkeypatch.setattr(worker_main.asyncio, "run", lambda coro: coro.close())
+
+    worker_main.main()
+
+    assert bootstrap_calls == [{"default_service_name": "hindsight-worker"}]

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -2116,12 +2116,14 @@ Hindsight provides OpenTelemetry-based observability for LLM calls, conforming t
 | `HINDSIGHT_API_OTEL_TRACES_ENABLED` | Enable distributed tracing for LLM calls | `false` |
 | `HINDSIGHT_API_OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP endpoint URL (e.g., Grafana LGTM, Langfuse, etc.) | - |
 | `HINDSIGHT_API_OTEL_EXPORTER_OTLP_HEADERS` | Headers for OTLP exporter (format: "key1=value1,key2=value2") | - |
-| `HINDSIGHT_API_OTEL_SERVICE_NAME` | Service name for traces | `hindsight-api` |
+| `HINDSIGHT_API_OTEL_SERVICE_NAME` | Service name for traces. Applies to the API and to standalone workers, which default to `hindsight-worker` when it is unset. | `hindsight-api` |
 | `HINDSIGHT_API_OTEL_DEPLOYMENT_ENVIRONMENT` | Deployment environment name (e.g., development, staging, production) | `development` |
 | `HINDSIGHT_API_METRICS_INCLUDE_BANK_ID` | Include `bank_id` in OTel metric attributes. Enable only for deployments with few banks — high cardinality causes unbounded memory growth. | `false` |
 | `HINDSIGHT_API_METRICS_BACKLOG_ENABLED` | Expose async-operation queue depth and consolidation-backlog gauges (`hindsight_async_operations`, `hindsight_consolidation_backlog`, `hindsight_consolidation_failed`). Runs periodic per-schema `COUNT` queries on a background task. | `false` |
+| `OTEL_PYTHON_FASTAPI_EXCLUDED_URLS` | Comma-separated URL patterns excluded from request tracing | `health,metrics` |
 
 **Features:**
+- Continues the caller's trace when a `traceparent` header is present
 - Full prompts and completions recorded as events
 - Token usage tracking (input/output)
 - Model and provider information

--- a/hindsight-docs/docs/developer/monitoring.md
+++ b/hindsight-docs/docs/developer/monitoring.md
@@ -344,3 +344,19 @@ Supports any OTLP-compatible backend (Grafana LGTM, Langfuse, OpenLIT, DataDog, 
 
 **Events:**
 - `gen_ai.client.inference.operation.details` - Full prompts and completions
+
+### Trace Context Propagation
+
+Hindsight participates in your existing traces rather than starting parallel ones. When a caller sends W3C trace context (the standard `traceparent` header, which most OpenTelemetry HTTP client instrumentations add automatically), Hindsight continues that trace: the API request appears as a server span under the caller, and every memory operation and LLM call it triggers nests beneath it.
+
+Requests that arrive without trace context still start their own trace, so nothing changes for un-instrumented callers.
+
+Health and metrics endpoints are excluded from tracing so probe traffic doesn't drown out real work. Set `OTEL_PYTHON_FASTAPI_EXCLUDED_URLS` to a comma-separated list of URL patterns to override this.
+
+### Worker Processes
+
+Standalone worker processes honour the same `HINDSIGHT_API_OTEL_*` variables as the API and export their own spans. This matters for deployments that run dedicated workers, since consolidation, background retain and mental model refresh — most of the long-running work and token spend — happen there.
+
+Give the worker its own `HINDSIGHT_API_OTEL_SERVICE_NAME` to separate it from the API in your tracing backend. When left unset, workers report themselves as `hindsight-worker`.
+
+Worker spans are currently their own traces: a background operation is not linked to the request that queued it, because it runs long after that request has returned.

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -2116,12 +2116,14 @@ Hindsight provides OpenTelemetry-based observability for LLM calls, conforming t
 | `HINDSIGHT_API_OTEL_TRACES_ENABLED` | Enable distributed tracing for LLM calls | `false` |
 | `HINDSIGHT_API_OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP endpoint URL (e.g., Grafana LGTM, Langfuse, etc.) | - |
 | `HINDSIGHT_API_OTEL_EXPORTER_OTLP_HEADERS` | Headers for OTLP exporter (format: "key1=value1,key2=value2") | - |
-| `HINDSIGHT_API_OTEL_SERVICE_NAME` | Service name for traces | `hindsight-api` |
+| `HINDSIGHT_API_OTEL_SERVICE_NAME` | Service name for traces. Applies to the API and to standalone workers, which default to `hindsight-worker` when it is unset. | `hindsight-api` |
 | `HINDSIGHT_API_OTEL_DEPLOYMENT_ENVIRONMENT` | Deployment environment name (e.g., development, staging, production) | `development` |
 | `HINDSIGHT_API_METRICS_INCLUDE_BANK_ID` | Include `bank_id` in OTel metric attributes. Enable only for deployments with few banks — high cardinality causes unbounded memory growth. | `false` |
 | `HINDSIGHT_API_METRICS_BACKLOG_ENABLED` | Expose async-operation queue depth and consolidation-backlog gauges (`hindsight_async_operations`, `hindsight_consolidation_backlog`, `hindsight_consolidation_failed`). Runs periodic per-schema `COUNT` queries on a background task. | `false` |
+| `OTEL_PYTHON_FASTAPI_EXCLUDED_URLS` | Comma-separated URL patterns excluded from request tracing | `health,metrics` |
 
 **Features:**
+- Continues the caller's trace when a `traceparent` header is present
 - Full prompts and completions recorded as events
 - Token usage tracking (input/output)
 - Model and provider information

--- a/skills/hindsight-docs/references/developer/monitoring.md
+++ b/skills/hindsight-docs/references/developer/monitoring.md
@@ -344,3 +344,19 @@ Supports any OTLP-compatible backend (Grafana LGTM, Langfuse, OpenLIT, DataDog, 
 
 **Events:**
 - `gen_ai.client.inference.operation.details` - Full prompts and completions
+
+### Trace Context Propagation
+
+Hindsight participates in your existing traces rather than starting parallel ones. When a caller sends W3C trace context (the standard `traceparent` header, which most OpenTelemetry HTTP client instrumentations add automatically), Hindsight continues that trace: the API request appears as a server span under the caller, and every memory operation and LLM call it triggers nests beneath it.
+
+Requests that arrive without trace context still start their own trace, so nothing changes for un-instrumented callers.
+
+Health and metrics endpoints are excluded from tracing so probe traffic doesn't drown out real work. Set `OTEL_PYTHON_FASTAPI_EXCLUDED_URLS` to a comma-separated list of URL patterns to override this.
+
+### Worker Processes
+
+Standalone worker processes honour the same `HINDSIGHT_API_OTEL_*` variables as the API and export their own spans. This matters for deployments that run dedicated workers, since consolidation, background retain and mental model refresh — most of the long-running work and token spend — happen there.
+
+Give the worker its own `HINDSIGHT_API_OTEL_SERVICE_NAME` to separate it from the API in your tracing backend. When left unset, workers report themselves as `hindsight-worker`.
+
+Worker spans are currently their own traces: a background operation is not linked to the request that queued it, because it runs long after that request has returned.


### PR DESCRIPTION
Fixes #3614 and #3604.

Both issues were reported with full root-cause analysis, and both reproduced exactly as filed. They are independent failures that happen to meet in the same subsystem, so they're fixed together here.

## #3614 — the worker emitted no spans

`initialize_tracing()` had exactly one non-test caller: the FastAPI lifespan in `create_app`. The standalone `hindsight-worker` entrypoint never goes through it, so in a `worker.enabled=true` deployment the process running consolidation, batch retain and mental-model refresh — most of the long-running work and nearly all of the token spend — produced nothing.

The failure was silent by construction: with the module globals left at their defaults, `create_operation_span` returns a `nullcontext()` and the composite span recorder fans out to an empty list, so neither chokepoint errors or warns.

The bootstrap now lives in `tracing.initialize_tracing_from_config()`, called by both entrypoints. The API path keeps its exact previous behaviour, including the same log lines and the same fail-open on error.

On the service-name mismatch noted in the issue: rather than changing `initialize_metrics`' defaults (which would silently rename worker metrics to `hindsight-api`), the helper takes a `default_service_name` used only when `HINDSIGHT_API_OTEL_SERVICE_NAME` is unset. Workers report `hindsight-worker` for traces, matching the name they already report for metrics; an explicitly set env var still wins in both processes.

## #3604 — spans never joined the caller's trace

`opentelemetry-instrumentation-fastapi` turned out to be a declared dependency already (`pyproject.toml:48`) that nothing imported, so this costs no new dependency. `create_app` now instruments the app when tracing is configured: the ASGI layer extracts W3C `traceparent`, opens a `kind: Server` span, and the engine's existing spans nest under it through the ambient context — no changes at any of the `start_as_current_span` call sites. Requests with no `traceparent` still start their own root trace.

Verified end to end against an in-memory exporter, with the SDK provider installed *after* instrumentation (the real lifespan order):

```
GET /v1/probe      kind=SERVER   trace=4bf92f35...4736  parent=00f067aa0ba902b7   <- the caller's span
hindsight.recall   kind=INTERNAL trace=4bf92f35...4736  parent=<the SERVER span>
```

Two deliberate choices, both commented in the code:

- **`excluded_urls`** defaults to `health,metrics` so probe traffic doesn't dominate the trace stream; `OTEL_PYTHON_FASTAPI_EXCLUDED_URLS` overrides it.
- **`exclude_spans=["receive", "send"]`** cuts three spans per request down to one, and — load-bearing — excluding `receive` makes the instrumentation pass the raw receive callable through untouched instead of wrapping it, which is what keeps `ClientDisconnectCancellationMiddleware` able to observe an abandoned request (#2122).

Instrumentation happens in `create_app`, not the lifespan: `instrument_app` patches `Starlette.build_middleware_stack`, which is already built by the time the lifespan handler runs. The tracer it captures is a proxy that resolves lazily, so the provider installed later still applies.

## Also in this PR

- **Flush on shutdown.** Both entrypoints now shut the pipeline down, so spans still queued in the `BatchSpanProcessor` survive SIGTERM. This is what the issue flagged as mattering most for the worker, where a single consolidation span can be minutes long.
- **`service.version`.** `tracing.py` hardcoded `"0.4.8"` (with a `# Could import from __version__` comment); it now reports the real package version, which explains the `0.4.8`-on-a-`0.9.1`-image oddity noted at the end of #3604.

## Testing

- `initialize_tracing_from_config` — disabled, endpoint-less (warns), enabled, service-name precedence both ways, exporter failure fails open, `service.version` tracks the package version.
- `shutdown_tracing` — flushes the provider, unregisters the recorder, no-ops when never initialized.
- Trace-context propagation — an injected `traceparent` becomes the handler's trace; no header still works; `/health` is excluded; the exclusion list is configurable; the app isn't instrumented when tracing is off or unexportable; instrumentation failure doesn't break app creation.
- Both entrypoints bootstrap — `main()` for the worker, the lifespan for the API (run headless), which is the parity guard against either one silently dropping the call again.

`./scripts/hooks/lint.sh`, `ty check`, and the new/adjacent suites (`test_tracing.py`, `test_tracing_context_propagation.py`, `test_worker_main.py`, `test_metrics.py`, `test_recall_cancellation.py`) all pass locally. `generate-openapi` produces no diff — no API surface changed, so no client regeneration is needed.

## Not included

Span links from `async_operations` back to the enqueuing request — the tail suggestion in #3604 — are left out. That needs a field to carry the trace context through the queue, and it's a separate change on top of this one. Worth its own issue.
