### PR TITLE
fix(coding-agents): answer tools/list when disabled (#3537)

### DIFF
--- a/hindsight-integrations/coding-agents/src/mcp-server.test.ts
+++ b/hindsight-integrations/coding-agents/src/mcp-server.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { resolveHarness, selectTools } from "./mcp-server";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { buildMcpServer, resolveHarness, selectTools } from "./mcp-server";
 import { resolveConfig } from "./core/config";
 import type { HindsightClient } from "./core/hindsight";
 
@@ -140,5 +142,23 @@ describe("every mcp-server.js registration names a harness", () => {
       return src.includes("mcp-server.js") && !SETS_HARNESS.test(src);
     });
     expect(nameless).toEqual([]);
+  });
+});
+
+describe("buildMcpServer", () => {
+  it("answers tools/list with an empty list when Hindsight is disabled", async () => {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const server = buildMcpServer([]);
+    const client = new Client({ name: "test-client", version: "0.1.0" });
+
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    try {
+      expect(client.getServerCapabilities()).toMatchObject({ tools: { listChanged: false } });
+      await expect(client.listTools()).resolves.toEqual({ tools: [] });
+    } finally {
+      await client.close();
+      await server.close();
+    }
   });
 });

--- a/hindsight-integrations/coding-agents/src/mcp-server.ts
+++ b/hindsight-integrations/coding-agents/src/mcp-server.ts
@@ -12,6 +12,7 @@
 import { fileURLToPath } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { type Config } from "./core/config";
 import { resolveHostMemory } from "./core/host-client";
 import { HindsightClient } from "./core/hindsight";
@@ -68,6 +69,27 @@ export function resolveHarness(env: NodeJS.ProcessEnv = process.env): string {
   return harness;
 }
 
+/**
+ * Build the MCP surface for the resolved project.
+ *
+ * An opted-out project intentionally has no Hindsight tools, but some clients probe `tools/list`
+ * without first checking the initialize capabilities. Advertising an empty, queryable tool list
+ * keeps that privacy boundary intact while preventing one optional probe from failing startup.
+ */
+export function buildMcpServer(tools: ToolSpec[]): McpServer {
+  const server = new McpServer({ name: "hindsight", version: "0.1.0" });
+  if (tools.length === 0) {
+    server.server.registerCapabilities({ tools: { listChanged: false } });
+    server.server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [] }));
+    return server;
+  }
+
+  for (const tool of tools) {
+    server.tool(tool.name, tool.description, tool.inputSchema, tool.handler);
+  }
+  return server;
+}
+
 async function main() {
   const cwd = process.env.HINDSIGHT_MCP_PROJECT_CWD || process.cwd();
   // Mirrors that harness's hooks: it selects the config `harnesses.<name>` section and feeds the
@@ -75,10 +97,7 @@ async function main() {
   const harness = resolveHarness();
   const { cfg, bankId, client } = resolveHostMemory(harness, cwd);
 
-  const server = new McpServer({ name: "hindsight", version: "0.1.0" });
-  for (const t of selectTools(cfg, client, bankId, { cwd, harness })) {
-    server.tool(t.name, t.description, t.inputSchema, t.handler);
-  }
+  const server = buildMcpServer(selectTools(cfg, client, bankId, { cwd, harness }));
 
   await server.connect(new StdioServerTransport());
 }


### PR DESCRIPTION
Rebase of #3537 onto current `main`. Original commit and authorship by @altaywtf preserved — #3537 could not be updated in place (pushing to the fork branch is rejected with a 403 despite `maintainer_can_modify`), so this branch carries the same commit rebased.

## Problem

`McpServer` only registers its `tools/list` handler the first time `server.tool()` is called. An opted-out project makes `selectTools` return `[]`, so no tool is ever registered and `tools/list` answers `-32601 Method not found`. Clients that probe tool discovery without first reading the initialize capabilities read that as an MCP startup failure, turning an intentionally inert server into a visible error.

## Fix

When the resolved project exposes no tools, advertise an empty `tools` capability and answer `tools/list` with `{ "tools": [] }`. Registration happens before `connect`, which `registerCapabilities` requires. Normal tool registration is unchanged — only the pre-existing zero-tool path gains a discovery response. The privacy boundary is intact: an opted-out server still exposes no tools, it just says so in a way the protocol allows.

The test drives a real `Client` over `InMemoryTransport` rather than asserting on server internals.

## Rebase notes

`main` refactored `main()` onto `resolveHostMemory` and added `resolveHarness` (#3603) after this branch was cut. Both conflicts were textual, not semantic:

- `mcp-server.ts` — kept `main`'s `resolveHostMemory` / `resolveHarness` imports, added `ListToolsRequestSchema`; `buildMcpServer` sits alongside `resolveHarness` and `main()` calls it with the harness resolved by #3603.
- `mcp-server.test.ts` — kept both #3603's registration-coverage suite and this PR's `buildMcpServer` suite.

## Verification

- `npx vitest run` — 619 passed, 23 skipped, 0 failed (full package suite, after `npm ci` in `hindsight-integrations/coding-agents`)
- `./scripts/hooks/lint.sh` — passed
- `/code-review` — no findings

Closes #3537.