### PR TITLE
chore(clients): regenerate the Go client lockfile for testify 1.12.1

### DIFF
--- a/hindsight-clients/go/go.mod
+++ b/hindsight-clients/go/go.mod
@@ -2,6 +2,6 @@ module github.com/vectorize-io/hindsight/hindsight-clients/go
 
 go 1.18
 
-require github.com/stretchr/testify v1.12.0
+require github.com/stretchr/testify v1.12.1
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require go.yaml.in/yaml/v3 v3.0.5 // indirect

--- a/hindsight-clients/go/go.sum
+++ b/hindsight-clients/go/go.sum
@@ -1,6 +1,4 @@
-github.com/stretchr/testify v1.12.0 h1:K6Mr6jO9JICuend/5xzTM03ydSV3vdNRYAdPSukj8uI=
-github.com/stretchr/testify v1.12.0/go.mod h1:bOYBZb5qJ00vPzWfIqBUZPaxK8jWiXc6d3ErP4Ca9Gw=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
+github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
+go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
+go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=


### PR DESCRIPTION
Unblocks `verify-generated-files`, which is currently failing on every open PR for reasons unrelated to their contents.

## Cause

`scripts/generate-clients.sh` deletes `go.mod` and `go.sum` before regenerating the Go client, then runs `go mod tidy`. With no lockfile present, tidy resolves each requirement to the newest version available *at that moment* rather than to what is committed — so the check drifts on its own schedule, whenever an upstream dependency publishes.

testify 1.12.1 shipped and moved its YAML dependency from `gopkg.in/yaml.v3` to `go.yaml.in/yaml/v3`. Committed files say testify 1.12.0 + `gopkg.in/yaml.v3`; CI regenerates 1.12.1 + `go.yaml.in/yaml/v3` and fails the comparison.

## Change

Regenerated `go.mod` / `go.sum` — testify 1.12.1, `go.yaml.in/yaml/v3 v3.0.5` indirect. The `go 1.18` directive the OpenAPI generator emits is preserved (a bare `go mod init` would stamp the local toolchain version instead).

The diff reproduces exactly what CI reported as missing: `go.mod | 4 ++--`, `go.sum | 10 ++++------`.

## Verification

- `go mod tidy` is a no-op on the result — it is a fixed point, not a snapshot mid-drift
- `go build ./...` passes

## Note

This will recur on the next release of any Go client dependency. Making `generate-clients.sh` preserve the existing `go.mod` instead of deleting it — or pinning the requirement — would stop the check from drifting on its own, but that is a change to the generation contract and is deliberately left out of this unblocking fix.