### PR TITLE
chore(clients): re-sync the Go client's go.mod/go.sum

### DIFF
--- a/hindsight-clients/go/go.mod
+++ b/hindsight-clients/go/go.mod
@@ -2,6 +2,6 @@ module github.com/vectorize-io/hindsight/hindsight-clients/go
 
 go 1.18
 
-require github.com/stretchr/testify v1.12.0
+require github.com/stretchr/testify v1.12.1
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require go.yaml.in/yaml/v3 v3.0.5 // indirect

--- a/hindsight-clients/go/go.sum
+++ b/hindsight-clients/go/go.sum
@@ -1,6 +1,4 @@
-github.com/stretchr/testify v1.12.0 h1:K6Mr6jO9JICuend/5xzTM03ydSV3vdNRYAdPSukj8uI=
-github.com/stretchr/testify v1.12.0/go.mod h1:bOYBZb5qJ00vPzWfIqBUZPaxK8jWiXc6d3ErP4Ca9Gw=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
+github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
+go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
+go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=


### PR DESCRIPTION
## Why

`verify-generated-files` is currently red on **every open PR** — not because of anything those PRs changed:

```
❌ Error: Generated files are out of sync with committed files.
 M hindsight-clients/go/go.mod
 M hindsight-clients/go/go.sum
```

Confirmed on #3583, #3480 and #3537 independently.

`scripts/generate-clients.sh` removes `go.mod`/`go.sum` before regenerating (line 432) and lets `go mod tidy` re-resolve from scratch, so the committed files drift the moment a dependency publishes. testify 1.12.1 shipped and swapped its YAML dependency from `gopkg.in/yaml.v3` to `go.yaml.in/yaml/v3`, which is exactly the diff CI reports.

## What

The regenerated files, nothing else. `go build ./...` is clean, and the diff matches CI's reported drift line for line (`go.mod` 2 lines, `go.sum` 6).

Merging this unblocks the generated-files job repo-wide.