### PR TITLE
test(ann): run tests at the shipped vector-index threshold, and build the index the ANN test measures

### DIFF
--- a/hindsight-api-slim/tests/conftest.py
+++ b/hindsight-api-slim/tests/conftest.py
@@ -124,23 +124,6 @@ os.environ.setdefault("HINDSIGHT_API_CONSOLIDATION_RECONCILE_INTERVAL_SECONDS", 
 os.environ.setdefault("HINDSIGHT_API_MENTAL_MODEL_REFRESH_TICK_SECONDS", "0")
 os.environ.setdefault("HINDSIGHT_API_LLM_TRACE_RETENTION_DAYS", "-1")
 
-# Keep incidental per-bank vector-index DDL out of the suite. The shipped default
-# is 0 — every bank holding rows earns its three indexes — which is right for a
-# deployment whose banks are long-lived and get built once, but wrong here: the
-# suite creates thousands of throwaway banks and writes one or two facts to each,
-# so every one of them would queue a build. Eight xdist workers issuing
-# CREATE INDEX CONCURRENTLY against a single shared memory_units deadlock each
-# other by design (CONCURRENTLY holds ShareUpdateExclusive while it waits out
-# every session whose snapshot could still see the index, including other
-# sessions' index DDL), and that lands on whatever unrelated test happens to be
-# writing at the time.
-#
-# A threshold no test bank can reach means the coverage machinery is inert unless
-# a test asks for it: tests that exercise it patch the threshold themselves (see
-# the low_threshold / default_threshold fixtures in
-# test_repair_bank_vector_indexes.py).
-os.environ.setdefault("HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS", "1000000")
-
 
 # Load environment variables from .env at the start of test session
 def pytest_configure(config):

--- a/hindsight-api-slim/tests/test_ann_iterative_scan.py
+++ b/hindsight-api-slim/tests/test_ann_iterative_scan.py
@@ -181,6 +181,11 @@ def _near_query_vector(seed: int) -> str:
 
 
 @pytest.mark.asyncio
+# Serialized onto the same xdist worker as the other per-bank index tests: this
+# issues CREATE INDEX CONCURRENTLY against the shared public.memory_units, and
+# concurrent index DDL on one relation deadlocks by design (see the note in
+# test_repair_bank_vector_indexes.py).
+@pytest.mark.xdist_group("vector_index_reconcile")
 async def test_the_kill_switch_flips_real_retrieval_depth(memory, request_context, ann_config):
     """End to end, through the pool: on, the budget reaches the index; off, it does not.
 
@@ -195,14 +200,13 @@ async def test_the_kill_switch_flips_real_retrieval_depth(memory, request_contex
     index are built directly: the property belongs to the index scan, and going through
     retain would drag in extraction and consolidation.
     """
+    from hindsight_api.engine.retain.bank_utils import _vector_index_clause, get_or_create_bank_profile
     from hindsight_api.engine.search.retrieval import retrieve_semantic_bm25_combined_sql
-    from hindsight_api.engine.retain.bank_utils import get_or_create_bank_profile
     from hindsight_api.engine.task_backend import fq_table
+    from hindsight_api.engine.vector_index_health import reconcile_bank_vector_indexes
 
     bank_id = f"test_iter_scan_{uuid.uuid4().hex[:8]}"
     budget = 400  # deliberately above the standing ef_search of 200
-    # Creating the bank also builds its per-(bank, fact_type) partial vector index —
-    # the same one recall uses — so this exercises the production index, not a stand-in.
     await get_or_create_bank_profile(memory._backend, bank_id)
     pool = await memory._get_pool()
     probe = _near_query_vector(0)
@@ -214,6 +218,18 @@ async def test_the_kill_switch_flips_real_retrieval_depth(memory, request_contex
                 [(bank_id, f"filler fact {i}", _near_query_vector(i)) for i in range(_ROWS)],
             )
             await conn.execute(f"ANALYZE {table}")
+            # Give the bank its per-(bank, fact_type) partial vector index — the same
+            # one recall uses — through the production reconcile, so this measures the
+            # real index rather than a stand-in.
+            #
+            # Bank creation used to build it, which is what this test relied on. Since
+            # #2645/#3485 coverage is reconciled separately (the repair suite pins that:
+            # "bank creation must not build indexes"), so the index has to be asked for.
+            # No threshold patching needed — the shipped default is 0, so a partition
+            # holding rows qualifies.
+            index_clause = _vector_index_clause()
+            assert index_clause is not None, "per-bank-index backend expected"
+            await reconcile_bank_vector_indexes(conn, "public", bank_id, index_clause)
 
         async def semantic_rows(iterative: bool) -> int:
             ann_config("ann_iterative_scan", iterative)


### PR DESCRIPTION
## Problem

Two things, both about the same divergence between the suite and what ships.

**1. The suite ran at a threshold nobody ships.** `tests/conftest.py` pinned `HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS=1000000`. The shipped default is **0** — every bank holding rows earns its per-`(bank, fact_type)` indexes. A suite that never builds the indexes production always builds cannot see anything that depends on them.

**2. `test_the_kill_switch_flips_real_retrieval_depth` is red on six of the last seven branches** to run CI (`store-owned-addressed-reads-pr`, `fix/3361-mental-model-delta-schema-v2`, `fix/otel-worker-tracing-and-context-propagation`, `fix/3475-unsay-retracted-facts`, `fix/mm-refresh-min-interval-3480`, `fix/3584-retain-chunking-config-loud`), so `test-api (1/3)` is red on essentially every PR.

It fails on a fixture problem, not on the behaviour it exists to measure:

```
AssertionError: expected an ANN scan, got:
Limit
  ->  Sort  (Disabled: true)
        ->  Index Scan using idx_memory_units_fact_type on memory_units
```

It asserts the planner picks an ANN scan, then measures how deep that scan goes with `hnsw.iterative_scan` on and off. It got its index from bank creation, as its own comment said:

> Creating the bank also builds its per-(bank, fact_type) partial vector index — the same one recall uses

Since #2645 / #3485 that is no longer true **at any threshold** — coverage is reconciled separately, which the repair suite pins directly: *"bank creation must not build indexes"*. So the index was simply absent and the planner fell back to the `fact_type` B-tree plus a sort. Dropping the threshold override alone does **not** fix it; I checked.

## Change

- Drop the `conftest.py` override, so tests run the shipped policy.
- The ANN test asks for its index through `reconcile_bank_vector_indexes` — the production path — and needs no threshold patching to do it, now that the shipped default applies.
- That test joins the `vector_index_reconcile` xdist group, because it issues `CREATE INDEX CONCURRENTLY` against the shared `public.memory_units`, and concurrent index DDL on one relation deadlocks by design (`CONCURRENTLY` holds ShareUpdateExclusive while waiting out every session whose snapshot could still see the index). Advisory locks are banned here, so the isolation has to come from the scheduler.

## Measured cost, and a caveat worth a maintainer's eye

The dropped override was not decorative — it was suppressing real contention. Same six modules, eight workers, before and after:

| | retain-path deadlock retries | wall clock | result |
|---|---|---|---|
| with the override (today) | **0** | 148s | 264 passed, 1 pre-existing failure |
| without it (this PR) | **3**, of a 4-attempt budget | 195s | 264 passed, 1 pre-existing failure |

Nothing broke in either run, and the one failure is `TestMentalModelRefreshTagSecurity::test_refresh_with_tags_only_accesses_same_tagged_models`, a real-LLM judge test that also fails on the base commit.

But three retries against a budget of four is thin. The pressure is now *visible* rather than configured away, which is the right direction — the suite is testing what ships — though it may want a follow-up (the retry budget, or making bank-creation-time index work cheaper) if it starts eating into CI.

## Verification

Reproduced the ANN failure locally on `main` (same plan, same assertion). `test_ann_iterative_scan.py` + `test_repair_bank_vector_indexes.py` pass 43/43 after the change.

## Still open, not fixed here

`test_llm_trace.py::test_disabled_writes_no_rows` is also failing in CI (on `store-owned-addressed-reads-pr` and on #3609). It passes 33/33 locally in isolation and I could not reproduce it, so I have not guessed at a fix. What is known: the test sets `memory._llm_recorder._enabled = False`, and recorders register into a *global* registry one per `MemoryEngine`, so a second engine's recorder could still be enabled and writing. Running it alongside a module that builds a second engine did **not** reproduce it, so that hypothesis is unconfirmed. Worth its own issue.
