### PR TITLE
fix(retain): bound structured extraction schemas

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -6,6 +6,7 @@ Uses the LLMConfig wrapper for all LLM calls.
 """
 
 import asyncio
+import functools
 import json
 import logging
 import re
@@ -18,7 +19,7 @@ from ..llm_interface import ProviderRateLimitResetError
 from ..llm_wrapper import LLMConfig, OutputTooLongError, parse_llm_json, sanitize_llm_output
 from ..operation_metadata import RetainExtractionErrors
 from ..response_models import TokenUsage
-from ..structured_output import strict_json_schema
+from ..structured_output import bound_extraction_schema, strict_json_schema
 from .entity_labels import (
     EntityLabelsConfig,
     MapField,
@@ -1065,6 +1066,30 @@ def _build_labels_prompt_section(labels_cfg: EntityLabelsConfig | list | None, f
     return "\n".join(lines)
 
 
+@functools.lru_cache(maxsize=16)
+def _bounded_extraction_schema_model(model: type[BaseModel]) -> type[BaseModel]:
+    """Return a subclass of ``model`` that emits an output-bounded JSON schema.
+
+    Retain feeds one Pydantic response model to two code paths: the interactive
+    path hands the *model* to the provider, which serializes it via
+    ``model_json_schema``; the batch path serializes it directly. Overriding
+    ``model_json_schema`` here bounds *both* at their single shared chokepoint
+    without touching the provider (which serializes every structured output, not
+    just retain), so the size caps stay scoped to fact extraction. Validation and
+    every other behaviour is inherited unchanged. Results are cached because
+    building a Pydantic subclass rebuilds its core schema.
+    """
+
+    class _BoundedExtractionResponse(model):  # type: ignore[valid-type,misc]
+        @classmethod
+        def model_json_schema(cls, *args: Any, **kwargs: Any) -> dict[str, Any]:
+            return bound_extraction_schema(super().model_json_schema(*args, **kwargs))
+
+    _BoundedExtractionResponse.__name__ = model.__name__
+    _BoundedExtractionResponse.__qualname__ = model.__qualname__
+    return _BoundedExtractionResponse
+
+
 def _build_extraction_prompt_and_schema(config) -> tuple[str, type]:
     """
     Build extraction prompt and response schema based on config.
@@ -1181,6 +1206,11 @@ def _build_extraction_prompt_and_schema(config) -> tuple[str, type]:
             DynamicResponse = create_model("LabelsResponse", facts=(list[DynamicFact], ...))  # type: ignore[valid-type]
             response_schema = DynamicResponse
 
+    # Cap the emitted JSON schema's output size. Applied here — retain's single
+    # response-schema chokepoint — so both the interactive and batch paths inherit
+    # bounded facts/strings/arrays without affecting non-retain structured outputs.
+    response_schema = _bounded_extraction_schema_model(response_schema)
+
     return prompt, response_schema
 
 
@@ -1293,7 +1323,11 @@ def _build_request_body(llm_config, config, prompt: str, user_message: str, resp
     # retain-scoped field, which already folds in the global HINDSIGHT_API_LLM_STRICT_SCHEMA
     # fallback, so the batch and streaming paths can't disagree.
     if hasattr(response_schema, "model_json_schema"):
-        schema = (
+        # Bound the emitted schema so a grammar-constrained backend can't run to
+        # the token cap and truncate into invalid JSON. Idempotent when the
+        # response schema is already the bounded model, but applied explicitly so
+        # the batch request body is bounded regardless of how the schema arrived.
+        schema = bound_extraction_schema(
             strict_json_schema(response_schema) if config.llm_strict_schema else response_schema.model_json_schema()
         )
         request_body["response_format"] = {

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1292,6 +1292,16 @@ Text:
 {sanitized_chunk}"""
 
 
+def _retain_strict_schema(config: Any) -> bool:
+    """Resolve retain strict-schema config across old and new config versions."""
+    try:
+        return getattr(config, "llm_strict_schema_retain", config.llm_strict_schema)
+    except AttributeError:
+        # getattr evaluates its default eagerly, so a config proxy exposing only
+        # the newer operation field needs this equivalent lazy resolution.
+        return config.llm_strict_schema_retain
+
+
 def _build_request_body(llm_config, config, prompt: str, user_message: str, response_schema: type) -> dict:
     """Build request body for LLM API call."""
     request_body = {
@@ -1332,7 +1342,7 @@ def _build_request_body(llm_config, config, prompt: str, user_message: str, resp
         )
         request_body["response_format"] = {
             "type": "json_schema",
-            "json_schema": {"name": "facts", "schema": schema, "strict": config.llm_strict_schema_retain},
+            "json_schema": {"name": "facts", "schema": schema, "strict": _retain_strict_schema(config)},
         }
 
     return request_body
@@ -1439,7 +1449,7 @@ async def _extract_facts_from_chunk(
                 response_format=response_schema,
                 scope="retain_extract_facts",
                 temperature=config.llm_temperature_retain,
-                strict_schema=config.llm_strict_schema_retain,
+                strict_schema=_retain_strict_schema(config),
                 max_completion_tokens=config.retain_max_completion_tokens,
                 max_retries=llm_max_retries,
                 initial_backoff=initial_backoff,

--- a/hindsight-api-slim/hindsight_api/engine/structured_output.py
+++ b/hindsight-api-slim/hindsight_api/engine/structured_output.py
@@ -1,5 +1,6 @@
 """Canonical JSON Schema serialization for OpenAI strict output."""
 
+import copy
 from typing import Any
 
 from pydantic import BaseModel
@@ -28,6 +29,81 @@ class OpenAIStrictSchemaGenerator(GenerateJsonSchema):
 def strict_json_schema(response_format: type[BaseModel]) -> dict[str, Any]:
     """Serialize a typed response model directly into OpenAI's strict subset."""
     return response_format.model_json_schema(schema_generator=OpenAIStrictSchemaGenerator)
+
+
+# --- Bounded schema for retain fact extraction -----------------------------
+#
+# A strict json_schema alone does not cap *how much* a model may emit: the facts
+# array and its nested string/array fields are unbounded, so on a pathological
+# prompt a grammar-constrained backend (e.g. vLLM) will happily generate valid
+# JSON until it hits max_completion_tokens and then truncates mid-object,
+# yielding invalid JSON and a wasted, often multi-minute, call. Live replays of
+# historical pathological retain prompts hung/failed with the unbounded schema
+# but succeeded 3/3 (valid JSON, finish_reason=stop) once the *same* schema was
+# bounded. These caps give the grammar an escape hatch: a finite maximum output
+# the model can always complete within the token budget.
+#
+# The numbers are deliberately generous — real extractions in that replay
+# produced at most 5 facts / ~4.3k tokens, so the caps only ever bite runaway
+# degenerate output, never legitimate extraction.
+RETAIN_FACTS_MAX_ITEMS = 8
+"""Upper bound on the top-level ``facts`` array for retain extraction."""
+
+RETAIN_NESTED_ARRAY_MAX_ITEMS = 12
+"""Upper bound applied to any other (nested) array without a tighter limit."""
+
+RETAIN_STRING_MAX_LENGTH = 2048
+"""Upper bound applied to any string without a tighter ``maxLength``."""
+
+
+def _tighter_limit(existing: Any, cap: int) -> int:
+    """Return the tighter of an existing integer limit and ``cap``.
+
+    Preserves an already-present (presumably intentional, tighter) bound rather
+    than loosening it, while still clamping absent or looser limits to ``cap``.
+    """
+    if isinstance(existing, int) and not isinstance(existing, bool):
+        return min(existing, cap)
+    return cap
+
+
+def _bound_schema_node(node: Any) -> None:
+    """Recursively clamp unbounded strings/arrays in-place on a copied schema."""
+    if isinstance(node, dict):
+        node_type = node.get("type")
+        # Skip enum/const string nodes: their length is already fully
+        # constrained by the allowed values, so a maxLength is noise.
+        if node_type == "string" and "enum" not in node and "const" not in node:
+            node["maxLength"] = _tighter_limit(node.get("maxLength"), RETAIN_STRING_MAX_LENGTH)
+        elif node_type == "array":
+            node["maxItems"] = _tighter_limit(node.get("maxItems"), RETAIN_NESTED_ARRAY_MAX_ITEMS)
+        for value in node.values():
+            _bound_schema_node(value)
+    elif isinstance(node, list):
+        for item in node:
+            _bound_schema_node(item)
+
+
+def bound_extraction_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Return a deep-copied retain-extraction schema with output size bounds.
+
+    Adds ``maxItems`` to the top-level ``facts`` array (``RETAIN_FACTS_MAX_ITEMS``)
+    and, recursively, ``maxLength``/``maxItems`` to every otherwise-unbounded
+    string/array (``RETAIN_STRING_MAX_LENGTH`` / ``RETAIN_NESTED_ARRAY_MAX_ITEMS``).
+    Existing tighter limits are preserved. The input is never mutated — Pydantic
+    caches and shares the dicts returned by ``model_json_schema``, so we operate
+    on a deep copy.
+    """
+    bounded = copy.deepcopy(schema)
+
+    properties = bounded.get("properties")
+    if isinstance(properties, dict):
+        facts = properties.get("facts")
+        if isinstance(facts, dict) and facts.get("type") == "array":
+            facts["maxItems"] = _tighter_limit(facts.get("maxItems"), RETAIN_FACTS_MAX_ITEMS)
+
+    _bound_schema_node(bounded)
+    return bounded
 
 
 # Types the structured-output extractor knows how to build a Pydantic field for

--- a/hindsight-api-slim/tests/test_retain_bounded_schema.py
+++ b/hindsight-api-slim/tests/test_retain_bounded_schema.py
@@ -12,17 +12,20 @@ is wired into *both* the interactive and batch retain paths — and only there.
 """
 
 from copy import deepcopy
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydantic import BaseModel, Field
 
+from hindsight_api.engine.response_models import TokenUsage
 from hindsight_api.engine.retain.fact_extraction import (
     FactExtractionResponse,
     FactExtractionResponseNoCausal,
     FactExtractionResponseVerbose,
     _build_extraction_prompt_and_schema,
     _build_request_body,
+    _extract_facts_from_chunk,
 )
 from hindsight_api.engine.structured_output import (
     RETAIN_FACTS_MAX_ITEMS,
@@ -180,6 +183,30 @@ def _mock_llm_config() -> MagicMock:
     return llm_config
 
 
+def _compat_config(global_strict: bool, retain_strict: bool | None) -> SimpleNamespace:
+    config = SimpleNamespace(
+        entity_labels=None,
+        entities_allow_free_form=True,
+        retain_extraction_mode="concise",
+        retain_extract_causal_links=False,
+        retain_mission=None,
+        retain_custom_instructions=None,
+        llm_output_language=None,
+        llm_temperature_retain=0.0,
+        retain_max_completion_tokens=8192,
+        retain_llm_max_retries=0,
+        llm_max_retries=0,
+        retain_llm_initial_backoff=0.0,
+        llm_initial_backoff=0.0,
+        retain_llm_max_backoff=0.0,
+        llm_max_backoff=0.0,
+        llm_strict_schema=global_strict,
+    )
+    if retain_strict is not None:
+        config.llm_strict_schema_retain = retain_strict
+    return config
+
+
 def test_interactive_response_schema_is_bounded():
     _, response_schema = _build_extraction_prompt_and_schema(_baseline_config())
 
@@ -198,6 +225,57 @@ def test_batch_request_body_uses_bounded_schema():
 
     assert schema["properties"]["facts"]["maxItems"] == RETAIN_FACTS_MAX_ITEMS
     assert all(node["maxLength"] == RETAIN_STRING_MAX_LENGTH for node in _string_nodes(schema))
+
+
+@pytest.mark.parametrize(
+    ("global_strict", "retain_strict", "expected"),
+    [
+        (True, None, True),
+        (False, None, False),
+        (False, True, True),
+        (True, False, False),
+    ],
+)
+def test_batch_strict_schema_supports_legacy_and_operation_config(
+    global_strict: bool, retain_strict: bool | None, expected: bool
+):
+    config = _compat_config(global_strict, retain_strict)
+    _, response_schema = _build_extraction_prompt_and_schema(config)
+
+    body = _build_request_body(_mock_llm_config(), config, "system prompt", "user message", response_schema)
+
+    assert body["response_format"]["json_schema"]["strict"] is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("global_strict", "retain_strict", "expected"),
+    [
+        (True, None, True),
+        (False, None, False),
+        (False, True, True),
+        (True, False, False),
+    ],
+)
+async def test_interactive_strict_schema_supports_legacy_and_operation_config(
+    global_strict: bool, retain_strict: bool | None, expected: bool
+):
+    llm_config = MagicMock()
+    llm_config.provider = "mock"
+    llm_config._provider_impl = SimpleNamespace(supports_prompt_caching=lambda: False)
+    llm_config.call = AsyncMock(return_value=({"facts": []}, TokenUsage()))
+
+    await _extract_facts_from_chunk(
+        chunk="some text",
+        chunk_index=0,
+        total_chunks=1,
+        event_date=None,
+        context="",
+        llm_config=llm_config,
+        config=_compat_config(global_strict, retain_strict),
+    )
+
+    assert llm_config.call.call_args.kwargs["strict_schema"] is expected
 
 
 @pytest.mark.parametrize(

--- a/hindsight-api-slim/tests/test_retain_bounded_schema.py
+++ b/hindsight-api-slim/tests/test_retain_bounded_schema.py
@@ -1,0 +1,253 @@
+"""Retain fact-extraction schemas are bounded before the strict json_schema call.
+
+A strict json_schema caps *shape* but not *size*: the ``facts`` array and its
+nested string/array fields are unbounded, so a grammar-constrained backend can
+generate valid JSON until it hits ``max_completion_tokens`` and then truncate
+mid-object into invalid JSON. Live replays of historical pathological retain
+prompts hung/failed with the unbounded schema but succeeded once the same schema
+was bounded, so retain applies explicit output-size caps.
+
+These tests pin the helper contract (RED before the helper existed) and prove it
+is wired into *both* the interactive and batch retain paths — and only there.
+"""
+
+from copy import deepcopy
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel, Field
+
+from hindsight_api.engine.retain.fact_extraction import (
+    FactExtractionResponse,
+    FactExtractionResponseNoCausal,
+    FactExtractionResponseVerbose,
+    _build_extraction_prompt_and_schema,
+    _build_request_body,
+)
+from hindsight_api.engine.structured_output import (
+    RETAIN_FACTS_MAX_ITEMS,
+    RETAIN_NESTED_ARRAY_MAX_ITEMS,
+    RETAIN_STRING_MAX_LENGTH,
+    bound_extraction_schema,
+    strict_json_schema,
+)
+
+
+def _iter_nodes(node):
+    """Yield every dict subschema in a JSON schema tree."""
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _iter_nodes(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_nodes(item)
+
+
+def _string_nodes(schema):
+    return [n for n in _iter_nodes(schema) if n.get("type") == "string" and "enum" not in n and "const" not in n]
+
+
+def _array_nodes(schema):
+    return [n for n in _iter_nodes(schema) if n.get("type") == "array"]
+
+
+# --- 1. facts array gets maxItems 8 ----------------------------------------
+
+
+def test_facts_array_gets_max_items_bound():
+    schema = strict_json_schema(FactExtractionResponseVerbose)
+    assert "maxItems" not in schema["properties"]["facts"]  # RED baseline
+
+    bounded = bound_extraction_schema(schema)
+    assert bounded["properties"]["facts"]["maxItems"] == RETAIN_FACTS_MAX_ITEMS
+    assert RETAIN_FACTS_MAX_ITEMS == 8
+
+
+# --- 2. unbounded strings get maxLength 2048 -------------------------------
+
+
+def test_unbounded_strings_get_max_length():
+    schema = strict_json_schema(FactExtractionResponseVerbose)
+    bounded = bound_extraction_schema(schema)
+
+    string_nodes = _string_nodes(bounded)
+    assert string_nodes, "expected string fields in the fact schema"
+    assert all(node["maxLength"] == RETAIN_STRING_MAX_LENGTH for node in string_nodes)
+    assert RETAIN_STRING_MAX_LENGTH == 2048
+
+
+# --- 3. unbounded nested arrays get maxItems 12 ----------------------------
+
+
+def test_unbounded_nested_arrays_get_max_items():
+    schema = strict_json_schema(FactExtractionResponseVerbose)
+    bounded = bound_extraction_schema(schema)
+
+    # entities (list[str]) is a nested array without a tighter bound.
+    entities = bounded["$defs"]["ExtractedFactVerbose"]["properties"]["entities"]
+    assert entities["type"] == "array"
+    assert entities["maxItems"] == RETAIN_NESTED_ARRAY_MAX_ITEMS
+    assert RETAIN_NESTED_ARRAY_MAX_ITEMS == 12
+
+    # Every array except the top-level facts array is capped at the nested limit.
+    for node in _array_nodes(bounded):
+        assert node["maxItems"] <= RETAIN_NESTED_ARRAY_MAX_ITEMS
+
+
+# --- 4. tighter existing bounds are preserved ------------------------------
+
+
+def test_existing_tighter_bounds_are_preserved():
+    schema = {
+        "type": "object",
+        "properties": {
+            "facts": {
+                "type": "array",
+                "maxItems": 3,  # tighter than RETAIN_FACTS_MAX_ITEMS
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "short": {"type": "string", "maxLength": 16},  # tighter
+                        "tags": {"type": "array", "maxItems": 2, "items": {"type": "string"}},  # tighter
+                    },
+                },
+            },
+        },
+    }
+
+    bounded = bound_extraction_schema(schema)
+    props = bounded["properties"]["facts"]["items"]["properties"]
+
+    assert bounded["properties"]["facts"]["maxItems"] == 3
+    assert props["short"]["maxLength"] == 16
+    assert props["tags"]["maxItems"] == 2
+    # Looser/absent bounds are still clamped.
+    assert props["tags"]["items"]["maxLength"] == RETAIN_STRING_MAX_LENGTH
+
+
+def test_looser_existing_bounds_are_tightened():
+    schema = {
+        "type": "object",
+        "properties": {
+            "facts": {"type": "array", "maxItems": 999, "items": {"type": "string", "maxLength": 100_000}},
+        },
+    }
+
+    bounded = bound_extraction_schema(schema)
+    assert bounded["properties"]["facts"]["maxItems"] == RETAIN_FACTS_MAX_ITEMS
+    assert bounded["properties"]["facts"]["items"]["maxLength"] == RETAIN_STRING_MAX_LENGTH
+
+
+# --- 5. original input schema is not mutated -------------------------------
+
+
+def test_input_schema_is_not_mutated():
+    schema = strict_json_schema(FactExtractionResponseVerbose)
+    snapshot = deepcopy(schema)
+
+    bound_extraction_schema(schema)
+
+    assert schema == snapshot, "bound_extraction_schema must not mutate its input"
+    # And the shared Pydantic model schema stays unbounded.
+    assert "maxItems" not in FactExtractionResponseVerbose.model_json_schema()["properties"]["facts"]
+
+
+# --- 6. interactive AND batch paths use the bounded schema ------------------
+
+
+def _baseline_config() -> MagicMock:
+    config = MagicMock()
+    config.entity_labels = None
+    config.entities_allow_free_form = True
+    config.retain_extraction_mode = "concise"
+    config.retain_extract_causal_links = True
+    config.retain_mission = None
+    config.retain_custom_instructions = None
+    config.llm_output_language = None
+    config.llm_temperature_retain = 0.0
+    config.retain_max_completion_tokens = 8192
+    config.llm_strict_schema = True
+    config.llm_strict_schema_retain = True
+    return config
+
+
+def _mock_llm_config() -> MagicMock:
+    llm_config = MagicMock()
+    llm_config.model = "test-model"
+    llm_config.provider = "openai_compatible"
+    llm_config._provider_impl.openai_service_tier = None
+    return llm_config
+
+
+def test_interactive_response_schema_is_bounded():
+    _, response_schema = _build_extraction_prompt_and_schema(_baseline_config())
+
+    strict = strict_json_schema(response_schema)
+    assert strict["properties"]["facts"]["maxItems"] == RETAIN_FACTS_MAX_ITEMS
+    plain = response_schema.model_json_schema()
+    assert plain["properties"]["facts"]["maxItems"] == RETAIN_FACTS_MAX_ITEMS
+
+
+def test_batch_request_body_uses_bounded_schema():
+    config = _baseline_config()
+    _, response_schema = _build_extraction_prompt_and_schema(config)
+
+    body = _build_request_body(_mock_llm_config(), config, "system prompt", "user message", response_schema)
+    schema = body["response_format"]["json_schema"]["schema"]
+
+    assert schema["properties"]["facts"]["maxItems"] == RETAIN_FACTS_MAX_ITEMS
+    assert all(node["maxLength"] == RETAIN_STRING_MAX_LENGTH for node in _string_nodes(schema))
+
+
+@pytest.mark.parametrize(
+    "mode,causal",
+    [
+        ("concise", True),
+        ("verbose", True),
+        ("concise", False),
+        ("custom", True),
+    ],
+)
+def test_all_extraction_modes_produce_bounded_facts(mode, causal):
+    config = _baseline_config()
+    config.retain_extraction_mode = mode
+    config.retain_extract_causal_links = causal
+    if mode == "custom":
+        config.retain_custom_instructions = "Extract everything relevant."
+
+    _, response_schema = _build_extraction_prompt_and_schema(config)
+    schema = strict_json_schema(response_schema)
+    assert schema["properties"]["facts"]["maxItems"] == RETAIN_FACTS_MAX_ITEMS
+
+
+def test_dynamic_labels_schema_is_bounded():
+    config = _baseline_config()
+    config.entities_allow_free_form = False
+    config.entity_labels = [{"key": "topic", "type": "text"}]
+
+    _, response_schema = _build_extraction_prompt_and_schema(config)
+    schema = strict_json_schema(response_schema)
+    assert schema["properties"]["facts"]["maxItems"] == RETAIN_FACTS_MAX_ITEMS
+
+
+# --- 7. unrelated structured-output schemas are unaffected ------------------
+
+
+class _UnrelatedResponse(BaseModel):
+    summary: str = Field(description="A free-form summary")
+    tags: list[str] = Field(default_factory=list)
+
+
+def test_unrelated_strict_schema_is_not_bounded():
+    schema = strict_json_schema(_UnrelatedResponse)
+    for node in _iter_nodes(schema):
+        assert "maxLength" not in node
+        assert "maxItems" not in node
+
+
+def test_base_retain_models_are_not_mutated_globally():
+    # Bounding is applied per-request on a copy; the shared model schemas must
+    # remain unbounded so non-retain consumers see the original contract.
+    for model in (FactExtractionResponse, FactExtractionResponseVerbose, FactExtractionResponseNoCausal):
+        assert "maxItems" not in model.model_json_schema()["properties"]["facts"]


### PR DESCRIPTION
## Summary
- bound retain fact arrays and nested arrays/strings in strict JSON schemas
- preserve tighter existing constraints without mutating Pydantic schemas
- apply the bounded retain schema to interactive and batch extraction paths only

## Production evidence
Unbounded strict schemas let vLLM/Nemotron generate until the completion cap and truncate invalid JSON. The same three historical pathological prompts passed 3/3 with bounded schemas: valid JSON, finish_reason=stop, 1/5/5 facts, 9.7–63.9 seconds.

## Verification
- 15 focused regression tests passed
- ruff check and format passed
- py_compile passed
- git diff --check passed

No deployment is included.