### PR TITLE
fix(memory-defense): fail the retain on a malformed policy instead of skipping screening

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -66,10 +66,20 @@ def redact_document_body(body: str, config: Any) -> str:
     oversized item carries the identical body, so re-screening would rescan the
     whole document once per sub-batch (issue #3282).
     """
-    try:
-        policy = parse_policy(config.memory_defense)
-    except Exception:
-        return body
+    # No try/except around the parse. A malformed policy must fail the retain, not
+    # quietly skip screening: this is a security control, so fail-open is the wrong
+    # default even for an unreachable state (the HTTP layer 422s a bad policy on
+    # write, so one can only reach the store by a direct DB edit).
+    #
+    # The blanket ``except Exception: return body`` this replaces could not buy a
+    # successful retain anyway — ``retain_batch`` parses the very same
+    # ``config.memory_defense`` unguarded before extracting, so anything raising here
+    # raises there moments later and the retain fails with nothing persisted. All the
+    # catch did was swallow the traceback that says *why* the policy did not parse,
+    # and hide that screening had been skipped first. It also made the large-batch
+    # path (the only caller) diverge from the small-batch path, which has always let
+    # the same error propagate.
+    policy = parse_policy(config.memory_defense)
     if not policy.enabled:
         return body
     if not any(r.on == "sensitive_data" for r in policy.rules):

--- a/hindsight-api-slim/tests/test_memory_defense.py
+++ b/hindsight-api-slim/tests/test_memory_defense.py
@@ -8,12 +8,14 @@ Sections:
   * bank config validation (DB)
   * retain: allow / redact / block / webhook (DB)
   * document-body scrubbing (DB)
+  * redact_document_body in isolation (unit)
 """
 
 import json
 
 import pytest
 
+from hindsight_api.config import HindsightConfig
 from hindsight_api.extensions.builtin.memory_defense_regex import MemoryDefenseRegexExtension
 from hindsight_api.extensions.loader import ExtensionLoadError, load_extension
 from hindsight_api.extensions.memory_defense import (
@@ -880,3 +882,82 @@ async def test_scrubs_secrets_from_oversized_chunked_input(api_client) -> None:
     original_text = r3.json()["original_text"]
     assert secret not in original_text, "oversized document.original_text leaked github token"
     assert ssn not in original_text, "oversized document.original_text leaked SSN"
+
+
+# ---------------------------------------------------------------------------
+# redact_document_body: the oversized-item scrubber, in isolation
+# ---------------------------------------------------------------------------
+
+
+def _defense_config(memory_defense: dict | None) -> HindsightConfig:
+    """A real resolved config carrying the given raw memory_defense policy.
+
+    Not a stub: ``redact_document_body`` reads ``config.memory_defense`` directly,
+    and a partial stand-in would raise AttributeError rather than exercise the parse.
+    """
+    import dataclasses
+
+    from hindsight_api.config import _get_raw_config
+
+    return dataclasses.replace(_get_raw_config(), memory_defense=memory_defense)
+
+
+def test_redact_document_body_scrubs_when_the_policy_redacts():
+    from hindsight_api.engine.retain.orchestrator import redact_document_body
+
+    secret = "ghp_" + "Q" * 36
+    out = redact_document_body(
+        f"deploy key: {secret}",
+        _defense_config({"enabled": True, "rules": [{"on": "sensitive_data", "action": "redact"}]}),
+    )
+
+    assert secret not in out
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [
+        None,
+        {"enabled": False, "rules": [{"on": "sensitive_data", "action": "redact"}]},
+        # Enabled, but no rule names the detector this OSS path screens for.
+        {"enabled": True, "rules": [{"on": "something_else", "action": "redact"}]},
+    ],
+    ids=["absent", "disabled", "no_sensitive_data_rule"],
+)
+def test_redact_document_body_passes_the_body_through_when_not_screening(policy):
+    from hindsight_api.engine.retain.orchestrator import redact_document_body
+
+    body = "deploy key: ghp_" + "Q" * 36
+    assert redact_document_body(body, _defense_config(policy)) == body
+
+
+def test_redact_document_body_raises_on_a_malformed_policy():
+    """A policy that will not parse fails the retain instead of skipping screening.
+
+    This used to be wrapped in ``except Exception: return body``, which returned the
+    body unscrubbed. Fail-open is the wrong default for a security control, and the
+    catch bought nothing: ``retain_batch`` parses the same ``config.memory_defense``
+    unguarded, so the retain died moments later anyway — only without the traceback
+    saying why, and without any sign that screening had been skipped first.
+    """
+    from hindsight_api.engine.retain.orchestrator import redact_document_body
+
+    body = "deploy key: ghp_" + "Q" * 36
+    malformed = {"enabled": True, "rules": [{"on": "sensitive_data", "action": "obliterate"}]}
+
+    with pytest.raises(ValueError, match="invalid action"):
+        redact_document_body(body, _defense_config(malformed))
+
+
+def test_redact_document_body_rejects_global_config():
+    """Handed global config, it raises rather than silently skipping screening.
+
+    ``memory_defense`` is bank-configurable, so ``StaticConfigProxy`` refuses it with
+    ConfigFieldAccessError — an AttributeError subclass the old blanket catch also
+    swallowed, turning a wrong-config bug into a silently unscrubbed document body.
+    """
+    from hindsight_api.config import ConfigFieldAccessError, StaticConfigProxy, _get_raw_config
+    from hindsight_api.engine.retain.orchestrator import redact_document_body
+
+    with pytest.raises(ConfigFieldAccessError, match="memory_defense"):
+        redact_document_body("deploy key: ghp_" + "Q" * 36, StaticConfigProxy(_get_raw_config()))


### PR DESCRIPTION
## Problem

`redact_document_body` is the scrubber for the one body that never goes through per-item `screen()`: the full original text of an oversized item, which the splitter hands to every slice and which lands in `documents.original_text` (#3282). Its policy parse was wrapped in a blanket catch:

```python
try:
    policy = parse_policy(config.memory_defense)
except Exception:
    return body          # <- unscrubbed
```

Anything at all going wrong returned the body **unscrubbed**. Fail-open is the wrong default for a security control.

Two things fall into that catch:

1. **A malformed stored policy.** `parse_policy` raises `ValueError` by contract for an empty `on` or an unknown `action`. The HTTP layer 422s those on write, so reaching the store requires a direct DB edit — but "unreachable" is a reason to let it raise, not to swallow it.
2. **A wrong config object.** `memory_defense` is bank-configurable, so `StaticConfigProxy` refuses it with `ConfigFieldAccessError` — an `AttributeError` subclass. That is the same silent-substitution class removed in #3610, and here it turned a wrong-config bug into a silently unscrubbed document body.

## Scope: this was not a live data leak

Worth stating plainly, because the fix reads scarier than the bug. `retain_batch` parses the very same `config.memory_defense` **unguarded** (`orchestrator.py`, "Memory Defense pre-extraction screening") before extracting anything, and the splitter path always reaches it with the same resolved config. So whatever raised here raised there moments later, the retain failed, and nothing was persisted.

What the catch actually cost was diagnosis: it swallowed the traceback saying *why* the policy did not parse, hid that screening had been skipped first, and made the large-batch path (its only caller) behave differently from the small-batch path, which has always let the same error propagate.

## Change

Delete the catch and let the parse raise. For a valid policy — enabled, disabled, absent, or naming a detector this OSS path does not screen — behaviour is unchanged. For a malformed one the retain now fails at the splitter with a real traceback instead of at `retain_batch` with a bare one.

## Testing

`redact_document_body` had **no test coverage at all**. Adds six:

- scrubs a token when the policy enables `sensitive_data` redaction
- passes the body through untouched for an absent / disabled / non-matching policy (parametrized)
- **raises on a malformed policy** rather than returning it unscrubbed
- **raises when handed global config** rather than silently skipping screening

The last two are regression tests, verified to fail against the previous behaviour (`DID NOT RAISE ValueError` / `DID NOT RAISE ConfigFieldAccessError`) and pass after.

Full `test_memory_defense.py`: 256 passed locally. 14 errors are local pg0 startup only (port already held by another instance) and are unrelated. `lint.sh` and `ty check` clean.

Follow-up to #3610, which flagged this site as the one place its "fail loud on a wrong config" rule did not hold.
