### PR TITLE
fix(db): make min_rows=0 mean "off", and stop counting rows on every write

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -205,7 +205,8 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_VECTOR_EXTENSION=pgvectorscale  # Auto-detects pg_diskann on Azure
 
 # Per-bank vector indexes (pgvector / pgvectorscale / vchord only; ScaNN and Oracle use one global index)
-# HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS=0  # Memories a bank needs in one fact type before that fact type gets its own vector index. 0 (default) = no minimum, every bank holding memories is indexed. Set ~10000 on deployments with thousands of banks: every index lives on the shared memory_units table and is planned against by every OTHER bank's queries, so unconditional per-bank indexes put a ceiling on bank count. Smaller banks then use exact search, which is faster AND exact.
+# HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS=0  # Memories a bank needs in one fact type before that fact type gets its own vector index. 0 (default) turns the threshold OFF: every bank is indexed when it is created, and no background maintenance runs. Set ~10000 on deployments with thousands of banks: every index lives on the shared memory_units table and is planned against by every OTHER bank's queries, so unconditional per-bank indexes put a ceiling on bank count. Smaller banks then use exact search, which is faster AND exact.
+# HINDSIGHT_API_VECTOR_INDEX_MAINTENANCE_MIN_INTERVAL_SECONDS=900  # Shortest gap between two index-maintenance runs for one bank, so a bank hovering at the threshold cannot build and drop the same index repeatedly. Unused while the threshold is off.
 
 # Text Search Extension (Optional - uses native PostgreSQL full-text search by default)
 # Backend options: "native" (default), "vchord", "pg_textsearch", "pgroonga", "pg_search"

--- a/hindsight-api-slim/hindsight_api/_vector_index.py
+++ b/hindsight-api-slim/hindsight_api/_vector_index.py
@@ -253,6 +253,11 @@ def uses_per_bank_vector_indexes(ext: str) -> bool:
 def per_bank_index_min_rows() -> int:
     """Rows a (bank, fact_type) needs before it earns its own partial vector index.
 
+    ``0`` — the default — means the threshold is off entirely: indexes are
+    created up front at bank creation, exactly as they were before the threshold
+    existed, and no maintenance operation ever runs. Everything below applies
+    only when an operator sets a positive value.
+
     Distinct from :func:`minimum_rows_for_index`, which is ScaNN's *build*
     requirement for its single global index (AlloyDB cannot construct one below
     a floor). This is a cost policy for the per-bank backends: the indexes sit on
@@ -272,59 +277,63 @@ def per_bank_index_min_rows() -> int:
     return get_config().vector_index_min_rows
 
 
-def per_bank_index_drop_rows() -> int:
-    """Row count below which an existing per-bank vector index is dropped.
+def per_bank_indexes_are_eager() -> bool:
+    """Whether indexes are created up front at bank creation rather than earned.
 
-    Strictly below :func:`per_bank_index_min_rows` so the build and drop
-    decisions cannot both be true at one row count. Without the gap, a bank
-    hovering at the threshold — consolidation prunes a few facts, retain adds
-    them back — would rebuild and drop the same ANN index on alternating sweeps.
+    True at the default threshold of ``0``, where this reverts to the behaviour
+    that predates the threshold: the bank-create transaction builds all three
+    partial indexes (instant — the bank is empty), bank deletion drops them, and
+    nothing in between inspects row counts. No ``vector_index_maintenance``
+    operation is submitted, and no write pays a coverage pre-check.
+
+    Making ``0`` mean *eager* rather than *lazy with no minimum* is what keeps
+    the default deployment on exactly its pre-#3561 behaviour. Lazily building
+    the same indexes on first write produced identical coverage, but reached it
+    through a visible async operation per (bank, fact_type) and charged every
+    subsequent write a row count to rediscover there was nothing to do.
+    """
+    return per_bank_index_min_rows() == 0
+
+
+def per_bank_index_build_bound() -> int:
+    """Rows at which a partition earns an index. Only meaningful when not eager.
+
+    Returned as a bound to *test membership against* rather than a count to
+    compare with, because nothing needs the exact size of a partition — only
+    whether it reaches this many rows. That distinction is what lets the planner
+    answer with an index-only probe bounded by the threshold instead of counting
+    every row the bank owns (issue #3485 made those counts run on every write).
+    """
+    return max(per_bank_index_min_rows(), 1)
+
+
+def per_bank_index_keep_bound() -> int:
+    """Rows below which an existing index is dropped. Only meaningful when not eager.
+
+    Deliberately lower than :func:`per_bank_index_build_bound` — keeping starts
+    below building — so a partition hovering at the threshold does not rebuild
+    and drop the same ANN index on alternating writes.
+
+    Never below 1: an emptied partition loses its index at every threshold,
+    whatever the ratio works out to. Without that floor a bank written to once
+    and then cleared would hold three indexes over nothing, which is the
+    accumulation the threshold exists to prevent.
     """
     from .config import VECTOR_INDEX_DROP_RATIO
 
-    return int(per_bank_index_min_rows() * VECTOR_INDEX_DROP_RATIO)
+    return max(int(per_bank_index_min_rows() * VECTOR_INDEX_DROP_RATIO), 1)
 
 
-def should_keep_per_bank_index(row_count: int) -> bool:
-    """Whether an *existing* index on a partition of ``row_count`` rows is kept.
+def per_bank_index_min_submit_interval_seconds() -> int:
+    """Shortest gap between two maintenance operations for one bank.
 
-    The counterpart to :func:`qualifies_for_per_bank_index`, and deliberately a
-    separate, lower bound: keeping starts below building, so a partition
-    hovering at the threshold does not rebuild and drop the same ANN index on
-    alternating writes.
-
-    The ``row_count > 0`` term is not redundant with the ratio. At the default
-    threshold of 0 the drop floor is also 0, so a bare ``row_count >= floor``
-    keeps an index over an *emptied* partition forever — every bank ever written
-    to and then cleared would hold three indexes over nothing, which is the
-    accumulation the threshold exists to prevent. An emptied partition loses its
-    index at every threshold.
+    Lives here with the rest of the policy rather than being read from config at
+    the call site so tests can shift it the same way they shift the bounds, and
+    so every reader of the policy is in one file.
     """
-    return row_count > 0 and row_count >= per_bank_index_drop_rows()
+    from .config import get_config
 
-
-def qualifies_for_per_bank_index(row_count: int) -> bool:
-    """Whether a (bank, fact_type) holding ``row_count`` rows should have an index.
-
-    At the default threshold of 0 this is true for every partition that holds
-    any rows at all, which is the behaviour before the threshold existed.
-
-    An empty partition is excluded explicitly rather than by arithmetic: at a
-    threshold of 0, ``row_count >= minimum`` alone is true for zero rows, so
-    every bank in the deployment would be entitled to three indexes over nothing
-    the moment it was created — the exact index explosion the threshold exists
-    to prevent, reintroduced by its own default.
-
-    Only the build side: an existing index is kept until the count falls under
-    :func:`per_bank_index_drop_rows`, so callers reconciling live state must
-    consult both bounds rather than treating this as the full policy.
-
-    Takes no extension: the backend question is settled before any reconcile
-    runs (``uses_per_bank_vector_indexes`` gates the maintenance operation and
-    ``_vector_index_clause`` gates the admin command), so re-asking it here
-    would be a second, weaker copy of a decision already made.
-    """
-    return row_count > 0 and row_count >= per_bank_index_min_rows()
+    return get_config().vector_index_maintenance_min_interval_seconds
 
 
 def bootstrap_extension(conn: Connection, ext: str) -> None:

--- a/hindsight-api-slim/hindsight_api/admin/cli.py
+++ b/hindsight-api-slim/hindsight_api/admin/cli.py
@@ -702,23 +702,27 @@ def repair_bank(
         help="Report what would be repaired without creating or dropping any index.",
     ),
 ):
-    """Reconcile per-(bank, fact_type) vector index coverage against the size threshold.
+    """Reconcile per-(bank, fact_type) vector index coverage.
 
-    A (bank, fact_type) earns a partial vector index once it holds
-    HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS rows; below that the planner answers the
-    same query exactly, and faster, from the (bank_id, fact_type) B-tree plus a
-    top-N sort. This command builds what qualifies and drops what no longer does
-    — including indexes orphaned by a deleted bank — detecting invalid coverage
-    too (an INVALID leftover, or an index whose access method drifted after a
-    backend switch, counts as missing). All DDL is CONCURRENTLY, so it never
-    blocks the live fleet.
+    With HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS at its default of 0 every bank is
+    owed all three indexes from the moment it exists, and this rebuilds whatever
+    is missing or invalid — a bank whose creation lost its DDL to a deadlock, one
+    restored around it, or one whose access method drifted after a backend
+    switch. Nothing is dropped in that mode.
 
-    Writes keep this converged on their own — every insert that could move a bank
-    across the threshold queues a vector_index_maintenance operation. Reach for
-    the command when you want convergence without waiting for a write: after a
-    restore or upgrade, after a backend switch, or to shed indexes in bulk on a
-    deployment recovering from lock-table exhaustion (#3485). Idempotent and safe
-    to re-run.
+    With a threshold set, a (bank, fact_type) earns its index once it holds that
+    many rows; below it the planner answers the same query exactly, and faster,
+    from the (bank_id, fact_type) B-tree plus a top-N sort. This command then
+    also drops what no longer qualifies. Either way it sheds indexes orphaned by
+    a deleted bank, and all DDL is CONCURRENTLY, so it never blocks the live
+    fleet.
+
+    With a threshold set, writes keep this converged on their own — every write
+    that could move a bank across it queues a vector_index_maintenance operation.
+    Reach for the command when you want convergence without waiting for a write:
+    after a restore or upgrade, after a backend switch, or to shed indexes in
+    bulk on a deployment recovering from lock-table exhaustion (#3485).
+    Idempotent and safe to re-run.
     """
     if bool(bank_id) == all_banks:
         typer.echo("Error: pass exactly one of --bank <id> or --all.", err=True)

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -880,6 +880,7 @@ ENV_RETENTION_SWEEP_INTERVAL_SECONDS = "HINDSIGHT_API_RETENTION_SWEEP_INTERVAL_S
 ENV_OPERATION_CLEANUP_INTERVAL_SECONDS = "HINDSIGHT_API_OPERATION_CLEANUP_INTERVAL_SECONDS"
 ENV_MAINTENANCE_START_JITTER_SECONDS = "HINDSIGHT_API_MAINTENANCE_START_JITTER_SECONDS"
 ENV_VECTOR_INDEX_MIN_ROWS = "HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS"
+ENV_VECTOR_INDEX_MAINTENANCE_MIN_INTERVAL_SECONDS = "HINDSIGHT_API_VECTOR_INDEX_MAINTENANCE_MIN_INTERVAL_SECONDS"
 
 # Disposition settings
 ENV_DISPOSITION_SKEPTICISM = "HINDSIGHT_API_DISPOSITION_SKEPTICISM"
@@ -1511,23 +1512,36 @@ DEFAULT_MAINTENANCE_START_JITTER_SECONDS = 60
 # paid by every other bank in the deployment. Three per bank exhausts the lock
 # table at a few thousand banks (issue #3485).
 #
-# 0 is the default and means "no minimum": every partition that holds rows gets
-# an index, which is the behaviour before the threshold existed. Deployments
-# holding thousands of banks raise it — above the threshold ANN wins, and below
-# it PostgreSQL answers the same query from the (bank_id, fact_type) B-tree plus
-# a top-N sort, which is exact rather than approximate *and* faster, because
-# sorting a few thousand rows by distance costs less than descending an ANN
-# graph. 10_000 is a reasonable starting point (it is also ScaNN's own build
-# floor, SCANN_MIN_ROWS_FOR_AUTO_INDEX).
+# 0 is the default and turns the threshold OFF: all three indexes are created in
+# the bank-create transaction (instant — the bank is empty) and dropped when the
+# bank is deleted, which is exactly the behaviour that predates the threshold. No
+# vector_index_maintenance operation is ever submitted and no write pays a
+# coverage check.
+#
+# Deployments holding thousands of banks set a positive value — above it ANN
+# wins, and below it PostgreSQL answers the same query from the
+# (bank_id, fact_type) B-tree plus a top-N sort, which is exact rather than
+# approximate *and* faster, because sorting a few thousand rows by distance costs
+# less than descending an ANN graph. 10_000 is a reasonable starting point (it is
+# also ScaNN's own build floor, SCANN_MIN_ROWS_FOR_AUTO_INDEX).
 DEFAULT_VECTOR_INDEX_MIN_ROWS = 0
 
 # A partition that falls back below MIN_ROWS * this ratio loses its index. The
 # gap between the build and drop thresholds is hysteresis: with a single
 # boundary, consolidation pruning a bank back and forth across it would rebuild
-# and drop the same ANN index on alternating writes. At the default threshold of
-# 0 there is no gap and nothing to flap — a partition either holds rows or does
-# not.
+# and drop the same ANN index on alternating writes. Unused at the default
+# threshold of 0, where coverage is not row-dependent at all.
 VECTOR_INDEX_DROP_RATIO = 0.5
+
+# Shortest gap between two vector_index_maintenance operations for one bank. Only
+# consulted once the pre-check has found real work, so a converged bank never
+# pays for it. Index DDL is the expensive thing this guards: a partition
+# oscillating across the threshold asks for an ANN build or drop on every
+# crossing, and a build that keeps failing leaves the plan non-empty so every
+# subsequent write re-queues it. Ignored by the job's own hand-off, whose purpose
+# is to re-check immediately when the bank moved under it. Unused at the default
+# threshold of 0, where the operation does not exist.
+DEFAULT_VECTOR_INDEX_MAINTENANCE_MIN_INTERVAL_SECONDS = 900
 
 # Default MCP tool descriptions (can be customized via env vars)
 DEFAULT_MCP_RETAIN_DESCRIPTION = """Store important information to long-term memory.
@@ -2703,8 +2717,12 @@ class HindsightConfig:
     # refresh (the per-model schedule lives in the mental model trigger). 0 = disabled.
     mental_model_refresh_tick_seconds: int
     # Rows a (bank, fact_type) needs before it gets its own partial vector index.
-    # 0 (default) = no minimum: every partition holding rows is indexed.
+    # 0 (default) = threshold off: indexes are created with the bank, as they were
+    # before the threshold existed, and no maintenance operation runs.
     vector_index_min_rows: int
+    # Shortest gap between two vector_index_maintenance operations for one bank.
+    # Unused while vector_index_min_rows is 0.
+    vector_index_maintenance_min_interval_seconds: int
 
     # Webhook configuration (static - server-level only, not per-bank)
     webhook_url: str | None  # Global webhook URL (None = disabled)
@@ -4081,6 +4099,11 @@ class HindsightConfig:
                 ENV_VECTOR_INDEX_MIN_ROWS,
                 os.getenv(ENV_VECTOR_INDEX_MIN_ROWS),
                 DEFAULT_VECTOR_INDEX_MIN_ROWS,
+            ),
+            vector_index_maintenance_min_interval_seconds=_parse_non_negative_int(
+                ENV_VECTOR_INDEX_MAINTENANCE_MIN_INTERVAL_SECONDS,
+                os.getenv(ENV_VECTOR_INDEX_MAINTENANCE_MIN_INTERVAL_SECONDS),
+                DEFAULT_VECTOR_INDEX_MAINTENANCE_MIN_INTERVAL_SECONDS,
             ),
             operation_cleanup_interval_seconds=_parse_non_negative_int(
                 ENV_OPERATION_CLEANUP_INTERVAL_SECONDS,

--- a/hindsight-api-slim/hindsight_api/engine/db/ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops.py
@@ -481,11 +481,28 @@ class DataAccessOps(ABC):
 
     # -- Bank index management -------------------------------------------
 
-    # No create counterpart: per-(bank, fact_type) partial vector indexes are
-    # earned by size and built by the maintenance sweep over its own autocommit
-    # connection (see engine/vector_index_health.py), never on a request path.
-    # The drop stays here because bank deletion must remove a large bank's
-    # indexes while it still knows the internal_id they are named after.
+    @abstractmethod
+    async def create_bank_vector_indexes(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        bank_id: str,
+        internal_id: str,
+        index_clause: str,
+        fact_types: dict[str, str],
+    ) -> None:
+        """Create per-bank partial vector indexes for a freshly created bank.
+
+        Only reached when the size threshold is off (the default), where indexes
+        are created up front rather than earned; with a threshold set, the
+        maintenance operation builds them CONCURRENTLY off the request path
+        instead. See ``per_bank_indexes_are_eager``.
+
+        PG creates per-(bank, fact_type) partial indexes.
+        Non-PG is a no-op (uses global index).
+        """
+        ...
+
     @abstractmethod
     async def drop_bank_vector_indexes(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -844,6 +844,23 @@ class OracleOps(DataAccessOps):
             bank_prefix="mu.",
         )
 
+    async def create_bank_vector_indexes(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        bank_id: str,
+        internal_id: str,
+        index_clause: str,
+        fact_types: dict[str, str],
+    ) -> None:
+        # Oracle 23ai supports HNSW vector indexes but does NOT support partial
+        # indexes (WHERE clause on CREATE INDEX for vector indexes). Uses a single
+        # global HNSW index with ORGANIZATION NEIGHBOR PARTITIONS created during
+        # migrations. memory_units is partitioned by LIST (bank_id) AUTOMATIC,
+        # so Oracle creates partitions per bank on INSERT and the optimizer can
+        # prune partitions on bank_id-scoped queries.
+        return
+
     async def drop_bank_vector_indexes(
         self,
         conn: DatabaseConnection,
@@ -856,7 +873,7 @@ class OracleOps(DataAccessOps):
         # Bank scoping comes from the table itself instead: memory_units is
         # partitioned LIST (bank_id) AUTOMATIC, so Oracle creates a partition per
         # bank on INSERT and the optimizer prunes on bank_id. That is why the
-        # size threshold and its sweep are PostgreSQL-only concerns.
+        # size threshold and its maintenance operation are PostgreSQL-only.
         return
 
     def get_entity_resolution_strategy(self) -> str:

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -1071,6 +1071,31 @@ class PostgreSQLOps(DataAccessOps):
             bank_prefix="",
         )
 
+    async def create_bank_vector_indexes(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        bank_id: str,
+        internal_id: str,
+        index_clause: str,
+        fact_types: dict[str, str],
+    ) -> None:
+        # Plain CREATE INDEX, not CONCURRENTLY: this runs inside the bank-create
+        # transaction, and CONCURRENTLY cannot. It is instant — the bank is empty
+        # — but it still takes a ShareLock on the shared memory_units table and
+        # so can deadlock with a concurrent writer. The caller retries the whole
+        # transaction for that reason; the body is idempotent.
+        escaped = bank_id.replace("'", "''")
+        async with self._index_ddl_lock(table):
+            for ft, suffix in fact_types.items():
+                uid = str(internal_id).replace("-", "")[:16]
+                idx = f"idx_mu_emb_{suffix}_{uid}"
+                await conn.execute(
+                    f"CREATE INDEX IF NOT EXISTS {idx} "
+                    f"ON {table} {index_clause} "
+                    f"WHERE fact_type = '{ft}' AND bank_id = '{escaped}'"
+                )
+
     async def drop_bank_vector_indexes(
         self,
         conn: DatabaseConnection,
@@ -1085,13 +1110,15 @@ class PostgreSQLOps(DataAccessOps):
         # (delete_bank) runs this on an autocommit connection after its delete
         # transaction has committed — CONCURRENTLY cannot run inside a tx.
         #
-        # The in-process lock serializes concurrent bank deletes against each
-        # other. It does not cover the maintenance sweep, which reconciles the
-        # same indexes over its own raw connection: an in-process lock could not
-        # help there anyway, since the sweep runs in every process and the real
-        # contention is cross-process. Both paths retry the transient deadlock
-        # (40P01) instead, which is the only lock-free option available — the
-        # project forbids advisory locks (unreliable behind poolers, #2817).
+        # The in-process lock serializes concurrent bank creates and deletes
+        # against each other; its key must match create_bank_vector_indexes',
+        # whose `table` is the fq name this reconstructs from `schema`. It does
+        # not cover the maintenance operation, which reconciles the same indexes
+        # over its own raw connection: an in-process lock could not help there
+        # anyway, since that runs in every process and the real contention is
+        # cross-process. Both paths retry the transient deadlock (40P01)
+        # instead, which is the only lock-free option available — the project
+        # forbids advisory locks (unreliable behind poolers, #2817).
         async with self._index_ddl_lock(f"{schema}.memory_units"):
             for ft, suffix in fact_types.items():
                 uid = str(internal_id).replace("-", "")[:16]

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -31,7 +31,12 @@ import asyncpg
 import httpx
 from pydantic import ValidationError
 
-from .._vector_index import ann_search_tuning_settings, configured_vector_extension
+from .._vector_index import (
+    ann_search_tuning_settings,
+    configured_vector_extension,
+    per_bank_index_min_submit_interval_seconds,
+    per_bank_indexes_are_eager,
+)
 from ..cancellation import OperationCancelledError
 from ..config import (
     DEFAULT_RECALL_CHUNKS_MAX_TOKENS,
@@ -53,6 +58,7 @@ from .audit import AuditLogger, audit_context
 from .bank_stats_cache import BankStatsCache, DistributedBankStatsCache
 from .db import DatabaseBackend, DatabaseConnection, ResultRow, create_database_backend
 from .db.ops_postgresql import pg_search_vector_expr
+from .db.postgresql import PostgreSQLBackend
 from .db.postgresql import apply_session_settings as _apply_session_settings
 from .db_budget import budgeted_operation
 from .llm_interface import ProviderRateLimitResetError
@@ -442,6 +448,7 @@ if TYPE_CHECKING:
     from .audit import AuditLogListResponse, AuditLogStatsResponse
     from .memories import MemoryScopeWatermark
     from .transfer import BankImportResult, ImportResult
+    from .vector_index_health import CoverageTrigger
 
 
 from enum import Enum
@@ -2680,7 +2687,7 @@ class MemoryEngine(MemoryEngineInterface):
         # partition. Retain's post-insert hook cannot see them — a bank whose
         # observations crossed the threshold here would otherwise wait for an
         # unrelated retain to notice (issue #3485).
-        await self._submit_vector_index_maintenance_quietly(bank_id, internal_context, after="consolidation")
+        await self._submit_vector_index_maintenance_quietly(bank_id, internal_context, after="consolidation", grew=True)
         return result
 
     async def _handle_graph_maintenance(self, task_dict: dict[str, Any]):
@@ -4853,7 +4860,7 @@ class MemoryEngine(MemoryEngineInterface):
             await self.submit_async_graph_maintenance(bank_id=bank_id, request_context=request_context)
         except Exception as e:
             logger.warning(f"Failed to submit graph maintenance task for bank {bank_id}: {e}")
-        await self._submit_vector_index_maintenance_quietly(bank_id, request_context, after="retain")
+        await self._submit_vector_index_maintenance_quietly(bank_id, request_context, after="retain", grew=True)
 
     async def _submit_vector_index_maintenance_quietly(
         self,
@@ -4861,6 +4868,7 @@ class MemoryEngine(MemoryEngineInterface):
         request_context: "RequestContext",
         *,
         after: str,
+        grew: bool,
     ) -> None:
         """Queue a vector-index reconcile for ``bank_id``, swallowing failures.
 
@@ -4871,12 +4879,24 @@ class MemoryEngine(MemoryEngineInterface):
         with nothing else scanning for that, an emptied bank that is never
         written to again would carry them forever.
 
+        ``grew`` is which way this caller moved the row count, and it is not
+        bookkeeping: it halves the work the pre-check has to do, because coverage
+        can only go wrong in one direction at a time (see
+        :class:`CoverageTrigger`). Every call site knows the answer statically —
+        a delete cannot add rows — so it costs nothing to say.
+
         Never raises. Index coverage is an optimisation — a bank without it
         falls back to exact search — so it must not be able to fail the delete or
         retain that produced the change.
         """
+        from .vector_index_health import CoverageTrigger
+
         try:
-            await self.submit_async_vector_index_maintenance(bank_id=bank_id, request_context=request_context)
+            await self.submit_async_vector_index_maintenance(
+                bank_id=bank_id,
+                request_context=request_context,
+                trigger=CoverageTrigger.GREW if grew else CoverageTrigger.SHRANK,
+            )
         except Exception as e:
             logger.warning(f"Failed to submit vector index maintenance after {after} for bank {bank_id}: {e}")
 
@@ -7597,7 +7617,9 @@ class MemoryEngine(MemoryEngineInterface):
                 )
             except Exception as e:
                 logger.warning(f"Failed to submit graph maintenance after document deletion for bank {bank_id}: {e}")
-            await self._submit_vector_index_maintenance_quietly(bank_id, request_context, after="document deletion")
+            await self._submit_vector_index_maintenance_quietly(
+                bank_id, request_context, after="document deletion", grew=False
+            )
 
         return result
 
@@ -7962,7 +7984,7 @@ class MemoryEngine(MemoryEngineInterface):
         if deleted and bank_id:
             await self._submit_refreshes_for_retracted_grounding(bank_id, request_context=request_context)
             await self._submit_vector_index_maintenance_quietly(
-                bank_id_for_graph_maintenance, request_context, after="memory deletion"
+                bank_id_for_graph_maintenance, request_context, after="memory deletion", grew=False
             )
 
         return result
@@ -8148,7 +8170,9 @@ class MemoryEngine(MemoryEngineInterface):
                 )
             except Exception as e:
                 logger.warning(f"Failed to submit graph maintenance after bulk memory deletion for bank {bank_id}: {e}")
-            await self._submit_vector_index_maintenance_quietly(bank_id, request_context, after="bulk memory deletion")
+            await self._submit_vector_index_maintenance_quietly(
+                bank_id, request_context, after="bulk memory deletion", grew=False
+            )
 
         return {
             "requested": len(unit_ids),
@@ -8392,7 +8416,7 @@ class MemoryEngine(MemoryEngineInterface):
         # an emptied bank is exactly the one nobody writes to again.
         if not delete_bank_profile:
             await self._submit_vector_index_maintenance_quietly(
-                bank_id, request_context, after="clearing bank memories"
+                bank_id, request_context, after="clearing bank memories", grew=False
             )
 
         return result
@@ -17644,43 +17668,66 @@ class MemoryEngine(MemoryEngineInterface):
         bank_id: str,
         *,
         request_context: "RequestContext",
+        trigger: "CoverageTrigger",
         dedupe_excludes_operation_id: str | None = None,
     ) -> dict[str, Any]:
         """Bring a bank's per-(bank, fact_type) vector indexes back in line with its size.
 
-        Called after a write that could have changed the bank's coverage —
-        retain, import, consolidation, curation. Only writes move a bank across
-        the threshold, so there is nothing for a periodic sweep to discover that
-        the writer did not already know; this replaces one.
+        Only ever does anything when ``HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS`` is
+        set. At its default of 0 the threshold is off, indexes are created with
+        the bank and dropped with it, and this returns ``no_work`` before issuing
+        a single query — no operation, and no per-write cost at all.
 
-        Idempotent and self-limiting: it plans first and short-circuits with
-        ``no_work=True`` when the bank's coverage already matches, so callers
-        can invoke it unconditionally without paying for an async_operations
-        row. At the default threshold of 0 that means one operation per
-        (bank, fact_type) at first write and silence forever after.
+        With a threshold set, this is called after a write that could have moved
+        the bank across it. Only writes move a bank, so there is nothing for a
+        periodic sweep to discover that the writer did not already know.
+        ``trigger`` says which way the bank moved, which is what lets the
+        pre-check settle most partitions from the catalog alone; see
+        :class:`CoverageTrigger`.
 
-        Deduplicates by bank against a job that is pending *or* already running:
-        the job re-plans from live row counts when it starts, so a job in flight
-        already covers a write that landed after it was queued.
+        Idempotent and self-limiting three ways, so an unconditional caller pays
+        almost nothing on a converged bank: it plans first and short-circuits
+        with ``no_work=True`` when coverage already matches; it dedupes by bank
+        against a job that is pending *or* already running (the job re-plans from
+        live counts when it starts, so one in flight already covers a write that
+        landed after it was queued); and it will not re-submit for a bank
+        reconciled within the last ``vector_index_maintenance_min_interval_seconds``.
 
         A no-op on backends without per-bank indexes (ScaNN keeps one global
         index) and on Oracle (partitioned by bank, no partial vector indexes).
         """
         await self._authenticate_tenant(request_context)
 
+        # Threshold off: coverage is settled at bank creation, so there is
+        # nothing to reconcile and nothing to look at. Checked before anything
+        # else because this is the default, and the whole point of it is that an
+        # ordinary deployment never pays for this path.
+        if per_bank_indexes_are_eager():
+            return {"operation_id": None, "no_work": True}
+
         index_clause = bank_utils._vector_index_clause()
         if index_clause is None:
             return {"operation_id": None, "no_work": True}
 
-        # Cheap pre-check: two bank-scoped index-only queries plus a catalog
-        # lookup. Mirrors submit_async_graph_maintenance — an unconditional
-        # caller must not create an empty worker task on every write.
+        # Postgres-only, and gated on the backend rather than on the configured
+        # extension name: an Oracle deployment leaves HINDSIGHT_API_VECTOR_EXTENSION
+        # at its pgvector default, so the clause above is not None there. Without
+        # this the planner would run asyncpg-shaped SQL against Oracle on every
+        # write, and the job would then find no DSN to build with and re-queue
+        # itself on the next one, forever.
+        backend = await self._get_backend()
+        if not isinstance(backend, PostgreSQLBackend):
+            return {"operation_id": None, "no_work": True}
+
+        # Cheap pre-check: one catalog lookup plus, for the partitions this
+        # direction cannot settle from the catalog, one capped count. Mirrors
+        # submit_async_graph_maintenance — an unconditional caller must not
+        # create an empty worker task on every write.
         from .vector_index_health import plan_bank_vector_indexes
 
-        backend = await self._get_backend()
         try:
             async with acquire_with_retry(backend) as conn:
-                plan = await plan_bank_vector_indexes(conn, get_current_schema(), bank_id)
+                plan = await plan_bank_vector_indexes(conn, get_current_schema(), bank_id, trigger=trigger)
         except Exception as e:
             # Planning is advisory: a bank whose coverage we could not read is
             # picked up by the next write, or by `hindsight-admin repair-bank`.
@@ -17688,6 +17735,41 @@ class MemoryEngine(MemoryEngineInterface):
             return {"operation_id": None, "no_work": True}
         if plan.is_empty:
             return {"operation_id": None, "no_work": True}
+
+        # There is work, but possibly not work worth doing yet. Index DDL is the
+        # expensive thing here, and two situations make a bank ask for it over
+        # and over: a partition oscillating across the threshold (each crossing
+        # is an ANN build or drop), and a build that keeps failing — the job logs
+        # rather than raises, so the plan stays non-empty and the next write
+        # queues it again. Both are damped by refusing to reconcile the same bank
+        # twice inside the interval. Checked only now, so a converged bank never
+        # pays for it, and skipped for the job's own hand-off, whose whole
+        # purpose is to re-check immediately when the bank moved under it.
+        if dedupe_excludes_operation_id is None:
+            interval = per_bank_index_min_submit_interval_seconds()
+            since = datetime.now(UTC) - timedelta(seconds=interval)
+            try:
+                async with acquire_with_retry(backend) as conn:
+                    recent = await conn.fetchval(
+                        f"""
+                        SELECT 1 FROM {fq_table("async_operations")}
+                        WHERE bank_id = $1 AND operation_type = 'vector_index_maintenance'
+                          AND created_at > $2
+                        LIMIT 1
+                        """,
+                        bank_id,
+                        since,
+                    )
+            except Exception as e:
+                # Advisory, like the plan above: failing to read the cooldown is
+                # not a reason to skip work the plan says is due.
+                logger.warning(f"Vector index cooldown check failed for bank {bank_id}: {e}")
+                recent = None
+            if recent is not None:
+                logger.debug(
+                    f"Vector index maintenance for bank {bank_id} deferred: reconciled within the last {interval}s"
+                )
+                return {"operation_id": None, "no_work": True}
 
         if self._operation_validator:
             from hindsight_api.extensions import BankWriteContext, BankWriteOperation
@@ -17733,10 +17815,15 @@ class MemoryEngine(MemoryEngineInterface):
         import asyncpg
 
         from ..pg0 import resolve_database_url
-        from .vector_index_health import reconcile_bank_vector_indexes
+        from .vector_index_health import CoverageTrigger, reconcile_bank_vector_indexes
 
         bank_id = task_dict.get("bank_id")
         if not bank_id:
+            return
+        # The threshold can be turned off while a job is queued. Coverage is then
+        # whatever bank creation gave the bank, and reconciling against a policy
+        # that no longer applies would drop indexes the deployment expects to keep.
+        if per_bank_indexes_are_eager():
             return
         index_clause = bank_utils._vector_index_clause()
         if index_clause is None:
@@ -17755,7 +17842,13 @@ class MemoryEngine(MemoryEngineInterface):
         backend = await self._get_backend()
         url = get_config().migration_database_url or getattr(backend, "dsn", None)
         if not url:
-            logger.debug("Vector index maintenance skipped: no database URL available")
+            # Not transient, unlike a failed build: nothing about the next write
+            # will produce a DSN. Warn rather than debug so the operator sees why
+            # coverage never converges, and return without the hand-off below.
+            logger.warning(
+                f"Vector index maintenance for bank {bank_id} skipped: no direct database URL available. "
+                f"Set HINDSIGHT_API_MIGRATION_DATABASE_URL to a session-pooled connection."
+            )
             return
 
         from hindsight_api.models import RequestContext
@@ -17816,6 +17909,10 @@ class MemoryEngine(MemoryEngineInterface):
             await self.submit_async_vector_index_maintenance(
                 bank_id=bank_id,
                 request_context=request_context,
+                # The job does not know which way the bank moved under it, and a
+                # hand-off is exactly the case where the directional
+                # short-circuits would be wrong to apply.
+                trigger=CoverageTrigger.FULL,
                 dedupe_excludes_operation_id=task_dict.get("operation_id"),
             )
         except Exception:

--- a/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
@@ -11,7 +11,7 @@ from typing import TypedDict
 
 from pydantic import BaseModel, Field
 
-from ..._vector_index import index_using_clause, uses_per_bank_vector_indexes
+from ..._vector_index import index_using_clause, per_bank_indexes_are_eager, uses_per_bank_vector_indexes
 from ...config import get_config
 from ..db_utils import acquire_with_retry, retry_with_backoff
 from ..memory_engine import fq_table, get_current_schema
@@ -43,6 +43,55 @@ def _vector_index_clause() -> str | None:
     if not uses_per_bank_vector_indexes(ext):
         return None
     return index_using_clause(ext)
+
+
+async def create_bank_vector_indexes(conn, bank_id: str, internal_id: str, *, ops) -> None:
+    """Create per-(bank, fact_type) partial vector indexes for a newly created bank.
+
+    Only does anything when the size threshold is off — the default — where a
+    bank is entitled to its indexes from the moment it exists and building them
+    here is instant, because the bank is empty. That is the behaviour that
+    predates the threshold, and keeping it means the default deployment never
+    submits a ``vector_index_maintenance`` operation and never pays a coverage
+    check on a write.
+
+    With ``HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS`` set, a fresh bank has not earned
+    anything yet, so this is a no-op and the maintenance operation builds an
+    index CONCURRENTLY if and when the bank grows into one — which also keeps
+    CREATE INDEX's ShareLock on the shared memory_units table off the write path.
+
+    Respects the HINDSIGHT_API_VECTOR_EXTENSION config to use the appropriate
+    index type (HNSW for pgvector, DiskANN for pgvectorscale, vchordrq for vchord).
+
+    AlloyDB ScaNN uses global vector indexes with filtered vector search; it
+    cannot safely create per-bank indexes at bank-creation time because new
+    banks have no embedding rows. On Oracle 23ai this is likewise a no-op —
+    Oracle uses a single global vector index created during migrations, and does
+    not support partial (WHERE-clause) vector indexes.
+
+    bank_id is escaped for SQL literal safety (apostrophes doubled).
+
+    ``ops`` is required rather than defaulting to None: it is only dereferenced
+    in the eager branch, so a caller that forgot it used to work fine until the
+    threshold happened to be off, and then failed on an AttributeError from
+    inside bank creation.
+    """
+    if not per_bank_indexes_are_eager():
+        return
+
+    index_clause = _vector_index_clause()
+    if index_clause is None:
+        logger.debug("Skipping per-bank vector indexes for configured backend")
+        return
+
+    await ops.create_bank_vector_indexes(
+        conn,
+        fq_table("memory_units"),
+        bank_id,
+        internal_id,
+        index_clause,
+        _BANK_INDEX_FACT_TYPES,
+    )
 
 
 async def drop_bank_vector_indexes(conn, internal_id: str, ops=None) -> None:
@@ -160,12 +209,15 @@ async def get_or_create_bank_profile(pool, bank_id: str) -> BankProfileResult:
     ``get_or_create_bank_profile_on_conn`` instead.
     """
 
-    # Retried as a whole transaction. This used to guard the per-bank CREATE
-    # INDEX that ran inline here and took a ShareLock on the shared memory_units
-    # table; that DDL is gone (#3485), but the lazy create can still lose a
-    # deadlock (40P01 / ORA-00060) to a concurrent writer touching the same
-    # bank row, and the body is idempotent (INSERT ... ON CONFLICT DO NOTHING),
-    # so retrying stays correct and cheap.
+    # Retried as a whole transaction. With the size threshold off (the default)
+    # a fresh bank builds its per-(bank, fact_type) partial vector indexes with a
+    # plain CREATE INDEX — it must, since this runs inside the bank-create tx and
+    # CONCURRENTLY cannot — and that CREATE takes a ShareLock on the shared
+    # memory_units table, which can deadlock with concurrent writers. Even with
+    # no DDL to issue, the lazy create can lose a deadlock (40P01 / ORA-00060) to
+    # a concurrent writer touching the same bank row. The body is idempotent
+    # (INSERT ... ON CONFLICT DO NOTHING + CREATE INDEX IF NOT EXISTS), so
+    # retrying the whole tx stays correct and cheap.
     async def _create() -> BankProfileResult:
         async with acquire_with_retry(pool) as conn:
             async with conn.transaction():
@@ -214,14 +266,9 @@ async def get_or_create_bank_profile_on_conn(conn, bank_id: str, *, ops) -> Bank
 
     # Bank doesn't exist, create with defaults. internal_id is minted here rather
     # than defaulted server-side so its value is known without a RETURNING
-    # round-trip; the vector-index sweep derives index names from it.
-    #
-    # No vector-index DDL here. A fresh bank holds no rows, so it cannot meet
-    # the size threshold that earns a per-(bank, fact_type) partial index; the
-    # maintenance sweep builds one if and when the bank grows into it. Keeping
-    # DDL out of this path also takes CREATE INDEX's ShareLock on the shared
-    # memory_units table off the retain hot path, where it deadlocked against
-    # concurrent writers. See issue #3485.
+    # round-trip: the index names derive from it, both for the eager create below
+    # and for the maintenance operation when a threshold is set.
+    internal_id = uuid.uuid4()
     inserted = await conn.fetchval(
         f"""
         INSERT INTO {fq_table("banks")} (bank_id, name, disposition, mission, internal_id)
@@ -233,10 +280,16 @@ async def get_or_create_bank_profile_on_conn(conn, bank_id: str, *, ops) -> Bank
         bank_id,  # Default name is the bank_id
         json.dumps(DEFAULT_DISPOSITION),
         "",
-        uuid.uuid4(),
+        internal_id,
     )
 
     created = inserted is not None
+    if created:
+        # Fresh insert — create per-bank vector indexes (instant on an empty
+        # bank). A no-op unless the size threshold is off; see
+        # create_bank_vector_indexes.
+        await create_bank_vector_indexes(conn, bank_id, str(internal_id), ops=ops)
+
     return BankProfileResult(
         profile=BankProfile(name=bank_id, disposition=DispositionTraits(**DEFAULT_DISPOSITION), mission=""),
         created=created,

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -13,7 +13,7 @@ from typing import Any
 from ...config import _get_raw_config
 from ..memory_engine import fq_table
 from ..metadata_utils import drop_null_values
-from .bank_utils import DEFAULT_DISPOSITION
+from .bank_utils import DEFAULT_DISPOSITION, create_bank_vector_indexes
 from .fact_extraction import _sanitize_text
 from .types import ProcessedFact
 
@@ -122,7 +122,7 @@ async def index_facts(
     await get_memories().index_facts(bank_id, unit_ids, facts, document_id, unit_entity_ids)
 
 
-async def ensure_bank_exists(conn, bank_id: str, ops=None) -> None:
+async def ensure_bank_exists(conn, bank_id: str, *, ops) -> None:
     """
     Ensure bank exists in the database.
 
@@ -131,27 +131,33 @@ async def ensure_bank_exists(conn, bank_id: str, ops=None) -> None:
     Args:
         conn: Database connection
         bank_id: Bank identifier
+        ops: Backend ``DataAccessOps``, needed for the per-bank vector index DDL
+            a fresh bank gets while the size threshold is off. Required rather
+            than defaulting to None, because it is dereferenced only in that
+            branch — a caller that omitted it worked until the threshold was off.
     """
     # internal_id is generated here rather than defaulted server-side so the
-    # value is known without a RETURNING round-trip; the vector-index sweep
-    # derives index names from it.
-    #
-    # No vector-index DDL on this path. A fresh bank holds no rows, so it cannot
-    # meet the size threshold that earns a per-(bank, fact_type) partial index;
-    # the maintenance sweep builds one if the bank later grows into it. See
-    # issue #3485.
-    await conn.execute(
+    # value is known without a RETURNING round-trip: the index names derive
+    # from it.
+    internal_id = uuid.uuid4()
+    inserted = await conn.fetchval(
         f"""
         INSERT INTO {fq_table("banks")} (bank_id, name, disposition, mission, internal_id)
         VALUES ($1, $2, $3::jsonb, $4, $5)
         ON CONFLICT (bank_id) DO NOTHING
+        RETURNING bank_id
         """,
         bank_id,
         bank_id,  # Default name is the bank_id (matches get_or_create_bank_profile)
         json.dumps(DEFAULT_DISPOSITION),
         "",
-        uuid.uuid4(),
+        internal_id,
     )
+    if inserted:
+        # Fresh insert — create per-bank vector indexes. A no-op unless the size
+        # threshold is off, in which case the maintenance operation owns them;
+        # see create_bank_vector_indexes.
+        await create_bank_vector_indexes(conn, bank_id, str(internal_id), ops=ops)
 
 
 async def delete_stale_observations_for_memories(

--- a/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
@@ -22,7 +22,7 @@ from typing import Any, Literal
 from ..causal_links import CANONICAL_CAUSAL_LINK_TYPE, LEGACY_CAUSAL_LINK_TYPES
 from ..db.ops_postgresql import pg_search_vector_expr
 from ..db_utils import acquire_with_retry
-from ..retain import chunk_storage, embedding_processing, fact_storage, link_utils, orchestrator
+from ..retain import bank_utils, chunk_storage, embedding_processing, fact_storage, link_utils, orchestrator
 from ..retain.types import (
     CausalRelation,
     ChunkMetadata,
@@ -559,15 +559,20 @@ async def import_bank(
             parsed.bank_rows.get("banks", []),
             bank_rows_json_encoding=bank_rows_json_encoding,
         )
-        # No vector-index DDL here. #2645 needed it because every bank was
-        # entitled to indexes and a restored bank bypassed the fresh-INSERT gate
-        # that created them; now entitlement is by size, and a restored bank's
-        # rows land through the normal import path where the maintenance sweep
-        # picks them up. Building inline would also be wrong twice over: the
-        # bank is empty at this point (the facts arrive below), and CREATE INDEX
-        # inside the import transaction takes a ShareLock on the shared
-        # memory_units table. An import large enough to deserve an index gets
-        # one on the next sweep. See #3485.
+        # The restored banks row bypasses the fresh-INSERT gate that normally
+        # creates per-bank vector indexes, so create them explicitly here while
+        # the bank is still empty (facts are imported below, so the build is
+        # instant). get_or_create_bank_profile would NOT do this: the row now
+        # exists, so it takes the SELECT branch and skips index creation —
+        # leaving the restored bank falling back to the global index +
+        # post-filter (slower, under-returning recall). See #2645.
+        #
+        # A no-op when a size threshold is set: entitlement is by size then, and
+        # the restored rows land through the normal import path, where the
+        # maintenance operation picks them up (#3485).
+        internal_id = await conn.fetchval(f"SELECT internal_id FROM {fq_table('banks')} WHERE bank_id = $1", bank_id)
+        if internal_id is not None:
+            await bank_utils.create_bank_vector_indexes(conn, bank_id, str(internal_id), ops=ops)
 
     # Only now does the bank row — and with it the archive's own config — exist, so
     # this is where the config the documents are replayed with has to come from.

--- a/hindsight-api-slim/hindsight_api/engine/vector_index_health.py
+++ b/hindsight-api-slim/hindsight_api/engine/vector_index_health.py
@@ -1,20 +1,27 @@
 """Per-bank vector index coverage: what a bank should have, and making it so.
 
-A (bank, fact_type) partition gets its own partial vector index once it holds
-``HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS`` rows. At the default of 0 that is every
-partition holding any rows — the behaviour before the threshold existed — and a
-deployment with thousands of banks raises it, because these indexes live on the
-shared ``memory_units`` table: PostgreSQL locks and plans against every index on
-a relation, and opens every one for each DML statement, so one bank's index is
-charged to every other bank's queries. Three per bank exhausts the lock table at
-a few thousand banks (issue #3485). Below the threshold the planner answers the
-same query from the ``(bank_id, fact_type)`` B-tree plus a top-N sort, which is
-exact rather than approximate and faster.
+``HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS`` decides how coverage is reached, and its
+default of ``0`` means nothing in this module runs at all. At ``0`` the three
+partial indexes are built in the bank-create transaction and dropped when the
+bank is deleted — the behaviour that predates the threshold, and still the right
+one for a deployment whose bank count is not the problem.
 
-Nothing here runs on a request path. Index DDL is issued only by the
-``vector_index_maintenance`` async operation (submitted after a write that could
-have changed a bank's coverage) and by the ``repair-bank`` admin command, both
-of which reconcile a bank against the plan this module computes.
+A deployment holding thousands of banks sets a positive threshold, because these
+indexes live on the shared ``memory_units`` table: PostgreSQL locks and plans
+against every index on a relation, and opens every one for each DML statement, so
+one bank's index is charged to every other bank's queries. Three per bank
+exhausts the lock table at a few thousand banks (issue #3485). Above the
+threshold a partition earns its own index; below it the planner answers the same
+query from the ``(bank_id, fact_type)`` B-tree plus a top-N sort, which is exact
+rather than approximate and faster.
+
+With a threshold set, coverage is reconciled by the ``vector_index_maintenance``
+async operation (submitted after a write that could have changed it) and by the
+``repair-bank`` admin command. Neither runs on a request path. The write path
+pays only :func:`plan_bank_vector_indexes`, which is kept cheap two ways: the
+:class:`CoverageTrigger` direction settles most partitions from the catalog
+without counting anything, and what is left is counted no further than the
+threshold rather than exactly.
 
 All DDL is ``CREATE/DROP INDEX CONCURRENTLY`` on a raw autocommit connection, so
 it never takes ``ACCESS EXCLUSIVE`` on the shared table. That is also what keeps
@@ -27,9 +34,14 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any
 
-from .._vector_index import qualifies_for_per_bank_index, should_keep_per_bank_index
+from .._vector_index import (
+    per_bank_index_build_bound,
+    per_bank_index_keep_bound,
+    per_bank_indexes_are_eager,
+)
 from .db_utils import retry_with_backoff
 from .retain.bank_utils import _BANK_INDEX_FACT_TYPES, _bank_index_name
 
@@ -54,6 +66,33 @@ _SUPPORTED_INDEX_AM: tuple[str, ...] = (
     "diskann",
     "vchordrq",
 )
+
+
+class CoverageTrigger(Enum):
+    """Which way the write that queued this reconcile moved the bank's row count.
+
+    The direction is what makes the pre-check affordable on every write. Coverage
+    can only become wrong in one direction at a time, so most partitions can be
+    settled from the catalog alone and never counted at all:
+
+    * ``GREW`` — rows were added. A partition that already has a healthy index
+      keeps earning it, because growth cannot take it below the keep bound.
+      Only an *unindexed* partition needs counting, to see if it crossed the
+      build bound.
+    * ``SHRANK`` — rows were removed. A partition with no index cannot have
+      earned one, because shrinking cannot take it above the build bound. Only
+      an *indexed* partition needs counting, to see if it fell below the keep
+      bound.
+    * ``FULL`` — count every partition. Used by the maintenance job when it
+      re-plans at start and by ``repair-bank``, neither of which knows what
+      moved, and which are the paths that recover anything the directional
+      short-circuits deferred (a build that failed, an index left over a
+      partition that shrank while nothing indexed was written).
+    """
+
+    GREW = "grew"
+    SHRANK = "shrank"
+    FULL = "full"
 
 
 @dataclass
@@ -132,16 +171,74 @@ async def _index_health(conn: Any, schema: str, index_names: list[str]) -> dict[
     return {row["index_name"]: bool(row["healthy"]) for row in rows}
 
 
-async def plan_bank_vector_indexes(conn: Any, schema: str, bank_id: str) -> BankIndexPlan:
+async def _capped_row_counts(
+    conn: Any,
+    schema: str,
+    bank_id: str,
+    fact_types: list[str],
+    cap: int,
+) -> dict[str, int]:
+    """Rows each partition holds, counted no further than ``cap``.
+
+    ``min(actual, cap)`` is all the policy needs: with ``cap`` set to the build
+    bound, one value answers both "does this reach the build bound?" and "is it
+    still at the keep bound?", since the keep bound is the lower of the two.
+
+    Counting to a cap rather than exactly is the point. The honest ``COUNT(*)``
+    this replaces was an index-only scan of every row the bank owned, run on
+    every retain, import, consolidation and delete, forever — on a large bank
+    that is hundreds of thousands of index tuples to rediscover that nothing
+    changed. Capped, the scan stops at the threshold, so its cost is set by the
+    configured bound instead of by how big the bank got.
+
+    The cap is a query parameter rather than an outer-column reference on
+    purpose: PostgreSQL rejects a LIMIT/OFFSET expression containing a variable
+    from an outer query level, and the bounds are global anyway, not per-fact-type.
+    """
+    if not fact_types:
+        return {}
+    qschema = _quote_identifier(schema)
+    rows = await conn.fetch(
+        f"""
+        SELECT t.fact_type,
+               (
+                   SELECT count(*) FROM (
+                       SELECT 1 FROM {qschema}.memory_units
+                       WHERE bank_id = $1 AND fact_type = t.fact_type
+                       LIMIT $2
+                   ) capped
+               ) AS row_count
+        FROM unnest($3::text[]) AS t(fact_type)
+        """,  # noqa: S608 — schema is a quoted identifier
+        bank_id,
+        cap,
+        fact_types,
+    )
+    return {row["fact_type"]: int(row["row_count"]) for row in rows}
+
+
+async def plan_bank_vector_indexes(
+    conn: Any,
+    schema: str,
+    bank_id: str,
+    *,
+    trigger: CoverageTrigger = CoverageTrigger.FULL,
+) -> BankIndexPlan:
     """Work out what ``bank_id``'s vector-index coverage should become.
 
-    Two cheap, bank-scoped queries plus one catalog lookup, so the write path
-    can call this on every write to decide whether an operation is worth
-    queueing at all. The row count is an index-only scan of
-    ``idx_memory_units_bank_fact_type``; deliberately unfiltered by
-    ``embedding IS NOT NULL``, since that predicate is not in the index and
-    would turn the scan into a heap read without changing a threshold decision
-    by enough to matter.
+    One catalog lookup, plus a capped count for only the partitions ``trigger``
+    says could have changed — often none, in which case the write path pays a
+    single indexed SELECT and one catalog query to decide there is nothing to do.
+    See :class:`CoverageTrigger` for which partitions each direction can settle
+    without counting.
+
+    With the threshold off, entitlement does not depend on rows at all: every
+    partition is owed an index from the moment the bank exists, so this reports
+    whatever bank creation did not manage to leave healthy and never drops
+    anything. The write path does not reach here in that mode (it short-circuits
+    before querying), but ``repair-bank`` does, and it is the path that repairs a
+    bank whose creation lost its DDL to a deadlock, or that was restored around
+    it.
 
     A bank whose row is gone yields an empty plan: its indexes are dropped by
     ``delete_bank`` while the internal_id they are named after is still known,
@@ -157,35 +254,48 @@ async def plan_bank_vector_indexes(conn: Any, schema: str, bank_id: str) -> Bank
     if internal_id is None:
         return plan
 
-    counts = {
-        row["fact_type"]: int(row["row_count"])
-        for row in await conn.fetch(
-            f"""
-            SELECT fact_type, COUNT(*) AS row_count
-            FROM {qschema}.memory_units
-            WHERE bank_id = $1 AND fact_type = ANY($2::text[])
-            GROUP BY fact_type
-            """,  # noqa: S608 — schema is a quoted identifier
-            bank_id,
-            list(_BANK_INDEX_FACT_TYPES),
-        )
-    }
-
     names = {ft: _bank_index_name(ft, str(internal_id)) for ft in _BANK_INDEX_FACT_TYPES}
     health = await _index_health(conn, schema, list(names.values()))
 
+    if per_bank_indexes_are_eager():
+        for fact_type, index_name in names.items():
+            if health.get(index_name) is True:
+                plan.already_present += 1
+            else:
+                plan.to_build.append(fact_type)
+        return plan
+
+    # Settle what the catalog alone can, and collect the rest for one round trip.
+    to_count: list[str] = []
     for fact_type, index_name in names.items():
-        row_count = counts.get(fact_type, 0)
         healthy = health.get(index_name)
-        if qualifies_for_per_bank_index(row_count):
+        if trigger is CoverageTrigger.GREW and healthy is True:
+            plan.already_present += 1
+            continue
+        if trigger is CoverageTrigger.SHRANK and healthy is None:
+            continue
+        to_count.append(fact_type)
+
+    if not to_count:
+        return plan
+
+    build_bound = per_bank_index_build_bound()
+    keep_bound = per_bank_index_keep_bound()
+    counts = await _capped_row_counts(conn, schema, bank_id, to_count, build_bound)
+
+    for fact_type in to_count:
+        index_name = names[fact_type]
+        healthy = health.get(index_name)
+        row_count = counts.get(fact_type, 0)
+        if row_count >= build_bound:
             if healthy is True:
                 plan.already_present += 1
             else:
                 plan.to_build.append(fact_type)
-        elif healthy is not None and not should_keep_per_bank_index(row_count):
+        elif healthy is not None and row_count < keep_bound:
             # Present but no longer earned. Keeping has its own, lower bound than
-            # building (see should_keep_per_bank_index) so a partition hovering
-            # at the threshold does not rebuild and drop the same ANN index on
+            # building (see per_bank_index_keep_bound) so a partition hovering at
+            # the threshold does not rebuild and drop the same ANN index on
             # alternating writes.
             plan.to_drop.append(index_name)
 
@@ -304,8 +414,14 @@ async def reconcile_bank_vector_indexes(
     *,
     dry_run: bool = False,
 ) -> BankIndexResult:
-    """Plan and apply one bank's vector-index coverage."""
-    plan = await plan_bank_vector_indexes(conn, schema, bank_id)
+    """Plan and apply one bank's vector-index coverage.
+
+    Always plans with :attr:`CoverageTrigger.FULL`. Both callers — the
+    maintenance job re-planning at start and ``repair-bank`` — reconcile a bank
+    without knowing which way it last moved, and they are what recovers whatever
+    a directional pre-check deferred.
+    """
+    plan = await plan_bank_vector_indexes(conn, schema, bank_id, trigger=CoverageTrigger.FULL)
     return await apply_bank_index_plan(conn, schema, index_clause, plan, dry_run=dry_run)
 
 

--- a/hindsight-api-slim/tests/conftest.py
+++ b/hindsight-api-slim/tests/conftest.py
@@ -124,23 +124,6 @@ os.environ.setdefault("HINDSIGHT_API_CONSOLIDATION_RECONCILE_INTERVAL_SECONDS", 
 os.environ.setdefault("HINDSIGHT_API_MENTAL_MODEL_REFRESH_TICK_SECONDS", "0")
 os.environ.setdefault("HINDSIGHT_API_LLM_TRACE_RETENTION_DAYS", "-1")
 
-# Keep incidental per-bank vector-index DDL out of the suite. The shipped default
-# is 0 — every bank holding rows earns its three indexes — which is right for a
-# deployment whose banks are long-lived and get built once, but wrong here: the
-# suite creates thousands of throwaway banks and writes one or two facts to each,
-# so every one of them would queue a build. Eight xdist workers issuing
-# CREATE INDEX CONCURRENTLY against a single shared memory_units deadlock each
-# other by design (CONCURRENTLY holds ShareUpdateExclusive while it waits out
-# every session whose snapshot could still see the index, including other
-# sessions' index DDL), and that lands on whatever unrelated test happens to be
-# writing at the time.
-#
-# A threshold no test bank can reach means the coverage machinery is inert unless
-# a test asks for it: tests that exercise it patch the threshold themselves (see
-# the low_threshold / default_threshold fixtures in
-# test_repair_bank_vector_indexes.py).
-os.environ.setdefault("HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS", "1000000")
-
 
 # Load environment variables from .env at the start of test session
 def pytest_configure(config):

--- a/hindsight-api-slim/tests/test_bank_utils.py
+++ b/hindsight-api-slim/tests/test_bank_utils.py
@@ -8,7 +8,17 @@ from hindsight_api.engine.retain import bank_utils
 
 
 class _BankOps:
-    """Dialect ops stub. Bank creation issues no index DDL (#3485), so this is bare."""
+    """Dialect ops stub.
+
+    Bank creation issues the per-bank index DDL again at the default threshold
+    (0 = off), so the stub has to answer for it and record that it was asked.
+    """
+
+    def __init__(self) -> None:
+        self.create_calls: list[str] = []
+
+    async def create_bank_vector_indexes(self, conn, table, bank_id, internal_id, index_clause, fact_types) -> None:
+        self.create_calls.append(bank_id)
 
 
 class _FakeTransaction:
@@ -88,11 +98,12 @@ async def test_lazy_bank_create_rolls_back_on_failure(monkeypatch: pytest.Monkey
 async def test_get_or_create_bank_profile_retries_on_deadlock(monkeypatch: pytest.MonkeyPatch) -> None:
     """A deadlock inside the create transaction is retried on a fresh one.
 
-    The retry originally guarded the per-bank CREATE INDEX that ran inline here;
-    that DDL is gone (#3485), but the lazy create can still lose a deadlock to a
-    concurrent writer touching the same bank row, and the body is idempotent
-    (INSERT ... ON CONFLICT DO NOTHING), so it must still retry rather than
-    surface the deadlock to the caller.
+    The retry guards two things: the per-bank CREATE INDEX that runs inline here
+    at the default threshold, which takes a ShareLock on the shared memory_units
+    table, and the plain bank-row insert, which can lose a deadlock to a
+    concurrent writer touching the same row. The body is idempotent
+    (INSERT ... ON CONFLICT DO NOTHING + CREATE INDEX IF NOT EXISTS), so it must
+    retry rather than surface the deadlock to the caller.
     """
     conn = _FakeConnection(raise_on_insert=DeadlockDetectedError("deadlock detected"))
     pool = _FakePool(conn)

--- a/hindsight-api-slim/tests/test_hnsw_indexes.py
+++ b/hindsight-api-slim/tests/test_hnsw_indexes.py
@@ -3,14 +3,13 @@ Tests for per-bank vector index lifecycle and UNION ALL retrieval.
 
 Covers:
 - _bank_index_name deterministic naming
-- At the default threshold (0 = no minimum), a retained bank still ends up with
-  its three per-(bank, fact_type) indexes — the pre-#3485 outcome — but they are
-  built by the queued vector_index_maintenance operation rather than inline on
-  the request path
-- An untouched bank gets none: bank creation issues no index DDL, and an index
-  over an empty partition serves nothing
-- Per-bank vector indexes dropped on bank deletion, the one request path that
-  still issues vector-index DDL
+- At the shipped default (threshold off) a bank gets its three
+  per-(bank, fact_type) indexes when it is created, and a retain finds them
+  already there — the pre-#3485 outcome, reached the pre-#3485 way
+- With a threshold set, bank creation issues no index DDL: an unearned index
+  covers no rows while still being planned against by every other bank
+- Per-bank vector indexes dropped on bank deletion, which is where the
+  internal_id they are named after is still known
 - retrieve_semantic_bm25_combined_sql groups results correctly by fact_type and source
 """
 
@@ -19,25 +18,30 @@ from datetime import datetime, timezone
 
 import pytest
 
+from hindsight_api.engine import memory_engine as memory_engine_module
 from hindsight_api.engine import vector_index_health
 from hindsight_api.engine.db_utils import retry_with_backoff
+from hindsight_api.engine.retain import bank_utils
 from hindsight_api.engine.retain.bank_utils import (
     _BANK_INDEX_FACT_TYPES,
     _bank_index_name,
     _vector_index_clause,
 )
+from hindsight_api.engine.vector_index_health import CoverageTrigger
 
 
 @pytest.fixture
-def default_threshold(monkeypatch):
-    """Restore the shipped default (0 = no minimum) for this test.
+def threshold_set(monkeypatch):
+    """Turn the size threshold on for this test.
 
-    conftest raises the threshold out of reach suite-wide so thousands of
-    throwaway banks don't each queue an index build; asserting the default
-    behaviour means putting it back.
+    The suite runs at the shipped default, where the threshold is off and every
+    bank is given its indexes at creation. A test about what happens *with* a
+    threshold has to say so — and has to patch every module that imported the
+    helper by name, since a missed one silently leaves the default in place and
+    turns the test into a vacuous pass.
     """
-    monkeypatch.setattr(vector_index_health, "qualifies_for_per_bank_index", lambda rows: rows > 0)
-    monkeypatch.setattr(vector_index_health, "should_keep_per_bank_index", lambda rows: rows > 0)
+    for module in (vector_index_health, bank_utils, memory_engine_module):
+        monkeypatch.setattr(module, "per_bank_indexes_are_eager", lambda: False)
 
 
 # ---------------------------------------------------------------------------
@@ -132,16 +136,13 @@ async def _build_bank_vector_indexes(pool, bank_id: str) -> list[str]:
 
 
 @pytest.mark.asyncio
-async def test_retain_still_ends_up_with_per_bank_indexes(memory, request_context, default_threshold):
-    """At the shipped default a retained bank has the same coverage it always had.
+async def test_retain_still_ends_up_with_per_bank_indexes(memory, request_context):
+    """At the shipped default a retained bank has the coverage it always had.
 
-    The threshold defaults to 0 — no minimum — so every partition holding rows is
-    indexed, exactly as before #3485. What changed is *who* builds them: the
-    index DDL used to run inside the retain transaction, taking a ShareLock on
-    the shared memory_units table that deadlocked against concurrent writers.
-    Now retain queues a vector_index_maintenance operation and returns; the tests
-    run a synchronous task backend, so the operation has completed by the time
-    retain_async does.
+    The threshold defaults to off, so the bank was given its three indexes when
+    it was created and retain adds rows to indexes that already exist. No
+    vector_index_maintenance operation is involved at all — which is the point:
+    the default deployment behaves exactly as it did before the threshold.
     """
     bank_id = f"test_hnsw_create_{uuid.uuid4().hex[:8]}"
     try:
@@ -159,12 +160,14 @@ async def test_retain_still_ends_up_with_per_bank_indexes(memory, request_contex
 
 
 @pytest.mark.asyncio
-async def test_bank_creation_alone_creates_no_vector_indexes(memory, request_context):
-    """Creating a bank must issue no index DDL — it is the request path that hurt.
+async def test_bank_creation_alone_creates_no_vector_indexes(memory, request_context, threshold_set):
+    """With a threshold set, creating a bank must issue no index DDL.
 
-    A fresh bank holds no rows, so its three indexes would cover nothing while
-    still being locked and planned against by every other bank's queries. This is
-    the difference that makes bank count stop being a ceiling (#3485).
+    A fresh bank has earned nothing, so its three indexes would cover no rows
+    while still being locked and planned against by every other bank's queries.
+    That is the difference that makes bank count stop being a ceiling (#3485),
+    and it is also what takes CREATE INDEX's ShareLock on the shared
+    memory_units table off the request path.
     """
     bank_id = f"test_hnsw_empty_{uuid.uuid4().hex[:8]}"
     try:
@@ -202,11 +205,11 @@ async def test_delete_bank_drops_vector_indexes(memory, request_context):
 
 
 @pytest.mark.asyncio
-async def test_retain_idempotent_bank_creation(memory, request_context, default_threshold):
+async def test_retain_idempotent_bank_creation(memory, request_context):
     """Retaining twice must not error, and must not duplicate or rebuild indexes.
 
-    The second retain queues another maintenance operation; its plan has to come
-    back empty so a busy bank is not rebuilding ANN indexes on every write.
+    At the shipped default the second retain must not reach the coverage
+    machinery at all: no operation, and no query behind the submit either.
     """
     bank_id = f"test_hnsw_idem_{uuid.uuid4().hex[:8]}"
     try:
@@ -224,7 +227,9 @@ async def test_retain_idempotent_bank_creation(memory, request_context, default_
         )
 
         assert await _get_bank_vector_indexes(memory._pool, bank_id) == after_first
-        submitted = await memory.submit_async_vector_index_maintenance(bank_id=bank_id, request_context=request_context)
+        submitted = await memory.submit_async_vector_index_maintenance(
+            bank_id=bank_id, request_context=request_context, trigger=CoverageTrigger.GREW
+        )
         assert submitted["no_work"] is True, "a settled bank must stop queueing maintenance"
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_repair_bank_vector_indexes.py
+++ b/hindsight-api-slim/tests/test_repair_bank_vector_indexes.py
@@ -30,12 +30,20 @@ from asyncpg.exceptions import DeadlockDetectedError
 from hindsight_api import RequestContext
 from hindsight_api.admin import cli
 from hindsight_api.admin.cli import _run_repair_bank
+from hindsight_api.engine import memory_engine as memory_engine_module
 from hindsight_api.engine import vector_index_health
 from hindsight_api.engine.db_utils import acquire_with_retry, retry_with_backoff
 from hindsight_api.engine.memory_engine import MemoryEngine
-from hindsight_api.engine.retain.bank_utils import _BANK_INDEX_FACT_TYPES, _bank_index_name, _vector_index_clause
+from hindsight_api.engine.retain import bank_utils
+from hindsight_api.engine.retain.fact_storage import ensure_bank_exists
+from hindsight_api.engine.retain.bank_utils import (
+    _BANK_INDEX_FACT_TYPES,
+    _bank_index_name,
+    _vector_index_clause,
+)
 from hindsight_api.engine.transfer import export_bank
 from hindsight_api.engine.vector_index_health import (
+    CoverageTrigger,
     drop_orphaned_bank_indexes,
     plan_bank_vector_indexes,
     reconcile_bank_vector_indexes,
@@ -63,33 +71,36 @@ _DROP_BELOW = 2
 _BETWEEN = 3
 
 
+# The three modules that import the policy helpers *by name*. Patching the config
+# would not reach an already-bound reference, so a fixture has to name every
+# importer; missing one is how a test silently keeps production's 10,000-row
+# threshold and turns into a vacuous pass. ``raising=True`` (monkeypatch's
+# default) is deliberate for the same reason: if a module stops using a helper,
+# the fixture must fail loudly rather than quietly do nothing.
+_POLICY_IMPORTERS = (vector_index_health, bank_utils, memory_engine_module)
+
+
 @pytest.fixture
 def low_threshold(monkeypatch):
     """Shrink the size threshold so tests need 4 rows, not 10,000.
 
-    Patched on ``vector_index_health``'s namespace because it imports both
-    helpers by name; patching the config would not reach the already-bound
-    references. ``raising=True`` (the default) is deliberate — if the reconcile
-    stops using one of these, this fixture must fail loudly rather than silently
-    leave the production 10,000-row threshold in place, which would turn every
-    test below into a vacuous pass.
+    Also pins eager mode *off*: the two are alternatives, and a threshold test
+    that ran in eager mode would assert nothing about the threshold.
     """
-    monkeypatch.setattr(vector_index_health, "qualifies_for_per_bank_index", lambda rows: rows >= _BUILD_AT)
-    monkeypatch.setattr(
-        vector_index_health, "should_keep_per_bank_index", lambda rows: rows > 0 and rows >= _DROP_BELOW
-    )
+    for module in _POLICY_IMPORTERS:
+        monkeypatch.setattr(module, "per_bank_indexes_are_eager", lambda: False)
+    monkeypatch.setattr(vector_index_health, "per_bank_index_build_bound", lambda: _BUILD_AT)
+    monkeypatch.setattr(vector_index_health, "per_bank_index_keep_bound", lambda: _DROP_BELOW)
 
 
-@pytest.fixture
-def default_threshold(monkeypatch):
-    """Restore the *shipped* default (0 = no minimum) for this test.
+def _patch_cooldown(monkeypatch, seconds: int) -> None:
+    """Set the per-bank submission cooldown for one test.
 
-    conftest raises the threshold out of reach for the whole suite so thousands
-    of throwaway banks don't each queue an index build; a test asserting the
-    default behaviour has to put it back.
+    Patched on the module that imported it by name, like the other policy
+    helpers — the config object itself is read-only, and re-reading the
+    environment would not reach the cached singleton anyway.
     """
-    monkeypatch.setattr(vector_index_health, "qualifies_for_per_bank_index", lambda rows: rows > 0)
-    monkeypatch.setattr(vector_index_health, "should_keep_per_bank_index", lambda rows: rows > 0)
+    monkeypatch.setattr(memory_engine_module, "per_bank_index_min_submit_interval_seconds", lambda: seconds)
 
 
 async def _bank_internal_id(conn, bank_id: str) -> str:
@@ -147,8 +158,10 @@ async def _insert_memory(conn, bank_id: str, fact_type: str, text: str) -> None:
 async def _seed_bank(memory: MemoryEngine, request_context: RequestContext, rows_per_fact_type: int) -> str:
     """Create a bank and give every fact_type ``rows_per_fact_type`` memories.
 
-    Bank creation issues no index DDL under the size policy, so whatever indexes
-    the bank ends up with are the ones a reconcile decided it earned.
+    Under ``low_threshold`` bank creation issues no index DDL, so whatever
+    indexes the bank ends up with are the ones a reconcile decided it earned. At
+    the shipped default it comes back already carrying all three, which is the
+    state those tests are about.
     """
     bank_id = f"test-repair-{uuid.uuid4().hex[:8]}"
     await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
@@ -171,20 +184,39 @@ async def _reconcile(conn, bank_id: str, *, dry_run: bool = False):
 async def _build_indexes_for(conn, bank_id: str) -> list[str]:
     """Give ``bank_id`` its three partial indexes directly, bypassing the policy.
 
-    Used to set up drop-side tests: the index has to exist before the reconcile
-    can be asked to remove it.
+    Used to set up tests that need coverage to already exist — drop-side cases,
+    and the pre-check cases that assert a converged bank queues nothing.
+
+    Drops before each build, inside the retry, for the same reason
+    ``apply_bank_index_plan`` does. A CONCURRENTLY build chosen as a deadlock
+    victim leaves an INVALID index behind; ``IF NOT EXISTS`` then *skips* it on
+    the retry, so the helper returns success having left the index unusable. The
+    reconcile correctly reports that index as missing, and the test fails
+    somewhere far away — which is exactly how this surfaced in CI, as a
+    ``KeyError: 'no_work'`` in a test that had nothing to do with index health.
+
+    The post-condition is asserted rather than assumed: a setup helper that
+    silently half-worked is worse than one that fails loudly, because every
+    assertion after it is then testing something other than what it says.
     """
     index_clause = _vector_index_clause()
     assert index_clause is not None
     names = await _expected_index_names(conn, bank_id)
     literal = await conn.fetchval("SELECT quote_literal($1::text)", bank_id)
     for ft, name in zip(_BANK_INDEX_FACT_TYPES, names, strict=True):
-        await retry_with_backoff(
-            lambda name=name, ft=ft: conn.execute(
+
+        async def _rebuild(name=name, ft=ft) -> None:
+            await conn.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_TEST_SCHEMA}.{name}")
+            await conn.execute(
                 f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {name} ON {_TEST_SCHEMA}.memory_units "
                 f"{index_clause} WHERE fact_type = '{ft}' AND bank_id = {literal}"
             )
-        )
+
+        await retry_with_backoff(_rebuild)
+
+    health = await vector_index_health._index_health(conn, _TEST_SCHEMA, names)
+    unhealthy = [name for name in names if health.get(name) is not True]
+    assert not unhealthy, f"setup: these indexes were not left valid and ready: {unhealthy}"
     return names
 
 
@@ -227,6 +259,36 @@ class _DeadlockOnceOnCreate:
             if self.create_calls == 1:
                 raise DeadlockDetectedError("deadlock detected")
         return await self._real.execute(query, *args, **kwargs)
+
+
+class _RecordingConn:
+    """Wrap a real asyncpg connection and record every query it is asked to run.
+
+    The planner's whole claim is about which queries it does *not* issue, so the
+    only way to assert it is to watch them. Delegates everything.
+    """
+
+    #: Substring unique to the capped row count (its derived table is aliased ``capped``).
+    COUNT_MARKER = "capped"
+
+    def __init__(self, real):
+        self._real = real
+        self.queries: list[str] = []
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+    async def fetch(self, query, *args, **kwargs):
+        self.queries.append(query)
+        return await self._real.fetch(query, *args, **kwargs)
+
+    async def fetchval(self, query, *args, **kwargs):
+        self.queries.append(query)
+        return await self._real.fetchval(query, *args, **kwargs)
+
+    @property
+    def counted(self) -> bool:
+        return any(self.COUNT_MARKER in q for q in self.queries)
 
 
 class TestSizeThresholdPolicy:
@@ -449,51 +511,103 @@ class TestPlan:
 
 
 class TestDefaultThresholdIsBackwardsCompatible:
-    """Shipped default: 0 rows — every bank holding memories is indexed.
+    """Shipped default: the threshold is *off*, and coverage is exactly pre-#3561.
 
-    The threshold is opt-in, so an existing deployment that upgrades keeps the
-    coverage it had. These use ``default_threshold`` rather than
-    ``low_threshold``: the suite-wide setting in conftest puts the threshold out
-    of reach, so asserting the shipped default means restoring it explicitly.
+    Indexes come with the bank, not with its rows: created in the bank-create
+    transaction and dropped when the bank is deleted. No coverage decision
+    depends on a row count, so no write queues an operation and no write pays a
+    count. That is the behaviour a deployment upgrading into the threshold keeps
+    unless it opts in.
+
+    No fixture: the suite runs at the shipped default, so this class simply does
+    not reach for ``low_threshold``. That is deliberate — the configuration
+    almost every deployment runs is the one the suite should exercise by
+    default, and #3561 regressed precisely because the suite had raised the
+    threshold out of reach for itself.
     """
 
     @pytest.mark.asyncio
-    async def test_a_single_row_earns_an_index_at_the_default(
-        self, memory: MemoryEngine, request_context: RequestContext, default_threshold
-    ):
-        bank_id = await _seed_bank(memory, request_context, 1)
+    async def test_bank_creation_builds_all_three_indexes(self, memory: MemoryEngine, request_context: RequestContext):
+        """The bank is entitled from the moment it exists, before any row lands."""
+        bank_id = f"test-repair-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
         backend = await memory._get_backend()
         try:
             async with acquire_with_retry(backend) as conn:
-                result = await _reconcile(conn, bank_id)
-
-                assert result.failed == 0, result.failed_indexes
-                assert result.created == len(_BANK_INDEX_FACT_TYPES)
                 for name in await _expected_index_names(conn, bank_id):
                     assert await _index_is_partial_vector(conn, name)
         finally:
             await memory.delete_bank(bank_id, request_context=request_context)
 
     @pytest.mark.asyncio
-    async def test_an_empty_bank_gets_nothing(
-        self, memory: MemoryEngine, request_context: RequestContext, default_threshold
-    ):
-        """Zero rows is not "at least zero rows".
+    async def test_no_write_queues_an_operation(self, memory: MemoryEngine, request_context: RequestContext):
+        """The reason 0 means *off* rather than *no minimum*.
 
-        An index over no rows serves nothing, and bank creation no longer builds
-        one — so a bank that exists but has never been written to stays clean.
+        Read as "no minimum" the default still produced an operation per
+        (bank, fact_type) on first write, and charged every later write a count
+        to rediscover there was nothing to do. Off, the submit returns before
+        issuing a single query.
         """
-        bank_id = await _seed_bank(memory, request_context, 0)
+        bank_id = await _seed_bank(memory, request_context, 1)
+        try:
+            result = await memory.submit_async_vector_index_maintenance(
+                bank_id=bank_id,
+                request_context=request_context,
+                trigger=CoverageTrigger.GREW,
+            )
+
+            assert result["no_work"] is True
+            assert result["operation_id"] is None
+        finally:
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_an_emptied_bank_keeps_its_indexes(self, memory: MemoryEngine, request_context: RequestContext):
+        """Coverage does not track rows here, so emptying a bank changes nothing.
+
+        Under the threshold an emptied partition loses its index; with the
+        threshold off it keeps it, exactly as it did before #3561. The bank is
+        still entitled — it just happens to be empty right now, which is also the
+        state it was in when the index was built.
+        """
+        bank_id = await _seed_bank(memory, request_context, 1)
         backend = await memory._get_backend()
         try:
             async with acquire_with_retry(backend) as conn:
+                await conn.execute("DELETE FROM memory_units WHERE bank_id = $1", bank_id)
+
                 plan = await plan_bank_vector_indexes(conn, _TEST_SCHEMA, bank_id)
+
+                assert plan.to_drop == []
+                for name in await _expected_index_names(conn, bank_id):
+                    assert await _index_exists(conn, name)
+        finally:
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_repair_bank_rebuilds_what_creation_missed(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """The escape hatch still works with the threshold off.
+
+        A bank whose creation lost its DDL to a deadlock, or one restored around
+        that path, has no other way back — the write path does not look at
+        coverage in this mode. ``repair-bank`` builds what is missing, and drops
+        nothing.
+        """
+        bank_id = await _seed_bank(memory, request_context, 1)
+        backend = await memory._get_backend()
+        try:
+            async with acquire_with_retry(backend) as conn:
+                await _drop_bank_indexes(conn, bank_id)
+
                 result = await _reconcile(conn, bank_id)
 
-                assert plan.is_empty
-                assert result.created == 0
+                assert result.failed == 0, result.failed_indexes
+                assert result.created == len(_BANK_INDEX_FACT_TYPES)
+                assert result.dropped == 0
                 for name in await _expected_index_names(conn, bank_id):
-                    assert not await _index_exists(conn, name)
+                    assert await _index_is_partial_vector(conn, name)
         finally:
             await memory.delete_bank(bank_id, request_context=request_context)
 
@@ -668,11 +782,42 @@ class TestRestoredBankCoverage:
     branch for a bank row that already existed. It was then left permanently
     without coverage, silently falling back to a global index plus post-filter.
 
-    That whole class of bug is now structurally impossible: nothing creates
-    indexes at bank-creation time, so there is no gate left to bypass.
-    Entitlement is recomputed from live row counts whenever a write queues a
-    reconcile, and how the rows got there is not something it can observe.
+    Both modes answer it, differently. With a threshold set, nothing creates
+    indexes at bank-creation time at all, so there is no gate left to bypass:
+    entitlement is recomputed from live row counts whenever a write queues a
+    reconcile, and how the rows got there is not something it can observe. With
+    the threshold off, the gate is back — so import has to build the indexes
+    itself, which is the original #2645 fix.
     """
+
+    @pytest.mark.asyncio
+    async def test_import_builds_the_indexes_at_the_default(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """The original #2645 fix, still needed while the threshold is off.
+
+        ``import_bank`` restores the ``banks`` row directly, so
+        ``get_or_create_bank_profile`` never sees a fresh INSERT and never builds
+        anything. Without an explicit build here the restored bank would fall
+        back to a global index plus post-filter — slower, and under-returning —
+        with nothing else in this mode ever noticing.
+        """
+        bank_id = f"test-import-{uuid.uuid4().hex[:8]}"
+        backend = await memory._get_backend()
+        try:
+            await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+            async with acquire_with_retry(backend) as conn:
+                archive = await export_bank(conn, bank_id)
+
+            await memory.delete_bank(bank_id, request_context=request_context)
+            result = await memory.import_bank_async(archive, request_context)
+            assert result.bank_id == bank_id
+
+            async with acquire_with_retry(backend) as conn:
+                for name in await _expected_index_names(conn, bank_id):
+                    assert await _index_is_partial_vector(conn, name), f"import should have built {name}"
+        finally:
+            await memory.delete_bank(bank_id, request_context=request_context)
 
     @pytest.mark.asyncio
     async def test_import_builds_no_indexes_inline(
@@ -796,7 +941,7 @@ class TestMaintenanceSubmission:
                 await _build_indexes_for(conn, bank_id)
 
             result = await memory.submit_async_vector_index_maintenance(
-                bank_id=bank_id, request_context=request_context
+                bank_id=bank_id, request_context=request_context, trigger=CoverageTrigger.FULL
             )
 
             assert result["no_work"] is True
@@ -813,7 +958,7 @@ class TestMaintenanceSubmission:
         bank_id = await _seed_bank(memory, request_context, _BUILD_AT)
         try:
             result = await memory.submit_async_vector_index_maintenance(
-                bank_id=bank_id, request_context=request_context
+                bank_id=bank_id, request_context=request_context, trigger=CoverageTrigger.FULL
             )
 
             assert result.get("no_work") is not True
@@ -833,7 +978,7 @@ class TestMaintenanceSubmission:
         bank_id = await _seed_bank(memory, request_context, 0)
         try:
             result = await memory.submit_async_vector_index_maintenance(
-                bank_id=bank_id, request_context=request_context
+                bank_id=bank_id, request_context=request_context, trigger=CoverageTrigger.FULL
             )
 
             assert result["no_work"] is True
@@ -861,18 +1006,324 @@ class TestMaintenanceSubmission:
         self, memory: MemoryEngine, request_context: RequestContext, low_threshold, monkeypatch
     ):
         """ScaNN keeps one global index; there is no per-bank coverage to maintain."""
-        from hindsight_api.engine.retain import bank_utils
-
         bank_id = await _seed_bank(memory, request_context, _BUILD_AT)
         try:
             monkeypatch.setattr(bank_utils, "_vector_index_clause", lambda: None)
 
             result = await memory.submit_async_vector_index_maintenance(
-                bank_id=bank_id, request_context=request_context
+                bank_id=bank_id, request_context=request_context, trigger=CoverageTrigger.FULL
             )
 
             assert result["no_work"] is True
         finally:
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+
+class TestDirectionalPreCheck:
+    """What the pre-check refuses to look at, and why that is safe.
+
+    This runs on every retain, import, consolidation and delete, so its cost is
+    charged to ordinary writes forever. Counting the bank's rows to decide there
+    was nothing to do is what made it expensive (#3485 shipped an uncapped
+    COUNT(*) over the whole partition). Coverage can only go wrong in one
+    direction at a time, so most partitions are settled from the catalog alone.
+    """
+
+    @pytest.mark.asyncio
+    async def test_growth_does_not_count_a_partition_that_is_already_indexed(
+        self, memory: MemoryEngine, request_context: RequestContext, low_threshold
+    ):
+        """The steady state: a big, indexed, actively-written bank.
+
+        Adding rows cannot take a partition below the keep bound, so an index
+        that is present and healthy stays earned no matter what the count is.
+        This is the case that has to cost nothing, because it is every write to
+        every bank that has already converged.
+        """
+        bank_id = await _seed_bank(memory, request_context, _BUILD_AT)
+        backend = await memory._get_backend()
+        try:
+            async with acquire_with_retry(backend) as conn:
+                await _build_indexes_for(conn, bank_id)
+
+                recorder = _RecordingConn(conn)
+                plan = await plan_bank_vector_indexes(recorder, _TEST_SCHEMA, bank_id, trigger=CoverageTrigger.GREW)
+
+                assert plan.is_empty
+                assert plan.already_present == len(_BANK_INDEX_FACT_TYPES)
+                assert not recorder.counted, "growth must not count an already-indexed partition"
+        finally:
+            async with acquire_with_retry(backend) as conn:
+                await _drop_bank_indexes(conn, bank_id)
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_shrinking_does_not_count_a_partition_that_has_no_index(
+        self, memory: MemoryEngine, request_context: RequestContext, low_threshold
+    ):
+        """The other steady state: a small bank being written to and pruned.
+
+        Removing rows cannot take a partition above the build bound, so a
+        partition with no index cannot have earned one on this write.
+        """
+        bank_id = await _seed_bank(memory, request_context, _BUILD_AT)
+        backend = await memory._get_backend()
+        try:
+            async with acquire_with_retry(backend) as conn:
+                recorder = _RecordingConn(conn)
+                plan = await plan_bank_vector_indexes(recorder, _TEST_SCHEMA, bank_id, trigger=CoverageTrigger.SHRANK)
+
+                assert plan.is_empty
+                assert not recorder.counted, "a delete must not count an unindexed partition"
+        finally:
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_growth_still_finds_a_partition_that_crossed_the_threshold(
+        self, memory: MemoryEngine, request_context: RequestContext, low_threshold
+    ):
+        """The short-circuit must not swallow the case it exists to serve."""
+        bank_id = await _seed_bank(memory, request_context, _BUILD_AT)
+        backend = await memory._get_backend()
+        try:
+            async with acquire_with_retry(backend) as conn:
+                plan = await plan_bank_vector_indexes(conn, _TEST_SCHEMA, bank_id, trigger=CoverageTrigger.GREW)
+
+                assert set(plan.to_build) == set(_BANK_INDEX_FACT_TYPES)
+        finally:
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_shrinking_still_finds_a_partition_that_fell_below_the_floor(
+        self, memory: MemoryEngine, request_context: RequestContext, low_threshold
+    ):
+        """The short-circuit must not swallow the case it exists to serve."""
+        bank_id = await _seed_bank(memory, request_context, _DROP_BELOW - 1)
+        backend = await memory._get_backend()
+        try:
+            async with acquire_with_retry(backend) as conn:
+                names = await _build_indexes_for(conn, bank_id)
+
+                plan = await plan_bank_vector_indexes(conn, _TEST_SCHEMA, bank_id, trigger=CoverageTrigger.SHRANK)
+
+                assert set(plan.to_drop) == set(names)
+        finally:
+            async with acquire_with_retry(backend) as conn:
+                await _drop_bank_indexes(conn, bank_id)
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_a_partition_far_above_the_threshold_is_not_counted_out(
+        self, memory: MemoryEngine, request_context: RequestContext, low_threshold
+    ):
+        """The cap must bound the scan without bounding the decision.
+
+        A capped count returns ``min(actual, build_bound)``, so a partition
+        holding many times the threshold reports exactly the bound. Comparing
+        with ``>=`` is what keeps that a build; a stricter comparison would leave
+        the largest banks — the ones the index is for — permanently unindexed.
+        """
+        bank_id = await _seed_bank(memory, request_context, _BUILD_AT * 3)
+        backend = await memory._get_backend()
+        try:
+            async with acquire_with_retry(backend) as conn:
+                plan = await plan_bank_vector_indexes(conn, _TEST_SCHEMA, bank_id, trigger=CoverageTrigger.FULL)
+
+                assert set(plan.to_build) == set(_BANK_INDEX_FACT_TYPES)
+                assert plan.to_drop == []
+        finally:
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+
+class TestSubmissionCooldown:
+    """A bank cannot ask for index DDL again and again.
+
+    Two things make one bank re-submit indefinitely: a partition oscillating
+    across the threshold, and a build that keeps failing — the job logs rather
+    than raises, so the plan stays non-empty and the next write queues it again.
+    Both are damped by refusing to reconcile the same bank twice inside the
+    interval.
+
+    Each test has to leave the plan *non-empty* after the first operation, or it
+    would pass on the pre-check alone and prove nothing about the cooldown. The
+    suite's task backend is synchronous, so the first submit has already built
+    the indexes by the time it returns; dropping them again is what puts the bank
+    back in the state a real oscillation or a failed build leaves it in.
+    """
+
+    @staticmethod
+    async def _submitted_then_still_due(memory, request_context, bank_id) -> str:
+        """Run one operation to completion, then make the bank due again."""
+        first = await memory.submit_async_vector_index_maintenance(
+            bank_id=bank_id, request_context=request_context, trigger=CoverageTrigger.GREW
+        )
+        assert first["operation_id"] is not None, "setup: the first submit should queue work"
+
+        backend = await memory._get_backend()
+        async with acquire_with_retry(backend) as conn:
+            await _drop_bank_indexes(conn, bank_id)
+            # Terminal, so the pending/processing dedupe cannot be what the tests
+            # below are actually observing.
+            await conn.execute(
+                "UPDATE async_operations SET status = 'completed' WHERE operation_id = $1",
+                first["operation_id"],
+            )
+        return first["operation_id"]
+
+    @pytest.mark.asyncio
+    async def test_second_submit_inside_the_interval_is_refused(
+        self, memory: MemoryEngine, request_context: RequestContext, low_threshold
+    ):
+        bank_id = await _seed_bank(memory, request_context, _BUILD_AT)
+        try:
+            await self._submitted_then_still_due(memory, request_context, bank_id)
+
+            second = await memory.submit_async_vector_index_maintenance(
+                bank_id=bank_id, request_context=request_context, trigger=CoverageTrigger.GREW
+            )
+
+            assert second["no_work"] is True
+            assert second["operation_id"] is None
+        finally:
+            async with acquire_with_retry(await memory._get_backend()) as conn:
+                await _drop_bank_indexes(conn, bank_id)
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_the_jobs_own_hand_off_is_exempt(
+        self, memory: MemoryEngine, request_context: RequestContext, low_threshold
+    ):
+        """The hand-off exists to re-check immediately when the bank moved.
+
+        Applying the cooldown to it would defeat it entirely — it always runs
+        moments after the operation it succeeds. It is bounded instead by its own
+        pre-check, which stops the chain as soon as coverage matches.
+        """
+        bank_id = await _seed_bank(memory, request_context, _BUILD_AT)
+        try:
+            first_id = await self._submitted_then_still_due(memory, request_context, bank_id)
+
+            hand_off = await memory.submit_async_vector_index_maintenance(
+                bank_id=bank_id,
+                request_context=request_context,
+                trigger=CoverageTrigger.FULL,
+                dedupe_excludes_operation_id=first_id,
+            )
+
+            assert hand_off["operation_id"] is not None
+            assert hand_off["operation_id"] != first_id
+        finally:
+            async with acquire_with_retry(await memory._get_backend()) as conn:
+                await _drop_bank_indexes(conn, bank_id)
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_a_zero_interval_turns_the_cooldown_off(
+        self, memory: MemoryEngine, request_context: RequestContext, low_threshold, monkeypatch
+    ):
+        """The damper has to be defeatable, or a genuine backlog cannot drain."""
+        bank_id = await _seed_bank(memory, request_context, _BUILD_AT)
+        try:
+            await self._submitted_then_still_due(memory, request_context, bank_id)
+
+            _patch_cooldown(monkeypatch, 0)
+            second = await memory.submit_async_vector_index_maintenance(
+                bank_id=bank_id, request_context=request_context, trigger=CoverageTrigger.GREW
+            )
+
+            assert second["operation_id"] is not None
+        finally:
+            async with acquire_with_retry(await memory._get_backend()) as conn:
+                await _drop_bank_indexes(conn, bank_id)
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+
+class TestEnsureBankExistsCoverage:
+    """The second bank-create path has to build indexes too.
+
+    ``fact_storage.ensure_bank_exists`` is a lower-level create than
+    ``get_or_create_bank_profile`` and reaches the same ``banks`` row, so a bank
+    born through it must end up with the same coverage — otherwise which helper
+    happened to create the bank decides whether it is ever indexed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_bank_created_here_gets_its_indexes_at_the_default(self, memory: MemoryEngine):
+        bank_id = f"test-ensure-{uuid.uuid4().hex[:8]}"
+        backend = await memory._get_backend()
+        try:
+            async with acquire_with_retry(backend) as conn:
+                await ensure_bank_exists(conn, bank_id, ops=backend.ops)
+
+                for name in await _expected_index_names(conn, bank_id):
+                    assert await _index_is_partial_vector(conn, name)
+        finally:
+            await memory.delete_bank(bank_id, request_context=RequestContext())
+
+
+class TestHandlerGuards:
+    """What the queued job refuses to do."""
+
+    @pytest.mark.asyncio
+    async def test_handler_does_nothing_once_the_threshold_is_switched_off(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """A job can outlive the configuration it was queued under.
+
+        Turning the threshold off means every bank is owed all three indexes, so
+        a job still reconciling against the old policy would drop indexes the
+        deployment now expects to keep. No fixture: the default *is* off, which
+        is the state a job queued under a threshold would land in.
+        """
+        bank_id = await _seed_bank(memory, request_context, 1)
+        backend = await memory._get_backend()
+        try:
+            async with acquire_with_retry(backend) as conn:
+                names = await _expected_index_names(conn, bank_id)
+                await conn.execute("DELETE FROM memory_units WHERE bank_id = $1", bank_id)
+
+            await memory._handle_vector_index_maintenance({"bank_id": bank_id})
+
+            async with acquire_with_retry(backend) as conn:
+                for name in names:
+                    assert await _index_exists(conn, name), f"{name} must survive a job that no longer applies"
+        finally:
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+
+class TestBackendGate:
+    """Only PostgreSQL has per-bank partial vector indexes to maintain."""
+
+    @pytest.mark.asyncio
+    async def test_a_non_postgresql_backend_never_queues(
+        self, memory: MemoryEngine, request_context: RequestContext, low_threshold, monkeypatch
+    ):
+        """Oracle leaves the extension setting at its pgvector default.
+
+        So the index clause is not None there, and gating on it alone let the
+        planner run asyncpg-shaped SQL against Oracle on every write — after
+        which the job found no DSN to build with and re-queued itself on the next
+        one, forever. The backend itself is the honest gate.
+        """
+        bank_id = await _seed_bank(memory, request_context, _BUILD_AT)
+        try:
+
+            class _NotPostgres:
+                """Stands in for a backend the per-bank index layout does not apply to."""
+
+            async def _not_postgres():
+                return _NotPostgres()
+
+            monkeypatch.setattr(memory, "_get_backend", _not_postgres)
+
+            result = await memory.submit_async_vector_index_maintenance(
+                bank_id=bank_id, request_context=request_context, trigger=CoverageTrigger.GREW
+            )
+
+            assert result["no_work"] is True
+            assert result["operation_id"] is None
+        finally:
+            monkeypatch.undo()
             await memory.delete_bank(bank_id, request_context=request_context)
 
 
@@ -886,14 +1337,14 @@ class TestDeletionDropsCoverage:
     """
 
     @pytest.mark.asyncio
-    async def test_emptied_bank_drops_its_indexes_at_the_default_threshold(
-        self, memory: MemoryEngine, request_context: RequestContext, default_threshold
+    async def test_emptied_bank_drops_its_indexes(
+        self, memory: MemoryEngine, request_context: RequestContext, low_threshold
     ):
-        """Regression: at threshold 0 the drop check read `0 < 0` and never fired.
+        """An emptied partition loses its index at every threshold.
 
-        An emptied bank kept three ANN indexes over nothing forever, because
-        nothing writes to an emptied bank — the exact accumulation the threshold
-        exists to prevent, in the configuration almost everyone runs.
+        The keep bound never falls to zero, whatever the drop ratio works out to.
+        Without that floor an emptied bank kept three ANN indexes over nothing
+        forever, because nothing writes to an emptied bank.
         """
         bank_id = await _seed_bank(memory, request_context, 3)
         backend = await memory._get_backend()
@@ -918,7 +1369,7 @@ class TestDeletionDropsCoverage:
 
     @pytest.mark.asyncio
     async def test_partially_emptied_bank_keeps_only_the_covered_fact_types(
-        self, memory: MemoryEngine, request_context: RequestContext, default_threshold
+        self, memory: MemoryEngine, request_context: RequestContext, low_threshold
     ):
         """Coverage is per (bank, fact_type), so a partial delete is a partial drop."""
         bank_id = await _seed_bank(memory, request_context, 3)
@@ -939,7 +1390,7 @@ class TestDeletionDropsCoverage:
 
     @pytest.mark.asyncio
     async def test_clearing_a_bank_drops_its_indexes(
-        self, memory: MemoryEngine, request_context: RequestContext, default_threshold
+        self, memory: MemoryEngine, request_context: RequestContext, low_threshold
     ):
         """`DELETE /memories` keeps the bank, so nothing else can drop its indexes.
 

--- a/hindsight-api-slim/tests/test_vector_index.py
+++ b/hindsight-api-slim/tests/test_vector_index.py
@@ -187,78 +187,54 @@ def _with_threshold(monkeypatch, min_rows: int) -> None:
     monkeypatch.setattr("hindsight_api.config.get_config", lambda: _ThresholdConfig(min_rows))
 
 
-def test_qualifies_at_and_around_the_threshold(monkeypatch):
-    """The build side is a floor, inclusive: exactly the threshold qualifies."""
+def test_build_bound_is_the_threshold_itself(monkeypatch):
+    """The build side is a floor, inclusive: exactly the threshold earns an index."""
     _with_threshold(monkeypatch, 10_000)
 
-    assert not _vector_index.qualifies_for_per_bank_index(9_999)
-    assert _vector_index.qualifies_for_per_bank_index(10_000)
-    assert _vector_index.qualifies_for_per_bank_index(10_001)
+    assert _vector_index.per_bank_index_build_bound() == 10_000
 
 
-def test_zero_threshold_indexes_every_partition_that_holds_rows(monkeypatch):
-    """0 is the shipped default and means "no minimum" — the pre-threshold behaviour."""
-    _with_threshold(monkeypatch, 0)
+def test_zero_threshold_is_eager_not_a_zero_minimum(monkeypatch):
+    """0 turns the threshold off rather than setting it to nothing.
 
-    assert _vector_index.qualifies_for_per_bank_index(1)
-    assert _vector_index.qualifies_for_per_bank_index(10_000_000)
-
-
-def test_an_empty_partition_never_qualifies(monkeypatch):
-    """Zero rows is excluded at every threshold, including the default of 0.
-
-    By arithmetic alone `0 >= 0` holds, which would entitle every bank in the
-    deployment to three indexes over nothing the moment it was created — the
-    index explosion the threshold exists to prevent, reintroduced by its own
-    default. An index over no rows serves no query either way.
+    The distinction is the whole point of the default. Read as "no minimum", 0
+    still routed every bank through the lazy path: an index earned on first write
+    via a visible async operation, and every later write paying a coverage check
+    to rediscover there was nothing to do. Read as "off", the bank gets its
+    indexes when it is created and nothing looks at row counts ever again — which
+    is what the deployment had before the threshold existed.
     """
     _with_threshold(monkeypatch, 0)
-    assert not _vector_index.qualifies_for_per_bank_index(0)
+    assert _vector_index.per_bank_indexes_are_eager()
 
     _with_threshold(monkeypatch, 10_000)
-    assert not _vector_index.qualifies_for_per_bank_index(0)
+    assert not _vector_index.per_bank_indexes_are_eager()
 
 
-def test_emptied_partition_loses_its_index_at_every_threshold(monkeypatch):
-    """Zero rows never keeps an index — including at the shipped default of 0.
+def test_an_emptied_partition_loses_its_index_at_every_threshold(monkeypatch):
+    """The keep bound never falls to zero, whatever the ratio works out to.
 
-    Regression for a drop side that was dead in the default configuration. The
-    check was `row_count < per_bank_index_drop_rows()`, and at a threshold of 0
-    the drop floor is also 0, so it read `0 < 0` — never true. Every bank ever
-    written to and then cleared kept three ANN indexes over nothing, forever,
-    because nothing writes to an emptied bank. That is the exact accumulation
-    the threshold exists to prevent, reintroduced by its own default.
+    Without a floor of 1 a partition emptied of rows still clears the bound, so a
+    bank written to once and then cleared would hold three ANN indexes over
+    nothing — forever, because nothing writes to an emptied bank. That is the
+    accumulation the threshold exists to prevent.
     """
-    _with_threshold(monkeypatch, 0)
-    assert not _vector_index.should_keep_per_bank_index(0)
-
-    _with_threshold(monkeypatch, 10_000)
-    assert not _vector_index.should_keep_per_bank_index(0)
+    for threshold in (1, 10_000):
+        _with_threshold(monkeypatch, threshold)
+        assert _vector_index.per_bank_index_keep_bound() >= 1
 
 
-def test_keeping_starts_below_building(monkeypatch):
-    """The hysteresis band: a partition between the two bounds is left alone.
+def test_the_hysteresis_band_is_non_empty(monkeypatch):
+    """Keeping has to start strictly below building, with room in between.
 
-    Keeping has to start lower than building, or a bank hovering at the
-    threshold rebuilds and drops the same ANN index on alternating writes.
-    """
-    _with_threshold(monkeypatch, 10_000)
-    between = _vector_index.per_bank_index_drop_rows() + 1
-
-    assert not _vector_index.qualifies_for_per_bank_index(between), "not enough to earn a new index"
-    assert _vector_index.should_keep_per_bank_index(between), "but enough to keep one it already has"
-
-
-def test_drop_threshold_sits_strictly_below_the_build_threshold(monkeypatch):
-    """The hysteresis gap must be non-empty, or an index at the boundary flaps.
-
-    A partition between the two bounds is neither built nor dropped: if it has
-    an index it keeps it, and if it does not it stays without one.
+    With a single boundary a bank hovering at the threshold rebuilds and drops
+    the same ANN index on alternating writes. The band is what the planner leaves
+    alone: a partition inside it neither earns an index nor loses the one it has.
     """
     _with_threshold(monkeypatch, 10_000)
 
-    build = _vector_index.per_bank_index_min_rows()
-    drop = _vector_index.per_bank_index_drop_rows()
+    keep = _vector_index.per_bank_index_keep_bound()
+    build = _vector_index.per_bank_index_build_bound()
 
-    assert drop < build
-    assert not _vector_index.qualifies_for_per_bank_index(drop)
+    assert keep < build
+    assert build - keep > 1, "no row count sits strictly inside the band"

--- a/hindsight-dev/benchmarks/perf/retain_perf.py
+++ b/hindsight-dev/benchmarks/perf/retain_perf.py
@@ -257,7 +257,7 @@ async def stress_test_deadlocks(
     from hindsight_api.engine.retain.fact_storage import ensure_bank_exists
 
     async with pool.acquire() as conn:
-        await ensure_bank_exists(conn, bank_id)
+        await ensure_bank_exists(conn, bank_id, ops=pool.ops)
 
     console.print("\n[bold]Stress test config:[/bold]")
     console.print(f"  Bank:          {bank_id}")

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -138,8 +138,9 @@ Hindsight supports four PostgreSQL vector extensions:
 #### Limiting vector indexes on large deployments
 
 On `pgvector`, `pgvectorscale` and `vchord`, a bank's memories are indexed per
-`(bank, fact_type)`. By default every bank that holds memories gets its own
-indexes, which is the right thing for most deployments.
+`(bank, fact_type)`. By default every bank gets its own indexes when it is
+created, which is the right thing for most deployments and needs no
+configuration.
 
 It stops being the right thing when you have thousands of banks. These indexes
 all live on one shared table, and PostgreSQL inspects and locks **every** index
@@ -158,14 +159,21 @@ limit.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS` | Memories a bank needs, in one fact type, before that fact type gets its own vector index. `0` (the default) means no minimum — every bank holding memories is indexed. `10000` is a good starting point for deployments with thousands of banks. | `0` |
+| `HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS` | Memories a bank needs, in one fact type, before that fact type gets its own vector index. `0` (the default) turns the threshold **off**: every bank is indexed from the moment it is created. `10000` is a good starting point for deployments with thousands of banks. | `0` |
+| `HINDSIGHT_API_VECTOR_INDEX_MAINTENANCE_MIN_INTERVAL_SECONDS` | Shortest gap between two index-maintenance runs for one bank. Stops a bank whose size hovers at the threshold from building and dropping the same index repeatedly. Unused while the threshold is off. | `900` |
 
-Coverage is maintained for you. Every write that could move a bank across the
-threshold queues a background `vector_index_maintenance` operation, which builds
-an index when a bank grows past the threshold and removes it if the bank shrinks
-well below it (the gap between those two points prevents churn at the boundary).
-Bank creation, ingestion and import never build indexes themselves, so no
-request ever waits on index DDL.
+**With the threshold off (the default),** indexes are created inside the
+transaction that creates the bank — instantly, because the bank is empty — and
+dropped when the bank is deleted. Nothing inspects bank sizes, and no background
+operation runs.
+
+**With a threshold set,** bank creation, ingestion and import build no indexes at
+all, so no request ever waits on index DDL. Instead, a write that could move a
+bank across the threshold queues a background `vector_index_maintenance`
+operation, which builds an index when a bank grows past the threshold and removes
+it if the bank shrinks well below it (the gap between those two points prevents
+churn at the boundary). You will see these operations in the bank's operations
+list.
 
 To reconcile without waiting for a write — after a restore, an upgrade, or an
 extension switch — run:
@@ -173,6 +181,9 @@ extension switch — run:
 ```bash
 hindsight-admin repair-bank --all
 ```
+
+This works in both modes: with the threshold off it rebuilds any index a bank is
+missing, and with one set it also drops what a bank no longer earns.
 
 **Switching extensions:**
 

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -205,7 +205,8 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_VECTOR_EXTENSION=pgvectorscale  # Auto-detects pg_diskann on Azure
 
 # Per-bank vector indexes (pgvector / pgvectorscale / vchord only; ScaNN and Oracle use one global index)
-# HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS=0  # Memories a bank needs in one fact type before that fact type gets its own vector index. 0 (default) = no minimum, every bank holding memories is indexed. Set ~10000 on deployments with thousands of banks: every index lives on the shared memory_units table and is planned against by every OTHER bank's queries, so unconditional per-bank indexes put a ceiling on bank count. Smaller banks then use exact search, which is faster AND exact.
+# HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS=0  # Memories a bank needs in one fact type before that fact type gets its own vector index. 0 (default) turns the threshold OFF: every bank is indexed when it is created, and no background maintenance runs. Set ~10000 on deployments with thousands of banks: every index lives on the shared memory_units table and is planned against by every OTHER bank's queries, so unconditional per-bank indexes put a ceiling on bank count. Smaller banks then use exact search, which is faster AND exact.
+# HINDSIGHT_API_VECTOR_INDEX_MAINTENANCE_MIN_INTERVAL_SECONDS=900  # Shortest gap between two index-maintenance runs for one bank, so a bank hovering at the threshold cannot build and drop the same index repeatedly. Unused while the threshold is off.
 
 # Text Search Extension (Optional - uses native PostgreSQL full-text search by default)
 # Backend options: "native" (default), "vchord", "pg_textsearch", "pgroonga", "pg_search"

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -138,8 +138,9 @@ Hindsight supports four PostgreSQL vector extensions:
 #### Limiting vector indexes on large deployments
 
 On `pgvector`, `pgvectorscale` and `vchord`, a bank's memories are indexed per
-`(bank, fact_type)`. By default every bank that holds memories gets its own
-indexes, which is the right thing for most deployments.
+`(bank, fact_type)`. By default every bank gets its own indexes when it is
+created, which is the right thing for most deployments and needs no
+configuration.
 
 It stops being the right thing when you have thousands of banks. These indexes
 all live on one shared table, and PostgreSQL inspects and locks **every** index
@@ -158,14 +159,21 @@ limit.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS` | Memories a bank needs, in one fact type, before that fact type gets its own vector index. `0` (the default) means no minimum — every bank holding memories is indexed. `10000` is a good starting point for deployments with thousands of banks. | `0` |
+| `HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS` | Memories a bank needs, in one fact type, before that fact type gets its own vector index. `0` (the default) turns the threshold **off**: every bank is indexed from the moment it is created. `10000` is a good starting point for deployments with thousands of banks. | `0` |
+| `HINDSIGHT_API_VECTOR_INDEX_MAINTENANCE_MIN_INTERVAL_SECONDS` | Shortest gap between two index-maintenance runs for one bank. Stops a bank whose size hovers at the threshold from building and dropping the same index repeatedly. Unused while the threshold is off. | `900` |
 
-Coverage is maintained for you. Every write that could move a bank across the
-threshold queues a background `vector_index_maintenance` operation, which builds
-an index when a bank grows past the threshold and removes it if the bank shrinks
-well below it (the gap between those two points prevents churn at the boundary).
-Bank creation, ingestion and import never build indexes themselves, so no
-request ever waits on index DDL.
+**With the threshold off (the default),** indexes are created inside the
+transaction that creates the bank — instantly, because the bank is empty — and
+dropped when the bank is deleted. Nothing inspects bank sizes, and no background
+operation runs.
+
+**With a threshold set,** bank creation, ingestion and import build no indexes at
+all, so no request ever waits on index DDL. Instead, a write that could move a
+bank across the threshold queues a background `vector_index_maintenance`
+operation, which builds an index when a bank grows past the threshold and removes
+it if the bank shrinks well below it (the gap between those two points prevents
+churn at the boundary). You will see these operations in the bank's operations
+list.
 
 To reconcile without waiting for a write — after a restore, an upgrade, or an
 extension switch — run:
@@ -173,6 +181,9 @@ extension switch — run:
 ```bash
 hindsight-admin repair-bank --all
 ```
+
+This works in both modes: with the threshold off it rebuilds any index a bank is
+missing, and with one set it also drops what a bank no longer earns.
 
 **Switching extensions:**
 


### PR DESCRIPTION
## The problem

#3561 made per-bank vector indexes something a bank earns by size, defaulting the threshold to `0`. But `0` meant **"no minimum"**, not **"off"** — so at the shipped default:

- every bank holding one row still earned all three indexes, just **lazily**: through a user-visible `vector_index_maintenance` operation instead of at bank creation;
- every retain, import, consolidation and delete paid an **uncapped `COUNT(*)`** over the bank's whole `memory_units` partition, forever, just to rediscover there was nothing to do. On a large bank that is hundreds of thousands of index tuples per write.

Neither is what the knob was for. It went in to remove a ceiling on bank count, not to change what a normal deployment does.

## `0` now turns the threshold off

Indexes are created in the bank-create transaction and dropped when the bank is deleted — exactly as before #3561. No operation is ever submitted, no write pays a coverage check, and `repair-bank` rebuilds what a bank is missing without dropping anything.

Bank creation, retain and import get their `CREATE INDEX` back, gated on the threshold being off, and import keeps the explicit build a restored bank needs (#2645).

## With a threshold set, the pre-check gets cheap

Coverage can only go wrong in one direction at a time, so the direction of the write settles most partitions from the catalog alone:

| write | partition **is** indexed | partition **is not** indexed |
|---|---|---|
| **grew** | can't fall below the keep bound → **no count** | count, to see if it crossed the build bound |
| **shrank** | count, to see if it fell below the keep bound | can't rise above the build bound → **no count** |

What's left is counted **no further than the threshold**: `min(actual, build_bound)` answers both bounds at once, since keeping starts below building. The scan's cost is set by the configured threshold instead of by how big the bank got.

A converged, actively-written bank now costs two indexed queries and counts nothing. `FULL` (the job re-planning at start, and `repair-bank`) still counts everything and is what recovers anything a directional pre-check deferred.

## Two churn sources on the same surface

- **A per-bank cooldown** (`HINDSIGHT_API_VECTOR_INDEX_MAINTENANCE_MIN_INTERVAL_SECONDS`, default 15 min) stops a bank hovering at the threshold from building and dropping the same ANN index repeatedly, and stops a permanently failing build — logged, never raised, so the plan stays non-empty — from re-queueing on every subsequent write. Consulted only once the pre-check has found real work, so a converged bank never pays for it; the job's own hand-off is exempt, since its whole purpose is to re-check immediately.
- **Oracle is now actually excluded.** It leaves `HINDSIGHT_API_VECTOR_EXTENSION` at its pgvector default, so gating on the index clause alone let the planner run asyncpg-shaped SQL against it on every write — after which the job found no DSN to build with and re-queued itself forever. The gate is the backend. A missing DSN now warns instead of logging at debug: nothing about the next write will produce one.

## Tests

The suite-wide threshold override #3561 added is **removed**. It existed to keep the operation's `CONCURRENTLY` DDL out of the suite, which at threshold 0 no longer happens. Running at the shipped default is why the suite caught nothing about the configuration almost everyone runs — and is what let `0` diverge from the pre-#3561 behaviour in the first place. Tests that need a threshold now say so with a fixture.

New coverage:

- the default builds all three indexes at bank creation, queues **no** operation, keeps an emptied bank's indexes, and lets `repair-bank` rebuild what creation missed;
- import builds inline at the default (#2645) and does not with a threshold set;
- the directional pre-check issues **no count** in each steady state — asserted by recording the queries the planner actually runs — and still finds both crossings it exists for;
- a partition far above the threshold is not counted out by the cap;
- the cooldown refuses a second submit, exempts the hand-off, and can be turned off;
- a non-PostgreSQL backend never queues;
- a job whose threshold was switched off underneath it drops nothing.

Full `hindsight-api-slim` suite run with and without the change: identical pass/fail. The failures present in both are pre-existing (missing LLM keys, separate-pg0 migration fixtures, and `test_recall_min_score`, which fails on clean `origin/main`).

Refs #3485, #2645
