### PR TITLE
fix(config): validate and persist bank config as one serialized unit (#3037)

### DIFF
--- a/hindsight-api-slim/hindsight_api/config_resolver.py
+++ b/hindsight-api-slim/hindsight_api/config_resolver.py
@@ -11,7 +11,7 @@ multiple API servers.
 import asyncio
 import json
 import logging
-from dataclasses import asdict, fields, replace
+from dataclasses import asdict, dataclass, fields, replace
 from functools import lru_cache
 from types import UnionType
 from typing import TYPE_CHECKING, Any, Union, get_args, get_origin
@@ -42,6 +42,44 @@ class BankConfigPersistenceConflictError(ValueError):
         super().__init__(f"Cannot update config for bank '{bank_id}': the bank does not exist")
 
 
+# Fields that participate in a constraint spanning more than one config field.
+# An update touching any of them is re-checked against the committed overrides
+# while the bank row is locked (see _persist_bank_config), because two updates
+# that are each valid against the old state can combine into an invalid one.
+#
+# An update touching none of them cannot change either side of any of these
+# constraints, so the constrained state it leaves behind is exactly the state it
+# found, and it needs no re-check.
+_CROSS_FIELD_CONSTRAINED_FIELDS = frozenset(
+    {
+        # retain_max_completion_tokens (server-level) > retain_chunk_size, for the
+        # bank config and for every retain strategy spliced onto it.
+        "retain_chunk_size",
+        "retain_structured_chunk_size",
+        "retain_strategies",
+        # recall_budget_min <= recall_budget_max
+        "recall_budget_min",
+        "recall_budget_max",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ValidatedBankConfigUpdate:
+    """Normalized bank overrides plus what is needed to re-validate them at write time.
+
+    ``updates`` is ready to merge into ``banks.config``. ``parent_config`` is the
+    resolved global + tenant base the projected configuration is rebuilt from
+    while the bank row is locked; it is None when the update touches no
+    cross-field constrained field and therefore needs no re-check. Resolving it
+    during validation (rather than during persistence) keeps the tenant config
+    hook on the once-per-request path and off the locked path.
+    """
+
+    updates: dict[str, Any]
+    parent_config: dict[str, Any] | None = None
+
+
 def _validate_retain_strategy_chunking(base_config: HindsightConfig, strategies: Any) -> None:
     """Validate retain strategy chunking with the same semantics as apply_strategy()."""
     if not isinstance(strategies, dict):
@@ -69,6 +107,36 @@ def _validate_retain_strategy_chunking(base_config: HindsightConfig, strategies:
             )
         except ValueError as e:
             raise ValueError(f"Invalid retain strategy {strategy_name!r}: {e}") from e
+
+
+def _validate_projected_bank_config(
+    parent_config: dict[str, Any],
+    current_overrides: dict[str, Any],
+    normalized_updates: dict[str, Any],
+    configurable_fields: set[str],
+) -> None:
+    """Validate the whole configuration an update would leave committed.
+
+    Every constraint here spans more than one field, so it can only be checked
+    against the complete projected state — never against the update alone.
+    """
+    projected = dict(current_overrides)
+    for key, value in normalized_updates.items():
+        if key not in configurable_fields:
+            continue
+        if value is None:
+            # JSON null is the "Server Default" tombstone: it clears the override.
+            projected.pop(key, None)
+        else:
+            projected[key] = value
+
+    base_config = HindsightConfig(**{**parent_config, **projected})
+    validate_retain_chunking_config(
+        base_config.retain_chunk_size,
+        base_config.retain_structured_chunk_size,
+    )
+    _validate_retain_strategy_chunking(base_config, base_config.retain_strategies)
+    _validate_recall_budget_bounds(base_config.recall_budget_min, base_config.recall_budget_max)
 
 
 class ConfigResolver:
@@ -286,23 +354,28 @@ class ConfigResolver:
                 )
 
                 if row and row["config"]:
-                    config_data = row["config"]
-
-                    # Handle case where JSONB is returned as JSON string
-                    if isinstance(config_data, str):
-                        config_data = json.loads(config_data)
-
-                    # Normalize keys (handle both env var format and Python field format)
-                    normalized = normalize_config_dict(config_data)
-
-                    # Only return active overrides for configurable fields. JSON null is a tombstone
-                    # for "Server Default" in the bank-config UI and should not override defaults.
-                    active = {k: v for k, v in normalized.items() if k in self._configurable_fields and v is not None}
-                    return _coerce_stored_bank_overrides(bank_id, active)
+                    return self._active_bank_overrides(bank_id, row["config"])
         except Exception as e:
             logger.error(f"Failed to load bank config for {bank_id}: {e}")
 
         return {}
+
+    def _active_bank_overrides(self, bank_id: str, config_data: Any) -> dict[str, Any]:
+        """Parse a stored ``banks.config`` value into active, normalized overrides."""
+        if not config_data:
+            return {}
+
+        # Handle case where JSONB is returned as JSON string
+        if isinstance(config_data, str):
+            config_data = json.loads(config_data)
+
+        # Normalize keys (handle both env var format and Python field format)
+        normalized = normalize_config_dict(config_data)
+
+        # Only active overrides for configurable fields. JSON null is a tombstone
+        # for "Server Default" in the bank-config UI and must not override defaults.
+        active = {k: v for k, v in normalized.items() if k in self._configurable_fields and v is not None}
+        return _coerce_stored_bank_overrides(bank_id, active)
 
     async def _load_bank_configs(self, bank_ids: list[str]) -> dict[str, dict[str, Any]]:
         """Bulk variant of :meth:`_load_bank_config`: load many banks' overrides in one query.
@@ -322,23 +395,9 @@ class ConfigResolver:
                     bank_ids,
                 )
                 for row in rows:
-                    config_data = row["config"]
-                    if not config_data:
-                        continue
-                    # Handle case where JSONB is returned as JSON string
-                    if isinstance(config_data, str):
-                        config_data = json.loads(config_data)
-
-                    # Normalize keys (handle both env var format and Python field format)
-                    normalized = normalize_config_dict(config_data)
-
-                    # Only active overrides for configurable fields. JSON null is a tombstone
-                    # for "Server Default" in the bank-config UI and must not override defaults.
-                    overrides = {
-                        k: v for k, v in normalized.items() if k in self._configurable_fields and v is not None
-                    }
+                    overrides = self._active_bank_overrides(row["bank_id"], row["config"])
                     if overrides:
-                        result[row["bank_id"]] = _coerce_stored_bank_overrides(row["bank_id"], overrides)
+                        result[row["bank_id"]] = overrides
         except Exception as e:
             logger.error(f"Failed to bulk-load bank configs: {e}")
         return result
@@ -351,9 +410,14 @@ class ConfigResolver:
         *,
         projected_bank_overrides: dict[str, Any] | None = None,
         check_permissions: bool = True,
-    ) -> dict[str, Any]:
+    ) -> ValidatedBankConfigUpdate:
         """
         Normalize and validate bank configuration overrides.
+
+        Permission hooks run here, once per request. Cross-field constraints are
+        checked here too, so an invalid update is rejected before the bank is
+        created — but they are checked again inside ``_persist_bank_config``,
+        which is where the result is actually guaranteed.
 
         Args:
             bank_id: Bank identifier
@@ -368,7 +432,8 @@ class ConfigResolver:
                 updates. Server-owned projected values set this to false.
 
         Returns:
-            Normalized updates ready to persist.
+            Normalized updates ready to persist, with the base needed to
+            re-validate them at write time.
 
         Raises:
             ValueError: If attempting to override invalid/disallowed fields.
@@ -460,34 +525,27 @@ class ConfigResolver:
         # Validate disposition trait fields (1-5 integer scale)
         _validate_disposition_updates(normalized_updates)
 
-        chunking_fields_updated = (
-            "retain_chunk_size" in normalized_updates
-            or "retain_structured_chunk_size" in normalized_updates
-            or "retain_strategies" in normalized_updates
-        )
-        if chunking_fields_updated:
-            config_dict = await self._resolve_parent_config_dict(bank_id, context)
-            active_bank_overrides = (
+        # Constraints spanning several fields need the whole projected
+        # configuration, not just the update. This check is the early one, so a
+        # bad update is rejected before the bank is created; _persist_bank_config
+        # repeats it against the committed state under the bank row lock, which
+        # is what makes the result independent of request interleaving.
+        parent_config: dict[str, Any] | None = None
+        if not _CROSS_FIELD_CONSTRAINED_FIELDS.isdisjoint(normalized_updates):
+            parent_config = await self._resolve_parent_config_dict(bank_id, context)
+            current_overrides = (
                 await self._load_bank_config(bank_id)
                 if projected_bank_overrides is None
                 else dict(projected_bank_overrides)
             )
-            for key, value in normalized_updates.items():
-                if key not in self._configurable_fields:
-                    continue
-                if value is None:
-                    active_bank_overrides.pop(key, None)
-                else:
-                    active_bank_overrides[key] = value
-            config_dict.update(active_bank_overrides)
-            base_config = HindsightConfig(**config_dict)
-            validate_retain_chunking_config(
-                base_config.retain_chunk_size,
-                base_config.retain_structured_chunk_size,
+            _validate_projected_bank_config(
+                parent_config,
+                current_overrides,
+                normalized_updates,
+                self._configurable_fields,
             )
-            _validate_retain_strategy_chunking(base_config, base_config.retain_strategies)
 
-        return normalized_updates
+        return ValidatedBankConfigUpdate(updates=normalized_updates, parent_config=parent_config)
 
     async def update_bank_config(
         self, bank_id: str, updates: dict[str, Any], context: RequestContext | None = None
@@ -497,39 +555,70 @@ class ConfigResolver:
         Bank creation belongs to ``MemoryEngine``; this raises ``ValueError`` if
         the bank does not exist rather than silently discarding the overrides.
         """
-        normalized_updates = await self.validate_bank_config_updates(bank_id, updates, context)
-        await self._persist_bank_config(bank_id, normalized_updates)
+        validated = await self.validate_bank_config_updates(bank_id, updates, context)
+        await self._persist_bank_config(bank_id, validated)
 
-    async def _persist_bank_config(self, bank_id: str, normalized_updates: dict[str, Any]) -> None:
-        """Persist already-validated overrides without changing bank lifecycle state."""
-        # Bank lifecycle belongs to MemoryEngine. Callers must create the row
-        # before reaching this persistence step. COALESCE guards against a NULL
-        # config column (NULL || jsonb is NULL), which would drop the override.
-        async with self._backend.acquire() as conn:
-            result = await conn.execute(
+    async def _persist_bank_config(self, bank_id: str, validated: ValidatedBankConfigUpdate) -> None:
+        """Persist validated overrides, re-checking them against the committed state.
+
+        Validation and persistence are one serialized unit: the bank row is
+        locked for the whole transaction, so a concurrent config write to the
+        same bank either commits before this one is validated or waits for it.
+        Neither can slip a cross-field constraint past the other by validating
+        against overrides that a third write has since replaced.
+
+        The lock is pessimistic on purpose. An optimistic revision would have to
+        re-run validation on retry, and validation calls tenant permission hooks
+        that may reserve quota or make time-sensitive decisions; those hooks run
+        exactly once, before this transaction opens. A caller that loses the race
+        gets the same ValueError the losing update would have raised had the two
+        writes been ordered, rather than a conflict status to retry.
+        """
+        async with self._backend.transaction() as conn:
+            # The lock is what serializes writers; it also settles whether the
+            # bank exists. Bank lifecycle belongs to MemoryEngine, so a missing
+            # row means a caller skipped the engine's provisioning step — fail
+            # loudly rather than update nothing and report success.
+            row = await conn.fetchrow(
+                f"""
+                SELECT config FROM {fq_table("banks")} WHERE bank_id = $1 FOR UPDATE
+                """,
+                bank_id,
+            )
+            if row is None:
+                raise BankConfigPersistenceConflictError(bank_id)
+
+            if validated.parent_config is not None:
+                _validate_projected_bank_config(
+                    validated.parent_config,
+                    self._active_bank_overrides(bank_id, row["config"]),
+                    validated.updates,
+                    self._configurable_fields,
+                )
+
+            # COALESCE guards against a NULL config column (NULL || jsonb is
+            # NULL), which would drop the override.
+            await conn.execute(
                 f"""
                 UPDATE {fq_table("banks")}
                 SET config = COALESCE(config, '{{}}'::jsonb) || $1::jsonb,
                     updated_at = now()
                 WHERE bank_id = $2
                 """,
-                json.dumps(normalized_updates),
+                json.dumps(validated.updates),
                 bank_id,
             )
 
-        # A missing bank row matches zero rows, which would otherwise persist
-        # nothing while reporting success. Fail loudly instead: reaching here
-        # without the row means a caller skipped the engine's provisioning step.
-        # (The Oracle wrapper reshapes rowcount into the same "UPDATE <n>" form.)
-        updated = int(result.split()[-1]) if isinstance(result, str) and result.startswith("UPDATE") else 0
-        if updated == 0:
-            raise BankConfigPersistenceConflictError(bank_id)
-
-        logger.info(f"Updated bank config for {bank_id}: {list(normalized_updates.keys())}")
+        logger.info(f"Updated bank config for {bank_id}: {list(validated.updates.keys())}")
 
     async def reset_bank_config(self, bank_id: str) -> None:
         """
         Reset bank configuration to defaults (remove all overrides).
+
+        No row lock here, unlike _persist_bank_config: this single statement
+        already blocks on the lock a concurrent config write holds, and the
+        state it leaves — no overrides at all — cannot violate a cross-field
+        constraint, so there is nothing to re-validate.
 
         Args:
             bank_id: Bank identifier
@@ -729,11 +818,18 @@ def _validate_recall_budget_updates(updates: dict[str, Any]) -> None:
                 raise ValueError(f"{key} must be a positive integer, got {value!r}")
 
     if "recall_budget_min" in updates and "recall_budget_max" in updates:
-        if updates["recall_budget_min"] > updates["recall_budget_max"]:
-            raise ValueError(
-                f"recall_budget_min ({updates['recall_budget_min']}) must be <= "
-                f"recall_budget_max ({updates['recall_budget_max']})"
-            )
+        # The one-sided case (only one bound in the update) is checked against
+        # the committed state in _validate_projected_bank_config; this catches a
+        # self-contradictory update without a database read.
+        _validate_recall_budget_bounds(updates["recall_budget_min"], updates["recall_budget_max"])
+
+
+def _validate_recall_budget_bounds(recall_budget_min: Any, recall_budget_max: Any) -> None:
+    """Validate the recall budget bounds against each other."""
+    if recall_budget_min is None or recall_budget_max is None:
+        return
+    if recall_budget_min > recall_budget_max:
+        raise ValueError(f"recall_budget_min ({recall_budget_min}) must be <= recall_budget_max ({recall_budget_max})")
 
 
 _DISPOSITION_KEYS = (

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -98,7 +98,7 @@ class _BankTemplateImportAuthorizationState:
     task: asyncio.Task[Any]
     bank_id: str
     requested_config_updates: dict[str, Any]
-    normalized_config_updates: dict[str, Any]
+    normalized_config_updates: "ValidatedBankConfigUpdate"
     bank_write_remaining: dict["BankTemplateImportWrite", int]
     mental_model_refresh_remaining: dict[str, int]
     mental_model_get_remaining: dict[str, int]
@@ -443,6 +443,7 @@ from .embeddings import Embeddings, create_embeddings_from_env
 from .interface import BankConfigState, BankTemplateImportWrite, MemoryEngineInterface
 
 if TYPE_CHECKING:
+    from hindsight_api.config_resolver import ValidatedBankConfigUpdate
     from hindsight_api.extensions import (
         BankWriteOperation,
         OperationValidatorExtension,
@@ -11137,6 +11138,8 @@ class MemoryEngine(MemoryEngineInterface):
         invoking the hooks a second time. The scope is installed only after bank
         creation, keeping server-owned default-template work outside it.
         """
+        from hindsight_api.config_resolver import ValidatedBankConfigUpdate
+
         await self._authenticate_tenant(request_context)
         normalized_updates = (
             await self._validate_bank_config_updates(
@@ -11146,7 +11149,7 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_exists=bank_exists,
             )
             if config_updates
-            else {}
+            else ValidatedBankConfigUpdate(updates={})
         )
 
         if self._operation_validator:
@@ -11254,7 +11257,7 @@ class MemoryEngine(MemoryEngineInterface):
         bank_id: str,
         updates: dict[str, Any],
         request_context: "RequestContext",
-    ) -> dict[str, Any] | None:
+    ) -> "ValidatedBankConfigUpdate | None":
         """Return prevalidated config when this is the authorized import write."""
         state = self._get_bank_template_import_authorization_state(bank_id, request_context)
         if state is None:
@@ -11300,7 +11303,7 @@ class MemoryEngine(MemoryEngineInterface):
         request_context: "RequestContext",
     ) -> None:
         """Persist config after the caller has authenticated and authorized it."""
-        normalized_updates = await self._validate_bank_config_updates(
+        validated_updates = await self._validate_bank_config_updates(
             bank_id,
             updates,
             request_context=request_context,
@@ -11310,7 +11313,7 @@ class MemoryEngine(MemoryEngineInterface):
         # an otherwise empty bank. Creation stays in the engine so every caller
         # shares its lifecycle hooks.
         await self._ensure_bank_exists(bank_id, request_context)
-        await self._config_resolver._persist_bank_config(bank_id, normalized_updates)
+        await self._config_resolver._persist_bank_config(bank_id, validated_updates)
 
     async def _validate_bank_config_updates(
         self,
@@ -11319,7 +11322,7 @@ class MemoryEngine(MemoryEngineInterface):
         *,
         request_context: "RequestContext",
         bank_exists: bool | None = None,
-    ) -> dict[str, Any]:
+    ) -> "ValidatedBankConfigUpdate":
         """Validate and normalize config without creating a bank or persisting."""
 
         # Keep API and MCP configuration updates consistent, including the
@@ -11349,16 +11352,18 @@ class MemoryEngine(MemoryEngineInterface):
                 default_manifest.bank.get_config_updates() if default_manifest and default_manifest.bank else {}
             )
             if default_updates:
-                projected_bank_overrides = await self._config_resolver.validate_bank_config_updates(
-                    bank_id,
-                    default_updates,
-                    request_context,
-                    projected_bank_overrides={},
-                    # The default template is server-owned. Its values are
-                    # needed only as the base for validating the client update,
-                    # so client field permissions must not apply to them.
-                    check_permissions=False,
-                )
+                projected_bank_overrides = (
+                    await self._config_resolver.validate_bank_config_updates(
+                        bank_id,
+                        default_updates,
+                        request_context,
+                        projected_bank_overrides={},
+                        # The default template is server-owned. Its values are
+                        # needed only as the base for validating the client update,
+                        # so client field permissions must not apply to them.
+                        check_permissions=False,
+                    )
+                ).updates
 
         return await self._config_resolver.validate_bank_config_updates(
             bank_id,
@@ -16668,12 +16673,17 @@ class MemoryEngine(MemoryEngineInterface):
             await self._ensure_bank_exists(bank_id, request_context)
 
         if normalized_config_updates is not None:
+            from hindsight_api.config_resolver import BankConfigPersistenceConflictError
+
             try:
                 await self._config_resolver._persist_bank_config(bank_id, normalized_config_updates)
-            except ValueError:
+            except BankConfigPersistenceConflictError:
                 # Update-only callers verified the bank above, so the row can only
                 # be gone if it was deleted concurrently. Surface that as the same
                 # 404 the final profile read below would produce, not a 400.
+                # A plain ValueError here is a genuine validation failure — the
+                # write-time re-check against a concurrently updated config — and
+                # stays a 400.
                 if create_if_missing:
                     raise
                 from hindsight_api.extensions import OperationValidationError

--- a/hindsight-api-slim/tests/test_bank_config_atomicity.py
+++ b/hindsight-api-slim/tests/test_bank_config_atomicity.py
@@ -1,0 +1,246 @@
+"""Bank config writes validate and persist as one serialized unit (#3037).
+
+Two updates that are each valid against the state they read must not be able to
+commit a combination that neither of them validated. The interleaving is forced
+with an ``asyncio.Barrier`` around the persistence step — both requests finish
+validation before either writes — rather than with sleeps.
+
+The helpers are shared with the Oracle suite (``test_oracle_integration.py``),
+which runs the recall-budget scenarios against Oracle 23ai. The retain-chunking
+scenario stays PG-only — see the comment on ``TestBankConfigAtomicity`` there.
+"""
+
+import asyncio
+import uuid
+
+import pytest
+
+from hindsight_api import MemoryEngine, RequestContext
+from hindsight_api.config_resolver import ConfigResolver, apply_strategy
+from hindsight_api.extensions.tenant import TenantExtension
+
+
+def bank_id(prefix: str) -> str:
+    return f"test-cfg-atomic-{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+async def run_interleaved_config_updates(
+    memory: MemoryEngine,
+    bank: str,
+    request_context: RequestContext,
+    first: dict[str, object],
+    second: dict[str, object],
+) -> list[BaseException]:
+    """Validate both updates before either persists, then return what each raised.
+
+    The barrier releases both requests into ``_persist_bank_config`` at the same
+    moment, so they can only be ordered by the bank row lock the write takes.
+    """
+    resolver = memory._config_resolver
+    original_persist = resolver._persist_bank_config
+    barrier = asyncio.Barrier(2)
+
+    async def gated_persist(persisted_bank_id, validated):
+        if persisted_bank_id == bank:
+            # A timeout rather than a bare wait: if one request is rejected
+            # before it reaches the write, the other must fail the test instead
+            # of hanging at the barrier forever.
+            await asyncio.wait_for(barrier.wait(), timeout=30)
+        return await original_persist(persisted_bank_id, validated)
+
+    resolver._persist_bank_config = gated_persist
+    try:
+        results = await asyncio.gather(
+            memory.update_bank_config(bank, first, request_context=request_context),
+            memory.update_bank_config(bank, second, request_context=request_context),
+            return_exceptions=True,
+        )
+    finally:
+        resolver._persist_bank_config = original_persist
+    return [r for r in results if isinstance(r, BaseException)]
+
+
+async def assert_recall_budget_race_is_serialized(memory: MemoryEngine, request_context: RequestContext) -> None:
+    """Concurrent one-sided recall-budget updates cannot cross min over max."""
+    bank = bank_id("budget")
+    try:
+        await memory.update_bank_config(
+            bank,
+            {"recall_budget_min": 100, "recall_budget_max": 1000},
+            request_context=request_context,
+        )
+
+        # 800 <= 1000 and 100 <= 500, but min=800 with max=500 is not a
+        # configuration either request validated.
+        errors = await run_interleaved_config_updates(
+            memory,
+            bank,
+            request_context,
+            {"recall_budget_min": 800},
+            {"recall_budget_max": 500},
+        )
+
+        assert len(errors) == 1, f"expected exactly one rejected update, got {errors}"
+        assert "recall_budget_min" in str(errors[0])
+        assert isinstance(errors[0], ValueError)
+
+        overrides = await memory._config_resolver._load_bank_config(bank)
+        assert overrides["recall_budget_min"] <= overrides["recall_budget_max"]
+    finally:
+        await memory.delete_bank(bank, request_context=request_context)
+
+
+async def assert_retain_chunking_race_is_serialized(memory: MemoryEngine, request_context: RequestContext) -> None:
+    """Concurrent chunk-size and strategy updates cannot wedge the retain config.
+
+    PostgreSQL only: the wedge depends on a ``retain_strategies`` write replacing
+    the whole map, which is what ``config || $1::jsonb`` does. Oracle rewrites
+    that statement to JSON_MERGEPATCH and merges into the nested object instead.
+    """
+    bank = bank_id("chunking")
+    resolved = await memory._config_resolver.resolve_full_config(bank, request_context)
+    if resolved.llm_provider == "none":
+        pytest.skip("the retain completion-token budget is not enforced without an LLM provider")
+    oversized_chunk = resolved.retain_max_completion_tokens + 1000
+
+    try:
+        await memory.update_bank_config(
+            bank,
+            {"retain_chunk_size": 3000, "retain_strategies": {"s": {"retain_chunk_size": 1000}}},
+            request_context=request_context,
+        )
+
+        # The oversized bank-level chunk size is only valid while strategy "s"
+        # pins its own; dropping that pin is only valid while the bank-level
+        # chunk size is small. Together they wedge retain under strategy "s".
+        errors = await run_interleaved_config_updates(
+            memory,
+            bank,
+            request_context,
+            {"retain_chunk_size": oversized_chunk},
+            {"retain_strategies": {"s": {"retain_extraction_mode": "detailed"}}},
+        )
+
+        assert len(errors) == 1, f"expected exactly one rejected update, got {errors}"
+        assert "retain_max_completion_tokens" in str(errors[0])
+        assert isinstance(errors[0], ValueError)
+
+        # The committed configuration is one retain can still run: this is the
+        # call retain makes to splice a strategy onto the resolved config, and
+        # it is what raised once the two updates had both landed.
+        apply_strategy(await memory._config_resolver.resolve_full_config(bank, request_context), "s")
+    finally:
+        await memory.delete_bank(bank, request_context=request_context)
+
+
+async def assert_one_sided_budget_update_sees_stored_state(
+    memory: MemoryEngine, request_context: RequestContext
+) -> None:
+    """A single bound is validated against the bound already stored, not ignored."""
+    bank = bank_id("stored")
+    try:
+        await memory.update_bank_config(bank, {"recall_budget_max": 100}, request_context=request_context)
+
+        with pytest.raises(ValueError, match="recall_budget_min"):
+            await memory.update_bank_config(bank, {"recall_budget_min": 500}, request_context=request_context)
+
+        overrides = await memory._config_resolver._load_bank_config(bank)
+        assert "recall_budget_min" not in overrides
+    finally:
+        await memory.delete_bank(bank, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_updates_cannot_persist_invalid_recall_budget_bounds(memory, request_context):
+    await assert_recall_budget_race_is_serialized(memory, request_context)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_updates_cannot_persist_invalid_retain_chunking(memory, request_context):
+    await assert_retain_chunking_race_is_serialized(memory, request_context)
+
+
+@pytest.mark.asyncio
+async def test_one_sided_recall_budget_update_is_validated_against_stored_state(memory, request_context):
+    await assert_one_sided_budget_update_sees_stored_state(memory, request_context)
+
+
+@pytest.mark.asyncio
+async def test_updates_untouched_by_cross_field_constraints_still_merge(memory, request_context):
+    """Two concurrent writes to unconstrained fields both survive.
+
+    Serializing on the bank row must not turn independent field writes into a
+    last-write-wins race: neither update participates in a cross-field
+    constraint, so both belong in the committed config.
+    """
+    bank = bank_id("merge")
+    try:
+        await memory.update_bank_config(bank, {"enable_reranking": True}, request_context=request_context)
+
+        errors = await run_interleaved_config_updates(
+            memory,
+            bank,
+            request_context,
+            {"enable_reranking": False},
+            {"enable_observations": False},
+        )
+
+        assert errors == []
+        overrides = await memory._config_resolver._load_bank_config(bank)
+        assert overrides["enable_reranking"] is False
+        assert overrides["enable_observations"] is False
+    finally:
+        await memory.delete_bank(bank, request_context=request_context)
+
+
+class CountingTenantExtension(TenantExtension):
+    """Tenant extension that records how often each config hook is invoked."""
+
+    def __init__(self) -> None:
+        self.tenant_config_calls = 0
+        self.allowed_config_field_calls = 0
+
+    async def authenticate(self, context):
+        from hindsight_api.extensions.tenant import TenantContext
+
+        return TenantContext(schema_name="public")
+
+    async def list_tenants(self):
+        from hindsight_api.extensions.tenant import Tenant
+
+        return [Tenant(schema="public")]
+
+    async def get_tenant_config(self, context):
+        self.tenant_config_calls += 1
+        return {}
+
+    async def get_allowed_config_fields(self, context, bank_id):
+        self.allowed_config_field_calls += 1
+        return None
+
+
+@pytest.mark.asyncio
+async def test_config_write_calls_each_tenant_hook_once(memory, request_context):
+    """Re-validating under the row lock must not replay per-request hooks.
+
+    Permission and tenant-config hooks may reserve quota or make time-sensitive
+    decisions, so the write-time re-check reuses what validation already
+    resolved instead of calling them again.
+    """
+    bank = bank_id("hooks")
+    extension = CountingTenantExtension()
+    resolver = ConfigResolver(backend=memory._backend, tenant_extension=extension)
+    try:
+        await memory.update_bank_config(bank, {"enable_observations": True}, request_context=request_context)
+
+        # An update that touches a cross-field constrained field takes the
+        # re-check path; the unconstrained one skips it. Neither may re-run a hook.
+        await resolver.update_bank_config(bank, {"recall_budget_max": 900}, request_context)
+        assert extension.tenant_config_calls == 1
+        assert extension.allowed_config_field_calls == 1
+
+        await resolver.update_bank_config(bank, {"enable_reranking": False}, request_context)
+        assert extension.tenant_config_calls == 1
+        assert extension.allowed_config_field_calls == 2
+    finally:
+        await memory.delete_bank(bank, request_context=request_context)

--- a/hindsight-api-slim/tests/test_hierarchical_config.py
+++ b/hindsight-api-slim/tests/test_hierarchical_config.py
@@ -51,6 +51,9 @@ class FakeBankConfigBackend:
     def acquire(self):
         return FakeBankConfigConnection(self)
 
+    def transaction(self):
+        return FakeBankConfigConnection(self)
+
 
 class FakeBankConfigConnection:
     def __init__(self, backend: FakeBankConfigBackend):

--- a/hindsight-api-slim/tests/test_oracle_integration.py
+++ b/hindsight-api-slim/tests/test_oracle_integration.py
@@ -20,6 +20,10 @@ import pytest_asyncio
 from hindsight_api import MemoryEngine, RequestContext
 from hindsight_api.engine.db import DatabaseConnection
 from hindsight_api.engine.memory_engine import Budget
+from tests.test_bank_config_atomicity import (
+    assert_one_sided_budget_update_sees_stored_state,
+    assert_recall_budget_race_is_serialized,
+)
 
 pytestmark = pytest.mark.oracle
 
@@ -364,6 +368,44 @@ class TestCoreCRUD:
             assert str(mem["id"]) == str(memory_id)
         finally:
             await _safe_cleanup(oracle_memory, bank_id, request_context)
+
+
+# ===================================================================
+# Tier 1b — Bank Config Atomicity (#3037)
+# ===================================================================
+#
+# Deliberately early in the file: the run is sequential (-n0), and the Oracle
+# Free container has a standing habit of dropping every connection partway
+# through the Tier 6 edge cases (DPY-4011), which would leave these tests
+# reporting a dead database instead of a verdict.
+
+
+class TestBankConfigAtomicity:
+    """Config writes serialize on the bank row under Oracle too.
+
+    The scenarios live in ``test_bank_config_atomicity`` so both dialects run
+    exactly the same interleavings; only the fixture differs.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_updates_cannot_persist_invalid_recall_budget_bounds(
+        self, oracle_memory: MemoryEngine, request_context: RequestContext
+    ):
+        await assert_recall_budget_race_is_serialized(oracle_memory, request_context)
+
+    # The retain-chunking scenario from that module is deliberately PG-only. It
+    # wedges the config by *replacing* retain_strategies so a nested chunk-size
+    # pin disappears, and only PostgreSQL does that: `config || $1::jsonb`
+    # concatenates at the top level, while the Oracle rewrite of the same
+    # statement (JSON_MERGEPATCH, RFC 7396) merges into the nested object and
+    # keeps the pin. The recall-budget scenarios here cover the same atomicity
+    # property with top-level scalars, which both dialects store identically.
+
+    @pytest.mark.asyncio
+    async def test_one_sided_recall_budget_update_is_validated_against_stored_state(
+        self, oracle_memory: MemoryEngine, request_context: RequestContext
+    ):
+        await assert_one_sided_budget_update_sees_stored_state(oracle_memory, request_context)
 
 
 # ===================================================================

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -2283,6 +2283,21 @@ Configuration fields are categorized for security:
    - Provider/Model selection: `llm_provider`, `llm_model` (requires presets - not yet implemented)
    - Performance tuning: `llm_max_concurrent`, `llm_timeout`, retrieval settings, optimization flags
 
+#### Concurrent Config Writes
+
+Config writes to the same bank are serialized. Validation and persistence run as
+one unit: the write locks the bank row, re-checks the update against the
+overrides actually committed at that moment, and only then merges it. Two
+requests can therefore never combine into a configuration that neither of them
+validated — for example one raising `retain_chunk_size` while the other removes
+the retain strategy that made the larger size legal.
+
+There is no conflict status to handle and no retry to implement. A request that
+loses the race is rejected with the same `400` validation error it would have
+received had the two updates arrived one after the other; a request whose fields
+are still valid against the newer state succeeds. Fields that no constraint spans
+are merged independently, so unrelated concurrent updates all survive.
+
 #### Enabling the API
 
 | Variable | Description | Default |

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -2283,6 +2283,21 @@ Configuration fields are categorized for security:
    - Provider/Model selection: `llm_provider`, `llm_model` (requires presets - not yet implemented)
    - Performance tuning: `llm_max_concurrent`, `llm_timeout`, retrieval settings, optimization flags
 
+#### Concurrent Config Writes
+
+Config writes to the same bank are serialized. Validation and persistence run as
+one unit: the write locks the bank row, re-checks the update against the
+overrides actually committed at that moment, and only then merges it. Two
+requests can therefore never combine into a configuration that neither of them
+validated — for example one raising `retain_chunk_size` while the other removes
+the retain strategy that made the larger size legal.
+
+There is no conflict status to handle and no retry to implement. A request that
+loses the race is rejected with the same `400` validation error it would have
+received had the two updates arrived one after the other; a request whose fields
+are still valid against the newer state succeeds. Fields that no constraint spans
+are merged independently, so unrelated concurrent updates all survive.
+
 #### Enabling the API
 
 | Variable | Description | Default |


### PR DESCRIPTION
Closes #3037.

## The problem is real, and reachable through the public API

`validate_bank_config_updates()` loaded the current overrides on one connection and `_persist_bank_config()` merged the update on another, with nothing in between. Two requests could each validate against the same old state and both commit a union neither had validated.

Reproduced end to end before writing any fix (barrier, no sleeps):

- start: `retain_chunk_size=3000`, `retain_strategies={"s": {"retain_chunk_size": 1000}}`
- request A sets `retain_chunk_size=100000` — valid, because strategy `s` pins its own chunk size
- request B sets `retain_strategies={"s": {"retain_extraction_mode": "detailed"}}` — valid against the old base of 3000

Both succeeded, and `retain_batch_async(..., strategy="s")` on that bank then raised `retain_max_completion_tokens (64000) must be greater than retain_chunk_size (100000)`. Applied **sequentially**, the second update is correctly rejected — the interleaving is what defeated the check.

## The fix

Persistence opens a transaction, takes `SELECT … FOR UPDATE` on the bank row, re-validates the update against the overrides actually committed at that moment, and only then merges. Writers to one bank serialize on that row.

Design choices worth reviewing:

- **Pessimistic lock, not an optimistic revision.** An optimistic retry would have to re-run validation, and validation calls the tenant permission hook, which may reserve quota or make a time-sensitive decision. The issue requires those hooks fire exactly once — here they run once, before the transaction opens. `ValidatedBankConfigUpdate` carries the already-resolved global+tenant base into the locked path so nothing is re-resolved under the lock.
- **No 409, no retry.** The loser of a race gets the same `400` it would have got had the two updates arrived in order. Documented in `configuration.md`.
- **Only cross-field-constrained updates re-check.** An update touching none of `retain_chunk_size` / `retain_structured_chunk_size` / `retain_strategies` / `recall_budget_min` / `recall_budget_max` cannot change either side of any constraint, so it merges as before and independent concurrent field writes both survive.
- **Missing-bank default-template projection is preserved** — and strengthened: the template is applied to the row before persistence runs, so the re-check validates against the real committed state rather than a projection.

`update_bank`'s `except ValueError → 404` is narrowed to `BankConfigPersistenceConflictError`, so a genuine write-time validation failure stays a 400 instead of being reported as "bank not found".

## Also fixed: a hole locking alone would not close

`recall_budget_min <= recall_budget_max` was only checked when both bounds arrived in the same update. Sequentially setting `recall_budget_max=100` and then `recall_budget_min=500` was accepted, no concurrency needed. Both bounds are now validated against the projected final configuration.

## Tests

`tests/test_bank_config_atomicity.py` — barrier-forced interleavings for both constraint families, a test that unconstrained concurrent writes still both land, and a hook-count test asserting each tenant hook fires exactly once across validate + persist. The three behavioral tests were confirmed to fail on the unfixed code and pass on the fix.

The same three scenarios run against Oracle 23ai via `TestBankConfigAtomicity` in `test_oracle_integration.py` (sharing the helpers, so both dialects run identical interleavings). Adding the `oracle-tests` label so that job runs.