### PR TITLE
fix(knowledge-pages): scope initiative pages by related page id

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2429,6 +2429,14 @@ class CreatePageRequest(BaseModel):
 
     name: str
     source_query: str
+    page_id: str | None = Field(
+        default=None,
+        pattern=r"^kp-[0-9a-f]{32}$",
+        description=(
+            "Optional globally unique caller-supplied page id. Supported clients use this to bind "
+            "page-scoped tags atomically."
+        ),
+    )
     parent_id: str | None = None
     tags: list[str] | None = None
     max_tokens: int | None = None
@@ -5755,6 +5763,7 @@ def _register_routes(app: FastAPI):
                 source_query=body.source_query,
                 content="Generating content...",
                 parent_id=body.parent_id,
+                page_id=body.page_id,
                 tags=body.tags if body.tags else None,
                 max_tokens=body.max_tokens,
                 # Only what the client actually set: the engine merges these over the

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -14308,6 +14308,7 @@ class MemoryEngine(MemoryEngineInterface):
         content: str,
         *,
         parent_id: str | None = None,
+        page_id: str | None = None,
         tags: list[str] | None = None,
         max_tokens: int | None = None,
         trigger: dict[str, Any] | None = None,
@@ -14341,7 +14342,7 @@ class MemoryEngine(MemoryEngineInterface):
         effective_max_tokens = max_tokens if max_tokens is not None else self.KNOWLEDGE_PAGE_DEFAULT_MAX_TOKENS
         effective_trigger = self._merge_page_trigger(trigger)
         backend = await self._get_backend()
-        page_id = f"kp-{uuid.uuid4().hex}"
+        page_id = page_id or f"kp-{uuid.uuid4().hex}"
         try:
             async with acquire_with_retry(backend) as conn:
                 # The page row and its backing model have one lifecycle, so they
@@ -14376,7 +14377,7 @@ class MemoryEngine(MemoryEngineInterface):
                         managed,
                     )
         except asyncpg.UniqueViolationError as exc:
-            if getattr(exc, "constraint_name", None) != "uq_kp_folder_pagename":
+            if getattr(exc, "constraint_name", None) not in {"uq_kp_folder_pagename", "pk_knowledge_pages"}:
                 raise
             # The transaction already rolled the MM back; preserve the existing
             # API contract that a duplicate page is surfaced as HTTP 409.

--- a/hindsight-api-slim/tests/test_knowledge_base.py
+++ b/hindsight-api-slim/tests/test_knowledge_base.py
@@ -633,6 +633,32 @@ class TestCreate:
         assert await memory.get_mental_model(bank_id, rolled_back_mm_id, request_context=request_context) is None
         await memory.delete_bank(bank_id, request_context=request_context)
 
+    async def test_client_supplied_page_id_is_persisted_and_unique(self, memory: MemoryEngine, request_context):
+        bank_id = f"test-kb-create-{uuid.uuid4().hex[:8]}"
+        page_id = f"kp-{uuid.uuid4().hex}"
+        page = await memory.create_knowledge_page(
+            bank_id,
+            "Client id",
+            "What uses the client id?",
+            "seed",
+            page_id=page_id,
+            tags=["knowledge:feature-work", f"relatedPageId:{page_id}"],
+            request_context=request_context,
+        )
+        assert page["id"] == page_id
+        assert page["tags"] == ["knowledge:feature-work", f"relatedPageId:{page_id}"]
+
+        duplicate = await memory.create_knowledge_page(
+            bank_id,
+            "Another name",
+            "What should conflict?",
+            "seed",
+            page_id=page_id,
+            request_context=request_context,
+        )
+        assert duplicate is None
+        await memory.delete_bank(bank_id, request_context=request_context)
+
     async def test_duplicate_mental_model_id_is_not_reported_as_duplicate_page(
         self, memory: MemoryEngine, request_context
     ):

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -5926,6 +5926,7 @@ components:
       description: Create a page (a mental model + tree node) under an optional parent
         folder.
       example:
+        page_id: page_id
         source_query: source_query
         max_tokens: 0
         parent_id: parent_id
@@ -5966,6 +5967,10 @@ components:
           type: string
         source_query:
           title: Source Query
+          type: string
+        page_id:
+          nullable: true
+          pattern: "^kp-[0-9a-f]{32}$"
           type: string
         parent_id:
           nullable: true

--- a/hindsight-clients/go/go.mod
+++ b/hindsight-clients/go/go.mod
@@ -2,6 +2,6 @@ module github.com/vectorize-io/hindsight/hindsight-clients/go
 
 go 1.18
 
-require github.com/stretchr/testify v1.12.0
+require github.com/stretchr/testify v1.12.1
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require go.yaml.in/yaml/v3 v3.0.5 // indirect

--- a/hindsight-clients/go/go.sum
+++ b/hindsight-clients/go/go.sum
@@ -1,6 +1,4 @@
-github.com/stretchr/testify v1.12.0 h1:K6Mr6jO9JICuend/5xzTM03ydSV3vdNRYAdPSukj8uI=
-github.com/stretchr/testify v1.12.0/go.mod h1:bOYBZb5qJ00vPzWfIqBUZPaxK8jWiXc6d3ErP4Ca9Gw=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
+github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
+go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
+go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=

--- a/hindsight-clients/go/model_create_page_request.go
+++ b/hindsight-clients/go/model_create_page_request.go
@@ -23,6 +23,7 @@ var _ MappedNullable = &CreatePageRequest{}
 type CreatePageRequest struct {
 	Name string `json:"name"`
 	SourceQuery string `json:"source_query"`
+	PageId NullableString `json:"page_id,omitempty" validate:"regexp=^kp-[0-9a-f]{32}$"`
 	ParentId NullableString `json:"parent_id,omitempty"`
 	Tags []string `json:"tags,omitempty"`
 	MaxTokens NullableInt32 `json:"max_tokens,omitempty"`
@@ -96,6 +97,48 @@ func (o *CreatePageRequest) GetSourceQueryOk() (*string, bool) {
 // SetSourceQuery sets field value
 func (o *CreatePageRequest) SetSourceQuery(v string) {
 	o.SourceQuery = v
+}
+
+// GetPageId returns the PageId field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *CreatePageRequest) GetPageId() string {
+	if o == nil || IsNil(o.PageId.Get()) {
+		var ret string
+		return ret
+	}
+	return *o.PageId.Get()
+}
+
+// GetPageIdOk returns a tuple with the PageId field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *CreatePageRequest) GetPageIdOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.PageId.Get(), o.PageId.IsSet()
+}
+
+// HasPageId returns a boolean if a field has been set.
+func (o *CreatePageRequest) HasPageId() bool {
+	if o != nil && o.PageId.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetPageId gets a reference to the given NullableString and assigns it to the PageId field.
+func (o *CreatePageRequest) SetPageId(v string) {
+	o.PageId.Set(&v)
+}
+// SetPageIdNil sets the value for PageId to be an explicit nil
+func (o *CreatePageRequest) SetPageIdNil() {
+	o.PageId.Set(nil)
+}
+
+// UnsetPageId ensures that no value is present for PageId, not even an explicit nil
+func (o *CreatePageRequest) UnsetPageId() {
+	o.PageId.Unset()
 }
 
 // GetParentId returns the ParentId field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -269,6 +312,9 @@ func (o CreatePageRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name
 	toSerialize["source_query"] = o.SourceQuery
+	if o.PageId.IsSet() {
+		toSerialize["page_id"] = o.PageId.Get()
+	}
 	if o.ParentId.IsSet() {
 		toSerialize["parent_id"] = o.ParentId.Get()
 	}

--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -1458,6 +1458,7 @@ class Hindsight:
         tags: list[str] | None = None,
         max_tokens: int | None = None,
         trigger: dict[str, Any] | None = None,
+        page_id: str | None = None,
     ):
         """
         Create a knowledge-base page (sync wrapper — use
@@ -1477,6 +1478,7 @@ class Hindsight:
             trigger: Optional trigger settings. Omit to use the page defaults
                 (observation-only, delta mode, refresh after consolidation); a
                 supplied trigger replaces those defaults rather than merging.
+            page_id: Optional globally unique caller-supplied page ID.
 
         Returns:
             CreateKnowledgePageResponse with page_id, mental_model_id and operation_id
@@ -1490,6 +1492,7 @@ class Hindsight:
         request_obj = create_page_request.CreatePageRequest(
             name=name,
             source_query=source_query,
+            page_id=page_id,
             parent_id=parent_id,
             tags=tags,
             max_tokens=max_tokens,

--- a/hindsight-clients/python/hindsight_client_api/models/create_page_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/create_page_request.py
@@ -17,8 +17,9 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictInt, StrictStr
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
+from typing_extensions import Annotated
 from hindsight_client_api.models.mental_model_trigger_input import MentalModelTriggerInput
 from typing import Optional, Set
 from typing_extensions import Self
@@ -29,11 +30,22 @@ class CreatePageRequest(BaseModel):
     """ # noqa: E501
     name: StrictStr
     source_query: StrictStr
+    page_id: Optional[Annotated[str, Field(strict=True)]] = None
     parent_id: Optional[StrictStr] = None
     tags: Optional[List[StrictStr]] = None
     max_tokens: Optional[StrictInt] = None
     trigger: Optional[MentalModelTriggerInput] = None
-    __properties: ClassVar[List[str]] = ["name", "source_query", "parent_id", "tags", "max_tokens", "trigger"]
+    __properties: ClassVar[List[str]] = ["name", "source_query", "page_id", "parent_id", "tags", "max_tokens", "trigger"]
+
+    @field_validator('page_id')
+    def page_id_validate_regular_expression(cls, value):
+        """Validates the regular expression"""
+        if value is None:
+            return value
+
+        if not re.match(r"^kp-[0-9a-f]{32}$", value):
+            raise ValueError(r"must validate the regular expression /^kp-[0-9a-f]{32}$/")
+        return value
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -77,6 +89,11 @@ class CreatePageRequest(BaseModel):
         # override the default output from pydantic by calling `to_dict()` of trigger
         if self.trigger:
             _dict['trigger'] = self.trigger.to_dict()
+        # set to None if page_id (nullable) is None
+        # and model_fields_set contains the field
+        if self.page_id is None and "page_id" in self.model_fields_set:
+            _dict['page_id'] = None
+
         # set to None if parent_id (nullable) is None
         # and model_fields_set contains the field
         if self.parent_id is None and "parent_id" in self.model_fields_set:
@@ -111,6 +128,7 @@ class CreatePageRequest(BaseModel):
         _obj = cls.model_validate({
             "name": obj.get("name"),
             "source_query": obj.get("source_query"),
+            "page_id": obj.get("page_id"),
             "parent_id": obj.get("parent_id"),
             "tags": obj.get("tags"),
             "max_tokens": obj.get("max_tokens"),

--- a/hindsight-clients/python/tests/test_knowledge_base_mapping.py
+++ b/hindsight-clients/python/tests/test_knowledge_base_mapping.py
@@ -30,6 +30,7 @@ def test_create_page_maps_every_option(monkeypatch):
         "bank-1",
         name="Deploying the API",
         source_query="How is the API deployed?",
+        page_id="kp-0123456789abcdef0123456789abcdef",
         parent_id="kf-1",
         tags=["ops", "type:runbook"],
         max_tokens=8192,
@@ -39,6 +40,7 @@ def test_create_page_maps_every_option(monkeypatch):
     assert bank_id == "bank-1"
     assert request.name == "Deploying the API"
     assert request.source_query == "How is the API deployed?"
+    assert request.page_id == "kp-0123456789abcdef0123456789abcdef"
     assert request.parent_id == "kf-1"
     assert request.tags == ["ops", "type:runbook"]
     assert request.max_tokens == 8192

--- a/hindsight-clients/rust/Cargo.lock
+++ b/hindsight-clients/rust/Cargo.lock
@@ -330,6 +330,7 @@ dependencies = [
  "progenitor",
  "progenitor-client",
  "regex",
+ "regress",
  "reqwest",
  "serde",
  "serde_json",

--- a/hindsight-clients/rust/Cargo.toml
+++ b/hindsight-clients/rust/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 thiserror = "1.0"
 # Progenitor client support
 progenitor-client = "0.11"
+# Regex support used by Progenitor-generated request validation
+regress = "0.10"
 # Additional types
 chrono = { version = "0.4", features = ["serde"] }
 # HTTP types

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -1384,6 +1384,12 @@ export type CreatePageRequest = {
    */
   source_query: string;
   /**
+   * Page Id
+   *
+   * Optional globally unique caller-supplied page id. Supported clients use this to bind page-scoped tags atomically.
+   */
+  page_id?: string | null;
+  /**
    * Parent Id
    */
   parent_id?: string | null;

--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -1143,6 +1143,8 @@ export class HindsightClient {
     name: string,
     sourceQuery: string,
     options?: {
+      /** Optional globally unique caller-supplied page ID. */
+      pageId?: string;
       parentId?: string | null;
       /** Scopes which memories the page is built from. A `type:<x>` tag also sets the page's rendered type. */
       tags?: string[];
@@ -1169,6 +1171,7 @@ export class HindsightClient {
       body: {
         name,
         source_query: sourceQuery,
+        page_id: options?.pageId,
         parent_id: options?.parentId,
         tags: options?.tags,
         max_tokens: options?.maxTokens,

--- a/hindsight-clients/typescript/tests/knowledge_base_mapping.test.ts
+++ b/hindsight-clients/typescript/tests/knowledge_base_mapping.test.ts
@@ -35,6 +35,7 @@ describe("createKnowledgePage mapping", () => {
 
   test("maps name, source query, parent and tags", async () => {
     await client.createKnowledgePage("bank", "Deploying the API", "How is the API deployed?", {
+      pageId: "kp-0123456789abcdef0123456789abcdef",
       parentId: "kf-1",
       tags: ["ops", "type:runbook"],
       maxTokens: 8192,
@@ -43,6 +44,7 @@ describe("createKnowledgePage mapping", () => {
     const body = mockedCreatePage.mock.calls[0][0].body as any;
     expect(body.name).toBe("Deploying the API");
     expect(body.source_query).toBe("How is the API deployed?");
+    expect(body.page_id).toBe("kp-0123456789abcdef0123456789abcdef");
     expect(body.parent_id).toBe("kf-1");
     expect(body.tags).toEqual(["ops", "type:runbook"]);
     expect(body.max_tokens).toBe(8192);

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -9068,6 +9068,19 @@
             "type": "string",
             "title": "Source Query"
           },
+          "page_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^kp-[0-9a-f]{32}$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Page Id",
+            "description": "Optional globally unique caller-supplied page id. Supported clients use this to bind page-scoped tags atomically."
+          },
           "parent_id": {
             "anyOf": [
               {

--- a/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
@@ -506,6 +506,41 @@ describe("HindsightClient.captureInitiative", () => {
     expect(marker.tags).toEqual(["knowledge:feature-work", "relatedPageId:kp-server"]);
   });
 
+  it("repairs missing relatedPageId tags under the Initiatives folder", async () => {
+    const calls: any[] = [];
+    stubFetchRouted(calls, [
+      {
+        match: (m, u) => m === "GET" && u.endsWith("/knowledge-base/tree"),
+        json: {
+          roots: [
+            {
+              id: "folder",
+              kind: "folder",
+              name: "Initiatives",
+              children: [
+                { id: "kp-old", kind: "page", name: "Old", tags: ["knowledge:feature-work"] },
+                {
+                  id: "kp-scoped",
+                  kind: "page",
+                  name: "Scoped",
+                  tags: ["knowledge:feature-work", "relatedPageId:kp-scoped"],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+    const c = new HindsightClient({ apiUrl: "http://x", bank: "repo-a" });
+    await c.seedPages();
+    const patches = calls.filter((k) => k.method === "PATCH");
+    expect(patches).toHaveLength(1);
+    expect(patches[0].url).toContain("/knowledge-base/nodes/kp-old");
+    expect(patches[0].body).toEqual({
+      tags: ["knowledge:feature-work", "relatedPageId:kp-old"],
+    });
+  });
+
   it("enhancement (relatesToPageId): NO page POST; marker tagged the existing page id", async () => {
     const calls: any[] = [];
     stubFetchRouted(calls, [

--- a/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
@@ -411,51 +411,52 @@ describe("HindsightClient.ensureFolder", () => {
 describe("HindsightClient.captureInitiative", () => {
   it("new initiative: POSTs a per-initiative page + a marker retain sharing the same relatedPageId", async () => {
     const calls: any[] = [];
-    stubFetchRouted(calls, [
-      { match: (m, u) => m === "GET" && u.endsWith("/knowledge-base/tree"), json: { roots: [] } },
-      {
-        match: (m, u) => m === "POST" && u.endsWith("/knowledge-base/folders"),
-        json: { id: "folder-abc" },
-      },
-      {
-        match: (m, u) => m === "POST" && u.endsWith("/knowledge-base/pages"),
-        json: { page_id: "pg" },
-      },
-      {
-        match: (m, u) => m === "POST" && u.endsWith("/memories"),
-        json: { operation_id: "op-1" },
-      },
-    ]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: any) => {
+        const body = init?.body ? JSON.parse(init.body) : undefined;
+        calls.push({ url, method: init?.method, body });
+        if (init?.method === "GET" && url.endsWith("/version"))
+          return { ok: true, status: 200, json: async () => ({ api_version: "0.9.2" }) } as any;
+        if (init?.method === "GET" && url.endsWith("/knowledge-base/tree"))
+          return { ok: true, status: 200, json: async () => ({ roots: [] }) } as any;
+        if (init?.method === "POST" && url.endsWith("/knowledge-base/folders"))
+          return { ok: true, status: 200, json: async () => ({ id: "folder-abc" }) } as any;
+        if (init?.method === "POST" && url.endsWith("/knowledge-base/pages"))
+          return { ok: true, status: 200, json: async () => ({ page_id: body.page_id }) } as any;
+        return { ok: true, status: 200, json: async () => ({ operation_id: "op-1" }) } as any;
+      }) as any
+    );
     const c = new HindsightClient({ apiUrl: "http://x", bank: "repo-a" });
     const result = await c.captureInitiative({
       title: "Retry backoff for the uploader",
       summary: "Add exponential backoff so transient upload failures retry.",
     });
 
-    // The returned id is the SERVER-ASSIGNED page id ("pg" from the mock), NOT the derived slug —
-    // the /knowledge-base/pages endpoint mints its own id.
-    expect(result).toEqual({ page_id: "pg" });
-
-    // Page POST: name = title, nested under the Initiatives folder. The page itself carries NO
-    // tags field at all (no tag taxonomy to maintain).
+    // Page POST: the client supplies the id and binds the page to its own scope atomically.
     const pagePost = calls.find(
       (k) => k.method === "POST" && k.url.endsWith("/knowledge-base/pages")
     );
     expect(pagePost).toBeDefined();
     expect(pagePost.body.name).toBe("Retry backoff for the uploader");
     expect(pagePost.body.parent_id).toBe("folder-abc");
-    expect(pagePost.body.tags).toEqual(["knowledge:feature-work"]);
+    expect(pagePost.body.page_id).toMatch(/^kp-[0-9a-f]{32}$/);
+    expect(pagePost.body.tags).toEqual([
+      "knowledge:feature-work",
+      `relatedPageId:${pagePost.body.page_id}`,
+    ]);
+    // The client-generated id is echoed by the server and becomes the page/marker binding key.
+    expect(result).toEqual({ page_id: pagePost.body.page_id });
 
-    // Marker retain POST to /memories: the ONLY tag is relatedPageId, pointing at the REAL
-    // server-assigned page id ("pg").
+    // Marker retain POST to /memories points at the same client/server page id.
     const memPost = calls.find((k) => k.method === "POST" && k.url.endsWith("/memories"));
     expect(memPost).toBeDefined();
     const item = memPost.body.items[0];
-    expect(item.tags).toEqual(["knowledge:feature-work", "relatedPageId:pg"]);
+    expect(item.tags).toEqual(["knowledge:feature-work", `relatedPageId:${result.page_id}`]);
     expect(item.strategy).toBe("document");
     expect(memPost.body.async).toBe(true);
     // Unique per-marker document id (NOT the page id) so repeated captures accrue.
-    expect(item.document_id).not.toBe("pg");
+    expect(item.document_id).not.toBe(result.page_id);
     expect(item.document_id).toContain("initiative-marker-retry-backoff-for-the-uploader-");
 
     // The returned page id and the marker tag's id must be identical (the real page node id).
@@ -463,6 +464,46 @@ describe("HindsightClient.captureInitiative", () => {
       .find((t: string) => t.startsWith("relatedPageId:"))
       .slice("relatedPageId:".length);
     expect(tagId).toBe(result.page_id);
+  });
+
+  it("old server: adopts the returned page id and repairs its scope without sending page_id", async () => {
+    const calls: any[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: any) => {
+        const body = init?.body ? JSON.parse(init.body) : undefined;
+        calls.push({ url, method: init?.method, body });
+        if (init?.method === "GET" && url.endsWith("/version"))
+          return { ok: true, status: 200, json: async () => ({ api_version: "0.9.1" }) } as any;
+        if (init?.method === "GET" && url.endsWith("/knowledge-base/tree"))
+          return { ok: true, status: 200, json: async () => ({ roots: [] }) } as any;
+        if (init?.method === "POST" && url.endsWith("/knowledge-base/folders"))
+          return { ok: true, status: 200, json: async () => ({ id: "folder-abc" }) } as any;
+        if (init?.method === "POST" && url.endsWith("/knowledge-base/pages"))
+          return { ok: true, status: 200, json: async () => ({ page_id: "kp-server" }) } as any;
+        return { ok: true, status: 200, json: async () => ({ operation_id: "op-1" }) } as any;
+      }) as any
+    );
+
+    const c = new HindsightClient({ apiUrl: "http://x", bank: "repo-a" });
+    const result = await c.captureInitiative({
+      title: "Legacy-compatible initiative",
+      summary: "Use the server-assigned page id on old deployments.",
+    });
+
+    const pagePost = calls.find(
+      (call) => call.method === "POST" && call.url.endsWith("/knowledge-base/pages")
+    );
+    expect(pagePost.body).not.toHaveProperty("page_id");
+    expect(pagePost.body.tags).toEqual(["knowledge:feature-work"]);
+    expect(result).toEqual({ page_id: "kp-server" });
+
+    const pagePatch = calls.find(
+      (call) => call.method === "PATCH" && call.url.endsWith("/knowledge-base/nodes/kp-server")
+    );
+    expect(pagePatch.body.tags).toEqual(["knowledge:feature-work", "relatedPageId:kp-server"]);
+    const marker = calls.find((call) => call.url.endsWith("/memories")).body.items[0];
+    expect(marker.tags).toEqual(["knowledge:feature-work", "relatedPageId:kp-server"]);
   });
 
   it("enhancement (relatesToPageId): NO page POST; marker tagged the existing page id", async () => {

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -24,6 +24,7 @@ export interface KnowledgeNode {
   name: string;
   /** The page's source query (OKF `description`) — what a re-sync compares against. */
   description?: string;
+  tags?: string[];
   children?: KnowledgeNode[];
 }
 
@@ -661,10 +662,39 @@ export class HindsightClient {
         updated++;
       }
     }
+    await this.repairInitiativePageTags(roots);
     this.log(
       `[bank] knowledge pages seeded on ${this.bank}: ${created} created, ${updated} re-synced, ` +
         `${pages.length - created - updated} unchanged`
     );
+  }
+
+  /** Repair the scope tag on initiative pages created before page ids were client-assigned. */
+  private async repairInitiativePageTags(roots: KnowledgeNode[]): Promise<number> {
+    const folder = roots.find(
+      (node) => node.kind === "folder" && node.name.toLowerCase() === "initiatives"
+    );
+    if (!folder) return 0;
+    let repaired = 0;
+    const walk = async (nodes: KnowledgeNode[]): Promise<void> => {
+      for (const node of nodes) {
+        if (node.kind === "page") {
+          const scopeTag = `relatedPageId:${node.id}`;
+          if (!(node.tags ?? []).includes(scopeTag)) {
+            await this.req(
+              "PATCH",
+              this.bankUrl(`/knowledge-base/nodes/${encodeURIComponent(node.id)}`),
+              { tags: [...new Set([...(node.tags ?? []), scopeTag])] }
+            );
+            repaired++;
+          }
+        }
+        if (node.children?.length) await walk(node.children);
+      }
+    };
+    await walk(folder.children ?? []);
+    if (repaired) this.log(`[bank] repaired ${repaired} initiative page scope tag(s)`);
+    return repaired;
   }
 
   /** URL/id-safe slug: lowercase, non-alphanumerics → "-", trim dashes, cap length; fallback "initiative". */

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -13,6 +13,7 @@ import {
   pagesFor,
   type PageTrigger,
 } from "./missions";
+import { randomUUID } from "node:crypto";
 import { pool, semverGte, sleep } from "./util";
 import type { RetainStamp } from "./retain-stamp";
 
@@ -83,6 +84,10 @@ export interface RetainOpts {
  *  Below it the field is silently ignored — unknown request fields are not rejected — so an append
  *  could be applied twice without us ever knowing. Hence: no idempotency, no append. */
 export const MIN_IDEMPOTENT_RETAIN_VERSION = "0.8.6";
+
+/** First server release that honours a caller-supplied knowledge-page id. Older Pydantic
+ *  request models silently discard the field, so capability must be established before write. */
+export const MIN_CLIENT_ASSIGNED_PAGE_ID_VERSION = "0.9.2";
 
 /**
  * Raised when the API rate-limits a request (HTTP 429), carrying how long it asked us to wait.
@@ -156,6 +161,8 @@ export class HindsightClient {
   knowledgePagesSupported: boolean | undefined;
   /** Tri-state capability probe: unknown until the first append-mode retain, then cached. */
   private idempotentRetain: boolean | undefined;
+  /** Tri-state capability probe: unknown until the first initiative page create, then cached. */
+  private clientAssignedPageIds: boolean | undefined;
   private readonly log: (msg: string) => void;
   readonly maxParallelRetains: number;
   readonly observationScopes: ObservationScopes;
@@ -306,6 +313,28 @@ export class HindsightClient {
       if (!r.ok) return false;
       const j = (await r.json()) as { api_version?: string };
       return semverGte(j.api_version, MIN_IDEMPOTENT_RETAIN_VERSION);
+    } catch {
+      return false;
+    }
+  }
+
+  /** Whether the server honours `page_id` when creating a knowledge page. */
+  async supportsClientAssignedPageIds(): Promise<boolean> {
+    if (this.clientAssignedPageIds === undefined) {
+      this.clientAssignedPageIds = await this.probeClientAssignedPageIds();
+      this.log(
+        `server client-assigned page ids: ${this.clientAssignedPageIds ? "supported" : "unavailable"}`
+      );
+    }
+    return this.clientAssignedPageIds;
+  }
+
+  private async probeClientAssignedPageIds(): Promise<boolean> {
+    try {
+      const r = await this.req("GET", `${this.apiUrl}/version`);
+      if (!r.ok) return false;
+      const j = (await r.json()) as { api_version?: string };
+      return semverGte(j.api_version, MIN_CLIENT_ASSIGNED_PAGE_ID_VERSION);
     } catch {
       return false;
     }
@@ -663,27 +692,46 @@ export class HindsightClient {
      *  carry its own hardcoded copy of this trigger. */
     pageTrigger?: PageTrigger;
   }): Promise<{ page_id: string }> {
-    // `/knowledge-base/pages` mints its OWN page id (kp-…); we can't set it. So for a new initiative
-    // we create the page first and adopt the server-assigned id — that id is what the return value
-    // and the marker's `relatedPageId` tag must use, or `read_knowledge_page(id)` 404s and the
-    // `[[page:<id>]]` link points at nothing.
     let pageId = args.relatesToPageId;
     if (!pageId) {
+      const clientAssignedPageId = await this.supportsClientAssignedPageIds();
+      const requestedPageId = clientAssignedPageId
+        ? `kp-${randomUUID().replaceAll("-", "")}`
+        : undefined;
       const folderId = await this.ensureFolder("Initiatives");
       const r = await this.req("POST", this.bankUrl("/knowledge-base/pages"), {
+        ...(requestedPageId ? { page_id: requestedPageId } : {}),
         name: args.title,
         source_query: `Summarize the "${args.title}" initiative: what is being built or changed and why, and its current state — drawn from the project's memory.`,
         parent_id: folderId,
-        tags: ["knowledge:feature-work"],
+        tags: requestedPageId
+          ? ["knowledge:feature-work", `relatedPageId:${requestedPageId}`]
+          : ["knowledge:feature-work"],
         trigger: args.pageTrigger ?? buildPageTrigger(),
       });
+      let responsePageId: string | undefined;
       try {
         const j = (await r.json()) as { page_id?: string; id?: string };
-        pageId = j.page_id ?? j.id;
+        responsePageId = j.page_id ?? j.id;
       } catch {
-        /* fall through to the slug fallback below */
+        throw new Error("knowledge page creation returned an invalid response");
       }
-      pageId ||= `initiative-${this.slugify(args.title)}`; // last resort if the response lacked an id
+      if (!responsePageId) {
+        throw new Error("knowledge page creation response did not include a page id");
+      }
+      if (requestedPageId && responsePageId !== requestedPageId) {
+        throw new Error(
+          "knowledge page id mismatch; the server does not support client-assigned page ids"
+        );
+      }
+      pageId = responsePageId;
+      if (!requestedPageId) {
+        await this.req(
+          "PATCH",
+          this.bankUrl(`/knowledge-base/nodes/${encodeURIComponent(pageId)}`),
+          { tags: ["knowledge:feature-work", `relatedPageId:${pageId}`] }
+        );
+      }
     }
     const verb = args.relatesToPageId ? "Enhancement to an existing initiative" : "New initiative";
     const content = `${verb}: ${args.title}. ${args.summary}`;

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -9068,6 +9068,19 @@
             "type": "string",
             "title": "Source Query"
           },
+          "page_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^kp-[0-9a-f]{32}$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Page Id",
+            "description": "Optional globally unique caller-supplied page id. Supported clients use this to bind page-scoped tags atomically."
+          },
           "parent_id": {
             "anyOf": [
               {


### PR DESCRIPTION
## Summary

Fixes #3641

Concrete initiative pages currently retrieve the same `knowledge:feature-work` fact pool as the overview because `relatedPageId` exists on marker memories but not on the pages that perform retrieval. This PR gives an initiative page a stable identity before creation, so that identity can be written into the page's own retrieval tags in the same create operation. It extends the knowledge-page API with an optional caller-assigned `page_id`, updates the SDKs, and keeps older clients, older servers, and existing initiative pages working.

## First principles

A concrete initiative page is intended to summarize only the memories associated with that initiative. `hindsight_capture_initiative` already writes `knowledge:feature-work` and `relatedPageId:<pageId>` onto the marker memory, but a knowledge-page refresh filters by the page's own tags with the default `all_strict` behavior. Marker tags are not inherited by the page.

| Page | Page tags used for refresh |
| --- | --- |
| Overview “Initiatives and enhancements” | `knowledge:feature-work` |
| Every concrete page under Initiatives | `knowledge:feature-work` |

All of these pages therefore retrieve from the same fact pool. A concrete page is separated only by the initiative title embedded in its `source_query`, so multiple initiatives can bleed into each other as the pool grows.

`relatedPageId` does appear in the overview page's `source_query`, but only as an instruction to render a source memory as `[[page:<id>]]`. That affects synthesis output; it is not a retrieval filter.

The required invariant is therefore:

```text
page.id = X
page.tags contains relatedPageId:X
marker.tags contains relatedPageId:X
refresh filters by page.tags
```

Before this change, the server generated `X` during page creation. The client could not know `X` while constructing the create request, so it could not atomically attach `relatedPageId:X` to the new page.

```mermaid
flowchart LR
    M1[Marker A] -->|knowledge:feature-work| P[Shared retrieval pool]
    M2[Marker B] -->|knowledge:feature-work| P
    P --> O[Initiatives overview]
    P --> A[Initiative A page]
    P --> B[Initiative B page]
```

The API change is not about exposing an arbitrary identifier knob. Its purpose is to let a caller establish the page's identity and retrieval boundary in one transaction, before the first refresh is queued.

## API design

`POST /knowledge-base/pages` now accepts an optional, validated `page_id`.

| Request | Server behavior |
| --- | --- |
| `page_id` omitted | Generate `kp-<uuid>` exactly as before |
| Valid unused `page_id` supplied | Create the page with that id |
| Existing id supplied again | Return the existing duplicate-page conflict |

The accepted form is `kp-<32 lowercase hex characters>`, matching the UUID form the server already generates. Caller-supplied ids use the same global resource-id namespace and must be freshly generated rather than copied from an existing page. The database primary key remains the final collision guard and returns `409` for a theoretical UUID collision or an invalid reuse. The page row and its backing mental model remain in one transaction, and the initial refresh is still queued only after creation succeeds.

```mermaid
sequenceDiagram
    participant C as Coding Agent
    participant A as Knowledge Page API
    participant D as Database
    participant R as Refresh Queue
    C->>C: Generate page id X
    C->>A: POST page_id=X, tags=[feature-work, relatedPageId:X]
    A->>D: Insert page and backing model in one transaction
    D-->>A: Created page X
    A->>R: Queue first refresh
    A-->>C: Return page_id=X
    C->>A: Retain marker tagged relatedPageId:X
```

## Compatibility

Compatibility is handled at four boundaries rather than requiring a coordinated server and plugin upgrade.

### Existing API clients

`page_id` is optional. Clients that do not send it keep the previous server-generated-id behavior with no request or response change.

### Coding Agent against an older server

Older Pydantic request models silently ignore unknown fields. Sending `page_id` and detecting support only after creation would be unsafe: the old server would create a different page id, while the submitted tag would point at an id that does not exist.

The plugin probes `/version` once and caches the result:

```mermaid
flowchart TD
    A[Create initiative] --> B{Server >= 0.9.2?}
    B -->|Yes| C[Generate X]
    C --> D[POST page_id X and relatedPageId:X]
    D --> E[Atomic scoped page]
    B -->|No| F[POST without page_id]
    F --> G[Adopt returned id Y]
    G --> H[PATCH page tags with relatedPageId:Y]
    H --> I[Retain marker with relatedPageId:Y]
    E --> J[Retain marker with relatedPageId:X]
```

| Server | Create behavior | Result |
| --- | --- | --- |
| `>= 0.9.2` | Client assigns the id and sends the final tags | Identity and scope are atomic before first refresh |
| `< 0.9.2` | Client omits the unsupported field, adopts the returned id, then patches tags | No ignored field, mismatched id, orphan page, or dangling marker |

The old-server path preserves operation on existing deployments. It cannot make the create and tag update atomic because the old API has no way to express that, but it converges immediately to the correct scope.

### Existing initiative pages

Pages created before this API existed may still have only `knowledge:feature-work`. The existing `deepen -> configureBank -> seedPages` path already reads the knowledge-page tree, so it now reuses that response to repair legacy pages:

```mermaid
flowchart LR
    T[Existing tree] --> I[Find Initiatives folder]
    I --> W[Walk descendant pages]
    W --> Q{Has relatedPageId:<page.id>?}
    Q -->|Yes| S[No request]
    Q -->|No| P[PATCH tags only]
```

This repair is independent of the `0.9.2` capability check. Any server that supports the knowledge-page tree and node PATCH APIs can repair stored pages. It preserves existing tags, does not rewrite content, does not migrate marker memories, and does not trigger an immediate full refresh.

### SDK users

The OpenAPI schema and all four generated SDK models include `page_id`. The maintained Python and TypeScript wrappers also expose and forward it, preventing the wrapper layer from silently dropping a valid request field.

| Client surface | Change |
| --- | --- |
| Rust generated client | Supports the validated field; adds the generated validator's `regress` runtime dependency |
| Python generated model | Adds optional validated `page_id` |
| TypeScript generated model | Adds optional `page_id` |
| Go generated model | Adds optional validated `PageId` |
| Python maintained wrapper | Exposes and forwards `page_id` |
| TypeScript maintained wrapper | Exposes `pageId` and forwards `page_id` |

Native MCP and CLI signatures remain unchanged because callers that do not need preassigned identity should continue using server-generated ids.

## Resulting retrieval model

```mermaid
flowchart LR
    MA[Marker A<br/>relatedPageId:A] --> PA[Initiative A page<br/>relatedPageId:A]
    MB[Marker B<br/>relatedPageId:B] --> PB[Initiative B page<br/>relatedPageId:B]
    MA --> O[Overview<br/>knowledge:feature-work]
    MB --> O
```

The overview intentionally retains the broad `knowledge:feature-work` scope. Each concrete initiative page gains tag-level isolation by its own id.

## Verification

| Check | Result |
| --- | --- |
| Coding Agent page tests | 34 passed |
| Python wrapper mapping | 8 passed |
| TypeScript wrapper mapping | 10 passed |
| Alembic DAG and migration shape | 200 passed, 99 skipped |
| Repository lint | Passed |
| Generated artifacts | OpenAPI, bank-template schema, four SDKs, and docs skill reference regenerated |
| Go client metadata | `go.mod` and `go.sum` refreshed by the generator |