### PR TITLE
feat(control-plane): show per-model staleness, and say it the same way everywhere

### DIFF
--- a/hindsight-control-plane/src/components/bank-stats-view.tsx
+++ b/hindsight-control-plane/src/components/bank-stats-view.tsx
@@ -709,6 +709,9 @@ function FailedConsolidationsDialog({
 
 function MentalModelsCard({ models }: { models: MentalModelSummary[] }) {
   const t = useTranslations("bankStats");
+  // The counts use the shared staleness vocabulary so the tile, the tree and the
+  // model dialog all say the same word for the same boolean.
+  const ts = useTranslations("staleness");
   const total = models.length;
   // `is_stale` is the API's per-model answer, evaluated against that model's own
   // tags and fact types — the same check that decides whether a scheduled refresh
@@ -717,8 +720,8 @@ function MentalModelsCard({ models }: { models: MentalModelSummary[] }) {
   // that had not read the newest memory in the bank even when that memory was
   // nowhere near its scope, and stayed that way for as long as the model's own
   // scope was quiet.
-  const needsRefresh = models.filter((m) => m.is_stale).length;
-  const upToDate = total - needsRefresh;
+  const stale = models.filter((m) => m.is_stale).length;
+  const inSync = total - stale;
 
   return (
     <Card>
@@ -733,28 +736,28 @@ function MentalModelsCard({ models }: { models: MentalModelSummary[] }) {
           <div className="text-sm text-muted-foreground py-4">{t("noMentalModels")}</div>
         ) : (
           <>
-            <ProgressRow done={upToDate} total={total} doneColor={CHART_COLORS.success} />
+            <ProgressRow done={inSync} total={total} doneColor={CHART_COLORS.success} />
             <div className="grid grid-cols-3 gap-3 pt-1">
               <div className="space-y-0.5">
                 <div className="flex items-center gap-1.5">
                   <CheckCircle2 className="w-3 h-3 text-emerald-500" />
                   <span className="text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
-                    {t("upToDate")}
+                    {ts("inSync")}
                   </span>
                 </div>
                 <span className="text-base font-semibold tabular-nums text-foreground block">
-                  {upToDate}
+                  {inSync}
                 </span>
               </div>
               <div className="space-y-0.5">
                 <div className="flex items-center gap-1.5">
                   <AlertCircle className="w-3 h-3 text-amber-500" />
                   <span className="text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
-                    {t("needsRefresh")}
+                    {ts("stale")}
                   </span>
                 </div>
                 <span className="text-base font-semibold tabular-nums text-foreground block">
-                  {needsRefresh}
+                  {stale}
                 </span>
               </div>
               <div className="space-y-0.5">

--- a/hindsight-control-plane/src/components/freshness-line.tsx
+++ b/hindsight-control-plane/src/components/freshness-line.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { formatAbsoluteDateTime, formatRelativeTime, formatWatermark } from "@/lib/relative-time";
+import { cn } from "@/lib/utils";
+import { NextRefresh } from "./next-refresh";
+import { StalenessBadge } from "./staleness-badge";
+
+type TriggerLike = {
+  refresh_after_consolidation?: boolean;
+  refresh_cron?: string | null;
+  fact_types?: string[];
+};
+
+function Sep() {
+  return (
+    <span aria-hidden className="text-muted-foreground/40">
+      ·
+    </span>
+  );
+}
+
+/**
+ * A model's freshness as one quiet line, rather than a row of competing pills.
+ *
+ * This replaced a header that carried five separate bordered chips — status,
+ * refreshed-at, memories-read-to, scope and next-refresh — which wrapped onto two
+ * rows, used three different chip styles, and gave the least important fact (the
+ * next scheduled run, in blue) the loudest treatment. Everything here is one size
+ * and one colour except the status dot, so the eye lands on the status first and
+ * the supporting detail reads as a sentence.
+ *
+ * `read to` is shown whenever the model has a watermark, and omitted only when it
+ * genuinely has none — a model no refresh has stamped yet. An earlier revision also
+ * hid it when it matched `refreshed`, to avoid saying the same thing twice, but that
+ * made an absent clause mean two different things ("same as the refresh" or "never
+ * stamped") with no way to tell them apart, and made the line look arbitrarily
+ * different from one row to the next.
+ *
+ * The redundancy that hiding was working around is better solved by formatting: the
+ * refresh is an *age* ("4 hours ago") and the watermark is a *position*
+ * (`formatWatermark`), so the two never collapse to the same string the way
+ * "refreshed 4 hours ago · read to 4 hours ago" did for timestamps two hours apart.
+ */
+export function FreshnessLine({
+  isStale,
+  trigger,
+  lastRefreshedAt,
+  lastMemorySeenAt,
+  className,
+}: {
+  isStale: boolean | null | undefined;
+  trigger?: TriggerLike | null;
+  lastRefreshedAt: string | null;
+  lastMemorySeenAt?: string | null;
+  className?: string;
+}) {
+  const t = useTranslations("mentalModels");
+
+  const factTypes = trigger?.fact_types?.length ? trigger.fact_types.join(", ") : null;
+
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground",
+        className
+      )}
+    >
+      <StalenessBadge isStale={isStale} trigger={trigger} variant="inline" />
+      {lastRefreshedAt && (
+        <>
+          {isStale !== null && isStale !== undefined && <Sep />}
+          <span title={formatAbsoluteDateTime(lastRefreshedAt)}>
+            {t("freshnessRefreshed", { time: formatRelativeTime(lastRefreshedAt) })}
+          </span>
+        </>
+      )}
+      {lastMemorySeenAt && (
+        <>
+          <Sep />
+          <span title={formatAbsoluteDateTime(lastMemorySeenAt)}>
+            {t("freshnessReadTo", { time: formatWatermark(lastMemorySeenAt) })}
+          </span>
+        </>
+      )}
+      <Sep />
+      <span>
+        {t("freshnessNext")} <NextRefresh trigger={trigger} />
+      </span>
+      {factTypes && (
+        <>
+          <Sep />
+          <span title={t("scopeFactTypesTitle")}>{factTypes}</span>
+        </>
+      )}
+    </div>
+  );
+}

--- a/hindsight-control-plane/src/components/knowledge-base-view.tsx
+++ b/hindsight-control-plane/src/components/knowledge-base-view.tsx
@@ -50,6 +50,8 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { formatAbsoluteDateTime, formatRelativeTime } from "@/lib/relative-time";
 import { CompactMarkdown } from "./compact-markdown";
+import { StalenessBadge } from "./staleness-badge";
+import { FreshnessLine } from "./freshness-line";
 import { MentalModelDetailModal } from "./mental-model-detail-modal";
 
 type PageDetail = Awaited<ReturnType<typeof client.getKnowledgePage>>;
@@ -216,6 +218,14 @@ export function KnowledgeBaseView() {
   // doesn't carry it); updates as the auto-refresh poll refreshes the tree.
   const selectedStale = useMemo(
     () => (selected ? (allNodes.find((n) => n.id === selected.id)?.is_stale ?? null) : null),
+    [selected, allNodes]
+  );
+
+  // The trigger comes from the same tree node, for the same reason: the page
+  // detail response carries neither, and the badge needs it to tell a page that
+  // will refresh itself from one that is waiting on a person.
+  const selectedTrigger = useMemo(
+    () => (selected ? (allNodes.find((n) => n.id === selected.id)?.trigger ?? null) : null),
     [selected, allNodes]
   );
 
@@ -559,26 +569,21 @@ export function KnowledgeBaseView() {
 
               {/* Freshness + tags. The generation prompt (machinery) is tucked
                   behind the expander so the page opens with the knowledge. */}
+              {/* The same freshness line the mental-model detail shows — a page is a
+                  mental model with a place in the tree, so the two headers read
+                  identically rather than one saying "Updated 5 hours ago [IN SYNC]"
+                  and the other a sentence. */}
+              {selected.timestamp ? (
+                <FreshnessLine
+                  className="mt-2"
+                  isStale={selectedStale}
+                  trigger={selectedTrigger}
+                  lastRefreshedAt={selected.timestamp}
+                />
+              ) : (
+                <div className="text-xs text-muted-foreground mt-2">{t("generating")}</div>
+              )}
               <div className="flex items-center gap-2 flex-wrap text-xs mt-2">
-                {selected.timestamp ? (
-                  <span
-                    className="text-muted-foreground"
-                    title={formatAbsoluteDateTime(selected.timestamp)}
-                  >
-                    {t("updatedLabel")} {formatRelativeTime(selected.timestamp)}
-                  </span>
-                ) : (
-                  <span className="text-muted-foreground">{t("generating")}</span>
-                )}
-                {selectedStale === false ? (
-                  <span className="px-1.5 py-0.5 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400">
-                    {t("inSync")}
-                  </span>
-                ) : selectedStale === true ? (
-                  <span className="px-1.5 py-0.5 rounded-full bg-amber-500/10 text-amber-600 dark:text-amber-400">
-                    {t("needsRefresh")}
-                  </span>
-                ) : null}
                 {selected.tags.map((tag) => (
                   <span
                     key={tag}
@@ -853,17 +858,11 @@ export function TreeRow({
                 title={t("autoBadge")}
               />
             )}
-            {!isFolder && node.is_stale === false && (
-              <span
-                className="w-1.5 h-1.5 rounded-full bg-emerald-500 flex-shrink-0"
-                title={t("inSync")}
-              />
-            )}
-            {!isFolder && node.is_stale === true && (
-              <span
-                className="w-1.5 h-1.5 rounded-full bg-amber-500 flex-shrink-0"
-                title={t("needsRefresh")}
-              />
+            {/* The dot variant of the shared badge: the tree is dense and the name
+                needs the width, but the meaning, colours and tooltips are the same
+                ones the page header and the mental-model list show. */}
+            {!isFolder && (
+              <StalenessBadge isStale={node.is_stale} trigger={node.trigger} variant="dot" />
             )}
           </div>
           {!isFolder && (

--- a/hindsight-control-plane/src/components/mental-model-detail-modal.tsx
+++ b/hindsight-control-plane/src/components/mental-model-detail-modal.tsx
@@ -31,6 +31,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { toast } from "sonner";
 import { CompactMarkdown } from "./compact-markdown";
+import { StalenessBadge } from "./staleness-badge";
 import { CronSchedulePreview } from "./cron-schedule-preview";
 import { NextRefresh } from "./next-refresh";
 import {
@@ -932,21 +933,10 @@ export function MentalModelDetailModal({
                         </span>
                       </div>
                       <div className="flex items-center gap-2">
-                        {mentalModel.is_stale === true ? (
-                          <span
-                            className="px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide bg-amber-500/15 text-amber-700 dark:text-amber-400"
-                            title={t("staleTitle")}
-                          >
-                            {t("stale")}
-                          </span>
-                        ) : mentalModel.is_stale === false ? (
-                          <span
-                            className="px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide bg-green-500/15 text-green-700 dark:text-green-400"
-                            title={t("inSyncTitle")}
-                          >
-                            {t("inSync")}
-                          </span>
-                        ) : null}
+                        <StalenessBadge
+                          isStale={mentalModel.is_stale}
+                          trigger={mentalModel.trigger}
+                        />
                         <span
                           title={formatDateTime(mentalModel.last_refreshed_at)}
                           className="flex items-center gap-1"

--- a/hindsight-control-plane/src/components/mental-models-view.tsx
+++ b/hindsight-control-plane/src/components/mental-models-view.tsx
@@ -54,7 +54,6 @@ import {
   Pencil,
   FolderOpen,
   FileText,
-  Clock,
 } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";
 import {
@@ -69,6 +68,8 @@ import { ResponseSchemaField } from "./response-schema-field";
 import { TagFilterInput } from "./tag-filter-input";
 import { CronSchedulePreview } from "./cron-schedule-preview";
 import { NextRefresh } from "./next-refresh";
+import { StalenessBadge } from "./staleness-badge";
+import { FreshnessLine } from "./freshness-line";
 import { TagChip } from "@/components/ui/facet-chip";
 
 interface ReflectResponseBasedOnFact {
@@ -108,6 +109,10 @@ interface MentalModel {
     keep_trace?: boolean;
   };
   last_refreshed_at: string;
+  /** Newest in-scope memory this model has read. Staleness compares against this. */
+  last_memory_seen_at: string | null;
+  /** Whether a memory in this model's own scope has been written since it last read them. */
+  is_stale?: boolean | null;
   created_at: string;
   reflect_response?: ReflectResponse;
 }
@@ -412,29 +417,28 @@ export function MentalModelsView() {
                             <CompactMarkdown>{m.content}</CompactMarkdown>
                             <div className="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t from-card to-transparent" />
                           </div>
-                          <div className="flex items-center justify-between text-xs border-t border-border pt-3">
-                            <div className="flex items-center gap-2">
-                              {m.tags.length > 0 && (
-                                <div className="flex gap-1">
-                                  {m.tags.slice(0, 2).map((tag) => (
-                                    <TagChip key={tag} tag={tag} size="xs" />
-                                  ))}
-                                  {m.tags.length > 2 && (
-                                    <span className="px-1.5 py-0.5 rounded text-xs bg-muted text-muted-foreground">
-                                      +{m.tags.length - 2}
-                                    </span>
-                                  )}
-                                </div>
-                              )}
-                            </div>
-                            <div className="text-right text-muted-foreground">
-                              <div title={formatAbsoluteDateTime(m.last_refreshed_at)}>
-                                {formatRelativeTime(m.last_refreshed_at)}
+                          {/* Tags and freshness on their own rows: side by side the
+                              freshness line wrapped mid-sentence against the tags in a
+                              three-column grid, and right-aligned wrapping reads ragged. */}
+                          <div className="border-t border-border pt-3 text-xs space-y-1.5">
+                            {m.tags.length > 0 && (
+                              <div className="flex flex-wrap gap-1">
+                                {m.tags.slice(0, 2).map((tag) => (
+                                  <TagChip key={tag} tag={tag} size="xs" />
+                                ))}
+                                {m.tags.length > 2 && (
+                                  <span className="px-1.5 py-0.5 rounded text-xs bg-muted text-muted-foreground">
+                                    +{m.tags.length - 2}
+                                  </span>
+                                )}
                               </div>
-                              <div className="text-[11px] text-muted-foreground/70">
-                                {t("nextRefreshLabel")}: <NextRefresh trigger={m.trigger} />
-                              </div>
-                            </div>
+                            )}
+                            <FreshnessLine
+                              isStale={m.is_stale}
+                              trigger={m.trigger}
+                              lastRefreshedAt={m.last_refreshed_at}
+                              lastMemorySeenAt={m.last_memory_seen_at}
+                            />
                           </div>
                         </CardContent>
                       </Card>
@@ -1767,8 +1771,14 @@ function FilesView({
                       >
                         {m.name}
                       </span>
+                      <StalenessBadge
+                        isStale={m.is_stale}
+                        trigger={m.trigger}
+                        variant="dot"
+                        className="ml-auto"
+                      />
                       <span
-                        className="ml-auto text-[10px] text-muted-foreground flex-shrink-0"
+                        className="text-[10px] text-muted-foreground flex-shrink-0"
                         title={formatAbsoluteDateTime(m.last_refreshed_at)}
                       >
                         {formatRelativeTime(m.last_refreshed_at)}
@@ -1802,26 +1812,20 @@ function FilesView({
                       &ldquo;{selected.source_query}&rdquo;
                     </p>
                   )}
-                  <div className="flex flex-wrap items-center gap-2 mt-2 text-xs">
-                    <span
-                      className="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/50 px-2.5 py-1 text-muted-foreground"
-                      title={formatAbsoluteDateTime(selected.last_refreshed_at)}
-                    >
-                      <RefreshCw className="w-3 h-3" />
-                      {t("refreshedLabel")} {formatRelativeTime(selected.last_refreshed_at)}
-                    </span>
-                    <span className="inline-flex items-center gap-1.5 rounded-full border border-blue-500/20 bg-blue-500/10 px-2.5 py-1 text-blue-600 dark:text-blue-400">
-                      <Clock className="w-3 h-3" />
-                      {t("nextRefreshLabel")}: <NextRefresh trigger={selected.trigger} />
-                    </span>
-                    {selected.tags.length > 0 && (
-                      <div className="flex gap-1">
-                        {selected.tags.map((tag) => (
-                          <TagChip key={tag} tag={tag} />
-                        ))}
-                      </div>
-                    )}
-                  </div>
+                  <FreshnessLine
+                    className="mt-2"
+                    isStale={selected.is_stale}
+                    trigger={selected.trigger}
+                    lastRefreshedAt={selected.last_refreshed_at}
+                    lastMemorySeenAt={selected.last_memory_seen_at}
+                  />
+                  {selected.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-2">
+                      {selected.tags.map((tag) => (
+                        <TagChip key={tag} tag={tag} />
+                      ))}
+                    </div>
+                  )}
                 </div>
                 <div className="flex items-center gap-1 flex-shrink-0">
                   <Button variant="outline" size="sm" onClick={() => onOpenDetail(selected)}>

--- a/hindsight-control-plane/src/components/staleness-badge.tsx
+++ b/hindsight-control-plane/src/components/staleness-badge.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
+
+type TriggerLike = {
+  refresh_after_consolidation?: boolean;
+  refresh_cron?: string | null;
+};
+
+/**
+ * The one staleness indicator, shared by knowledge pages and mental models.
+ *
+ * They are the same object — a page is a mental model with a place in the tree —
+ * so they get the same answer rendered the same way, rather than a badge here and
+ * a differently-worded dot there.
+ *
+ * `is_stale` is the API's per-model answer: a memory in *this* model's scope has
+ * been written since it last read the memories. It is the same check that decides
+ * whether a scheduled refresh does any work, so a flagged model is one a refresh
+ * would actually rewrite (#3291).
+ *
+ * Two states, two colours. An earlier revision split "stale" into two colours —
+ * one for models that refresh themselves and one for manual ones — but every
+ * surface that shows this badge already shows "Next refresh: …" beside it, so the
+ * colour restated a fact that was on screen anyway and could only be decoded by
+ * hovering. The distinction lives in the tooltip instead.
+ *
+ * `variant` picks the presentation, not the meaning: compact rows (the pages tree,
+ * the mental-model list) have no room for a label and use the dot; headers and
+ * detail panes use the labelled badge.
+ */
+export function StalenessBadge({
+  isStale,
+  trigger,
+  variant = "badge",
+  className,
+}: {
+  isStale: boolean | null | undefined;
+  trigger?: TriggerLike | null;
+  variant?: "badge" | "dot" | "inline";
+  className?: string;
+}) {
+  const t = useTranslations("staleness");
+
+  // Null/undefined means the surface did not ask for staleness — render nothing
+  // rather than guessing, so "unknown" never reads as "in sync".
+  if (isStale === null || isStale === undefined) return null;
+
+  const selfHealing = Boolean(
+    trigger?.refresh_cron?.trim() || trigger?.refresh_after_consolidation
+  );
+  const title = !isStale
+    ? t("inSyncTitle")
+    : selfHealing
+      ? t("staleAutoTitle")
+      : t("staleManualTitle");
+
+  if (variant === "inline") {
+    // Dot + label with no chip around it, for the freshness line: there the status
+    // is one clause in a sentence, and a bordered pill would out-shout the rest.
+    return (
+      <span
+        className={cn(
+          "inline-flex items-center gap-1.5 font-medium",
+          isStale ? "text-amber-600 dark:text-amber-400" : "text-emerald-600 dark:text-emerald-400",
+          className
+        )}
+        title={title}
+      >
+        <span
+          className={cn("w-1.5 h-1.5 rounded-full", isStale ? "bg-amber-500" : "bg-emerald-500")}
+        />
+        {isStale ? t("stale") : t("inSync")}
+      </span>
+    );
+  }
+
+  if (variant === "dot") {
+    return (
+      <span
+        className={cn(
+          "w-1.5 h-1.5 rounded-full flex-shrink-0",
+          isStale ? "bg-amber-500" : "bg-emerald-500",
+          className
+        )}
+        title={title}
+      />
+    );
+  }
+
+  return (
+    <span
+      className={cn(
+        "px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide whitespace-nowrap",
+        isStale
+          ? "bg-amber-500/15 text-amber-700 dark:text-amber-400"
+          : "bg-green-500/15 text-green-700 dark:text-green-400",
+        className
+      )}
+      title={title}
+    >
+      {isStale ? t("stale") : t("inSync")}
+    </span>
+  );
+}

--- a/hindsight-control-plane/src/lib/relative-time.ts
+++ b/hindsight-control-plane/src/lib/relative-time.ts
@@ -36,3 +36,36 @@ export function formatAbsoluteDateTime(dateStr: string): string {
     hour12: false,
   })}`;
 }
+
+/**
+ * A timestamp that is a *position* rather than an age — a read watermark, say.
+ *
+ * Relative rendering ("4 hours ago") is wrong for these: shown next to a relative
+ * age it collapses to the same string even when the two moments are hours apart,
+ * which reads as the same fact printed twice. So this is always absolute, and only
+ * as long as it needs to be:
+ *
+ * - today        -> `14:38`
+ * - this year    -> `19 Aug 14:38`
+ * - earlier year -> `19 Aug 2025`
+ *
+ * The full date and time is expected to be on the element's `title`, so the label
+ * can stay short without losing anything.
+ */
+export function formatWatermark(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const time = date.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  if (date.toDateString() === now.toDateString()) return time;
+  const dayMonth = date.toLocaleDateString(undefined, { day: "numeric", month: "short" });
+  if (date.getFullYear() === now.getFullYear()) return `${dayMonth} ${time}`;
+  return date.toLocaleDateString(undefined, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}

--- a/hindsight-control-plane/src/messages/de.json
+++ b/hindsight-control-plane/src/messages/de.json
@@ -277,8 +277,6 @@
     "viewFailedMemoriesLabel": "Fehlgeschlagene Erinnerungen anzeigen",
     "mentalModels": "Mentale Modelle",
     "noMentalModels": "Keine mentalen Modelle",
-    "upToDate": "Aktuell",
-    "needsRefresh": "Aktualisierung nötig",
     "total": "Gesamt",
     "activity": "Aktivität",
     "memoriesIngested": "Aufgenommene Erinnerungen",
@@ -778,6 +776,10 @@
     "badgeAutoRefresh": "Automatische Aktualisierung",
     "badgeScheduled": "Geplant",
     "nextRefreshLabel": "Nächste Aktualisierung",
+    "freshnessRefreshed": "aktualisiert {time}",
+    "freshnessReadTo": "gelesen bis {time}",
+    "freshnessNext": "nächste:",
+    "scopeFactTypesTitle": "Welche Faktentypen dieses Modell liest.",
     "refreshedLabel": "Aktualisiert",
     "nextRefreshAuto": "bei neuen Erinnerungen",
     "nextRefreshManual": "bei Bedarf",
@@ -1444,10 +1446,6 @@
     "actionDelete": "Löschen",
     "storedContent": "Gespeicherter Inhalt",
     "charsCount": "{count} Zeichen",
-    "stale": "Veraltet",
-    "staleTitle": "Seit der letzten Aktualisierung dieses mentalen Modells wurden neue Erinnerungen in seinem Bereich aufgenommen",
-    "inSync": "Synchronisiert",
-    "inSyncTitle": "Seit der letzten Aktualisierung dieses mentalen Modells keine neuen Erinnerungen in seinem Bereich",
     "lastRefreshed": "Zuletzt aktualisiert {time}",
     "basedOn": "Basiert auf",
     "basedOnWithCount": "Basiert auf ({count})",
@@ -1798,8 +1796,6 @@
     "createFolderTitle": "New folder",
     "createPageTitle": "New page",
     "autoBadge": "auto",
-    "inSync": "In sync",
-    "needsRefresh": "Aktualisierung nötig",
     "generating": "Generating…",
     "howDerived": "How this page is derived",
     "backedBy": "Backed by {count} memories",
@@ -1878,5 +1874,12 @@
     "toolOutputLabel": "Ausgabe:",
     "toolWindowBound": "Fenster: nur Erinnerungen, die nach {time} aktualisiert wurden",
     "toolWindowUnbounded": "Fenster: keines – dieses Tool ist nicht zeitlich begrenzt"
+  },
+  "staleness": {
+    "stale": "Veraltet",
+    "inSync": "Aktuell",
+    "staleAutoTitle": "Neue Erinnerungen im Bereich dieses Modells — es aktualisiert sich selbst",
+    "staleManualTitle": "Neue Erinnerungen im Bereich dieses Modells — aktualisieren, um aufzuholen",
+    "inSyncTitle": "Keine neuen Erinnerungen im Bereich dieses Modells"
   }
 }

--- a/hindsight-control-plane/src/messages/en.json
+++ b/hindsight-control-plane/src/messages/en.json
@@ -277,8 +277,6 @@
     "viewFailedMemoriesLabel": "View failed memories",
     "mentalModels": "Mental Models",
     "noMentalModels": "No mental models",
-    "upToDate": "Up to date",
-    "needsRefresh": "Needs refresh",
     "total": "Total",
     "activity": "Activity",
     "memoriesIngested": "Memories ingested",
@@ -778,6 +776,10 @@
     "badgeAutoRefresh": "Auto Refresh",
     "badgeScheduled": "Scheduled",
     "nextRefreshLabel": "Next refresh",
+    "freshnessRefreshed": "refreshed {time}",
+    "freshnessReadTo": "read to {time}",
+    "freshnessNext": "next:",
+    "scopeFactTypesTitle": "Which fact types this model reads. Knowledge pages read observations, which only exist after consolidation runs.",
     "refreshedLabel": "Refreshed",
     "nextRefreshAuto": "on new memories",
     "nextRefreshManual": "on demand",
@@ -1444,10 +1446,6 @@
     "actionDelete": "Delete",
     "storedContent": "Stored content",
     "charsCount": "{count} chars",
-    "stale": "Stale",
-    "staleTitle": "New memories in this mental model's scope have been ingested since it was last refreshed",
-    "inSync": "In sync",
-    "inSyncTitle": "No new memories in this mental model's scope since it was last refreshed",
     "lastRefreshed": "Last refreshed {time}",
     "basedOn": "Based On",
     "basedOnWithCount": "Based On ({count})",
@@ -1798,8 +1796,6 @@
     "createFolderTitle": "New folder",
     "createPageTitle": "New page",
     "autoBadge": "auto",
-    "inSync": "In sync",
-    "needsRefresh": "Needs refresh",
     "generating": "Generating…",
     "howDerived": "How this page is derived",
     "backedBy": "Backed by {count} memories",
@@ -1878,5 +1874,12 @@
     "toolOutputLabel": "Output:",
     "toolWindowBound": "window: only memories updated after {time}",
     "toolWindowUnbounded": "window: none — this tool is not time-bounded"
+  },
+  "staleness": {
+    "stale": "Stale",
+    "inSync": "In sync",
+    "staleAutoTitle": "New memories in this model's scope since it last read them — it refreshes itself, so this clears on its own",
+    "staleManualTitle": "New memories in this model's scope since it last read them — refresh it to catch up",
+    "inSyncTitle": "No new memories in this model's scope since it last read them"
   }
 }

--- a/hindsight-control-plane/src/messages/es.json
+++ b/hindsight-control-plane/src/messages/es.json
@@ -277,8 +277,6 @@
     "viewFailedMemoriesLabel": "Ver memorias fallidas",
     "mentalModels": "Modelos mentales",
     "noMentalModels": "No hay modelos mentales",
-    "upToDate": "Al día",
-    "needsRefresh": "Necesita actualización",
     "total": "Total",
     "activity": "Actividad",
     "memoriesIngested": "Memorias ingestadas",
@@ -778,6 +776,10 @@
     "badgeAutoRefresh": "Actualización automática",
     "badgeScheduled": "Programado",
     "nextRefreshLabel": "Próxima actualización",
+    "freshnessRefreshed": "actualizado {time}",
+    "freshnessReadTo": "leído hasta {time}",
+    "freshnessNext": "próxima:",
+    "scopeFactTypesTitle": "Qué tipos de hechos lee este modelo.",
     "refreshedLabel": "Actualizado",
     "nextRefreshAuto": "con nuevas memorias",
     "nextRefreshManual": "a demanda",
@@ -1444,10 +1446,6 @@
     "actionDelete": "Eliminar",
     "storedContent": "Contenido almacenado",
     "charsCount": "{count} caracteres",
-    "stale": "Desactualizado",
-    "staleTitle": "Se han incorporado nuevas memorias en el alcance de este modelo mental desde su última actualización",
-    "inSync": "Sincronizado",
-    "inSyncTitle": "No hay nuevas memorias en el alcance de este modelo mental desde su última actualización",
     "lastRefreshed": "Última actualización {time}",
     "basedOn": "Basado en",
     "basedOnWithCount": "Basado en ({count})",
@@ -1798,8 +1796,6 @@
     "createFolderTitle": "New folder",
     "createPageTitle": "New page",
     "autoBadge": "auto",
-    "inSync": "In sync",
-    "needsRefresh": "Necesita actualización",
     "generating": "Generating…",
     "howDerived": "How this page is derived",
     "backedBy": "Backed by {count} memories",
@@ -1878,5 +1874,12 @@
     "toolOutputLabel": "Salida:",
     "toolWindowBound": "ventana: solo memorias actualizadas después de {time}",
     "toolWindowUnbounded": "ventana: ninguna — esta herramienta no está acotada en el tiempo"
+  },
+  "staleness": {
+    "stale": "Desactualizado",
+    "inSync": "Al día",
+    "staleAutoTitle": "Nuevos recuerdos en el ámbito de este modelo — se actualiza solo",
+    "staleManualTitle": "Nuevos recuerdos en el ámbito de este modelo — actualízalo para ponerlo al día",
+    "inSyncTitle": "Sin recuerdos nuevos en el ámbito de este modelo"
   }
 }

--- a/hindsight-control-plane/src/messages/fr.json
+++ b/hindsight-control-plane/src/messages/fr.json
@@ -277,8 +277,6 @@
     "viewFailedMemoriesLabel": "Voir les souvenirs échoués",
     "mentalModels": "Modèles mentaux",
     "noMentalModels": "Aucun modèle mental",
-    "upToDate": "À jour",
-    "needsRefresh": "Actualisation requise",
     "total": "Total",
     "activity": "Activité",
     "memoriesIngested": "Souvenirs ingérés",
@@ -778,6 +776,10 @@
     "badgeAutoRefresh": "Actualisation auto",
     "badgeScheduled": "Planifié",
     "nextRefreshLabel": "Prochaine actualisation",
+    "freshnessRefreshed": "actualisé {time}",
+    "freshnessReadTo": "lu jusqu'à {time}",
+    "freshnessNext": "prochaine :",
+    "scopeFactTypesTitle": "Quels types de faits ce modèle lit.",
     "refreshedLabel": "Actualisé",
     "nextRefreshAuto": "sur nouvelles mémoires",
     "nextRefreshManual": "à la demande",
@@ -1444,10 +1446,6 @@
     "actionDelete": "Supprimer",
     "storedContent": "Contenu stocké",
     "charsCount": "{count} caractères",
-    "stale": "Obsolète",
-    "staleTitle": "De nouvelles mémoires dans la portée de ce modèle mental ont été ingérées depuis sa dernière actualisation",
-    "inSync": "Synchronisé",
-    "inSyncTitle": "Aucune nouvelle mémoire dans la portée de ce modèle mental depuis sa dernière actualisation",
     "lastRefreshed": "Dernière actualisation {time}",
     "basedOn": "Basé sur",
     "basedOnWithCount": "Basé sur ({count})",
@@ -1798,8 +1796,6 @@
     "createFolderTitle": "New folder",
     "createPageTitle": "New page",
     "autoBadge": "auto",
-    "inSync": "In sync",
-    "needsRefresh": "Actualisation requise",
     "generating": "Generating…",
     "howDerived": "How this page is derived",
     "backedBy": "Backed by {count} memories",
@@ -1878,5 +1874,12 @@
     "toolOutputLabel": "Sortie :",
     "toolWindowBound": "fenêtre : uniquement les mémoires mises à jour après {time}",
     "toolWindowUnbounded": "fenêtre : aucune — cet outil n'est pas borné dans le temps"
+  },
+  "staleness": {
+    "stale": "Obsolète",
+    "inSync": "À jour",
+    "staleAutoTitle": "Nouveaux souvenirs dans la portée de ce modèle — il se met à jour tout seul",
+    "staleManualTitle": "Nouveaux souvenirs dans la portée de ce modèle — actualisez-le pour le mettre à jour",
+    "inSyncTitle": "Aucun nouveau souvenir dans la portée de ce modèle"
   }
 }

--- a/hindsight-control-plane/src/messages/ja.json
+++ b/hindsight-control-plane/src/messages/ja.json
@@ -277,8 +277,6 @@
     "viewFailedMemoriesLabel": "失敗したメモリを表示",
     "mentalModels": "メンタルモデル",
     "noMentalModels": "メンタルモデルなし",
-    "upToDate": "最新",
-    "needsRefresh": "要更新",
     "total": "合計",
     "activity": "アクティビティ",
     "memoriesIngested": "取り込まれたメモリ",
@@ -778,6 +776,10 @@
     "badgeAutoRefresh": "自動更新",
     "badgeScheduled": "スケジュール",
     "nextRefreshLabel": "次回更新",
+    "freshnessRefreshed": "更新 {time}",
+    "freshnessReadTo": "既読 {time}",
+    "freshnessNext": "次回:",
+    "scopeFactTypesTitle": "このモデルが読む事実タイプ。",
     "refreshedLabel": "更新",
     "nextRefreshAuto": "新しいメモリ時",
     "nextRefreshManual": "オンデマンド",
@@ -1444,10 +1446,6 @@
     "actionDelete": "削除",
     "storedContent": "保存済みコンテンツ",
     "charsCount": "{count}文字",
-    "stale": "古い",
-    "staleTitle": "最後の更新以降、このメンタルモデルのスコープに新しいメモリが取り込まれました",
-    "inSync": "同期済み",
-    "inSyncTitle": "最後の更新以降、このメンタルモデルのスコープに新しいメモリはありません",
     "lastRefreshed": "最終更新 {time}",
     "basedOn": "基準",
     "basedOnWithCount": "基準（{count}件）",
@@ -1798,8 +1796,6 @@
     "createFolderTitle": "New folder",
     "createPageTitle": "New page",
     "autoBadge": "auto",
-    "inSync": "In sync",
-    "needsRefresh": "要更新",
     "generating": "Generating…",
     "howDerived": "How this page is derived",
     "backedBy": "Backed by {count} memories",
@@ -1878,5 +1874,12 @@
     "toolOutputLabel": "出力：",
     "toolWindowBound": "範囲: {time} 以降に更新された記憶のみ",
     "toolWindowUnbounded": "範囲: なし — このツールは時間で絞り込まれません"
+  },
+  "staleness": {
+    "stale": "要更新",
+    "inSync": "最新",
+    "staleAutoTitle": "このモデルの範囲に新しい記憶があります — 自動的に更新されます",
+    "staleManualTitle": "このモデルの範囲に新しい記憶があります — 更新してください",
+    "inSyncTitle": "このモデルの範囲に新しい記憶はありません"
   }
 }

--- a/hindsight-control-plane/src/messages/ko.json
+++ b/hindsight-control-plane/src/messages/ko.json
@@ -277,8 +277,6 @@
     "viewFailedMemoriesLabel": "실패한 메모리 보기",
     "mentalModels": "멘탈 모델",
     "noMentalModels": "멘탈 모델 없음",
-    "upToDate": "최신 상태",
-    "needsRefresh": "갱신 필요",
     "total": "합계",
     "activity": "활동",
     "memoriesIngested": "수집된 메모리",
@@ -778,6 +776,10 @@
     "badgeAutoRefresh": "자동 새로고침",
     "badgeScheduled": "예약됨",
     "nextRefreshLabel": "다음 새로고침",
+    "freshnessRefreshed": "갱신 {time}",
+    "freshnessReadTo": "읽음 {time}",
+    "freshnessNext": "다음:",
+    "scopeFactTypesTitle": "이 모델이 읽는 사실 유형.",
     "refreshedLabel": "새로고침",
     "nextRefreshAuto": "새 메모리에",
     "nextRefreshManual": "온디맨드",
@@ -1444,10 +1446,6 @@
     "actionDelete": "삭제",
     "storedContent": "저장된 콘텐츠",
     "charsCount": "{count}자",
-    "stale": "오래됨",
-    "staleTitle": "마지막 새로 고침 이후 이 멘탈 모델 범위 내에 새 메모리가 수집되었습니다",
-    "inSync": "동기화됨",
-    "inSyncTitle": "마지막 새로 고침 이후 이 멘탈 모델 범위 내에 새 메모리가 없습니다",
     "lastRefreshed": "{time}에 마지막으로 새로 고침됨",
     "basedOn": "기반",
     "basedOnWithCount": "기반 ({count})",
@@ -1798,8 +1796,6 @@
     "createFolderTitle": "New folder",
     "createPageTitle": "New page",
     "autoBadge": "auto",
-    "inSync": "In sync",
-    "needsRefresh": "갱신 필요",
     "generating": "Generating…",
     "howDerived": "How this page is derived",
     "backedBy": "Backed by {count} memories",
@@ -1878,5 +1874,12 @@
     "toolOutputLabel": "출력:",
     "toolWindowBound": "범위: {time} 이후에 업데이트된 기억만",
     "toolWindowUnbounded": "범위: 없음 — 이 도구는 시간으로 제한되지 않습니다"
+  },
+  "staleness": {
+    "stale": "오래됨",
+    "inSync": "최신",
+    "staleAutoTitle": "이 모델 범위에 새 기억이 있습니다 — 자동으로 갱신됩니다",
+    "staleManualTitle": "이 모델 범위에 새 기억이 있습니다 — 갱신하세요",
+    "inSyncTitle": "이 모델 범위에 새 기억이 없습니다"
   }
 }

--- a/hindsight-control-plane/src/messages/pt.json
+++ b/hindsight-control-plane/src/messages/pt.json
@@ -277,8 +277,6 @@
     "viewFailedMemoriesLabel": "Ver memórias com falha",
     "mentalModels": "Modelos Mentais",
     "noMentalModels": "Nenhum modelo mental",
-    "upToDate": "Atualizado",
-    "needsRefresh": "Precisa de atualização",
     "total": "Total",
     "activity": "Atividade",
     "memoriesIngested": "Memórias ingeridas",
@@ -778,6 +776,10 @@
     "badgeAutoRefresh": "Atualização Automática",
     "badgeScheduled": "Agendado",
     "nextRefreshLabel": "Próxima atualização",
+    "freshnessRefreshed": "atualizado {time}",
+    "freshnessReadTo": "lido até {time}",
+    "freshnessNext": "próxima:",
+    "scopeFactTypesTitle": "Quais tipos de fato este modelo lê.",
     "refreshedLabel": "Atualizado",
     "nextRefreshAuto": "em novas memórias",
     "nextRefreshManual": "sob demanda",
@@ -1444,10 +1446,6 @@
     "actionDelete": "Excluir",
     "storedContent": "Conteúdo armazenado",
     "charsCount": "{count} caracteres",
-    "stale": "Desatualizado",
-    "staleTitle": "Novas memórias no escopo deste modelo mental foram ingeridas desde a última atualização",
-    "inSync": "Sincronizado",
-    "inSyncTitle": "Nenhuma memória nova no escopo deste modelo mental desde a última atualização",
     "lastRefreshed": "Última atualização {time}",
     "basedOn": "Baseado em",
     "basedOnWithCount": "Baseado em ({count})",
@@ -1798,8 +1796,6 @@
     "createFolderTitle": "New folder",
     "createPageTitle": "New page",
     "autoBadge": "auto",
-    "inSync": "In sync",
-    "needsRefresh": "Precisa de atualização",
     "generating": "Generating…",
     "howDerived": "How this page is derived",
     "backedBy": "Backed by {count} memories",
@@ -1878,5 +1874,12 @@
     "toolOutputLabel": "Saída:",
     "toolWindowBound": "janela: apenas memórias atualizadas após {time}",
     "toolWindowUnbounded": "janela: nenhuma — esta ferramenta não é limitada no tempo"
+  },
+  "staleness": {
+    "stale": "Desatualizado",
+    "inSync": "Em dia",
+    "staleAutoTitle": "Novas memórias no escopo deste modelo — ele se atualiza sozinho",
+    "staleManualTitle": "Novas memórias no escopo deste modelo — atualize para colocá-lo em dia",
+    "inSyncTitle": "Sem memórias novas no escopo deste modelo"
   }
 }

--- a/hindsight-control-plane/src/messages/yue-Hant.json
+++ b/hindsight-control-plane/src/messages/yue-Hant.json
@@ -277,8 +277,6 @@
     "viewFailedMemoriesLabel": "檢視失敗記憶",
     "mentalModels": "心智模型",
     "noMentalModels": "沒有心智模型",
-    "upToDate": "最新",
-    "needsRefresh": "需要更新",
     "total": "總計",
     "activity": "活動",
     "memoriesIngested": "已新增記憶",
@@ -778,6 +776,10 @@
     "badgeAutoRefresh": "自動重新整理",
     "badgeScheduled": "已排程",
     "nextRefreshLabel": "下次重新整理",
+    "freshnessRefreshed": "更新於 {time}",
+    "freshnessReadTo": "已讀至 {time}",
+    "freshnessNext": "下次:",
+    "scopeFactTypesTitle": "呢個模型讀取嘅事實類型。",
     "refreshedLabel": "已重新整理",
     "nextRefreshAuto": "有新記憶時",
     "nextRefreshManual": "按需",
@@ -1444,10 +1446,6 @@
     "actionDelete": "刪除",
     "storedContent": "已儲存的內容",
     "charsCount": "{count} 個字元",
-    "stale": "已過期",
-    "staleTitle": "自上次重新整理以來，此心智模型範圍內已有新增記憶",
-    "inSync": "已和步",
-    "inSyncTitle": "自上次重新整理以來，此心智模型範圍內沒有新增記憶",
     "lastRefreshed": "上次重新整理於 {time}",
     "basedOn": "依據",
     "basedOnWithCount": "基於（{count}）",
@@ -1798,8 +1796,6 @@
     "createFolderTitle": "New folder",
     "createPageTitle": "New page",
     "autoBadge": "auto",
-    "inSync": "In sync",
-    "needsRefresh": "需要更新",
     "generating": "Generating…",
     "howDerived": "How this page is derived",
     "backedBy": "Backed by {count} memories",
@@ -1878,5 +1874,12 @@
     "toolOutputLabel": "輸出：",
     "toolWindowBound": "範圍：只有 {time} 之後更新嘅記憶",
     "toolWindowUnbounded": "範圍：冇 — 呢個工具唔受時間限制"
+  },
+  "staleness": {
+    "stale": "已過期",
+    "inSync": "已同步",
+    "staleAutoTitle": "呢個模型範圍內有新記憶 — 佢會自動更新",
+    "staleManualTitle": "呢個模型範圍內有新記憶 — 請更新",
+    "inSyncTitle": "呢個模型範圍內冇新記憶"
   }
 }

--- a/hindsight-control-plane/src/messages/zh-CN.json
+++ b/hindsight-control-plane/src/messages/zh-CN.json
@@ -277,8 +277,6 @@
     "viewFailedMemoriesLabel": "查看失败记忆",
     "mentalModels": "心智模型",
     "noMentalModels": "没有心智模型",
-    "upToDate": "最新",
-    "needsRefresh": "需要刷新",
     "total": "总计",
     "activity": "活动",
     "memoriesIngested": "已摄入记忆",
@@ -778,6 +776,10 @@
     "badgeAutoRefresh": "自动刷新",
     "badgeScheduled": "已计划",
     "nextRefreshLabel": "下次刷新",
+    "freshnessRefreshed": "更新于 {time}",
+    "freshnessReadTo": "已读至 {time}",
+    "freshnessNext": "下次:",
+    "scopeFactTypesTitle": "此模型读取的事实类型。",
     "refreshedLabel": "已刷新",
     "nextRefreshAuto": "有新记忆时",
     "nextRefreshManual": "按需",
@@ -1444,10 +1446,6 @@
     "actionDelete": "删除",
     "storedContent": "已存储内容",
     "charsCount": "{count} 个字符",
-    "stale": "已过期",
-    "staleTitle": "自上次刷新以来，此心智模型范围内已摄入新记忆",
-    "inSync": "已同步",
-    "inSyncTitle": "自上次刷新以来，此心智模型范围内没有新记忆",
     "lastRefreshed": "上次刷新于 {time}",
     "basedOn": "依据",
     "basedOnWithCount": "基于（{count}）",
@@ -1798,8 +1796,6 @@
     "createFolderTitle": "New folder",
     "createPageTitle": "New page",
     "autoBadge": "auto",
-    "inSync": "In sync",
-    "needsRefresh": "需要刷新",
     "generating": "Generating…",
     "howDerived": "How this page is derived",
     "backedBy": "Backed by {count} memories",
@@ -1878,5 +1874,12 @@
     "toolOutputLabel": "输出：",
     "toolWindowBound": "范围：仅 {time} 之后更新的记忆",
     "toolWindowUnbounded": "范围：无 — 该工具不受时间限制"
+  },
+  "staleness": {
+    "stale": "已过期",
+    "inSync": "已同步",
+    "staleAutoTitle": "此模型范围内有新记忆 — 它会自动刷新",
+    "staleManualTitle": "此模型范围内有新记忆 — 请刷新以同步",
+    "inSyncTitle": "此模型范围内没有新记忆"
   }
 }

--- a/hindsight-control-plane/src/messages/zh-TW.json
+++ b/hindsight-control-plane/src/messages/zh-TW.json
@@ -277,8 +277,6 @@
     "viewFailedMemoriesLabel": "檢視失敗記憶",
     "mentalModels": "心智模型",
     "noMentalModels": "沒有心智模型",
-    "upToDate": "最新",
-    "needsRefresh": "需要更新",
     "total": "總計",
     "activity": "活動",
     "memoriesIngested": "已匯入記憶",
@@ -778,6 +776,10 @@
     "badgeAutoRefresh": "自動重新整理",
     "badgeScheduled": "已排程",
     "nextRefreshLabel": "下次重新整理",
+    "freshnessRefreshed": "更新於 {time}",
+    "freshnessReadTo": "已讀至 {time}",
+    "freshnessNext": "下次:",
+    "scopeFactTypesTitle": "此模型讀取的事實類型。",
     "refreshedLabel": "已重新整理",
     "nextRefreshAuto": "有新記憶時",
     "nextRefreshManual": "按需",
@@ -1444,10 +1446,6 @@
     "actionDelete": "刪除",
     "storedContent": "已儲存內容",
     "charsCount": "{count} 個字元",
-    "stale": "已過期",
-    "staleTitle": "自上次重新整理以來，此心智模型範圍內已有新增記憶",
-    "inSync": "已同步",
-    "inSyncTitle": "自上次重新整理以來，此心智模型範圍內沒有新記憶",
     "lastRefreshed": "上次重新整理於 {time}",
     "basedOn": "依據",
     "basedOnWithCount": "基於（{count}）",
@@ -1798,8 +1796,6 @@
     "createFolderTitle": "New folder",
     "createPageTitle": "New page",
     "autoBadge": "auto",
-    "inSync": "In sync",
-    "needsRefresh": "需要更新",
     "generating": "Generating…",
     "howDerived": "How this page is derived",
     "backedBy": "Backed by {count} memories",
@@ -1878,5 +1874,12 @@
     "toolOutputLabel": "輸出：",
     "toolWindowBound": "範圍：僅 {time} 之後更新的記憶",
     "toolWindowUnbounded": "範圍：無 — 此工具不受時間限制"
+  },
+  "staleness": {
+    "stale": "已過期",
+    "inSync": "已同步",
+    "staleAutoTitle": "此模型範圍內有新記憶 — 它會自動更新",
+    "staleManualTitle": "此模型範圍內有新記憶 — 請更新以同步",
+    "inSyncTitle": "此模型範圍內沒有新記憶"
   }
 }

--- a/hindsight-control-plane/tests/lib/relative-time.test.ts
+++ b/hindsight-control-plane/tests/lib/relative-time.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { formatWatermark } from "@/lib/relative-time";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+/** Pin "now" so the today/this-year/earlier-year branches are decidable. */
+function at(now: string) {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(now));
+}
+
+describe("formatWatermark", () => {
+  it("shows only the clock time for today", () => {
+    at("2026-08-19T18:00:00Z");
+    // A watermark earlier the same day needs no date to be unambiguous.
+    expect(formatWatermark("2026-08-19T12:38:00Z")).toMatch(/^\d{2}:\d{2}$/);
+  });
+
+  it("keeps the time when the day differs but the year does not", () => {
+    at("2026-08-19T18:00:00Z");
+    // Dropping the time here was the bug: "3 Aug" hid how far behind the model
+    // actually was within that day.
+    const out = formatWatermark("2026-08-18T08:38:00Z");
+    expect(out).toMatch(/\d{2}:\d{2}$/);
+    expect(out).not.toMatch(/^\d{2}:\d{2}$/);
+    expect(out).not.toContain("2026");
+  });
+
+  it("carries the year once the watermark is from an earlier one", () => {
+    at("2026-08-19T18:00:00Z");
+    // Without this, a watermark from last August rendered identically to this
+    // August — the same string for a year-old document and a fresh one.
+    expect(formatWatermark("2025-08-19T12:38:00Z")).toContain("2025");
+  });
+
+  it("distinguishes two moments that read the same relatively", () => {
+    at("2026-08-19T15:19:00Z");
+    // The reason this is absolute at all: 11:19 and 09:18 both render as
+    // "4 hours ago", which made "refreshed 4 hours ago · read to 4 hours ago"
+    // look like the same fact printed twice.
+    expect(formatWatermark("2026-08-19T11:19:00Z")).not.toBe(
+      formatWatermark("2026-08-19T09:18:00Z")
+    );
+  });
+});


### PR DESCRIPTION
Follow-up to #3589, which made per-page staleness exact and put `is_stale` on the
mental-model list. This surfaces it, and makes every surface say it the same way.

## The Mental Models tab did not show staleness at all

It showed *when a model last refreshed* and *when it will next refresh*, but not
whether it was behind the data — the one thing you actually want when deciding
whether to trust it. The answer was already in the list response after #3589; it
just wasn't rendered.

## Three vocabularies for one boolean

The surfaces that *did* show it disagreed on wording: the model dialog said
**Stale**, the pages tree said **Needs refresh**, the stats tile said **Up to
date**. One `StalenessBadge` now answers everywhere, with a `dot` or `badge`
variant chosen by row density rather than by feature — a page is a mental model
with a place in the tree, so the two render identically at the same density:

| Surface | Render |
|---|---|
| Pages tree (and Home, via the shared `TreeRow`) | dot |
| Mental-model list rows | dot |
| Page detail header, model detail, dashboard cards, model dialog | badge / line |
| Bank stats tile | counts, same words |

The vocabulary collapses to **Stale / In sync**, and the eight strings it
replaces (`bankStats.upToDate/needsRefresh`, `knowledgeBase.inSync/needsRefresh`,
`mentalModelDetailModal.stale/staleTitle/inSync/inSyncTitle`) are deleted from all
ten locales rather than left orphaned.

## The header was chip soup

The model and page headers carried freshness as five bordered chips in three
styles, wrapping onto two rows, with the least important fact — the next scheduled
run — in the loudest colour:

```
[IN SYNC] [⟳ Refreshed 56 minutes ago] [👁 read memories up to 56 minutes ago] [Scope: observation]
[🕐 Next refresh: on new memories] [#user:alice]
```

`FreshnessLine` replaces it with one quiet sentence, where the status dot is the
only colour and everything else is one size:

```
● In sync · refreshed 56 minutes ago · read to 14:37 · next: on new memories · observation
```

Dashboard cards get the same line, which also removes a `STALE` badge that sat on
top of its own duplicate `Next refresh:` caption.

## Two diagnostics that were not exposed

- **`read to`** — the newest in-scope memory the model has actually read
  (`last_memory_seen_at`). This is what explains a model that refreshed two minutes
  ago and is *still* stale, which otherwise reads as a bug. The two timestamps
  answer different questions and only together do they explain the status.
- **the scope's fact types** — why writing a memory does not always flag a page.
  Pages read observations, and those only exist once consolidation has run.

`read to` renders absolute via a new `formatWatermark`, because it is a *position*
rather than an age: rendered relatively it collapsed to the same string as the
refresh age for timestamps two hours apart ("refreshed 4 hours ago · read to 4
hours ago"). It adapts to distance — `14:38` today, `Aug 18 10:38` this year,
`Jul 15, 2025` earlier — with the full datetime on hover. Unit-tested against all
three branches plus the two-moments-same-relative-string case that motivated it.

## Two things this branch tried and removed

Both are called out because the code no longer shows them:

- **Stale in two colours** (sky for self-healing cron/after-consolidation, amber
  for manual). It restated the `Next refresh:` text sitting next to it, in a form
  you could only decode by hovering, and made a boolean into three visual states.
  The distinction survives in the tooltip, where it costs nothing.
- **Hiding `read to` when it matched `refreshed`**, to avoid saying the same thing
  twice. That made an absent clause mean either "same as the refresh" or "never
  stamped" with no way to tell them apart, and made the line look arbitrarily
  different row to row. Formatting solves the redundancy instead.

## Testing

- New `tests/lib/relative-time.test.ts` covers `formatWatermark`'s three branches
  and the collapse case.
- Full control-plane suite: 139 passed.
- `tsc`, `lint.sh`, `knip` and the production build are clean; all ten locales are
  in key parity (verified programmatically, 1737 keys each).
- Exercised against a live stack on a seeded bank with a genuine mix of states —
  in-sync, stale-manual, and a cron-scheduled model that is stale until 03:00 —
  rather than mocked data.

Rebased onto #3621 (`min_refresh_interval_seconds`); that throttle is a form field
and does not change what this line reports, though a throttled model can now be
stale for longer than "next: on new memories" implies.
