### PR TITLE
fix(recall): build ANN index before scan depth assertion

### DIFF
--- a/hindsight-api-slim/tests/test_ann_iterative_scan.py
+++ b/hindsight-api-slim/tests/test_ann_iterative_scan.py
@@ -185,8 +185,9 @@ def _near_query_vector(seed: int) -> str:
     return "[" + ",".join(f"{v / norm:.5f}" for v in values) + "]"
 
 
+@pytest.mark.xdist_group("vector_index_reconcile")
 @pytest.mark.asyncio
-async def test_the_kill_switch_flips_real_retrieval_depth(memory, request_context, ann_config):
+async def test_the_kill_switch_flips_real_retrieval_depth(memory, request_context, ann_config, monkeypatch):
     """End to end, through the pool: on, the budget reaches the index; off, it does not.
 
     Both halves matter. On is the fix — with iterative scans off the ground-layer search
@@ -200,14 +201,20 @@ async def test_the_kill_switch_flips_real_retrieval_depth(memory, request_contex
     index are built directly: the property belongs to the index scan, and going through
     retain would drag in extraction and consolidation.
     """
+    from hindsight_api.engine import vector_index_health
+    from hindsight_api.engine.memory_engine import get_current_schema
+    from hindsight_api.engine.retain.bank_utils import _vector_index_clause, get_or_create_bank_profile
     from hindsight_api.engine.search.retrieval import retrieve_semantic_bm25_combined_sql
-    from hindsight_api.engine.retain.bank_utils import get_or_create_bank_profile
     from hindsight_api.engine.task_backend import fq_table
+    from hindsight_api.engine.vector_index_health import reconcile_bank_vector_indexes
 
     bank_id = f"test_iter_scan_{uuid.uuid4().hex[:8]}"
     budget = 400  # deliberately above the standing ef_search of 200
-    # Creating the bank also builds its per-(bank, fact_type) partial vector index —
-    # the same one recall uses — so this exercises the production index, not a stand-in.
+    # The suite raises this threshold out of reach to stop incidental index DDL.
+    # Restore the shipped default here because this test deliberately exercises
+    # the production per-(bank, fact_type) index lifecycle.
+    monkeypatch.setattr(vector_index_health, "qualifies_for_per_bank_index", lambda rows: rows > 0)
+    monkeypatch.setattr(vector_index_health, "should_keep_per_bank_index", lambda rows: rows > 0)
     await get_or_create_bank_profile(memory._backend, bank_id)
     pool = await memory._get_pool()
     probe = _near_query_vector(0)
@@ -219,6 +226,12 @@ async def test_the_kill_switch_flips_real_retrieval_depth(memory, request_contex
                 [(bank_id, f"filler fact {i}", _near_query_vector(i)) for i in range(_ROWS)],
             )
             await conn.execute(f"ANALYZE {table}")
+            # Bank creation no longer builds empty indexes. Reconcile after the
+            # rows exist, just as vector_index_maintenance does in production.
+            index_clause = _vector_index_clause()
+            assert index_clause is not None
+            index_result = await reconcile_bank_vector_indexes(conn, get_current_schema(), bank_id, index_clause)
+            assert index_result.created == 1 and index_result.failed == 0, index_result
 
         async def semantic_rows(iterative: bool) -> int:
             ann_config("ann_iterative_scan", iterative)


### PR DESCRIPTION
## Summary

- restore the shipped per-bank vector-index threshold for the ANN depth integration test
- reconcile the bank's real partial vector index after seeding the test rows
- serialize this concurrent-index-DDL test with the existing `vector_index_reconcile` xdist group

## Root cause

#3485 moved per-bank vector-index creation out of bank creation and into the maintenance reconcile path. This test still assumed that creating an empty bank built its partial HNSW index. The test suite also raises the index threshold globally to keep incidental DDL out of parallel tests, so merely invoking the reconcile without restoring the shipped default would still leave the seeded 600-row bank unindexed.

The updated setup restores the production default policy, loads and analyzes the rows, then calls `reconcile_bank_vector_indexes` with the backend's real index clause. The existing plan assertion therefore measures the intended ANN path instead of the fallback B-tree scan plus sort.

## Validation

- `python3 -m py_compile hindsight-api-slim/tests/test_ann_iterative_scan.py`
- `uvx 'ruff==0.14.9' format --check hindsight-api-slim/tests/test_ann_iterative_scan.py`
- `git diff --check origin/main...HEAD`

The full pgvector integration test was not run locally because it requires the repository's database and embedding test environment; GitHub CI will exercise it.

Fixes #3628
