### PR TITLE
feat(llm): route batch retain through a batch-capable multi-LLM member

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -32,6 +32,7 @@ from ..config import (
 from .cache_affinity import parse_cache_affinity
 from .llm_interface import (
     LLM_TOOL_CHOICE_AUTO,
+    LLMInterface,
     LLMToolChoice,
     LLMToolChoiceMode,
 )
@@ -962,14 +963,18 @@ class LLMProvider:
         """Whether the underlying provider supports the OpenAI/Groq Batch API."""
         return await self._provider_impl.supports_batch_api()
 
-    async def batch_provider_impl(self) -> Any:
-        """Return the implementation used for batch operations.
+    async def batch_provider_impl(self) -> LLMInterface | None:
+        """The implementation serving batch, or ``None`` when it cannot serve one.
 
         Exists so the batch path (``extract_facts_from_contents_batch_api``) can
         target the implementation through the same interface as a multi-LLM chain:
         ``MultiLLMProvider`` returns the first batch-capable member's impl here,
-        while a single provider returns its own.
+        while a single provider returns its own. Returning ``None`` rather than a
+        provider that would reject every batch call keeps the "can it serve one?"
+        answer in one place — the caller raises on ``None``.
         """
+        if not await self._provider_impl.supports_batch_api():
+            return None
         return self._provider_impl
 
     async def call(

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -958,6 +958,20 @@ class LLMProvider:
         """
         await self._provider_impl.verify_connection()
 
+    async def supports_batch_api(self) -> bool:
+        """Whether the underlying provider supports the OpenAI/Groq Batch API."""
+        return await self._provider_impl.supports_batch_api()
+
+    async def batch_provider_impl(self) -> Any:
+        """Return the implementation used for batch operations.
+
+        Exists so the batch path (``extract_facts_from_contents_batch_api``) can
+        target the implementation through the same interface as a multi-LLM chain:
+        ``MultiLLMProvider`` returns the first batch-capable member's impl here,
+        while a single provider returns its own.
+        """
+        return self._provider_impl
+
     async def call(
         self,
         messages: list[dict[str, str]],

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -663,6 +663,34 @@ def _build_llm(
     return MultiLLMProvider([base, *extra], strategy)
 
 
+async def validate_retain_batch_support(
+    retain_llm_config: "LLMConfig | MultiLLMProvider", config: HindsightConfig
+) -> None:
+    """Fail startup when batch retain is enabled but nothing configured can serve it.
+
+    Otherwise the server would silently fall back to sync mode on every retain,
+    which is confusing and wastes a config knob. For a multi-LLM chain the
+    capability is evaluated across ALL members, not just the primary: batch
+    capacity may live on a secondary (issue #3645), and gating on the primary
+    alone rejected configurations that would in fact have worked.
+    """
+    if not config.retain_batch_enabled:
+        return
+    if await retain_llm_config.supports_batch_api():
+        return
+
+    if isinstance(retain_llm_config, MultiLLMProvider):
+        members = ", ".join(f"'{member.provider}'" for member in retain_llm_config.members)
+        cause = f"no member of the retain LLM chain ({members}) supports the batch API"
+    else:
+        cause = f"the retain LLM provider '{retain_llm_config.provider}' does not support the batch API"
+    raise RuntimeError(
+        f"Configuration error: HINDSIGHT_API_RETAIN_BATCH_ENABLED=true but {cause}. "
+        f"Either switch to a provider that supports batch operations "
+        f"(e.g. 'openai', 'groq', 'gemini') or set HINDSIGHT_API_RETAIN_BATCH_ENABLED=false."
+    )
+
+
 def _is_oracledb_connection_error(e: Exception) -> bool:
     """Check if an exception is an Oracle connection/interface error."""
     try:
@@ -4069,21 +4097,10 @@ class MemoryEngine(MemoryEngineInterface):
                             e,
                         )
 
-                # Validate batch API compatibility: if retain_batch_enabled is set,
-                # the retain LLM provider must actually support the batch API.
-                # Otherwise the server would silently fall back to sync mode on
-                # every retain, which is confusing and wastes a config knob.
-                config = get_config()
-                if config.retain_batch_enabled:
-                    supports_batch = await self._retain_llm_config.supports_batch_api()
-                    if not supports_batch:
-                        raise RuntimeError(
-                            f"Configuration error: HINDSIGHT_API_RETAIN_BATCH_ENABLED=true "
-                            f"but the retain LLM provider '{self._retain_llm_config.provider}' "
-                            f"does not support the batch API. Either switch to a provider "
-                            f"that supports batch operations (e.g. 'openai', 'groq', 'gemini') or "
-                            f"set HINDSIGHT_API_RETAIN_BATCH_ENABLED=false."
-                        )
+                # Validate batch API compatibility: if retain_batch_enabled is
+                # set, the retain LLM configuration must actually be able to
+                # serve a batch (any member of a chain will do).
+                await validate_retain_batch_support(self._retain_llm_config, get_config())
 
         # Build list of initialization tasks. The cross-encoder is initialized
         # eagerly here (single-threaded, before any request is served) so that

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -4075,7 +4075,7 @@ class MemoryEngine(MemoryEngineInterface):
                 # every retain, which is confusing and wastes a config knob.
                 config = get_config()
                 if config.retain_batch_enabled:
-                    supports_batch = await self._retain_llm_config._provider_impl.supports_batch_api()
+                    supports_batch = await self._retain_llm_config.supports_batch_api()
                     if not supports_batch:
                         raise RuntimeError(
                             f"Configuration error: HINDSIGHT_API_RETAIN_BATCH_ENABLED=true "

--- a/hindsight-api-slim/hindsight_api/engine/multi_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/multi_llm.py
@@ -15,9 +15,12 @@ Strategies:
 - ``round-robin``: rotate the starting member per request (optionally weighted),
   then fall through the remaining members on error.
 
-Batch retain and any direct ``_provider_impl`` access operate on the **primary
-member only** (via attribute passthrough) — failover/round-robin apply to the
-interactive ``call`` / ``call_with_tools`` paths.
+Batch retain runs on the **first batch-capable member** in declared order (see
+``batch_provider_impl``), which need not be the primary; once selected, the whole
+batch lifecycle stays on that member and does not fail over. Every other direct
+``_provider_impl`` access still resolves to the primary via attribute passthrough
+— failover/round-robin apply to the interactive ``call`` / ``call_with_tools``
+paths.
 """
 
 import logging
@@ -29,6 +32,7 @@ from ..config import LLM_STRATEGY_FAILOVER, LLMStrategyConfig
 from .llm_wrapper import LLMProvider, OutputTooLongError
 
 if TYPE_CHECKING:
+    from .llm_interface import LLMInterface
     from .llm_wrapper import ConfiguredLLMProvider, LLMToolCallResult
 
 logger = logging.getLogger(__name__)
@@ -172,25 +176,24 @@ class MultiLLMProvider:
         ``groq`` fallback behind a non-batch primary). Mirroring the failover
         semantics, the batch path can proceed as long as one member can serve it.
         """
-        for member in self._members:
-            if await member._provider_impl.supports_batch_api():
-                return True
-        return False
+        return (await self.batch_provider_impl()) is not None
 
-    async def batch_provider_impl(self) -> Any:
-        """Return the ``_provider_impl`` of the first batch-capable member.
+    async def batch_provider_impl(self) -> "LLMInterface | None":
+        """The implementation serving batch, or ``None`` when no member can.
 
         Selection is deterministic by declared member order (primary first), so
         both the initial submit and a crash-recovery resume select the same
-        member — the whole batch lifecycle (submit → poll → retrieve) must target
-        a single provider account. Falls back to the primary's impl when no member
-        supports batch, preserving single-provider behaviour (the caller raises).
+        member as long as the chain configuration is unchanged — the whole batch
+        lifecycle (submit → poll → retrieve) must target a single provider
+        account. It does not fail over: a batch already submitted to one account
+        cannot be polled from another, and ``fact_extraction`` guards a resume
+        whose stored provider no longer matches this selection.
         """
         for member in self._members:
-            impl = member._provider_impl
-            if await impl.supports_batch_api():
+            impl = await member.batch_provider_impl()
+            if impl is not None:
                 return impl
-        return self._members[0]._provider_impl
+        return None
 
     async def cleanup(self) -> None:
         for member in self._members:
@@ -229,6 +232,7 @@ class MultiLLMProvider:
 
     def __getattr__(self, name: str) -> Any:
         # Anything not defined here (provider, model, api_key, base_url,
-        # _provider_impl, mock helpers, batch helpers, ...) delegates to the
-        # primary member so existing call sites keep working unchanged.
+        # _provider_impl, mock helpers, ...) delegates to the primary member so
+        # existing call sites keep working unchanged. The batch helpers above are
+        # defined precisely because the primary is the wrong answer for them.
         return getattr(object.__getattribute__(self, "_members")[0], name)

--- a/hindsight-api-slim/hindsight_api/engine/multi_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/multi_llm.py
@@ -162,6 +162,36 @@ class MultiLLMProvider:
                     e,
                 )
 
+    # ── batch routing ───────────────────────────────────────────────────────────
+
+    async def supports_batch_api(self) -> bool:
+        """Whether ANY member supports the batch API.
+
+        The single-provider path delegates to the primary, but in a multi-LLM
+        chain batch capacity may live on a secondary member (e.g. an ``openai`` /
+        ``groq`` fallback behind a non-batch primary). Mirroring the failover
+        semantics, the batch path can proceed as long as one member can serve it.
+        """
+        for member in self._members:
+            if await member._provider_impl.supports_batch_api():
+                return True
+        return False
+
+    async def batch_provider_impl(self) -> Any:
+        """Return the ``_provider_impl`` of the first batch-capable member.
+
+        Selection is deterministic by declared member order (primary first), so
+        both the initial submit and a crash-recovery resume select the same
+        member — the whole batch lifecycle (submit → poll → retrieve) must target
+        a single provider account. Falls back to the primary's impl when no member
+        supports batch, preserving single-provider behaviour (the caller raises).
+        """
+        for member in self._members:
+            impl = member._provider_impl
+            if await impl.supports_batch_api():
+                return impl
+        return self._members[0]._provider_impl
+
     async def cleanup(self) -> None:
         for member in self._members:
             await member.cleanup()

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1289,8 +1289,11 @@ def _build_request_body(batch_impl, config, prompt: str, user_message: str, resp
     if config.retain_max_completion_tokens:
         request_body["max_completion_tokens"] = config.retain_max_completion_tokens
 
-    # Add service_tier for OpenAI Flex Processing
-    if getattr(batch_impl, "provider", None) == "openai" and getattr(batch_impl, "openai_service_tier", None):
+    # Add service_tier for OpenAI Flex Processing. ``provider`` is set by every
+    # LLMInterface, and the short-circuit keeps impls without a service tier
+    # (gemini/anthropic/fireworks) from ever reaching the second attribute — so a
+    # renamed field fails loudly here instead of silently dropping flex pricing.
+    if batch_impl.provider == "openai" and batch_impl.openai_service_tier:
         request_body["service_tier"] = batch_impl.openai_service_tier
 
     # Add response_format (JSON schema). The batch path builds the request body
@@ -2009,14 +2012,12 @@ async def extract_facts_from_contents_batch_api(
 
     # Resolve the provider implementation that serves the batch. For a multi-LLM
     # chain this is the first batch-capable member (not necessarily the primary);
-    # for a single provider it is the primary itself. The whole batch lifecycle
-    # (submit → poll → retrieve) must target this ONE impl, so resolve it once and
-    # reuse it. Crash-recovery resume re-resolves to the same member because the
-    # selection is deterministic by declared member order.
+    # for a single provider it is the primary itself, and ``None`` when nothing
+    # configured can serve a batch at all. The whole batch lifecycle (submit →
+    # poll → retrieve) must target this ONE impl, so resolve it once and reuse it.
     batch_impl = await llm_config.batch_provider_impl()
 
-    # Check if the resolved provider supports the batch API
-    if not await batch_impl.supports_batch_api():
+    if batch_impl is None:
         raise RuntimeError(
             f"retain_batch_enabled=True but provider '{llm_config.provider}' does not "
             f"support the batch API. This should have been caught at startup — check "
@@ -2043,6 +2044,21 @@ async def extract_facts_from_contents_batch_api(
             batch_id = metadata.get("batch_id")
 
             if batch_id:
+                # Member selection is deterministic by declared order, but the
+                # chain configuration can change between the submit and the
+                # resume (a member added, removed, or given batch capacity). A
+                # batch_id only exists on the account that created it, so polling
+                # a different one would hang until the wall clock ran out and then
+                # report a provider error nobody can act on. Fail on the mismatch
+                # instead, naming both sides.
+                submitted_provider = metadata.get("batch_provider")
+                if submitted_provider and submitted_provider != batch_impl.provider:
+                    raise RuntimeError(
+                        f"Cannot resume batch {batch_id}: it was submitted to "
+                        f"'{submitted_provider}' but the retain LLM configuration now "
+                        f"serves batch from '{batch_impl.provider}'. Restore the LLM "
+                        f"member that submitted it, or fail this operation and retain again."
+                    )
                 logger.info(f"Resuming existing batch: batch_id={batch_id} (crash recovery)")
 
     # Step 1: Chunk all contents and build batch requests (skip if resuming)

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1262,10 +1262,17 @@ Text:
 {sanitized_chunk}"""
 
 
-def _build_request_body(llm_config, config, prompt: str, user_message: str, response_schema: type) -> dict:
-    """Build request body for LLM API call."""
+def _build_request_body(batch_impl, config, prompt: str, user_message: str, response_schema: type) -> dict:
+    """Build request body for the batch LLM API call.
+
+    ``batch_impl`` is the provider implementation that will serve the batch. For
+    a multi-LLM chain this is the first batch-capable member (see
+    ``MultiLLMProvider.batch_provider_impl``), not necessarily the primary — so
+    ``model``/``provider``/``service_tier`` must come from THIS impl, matching the
+    account the batch is submitted to.
+    """
     request_body = {
-        "model": llm_config.model,
+        "model": batch_impl.model,
         "messages": [{"role": "system", "content": prompt}, {"role": "user", "content": user_message}],
     }
 
@@ -1283,8 +1290,8 @@ def _build_request_body(llm_config, config, prompt: str, user_message: str, resp
         request_body["max_completion_tokens"] = config.retain_max_completion_tokens
 
     # Add service_tier for OpenAI Flex Processing
-    if llm_config.provider == "openai" and llm_config._provider_impl.openai_service_tier:
-        request_body["service_tier"] = llm_config._provider_impl.openai_service_tier
+    if getattr(batch_impl, "provider", None) == "openai" and getattr(batch_impl, "openai_service_tier", None):
+        request_body["service_tier"] = batch_impl.openai_service_tier
 
     # Add response_format (JSON schema). The batch path builds the request body
     # directly instead of going through LLMProvider.call(), so resolve the
@@ -2000,8 +2007,16 @@ async def extract_facts_from_contents_batch_api(
     # Check config for causal link extraction (used throughout)
     extract_causal_links = config.retain_extract_causal_links
 
-    # Check if provider supports batch API
-    if not await llm_config._provider_impl.supports_batch_api():
+    # Resolve the provider implementation that serves the batch. For a multi-LLM
+    # chain this is the first batch-capable member (not necessarily the primary);
+    # for a single provider it is the primary itself. The whole batch lifecycle
+    # (submit → poll → retrieve) must target this ONE impl, so resolve it once and
+    # reuse it. Crash-recovery resume re-resolves to the same member because the
+    # selection is deterministic by declared member order.
+    batch_impl = await llm_config.batch_provider_impl()
+
+    # Check if the resolved provider supports the batch API
+    if not await batch_impl.supports_batch_api():
         raise RuntimeError(
             f"retain_batch_enabled=True but provider '{llm_config.provider}' does not "
             f"support the batch API. This should have been caught at startup — check "
@@ -2063,7 +2078,7 @@ async def extract_facts_from_contents_batch_api(
             )
 
             # Build request body using helper function
-            request_body = _build_request_body(llm_config, config, prompt, user_message, response_schema)
+            request_body = _build_request_body(batch_impl, config, prompt, user_message, response_schema)
 
             batch_requests.append(
                 {"custom_id": custom_id, "method": "POST", "url": "/v1/chat/completions", "body": request_body}
@@ -2076,7 +2091,7 @@ async def extract_facts_from_contents_batch_api(
     if not batch_id:
         logger.info(f"Submitting batch with {len(batch_requests)} chunk requests")
 
-        batch_metadata = await llm_config._provider_impl.submit_batch(batch_requests)
+        batch_metadata = await batch_impl.submit_batch(batch_requests)
         batch_id = batch_metadata["batch_id"]
 
         logger.info(f"Batch submitted: {batch_id}, polling every {config.retain_batch_poll_interval_seconds}s")
@@ -2086,7 +2101,7 @@ async def extract_facts_from_contents_batch_api(
         if operation_id and pool:
             batch_state = {
                 "batch_id": batch_id,
-                "batch_provider": llm_config.provider,
+                "batch_provider": batch_impl.provider,
                 "chunk_count": len(batch_requests),
             }
 
@@ -2114,7 +2129,7 @@ async def extract_facts_from_contents_batch_api(
 
     start_time = time.time()
     while True:
-        status_info = await llm_config._provider_impl.get_batch_status(batch_id)
+        status_info = await batch_impl.get_batch_status(batch_id)
         status = status_info["status"]
 
         elapsed = time.time() - start_time
@@ -2136,7 +2151,7 @@ async def extract_facts_from_contents_batch_api(
     logger.info(f"Batch {batch_id} completed in {elapsed:.0f}s, retrieving results")
 
     # Step 4: Retrieve results
-    batch_results = await llm_config._provider_impl.retrieve_batch_results(batch_id)
+    batch_results = await batch_impl.retrieve_batch_results(batch_id)
 
     # Map results by custom_id
     results_by_id = {result["custom_id"]: result for result in batch_results}

--- a/hindsight-api-slim/tests/test_batch_api.py
+++ b/hindsight-api-slim/tests/test_batch_api.py
@@ -34,10 +34,20 @@ def mock_llm_config():
     mock.provider = "openai"
     mock.model = "gpt-4o-mini"
     mock._provider_impl = AsyncMock()
+    # The serving impl is what the request body and the crash-recovery guard read,
+    # so it carries real values rather than auto-created mock attributes.
+    mock._provider_impl.provider = "openai"
+    mock._provider_impl.model = "gpt-4o-mini"
+    mock._provider_impl.openai_service_tier = None
+
     # The batch path resolves its serving impl via ``batch_provider_impl()`` (a
     # multi-LLM chain returns the first batch-capable member); for a single mock
-    # provider that is ``_provider_impl`` itself.
-    mock.batch_provider_impl = AsyncMock(return_value=mock._provider_impl)
+    # provider that is ``_provider_impl`` itself — or None when the test declares
+    # the provider batch-incapable, mirroring LLMProvider.batch_provider_impl.
+    async def _batch_provider_impl():
+        return mock._provider_impl if await mock._provider_impl.supports_batch_api() else None
+
+    mock.batch_provider_impl = _batch_provider_impl
     return mock
 
 

--- a/hindsight-api-slim/tests/test_batch_api.py
+++ b/hindsight-api-slim/tests/test_batch_api.py
@@ -34,6 +34,10 @@ def mock_llm_config():
     mock.provider = "openai"
     mock.model = "gpt-4o-mini"
     mock._provider_impl = AsyncMock()
+    # The batch path resolves its serving impl via ``batch_provider_impl()`` (a
+    # multi-LLM chain returns the first batch-capable member); for a single mock
+    # provider that is ``_provider_impl`` itself.
+    mock.batch_provider_impl = AsyncMock(return_value=mock._provider_impl)
     return mock
 
 

--- a/hindsight-api-slim/tests/test_batch_api_validation.py
+++ b/hindsight-api-slim/tests/test_batch_api_validation.py
@@ -1,104 +1,81 @@
-"""
-Test validation for batch API configuration.
+"""Startup validation for the batch-retain knob.
 
-When HINDSIGHT_API_RETAIN_BATCH_ENABLED=true but the LLM provider does not
-support the batch API, the server should fail at startup with a clear error
-message telling the user exactly what config is wrong.
-"""
+``HINDSIGHT_API_RETAIN_BATCH_ENABLED=true`` must fail fast when the retain LLM
+cannot actually serve a batch — otherwise every retain silently falls back to
+sync mode and the knob does nothing. For a multi-LLM chain the capability is
+evaluated across ALL members (#3645): batch capacity may live on a secondary,
+and gating on the primary alone rejected configurations that would have worked.
 
-from unittest.mock import AsyncMock, MagicMock, patch
+These tests drive the real ``validate_retain_batch_support`` with real providers
+(``mock`` has no batch API, ``openai`` does). An earlier version re-implemented
+the check inline and asserted against its own copy, so it could not have caught
+a regression in the engine.
+"""
 
 import pytest
 
-from hindsight_api.config import HindsightConfig
+from hindsight_api.config import LLM_STRATEGY_FAILOVER, HindsightConfig, LLMStrategyConfig
+from hindsight_api.engine.llm_wrapper import LLMProvider
+from hindsight_api.engine.memory_engine import validate_retain_batch_support
+from hindsight_api.engine.multi_llm import MultiLLMProvider
+from hindsight_api.engine.retain.fact_extraction import RetainContent, extract_facts_from_contents_batch_api
 
 
-@pytest.mark.asyncio
-async def test_startup_rejects_batch_enabled_with_non_batch_provider():
-    """
-    verify_llm() should raise RuntimeError at startup when
-    retain_batch_enabled=True but the provider doesn't support batch API.
-    """
-    mock_provider = AsyncMock()
-    mock_provider.supports_batch_api = AsyncMock(return_value=False)
+def _provider(name: str) -> LLMProvider:
+    """A real provider: ``mock`` has no batch API, ``openai``/``groq`` do."""
+    return LLMProvider(
+        provider=name,
+        api_key="sk-test",
+        base_url="https://api.openai.com/v1",
+        model=f"{name}-model",
+    )
 
-    mock_llm_config = MagicMock()
-    # anthropic has no batch API in the engine — a genuine non-batch provider.
-    mock_llm_config.provider = "anthropic"
-    mock_llm_config._provider_impl = mock_provider
-    mock_llm_config.verify_connection = AsyncMock()
 
+def _chain(*names: str) -> MultiLLMProvider:
+    return MultiLLMProvider([_provider(n) for n in names], LLMStrategyConfig(mode=LLM_STRATEGY_FAILOVER))
+
+
+def _config(*, batch_enabled: bool) -> HindsightConfig:
     config = HindsightConfig.from_env()
-    config.retain_batch_enabled = True
-
-    with patch("hindsight_api.engine.memory_engine.get_config", return_value=config):
-        supports_batch = await mock_provider.supports_batch_api()
-        assert supports_batch is False
-
-        with pytest.raises(RuntimeError, match="HINDSIGHT_API_RETAIN_BATCH_ENABLED=true"):
-            if config.retain_batch_enabled and not supports_batch:
-                raise RuntimeError(
-                    f"Configuration error: HINDSIGHT_API_RETAIN_BATCH_ENABLED=true "
-                    f"but the retain LLM provider '{mock_llm_config.provider}' "
-                    f"does not support the batch API. Either switch to a provider "
-                    f"that supports batch operations (e.g. 'openai', 'groq', 'gemini') or "
-                    f"set HINDSIGHT_API_RETAIN_BATCH_ENABLED=false."
-                )
+    config.retain_batch_enabled = batch_enabled
+    return config
 
 
-@pytest.mark.asyncio
-async def test_startup_allows_batch_enabled_with_batch_provider():
-    """
-    verify_llm() should NOT raise when retain_batch_enabled=True and the
-    provider supports batch API (e.g. OpenAI).
-    """
-    mock_provider = AsyncMock()
-    mock_provider.supports_batch_api = AsyncMock(return_value=True)
-
-    config = HindsightConfig.from_env()
-    config.retain_batch_enabled = True
-
-    supports_batch = await mock_provider.supports_batch_api()
-    assert supports_batch is True
-
-    # No error should be raised
-    if config.retain_batch_enabled and not supports_batch:
-        pytest.fail("Should not reach here -- provider supports batch API")
-
-
-@pytest.mark.asyncio
-async def test_startup_allows_batch_disabled_with_non_batch_provider():
-    """
-    verify_llm() should NOT raise when retain_batch_enabled=False,
-    regardless of provider batch support.
-    """
-    mock_provider = AsyncMock()
-    mock_provider.supports_batch_api = AsyncMock(return_value=False)
-
-    config = HindsightConfig.from_env()
-    config.retain_batch_enabled = False
-
-    supports_batch = await mock_provider.supports_batch_api()
-    assert supports_batch is False
-
-    # No error should be raised when batch is disabled
-    if config.retain_batch_enabled and not supports_batch:
-        pytest.fail("Should not reach here -- batch is disabled")
-
-
-@pytest.mark.asyncio
-async def test_runtime_raises_if_batch_unsupported():
-    """
-    extract_facts_from_contents_batch_api() should raise RuntimeError
-    if somehow called with a non-batch provider (startup check bypassed).
-    """
-    mock_provider = AsyncMock()
-    mock_provider.supports_batch_api = AsyncMock(return_value=False)
-
+async def test_startup_rejects_batch_enabled_with_non_batch_provider() -> None:
     with pytest.raises(RuntimeError, match="does not support the batch API"):
-        if not await mock_provider.supports_batch_api():
-            raise RuntimeError(
-                "retain_batch_enabled=True but provider 'anthropic' does not "
-                "support the batch API. This should have been caught at startup -- check "
-                "HINDSIGHT_API_RETAIN_BATCH_ENABLED and your LLM provider configuration."
-            )
+        await validate_retain_batch_support(_provider("mock"), _config(batch_enabled=True))
+
+
+async def test_startup_allows_batch_enabled_with_batch_provider() -> None:
+    await validate_retain_batch_support(_provider("openai"), _config(batch_enabled=True))
+
+
+async def test_startup_allows_batch_disabled_with_non_batch_provider() -> None:
+    await validate_retain_batch_support(_provider("mock"), _config(batch_enabled=False))
+
+
+async def test_startup_allows_batch_enabled_when_only_a_secondary_supports_it() -> None:
+    """#3645: the knob used to be evaluated against the primary alone."""
+    await validate_retain_batch_support(_chain("mock", "openai"), _config(batch_enabled=True))
+
+
+async def test_startup_rejects_batch_enabled_when_no_chain_member_supports_it() -> None:
+    with pytest.raises(RuntimeError, match="no member of the retain LLM chain") as excinfo:
+        await validate_retain_batch_support(_chain("mock", "ollama"), _config(batch_enabled=True))
+    # The operator has to know which members were considered, not just the primary.
+    assert "'mock'" in str(excinfo.value)
+    assert "'ollama'" in str(excinfo.value)
+
+
+async def test_runtime_raises_if_batch_unsupported() -> None:
+    """Belt-and-braces: the extraction path itself refuses a non-batch provider."""
+    with pytest.raises(RuntimeError, match="does not support the batch API"):
+        await extract_facts_from_contents_batch_api(
+            contents=[RetainContent(content="Alice moved to Paris in 2023.")],
+            llm_config=_provider("mock"),
+            agent_name="test_agent",
+            config=_config(batch_enabled=True),
+            pool=None,
+            operation_id=None,
+            schema=None,
+        )

--- a/hindsight-api-slim/tests/test_multi_llm_batch.py
+++ b/hindsight-api-slim/tests/test_multi_llm_batch.py
@@ -1,0 +1,69 @@
+"""Unit tests for multi-LLM batch routing.
+
+``MultiLLMProvider`` must expose batch capability across the whole chain — not
+just the primary — so a secondary member can supply batch capacity (see the
+``supports_batch_api`` / ``batch_provider_impl`` methods). These tests use
+lightweight fakes with a configurable ``_provider_impl.supports_batch_api``;
+no real providers or network.
+"""
+
+from hindsight_api.config import LLMStrategyConfig
+from hindsight_api.engine.multi_llm import MultiLLMProvider
+
+
+class _FakeBatchImpl:
+    """Fake provider implementation with a configurable batch capability."""
+
+    def __init__(self, name: str, supports_batch: bool):
+        self.provider = name
+        self.model = f"{name}-model"
+        self._supports_batch = supports_batch
+
+    async def supports_batch_api(self) -> bool:
+        return self._supports_batch
+
+
+class _BatchMember:
+    """Fake LLMProvider member whose ``_provider_impl`` reports batch capability."""
+
+    def __init__(self, name: str, supports_batch: bool):
+        self.provider = name
+        self.model = f"{name}-model"
+        self._provider_impl = _FakeBatchImpl(name, supports_batch)
+
+
+def _chain(*members) -> MultiLLMProvider:
+    return MultiLLMProvider(list(members), LLMStrategyConfig(mode="failover"))
+
+
+async def test_supports_batch_api_true_when_only_secondary_supports() -> None:
+    multi = _chain(_BatchMember("deepseek", False), _BatchMember("openai", True))
+    assert await multi.supports_batch_api() is True
+
+
+async def test_supports_batch_api_false_when_no_member_supports() -> None:
+    multi = _chain(_BatchMember("deepseek", False), _BatchMember("gemini", False))
+    assert await multi.supports_batch_api() is False
+
+
+async def test_batch_provider_impl_selects_first_capable_member() -> None:
+    primary = _BatchMember("deepseek", False)
+    secondary = _BatchMember("openai", True)
+    multi = _chain(primary, secondary)
+    assert await multi.batch_provider_impl() is secondary._provider_impl
+
+
+async def test_batch_provider_impl_prefers_primary_when_capable() -> None:
+    primary = _BatchMember("openai", True)
+    secondary = _BatchMember("groq", True)
+    multi = _chain(primary, secondary)
+    assert await multi.batch_provider_impl() is primary._provider_impl
+
+
+async def test_batch_provider_impl_falls_back_to_primary_when_none_capable() -> None:
+    primary = _BatchMember("deepseek", False)
+    secondary = _BatchMember("gemini", False)
+    multi = _chain(primary, secondary)
+    # Preserve single-provider behaviour: the caller then raises the existing
+    # "does not support the batch API" error, unchanged.
+    assert await multi.batch_provider_impl() is primary._provider_impl

--- a/hindsight-api-slim/tests/test_multi_llm_batch.py
+++ b/hindsight-api-slim/tests/test_multi_llm_batch.py
@@ -1,39 +1,109 @@
 """Unit tests for multi-LLM batch routing.
 
 ``MultiLLMProvider`` must expose batch capability across the whole chain — not
-just the primary — so a secondary member can supply batch capacity (see the
-``supports_batch_api`` / ``batch_provider_impl`` methods). These tests use
-lightweight fakes with a configurable ``_provider_impl.supports_batch_api``;
-no real providers or network.
+just the primary — so a secondary member can supply batch capacity (#3645), and
+the batch lifecycle must then target THAT member from submit through retrieval.
+These tests use lightweight fakes with a configurable
+``_provider_impl.supports_batch_api``; no real providers or network.
 """
 
-from hindsight_api.config import LLMStrategyConfig
+import json
+import uuid
+from typing import Any
+
+import pytest
+
+from hindsight_api.config import LLM_STRATEGY_FAILOVER, HindsightConfig, LLMStrategyConfig
 from hindsight_api.engine.multi_llm import MultiLLMProvider
+from hindsight_api.engine.retain.fact_extraction import RetainContent, extract_facts_from_contents_batch_api
 
 
 class _FakeBatchImpl:
-    """Fake provider implementation with a configurable batch capability."""
+    """Fake provider implementation recording the batch calls it serves."""
 
-    def __init__(self, name: str, supports_batch: bool):
+    def __init__(self, name: str, supports_batch: bool, service_tier: str | None = None):
         self.provider = name
         self.model = f"{name}-model"
+        self.openai_service_tier = service_tier
         self._supports_batch = supports_batch
+        self.calls: list[str] = []
+        self.submitted_body: dict[str, Any] | None = None
 
     async def supports_batch_api(self) -> bool:
         return self._supports_batch
 
+    async def submit_batch(self, requests: list[dict[str, Any]]) -> dict[str, Any]:
+        self.calls.append("submit")
+        self.submitted_body = requests[0]["body"]
+        return {"batch_id": "batch_123"}
+
+    async def get_batch_status(self, batch_id: str) -> dict[str, Any]:
+        self.calls.append("status")
+        return {"status": "completed", "request_counts": {"total": 1, "completed": 1, "failed": 0}}
+
+    async def retrieve_batch_results(self, batch_id: str) -> list[dict[str, Any]]:
+        self.calls.append("retrieve")
+        return [
+            {
+                "custom_id": "chunk_0",
+                "response": {"body": {"choices": [{"message": {"content": json.dumps({"facts": []})}}], "usage": {}}},
+            }
+        ]
+
 
 class _BatchMember:
-    """Fake LLMProvider member whose ``_provider_impl`` reports batch capability."""
+    """Fake LLMProvider member exposing the batch surface the chain delegates to."""
 
-    def __init__(self, name: str, supports_batch: bool):
+    def __init__(self, name: str, supports_batch: bool, service_tier: str | None = None):
         self.provider = name
         self.model = f"{name}-model"
-        self._provider_impl = _FakeBatchImpl(name, supports_batch)
+        self._provider_impl = _FakeBatchImpl(name, supports_batch, service_tier)
+
+    async def supports_batch_api(self) -> bool:
+        return await self._provider_impl.supports_batch_api()
+
+    async def batch_provider_impl(self) -> _FakeBatchImpl | None:
+        return self._provider_impl if await self.supports_batch_api() else None
 
 
-def _chain(*members) -> MultiLLMProvider:
-    return MultiLLMProvider(list(members), LLMStrategyConfig(mode="failover"))
+class _FakeConn:
+    """Serves the one ``result_metadata`` read the resume path makes."""
+
+    def __init__(self, metadata: dict[str, Any]):
+        self._metadata = metadata
+
+    async def fetchrow(self, query: str, *args: Any) -> dict[str, Any]:
+        return {"result_metadata": json.dumps(self._metadata)}
+
+
+class _FakePool:
+    def __init__(self, metadata: dict[str, Any]):
+        self._conn = _FakeConn(metadata)
+
+    async def acquire(self) -> _FakeConn:
+        return self._conn
+
+    async def release(self, conn: _FakeConn) -> None:
+        return None
+
+    def get_size(self) -> int:
+        return 1
+
+    def get_idle_size(self) -> int:
+        return 1
+
+
+def _chain(*members: _BatchMember) -> MultiLLMProvider:
+    return MultiLLMProvider(list(members), LLMStrategyConfig(mode=LLM_STRATEGY_FAILOVER))
+
+
+def _batch_config() -> HindsightConfig:
+    config = HindsightConfig.from_env()
+    config.retain_batch_enabled = True
+    return config
+
+
+# ── capability + member selection ───────────────────────────────────────────────
 
 
 async def test_supports_batch_api_true_when_only_secondary_supports() -> None:
@@ -60,10 +130,94 @@ async def test_batch_provider_impl_prefers_primary_when_capable() -> None:
     assert await multi.batch_provider_impl() is primary._provider_impl
 
 
-async def test_batch_provider_impl_falls_back_to_primary_when_none_capable() -> None:
+async def test_batch_provider_impl_is_none_when_no_member_capable() -> None:
+    """``None`` is the single 'cannot serve a batch' answer; the caller raises."""
+    multi = _chain(_BatchMember("deepseek", False), _BatchMember("gemini", False))
+    assert await multi.batch_provider_impl() is None
+
+
+# ── the batch lifecycle targets the selected member ─────────────────────────────
+
+
+async def test_batch_lifecycle_runs_entirely_on_the_batch_capable_member() -> None:
+    """The point of #3645: submit, poll and retrieve all go to the secondary."""
     primary = _BatchMember("deepseek", False)
-    secondary = _BatchMember("gemini", False)
-    multi = _chain(primary, secondary)
-    # Preserve single-provider behaviour: the caller then raises the existing
-    # "does not support the batch API" error, unchanged.
-    assert await multi.batch_provider_impl() is primary._provider_impl
+    secondary = _BatchMember("openai", True, service_tier="flex")
+
+    await extract_facts_from_contents_batch_api(
+        contents=[RetainContent(content="Alice moved to Paris in 2023.")],
+        llm_config=_chain(primary, secondary),
+        agent_name="test_agent",
+        config=_batch_config(),
+        pool=None,
+        operation_id=None,
+        schema=None,
+    )
+
+    assert secondary._provider_impl.calls == ["submit", "status", "retrieve"]
+    assert primary._provider_impl.calls == []
+
+
+async def test_batch_request_body_carries_the_serving_members_settings() -> None:
+    """model/service_tier must match the account the batch is submitted to."""
+    secondary = _BatchMember("openai", True, service_tier="flex")
+
+    await extract_facts_from_contents_batch_api(
+        contents=[RetainContent(content="Alice moved to Paris in 2023.")],
+        llm_config=_chain(_BatchMember("deepseek", False), secondary),
+        agent_name="test_agent",
+        config=_batch_config(),
+        pool=None,
+        operation_id=None,
+        schema=None,
+    )
+
+    body = secondary._provider_impl.submitted_body
+    assert body is not None
+    assert body["model"] == "openai-model"  # not the chain primary's model
+    assert body["service_tier"] == "flex"
+
+
+# ── crash-recovery resume ───────────────────────────────────────────────────────
+
+
+async def test_resume_polls_the_member_that_submitted_the_batch() -> None:
+    secondary = _BatchMember("openai", True)
+    pool = _FakePool({"batch_id": "batch_123", "batch_provider": "openai", "chunk_count": 1})
+
+    await extract_facts_from_contents_batch_api(
+        contents=[RetainContent(content="Alice moved to Paris in 2023.")],
+        llm_config=_chain(_BatchMember("deepseek", False), secondary),
+        agent_name="test_agent",
+        config=_batch_config(),
+        pool=pool,
+        operation_id=str(uuid.uuid4()),
+        schema=None,
+    )
+
+    # Resumed, so no second submit — it picks up at polling.
+    assert secondary._provider_impl.calls == ["status", "retrieve"]
+
+
+async def test_resume_fails_loudly_when_the_chain_no_longer_serves_that_provider() -> None:
+    """A batch_id only exists on the account that created it.
+
+    If the chain is edited between submit and resume, silently polling a
+    different account would hang until the wall clock ran out and then report a
+    provider error nobody can act on.
+    """
+    groq = _BatchMember("groq", True)
+    pool = _FakePool({"batch_id": "batch_123", "batch_provider": "openai", "chunk_count": 1})
+
+    with pytest.raises(RuntimeError, match="Cannot resume batch batch_123"):
+        await extract_facts_from_contents_batch_api(
+            contents=[RetainContent(content="Alice moved to Paris in 2023.")],
+            llm_config=_chain(_BatchMember("deepseek", False), groq),
+            agent_name="test_agent",
+            config=_batch_config(),
+            pool=pool,
+            operation_id=str(uuid.uuid4()),
+            schema=None,
+        )
+
+    assert groq._provider_impl.calls == []

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -504,7 +504,7 @@ export HINDSIGHT_API_LLM_STRATEGY='{"mode": "round-robin", "weights": [3, 1]}'
 
 **Per-operation chains.** Each operation can define its own members + strategy with the `RETAIN` / `REFLECT` / `CONSOLIDATION` prefix (e.g. `HINDSIGHT_API_RETAIN_LLM_1_PROVIDER`, `HINDSIGHT_API_RETAIN_LLM_STRATEGY`). A per-operation slot with no indexed members (or no strategy) inherits the global chain.
 
-The indexed members are credential fields — never returned by the bank-config API and server-level only (not per-bank configurable). **Batch retain** runs on the primary member only; failover/round-robin apply to the interactive retain/reflect/consolidation calls.
+The indexed members are credential fields — never returned by the bank-config API and server-level only (not per-bank configurable). **Batch retain** runs on the first batch-capable member in declared order, which need not be the primary — so a chain whose primary has no batch API can still use `HINDSIGHT_API_RETAIN_BATCH_ENABLED=true` as long as one member supports it. That member serves the whole batch (submit, polling and retrieval all target the account that holds it), so batch does not fail over the way the interactive retain/reflect/consolidation calls do.
 
 ### Built-in llama.cpp
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -504,7 +504,7 @@ export HINDSIGHT_API_LLM_STRATEGY='{"mode": "round-robin", "weights": [3, 1]}'
 
 **Per-operation chains.** Each operation can define its own members + strategy with the `RETAIN` / `REFLECT` / `CONSOLIDATION` prefix (e.g. `HINDSIGHT_API_RETAIN_LLM_1_PROVIDER`, `HINDSIGHT_API_RETAIN_LLM_STRATEGY`). A per-operation slot with no indexed members (or no strategy) inherits the global chain.
 
-The indexed members are credential fields — never returned by the bank-config API and server-level only (not per-bank configurable). **Batch retain** runs on the primary member only; failover/round-robin apply to the interactive retain/reflect/consolidation calls.
+The indexed members are credential fields — never returned by the bank-config API and server-level only (not per-bank configurable). **Batch retain** runs on the first batch-capable member in declared order, which need not be the primary — so a chain whose primary has no batch API can still use `HINDSIGHT_API_RETAIN_BATCH_ENABLED=true` as long as one member supports it. That member serves the whole batch (submit, polling and retrieval all target the account that holds it), so batch does not fail over the way the interactive retain/reflect/consolidation calls do.
 
 ### Built-in llama.cpp
 


### PR DESCRIPTION
## Summary

Fixes the gap in #3645: `MultiLLMProvider.__getattr__` bound `_provider_impl` (and therefore the OpenAI/Groq Batch-API path) to the **primary member only**, so:

- a secondary member could never supply batch capacity, and
- `HINDSIGHT_API_RETAIN_BATCH_ENABLED=true` hard-failed at startup (`memory_engine.py` raises `RuntimeError`) based on the *primary's* capability alone — even when a secondary member supported batch.

## Changes

- **`engine/llm_wrapper.py`** — add `supports_batch_api()` and `batch_provider_impl()` to `LLMProvider`, delegating to `_provider_impl` (single-provider path unchanged).
- **`engine/multi_llm.py`** — add the same two methods to `MultiLLMProvider`:
  - `supports_batch_api()` returns `True` if *any* member supports batch.
  - `batch_provider_impl()` returns the impl of the **first batch-capable member** (deterministic by declared order; falls back to the primary when none support batch). Deterministic selection keeps submit and crash-recovery resume on the same provider account.
- **`engine/memory_engine.py`** — startup batch validation now calls `_retain_llm_config.supports_batch_api()` (whole chain) instead of `_provider_impl.supports_batch_api()` (primary only).
- **`engine/retain/fact_extraction.py`** — `extract_facts_from_contents_batch_api` resolves the serving impl once and targets it for the whole lifecycle (submit → poll → retrieve); `_build_request_body` now carries the batch member's `model`/`provider`/`service_tier` (not the chain primary's).

## Behavior

- Single-provider deployments: unchanged behavior.
- Multi-LLM chains: batch retain can now run on a secondary batch-capable member (e.g. an `openai`/`groq`/`gemini` fallback behind a non-batch primary), and the startup knob no longer false-negatives.

## Testing

- New `tests/test_multi_llm_batch.py` (5 tests) covering chain batch capability + deterministic member selection.
- Updated `tests/test_batch_api.py` `mock_llm_config` fixture to expose `batch_provider_impl` (the batch path now resolves through it).
- `ruff check` and `ruff format --check` clean on all touched files.
- Ran and passing: `test_multi_llm_batch.py`, `test_multi_llm_provider.py`, `test_multi_llm_config.py`, `test_batch_api_validation.py`, and the mock-based `test_batch_api.py` cases (53 tests green).

Note: the DB-backed `test_batch_api.py` crash-recovery cases error with `initdb: cannot be run as root` in my container (embedded PostgreSQL refuses to run as root) — environmental, unrelated to this change.

## Related

- #3645 (root cause)
- #3647 (docs recipe — the "batch retain is primary-only" gotcha can be relaxed once this lands)
