### PR TITLE
fix(retain): preserve nested conversation chunks during output retry

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -258,8 +258,8 @@ def _split_chunk_for_output_retry(chunk: str) -> tuple[str, str] | None:
         parsed = None
 
     if isinstance(parsed, list):
-        # Some OpenAI-compatible providers wrap a conversation array once more;
-        # normalize that shape before applying the existing array split logic.
+        # Some integrations wrap a conversation array once more; normalize that
+        # shape before applying the existing array split logic.
         if len(parsed) == 1 and isinstance(parsed[0], list) and all(isinstance(item, dict) for item in parsed[0]):
             parsed = parsed[0]
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -258,6 +258,11 @@ def _split_chunk_for_output_retry(chunk: str) -> tuple[str, str] | None:
         parsed = None
 
     if isinstance(parsed, list):
+        # Some OpenAI-compatible providers wrap a conversation array once more;
+        # normalize that shape before applying the existing array split logic.
+        if len(parsed) == 1 and isinstance(parsed[0], list) and all(isinstance(item, dict) for item in parsed[0]):
+            parsed = parsed[0]
+
         if len(parsed) >= 2:
             mid = len(parsed) // 2
             return json.dumps(parsed[:mid]), json.dumps(parsed[mid:])

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -39,7 +39,7 @@ def test_output_retry_split_preserves_conversation_array_boundaries():
 
 
 def test_output_retry_split_unwraps_nested_conversation_array():
-    """A provider-wrapped conversation array should use the normal turn splitter."""
+    """A nested conversation array should use the normal turn splitter."""
     from hindsight_api.engine.retain.fact_extraction import _split_chunk_for_output_retry
 
     turns = [
@@ -55,6 +55,30 @@ def test_output_retry_split_unwraps_nested_conversation_array():
     first, second = split
     assert json.loads(first) == turns[:2]
     assert json.loads(second) == turns[2:]
+
+
+def test_output_retry_split_unwraps_nested_single_conversation_turn():
+    """A nested single turn should reach the existing content splitter."""
+    from hindsight_api.engine.retain.fact_extraction import _split_chunk_for_output_retry
+
+    turn = {
+        "role": "user",
+        "content": "abcdefghijklmnopqrstuvwxyz" * 40,
+        "name": "casey",
+    }
+
+    split = _split_chunk_for_output_retry(json.dumps([[turn]]))
+
+    assert split is not None
+    first, second = split
+
+    first_turn = json.loads(first)[0]
+    second_turn = json.loads(second)[0]
+    assert first_turn["role"] == "user"
+    assert second_turn["role"] == "user"
+    assert first_turn["name"] == "casey"
+    assert second_turn["name"] == "casey"
+    assert first_turn["content"] + second_turn["content"] == turn["content"]
 
 
 def test_output_retry_split_divides_single_oversized_turn_content():

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -38,6 +38,25 @@ def test_output_retry_split_preserves_conversation_array_boundaries():
     assert json.loads(second) == turns[2:]
 
 
+def test_output_retry_split_unwraps_nested_conversation_array():
+    """A provider-wrapped conversation array should use the normal turn splitter."""
+    from hindsight_api.engine.retain.fact_extraction import _split_chunk_for_output_retry
+
+    turns = [
+        {"role": "user", "content": "alpha " * 40},
+        {"role": "assistant", "content": "bravo " * 40},
+        {"role": "user", "content": "charlie " * 40},
+        {"role": "assistant", "content": "delta " * 40},
+    ]
+
+    split = _split_chunk_for_output_retry(json.dumps([turns]))
+
+    assert split is not None
+    first, second = split
+    assert json.loads(first) == turns[:2]
+    assert json.loads(second) == turns[2:]
+
+
 def test_output_retry_split_divides_single_oversized_turn_content():
     """A lone oversized conversation turn is split inside content and rewrapped."""
     from hindsight_api.engine.retain.fact_extraction import _split_chunk_for_output_retry


### PR DESCRIPTION
## Summary

Defensively unwrap a single-element list containing a list of turn dictionaries before the existing retain output-retry splitter logic.

## Reproduction

On Hindsight 0.9.1, an integration can provide a conversation shaped like:

```json
[[{"role": "user", "content": "..."}]]
```

This is parsed as a one-element list whose element is another list. `_split_chunk_for_output_retry` only handled a standard list of turns, so it returned `None` for this nested/wrapped shape. The caller then logged that it was dropping the sub-chunk.

The fix normalizes only the concrete `list -> list -> dict` shape to the standard turn-list shape, allowing the existing split-and-retry path to process it. It does not flatten arbitrary JSON values.

## Impact

This can cause silent data loss: the retain operation may report `completed` even though the oversized sub-chunk was dropped and its facts were never stored.

## Scope

- Fixes only nested conversation-array handling in the retain splitter.
- Does not change behavior for standard lists of turns.
- Does not change behavior for plain-text chunks.
- Does not include the `maxItems`/saturation guard or strict-schema flag fixes.

## Testing

- `tests/test_fact_extraction_retry.py`: 27 passed
- Regression coverage includes both `[[{turn}, ...]]` list splitting and the exact `[[{single turn}]]` path that unwraps and then splits one turn's content.
- Ruff check and format check passed.
