### PR TITLE
fix(retain): honor retain strict-schema flag

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1293,12 +1293,11 @@ def _build_request_body(llm_config, config, prompt: str, user_message: str, resp
     # retain-scoped field, which already folds in the global HINDSIGHT_API_LLM_STRICT_SCHEMA
     # fallback, so the batch and streaming paths can't disagree.
     if hasattr(response_schema, "model_json_schema"):
-        schema = (
-            strict_json_schema(response_schema) if config.llm_strict_schema else response_schema.model_json_schema()
-        )
+        retain_strict_schema = config.llm_strict_schema_retain
+        schema = strict_json_schema(response_schema) if retain_strict_schema else response_schema.model_json_schema()
         request_body["response_format"] = {
             "type": "json_schema",
-            "json_schema": {"name": "facts", "schema": schema, "strict": config.llm_strict_schema_retain},
+            "json_schema": {"name": "facts", "schema": schema, "strict": retain_strict_schema},
         }
 
     return request_body

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -470,6 +470,7 @@ def _make_batch_temp_config(temperature):
     cfg.llm_temperature_retain = temperature
     cfg.retain_max_completion_tokens = None
     cfg.llm_strict_schema = False
+    cfg.llm_strict_schema_retain = False
     return cfg
 
 
@@ -500,6 +501,27 @@ def test_build_request_body_omits_temperature_when_none():
 
     body = _build_request_body(_make_batch_llm_config(), _make_batch_temp_config(None), "sys", "user", dict)
     assert "temperature" not in body
+
+
+def test_build_request_body_uses_retain_strict_schema_flag_for_schema_and_request():
+    """The batch retain path must use one resolved strict-schema flag consistently."""
+    from hindsight_api.engine.retain.fact_extraction import _build_request_body
+
+    config = _make_batch_temp_config(None)
+    config.llm_strict_schema = False
+    config.llm_strict_schema_retain = True
+    response_schema = MagicMock()
+    response_schema.model_json_schema.return_value = {"schema": "non-strict"}
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction.strict_json_schema",
+        return_value={"schema": "strict"},
+    ) as strict_schema:
+        body = _build_request_body(_make_batch_llm_config(), config, "sys", "user", response_schema)
+
+    strict_schema.assert_called_once_with(response_schema)
+    assert body["response_format"]["json_schema"]["schema"] == {"schema": "strict"}
+    assert body["response_format"]["json_schema"]["strict"] is True
 
 
 # --- Retry budget semantics (issue #2731) -----------------------------------

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -524,6 +524,24 @@ def test_build_request_body_uses_retain_strict_schema_flag_for_schema_and_reques
     assert body["response_format"]["json_schema"]["strict"] is True
 
 
+def test_build_request_body_retain_strict_false_overrides_global_true():
+    """The retain opt-out must disable strict schema in the batch request body."""
+    from hindsight_api.engine.retain.fact_extraction import _build_request_body
+
+    config = _make_batch_temp_config(None)
+    config.llm_strict_schema = True
+    config.llm_strict_schema_retain = False
+    response_schema = MagicMock()
+    response_schema.model_json_schema.return_value = {"schema": "non-strict"}
+
+    with patch("hindsight_api.engine.retain.fact_extraction.strict_json_schema") as strict_schema:
+        body = _build_request_body(_make_batch_llm_config(), config, "sys", "user", response_schema)
+
+    strict_schema.assert_not_called()
+    assert body["response_format"]["json_schema"]["schema"] == {"schema": "non-strict"}
+    assert body["response_format"]["json_schema"]["strict"] is False
+
+
 # --- Retry budget semantics (issue #2731) -----------------------------------
 #
 # A retry BUDGET of N means N retries *after* the initial request — the meaning


### PR DESCRIPTION
## Summary

Use the retain-scoped strict-schema flag consistently when building the Batch API request body.

## Reproduction

Hindsight 0.9.1 can resolve:

```text
llm_strict_schema        = false
llm_strict_schema_retain = true
```

The batch retain path used the global flag to choose between `strict_json_schema()` and the ordinary Pydantic schema, but used the retain flag for the request's `strict` field. That sent `strict: true` with a schema built through the non-strict path, so retain-specific strict-subset constraints were absent from the final request body.

## Impact

Retain requests could advertise strict structured output while omitting constraints that were present in the retain strict schema, including array bounds used by downstream safeguards. The batch path could therefore disagree with the streaming retain path.

## Fix

Resolve `llm_strict_schema_retain` once and use it for both:

- selecting `strict_json_schema()` versus the regular schema;
- the JSON-schema request body's `strict` field.

This preserves the intended per-operation override and does not change reflect or consolidation behavior.

## Testing

- `tests/test_fact_extraction_retry.py` and `tests/test_strict_json_schema.py`: 29 passed.
- Regression coverage includes both override directions:
  - `global=false / retain=true` selects the strict schema and sends `strict: true`;
  - `global=true / retain=false` does not call `strict_json_schema()` and sends `strict: false`.
- Ruff check and format check passed.

Found while diagnosing Hindsight 0.9.1 retain behavior. This PR is intentionally separate from the nested-conversation splitter fix and the maxItems/saturation changes.
