### PR TITLE
fix(retain): guard saturated fact extraction output

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -465,6 +465,11 @@ class VerbatimFactExtractionResponse(BaseModel):
     facts: list[VerbatimExtractedFact] = Field(description="List of metadata entries (one per chunk)")
 
 
+# A response at this cap is treated as saturated and sent through the existing
+# split/retry path, so the schema bound cannot silently truncate a dense chunk.
+RETAIN_FACTS_MAX_ITEMS = 16
+
+
 # Separators for sentence-aware recursive text splitting, ordered most- to
 # least-preferred. The final "" lets the splitter break mid-word as a last
 # resort so a chunk can never exceed the size budget.
@@ -1181,6 +1186,25 @@ def _build_extraction_prompt_and_schema(config) -> tuple[str, type]:
             DynamicResponse = create_model("LabelsResponse", facts=(list[DynamicFact], ...))  # type: ignore[valid-type]
             response_schema = DynamicResponse
 
+    # Keep the facts array below the output-token ceiling when the configured
+    # structured-output backend accepts JSON Schema maxItems. The saturation
+    # check in _extract_facts_from_chunk remains authoritative for providers
+    # that do not enforce this schema keyword.
+    if getattr(config, "llm_supports_max_items", True):
+        facts_field = response_schema.model_fields["facts"]
+        response_schema = create_model(
+            "BoundedFactExtractionResponse",
+            __base__=response_schema,
+            facts=(
+                facts_field.annotation,
+                Field(
+                    ...,
+                    max_length=RETAIN_FACTS_MAX_ITEMS,
+                    description=facts_field.description,
+                ),
+            ),
+        )
+
     return prompt, response_schema
 
 
@@ -1443,6 +1467,10 @@ async def _extract_facts_from_chunk(
             extraction_response_json = coerced_response_json
 
             raw_facts = extraction_response_json.get("facts", [])
+            if isinstance(raw_facts, list) and len(raw_facts) >= RETAIN_FACTS_MAX_ITEMS:
+                raise OutputTooLongError(
+                    f"Fact extraction reached the {RETAIN_FACTS_MAX_ITEMS}-fact saturation limit; input must be split."
+                )
 
             if not raw_facts:
                 logger.debug(

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -465,8 +465,9 @@ class VerbatimFactExtractionResponse(BaseModel):
     facts: list[VerbatimExtractedFact] = Field(description="List of metadata entries (one per chunk)")
 
 
-# A response at this cap is treated as saturated and sent through the existing
-# split/retry path, so the schema bound cannot silently truncate a dense chunk.
+# This is a saturation/split threshold, not an extraction or storage limit. A
+# response at this cap is sent through the existing split/retry path, so the
+# schema bound cannot silently truncate a degenerate or excessively dense chunk.
 RETAIN_FACTS_MAX_ITEMS = 16
 
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -465,10 +465,25 @@ class VerbatimFactExtractionResponse(BaseModel):
     facts: list[VerbatimExtractedFact] = Field(description="List of metadata entries (one per chunk)")
 
 
-# This is a saturation/split threshold, not an extraction or storage limit. A
-# response at this cap is sent through the existing split/retry path, so the
-# schema bound cannot silently truncate a degenerate or excessively dense chunk.
-RETAIN_FACTS_MAX_ITEMS = 16
+# Saturation/split threshold, not an extraction or storage limit. A response at
+# this bound is sent through the existing split/retry path, so it can never
+# silently truncate a degenerate or excessively dense chunk.
+#
+# The bound is derived from the configured output budget rather than fixed, so a
+# deployment with a large ceiling is not forced into constant splitting. A fact
+# object costs roughly this many output tokens; halving the budget keeps the item
+# bound biting before the token limit rather than at the same point.
+RETAIN_FACTS_SATURATION_FLOOR = 16
+_APPROX_OUTPUT_TOKENS_PER_FACT = 85
+
+
+def resolve_facts_saturation_limit(config) -> int:
+    """Facts a single extraction may return before the response counts as saturated."""
+    budget = getattr(config, "retain_max_completion_tokens", None)
+    if not isinstance(budget, int) or budget <= 0:
+        return RETAIN_FACTS_SATURATION_FLOOR
+    derived = budget // (2 * _APPROX_OUTPUT_TOKENS_PER_FACT)
+    return max(RETAIN_FACTS_SATURATION_FLOOR, derived)
 
 
 # Separators for sentence-aware recursive text splitting, ordered most- to
@@ -1200,7 +1215,7 @@ def _build_extraction_prompt_and_schema(config) -> tuple[str, type]:
                 facts_field.annotation,
                 Field(
                     ...,
-                    max_length=RETAIN_FACTS_MAX_ITEMS,
+                    max_length=resolve_facts_saturation_limit(config),
                     description=facts_field.description,
                 ),
             ),
@@ -1468,9 +1483,10 @@ async def _extract_facts_from_chunk(
             extraction_response_json = coerced_response_json
 
             raw_facts = extraction_response_json.get("facts", [])
-            if isinstance(raw_facts, list) and len(raw_facts) >= RETAIN_FACTS_MAX_ITEMS:
+            saturation_limit = resolve_facts_saturation_limit(config)
+            if isinstance(raw_facts, list) and len(raw_facts) >= saturation_limit:
                 raise OutputTooLongError(
-                    f"Fact extraction reached the {RETAIN_FACTS_MAX_ITEMS}-fact saturation limit; input must be split."
+                    f"Fact extraction reached the {saturation_limit}-fact saturation limit; input must be split."
                 )
 
             if not raw_facts:

--- a/hindsight-api-slim/tests/test_fact_extraction_entities_schema.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_entities_schema.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from hindsight_api.engine.retain.fact_extraction import (
-    RETAIN_FACTS_MAX_ITEMS,
+    resolve_facts_saturation_limit,
     ExtractedFact,
     ExtractedFactNoCausal,
     ExtractedFactVerbose,
@@ -80,9 +80,10 @@ def test_labels_only_mode_keeps_entities_as_strings():
 
 def test_fact_response_schema_caps_facts_when_max_items_is_supported():
     """Retain's response schema should expose the saturation cap to capable backends."""
-    _, schema = _build_extraction_prompt_and_schema(_baseline_config())
+    config = _baseline_config()
+    _, schema = _build_extraction_prompt_and_schema(config)
 
-    assert schema.model_json_schema()["properties"]["facts"]["maxItems"] == RETAIN_FACTS_MAX_ITEMS
+    assert schema.model_json_schema()["properties"]["facts"]["maxItems"] == resolve_facts_saturation_limit(config)
 
 
 def test_fact_response_schema_omits_max_items_when_backend_does_not_support_it():

--- a/hindsight-api-slim/tests/test_fact_extraction_entities_schema.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_entities_schema.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from hindsight_api.engine.retain.fact_extraction import (
+    RETAIN_FACTS_MAX_ITEMS,
     ExtractedFact,
     ExtractedFactNoCausal,
     ExtractedFactVerbose,
@@ -29,6 +30,7 @@ def _baseline_config() -> MagicMock:
     config.retain_mission = None
     config.retain_custom_instructions = None
     config.llm_output_language = None
+    config.llm_supports_max_items = True
     return config
 
 
@@ -74,3 +76,20 @@ def test_labels_only_mode_keeps_entities_as_strings():
 
     entities_schema = schema.model_fields["facts"].annotation.__args__[0].model_json_schema()["properties"]["entities"]
     assert entities_schema["items"] == {"type": "string"}
+
+
+def test_fact_response_schema_caps_facts_when_max_items_is_supported():
+    """Retain's response schema should expose the saturation cap to capable backends."""
+    _, schema = _build_extraction_prompt_and_schema(_baseline_config())
+
+    assert schema.model_json_schema()["properties"]["facts"]["maxItems"] == RETAIN_FACTS_MAX_ITEMS
+
+
+def test_fact_response_schema_omits_max_items_when_backend_does_not_support_it():
+    """Providers that reject maxItems must retain the uncapped wire schema."""
+    config = _baseline_config()
+    config.llm_supports_max_items = False
+
+    _, schema = _build_extraction_prompt_and_schema(config)
+
+    assert "maxItems" not in schema.model_json_schema()["properties"]["facts"]

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -505,10 +505,10 @@ def test_build_request_body_omits_temperature_when_none():
 @pytest.mark.asyncio
 async def test_fact_saturation_boundary_allows_fifteen_facts():
     """A response below the saturation boundary remains a normal success."""
-    from hindsight_api.engine.retain.fact_extraction import RETAIN_FACTS_MAX_ITEMS, _extract_facts_from_chunk
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk, resolve_facts_saturation_limit
 
     config = _make_config(llm_max_retries=0)
-    fact_count = RETAIN_FACTS_MAX_ITEMS - 1
+    fact_count = resolve_facts_saturation_limit(config) - 1
     llm_config = _make_llm_config(mock_response={"facts": [{"what": f"fact {index}"} for index in range(fact_count)]})
 
     with patch(
@@ -534,11 +534,12 @@ async def test_fact_saturation_boundary_allows_fifteen_facts():
 async def test_fact_saturation_boundary_raises_output_too_long():
     """A response at the saturation boundary must enter the split path."""
     from hindsight_api.engine.llm_wrapper import OutputTooLongError
-    from hindsight_api.engine.retain.fact_extraction import RETAIN_FACTS_MAX_ITEMS, _extract_facts_from_chunk
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk, resolve_facts_saturation_limit
 
     config = _make_config(llm_max_retries=0)
+    saturation_limit = resolve_facts_saturation_limit(config)
     llm_config = _make_llm_config(
-        mock_response={"facts": [{"what": f"fact {index}"} for index in range(RETAIN_FACTS_MAX_ITEMS)]}
+        mock_response={"facts": [{"what": f"fact {index}"} for index in range(saturation_limit)]}
     )
 
     with patch(
@@ -565,7 +566,7 @@ async def test_fact_saturation_uses_auto_split_and_returns_subchunk_facts():
     """Saturation must split the chunk and return facts from both sub-chunks."""
     from hindsight_api.engine.response_models import TokenUsage
     from hindsight_api.engine.retain.fact_extraction import (
-        RETAIN_FACTS_MAX_ITEMS,
+        resolve_facts_saturation_limit,
         _extract_facts_with_auto_split,
     )
 
@@ -574,7 +575,7 @@ async def test_fact_saturation_uses_auto_split_and_returns_subchunk_facts():
     llm_config.call = AsyncMock(
         side_effect=[
             (
-                {"facts": [{"what": f"saturated fact {index}"} for index in range(RETAIN_FACTS_MAX_ITEMS)]},
+                {"facts": [{"what": f"saturated fact {index}"} for index in range(resolve_facts_saturation_limit(config))]},
                 TokenUsage(),
             ),
             ({"facts": [{"what": "left fact"}]}, TokenUsage()),
@@ -725,3 +726,32 @@ async def test_malformed_response_still_attempts_then_fails_loudly(retain_config
 
     assert llm.call.call_count == expected_calls
     assert "after 0 attempts" not in str(exc.value)
+
+
+def test_facts_saturation_limit_scales_with_output_budget():
+    """The saturation bound tracks the configured output ceiling."""
+    from hindsight_api.engine.retain.fact_extraction import (
+        RETAIN_FACTS_SATURATION_FLOOR,
+        resolve_facts_saturation_limit,
+    )
+
+    small = MagicMock()
+    small.retain_max_completion_tokens = 4096
+    large = MagicMock()
+    large.retain_max_completion_tokens = 65536
+
+    assert resolve_facts_saturation_limit(small) < resolve_facts_saturation_limit(large)
+    assert resolve_facts_saturation_limit(small) >= RETAIN_FACTS_SATURATION_FLOOR
+
+
+def test_facts_saturation_limit_falls_back_to_floor_without_budget():
+    """An unset or non-numeric ceiling falls back to the conservative floor."""
+    from hindsight_api.engine.retain.fact_extraction import (
+        RETAIN_FACTS_SATURATION_FLOOR,
+        resolve_facts_saturation_limit,
+    )
+
+    unset = MagicMock()
+    unset.retain_max_completion_tokens = None
+
+    assert resolve_facts_saturation_limit(unset) == RETAIN_FACTS_SATURATION_FLOOR

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -502,6 +502,36 @@ def test_build_request_body_omits_temperature_when_none():
     assert "temperature" not in body
 
 
+@pytest.mark.asyncio
+async def test_fact_saturation_raises_output_too_long_for_existing_split_path():
+    """A saturated facts array must enter the existing recursive split path."""
+    from hindsight_api.engine.llm_wrapper import OutputTooLongError
+    from hindsight_api.engine.retain.fact_extraction import RETAIN_FACTS_MAX_ITEMS, _extract_facts_from_chunk
+
+    config = _make_config(llm_max_retries=0)
+    llm_config = _make_llm_config(
+        mock_response={"facts": [{"what": f"fact {index}"} for index in range(RETAIN_FACTS_MAX_ITEMS)]}
+    )
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        with pytest.raises(OutputTooLongError, match="saturation limit"):
+            await _extract_facts_from_chunk(
+                chunk="A dense chunk.",
+                chunk_index=0,
+                total_chunks=1,
+                event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                context="",
+                llm_config=llm_config,
+                config=config,
+                agent_name="agent",
+            )
+
+    assert llm_config.call.call_count == 1
+
+
 # --- Retry budget semantics (issue #2731) -----------------------------------
 #
 # A retry BUDGET of N means N retries *after* the initial request — the meaning

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -503,8 +503,36 @@ def test_build_request_body_omits_temperature_when_none():
 
 
 @pytest.mark.asyncio
-async def test_fact_saturation_raises_output_too_long_for_existing_split_path():
-    """A saturated facts array must enter the existing recursive split path."""
+async def test_fact_saturation_boundary_allows_fifteen_facts():
+    """A response below the saturation boundary remains a normal success."""
+    from hindsight_api.engine.retain.fact_extraction import RETAIN_FACTS_MAX_ITEMS, _extract_facts_from_chunk
+
+    config = _make_config(llm_max_retries=0)
+    fact_count = RETAIN_FACTS_MAX_ITEMS - 1
+    llm_config = _make_llm_config(mock_response={"facts": [{"what": f"fact {index}"} for index in range(fact_count)]})
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        facts, _usage = await _extract_facts_from_chunk(
+            chunk="A normal chunk.",
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            context="",
+            llm_config=llm_config,
+            config=config,
+            agent_name="agent",
+        )
+
+    assert len(facts) == fact_count
+    assert llm_config.call.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_fact_saturation_boundary_raises_output_too_long():
+    """A response at the saturation boundary must enter the split path."""
     from hindsight_api.engine.llm_wrapper import OutputTooLongError
     from hindsight_api.engine.retain.fact_extraction import RETAIN_FACTS_MAX_ITEMS, _extract_facts_from_chunk
 
@@ -530,6 +558,48 @@ async def test_fact_saturation_raises_output_too_long_for_existing_split_path():
             )
 
     assert llm_config.call.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_fact_saturation_uses_auto_split_and_returns_subchunk_facts():
+    """Saturation must split the chunk and return facts from both sub-chunks."""
+    from hindsight_api.engine.response_models import TokenUsage
+    from hindsight_api.engine.retain.fact_extraction import (
+        RETAIN_FACTS_MAX_ITEMS,
+        _extract_facts_with_auto_split,
+    )
+
+    config = _make_config(llm_max_retries=0)
+    llm_config = _make_llm_config(mock_response=None)
+    llm_config.call = AsyncMock(
+        side_effect=[
+            (
+                {"facts": [{"what": f"saturated fact {index}"} for index in range(RETAIN_FACTS_MAX_ITEMS)]},
+                TokenUsage(),
+            ),
+            ({"facts": [{"what": "left fact"}]}, TokenUsage()),
+            ({"facts": [{"what": "right fact"}]}, TokenUsage()),
+        ]
+    )
+    chunk = "A sentence that needs extraction. " * 40
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        facts, _usage = await _extract_facts_with_auto_split(
+            chunk=chunk,
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            context="",
+            llm_config=llm_config,
+            config=config,
+            agent_name="agent",
+        )
+
+    assert [fact.fact for fact in facts] == ["left fact", "right fact"]
+    assert llm_config.call.call_count == 3
 
 
 # --- Retry budget semantics (issue #2731) -----------------------------------


### PR DESCRIPTION
## Summary

Fact extraction may enter a degenerate or excessively dense structured-output response where the `facts` array keeps growing until the output token limit. Introduce a saturation boundary that never silently accepts a capped response: reaching the boundary raises `OutputTooLongError` and delegates completeness to the existing recursive split/retry path.

The boundary is a split threshold, not an extraction or storage limit. A legitimate chunk with more than 16 facts is split and all sub-chunk facts are still returned.

## Reproduction / impact

In Hindsight 0.9.1, the same small retain chunk can sometimes complete normally and sometimes produce a degenerate/looping response that keeps emitting facts until the output ceiling. Without a deterministic saturation signal, the extraction path has no reliable point at which to split the input.

This PR adds:

- `maxItems=16` to the retain `facts` array when the configured backend supports that JSON Schema keyword;
- a runtime `len(facts) >= 16` guard that raises `OutputTooLongError` instead of treating the boundary response as complete;
- delegation to the existing recursive split/retry path, which preserves facts by extracting the smaller sub-chunks.

## Backend capability behavior

For `llm_supports_max_items=True`, the schema-level boundary prevents capable structured-output backends from accepting more than the split threshold. For `llm_supports_max_items=False`, the wire schema remains uncapped because some providers reject `maxItems`; the runtime guard is authoritative when a complete response contains 16 or more facts. It cannot interrupt generation in that case, so a provider that loops until `finish_reason=length` still relies on the existing output-too-long handling to trigger the split.

## Scope

- Hindsight version: 0.9.1
- `16` is a saturation/circuit-breaker threshold, not a legal maximum fact count or a truncation policy.
- Separate from the nested `[[{turn}, ...]]` splitter fix in #3652.
- Separate from the strict-schema flag fix in #3653.
- No changes to saturation behavior in unrelated extraction paths.

## Validation

- `tests/test_fact_extraction_retry.py tests/test_fact_extraction_entities_schema.py`: 40 passed
- Boundary coverage: 15 facts succeeds; 16 facts raises `OutputTooLongError`.
- End-to-end retry coverage: 16 facts → recursive split → two successful sub-chunk responses → both facts returned.
- Ruff check: passed
- Ruff format check: passed

The repository hook was not used because this checkout does not have `uv` installed; the equivalent targeted Ruff checks were run directly.


---

## Depends on #3652

This PR raises how often `OutputTooLongError` is signalled, which routes more work
into the existing split path. #3652 is what makes that path succeed for
conversation payloads that arrive wrapped in an extra array. Merging this without
#3652 would increase the number of splits while leaving those splits unable to
make progress.

## On the bound

The bound is derived from `retain_max_completion_tokens` rather than fixed, so a
deployment with a large ceiling is not pushed into constant splitting:

```
budget 4096  -> 24 facts
budget 65536 -> 385 facts
unset        -> 16 facts (floor)
```

An earlier revision hard-coded 16, which was tuned against a 4096-token ceiling on
a small local model. At that ceiling a fact object costs roughly 85 output tokens,
so a bound of 48 would have landed at the same point as the token limit and done
nothing. Halving the budget keeps the item bound biting first.

Field data behind the floor, from 168 single-chunk extractions on one deployment:
median 2 facts, p95 10, max 29.
