### PR TITLE
fix(retain): fail when oversized chunk cannot split

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1720,6 +1720,9 @@ async def _extract_facts_with_auto_split(
 
     Returns:
         Tuple of (facts list, token usage) extracted from the chunk (possibly from sub-chunks)
+
+    Raises:
+        RuntimeError: If output is too long and the chunk cannot be split further.
     """
     import logging
 
@@ -1748,11 +1751,15 @@ async def _extract_facts_with_auto_split(
 
         split_chunks = _split_chunk_for_output_retry(chunk)
         if split_chunks is None:
-            logger.warning(
-                f"Cannot make progress splitting chunk {chunk_index + 1}/{total_chunks} "
-                f"({len(chunk)} chars); dropping this sub-chunk."
+            error_message = (
+                f"Fact extraction cannot make progress splitting chunk {chunk_index + 1}/{total_chunks} "
+                f"({len(chunk)} chars) after the output limit was reached; refusing to drop this sub-chunk."
             )
-            return [], TokenUsage()
+            logger.error(
+                f"Cannot make progress splitting chunk {chunk_index + 1}/{total_chunks} "
+                f"({len(chunk)} chars); failing retain instead of dropping this sub-chunk."
+            )
+            raise RuntimeError(error_message)
 
         first_half, second_half = split_chunks
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1741,7 +1741,7 @@ async def _extract_facts_with_auto_split(
             agent_name=agent_name,
             metadata=metadata,
         )
-    except OutputTooLongError:
+    except OutputTooLongError as exc:
         # Output exceeded token limits - split the chunk and retry. Conversation
         # chunks are JSON arrays, so preserve array/turn boundaries when possible.
         logger.warning(
@@ -1759,7 +1759,7 @@ async def _extract_facts_with_auto_split(
                 f"Cannot make progress splitting chunk {chunk_index + 1}/{total_chunks} "
                 f"({len(chunk)} chars); failing retain instead of dropping this sub-chunk."
             )
-            raise RuntimeError(error_message)
+            raise RuntimeError(error_message) from exc
 
         first_half, second_half = split_chunks
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1793,14 +1793,33 @@ async def _extract_facts_with_auto_split(
             ),
         ]
 
-        sub_results = await asyncio.gather(*sub_tasks)
+        # return_exceptions so one unsplittable half cannot discard facts the other
+        # half extracted successfully. Losing good data is the failure mode this
+        # path exists to prevent, so salvage what succeeded and only fail when the
+        # split produced nothing at all.
+        sub_results = await asyncio.gather(*sub_tasks, return_exceptions=True)
 
         # Combine results from both halves
         all_facts = []
         total_usage = TokenUsage()
-        for sub_facts, sub_usage in sub_results:
+        failures: list[BaseException] = []
+        for sub_result in sub_results:
+            if isinstance(sub_result, BaseException):
+                failures.append(sub_result)
+                continue
+            sub_facts, sub_usage = sub_result
             all_facts.extend(sub_facts)
             total_usage = total_usage + sub_usage
+
+        if failures and not all_facts:
+            raise failures[0]
+
+        if failures:
+            logger.error(
+                f"Chunk {chunk_index + 1}/{total_chunks}: {len(failures)} of {len(sub_results)} sub-chunks "
+                f"failed after splitting; keeping {len(all_facts)} facts from the sub-chunks that succeeded. "
+                f"First failure: {failures[0]}"
+            )
 
         logger.info(f"Successfully extracted {len(all_facts)} facts from split chunk {chunk_index + 1}")
 

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -106,8 +106,8 @@ def test_output_retry_split_drops_subchunk_below_minimum_floor():
 
 
 @pytest.mark.asyncio
-async def test_output_too_long_drops_unsplittable_subchunk_without_recursing():
-    """If a chunk cannot be reduced further, auto-split exits gracefully."""
+async def test_output_too_long_fails_unsplittable_subchunk_without_recursing():
+    """If a chunk cannot be reduced further, auto-split fails without dropping it."""
     from hindsight_api.engine.llm_wrapper import OutputTooLongError
     from hindsight_api.engine.retain.fact_extraction import _extract_facts_with_auto_split
 
@@ -118,18 +118,18 @@ async def test_output_too_long_drops_unsplittable_subchunk_without_recursing():
         "hindsight_api.engine.retain.fact_extraction._extract_facts_from_chunk",
         side_effect=OutputTooLongError("too long"),
     ) as extract:
-        facts, usage = await _extract_facts_with_auto_split(
-            chunk="x",
-            chunk_index=0,
-            total_chunks=1,
-            event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
-            context="",
-            llm_config=llm_config,
-            config=config,
-            agent_name="agent",
-        )
+        with pytest.raises(RuntimeError, match="refusing to drop this sub-chunk"):
+            await _extract_facts_with_auto_split(
+                chunk="x",
+                chunk_index=0,
+                total_chunks=1,
+                event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                context="",
+                llm_config=llm_config,
+                config=config,
+                agent_name="agent",
+            )
 
-    assert facts == []
     assert extract.call_count == 1
 
 

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -133,6 +133,46 @@ async def test_output_too_long_fails_unsplittable_subchunk_without_recursing():
     assert extract.call_count == 1
 
 
+@pytest.mark.asyncio
+async def test_output_too_long_keeps_facts_from_sibling_when_one_half_fails():
+    """One unsplittable half must not discard facts the other half extracted."""
+    from hindsight_api.engine.llm_wrapper import OutputTooLongError
+    from hindsight_api.engine.retain.fact_extraction import TokenUsage, _extract_facts_with_auto_split
+
+    long_turn = {"role": "user", "content": "alpha " * 300}
+    tiny_turn = {"role": "assistant", "content": "b"}
+    chunk = json.dumps([long_turn, tiny_turn])
+
+    async def _extract(*, chunk: str, **_kwargs):
+        # Only the half holding solely the user turn succeeds. Anything still
+        # carrying the assistant turn overflows, so the whole chunk splits first
+        # and the tiny assistant half then fails unsplittably. Keyed on content,
+        # not call order, so gather scheduling cannot flip the test.
+        if "assistant" not in chunk:
+            return [{"fact": "kept"}], TokenUsage()
+        raise OutputTooLongError("too long")
+
+    config = _make_config(llm_max_retries=0)
+    llm_config = _make_llm_config(mock_response={})
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._extract_facts_from_chunk",
+        side_effect=_extract,
+    ):
+        facts, _usage = await _extract_facts_with_auto_split(
+            chunk=chunk,
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            context="",
+            llm_config=llm_config,
+            config=config,
+            agent_name="agent",
+        )
+
+    assert facts == [{"fact": "kept"}]
+
+
 def _make_config(llm_max_retries: int = 3, retain_llm_max_retries: int | None = None):
     """Build a minimal HindsightConfig for fact extraction tests."""
     from hindsight_api.config import _get_raw_config


### PR DESCRIPTION
## Summary

In Hindsight 0.9.1, the retain output-retry splitter logs a warning and returns an empty result when an overlong sub-chunk cannot be split any further. The caller then treats that result as successful extraction, which can allow an operation to report `completed` while the sub-chunk's data was silently lost.

This draft PR changes only that terminal branch:

- keep the existing minimum-size/no-progress decision in `_split_chunk_for_output_retry`;
- raise a descriptive `RuntimeError` when an `OutputTooLongError` cannot be followed by a valid split;
- let the existing `extract_facts_from_text` failure propagation mark the retain as failed/retryable instead of committing a partial result.

## Reproduction / impact

1. A retain chunk raises `OutputTooLongError`.
2. `_split_chunk_for_output_retry` returns `None` because the chunk is too small or cannot be reduced.
3. Before this change, `_extract_facts_with_auto_split` returned `([], TokenUsage())` and logged that it was dropping the sub-chunk.
4. The extraction could therefore continue with missing data and eventually report success.

The regression test uses a one-character chunk and a mocked `OutputTooLongError`; it now verifies that the helper raises and makes exactly one extraction attempt. Splittable chunks and the standard successful extraction path are unchanged.

## Scope

- Hindsight version: 0.9.1
- Separate from the nested `[[{turn}, ...]]` splitter fix in #3652.
- Separate from the strict-schema flag fix in #3653.
- Separate from the facts-array saturation guard in #3654.

## Validation

- `tests/test_fact_extraction_retry.py`: 25 passed
- Ruff check: passed
- Ruff format check: passed

The repository hook was not used because this checkout does not have `uv` installed; the equivalent targeted Ruff checks were run directly.


---

## Depends on #3652

Without #3652, conversation payloads wrapped in an extra array cannot be split at
all, so this change would turn a recoverable case into a hard failure. #3652 makes
those splits succeed; this PR then only fails when a chunk genuinely cannot be
reduced further.

## Partial results are preserved

The recursive split previously gathered sub-chunk results without
`return_exceptions`, so one unsplittable half discarded facts the other half had
already extracted. That is the same data-loss shape this PR is meant to remove, so
sub-chunk results are now collected tolerantly:

- some halves fail, others succeed -> keep the extracted facts, log the partial
  failure at error level with counts
- every half fails -> re-raise, so the operation cannot report success

The remaining trade-off is deliberate: a partially-failed chunk still completes,
with the loss visible in logs rather than silent at the operation level.
