### PR TITLE
fix(retain): honour the retain strict-schema flag in the batch path

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1293,12 +1293,11 @@ def _build_request_body(llm_config, config, prompt: str, user_message: str, resp
     # retain-scoped field, which already folds in the global HINDSIGHT_API_LLM_STRICT_SCHEMA
     # fallback, so the batch and streaming paths can't disagree.
     if hasattr(response_schema, "model_json_schema"):
-        schema = (
-            strict_json_schema(response_schema) if config.llm_strict_schema else response_schema.model_json_schema()
-        )
+        retain_strict_schema = config.llm_strict_schema_retain
+        schema = strict_json_schema(response_schema) if retain_strict_schema else response_schema.model_json_schema()
         request_body["response_format"] = {
             "type": "json_schema",
-            "json_schema": {"name": "facts", "schema": schema, "strict": config.llm_strict_schema_retain},
+            "json_schema": {"name": "facts", "schema": schema, "strict": retain_strict_schema},
         }
 
     return request_body

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -470,6 +470,7 @@ def _make_batch_temp_config(temperature):
     cfg.llm_temperature_retain = temperature
     cfg.retain_max_completion_tokens = None
     cfg.llm_strict_schema = False
+    cfg.llm_strict_schema_retain = False
     return cfg
 
 
@@ -500,6 +501,27 @@ def test_build_request_body_omits_temperature_when_none():
 
     body = _build_request_body(_make_batch_llm_config(), _make_batch_temp_config(None), "sys", "user", dict)
     assert "temperature" not in body
+
+
+def test_build_request_body_uses_retain_strict_schema_flag_for_schema_and_request():
+    """The batch retain path must use one resolved strict-schema flag consistently."""
+    from hindsight_api.engine.retain.fact_extraction import _build_request_body
+
+    config = _make_batch_temp_config(None)
+    config.llm_strict_schema = False
+    config.llm_strict_schema_retain = True
+    response_schema = MagicMock()
+    response_schema.model_json_schema.return_value = {"schema": "non-strict"}
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction.strict_json_schema",
+        return_value={"schema": "strict"},
+    ) as strict_schema:
+        body = _build_request_body(_make_batch_llm_config(), config, "sys", "user", response_schema)
+
+    strict_schema.assert_called_once_with(response_schema)
+    assert body["response_format"]["json_schema"]["schema"] == {"schema": "strict"}
+    assert body["response_format"]["json_schema"]["strict"] is True
 
 
 # --- Retry budget semantics (issue #2731) -----------------------------------

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -524,6 +524,24 @@ def test_build_request_body_uses_retain_strict_schema_flag_for_schema_and_reques
     assert body["response_format"]["json_schema"]["strict"] is True
 
 
+def test_build_request_body_retain_strict_false_overrides_global_true():
+    """The retain opt-out must disable strict schema in the batch request body."""
+    from hindsight_api.engine.retain.fact_extraction import _build_request_body
+
+    config = _make_batch_temp_config(None)
+    config.llm_strict_schema = True
+    config.llm_strict_schema_retain = False
+    response_schema = MagicMock()
+    response_schema.model_json_schema.return_value = {"schema": "non-strict"}
+
+    with patch("hindsight_api.engine.retain.fact_extraction.strict_json_schema") as strict_schema:
+        body = _build_request_body(_make_batch_llm_config(), config, "sys", "user", response_schema)
+
+    strict_schema.assert_not_called()
+    assert body["response_format"]["json_schema"]["schema"] == {"schema": "non-strict"}
+    assert body["response_format"]["json_schema"]["strict"] is False
+
+
 # --- Retry budget semantics (issue #2731) -----------------------------------
 #
 # A retry BUDGET of N means N retries *after* the initial request — the meaning


### PR DESCRIPTION
## Summary

The retain strict-schema flag was half-applied in the batch path.

`_build_request_body` chose the **schema builder** from the global
`llm_strict_schema` but sent `strict:` from the **retain-scoped**
`llm_strict_schema_retain`. #2825 moved the `strict:` field to the retain-scoped
flag (and wrote the comment above it describing exactly that intent) but left
the builder behind, so the two can disagree:

- `llm_strict_schema=false`, `llm_strict_schema_retain=true` → a plain
  `model_json_schema()` is sent with `strict: true`. OpenAI-compatible backends
  reject that combination (`additionalProperties`), so retain fails outright
  instead of grammar-enforcing the output.
- `llm_strict_schema=true`, `llm_strict_schema_retain=false` → the strict-subset
  schema is built even though the operator opted retain out.

The fix resolves the flag once and uses it for both, which is what every
provider already does (`litellm_llm.py`, `codex_llm.py`) and what the streaming
retain path does via `LLMProvider.call(strict_schema=config.llm_strict_schema_retain)`.

## Tests

Two tests covering both directions of the disagreement. `_make_batch_temp_config`
also gains an explicit `llm_strict_schema_retain = False` — it is a
`MagicMock(spec=HindsightConfig)`, so the attribute was previously leaking a
truthy mock into `strict:`.

```
27 passed
```

## Note

This PR originally also carried a fix to `_split_chunk_for_output_retry` for
doubly-nested conversation arrays. That change has been dropped from this branch
and will be handled separately, so this PR is now the strict-schema fix alone.
