### PR TITLE
fix(retain): bound and recover degenerate fact-extraction output

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -469,12 +469,27 @@ class VerbatimFactExtractionResponse(BaseModel):
 # this bound is sent through the existing split/retry path, so it can never
 # silently truncate a degenerate or excessively dense chunk.
 #
-# The bound is derived from the configured output budget rather than fixed, so a
-# deployment with a large ceiling is not forced into constant splitting. A fact
-# object costs roughly this many output tokens; halving the budget keeps the item
-# bound biting before the token limit rather than at the same point.
-RETAIN_FACTS_SATURATION_FLOOR = 16
+# The bound has to sit in a window with a floor and a ceiling:
+#
+#   above legitimate density, or dense chunks are split for no reason. Field data
+#   from 168 single-chunk extractions: median 2 facts, p95 10, max 29. A measured
+#   worst case on a deliberately dense ~2 kB chunk produced 21-22 facts.
+#
+#   below the output-token ceiling, or the schema bound never gets to stop the
+#   array and the response comes back truncated at finish_reason=length instead.
+#   At a 4096-token budget that ceiling is around 48 facts.
+#
+# So the bound is three quarters of the token-limited count, not half the budget:
+# an earlier revision halved it and produced 24 at a 4096-token budget, below the
+# observed maximum of 29, so it would have forced splits on honest input.
+#
+# The per-fact cost is measured, not assumed. Against a strict json_schema — the
+# shape retain actually sends — four runs across two models gave 80.1, 82.1, 89.5
+# and 101.5 output tokens per fact, so 85 is a central estimate rather than a
+# guess. Modes that emit fewer fields are cheaper and simply bind later.
+RETAIN_FACTS_SATURATION_FLOOR = 32
 _APPROX_OUTPUT_TOKENS_PER_FACT = 85
+_SATURATION_BUDGET_SHARE = 3, 4  # numerator, denominator
 
 
 def resolve_facts_saturation_limit(config) -> int:
@@ -484,8 +499,15 @@ def resolve_facts_saturation_limit(config) -> int:
     # which subclasses AttributeError, so a default would silently substitute the
     # global value for the bank's resolved one (#3610). The field is required and
     # validated positive by validate_retain_completion_token_budget.
-    derived = config.retain_max_completion_tokens // (2 * _APPROX_OUTPUT_TOKENS_PER_FACT)
-    return max(RETAIN_FACTS_SATURATION_FLOOR, derived)
+    budget = config.retain_max_completion_tokens
+    numerator, denominator = _SATURATION_BUDGET_SHARE
+    derived = budget * numerator // (denominator * _APPROX_OUTPUT_TOKENS_PER_FACT)
+    # Never advertise a bound the budget cannot reach. Below roughly 2.7k output
+    # tokens the floor would exceed the token-limited count, putting a maxItems
+    # in the schema that the response can never hit — the array would run to
+    # finish_reason=length instead, which is the path this bound exists to avoid.
+    reachable_floor = min(RETAIN_FACTS_SATURATION_FLOOR, budget // _APPROX_OUTPUT_TOKENS_PER_FACT)
+    return max(reachable_floor, derived)
 
 
 # Separators for sentence-aware recursive text splitting, ordered most- to

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -465,6 +465,11 @@ class VerbatimFactExtractionResponse(BaseModel):
     facts: list[VerbatimExtractedFact] = Field(description="List of metadata entries (one per chunk)")
 
 
+# A response at this cap is treated as saturated and sent through the existing
+# split/retry path, so the schema bound cannot silently truncate a dense chunk.
+RETAIN_FACTS_MAX_ITEMS = 16
+
+
 # Separators for sentence-aware recursive text splitting, ordered most- to
 # least-preferred. The final "" lets the splitter break mid-word as a last
 # resort so a chunk can never exceed the size budget.
@@ -1181,6 +1186,25 @@ def _build_extraction_prompt_and_schema(config) -> tuple[str, type]:
             DynamicResponse = create_model("LabelsResponse", facts=(list[DynamicFact], ...))  # type: ignore[valid-type]
             response_schema = DynamicResponse
 
+    # Keep the facts array below the output-token ceiling when the configured
+    # structured-output backend accepts JSON Schema maxItems. The saturation
+    # check in _extract_facts_from_chunk remains authoritative for providers
+    # that do not enforce this schema keyword.
+    if getattr(config, "llm_supports_max_items", True):
+        facts_field = response_schema.model_fields["facts"]
+        response_schema = create_model(
+            "BoundedFactExtractionResponse",
+            __base__=response_schema,
+            facts=(
+                facts_field.annotation,
+                Field(
+                    ...,
+                    max_length=RETAIN_FACTS_MAX_ITEMS,
+                    description=facts_field.description,
+                ),
+            ),
+        )
+
     return prompt, response_schema
 
 
@@ -1452,6 +1476,10 @@ async def _extract_facts_from_chunk(
             extraction_response_json = coerced_response_json
 
             raw_facts = extraction_response_json.get("facts", [])
+            if isinstance(raw_facts, list) and len(raw_facts) >= RETAIN_FACTS_MAX_ITEMS:
+                raise OutputTooLongError(
+                    f"Fact extraction reached the {RETAIN_FACTS_MAX_ITEMS}-fact saturation limit; input must be split."
+                )
 
             if not raw_facts:
                 logger.debug(

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1774,6 +1774,9 @@ async def _extract_facts_with_auto_split(
 
     Returns:
         Tuple of (facts list, token usage) extracted from the chunk (possibly from sub-chunks)
+
+    Raises:
+        RuntimeError: If output is too long and the chunk cannot be split further.
     """
     import logging
 
@@ -1802,11 +1805,15 @@ async def _extract_facts_with_auto_split(
 
         split_chunks = _split_chunk_for_output_retry(chunk)
         if split_chunks is None:
-            logger.warning(
-                f"Cannot make progress splitting chunk {chunk_index + 1}/{total_chunks} "
-                f"({len(chunk)} chars); dropping this sub-chunk."
+            error_message = (
+                f"Fact extraction cannot make progress splitting chunk {chunk_index + 1}/{total_chunks} "
+                f"({len(chunk)} chars) after the output limit was reached; refusing to drop this sub-chunk."
             )
-            return [], TokenUsage()
+            logger.error(
+                f"Cannot make progress splitting chunk {chunk_index + 1}/{total_chunks} "
+                f"({len(chunk)} chars); failing retain instead of dropping this sub-chunk."
+            )
+            raise RuntimeError(error_message)
 
         first_half, second_half = split_chunks
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1847,14 +1847,33 @@ async def _extract_facts_with_auto_split(
             ),
         ]
 
-        sub_results = await asyncio.gather(*sub_tasks)
+        # return_exceptions so one unsplittable half cannot discard facts the other
+        # half extracted successfully. Losing good data is the failure mode this
+        # path exists to prevent, so salvage what succeeded and only fail when the
+        # split produced nothing at all.
+        sub_results = await asyncio.gather(*sub_tasks, return_exceptions=True)
 
         # Combine results from both halves
         all_facts = []
         total_usage = TokenUsage()
-        for sub_facts, sub_usage in sub_results:
+        failures: list[BaseException] = []
+        for sub_result in sub_results:
+            if isinstance(sub_result, BaseException):
+                failures.append(sub_result)
+                continue
+            sub_facts, sub_usage = sub_result
             all_facts.extend(sub_facts)
             total_usage = total_usage + sub_usage
+
+        if failures and not all_facts:
+            raise failures[0]
+
+        if failures:
+            logger.error(
+                f"Chunk {chunk_index + 1}/{total_chunks}: {len(failures)} of {len(sub_results)} sub-chunks "
+                f"failed after splitting; keeping {len(all_facts)} facts from the sub-chunks that succeeded. "
+                f"First failure: {failures[0]}"
+            )
 
         logger.info(f"Successfully extracted {len(all_facts)} facts from split chunk {chunk_index + 1}")
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -465,10 +465,25 @@ class VerbatimFactExtractionResponse(BaseModel):
     facts: list[VerbatimExtractedFact] = Field(description="List of metadata entries (one per chunk)")
 
 
-# This is a saturation/split threshold, not an extraction or storage limit. A
-# response at this cap is sent through the existing split/retry path, so the
-# schema bound cannot silently truncate a degenerate or excessively dense chunk.
-RETAIN_FACTS_MAX_ITEMS = 16
+# Saturation/split threshold, not an extraction or storage limit. A response at
+# this bound is sent through the existing split/retry path, so it can never
+# silently truncate a degenerate or excessively dense chunk.
+#
+# The bound is derived from the configured output budget rather than fixed, so a
+# deployment with a large ceiling is not forced into constant splitting. A fact
+# object costs roughly this many output tokens; halving the budget keeps the item
+# bound biting before the token limit rather than at the same point.
+RETAIN_FACTS_SATURATION_FLOOR = 16
+_APPROX_OUTPUT_TOKENS_PER_FACT = 85
+
+
+def resolve_facts_saturation_limit(config) -> int:
+    """Facts a single extraction may return before the response counts as saturated."""
+    budget = getattr(config, "retain_max_completion_tokens", None)
+    if not isinstance(budget, int) or budget <= 0:
+        return RETAIN_FACTS_SATURATION_FLOOR
+    derived = budget // (2 * _APPROX_OUTPUT_TOKENS_PER_FACT)
+    return max(RETAIN_FACTS_SATURATION_FLOOR, derived)
 
 
 # Separators for sentence-aware recursive text splitting, ordered most- to
@@ -1200,7 +1215,7 @@ def _build_extraction_prompt_and_schema(config) -> tuple[str, type]:
                 facts_field.annotation,
                 Field(
                     ...,
-                    max_length=RETAIN_FACTS_MAX_ITEMS,
+                    max_length=resolve_facts_saturation_limit(config),
                     description=facts_field.description,
                 ),
             ),
@@ -1477,9 +1492,10 @@ async def _extract_facts_from_chunk(
             extraction_response_json = coerced_response_json
 
             raw_facts = extraction_response_json.get("facts", [])
-            if isinstance(raw_facts, list) and len(raw_facts) >= RETAIN_FACTS_MAX_ITEMS:
+            saturation_limit = resolve_facts_saturation_limit(config)
+            if isinstance(raw_facts, list) and len(raw_facts) >= saturation_limit:
                 raise OutputTooLongError(
-                    f"Fact extraction reached the {RETAIN_FACTS_MAX_ITEMS}-fact saturation limit; input must be split."
+                    f"Fact extraction reached the {saturation_limit}-fact saturation limit; input must be split."
                 )
 
             if not raw_facts:

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1795,7 +1795,7 @@ async def _extract_facts_with_auto_split(
             agent_name=agent_name,
             metadata=metadata,
         )
-    except OutputTooLongError:
+    except OutputTooLongError as exc:
         # Output exceeded token limits - split the chunk and retry. Conversation
         # chunks are JSON arrays, so preserve array/turn boundaries when possible.
         logger.warning(
@@ -1813,7 +1813,7 @@ async def _extract_facts_with_auto_split(
                 f"Cannot make progress splitting chunk {chunk_index + 1}/{total_chunks} "
                 f"({len(chunk)} chars); failing retain instead of dropping this sub-chunk."
             )
-            raise RuntimeError(error_message)
+            raise RuntimeError(error_message) from exc
 
         first_half, second_half = split_chunks
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -465,8 +465,9 @@ class VerbatimFactExtractionResponse(BaseModel):
     facts: list[VerbatimExtractedFact] = Field(description="List of metadata entries (one per chunk)")
 
 
-# A response at this cap is treated as saturated and sent through the existing
-# split/retry path, so the schema bound cannot silently truncate a dense chunk.
+# This is a saturation/split threshold, not an extraction or storage limit. A
+# response at this cap is sent through the existing split/retry path, so the
+# schema bound cannot silently truncate a degenerate or excessively dense chunk.
 RETAIN_FACTS_MAX_ITEMS = 16
 
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -479,10 +479,12 @@ _APPROX_OUTPUT_TOKENS_PER_FACT = 85
 
 def resolve_facts_saturation_limit(config) -> int:
     """Facts a single extraction may return before the response counts as saturated."""
-    budget = getattr(config, "retain_max_completion_tokens", None)
-    if not isinstance(budget, int) or budget <= 0:
-        return RETAIN_FACTS_SATURATION_FLOOR
-    derived = budget // (2 * _APPROX_OUTPUT_TOKENS_PER_FACT)
+    # Direct attribute access, never getattr with a default: StaticConfigProxy
+    # signals "this field is bank-configurable" by raising ConfigFieldAccessError,
+    # which subclasses AttributeError, so a default would silently substitute the
+    # global value for the bank's resolved one (#3610). The field is required and
+    # validated positive by validate_retain_completion_token_budget.
+    derived = config.retain_max_completion_tokens // (2 * _APPROX_OUTPUT_TOKENS_PER_FACT)
     return max(RETAIN_FACTS_SATURATION_FLOOR, derived)
 
 
@@ -1206,7 +1208,7 @@ def _build_extraction_prompt_and_schema(config) -> tuple[str, type]:
     # structured-output backend accepts JSON Schema maxItems. The saturation
     # check in _extract_facts_from_chunk remains authoritative for providers
     # that do not enforce this schema keyword.
-    if getattr(config, "llm_supports_max_items", True):
+    if config.llm_supports_max_items:
         facts_field = response_schema.model_fields["facts"]
         response_schema = create_model(
             "BoundedFactExtractionResponse",
@@ -1847,33 +1849,19 @@ async def _extract_facts_with_auto_split(
             ),
         ]
 
-        # return_exceptions so one unsplittable half cannot discard facts the other
-        # half extracted successfully. Losing good data is the failure mode this
-        # path exists to prevent, so salvage what succeeded and only fail when the
-        # split produced nothing at all.
-        sub_results = await asyncio.gather(*sub_tasks, return_exceptions=True)
+        # A failing half must propagate, not be salvaged around. extract_facts_from_text
+        # already fails the retain if ANY chunk could not be extracted — "partial
+        # extraction is not acceptable" — so keeping one half's facts while the other
+        # is lost would report the operation completed with data silently missing,
+        # which is the exact failure this path exists to prevent.
+        sub_results = await asyncio.gather(*sub_tasks)
 
         # Combine results from both halves
         all_facts = []
         total_usage = TokenUsage()
-        failures: list[BaseException] = []
-        for sub_result in sub_results:
-            if isinstance(sub_result, BaseException):
-                failures.append(sub_result)
-                continue
-            sub_facts, sub_usage = sub_result
+        for sub_facts, sub_usage in sub_results:
             all_facts.extend(sub_facts)
             total_usage = total_usage + sub_usage
-
-        if failures and not all_facts:
-            raise failures[0]
-
-        if failures:
-            logger.error(
-                f"Chunk {chunk_index + 1}/{total_chunks}: {len(failures)} of {len(sub_results)} sub-chunks "
-                f"failed after splitting; keeping {len(all_facts)} facts from the sub-chunks that succeeded. "
-                f"First failure: {failures[0]}"
-            )
 
         logger.info(f"Successfully extracted {len(all_facts)} facts from split chunk {chunk_index + 1}")
 

--- a/hindsight-api-slim/tests/test_fact_extraction_entities_schema.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_entities_schema.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from hindsight_api.engine.retain.fact_extraction import (
-    RETAIN_FACTS_MAX_ITEMS,
+    resolve_facts_saturation_limit,
     ExtractedFact,
     ExtractedFactNoCausal,
     ExtractedFactVerbose,
@@ -80,9 +80,10 @@ def test_labels_only_mode_keeps_entities_as_strings():
 
 def test_fact_response_schema_caps_facts_when_max_items_is_supported():
     """Retain's response schema should expose the saturation cap to capable backends."""
-    _, schema = _build_extraction_prompt_and_schema(_baseline_config())
+    config = _baseline_config()
+    _, schema = _build_extraction_prompt_and_schema(config)
 
-    assert schema.model_json_schema()["properties"]["facts"]["maxItems"] == RETAIN_FACTS_MAX_ITEMS
+    assert schema.model_json_schema()["properties"]["facts"]["maxItems"] == resolve_facts_saturation_limit(config)
 
 
 def test_fact_response_schema_omits_max_items_when_backend_does_not_support_it():

--- a/hindsight-api-slim/tests/test_fact_extraction_entities_schema.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_entities_schema.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from hindsight_api.engine.retain.fact_extraction import (
+    RETAIN_FACTS_MAX_ITEMS,
     ExtractedFact,
     ExtractedFactNoCausal,
     ExtractedFactVerbose,
@@ -29,6 +30,7 @@ def _baseline_config() -> MagicMock:
     config.retain_mission = None
     config.retain_custom_instructions = None
     config.llm_output_language = None
+    config.llm_supports_max_items = True
     return config
 
 
@@ -74,3 +76,20 @@ def test_labels_only_mode_keeps_entities_as_strings():
 
     entities_schema = schema.model_fields["facts"].annotation.__args__[0].model_json_schema()["properties"]["entities"]
     assert entities_schema["items"] == {"type": "string"}
+
+
+def test_fact_response_schema_caps_facts_when_max_items_is_supported():
+    """Retain's response schema should expose the saturation cap to capable backends."""
+    _, schema = _build_extraction_prompt_and_schema(_baseline_config())
+
+    assert schema.model_json_schema()["properties"]["facts"]["maxItems"] == RETAIN_FACTS_MAX_ITEMS
+
+
+def test_fact_response_schema_omits_max_items_when_backend_does_not_support_it():
+    """Providers that reject maxItems must retain the uncapped wire schema."""
+    config = _baseline_config()
+    config.llm_supports_max_items = False
+
+    _, schema = _build_extraction_prompt_and_schema(config)
+
+    assert "maxItems" not in schema.model_json_schema()["properties"]["facts"]

--- a/hindsight-api-slim/tests/test_fact_extraction_entities_schema.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_entities_schema.py
@@ -31,6 +31,7 @@ def _baseline_config() -> MagicMock:
     config.retain_custom_instructions = None
     config.llm_output_language = None
     config.llm_supports_max_items = True
+    config.retain_max_completion_tokens = 4096
     return config
 
 

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -106,8 +106,8 @@ def test_output_retry_split_drops_subchunk_below_minimum_floor():
 
 
 @pytest.mark.asyncio
-async def test_output_too_long_drops_unsplittable_subchunk_without_recursing():
-    """If a chunk cannot be reduced further, auto-split exits gracefully."""
+async def test_output_too_long_fails_unsplittable_subchunk_without_recursing():
+    """If a chunk cannot be reduced further, auto-split fails without dropping it."""
     from hindsight_api.engine.llm_wrapper import OutputTooLongError
     from hindsight_api.engine.retain.fact_extraction import _extract_facts_with_auto_split
 
@@ -118,18 +118,18 @@ async def test_output_too_long_drops_unsplittable_subchunk_without_recursing():
         "hindsight_api.engine.retain.fact_extraction._extract_facts_from_chunk",
         side_effect=OutputTooLongError("too long"),
     ) as extract:
-        facts, usage = await _extract_facts_with_auto_split(
-            chunk="x",
-            chunk_index=0,
-            total_chunks=1,
-            event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
-            context="",
-            llm_config=llm_config,
-            config=config,
-            agent_name="agent",
-        )
+        with pytest.raises(RuntimeError, match="refusing to drop this sub-chunk"):
+            await _extract_facts_with_auto_split(
+                chunk="x",
+                chunk_index=0,
+                total_chunks=1,
+                event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                context="",
+                llm_config=llm_config,
+                config=config,
+                agent_name="agent",
+            )
 
-    assert facts == []
     assert extract.call_count == 1
 
 

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -586,7 +586,7 @@ def test_build_request_body_retain_strict_false_overrides_global_true():
 
 
 @pytest.mark.asyncio
-async def test_fact_saturation_boundary_allows_fifteen_facts():
+async def test_fact_saturation_boundary_allows_a_response_below_the_bound():
     """A response below the saturation boundary remains a normal success."""
     from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk, resolve_facts_saturation_limit
 
@@ -813,6 +813,46 @@ async def test_malformed_response_still_attempts_then_fails_loudly(retain_config
 
     assert llm.call.call_count == expected_calls
     assert "after 0 attempts" not in str(exc.value)
+
+
+def test_facts_saturation_limit_stays_inside_the_calibration_window():
+    """The bound must clear real density and still land under the token ceiling.
+
+    Both edges have bitten. An earlier revision halved the budget and produced 24
+    at a 4096-token ceiling, below the 29 facts seen in the field, so honest input
+    was split for nothing. Going the other way and exceeding the token-limited
+    count makes the schema bound unreachable, leaving the array to run to
+    finish_reason=length — the case the bound exists to prevent.
+    """
+    from hindsight_api.engine.retain.fact_extraction import (
+        _APPROX_OUTPUT_TOKENS_PER_FACT,
+        resolve_facts_saturation_limit,
+    )
+
+    OBSERVED_MAX_FACTS = 29
+
+    for budget in (4096, 8192, 16384, 65536):
+        config = MagicMock()
+        config.retain_max_completion_tokens = budget
+        limit = resolve_facts_saturation_limit(config)
+        assert limit > OBSERVED_MAX_FACTS, f"budget {budget} would split honest input at {limit} facts"
+        assert limit <= budget // _APPROX_OUTPUT_TOKENS_PER_FACT, f"budget {budget} advertises an unreachable bound"
+
+
+def test_facts_saturation_limit_never_exceeds_a_small_budget():
+    """A budget too small for the floor gets the token-limited count, not the floor."""
+    from hindsight_api.engine.retain.fact_extraction import (
+        _APPROX_OUTPUT_TOKENS_PER_FACT,
+        RETAIN_FACTS_SATURATION_FLOOR,
+        resolve_facts_saturation_limit,
+    )
+
+    config = MagicMock()
+    config.retain_max_completion_tokens = 1024
+    limit = resolve_facts_saturation_limit(config)
+
+    assert limit < RETAIN_FACTS_SATURATION_FLOOR
+    assert limit == 1024 // _APPROX_OUTPUT_TOKENS_PER_FACT
 
 
 def test_facts_saturation_limit_scales_with_output_budget():

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -134,8 +134,8 @@ async def test_output_too_long_fails_unsplittable_subchunk_without_recursing():
 
 
 @pytest.mark.asyncio
-async def test_output_too_long_keeps_facts_from_sibling_when_one_half_fails():
-    """One unsplittable half must not discard facts the other half extracted."""
+async def test_output_too_long_propagates_when_one_half_cannot_be_split():
+    """A failing half must fail the chunk, not return the other half's facts."""
     from hindsight_api.engine.llm_wrapper import OutputTooLongError
     from hindsight_api.engine.retain.fact_extraction import TokenUsage, _extract_facts_with_auto_split
 
@@ -146,8 +146,9 @@ async def test_output_too_long_keeps_facts_from_sibling_when_one_half_fails():
     async def _extract(*, chunk: str, **_kwargs):
         # Only the half holding solely the user turn succeeds. Anything still
         # carrying the assistant turn overflows, so the whole chunk splits first
-        # and the tiny assistant half then fails unsplittably. Keyed on content,
-        # not call order, so gather scheduling cannot flip the test.
+        # and the tiny assistant half then fails unsplittably — below the split
+        # floor, so it cannot be reduced further. Keyed on content, not call
+        # order, so gather scheduling cannot flip the test.
         if "assistant" not in chunk:
             return [{"fact": "kept"}], TokenUsage()
         raise OutputTooLongError("too long")
@@ -159,18 +160,20 @@ async def test_output_too_long_keeps_facts_from_sibling_when_one_half_fails():
         "hindsight_api.engine.retain.fact_extraction._extract_facts_from_chunk",
         side_effect=_extract,
     ):
-        facts, _usage = await _extract_facts_with_auto_split(
-            chunk=chunk,
-            chunk_index=0,
-            total_chunks=1,
-            event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
-            context="",
-            llm_config=llm_config,
-            config=config,
-            agent_name="agent",
-        )
-
-    assert facts == [{"fact": "kept"}]
+        # Returning the successful half's facts here would report the retain
+        # complete with the assistant turn silently missing, which is the
+        # failure mode this whole path exists to prevent.
+        with pytest.raises(RuntimeError, match="refusing to drop this sub-chunk"):
+            await _extract_facts_with_auto_split(
+                chunk=chunk,
+                chunk_index=0,
+                total_chunks=1,
+                event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                context="",
+                llm_config=llm_config,
+                config=config,
+                agent_name="agent",
+            )
 
 
 def _make_config(llm_max_retries: int = 3, retain_llm_max_retries: int | None = None):
@@ -827,15 +830,3 @@ def test_facts_saturation_limit_scales_with_output_budget():
     assert resolve_facts_saturation_limit(small) < resolve_facts_saturation_limit(large)
     assert resolve_facts_saturation_limit(small) >= RETAIN_FACTS_SATURATION_FLOOR
 
-
-def test_facts_saturation_limit_falls_back_to_floor_without_budget():
-    """An unset or non-numeric ceiling falls back to the conservative floor."""
-    from hindsight_api.engine.retain.fact_extraction import (
-        RETAIN_FACTS_SATURATION_FLOOR,
-        resolve_facts_saturation_limit,
-    )
-
-    unset = MagicMock()
-    unset.retain_max_completion_tokens = None
-
-    assert resolve_facts_saturation_limit(unset) == RETAIN_FACTS_SATURATION_FLOOR

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -580,6 +580,8 @@ def test_build_request_body_retain_strict_false_overrides_global_true():
     strict_schema.assert_not_called()
     assert body["response_format"]["json_schema"]["schema"] == {"schema": "non-strict"}
     assert body["response_format"]["json_schema"]["strict"] is False
+
+
 @pytest.mark.asyncio
 async def test_fact_saturation_boundary_allows_fifteen_facts():
     """A response below the saturation boundary remains a normal success."""
@@ -644,8 +646,8 @@ async def test_fact_saturation_uses_auto_split_and_returns_subchunk_facts():
     """Saturation must split the chunk and return facts from both sub-chunks."""
     from hindsight_api.engine.response_models import TokenUsage
     from hindsight_api.engine.retain.fact_extraction import (
-        resolve_facts_saturation_limit,
         _extract_facts_with_auto_split,
+        resolve_facts_saturation_limit,
     )
 
     config = _make_config(llm_max_retries=0)
@@ -653,7 +655,11 @@ async def test_fact_saturation_uses_auto_split_and_returns_subchunk_facts():
     llm_config.call = AsyncMock(
         side_effect=[
             (
-                {"facts": [{"what": f"saturated fact {index}"} for index in range(resolve_facts_saturation_limit(config))]},
+                {
+                    "facts": [
+                        {"what": f"saturated fact {index}"} for index in range(resolve_facts_saturation_limit(config))
+                    ]
+                },
                 TokenUsage(),
             ),
             ({"facts": [{"what": "left fact"}]}, TokenUsage()),

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -540,6 +540,34 @@ def test_build_request_body_retain_strict_false_overrides_global_true():
     strict_schema.assert_not_called()
     assert body["response_format"]["json_schema"]["schema"] == {"schema": "non-strict"}
     assert body["response_format"]["json_schema"]["strict"] is False
+@pytest.mark.asyncio
+async def test_fact_saturation_raises_output_too_long_for_existing_split_path():
+    """A saturated facts array must enter the existing recursive split path."""
+    from hindsight_api.engine.llm_wrapper import OutputTooLongError
+    from hindsight_api.engine.retain.fact_extraction import RETAIN_FACTS_MAX_ITEMS, _extract_facts_from_chunk
+
+    config = _make_config(llm_max_retries=0)
+    llm_config = _make_llm_config(
+        mock_response={"facts": [{"what": f"fact {index}"} for index in range(RETAIN_FACTS_MAX_ITEMS)]}
+    )
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        with pytest.raises(OutputTooLongError, match="saturation limit"):
+            await _extract_facts_from_chunk(
+                chunk="A dense chunk.",
+                chunk_index=0,
+                total_chunks=1,
+                event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                context="",
+                llm_config=llm_config,
+                config=config,
+                agent_name="agent",
+            )
+
+    assert llm_config.call.call_count == 1
 
 
 # --- Retry budget semantics (issue #2731) -----------------------------------

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -869,4 +869,3 @@ def test_facts_saturation_limit_scales_with_output_budget():
 
     assert resolve_facts_saturation_limit(small) < resolve_facts_saturation_limit(large)
     assert resolve_facts_saturation_limit(small) >= RETAIN_FACTS_SATURATION_FLOOR
-

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -541,8 +541,36 @@ def test_build_request_body_retain_strict_false_overrides_global_true():
     assert body["response_format"]["json_schema"]["schema"] == {"schema": "non-strict"}
     assert body["response_format"]["json_schema"]["strict"] is False
 @pytest.mark.asyncio
-async def test_fact_saturation_raises_output_too_long_for_existing_split_path():
-    """A saturated facts array must enter the existing recursive split path."""
+async def test_fact_saturation_boundary_allows_fifteen_facts():
+    """A response below the saturation boundary remains a normal success."""
+    from hindsight_api.engine.retain.fact_extraction import RETAIN_FACTS_MAX_ITEMS, _extract_facts_from_chunk
+
+    config = _make_config(llm_max_retries=0)
+    fact_count = RETAIN_FACTS_MAX_ITEMS - 1
+    llm_config = _make_llm_config(mock_response={"facts": [{"what": f"fact {index}"} for index in range(fact_count)]})
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        facts, _usage = await _extract_facts_from_chunk(
+            chunk="A normal chunk.",
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            context="",
+            llm_config=llm_config,
+            config=config,
+            agent_name="agent",
+        )
+
+    assert len(facts) == fact_count
+    assert llm_config.call.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_fact_saturation_boundary_raises_output_too_long():
+    """A response at the saturation boundary must enter the split path."""
     from hindsight_api.engine.llm_wrapper import OutputTooLongError
     from hindsight_api.engine.retain.fact_extraction import RETAIN_FACTS_MAX_ITEMS, _extract_facts_from_chunk
 
@@ -568,6 +596,48 @@ async def test_fact_saturation_raises_output_too_long_for_existing_split_path():
             )
 
     assert llm_config.call.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_fact_saturation_uses_auto_split_and_returns_subchunk_facts():
+    """Saturation must split the chunk and return facts from both sub-chunks."""
+    from hindsight_api.engine.response_models import TokenUsage
+    from hindsight_api.engine.retain.fact_extraction import (
+        RETAIN_FACTS_MAX_ITEMS,
+        _extract_facts_with_auto_split,
+    )
+
+    config = _make_config(llm_max_retries=0)
+    llm_config = _make_llm_config(mock_response=None)
+    llm_config.call = AsyncMock(
+        side_effect=[
+            (
+                {"facts": [{"what": f"saturated fact {index}"} for index in range(RETAIN_FACTS_MAX_ITEMS)]},
+                TokenUsage(),
+            ),
+            ({"facts": [{"what": "left fact"}]}, TokenUsage()),
+            ({"facts": [{"what": "right fact"}]}, TokenUsage()),
+        ]
+    )
+    chunk = "A sentence that needs extraction. " * 40
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        facts, _usage = await _extract_facts_with_auto_split(
+            chunk=chunk,
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            context="",
+            llm_config=llm_config,
+            config=config,
+            agent_name="agent",
+        )
+
+    assert [fact.fact for fact in facts] == ["left fact", "right fact"]
+    assert llm_config.call.call_count == 3
 
 
 # --- Retry budget semantics (issue #2731) -----------------------------------

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -133,6 +133,46 @@ async def test_output_too_long_fails_unsplittable_subchunk_without_recursing():
     assert extract.call_count == 1
 
 
+@pytest.mark.asyncio
+async def test_output_too_long_keeps_facts_from_sibling_when_one_half_fails():
+    """One unsplittable half must not discard facts the other half extracted."""
+    from hindsight_api.engine.llm_wrapper import OutputTooLongError
+    from hindsight_api.engine.retain.fact_extraction import TokenUsage, _extract_facts_with_auto_split
+
+    long_turn = {"role": "user", "content": "alpha " * 300}
+    tiny_turn = {"role": "assistant", "content": "b"}
+    chunk = json.dumps([long_turn, tiny_turn])
+
+    async def _extract(*, chunk: str, **_kwargs):
+        # Only the half holding solely the user turn succeeds. Anything still
+        # carrying the assistant turn overflows, so the whole chunk splits first
+        # and the tiny assistant half then fails unsplittably. Keyed on content,
+        # not call order, so gather scheduling cannot flip the test.
+        if "assistant" not in chunk:
+            return [{"fact": "kept"}], TokenUsage()
+        raise OutputTooLongError("too long")
+
+    config = _make_config(llm_max_retries=0)
+    llm_config = _make_llm_config(mock_response={})
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._extract_facts_from_chunk",
+        side_effect=_extract,
+    ):
+        facts, _usage = await _extract_facts_with_auto_split(
+            chunk=chunk,
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            context="",
+            llm_config=llm_config,
+            config=config,
+            agent_name="agent",
+        )
+
+    assert facts == [{"fact": "kept"}]
+
+
 def _make_config(llm_max_retries: int = 3, retain_llm_max_retries: int | None = None):
     """Build a minimal HindsightConfig for fact extraction tests."""
     from hindsight_api.config import _get_raw_config

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -543,10 +543,10 @@ def test_build_request_body_retain_strict_false_overrides_global_true():
 @pytest.mark.asyncio
 async def test_fact_saturation_boundary_allows_fifteen_facts():
     """A response below the saturation boundary remains a normal success."""
-    from hindsight_api.engine.retain.fact_extraction import RETAIN_FACTS_MAX_ITEMS, _extract_facts_from_chunk
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk, resolve_facts_saturation_limit
 
     config = _make_config(llm_max_retries=0)
-    fact_count = RETAIN_FACTS_MAX_ITEMS - 1
+    fact_count = resolve_facts_saturation_limit(config) - 1
     llm_config = _make_llm_config(mock_response={"facts": [{"what": f"fact {index}"} for index in range(fact_count)]})
 
     with patch(
@@ -572,11 +572,12 @@ async def test_fact_saturation_boundary_allows_fifteen_facts():
 async def test_fact_saturation_boundary_raises_output_too_long():
     """A response at the saturation boundary must enter the split path."""
     from hindsight_api.engine.llm_wrapper import OutputTooLongError
-    from hindsight_api.engine.retain.fact_extraction import RETAIN_FACTS_MAX_ITEMS, _extract_facts_from_chunk
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk, resolve_facts_saturation_limit
 
     config = _make_config(llm_max_retries=0)
+    saturation_limit = resolve_facts_saturation_limit(config)
     llm_config = _make_llm_config(
-        mock_response={"facts": [{"what": f"fact {index}"} for index in range(RETAIN_FACTS_MAX_ITEMS)]}
+        mock_response={"facts": [{"what": f"fact {index}"} for index in range(saturation_limit)]}
     )
 
     with patch(
@@ -603,7 +604,7 @@ async def test_fact_saturation_uses_auto_split_and_returns_subchunk_facts():
     """Saturation must split the chunk and return facts from both sub-chunks."""
     from hindsight_api.engine.response_models import TokenUsage
     from hindsight_api.engine.retain.fact_extraction import (
-        RETAIN_FACTS_MAX_ITEMS,
+        resolve_facts_saturation_limit,
         _extract_facts_with_auto_split,
     )
 
@@ -612,7 +613,7 @@ async def test_fact_saturation_uses_auto_split_and_returns_subchunk_facts():
     llm_config.call = AsyncMock(
         side_effect=[
             (
-                {"facts": [{"what": f"saturated fact {index}"} for index in range(RETAIN_FACTS_MAX_ITEMS)]},
+                {"facts": [{"what": f"saturated fact {index}"} for index in range(resolve_facts_saturation_limit(config))]},
                 TokenUsage(),
             ),
             ({"facts": [{"what": "left fact"}]}, TokenUsage()),
@@ -763,3 +764,32 @@ async def test_malformed_response_still_attempts_then_fails_loudly(retain_config
 
     assert llm.call.call_count == expected_calls
     assert "after 0 attempts" not in str(exc.value)
+
+
+def test_facts_saturation_limit_scales_with_output_budget():
+    """The saturation bound tracks the configured output ceiling."""
+    from hindsight_api.engine.retain.fact_extraction import (
+        RETAIN_FACTS_SATURATION_FLOOR,
+        resolve_facts_saturation_limit,
+    )
+
+    small = MagicMock()
+    small.retain_max_completion_tokens = 4096
+    large = MagicMock()
+    large.retain_max_completion_tokens = 65536
+
+    assert resolve_facts_saturation_limit(small) < resolve_facts_saturation_limit(large)
+    assert resolve_facts_saturation_limit(small) >= RETAIN_FACTS_SATURATION_FLOOR
+
+
+def test_facts_saturation_limit_falls_back_to_floor_without_budget():
+    """An unset or non-numeric ceiling falls back to the conservative floor."""
+    from hindsight_api.engine.retain.fact_extraction import (
+        RETAIN_FACTS_SATURATION_FLOOR,
+        resolve_facts_saturation_limit,
+    )
+
+    unset = MagicMock()
+    unset.retain_max_completion_tokens = None
+
+    assert resolve_facts_saturation_limit(unset) == RETAIN_FACTS_SATURATION_FLOOR


### PR DESCRIPTION
## Summary

Bounds and recovery for degenerate fact-extraction output. Depends on #3673 — see
below.

### The failure

Against a local OpenAI-compatible backend, the same 2376-token prompt produced
16 384 output tokens with `finish_reason=length` on five attempts and completed
normally in 554 tokens on the sixth. Input size, sampling parameters and chunk
size were all ruled out: the model stochastically degenerates into repeating
structurally valid fact objects, and nothing in the schema tells the grammar to
stop. This repo already documents the same conclusion for the split floor:

> if a chunk this small still overflows the model's output cap, the cause is
> degenerate or looping model output rather than genuinely dense input

### 1. Bound the facts array, and never accept the bound as success

The response schema gains a `maxItems` bound so a capable structured-output
backend stops the array itself. Reaching the bound is **not** treated as a
result — it raises `OutputTooLongError` and enters the existing split path, so the
bound can never silently truncate a genuinely dense chunk. In the worst case a
chunk is split unnecessarily; no facts are lost.

The bound is derived from `retain_max_completion_tokens` rather than fixed, and it
has to land inside a window:

- **above real density**, or dense chunks are split for nothing. Field data from
  168 single-chunk extractions: median 2 facts, p95 10, **max 29**.
- **below the output-token ceiling**, or the schema bound is unreachable and the
  array runs to `finish_reason=length` instead — the case this exists to prevent.

Three quarters of the token-limited count clears both:

```
budget  4096 -> 36 facts   (ceiling ~48, field max 29)
budget  8192 -> 72 facts   (ceiling ~96)
budget 65536 -> 578 facts  (ceiling ~771)
```

Two earlier revisions got this wrong in both directions. One hard-coded 16. The
next halved the budget, giving 24 at a 4096-token ceiling — below the 29 already
reported above, so it would have split honest input. Regression tests now pin the
window from both sides.

The per-fact cost is measured, not assumed. Against a strict `json_schema` — the
shape retain actually sends — four runs across two local models gave 80.1, 82.1,
89.5 and 101.5 output tokens per fact, so the estimate of 85 holds and only the
halving was wrong.

The floor is additionally capped by what the budget can reach: below roughly 2.7k
output tokens a floor of 32 would advertise a `maxItems` the response can never
hit, so such budgets get the token-limited count instead.

**`maxItems` support is backend-dependent and hard to verify from the outside,
which is why the Python-side check stays authoritative.**

xgrammar tracks `minItems`/`maxItems` as a known gap (mlc-ai/xgrammar#160,
vllm-project/vllm#12131, and vllm-project/vllm#12201, where the constraint fails
without falling back to outlines), and xgrammar 0.2.3's compiled binding carries
no array-length keyword among its schema strings. Yet measured end to end against
oMLX 0.6.3rc2 with that same xgrammar build and no fallback logged, a schema with
`maxItems: 8` returned exactly 8 facts where the uncapped schema returned 22.

I cannot tell from outside whether the bound was enforced by the grammar or merely
obeyed by the model, because stating the same cap in the prompt alone also produced
exactly 8. That ambiguity is the point: a caller cannot know whether `maxItems`
binds, so treating it as a guarantee would be unsafe. The saturation check in
`_extract_facts_from_chunk` counts the parsed facts and is provider-independent;
`maxItems` is an optimisation that lets a backend which honours it stop before
spending the tokens.


`retain_max_completion_tokens` and `llm_supports_max_items` are read by direct
attribute access. An earlier revision used `getattr(config, ..., default)`, which
#3610 had just removed everywhere in the engine: `StaticConfigProxy` signals
"bank-configurable" by raising `ConfigFieldAccessError`, a subclass of
`AttributeError`, so a default silently substitutes the global value for the
bank's resolved one. Both fields are required, and
`validate_retain_completion_token_budget` already guarantees the budget is
positive, so there is nothing legitimate for a default to cover.

### 2. Fail instead of dropping

When a chunk cannot be reduced further, the splitter previously returned an empty
result that the caller counted as a successful extraction — the operation reported
`completed` with the sub-chunk's data gone. It now raises.

A failing half propagates rather than being salvaged around. An earlier revision
gathered sub-chunks with `return_exceptions=True` and kept the successful half's
facts, but that contradicts both this PR and the caller: `extract_facts_from_text`
fails the retain if *any* chunk could not be extracted, on the stated grounds that
"partial extraction is not acceptable". Keeping half the facts would have reported
the operation complete with the rest silently missing — the exact failure this
change exists to prevent.

### Behaviour change, stated plainly

This resolves a contradiction already in the tree rather than adding a policy. The
`_MIN_SPLIT_CHUNK_CHARS` comment documents the sub-chunk drop as a deliberate
runaway bound, while `extract_facts_from_text` documents partial extraction as
unacceptable. Both cannot hold. This PR keeps the runaway bound — the recursion
still terminates in the same number of calls — and changes only what happens at
the bound: a loud failure instead of a silent hole in the stored memory.

The cost is real and worth naming: a deployment that currently absorbs these
events silently will start seeing retain operations fail. In the deployment that
motivated this PR that is roughly two per day, against 10 confirmed silent drops
over five days.

## Depends on #3673

That PR is what makes splits succeed for conversation payloads wrapped in an extra
array. This PR increases how often the split path is entered and makes the
unsplittable case fatal, so merging it alone would turn exactly those recoverable
cases into hard failures.

(The dependency was previously written as #3656. That was a copy-paste error from
when both fixes shared a branch — #3656 is the strict-schema flag, already merged.
The nested-array fix is #3673.)

## Tests

```
46 passed
```

Verified end-to-end on a document that previously lost its content: saturation at
the bound → `OutputTooLongError` → recursive split (2747 → 1824 + 922 → …) →
8/2/7/11 facts extracted, every call `finish_reason=stop`, no dropped sub-chunk.
