### PR TITLE
bank list: take last_write_at and last_document_at from the store

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -855,6 +855,28 @@ class MemoriesExtension(Extension, ABC):
                 out[bank_id] = counts
         return out
 
+    async def last_write_at_many(self, *, bank_ids: "list[str]") -> "dict[str, datetime]":
+        """When each bank was last written — ``{bank_id: datetime}``, for many banks at once.
+
+        The bank list is ORDERED by this. Postgres derives it with ``MAX`` over live
+        ``documents`` / ``memory_units`` rows, which a store owning those rows leaves empty, so
+        without an answer here such a bank's ordering silently degenerates to created-at.
+
+        Empty by default: the SQL path already has the columns and does not need this, and a store
+        that cannot answer should say nothing rather than guess. **A bank absent from the result
+        keeps whatever the caller already had — absent means "unknown", never "the epoch".**
+        """
+        return {}
+
+    async def last_document_at_many(self, *, bank_ids: "list[str]") -> "dict[str, datetime]":
+        """When each bank last INGESTED a new document — ``{bank_id: datetime}``.
+
+        Not the same question as :meth:`last_write_at_many`: re-retaining an existing document is a
+        write but not a new document, and the bank list shows the two separately. Empty by default,
+        with the same rule — a bank absent from the result keeps whatever the caller had.
+        """
+        return {}
+
     async def get_chunk_texts(self, *, bank_id: str, refs: "list[tuple[str, int]]") -> "list[str | None]":
         """Many chunks' text at once — ``refs`` is ``(document_id, chunk_index)``.
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
@@ -497,8 +497,52 @@ async def list_banks(pool, *, search_query: str | None = None) -> list:
                 }
             )
 
+        # Banks whose memories live outside SQL have no `documents` / `memory_units` rows for the
+        # joins above to take a MAX over, so their `last_write_at` came back NULL and they sorted as
+        # if never written. The store can answer it, and the Counters RPC is BATCHED — every such
+        # bank costs one call in total — so it is done here, BEFORE the sort. Doing it in the
+        # page-level overlay instead would fix the field but leave the order wrong, and
+        # inconsistent across pages, which is worse than uniformly wrong.
+        await _apply_store_last_write(result, sort_keys)
+
         result.sort(key=lambda bank: sort_keys[bank["bank_id"]], reverse=True)
         return result
+
+
+async def _apply_store_last_write(banks: list[dict], sort_keys: "dict[str, datetime]") -> None:
+    """Fill `last_write_at` (and the sort key) from the store, for banks SQL cannot answer for.
+
+    One batched call for all of them. A bank the store has no time for is left exactly as it was —
+    absent means "unknown", never "the epoch", so an un-folded bank keeps whatever ordering it had
+    rather than being pushed to the bottom on a guess.
+    """
+    from ..memories import get_memories
+
+    store = get_memories()
+    external = [b for b in banks if not store.writes_memory_rows_in_sql_for(b["bank_id"])]
+    if not external:
+        return
+    ids = [b["bank_id"] for b in external]
+    try:
+        times = await store.last_write_at_many(bank_ids=ids)
+        # Asked for separately, because they are different questions: `last_document_at` is
+        # INGESTION time and must not move when an existing document is re-retained, while
+        # `last_write_at` must. Reporting one under both names looked harmless and is not — it makes
+        # a rewrite read as a new document.
+        doc_times = await store.last_document_at_many(bank_ids=ids)
+    except Exception as e:  # noqa: BLE001 - ordering is a nicety; the list itself must still render
+        logger.warning(f"Could not read write times from the store for {len(external)} bank(s): {e}")
+        return
+    for bank in external:
+        doc_when = doc_times.get(bank["bank_id"])
+        if doc_when is not None:
+            bank["last_document_at"] = doc_when.isoformat()
+    for bank in external:
+        when = times.get(bank["bank_id"])
+        if when is None:
+            continue
+        bank["last_write_at"] = when.isoformat()
+        sort_keys[bank["bank_id"]] = when
 
 
 async def apply_store_fact_counts(pool, banks: list[dict]) -> None:


### PR DESCRIPTION
The engine half of taking these two times from the store. The interface defaults return `{}`, so a store that does not report them is unaffected and the Postgres path is untouched.

## The gap

A store-owned bank's row had neither `last_write_at` nor `last_document_at`: both come from `MAX` over SQL tables such a bank leaves empty, and the response model drops null keys, so the fields vanished from the JSON rather than reading null (clients saw a `KeyError`, not a `None`). **The list is ordered by last write**, so that ordering silently degenerated to created-at.

## Two decisions worth reviewing

**Applied before the sort, over every bank — not in the page-level overlay.** The Counters RPC is batched, so all banks cost one call. Doing it per page would fix the field while leaving the order wrong *and inconsistent across pages*, which is worse than uniformly wrong.

**The two times are asked for separately, because they are different questions.** `last_document_at` is INGESTION time and must not move when an existing document is re-retained; `last_write_at` must. Reporting one clock under both names looked harmless and is not — it makes a rewrite read as a new document, which is exactly what `test_last_write_at_advances_when_existing_document_is_rewritten` pins. (The store preserves a document's original `created_at` across re-ingest deliberately, so the ingestion counter is stable by construction.)

A bank the store cannot answer for keeps whatever SQL gave it: **absent means "unknown", never "the epoch"**, so an un-folded bank is not pushed to the bottom of the order on a guess.

## Verification

* Against a store-owned backend: `test_bank_last_write_at` **3/3**, `test_list_banks_non_sql_store` and `test_http_api_integration` green.
* Postgres: unaffected (4/4 on its own bank-list tests).

One caveat, stated rather than hidden: `test_last_write_at_advances_when_existing_document_is_rewritten` fails when run alongside several other modules and passes 3/3 alone. The mechanism that could move that field is a missed read of the prior document record under concurrency, not this code — but I have not proven that, so I am flagging it rather than calling it clean.
