### PR TITLE
comments: keep the store-extension comments backend-generic

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8269,7 +8269,7 @@ class MemoryEngine(MemoryEngineInterface):
                             # Store-owned: the tombstone is the ONLY write here (the relink/prune
                             # enqueues above join memory_units/unit_entities, which this store keeps
                             # no rows in — so they touch nothing; stale-observation cleanup routes to
-                            # the store and is not part of this txn either). One memlake delete needs
+                            # the store and is not part of this txn either). One store-side delete needs
                             # no write-group — a plain, immediately-durable tombstone leaves no witness
                             # to go undecided (a store-owned retain creates none of these either).
                             await _store.delete_facts(bank_id, [unit_id])

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -2447,9 +2447,10 @@ async def _streaming_retain_batch(
                 if _edge_provider.store_owned_retain_for(bank_id):
                     # Store-owned 0-fact (re-)ingest: the document's bodies are already in the store
                     # (via _store_document_bodies) and there are no new memories. A re-ingest that now
-                    # yields 0 facts must drop the document's PRIOR memories — ONE plain memlake
-                    # delete-by-document. No Postgres documents row, no lock, no write-group
-                    # (memlake-only), so nothing is left undecided to stall the store's indexer. This
+                    # yields 0 facts must drop the document's PRIOR memories — ONE plain store-side
+                    # delete-by-document. No Postgres documents row, no lock, no write-group (there is
+                    # no SQL witness to decide), so nothing is left undecided to stall the store's
+                    # indexer. This
                     # is the 0-fact analogue of the fact-bearing PG-free path's replace-tombstone.
                     await _edge_provider.delete_document(
                         conn=None, fq_table=fq_table, bank_id=bank_id, document_id=effective_doc_id

--- a/hindsight-api-slim/hindsight_api/engine/transfer/export.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/export.py
@@ -636,7 +636,7 @@ async def _load_observations_from_store(
 
     Same rule as the SQL loader: an observation referencing a fact outside the export would import
     as a dangling reference, so it is skipped rather than emitted. Sources come off the memory's own
-    `source_memory_ids` here instead of a column, which is also how the memlake path already
+    `source_memory_ids` here instead of a column, which is also how a store-owned path already
     resolves them — an observation's sources are denormalised onto it at write time.
     """
     stored = await _scan_all_memories(memories, bank_id, ["observation"])

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -1863,7 +1863,7 @@ async def test_download_route_rejects_unauthorized_keys(api_client, memory, requ
 
 
 class _StoreOwnedMemories:
-    """A memories store that keeps memories outside SQL, like the memlake extension."""
+    """A memories store that keeps memories outside SQL, like an external store extension."""
 
     def writes_memory_rows_in_sql_for(self, bank_id: str) -> bool:
         return False


### PR DESCRIPTION
Four comments added in #3560 named a specific downstream store by name.

The seam they describe is the generic store-owned one (`store_owned_retain_for` /
`writes_memory_rows_in_sql_for`), and the reasoning holds for any store that keeps memories outside
SQL — so the comments now say that instead of naming one implementation.

One of them also said "no write-group (X-only)", which read as a property of that store; the reason
is actually that there is no SQL witness to decide, so it now says that.

Comment-only — no behaviour change, no test change. `ruff check` and `ruff format --check` clean.