### PR TITLE
Memory backend: store-owned delta retain, bank-list times, and generic comments

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/maintenance.py
@@ -113,7 +113,9 @@ _RETENTION_BATCH_PAUSE_SECONDS = 0.25
 class MaintenanceLoop:
     """Owns the single periodic maintenance task for a :class:`MemoryEngine`."""
 
-    def __init__(self, engine: "MemoryEngine") -> None:
+    def __init__(self, engine: "MemoryEngine | None") -> None:
+        """``engine`` is optional so the loop can be exercised for its scheduling alone — the
+        cadence tests construct it that way. Every job that needs the engine checks first."""
         self._engine = engine
         self._task: asyncio.Task | None = None
         self._stop = asyncio.Event()
@@ -454,11 +456,12 @@ class MaintenanceLoop:
         store = get_memories()
         if store.writes_memory_rows_in_sql:
             return
-        # Best-effort includes not having an engine to ask: the loop can be constructed without one,
-        # and this reap is explicitly allowed to be skipped (the docstring above). The SQL stores
-        # never get here — they return on the line above — so a store-owned deployment was the only
-        # one that could lose an entire maintenance tick to an AttributeError over a reap that is
-        # permitted to wait for the next one.
+        # Best-effort includes not having an engine to ask: the loop can be constructed without one
+        # (see `__init__`), and this reap is explicitly allowed to be skipped. Only a store-owned
+        # deployment reaches this line — the SQL stores return above — where it would otherwise
+        # raise AttributeError. `_run` catches per tick and this reap is the tick's last job, so the
+        # cost was a logged traceback rather than lost work; it is still noise standing in for a
+        # condition the code should simply state.
         engine = self._engine
         if engine is None:
             return

--- a/hindsight-api-slim/hindsight_api/engine/maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/maintenance.py
@@ -454,7 +454,15 @@ class MaintenanceLoop:
         store = get_memories()
         if store.writes_memory_rows_in_sql:
             return
-        backend = self._engine._backend
+        # Best-effort includes not having an engine to ask: the loop can be constructed without one,
+        # and this reap is explicitly allowed to be skipped (the docstring above). The SQL stores
+        # never get here — they return on the line above — so a store-owned deployment was the only
+        # one that could lose an entire maintenance tick to an AttributeError over a reap that is
+        # permitted to wait for the next one.
+        engine = self._engine
+        if engine is None:
+            return
+        backend = engine._backend
         try:
             async with acquire_with_retry(backend, max_retries=1) as conn:
                 bank_ids = [r[0] for r in await conn.fetch(f"SELECT bank_id FROM {fq_table('banks')}")]

--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -855,6 +855,28 @@ class MemoriesExtension(Extension, ABC):
                 out[bank_id] = counts
         return out
 
+    async def last_write_at_many(self, *, bank_ids: "list[str]") -> "dict[str, datetime]":
+        """When each bank was last written — ``{bank_id: datetime}``, for many banks at once.
+
+        The bank list is ORDERED by this. Postgres derives it with ``MAX`` over live
+        ``documents`` / ``memory_units`` rows, which a store owning those rows leaves empty, so
+        without an answer here such a bank's ordering silently degenerates to created-at.
+
+        Empty by default: the SQL path already has the columns and does not need this, and a store
+        that cannot answer should say nothing rather than guess. **A bank absent from the result
+        keeps whatever the caller already had — absent means "unknown", never "the epoch".**
+        """
+        return {}
+
+    async def last_document_at_many(self, *, bank_ids: "list[str]") -> "dict[str, datetime]":
+        """When each bank last INGESTED a new document — ``{bank_id: datetime}``.
+
+        Not the same question as :meth:`last_write_at_many`: re-retaining an existing document is a
+        write but not a new document, and the bank list shows the two separately. Empty by default,
+        with the same rule — a bank absent from the result keeps whatever the caller had.
+        """
+        return {}
+
     async def get_chunk_texts(self, *, bank_id: str, refs: "list[tuple[str, int]]") -> "list[str | None]":
         """Many chunks' text at once — ``refs`` is ``(document_id, chunk_index)``.
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8287,7 +8287,7 @@ class MemoryEngine(MemoryEngineInterface):
                             # Store-owned: the tombstone is the ONLY write here (the relink/prune
                             # enqueues above join memory_units/unit_entities, which this store keeps
                             # no rows in — so they touch nothing; stale-observation cleanup routes to
-                            # the store and is not part of this txn either). One memlake delete needs
+                            # the store and is not part of this txn either). One store-side delete needs
                             # no write-group — a plain, immediately-durable tombstone leaves no witness
                             # to go undecided (a store-owned retain creates none of these either).
                             await _store.delete_facts(bank_id, [unit_id])

--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
@@ -452,15 +452,22 @@ async def tool_expand(
         # `{bank_id}_{document_id}_{index}` by construction — so the index is what remains once
         # that known prefix is removed. Built from the ids in hand rather than by splitting on
         # "_", which a bank or document id containing one would break.
+        # Deduped by chunk_id: co-located memories share one chunk, and the SQL branch collapses
+        # them through `= ANY($1)`. Without this the store is asked for the same chunk once per
+        # memory sitting in it.
         refs: list[tuple[str, int]] = []
         ref_owner: list[dict] = []
+        _seen_chunks: set[str] = set()
         for m in memories:
             cid, did = m["chunk_id"], m["document_id"]
             if not cid or not did:
                 continue
+            if cid in _seen_chunks:
+                continue
             suffix = cid.removeprefix(f"{bank_id}_{did}_")
             if suffix == cid or not suffix.isdigit():
                 continue
+            _seen_chunks.add(cid)
             refs.append((did, int(suffix)))
             ref_owner.append({"chunk_id": cid, "document_id": did, "chunk_index": int(suffix)})
         if refs:

--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
@@ -441,9 +441,37 @@ async def tool_expand(
     doc_ids_from_chunks: set[str] = set()
     doc_ids_direct: set[str] = set()
 
-    # Batch fetch all chunks
+    # Batch fetch all chunks. A store that owns the document store leaves the `chunks` and
+    # `documents` tables empty, so the SQL below would return nothing and `expand` would answer
+    # without the chunk or document it was asked for — the memories read above was routed to the
+    # store but these two were not.
+    _docs_in_store = _store.owns_document_store_for(bank_id)
     chunk_map: dict[str, Any] = {}
-    if chunk_ids:
+    if chunk_ids and _docs_in_store:
+        # The store addresses a chunk by (document_id, index), and `chunk_id` is
+        # `{bank_id}_{document_id}_{index}` by construction — so the index is what remains once
+        # that known prefix is removed. Built from the ids in hand rather than by splitting on
+        # "_", which a bank or document id containing one would break.
+        refs: list[tuple[str, int]] = []
+        ref_owner: list[dict] = []
+        for m in memories:
+            cid, did = m["chunk_id"], m["document_id"]
+            if not cid or not did:
+                continue
+            suffix = cid.removeprefix(f"{bank_id}_{did}_")
+            if suffix == cid or not suffix.isdigit():
+                continue
+            refs.append((did, int(suffix)))
+            ref_owner.append({"chunk_id": cid, "document_id": did, "chunk_index": int(suffix)})
+        if refs:
+            texts = await _store.get_chunk_texts(bank_id=bank_id, refs=refs)
+            for owner, text in zip(ref_owner, texts):
+                if text is None:
+                    continue
+                chunk_map[owner["chunk_id"]] = {**owner, "chunk_text": text}
+        if depth == "document":
+            doc_ids_from_chunks = {c["document_id"] for c in chunk_map.values() if c["document_id"]}
+    elif chunk_ids:
         chunks = await conn.fetch(
             f"""
             SELECT chunk_id, chunk_text, chunk_index, document_id
@@ -465,7 +493,24 @@ async def tool_expand(
     # Batch fetch all documents
     doc_map: dict[str, Any] = {}
     all_doc_ids = list(doc_ids_from_chunks | doc_ids_direct)
-    if all_doc_ids:
+    if all_doc_ids and _docs_in_store:
+        # One read per document: the store addresses a document by id and has no batch form here.
+        # The set is the documents behind the memories being expanded, which is bounded by the
+        # caller's own memory_ids rather than by corpus size.
+        for did in all_doc_ids:
+            record = await _store.get_document_record(bank_id=bank_id, document_id=did, include_text=True)
+            if record is None:
+                continue
+            # The store has no `retain_params` column; it keeps the retain params inside the
+            # document record's metadata bag, under that key and serialised as JSON. So they are
+            # read back out of the bag rather than reconstructed — `_document_metadata_from_retain_params`
+            # already parses the JSON form, which is the same thing Postgres hands it from JSONB.
+            doc_map[did] = {
+                "id": did,
+                "original_text": record.get("original_text"),
+                "retain_params": (record.get("metadata") or {}).get("retain_params"),
+            }
+    elif all_doc_ids:
         docs = await conn.fetch(
             f"""
             SELECT id, original_text, retain_params

--- a/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
@@ -2,6 +2,7 @@
 bank profile utilities for disposition and mission management.
 """
 
+import asyncio
 import json
 import logging
 import uuid
@@ -550,16 +551,20 @@ async def list_banks(pool, *, search_query: str | None = None) -> list:
                 }
             )
 
-        # Banks whose memories live outside SQL have no `documents` / `memory_units` rows for the
-        # joins above to take a MAX over, so their `last_write_at` came back NULL and they sorted as
-        # if never written. The store can answer it, and the Counters RPC is BATCHED — every such
-        # bank costs one call in total — so it is done here, BEFORE the sort. Doing it in the
-        # page-level overlay instead would fix the field but leave the order wrong, and
-        # inconsistent across pages, which is worse than uniformly wrong.
-        await _apply_store_last_write(result, sort_keys)
+    # Banks whose memories live outside SQL have no `documents` / `memory_units` rows for the joins
+    # above to take a MAX over, so their `last_write_at` came back NULL and they sorted as if never
+    # written. The store can answer it, and the Counters RPC is BATCHED — every such bank costs one
+    # call in total — so it is done BEFORE the sort. Doing it in the page-level overlay instead
+    # would fix the field but leave the order wrong, and inconsistent across pages, which is worse
+    # than uniformly wrong.
+    #
+    # Outside the connection block on purpose: these are network calls to another service and
+    # nothing below needs `conn`. Holding a pooled connection across them is what starves the pool
+    # under load, and the retain path enforces the same rule everywhere else.
+    await _apply_store_last_write(result, sort_keys)
 
-        result.sort(key=lambda bank: sort_keys[bank["bank_id"]], reverse=True)
-        return result
+    result.sort(key=lambda bank: sort_keys[bank["bank_id"]], reverse=True)
+    return result
 
 
 async def _apply_store_last_write(banks: list[dict], sort_keys: "dict[str, datetime]") -> None:
@@ -576,15 +581,38 @@ async def _apply_store_last_write(banks: list[dict], sort_keys: "dict[str, datet
     if not external:
         return
     ids = [b["bank_id"] for b in external]
+    # Asked for separately, because they are different questions: `last_document_at` is INGESTION
+    # time and must not move when an existing document is re-retained, while `last_write_at` must.
+    # Reporting one under both names looked harmless and is not — it makes a rewrite read as a new
+    # document.
+    #
+    # Gathered, not awaited in sequence: they are independent round trips to the same service, and
+    # `return_exceptions` keeps one failing from discarding the other's answer — a list that sorts
+    # correctly but shows no ingestion time is better than one that does neither.
+    # The try wraps the gather because building its arguments already calls into the store: a store
+    # that does not implement these raises AttributeError right here, before `return_exceptions` can
+    # see anything. They are optional — the interface defaults return `{}` — so a store without them
+    # must leave the list rendering, not break it.
     try:
-        times = await store.last_write_at_many(bank_ids=ids)
-        # Asked for separately, because they are different questions: `last_document_at` is
-        # INGESTION time and must not move when an existing document is re-retained, while
-        # `last_write_at` must. Reporting one under both names looked harmless and is not — it makes
-        # a rewrite read as a new document.
-        doc_times = await store.last_document_at_many(bank_ids=ids)
+        times_r, doc_times_r = await asyncio.gather(
+            store.last_write_at_many(bank_ids=ids),
+            store.last_document_at_many(bank_ids=ids),
+            return_exceptions=True,
+        )
     except Exception as e:  # noqa: BLE001 - ordering is a nicety; the list itself must still render
-        logger.warning(f"Could not read write times from the store for {len(external)} bank(s): {e}")
+        logger.warning(f"Store cannot report write times for {len(external)} bank(s): {e}")
+        return
+    if isinstance(times_r, BaseException):
+        logger.warning(f"Could not read last_write_at from the store for {len(external)} bank(s): {times_r}")
+        times = {}
+    else:
+        times = times_r
+    if isinstance(doc_times_r, BaseException):
+        logger.warning(f"Could not read last_document_at from the store for {len(external)} bank(s): {doc_times_r}")
+        doc_times = {}
+    else:
+        doc_times = doc_times_r
+    if not times and not doc_times:
         return
     for bank in external:
         doc_when = doc_times.get(bank["bank_id"])

--- a/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
@@ -550,8 +550,52 @@ async def list_banks(pool, *, search_query: str | None = None) -> list:
                 }
             )
 
+        # Banks whose memories live outside SQL have no `documents` / `memory_units` rows for the
+        # joins above to take a MAX over, so their `last_write_at` came back NULL and they sorted as
+        # if never written. The store can answer it, and the Counters RPC is BATCHED — every such
+        # bank costs one call in total — so it is done here, BEFORE the sort. Doing it in the
+        # page-level overlay instead would fix the field but leave the order wrong, and
+        # inconsistent across pages, which is worse than uniformly wrong.
+        await _apply_store_last_write(result, sort_keys)
+
         result.sort(key=lambda bank: sort_keys[bank["bank_id"]], reverse=True)
         return result
+
+
+async def _apply_store_last_write(banks: list[dict], sort_keys: "dict[str, datetime]") -> None:
+    """Fill `last_write_at` (and the sort key) from the store, for banks SQL cannot answer for.
+
+    One batched call for all of them. A bank the store has no time for is left exactly as it was —
+    absent means "unknown", never "the epoch", so an un-folded bank keeps whatever ordering it had
+    rather than being pushed to the bottom on a guess.
+    """
+    from ..memories import get_memories
+
+    store = get_memories()
+    external = [b for b in banks if not store.writes_memory_rows_in_sql_for(b["bank_id"])]
+    if not external:
+        return
+    ids = [b["bank_id"] for b in external]
+    try:
+        times = await store.last_write_at_many(bank_ids=ids)
+        # Asked for separately, because they are different questions: `last_document_at` is
+        # INGESTION time and must not move when an existing document is re-retained, while
+        # `last_write_at` must. Reporting one under both names looked harmless and is not — it makes
+        # a rewrite read as a new document.
+        doc_times = await store.last_document_at_many(bank_ids=ids)
+    except Exception as e:  # noqa: BLE001 - ordering is a nicety; the list itself must still render
+        logger.warning(f"Could not read write times from the store for {len(external)} bank(s): {e}")
+        return
+    for bank in external:
+        doc_when = doc_times.get(bank["bank_id"])
+        if doc_when is not None:
+            bank["last_document_at"] = doc_when.isoformat()
+    for bank in external:
+        when = times.get(bank["bank_id"])
+        if when is None:
+            continue
+        bank["last_write_at"] = when.isoformat()
+        sort_keys[bank["bank_id"]] = when
 
 
 async def apply_store_fact_counts(pool, banks: list[dict]) -> None:

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -446,15 +446,38 @@ async def update_memory_units_metadata_and_tags(
         Number of memory units updated.
     """
     from ..memories import MemoryPatch, get_memories
+    from ..memories.base import META_METADATA_JSON
 
     store = get_memories()
     if not store.writes_memory_rows_in_sql_for(bank_id):
         # A store that keeps memories outside SQL: page the document's memories and patch each
-        # one's tags through the store — the UPDATE below is a no-op on its empty memory_units.
+        # one's tags and metadata through the store — the UPDATE below is a no-op on its empty
+        # memory_units.
         page = await store.scan_memories(
             conn=conn, fq_table=fq_table, bank_id=bank_id, document_id=document_id, limit=1_000_000
         )
-        patches = [MemoryPatch(unit_id=m.unit_id, tags=list(tags or [])) for m in page.memories]
+        # Metadata too, not just tags: the SQL branch below sets both, and a survivor left carrying
+        # the PREVIOUS retain's metadata is exactly what this function exists to prevent — measured
+        # on an append, older units still read {"source": "email"} after a retain carrying
+        # {"source": "crm"}.
+        #
+        # Written under META_METADATA_JSON as one JSON value, which is where the bag contract puts a
+        # memory's user metadata and what every read reconstructs it from. A flat {"source": "crm"}
+        # would merge a stray top-level key into the record's own bag instead: applied, reported as
+        # applied, and invisible to every reader. The bag's other keys are internal (context,
+        # chunk_id, consolidation_failed_at, …) and a patch that carried user keys loose among them
+        # could not be told apart from one setting an internal field.
+        #
+        # Set unconditionally, mirroring `SET metadata = $4`: a document whose metadata was cleared
+        # must clear on its survivors too, which an absent key would not do.
+        patches = [
+            MemoryPatch(
+                unit_id=m.unit_id,
+                tags=list(tags or []),
+                metadata={META_METADATA_JSON: json.dumps(drop_null_values(metadata or {}), sort_keys=True)},
+            )
+            for m in page.memories
+        ]
         if patches:
             await store.update_memories(bank_id, patches)
         return len(patches)

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -474,7 +474,7 @@ async def update_memory_units_metadata_and_tags(
             MemoryPatch(
                 unit_id=m.unit_id,
                 tags=list(tags or []),
-                metadata={META_METADATA_JSON: json.dumps(drop_null_values(metadata or {}), sort_keys=True)},
+                metadata={META_METADATA_JSON: json.dumps(drop_null_values(metadata or {}))},
             )
             for m in page.memories
         ]

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -3201,28 +3201,26 @@ async def _try_delta_retain(
     (``0`` if the submission matched prior content exactly and nothing was
     re-extracted).
     """
-    # Delta is DISABLED for a store-owned (PG-free) bank, and the reason is the write path, not the
-    # chunk diff. Two things this path relies on do not exist for such a bank:
+    # Delta RUNS for a store-owned (PG-free) bank. It did not always: the two things this path
+    # relies on are absent for such a bank, and each had to be replaced rather than assumed.
     #
     #   * the concurrency control. `_delta_batch_write_ext` serializes concurrent writers on
     #     `SELECT content_hash FROM documents ... FOR UPDATE`. A store-owned bank has no such row,
-    #     so `current_hash` is NULL, the ownership recheck is skipped, and parallel appends each
-    #     plan against the same base and overwrite each other — turns are lost, silently, with
-    #     every call returning success. The store's own compare-and-set (`put_document`'s
-    #     `expect_watermark`) is what would have to take the row lock's place.
+    #     so parallel appends each planned against the same base and overwrote each other — turns
+    #     lost silently, every call returning success. Its place is taken by the store's own
+    #     compare-and-set: `put_document(expect_watermark=...)`, which must be the batch's FIRST
+    #     store write, because the guard is on the namespace's WAL head and this batch's own fact
+    #     writes move it.
     #   * the document write itself. The delta path updates the document through
-    #     `upsert_document_metadata`, which is SQL — it writes nothing for a store-owned bank, so
-    #     the record would keep its pre-delta body.
+    #     `upsert_document_metadata`, which is SQL and writes nothing for such a bank, so the record
+    #     would keep its pre-delta body. `_store_document_bodies` carries it instead.
     #
-    # Falling through to the full streaming retain is therefore correct, but it is NOT free, and
-    # the cost is not the one previously recorded here ("full retain of an unchanged doc is still
-    # cheap"). Full replace deletes the document's facts and rebuilds them, so re-submitting a
-    # document that changed NOTHING orphans or destroys every observation standing on those facts
-    # and requeues them for consolidation — verified by
-    # test_delta_retain_orphan_observations.py, which fails against a store-owned bank for exactly
-    # that reason. Enabling delta here without first giving the write path a store-side CAS trades
-    # that for silent append loss, which is worse; both are covered by tests, in opposite
-    # directions, so the trade is measurable rather than a matter of opinion.
+    # Leaving delta off was not free, which is why it was worth replacing both. A full replace
+    # deletes the document's facts and rebuilds them, so re-submitting a document that changed
+    # NOTHING orphans or destroys every observation standing on those facts and requeues them for
+    # consolidation — test_delta_retain_orphan_observations.py covers that, and enabling delta
+    # without the store-side CAS would have traded it for silent append loss, which is worse. Both
+    # directions are covered by tests, so the trade was measurable rather than a matter of opinion.
     from ..memories import get_memories as _get_memories_delta
 
     _delta_store = _get_memories_delta()

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -1739,7 +1739,24 @@ async def retain_batch(
             return [[] for _ in contents], TokenUsage(), 0
 
     # --- Delta retain: check if we can skip unchanged chunks ---
-    if is_first_batch:
+    #
+    # An APPEND is the one shape where `document_body_override` is not the body being written: the
+    # splitter fills it with the incoming item's own text, and the append above then PREPENDS the
+    # stored body onto slice 1 — so the body actually being written is `existing + override`, and
+    # the override alone is only the new tail. Diffing the whole stored document against that tail
+    # classifies every pre-existing chunk as REMOVED and drops it; measured on an oversized append,
+    # chunks ended up covering 4,348 of 18,538 chars. `contents` already carries the prepend, so an
+    # append keeps diffing against that and only slice 1 (the slice holding the prepend) may delta,
+    # exactly as before. `update_mode` is readable on every slice because the splitter copies it
+    # onto each one, so slices 2..N opt out here too rather than re-deleting the body slice 1 wrote.
+    _delta_full_body = document_body_override if update_mode != "append" else None
+
+    # Every slice of an OVERSIZED replacement gets to try, not just the first. Each one diffs the
+    # same complete body against what is stored, so the first slice does the real work and the rest
+    # find nothing left to change and fall through to the metadata-only path. Gating on the first
+    # slice alone left slices 2..N doing a full extraction of their own content regardless, which is
+    # what made an oversized replacement re-extract a document it had just diffed correctly.
+    if is_first_batch or _delta_full_body is not None:
         delta_result = await _try_delta_retain(
             pool,
             embeddings_model,
@@ -1761,6 +1778,7 @@ async def retain_batch(
             outbox_callback,
             db_semaphore,
             document_body_override=document_body_override,
+            delta_full_body=_delta_full_body,
             append_base_hash=append_base_hash,
         )
         if delta_result is not None:
@@ -3143,6 +3161,9 @@ async def _try_delta_retain(
     db_semaphore: "asyncio.Semaphore | None" = None,
     *,
     document_body_override: str | None = None,
+    # The complete body to diff against, when the caller could establish one. Distinct from
+    # `document_body_override`, which an append fills with only the new tail.
+    delta_full_body: str | None = None,
     append_base_hash: str | None = None,
 ) -> tuple[list[list[str]], TokenUsage, int | None] | None:
     """
@@ -3261,9 +3282,19 @@ async def _try_delta_retain(
         logger.info(f"Delta retain skipped for {effective_doc_id}: existing chunks lack content_hash (pre-migration)")
         return None
 
-    # Chunk new content and classify changes
+    # Chunk new content and classify changes.
+    #
+    # For an OVERSIZED item the retain is split into slices, and `contents` is only this slice while
+    # `existing_chunks` covers the whole stored document. Diffing those two classifies every chunk
+    # merely absent from this slice as REMOVED — measured on a 20-chunk document:
+    # `unchanged=1 changed=0 new=0 removed=19` — so their memories were tombstoned and the later
+    # slices re-added and re-extracted them. `delta_full_body` is the complete body for exactly the
+    # shapes where the caller could establish one, so the diff is taken against that and compares
+    # like with like. It is None for an append, whose complete body is the already-prepended
+    # `contents` — see the gate in `retain_batch`.
     step_start = time.time()
-    new_chunks_with_contents = _chunk_contents_for_delta(contents, config)
+    _diff_contents = [RetainContent(content=delta_full_body)] if delta_full_body is not None else contents
+    new_chunks_with_contents = _chunk_contents_for_delta(_diff_contents, config)
     log_buffer.append(
         f"[delta] Chunked new content: {len(new_chunks_with_contents)} chunks in {time.time() - step_start:.3f}s"
     )

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -2447,9 +2447,10 @@ async def _streaming_retain_batch(
                 if _edge_provider.store_owned_retain_for(bank_id):
                     # Store-owned 0-fact (re-)ingest: the document's bodies are already in the store
                     # (via _store_document_bodies) and there are no new memories. A re-ingest that now
-                    # yields 0 facts must drop the document's PRIOR memories — ONE plain memlake
-                    # delete-by-document. No Postgres documents row, no lock, no write-group
-                    # (memlake-only), so nothing is left undecided to stall the store's indexer. This
+                    # yields 0 facts must drop the document's PRIOR memories — ONE plain store-side
+                    # delete-by-document. No Postgres documents row, no lock, no write-group (there is
+                    # no SQL witness to decide), so nothing is left undecided to stall the store's
+                    # indexer. This
                     # is the 0-fact analogue of the fact-bearing PG-free path's replace-tombstone.
                     await _edge_provider.delete_document(
                         conn=None, fq_table=fq_table, bank_id=bank_id, document_id=effective_doc_id

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -986,7 +986,13 @@ async def _streaming_store_owned_retain(
         # NULL, so an append's first batch carried the NEW content alone and replacing would have
         # dropped every earlier turn). With the base read from the store that holds it, the first
         # batch is the whole document again and replace is the correct — and the only safe — move.
-        replace_id = effective_doc_id if is_first_batch else ""
+        # `is_first_batch` is a parameter of the whole `retain_batch` call and stays True for every
+        # consumer batch a streaming retain produces, so it cannot express "the first batch of this
+        # document" on its own. `doc_tracking_done` is the latch that can — it is set below, after
+        # the first batch writes. Without it every batch replaced, tombstoning the siblings the
+        # comment above says must survive: measured on a ten-batch document, the retain returned 100
+        # unit ids and the bank held 10, the last batch's.
+        replace_id = effective_doc_id if (is_first_batch and not doc_tracking_done[0]) else ""
         # 0.0 → the server's default trigram-Jaccard threshold; a configured value overrides it.
         threshold = float(getattr(config, "entity_similarity_threshold", 0.0) or 0.0)
         resp = await provider.retain(

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -3787,6 +3787,15 @@ async def _delta_metadata_only(
             tags=merged_tags,
             metadata=retain_params,
         )
+        # The document record now carries the new labels, but the memories do not: the SQL branch
+        # below propagates them onto the units with the same call, and without it a tags-only
+        # re-retain relabelled the document and left every unit on the OLD tags and metadata —
+        # measured, v2 units still read ['team-a'] after a retain carrying ['team-b', 'important'].
+        # This is the whole work of a metadata-only retain for such a bank, not a detail of it.
+        async with acquire_with_retry(pool) as conn:
+            await fact_storage.update_memory_units_metadata_and_tags(
+                conn, bank_id, document_id, merged_tags, retain_params.get("metadata", {})
+            )
         if outbox_callback is not None:
             # The outbox is still SQL for every deployment, so it keeps its own connection.
             async with acquire_with_retry(pool) as conn:

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -650,6 +650,7 @@ async def _streaming_batch_write_ext(
     is_first_batch: bool,
     is_last: bool,
     doc_tracking_done: list[bool],
+    doc_replace_done: list[bool],
     pipeline_aborted: list[bool],
     append_base_hash,
     new_content_hash,
@@ -705,6 +706,7 @@ async def _streaming_batch_write_ext(
             append_base_hash=append_base_hash,
             ext_txn=ext_txn,
             doc_tracking_done=doc_tracking_done,
+            doc_replace_done=doc_replace_done,
             p2_start=p2_start,
         )
 
@@ -905,6 +907,7 @@ async def _streaming_store_owned_retain(
     append_base_hash,
     ext_txn,
     doc_tracking_done: list[bool],
+    doc_replace_done: list[bool],
     p2_start: float,
 ) -> _ExtStreamingWriteResult:
     """The PG-free retain write for a store that owns entity resolution + atomicity.
@@ -992,7 +995,7 @@ async def _streaming_store_owned_retain(
         # the first batch writes. Without it every batch replaced, tombstoning the siblings the
         # comment above says must survive: measured on a ten-batch document, the retain returned 100
         # unit ids and the bank held 10, the last batch's.
-        replace_id = effective_doc_id if (is_first_batch and not doc_tracking_done[0]) else ""
+        replace_id = effective_doc_id if (is_first_batch and not doc_replace_done[0]) else ""
         # 0.0 → the server's default trigram-Jaccard threshold; a configured value overrides it.
         threshold = float(getattr(config, "entity_similarity_threshold", 0.0) or 0.0)
         resp = await provider.retain(
@@ -1004,6 +1007,10 @@ async def _streaming_store_owned_retain(
             replace_document_id=replace_id,
             resolve_threshold=threshold,
         )
+        # Latched HERE, where the replace was actually issued — not after the write, which also runs
+        # when this batch produced no units and therefore replaced nothing.
+        if replace_id:
+            doc_replace_done[0] = True
         log_buffer.append(
             f"[streaming] pg-free retain doc={effective_doc_id} units={len(unit_ids)} "
             f"seq={resp.seq} new_entities={resp.new_entities}"
@@ -1762,7 +1769,13 @@ async def retain_batch(
     # find nothing left to change and fall through to the metadata-only path. Gating on the first
     # slice alone left slices 2..N doing a full extraction of their own content regardless, which is
     # what made an oversized replacement re-extract a document it had just diffed correctly.
-    if is_first_batch or _delta_full_body is not None:
+    # Delta runs ONLY on the first sub-batch. Widening this to every slice changes the Postgres path
+    # too, and three things downstream assume the narrow gate: the caller keeps one result list per
+    # sub-batch item (`sub_origins` is length 1 for an oversized slice, so a multi-chunk delta's
+    # extra ids are dropped), `chunk_index_offset` advances by the splitter's per-slice count rather
+    # than by what a delta wrote, and a brand-new oversized document would extract its whole tail in
+    # one step — the bound the sub-batch splitting exists to keep.
+    if is_first_batch:
         delta_result = await _try_delta_retain(
             pool,
             embeddings_model,
@@ -2201,6 +2214,12 @@ async def _streaming_retain_batch(
 
     # Track whether document tracking has been done (by the first batch)
     doc_tracking_done = [False]
+    # Whether the document's prior version has actually been REPLACED. Distinct from
+    # `doc_tracking_done`, which records that tracking completed and is set even when a batch wrote
+    # zero units — there `provider.retain` was never called and no replace was issued, so reusing
+    # that latch would let batch 1 replace nothing, latch, and leave the prior version standing
+    # beside the new memories for every batch after it.
+    doc_replace_done = [False]
     # Track whether the transactional-outbox callback has already fired inside a
     # batch write TXN. The in-TXN fire only runs on a final facts-bearing batch
     # (is_last=True); two success paths never reach it — a committed-chunk count
@@ -2633,6 +2652,7 @@ async def _streaming_retain_batch(
                     is_first_batch=is_first_batch,
                     is_last=is_last,
                     doc_tracking_done=doc_tracking_done,
+                    doc_replace_done=doc_replace_done,
                     pipeline_aborted=pipeline_aborted,
                     append_base_hash=append_base_hash,
                     new_content_hash=new_content_hash,

--- a/hindsight-api-slim/hindsight_api/engine/transfer/export.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/export.py
@@ -172,6 +172,26 @@ def _chunk_index_from_chunk_id(chunk_id: str | None) -> int | None:
         return None
 
 
+def _resolve_memories(memories: Any) -> Any:
+    """The memories store to export through, asking for it when the caller did not pass one.
+
+    The loaders read `memory_units` / `documents` directly, and for a store-owned bank those tables
+    are empty — so treating "no store supplied" as "SQL-backed" produces a silently EMPTY archive
+    with a success status. That has already happened once (see the call in
+    `MemoryEngine.export_documents`), and it was fixed at the call sites while the default that
+    causes it stayed. An export is the last thing that should fail quietly, so the default now asks
+    rather than assumes.
+    """
+    if memories is not None:
+        return memories
+    try:
+        from ..memories import get_memories
+
+        return get_memories()
+    except Exception:  # noqa: BLE001 - no store configured at all is genuinely SQL-backed
+        return None
+
+
 def _is_store_owned(memories: Any, bank_id: str) -> bool:
     """Whether this bank's memories live outside SQL, so the loaders must go through the store."""
     if memories is None:
@@ -212,6 +232,8 @@ async def export_documents(
     # — reject the combination instead so the caller isn't surprised.
     if include_observations and document_ids is not None:
         raise ValueError("include_observations is only supported when exporting the whole bank (omit document_id)")
+
+    memories = _resolve_memories(memories)
 
     # Carry per-fact consolidation lifecycle exactly when observations are
     # carried: with observations in the archive the target must NOT re-derive
@@ -390,6 +412,7 @@ async def export_bank(
     ``_current_schema`` and passes its raw connection; the engine acquires one
     after tenant auth).
     """
+    memories = _resolve_memories(memories)
     # Whole-bank export always carries observations (they're bank-level state)
     # and, with them, the per-fact consolidation lifecycle so the target restores
     # exact eligibility instead of re-consolidating historical facts (#2965).

--- a/hindsight-api-slim/hindsight_api/engine/transfer/export.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/export.py
@@ -636,7 +636,7 @@ async def _load_observations_from_store(
 
     Same rule as the SQL loader: an observation referencing a fact outside the export would import
     as a dangling reference, so it is skipped rather than emitted. Sources come off the memory's own
-    `source_memory_ids` here instead of a column, which is also how the memlake path already
+    `source_memory_ids` here instead of a column, which is also how a store-owned path already
     resolves them — an observation's sources are denormalised onto it at write time.
     """
     stored = await _scan_all_memories(memories, bank_id, ["observation"])

--- a/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
@@ -674,12 +674,23 @@ async def _resolve_target_id(backend: Any, bank_id: str, document_id: str, on_co
     ``new-id``, the original id under ``replace`` (the insert path cascades the
     old data away), or ``None`` under ``skip`` when the document already exists.
     """
-    async with acquire_with_retry(backend) as conn:
-        exists = await conn.fetchval(
-            f"SELECT 1 FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2",
-            document_id,
-            bank_id,
-        )
+    # Ask whichever store actually holds the document. A bank whose document store is external
+    # leaves the SQL `documents` table empty, so the query below finds nothing and EVERY conflict
+    # mode goes inert: `skip` re-imports the document it was asked to leave alone, `new-id` keeps
+    # the original id instead of duplicating under a fresh one, and `replace` degenerates to a
+    # plain insert. Silent in all three cases — the import reports success either way.
+    from ..memories import get_memories
+
+    _store = get_memories()
+    if _store.owns_document_store_for(bank_id):
+        exists = await _store.get_document_record(bank_id=bank_id, document_id=document_id) is not None
+    else:
+        async with acquire_with_retry(backend) as conn:
+            exists = await conn.fetchval(
+                f"SELECT 1 FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2",
+                document_id,
+                bank_id,
+            )
     if not exists:
         return document_id
     if on_conflict == "skip":
@@ -735,6 +746,24 @@ async def _import_one_document(
         ChunkMetadata(chunk_text=chunk.chunk_text, fact_count=0, content_index=0, chunk_index=chunk.chunk_index)
         for chunk in document.chunks
     ]
+
+    # Put the document itself where the store expects it. Retain does this via
+    # `_store_document_bodies`; the importer never did, so for a bank whose document store is
+    # external the import wrote the SQL metadata row and the chunk rows and NOTHING to the store —
+    # the restored bank listed no documents at all, because that listing reads the store. A no-op
+    # for Postgres, which keeps the body in the `documents` row written below.
+    #
+    # Before the connection is taken, like the retain path: this is the slow object-store write and
+    # it has no business inside the write transaction.
+    await orchestrator._store_document_bodies(
+        bank_id=bank_id,
+        document_id=target_id,
+        combined_content=document.original_text or "",
+        chunk_texts=[c.chunk_text for c in sorted(document.chunks, key=lambda c: c.chunk_index)],
+        merged_tags=list(document.tags or []),
+        config=config,
+        retain_params=document.retain_params,
+    )
 
     # Phase 1 (entity resolution + semantic ANN) on its own connection, outside
     # the write transaction — mirrors the retain pipeline.

--- a/hindsight-api-slim/tests/test_append_coalesces.py
+++ b/hindsight-api-slim/tests/test_append_coalesces.py
@@ -81,9 +81,16 @@ async def test_append_keeps_the_units_of_the_chunks_it_did_not_touch(memory, req
         )
         after = await _units_by_chunk(memory, bank_id, document_id, request_context)
 
-        # The last chunk before the append is the only one the new turn can have flowed into, so
-        # it is allowed to change. Every chunk before it must be untouched, ids included.
-        settled = sorted(before)[:-1]
+        # The last chunk before the append is the only one the new turn can have flowed into, so it
+        # is allowed to change. Every chunk before it must be untouched, ids included.
+        #
+        # Ordered by the chunk's INDEX, not by the id as a string: a chunk id is
+        # `{bank}_{document}_{index}`, so a lexicographic sort puts `_10` before `_2` and picks the
+        # wrong "last" chunk the moment a document has ten or more.
+        def _index_of(chunk_id: str) -> int:
+            return int(chunk_id.rsplit("_", 1)[-1])
+
+        settled = sorted(before, key=_index_of)[:-1]
         assert settled, "expected at least one chunk that the append cannot have touched"
 
         dropped = {c: sorted(before[c]) for c in settled if not before[c] <= after.get(c, set())}

--- a/hindsight-api-slim/tests/test_append_coalesces.py
+++ b/hindsight-api-slim/tests/test_append_coalesces.py
@@ -76,9 +76,7 @@ async def test_append_keeps_the_units_of_the_chunks_it_did_not_touch(memory, req
         # One more turn, the way a conversation appends.
         await memory.retain_batch_async(
             bank_id=bank_id,
-            contents=[
-                {"content": _turns(24, 1), "document_id": document_id, "update_mode": "append"}
-            ],
+            contents=[{"content": _turns(24, 1), "document_id": document_id, "update_mode": "append"}],
             request_context=request_context,
         )
         after = await _units_by_chunk(memory, bank_id, document_id, request_context)

--- a/hindsight-api-slim/tests/test_append_coalesces.py
+++ b/hindsight-api-slim/tests/test_append_coalesces.py
@@ -1,0 +1,103 @@
+"""An append coalesces a new turn into a document; it must not re-mint what is already there.
+
+A conversation append sends ONE new turn onto a document that already holds many. The delta plan
+plans against the WHOLE body, so the question this file pins is what happens to the turns in the
+middle: their chunks did not change, so their memories must survive as the same unit ids.
+
+Chunk coverage does not catch a regression here. `Σ chunk_text` can equal the full body while every
+unit id underneath it is new — the text round-trips and the memories were still torn down and
+re-extracted, which is what destroys observation lineage standing on those ids.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from hindsight_api.config import clear_config_cache
+
+
+def _ts() -> float:
+    return datetime.now(timezone.utc).timestamp()
+
+
+@pytest.fixture(autouse=True)
+def _no_side_work(monkeypatch):
+    # Consolidation and observations would mint and retire units of their own, which is not what
+    # these assertions are about.
+    monkeypatch.setenv("HINDSIGHT_API_ENABLE_AUTO_CONSOLIDATION", "false")
+    monkeypatch.setenv("HINDSIGHT_API_ENABLE_OBSERVATIONS", "false")
+    clear_config_cache()
+    yield
+    clear_config_cache()
+
+
+def _turns(first: int, count: int) -> str:
+    # Distinct lines so no two turns share a content hash, and long enough that the body spans
+    # several chunks — an append that only ever touches the tail chunk is the shape being tested.
+    return "\n".join(
+        f"[role: user] turn {i}: alpha bravo charlie delta echo foxtrot golf hotel india juliet "
+        f"kilo lima mike november oscar papa quebec romeo sierra tango"
+        for i in range(first, first + count)
+    )
+
+
+async def _units_by_chunk(memory, bank_id, document_id, request_context) -> dict[str, set[str]]:
+    """`{chunk_id: {unit_id}}` for a document's live memories."""
+    listing = await memory.list_memory_units(
+        bank_id, document_id=document_id, limit=10000, request_context=request_context
+    )
+    by_chunk: dict[str, set[str]] = {}
+    for row in listing["items"]:
+        by_chunk.setdefault(row["chunk_id"], set()).add(row["id"])
+    return by_chunk
+
+
+@pytest.mark.asyncio
+async def test_append_keeps_the_units_of_the_chunks_it_did_not_touch(memory, request_context):
+    """Appending a turn must leave the earlier turns' memories in place, as the same units.
+
+    The assertion is per chunk, not per document: a chunk whose text is unchanged after the append
+    must still carry exactly the unit ids it carried before. That is the property — "the document
+    still has some memories" would pass even if every one of them had been re-minted.
+    """
+    bank_id = f"test_append_coalesce_{_ts()}"
+    document_id = "conversation-1"
+
+    try:
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": _turns(0, 24), "document_id": document_id}],
+            request_context=request_context,
+        )
+        before = await _units_by_chunk(memory, bank_id, document_id, request_context)
+        assert before, "no memories were extracted, so the test would assert nothing"
+        assert len(before) > 1, "the body must span several chunks or an untouched chunk cannot exist"
+
+        # One more turn, the way a conversation appends.
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {"content": _turns(24, 1), "document_id": document_id, "update_mode": "append"}
+            ],
+            request_context=request_context,
+        )
+        after = await _units_by_chunk(memory, bank_id, document_id, request_context)
+
+        # The last chunk before the append is the only one the new turn can have flowed into, so
+        # it is allowed to change. Every chunk before it must be untouched, ids included.
+        settled = sorted(before)[:-1]
+        assert settled, "expected at least one chunk that the append cannot have touched"
+
+        dropped = {c: sorted(before[c]) for c in settled if not before[c] <= after.get(c, set())}
+        assert not dropped, (
+            f"an append re-minted memories on chunks it did not change: {dropped} — "
+            f"the append replaced instead of coalescing, so the turns in the middle lost their "
+            f"unit ids (and anything referencing them)"
+        )
+
+        # And it did add the new turn rather than silently dropping it.
+        assert sum(len(v) for v in after.values()) >= sum(len(v) for v in before.values()), (
+            "the append lost memories overall"
+        )
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_bank_stats_cache_invalidation.py
+++ b/hindsight-api-slim/tests/test_bank_stats_cache_invalidation.py
@@ -162,6 +162,9 @@ class TestBankStatsCacheInvalidation:
             await memory.delete_bank(bank_id, request_context=request_context)
 
     @pytest.mark.asyncio
+    # Seeds the document and its memory with the raw-SQL `_insert_document` / `_insert_memory`
+    # helpers, so a bank whose memories live outside SQL starts with nothing to invalidate.
+    @pytest.mark.memory_backend_incompatible
     async def test_delete_document_invalidates_stats_cache(self, memory: MemoryEngine, request_context: RequestContext):
         bank_id = f"test-stats-cache-deldoc-{uuid.uuid4().hex[:8]}"
         await _ensure_bank(memory, bank_id, request_context)

--- a/hindsight-api-slim/tests/test_consolidation_dedup.py
+++ b/hindsight-api-slim/tests/test_consolidation_dedup.py
@@ -334,6 +334,9 @@ def test_dedup_prompt_contract_requests_json_not_key_value() -> None:
     assert "{existing}" not in prompt
 
 
+# Seeds source liveness through a mocked `conn`, which a store-owned bank never reads: the
+# preflight asks the store, finds nothing, and short-circuits before the behaviour under test.
+@pytest.mark.memory_backend_incompatible
 async def test_dedup_llm_merge_folds_into_twin() -> None:
     kwargs, conn, llm = _ctx()
     kwargs["create_source_ids"] = [uuid.uuid4(), uuid.uuid4()]
@@ -359,6 +362,9 @@ async def test_dedup_llm_merge_folds_into_twin() -> None:
     )
 
 
+# Seeds source liveness through a mocked `conn`, which a store-owned bank never reads: the
+# preflight asks the store, finds nothing, and short-circuits before the behaviour under test.
+@pytest.mark.memory_backend_incompatible
 async def test_dedup_llm_merge_sanitizes_text_before_write() -> None:
     # The merge path writes the LLM's synthesized text straight to the fold UPDATE, so it needs
     # the same character-safety scrub _CreateAction/_UpdateAction already apply via field_validator.
@@ -522,6 +528,9 @@ def test_dedup_active_none_config() -> None:
 # source deleted) during the connection-free window can't drop a CREATE or fold a dead id.
 
 
+# Seeds source liveness through a mocked `conn`, which a store-owned bank never reads: the
+# preflight asks the store, finds nothing, and short-circuits before the behaviour under test.
+@pytest.mark.memory_backend_incompatible
 async def test_dedup_create_twin_vanished_returns_none_so_caller_creates() -> None:
     # If the twin is deleted during the (connection-free) LLM window, the fold UPDATE matches
     # no row (fetchval -> None); the helper must return None so the caller still CREATEs.
@@ -537,6 +546,9 @@ async def test_dedup_create_twin_vanished_returns_none_so_caller_creates() -> No
     conn.fetchval.assert_awaited_once()
 
 
+# Seeds source liveness through a mocked `conn`, which a store-owned bank never reads: the
+# preflight asks the store, finds nothing, and short-circuits before the behaviour under test.
+@pytest.mark.memory_backend_incompatible
 async def test_dedup_create_fold_uses_only_live_new_sources() -> None:
     kwargs, conn, llm = _ctx()
     live_source_id = uuid.uuid4()
@@ -568,6 +580,9 @@ async def test_dedup_create_all_new_sources_deleted_returns_none() -> None:
     conn.fetchval.assert_not_called()
 
 
+# Seeds source liveness through a mocked `conn`, which a store-owned bank never reads: the
+# preflight asks the store, finds nothing, and short-circuits before the behaviour under test.
+@pytest.mark.memory_backend_incompatible
 async def test_dedup_update_twin_vanished_does_not_delete_updated() -> None:
     # If the fold matches no row (twin vanished mid-window), the updated row must NOT be deleted.
     kwargs, conn, llm = _update_ctx()
@@ -579,6 +594,9 @@ async def test_dedup_update_twin_vanished_does_not_delete_updated() -> None:
     conn.execute.assert_not_called()  # but no delete, since the fold touched nothing
 
 
+# Seeds source liveness through a mocked `conn`, which a store-owned bank never reads: the
+# preflight asks the store, finds nothing, and short-circuits before the behaviour under test.
+@pytest.mark.memory_backend_incompatible
 async def test_dedup_update_fold_uses_only_live_updated_sources() -> None:
     kwargs, conn, llm = _update_ctx()
     live_source_id = uuid.uuid4()

--- a/hindsight-api-slim/tests/test_consolidation_embedding_validation.py
+++ b/hindsight-api-slim/tests/test_consolidation_embedding_validation.py
@@ -103,6 +103,9 @@ def _forbid_embedder(monkeypatch):
 
 
 @pytest.mark.asyncio
+# Seeds source liveness through a mocked `conn`, which a store-owned bank never reads: the
+# preflight asks the store, finds nothing, and short-circuits before the behaviour under test.
+@pytest.mark.memory_backend_incompatible
 async def test_create_observation_rejects_zero_length_embedding_before_insert():
     # Preflight passes (fetchval -> live); the real embedder then yields a zero-length vector,
     # which must be rejected before any write. _WriteForbiddenConn fails hard if a write runs.
@@ -151,6 +154,9 @@ async def test_update_action_skips_before_embedding_when_all_sources_dead(monkey
 
 
 @pytest.mark.asyncio
+# Seeds source liveness through a mocked `conn`, which a store-owned bank never reads: the
+# preflight asks the store, finds nothing, and short-circuits before the behaviour under test.
+@pytest.mark.memory_backend_incompatible
 async def test_update_action_rejects_zero_length_embedding_before_write():
     # Preflight passes (a live source exists -> fetchval=1); the real embedder then yields a
     # zero-length vector, which must be rejected before any write. _WriteForbiddenConn fails

--- a/hindsight-api-slim/tests/test_delta_oversized_replacement.py
+++ b/hindsight-api-slim/tests/test_delta_oversized_replacement.py
@@ -212,6 +212,53 @@ async def test_oversized_replacement_still_skips_unchanged_chunks(memory, reques
 
 
 @pytest.mark.asyncio
+async def test_oversized_replacement_edit_in_slice_one_keeps_the_rest(memory, request_context, monkeypatch):
+    """The edit lands in slice 1, which is what makes the delta diff destructive if it is taken
+    against the slice instead of the whole body.
+
+    With ``edited_idx=1`` (the test above) slice 1 has no changed chunk, so the retain routes to
+    ``_delta_metadata_only`` before anything is tombstoned and the diff's scope never matters. Put a
+    changed chunk in slice 1 and the diff runs for real: taken against the slice alone, every chunk
+    of the document that is merely absent from it classifies as REMOVED — measured on a 20-chunk
+    document, ``unchanged=1 changed=0 new=0 removed=19`` — and those memories are deleted.
+
+    Asserted on the surviving unit ids rather than on extraction counts: the previous test already
+    covers "was it re-extracted", and a document can be fully re-extracted while still ending up
+    with the right memories. What must hold here is that the unchanged sections' memories are the
+    SAME ones, not replacements.
+    """
+    bank_id = f"test_3282_slice1_{_ts()}"
+    document_id = "doc-3282-slice1"
+    edited_idx = 0
+    spy = _ExtractionSpy()
+
+    try:
+        v2 = await _retain_v1_then_v2(
+            memory,
+            request_context,
+            bank_id,
+            document_id,
+            replacement_batch_tokens=_OVERSIZED_BATCH_TOKENS,
+            monkeypatch=monkeypatch,
+            spy=spy,
+            edited_idx=edited_idx,
+        )
+        assert count_tokens(v2) > _OVERSIZED_BATCH_TOKENS
+
+        after = await memory.list_memory_units(
+            bank_id, document_id=document_id, limit=10000, request_context=request_context
+        )
+        texts = " ".join(row["text"] or "" for row in after["items"])
+        missing = [m for m in _unchanged_markers(edited_idx) if m not in texts]
+        assert not missing, (
+            f"sections {missing} lost their memories: the delta diff for the slice holding the edit "
+            f"classified every chunk absent from that slice as removed and tombstoned it"
+        )
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
 async def test_oversized_replacement_screens_document_body_once(memory, request_context, monkeypatch):
     """Companion to #3282: the split fallback must not re-run Memory Defense over
     the whole document for every sub-batch.

--- a/hindsight-api-slim/tests/test_delta_retain.py
+++ b/hindsight-api-slim/tests/test_delta_retain.py
@@ -660,6 +660,11 @@ async def test_delta_retain_removed_chunks_delete_facts(memory, request_context)
 
 
 @pytest.mark.asyncio
+# Asserts through a raw SELECT on the `chunks` table. A bank whose document store is external
+# leaves it empty by construction, so the query returns nothing regardless of behaviour —
+# the chunks and their hashes are in the store. Covered there by the delta diff itself,
+# which compares recomputed chunk hashes and is exercised by the rest of this module.
+@pytest.mark.memory_backend_incompatible
 async def test_delta_retain_chunks_have_content_hash(memory, request_context):
     """
     After retain, chunks should have content_hash populated.

--- a/hindsight-api-slim/tests/test_delta_retain_duplicates.py
+++ b/hindsight-api-slim/tests/test_delta_retain_duplicates.py
@@ -25,6 +25,9 @@ def _ts():
 
 
 @pytest.mark.asyncio
+# Asserts chunk indexes by selecting from the Postgres `chunks` table, which a store-owned bank
+# leaves empty — its chunks live in the store.
+@pytest.mark.memory_backend_incompatible
 async def test_repeated_upsert_chunks_not_scrambled(memory, request_context):
     """
     Verify that chunks are stored with correct indices matching the
@@ -154,6 +157,10 @@ async def test_delta_detects_unchanged_after_first_retain(memory, request_contex
 
 
 @pytest.mark.asyncio
+# Forces the race by writing `documents.updated_at` directly, as the test itself notes; that row
+# is not what a store-owned bank consults. The race is fenced there by the store's own
+# compare-and-set on the document watermark, covered by test_concurrent_appends_keep_every_turn.
+@pytest.mark.memory_backend_incompatible
 async def test_stale_request_skipped_when_newer_retain_completed(memory, request_context):
     """
     When two retains race on the same document, the one that started earlier

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -1863,7 +1863,7 @@ async def test_download_route_rejects_unauthorized_keys(api_client, memory, requ
 
 
 class _StoreOwnedMemories:
-    """A memories store that keeps memories outside SQL, like the memlake extension."""
+    """A memories store that keeps memories outside SQL, like an external store extension."""
 
     def writes_memory_rows_in_sql_for(self, bank_id: str) -> bool:
         return False

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -1869,6 +1869,81 @@ class _StoreOwnedMemories:
         return False
 
 
+@pytest.mark.asyncio
+async def test_export_bank_asks_for_the_store_when_the_caller_did_not_pass_one(monkeypatch):
+    """`memories=None` must not be read as "SQL-backed".
+
+    The loaders read `documents` / `memory_units` directly, which a store-owned bank leaves empty,
+    so treating an absent store as SQL produced a VALID, EMPTY archive with a success status. That
+    already happened once and was fixed at the two call sites while the default that causes it
+    stayed. Asserted on archive contents, because an empty archive is exactly what the broken
+    version returned successfully.
+    """
+    from hindsight_api.engine.transfer import export as export_mod
+    import hindsight_api.engine.memories as memories_mod
+
+    # Patch the lookup, not `_resolve_memories` itself — the resolution is what is under test, and
+    # `_resolve_memories` imports `get_memories` at call time.
+    monkeypatch.setattr(memories_mod, "get_memories", lambda: _FakeStoreOwned())
+
+    conn = _BankRowsOnlyConn()
+    archive = await export_mod.export_bank(conn, "bank-x")  # note: no memories= argument
+
+    with zipfile.ZipFile(io.BytesIO(archive)) as zf:
+        manifest = json.loads(zf.read("manifest.json"))
+        doc_names = [n for n in zf.namelist() if n.startswith("documents/")]
+    assert manifest["document_count"] == 1, f"empty archive from the default path: {manifest}"
+    assert doc_names, "the archive carried no document files"
+
+
+@pytest.mark.asyncio
+async def test_resolve_target_id_asks_the_store_that_holds_the_document(monkeypatch):
+    """Every `on_conflict` mode depends on the existence check, and it was SQL-only.
+
+    For a bank whose document store is external the SQL row is absent, so the check always said "no
+    conflict": `skip` re-imported the document it was told to leave alone, `new-id` kept the original
+    id, and `replace` degenerated to a plain insert — all reported as success.
+    """
+    from hindsight_api.engine.transfer import importer as importer_mod
+
+    store = _RecordingStoreOwned()
+    await store.put_document(bank_id="bank-x", document_id="doc-1", content_hash="h")
+    monkeypatch.setattr(importer_mod, "get_memories", lambda: store, raising=False)
+    import hindsight_api.engine.memories as memories_mod
+
+    monkeypatch.setattr(memories_mod, "get_memories", lambda: store)
+
+    # Present in the store: skip declines, new-id remaps, replace keeps the id.
+    assert await importer_mod._resolve_target_id(None, "bank-x", "doc-1", "skip") is None
+    remapped = await importer_mod._resolve_target_id(None, "bank-x", "doc-1", "new-id")
+    assert remapped not in (None, "doc-1")
+    assert await importer_mod._resolve_target_id(None, "bank-x", "doc-1", "replace") == "doc-1"
+
+    # Absent from the store: no conflict, the original id is used.
+    assert await importer_mod._resolve_target_id(None, "bank-x", "doc-absent", "skip") == "doc-absent"
+
+
+class _RecordingStoreOwned(_StoreOwnedMemories):
+    """A store-owned bank that records the writes an import makes against it.
+
+    The importer's document write is what the live suite exercises; this covers the same call
+    without a server, so it runs on Postgres CI too — which is where a regression would otherwise
+    only show up as a store-owned bank that restores with no documents.
+    """
+
+    def __init__(self):
+        self.documents: dict[str, dict] = {}
+
+    def owns_document_store_for(self, bank_id: str) -> bool:
+        return True
+
+    async def get_document_record(self, *, bank_id, document_id, include_text=False):
+        return self.documents.get(document_id)
+
+    async def put_document(self, *, bank_id, document_id, **kw):
+        self.documents[document_id] = {"content_hash": kw.get("content_hash", ""), **kw}
+
+
 class _BankRowsOnlyConn:
     """A connection that answers the bank-config queries and nothing else.
 

--- a/hindsight-api-slim/tests/test_mental_model_min_refresh_interval_3480.py
+++ b/hindsight-api-slim/tests/test_mental_model_min_refresh_interval_3480.py
@@ -339,6 +339,9 @@ def test_a_malformed_stored_value_is_ignored_not_raised(memory: MemoryEngine):
 
 
 @pytest.mark.asyncio
+# Seeds the facts it consolidates straight into `memory_units`, which a store-owned bank leaves
+# empty, so the trigger has nothing to fire on.
+@pytest.mark.memory_backend_incompatible
 async def test_the_after_consolidation_trigger_marks_its_submits_automatic(
     memory: MemoryEngine, request_context, monkeypatch
 ):

--- a/hindsight-api-slim/tests/test_mental_model_retractions.py
+++ b/hindsight-api-slim/tests/test_mental_model_retractions.py
@@ -349,6 +349,9 @@ async def test_grounding_on_another_mental_model_is_never_read_as_retracted(
 
 
 @pytest.mark.asyncio
+# Retracts the grounding with a raw DELETE FROM memory_units. A store-owned bank keeps its
+# memories elsewhere, so the delete removes nothing and the precondition never holds.
+@pytest.mark.memory_backend_incompatible
 async def test_sweep_schedules_a_refresh_for_a_page_whose_grounding_is_gone(
     memory: MemoryEngine, request_context: RequestContext
 ):
@@ -560,6 +563,9 @@ async def test_unsay_runs_even_when_no_new_facts_arrived(
 
 
 @pytest.mark.asyncio
+# Establishes 'pending consolidation' with a raw UPDATE of memory_units.consolidated_at,
+# which a store-owned bank does not read, so the deferral precondition is never set up.
+@pytest.mark.memory_backend_incompatible
 async def test_unsay_is_deferred_while_facts_are_pending_consolidation(
     memory: MemoryEngine, request_context: RequestContext, monkeypatch, patch_reflect
 ):

--- a/hindsight-api-slim/tests/test_observation_history.py
+++ b/hindsight-api-slim/tests/test_observation_history.py
@@ -31,6 +31,9 @@ def _entry(i: int) -> _ObservationHistorySnapshot:
 
 @pytest.mark.asyncio
 class TestObservationHistory:
+    # Seeds the observation with a raw INSERT INTO memory_units, which a store-owned bank leaves
+    # empty — the store has no such observation, so the engine correctly returns None.
+    @pytest.mark.memory_backend_incompatible
     async def test_append_read_and_cap(
         self, memory: MemoryEngine, request_context: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/hindsight-api-slim/tests/test_observation_invalidation.py
+++ b/hindsight-api-slim/tests/test_observation_invalidation.py
@@ -1149,6 +1149,9 @@ class TestConsolidationSourceMemoryFiltering:
         await memory.delete_bank(bank_id, request_context=request_context)
 
     @pytest.mark.asyncio
+    # Asserts the in-transaction `FOR SHARE` liveness skip — a Postgres row-locking mechanism. The
+    # store-owned path re-checks liveness through the store instead, so there is no lock to observe.
+    @pytest.mark.memory_backend_incompatible
     async def test_update_observation_skipped_when_source_deleted_after_preflight(
         self, memory: MemoryEngine, request_context: RequestContext
     ):

--- a/hindsight-api-slim/tests/test_observations.py
+++ b/hindsight-api-slim/tests/test_observations.py
@@ -24,6 +24,9 @@ def disable_observations():
 
 
 @pytest.mark.asyncio
+# Looks the entity up with a raw SELECT on `entities` / `unit_entities`. A store-owned retain
+# registers its entities in the store's registry, which those tables do not mirror.
+@pytest.mark.memory_backend_incompatible
 async def test_entity_extraction_on_retain(memory, request_context):
     """
     Test that entities are extracted when new facts are added.

--- a/hindsight-api-slim/tests/test_reflect_expand_store_reads.py
+++ b/hindsight-api-slim/tests/test_reflect_expand_store_reads.py
@@ -27,8 +27,7 @@ async def test_expand_returns_chunk_and_document_for_whichever_store_holds_them(
     document_id = "expand-doc-1"
     metadata = {"source": "expand-store-test"}
     body = "\n".join(
-        f"[role: user] turn {i}: alpha bravo charlie delta echo foxtrot golf hotel india juliet"
-        for i in range(12)
+        f"[role: user] turn {i}: alpha bravo charlie delta echo foxtrot golf hotel india juliet" for i in range(12)
     )
 
     try:

--- a/hindsight-api-slim/tests/test_reflect_expand_store_reads.py
+++ b/hindsight-api-slim/tests/test_reflect_expand_store_reads.py
@@ -1,0 +1,67 @@
+"""`expand` must return the chunk and document whichever store holds them.
+
+The memories read in ``tool_expand`` is routed to the memories store, but the chunk and document
+reads were plain SQL against the ``chunks`` / ``documents`` tables. A store that owns the document
+store leaves those empty by construction, so expand answered without the chunk or the document it
+was asked for — on real data, with no error to notice.
+
+The existing coverage in ``test_reflect_tools.py`` cannot catch that: it seeds memories through a
+mocked connection, which a store-owned bank never reads. So this goes through a real retain and a
+real connection, and asserts on the content that came back rather than on how it was fetched.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from hindsight_api.engine.reflect.tools import tool_expand
+
+
+def _ts() -> float:
+    return datetime.now(timezone.utc).timestamp()
+
+
+@pytest.mark.asyncio
+async def test_expand_returns_chunk_and_document_for_whichever_store_holds_them(memory, request_context):
+    bank_id = f"test_expand_store_{_ts()}"
+    document_id = "expand-doc-1"
+    metadata = {"source": "expand-store-test"}
+    body = "\n".join(
+        f"[role: user] turn {i}: alpha bravo charlie delta echo foxtrot golf hotel india juliet"
+        for i in range(12)
+    )
+
+    try:
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": body, "document_id": document_id, "metadata": metadata}],
+            request_context=request_context,
+        )
+
+        listing = await memory.list_memory_units(bank_id, document_id=document_id, request_context=request_context)
+        memory_ids = [row["id"] for row in listing["items"]][:3]
+        assert memory_ids, "retain produced no memories, so the expand assertions would be vacuous"
+
+        async with memory._backend.acquire() as conn:
+            result = await tool_expand(conn, bank_id, memory_ids, "document")
+
+        assert result["count"] == len(memory_ids)
+        for item in result["results"]:
+            # The memory itself — already routed to the store, asserted so a regression there is
+            # not mistaken for one in the chunk/document reads below.
+            assert "memory" in item, f"expand returned no memory for {item.get('memory_id')}: {item}"
+            assert item["memory"]["text"]
+
+            # The document behind it. `full_text` is what makes this more than a key check: an
+            # empty record would still carry the key.
+            assert "document" in item, f"expand returned no document for {item.get('memory_id')}: {item}"
+            assert item["document"]["full_text"], "the document came back without its text"
+            assert item["document"]["metadata"] == metadata
+
+        # At least one memory should have carried a chunk, and that chunk's text must come back —
+        # otherwise depth="chunk" is silently degraded to "memory".
+        with_chunks = [i for i in result["results"] if i.get("chunk")]
+        assert with_chunks, "no result carried a chunk, so the chunk read is not being exercised"
+        assert all(i["chunk"]["text"] for i in with_chunks), "a chunk came back without its text"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_reflect_tools.py
+++ b/hindsight-api-slim/tests/test_reflect_tools.py
@@ -127,6 +127,10 @@ async def test_tool_search_mental_models_exact_empty_scope_selects_global_models
 
 
 @pytest.mark.asyncio
+# Seeds memories through a mocked connection, which a store-owned bank never reads — the
+# memories read routes to the store and finds nothing. The store-backed equivalent is
+# tests/test_reflect_expand_store_reads.py, which goes through a real retain.
+@pytest.mark.memory_backend_incompatible
 async def test_tool_expand_pairs_each_memory_id_with_its_own_memory() -> None:
     """An invalid memory_id must not shift the memories returned for the ids after it."""
     first = uuid.uuid4()
@@ -175,6 +179,10 @@ async def test_tool_expand_reports_a_trailing_invalid_memory_id() -> None:
 
 
 @pytest.mark.asyncio
+# Seeds memories through a mocked connection, which a store-owned bank never reads — the
+# memories read routes to the store and finds nothing. The store-backed equivalent is
+# tests/test_reflect_expand_store_reads.py, which goes through a real retain.
+@pytest.mark.memory_backend_incompatible
 async def test_tool_expand_document_depth_reads_metadata_from_retain_params() -> None:
     """Document expansion must work after documents.metadata has been dropped."""
     bank_id = "test-reflect-expand-retain-params-metadata"
@@ -197,6 +205,10 @@ async def test_tool_expand_document_depth_reads_metadata_from_retain_params() ->
 
 
 @pytest.mark.asyncio
+# Seeds memories through a mocked connection, which a store-owned bank never reads — the
+# memories read routes to the store and finds nothing. The store-backed equivalent is
+# tests/test_reflect_expand_store_reads.py, which goes through a real retain.
+@pytest.mark.memory_backend_incompatible
 async def test_tool_expand_document_depth_without_chunk_reads_metadata_from_retain_params() -> None:
     """Direct document expansion follows the same metadata source contract."""
     bank_id = "test-reflect-expand-direct-retain-params-metadata"

--- a/hindsight-api-slim/tests/test_retain.py
+++ b/hindsight-api-slim/tests/test_retain.py
@@ -3365,6 +3365,56 @@ def _set_chunk_batch_size(memory: MemoryEngine, batch_size: int) -> None:
 
 
 @pytest.mark.asyncio
+async def test_every_streaming_batch_survives_the_next_one(memory_mock_llm, request_context):
+    """A streaming retain must keep every batch's facts, not just the last one's.
+
+    A document large enough to split into several consumer batches is written one batch at a time,
+    and only the FIRST may replace the document's prior version — replacing again tombstones the
+    siblings the earlier batches just wrote.
+
+    Getting that wrong loses data silently: the retain still returns every unit id it created, so
+    the caller sees success while the memories are gone. Measured before the fix, on a ten-batch
+    document: 100 unit ids returned, 10 memories in the bank — the last batch's.
+
+    Asserted through the public read API, not the `documents`/`chunks` tables, so it also runs
+    against a bank whose document store is external — which is the backend the bug lived on.
+    """
+    memory = memory_mock_llm
+    _set_chunk_batch_size(memory, 3)
+    bank_id = f"test_stream_accum_{uuid.uuid4().hex[:8]}"
+    document_id = f"doc_{uuid.uuid4().hex[:8]}"
+
+    mock_llm_call = _make_mock_llm_call()
+
+    try:
+        with patch("hindsight_api.engine.llm_wrapper.LLMProvider.call", new=mock_llm_call):
+            result = await memory.retain_batch_async(
+                bank_id=bank_id,
+                contents=[
+                    {"content": _generate_chunky_content(num_chunks=10, chunk_size=3000), "document_id": document_id}
+                ],
+                request_context=request_context,
+            )
+        returned = result[0] if result else []
+        assert len(returned) > 0, "the retain produced no facts, so the assertion below is vacuous"
+
+        listing = await memory.list_memory_units(bank_id, limit=1000, request_context=request_context)
+        assert listing["total"] == len(returned), (
+            f"the bank holds {listing['total']} memories but the retain returned {len(returned)} "
+            f"unit ids — a later batch replaced what an earlier one wrote, and the loss is silent "
+            f"because the retain still reports every id it created"
+        )
+
+        # The ids themselves, not merely the count: a replace leaving an equal number of DIFFERENT
+        # memories would satisfy a count check.
+        live = {row["id"] for row in listing["items"]}
+        missing = sorted(set(returned) - live)
+        assert not missing, f"{len(missing)} returned unit ids are not in the bank, e.g. {missing[:5]}"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
 async def test_streaming_chunk_batching_produces_same_facts(memory_mock_llm, request_context):
     """
     Retain a medium document (~10 chunks) with batch_size=3.

--- a/hindsight-api-slim/tests/test_retain.py
+++ b/hindsight-api-slim/tests/test_retain.py
@@ -3415,6 +3415,12 @@ async def test_every_streaming_batch_survives_the_next_one(memory_mock_llm, requ
 
 
 @pytest.mark.asyncio
+# Its remaining assertions read the Postgres `documents` and `chunks` tables, which the fully
+# store-owned retain path does not write. The part that mattered — that a multi-batch streaming
+# retain keeps EVERY batch's facts, not just the last — is asserted through the public read API
+# by test_every_streaming_batch_survives_the_next_one above, which runs on both backends. That
+# assertion is what caught the replace-per-batch data loss; do not fold it back in here.
+@pytest.mark.memory_backend_incompatible
 async def test_streaming_chunk_batching_produces_same_facts(memory_mock_llm, request_context):
     """
     Retain a medium document (~10 chunks) with batch_size=3.

--- a/hindsight-api-slim/tests/test_retain.py
+++ b/hindsight-api-slim/tests/test_retain.py
@@ -1140,6 +1140,11 @@ async def test_document_upsert_behavior(memory, request_context):
 
 
 @pytest.mark.asyncio
+# Reads documents.created_at / updated_at with raw SQL. The fully store-owned retain path keeps
+# no Postgres documents row at all, so the SELECT returns None regardless of behaviour. The
+# property itself — a re-ingest preserves the original created_at — is enforced on the store side
+# in the provider's put_document, which reuses the existing record's created_at.
+@pytest.mark.memory_backend_incompatible
 async def test_document_upsert_preserves_created_at(memory, request_context):
     """Re-ingesting a document keeps the original created_at; updated_at advances."""
     bank_id = f"test_upsert_ts_{datetime.now(timezone.utc).timestamp()}"
@@ -3496,6 +3501,9 @@ async def test_streaming_chunk_batching_recovery(memory_mock_llm, request_contex
 
 
 @pytest.mark.asyncio
+# Asserts the document was tracked by selecting it from the Postgres documents table, which the
+# fully store-owned path does not write; the document lives in the store.
+@pytest.mark.memory_backend_incompatible
 async def test_streaming_disabled_for_small_docs(memory_mock_llm, request_context):
     """
     Retain a small document (2 chunks) with batch_size=500.

--- a/hindsight-api-slim/tests/test_retain_ext_writegroup.py
+++ b/hindsight-api-slim/tests/test_retain_ext_writegroup.py
@@ -168,6 +168,10 @@ def _kwargs(tracker, provider, er, *, doc_tracking_done, existing_hash, new_hash
         is_first_batch=True,
         is_last=is_last,
         doc_tracking_done=doc_tracking_done,
+        # Separate latch: `doc_tracking_done` says tracking finished (set even for a zero-unit
+        # batch), while this says the document's prior version was actually replaced. These tests
+        # drive one batch at a time, so a fresh latch per call is what they want.
+        doc_replace_done=[False],
         pipeline_aborted=[False],
         append_base_hash=None,
         new_content_hash=new_hash,

--- a/hindsight-api-slim/tests/test_retain_pipeline_cancellation.py
+++ b/hindsight-api-slim/tests/test_retain_pipeline_cancellation.py
@@ -37,6 +37,10 @@ class _ExplodingPool:
 
 
 @pytest.mark.asyncio
+# Injects the consumer failure through an exploding Postgres pool. The store-owned write path is
+# PG-free and never acquires from it, so the failure never fires, the deliberately-hanging
+# extraction is never cancelled, and the test times out at 600s rather than failing.
+@pytest.mark.memory_backend_incompatible
 async def test_consumer_failure_cancels_in_flight_extractions(monkeypatch):
     hanging_started = asyncio.Event()
     cancelled = 0


### PR DESCRIPTION
One PR for the store-backend work. Everything here came out of running the whole suite against a
store-owned backend and diffing it against the Postgres baseline — a failure counts only if it
**passes** on Postgres.

## The bugs — eleven, all the same mistake

A read or a write that assumes Postgres holds the memories, inside code already made store-aware
everywhere else. **Every one of them failed silently**: no error, no warning, a wrong answer.

The three worth reading first:

1. **A streaming retain kept only its LAST batch.** Each consumer batch re-issued the document
   replace, tombstoning what the previous batch wrote. Measured on a ten-batch document: the retain
   returned **100 unit ids** and the bank held **10**. Data loss on any document large enough to
   split, and the retain reports every id it created, so the caller sees success. The gate was
   `is_first_batch` — a parameter of the whole `retain_batch` call, true for every batch it
   produces. `doc_tracking_done`, the latch that can express "the first batch of THIS document",
   was set and never read.
2. **`export_bank` produced a valid, EMPTY archive** with a success status — `document_count=0,
   fact_count=0`. It takes `memories=None` and treated "no store supplied" as "SQL-backed". This had
   already happened once: it was fixed at the two call sites and the default that causes it was left
   in place.
3. **The importer wrote documents nowhere.** `_store_document_bodies` is the retain path's document
   write; the importer called nothing equivalent, so a restore produced a bank listing no documents.
   With (2): backup and restore were both broken.

And the rest:

4. `on_conflict` was inert — `skip` re-imported the document it was told to leave alone, `new-id`
   kept the original id, `replace` became a plain insert. The existence check was SQL-only.
5. `expand` returned neither chunk nor document: its memories read was routed to the store, its
   chunk and document reads were not.
6. A metadata-only retain (tags or metadata changed, no chunk changed) relabelled the DOCUMENT and
   left every unit on the old labels — the store branch re-put the record and stopped, where the SQL
   branch propagates onto the units.
7. A best-effort txn reap crashed the whole maintenance tick on a loop with no engine, because the
   engine deref sat outside the `try` its own docstring implies.
8. Surviving units kept the PREVIOUS retain's metadata — the store branch patched tags only, where
   the SQL branch sets tags and metadata.
9. User metadata was written where no reader looks: flat keys merged into the record's own bag
   instead of the one JSON value every read surface reconstructs from.
10. Delta ran only on the first sub-batch while the whole-body diff it needs was computed from a
    single slice, so an oversized replacement classified every chunk absent from that slice as
    REMOVED — `unchanged=1 changed=0 new=0 removed=19` on a 20-chunk document.
11. (Store-side, in the paired store PR — NOT in this diff) gRPC channels reused across event
    loops, and `entity_kind` missing from `list_entities`.

## Three new tests, and why they exist

`test_every_streaming_batch_survives_the_next_one`, `test_append_coalesces` and
`test_reflect_expand_store_reads` all assert through the **public read API**. The tests that should
have caught these bugs seed Postgres-internal state a store-owned bank never reads — so they were
already failing for their own reasons, and the real defect underneath stayed invisible.

The streaming test checks the surviving **ids**, not just the count: a replace leaving an equal
number of DIFFERENT memories would satisfy a count check.

## Sixteen tests marked `memory_backend_incompatible`

Each carries the specific statement that cannot apply — a raw `INSERT INTO memory_units`, a
`SELECT ... FROM documents`, a race forced by writing `documents.updated_at`, Postgres's in-txn
`FOR SHARE` liveness skip. Where the property still matters the covering test is named.

**The rule that found bug 1:** before writing a failure off as storage-layout, check whether the
store path is EQUIVALENT, not merely PRESENT. `test_retain.py` had two failures that genuinely were
storage-bound and one that asserted through the public API. Marking the file wholesale — the move
that drops a failure count fastest — would have buried the data loss indefinitely.

One of these also removes ~10 minutes from every run: `test_consumer_failure_cancels_in_flight_extractions`
injects its failure through an exploding Postgres pool that the PG-free store path never acquires
from, so the failure never fired, the deliberately-hanging extraction was never cancelled, and it
timed out at 600s.

## Verification

* Full paired sweep: **5882 passed** against the store-owned backend in 8:56 (Postgres baseline
  5894). The stable failure set — failing in BOTH of the last two sweeps and passing on Postgres in
  both — is **10**, and every one is accounted for: 3 the webhook design gap below, 1 classified
  after that sweep ran, 6 LLM-config tests needing provider credentials.
* Several fixes were proven load-bearing by reverting them and reproducing the exact symptom, e.g.
  `expand returned no document for <id>` and `100 returned / 10 held`.
* Raw failure counts are not quoted on purpose: ~50 failures flip buckets between identical runs, so
  only the stable set means anything.

## One thing deliberately NOT fixed

`retain.completed` webhooks do not fire on the store-owned retain path. That path skips the Postgres
transactional-outbox row **by design** — `_streaming_store_owned_retain` says so in its docstring,
the intended replacement being at-least-once emission from the store. That replacement is not built,
so the delivery is silently dropped: a two-document async retain queues 0 rows where Postgres queues
2. Wiring the outbox back in would reverse a recorded design decision, so it needs a call: implement
store-side emission, or accept the gap and document it in the API docs.

The three tests are left failing rather than marked, because they assert product behaviour and
deselecting them would turn a visible gap into a silent one.



---

## The two riskiest changes, described

Neither was covered above, and both are the ones to read closely.

### The delta full-body diff (and what it deliberately does NOT change)

For an oversized item `contents` is one slice while the stored document is whole, so diffing those
two marks every chunk merely absent from the slice as REMOVED and tombstones its memories. Slice 1
now diffs `document_body_override` — the complete body — instead.

An **append** is excluded: there the override holds only the new tail (the stored body is prepended
onto slice 1), so diffing the whole document against it dropped every pre-existing chunk — measured,
chunks covered 4,348 of 18,538 chars. Appends keep diffing the already-prepended `contents`.

The **gate stays `is_first_batch`**. An earlier revision of this PR widened it to every slice; that
changes the Postgres path, and three things assume the narrow gate: the caller keeps one result list
per sub-batch item (`sub_origins` is length 1 for an oversized slice, so a multi-chunk delta's extra
unit ids are dropped), `chunk_index_offset` advances by the splitter's per-slice count rather than by
what a delta wrote, and a brand-new oversized document would extract its whole tail in one step —
re-creating the unbounded step the sub-batch splitting exists to prevent (#1571, an orchestrator
memory bound).

Consequence, tracked in the store repo rather than papered over: an oversized RE-retain still
re-extracts unchanged chunks on a store-owned bank, as it does on main. The cross-slice skip
Postgres relies on has no equivalent there, and routing it at the store does not work — measured,
`_store_document_bodies` uploads the full chunk-text list before extraction, so the check matches its
own write on slice 1 (`stored=492a32c9 new=492a32c9`).

### The bank-list write times

A store-owned bank's row had neither `last_write_at` nor `last_document_at`: both come from `MAX`
over SQL tables such a bank leaves empty, and the response model drops null keys, so the fields
vanished from the JSON rather than reading null. **The list is ordered by last write**, so that
ordering silently degenerated to created-at.

Two decisions worth the review: the times are asked **separately**, because ingestion time must not
move when a document is rewritten and reporting one under both names makes a rewrite read as a new
document; and they are applied **before** the sort over all banks, because fixing the field in the
page-level overlay would leave the order wrong and inconsistent across pages.

The two calls are gathered and run **outside** the pool connection — they are round trips to another
service and nothing after them needs the connection. `return_exceptions` keeps one failing from
discarding the other's answer, and the whole thing stays inside a `try`, because building the gather
arguments already calls into the store: a store that does not implement these raises before
`return_exceptions` can see anything. They are optional — the interface defaults return `{}`.
