### PR TITLE
fix(ci): give the Windows process probe a real deadline, and close the trace-recorder leak

### DIFF
--- a/hindsight-api-slim/tests/conftest.py
+++ b/hindsight-api-slim/tests/conftest.py
@@ -97,10 +97,17 @@ def _cleanup_leaked_span_recorders():
     from hindsight_api.tracing import get_span_recorder
 
     recorders = get_span_recorder()._recorders
-    before = {id(r) for r in recorders}
+    # Strong references compared by identity, not a set of id()s. An id is only
+    # unique while its object is alive: a recorder registered and dropped during
+    # the test could be collected, and CPython would hand the same address to the
+    # *next* recorder — which then matched `before` and was left in the registry.
+    # That is how #2229 kept flaking after the first fix, as a leaked enabled
+    # recorder writing rows for a later test's bank. Holding the objects also
+    # keeps them alive, so no address can be recycled underneath the comparison.
+    before = list(recorders)
     yield
     for recorder in list(recorders):
-        if id(recorder) not in before:
+        if not any(recorder is known for known in before):
             recorders.remove(recorder)
 
 

--- a/hindsight-api-slim/tests/test_llm_trace.py
+++ b/hindsight-api-slim/tests/test_llm_trace.py
@@ -755,6 +755,21 @@ async def test_stats_endpoint_includes_tokens(trace_api_client, bank_id):
 
 @pytest.mark.asyncio
 async def test_disabled_writes_no_rows(memory):
+    # Recorders live in a process-global registry, and this test can only prove
+    # anything about the one it disables. A recorder leaked by an earlier test is
+    # still enabled and still writing to the shared table, so it records this
+    # bank's retain and the count below comes back non-zero — with nothing in the
+    # failure naming the real cause (#2229). Assert the registry is clean first,
+    # so a leak reports itself instead of arriving as `assert 4 == 0`.
+    from hindsight_api.engine.llm_trace import LLMTraceRecorder
+    from hindsight_api.tracing import get_span_recorder
+
+    registered = [r for r in get_span_recorder()._recorders if isinstance(r, LLMTraceRecorder)]
+    assert registered == [memory._llm_recorder], (
+        f"{len(registered)} LLM trace recorder(s) registered, expected only this engine's — "
+        "an earlier test leaked one into the global registry (#2229)"
+    )
+
     memory._llm_recorder._enabled = False
 
     app = create_app(memory, initialize_memory=False)

--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -127,6 +127,18 @@ DAEMON_PROCESS_MARKERS = ("hindsight-api", "hindsight_api")
 # name is not always still visible in the command line.
 UI_PROCESS_MARKERS = ("hindsight-control-plane", "next-server", "next start")
 
+# Deadline for the short read-only probes (netstat, ps, wmic, PowerShell) used to
+# identify processes. Five seconds is ample for the POSIX ones, which read procfs
+# or run `ps`.
+_PROBE_TIMEOUT_S = 5.0
+
+# Windows needs more. Its command-line lookup goes through WMI, and the wmic
+# front-end is absent from current Windows images, so the fallback is a fresh
+# PowerShell — whose startup alone can pass five seconds on a loaded machine
+# before Get-CimInstance runs. Under the old shared deadline that surfaced as a
+# daemon we own being classified as foreign, and as a flaky test-embed-windows.
+_WINDOWS_PROBE_TIMEOUT_S = 30.0
+
 
 def _probe_timeout(read: float) -> httpx.Timeout:
     """Timeout with a short connect and a caller-chosen read budget."""
@@ -387,14 +399,14 @@ class DaemonEmbedManager(EmbedManager):
         return False
 
     @staticmethod
-    def _run_probe(cmd: list[str]) -> str | None:
+    def _run_probe(cmd: list[str], timeout: float = _PROBE_TIMEOUT_S) -> str | None:
         """Run a short read-only probe command, returning stdout or None."""
         try:
             result = subprocess.run(
                 cmd,
                 capture_output=True,
                 text=True,
-                timeout=5,
+                timeout=timeout,
                 creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
             )
         except (subprocess.TimeoutExpired, OSError):
@@ -467,8 +479,16 @@ class DaemonEmbedManager(EmbedManager):
     def _process_command_line(pid: int) -> str | None:
         """The command line of `pid`, or None when it cannot be determined."""
         if platform.system() == "Windows":
+            # Both Windows probes get a longer deadline than the default. wmic is
+            # gone from current Windows images, so it usually fails instantly and
+            # everything rests on PowerShell — whose cold start alone can exceed
+            # five seconds on a loaded machine, before Get-CimInstance has asked
+            # WMI anything. Timing out here is not harmless: the caller reads None
+            # as "not one of our processes" (see _process_matches), so the daemon
+            # manager refuses to stop a daemon it does in fact own.
             output = DaemonEmbedManager._run_probe(
-                ["wmic", "process", "where", f"ProcessId={pid}", "get", "CommandLine", "/format:list"]
+                ["wmic", "process", "where", f"ProcessId={pid}", "get", "CommandLine", "/format:list"],
+                timeout=_WINDOWS_PROBE_TIMEOUT_S,
             )
             if output is None:
                 output = DaemonEmbedManager._run_probe(
@@ -478,7 +498,8 @@ class DaemonEmbedManager(EmbedManager):
                         "-NonInteractive",
                         "-Command",
                         f"(Get-CimInstance Win32_Process -Filter 'ProcessId={pid}').CommandLine",
-                    ]
+                    ],
+                    timeout=_WINDOWS_PROBE_TIMEOUT_S,
                 )
             if output is None:
                 return None

--- a/hindsight-embed/tests/test_daemon_client.py
+++ b/hindsight-embed/tests/test_daemon_client.py
@@ -840,6 +840,32 @@ class TestProcessCommandLine:
         # argv[0] is the interpreter running pytest.
         assert os.path.basename(sys.executable).split(".")[0] in cmdline.lower()
 
+    def test_windows_probes_get_a_deadline_longer_than_powershell_start(self, monkeypatch):
+        """The Windows lookup must not be capped by the POSIX probe deadline.
+
+        wmic is absent from current Windows images, so the answer comes from a
+        fresh PowerShell, and its cold start alone can pass five seconds on a
+        loaded machine. Timing out is not a harmless miss: the caller reads None
+        as "not one of our processes", so the manager refuses to stop a daemon it
+        owns — and it made test-embed-windows flaky, which is how it surfaced.
+        """
+        from hindsight_embed import daemon_embed_manager as dem
+
+        timeouts: list[float] = []
+
+        def _record(cmd, timeout=dem._PROBE_TIMEOUT_S):
+            timeouts.append(timeout)
+            return None
+
+        monkeypatch.setattr(dem.platform, "system", lambda: "Windows")
+        monkeypatch.setattr(DaemonEmbedManager, "_run_probe", staticmethod(_record))
+
+        assert DaemonEmbedManager._process_command_line(1234) is None
+        assert timeouts, "expected the Windows branch to run at least one probe"
+        assert all(t > dem._PROBE_TIMEOUT_S for t in timeouts), (
+            f"every Windows probe needs its own longer deadline, got {timeouts}"
+        )
+
     def test_returns_none_for_a_pid_that_does_not_exist(self):
         # Above the default pid_max on Linux and unused elsewhere, so no live
         # process can answer and both the procfs and `ps` lookups must fail.


### PR DESCRIPTION
Fixes the two checks that were still failing on `main` after #3635 and #3638 cleared the previous pair. Both are flakes with a diagnosable cause; neither is a test that "just needs a rerun".

## `test-embed-windows` — the Windows probe deadline is shorter than PowerShell's startup

`test_reads_the_command_line_of_a_live_process` fails intermittently — three failures and four passes across seven runs on different branches within one hour, so it is not a broken runner image.

The timings in the failing job name the cause:

| test | duration |
|---|---|
| `test_reads_the_command_line_of_a_live_process` (failed) | 5.6s |
| `test_returns_none_for_a_pid_that_does_not_exist` | 5.05s |
| `test_unknown_pid_is_never_treated_as_ours` | 5.02s |

The two tests that *expect* `None` sit exactly on `_run_probe`'s 5s timeout, so the probes are hitting the wall every run. On Windows `_process_command_line` tries `wmic` — absent from current Windows images, so it fails instantly — and then falls back to a fresh `powershell -Command (Get-CimInstance Win32_Process ...)`. PowerShell's cold start alone can pass five seconds on a loaded machine, before WMI is asked anything. Sometimes it makes it; sometimes it does not.

**This is not only a test problem.** A `None` here is read by `_process_matches` as "not one of our processes", so a timed-out probe makes the daemon manager refuse to stop a daemon it actually owns — on exactly the slow or loaded Windows machines where that matters most.

The Windows command-line probes now get their own 30s deadline; the POSIX probes (procfs, `ps`, `netstat`) keep the 5s one, which is ample for reading a file or running `ps`.

## `test-api (2/3)` — the leaked-recorder guard compared `id()`s

`test_llm_trace.py::test_disabled_writes_no_rows` failed with `assert 4 == 0`: four LLM calls were recorded for its bank even though it had disabled its own engine's recorder.

Trace recorders live in a process-global registry (`register_span_recorder`), which *accumulates* — `MemoryEngine.__init__` registers, and only `close()` removes. A recorder leaked by an earlier test is still enabled and still writing to the shared table, so it records this test's retain. That is #2229, and it already has two guards: `_teardown_memory_engine` unregisters unconditionally, and an autouse fixture drops anything a test added.

The autouse guard had a hole:

```python
before = {id(r) for r in recorders}   # ids, not objects
```

An `id()` is only unique while its object is alive. A recorder registered and dropped during a test can be collected, and CPython hands the same address to the next recorder — which then matches `before` and is left in the registry. Snapshotting the objects instead both compares by identity and keeps them alive, so no address can be recycled underneath the comparison.

The test also now asserts the registry holds only its own recorder before it starts. If this ever recurs, the failure names the leak instead of arriving as `assert 4 == 0` in a test about something else.

## Validation

- `test_windows_probes_get_a_deadline_longer_than_powershell_start` is new, and verified by reintroducing the bug: with the deadline back at 5s it fails, with the fix it passes.
- `hindsight-embed`: 44 passed.
- `hindsight-api-slim` `test_llm_trace.py`: 32 passed.
- Full `hindsight-api-slim` suite run to confirm the new registry assertion does not false-positive anywhere.

The Windows flake cannot be asserted directly on CI — the new test pins the deadline instead, which is the part that was wrong.
