### PR TITLE
fix(engine): drop per-bank vector indexes before the delete transaction (#3485)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -1107,8 +1107,10 @@ class PostgreSQLOps(DataAccessOps):
         # EXCLUSIVE, on the shared memory_units table. A plain DROP INDEX blocks
         # (and deadlocks with) every other bank's concurrent reads/writes on the
         # table; CONCURRENTLY does not conflict with DML. The caller
-        # (delete_bank) runs this on an autocommit connection after its delete
-        # transaction has committed — CONCURRENTLY cannot run inside a tx.
+        # (delete_bank) runs this on an autocommit connection before its delete
+        # transaction begins — CONCURRENTLY cannot run inside a tx — and then
+        # idempotently once more after the transaction commits, so a concurrent
+        # maintenance rebuild that landed in between cannot leave an orphan.
         #
         # The in-process lock serializes concurrent bank creates and deletes
         # against each other; its key must match create_bank_vector_indexes',

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8586,10 +8586,36 @@ class MemoryEngine(MemoryEngineInterface):
         backend = await self._get_backend()
         invalidated_obs = 0
         result: dict[str, int] = {}
-        bank_internal_id: str | None = None
         async with acquire_with_retry(backend) as conn:
             # Ensure connection is not in read-only mode (can happen with connection poolers)
             await conn.execute("SET SESSION CHARACTERISTICS AS TRANSACTION READ WRITE")
+
+            # Drop this bank's per-bank vector indexes BEFORE the delete
+            # transaction (issue #3485): when the cluster-wide index count
+            # approaches the lock-table budget, planning any statement against
+            # memory_units fails — including the delete DML — while DROP INDEX
+            # (a utility statement) only locks its own index and the table, so
+            # it still works. Dropping first keeps bank deletion usable as a
+            # recovery path and frees lock-table space for the delete that
+            # follows. The drop runs CONCURRENTLY (see
+            # ops.drop_bank_vector_indexes), which cannot run inside a
+            # transaction block — this autocommit connection is exactly where
+            # it belongs. Only the full-delete path drops indexes:
+            # fact_type-scoped deletes and delete_bank_profile=False keep them.
+            if not fact_type and delete_bank_profile:
+                internal_id = await conn.fetchval(
+                    f"SELECT internal_id FROM {fq_table('banks')} WHERE bank_id = $1", bank_id
+                )
+                if internal_id:
+                    # Retry the transient deadlock a concurrent index
+                    # build/drop on the shared memory_units table can still
+                    # trigger (sqlstate 40P01 / ORA-00060).
+                    await retry_with_backoff(
+                        lambda: bank_utils.drop_bank_vector_indexes(conn, str(internal_id), ops=self._backend.ops),
+                        max_retries=7,
+                        max_delay=10.0,
+                    )
+
             async with conn.transaction():
                 try:
                     if fact_type:
@@ -8740,35 +8766,13 @@ class MemoryEngine(MemoryEngineInterface):
                         }
 
                         if delete_bank_profile:
-                            # Delete the bank profile and retrieve internal_id for HNSW index cleanup
-                            internal_id = await conn.fetchval(
-                                f"DELETE FROM {fq_table('banks')} WHERE bank_id = $1 RETURNING internal_id", bank_id
-                            )
-                            if internal_id:
-                                bank_internal_id = str(internal_id)
+                            # Delete the bank profile (its vector indexes were
+                            # already dropped above, before the delete tx).
+                            await conn.execute(f"DELETE FROM {fq_table('banks')} WHERE bank_id = $1", bank_id)
                             result["bank_deleted"] = True
 
                 except Exception as e:
                     raise Exception(f"Failed to delete agent data: {str(e)}")
-
-            # Drop per-bank vector indexes AFTER the transaction commits: the
-            # drop runs CONCURRENTLY (see ops.drop_bank_vector_indexes), which
-            # cannot run inside a transaction block. Same-process drops are
-            # serialized by the ops-level DDL lock; retry_with_backoff absorbs
-            # the residual cross-process deadlock a concurrent index build/drop
-            # on the shared memory_units table can still trigger (sqlstate
-            # 40P01 / ORA-00060) so a delete is never lost to a transient lock
-            # cycle. Sized well above the defaults: a many-process delete storm
-            # (CI teardown ran 8 workers' drops at once) drains at roughly one
-            # deadlock victim per deadlock_timeout (1s), so the default ~2.4s
-            # of backoff lost every retry; ~30s of jittered backoff outlasts
-            # any realistic pile-up.
-            if bank_internal_id:
-                await retry_with_backoff(
-                    lambda: bank_utils.drop_bank_vector_indexes(conn, bank_internal_id, ops=self._backend.ops),
-                    max_retries=7,
-                    max_delay=10.0,
-                )
 
         # A store that keeps memories outside SQL leaves memory_units empty, so every DELETE
         # above was a no-op on its data — it must be told to drop the bank's memories too, or

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8586,32 +8586,30 @@ class MemoryEngine(MemoryEngineInterface):
         backend = await self._get_backend()
         invalidated_obs = 0
         result: dict[str, int] = {}
+        bank_internal_id: str | None = None
         async with acquire_with_retry(backend) as conn:
             # Ensure connection is not in read-only mode (can happen with connection poolers)
             await conn.execute("SET SESSION CHARACTERISTICS AS TRANSACTION READ WRITE")
 
             # Drop this bank's per-bank vector indexes BEFORE the delete
-            # transaction (issue #3485): when the cluster-wide index count
-            # approaches the lock-table budget, planning any statement against
-            # memory_units fails — including the delete DML — while DROP INDEX
-            # (a utility statement) only locks its own index and the table, so
-            # it still works. Dropping first keeps bank deletion usable as a
-            # recovery path and frees lock-table space for the delete that
-            # follows. The drop runs CONCURRENTLY (see
-            # ops.drop_bank_vector_indexes), which cannot run inside a
-            # transaction block — this autocommit connection is exactly where
-            # it belongs. Only the full-delete path drops indexes:
-            # fact_type-scoped deletes and delete_bank_profile=False keep them.
+            # transaction (issue #3485): at the lock-table wall, planning any
+            # DML against memory_units fails, while DROP INDEX — a utility
+            # statement — still works, and each drop frees lock-table space for
+            # the delete that follows. The drop runs CONCURRENTLY, which cannot
+            # run inside a transaction, so it belongs on this autocommit
+            # connection. Only the full-delete path drops indexes; internal_id
+            # is kept for the idempotent re-drop after commit.
             if not fact_type and delete_bank_profile:
                 internal_id = await conn.fetchval(
                     f"SELECT internal_id FROM {fq_table('banks')} WHERE bank_id = $1", bank_id
                 )
                 if internal_id:
+                    bank_internal_id = str(internal_id)
                     # Retry the transient deadlock a concurrent index
                     # build/drop on the shared memory_units table can still
                     # trigger (sqlstate 40P01 / ORA-00060).
                     await retry_with_backoff(
-                        lambda: bank_utils.drop_bank_vector_indexes(conn, str(internal_id), ops=self._backend.ops),
+                        lambda: bank_utils.drop_bank_vector_indexes(conn, bank_internal_id, ops=self._backend.ops),
                         max_retries=7,
                         max_delay=10.0,
                     )
@@ -8766,13 +8764,32 @@ class MemoryEngine(MemoryEngineInterface):
                         }
 
                         if delete_bank_profile:
-                            # Delete the bank profile (its vector indexes were
-                            # already dropped above, before the delete tx).
-                            await conn.execute(f"DELETE FROM {fq_table('banks')} WHERE bank_id = $1", bank_id)
+                            # RETURNING internal_id so the post-commit drop
+                            # names the row actually deleted — a bank (re)created
+                            # since the pre-drop SELECT would otherwise leave its
+                            # indexes orphaned.
+                            deleted_internal_id = await conn.fetchval(
+                                f"DELETE FROM {fq_table('banks')} WHERE bank_id = $1 RETURNING internal_id",
+                                bank_id,
+                            )
+                            if deleted_internal_id:
+                                bank_internal_id = str(deleted_internal_id)
                             result["bank_deleted"] = True
 
                 except Exception as e:
                     raise Exception(f"Failed to delete agent data: {str(e)}")
+
+            # Idempotent re-drop after commit: maintenance can rebuild the
+            # indexes between the pre-drop and this commit (its plan saw the
+            # bank row still there). This covers a rebuild that finished before
+            # commit; apply_bank_index_plan's post-build re-check covers one
+            # that finishes after.
+            if bank_internal_id:
+                await retry_with_backoff(
+                    lambda: bank_utils.drop_bank_vector_indexes(conn, bank_internal_id, ops=self._backend.ops),
+                    max_retries=7,
+                    max_delay=10.0,
+                )
 
         # A store that keeps memories outside SQL leaves memory_units empty, so every DELETE
         # above was a no-op on its data — it must be told to drop the bank's memories too, or

--- a/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
@@ -97,7 +97,9 @@ async def create_bank_vector_indexes(conn, bank_id: str, internal_id: str, *, op
 async def drop_bank_vector_indexes(conn, internal_id: str, ops=None) -> None:
     """Drop per-(bank, fact_type) partial vector indexes for a bank being deleted.
 
-    Called before the bank row is deleted so internal_id is still known.
+    Called before the bank row is deleted so internal_id is still known, and
+    again idempotently after the delete transaction commits, so a concurrent
+    maintenance rebuild that landed in between cannot leave an orphan.
     Idempotent via DROP INDEX IF EXISTS.
 
     On Oracle, this is a no-op (uses single global vector index).

--- a/hindsight-api-slim/hindsight_api/engine/vector_index_health.py
+++ b/hindsight-api-slim/hindsight_api/engine/vector_index_health.py
@@ -323,6 +323,10 @@ async def apply_bank_index_plan(
     ``CREATE INDEX CONCURRENTLY IF NOT EXISTS`` guarded by a valid/ready health
     check and every drop is ``DROP INDEX CONCURRENTLY IF EXISTS``, so a second
     concurrent run is a no-op on work the first already did.
+
+    After each successful build the bank row is re-checked: a bank deleted (or
+    recreated under a fresh ``internal_id``) mid-build leaves an orphan index
+    ``delete_bank`` cannot name, so the build drops its own index instead.
     """
     result = BankIndexResult(bank_id=plan.bank_id, already_present=plan.already_present)
     qschema = _quote_identifier(schema)
@@ -356,12 +360,13 @@ async def apply_bank_index_plan(
         # The bank was deleted between planning and applying; delete_bank has
         # already dropped its indexes and there is nothing left to name.
         return result
+    internal_id_str = str(internal_id)
 
     for fact_type in plan.to_build:
         if dry_run:
             result.skipped += 1
             continue
-        qindex = _quote_identifier(_bank_index_name(fact_type, str(internal_id)))
+        qindex = _quote_identifier(_bank_index_name(fact_type, internal_id_str))
         qualified = f"{qschema}.{qindex}"
 
         async def _rebuild(qindex: str = qindex, qualified: str = qualified, fact_type: str = fact_type) -> None:
@@ -383,8 +388,6 @@ async def apply_bank_index_plan(
             # That is transient — Postgres aborts one side to break the cycle —
             # so retry the drop+build before recording a permanent failure.
             await retry_with_backoff(_rebuild)
-            result.created += 1
-            logger.info("Built vector index %s (bank=%s, fact_type=%s)", qualified, plan.bank_id, fact_type)
         except Exception as exc:  # noqa: BLE001 — one failed index must not abort the rest
             result.failed += 1
             result.failed_indexes.append(qualified)
@@ -402,6 +405,32 @@ async def apply_bank_index_plan(
                 await conn.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {qualified}")
             except Exception as cleanup_exc:  # noqa: BLE001
                 logger.warning("Cleanup DROP INDEX for %s also failed: %s", qualified, cleanup_exc)
+        else:
+            # Re-check the bank after the build: if it was deleted (or
+            # recreated under a fresh internal_id) while CREATE INDEX
+            # CONCURRENTLY was running, the index just built is an orphan that
+            # delete_bank's post-commit drop could not name. Drop it, don't
+            # count it, and stop — the remaining fact_types would only build
+            # more orphans.
+            still = await conn.fetchval(
+                f"SELECT internal_id FROM {qschema}.banks WHERE bank_id = $1",  # noqa: S608 — quoted identifier
+                plan.bank_id,
+            )
+            if still is None or str(still) != internal_id_str:
+                try:
+                    await retry_with_backoff(
+                        lambda qualified=qualified: conn.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {qualified}")
+                    )
+                except Exception as cleanup_exc:  # noqa: BLE001
+                    logger.warning(
+                        "Bank %s was deleted during build of %s; orphan drop failed: %s",
+                        plan.bank_id,
+                        qualified,
+                        cleanup_exc,
+                    )
+                break
+            result.created += 1
+            logger.info("Built vector index %s (bank=%s, fact_type=%s)", qualified, plan.bank_id, fact_type)
 
     return result
 

--- a/hindsight-api-slim/tests/test_bank_lifecycle_deadlock_retry.py
+++ b/hindsight-api-slim/tests/test_bank_lifecycle_deadlock_retry.py
@@ -4,8 +4,9 @@ The test-api shard runs 8 pytest-xdist workers against one shared pg0 database
 (``public`` schema), so every bank create/delete does index DDL on the same
 ``memory_units`` table other workers are writing. A fresh bank builds its
 partial indexes with a plain ``CREATE INDEX`` inside the bank-create tx
-(ShareLock), and ``delete_bank`` drops them (CONCURRENTLY, post-commit); both
-can be chosen as a deadlock victim. These are the exact production paths that
+(ShareLock), and ``delete_bank`` drops them (CONCURRENTLY, once before the
+delete transaction and again after commit); both can be chosen as a deadlock
+victim. These are the exact production paths that
 flaked in CI — they must retry the transient deadlock, not surface it.
 
 The deadlock is injected via monkeypatch (one-shot ``DeadlockDetectedError``)
@@ -53,7 +54,12 @@ async def test_bank_create_retries_transient_deadlock(
 async def test_bank_delete_retries_transient_deadlock(
     memory: MemoryEngine, request_context: RequestContext, monkeypatch
 ):
-    """A deadlock while dropping per-bank indexes on delete is retried."""
+    """A deadlock while dropping per-bank indexes on delete is retried.
+
+    delete_bank drops once before the delete transaction and once after it
+    commits; the injected deadlock is retried on the first drop, and the
+    second drop is the post-commit no-op that closes the maintenance race.
+    """
     bank_id = f"test-deadlock-{uuid.uuid4().hex[:8]}"
     await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
 
@@ -71,5 +77,5 @@ async def test_bank_delete_retries_transient_deadlock(
     monkeypatch.setattr(backend.ops, "drop_bank_vector_indexes", flaky)
 
     result = await memory.delete_bank(bank_id, request_context=request_context)
-    assert calls == 2, "expected exactly one retry after the injected deadlock"
+    assert calls == 3, "one deadlock retried on the pre-drop, plus the post-commit drop"
     assert result["bank_deleted"] is True

--- a/hindsight-api-slim/tests/test_hnsw_indexes.py
+++ b/hindsight-api-slim/tests/test_hnsw_indexes.py
@@ -27,7 +27,7 @@ from hindsight_api.engine.retain.bank_utils import (
     _bank_index_name,
     _vector_index_clause,
 )
-from hindsight_api.engine.vector_index_health import CoverageTrigger
+from hindsight_api.engine.vector_index_health import BankIndexPlan, CoverageTrigger, apply_bank_index_plan
 
 
 @pytest.fixture
@@ -227,13 +227,17 @@ async def test_delete_bank_drops_indexes_before_data(memory, request_context, mo
     drop_profile_present: bool | None = None
 
     async def recording_drop(conn, schema, internal_id, fact_types):
-        # At drop time the bank's memory rows and profile must still exist —
-        # the drop runs before the delete transaction, not after it.
+        # Sample only the FIRST call — the pre-drop before the delete tx.
+        # The post-commit drop is a no-op that runs after the rows are gone,
+        # and must not overwrite the pre-drop observations.
         nonlocal drop_rows_present, drop_profile_present
-        drop_rows_present = (await conn.fetchval("SELECT COUNT(*) FROM memory_units WHERE bank_id = $1", bank_id)) > 0
-        drop_profile_present = (
-            await conn.fetchval("SELECT internal_id FROM banks WHERE bank_id = $1", bank_id)
-        ) is not None
+        if drop_rows_present is None:
+            drop_rows_present = (
+                await conn.fetchval("SELECT COUNT(*) FROM memory_units WHERE bank_id = $1", bank_id)
+            ) > 0
+            drop_profile_present = (
+                await conn.fetchval("SELECT internal_id FROM banks WHERE bank_id = $1", bank_id)
+            ) is not None
         return await real(conn, schema, internal_id, fact_types)
 
     monkeypatch.setattr(backend.ops, "drop_bank_vector_indexes", recording_drop)
@@ -243,6 +247,91 @@ async def test_delete_bank_drops_indexes_before_data(memory, request_context, mo
     assert drop_rows_present is True, "indexes must be dropped while the bank's rows still exist"
     assert drop_profile_present is True, "indexes must be dropped before the bank profile is deleted"
     assert await _get_bank_vector_indexes(memory._pool, bank_id) == []
+
+
+class _DeleteBankOnCreate:
+    """Connection wrapper that deletes the bank row right after the first
+    ``CREATE INDEX CONCURRENTLY``, simulating a bank deleted mid-build."""
+
+    def __init__(self, real, bank_id: str):
+        self._real = real
+        self._bank_id = bank_id
+        self.deleted = False
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+    async def execute(self, query, *args, **kwargs):
+        result = await self._real.execute(query, *args, **kwargs)
+        if "CREATE INDEX CONCURRENTLY" in query and not self.deleted:
+            await self._real.execute("DELETE FROM banks WHERE bank_id = $1", self._bank_id)
+            self.deleted = True
+        return result
+
+
+@pytest.mark.asyncio
+async def test_delete_bank_drops_indexes_rebuilt_in_window(memory, request_context, monkeypatch):
+    """The post-commit drop removes an index maintenance rebuilt in the window.
+
+    Two-sided handshake, delete side: after the pre-drop but before the delete
+    transaction, maintenance rebuilds the bank indexes from a plan made while
+    the bank row still existed. The post-commit drop must remove them — the
+    bank row is gone by then and nothing else can name the orphan.
+    """
+    bank_id = f"test_hnsw_window_{uuid.uuid4().hex[:8]}"
+    await memory.retain_async(
+        bank_id=bank_id,
+        content="Frank is a physicist.",
+        request_context=request_context,
+    )
+
+    backend = await memory._get_backend()
+    real = backend.ops.drop_bank_vector_indexes
+    rebuilt = False
+
+    async def rebuild_in_window(conn, schema, internal_id, fact_types):
+        nonlocal rebuilt
+        await real(conn, schema, internal_id, fact_types)  # the real pre-drop
+        if not rebuilt:
+            rebuilt = True
+            index_clause = _vector_index_clause()
+            assert index_clause is not None
+            plan = BankIndexPlan(bank_id=bank_id, to_build=list(_BANK_INDEX_FACT_TYPES))
+            pool = await memory._get_pool()
+            async with pool.acquire() as build_conn:
+                await apply_bank_index_plan(build_conn, memory_engine_module.get_current_schema(), index_clause, plan)
+
+    monkeypatch.setattr(backend.ops, "drop_bank_vector_indexes", rebuild_in_window)
+
+    await memory.delete_bank(bank_id, request_context=request_context)
+
+    assert rebuilt is True
+    assert await _get_bank_vector_indexes(memory._pool, bank_id) == []
+
+
+@pytest.mark.asyncio
+async def test_apply_index_plan_drops_orphan_built_during_delete(memory, request_context, threshold_set):
+    """apply_bank_index_plan re-checks the bank row after each build.
+
+    Two-sided handshake, maintenance side: the bank is deleted while a
+    ``CREATE INDEX CONCURRENTLY`` is building. The just-built index is an
+    orphan the delete path cannot name, so apply must drop it itself and not
+    count it as created.
+    """
+    bank_id = f"test_hnsw_selfcheck_{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    pool = await memory._get_pool()
+    async with pool.acquire() as conn:
+        wrapped = _DeleteBankOnCreate(conn, bank_id)
+        index_clause = _vector_index_clause()
+        assert index_clause is not None
+        plan = BankIndexPlan(bank_id=bank_id, to_build=list(_BANK_INDEX_FACT_TYPES))
+        result = await apply_bank_index_plan(wrapped, memory_engine_module.get_current_schema(), index_clause, plan)
+
+    assert wrapped.deleted is True
+    assert result.created == 0
+    assert await _get_bank_vector_indexes(pool, bank_id) == []
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_hnsw_indexes.py
+++ b/hindsight-api-slim/tests/test_hnsw_indexes.py
@@ -205,6 +205,76 @@ async def test_delete_bank_drops_vector_indexes(memory, request_context):
 
 
 @pytest.mark.asyncio
+async def test_delete_bank_drops_indexes_before_data(memory, request_context, monkeypatch):
+    """delete_bank must drop the per-bank vector indexes BEFORE the delete transaction.
+
+    Regression test for #3485: when the cluster-wide index count approaches the
+    Postgres lock-table budget, planning ANY statement against memory_units
+    fails — including the delete DML. DROP INDEX (a utility statement) only
+    locks its own index and the table, so it keeps working; dropping first is
+    what keeps bank deletion usable at high bank counts.
+    """
+    bank_id = f"test_hnsw_order_{uuid.uuid4().hex[:8]}"
+    await memory.retain_async(
+        bank_id=bank_id,
+        content="Dana is a research scientist.",
+        request_context=request_context,
+    )
+
+    backend = await memory._get_backend()
+    real = backend.ops.drop_bank_vector_indexes
+    drop_rows_present: bool | None = None
+    drop_profile_present: bool | None = None
+
+    async def recording_drop(conn, schema, internal_id, fact_types):
+        # At drop time the bank's memory rows and profile must still exist —
+        # the drop runs before the delete transaction, not after it.
+        nonlocal drop_rows_present, drop_profile_present
+        drop_rows_present = (await conn.fetchval("SELECT COUNT(*) FROM memory_units WHERE bank_id = $1", bank_id)) > 0
+        drop_profile_present = (
+            await conn.fetchval("SELECT internal_id FROM banks WHERE bank_id = $1", bank_id)
+        ) is not None
+        return await real(conn, schema, internal_id, fact_types)
+
+    monkeypatch.setattr(backend.ops, "drop_bank_vector_indexes", recording_drop)
+
+    await memory.delete_bank(bank_id, request_context=request_context)
+
+    assert drop_rows_present is True, "indexes must be dropped while the bank's rows still exist"
+    assert drop_profile_present is True, "indexes must be dropped before the bank profile is deleted"
+    assert await _get_bank_vector_indexes(memory._pool, bank_id) == []
+
+
+@pytest.mark.asyncio
+async def test_delete_bank_fact_type_scoped_keeps_indexes(memory, request_context):
+    """A fact_type-scoped delete must not drop the bank's vector indexes.
+
+    Only the full-delete path drops indexes: the bank survives a
+    fact_type-scoped delete, so its remaining partitions still earn them, and
+    nothing else knows the internal_id they are named after.
+    """
+    bank_id = f"test_hnsw_facttype_{uuid.uuid4().hex[:8]}"
+    try:
+        await memory.retain_async(
+            bank_id=bank_id,
+            content="Eve is a data analyst.",
+            request_context=request_context,
+        )
+        await _build_bank_vector_indexes(memory._pool, bank_id)
+        indexes_before = await _get_bank_vector_indexes(memory._pool, bank_id)
+        assert len(indexes_before) == 3, "setup: the bank should have indexes to keep"
+
+        await memory.delete_bank(bank_id, fact_type="world", request_context=request_context)
+
+        indexes_after = await _get_bank_vector_indexes(memory._pool, bank_id)
+        assert indexes_after == indexes_before, (
+            f"fact_type-scoped delete must keep the bank's indexes, got: {indexes_after}"
+        )
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
 async def test_retain_idempotent_bank_creation(memory, request_context):
     """Retaining twice must not error, and must not duplicate or rebuild indexes.
 


### PR DESCRIPTION
## Problem

At the shipped default (`HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS=0`), every bank is still given its three per-(bank, fact_type) partial vector indexes at creation — the behaviour #3638 deliberately restored ("exactly as before #3561"). So the cluster-wide index count still scales with bank count, and the #3485 lock-table exhaustion failure mode remains in the default configuration; only a deployment that sets the threshold (e.g. `10000`) escapes it.

In that failure mode `delete_bank` is the only recovery path — but today it drops the bank's indexes **after** the delete transaction commits. At lock-table exhaustion, planning the delete DML itself fails, so the transaction never commits and the drop never runs. The one tool that still works there — `DROP INDEX` is a utility statement that locks only its own index plus the table — is placed where it can never be reached.

## Change

Drop the bank's per-bank vector indexes **before** the delete transaction starts, on the autocommit connection (where `DROP INDEX CONCURRENTLY` already has to run). The bank row and its rows still exist at that point, so the `internal_id` the index names derive from is read with a plain `SELECT` instead of `DELETE ... RETURNING`. The delete transaction then runs against a `memory_units` with three fewer indexes, freeing lock-table space as it goes.

- Only the full-delete path drops indexes; `fact_type`-scoped deletes and `delete_bank_profile=False` are unchanged.
- Same `DROP INDEX CONCURRENTLY` + `retry_with_backoff` as before; Oracle remains a no-op.
- New regression test asserts the drop happens while the bank's rows and profile still exist.

## On "CONCURRENTLY cannot run inside a transaction block"

That constraint is exactly why the drop has to run *outside* the delete transaction — but "outside" has two sides: before it or after it. The current code chose after; this PR chooses before, on the same autocommit connection `DROP INDEX CONCURRENTLY` already requires. The constraint does not argue for after-transaction in particular, and the failure mode does: when the lock table is exhausted the delete transaction never commits, so an after-transaction drop never runs, while a before-transaction drop always can.

Nor do retries cover this: `retry_with_backoff` absorbs *transient deadlocks* (40P01) between concurrent DDL, but lock-table exhaustion fails every DML at plan time — the same failure repeats on every retry, while `DROP INDEX` never plans against the relation's other indexes.

## Failure semantics

- **Drop fails (after retries):** `delete_bank` fails and the bank's data is untouched — the whole operation can simply be retried.
- **Drop succeeds, delete transaction later fails:** the bank keeps its data without its indexes and recall serves through the exact B-tree path — slower, never wrong.
- Both are safer than the status quo, where the data is already gone when the post-commit drop fails and the leftover indexes become orphans that only a catalog sweep can find.

## Why not "just set the threshold"

The threshold is opt-in and defaults to 0, so the default deployment's index count still grows with bank count. Until `HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS` ships with a non-zero default (e.g. `10000`), this drop-first ordering is the only thing keeping `delete_bank` usable as a recovery path in the default configuration — and even at a raised threshold, banks above it still have indexes and need the same ordering.

#3561's own orphan sweep (`repair-bank --all`) exists precisely because a deployment at the #3485 wall could not run `delete_bank` at all — its test simulates a bank whose rows were deleted manually with the indexes left behind. That is exactly the state an after-transaction drop produces by construction at lock-table exhaustion; this PR makes `delete_bank` the one that drops them instead.

This fixes the ordering half of #3485; #3561/#3638 address the count half. Both are needed while the default stays 0.

## Validation

- `pytest tests/test_hnsw_indexes.py` — 11 passed (incl. new `test_delete_bank_drops_indexes_before_data`)
- `pytest tests/test_bank_lifecycle_deadlock_retry.py` — 6 passed
- `pytest tests/test_bank_vector_index_ddl_lock.py` — 4 passed
- `ruff check` / `ruff format --check` clean
