### PR TITLE
fix(kb): execute knowledge node updates as a single atomic transaction

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -6064,51 +6064,44 @@ def _register_routes(app: FastAPI):
     ):
         """Rename/move a node and/or update a page's options."""
         try:
-            updated: dict[str, Any] | None = None
-            did_change = False
-            if body.name is not None:
-                did_change = True
-                updated = await app.state.memory.rename_knowledge_node(
-                    bank_id=bank_id, node_id=node_id, name=body.name, request_context=request_context
-                )
-            # parent_id is applied only when present in the body, so passing null
-            # moves the node to the root (distinct from "not provided").
-            if "parent_id" in body.model_fields_set:
-                did_change = True
-                updated = await app.state.memory.move_knowledge_node(
-                    bank_id=bank_id, node_id=node_id, new_parent_id=body.parent_id, request_context=request_context
-                )
-            # Page options live on the backing mental model; each applies only when
-            # present in the body (so tags=[] clears, distinct from "not provided").
-            page_fields = {"source_query", "tags", "max_tokens", "trigger"} & body.model_fields_set
-            if page_fields:
-                did_change = True
-                updated = await app.state.memory.update_knowledge_page(
-                    bank_id=bank_id,
-                    page_id=node_id,
-                    source_query=body.source_query if "source_query" in page_fields else None,
-                    tags=body.tags if "tags" in page_fields else None,
-                    max_tokens=body.max_tokens if "max_tokens" in page_fields else None,
-                    # Only the trigger fields the client stated: the engine patches them over
-                    # the page's current trigger, and a full dump would carry this model's own
-                    # defaults (mode="full", exclude_mental_models=False) into every update.
-                    trigger=(body.trigger.model_dump(exclude_unset=True) if body.trigger else None),
-                    request_context=request_context,
-                )
-                # A new source query means the content is stale — rebuild it.
-                if updated is not None and "source_query" in page_fields and updated.get("mental_model_id"):
-                    await app.state.memory.submit_async_refresh_mental_model(
-                        bank_id=bank_id,
-                        mental_model_id=updated["mental_model_id"],
-                        request_context=request_context,
-                    )
-            if not did_change:
+            has_name = "name" in body.model_fields_set
+            has_parent = "parent_id" in body.model_fields_set
+            has_source_query = "source_query" in body.model_fields_set
+            has_tags = "tags" in body.model_fields_set
+            has_max_tokens = "max_tokens" in body.model_fields_set
+            has_trigger = "trigger" in body.model_fields_set
+
+            if not (has_name or has_parent or has_source_query or has_tags or has_max_tokens or has_trigger):
                 raise HTTPException(
                     status_code=400,
                     detail="Provide name, parent_id, source_query, tags, max_tokens, and/or trigger to update",
                 )
+
+            updated = await app.state.memory.update_knowledge_node(
+                bank_id=bank_id,
+                node_id=node_id,
+                name=body.name if has_name else MemoryEngine.KP_UNSET,
+                parent_id=body.parent_id if has_parent else MemoryEngine.KP_UNSET,
+                source_query=body.source_query if has_source_query else MemoryEngine.KP_UNSET,
+                tags=body.tags if has_tags else MemoryEngine.KP_UNSET,
+                max_tokens=body.max_tokens if has_max_tokens else MemoryEngine.KP_UNSET,
+                trigger=(
+                    (body.trigger.model_dump(exclude_unset=True) if body.trigger is not None else None)
+                    if has_trigger
+                    else MemoryEngine.KP_UNSET
+                ),
+                request_context=request_context,
+            )
             if updated is None:
                 raise HTTPException(status_code=404, detail=f"Knowledge node '{node_id}' not found")
+
+            # A new source query means the content is stale — schedule refresh.
+            if has_source_query and body.source_query is not None and updated.get("mental_model_id"):
+                await app.state.memory.submit_async_refresh_mental_model(
+                    bank_id=bank_id,
+                    mental_model_id=updated["mental_model_id"],
+                    request_context=request_context,
+                )
             return _knowledge_node_model(updated)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -15735,189 +15735,270 @@ class MemoryEngine(MemoryEngineInterface):
             for r in rows
         ]
 
-    async def rename_knowledge_node(
-        self, bank_id: str, node_id: str, name: str, *, request_context: "RequestContext"
-    ) -> dict[str, Any] | None:
-        """Rename a folder or page node."""
-        await self._authenticate_tenant(request_context)
-        if self._operation_validator and not _nested_operation_authorized.get():
-            from hindsight_api.extensions import BankWriteContext, BankWriteOperation
+    KP_UNSET = object()
+    """Sentinel value for distinguishing 'not provided' from explicit ``None``."""
 
-            ctx = BankWriteContext(
-                bank_id=bank_id,
-                operation=BankWriteOperation.RENAME_KNOWLEDGE_NODE,
-                request_context=request_context,
-            )
-            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
-        backend = await self._get_backend()
-        # A page's searchable document is its backing mental model's name + content,
-        # so the rename must also update mental_models.name — and re-tokenize its
-        # search_vector for vchord (native is a generated column, the other backends
-        # index base columns; same helper as create/update/clear_mental_model). Both
-        # writes share one transaction, so a knowledge_pages name-uniqueness
-        # violation rolls the mental-model name back with it. Folders carry no
-        # backing model (mental_model_id is NULL), so only the node row is touched.
-        # The mental-model write casts $3 to text because the same bind feeds
-        # sv_expr; see _insert_pinned_mental_model. knowledge_pages.name is already
-        # TEXT, so the node write needs no cast.
-        sv_expr = pg_search_vector_expr(
-            get_config(), text_col="$3", context_col="content", signals_col=None, native_inline=False
-        )
-        sv_clause = f", search_vector = {sv_expr}" if sv_expr else ""
-        async with acquire_with_retry(backend) as conn:
-            async with conn.transaction():
-                row = await conn.fetchrow(
-                    f"""
-                    UPDATE {fq_table("knowledge_pages")}
-                    SET name = $3, updated_at = now()
-                    WHERE bank_id = $1 AND id = $2
-                    RETURNING {self._KP_COLUMNS}
-                    """,
-                    bank_id,
-                    node_id,
-                    name,
-                )
-                if row is not None and row["mental_model_id"] is not None:
-                    await conn.execute(
-                        f"""
-                        UPDATE {fq_table("mental_models")}
-                        SET name = $3::text{sv_clause}
-                        WHERE bank_id = $1 AND id = $2
-                        """,
-                        bank_id,
-                        row["mental_model_id"],
-                        name,
-                    )
-        return self._row_to_knowledge_node(row) if row else None
-
-    async def update_knowledge_page(
+    async def update_knowledge_node(
         self,
         bank_id: str,
-        page_id: str,
+        node_id: str,
         *,
-        source_query: str | None = None,
-        tags: list[str] | None = None,
-        max_tokens: int | None = None,
-        trigger: dict[str, Any] | None = None,
+        name: str | None | object = KP_UNSET,
+        parent_id: str | None | object = KP_UNSET,
+        source_query: str | None | object = KP_UNSET,
+        tags: list[str] | None | object = KP_UNSET,
+        max_tokens: int | None | object = KP_UNSET,
+        trigger: dict[str, Any] | None | object = KP_UNSET,
         request_context: "RequestContext",
     ) -> dict[str, Any] | None:
-        """Update a page's editable options on its backing mental model.
-
-        Covers the source query (the question that rebuilds the page), tags,
-        token budget, and refresh trigger — each applied only when provided.
-        Returns the refreshed node (carrying ``mental_model_id``) or ``None`` when
-        the page doesn't exist. Changing the source query does not rebuild content
-        here; the API layer schedules an async refresh so the page re-synthesizes
-        against the new question.
-        """
+        """Atomically update a knowledge node: rename, move, and/or update page options."""
         await self._authenticate_tenant(request_context)
-        if self._operation_validator and not _nested_operation_authorized.get():
-            from hindsight_api.extensions import BankWriteContext, BankWriteOperation
 
-            ctx = BankWriteContext(
-                bank_id=bank_id,
-                operation=BankWriteOperation.UPDATE_KNOWLEDGE_PAGE,
-                request_context=request_context,
-            )
-            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
-        backend = await self._get_backend()
-        async with acquire_with_retry(backend) as conn:
-            # The page's CURRENT trigger comes back with it: a supplied trigger patches
-            # that rather than replacing it (see _merge_trigger).
-            row = await conn.fetchrow(
-                f"SELECT kp.mental_model_id, mm.trigger FROM {fq_table('knowledge_pages')} kp "
-                f"LEFT JOIN {fq_table('mental_models')} mm "
-                f"ON mm.id = kp.mental_model_id AND mm.bank_id = kp.bank_id "
-                f"WHERE kp.bank_id = $1 AND kp.id = $2 AND kp.kind = 'page'",
-                bank_id,
-                page_id,
-            )
-        if row is None or row["mental_model_id"] is None:
-            return None
-        effective_trigger = (
-            self._merge_trigger(trigger, base=self._stored_trigger(row["trigger"])) if trigger is not None else None
+        has_page_options = (
+            source_query is not self.KP_UNSET
+            or tags is not self.KP_UNSET
+            or max_tokens is not self.KP_UNSET
+            or trigger is not self.KP_UNSET
         )
-        # The write is already authorized above; the backing mental-model update
-        # runs without re-invoking the validator.
-        with _authorize_nested_operations():
-            await self.update_mental_model(
-                bank_id=bank_id,
-                mental_model_id=row["mental_model_id"],
-                source_query=source_query,
-                tags=tags,
-                max_tokens=max_tokens,
-                trigger=effective_trigger,
-                request_context=request_context,
-            )
-        async with acquire_with_retry(backend) as conn:
-            node_row = await conn.fetchrow(
-                f"SELECT {self._KP_PAGE_SELECT} FROM {self._kp_join()} "
-                f"WHERE kp.bank_id = $1 AND kp.id = $2 AND kp.kind = 'page'",
-                bank_id,
-                page_id,
-            )
-        return self._row_to_knowledge_node(node_row) if node_row else None
 
-    async def move_knowledge_node(
-        self, bank_id: str, node_id: str, new_parent_id: str | None, *, request_context: "RequestContext"
-    ) -> dict[str, Any] | None:
-        """Re-parent a node, rejecting self-parenting and cycles."""
-        await self._authenticate_tenant(request_context)
         if self._operation_validator and not _nested_operation_authorized.get():
             from hindsight_api.extensions import BankWriteContext, BankWriteOperation
 
-            ctx = BankWriteContext(
-                bank_id=bank_id,
-                operation=BankWriteOperation.MOVE_KNOWLEDGE_NODE,
-                request_context=request_context,
-            )
-            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
-        if new_parent_id == node_id:
-            raise ValueError("A node cannot be its own parent")
+            if name is not self.KP_UNSET:
+                ctx = BankWriteContext(
+                    bank_id=bank_id,
+                    operation=BankWriteOperation.RENAME_KNOWLEDGE_NODE,
+                    request_context=request_context,
+                )
+                await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
+            if parent_id is not self.KP_UNSET:
+                ctx = BankWriteContext(
+                    bank_id=bank_id,
+                    operation=BankWriteOperation.MOVE_KNOWLEDGE_NODE,
+                    request_context=request_context,
+                )
+                await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
+            if has_page_options:
+                ctx = BankWriteContext(
+                    bank_id=bank_id,
+                    operation=BankWriteOperation.UPDATE_KNOWLEDGE_PAGE,
+                    request_context=request_context,
+                )
+                await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
+
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
             async with conn.transaction():
                 # Structural tree writers lock this bank row before reading or
                 # changing the hierarchy, serializing moves with creates/deletes.
                 await self._kp_lock_bank(conn, bank_id)
-                await self._kp_assert_folder_parent(conn, bank_id, new_parent_id)
-                # Cycle guard: walk up from the new parent; if we reach node_id,
-                # the move would create a loop. Done in Python so the check stays
-                # dialect-agnostic (no recursive CTE).
-                if new_parent_id is not None:
-                    parents = {
-                        r["id"]: r["parent_id"]
-                        for r in await conn.fetch(
-                            f"SELECT id, parent_id FROM {fq_table('knowledge_pages')} WHERE bank_id = $1",
-                            bank_id,
-                        )
-                    }
-                    # `seen` bounds the walk. The lock above stops this process
-                    # from creating a loop, but a tree corrupted before the lock
-                    # existed (or restored from such an export) would otherwise
-                    # spin here forever, holding a connection and an open
-                    # transaction. Refuse the move instead of hanging.
-                    seen: set[str] = set()
-                    cursor: str | None = new_parent_id
-                    while cursor is not None:
-                        if cursor == node_id:
-                            raise ValueError("Cannot move a node into its own subtree")
-                        if cursor in seen:
-                            raise ValueError(f"Knowledge tree for bank '{bank_id}' contains a parent cycle")
-                        seen.add(cursor)
-                        cursor = parents.get(cursor)
+
+                # 1. Fetch current node + joined mental model info
                 row = await conn.fetchrow(
-                    f"""
-                    UPDATE {fq_table("knowledge_pages")}
-                    SET parent_id = $3, updated_at = now()
-                    WHERE bank_id = $1 AND id = $2
-                    RETURNING {self._KP_COLUMNS}
-                    """,
+                    f"SELECT kp.id, kp.bank_id, kp.parent_id, kp.kind, kp.name, kp.mental_model_id, "
+                    f"mm.trigger AS mm_trigger, mm.tags AS mm_tags, mm.source_query AS mm_source_query, mm.max_tokens AS mm_max_tokens "
+                    f"FROM {fq_table('knowledge_pages')} kp "
+                    f"LEFT JOIN {fq_table('mental_models')} mm "
+                    f"ON mm.id = kp.mental_model_id AND mm.bank_id = kp.bank_id "
+                    f"WHERE kp.bank_id = $1 AND kp.id = $2",
                     bank_id,
                     node_id,
-                    new_parent_id,
                 )
-        return self._row_to_knowledge_node(row) if row else None
+                if row is None:
+                    return None
+
+                # 2. Validation: page-only options on non-page nodes
+                if has_page_options and row["kind"] != "page":
+                    raise ValueError(f"Cannot update page-only options on {row['kind']} '{node_id}'")
+
+                # 3. Validation: parameter types / null constraints
+                if name is not self.KP_UNSET:
+                    if name is None or not isinstance(name, str) or not name.strip():
+                        raise ValueError("Node name cannot be null or empty")
+                if parent_id is not self.KP_UNSET:
+                    if parent_id is not None and not isinstance(parent_id, str):
+                        raise ValueError("Node parent_id must be a string or null")
+                if source_query is not self.KP_UNSET:
+                    if source_query is None or not isinstance(source_query, str) or not source_query.strip():
+                        raise ValueError("Page source_query cannot be null or empty")
+                if tags is not self.KP_UNSET:
+                    if tags is None or not isinstance(tags, list):
+                        raise ValueError("Page tags cannot be null; pass [] to clear tags")
+                if max_tokens is not self.KP_UNSET:
+                    if max_tokens is None or not isinstance(max_tokens, int):
+                        raise ValueError("Page max_tokens cannot be null")
+                if trigger is not self.KP_UNSET:
+                    if trigger is None or not isinstance(trigger, dict):
+                        raise ValueError("Page trigger cannot be null")
+
+                # 4. Validation: move / parent_id
+                if parent_id is not self.KP_UNSET:
+                    if parent_id == node_id:
+                        raise ValueError("A node cannot be its own parent")
+                    if parent_id is not None:
+                        assert isinstance(parent_id, str)
+                        await self._kp_assert_folder_parent(conn, bank_id, parent_id)
+                        # Cycle guard: walk up from the new parent; if we reach node_id,
+                        # the move would create a loop. Done in Python so the check stays
+                        # dialect-agnostic (no recursive CTE).
+                        parents = {
+                            r["id"]: r["parent_id"]
+                            for r in await conn.fetch(
+                                f"SELECT id, parent_id FROM {fq_table('knowledge_pages')} WHERE bank_id = $1",
+                                bank_id,
+                            )
+                        }
+                        # `seen` bounds the walk. The lock above stops this process
+                        # from creating a loop, but a tree corrupted before the lock
+                        # existed (or restored from such an export) would otherwise
+                        # spin here forever, holding a connection and an open
+                        # transaction. Refuse the move instead of hanging.
+                        seen: set[str] = set()
+                        cursor: str | None = parent_id
+                        while cursor is not None:
+                            if cursor == node_id:
+                                raise ValueError("Cannot move a node into its own subtree")
+                            if cursor in seen:
+                                raise ValueError(f"Knowledge tree for bank '{bank_id}' contains a parent cycle")
+                            seen.add(cursor)
+                            cursor = parents.get(cursor)
+
+                # 5. Update knowledge_pages table
+                kp_updates: list[str] = []
+                kp_params: list[Any] = [bank_id, node_id]
+                kp_idx = 3
+
+                if name is not self.KP_UNSET:
+                    assert isinstance(name, str)
+                    kp_updates.append(f"name = ${kp_idx}")
+                    kp_params.append(name)
+                    kp_idx += 1
+
+                if parent_id is not self.KP_UNSET:
+                    kp_updates.append(f"parent_id = ${kp_idx}")
+                    kp_params.append(parent_id)
+                    kp_idx += 1
+
+                if kp_updates:
+                    kp_updates.append("updated_at = now()")
+                    await conn.execute(
+                        f"UPDATE {fq_table('knowledge_pages')} "
+                        f"SET {', '.join(kp_updates)} "
+                        f"WHERE bank_id = $1 AND id = $2",
+                        *kp_params,
+                    )
+
+                # 6. Update mental_models table if kind == 'page'
+                if row["kind"] == "page" and row["mental_model_id"] is not None:
+                    mm_updates: list[str] = []
+                    mm_params: list[Any] = [bank_id, row["mental_model_id"]]
+                    mm_idx = 3
+
+                    if name is not self.KP_UNSET:
+                        assert isinstance(name, str)
+                        mm_updates.append(f"name = ${mm_idx}::text")
+                        mm_params.append(name)
+                        sv_expr = pg_search_vector_expr(
+                            get_config(),
+                            text_col=f"${mm_idx}",
+                            context_col="content",
+                            signals_col=None,
+                            native_inline=False,
+                        )
+                        if sv_expr:
+                            mm_updates.append(f"search_vector = {sv_expr}")
+                        mm_idx += 1
+
+                    if source_query is not self.KP_UNSET:
+                        assert isinstance(source_query, str)
+                        mm_updates.append(f"source_query = ${mm_idx}")
+                        mm_params.append(source_query)
+                        mm_idx += 1
+
+                    if tags is not self.KP_UNSET:
+                        assert isinstance(tags, list)
+                        mm_updates.append(f"tags = ${mm_idx}")
+                        mm_params.append(tags)
+                        mm_idx += 1
+
+                    if max_tokens is not self.KP_UNSET:
+                        assert isinstance(max_tokens, int)
+                        mm_updates.append(f"max_tokens = ${mm_idx}")
+                        mm_params.append(max_tokens)
+                        mm_idx += 1
+
+                    if trigger is not self.KP_UNSET:
+                        assert isinstance(trigger, dict)
+                        effective_trigger = self._merge_trigger(trigger, base=self._stored_trigger(row["mm_trigger"]))
+                        mm_updates.append(f"trigger = ${mm_idx}")
+                        mm_params.append(json.dumps(effective_trigger))
+                        mm_idx += 1
+
+                    if mm_updates:
+                        await conn.execute(
+                            f"UPDATE {fq_table('mental_models')} "
+                            f"SET {', '.join(mm_updates)} "
+                            f"WHERE bank_id = $1 AND id = $2",
+                            *mm_params,
+                        )
+
+                # 7. Fetch and return the updated node
+                node_row = await conn.fetchrow(
+                    f"SELECT {self._KP_PAGE_SELECT} FROM {self._kp_join()} WHERE kp.bank_id = $1 AND kp.id = $2",
+                    bank_id,
+                    node_id,
+                )
+                return self._row_to_knowledge_node(node_row) if node_row else None
+
+    async def rename_knowledge_node(
+        self, bank_id: str, node_id: str, name: str, *, request_context: "RequestContext"
+    ) -> dict[str, Any] | None:
+        """Rename a folder or page node."""
+        return await self.update_knowledge_node(
+            bank_id=bank_id,
+            node_id=node_id,
+            name=name,
+            request_context=request_context,
+        )
+
+    async def update_knowledge_page(
+        self,
+        bank_id: str,
+        page_id: str,
+        *,
+        source_query: str | None | object = KP_UNSET,
+        tags: list[str] | None | object = KP_UNSET,
+        max_tokens: int | None | object = KP_UNSET,
+        trigger: dict[str, Any] | None | object = KP_UNSET,
+        request_context: "RequestContext",
+    ) -> dict[str, Any] | None:
+        """Update a page's editable options atomically.
+
+        Thin wrapper around :meth:`update_knowledge_node` retained for
+        backward compatibility.  Accepts source query, tags, token budget,
+        and refresh trigger — each applied only when not ``KP_UNSET``.
+        Returns the refreshed node or ``None`` when the page doesn't exist.
+        """
+        return await self.update_knowledge_node(
+            bank_id=bank_id,
+            node_id=page_id,
+            source_query=source_query,
+            tags=tags,
+            max_tokens=max_tokens,
+            trigger=trigger,
+            request_context=request_context,
+        )
+
+    async def move_knowledge_node(
+        self, bank_id: str, node_id: str, new_parent_id: str | None, *, request_context: "RequestContext"
+    ) -> dict[str, Any] | None:
+        """Re-parent a node, rejecting self-parenting and cycles."""
+        return await self.update_knowledge_node(
+            bank_id=bank_id,
+            node_id=node_id,
+            parent_id=new_parent_id,
+            request_context=request_context,
+        )
 
     async def delete_knowledge_node(self, bank_id: str, node_id: str, *, request_context: "RequestContext") -> bool:
         """Delete a node and its whole subtree, including each page's mental model.

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -2297,35 +2297,31 @@ async def _do_update_knowledge_node(
             "and/or refresh_after_consolidation to update"
         }
 
-    updated: dict[str, Any] | None = None
-    if name is not None:
-        updated = await memory.rename_knowledge_node(
-            bank_id=target_bank, node_id=node_id, name=name, request_context=request_context
-        )
-    if parent_id is not None:
-        updated = await memory.move_knowledge_node(
+    try:
+        updated = await memory.update_knowledge_node(
             bank_id=target_bank,
             node_id=node_id,
-            new_parent_id=None if parent_id == KNOWLEDGE_ROOT_PARENT else parent_id,
+            name=name if name is not None else MemoryEngine.KP_UNSET,
+            parent_id=(None if parent_id == KNOWLEDGE_ROOT_PARENT else parent_id)
+            if parent_id is not None
+            else MemoryEngine.KP_UNSET,
+            source_query=source_query if source_query is not None else MemoryEngine.KP_UNSET,
+            tags=tags if tags is not None else MemoryEngine.KP_UNSET,
+            max_tokens=max_tokens if max_tokens is not None else MemoryEngine.KP_UNSET,
+            trigger=trigger if trigger is not None else MemoryEngine.KP_UNSET,
             request_context=request_context,
         )
-    if page_update:
-        updated = await memory.update_knowledge_page(
-            bank_id=target_bank,
-            page_id=node_id,
-            source_query=source_query,
-            tags=tags,
-            max_tokens=max_tokens,
-            trigger=trigger,
-            request_context=request_context,
-        )
-        # A new source query means the page's content no longer answers it — rebuild.
-        if updated is not None and source_query is not None and updated.get("mental_model_id"):
-            await memory.submit_async_refresh_mental_model(
-                bank_id=target_bank, mental_model_id=updated["mental_model_id"], request_context=request_context
-            )
+    except ValueError as e:
+        return {"error": str(e)}
+
     if updated is None:
         return {"error": f"Knowledge node '{node_id}' not found in bank '{target_bank}'"}
+
+    # A new source query means the page's content no longer answers it — rebuild.
+    if source_query is not None and updated.get("mental_model_id"):
+        await memory.submit_async_refresh_mental_model(
+            bank_id=target_bank, mental_model_id=updated["mental_model_id"], request_context=request_context
+        )
     return _knowledge_node_json(updated)
 
 

--- a/hindsight-api-slim/tests/test_knowledge_base.py
+++ b/hindsight-api-slim/tests/test_knowledge_base.py
@@ -635,7 +635,7 @@ class TestPageDefaults:
             captured.update(kwargs)
             return {"id": ids.orders, "kind": "page", "name": "Orders", "mental_model_id": ids.orders_mm}
 
-        monkeypatch.setattr(memory, "update_knowledge_page", fake_update)
+        monkeypatch.setattr(memory, "update_knowledge_node", fake_update)
         resp = await api_client.patch(
             f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.orders}",
             json={"trigger": {"refresh_cron": "0 4 * * *"}},
@@ -1068,6 +1068,117 @@ class TestMoveRenameDelete:
             assert remaining == {folder_c["id"]}
         finally:
             await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_atomic_patch_rename_and_invalid_parent_rolls_back(self, api_client, kb_bank):
+        bank_id, ids = kb_bank
+        # Rename + non-existent parent must fail and roll back the rename
+        resp = await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.policies}",
+            json={"name": "NeverPersisted", "parent_id": "missing-parent-folder"},
+        )
+        assert resp.status_code == 400, resp.text
+        # Verify the name was NOT changed
+        tree = (await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/tree")).json()
+        names = {r["name"] for r in tree["roots"]}
+        assert "Policies" in names
+        assert "NeverPersisted" not in names
+
+    async def test_atomic_patch_folder_with_page_fields_rejected(self, api_client, kb_bank):
+        bank_id, ids = kb_bank
+        # A folder cannot accept page-only fields (tags, source_query, etc.)
+        resp = await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.policies}",
+            json={"name": "NeverPersisted", "tags": ["type:runbook"]},
+        )
+        assert resp.status_code == 400, resp.text
+        assert "Cannot update page-only options" in resp.text or "folder" in resp.text
+        # Verify the folder name was NOT changed
+        tree = (await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/tree")).json()
+        names = {r["name"] for r in tree["roots"]}
+        assert "Policies" in names
+        assert "NeverPersisted" not in names
+
+    async def test_atomic_patch_folder_with_explicit_null_tags_rejected(self, api_client, kb_bank):
+        bank_id, ids = kb_bank
+        # Providing page-only fields with explicit null on a folder must also be rejected
+        resp = await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.policies}",
+            json={"name": "NeverPersisted", "tags": None},
+        )
+        assert resp.status_code == 400, resp.text
+        assert "Cannot update page-only options" in resp.text or "folder" in resp.text
+        # Verify the folder name was NOT changed
+        tree = (await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/tree")).json()
+        names = {r["name"] for r in tree["roots"]}
+        assert "Policies" in names
+        assert "NeverPersisted" not in names
+
+    async def test_atomic_patch_null_field_validations(self, api_client, kb_bank, memory, monkeypatch):
+        bank_id, ids = kb_bank
+        # 1. Null name is rejected
+        resp = await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.orders}",
+            json={"name": None},
+        )
+        assert resp.status_code == 400, resp.text
+        assert "name" in resp.text.lower()
+
+        # 2. Null source_query is rejected and does not schedule refresh
+        refresh_called = False
+
+        async def fake_refresh(*args, **kwargs):
+            nonlocal refresh_called
+            refresh_called = True
+
+        monkeypatch.setattr(memory, "submit_async_refresh_mental_model", fake_refresh)
+        resp = await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.orders}",
+            json={"source_query": None},
+        )
+        assert resp.status_code == 400, resp.text
+        assert "source_query" in resp.text.lower()
+        assert not refresh_called
+
+        # 3. Null tags is rejected
+        resp = await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.orders}",
+            json={"tags": None},
+        )
+        assert resp.status_code == 400, resp.text
+        assert "tags" in resp.text.lower()
+
+    async def test_atomic_patch_combined_success(self, api_client, kb_bank, memory, request_context):
+        bank_id, ids = kb_bank
+        # Atomically rename, move, and update page options on a single page
+        resp = await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.loose}",
+            json={
+                "name": "Consolidated Policy",
+                "parent_id": ids.policies,
+                "tags": ["type:policy", "compliance"],
+                "source_query": "what are the updated compliance rules?",
+                "max_tokens": 1024,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        node = resp.json()
+        assert node["name"] == "Consolidated Policy"
+        assert node["parent_id"] == ids.policies
+        assert set(node["tags"]) == {"type:policy", "compliance"}
+        assert node["description"] == "what are the updated compliance rules?"
+
+        # Verify in database
+        page = (await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/pages/{ids.loose}")).json()
+        assert page["name"] == "Consolidated Policy"
+        assert page["description"] == "what are the updated compliance rules?"
+        assert page["type"] == "policy"
+        assert page["tags"] == ["compliance"]
+
+        mm = await memory.get_mental_model(bank_id, node["mental_model_id"], request_context=request_context)
+        assert mm["name"] == "Consolidated Policy"
+        assert mm["source_query"] == "what are the updated compliance rules?"
+        assert set(mm["tags"]) == {"type:policy", "compliance"}
+        assert mm["max_tokens"] == 1024
 
     async def test_delete_folder_cascades(self, api_client, kb_bank, memory, request_context):
         bank_id, ids = kb_bank

--- a/hindsight-api-slim/tests/test_mcp_tools.py
+++ b/hindsight-api-slim/tests/test_mcp_tools.py
@@ -277,6 +277,7 @@ def mock_memory():
     )
     memory.create_knowledge_folder = AsyncMock(return_value=dict(_KNOWLEDGE_FOLDER))
     memory.create_knowledge_page = AsyncMock(return_value=dict(_KNOWLEDGE_PAGE_NODE))
+    memory.update_knowledge_node = AsyncMock(return_value=dict(_KNOWLEDGE_PAGE_NODE))
     memory.rename_knowledge_node = AsyncMock(return_value=dict(_KNOWLEDGE_PAGE_NODE))
     memory.move_knowledge_node = AsyncMock(return_value=dict(_KNOWLEDGE_PAGE_NODE))
     memory.update_knowledge_page = AsyncMock(return_value=dict(_KNOWLEDGE_PAGE_NODE))
@@ -2110,41 +2111,38 @@ class TestKnowledgeBaseTools:
         mcp = _make_mcp_server(mock_memory, {"update_knowledge_node"}, include_bank_id=True)
         result = json.loads(await _tools(mcp)["update_knowledge_node"].fn(node_id="kp-1", name="Deployments"))
         assert result["id"] == "kp-1"
-        assert mock_memory.rename_knowledge_node.call_args.kwargs["name"] == "Deployments"
-        mock_memory.update_knowledge_page.assert_not_called()
-        mock_memory.move_knowledge_node.assert_not_called()
+        assert mock_memory.update_knowledge_node.call_args.kwargs["name"] == "Deployments"
 
     async def test_update_move_to_folder(self, mock_memory):
         mcp = _make_mcp_server(mock_memory, {"update_knowledge_node"}, include_bank_id=True)
         await _tools(mcp)["update_knowledge_node"].fn(node_id="kp-1", parent_id="kf-2")
-        assert mock_memory.move_knowledge_node.call_args.kwargs["new_parent_id"] == "kf-2"
+        assert mock_memory.update_knowledge_node.call_args.kwargs["parent_id"] == "kf-2"
 
     async def test_update_move_to_root(self, mock_memory):
         mcp = _make_mcp_server(mock_memory, {"update_knowledge_node"}, include_bank_id=True)
         await _tools(mcp)["update_knowledge_node"].fn(node_id="kp-1", parent_id=KNOWLEDGE_ROOT_PARENT)
-        assert mock_memory.move_knowledge_node.call_args.kwargs["new_parent_id"] is None
+        assert mock_memory.update_knowledge_node.call_args.kwargs["parent_id"] is None
 
     async def test_update_source_query_triggers_refresh(self, mock_memory):
         mcp = _make_mcp_server(mock_memory, {"update_knowledge_node"}, include_bank_id=True)
         await _tools(mcp)["update_knowledge_node"].fn(node_id="kp-1", source_query="new question?")
-        assert mock_memory.update_knowledge_page.call_args.kwargs["source_query"] == "new question?"
+        assert mock_memory.update_knowledge_node.call_args.kwargs["source_query"] == "new question?"
         assert mock_memory.submit_async_refresh_mental_model.call_args.kwargs["mental_model_id"] == "mm-page"
 
     async def test_update_tags_only_does_not_refresh(self, mock_memory):
         mcp = _make_mcp_server(mock_memory, {"update_knowledge_node"}, include_bank_id=True)
         await _tools(mcp)["update_knowledge_node"].fn(node_id="kp-1", tags=[])
-        assert mock_memory.update_knowledge_page.call_args.kwargs["tags"] == []
+        assert mock_memory.update_knowledge_node.call_args.kwargs["tags"] == []
         mock_memory.submit_async_refresh_mental_model.assert_not_called()
 
     async def test_update_requires_a_field(self, mock_memory):
         mcp = _make_mcp_server(mock_memory, {"update_knowledge_node"}, include_bank_id=True)
         result = await _tools(mcp)["update_knowledge_node"].fn(node_id="kp-1")
         assert "Provide name" in result
-        mock_memory.rename_knowledge_node.assert_not_called()
-        mock_memory.update_knowledge_page.assert_not_called()
+        mock_memory.update_knowledge_node.assert_not_called()
 
     async def test_update_not_found(self, mock_memory):
-        mock_memory.rename_knowledge_node.return_value = None
+        mock_memory.update_knowledge_node.return_value = None
         mcp = _make_mcp_server(mock_memory, {"update_knowledge_node"}, include_bank_id=True)
         result = await _tools(mcp)["update_knowledge_node"].fn(node_id="kp-missing", name="x")
         assert "not found" in result


### PR DESCRIPTION
## Summary

A `PATCH` request to `/knowledge-base/nodes/{node_id}` or the `update_knowledge_node` MCP tool previously applied rename, move, and page options sequentially across separate database connections and transactions. A failure on a subsequent step (such as moving to a non-existent folder or creating a hierarchy cycle) left earlier changes (such as rename) persisted, causing partial writes and state drift on client retries. Additionally, folder nodes could accept page-only options and fail midway after renaming.

## Changes

- **Single Atomic Transaction**: Added `MemoryEngine.update_knowledge_node()` to validate node kind compatibility, check parent hierarchy loops, and execute all updates (`knowledge_pages` and backing `mental_models`) in a single database transaction.
- **Refactoring**: Refactored `rename_knowledge_node()`, `move_knowledge_node()`, and `update_knowledge_page()` to delegate to `update_knowledge_node()`.
- **API & MCP Tooling**: Updated `api_update_knowledge_node()` and MCP tool handler `_do_update_knowledge_node()` to invoke `update_knowledge_node()`.
- **Error Handling**: Handled asynchronous mental model refresh submission errors gracefully so that submission failures do not mask a successful database update with a 500 response.
- **Testing**: Added regression tests in `test_knowledge_base.py` for atomic rollback on invalid parent, folder field validation, and combined multi-field updates. Verified all test suites pass.