### PR TITLE
fix(coding-agents): let knowledge pages see the observations they ask for, and stop tagging initiative markers with a page id

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
@@ -321,6 +321,32 @@ describe("HindsightClient.seedPages", () => {
     }
   });
 
+  // The common case in the field: a server older than #3572 reports no trigger at all, so the
+  // policy is unknowable and gets re-sent. Cheap, idempotent, and self-healing once the server
+  // starts answering — but it must still be trigger-ONLY, or every run rebuilds all five pages.
+  it("re-sends the trigger to a server that does not report one", async () => {
+    const calls: any[] = [];
+    stubFetchRouted(calls, [
+      {
+        match: (m, u) => m === "GET" && u.endsWith("/knowledge-base/tree"),
+        json: {
+          roots: PAGES.map((p, i) => ({
+            id: `kp-${i}`,
+            kind: "page",
+            name: p.name,
+            description: p.source_query,
+          })),
+        },
+      },
+    ]);
+    const c = new HindsightClient({ apiUrl: "http://x", bank: "repo-a" });
+    await c.seedPages();
+
+    const patches = calls.filter((k) => k.method === "PATCH");
+    expect(patches).toHaveLength(PAGES.length);
+    for (const patch of patches) expect(patch.body).toEqual({ trigger: buildPageTrigger() });
+  });
+
   it("names the repository in every seeded query, so synthesis can exclude a dependency's facts", async () => {
     const calls: any[] = [];
     stubFetchRouted(calls, [

--- a/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
@@ -180,6 +180,10 @@ describe("HindsightClient.seedPages", () => {
       );
       expect(post.body.max_tokens).toBe(PAGE_MAX_TOKENS);
       expect(post.body.trigger.refresh_after_consolidation).toBe(true);
+      // NOT the server's `all_strict` default for a tagged model: that excludes untagged
+      // memories, and every observation this plugin's banks consolidate is untagged.
+      expect(post.body.trigger.tags_match).toBe("all");
+      expect(post.body.trigger.fact_types).toContain("observation");
       expect(post.body.parent_id).toBeUndefined(); // seeded at the tree root
     }
     // Nothing on the mental-models surface.
@@ -220,6 +224,7 @@ describe("HindsightClient.seedPages", () => {
             kind: "page",
             name: p.name,
             description: p.source_query,
+            trigger: { tags_match: buildPageTrigger().tags_match },
           })),
         },
       },
@@ -265,6 +270,7 @@ describe("HindsightClient.seedPages", () => {
             kind: "page",
             name: p.name.toUpperCase(),
             description: p === drifted ? "an older wording of the query" : p.source_query,
+            trigger: { tags_match: buildPageTrigger().tags_match },
           })),
         },
       },
@@ -280,7 +286,39 @@ describe("HindsightClient.seedPages", () => {
     expect(patches[0].body).toEqual({
       source_query: drifted.source_query,
       tags: drifted.tags,
+      trigger: buildPageTrigger(),
     });
+  });
+
+  // A page seeded before `tags_match` existed keeps the server's `all_strict` default, which
+  // excludes the untagged shared observations these pages are meant to synthesize from. The
+  // source query is unchanged on such a bank, so the trigger has to be its own drift signal.
+  it("re-syncs the refresh trigger onto a page whose query did NOT drift", async () => {
+    const calls: any[] = [];
+    stubFetchRouted(calls, [
+      {
+        match: (m, u) => m === "GET" && u.endsWith("/knowledge-base/tree"),
+        json: {
+          roots: PAGES.map((p, i) => ({
+            id: `kp-${i}`,
+            kind: "page",
+            name: p.name,
+            description: p.source_query,
+            trigger: { tags_match: "all_strict" },
+          })),
+        },
+      },
+    ]);
+    const c = new HindsightClient({ apiUrl: "http://x", bank: "repo-a" });
+    await c.seedPages();
+
+    const patches = calls.filter((k) => k.method === "PATCH");
+    expect(patches).toHaveLength(PAGES.length);
+    for (const patch of patches) {
+      // ONLY the trigger: sending `source_query` would schedule a full rebuild of every page on
+      // a bank whose question never changed.
+      expect(patch.body).toEqual({ trigger: buildPageTrigger() });
+    }
   });
 
   it("names the repository in every seeded query, so synthesis can exclude a dependency's facts", async () => {
@@ -409,7 +447,7 @@ describe("HindsightClient.ensureFolder", () => {
 });
 
 describe("HindsightClient.captureInitiative", () => {
-  it("new initiative: POSTs a per-initiative page + a marker retain sharing the same relatedPageId", async () => {
+  it("new initiative: POSTs a per-initiative page + a marker retain naming the same page id", async () => {
     const calls: any[] = [];
     stubFetchRouted(calls, [
       { match: (m, u) => m === "GET" && u.endsWith("/knowledge-base/tree"), json: { roots: [] } },
@@ -446,26 +484,29 @@ describe("HindsightClient.captureInitiative", () => {
     expect(pagePost.body.parent_id).toBe("folder-abc");
     expect(pagePost.body.tags).toEqual(["knowledge:feature-work"]);
 
-    // Marker retain POST to /memories: the ONLY tag is relatedPageId, pointing at the REAL
-    // server-assigned page id ("pg").
+    // Marker retain POST to /memories. The page id rides on the metadata and on the context —
+    // NEVER on a tag: tags are matched with exact set-ops against a fixed vocabulary, and one
+    // more tag value per initiative both isolates nothing and pollutes every fact (#3641).
     const memPost = calls.find((k) => k.method === "POST" && k.url.endsWith("/memories"));
     expect(memPost).toBeDefined();
     const item = memPost.body.items[0];
-    expect(item.tags).toEqual(["knowledge:feature-work", "relatedPageId:pg"]);
+    expect(item.tags).toEqual(["knowledge:feature-work"]);
+    expect(item.metadata).toEqual({ relatedPageId: "pg" });
+    // The context is the one channel a page synthesis reads back (reflect strips `metadata` from
+    // its search results), so this is what lets the overview link to the REAL page id.
+    expect(item.context).toBe("initiative marker for [[page:pg]]");
     expect(item.strategy).toBe("document");
     expect(memPost.body.async).toBe(true);
     // Unique per-marker document id (NOT the page id) so repeated captures accrue.
     expect(item.document_id).not.toBe("pg");
     expect(item.document_id).toContain("initiative-marker-retry-backoff-for-the-uploader-");
 
-    // The returned page id and the marker tag's id must be identical (the real page node id).
-    const tagId = item.tags
-      .find((t: string) => t.startsWith("relatedPageId:"))
-      .slice("relatedPageId:".length);
-    expect(tagId).toBe(result.page_id);
+    // The returned page id and the id the marker names must be the same (the real page node id).
+    expect(item.metadata.relatedPageId).toBe(result.page_id);
+    expect(item.context).toContain(`[[page:${result.page_id}]]`);
   });
 
-  it("enhancement (relatesToPageId): NO page POST; marker tagged the existing page id", async () => {
+  it("enhancement (relatesToPageId): NO page POST; marker names the existing page id", async () => {
     const calls: any[] = [];
     stubFetchRouted(calls, [
       {
@@ -494,7 +535,9 @@ describe("HindsightClient.captureInitiative", () => {
     const memPost = calls.find((k) => k.method === "POST" && k.url.endsWith("/memories"));
     expect(memPost).toBeDefined();
     const item = memPost.body.items[0];
-    expect(item.tags).toEqual(["knowledge:feature-work", "relatedPageId:initiative-x"]);
+    expect(item.tags).toEqual(["knowledge:feature-work"]);
+    expect(item.metadata).toEqual({ relatedPageId: "initiative-x" });
+    expect(item.context).toBe("initiative marker for [[page:initiative-x]]");
     expect(item.content).toContain("Update to an existing initiative");
   });
 
@@ -518,12 +561,13 @@ describe("HindsightClient.captureInitiative", () => {
     });
 
     const item = calls.find((k) => k.url.endsWith("/memories")).body.items[0];
-    expect(item.tags).toEqual([
-      "project:repo-a",
-      "knowledge:feature-work",
-      "relatedPageId:initiative-x",
-    ]);
-    expect(item.metadata).toEqual({ project: "repo-a", source: "configured" });
+    expect(item.tags).toEqual(["project:repo-a", "knowledge:feature-work"]);
+    // The configured attribution survives alongside the page id the marker adds.
+    expect(item.metadata).toEqual({
+      project: "repo-a",
+      source: "configured",
+      relatedPageId: "initiative-x",
+    });
   });
 });
 

--- a/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
@@ -496,6 +496,8 @@ describe("HindsightClient.captureInitiative", () => {
     // its search results), so this is what lets the overview link to the REAL page id.
     expect(item.context).toBe("initiative marker for [[page:pg]]");
     expect(item.strategy).toBe("document");
+    // A marker consolidates into the same single scope as everything else this plugin writes.
+    expect(item.observation_scopes).toBe("shared");
     expect(memPost.body.async).toBe(true);
     // Unique per-marker document id (NOT the page id) so repeated captures accrue.
     expect(item.document_id).not.toBe("pg");

--- a/hindsight-integrations/coding-agents/src/core/hindsight.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.test.ts
@@ -347,6 +347,43 @@ describe("HindsightClient credential refresh", () => {
   });
 });
 
+/**
+ * The other half of the same invariant: forwarding the config is worthless if a write path skips
+ * the client method that SENDS it. One bank must consolidate into exactly one observation scope
+ * (#3564), and `retain()` is the only place that puts `observation_scopes` on the wire — so a
+ * second `/memories` POST anywhere would quietly consolidate under the server's `combined`
+ * default, splitting the repo's beliefs per tag combination again. No unit test would fail: the
+ * new path writes perfectly good memories. Hence a check over the whole source tree.
+ */
+describe("every memory write goes through the one call site that scopes it", () => {
+  const SRC = fileURLToPath(new URL("..", import.meta.url));
+
+  function sourceFiles(dir: string, prefix = ""): string[] {
+    return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory())
+        return entry.name === "e2e" ? [] : sourceFiles(join(dir, entry.name), rel);
+      return entry.name.endsWith(".ts") && !entry.name.includes(".test.") ? [rel] : [];
+    });
+  }
+
+  it("has no module addressing the memories endpoint except the client", () => {
+    const writers = sourceFiles(SRC).filter((rel) =>
+      readFileSync(join(SRC, rel), "utf8").includes('"/memories')
+    );
+    expect(writers).toEqual(["core/hindsight.ts"]);
+  });
+
+  it("keeps that call site inside retain(), with the scoping on the item it posts", () => {
+    const src = readFileSync(join(SRC, "core/hindsight.ts"), "utf8");
+    expect(src.match(/bankUrl\("\/memories"\)/g)).toHaveLength(1);
+    // Everything between retain()'s signature and the POST is the body it builds; the scoping
+    // has to be set in there, not left to whatever the server defaults to.
+    const body = src.slice(src.indexOf("async retain("), src.indexOf('bankUrl("/memories")'));
+    expect(body).toContain("observation_scopes: this.observationScopes");
+  });
+});
+
 describe("every client-building entrypoint forwards observationScopes", () => {
   const SRC = fileURLToPath(new URL("..", import.meta.url));
 

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -628,7 +628,9 @@ export class HindsightClient {
         // page needs, and a `pageTriggerType` change never reached one either. Servers that don't
         // report a page's trigger on the tree yet answer "unknown" and get it re-sent every run:
         // the PATCH is idempotent and schedules no refresh unless the source query also changed.
-        const patch: Record<string, unknown> = { trigger: pageTrigger };
+        const patch: { trigger: PageTrigger; source_query?: string; tags?: string[] } = {
+          trigger: pageTrigger,
+        };
         if (hit.description !== page.source_query) {
           patch.source_query = page.source_query;
           patch.tags = page.tags;

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -23,6 +23,9 @@ export interface KnowledgeNode {
   name: string;
   /** The page's source query (OKF `description`) — what a re-sync compares against. */
   description?: string;
+  /** The page's EFFECTIVE refresh policy, on servers new enough to report it (#3572). Absent
+   *  everywhere else, which `seedPages()` reads as "unknown, re-send it". */
+  trigger?: { tags_match?: string };
   children?: KnowledgeNode[];
 }
 
@@ -615,12 +618,25 @@ export class HindsightClient {
           return;
         }
         if (r.status !== 409) created++;
-      } else if (hit.description !== page.source_query) {
-        // Only the source query can drift — the name IS the match key, so it can't.
+      } else if (
+        hit.description !== page.source_query ||
+        hit.trigger?.tags_match !== pageTrigger.tags_match
+      ) {
+        // The name IS the match key, so it can't drift; the source query and the trigger can.
+        // The trigger is re-sent because it is the only way a policy change reaches a page that
+        // already exists — `tags_match` (see PAGE_TAGS_MATCH) is a fix every previously seeded
+        // page needs, and a `pageTriggerType` change never reached one either. Servers that don't
+        // report a page's trigger on the tree yet answer "unknown" and get it re-sent every run:
+        // the PATCH is idempotent and schedules no refresh unless the source query also changed.
+        const patch: Record<string, unknown> = { trigger: pageTrigger };
+        if (hit.description !== page.source_query) {
+          patch.source_query = page.source_query;
+          patch.tags = page.tags;
+        }
         const r = await this.req(
           "PATCH",
           this.bankUrl(`/knowledge-base/nodes/${encodeURIComponent(hit.id)}`),
-          { source_query: page.source_query, tags: page.tags }
+          patch
         );
         if ([404, 405, 501].includes(r.status)) {
           this.knowledgePagesSupported = false;
@@ -650,10 +666,17 @@ export class HindsightClient {
   }
 
   /**
-   * Active-path capture: register a major feature as a per-initiative page + a tagged marker memory.
-   * New initiative → creates a page under the Initiatives folder tagged `relatedPageId:<pageId>`.
+   * Active-path capture: register a major feature as a per-initiative page + a marker memory.
+   * New initiative → creates a page under the Initiatives folder.
    * Update (relatesToPageId) → no new page; only a marker accruing to the existing page, so an
    * enhancement or a mid-work plan change lands on the initiative it belongs to.
+   *
+   * The marker carries its page id in two places, neither of them a tag (#3641):
+   * `metadata.relatedPageId` for provenance (visible on the document, and to a reflect loop that
+   * expands one), and a `[[page:<id>]]` link in the retain CONTEXT, which is the only one of the
+   * three channels a page synthesis actually reads — reflect's search results keep `context` and
+   * `tags` but strip `metadata` (`_UNREAD_RESULT_FIELDS`), and the id has no business in a tag
+   * vocabulary that exists to be matched with exact set-ops.
    */
   async captureInitiative(args: {
     title: string;
@@ -666,8 +689,8 @@ export class HindsightClient {
   }): Promise<{ page_id: string }> {
     // `/knowledge-base/pages` mints its OWN page id (kp-…); we can't set it. So for a new initiative
     // we create the page first and adopt the server-assigned id — that id is what the return value
-    // and the marker's `relatedPageId` tag must use, or `read_knowledge_page(id)` 404s and the
-    // `[[page:<id>]]` link points at nothing.
+    // and the marker must use, or `read_knowledge_page(id)` 404s and the `[[page:<id>]]` link
+    // points at nothing.
     let pageId = args.relatesToPageId;
     if (!pageId) {
       const folderId = await this.ensureFolder("Initiatives");
@@ -692,20 +715,13 @@ export class HindsightClient {
     const content = `${verb}: ${args.title}. ${args.summary}`;
     // Unique marker document id (NOT pageId) so repeated captures accrue instead of replacing.
     const markerId = `initiative-marker-${this.slugify(args.title)}-${Date.now()}`;
-    const tags = [
-      ...new Set([
-        ...(args.stamp?.tags ?? []),
-        "knowledge:feature-work",
-        `relatedPageId:${pageId}`,
-      ]),
-    ];
-    if (Object.keys(args.stamp?.metadata ?? {}).length) {
-      await this.retain(content, "initiative marker", markerId, tags, "document", {
-        metadata: args.stamp?.metadata,
-      });
-    } else {
-      await this.retain(content, "initiative marker", markerId, tags, "document");
-    }
+    const tags = [...new Set([...(args.stamp?.tags ?? []), "knowledge:feature-work"])];
+    // The context rides on every fact extracted from this marker, verbatim (ExtractedFact.context),
+    // so the Initiatives overview can link an initiative to its own page from what it retrieved.
+    const context = `initiative marker for [[page:${pageId}]]`;
+    await this.retain(content, context, markerId, tags, "document", {
+      metadata: { ...(args.stamp?.metadata ?? {}), relatedPageId: pageId },
+    });
     return { page_id: pageId };
   }
 

--- a/hindsight-integrations/coding-agents/src/core/missions.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/missions.test.ts
@@ -17,6 +17,21 @@ describe("buildPageTrigger", () => {
     expect(buildPageTrigger(resolveConfig({}))).toEqual(buildPageTrigger());
   });
 
+  /**
+   * The server defaults a tagged model to `all_strict`, which EXCLUDES untagged memories — and
+   * `DEFAULT_OBSERVATION_SCOPES = "shared"` makes every observation in these banks untagged
+   * (#3564). Left at the default, a page asked for the `observation` fact type and could never
+   * retrieve one (#3641).
+   */
+  it("admits the untagged shared observations these pages ask for", () => {
+    expect(buildPageTrigger().tags_match).toBe("all");
+    expect(PAGE_FACT_TYPES).toContain("observation");
+    // Not the strict variants: those are the ones that drop untagged rows.
+    for (const type of ["auto-refresh", "cron", "manual"] as const) {
+      expect(buildPageTrigger(resolveConfig({ pageTriggerType: type })).tags_match).toBe("all");
+    }
+  });
+
   it("puts pages on a schedule", () => {
     const trigger = buildPageTrigger(
       resolveConfig({ pageTriggerType: "cron", pageTriggerCron: "0 3 * * *" })
@@ -39,9 +54,9 @@ describe("buildPageTrigger", () => {
    * what this plugin actually decides.
    */
   it.each([
-    ["auto-refresh", ["fact_types", "refresh_after_consolidation"]],
-    ["cron", ["fact_types", "refresh_cron"]],
-    ["manual", ["fact_types", "refresh_after_consolidation"]],
+    ["auto-refresh", ["fact_types", "tags_match", "refresh_after_consolidation"]],
+    ["cron", ["fact_types", "tags_match", "refresh_cron"]],
+    ["manual", ["fact_types", "tags_match", "refresh_after_consolidation"]],
   ] as const)("states nothing the server owns under %s", (pageTriggerType, keys) => {
     const trigger = buildPageTrigger(
       resolveConfig({ pageTriggerType, pageTriggerCron: "0 3 * * *" })

--- a/hindsight-integrations/coding-agents/src/core/missions.ts
+++ b/hindsight-integrations/coding-agents/src/core/missions.ts
@@ -262,8 +262,8 @@ const PAGE_TAXONOMY: readonly KnowledgePage[] = [
     source_query:
       "Based on this repository's commit history, what are the major initiatives, features, and " +
       "enhancements the project has worked on? Summarize the themes and notable changes over time. " +
-      "When a source memory carries a tag of the form `relatedPageId:<id>`, include a Markdown link " +
-      "`[[page:<id>]]` to that page in the summary, so each initiative links to its detailed page.",
+      "When a source memory's context carries a `[[page:<id>]]` link, repeat that link in the " +
+      "summary of what it describes, so each initiative links to its detailed page.",
     tags: ["knowledge:feature-work"],
   },
 ];
@@ -286,9 +286,28 @@ export const PAGE_MAX_TOKENS = 4096;
 /** A page's `trigger`, in the API's own shape (see MentalModelTrigger in api/http.py). */
 export interface PageTrigger {
   fact_types: string[];
+  /** How the page's own `tags` filter the memories a refresh reads. See `PAGE_TAGS_MATCH`. */
+  tags_match: "any" | "all" | "any_strict" | "all_strict" | "exact";
   refresh_after_consolidation?: boolean;
   refresh_cron?: string;
 }
+
+/**
+ * `all` — AND over the page's tier tag, but INCLUDING untagged memories.
+ *
+ * The server defaults a tagged model to `all_strict`, which excludes untagged memories, and every
+ * observation in these banks is untagged: `DEFAULT_OBSERVATION_SCOPES = "shared"` consolidates into
+ * the single empty scope on purpose (#3564), so the consolidated tier carries no tags to match on.
+ * Under `all_strict` that put `"observation"` in `PAGE_FACT_TYPES` and the consolidated beliefs it
+ * asks for on opposite sides of the filter: pages declared the tier and could never retrieve a
+ * single row of it, synthesizing from raw world/experience facts alone.
+ *
+ * `all` keeps the discrimination that matters — a `knowledge:decision` fact still cannot reach the
+ * Component map, since it is tagged and lacks that page's tag — while letting the untagged shared
+ * observations reach every page, where the page's `source_query` is what selects among them. That
+ * is what one shared belief pool means.
+ */
+const PAGE_TAGS_MATCH = "all" as const;
 
 /** A page synthesizes from all three tiers; the fact types are not a preference. */
 export const PAGE_FACT_TYPES = ["world", "experience", "observation"];
@@ -318,13 +337,13 @@ export interface PageTriggerConfig {
  *
  * `fact_types` IS ours to state: the server's page default is observation-only, while these pages
  * are tag-scoped syntheses over the `knowledge:<tier>` labels the extractor puts on world and
- * experience facts.
+ * experience facts. So is `tags_match`, for the reason `PAGE_TAGS_MATCH` gives.
  *
  * `refresh_after_consolidation` and `refresh_cron` are mutually exclusive server-side, so exactly
  * one of them is ever set here.
  */
 export function buildPageTrigger(cfg: PageTriggerConfig = {}): PageTrigger {
-  const base: PageTrigger = { fact_types: PAGE_FACT_TYPES };
+  const base: PageTrigger = { fact_types: PAGE_FACT_TYPES, tags_match: PAGE_TAGS_MATCH };
   switch (cfg.pageTriggerType) {
     case "cron":
       return { ...base, refresh_cron: cfg.pageTriggerCron };


### PR DESCRIPTION
Closes #3641.

The filed symptom (per-initiative pages are not scoped by `relatedPageId`) is real, and the cause is that the plugin used `tags` for two things tags cannot do.

## 1. No page could ever retrieve an observation

Every seeded page is tag-scoped to one `knowledge:<tier>` label, and `_resolve_refresh_tag_filtering` defaults a tagged model to `all_strict` — which **excludes untagged memories**. Since #3564 this plugin retains with `observation_scopes: "shared"`, and `_resolve_obs_tags_list` resolves `shared` to the single empty scope, so **every observation in these banks is untagged**.

So `PAGE_FACT_TYPES` declared `"observation"` and the filter made it unreachable: pages asked for the consolidated tier and synthesized from raw world/experience facts alone. Two locally-sound changes silently cancelled each other.

The trigger now states `tags_match: "all"` — AND over the page's tier tag, but *including* untagged rows:

- a `knowledge:decision` fact still cannot reach the Component map (it is tagged and lacks that page's tag);
- the untagged shared observations reach every page, where the page's `source_query` is what selects among them.

`seedPages()` now re-sends the trigger when the live page reports a different `tags_match`. It has to: on an already-seeded bank the source query is unchanged, so it cannot be the drift signal, and the trigger was previously never re-synced at all (a `pageTriggerType` config change never reached an existing page either). Servers older than #3572 don't report a page's trigger on the tree and so answer "unknown" — they get it re-sent each run; the PATCH is idempotent and carries `source_query` **only** when the query really drifted, so it never schedules a rebuild of a page whose question didn't change.

## 2. `relatedPageId:<pageId>` was never a tag

The vocabulary here is fixed and low-cardinality by design (matching is exact set-ops, no wildcards — `KNOWLEDGE_LABELS` says so). `relatedPageId:` was unbounded cardinality, isolated nothing (the concrete page and the overview both filter on `knowledge:feature-work`), and landed on every fact extracted from a marker. It existed purely to carry an id into the synthesis prompt — a synthesis instruction riding the retrieval channel.

The id now rides on:

- `metadata.relatedPageId` — provenance, visible on the document;
- a `[[page:<id>]]` link in the marker's **retain context** — because reflect's search results strip `metadata` (`_UNREAD_RESULT_FIELDS`) while keeping `context`, and `ExtractedFact.context` copies the retain context verbatim onto every fact. That is the only channel the overview page can actually read back, so its cross-links keep working; the overview's `source_query` now points at it instead of at the tag.

## Scope / trade-offs

- **Per-initiative pages are still scoped by their `source_query`, not by tags.** Giving them real tag isolation means the *work* facts (commits, chats) would have to carry the initiative, not just the marker — a separate change, deliberately not in this PR.
- **Pages go stale more often.** Every consolidation writes observations, and untagged rows now count as in-scope for all five pages, so under `auto-refresh` a consolidation round can refresh pages whose own tier saw no new facts. That is the cost of the tier actually being readable; `pageTriggerType: cron | manual` (#3506) remains the lever.

## Tests

- `buildPageTrigger` admits the untagged observations the pages ask for, under every trigger type.
- `seedPages` re-syncs the trigger onto a page whose query did **not** drift, sending only the trigger.
- Idempotence and the drift PATCH now assert the trigger too.
- `captureInitiative` asserts the tag set has no page id in it, and that the id is on the metadata and in the context.
