### PR TITLE
fix(query-analyzer): reject lone four-digit integers as years (#3250)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/query_analyzer.py
+++ b/hindsight-api-slim/hindsight_api/engine/query_analyzer.py
@@ -125,22 +125,46 @@ def _query_can_score(query: str) -> bool:
     return bool(_SCOREABLE_RE.search(_NON_ALNUM_RE.sub("", low)))
 
 
+def _is_bare_year_span(tokens: list[str], token_set: set[str]) -> bool:
+    """Whether a matched span's only date content is a single four-digit integer.
+
+    dateparser resolves an isolated four-digit integer to a year, so port
+    numbers, ticket ids and buffer sizes come back as dates that outscore every
+    other candidate — the false-positive class from issue #3250. A real date
+    always carries something more: a second number ("2026-06-10", "15:30"), a
+    month or period word ("March 1890", "year 2019"), or an ordinal/unit suffix
+    ("the 21st", "10am"), all of which leave this predicate False.
+
+    The cost is that a bare year introduced only by a preposition ("since 2019")
+    is no longer temporal. That is deliberate: the span carries no month or day,
+    so the constraint it produced was the reference date's month/day in that
+    year — a single wrong day, never the year the user asked for.
+    """
+    numeric = [token for token in tokens if token.isdigit()]
+    if len(numeric) != 1 or len(numeric[0]) != 4:
+        return False
+    return not (token_set & _SCOREABLE_WORDS)
+
+
 def _date_match_score(text: str) -> int:
     """Score how strong a temporal signal a matched span carries.
 
-    A score of 0 means the span is a bare token with no explicit date content
-    (the false-positive class from issue #2768) and should be rejected. Higher
-    scores mean a stronger, less ambiguous date reference. A digit is the
-    strongest signal (day/year/ISO date); an explicit English month/relative
-    word next; weekday names and period words weakest but still explicit.
+    A score of 0 means the span carries no explicit date content and should be
+    rejected: a bare token (issue #2768) or a lone four-digit integer, which
+    dateparser resolves to a year (issue #3250). Higher scores mean a stronger,
+    less ambiguous date reference. A digit is the strongest signal (day/year/ISO
+    date); an explicit English month/relative word next; weekday names and
+    period words weakest but still explicit.
     """
     tokens = _TOKEN_RE.findall(text.lower())
     if not tokens:
         return 0
+    token_set = set(tokens)
     score = 0
     if any(any(ch.isdigit() for ch in tok) for tok in tokens):
+        if _is_bare_year_span(tokens, token_set):
+            return 0
         score += 100
-    token_set = set(tokens)
     if token_set & _MONTH_WORDS:
         score += 50
     if token_set & _RELATIVE_WORDS:

--- a/hindsight-api-slim/hindsight_api/engine/query_analyzer.py
+++ b/hindsight-api-slim/hindsight_api/engine/query_analyzer.py
@@ -135,10 +135,11 @@ def _is_bare_year_span(tokens: list[str], token_set: set[str]) -> bool:
     month or period word ("March 1890", "year 2019"), or an ordinal/unit suffix
     ("the 21st", "10am"), all of which leave this predicate False.
 
-    The cost is that a bare year introduced only by a preposition ("since 2019")
-    is no longer temporal. That is deliberate: the span carries no month or day,
-    so the constraint it produced was the reference date's month/day in that
-    year — a single wrong day, never the year the user asked for.
+    Genuine bare years never reach here: ``extract_period`` runs first and
+    resolves the ones a word disambiguates ("in 2019") to the whole calendar
+    year, which is the window the query actually asks for. This path only sees
+    the ones nothing introduces, where dateparser would have produced the
+    reference date's month/day in that year — a single wrong day.
     """
     numeric = [token for token in tokens if token.isdigit()]
     if len(numeric) != 1 or len(numeric[0]) != 4:

--- a/hindsight-api-slim/hindsight_api/engine/temporal_periods.py
+++ b/hindsight-api-slim/hindsight_api/engine/temporal_periods.py
@@ -62,7 +62,7 @@ def _month_end(year: int, month: int) -> datetime:
 # narrower window than asked for.
 _YEAR_ONLY_RE = re.compile(
     r"\b(?:in|during|throughout|year|en|durante|a[nñ]o|nel|anno|dans|pendant|ann[ée]e|im|w[äa]hrend|jahr|в)\s+"
-    r"(?<![-/.])(?P<year>\d{4})\b(?![-/.]\d)",
+    r"(?P<year>\d{4})\b(?![-/.]\d)",
     re.IGNORECASE,
 )
 

--- a/hindsight-api-slim/hindsight_api/engine/temporal_periods.py
+++ b/hindsight-api-slim/hindsight_api/engine/temporal_periods.py
@@ -50,6 +50,23 @@ def _month_end(year: int, month: int) -> datetime:
     return datetime(year, month, calendar.monthrange(year, month)[1])
 
 
+# A four-digit year on its own is ambiguous — dateparser reads every isolated
+# integer as one, which is how port and ticket numbers became temporal
+# constraints (issue #3250). What disambiguates it is the word introducing it:
+# "in 2019" is a year, "port 2019" is not. dateparser cannot make that call (it
+# returns the identical span "2019" for both), so the rule lives here, where the
+# whole query is still in hand and periods already resolve to a full range.
+#
+# Deliberately excludes "since"/"from", which open an interval ending now rather
+# than selecting the named year — collapsing those to Jan-Dec would be a
+# narrower window than asked for.
+_YEAR_ONLY_RE = re.compile(
+    r"\b(?:in|during|throughout|year|en|durante|a[nñ]o|nel|anno|dans|pendant|ann[ée]e|im|w[äa]hrend|jahr|в)\s+"
+    r"(?<![-/.])(?P<year>\d{4})\b(?![-/.]\d)",
+    re.IGNORECASE,
+)
+
+
 def _extract_non_chinese_period(
     query: str, reference_date: datetime
 ) -> DateRange | NoTemporalConstraintSentinel | None:
@@ -171,6 +188,24 @@ def _extract_non_chinese_period(
                 return NO_TEMPORAL_CONSTRAINT
             start = datetime(year, month_num, 1)
             return _constraint(start, _month_end(year, month_num))
+
+    year_only = _YEAR_ONLY_RE.search(query)
+    if year_only:
+        year = int(year_only.group("year"))
+        # A year with no month or day beside it is only credible near the
+        # reference date. "listening in 8080" is a port someone happened to
+        # phrase with a preposition, and a year-8080 window is the silent
+        # empty-arm failure of issue #3250 all over again.
+        #
+        # Implausible years fall through rather than returning
+        # NO_TEMPORAL_CONSTRAINT (which the month rule uses for "june 0000"):
+        # the sentinel would drop a genuine date elsewhere in the same query,
+        # and there is nothing to protect against downstream any more — the
+        # dateparser fallback now rejects bare integers on its own.
+        # max() with datetime.min.year keeps "in 0000" out of datetime() for a
+        # reference date low enough that the window would otherwise admit it.
+        if max(datetime.min.year, reference_date.year - 120) <= year <= reference_date.year + 20:
+            return _constraint(datetime(year, 1, 1), datetime(year, 12, 31))
 
     return None
 

--- a/hindsight-api-slim/tests/data/query_analyzer_golden.json
+++ b/hindsight-api-slim/tests/data/query_analyzer_golden.json
@@ -34,10 +34,7 @@
   "2026-07-13T00:00:00",
   "2026-07-13T23:59:59.999999"
  ],
- "2024-02-29T12:00:00\u001f15.01.2024": [
-  "2024-02-29T00:00:00",
-  "2024-02-29T23:59:59.999999"
- ],
+ "2024-02-29T12:00:00\u001f15.01.2024": null,
  "2024-02-29T12:00:00\u001f1mon ago": [
   "2024-01-29T00:00:00",
   "2024-01-29T23:59:59.999999"
@@ -47,10 +44,7 @@
   "2024-01-15T00:00:00",
   "2024-01-15T23:59:59.999999"
  ],
- "2024-02-29T12:00:00\u001f2024年": [
-  "2024-02-29T00:00:00",
-  "2024-02-29T23:59:59.999999"
- ],
+ "2024-02-29T12:00:00\u001f2024年": null,
  "2024-02-29T12:00:00\u001f2024年3月": [
   "2024-03-01T00:00:00",
   "2024-03-31T23:59:59.999999"
@@ -77,8 +71,8 @@
   "1999-12-31T23:59:59.999999"
  ],
  "2024-02-29T12:00:00\u001f31 february 2020": [
-  "2020-02-29T00:00:00",
-  "2020-02-29T23:59:59.999999"
+  "2024-02-29T00:00:00",
+  "2024-02-29T23:59:59.999999"
  ],
  "2024-02-29T12:00:00\u001f3:30pm": null,
  "2024-02-29T12:00:00\u001f3月3日": [
@@ -117,22 +111,13 @@
  ],
  "2024-02-29T12:00:00\u001fSELECT * FROM memory_units": null,
  "2024-02-29T12:00:00\u001fTODO": null,
- "2024-02-29T12:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": [
-  "2000-02-29T00:00:00",
-  "2000-02-29T23:59:59.999999"
- ],
- "2024-02-29T12:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": [
-  "2000-02-29T00:00:00",
-  "2000-02-29T23:59:59.999999"
- ],
+ "2024-02-29T12:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": null,
+ "2024-02-29T12:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": null,
  "2024-02-29T12:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The migration ran on 2026-06-10 without incident.": [
   "2026-06-10T00:00:00",
   "2026-06-10T23:59:59.999999"
  ],
- "2024-02-29T12:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": [
-  "2000-02-29T00:00:00",
-  "2000-02-29T23:59:59.999999"
- ],
+ "2024-02-29T12:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": null,
  "2024-02-29T12:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. This was decided last week during the architecture review.": [
   "2024-02-19T00:00:00",
   "2024-02-25T23:59:59.999999"
@@ -1420,10 +1405,7 @@
   "2026-07-13T00:00:00",
   "2026-07-13T23:59:59.999999"
  ],
- "2026-01-01T00:00:00\u001f15.01.2024": [
-  "2024-01-01T00:00:00",
-  "2024-01-01T23:59:59.999999"
- ],
+ "2026-01-01T00:00:00\u001f15.01.2024": null,
  "2026-01-01T00:00:00\u001f1mon ago": [
   "2025-12-01T00:00:00",
   "2025-12-01T23:59:59.999999"
@@ -1433,10 +1415,7 @@
   "2024-01-15T00:00:00",
   "2024-01-15T23:59:59.999999"
  ],
- "2026-01-01T00:00:00\u001f2024年": [
-  "0002-01-01T00:00:00",
-  "0002-01-01T23:59:59.999999"
- ],
+ "2026-01-01T00:00:00\u001f2024年": null,
  "2026-01-01T00:00:00\u001f2024年3月": [
   "2024-03-01T00:00:00",
   "2024-03-31T23:59:59.999999"
@@ -1463,8 +1442,8 @@
   "1999-12-31T23:59:59.999999"
  ],
  "2026-01-01T00:00:00\u001f31 february 2020": [
-  "2020-01-01T00:00:00",
-  "2020-01-01T23:59:59.999999"
+  "2025-02-01T00:00:00",
+  "2025-02-01T23:59:59.999999"
  ],
  "2026-01-01T00:00:00\u001f3:30pm": null,
  "2026-01-01T00:00:00\u001f3月3日": [
@@ -1503,22 +1482,13 @@
  ],
  "2026-01-01T00:00:00\u001fSELECT * FROM memory_units": null,
  "2026-01-01T00:00:00\u001fTODO": null,
- "2026-01-01T00:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": [
-  "2000-01-01T00:00:00",
-  "2000-01-01T23:59:59.999999"
- ],
- "2026-01-01T00:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": [
-  "2000-01-01T00:00:00",
-  "2000-01-01T23:59:59.999999"
- ],
+ "2026-01-01T00:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": null,
+ "2026-01-01T00:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": null,
  "2026-01-01T00:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The migration ran on 2026-06-10 without incident.": [
   "2026-06-10T00:00:00",
   "2026-06-10T23:59:59.999999"
  ],
- "2026-01-01T00:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": [
-  "2000-01-01T00:00:00",
-  "2000-01-01T23:59:59.999999"
- ],
+ "2026-01-01T00:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": null,
  "2026-01-01T00:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. This was decided last week during the architecture review.": [
   "2025-12-22T00:00:00",
   "2025-12-28T23:59:59.999999"
@@ -2806,10 +2776,7 @@
   "2026-07-13T00:00:00",
   "2026-07-13T23:59:59.999999"
  ],
- "2026-08-03T09:00:00\u001f15.01.2024": [
-  "2024-08-03T00:00:00",
-  "2024-08-03T23:59:59.999999"
- ],
+ "2026-08-03T09:00:00\u001f15.01.2024": null,
  "2026-08-03T09:00:00\u001f1mon ago": [
   "2026-07-03T00:00:00",
   "2026-07-03T23:59:59.999999"
@@ -2819,10 +2786,7 @@
   "2024-01-15T00:00:00",
   "2024-01-15T23:59:59.999999"
  ],
- "2026-08-03T09:00:00\u001f2024年": [
-  "0002-08-03T00:00:00",
-  "0002-08-03T23:59:59.999999"
- ],
+ "2026-08-03T09:00:00\u001f2024年": null,
  "2026-08-03T09:00:00\u001f2024年3月": [
   "2024-03-01T00:00:00",
   "2024-03-31T23:59:59.999999"
@@ -2849,8 +2813,8 @@
   "1999-12-31T23:59:59.999999"
  ],
  "2026-08-03T09:00:00\u001f31 february 2020": [
-  "2020-08-03T00:00:00",
-  "2020-08-03T23:59:59.999999"
+  "2026-02-03T00:00:00",
+  "2026-02-03T23:59:59.999999"
  ],
  "2026-08-03T09:00:00\u001f3:30pm": null,
  "2026-08-03T09:00:00\u001f3月3日": [
@@ -2889,22 +2853,13 @@
  ],
  "2026-08-03T09:00:00\u001fSELECT * FROM memory_units": null,
  "2026-08-03T09:00:00\u001fTODO": null,
- "2026-08-03T09:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": [
-  "2000-08-03T00:00:00",
-  "2000-08-03T23:59:59.999999"
- ],
- "2026-08-03T09:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": [
-  "2000-08-03T00:00:00",
-  "2000-08-03T23:59:59.999999"
- ],
+ "2026-08-03T09:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": null,
+ "2026-08-03T09:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": null,
  "2026-08-03T09:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The migration ran on 2026-06-10 without incident.": [
   "2026-06-10T00:00:00",
   "2026-06-10T23:59:59.999999"
  ],
- "2026-08-03T09:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": [
-  "2000-08-03T00:00:00",
-  "2000-08-03T23:59:59.999999"
- ],
+ "2026-08-03T09:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": null,
  "2026-08-03T09:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. This was decided last week during the architecture review.": [
   "2026-07-27T00:00:00",
   "2026-08-02T23:59:59.999999"
@@ -4192,10 +4147,7 @@
   "2026-07-13T00:00:00",
   "2026-07-13T23:59:59.999999"
  ],
- "2026-08-09T18:00:00\u001f15.01.2024": [
-  "2024-08-09T00:00:00",
-  "2024-08-09T23:59:59.999999"
- ],
+ "2026-08-09T18:00:00\u001f15.01.2024": null,
  "2026-08-09T18:00:00\u001f1mon ago": [
   "2026-07-09T00:00:00",
   "2026-07-09T23:59:59.999999"
@@ -4205,10 +4157,7 @@
   "2024-01-15T00:00:00",
   "2024-01-15T23:59:59.999999"
  ],
- "2026-08-09T18:00:00\u001f2024年": [
-  "0002-08-09T00:00:00",
-  "0002-08-09T23:59:59.999999"
- ],
+ "2026-08-09T18:00:00\u001f2024年": null,
  "2026-08-09T18:00:00\u001f2024年3月": [
   "2024-03-01T00:00:00",
   "2024-03-31T23:59:59.999999"
@@ -4235,8 +4184,8 @@
   "1999-12-31T23:59:59.999999"
  ],
  "2026-08-09T18:00:00\u001f31 february 2020": [
-  "2020-08-09T00:00:00",
-  "2020-08-09T23:59:59.999999"
+  "2026-02-09T00:00:00",
+  "2026-02-09T23:59:59.999999"
  ],
  "2026-08-09T18:00:00\u001f3:30pm": null,
  "2026-08-09T18:00:00\u001f3月3日": [
@@ -4275,22 +4224,13 @@
  ],
  "2026-08-09T18:00:00\u001fSELECT * FROM memory_units": null,
  "2026-08-09T18:00:00\u001fTODO": null,
- "2026-08-09T18:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": [
-  "2000-08-09T00:00:00",
-  "2000-08-09T23:59:59.999999"
- ],
- "2026-08-09T18:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": [
-  "2000-08-09T00:00:00",
-  "2000-08-09T23:59:59.999999"
- ],
+ "2026-08-09T18:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": null,
+ "2026-08-09T18:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": null,
  "2026-08-09T18:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The migration ran on 2026-06-10 without incident.": [
   "2026-06-10T00:00:00",
   "2026-06-10T23:59:59.999999"
  ],
- "2026-08-09T18:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": [
-  "2000-08-09T00:00:00",
-  "2000-08-09T23:59:59.999999"
- ],
+ "2026-08-09T18:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": null,
  "2026-08-09T18:00:00\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. This was decided last week during the architecture review.": [
   "2026-07-27T00:00:00",
   "2026-08-02T23:59:59.999999"
@@ -5578,10 +5518,7 @@
   "2026-07-13T00:00:00",
   "2026-07-13T23:59:59.999999"
  ],
- "2026-08-12T14:30:45.123456\u001f15.01.2024": [
-  "2024-08-12T00:00:00",
-  "2024-08-12T23:59:59.999999"
- ],
+ "2026-08-12T14:30:45.123456\u001f15.01.2024": null,
  "2026-08-12T14:30:45.123456\u001f1mon ago": [
   "2026-07-12T00:00:00",
   "2026-07-12T23:59:59.999999"
@@ -5591,10 +5528,7 @@
   "2024-01-15T00:00:00",
   "2024-01-15T23:59:59.999999"
  ],
- "2026-08-12T14:30:45.123456\u001f2024年": [
-  "0002-08-12T00:00:00",
-  "0002-08-12T23:59:59.999999"
- ],
+ "2026-08-12T14:30:45.123456\u001f2024年": null,
  "2026-08-12T14:30:45.123456\u001f2024年3月": [
   "2024-03-01T00:00:00",
   "2024-03-31T23:59:59.999999"
@@ -5621,8 +5555,8 @@
   "1999-12-31T23:59:59.999999"
  ],
  "2026-08-12T14:30:45.123456\u001f31 february 2020": [
-  "2020-08-12T00:00:00",
-  "2020-08-12T23:59:59.999999"
+  "2026-02-12T00:00:00",
+  "2026-02-12T23:59:59.999999"
  ],
  "2026-08-12T14:30:45.123456\u001f3:30pm": null,
  "2026-08-12T14:30:45.123456\u001f3月3日": [
@@ -5661,22 +5595,13 @@
  ],
  "2026-08-12T14:30:45.123456\u001fSELECT * FROM memory_units": null,
  "2026-08-12T14:30:45.123456\u001fTODO": null,
- "2026-08-12T14:30:45.123456\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": [
-  "2000-08-12T00:00:00",
-  "2000-08-12T23:59:59.999999"
- ],
- "2026-08-12T14:30:45.123456\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": [
-  "2000-08-12T00:00:00",
-  "2000-08-12T23:59:59.999999"
- ],
+ "2026-08-12T14:30:45.123456\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": null,
+ "2026-08-12T14:30:45.123456\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": null,
  "2026-08-12T14:30:45.123456\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The migration ran on 2026-06-10 without incident.": [
   "2026-06-10T00:00:00",
   "2026-06-10T23:59:59.999999"
  ],
- "2026-08-12T14:30:45.123456\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": [
-  "2000-08-12T00:00:00",
-  "2000-08-12T23:59:59.999999"
- ],
+ "2026-08-12T14:30:45.123456\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": null,
  "2026-08-12T14:30:45.123456\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. This was decided last week during the architecture review.": [
   "2026-08-03T00:00:00",
   "2026-08-09T23:59:59.999999"
@@ -6964,10 +6889,7 @@
   "2026-07-13T00:00:00",
   "2026-07-13T23:59:59.999999"
  ],
- "2026-12-31T23:59:59\u001f15.01.2024": [
-  "2024-12-31T00:00:00",
-  "2024-12-31T23:59:59.999999"
- ],
+ "2026-12-31T23:59:59\u001f15.01.2024": null,
  "2026-12-31T23:59:59\u001f1mon ago": [
   "2026-11-30T00:00:00",
   "2026-11-30T23:59:59.999999"
@@ -6977,10 +6899,7 @@
   "2024-01-15T00:00:00",
   "2024-01-15T23:59:59.999999"
  ],
- "2026-12-31T23:59:59\u001f2024年": [
-  "0002-12-31T00:00:00",
-  "0002-12-31T23:59:59.999999"
- ],
+ "2026-12-31T23:59:59\u001f2024年": null,
  "2026-12-31T23:59:59\u001f2024年3月": [
   "2024-03-01T00:00:00",
   "2024-03-31T23:59:59.999999"
@@ -7007,8 +6926,8 @@
   "1999-12-31T23:59:59.999999"
  ],
  "2026-12-31T23:59:59\u001f31 february 2020": [
-  "2020-12-31T00:00:00",
-  "2020-12-31T23:59:59.999999"
+  "2026-02-28T00:00:00",
+  "2026-02-28T23:59:59.999999"
  ],
  "2026-12-31T23:59:59\u001f3:30pm": null,
  "2026-12-31T23:59:59\u001f3月3日": [
@@ -7047,22 +6966,13 @@
  ],
  "2026-12-31T23:59:59\u001fSELECT * FROM memory_units": null,
  "2026-12-31T23:59:59\u001fTODO": null,
- "2026-12-31T23:59:59\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": [
-  "2000-12-31T00:00:00",
-  "2000-12-31T23:59:59.999999"
- ],
- "2026-12-31T23:59:59\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": [
-  "2000-12-31T00:00:00",
-  "2000-12-31T23:59:59.999999"
- ],
+ "2026-12-31T23:59:59\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": null,
+ "2026-12-31T23:59:59\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": null,
  "2026-12-31T23:59:59\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The migration ran on 2026-06-10 without incident.": [
   "2026-06-10T00:00:00",
   "2026-06-10T23:59:59.999999"
  ],
- "2026-12-31T23:59:59\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": [
-  "2000-12-31T00:00:00",
-  "2000-12-31T23:59:59.999999"
- ],
+ "2026-12-31T23:59:59\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. The user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. ": null,
  "2026-12-31T23:59:59\u001fThe user configured the retain pipeline to use a chunk size of 2000 tokens and enabled delta refresh for mental models. They prefer functional patterns and asked that the reranker stay on the local cross-encoder rather than TEI. This was decided last week during the architecture review.": [
   "2026-12-21T00:00:00",
   "2026-12-27T23:59:59.999999"

--- a/hindsight-api-slim/tests/test_query_analyzer.py
+++ b/hindsight-api-slim/tests/test_query_analyzer.py
@@ -971,23 +971,30 @@ def test_query_analyzer_bare_year_resolves_to_whole_year(query_analyzer, query):
 
 
 @pytest.mark.parametrize(
-    ("query", "reason"),
+    ("query", "expected_start", "expected_end"),
     [
-        ("meeting in room 2019", "the word must introduce the number directly"),
-        ("listening in 8080", "an implausible year is a port someone prepositioned"),
-        ("in 2026-06-10", "an explicit date must not collapse to its year"),
-        ("in june 2019", "month+year is more precise than the year"),
+        # The word has to introduce the number directly, not merely precede it.
+        ("meeting in room 2019", None, None),
+        # An implausible year is a port someone happened to put a preposition on.
+        ("listening in 8080", None, None),
+        # An explicit date must not collapse to its year.
+        ("in 2026-06-10", datetime(2026, 6, 10), datetime(2026, 6, 10)),
+        # Month+year is more precise than the year, and already handled above it.
+        ("in june 2019", datetime(2019, 6, 1), datetime(2019, 6, 30)),
     ],
 )
-def test_query_analyzer_bare_year_rule_does_not_overreach(query_analyzer, query, reason):
+def test_query_analyzer_bare_year_rule_does_not_overreach(query_analyzer, query, expected_start, expected_end):
     """#3250: the year rule must not swallow ports, exact dates or month+year."""
     reference_date = datetime(2026, 8, 7, 12, 0, 0)
 
     analysis = query_analyzer.analyze(query, reference_date)
 
-    whole_2019 = datetime(2019, 1, 1).date()
-    if analysis.temporal_constraint is not None:
-        assert analysis.temporal_constraint.start_date.date() != whole_2019, reason
+    if expected_start is None:
+        assert analysis.temporal_constraint is None
+        return
+    assert analysis.temporal_constraint is not None
+    assert analysis.temporal_constraint.start_date.date() == expected_start.date()
+    assert analysis.temporal_constraint.end_date.date() == expected_end.date()
 
 
 def test_query_analyzer_implausible_bare_year_keeps_a_real_date(query_analyzer):

--- a/hindsight-api-slim/tests/test_query_analyzer.py
+++ b/hindsight-api-slim/tests/test_query_analyzer.py
@@ -941,6 +941,68 @@ def test_query_analyzer_rejects_bare_integer_as_year(query_analyzer, query):
     assert analysis.temporal_constraint is None
 
 
+@pytest.mark.parametrize(
+    "query",
+    [
+        "what happened in 2019",
+        "during 2019",
+        "throughout 2019",
+        "the year 2019",
+        "что было в 2019 году",
+        "qué pasó en 2019",
+        "cosa è successo nel 2019",
+        "was ist im 2019 passiert",
+    ],
+)
+def test_query_analyzer_bare_year_resolves_to_whole_year(query_analyzer, query):
+    """#3250: a year a word disambiguates is temporal, and spans the year.
+
+    dateparser returns the same span for "in 2019" and "port 2019", so the
+    introducing word is the only signal — which is why the rule lives in
+    extract_period, where the whole query is still in hand.
+    """
+    reference_date = datetime(2026, 8, 7, 12, 0, 0)
+
+    analysis = query_analyzer.analyze(query, reference_date)
+
+    assert analysis.temporal_constraint is not None
+    assert analysis.temporal_constraint.start_date.date() == datetime(2019, 1, 1).date()
+    assert analysis.temporal_constraint.end_date.date() == datetime(2019, 12, 31).date()
+
+
+@pytest.mark.parametrize(
+    ("query", "reason"),
+    [
+        ("meeting in room 2019", "the word must introduce the number directly"),
+        ("listening in 8080", "an implausible year is a port someone prepositioned"),
+        ("in 2026-06-10", "an explicit date must not collapse to its year"),
+        ("in june 2019", "month+year is more precise than the year"),
+    ],
+)
+def test_query_analyzer_bare_year_rule_does_not_overreach(query_analyzer, query, reason):
+    """#3250: the year rule must not swallow ports, exact dates or month+year."""
+    reference_date = datetime(2026, 8, 7, 12, 0, 0)
+
+    analysis = query_analyzer.analyze(query, reference_date)
+
+    whole_2019 = datetime(2019, 1, 1).date()
+    if analysis.temporal_constraint is not None:
+        assert analysis.temporal_constraint.start_date.date() != whole_2019, reason
+
+
+def test_query_analyzer_implausible_bare_year_keeps_a_real_date(query_analyzer):
+    """#3250: an implausible year falls through instead of dropping the query.
+
+    Returning NO_TEMPORAL_CONSTRAINT here would lose "last Tuesday" as well.
+    """
+    reference_date = datetime(2026, 8, 7, 12, 0, 0)  # Friday
+
+    analysis = query_analyzer.analyze("listening in 8080 and also last Tuesday", reference_date)
+
+    assert analysis.temporal_constraint is not None
+    assert analysis.temporal_constraint.start_date.date() == datetime(2026, 8, 4).date()
+
+
 def test_query_analyzer_prefers_real_date_over_bare_integer(query_analyzer):
     """#3250: rejection happens during scoring, so a genuine date elsewhere in
     the same query still wins instead of the query going non-temporal."""

--- a/hindsight-api-slim/tests/test_query_analyzer.py
+++ b/hindsight-api-slim/tests/test_query_analyzer.py
@@ -895,6 +895,82 @@ def test_query_analyzer_prefers_explicit_date_over_leading_weak_word(query_analy
     assert analysis.temporal_constraint.start_date.day == 10
 
 
+@pytest.mark.parametrize(
+    "text",
+    ["9077", "9077 and", "the 2019", "in 2019", "2000"],
+)
+def test_date_match_score_rejects_bare_year_integers(text):
+    """#3250: an isolated four-digit integer (port, ticket id, chunk size) is
+    not a date signal, however dateparser resolves it."""
+    from hindsight_api.engine.query_analyzer import _date_match_score
+
+    assert _date_match_score(text) == 0
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["on 2026-06-10", "from 1890-03-05", "year 2019", "on 31 October, 2022", "on the 21st", "at 15:30"],
+)
+def test_date_match_score_keeps_years_with_date_structure(text):
+    """The #3250 rejection is limited to lone integers: a second number, a
+    calendar word or an ordinal all keep the span scoring."""
+    from hindsight_api.engine.query_analyzer import _date_match_score
+
+    assert _date_match_score(text) > 0
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "is hindsight listening on port 9077",
+        "check job 4417 for Castle Pines",
+        "what did PR 2024 change",
+        "buffer size 1024 vs 4096",
+    ],
+)
+def test_query_analyzer_rejects_bare_integer_as_year(query_analyzer, query):
+    """#3250: identifiers must not silently become a temporal constraint.
+
+    Includes an in-range number (``PR 2024``) because a reference-relative
+    plausibility window alone would let that one through.
+    """
+    reference_date = datetime(2026, 8, 7, 12, 0, 0)
+
+    analysis = query_analyzer.analyze(query, reference_date)
+
+    assert analysis.temporal_constraint is None
+
+
+def test_query_analyzer_prefers_real_date_over_bare_integer(query_analyzer):
+    """#3250: rejection happens during scoring, so a genuine date elsewhere in
+    the same query still wins instead of the query going non-temporal."""
+    reference_date = datetime(2026, 8, 7, 12, 0, 0)  # Friday
+
+    analysis = query_analyzer.analyze("port 9077 and also last Tuesday", reference_date)
+
+    assert analysis.temporal_constraint is not None
+    assert analysis.temporal_constraint.start_date.date() == datetime(2026, 8, 4).date()
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("notes from 1890-03-05", datetime(1890, 3, 5)),
+        ("the roadmap milestone on 2050-01-15", datetime(2050, 1, 15)),
+        ("notes from March 1890", datetime(1890, 3, 1)),
+    ],
+)
+def test_query_analyzer_keeps_dates_far_from_reference(query_analyzer, query, expected):
+    """#3250: the rejection keys on span structure, not on how far the year is
+    from the reference date, so distant but explicit dates survive."""
+    reference_date = datetime(2026, 8, 7, 12, 0, 0)
+
+    analysis = query_analyzer.analyze(query, reference_date)
+
+    assert analysis.temporal_constraint is not None
+    assert analysis.temporal_constraint.start_date.date() == expected.date()
+
+
 def test_query_analyzer_keeps_real_month_with_leading_weak_word(query_analyzer):
     """#2768: the real month must survive even when a weak word precedes it in
     the query."""


### PR DESCRIPTION
## Problem

`_date_match_score` awards `+100` — its largest signal — for "any token contains a digit", and dateparser resolves any isolated four-digit integer to a year with month/day taken from the reference date. So a bare integer anywhere in a query outscores every real candidate, wins `max()`, and becomes a single-day constraint in whatever year the integer names:

```
is hindsight listening on port 9077  ->  9077-08-07 .. 9077-08-07
```

The constraint is non-null, so nothing downstream can tell extraction failed. The temporal arm returns zero candidates while still paying its latency. Same class as #2768, which fixed bare *words*.

Closes #3250. Supersedes #3259.

## Fix

Reject the span during scoring when its only date content is a single four-digit integer. A real date always carries more — a second number (`2026-06-10`, `15:30`), a calendar word (`March 1890`, `year 2019`), or an ordinal/unit suffix (`the 21st`, `10am`) — so the predicate is False for all of those.

Rejecting during scoring rather than filtering afterwards is what lets `port 9077 and also last Tuesday` still resolve to last Tuesday.

### Why not the year-plausibility window (#3259)

A reference-relative window catches the numbers in the report but misses everything inside it, and PR/issue/ticket numbers between 1900 and 2046 are as common in developer queries as ports:

| query | year window | this PR |
|---|---|---|
| `is hindsight listening on port 9077` | None | None |
| `check job 4417 for Castle Pines` | None | None |
| `what did PR 2024 change` | **2024-08-07** | None |
| `ticket 2025 status` | **2025-08-07** | None |
| `buffer size 1024 vs 4096` | None | None |
| `port 9077 and also last Tuesday` | 2026-08-04 | 2026-08-04 |

It also needs an English padding-word list (`and`, `at`, `the`, …) to cope with dateparser widening the span — the "moving target" the #2768 comment warns against. Keying on span structure needs no word list and no reference-date arithmetic, so `notes from 1890-03-05` and `on 2050-01-15` survive on their own merits rather than by an exemption.

## `in 2019` resolves to the whole year

A bare year *is* temporal when a word introduces it. dateparser cannot make that
call — it returns the identical span `2019` for `in 2019` and `port 2019` — so
the rule goes in `extract_period`, which already resolves periods to a full
range (`last year`, `june 2019`) and still has the whole query in hand:

| query | before | after |
|---|---|---|
| `what happened in 2019` | `2019-08-07` (one day) | `2019-01-01 .. 2019-12-31` |
| `что было в 2019 году` | `2019-08-07` | `2019-01-01 .. 2019-12-31` |
| `meeting in room 2019` | `2019-08-07` | None |
| `listening in 8080` | `8080-08-07` | None |
| `in 2026-06-10` | `2026-06-10` | `2026-06-10` |
| `in june 2019` | `2019-06-01 .. 2019-06-30` | unchanged |

The whole-year window is one the old path never produced: dateparser filled
month/day from the reference date, so `in 2019` meant the single day
`2019-<today's month/day>`.

Covers `in`/`during`/`throughout`/`year` plus the es/it/fr/de/ru equivalents,
matching the language set of the neighbouring rules. `since`/`from` are
deliberately excluded — they open an interval ending now rather than selecting
the named year, so collapsing them to Jan–Dec would be narrower than asked; they
fall through and return no constraint, as before.

The year must be plausible relative to the reference date, or `listening in 8080`
recreates the empty-arm failure with a preposition in front of it. Implausible
years fall through rather than returning `NO_TEMPORAL_CONSTRAINT`: the sentinel
would also drop a real date elsewhere in the query
(`listening in 8080 and also last Tuesday` still resolves to last Tuesday), and
there is nothing left to guard against downstream now that the fallback rejects
bare integers itself.

## Golden corpus

`tests/data/query_analyzer_golden.json` regenerated — 36 diffs over 4 queries, three of which were recording this bug:

| query | golden | now |
|---|---|---|
| `…chunk size of 2000 tokens…` (18) | year **2000** | None |
| `2024年` (6) | year **0002** at 5 of 6 refs | None |
| `15.01.2024` (6) | `2024-<ref month/day>`, never Jan 15 | None |
| `31 february 2020` (6) | `2020-<ref md>` | `<ref year>-02-<ref d>` |

The last is the only regression, and both values are wrong: `31 february` is not a date, so it splits into two spans and the month span now wins the year.

## Known remaining hole (not this PR)

Multi-number identifiers still score: `ip 192.168.1.1` -> `2026-01-01`. Different class, worth its own issue if it shows up in logs.

## Test

- `uv run pytest tests/test_query_analyzer.py tests/test_temporal_extraction.py` — 588 passed, 6 skipped
- `./scripts/hooks/lint.sh`, `uv run ty check`, `./scripts/hooks/check-unused.sh` — clean
