### PR TITLE
fix(retain): replace the previous version when an oversized re-retain rewrites a chunk

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -14,6 +14,7 @@ import contextvars
 import copy
 import difflib
 import functools
+import hashlib
 import inspect
 import json
 import logging
@@ -5226,6 +5227,22 @@ class MemoryEngine(MemoryEngineInterface):
 
             chunk_offsets: dict[str, int] = {}
 
+            # The content hash of the COMPLETE body each split document is being replaced with —
+            # the same value the retain writes to documents.content_hash. Kept so the tail
+            # truncation after the loop can prove this retain still owns the document before it
+            # deletes anything (a concurrent takeover writes a different hash, and its version
+            # may legitimately have more chunks than ours).
+            split_document_hashes: dict[str, str] = {}
+            for _sub_batch, _override in zip(sub_batches, document_body_overrides):
+                _override_doc_id = document_id or _sub_batch[0].get("document_id")
+                # Append grows a document, so it has no tail to drop — and its stored body is the
+                # prepend, not this override, so the hash below would not be the one written.
+                if _override is None or not _override_doc_id or _sub_batch[0].get("update_mode") == "append":
+                    continue
+                split_document_hashes[_override_doc_id] = hashlib.sha256(
+                    (fact_extraction._sanitize_text(_override) or "").encode()
+                ).hexdigest()
+
             # In update_mode="append", retain_batch prepends the existing document
             # body to the FIRST sub-batch as an extra content item before chunking
             # (see orchestrator.retain_batch), consuming chunks(existing_body)
@@ -5344,6 +5361,13 @@ class MemoryEngine(MemoryEngineInterface):
                 # retain pipeline emits finer-grained "storing N/total chunks" snapshots
                 # via progress_callback as each sub-batch's chunks commit.
 
+            # Every sub-batch has landed, so chunk_offsets now holds each split document's real
+            # chunk count. Drop whatever the previous version left beyond it (see the helper).
+            # Skipped when the run was cancelled part-way: the later slices never wrote, so the
+            # counts describe a document that was only partly replaced.
+            if not cancelled:
+                await self._truncate_replaced_document_tails(bank_id, chunk_offsets, split_document_hashes)
+
             total_time = time.time() - start_time
             logger.info(
                 f"RETAIN_BATCH_ASYNC (chunked) COMPLETE: {len(per_input_results)} results from {len(contents)} contents in {total_time:.3f}s"
@@ -5374,6 +5398,50 @@ class MemoryEngine(MemoryEngineInterface):
             processed_content_tokens=total_processed_content_tokens,
             cancelled=cancelled,
         )
+
+    async def _truncate_replaced_document_tails(
+        self,
+        bank_id: str,
+        chunk_counts: dict[str, int],
+        expected_hashes: dict[str, str],
+    ) -> None:
+        """Delete what a shrinking oversized replacement left past its new last chunk.
+
+        A replacement body over ``retain_batch_tokens`` is delivered as N sequential
+        ``retain_batch`` calls, and only the first carries ``is_first_batch`` — the flag that
+        cascade-deletes the outgoing version. That first slice normally resolves through delta
+        retain, which deletes nothing outside its own slice, so a document re-retained with fewer
+        chunks kept the dropped tail: its facts stayed recallable as part of a document that no
+        longer contains them.
+
+        Runs once, after every sub-batch has committed, because only then is the document's real
+        chunk count known. The document row is locked and its hash compared with the body this
+        retain wrote, so a concurrent takeover's (possibly longer) version is never truncated.
+        """
+        if not chunk_counts:
+            return
+        from .retain import chunk_storage
+
+        backend = await self._get_backend()
+        for document_id, chunk_count in chunk_counts.items():
+            expected_hash = expected_hashes.get(document_id)
+            if expected_hash is None:
+                continue
+            async with acquire_with_retry(backend) as conn:
+                async with conn.transaction():
+                    current_hash = await backend.ops.lock_document_for_write(
+                        conn, fq_table("documents"), document_id, bank_id
+                    )
+                    if current_hash != expected_hash:
+                        continue
+                    removed = await chunk_storage.delete_chunks_from_index(
+                        conn, bank_id, document_id, chunk_count, ops=backend.ops
+                    )
+            if removed:
+                logger.info(
+                    f"[BATCH_RETAIN] bank={bank_id} document={document_id}: dropped {removed} chunk(s) "
+                    f"left beyond the replacement's {chunk_count} chunk(s)"
+                )
 
     async def _retain_batch_async_internal(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/retain/chunk_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/chunk_storage.py
@@ -236,6 +236,40 @@ async def delete_chunks_by_ids(conn, chunk_ids: list[str], bank_id: str | None =
     return invalidated
 
 
+async def delete_chunks_from_index(
+    conn, bank_id: str, document_id: str, first_index: int, *, ops=None, txn=None
+) -> int:
+    """Delete the document's chunks at or beyond ``first_index`` — its previous version's tail.
+
+    A re-retain that SHRINKS a document writes chunk indices ``[0, new_count)`` and leaves
+    everything past them untouched. The whole-document cascade delete normally clears them, but
+    it only runs on the retain's first batch, so an oversized replacement (delivered as N
+    separate ``retain_batch`` calls, only slice 1 of which carries that flag, and which resolves
+    through delta retain that deletes nothing outside its own slice) left the dropped tail —
+    chunks, facts and all — recallable as if it were still part of the document.
+
+    Deletes through :func:`delete_chunks_by_ids`, so the facts, their observations, the entity
+    prune/relink bookkeeping and the store-side memories all go with them. Returns how many
+    chunks were removed.
+    """
+    rows = await conn.fetch(
+        f"""
+        SELECT chunk_id
+        FROM {fq_table("chunks")}
+        WHERE document_id = $1 AND bank_id = $2 AND chunk_index >= $3
+        ORDER BY chunk_index
+        """,
+        document_id,
+        bank_id,
+        first_index,
+    )
+    chunk_ids = [row["chunk_id"] for row in rows]
+    if not chunk_ids:
+        return 0
+    await delete_chunks_by_ids(conn, chunk_ids, bank_id, txn=txn, ops=ops)
+    return len(chunk_ids)
+
+
 async def store_chunks_batch(
     conn,
     bank_id: str,

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -614,6 +614,44 @@ async def _insert_facts_and_links(
     return result_unit_ids
 
 
+async def _supersede_rewritten_chunks(
+    conn,
+    *,
+    bank_id: str,
+    batch_chunk_meta: list,
+    existing_chunk_id_by_index: dict[int, str],
+    txn,
+    ops,
+    log_buffer: list[str],
+) -> None:
+    """Take the outgoing facts of the chunk indices this batch is about to write.
+
+    A chunk_id is ``{bank}_{document}_{index}``, so writing a chunk index REPLACES whatever
+    occupied it. The whole-document cascade delete that normally clears the previous version
+    runs only on the retain's first batch — and an oversized replacement is delivered as N
+    separate ``retain_batch`` calls of which only slice 1 carries ``is_first_batch``, while
+    slice 1 itself usually resolves through delta retain, which deletes nothing outside its own
+    slice. Without this the new facts for a changed chunk land NEXT TO the previous version's:
+    the chunk ends up holding both generations, and each further re-retain adds another.
+
+    Caller must skip this when its own document tracking just cascade-deleted the version —
+    there is nothing left to supersede and the rows read before extraction are already gone.
+    """
+    if not batch_chunk_meta or not existing_chunk_id_by_index:
+        return
+    superseded = [
+        chunk_id for chunk_id in (existing_chunk_id_by_index.get(cm.chunk_index) for cm in batch_chunk_meta) if chunk_id
+    ]
+    if not superseded:
+        return
+    step_start = time.time()
+    invalidated_obs = await chunk_storage.delete_chunks_by_ids(conn, superseded, bank_id, txn=txn, ops=ops)
+    log_buffer.append(
+        f"  Superseded {len(superseded)} previous-version chunk(s) at the indices this batch "
+        f"rewrites, invalidated {invalidated_obs} observation(s) in {time.time() - step_start:.3f}s"
+    )
+
+
 @dataclass
 class _ExtStreamingWriteResult:
     """Outcome of :func:`_streaming_batch_write_ext`."""
@@ -651,6 +689,8 @@ async def _streaming_batch_write_ext(
     is_last: bool,
     doc_tracking_done: list[bool],
     doc_replace_done: list[bool],
+    document_cascade_deleted: list[bool],
+    existing_chunk_id_by_index: dict[int, str],
     pipeline_aborted: list[bool],
     append_base_hash,
     new_content_hash,
@@ -809,6 +849,7 @@ async def _streaming_batch_write_ext(
                             txn=ext_txn,
                         )
                         log_buffer.append(f"[streaming] Document {effective_doc_id} tracked (full content)")
+                        document_cascade_deleted[0] = is_first_batch
                     doc_tracking_done[0] = True
                 else:
                     # Later batches: verify we still own the document.
@@ -830,6 +871,16 @@ async def _streaming_batch_write_ext(
                         return _ExtStreamingWriteResult(aborted=True, batch_result_ids=batch_result_ids)
 
                 _pt["track"] = time.time()
+                if not document_cascade_deleted[0]:
+                    await _supersede_rewritten_chunks(
+                        conn,
+                        bank_id=bank_id,
+                        batch_chunk_meta=batch_chunk_meta,
+                        existing_chunk_id_by_index=existing_chunk_id_by_index,
+                        txn=ext_txn,
+                        ops=pool.ops,
+                        log_buffer=log_buffer,
+                    )
                 # Chunk metadata rows (bulky bodies were already stored before this call).
                 if batch_chunk_meta:
                     await chunk_storage.store_chunks_batch(
@@ -927,6 +978,11 @@ async def _streaming_store_owned_retain(
     make atomic *together*. Document/chunk BODIES were already sent to the store's document store by
     ``_store_document_bodies`` (``owns_document_store``); the small Postgres metadata rows that the
     Protocol-B path still wrote are simply gone.
+
+    With no chunk rows there is also nothing for :func:`_supersede_rewritten_chunks` (the two SQL
+    write paths' per-index replacement) to do here: ``replace_document_id`` below tombstones the
+    document's whole prior version inside the first batch's atomic retain, so a re-retain cannot
+    leave a previous version's facts sitting under a chunk index this one rewrites.
 
     Known gaps, tracked for the follow-on phases:
     * Concurrent same-document ownership/takeover is no longer serialized by a Postgres row lock;
@@ -2151,6 +2207,15 @@ async def _streaming_retain_batch(
     # Memory: sanitized_content is only needed for the hash; free it immediately.
     sanitized_content = ""
     is_recovery = False
+    # Which chunk_id currently occupies each of the document's chunk indices. Loaded whether or
+    # not this is a recovery, because it is also what makes the write below a *positional
+    # replacement*: a batch that re-extracts chunk index i must take the facts of whatever
+    # occupied i before, and only the retain's FIRST batch cascade-deletes the outgoing version.
+    # An oversized replacement arrives as N separate `retain_batch` calls of which only slice 1
+    # carries `is_first_batch` — and slice 1 typically resolves through delta retain, which
+    # deletes nothing outside its own slice. Without this, a changed chunk's new facts land NEXT
+    # TO the previous version's and every re-retain piles on another generation.
+    existing_chunk_id_by_index: dict[int, str] = {}
 
     try:
         async with acquire_with_retry(pool) as conn:
@@ -2159,15 +2224,17 @@ async def _streaming_retain_batch(
                 effective_doc_id,
                 bank_id,
             )
-            if doc_row and doc_row["content_hash"] == new_content_hash:
+            if doc_row:
                 existing_rows = await chunk_storage.load_existing_chunks(conn, bank_id, effective_doc_id)
-                existing_chunk_hashes = {c.content_hash for c in existing_rows if c.content_hash}
-                if existing_chunk_hashes:
-                    is_recovery = True
-                    log_buffer.append(
-                        f"[streaming] RECOVERY: found {len(existing_chunk_hashes)} already-committed chunks — "
-                        f"will skip matching and preserve existing data"
-                    )
+                existing_chunk_id_by_index = {c.chunk_index: c.chunk_id for c in existing_rows}
+                if doc_row["content_hash"] == new_content_hash:
+                    existing_chunk_hashes = {c.content_hash for c in existing_rows if c.content_hash}
+                    if existing_chunk_hashes:
+                        is_recovery = True
+                        log_buffer.append(
+                            f"[streaming] RECOVERY: found {len(existing_chunk_hashes)} already-committed chunks — "
+                            f"will skip matching and preserve existing data"
+                        )
     except Exception:
         pass  # If we can't load, just process all chunks
 
@@ -2220,6 +2287,10 @@ async def _streaming_retain_batch(
     # that latch would let batch 1 replace nothing, latch, and leave the prior version standing
     # beside the new memories for every batch after it.
     doc_replace_done = [False]
+    # ...and whether that tracking cascade-deleted the outgoing version, which only the retain's
+    # first batch does. When it did, the chunk indices below start empty and the per-batch
+    # positional replacement has nothing to supersede.
+    document_cascade_deleted = [False]
     # Track whether the transactional-outbox callback has already fired inside a
     # batch write TXN. The in-TXN fire only runs on a final facts-bearing batch
     # (is_last=True); two success paths never reach it — a committed-chunk count
@@ -2653,6 +2724,8 @@ async def _streaming_retain_batch(
                     is_last=is_last,
                     doc_tracking_done=doc_tracking_done,
                     doc_replace_done=doc_replace_done,
+                    document_cascade_deleted=document_cascade_deleted,
+                    existing_chunk_id_by_index=existing_chunk_id_by_index,
                     pipeline_aborted=pipeline_aborted,
                     append_base_hash=append_base_hash,
                     new_content_hash=new_content_hash,
@@ -2747,6 +2820,9 @@ async def _streaming_retain_batch(
                                 txn=_group_txn,
                             )
                             log_buffer.append(f"[streaming] Document {effective_doc_id} tracked (full content)")
+                            # That call cascade-deleted the whole outgoing version (it only does so
+                            # on the retain's first batch), so nothing is left to replace per chunk.
+                            document_cascade_deleted[0] = is_first_batch
                         doc_tracking_done[0] = True
                         # Memory: combined_content is no longer needed after
                         # this first-batch tracking call. Release it so the
@@ -2778,6 +2854,17 @@ async def _streaming_retain_batch(
                             # Signal the consumer to stop processing further batches
                             pipeline_aborted[0] = True
                             return
+
+                    if not document_cascade_deleted[0]:
+                        await _supersede_rewritten_chunks(
+                            conn,
+                            bank_id=bank_id,
+                            batch_chunk_meta=batch_chunk_meta,
+                            existing_chunk_id_by_index=existing_chunk_id_by_index,
+                            txn=_group_txn,
+                            ops=pool.ops,
+                            log_buffer=log_buffer,
+                        )
 
                     # Store chunks with correct global indices
                     step_start = time.time()
@@ -3332,6 +3419,19 @@ async def _try_delta_retain(
     new_indices = diff.new
     removed_indices = diff.removed
 
+    if document_body_override is not None and removed_indices:
+        # This delta is looking at ONE SLICE of an oversized replacement (only the first slice
+        # runs delta at all), so every stored chunk outside the slice reads as "removed" — they
+        # are the other slices' chunks, not deletions. Tombstoning them here left the rest of the
+        # document to be re-extracted in full, which is exactly the cost the split path exists to
+        # avoid. Chunks the new body genuinely drops are removed once the whole retain has
+        # landed, by the caller's tail truncation, which knows the document's real chunk count.
+        log_buffer.append(
+            f"[delta] Ignoring {len(removed_indices)} stored chunk(s) outside this slice — "
+            f"a slice cannot conclude they were removed from the document"
+        )
+        removed_indices = []
+
     log_buffer.append(
         f"[delta] Chunk diff: {len(unchanged_indices)} unchanged, "
         f"{len(changed_indices)} changed, {len(new_indices)} new, "
@@ -3362,8 +3462,21 @@ async def _try_delta_retain(
                 config=config,
                 expected_content_hash=doc_hash_at_load,
             )
-        logger.info(f"Delta retain: no unchanged chunks for {effective_doc_id}, falling back to full retain")
-        return None
+        if document_body_override is not None and existing_by_index:
+            # A SLICE of an oversized replacement whose own chunks all changed says nothing about
+            # the rest of the document — the stored chunks it cannot see are the other slices'.
+            # Falling back here handed the document to the streaming path with ``is_first_batch``,
+            # which cascade-deletes the ENTIRE outgoing version: the later slices then had nothing
+            # left to skip and a one-chunk edit re-extracted the whole document. Proceeding
+            # instead replaces this slice's chunks and leaves the rest to their own slices, which
+            # supersede their positions as they write (and to the tail truncation once they have).
+            log_buffer.append(
+                "[delta] Every chunk in this slice changed; the rest of the document is other "
+                "slices' to replace — running delta on this slice rather than replacing whole"
+            )
+        else:
+            logger.info(f"Delta retain: no unchanged chunks for {effective_doc_id}, falling back to full retain")
+            return None
 
     chunks_to_process = changed_indices + new_indices
 

--- a/hindsight-api-slim/tests/test_delta_oversized_stale_facts.py
+++ b/hindsight-api-slim/tests/test_delta_oversized_stale_facts.py
@@ -1,0 +1,227 @@
+"""An oversized re-retain must not leave the previous version's facts behind.
+
+Companion to ``test_delta_oversized_replacement.py``, which pins what the split
+path re-*extracts*. This file pins what it *stores*.
+
+A replacement body over ``retain_batch_tokens`` is cut into sub-batches before
+any retain logic runs, and only sub-batch 1 carries ``is_first_batch=True`` —
+the flag that makes ``handle_document_tracking`` cascade-delete the outgoing
+version. Sub-batch 1 takes the delta path (it sees only its own slice); every
+later sub-batch runs in *recovery* mode, because the document row already
+carries the new content hash, and recovery deliberately does NOT delete: it
+calls ``upsert_document_metadata`` and skips the chunks whose hash is already
+committed.
+
+A CHANGED chunk hashes differently, so it is (correctly) re-extracted — but no
+one deleted the facts the previous version left on that same ``chunk_id``, so
+both generations end up stored. Re-editing the same section again piles another
+generation on top.
+"""
+
+from collections import Counter
+from datetime import datetime, timezone
+
+import pytest
+
+from hindsight_api.config import clear_config_cache
+from hindsight_api.engine.memory_engine import count_tokens
+from tests.test_delta_oversized_replacement import _ExtractionSpy
+
+# Each section is just under retain_chunk_size, so the chunker emits a stable
+# chunk per section and only the edited section's chunk changes.
+_SECTION_REPEATS = 117
+_BASE_SECTIONS = 10
+_EDITED_SECTION = 9  # late in the document: several sub-batches in
+_OVERSIZED_BATCH_TOKENS = 300
+_REVISIONS = 3
+
+
+def _section(idx: int, revision: int = 0, *, head_edit: bool = False) -> str:
+    marker = f"MARKER{idx:02d}"
+    head = f"Section {idx:02d} {marker} REVISED." if head_edit else f"Section {idx:02d} {marker}."
+    body = head + " " + f"{marker} filler word here. " * _SECTION_REPEATS
+    return body + f"Tail revision {revision:02d} word."
+
+
+def _body(revision: int) -> str:
+    """The same document every time, except section ``_EDITED_SECTION``'s tail."""
+    return "\n\n".join(_section(i, revision if i == _EDITED_SECTION else 0) for i in range(_BASE_SECTIONS))
+
+
+@pytest.fixture(autouse=True)
+def _fast_retain_env(monkeypatch):
+    monkeypatch.setenv("HINDSIGHT_API_ENABLE_AUTO_CONSOLIDATION", "false")
+    monkeypatch.setenv("HINDSIGHT_API_ENABLE_OBSERVATIONS", "false")
+    clear_config_cache()
+    yield
+    clear_config_cache()
+
+
+async def _retain_revisions(memory, request_context, bank_id: str, document_id: str) -> list[Counter]:
+    """Retain the document once per revision; return each pass's facts-per-chunk histogram."""
+    histograms: list[Counter] = []
+    for revision in range(_REVISIONS):
+        await memory.retain_async(
+            bank_id=bank_id,
+            content=_body(revision),
+            context="notes",
+            document_id=document_id,
+            request_context=request_context,
+        )
+        units = await memory.list_memory_units(
+            bank_id, document_id=document_id, limit=2000, request_context=request_context
+        )
+        histograms.append(Counter(str(u.get("chunk_id", "")).rsplit("_", 1)[-1] for u in units["items"]))
+    return histograms
+
+
+@pytest.mark.asyncio
+async def test_replacement_within_budget_replaces_the_changed_chunks_facts(memory, request_context, monkeypatch):
+    """Control: inside the transport budget, re-editing one section replaces that
+    chunk's facts rather than adding a second copy."""
+    bank_id = f"test_stale_control_{datetime.now(timezone.utc).timestamp()}"
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_BATCH_TOKENS", "100000")  # no splitting
+    clear_config_cache()
+    try:
+        histograms = await _retain_revisions(memory, request_context, bank_id, "doc-stale-control")
+        first = histograms[0]
+        for pass_no, hist in enumerate(histograms):
+            assert sum(hist.values()) == sum(first.values()), (
+                f"pass {pass_no}: total facts moved from {sum(first.values())} to {sum(hist.values())}"
+            )
+            assert max(hist.values()) == max(first.values()), f"pass {pass_no}: a chunk gained facts — {hist}"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_oversized_replacement_does_not_accumulate_stale_facts(memory, request_context, monkeypatch):
+    """Repro: over the transport budget, the edited section's chunk keeps every
+    previous version's facts as well as the new ones."""
+    bank_id = f"test_stale_oversized_{datetime.now(timezone.utc).timestamp()}"
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_BATCH_TOKENS", str(_OVERSIZED_BATCH_TOKENS))
+    clear_config_cache()
+    try:
+        histograms = await _retain_revisions(memory, request_context, bank_id, "doc-stale-oversized")
+        first = histograms[0]
+        per_chunk = max(first.values())
+        for pass_no, hist in enumerate(histograms):
+            worst_chunk, worst_count = hist.most_common(1)[0]
+            assert worst_count == per_chunk, (
+                f"after re-retain #{pass_no}, chunk {worst_chunk} holds {worst_count} facts where a "
+                f"chunk holds {per_chunk} — the previous version's facts for the edited chunk were "
+                f"never deleted (totals per pass: {[sum(h.values()) for h in histograms]})"
+            )
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_oversized_replacement_extracts_a_late_edit(memory, request_context, monkeypatch):
+    """The skip is keyed on the chunk hash, so an edit landing in a LATE sub-batch
+    still reaches extraction — recovery only skips chunks that are byte-identical
+    to an already-committed one."""
+    bank_id = f"test_stale_late_edit_{datetime.now(timezone.utc).timestamp()}"
+    document_id = "doc-stale-late-edit"
+    try:
+        await memory.retain_async(
+            bank_id=bank_id,
+            content=_body(0),
+            context="notes",
+            document_id=document_id,
+            request_context=request_context,
+        )
+        monkeypatch.setenv("HINDSIGHT_API_RETAIN_BATCH_TOKENS", str(_OVERSIZED_BATCH_TOKENS))
+        clear_config_cache()
+        spy = _ExtractionSpy()
+        spy.install(monkeypatch)
+        await memory.retain_async(
+            bank_id=bank_id,
+            content=_body(1),
+            context="notes",
+            document_id=document_id,
+            request_context=request_context,
+        )
+        assert "Tail revision 01" in "\n".join(spy.texts), (
+            "the edited tail of a late sub-batch never reached fact extraction"
+        )
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_oversized_replacement_drops_the_removed_tail(memory, request_context, monkeypatch):
+    """A shrinking oversized replacement must not leave the dropped sections behind.
+
+    Only the retain's first sub-batch cascade-deletes the outgoing version, and it resolves
+    through delta retain, which touches nothing outside its own slice — so the chunks past the
+    new document's end were never deleted and their facts stayed recallable.
+    """
+    bank_id = f"test_stale_shrink_{datetime.now(timezone.utc).timestamp()}"
+    document_id = "doc-stale-shrink"
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_BATCH_TOKENS", str(_OVERSIZED_BATCH_TOKENS))
+    clear_config_cache()
+    try:
+        await memory.retain_async(
+            bank_id=bank_id,
+            content="\n\n".join(_section(i) for i in range(_BASE_SECTIONS)),
+            context="notes",
+            document_id=document_id,
+            request_context=request_context,
+        )
+        kept = 6
+        await memory.retain_async(
+            bank_id=bank_id,
+            content="\n\n".join(_section(i) for i in range(kept)),
+            context="notes",
+            document_id=document_id,
+            request_context=request_context,
+        )
+        units = await memory.list_memory_units(
+            bank_id, document_id=document_id, limit=2000, request_context=request_context
+        )
+        stored = "\n".join(str(u) for u in units["items"])
+        survivors = [f"MARKER{i:02d}" for i in range(kept, _BASE_SECTIONS) if f"MARKER{i:02d}" in stored]
+        assert survivors == [], f"sections {survivors} were removed from the document but their facts are still stored"
+        assert f"MARKER{kept - 1:02d}" in stored, "the sections that survived the edit lost their facts"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_oversized_first_chunk_edit_keeps_the_rest_of_the_document(memory, request_context, monkeypatch):
+    """Editing the FIRST chunk must not cost a full re-extraction.
+
+    Delta retain runs on sub-batch 1 only and sees only that slice, so every stored chunk after
+    it looked "removed": tombstoning them left the following sub-batches nothing to skip and the
+    whole document went back through the LLM.
+    """
+    bank_id = f"test_stale_head_{datetime.now(timezone.utc).timestamp()}"
+    document_id = "doc-stale-head"
+    v1 = "\n\n".join(_section(i) for i in range(_BASE_SECTIONS))
+    try:
+        await memory.retain_async(
+            bank_id=bank_id,
+            content=v1,
+            context="notes",
+            document_id=document_id,
+            request_context=request_context,
+        )
+        monkeypatch.setenv("HINDSIGHT_API_RETAIN_BATCH_TOKENS", str(_OVERSIZED_BATCH_TOKENS))
+        clear_config_cache()
+        spy = _ExtractionSpy()
+        spy.install(monkeypatch)
+        await memory.retain_async(
+            bank_id=bank_id,
+            content="\n\n".join(_section(i, head_edit=(i == 0)) for i in range(_BASE_SECTIONS)),
+            context="notes",
+            document_id=document_id,
+            request_context=request_context,
+        )
+        re_extracted = [f"MARKER{i:02d}" for i in range(1, _BASE_SECTIONS) if f"MARKER{i:02d}" in "\n".join(spy.texts)]
+        assert re_extracted == [], (
+            f"editing the first chunk re-extracted {re_extracted} — {sum(count_tokens(t) for t in spy.texts):,} "
+            f"tokens for a one-chunk edit of a {count_tokens(v1):,}-token document"
+        )
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_retain_ext_writegroup.py
+++ b/hindsight-api-slim/tests/test_retain_ext_writegroup.py
@@ -172,6 +172,10 @@ def _kwargs(tracker, provider, er, *, doc_tracking_done, existing_hash, new_hash
         # batch), while this says the document's prior version was actually replaced. These tests
         # drive one batch at a time, so a fresh latch per call is what they want.
         doc_replace_done=[False],
+        # No chunk rows survive from a previous version here, so the positional replacement the
+        # write path runs before storing its chunks has nothing to supersede.
+        document_cascade_deleted=[False],
+        existing_chunk_id_by_index={},
         pipeline_aborted=[False],
         append_base_hash=None,
         new_content_hash=new_hash,


### PR DESCRIPTION
## The problem

A replacement body over `retain_batch_tokens` is sliced into sub-batches before any retain logic
runs, and each slice is its own `retain_batch` call. Only slice 1 carries `is_first_batch` — the
flag that makes document tracking cascade-delete the outgoing version — and slice 1 normally
resolves through delta retain, which deletes nothing outside its own slice.

So for an oversized re-retain, **nothing ever removed the previous version's facts for the chunks
the later slices rewrote.** Measured on a 10-section document (20 chunks, 10 facts each):

| | before | after |
|---|---|---|
| Edit one section, re-retain 4x | 200 → 210 → 220 → 230 units; the edited chunk holds 10 → 20 → 30 → 40 facts | stays 200, edited chunk stays at 10 |
| Re-retain 10 sections as 6 | 200 units, all 20 chunk indices populated, sections 7-10 still recallable | the dropped tail is gone |
| Edit the *first* chunk | 8,322 tokens through the LLM for a one-chunk edit of an 8,320-token document | only the edited chunk |

The first two are correctness: recall returns facts from a version of the document that no longer
exists, and it compounds with every re-ingest. The third is cost — exactly the cost the split path
exists to avoid.

The same document inside `retain_batch_tokens` (the plain delta path) was correct throughout, which
is what made this invisible: it only shows up once transport splits the body.

## The fix

`is_first_batch` keeps meaning what it did for the document row and its content hash. What changes
is that replacement becomes **positional** where the whole-document cascade cannot reach:

* **`_supersede_rewritten_chunks`** (`retain/orchestrator.py`) — a `chunk_id` is
  `{bank}_{document}_{index}`, so writing an index replaces its occupant. Before storing its chunk
  rows, a batch now takes the outgoing facts at those indices — with the observations, entity-prune
  and relink bookkeeping `delete_chunks_by_ids` already does for delta. Skipped when that batch's
  own tracking just cascade-deleted the version. Called from both SQL write paths (Postgres and
  Protocol-B); a store-owned bank has no chunk rows and replaces the document wholesale on its
  first batch, so it needs nothing — noted in `_streaming_store_owned_retain`'s docstring.
* **`MemoryEngine._truncate_replaced_document_tails`** + `chunk_storage.delete_chunks_from_index` —
  drops whatever sits past the new last chunk, once every sub-batch has landed and the document's
  real chunk count is known. Takes the document row lock and only acts while the stored hash is
  still the body this retain wrote, so a concurrent takeover's (possibly longer) version is never
  truncated; skipped when the run was cancelled part-way.
* **Delta retain stops drawing document-wide conclusions from one slice** — stored chunks outside
  the slice are no longer counted as "removed" (they are the other slices'), and a slice whose own
  chunks have all changed now runs delta on itself instead of falling back to the streaming path,
  whose `is_first_batch` cascade wiped the version the other slices were about to skip.

## Tests

`tests/test_delta_oversized_stale_facts.py` — five tests, three of which fail on `main`:

* no stale-fact accumulation across repeated edits of an oversized document
* the removed tail of a shrinking oversized replacement is deleted
* a first-chunk edit no longer re-extracts the rest of the document
* control: the same edit within the transport budget replaces rather than accumulates
* an edit landing in a *late* sub-batch still reaches extraction (the skip is keyed on the chunk
  hash, so a changed chunk is never skipped — pinning that the fix does not overshoot)

`tests/test_retain_ext_writegroup.py` calls `_streaming_batch_write_ext` directly and gains the two
new arguments.

## Verification

* Full `hindsight-api-slim` suite: 6,167 passed. The 29 failures / 21 errors are pre-existing and
  environmental — LLM-provider, tracing, S3 and real-LLM tests, migration tests that need their own
  pg0 instance, plus a handful of parallel-unsafe tests; every retain/delta one of them passes when
  re-run on this branch.
* Targeted run of every retain / delta / chunk / document / append / observation test file: 506
  passed.
* `./scripts/hooks/lint.sh` and `uv run ty check hindsight_api/` clean; `check-unused.sh` reports
  nothing new.
