### PR TITLE
fix(webhooks): omit Content-Type and signature on GET deliveries

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -3384,13 +3384,23 @@ class MemoryEngine(MemoryEngineInterface):
         else:
             payload_bytes = str(raw_payload).encode()
 
-        headers: dict[str, str] = {
-            "Content-Type": "application/json",
-            "X-Hindsight-Event": event_type,
-            **http_config.headers,
-        }
-        if secret and self._webhook_manager:
-            headers["X-Hindsight-Signature"] = self._webhook_manager._sign_payload(secret, payload_bytes)
+        is_get = http_config.method.upper() == "GET"
+        if is_get:
+            # GET has no body, so Content-Type and X-Hindsight-Signature are
+            # meaningless (the signature would be over bytes the receiver never
+            # gets). Send only the event header plus any caller-supplied headers.
+            headers: dict[str, str] = {
+                "X-Hindsight-Event": event_type,
+                **http_config.headers,
+            }
+        else:
+            headers = {
+                "Content-Type": "application/json",
+                "X-Hindsight-Event": event_type,
+                **http_config.headers,
+            }
+            if secret and self._webhook_manager:
+                headers["X-Hindsight-Signature"] = self._webhook_manager._sign_payload(secret, payload_bytes)
 
         if self._http_client is None:
             raise RuntimeError("HTTP client not initialized")
@@ -3402,7 +3412,7 @@ class MemoryEngine(MemoryEngineInterface):
                 "params": http_config.params if http_config.params else None,
                 "timeout": http_config.timeout_seconds,
             }
-            if http_config.method.upper() == "GET":
+            if is_get:
                 response = await self._http_client.get(url, **request_kwargs)
             else:
                 response = await self._http_client.post(url, content=payload_bytes, **request_kwargs)

--- a/hindsight-api-slim/tests/test_webhooks.py
+++ b/hindsight-api-slim/tests/test_webhooks.py
@@ -1920,3 +1920,105 @@ def test_memory_defense_hit_rejects_missing_preview() -> None:
         MemoryDefenseHit(detector="GitHub Token")  # type: ignore[call-arg]
     with pytest.raises(Exception):
         MemoryDefenseHit(preview="ghp_AAAA...BBBB")  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# Honest-GET header tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetWebhookHeaders:
+    """GET deliveries must not send Content-Type or X-Hindsight-Signature.
+
+    A GET request has no body, so the HMAC signature is computed over bytes
+    the receiver never sees, and Content-Type: application/json is equally
+    misleading. Both headers are suppressed for GET; POST keeps them.
+    """
+
+    def _make_get_task(self, secret: str | None = "s3cr3t") -> dict:
+        return {
+            "type": "webhook_delivery",
+            "bank_id": "bank-1",
+            "url": "https://example.com/hook",
+            "secret": secret,
+            "event_type": "consolidation.completed",
+            "payload": '{"event":"consolidation.completed"}',
+            "webhook_id": None,
+            "_retry_count": 0,
+            "http_config": {"method": "GET", "timeout_seconds": 30, "headers": {}, "params": {}},
+        }
+
+    def _make_post_task(self, secret: str | None = "s3cr3t") -> dict:
+        return {
+            "type": "webhook_delivery",
+            "bank_id": "bank-1",
+            "url": "https://example.com/hook",
+            "secret": secret,
+            "event_type": "consolidation.completed",
+            "payload": '{"event":"consolidation.completed"}',
+            "webhook_id": None,
+            "_retry_count": 0,
+            "http_config": {"method": "POST", "timeout_seconds": 30, "headers": {}, "params": {}},
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_omits_content_type_and_signature(self, memory: MemoryEngine) -> None:
+        """GET delivery must not include Content-Type or X-Hindsight-Signature."""
+        captured: dict = {}
+
+        async def fake_get(url: str, **kwargs: object) -> object:
+            captured.update(kwargs)
+            mock = MagicMock()
+            mock.raise_for_status = MagicMock()
+            mock.status_code = 200
+            mock.text = ""
+            return mock
+
+        with patch.object(memory._http_client, "get", side_effect=fake_get):
+            await memory._handle_webhook_delivery(self._make_get_task())
+
+        sent_headers: dict[str, str] = captured.get("headers", {})
+        assert "Content-Type" not in sent_headers, "GET must not send Content-Type"
+        assert "X-Hindsight-Signature" not in sent_headers, "GET must not send X-Hindsight-Signature"
+        assert sent_headers.get("X-Hindsight-Event") == "consolidation.completed"
+
+    @pytest.mark.asyncio
+    async def test_get_without_secret_also_omits_signature(self, memory: MemoryEngine) -> None:
+        """Even with no secret configured, GET must not send signature or Content-Type."""
+        captured: dict = {}
+
+        async def fake_get(url: str, **kwargs: object) -> object:
+            captured.update(kwargs)
+            mock = MagicMock()
+            mock.raise_for_status = MagicMock()
+            mock.status_code = 200
+            mock.text = ""
+            return mock
+
+        with patch.object(memory._http_client, "get", side_effect=fake_get):
+            await memory._handle_webhook_delivery(self._make_get_task(secret=None))
+
+        sent_headers: dict[str, str] = captured.get("headers", {})
+        assert "Content-Type" not in sent_headers
+        assert "X-Hindsight-Signature" not in sent_headers
+
+    @pytest.mark.asyncio
+    async def test_post_still_includes_content_type_and_signature(self, memory: MemoryEngine) -> None:
+        """POST delivery must still send Content-Type and X-Hindsight-Signature."""
+        captured: dict = {}
+
+        async def fake_post(url: str, **kwargs: object) -> object:
+            captured.update(kwargs)
+            mock = MagicMock()
+            mock.raise_for_status = MagicMock()
+            mock.status_code = 200
+            mock.text = ""
+            return mock
+
+        with patch.object(memory._http_client, "post", side_effect=fake_post):
+            await memory._handle_webhook_delivery(self._make_post_task())
+
+        sent_headers: dict[str, str] = captured.get("headers", {})
+        assert sent_headers.get("Content-Type") == "application/json"
+        assert "X-Hindsight-Signature" in sent_headers
+        assert sent_headers["X-Hindsight-Signature"].startswith("sha256=")


### PR DESCRIPTION
## Context & Relationship to #3368

In #3368, we identified that GET webhook deliveries compute `X-Hindsight-Signature` and set `Content-Type: application/json` over the serialized event payload, but dispatched the request without a body via `.get()`, leaving receivers with an empty body and an unverifiable signature.

#3368 was closed to avoid the breaking changes and network interoperability issues associated with adding request bodies to GET requests (e.g., intermediary proxies/gateways stripping bodies or servers rejecting GET requests with `Content-Length`, per RFC 9110 §9.3.1).

As suggested in the [review on #3368](https://github.com/vectorize-io/hindsight/pull/3368#issuecomment-5353617125) (Option 1), this PR makes GET deliveries honest:
- Since GET requests carry no body, we do not send `Content-Type: application/json` or `X-Hindsight-Signature`.
- GET requests continue to send `X-Hindsight-Event` and any caller-configured `http_config.headers`.
- POST delivery semantics and signature generation remain completely untouched.

## Changes
- `hindsight_api/engine/memory_engine.py`: Conditionally assemble headers based on whether `http_config.method` is `GET` or `POST`.
- `tests/test_webhooks.py`: Add `TestGetWebhookHeaders` test class covering:
  - GET delivery omits `Content-Type` and `X-Hindsight-Signature` while preserving `X-Hindsight-Event`.
  - GET delivery without secret also omits both headers.
  - POST delivery continues to send `Content-Type: application/json` and a valid HMAC signature.

## Verification
- Ran webhook delivery and header tests in `tests/test_webhooks.py`: all passed.
- Ran `./scripts/hooks/lint.sh` (`ruff check`, `ruff format`, vulture, knip): all passed cleanly.