### PR TITLE
fix(tests): unbreak main — post-#3649 batch stubs and a leaked tracing global

### DIFF
--- a/hindsight-api-slim/tests/test_causal_relation_offsets.py
+++ b/hindsight-api-slim/tests/test_causal_relation_offsets.py
@@ -116,6 +116,8 @@ async def test_batch_causal_targets_use_each_chunk_start(monkeypatch):
     ]
 
     class Provider:
+        provider = "test"
+
         async def supports_batch_api(self):
             return True
 
@@ -154,7 +156,15 @@ async def test_batch_causal_targets_use_each_chunk_start(monkeypatch):
         retain_structured_chunk_size=100,
         retain_batch_poll_interval_seconds=0,
     )
-    llm_config = SimpleNamespace(_provider_impl=Provider(), provider="test")
+    # The batch lifecycle targets the impl `batch_provider_impl()` resolves — for a
+    # multi-LLM chain the first batch-capable member, not necessarily the primary
+    # (#3649). Stubbing `_provider_impl` instead would model the pre-#3649 shape.
+    batch_impl = Provider()
+
+    async def _batch_provider_impl():
+        return batch_impl
+
+    llm_config = SimpleNamespace(batch_provider_impl=_batch_provider_impl, provider="test")
     facts, _, _ = await fact_extraction.extract_facts_from_contents_batch_api(
         [RetainContent(content="preceding"), RetainContent(content="first|second")],
         llm_config=llm_config,

--- a/hindsight-api-slim/tests/test_llm_strict_schema.py
+++ b/hindsight-api-slim/tests/test_llm_strict_schema.py
@@ -270,7 +270,10 @@ def test_batch_request_body_strict_follows_retain_config(strict):
     """
     from hindsight_api.engine.retain.fact_extraction import _build_request_body
 
-    llm_config = SimpleNamespace(model="gpt-4o-mini", provider="openai", _provider_impl=SimpleNamespace())
+    # The batch impl that serves the batch — since #3649 this is what
+    # _build_request_body reads model/provider/service tier off, rather than the
+    # wrapper, so that they match the account the batch is submitted to.
+    batch_impl = SimpleNamespace(model="gpt-4o-mini", provider="openai", openai_service_tier=None)
     config = SimpleNamespace(
         retain_max_completion_tokens=None,
         # Global deliberately set opposite to the retain override: if the batch path
@@ -279,10 +282,8 @@ def test_batch_request_body_strict_follows_retain_config(strict):
         llm_strict_schema_retain=strict,
         llm_temperature_retain=None,
     )
-    # provider != "openai" service-tier branch skipped via _provider_impl without attr
-    llm_config._provider_impl.openai_service_tier = None
 
-    body = _build_request_body(llm_config, config, "system prompt", "user message", _Resp)
+    body = _build_request_body(batch_impl, config, "system prompt", "user message", _Resp)
     assert body["response_format"]["json_schema"]["strict"] is strict
 
 

--- a/hindsight-api-slim/tests/test_reflect_tracing.py
+++ b/hindsight-api-slim/tests/test_reflect_tracing.py
@@ -9,7 +9,7 @@ import pytest
 async def test_reflect_creates_child_spans(memory, request_context):
     """Test that reflect operation creates child LLM spans."""
     from datetime import datetime, timezone
-    from hindsight_api.tracing import initialize_tracing, get_span_recorder, create_span_recorder
+    from hindsight_api.tracing import initialize_tracing, get_span_recorder, create_span_recorder, shutdown_tracing
 
     # Initialize tracing with a mock endpoint
     initialize_tracing(service_name="test-hindsight", endpoint="http://localhost:4318", deployment_environment="test")
@@ -40,3 +40,9 @@ async def test_reflect_creates_child_spans(memory, request_context):
 
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)
+        # initialize_tracing flips process-global state, so leaving it on leaks
+        # into every later test in this xdist worker: test_tracing's
+        # `is_tracing_enabled() is False` assertions then fail, depending purely
+        # on how xdist happened to distribute the files. Same shape as the
+        # leaked-span-recorder fail-safe in conftest (#2229).
+        shutdown_tracing()


### PR DESCRIPTION
## Summary

`main` is red on two independent test-only defects. Neither is a product bug; both are stale/leaky test state. Test files only — no product code changes.

## 1. Batch-retain stubs left behind by #3649

```
FAILED tests/test_causal_relation_offsets.py::test_batch_causal_targets_use_each_chunk_start
  - AttributeError: 'types.SimpleNamespace' object has no attribute 'batch_provider_impl'
FAILED tests/test_llm_strict_schema.py::test_batch_request_body_strict_follows_retain_config[True]
FAILED tests/test_llm_strict_schema.py::test_batch_request_body_strict_follows_retain_config[False]
  - AttributeError: 'types.SimpleNamespace' object has no attribute 'openai_service_tier'
```

#3649 routed batch retain through the first *batch-capable* member of a multi-LLM chain rather than the primary. Two shapes changed:

- `extract_facts_from_contents_batch_api` resolves the impl once via `await llm_config.batch_provider_impl()` and runs the whole submit → poll → retrieve lifecycle against it, instead of reaching into `llm_config._provider_impl`.
- `_build_request_body`'s first parameter became that batch impl, so `model` / `provider` / `openai_service_tier` come from the account the batch is actually submitted to.

Two hand-built `SimpleNamespace` stubs still modelled the pre-#3649 shape: `test_causal_relation_offsets` stubbed `_provider_impl` (nothing reads it any more), and `test_llm_strict_schema` hung `openai_service_tier` off a nested `_provider_impl` while the code reads it off the top-level impl. Both now model the impl the code actually calls.

The sibling stub in `test_fact_extraction_retry._make_batch_llm_config` survived the same refactor because it is a `MagicMock(spec=LLMProvider)`. A bare `SimpleNamespace` accepts any shape and only fails at attribute-read time, which is why this drift reached `main` instead of failing in #3649's own CI.

## 2. `test_reflect_tracing` leaks enabled tracing into the rest of its xdist worker

```
FAILED tests/test_tracing.py::test_initialize_tracing_from_config_disabled - assert True is False
FAILED tests/test_tracing.py::test_initialize_tracing_from_config_never_raises - assert True is False
FAILED tests/test_tracing.py::test_initialize_tracing_from_config_without_endpoint_warns
```

`initialize_tracing` flips process-global state (`_tracing_enabled`, `_provider`, `_span_recorder`). `test_reflect_creates_child_spans` calls it and never turns it back off, so every later test in the same worker runs with tracing enabled and `test_tracing`'s `is_tracing_enabled() is False` assertions fail. Whether that happens depends purely on how xdist distributes the files, which is why it presents as an intermittent shard failure — `test-api (3/3)` was green on one run of this branch and red on the next two.

Deterministic repro before the fix:

```
pytest tests/test_reflect_tracing.py tests/test_tracing.py -n 0
-> 3 failed
```

This is very likely also behind `test_llm_trace::test_disabled_writes_no_rows - assert 4 == 0` on main's own last run — the same leak, one layer down. `conftest` already carries a fail-safe for the leaked *span recorder* half of this (#2229); this is the tracing-globals half.

## Validation

- `./scripts/hooks/lint.sh`
- `pytest tests/test_llm_strict_schema.py tests/test_causal_relation_offsets.py tests/test_fact_extraction_retry.py tests/test_batch_api_validation.py tests/test_experience_fact_type_passthrough.py -q` — 66 passed (was 3 failed)
- `pytest tests/test_reflect_tracing.py tests/test_tracing.py tests/test_llm_trace.py -q -n 0` — 62 passed (was 3 failed)

I checked the rest of both surfaces for the same drift: `test_batch_api_validation` and `test_experience_fact_type_passthrough` were already updated in #3649 and `test_fact_extraction_retry` is spec'd; `test_tracing_integration` and `test_tracing_spans_verification` never call `initialize_tracing`, so `test_reflect_tracing` was the only leaker.

**Worth considering as a follow-up:** an autouse conftest fixture that restores the tracing globals after every test, mirroring `_cleanup_leaked_span_recorders`. That would stop the next leaker rather than the current one. Left out here to keep this to unbreaking `main`.
