### PR TITLE
store-owned: finish Protocol-B removal (PG-free zero-batch tracking)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -1395,8 +1395,19 @@ async def _run_consolidation_job(
             # they are durable-but-invisible in the external store while this batch runs its LLM work. The
             # witness row + decide happen in ONE short transaction at the end (below) — we must not
             # hold a Postgres transaction across the LLM calls in the sub-batch loop.
+            #
+            # A store that owns the whole retain (store_owned_retain) keeps ALL of this batch's memory
+            # writes — observation upserts/deletes and the mark_consolidated stamps — in ITS store, not
+            # Postgres, so there is nothing to make atomic with a Postgres witness. Skip the write-group
+            # entirely (``_batch_txn = None`` → the writes below are plain, immediately-visible writes).
+            # This is also why consolidation was the source of the undecided write-group txns that stall
+            # the store's indexer: mint-early / witness-late meant a crash or a sibling-cancel between
+            # mint and decide left a pending txn with no witness. With no txn there is nothing to leave
+            # undecided. The mental-model refresh-tag bookkeeping below becomes a plain Postgres write
+            # (best-effort rather than atomic-with-the-batch — a missed tag only defers a refresh).
             _txn_provider = get_memories()
-            _batch_txn = await _txn_provider.mint_txn(bank_id=bank_id, mutating=True)
+            _store_owned = _txn_provider.store_owned_retain_for(bank_id)
+            _batch_txn = None if _store_owned else await _txn_provider.mint_txn(bank_id=bank_id, mutating=True)
 
             try:
                 pending: list[list[dict[str, Any]]] = [llm_batch_local]
@@ -1511,11 +1522,13 @@ async def _run_consolidation_job(
                             txn=_batch_txn,
                         )
                     async with conn.transaction():
-                        await _txn_provider.write_txn_witness(_batch_txn, conn=conn, fq_table=fq_table)
+                        if _batch_txn is not None:
+                            await _txn_provider.write_txn_witness(_batch_txn, conn=conn, fq_table=fq_table)
                         # Persist this batch's mental-model refresh tags atomically with the
                         # witness, so they share the batch's fate: durable iff the batch is
                         # (#3411). Only the succeeded source facts — the ones just marked
-                        # consolidated — contribute a tag.
+                        # consolidated — contribute a tag. (Store-owned: no witness, so this is a
+                        # plain best-effort write; a missed tag only defers a mental-model refresh.)
                         if operation_id and succeeded_ids:
                             succeeded_set = {str(mem_id) for mem_id in succeeded_ids}
                             batch_tags = sorted(
@@ -1535,18 +1548,23 @@ async def _run_consolidation_job(
                 # task mid-batch instead of letting it run to completion. Kept OUTSIDE the
                 # decide(commit=True) below on purpose: once the witness has committed, the
                 # batch's fate is decided and an abort here would discard durable writes.
-                try:
-                    await _txn_provider.decide_txn(_batch_txn, commit=False)
-                except Exception:
-                    logger.warning(
-                        f"[CONSOLIDATION] bank={bank_id} failed to abort write-group for"
-                        f" llm_batch #{batch_num_local}; recovery sweep will resolve it",
-                        exc_info=True,
-                    )
+                # Store-owned batches hold no write-group (writes were plain and are already
+                # durable/visible); there is nothing to abort — consolidation is idempotent on retry.
+                if _batch_txn is not None:
+                    try:
+                        await _txn_provider.decide_txn(_batch_txn, commit=False)
+                    except Exception:
+                        logger.warning(
+                            f"[CONSOLIDATION] bank={bank_id} failed to abort write-group for"
+                            f" llm_batch #{batch_num_local}; recovery sweep will resolve it",
+                            exc_info=True,
+                        )
                 raise
             # Postgres committed the witness: publish the batch's write-group. On a crash before
-            # here the writes stay invisible and the recovery sweep resolves them (spec §5).
-            await _txn_provider.decide_txn(_batch_txn, commit=True)
+            # here the writes stay invisible and the recovery sweep resolves them (spec §5). No-op for
+            # a store-owned batch (no write-group; its writes were already visible).
+            if _batch_txn is not None:
+                await _txn_provider.decide_txn(_batch_txn, commit=True)
 
             cancelled_local = False
             if operation_id and not await memory_engine._check_op_alive(operation_id):

--- a/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
+++ b/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
@@ -1246,6 +1246,7 @@ class EntityResolver:
         self,
         unit_entity_pairs: list[tuple[str, str]] | list[tuple[str, str, datetime | None]],
         bank_id: str | None = None,
+        store_write: bool = True,
     ):
         """Store-owned variant of :meth:`link_units_to_entities_batch` that touches NO
         Postgres connection.
@@ -1257,6 +1258,13 @@ class EntityResolver:
         its connection-free store phase and never hold the data-plane connection across the
         object-store write. NOT for the Postgres store, whose posting is a real ``unit_entities``
         INSERT that requires the connection.
+
+        ``store_write=False`` skips the store-side posting and does ONLY the co-occurrence
+        accumulation. The caller uses this when it has already attached entity ids to the memories
+        as part of the same write (a single deferred write with entities inline, instead of
+        write-then-reattach) — so the store row is already correct and a second store write would
+        be redundant. Co-occurrence still runs: it references only ``entities`` and is needed by the
+        entity-graph endpoint and resolution's disambiguation signal regardless of who wrote the row.
         """
         if not unit_entity_pairs:
             return
@@ -1265,10 +1273,16 @@ class EntityResolver:
             (t[0], t[1], t[2] if len(t) >= 3 else None)  # type: ignore[misc]
             for t in unit_entity_pairs
         ]
-        return await self._link_units_to_entities_batch_impl(None, normalized, bank_id)
+        return await self._link_units_to_entities_batch_impl(
+            None, normalized, bank_id, store_write=store_write
+        )
 
     async def _link_units_to_entities_batch_impl(
-        self, conn, unit_entity_pairs: list[tuple[str, str, datetime | None]], bank_id: str | None = None
+        self,
+        conn,
+        unit_entity_pairs: list[tuple[str, str, datetime | None]],
+        bank_id: str | None = None,
+        store_write: bool = True,
     ):
         # Sorted bulk insert to prevent deadlocks from inconsistent lock ordering
         # across concurrent transactions on the unit_entities unique index.
@@ -1280,16 +1294,19 @@ class EntityResolver:
         # memories store records it. Co-occurrence below is separate and unaffected:
         # it references only `entities`, which stays in Postgres either way, and is
         # read by the entity-graph endpoint and by resolution's disambiguation signal.
+        # `store_write=False` means the caller already wrote the postings inline with the
+        # memories, so we skip the (redundant) second store write and keep only co-occurrence.
         from .memories import get_memories
 
-        await get_memories().record_unit_entities(
-            conn=conn,
-            ops=self._ops,
-            fq_table=fq_table,
-            bank_id=bank_id,
-            unit_ids=unit_ids,
-            entity_ids=entity_ids,
-        )
+        if store_write:
+            await get_memories().record_unit_entities(
+                conn=conn,
+                ops=self._ops,
+                fq_table=fq_table,
+                bank_id=bank_id,
+                unit_ids=unit_ids,
+                entity_ids=entity_ids,
+            )
 
         # Build maps keyed by unit_id:
         #   unit_to_entities: entity set per unit (for the co-occurrence cross-product)

--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -1174,6 +1174,7 @@ class MemoriesExtension(Extension, ABC):
         event_date,
         mentioned_at,
         entity_ids: list[str] | None,
+        entity_names: list[str] | None = None,
         txn=None,
     ) -> None:
         """Apply a curation field edit to a live memory.
@@ -1184,10 +1185,20 @@ class MemoriesExtension(Extension, ABC):
         embedding is *not* written here — the caller re-embeds from the new fields
         and calls :meth:`set_memory_embedding` after.
 
-        ``entity_ids`` is the resolved entity set the memory should now carry; a
-        store that keeps them on the memory writes them here, one that keeps them
-        in a join table has already re-linked them and ignores this. ``None`` means
-        the entity set was not part of this edit.
+        The new entity set for the memory is supplied one of two ways, and a store
+        uses whichever fits how it keeps its registry:
+
+        * ``entity_names`` — the raw names the edit resolved to. A store that owns
+          its entity registry resolves + mints these against its OWN registry
+          (exactly as its :meth:`retain` does) and rewrites the memory's entity
+          ids from the result, so a brand-new entity created by an edit lands in
+          that registry. When it is not ``None`` it is the authoritative set and
+          ``entity_ids`` is ignored.
+        * ``entity_ids`` — the already-resolved set, for a store whose registry is
+          the host's SQL (the host minted them and, for a join-table store, has
+          already re-linked them, so it ignores this).
+
+        Both ``None`` means the entity set was not part of this edit.
         """
         raise NotImplementedError
 

--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -453,6 +453,21 @@ class MemoriesExtension(Extension, ABC):
     #: the inline SQL. Cold, never-searched, key-based — see docs/documents-chunks.md.
     owns_document_store: bool = False
 
+    #: Whether this store commits the ENTIRE retain — entity resolution/minting, the memory upserts,
+    #: and the document replace — in ONE atomic server-side call (its ``retain`` method). Default
+    #: False: the host runs its normal retain (Phase-1 entity resolution in SQL, then the write). A
+    #: store that sets this True resolves entity NAMES itself and needs no Postgres connection phase,
+    #: so the orchestrator skips SQL entity resolution + the documents/chunks/entities rows + the
+    #: commit witness and issues one ``retain`` instead. Bank-scoped via
+    #: :meth:`store_owned_retain_for`.
+    store_owned_retain: bool = False
+
+    def store_owned_retain_for(self, bank_id: str) -> bool:
+        """Per-bank form of :attr:`store_owned_retain`. Defaults to the class attribute; a router
+        that keeps some banks in a store-owned backend and others in SQL overrides it to answer PER
+        BANK. See :meth:`owns_document_store_for`."""
+        return self.store_owned_retain
+
     def writes_memory_rows_in_sql_for(self, bank_id: str) -> bool:
         """Per-bank form of :attr:`writes_memory_rows_in_sql`. Defaults to the class attribute, so a
         single-store extension needs no override. A store that keeps different banks in different

--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -468,6 +468,25 @@ class MemoriesExtension(Extension, ABC):
         BANK. See :meth:`owns_document_store_for`."""
         return self.store_owned_retain
 
+    async def retain(
+        self,
+        bank_id: str,
+        unit_ids: list[str],
+        facts: list,
+        *,
+        document_id: str | None = None,
+        unit_entity_names: dict[str, list[str]] | None = None,
+        replace_document_id: str = "",
+        resolve_threshold: float = 0.0,
+    ):
+        """Commit an entire retain in one server-side call — resolve/mint the ``unit_entity_names``
+        against the store's own registry, write the memories with the resulting entity ids, and
+        (when ``replace_document_id`` is set) tombstone the document's prior version — all atomically.
+        Only a store advertising :attr:`store_owned_retain` implements this; the orchestrator calls it
+        exactly when :meth:`store_owned_retain_for` is true, so the default never runs. It exists on
+        the interface so a routing extension delegates it automatically (see RoutingMemories)."""
+        raise NotImplementedError("this store does not support a store-owned retain")
+
     def writes_memory_rows_in_sql_for(self, bank_id: str) -> bool:
         """Per-bank form of :attr:`writes_memory_rows_in_sql`. Defaults to the class attribute, so a
         single-store extension needs no override. A store that keeps different banks in different

--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -695,6 +695,21 @@ class MemoriesExtension(Extension, ABC):
         """A document's metadata (and, if asked, its extracted ``original_text``), or ``None``."""
         raise NotImplementedError
 
+    async def list_documents(
+        self,
+        *,
+        bank_id: str,
+        search_query: "str | None" = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> dict:
+        """Page this bank's documents from the store's OWN registry — the ``{items, total, limit,
+        offset}`` shape the documents browser expects. Only a store that owns its document metadata
+        overrides this (a Postgres-backed store lists from the SQL ``documents`` table instead, so
+        the engine only calls this for an ``owns_document_store`` store). Default raises so a
+        mis-routed call is loud rather than silently empty."""
+        raise NotImplementedError
+
     async def get_chunk_text(self, *, bank_id: str, document_id: str, chunk_index: int) -> "str | None":
         """One chunk's text by position, or ``None`` if the document/index does not exist."""
         raise NotImplementedError

--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -710,6 +710,12 @@ class MemoriesExtension(Extension, ABC):
         mis-routed call is loud rather than silently empty."""
         raise NotImplementedError
 
+    async def count_documents(self, *, bank_id: str) -> int:
+        """This bank's document count, from the store's own registry — the bank-stats document
+        total. Only an ``owns_document_store`` store overrides this (a Postgres store counts the
+        SQL ``documents`` table instead); the engine only calls it for a store that owns its docs."""
+        raise NotImplementedError
+
     async def get_chunk_text(self, *, bank_id: str, document_id: str, chunk_index: int) -> "str | None":
         """One chunk's text by position, or ``None`` if the document/index does not exist."""
         raise NotImplementedError

--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -716,6 +716,13 @@ class MemoriesExtension(Extension, ABC):
         SQL ``documents`` table instead); the engine only calls it for a store that owns its docs."""
         raise NotImplementedError
 
+    async def get_entity_graph(self, *, bank_id: str, limit: int = 1000, min_count: int = 1) -> dict:
+        """The entity co-occurrence graph (``{nodes, edges, ...}``) from the store's OWN aggregate.
+        Only a store that owns its entities overrides this (a Postgres store reads its
+        ``entity_cooccurrences`` table); the engine calls it only for a store-owned bank, whose SQL
+        table is empty."""
+        raise NotImplementedError
+
     async def get_chunk_text(self, *, bank_id: str, document_id: str, chunk_index: int) -> "str | None":
         """One chunk's text by position, or ``None`` if the document/index does not exist."""
         raise NotImplementedError

--- a/hindsight-api-slim/hindsight_api/engine/memories/postgres.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/postgres.py
@@ -535,6 +535,7 @@ class PostgresMemories(MemoriesExtension):
         event_date,
         mentioned_at,
         entity_ids: list[str] | None,
+        entity_names: list[str] | None = None,  # noqa: ARG002 — this store's registry is SQL; the host already minted+linked, so entity_ids is authoritative.
         txn=None,
     ) -> None:
         await writes.apply_edit(

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -6345,8 +6345,15 @@ class MemoryEngine(MemoryEngineInterface):
                 ordered_items: list[tuple[str, str]] = []
                 seen_chunk_ids: set[str] = set()
                 observation_ids_ordered: list[uuid.UUID] = []
+                # chunk_id -> document_id, harvested from the hits themselves. A store that owns the
+                # document store keeps NO SQL chunks row (PG-free retain writes none), so the chunk
+                # metadata cannot come from the chunks table — it comes from the hits, whose chunk_id
+                # and document_id are enough to fetch the text from the store.
+                chunk_doc: dict[str, str] = {}
                 for sr in top_scored:
                     chunk_id = sr.retrieval.chunk_id
+                    if chunk_id and getattr(sr.retrieval, "document_id", None):
+                        chunk_doc.setdefault(chunk_id, sr.retrieval.document_id)
                     if chunk_id and chunk_id not in seen_chunk_ids:
                         ordered_items.append(("chunk", chunk_id))
                         seen_chunk_ids.add(chunk_id)
@@ -6443,19 +6450,40 @@ class MemoryEngine(MemoryEngineInterface):
                     # per-chunk ``dict`` allocation for an overlay it never runs.
                     _chunk_store = get_memories()
                     _owns_docs = _chunk_store.owns_document_store_for(bank_id)
-                    if _owns_docs:
-                        _chunk_cols = "chunk_id, chunk_text, chunk_index, document_id"
+                    if _chunk_store.store_owned_retain_for(bank_id):
+                        # PG-free retain writes NO SQL chunks row, so the metadata cannot be queried
+                        # from the chunks table (it is empty). Synthesize each row from the hit's
+                        # chunk_id + document_id — the chunk_index is the chunk_id's suffix after the
+                        # ``{bank}_{document}_`` prefix — and let the overlay below fill in the text
+                        # from the store. One ``list_chunk_texts`` per document, same as before.
+                        chunks_rows = []
+                        for _cid in chunk_ids_ordered:
+                            _doc = chunk_doc.get(_cid)
+                            if _doc is None:
+                                continue
+                            _prefix = f"{bank_id}_{_doc}_"
+                            _idx_s = _cid[len(_prefix):] if _cid.startswith(_prefix) else _cid.rsplit("_", 1)[-1]
+                            try:
+                                _idx = int(_idx_s)
+                            except ValueError:
+                                continue
+                            chunks_rows.append(
+                                {"chunk_id": _cid, "chunk_text": "", "chunk_index": _idx, "document_id": _doc}
+                            )
                     else:
-                        _chunk_cols = "chunk_id, chunk_text, chunk_index"
-                    async with acquire_with_retry(backend) as conn:
-                        chunks_rows = await conn.fetch(
-                            f"""
-                            SELECT {_chunk_cols}
-                            FROM {fq_table("chunks")}
-                            WHERE chunk_id = ANY($1::text[])
-                            """,
-                            chunk_ids_ordered,
-                        )
+                        if _owns_docs:
+                            _chunk_cols = "chunk_id, chunk_text, chunk_index, document_id"
+                        else:
+                            _chunk_cols = "chunk_id, chunk_text, chunk_index"
+                        async with acquire_with_retry(backend) as conn:
+                            chunks_rows = await conn.fetch(
+                                f"""
+                                SELECT {_chunk_cols}
+                                FROM {fq_table("chunks")}
+                                WHERE chunk_id = ANY($1::text[])
+                                """,
+                                chunk_ids_ordered,
+                            )
 
                     if _owns_docs:
                         # Overlay the store's chunk TEXT (empty in the SQL row for this store) —
@@ -7596,9 +7624,18 @@ class MemoryEngine(MemoryEngineInterface):
                 else:
                     deleted = unit_id if fact_type is not None else None
                     if deleted:
-                        # Tag the store tombstone so it commits atomically with this transaction.
-                        _del_txn = await _store.begin_txn(conn=conn, fq_table=fq_table, bank_id=bank_id, mutating=True)
-                        await _store.delete_facts(bank_id, [unit_id], txn=_del_txn)
+                        if _store.store_owned_retain_for(bank_id):
+                            # Store-owned: the tombstone is the ONLY write here (the relink/prune
+                            # enqueues above join memory_units/unit_entities, which this store keeps
+                            # no rows in — so they touch nothing; stale-observation cleanup routes to
+                            # the store and is not part of this txn either). One store-side delete needs
+                            # no write-group — a plain, immediately-durable tombstone leaves no witness
+                            # to go undecided (a store-owned retain creates none of these either).
+                            await _store.delete_facts(bank_id, [unit_id])
+                        else:
+                            # Tag the store tombstone so it commits atomically with this transaction.
+                            _del_txn = await _store.begin_txn(conn=conn, fq_table=fq_table, bank_id=bank_id, mutating=True)
+                            await _store.delete_facts(bank_id, [unit_id], txn=_del_txn)
 
                 # Invalidate observations referencing this (now-deleted) source memory
                 if bank_id and fact_type in ("experience", "world"):

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -6335,7 +6335,6 @@ class MemoryEngine(MemoryEngineInterface):
             chunks_dict = None
             total_chunk_tokens = 0
             chunk_fetch_start = time.time()
-            if include_chunks:
             if include_chunks and top_scored:
                 from .response_models import ChunkInfo
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -9554,6 +9554,16 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id, operation=BankReadOperation.LIST_DOCUMENTS, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+
+        # A store that owns its document metadata keeps no rows in the SQL `documents` table, so the
+        # query below would return an empty page for it. List from the store's own registry instead.
+        from .memories import get_memories
+
+        _docs_store = get_memories()
+        if _docs_store.owns_document_store_for(bank_id):
+            return await _docs_store.list_documents(
+                bank_id=bank_id, search_query=search_query, limit=limit, offset=offset
+            )
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
             # Build query conditions

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -6335,6 +6335,7 @@ class MemoryEngine(MemoryEngineInterface):
             chunks_dict = None
             total_chunk_tokens = 0
             chunk_fetch_start = time.time()
+            if include_chunks:
             if include_chunks and top_scored:
                 from .response_models import ChunkInfo
 
@@ -6345,15 +6346,8 @@ class MemoryEngine(MemoryEngineInterface):
                 ordered_items: list[tuple[str, str]] = []
                 seen_chunk_ids: set[str] = set()
                 observation_ids_ordered: list[uuid.UUID] = []
-                # chunk_id -> document_id, harvested from the hits themselves. A store that owns the
-                # document store keeps NO SQL chunks row (PG-free retain writes none), so the chunk
-                # metadata cannot come from the chunks table — it comes from the hits, whose chunk_id
-                # and document_id are enough to fetch the text from the store.
-                chunk_doc: dict[str, str] = {}
                 for sr in top_scored:
                     chunk_id = sr.retrieval.chunk_id
-                    if chunk_id and getattr(sr.retrieval, "document_id", None):
-                        chunk_doc.setdefault(chunk_id, sr.retrieval.document_id)
                     if chunk_id and chunk_id not in seen_chunk_ids:
                         ordered_items.append(("chunk", chunk_id))
                         seen_chunk_ids.add(chunk_id)
@@ -6450,39 +6444,43 @@ class MemoryEngine(MemoryEngineInterface):
                     # per-chunk ``dict`` allocation for an overlay it never runs.
                     _chunk_store = get_memories()
                     _owns_docs = _chunk_store.owns_document_store_for(bank_id)
-                    if _chunk_store.store_owned_retain_for(bank_id):
-                        # PG-free retain writes NO SQL chunks row, so the metadata cannot be queried
-                        # from the chunks table (it is empty). Synthesize each row from the hit's
-                        # chunk_id + document_id — the chunk_index is the chunk_id's suffix after the
-                        # ``{bank}_{document}_`` prefix — and let the overlay below fill in the text
-                        # from the store. One ``list_chunk_texts`` per document, same as before.
+                    _chunk_cols = (
+                        "chunk_id, chunk_text, chunk_index, document_id"
+                        if _owns_docs
+                        else "chunk_id, chunk_text, chunk_index"
+                    )
+                    async with acquire_with_retry(backend) as conn:
+                        chunks_rows = await conn.fetch(
+                            f"""
+                            SELECT {_chunk_cols}
+                            FROM {fq_table("chunks")}
+                            WHERE chunk_id = ANY($1::text[])
+                            """,
+                            chunk_ids_ordered,
+                        )
+                    if _owns_docs and not chunks_rows:
+                        # A store that owns the document store AND wrote no SQL chunks row (PG-free
+                        # retain) leaves the chunks table empty, so the query above found nothing.
+                        # Synthesize the metadata from the chunk_ids themselves — a chunk_id is
+                        # ``{bank_id}_{document_id}_{chunk_index}`` and bank_id is known, so the last
+                        # ``_``-segment is the index and everything between is the document_id — then
+                        # let the overlay below fill in the text from the store. Independent of the
+                        # per-request capability flags: it fires whenever docs are owned and SQL is
+                        # empty, which is exactly the PG-free case.
+                        _pfx = f"{bank_id}_"
                         chunks_rows = []
                         for _cid in chunk_ids_ordered:
-                            _doc = chunk_doc.get(_cid)
-                            if _doc is None:
+                            if not _cid.startswith(_pfx):
                                 continue
-                            _prefix = f"{bank_id}_{_doc}_"
-                            _idx_s = _cid[len(_prefix):] if _cid.startswith(_prefix) else _cid.rsplit("_", 1)[-1]
+                            _doc, _, _idx_s = _cid[len(_pfx):].rpartition("_")
+                            if not _doc:
+                                continue
                             try:
                                 _idx = int(_idx_s)
                             except ValueError:
                                 continue
                             chunks_rows.append(
                                 {"chunk_id": _cid, "chunk_text": "", "chunk_index": _idx, "document_id": _doc}
-                            )
-                    else:
-                        if _owns_docs:
-                            _chunk_cols = "chunk_id, chunk_text, chunk_index, document_id"
-                        else:
-                            _chunk_cols = "chunk_id, chunk_text, chunk_index"
-                        async with acquire_with_retry(backend) as conn:
-                            chunks_rows = await conn.fetch(
-                                f"""
-                                SELECT {_chunk_cols}
-                                FROM {fq_table("chunks")}
-                                WHERE chunk_id = ANY($1::text[])
-                                """,
-                                chunk_ids_ordered,
                             )
 
                     if _owns_docs:

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -11731,6 +11731,14 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id, operation=BankReadOperation.GET_ENTITY_GRAPH, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+
+        # A store that owns its entities keeps no rows in the SQL entity_cooccurrences/entities
+        # tables, so the query below would return an empty graph. Read the store's own aggregate.
+        from .memories import get_memories
+
+        _eg_store = get_memories()
+        if _eg_store.store_owned_retain_for(bank_id):
+            return await _eg_store.get_entity_graph(bank_id=bank_id, limit=limit, min_count=min_count)
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
             edge_rows = await conn.fetch(

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7278,20 +7278,32 @@ class MemoryEngine(MemoryEngineInterface):
                 )
 
                 # For a store that keeps memories outside SQL, deleting the documents row does not
-                # cascade to its memories (they are not SQL rows) — drop them through the store,
-                # tagged with a write-group so the store tombstone commits atomically with the
-                # Postgres document delete (a rolled-back delete must not orphan the memories).
-                if deleted and not _store.writes_memory_rows_in_sql_for(bank_id):
-                    _del_txn = await _store.begin_txn(conn=conn, fq_table=fq_table, bank_id=bank_id, mutating=True)
-                    await _store.delete_document(
-                        conn=conn, fq_table=fq_table, bank_id=bank_id, document_id=document_id, txn=_del_txn
-                    )
-                    # A store that owns the document store also drops the document RECORD (its
-                    # extracted text + chunk bodies; the orphan sweep reclaims the blobs), under the
-                    # same write-group so it commits atomically with the Postgres document delete.
-                    # This is the EXPLICIT deletion — distinct from the re-ingest facts-delete above.
-                    if _store.owns_document_store_for(bank_id):
-                        await _store.delete_document_record(bank_id=bank_id, document_id=document_id, txn=_del_txn)
+                # cascade to its memories (they are not SQL rows) — drop them through the store.
+                if not _store.writes_memory_rows_in_sql_for(bank_id):
+                    # A store-owned (PG-free) bank writes NO Postgres documents row, so the DELETE
+                    # above is a no-op and `deleted` is None — the deletion must be DRIVEN off the
+                    # store, not gated on the SQL result (otherwise a store-owned document could never
+                    # be deleted at all). The memory tombstone-by-document and the doc-record delete
+                    # are the only writes, both in the store, so no write-group is needed — nothing in
+                    # Postgres to be atomic with. (The legacy path that DID write a documents row for
+                    # such a store still tagged a txn; that row no longer exists under PG-free retain.)
+                    had_memories = bool(unit_ids) or units_count > 0
+                    if _store.store_owned_retain_for(bank_id):
+                        await _store.delete_document(conn=conn, fq_table=fq_table, bank_id=bank_id, document_id=document_id)
+                        if _store.owns_document_store_for(bank_id):
+                            await _store.delete_document_record(bank_id=bank_id, document_id=document_id)
+                        # Report the deletion off the store's own count (SQL `deleted` is None here).
+                        if had_memories or _store.owns_document_store_for(bank_id):
+                            deleted = deleted or document_id
+                    elif deleted:
+                        # Legacy store-outside-SQL that still writes a Postgres documents row: keep
+                        # the write-group so the store tombstone commits atomically with the SQL delete.
+                        _del_txn = await _store.begin_txn(conn=conn, fq_table=fq_table, bank_id=bank_id, mutating=True)
+                        await _store.delete_document(
+                            conn=conn, fq_table=fq_table, bank_id=bank_id, document_id=document_id, txn=_del_txn
+                        )
+                        if _store.owns_document_store_for(bank_id):
+                            await _store.delete_document_record(bank_id=bank_id, document_id=document_id, txn=_del_txn)
 
                 # Invalidate observations referencing these (now-deleted) memories
                 if unit_ids:
@@ -8713,7 +8725,19 @@ class MemoryEngine(MemoryEngineInterface):
                     # One cross-store write-group for this curation edit/invalidate/revert: the
                     # store's writes below are tagged so they commit together with this Postgres
                     # transaction; decided (published) after it commits.
-                    _curation_txn = await store.begin_txn(conn=conn, fq_table=fq_table, bank_id=bank_id, mutating=True)
+                    #
+                    # A store that owns the whole retain keeps the edited MEMORY in the store (its
+                    # apply_edit / invalidate / restore below), and its one write is atomic on its own —
+                    # there is nothing to make atomic with a Postgres witness. Skip the write-group
+                    # (``_curation_txn = None`` → the store writes are plain, immediately visible), so
+                    # curation leaves no undecided txn to stall the store's indexer (same reasoning as
+                    # consolidation). The Postgres entity/posting writes below become plain best-effort
+                    # rows the store's reads no longer consult.
+                    _curation_txn = (
+                        None
+                        if store.store_owned_retain_for(bank_id)
+                        else await store.begin_txn(conn=conn, fq_table=fq_table, bank_id=bank_id, mutating=True)
+                    )
 
                     # --- Apply edit (live rows only) ---
                     if edit_plan is not None and live2:
@@ -8856,7 +8880,9 @@ class MemoryEngine(MemoryEngineInterface):
 
                 # Postgres committed the curation change: publish the store's write-group. On a
                 # crash before here the writes stay invisible and the recovery sweep resolves them.
-                await store.decide_txn(_curation_txn, commit=True)
+                # No-op for a store-owned edit (no write-group; its store writes were already visible).
+                if _curation_txn is not None:
+                    await store.decide_txn(_curation_txn, commit=True)
                 phase2_committed = True
         finally:
             # Entities were resolved (and possibly autocommitted) in Phase 1 but the edit did not

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -12084,10 +12084,16 @@ class MemoryEngine(MemoryEngineInterface):
                 """,
                 bank_id,
             )
-            doc_count_row = await conn.fetchrow(
-                f"SELECT COUNT(*) as count FROM {fq_table('documents')} WHERE bank_id = $1",
-                bank_id,
-            )
+            # Document count, like link/node counts above, must be asked of the store: a store that
+            # owns its documents keeps no rows in the SQL `documents` table, so the query returns 0.
+            if store.owns_document_store_for(bank_id):
+                total_documents = await store.count_documents(bank_id=bank_id)
+            else:
+                doc_count_row = await conn.fetchrow(
+                    f"SELECT COUNT(*) as count FROM {fq_table('documents')} WHERE bank_id = $1",
+                    bank_id,
+                )
+                total_documents = doc_count_row["count"] if doc_count_row else 0
             # Consolidation freshness (last-consolidated, pending, failed) lives on the memories,
             # so a store that keeps them outside SQL must answer this — the memory_units query
             # returns 0/None for it. Same {last_consolidated_at, pending, failed} shape either way.
@@ -12140,7 +12146,7 @@ class MemoryEngine(MemoryEngineInterface):
                 "link_counts_by_fact_type": {},
                 "link_breakdown": [],
                 "operations": ops_by_status,
-                "total_documents": doc_count_row["count"] if doc_count_row else 0,
+                "total_documents": total_documents,
                 "last_consolidated_at": last_consolidated_at.isoformat() if last_consolidated_at else None,
                 "last_memory_write_at": last_memory_write_at.isoformat() if last_memory_write_at else None,
                 "pending_consolidation": consolidation_row["pending"] if consolidation_row else 0,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -1388,6 +1388,9 @@ class _MemoryEditPlan:
     # mismatch (a concurrent entity-only edit landed between the phases) triggers a bounded in-txn
     # re-embed so the stored vector stays consistent with the committed entity set.
     names: list[str]
+    # The raw entity names to hand a store that owns its entity registry (it resolves + mints them
+    # itself). None for a SQL-registry store, which uses the pre-resolved ``edit_entity_ids`` instead.
+    entity_names_for_store: list[str] | None = None
     embedding: str | None = None
 
 
@@ -8597,39 +8600,49 @@ class MemoryEngine(MemoryEngineInterface):
                 entity_resolution = None
                 resolved_for_unit = None
                 edit_entity_ids = None
+                entity_names_for_store = None
                 entity_date = None
                 if new_entities is not None:
                     entity_date = new_occ_start or live.mentioned_at
-                    # resolve_entities_only find-or-creates the corrected entities (idempotent) and
-                    # autocommits them on this short connection; the Phase-2 relink writes exactly
-                    # this resolved set, keeping the stored embedding consistent with the links.
                     entities_resolved = True
-                    entity_resolution = await resolve_entities_only(
-                        self.entity_resolver,
-                        conn,
-                        bank_id,
-                        [str(memory_uuid)],
-                        [new_text],
-                        new_context or "",
-                        [entity_date],
-                        [[{"text": name, "type": "CONCEPT"} for name in new_entities]],
-                        entity_labels=entity_labels,
-                    )
-                    resolved_for_unit = entity_resolution.unit_to_entity_ids.get(str(memory_uuid), [])
-                    edit_entity_ids = [str(eid) for eid in resolved_for_unit]
-                    # Canonical names of the newly-resolved set (the entity registry is always in
-                    # SQL, whichever store owns the memory rows), used to build the embedding.
-                    name_rows = (
-                        await conn.fetch(
-                            f"SELECT canonical_name FROM {fq_table('entities')} "
-                            f"WHERE id = ANY($1::uuid[]) AND bank_id = $2 ORDER BY id",
-                            resolved_for_unit,
+                    if store.store_owned_retain_for(bank_id):
+                        # The store owns its entity registry: hand it the raw names and let its
+                        # apply_edit resolve + mint them (exactly as its retain does), so a new
+                        # entity from an edit lands in that registry. Nothing is written to — or
+                        # read from — the SQL entities table; the names ARE the input, and the
+                        # embedding is built from them directly.
+                        names = list(new_entities)
+                        entity_names_for_store = names
+                    else:
+                        # resolve_entities_only find-or-creates the corrected entities (idempotent)
+                        # and autocommits them on this short connection; the Phase-2 relink writes
+                        # exactly this resolved set, keeping the embedding consistent with the links.
+                        entity_resolution = await resolve_entities_only(
+                            self.entity_resolver,
+                            conn,
                             bank_id,
+                            [str(memory_uuid)],
+                            [new_text],
+                            new_context or "",
+                            [entity_date],
+                            [[{"text": name, "type": "CONCEPT"} for name in new_entities]],
+                            entity_labels=entity_labels,
                         )
-                        if resolved_for_unit
-                        else []
-                    )
-                    names = [r["canonical_name"] for r in name_rows]
+                        resolved_for_unit = entity_resolution.unit_to_entity_ids.get(str(memory_uuid), [])
+                        edit_entity_ids = [str(eid) for eid in resolved_for_unit]
+                        # Canonical names of the newly-resolved set (this store's registry is the
+                        # host's SQL), used to build the embedding.
+                        name_rows = (
+                            await conn.fetch(
+                                f"SELECT canonical_name FROM {fq_table('entities')} "
+                                f"WHERE id = ANY($1::uuid[]) AND bank_id = $2 ORDER BY id",
+                                resolved_for_unit,
+                                bank_id,
+                            )
+                            if resolved_for_unit
+                            else []
+                        )
+                        names = [r["canonical_name"] for r in name_rows]
                 else:
                     # Entities untouched: the embedding uses the unit's current linked names.
                     emap = await store.entity_map_for_units(
@@ -8649,6 +8662,7 @@ class MemoryEngine(MemoryEngineInterface):
                     edit_entity_ids=edit_entity_ids,
                     entity_date=entity_date,
                     names=names,
+                    entity_names_for_store=entity_names_for_store,
                 )
 
             # --- Classify the state change (applied in Phase 2). Edit + invalidate can co-occur
@@ -8741,7 +8755,13 @@ class MemoryEngine(MemoryEngineInterface):
 
                     # --- Apply edit (live rows only) ---
                     if edit_plan is not None and live2:
-                        if edit_plan.resolved_for_unit is not None:
+                        if edit_plan.entity_names_for_store is not None:
+                            # The store owns its entity registry: apply_edit below resolves + mints
+                            # these names and rewrites the memory's entity ids. There are no SQL
+                            # postings to clear/relink and no prune queue — the store keeps entity
+                            # ids on the memory itself, so the edit's rewrite replaces the whole set.
+                            edit_embedding = edit_plan.embedding
+                        elif edit_plan.resolved_for_unit is not None:
                             # Entities are being changed: rebuild unit_entities to the resolved set.
                             # The entities this unit is about to stop referencing may have been
                             # holding on by that posting alone, so queue them as prune candidates
@@ -8804,6 +8824,7 @@ class MemoryEngine(MemoryEngineInterface):
                             event_date=edit_plan.new_event_date,
                             mentioned_at=edit_plan.mentioned_at,
                             entity_ids=edit_plan.edit_entity_ids,
+                            entity_names=edit_plan.entity_names_for_store,
                             txn=_curation_txn,
                         )
                         if edit_embedding is not None:

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -109,16 +109,21 @@ async def index_facts(
     facts: list[ProcessedFact],
     document_id: str | None = None,
     unit_entity_ids: dict[str, list[str]] | None = None,
+    txn=None,
 ) -> None:
     """Complete a deferred `insert_facts_batch`, now that the edges are known.
 
     ``unit_entity_ids`` is the unit→entity posting and each fact's causal
     relations are its edges; both travel with the memory for a store that owns
     them. A no-op for the Postgres store, which wrote all of it already.
+
+    ``txn`` rides a cross-store write-group handle so this single, entity-bearing
+    write commits (and becomes visible) atomically with the rest of the group —
+    the store-owned retain path writes facts ONCE here rather than write-then-reattach.
     """
     from ..memories import get_memories
 
-    await get_memories().index_facts(bank_id, unit_ids, facts, document_id, unit_entity_ids)
+    await get_memories().index_facts(bank_id, unit_ids, facts, document_id, unit_entity_ids, txn=txn)
 
 
 async def ensure_bank_exists(conn, bank_id: str, ops=None) -> None:

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -2772,55 +2772,73 @@ async def _streaming_retain_batch(
 
             _edge_provider = get_memories()
             _edge_txn = None
-            async with acquire_with_retry(pool) as conn:
-                async with conn.transaction():
-                    await conn.execute(
-                        f"INSERT INTO {fq_table('documents')} (id, bank_id, original_text, content_hash) "
-                        f"VALUES ($1, $2, '', '__pending__') "
-                        f"ON CONFLICT (id, bank_id) DO NOTHING",
-                        effective_doc_id,
-                        bank_id,
-                    )
-                    await conn.fetchval(
-                        f"SELECT content_hash FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2 FOR UPDATE",
-                        effective_doc_id,
-                        bank_id,
-                    )
-                    if is_recovery:
-                        await fact_storage.upsert_document_metadata(
-                            conn,
-                            bank_id,
+            if _edge_provider.store_owned_retain_for(bank_id):
+                # Store-owned zero-batch retain — the post-loop analogue of the per-batch 0-fact
+                # PG-free branch above. Reached when NO batch ran at all (empty/gibberish content,
+                # or a recovery where every chunk was already committed as a prior attempt). The
+                # document's bodies are already in the store (via _store_document_bodies); a
+                # re-ingest that yields no facts must still drop the document's PRIOR memories —
+                # ONE plain store-side delete-by-document. No Postgres documents row, no
+                # write-group (store-only), so nothing is left undecided to stall the store's
+                # indexer.
+                await _edge_provider.delete_document(
+                    conn=None, fq_table=fq_table, bank_id=bank_id, document_id=effective_doc_id
+                )
+                doc_tracking_done[0] = True
+                combined_content = ""
+                log_buffer.append(
+                    f"[streaming] Document {effective_doc_id} tracked (no facts, store-owned, PG-free)"
+                )
+            else:
+                async with acquire_with_retry(pool) as conn:
+                    async with conn.transaction():
+                        await conn.execute(
+                            f"INSERT INTO {fq_table('documents')} (id, bank_id, original_text, content_hash) "
+                            f"VALUES ($1, $2, '', '__pending__') "
+                            f"ON CONFLICT (id, bank_id) DO NOTHING",
                             effective_doc_id,
-                            combined_content,
-                            retain_params,
-                            merged_tags,
-                            store_document_text=getattr(config, "store_document_text", True),
-                        )
-                    else:
-                        # A no-facts re-ingest still deletes the outgoing memories — tag that
-                        # tombstone with a write-group so it commits atomically with the doc row.
-                        _edge_txn = await _edge_provider.begin_txn(
-                            conn=conn, fq_table=fq_table, bank_id=bank_id, mutating=True
-                        )
-                        await fact_storage.handle_document_tracking(
-                            conn,
                             bank_id,
-                            effective_doc_id,
-                            combined_content,
-                            is_first_batch,
-                            retain_params,
-                            merged_tags,
-                            ops=pool.ops,
-                            store_document_text=getattr(config, "store_document_text", True),
-                            txn=_edge_txn,
                         )
-                    doc_tracking_done[0] = True
-                    # Memory: combined_content has been persisted and won't be
-                    # read again — release the per-document text now.
-                    combined_content = ""
-                    log_buffer.append(f"[streaming] Document {effective_doc_id} tracked (no facts extracted)")
-            if _edge_txn is not None:
-                await _edge_provider.decide_txn(_edge_txn, commit=True)
+                        await conn.fetchval(
+                            f"SELECT content_hash FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2 FOR UPDATE",
+                            effective_doc_id,
+                            bank_id,
+                        )
+                        if is_recovery:
+                            await fact_storage.upsert_document_metadata(
+                                conn,
+                                bank_id,
+                                effective_doc_id,
+                                combined_content,
+                                retain_params,
+                                merged_tags,
+                                store_document_text=getattr(config, "store_document_text", True),
+                            )
+                        else:
+                            # A no-facts re-ingest still deletes the outgoing memories — tag that
+                            # tombstone with a write-group so it commits atomically with the doc row.
+                            _edge_txn = await _edge_provider.begin_txn(
+                                conn=conn, fq_table=fq_table, bank_id=bank_id, mutating=True
+                            )
+                            await fact_storage.handle_document_tracking(
+                                conn,
+                                bank_id,
+                                effective_doc_id,
+                                combined_content,
+                                is_first_batch,
+                                retain_params,
+                                merged_tags,
+                                ops=pool.ops,
+                                store_document_text=getattr(config, "store_document_text", True),
+                                txn=_edge_txn,
+                            )
+                        doc_tracking_done[0] = True
+                        # Memory: combined_content has been persisted and won't be
+                        # read again — release the per-document text now.
+                        combined_content = ""
+                        log_buffer.append(f"[streaming] Document {effective_doc_id} tracked (no facts extracted)")
+                if _edge_txn is not None:
+                    await _edge_provider.decide_txn(_edge_txn, commit=True)
 
         # Transactional-outbox fallback. The in-TXN fire only runs on a final
         # facts-bearing batch (is_last=True). When the committed-chunk count lands

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -674,7 +674,7 @@ async def _streaming_batch_write_ext(
     # write-group witness, one server-side retain. Everything below (the two-phase Protocol-B
     # dance) is for a store whose memory rows live elsewhere but whose metadata still lands in
     # Postgres.
-    if getattr(provider, "store_owned_retain", False):
+    if provider.store_owned_retain_for(bank_id):
         return await _streaming_store_owned_retain(
             provider=provider,
             pool=pool,
@@ -2379,7 +2379,7 @@ async def _streaming_retain_batch(
             # trigram scan + entity INSERTs entirely — the PG-free path touches no Postgres in retain.
             from ..memories import get_memories as _get_memories_p1
 
-            _store_owned_retain = getattr(_get_memories_p1(), "store_owned_retain", False)
+            _store_owned_retain = _get_memories_p1().store_owned_retain_for(bank_id)
             p1_start = time.time()
             phase1 = await _pre_resolve_phase1(
                 pool,
@@ -2990,7 +2990,7 @@ async def _try_delta_retain(
     # diff) is a follow-up. Full retain of an unchanged doc is still cheap.
     from ..memories import get_memories as _get_memories_delta
 
-    if getattr(_get_memories_delta(), "store_owned_retain", False):
+    if _get_memories_delta().store_owned_retain_for(bank_id):
         return None
 
     # Need a single document_id

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -2307,6 +2307,24 @@ async def _streaming_retain_batch(
 
                 _edge_provider = get_memories()
                 _edge_txn = None
+                if _edge_provider.store_owned_retain_for(bank_id):
+                    # Store-owned 0-fact (re-)ingest: the document's bodies are already in the store
+                    # (via _store_document_bodies) and there are no new memories. A re-ingest that now
+                    # yields 0 facts must drop the document's PRIOR memories — ONE plain store-side
+                    # delete-by-document. No Postgres documents row, no lock, no write-group
+                    # (store-only), so nothing is left undecided to stall the store's indexer. This
+                    # is the 0-fact analogue of the fact-bearing PG-free path's replace-tombstone.
+                    await _edge_provider.delete_document(
+                        conn=None, fq_table=fq_table, bank_id=bank_id, document_id=effective_doc_id
+                    )
+                    doc_tracking_done[0] = True
+                    combined_content = ""
+                    log_buffer.append(f"[streaming] Document {effective_doc_id} tracked (0 facts, store-owned, PG-free)")
+                    log_buffer.append(
+                        f"[streaming] Consumer batch {consumer_batch_idx + 1}: "
+                        f"0 facts extracted from {len(batch)} chunks, skipping"
+                    )
+                    return
                 async with acquire_with_retry(pool) as conn:
                     async with conn.transaction():
                         # Same create-and-lock the fact-bearing path uses. Routed

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -276,6 +276,7 @@ from .types import (
     CausalRelation,
     ChunkMetadata,
     ConcurrentAppendConflict,
+    EntityResolutionResult,
     ExtractedFact,
     Phase1Result,
     ProcessedFact,
@@ -389,6 +390,7 @@ async def _pre_resolve_phase1(
     config,
     log_buffer: list[str],
     skip_semantic_ann: bool = False,
+    skip_entity_resolution: bool = False,
 ) -> Phase1Result:
     """
     Phase 1: Run expensive read-heavy operations on a separate connection
@@ -399,9 +401,21 @@ async def _pre_resolve_phase1(
 
     Running these outside the transaction avoids holding row locks during
     slow reads, eliminating TimeoutErrors under concurrent load.
+
+    ``skip_entity_resolution`` is set for a store that resolves/mints entities itself
+    (``store_owned_retain``): the store owns its own entity registry and resolves raw names
+    server-side inside its atomic retain, so the Postgres trigram scan + entity INSERTs here
+    are pure waste (and the whole point of the PG-free path is to not touch Postgres). We return an
+    empty entity result; the store-owned write path reconstructs raw names straight from the facts.
     """
     set_stage("retain.phase1.resolve")
     from .link_utils import compute_semantic_links_ann
+
+    if skip_entity_resolution:
+        # No Postgres. Semantic ANN is already deferred in streaming, so there is nothing read-heavy
+        # left to do — the store-owned write path carries entity NAMES to the server itself.
+        empty = EntityResolutionResult(resolved_entities=[], entity_to_unit=[], unit_to_entity_ids={})
+        return Phase1Result(entities=empty, semantic_ann_links=[])
 
     user_entities_per_content = {idx: content.entities for idx, content in enumerate(contents) if content.entities}
 
@@ -655,6 +669,30 @@ async def _streaming_batch_write_ext(
     :class:`ConcurrentAppendConflict` for a lost append race, exactly like the Postgres path —
     the staged writes are discarded on that path too.
     """
+    # A store that resolves entities and commits the whole retain atomically in one server-side
+    # call (``store_owned_retain``) takes the PG-free path: no connection phase at all, no
+    # write-group witness, one server-side retain. Everything below (the two-phase Protocol-B
+    # dance) is for a store whose memory rows live elsewhere but whose metadata still lands in
+    # Postgres.
+    if getattr(provider, "store_owned_retain", False):
+        return await _streaming_store_owned_retain(
+            provider=provider,
+            pool=pool,
+            bank_id=bank_id,
+            batch_contents=batch_contents,
+            batch_extracted=batch_extracted,
+            batch_processed=batch_processed,
+            batch_chunk_meta=batch_chunk_meta,
+            effective_doc_id=effective_doc_id,
+            config=config,
+            log_buffer=log_buffer,
+            is_first_batch=is_first_batch,
+            append_base_hash=append_base_hash,
+            ext_txn=ext_txn,
+            doc_tracking_done=doc_tracking_done,
+            p2_start=p2_start,
+        )
+
     # ---- STORE PHASE (no connection held) ----
     # Chunk ids are a deterministic function of identity (mirrors chunk_storage.store_chunks_batch),
     # so facts can be tagged with document_id + chunk_id before the metadata rows are written.
@@ -711,14 +749,18 @@ async def _streaming_batch_write_ext(
         )
 
     # ---- CONNECTION PHASE (short transaction: local metadata + commit witness) ----
+    # [PG-PROFILE] sub-step timing to find where retain wall-time goes (Phase 0 of PG-free retain).
+    _pt = {"c0": time.time()}
     try:
         async with acquire_with_retry(pool) as conn:
+            _pt["acq"] = time.time()
             async with conn.transaction():
                 # Ownership gate: lock the document row (serializes concurrent same-document
                 # writers) and read its pre-existing hash for the takeover check.
                 existing_hash = await pool.ops.lock_document_for_write(
                     conn, fq_table("documents"), effective_doc_id, bank_id
                 )
+                _pt["lock"] = time.time()
 
                 if not doc_tracking_done[0]:
                     # Append compare-and-swap under the row lock (same as the Postgres path).
@@ -770,6 +812,7 @@ async def _streaming_batch_write_ext(
                         pipeline_aborted[0] = True
                         return _ExtStreamingWriteResult(aborted=True, batch_result_ids=batch_result_ids)
 
+                _pt["track"] = time.time()
                 # Chunk metadata rows (bulky bodies were already stored before this call).
                 if batch_chunk_meta:
                     await chunk_storage.store_chunks_batch(
@@ -780,11 +823,13 @@ async def _streaming_batch_write_ext(
                         ops=pool.ops,
                         store_document_text=getattr(config, "store_document_text", True),
                     )
+                _pt["chunks"] = time.time()
 
                 # Entity registry reassert (Postgres `entities`): re-create the resolved parents
                 # this txn so a concurrent prune can't leave the postings dangling (#2662).
                 if unit_ids:
                     await entity_resolver.reassert_entities_batch(bank_id, phase1.entities.resolved_entities, conn=conn)
+                _pt["entities"] = time.time()
 
                 # Transactional-outbox row — must ride this Postgres transaction.
                 if is_last and outbox_callback is not None:
@@ -792,9 +837,29 @@ async def _streaming_batch_write_ext(
 
                 # The commit witness: its presence at commit is what the recovery sweep consults.
                 await provider.write_txn_witness(ext_txn, conn=conn, fq_table=fq_table)
+                _pt["witness"] = time.time()
 
+            _pt["commit"] = time.time()
             # Postgres committed the witness: publish the write-group (object-store marker, no conn).
             await provider.decide_txn(ext_txn, commit=True)
+            _pt["decide"] = time.time()
+
+            def _d(a, b):
+                return int((_pt.get(b, _pt["c0"]) - _pt.get(a, _pt["c0"])) * 1000)
+
+            logger.info(
+                "[PG-PROFILE] total=%dms acquire=%d lock=%d doctrack=%d chunks=%d entities=%d "
+                "witness+outbox=%d pg_commit=%d decide=%d",
+                int((_pt["decide"] - _pt["c0"]) * 1000),
+                _d("c0", "acq"),
+                _d("acq", "lock"),
+                _d("lock", "track"),
+                _d("track", "chunks"),
+                _d("chunks", "entities"),
+                _d("entities", "witness"),
+                _d("witness", "commit"),
+                _d("commit", "decide"),
+            )
             logger.info(f"[streaming] Phase 2 (ext write txn): {time.time() - p2_start:.3f}s")
     except BaseException:
         # The witness never committed (this also covers a lost-append ConcurrentAppendConflict)
@@ -806,6 +871,115 @@ async def _streaming_batch_write_ext(
             logger.warning(f"[streaming] best-effort abort of ext txn for {effective_doc_id} failed", exc_info=True)
         raise
 
+    return _ExtStreamingWriteResult(aborted=False, batch_result_ids=batch_result_ids)
+
+
+async def _streaming_store_owned_retain(
+    *,
+    provider,
+    pool,
+    bank_id: str,
+    batch_contents: list,
+    batch_extracted: list,
+    batch_processed: list,
+    batch_chunk_meta: list,
+    effective_doc_id: str,
+    config,
+    log_buffer: list[str],
+    is_first_batch: bool,
+    append_base_hash,
+    ext_txn,
+    doc_tracking_done: list[bool],
+    p2_start: float,
+) -> _ExtStreamingWriteResult:
+    """The PG-free retain write for a store that owns entity resolution + atomicity.
+
+    ONE server-side retain does everything the old two-phase path split across an object-store
+    write and a Postgres connection phase:
+
+    * resolves each fact's raw entity NAMES (reconstructed here with no Postgres, exactly the merge
+      the PG resolver used to do) against the store's own entity registry, minting deterministic ids
+      for new names;
+    * writes the memories with their entity ids attached;
+    * on the document's first batch, tombstones the prior version of the document in the SAME atomic
+      entry (a re-retain replaces; the same-entry upserts are spared).
+
+    No connection is acquired, no ``documents``/``chunks``/``entities`` rows, no commit witness, no
+    ``decide_txn`` — the store's single write is already atomic, so Protocol B has nothing left to
+    make atomic *together*. Document/chunk BODIES were already sent to the store's document store by
+    ``_store_document_bodies`` (``owns_document_store``); the small Postgres metadata rows that the
+    Protocol-B path still wrote are simply gone.
+
+    Known gaps, tracked for the follow-on phases:
+    * Concurrent same-document ownership/takeover is no longer serialized by a Postgres row lock;
+      the store's atomic replace gives last-writer-wins. A store-side document content-hash CAS is a
+      follow-up. ``append_base_hash`` (strict-append base check) is likewise deferred to that CAS,
+      so an append here does not verify its base — it just does not replace.
+    * The transactional-outbox (webhook delivery) is not emitted here; the intended design is
+      at-least-once emission from the store, which replaces the Postgres outbox row.
+    """
+    # Tag each fact with its document + deterministic chunk id (mirrors the Protocol-B store phase
+    # and chunk_storage.store_chunks_batch, so a fact's chunk_id matches its chunk metadata).
+    chunk_id_by_index = {}
+    if batch_chunk_meta:
+        chunk_id_by_index = {
+            cm.chunk_index: f"{bank_id}_{effective_doc_id}_{cm.chunk_index}" for cm in batch_chunk_meta
+        }
+    for fact, processed_fact in zip(batch_extracted, batch_processed):
+        processed_fact.document_id = effective_doc_id
+        if batch_chunk_meta and fact.chunk_index is not None:
+            cid = chunk_id_by_index.get(fact.chunk_index)
+            if cid:
+                processed_fact.chunk_id = cid
+
+    # Mint the unit ids WITHOUT writing (defer_index) — connection-free and Postgres-free; the
+    # single server-side retain below is the only write.
+    unit_ids = await fact_storage.insert_facts_batch(
+        None, bank_id, batch_processed, ops=pool.ops, txn=ext_txn, defer_index=True
+    )
+    batch_result_ids = _map_results_to_contents(batch_contents, batch_processed, unit_ids if unit_ids else [])
+
+    if unit_ids:
+        # Reconstruct each fact's raw entity NAMES (LLM-extracted ∪ user-supplied), the exact merge
+        # the Postgres resolver did — but without touching Postgres. The server resolves/mints.
+        user_entities_per_content = {
+            idx: content.entities for idx, content in enumerate(batch_contents) if getattr(content, "entities", None)
+        }
+        _texts, _dates, entities_per_fact = entity_processing._prepare_facts_for_entity_processing(
+            batch_processed, user_entities_per_content
+        )
+        unit_entity_names = {
+            unit_ids[i]: [e["text"] for e in entities_per_fact[i]]
+            for i in range(min(len(unit_ids), len(entities_per_fact)))
+        }
+        # Replace the document's prior version only on its FIRST batch (later batches append to what
+        # batch 1 just wrote — replacing again would tombstone those siblings), and never when
+        # appending to an existing document.
+        replace_id = effective_doc_id if (is_first_batch and append_base_hash is None) else ""
+        # 0.0 → the server's default trigram-Jaccard threshold; a configured value overrides it.
+        threshold = float(getattr(config, "entity_similarity_threshold", 0.0) or 0.0)
+        resp = await provider.retain(
+            bank_id,
+            unit_ids,
+            batch_processed,
+            document_id=effective_doc_id,
+            unit_entity_names=unit_entity_names,
+            replace_document_id=replace_id,
+            resolve_threshold=threshold,
+        )
+        log_buffer.append(
+            f"[streaming] pg-free retain doc={effective_doc_id} units={len(unit_ids)} "
+            f"seq={resp.seq} new_entities={resp.new_entities}"
+        )
+    # Mark the document tracked so the post-loop "no facts / not-yet-tracked" finalizer does NOT
+    # fire. That finalizer (a) writes a Postgres documents row and (b) runs handle_document_tracking,
+    # whose store.delete_document tombstones by document_id — which, landing at a LATER seq than this
+    # retain, would delete the very memories we just wrote (the same-entry sparing only protects the
+    # replace inside the store's atomic retain, not a later separate tombstone). The atomic retain
+    # above is the whole write, so tracking is complete here. Set it even when there were 0 units,
+    # matching the Protocol-B path which marks the document tracked regardless of extraction results.
+    doc_tracking_done[0] = True
+    logger.info(f"[streaming] Phase 2 (pg-free retain): {time.time() - p2_start:.3f}s")
     return _ExtStreamingWriteResult(aborted=False, batch_result_ids=batch_result_ids)
 
 
@@ -2200,7 +2374,12 @@ async def _streaming_retain_batch(
             entity_resolver.discard_pending_stats()
             mb_start = time.time()
 
-            # Phase 1 — Entity Resolution only (no ANN — deferred to Phase 3)
+            # Phase 1 — Entity Resolution only (no ANN — deferred to Phase 3). A store that resolves
+            # and mints entities itself (server-side, ``store_owned_retain``) skips the Postgres
+            # trigram scan + entity INSERTs entirely — the PG-free path touches no Postgres in retain.
+            from ..memories import get_memories as _get_memories_p1
+
+            _store_owned_retain = getattr(_get_memories_p1(), "store_owned_retain", False)
             p1_start = time.time()
             phase1 = await _pre_resolve_phase1(
                 pool,
@@ -2211,6 +2390,7 @@ async def _streaming_retain_batch(
                 config,
                 log_buffer,
                 skip_semantic_ann=True,
+                skip_entity_resolution=_store_owned_retain,
             )
 
             logger.info(f"[streaming] Phase 1 (entity resolution): {time.time() - p1_start:.3f}s")
@@ -2803,6 +2983,16 @@ async def _try_delta_retain(
     (``0`` if the submission matched prior content exactly and nothing was
     re-extracted).
     """
+    # A store-owned (PG-free) retain resolves entities and replaces atomically server-side; the
+    # delta optimization's chunk-diff still rides a Postgres connection phase (documents/chunks
+    # tombstones + witness), so for now fall straight through to the full streaming retain, which
+    # has its own PG-free path. Re-enabling delta for a store-owned backend (a store-side chunk
+    # diff) is a follow-up. Full retain of an unchanged doc is still cheap.
+    from ..memories import get_memories as _get_memories_delta
+
+    if getattr(_get_memories_delta(), "store_owned_retain", False):
+        return None
+
     # Need a single document_id
     effective_doc_id = document_id
     if not effective_doc_id:

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -670,14 +670,18 @@ async def _streaming_batch_write_ext(
             if cid:
                 processed_fact.chunk_id = cid
 
-    # Stage the memory records to the store (conn unused by a store-owned backend), tagged with
-    # ext_txn. This is the slow object-store write we are keeping OUT of the connection window.
-    unit_ids = await fact_storage.insert_facts_batch(None, bank_id, batch_processed, ops=pool.ops, txn=ext_txn)
+    # Mint the unit ids WITHOUT writing (defer_index): entities can only be resolved onto real ids
+    # after they exist, so we write the memories to the store ONCE below — with their entity ids
+    # already attached — instead of writing them here and then re-upserting each one with entities.
+    # That reattach cost a SECOND full object-store write per memory (plus a read-back of the just-
+    # written records), doubling the store round-trips on the slow path. Connection-free either way.
+    unit_ids = await fact_storage.insert_facts_batch(
+        None, bank_id, batch_processed, ops=pool.ops, txn=ext_txn, defer_index=True
+    )
     batch_result_ids = _map_results_to_contents(batch_contents, batch_processed, unit_ids if unit_ids else [])
 
     if unit_ids:
-        # Remap Phase-1 placeholder ids onto the real unit ids, then re-write each memory with its
-        # entity ids attached — also connection-free for a store-owned backend.
+        # Remap Phase-1 placeholder ids onto the real unit ids.
         resolved_entity_ids = [entity.entity_id for entity in phase1.entities.resolved_entities]
         remapped_entity_to_unit, _remapped_unit_to_entity_ids, _remapped_semantic = _remap_phase1_results(
             resolved_entity_ids, phase1.entities.entity_to_unit, phase1.entities.unit_to_entity_ids, [], unit_ids
@@ -686,7 +690,25 @@ async def _streaming_batch_write_ext(
             (unit_id, resolved_entity_ids[idx], fact_date)
             for idx, (unit_id, _local_idx, fact_date) in enumerate(remapped_entity_to_unit)
         ]
-        await entity_resolver.record_unit_entity_postings(unit_entity_pairs, bank_id=bank_id)
+        # The single, entity-bearing store write — connection-free, and tagged with ext_txn so it
+        # commits (and becomes visible) atomically with the rest of the write-group. This replaces
+        # the earlier insert-then-reattach pair with one write.
+        unit_entity_ids: dict[str, list[str]] = {}
+        for unit_id, entity_id, _fd in unit_entity_pairs:
+            unit_entity_ids.setdefault(unit_id, []).append(entity_id)
+        await fact_storage.index_facts(
+            bank_id,
+            unit_ids,
+            batch_processed,
+            document_id=effective_doc_id,
+            unit_entity_ids=unit_entity_ids,
+            txn=ext_txn,
+        )
+        # The store row was just written with its entities inline, so skip the (now redundant)
+        # second store write and keep ONLY the co-occurrence accumulation the entity graph needs.
+        await entity_resolver.record_unit_entity_postings(
+            unit_entity_pairs, bank_id=bank_id, store_write=False
+        )
 
     # ---- CONNECTION PHASE (short transaction: local metadata + commit witness) ----
     try:

--- a/hindsight-api-slim/tests/test_retain_ext_writegroup.py
+++ b/hindsight-api-slim/tests/test_retain_ext_writegroup.py
@@ -63,11 +63,20 @@ def _make_common(monkeypatch, tracker, *, calls):
     """Patch the module-level collaborators the helper reaches for."""
     monkeypatch.setattr(orch, "acquire_with_retry", lambda pool: tracker.acquire())
 
-    async def _insert_facts_batch(conn, bank_id, processed, ops=None, txn=None):
-        calls.append(("insert_facts", conn, tracker.open))
-        tracker.store_writes_saw_open.append(tracker.open)
+    async def _insert_facts_batch(conn, bank_id, processed, ops=None, txn=None, defer_index=False):
+        # defer_index=True mints ids WITHOUT writing — the entity-bearing write happens in
+        # index_facts below, so this call is a no-op store-side (records no write).
+        calls.append(("insert_facts", conn, tracker.open, defer_index))
         assert conn is None, "ext store write must not receive a connection"
+        if not defer_index:
+            tracker.store_writes_saw_open.append(tracker.open)
         return ["u1"]
+
+    async def _index_facts(bank_id, unit_ids, facts, document_id=None, unit_entity_ids=None, txn=None):
+        # The single, entity-bearing store write — must be connection-free and carry the txn.
+        calls.append(("index_facts", tracker.open))
+        tracker.store_writes_saw_open.append(tracker.open)
+        assert txn is not None, "the deferred store write must ride the write-group txn"
 
     async def _store_chunks_batch(conn, bank_id, doc_id, meta, ops=None, store_document_text=True):
         calls.append(("store_chunks", tracker.open))
@@ -77,6 +86,7 @@ def _make_common(monkeypatch, tracker, *, calls):
         calls.append(("handle_doc_tracking", tracker.open))
 
     monkeypatch.setattr(orch.fact_storage, "insert_facts_batch", _insert_facts_batch)
+    monkeypatch.setattr(orch.fact_storage, "index_facts", _index_facts)
     monkeypatch.setattr(orch.chunk_storage, "store_chunks_batch", _store_chunks_batch)
     monkeypatch.setattr(orch.fact_storage, "handle_document_tracking", _handle_doc_tracking)
     monkeypatch.setattr(orch, "_map_results_to_contents", lambda contents, pf, uids: [list(uids)])
@@ -109,10 +119,11 @@ class _EntityResolver:
         self.postings = []
         self.reasserts = []
 
-    async def record_unit_entity_postings(self, pairs, bank_id=None):
-        # THE contract: the store re-posting runs with no connection held.
+    async def record_unit_entity_postings(self, pairs, bank_id=None, store_write=True):
+        # THE contract: co-occurrence accumulation runs with no connection held. store_write=False
+        # here because the entity ids were already written inline by index_facts (single write).
         assert self._t.open is False, "entity posting must run connection-free"
-        self.postings.append(pairs)
+        self.postings.append((pairs, store_write))
 
     async def reassert_entities_batch(self, bank_id, resolved, conn):
         assert conn is not None
@@ -174,10 +185,11 @@ async def test_store_writes_are_connection_free_and_witness_is_in_txn(monkeypatc
 
     assert result.aborted is False
     assert result.batch_result_ids == [["u1"]]
-    # The fact write happened with no connection held.
+    # The fact write happened with no connection held (a single deferred write via index_facts).
     assert tracker.store_writes_saw_open == [False]
-    # Entity re-posting happened (also connection-free — asserted inside the fake).
-    assert er.postings == [[("u1", "e1", None)]]
+    assert ("index_facts", False) in calls  # the entity-bearing store write ran connection-free
+    # Co-occurrence ran connection-free, with store_write=False (entities already written inline).
+    assert er.postings == [([("u1", "e1", None)], False)]
     # Witness written with a real connection, exactly once; commit published after release.
     assert len(provider.witnesses) == 1 and provider.witnesses[0][1] is not None
     assert provider.decisions == [True]
@@ -333,10 +345,11 @@ async def test_delta_store_writes_are_connection_free(monkeypatch):
 
     assert result.fell_back is False
     assert result.result_unit_ids == [["u1"]]
-    # Fact write + body store + entity re-posting all happened connection-free.
+    # Fact write + body store + entity re-posting all happened connection-free. The delta path
+    # still writes-then-reposts (store_write=True) — only the streaming path uses the single write.
     assert tracker.store_writes_saw_open == [False]
     assert ("store_document_bodies", False) in calls
-    assert er.postings == [[("u1", "e1", None)]]
+    assert er.postings == [([("u1", "e1", None)], True)]
     # Witness inside the txn; publish after release.
     assert len(provider.witnesses) == 1 and provider.witnesses[0][1] is not None
     assert provider.decisions == [True]


### PR DESCRIPTION
## What

Completes the store-owned / PG-free write path so a store that owns retain, entities, and document
metadata (`store_owned_retain_for(bank_id)` / `owns_document_store_for(bank_id)`) no longer goes
through cross-store write-group (Protocol-B) transactions for **any** operation.

Consolidation, curation edits, unit deletes, delete-document/where, delta re-ingest, the main
streaming write, and the per-batch 0-fact path were already converted in the preceding commits. This
adds the **one remaining gap**:

### The fix — zero-batch document tracking

`_streaming_retain_batch`'s post-loop "no batch processed" finalizer created a Postgres `documents`
row and opened a `begin_txn` / `decide_txn` write-group **even for a store-owned retain**. It is
reached when a retain yields *zero* batches:

- empty or gibberish content (no facts extracted at all), or
- a recovery where every chunk was already committed on a prior attempt.

In that window the per-batch 0-fact branch's store-owned path never runs, so `doc_tracking_done`
stays False and the finalizer falls through to the legacy Postgres path. That reintroduces both a
Postgres write and an undecided write-group on the supposedly PG-free path.

The finalizer now takes the same store-owned branch the per-batch 0-fact path uses: for a
store-owned retain, drop the document's prior memories with one plain store-side
delete-by-document — no Postgres row, no write-group, nothing left undecided to stall the store's
indexer.

## Also

A comments-only commit describes the store-owned delete generically (drops an internal backend name
from three comments); no behavioural change.

## Status

Draft — not for merge yet. Opened to make the completed store-owned series reviewable against
`main` and to continue the remaining work here.

## Test notes

- `orchestrator.py` and `memory_engine.py` parse clean.
- The finalizer change mirrors the reviewed per-batch 0-fact store-owned branch (same guard, same
  `delete_document(conn=None, ...)` shape).
- Still to run here: the retain zero-batch / recovery paths and the store-owned e2e suite.
