### PR TITLE
refactor(bank): eliminate redundant existence queries in _ensure_bank_exists

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -11444,32 +11444,46 @@ class MemoryEngine(MemoryEngineInterface):
             if created:
                 await self._apply_default_bank_template(bank_id, rc)
 
+        Concurrency & Validation:
+          * Lockless Optimistic Concurrency: To avoid advisory lock deadlocks
+            and holding transactions across async validator hooks, all callers
+            observing an uncreated bank state independently evaluate
+            `validate_create_bank` before attempting database insertion.
+          * Atomic Arbitration: The database unique constraint arbitrates
+            competing inserts (via `INSERT ... ON CONFLICT DO NOTHING`). Only
+            the winning caller receives `created=True` and applies the default
+            bank template; concurrent losers safely receive `created=False`.
+          * Existing Bank Bypass: Once a bank is committed, subsequent callers
+            observe `exists=True` on their initial probe, returning `False`
+            immediately and bypassing `validate_create_bank`.
+
         Returns:
             True if the bank was freshly created on this call.
         """
         backend = await self._get_backend()
-        if self._operation_validator:
-            if conn is not None:
-                exists = await conn.fetchval(f"SELECT 1 FROM {fq_table('banks')} WHERE bank_id = $1", bank_id)
-            else:
-                exists = await bank_utils.get_bank_profile_if_exists(backend, bank_id)
-            if not exists:
-                from hindsight_api.extensions import CreateBankContext
+        if conn is not None:
+            exists = bool(await conn.fetchval(f"SELECT 1 FROM {fq_table('banks')} WHERE bank_id = $1", bank_id))
+        else:
+            exists = bool(await bank_utils.get_bank_profile_if_exists(backend, bank_id))
+        if exists:
+            return False
 
-                ctx = CreateBankContext(
-                    bank_id=bank_id,
-                    request_context=request_context,
-                )
-                await self._validate_operation(self._operation_validator.validate_create_bank(ctx))
+        if self._operation_validator:
+            from hindsight_api.extensions import CreateBankContext
+
+            ctx = CreateBankContext(
+                bank_id=bank_id,
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_create_bank(ctx))
 
         if conn is not None:
-            result = await bank_utils.get_or_create_bank_profile_on_conn(conn, bank_id, ops=backend.ops)
-            return result.created
+            return await bank_utils.create_bank_row_on_conn(conn, bank_id, ops=backend.ops)
 
-        result = await bank_utils.get_or_create_bank_profile(backend, bank_id)
-        if result.created:
+        created = await bank_utils.create_bank_if_missing(backend, bank_id)
+        if created:
             await self._apply_default_bank_template(bank_id, request_context)
-        return result.created
+        return created
 
     async def get_bank_config(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -11705,32 +11705,46 @@ class MemoryEngine(MemoryEngineInterface):
             if created:
                 await self._apply_default_bank_template(bank_id, rc)
 
+        Concurrency & Validation:
+          * Lockless Optimistic Concurrency: To avoid advisory lock deadlocks
+            and holding transactions across async validator hooks, all callers
+            observing an uncreated bank state independently evaluate
+            `validate_create_bank` before attempting database insertion.
+          * Atomic Arbitration: The database unique constraint arbitrates
+            competing inserts (via `INSERT ... ON CONFLICT DO NOTHING`). Only
+            the winning caller receives `created=True` and applies the default
+            bank template; concurrent losers safely receive `created=False`.
+          * Existing Bank Bypass: Once a bank is committed, subsequent callers
+            observe `exists=True` on their initial probe, returning `False`
+            immediately and bypassing `validate_create_bank`.
+
         Returns:
             True if the bank was freshly created on this call.
         """
         backend = await self._get_backend()
-        if self._operation_validator:
-            if conn is not None:
-                exists = await conn.fetchval(f"SELECT 1 FROM {fq_table('banks')} WHERE bank_id = $1", bank_id)
-            else:
-                exists = await bank_utils.get_bank_profile_if_exists(backend, bank_id)
-            if not exists:
-                from hindsight_api.extensions import CreateBankContext
+        if conn is not None:
+            exists = bool(await conn.fetchval(f"SELECT 1 FROM {fq_table('banks')} WHERE bank_id = $1", bank_id))
+        else:
+            exists = bool(await bank_utils.get_bank_profile_if_exists(backend, bank_id))
+        if exists:
+            return False
 
-                ctx = CreateBankContext(
-                    bank_id=bank_id,
-                    request_context=request_context,
-                )
-                await self._validate_operation(self._operation_validator.validate_create_bank(ctx))
+        if self._operation_validator:
+            from hindsight_api.extensions import CreateBankContext
+
+            ctx = CreateBankContext(
+                bank_id=bank_id,
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_create_bank(ctx))
 
         if conn is not None:
-            result = await bank_utils.get_or_create_bank_profile_on_conn(conn, bank_id, ops=backend.ops)
-            return result.created
+            return await bank_utils.create_bank_row_on_conn(conn, bank_id, ops=backend.ops)
 
-        result = await bank_utils.get_or_create_bank_profile(backend, bank_id)
-        if result.created:
+        created = await bank_utils.create_bank_if_missing(backend, bank_id)
+        if created:
             await self._apply_default_bank_template(bank_id, request_context)
-        return result.created
+        return created
 
     async def get_bank_config(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -11705,27 +11705,30 @@ class MemoryEngine(MemoryEngineInterface):
             if created:
                 await self._apply_default_bank_template(bank_id, rc)
 
-        Concurrency & Validation:
-          * Lockless Optimistic Concurrency: To avoid advisory lock deadlocks
-            and holding transactions across async validator hooks, all callers
-            observing an uncreated bank state independently evaluate
-            `validate_create_bank` before attempting database insertion.
-          * Atomic Arbitration: The database unique constraint arbitrates
-            competing inserts (via `INSERT ... ON CONFLICT DO NOTHING`). Only
-            the winning caller receives `created=True` and applies the default
-            bank template; concurrent losers safely receive `created=False`.
-          * Existing Bank Bypass: Once a bank is committed, subsequent callers
-            observe `exists=True` on their initial probe, returning `False`
-            immediately and bypassing `validate_create_bank`.
+        Concurrency:
+          An existence probe runs first, so a write to an already-existing bank
+          — the overwhelmingly common case — costs one bare SELECT and issues no
+          write statement and no `validate_create_bank` call.
+
+          The probe, the validator hook and the insert are deliberately NOT
+          serialised: `validate_create_bank` is an extension hook that may do
+          arbitrary I/O, and neither an advisory lock nor a held connection may
+          span it. So concurrent callers can all observe the bank as missing and
+          all run the validator. The unique constraint arbitrates instead — the
+          `INSERT ... ON CONFLICT DO NOTHING` gives exactly one caller
+          `created=True`, and only that one applies the default bank template.
+          A validator must therefore tolerate being called more than once for a
+          bank that ends up created once. This is unchanged from before the
+          probe was hoisted; it has always been the contract.
 
         Returns:
             True if the bank was freshly created on this call.
         """
         backend = await self._get_backend()
         if conn is not None:
-            exists = bool(await conn.fetchval(f"SELECT 1 FROM {fq_table('banks')} WHERE bank_id = $1", bank_id))
+            exists = await bank_utils.bank_exists_on_conn(conn, bank_id)
         else:
-            exists = bool(await bank_utils.get_bank_profile_if_exists(backend, bank_id))
+            exists = await bank_utils.bank_exists(backend, bank_id)
         if exists:
             return False
 
@@ -11741,6 +11744,9 @@ class MemoryEngine(MemoryEngineInterface):
         if conn is not None:
             return await bank_utils.create_bank_row_on_conn(conn, bank_id, ops=backend.ops)
 
+        # Second connection, on purpose: the validator hook above must not run
+        # while one is held. Only ever paid once per bank, on the call that
+        # creates it — every later call returns above on the probe.
         created = await bank_utils.create_bank_if_missing(backend, bank_id)
         if created:
             await self._apply_default_bank_template(bank_id, request_context)

--- a/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
@@ -8,7 +8,7 @@ import logging
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 from pydantic import BaseModel, Field
 
@@ -17,6 +17,10 @@ from ...config import get_config
 from ..db_utils import acquire_with_retry, retry_with_backoff
 from ..memory_engine import fq_table, get_current_schema
 from ..response_models import DispositionTraits
+
+if TYPE_CHECKING:
+    from ..db.base import DatabaseConnection
+    from ..db.ops import DataAccessOps
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +50,9 @@ def _vector_index_clause() -> str | None:
     return index_using_clause(ext)
 
 
-async def create_bank_vector_indexes(conn, bank_id: str, internal_id: str, *, ops) -> None:
+async def create_bank_vector_indexes(
+    conn: "DatabaseConnection", bank_id: str, internal_id: str, *, ops: "DataAccessOps"
+) -> None:
     """Create per-(bank, fact_type) partial vector indexes for a newly created bank.
 
     Only does anything when the size threshold is off — the default — where a
@@ -95,7 +101,7 @@ async def create_bank_vector_indexes(conn, bank_id: str, internal_id: str, *, op
     )
 
 
-async def drop_bank_vector_indexes(conn, internal_id: str, ops=None) -> None:
+async def drop_bank_vector_indexes(conn: "DatabaseConnection", internal_id: str, *, ops: "DataAccessOps") -> None:
     """Drop per-(bank, fact_type) partial vector indexes for a bank being deleted.
 
     Called before the bank row is deleted so internal_id is still known.
@@ -160,6 +166,30 @@ async def get_bank_profile(pool, bank_id: str) -> BankProfile:
     return result.profile
 
 
+async def get_bank_profile_if_exists_on_conn(conn: "DatabaseConnection", bank_id: str) -> BankProfile | None:
+    """Get bank profile (name, disposition + mission) on conn without auto-creating.
+
+    Returns None if the bank does not exist.
+    """
+    row = await conn.fetchrow(
+        f"""
+        SELECT name, disposition, mission
+        FROM {fq_table("banks")} WHERE bank_id = $1
+        """,
+        bank_id,
+    )
+    if not row:
+        return None
+    disposition_data = row["disposition"]
+    if isinstance(disposition_data, str):
+        disposition_data = json.loads(disposition_data)
+    return BankProfile(
+        name=row["name"],
+        disposition=DispositionTraits(**disposition_data),
+        mission=row["mission"] or "",
+    )
+
+
 async def get_bank_profile_if_exists(pool, bank_id: str) -> BankProfile | None:
     """
     Get bank profile (name, disposition + mission) without auto-creating.
@@ -176,23 +206,55 @@ async def get_bank_profile_if_exists(pool, bank_id: str) -> BankProfile | None:
         BankProfile if the bank exists, otherwise None.
     """
     async with acquire_with_retry(pool) as conn:
-        row = await conn.fetchrow(
-            f"""
-            SELECT name, disposition, mission
-            FROM {fq_table("banks")} WHERE bank_id = $1
-            """,
-            bank_id,
-        )
-        if not row:
-            return None
-        disposition_data = row["disposition"]
-        if isinstance(disposition_data, str):
-            disposition_data = json.loads(disposition_data)
-        return BankProfile(
-            name=row["name"],
-            disposition=DispositionTraits(**disposition_data),
-            mission=row["mission"] or "",
-        )
+        return await get_bank_profile_if_exists_on_conn(conn, bank_id)
+
+
+async def create_bank_row_on_conn(conn: "DatabaseConnection", bank_id: str, *, ops: "DataAccessOps") -> bool:
+    """Idempotently insert a default bank row and its vector indexes on conn.
+
+    Uses ``INSERT ... ON CONFLICT (bank_id) DO NOTHING RETURNING bank_id``.
+    Returns True if the bank was freshly inserted on this call, False if it already existed.
+
+    Note: On Oracle, the dialect layer strips RETURNING from ON CONFLICT DO NOTHING,
+    so fetchval returns None and created evaluates to False (pre-existing dialect behaviour).
+    """
+    internal_id = uuid.uuid4()
+    inserted = await conn.fetchval(
+        f"""
+        INSERT INTO {fq_table("banks")} (bank_id, name, disposition, mission, internal_id)
+        VALUES ($1, $2, $3::jsonb, $4, $5)
+        ON CONFLICT (bank_id) DO NOTHING
+        RETURNING bank_id
+        """,
+        bank_id,
+        bank_id,  # Default name is the bank_id
+        json.dumps(DEFAULT_DISPOSITION),
+        "",
+        internal_id,
+    )
+
+    created = inserted is not None
+    if created:
+        # Fresh insert — create per-bank vector indexes (instant on an empty
+        # bank). A no-op unless the size threshold is off; see
+        # create_bank_vector_indexes.
+        await create_bank_vector_indexes(conn, bank_id, str(internal_id), ops=ops)
+
+    return created
+
+
+async def create_bank_if_missing(pool, bank_id: str) -> bool:
+    """Dedicated-connection variant of create_bank_row_on_conn with transaction & deadlock retry.
+
+    Returns True if freshly created on this call, False if it already existed.
+    """
+
+    async def _create() -> bool:
+        async with acquire_with_retry(pool) as conn:
+            async with conn.transaction():
+                return await create_bank_row_on_conn(conn, bank_id, ops=pool.ops)
+
+    return await retry_with_backoff(_create)
 
 
 async def get_or_create_bank_profile(pool, bank_id: str) -> BankProfileResult:
@@ -227,7 +289,9 @@ async def get_or_create_bank_profile(pool, bank_id: str) -> BankProfileResult:
     return await retry_with_backoff(_create)
 
 
-async def get_or_create_bank_profile_on_conn(conn, bank_id: str, *, ops) -> BankProfileResult:
+async def get_or_create_bank_profile_on_conn(
+    conn: "DatabaseConnection", bank_id: str, *, ops: "DataAccessOps"
+) -> BankProfileResult:
     """
     Connection-bound variant of ``get_or_create_bank_profile``.
 
@@ -241,55 +305,18 @@ async def get_or_create_bank_profile_on_conn(conn, bank_id: str, *, ops) -> Bank
     ``ops`` is the backend's dialect ops object (``backend.ops``), needed for
     per-bank vector index DDL.
     """
-    # Try to get existing bank
-    row = await conn.fetchrow(
-        f"""
-        SELECT name, disposition, mission
-        FROM {fq_table("banks")} WHERE bank_id = $1
-        """,
-        bank_id,
-    )
-
-    if row:
-        # asyncpg returns JSONB as a string, so parse it
-        disposition_data = row["disposition"]
-        if isinstance(disposition_data, str):
-            disposition_data = json.loads(disposition_data)
-
+    profile = await get_bank_profile_if_exists_on_conn(conn, bank_id)
+    if profile is not None:
         return BankProfileResult(
-            profile=BankProfile(
-                name=row["name"],
-                disposition=DispositionTraits(**disposition_data),
-                mission=row["mission"] or "",
-            ),
+            profile=profile,
             created=False,
         )
 
-    # Bank doesn't exist, create with defaults. internal_id is minted here rather
-    # than defaulted server-side so its value is known without a RETURNING
-    # round-trip: the index names derive from it, both for the eager create below
-    # and for the maintenance operation when a threshold is set.
-    internal_id = uuid.uuid4()
-    inserted = await conn.fetchval(
-        f"""
-        INSERT INTO {fq_table("banks")} (bank_id, name, disposition, mission, internal_id)
-        VALUES ($1, $2, $3::jsonb, $4, $5)
-        ON CONFLICT (bank_id) DO NOTHING
-        RETURNING bank_id
-        """,
-        bank_id,
-        bank_id,  # Default name is the bank_id
-        json.dumps(DEFAULT_DISPOSITION),
-        "",
-        internal_id,
-    )
-
-    created = inserted is not None
-    if created:
-        # Fresh insert — create per-bank vector indexes (instant on an empty
-        # bank). A no-op unless the size threshold is off; see
-        # create_bank_vector_indexes.
-        await create_bank_vector_indexes(conn, bank_id, str(internal_id), ops=ops)
+    # Bank doesn't exist, create with defaults. internal_id is minted inside
+    # create_bank_row_on_conn rather than defaulted server-side so its value is
+    # known without a RETURNING round-trip: the index names derive from it, both
+    # for the eager create and for the maintenance operation when a threshold is set.
+    created = await create_bank_row_on_conn(conn, bank_id, ops=ops)
 
     return BankProfileResult(
         profile=BankProfile(name=bank_id, disposition=DispositionTraits(**DEFAULT_DISPOSITION), mission=""),

--- a/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
@@ -166,6 +166,27 @@ async def get_bank_profile(pool, bank_id: str) -> BankProfile:
     return result.profile
 
 
+async def bank_exists_on_conn(conn: "DatabaseConnection", bank_id: str) -> bool:
+    """Existence probe for a bank row on a caller-supplied connection.
+
+    Deliberately narrower than ``get_bank_profile_if_exists_on_conn``: callers on
+    the lazy-create hot path only need to know whether the row is there, so this
+    selects a constant instead of reading and JSON-decoding the disposition.
+    """
+    return await conn.fetchval(f"SELECT 1 FROM {fq_table('banks')} WHERE bank_id = $1", bank_id) is not None
+
+
+async def bank_exists(pool, bank_id: str) -> bool:
+    """Dedicated-connection variant of ``bank_exists_on_conn``.
+
+    A bare SELECT with no surrounding transaction — this is the read-only fast
+    path taken by every write to an already-existing bank, so it must not pay
+    for a BEGIN/COMMIT round trip.
+    """
+    async with acquire_with_retry(pool) as conn:
+        return await bank_exists_on_conn(conn, bank_id)
+
+
 async def get_bank_profile_if_exists_on_conn(conn: "DatabaseConnection", bank_id: str) -> BankProfile | None:
     """Get bank profile (name, disposition + mission) on conn without auto-creating.
 
@@ -215,9 +236,18 @@ async def create_bank_row_on_conn(conn: "DatabaseConnection", bank_id: str, *, o
     Uses ``INSERT ... ON CONFLICT (bank_id) DO NOTHING RETURNING bank_id``.
     Returns True if the bank was freshly inserted on this call, False if it already existed.
 
-    Note: On Oracle, the dialect layer strips RETURNING from ON CONFLICT DO NOTHING,
-    so fetchval returns None and created evaluates to False (pre-existing dialect behaviour).
+    The ``created`` flag drives one-time side effects (per-bank vector indexes
+    here, the default-bank-template hook in the caller), so it has to be exact on
+    both dialects. It is: the Oracle layer strips RETURNING from ON CONFLICT DO
+    NOTHING, but ``fetchval`` compensates — it returns the first bind argument on
+    a successful insert and None when it suppresses ORA-00001 (see
+    ``db/oracle.py``). Use ``fetchval`` here, not ``fetchrow``, which has no such
+    compensation and would report every fresh Oracle insert as an existing row.
     """
+    # internal_id is minted here rather than defaulted server-side so its value is
+    # known without a RETURNING round-trip: the index names derive from it, both
+    # for the eager create below and for the maintenance operation when a
+    # threshold is set.
     internal_id = uuid.uuid4()
     inserted = await conn.fetchval(
         f"""
@@ -244,11 +274,20 @@ async def create_bank_row_on_conn(conn: "DatabaseConnection", bank_id: str, *, o
 
 
 async def create_bank_if_missing(pool, bank_id: str) -> bool:
-    """Dedicated-connection variant of create_bank_row_on_conn with transaction & deadlock retry.
+    """Dedicated-connection variant of ``create_bank_row_on_conn``.
 
     Returns True if freshly created on this call, False if it already existed.
     """
 
+    # Retried as a whole transaction. With the size threshold off (the default)
+    # a fresh bank builds its per-(bank, fact_type) partial vector indexes with a
+    # plain CREATE INDEX — it must, since this runs inside the bank-create tx and
+    # CONCURRENTLY cannot — and that CREATE takes a ShareLock on the shared
+    # memory_units table, which can deadlock with concurrent writers. Even with
+    # no DDL to issue, the lazy create can lose a deadlock (40P01 / ORA-00060) to
+    # a concurrent writer touching the same bank row. The body is idempotent
+    # (INSERT ... ON CONFLICT DO NOTHING + CREATE INDEX IF NOT EXISTS), so
+    # retrying the whole tx stays correct and cheap.
     async def _create() -> bool:
         async with acquire_with_retry(pool) as conn:
             async with conn.transaction():
@@ -272,15 +311,8 @@ async def get_or_create_bank_profile(pool, bank_id: str) -> BankProfileResult:
     ``get_or_create_bank_profile_on_conn`` instead.
     """
 
-    # Retried as a whole transaction. With the size threshold off (the default)
-    # a fresh bank builds its per-(bank, fact_type) partial vector indexes with a
-    # plain CREATE INDEX — it must, since this runs inside the bank-create tx and
-    # CONCURRENTLY cannot — and that CREATE takes a ShareLock on the shared
-    # memory_units table, which can deadlock with concurrent writers. Even with
-    # no DDL to issue, the lazy create can lose a deadlock (40P01 / ORA-00060) to
-    # a concurrent writer touching the same bank row. The body is idempotent
-    # (INSERT ... ON CONFLICT DO NOTHING + CREATE INDEX IF NOT EXISTS), so
-    # retrying the whole tx stays correct and cheap.
+    # Retried as a whole transaction — see the deadlock note on
+    # ``create_bank_if_missing``; the body is idempotent, so retrying is safe.
     async def _create() -> BankProfileResult:
         async with acquire_with_retry(pool) as conn:
             async with conn.transaction():
@@ -312,10 +344,7 @@ async def get_or_create_bank_profile_on_conn(
             created=False,
         )
 
-    # Bank doesn't exist, create with defaults. internal_id is minted inside
-    # create_bank_row_on_conn rather than defaulted server-side so its value is
-    # known without a RETURNING round-trip: the index names derive from it, both
-    # for the eager create and for the maintenance operation when a threshold is set.
+    # Bank doesn't exist, create with defaults.
     created = await create_bank_row_on_conn(conn, bank_id, ops=ops)
 
     return BankProfileResult(

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -13,7 +13,7 @@ from typing import Any
 from ...config import _get_raw_config
 from ..memory_engine import fq_table
 from ..metadata_utils import drop_null_values
-from .bank_utils import DEFAULT_DISPOSITION, create_bank_vector_indexes
+from .bank_utils import create_bank_row_on_conn
 from .fact_extraction import _sanitize_text
 from .types import ProcessedFact
 
@@ -131,7 +131,10 @@ async def ensure_bank_exists(conn, bank_id: str, *, ops) -> None:
     """
     Ensure bank exists in the database.
 
-    Creates bank with default values if it doesn't exist.
+    Creates bank with default values if it doesn't exist. Retain's entry point
+    into the lazy bank-create; the row and its per-bank vector indexes are
+    written by ``bank_utils.create_bank_row_on_conn`` so that a bank born here
+    is byte-for-byte the same as one born through ``get_or_create_bank_profile``.
 
     Args:
         conn: Database connection
@@ -141,28 +144,7 @@ async def ensure_bank_exists(conn, bank_id: str, *, ops) -> None:
             than defaulting to None, because it is dereferenced only in that
             branch — a caller that omitted it worked until the threshold was off.
     """
-    # internal_id is generated here rather than defaulted server-side so the
-    # value is known without a RETURNING round-trip: the index names derive
-    # from it.
-    internal_id = uuid.uuid4()
-    inserted = await conn.fetchval(
-        f"""
-        INSERT INTO {fq_table("banks")} (bank_id, name, disposition, mission, internal_id)
-        VALUES ($1, $2, $3::jsonb, $4, $5)
-        ON CONFLICT (bank_id) DO NOTHING
-        RETURNING bank_id
-        """,
-        bank_id,
-        bank_id,  # Default name is the bank_id (matches get_or_create_bank_profile)
-        json.dumps(DEFAULT_DISPOSITION),
-        "",
-        internal_id,
-    )
-    if inserted:
-        # Fresh insert — create per-bank vector indexes. A no-op unless the size
-        # threshold is off, in which case the maintenance operation owns them;
-        # see create_bank_vector_indexes.
-        await create_bank_vector_indexes(conn, bank_id, str(internal_id), ops=ops)
+    await create_bank_row_on_conn(conn, bank_id, ops=ops)
 
 
 async def delete_stale_observations_for_memories(

--- a/hindsight-api-slim/tests/test_ensure_bank_exists_optimization.py
+++ b/hindsight-api-slim/tests/test_ensure_bank_exists_optimization.py
@@ -1,0 +1,428 @@
+"""Tests for _ensure_bank_exists optimization and bank_utils primitives.
+
+Verifies that:
+1. Both validator-enabled and default non-validator paths execute a SELECT-first check
+   and do not issue write statements for already existing banks.
+2. Existing banks do not trigger validate_create_bank or duplicate queries.
+3. Missing banks execute exactly one pre-check query and one atomic insert.
+4. Concurrent creation is idempotent and applies default template exactly once.
+5. Validator rejection prevents bank row insertion.
+6. Primitives in bank_utils are properly typed and behave as expected.
+"""
+
+import asyncio
+import uuid
+
+import pytest
+
+from hindsight_api import RequestContext
+from hindsight_api.engine.db_utils import acquire_with_retry
+from hindsight_api.engine.memory_engine import MemoryEngine
+from hindsight_api.engine.retain import bank_utils
+from hindsight_api.extensions import CreateBankContext, OperationValidationError, ValidationResult
+
+
+class TrackingValidator:
+    """Validator that tracks validate_create_bank invocations and can reject."""
+
+    def __init__(self, reject: bool = False):
+        self.reject = reject
+        self.create_bank_calls: list[CreateBankContext] = []
+
+    async def validate_create_bank(self, ctx: CreateBankContext) -> ValidationResult:
+        self.create_bank_calls.append(ctx)
+        if self.reject:
+            return ValidationResult.reject("bank creation not allowed", status_code=403)
+        return ValidationResult.accept()
+
+
+@pytest.mark.asyncio
+async def test_ensure_bank_exists_skips_validation_and_duplicate_query_for_existing_bank(
+    memory: MemoryEngine, request_context: RequestContext
+) -> None:
+    """When bank exists, _ensure_bank_exists runs only 1 query and skips validate_create_bank."""
+    bank_id = f"test-opt-exist-{uuid.uuid4().hex[:8]}"
+    backend = await memory._get_backend()
+
+    # Pre-create the bank
+    await bank_utils.create_bank_if_missing(backend, bank_id)
+
+    validator = TrackingValidator()
+    memory._operation_validator = validator
+
+    # Call _ensure_bank_exists without conn
+    created = await memory._ensure_bank_exists(bank_id, request_context)
+    assert created is False
+    assert len(validator.create_bank_calls) == 0
+
+    # Call _ensure_bank_exists with conn
+    async with acquire_with_retry(backend) as conn:
+        async with conn.transaction():
+            created_on_conn = await memory._ensure_bank_exists(bank_id, request_context, conn=conn)
+            assert created_on_conn is False
+    assert len(validator.create_bank_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_ensure_bank_exists_non_validator_path_is_read_only_for_existing_bank(
+    memory: MemoryEngine, request_context: RequestContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Under default (no-validator) mode, existing banks perform only a SELECT and no INSERT."""
+    bank_id = f"test-opt-novalidator-exist-{uuid.uuid4().hex[:8]}"
+    backend = await memory._get_backend()
+
+    # Pre-create the bank
+    await bank_utils.create_bank_if_missing(backend, bank_id)
+
+    memory._operation_validator = None
+
+    create_row_calls = 0
+    real_create_row = bank_utils.create_bank_row_on_conn
+
+    async def spy_create_row(conn, b_id, *, ops):
+        nonlocal create_row_calls
+        if b_id == bank_id:
+            create_row_calls += 1
+        return await real_create_row(conn, b_id, ops=ops)
+
+    monkeypatch.setattr(bank_utils, "create_bank_row_on_conn", spy_create_row)
+
+    # Calling on existing bank without conn must NOT call create_bank_row_on_conn
+    created = await memory._ensure_bank_exists(bank_id, request_context)
+    assert created is False
+    assert create_row_calls == 0, "Existing bank in non-validator path must not execute insert"
+
+    # Calling on existing bank with conn must NOT call create_bank_row_on_conn
+    async with acquire_with_retry(backend) as conn:
+        async with conn.transaction():
+            created_on_conn = await memory._ensure_bank_exists(bank_id, request_context, conn=conn)
+            assert created_on_conn is False
+    assert create_row_calls == 0, "Existing bank in non-validator on-conn path must not execute insert"
+
+
+@pytest.mark.asyncio
+async def test_ensure_bank_exists_missing_bank_query_count(
+    memory: MemoryEngine, request_context: RequestContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When bank is missing, _ensure_bank_exists validates and inserts without duplicate SELECT."""
+    bank_id = f"test-opt-missing-{uuid.uuid4().hex[:8]}"
+    backend = await memory._get_backend()
+
+    validator = TrackingValidator()
+    memory._operation_validator = validator
+
+    # Spy on get_bank_profile_if_exists to ensure it is called only once per _ensure_bank_exists invocation
+    real_get_if_exists = bank_utils.get_bank_profile_if_exists
+    get_if_exists_calls = 0
+
+    async def spy_get_if_exists(pool, b_id):
+        nonlocal get_if_exists_calls
+        if b_id == bank_id:
+            get_if_exists_calls += 1
+        return await real_get_if_exists(pool, b_id)
+
+    # Spy on create_bank_row_on_conn to ensure it is called directly
+    real_create_row = bank_utils.create_bank_row_on_conn
+    create_row_calls = 0
+
+    async def spy_create_row(conn, b_id, *, ops):
+        nonlocal create_row_calls
+        if b_id == bank_id:
+            create_row_calls += 1
+        return await real_create_row(conn, b_id, ops=ops)
+
+    monkeypatch.setattr(bank_utils, "get_bank_profile_if_exists", spy_get_if_exists)
+    monkeypatch.setattr(bank_utils, "create_bank_row_on_conn", spy_create_row)
+
+    # Execute _ensure_bank_exists (without conn)
+    created = await memory._ensure_bank_exists(bank_id, request_context)
+
+    assert created is True
+    assert len(validator.create_bank_calls) == 1
+    assert validator.create_bank_calls[0].bank_id == bank_id
+    assert get_if_exists_calls == 1, "Expected exactly 1 existence query before validation"
+    assert create_row_calls == 1, "Expected exactly 1 atomic insert call"
+
+    # Subsequent call on now-existing bank: no validate, no insert
+    created_again = await memory._ensure_bank_exists(bank_id, request_context)
+    assert created_again is False
+    assert len(validator.create_bank_calls) == 1, "Existing bank must not trigger validation"
+    assert get_if_exists_calls == 2, "Expected 2 total existence checks across the two invocations"
+    assert create_row_calls == 1, "Insert must not be called again"
+
+
+@pytest.mark.asyncio
+async def test_ensure_bank_exists_on_conn_missing_bank_query_count(
+    memory: MemoryEngine, request_context: RequestContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When bank is missing and conn is provided, _ensure_bank_exists executes 1 SELECT and 1 INSERT."""
+    bank_id = f"test-opt-conn-{uuid.uuid4().hex[:8]}"
+    backend = await memory._get_backend()
+
+    validator = TrackingValidator()
+    memory._operation_validator = validator
+
+    create_row_calls = 0
+    real_create_row = bank_utils.create_bank_row_on_conn
+
+    async def spy_create_row(conn, b_id, *, ops):
+        nonlocal create_row_calls
+        if b_id == bank_id:
+            create_row_calls += 1
+        return await real_create_row(conn, b_id, ops=ops)
+
+    monkeypatch.setattr(bank_utils, "create_bank_row_on_conn", spy_create_row)
+
+    async with acquire_with_retry(backend) as conn:
+        async with conn.transaction():
+            created = await memory._ensure_bank_exists(bank_id, request_context, conn=conn)
+
+    assert created is True
+    assert len(validator.create_bank_calls) == 1
+    assert create_row_calls == 1
+
+    # Verify on-conn check on existing bank returns False and does not call create_row
+    async with acquire_with_retry(backend) as conn:
+        async with conn.transaction():
+            created_again = await memory._ensure_bank_exists(bank_id, request_context, conn=conn)
+
+    assert created_again is False
+    assert len(validator.create_bank_calls) == 1
+    assert create_row_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_bank_exists_validator_rejection_prevents_insert(
+    memory: MemoryEngine, request_context: RequestContext
+) -> None:
+    """When validate_create_bank rejects, no bank row is created in the database."""
+    bank_id = f"test-opt-reject-{uuid.uuid4().hex[:8]}"
+    backend = await memory._get_backend()
+
+    validator = TrackingValidator(reject=True)
+    memory._operation_validator = validator
+
+    with pytest.raises(OperationValidationError) as exc_info:
+        await memory._ensure_bank_exists(bank_id, request_context)
+
+    assert "bank creation not allowed" in str(exc_info.value)
+    assert len(validator.create_bank_calls) == 1
+
+    # Ensure no row was created
+    profile = await bank_utils.get_bank_profile_if_exists(backend, bank_id)
+    assert profile is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_bank_exists_concurrent_creation_applies_template_once(
+    memory: MemoryEngine, request_context: RequestContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Concurrent calls to _ensure_bank_exists result in exactly one created=True and one template application."""
+    bank_id = f"test-opt-concurrent-{uuid.uuid4().hex[:8]}"
+    backend = await memory._get_backend()
+
+    validator = TrackingValidator()
+    memory._operation_validator = validator
+
+    template_applied_count = 0
+    real_apply_template = memory._apply_default_bank_template
+
+    async def spy_apply_template(b_id, ctx):
+        nonlocal template_applied_count
+        if b_id == bank_id:
+            template_applied_count += 1
+        return await real_apply_template(b_id, ctx)
+
+    monkeypatch.setattr(memory, "_apply_default_bank_template", spy_apply_template)
+
+    # Launch two concurrent _ensure_bank_exists calls
+    results = await asyncio.gather(
+        memory._ensure_bank_exists(bank_id, request_context),
+        memory._ensure_bank_exists(bank_id, request_context),
+    )
+
+    # Exactly one must return True (created) and one False (already created by the other)
+    assert sorted(results) == [False, True]
+    assert template_applied_count == 1, "Default bank template must be applied exactly once"
+
+    # Verify bank profile exists
+    profile = await bank_utils.get_bank_profile_if_exists(backend, bank_id)
+    assert profile is not None
+    assert profile["name"] == bank_id
+
+
+@pytest.mark.asyncio
+async def test_ensure_bank_exists_creation_race_barrier_delayed_validation(
+    memory: MemoryEngine, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Barrier test: Caller 2 observes missing bank, Caller 1 commits insert, then Caller 2 validates & inserts."""
+    bank_id = f"test-opt-race-barrier-{uuid.uuid4().hex[:8]}"
+    backend = await memory._get_backend()
+
+    rc1 = RequestContext(tenant_id="tenant-caller-1")
+    rc2 = RequestContext(tenant_id="tenant-caller-2")
+
+    validator = TrackingValidator()
+    memory._operation_validator = validator
+
+    template_applied_count = 0
+    real_apply_template = memory._apply_default_bank_template
+
+    async def spy_apply_template(b_id, ctx):
+        nonlocal template_applied_count
+        if b_id == bank_id:
+            template_applied_count += 1
+        return await real_apply_template(b_id, ctx)
+
+    monkeypatch.setattr(memory, "_apply_default_bank_template", spy_apply_template)
+
+    caller1_committed_event = asyncio.Event()
+    caller2_probed_missing_event = asyncio.Event()
+
+    real_get_if_exists = bank_utils.get_bank_profile_if_exists
+
+    async def spy_get_if_exists(pool, b_id):
+        res = await real_get_if_exists(pool, b_id)
+        if b_id == bank_id and not caller2_probed_missing_event.is_set():
+            caller2_probed_missing_event.set()
+        return res
+
+    monkeypatch.setattr(bank_utils, "get_bank_profile_if_exists", spy_get_if_exists)
+
+    real_validate = validator.validate_create_bank
+
+    async def synchronized_validate(ctx: CreateBankContext) -> ValidationResult:
+        if ctx.request_context and ctx.request_context.tenant_id == "tenant-caller-2":
+            # Caller 2: pause inside validation until Caller 1 has committed its insert
+            await caller1_committed_event.wait()
+        return await real_validate(ctx)
+
+    validator.validate_create_bank = synchronized_validate
+
+    async def run_caller1():
+        # Wait until Caller 2 has probed missing bank state
+        await caller2_probed_missing_event.wait()
+        res = await memory._ensure_bank_exists(bank_id, rc1)
+        caller1_committed_event.set()
+        return res
+
+    async def run_caller2():
+        return await memory._ensure_bank_exists(bank_id, rc2)
+
+    # Start Caller 2 first so its probe runs before Caller 1 starts
+    task2 = asyncio.create_task(run_caller2())
+    task1 = asyncio.create_task(run_caller1())
+
+    res2, res1 = await asyncio.gather(task2, task1)
+
+    assert res1 is True, "Caller 1 was the winning insert and should report created=True"
+    assert res2 is False, "Caller 2 was the losing insert and should report created=False"
+    assert len(validator.create_bank_calls) == 2, "Both concurrent callers executed validation"
+    assert template_applied_count == 1, "Default bank template must be applied exactly once"
+
+    # Verify exactly 1 bank in database
+    profile = await bank_utils.get_bank_profile_if_exists(backend, bank_id)
+    assert profile is not None
+    assert profile["name"] == bank_id
+
+
+@pytest.mark.asyncio
+async def test_ensure_bank_exists_creation_race_barrier_delayed_validation_rejected(
+    memory: MemoryEngine, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Barrier test: Caller 2 observes missing bank, Caller 1 commits, Caller 2 delayed validation is rejected."""
+    bank_id = f"test-opt-race-reject-{uuid.uuid4().hex[:8]}"
+    backend = await memory._get_backend()
+
+    rc1 = RequestContext(tenant_id="tenant-caller-1")
+    rc2 = RequestContext(tenant_id="tenant-caller-2")
+
+    validator = TrackingValidator()
+    memory._operation_validator = validator
+
+    template_applied_count = 0
+    real_apply_template = memory._apply_default_bank_template
+
+    async def spy_apply_template(b_id, ctx):
+        nonlocal template_applied_count
+        if b_id == bank_id:
+            template_applied_count += 1
+        return await real_apply_template(b_id, ctx)
+
+    monkeypatch.setattr(memory, "_apply_default_bank_template", spy_apply_template)
+
+    caller1_committed_event = asyncio.Event()
+    caller2_probed_missing_event = asyncio.Event()
+
+    real_get_if_exists = bank_utils.get_bank_profile_if_exists
+
+    async def spy_get_if_exists(pool, b_id):
+        res = await real_get_if_exists(pool, b_id)
+        if b_id == bank_id and not caller2_probed_missing_event.is_set():
+            caller2_probed_missing_event.set()
+        return res
+
+    monkeypatch.setattr(bank_utils, "get_bank_profile_if_exists", spy_get_if_exists)
+
+    async def synchronized_validate(ctx: CreateBankContext) -> ValidationResult:
+        validator.create_bank_calls.append(ctx)
+        if ctx.request_context and ctx.request_context.tenant_id == "tenant-caller-2":
+            # Caller 2: wait until Caller 1 has committed, then reject
+            await caller1_committed_event.wait()
+            return ValidationResult.reject("caller 2 quota exhausted", status_code=403)
+        return ValidationResult.accept()
+
+    validator.validate_create_bank = synchronized_validate
+
+    async def run_caller1():
+        await caller2_probed_missing_event.wait()
+        res = await memory._ensure_bank_exists(bank_id, rc1)
+        caller1_committed_event.set()
+        return res
+
+    async def run_caller2():
+        return await memory._ensure_bank_exists(bank_id, rc2)
+
+    task2 = asyncio.create_task(run_caller2())
+    task1 = asyncio.create_task(run_caller1())
+
+    res1 = await task1
+    assert res1 is True, "Caller 1 created bank successfully"
+
+    with pytest.raises(OperationValidationError) as exc_info:
+        await task2
+
+    assert "caller 2 quota exhausted" in str(exc_info.value)
+    assert len(validator.create_bank_calls) == 2
+    assert template_applied_count == 1, "Default bank template applied by Caller 1"
+
+    # Bank created by Caller 1 remains intact in database
+    profile = await bank_utils.get_bank_profile_if_exists(backend, bank_id)
+    assert profile is not None
+    assert profile["name"] == bank_id
+
+
+@pytest.mark.asyncio
+async def test_bank_utils_primitives_direct(memory: MemoryEngine) -> None:
+    """Test get_bank_profile_if_exists_on_conn and create_bank_row_on_conn directly."""
+    bank_id = f"test-opt-primitives-{uuid.uuid4().hex[:8]}"
+    backend = await memory._get_backend()
+
+    async with acquire_with_retry(backend) as conn:
+        async with conn.transaction():
+            # Initially missing
+            profile = await bank_utils.get_bank_profile_if_exists_on_conn(conn, bank_id)
+            assert profile is None
+
+            # First create: created=True
+            created = await bank_utils.create_bank_row_on_conn(conn, bank_id, ops=backend.ops)
+            assert created is True
+
+            # Second create (same tx or after): created=False (ON CONFLICT DO NOTHING)
+            created_again = await bank_utils.create_bank_row_on_conn(conn, bank_id, ops=backend.ops)
+            assert created_again is False
+
+            # Now exists
+            profile_after = await bank_utils.get_bank_profile_if_exists_on_conn(conn, bank_id)
+            assert profile_after is not None
+            assert profile_after["name"] == bank_id

--- a/hindsight-api-slim/tests/test_ensure_bank_exists_optimization.py
+++ b/hindsight-api-slim/tests/test_ensure_bank_exists_optimization.py
@@ -1,19 +1,21 @@
-"""Tests for _ensure_bank_exists optimization and bank_utils primitives.
+"""Coverage for the lazy bank-create fast path in ``MemoryEngine._ensure_bank_exists``.
 
-Verifies that:
-1. Both validator-enabled and default non-validator paths execute a SELECT-first check
-   and do not issue write statements for already existing banks.
-2. Existing banks do not trigger validate_create_bank or duplicate queries.
-3. Missing banks execute exactly one pre-check query and one atomic insert.
-4. Concurrent creation is idempotent and applies default template exactly once.
-5. Validator rejection prevents bank row insertion.
-6. Primitives in bank_utils are properly typed and behave as expected.
+The contract under test:
+
+* An already-existing bank costs one bare SELECT — no write statement, no
+  ``validate_create_bank`` call, no surrounding transaction.
+* A missing bank probes once, validates once, then issues one idempotent insert.
+* A rejected ``validate_create_bank`` leaves no bank row behind.
+* Concurrent callers may all validate, but exactly one wins the insert and
+  exactly one applies the default bank template.
 """
 
 import asyncio
 import uuid
+from collections.abc import AsyncIterator, Callable
 
 import pytest
+import pytest_asyncio
 
 from hindsight_api import RequestContext
 from hindsight_api.engine.db_utils import acquire_with_retry
@@ -23,7 +25,7 @@ from hindsight_api.extensions import CreateBankContext, OperationValidationError
 
 
 class TrackingValidator:
-    """Validator that tracks validate_create_bank invocations and can reject."""
+    """Records ``validate_create_bank`` calls, optionally rejecting them all."""
 
     def __init__(self, reject: bool = False):
         self.reject = reject
@@ -36,393 +38,292 @@ class TrackingValidator:
         return ValidationResult.accept()
 
 
-@pytest.mark.asyncio
-async def test_ensure_bank_exists_skips_validation_and_duplicate_query_for_existing_bank(
-    memory: MemoryEngine, request_context: RequestContext
-) -> None:
-    """When bank exists, _ensure_bank_exists runs only 1 query and skips validate_create_bank."""
-    bank_id = f"test-opt-exist-{uuid.uuid4().hex[:8]}"
-    backend = await memory._get_backend()
+@pytest_asyncio.fixture
+async def bank_name(memory: MemoryEngine, request_context: RequestContext) -> AsyncIterator[Callable[[str], str]]:
+    """Mint unique bank ids and drop whatever they named at teardown."""
+    created: list[str] = []
 
-    # Pre-create the bank
-    await bank_utils.create_bank_if_missing(backend, bank_id)
+    def _mint(prefix: str) -> str:
+        bank_id = f"test-{prefix}-{uuid.uuid4().hex[:8]}"
+        created.append(bank_id)
+        return bank_id
 
-    validator = TrackingValidator()
-    memory._operation_validator = validator
+    yield _mint
 
-    # Call _ensure_bank_exists without conn
-    created = await memory._ensure_bank_exists(bank_id, request_context)
-    assert created is False
-    assert len(validator.create_bank_calls) == 0
-
-    # Call _ensure_bank_exists with conn
-    async with acquire_with_retry(backend) as conn:
-        async with conn.transaction():
-            created_on_conn = await memory._ensure_bank_exists(bank_id, request_context, conn=conn)
-            assert created_on_conn is False
-    assert len(validator.create_bank_calls) == 0
-
-
-@pytest.mark.asyncio
-async def test_ensure_bank_exists_non_validator_path_is_read_only_for_existing_bank(
-    memory: MemoryEngine, request_context: RequestContext, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Under default (no-validator) mode, existing banks perform only a SELECT and no INSERT."""
-    bank_id = f"test-opt-novalidator-exist-{uuid.uuid4().hex[:8]}"
-    backend = await memory._get_backend()
-
-    # Pre-create the bank
-    await bank_utils.create_bank_if_missing(backend, bank_id)
-
+    # Cleanup runs unvalidated: the tracking validators here implement only
+    # validate_create_bank.
     memory._operation_validator = None
+    for bank_id in created:
+        await memory.delete_bank(bank_id, request_context=request_context)
 
-    create_row_calls = 0
-    real_create_row = bank_utils.create_bank_row_on_conn
 
-    async def spy_create_row(conn, b_id, *, ops):
-        nonlocal create_row_calls
+def spy_on(module_or_obj, name: str, bank_id: str, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Patch ``name`` with a pass-through that appends to the returned list for ``bank_id``.
+
+    The wrapped callable takes the bank id as its second positional argument,
+    which is true of every ``bank_utils`` helper spied on here.
+    """
+    calls: list[str] = []
+    real = getattr(module_or_obj, name)
+
+    async def _spy(first, b_id, *args, **kwargs):
         if b_id == bank_id:
-            create_row_calls += 1
-        return await real_create_row(conn, b_id, ops=ops)
+            calls.append(b_id)
+        return await real(first, b_id, *args, **kwargs)
 
-    monkeypatch.setattr(bank_utils, "create_bank_row_on_conn", spy_create_row)
-
-    # Calling on existing bank without conn must NOT call create_bank_row_on_conn
-    created = await memory._ensure_bank_exists(bank_id, request_context)
-    assert created is False
-    assert create_row_calls == 0, "Existing bank in non-validator path must not execute insert"
-
-    # Calling on existing bank with conn must NOT call create_bank_row_on_conn
-    async with acquire_with_retry(backend) as conn:
-        async with conn.transaction():
-            created_on_conn = await memory._ensure_bank_exists(bank_id, request_context, conn=conn)
-            assert created_on_conn is False
-    assert create_row_calls == 0, "Existing bank in non-validator on-conn path must not execute insert"
+    monkeypatch.setattr(module_or_obj, name, _spy)
+    return calls
 
 
 @pytest.mark.asyncio
-async def test_ensure_bank_exists_missing_bank_query_count(
-    memory: MemoryEngine, request_context: RequestContext, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize("with_validator", [True, False], ids=["validator", "no-validator"])
+async def test_existing_bank_is_read_only_and_skips_validation(
+    memory: MemoryEngine,
+    request_context: RequestContext,
+    monkeypatch: pytest.MonkeyPatch,
+    bank_name: Callable[[str], str],
+    with_validator: bool,
 ) -> None:
-    """When bank is missing, _ensure_bank_exists validates and inserts without duplicate SELECT."""
-    bank_id = f"test-opt-missing-{uuid.uuid4().hex[:8]}"
+    """An existing bank issues no insert and never reaches ``validate_create_bank``."""
+    bank_id = bank_name("exists")
+    backend = await memory._get_backend()
+    await bank_utils.create_bank_if_missing(backend, bank_id)
+
+    validator = TrackingValidator() if with_validator else None
+    memory._operation_validator = validator
+
+    inserts = spy_on(bank_utils, "create_bank_row_on_conn", bank_id, monkeypatch)
+
+    assert await memory._ensure_bank_exists(bank_id, request_context) is False
+    async with acquire_with_retry(backend) as conn:
+        async with conn.transaction():
+            assert await memory._ensure_bank_exists(bank_id, request_context, conn=conn) is False
+
+    assert inserts == [], "An existing bank must not issue an insert on either path"
+    if validator is not None:
+        assert validator.create_bank_calls == [], "An existing bank must not be re-validated"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("on_conn", [True, False], ids=["on-conn", "own-conn"])
+async def test_missing_bank_probes_once_then_inserts_once(
+    memory: MemoryEngine,
+    request_context: RequestContext,
+    monkeypatch: pytest.MonkeyPatch,
+    bank_name: Callable[[str], str],
+    on_conn: bool,
+) -> None:
+    """A missing bank costs one existence probe, one validation and one insert."""
+    bank_id = bank_name("missing")
     backend = await memory._get_backend()
 
     validator = TrackingValidator()
     memory._operation_validator = validator
 
-    # Spy on get_bank_profile_if_exists to ensure it is called only once per _ensure_bank_exists invocation
-    real_get_if_exists = bank_utils.get_bank_profile_if_exists
-    get_if_exists_calls = 0
+    probes = spy_on(bank_utils, "bank_exists_on_conn" if on_conn else "bank_exists", bank_id, monkeypatch)
+    inserts = spy_on(bank_utils, "create_bank_row_on_conn", bank_id, monkeypatch)
 
-    async def spy_get_if_exists(pool, b_id):
-        nonlocal get_if_exists_calls
-        if b_id == bank_id:
-            get_if_exists_calls += 1
-        return await real_get_if_exists(pool, b_id)
+    async def ensure() -> bool:
+        if not on_conn:
+            return await memory._ensure_bank_exists(bank_id, request_context)
+        async with acquire_with_retry(backend) as conn:
+            async with conn.transaction():
+                return await memory._ensure_bank_exists(bank_id, request_context, conn=conn)
 
-    # Spy on create_bank_row_on_conn to ensure it is called directly
-    real_create_row = bank_utils.create_bank_row_on_conn
-    create_row_calls = 0
-
-    async def spy_create_row(conn, b_id, *, ops):
-        nonlocal create_row_calls
-        if b_id == bank_id:
-            create_row_calls += 1
-        return await real_create_row(conn, b_id, ops=ops)
-
-    monkeypatch.setattr(bank_utils, "get_bank_profile_if_exists", spy_get_if_exists)
-    monkeypatch.setattr(bank_utils, "create_bank_row_on_conn", spy_create_row)
-
-    # Execute _ensure_bank_exists (without conn)
-    created = await memory._ensure_bank_exists(bank_id, request_context)
-
-    assert created is True
+    assert await ensure() is True
     assert len(validator.create_bank_calls) == 1
     assert validator.create_bank_calls[0].bank_id == bank_id
-    assert get_if_exists_calls == 1, "Expected exactly 1 existence query before validation"
-    assert create_row_calls == 1, "Expected exactly 1 atomic insert call"
+    assert len(probes) == 1, "Expected exactly one existence probe before validation"
+    assert len(inserts) == 1, "Expected exactly one insert"
 
-    # Subsequent call on now-existing bank: no validate, no insert
-    created_again = await memory._ensure_bank_exists(bank_id, request_context)
-    assert created_again is False
+    # The bank now exists: the second call returns on the probe.
+    assert await ensure() is False
     assert len(validator.create_bank_calls) == 1, "Existing bank must not trigger validation"
-    assert get_if_exists_calls == 2, "Expected 2 total existence checks across the two invocations"
-    assert create_row_calls == 1, "Insert must not be called again"
+    assert len(probes) == 2
+    assert len(inserts) == 1, "Existing bank must not re-insert"
 
 
 @pytest.mark.asyncio
-async def test_ensure_bank_exists_on_conn_missing_bank_query_count(
-    memory: MemoryEngine, request_context: RequestContext, monkeypatch: pytest.MonkeyPatch
+async def test_validator_rejection_creates_no_row(
+    memory: MemoryEngine, request_context: RequestContext, bank_name: Callable[[str], str]
 ) -> None:
-    """When bank is missing and conn is provided, _ensure_bank_exists executes 1 SELECT and 1 INSERT."""
-    bank_id = f"test-opt-conn-{uuid.uuid4().hex[:8]}"
-    backend = await memory._get_backend()
-
-    validator = TrackingValidator()
-    memory._operation_validator = validator
-
-    create_row_calls = 0
-    real_create_row = bank_utils.create_bank_row_on_conn
-
-    async def spy_create_row(conn, b_id, *, ops):
-        nonlocal create_row_calls
-        if b_id == bank_id:
-            create_row_calls += 1
-        return await real_create_row(conn, b_id, ops=ops)
-
-    monkeypatch.setattr(bank_utils, "create_bank_row_on_conn", spy_create_row)
-
-    async with acquire_with_retry(backend) as conn:
-        async with conn.transaction():
-            created = await memory._ensure_bank_exists(bank_id, request_context, conn=conn)
-
-    assert created is True
-    assert len(validator.create_bank_calls) == 1
-    assert create_row_calls == 1
-
-    # Verify on-conn check on existing bank returns False and does not call create_row
-    async with acquire_with_retry(backend) as conn:
-        async with conn.transaction():
-            created_again = await memory._ensure_bank_exists(bank_id, request_context, conn=conn)
-
-    assert created_again is False
-    assert len(validator.create_bank_calls) == 1
-    assert create_row_calls == 1
-
-
-@pytest.mark.asyncio
-async def test_ensure_bank_exists_validator_rejection_prevents_insert(
-    memory: MemoryEngine, request_context: RequestContext
-) -> None:
-    """When validate_create_bank rejects, no bank row is created in the database."""
-    bank_id = f"test-opt-reject-{uuid.uuid4().hex[:8]}"
+    """A rejected ``validate_create_bank`` leaves the bank uncreated."""
+    bank_id = bank_name("reject")
     backend = await memory._get_backend()
 
     validator = TrackingValidator(reject=True)
     memory._operation_validator = validator
 
-    with pytest.raises(OperationValidationError) as exc_info:
+    with pytest.raises(OperationValidationError, match="bank creation not allowed"):
         await memory._ensure_bank_exists(bank_id, request_context)
 
-    assert "bank creation not allowed" in str(exc_info.value)
     assert len(validator.create_bank_calls) == 1
-
-    # Ensure no row was created
-    profile = await bank_utils.get_bank_profile_if_exists(backend, bank_id)
-    assert profile is None
+    assert await bank_utils.bank_exists(backend, bank_id) is False
 
 
 @pytest.mark.asyncio
-async def test_ensure_bank_exists_concurrent_creation_applies_template_once(
-    memory: MemoryEngine, request_context: RequestContext, monkeypatch: pytest.MonkeyPatch
+async def test_concurrent_creation_applies_the_template_once(
+    memory: MemoryEngine,
+    request_context: RequestContext,
+    monkeypatch: pytest.MonkeyPatch,
+    bank_name: Callable[[str], str],
 ) -> None:
-    """Concurrent calls to _ensure_bank_exists result in exactly one created=True and one template application."""
-    bank_id = f"test-opt-concurrent-{uuid.uuid4().hex[:8]}"
+    """Two racing callers produce one created=True and one template application."""
+    bank_id = bank_name("concurrent")
     backend = await memory._get_backend()
+    memory._operation_validator = TrackingValidator()
 
-    validator = TrackingValidator()
-    memory._operation_validator = validator
+    templates: list[str] = []
+    real_apply = memory._apply_default_bank_template
 
-    template_applied_count = 0
-    real_apply_template = memory._apply_default_bank_template
-
-    async def spy_apply_template(b_id, ctx):
-        nonlocal template_applied_count
+    async def spy_apply(b_id, ctx):
         if b_id == bank_id:
-            template_applied_count += 1
-        return await real_apply_template(b_id, ctx)
+            templates.append(b_id)
+        return await real_apply(b_id, ctx)
 
-    monkeypatch.setattr(memory, "_apply_default_bank_template", spy_apply_template)
+    monkeypatch.setattr(memory, "_apply_default_bank_template", spy_apply)
 
-    # Launch two concurrent _ensure_bank_exists calls
     results = await asyncio.gather(
         memory._ensure_bank_exists(bank_id, request_context),
         memory._ensure_bank_exists(bank_id, request_context),
     )
 
-    # Exactly one must return True (created) and one False (already created by the other)
-    assert sorted(results) == [False, True]
-    assert template_applied_count == 1, "Default bank template must be applied exactly once"
-
-    # Verify bank profile exists
-    profile = await bank_utils.get_bank_profile_if_exists(backend, bank_id)
-    assert profile is not None
-    assert profile["name"] == bank_id
+    assert sorted(results) == [False, True], "Exactly one caller must win the insert"
+    assert templates == [bank_id], "Default bank template must be applied exactly once"
+    assert await bank_utils.bank_exists(backend, bank_id) is True
 
 
-@pytest.mark.asyncio
-async def test_ensure_bank_exists_creation_race_barrier_delayed_validation(
-    memory: MemoryEngine, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Barrier test: Caller 2 observes missing bank, Caller 1 commits insert, then Caller 2 validates & inserts."""
-    bank_id = f"test-opt-race-barrier-{uuid.uuid4().hex[:8]}"
-    backend = await memory._get_backend()
+class _CreationRace:
+    """Drives the interleaving the fast path cannot serialise.
 
-    rc1 = RequestContext(tenant_id="tenant-caller-1")
-    rc2 = RequestContext(tenant_id="tenant-caller-2")
+    Caller 2 probes the bank as missing and then stalls inside its validator
+    until caller 1 has committed the insert. Caller 2 therefore reaches its own
+    insert against a bank that already exists — the case that decides whether
+    losing a creation race is reported as ``created=False`` or corrupts the row.
+    """
 
-    validator = TrackingValidator()
-    memory._operation_validator = validator
+    def __init__(self, memory: MemoryEngine, bank_id: str, monkeypatch: pytest.MonkeyPatch):
+        self.memory = memory
+        self.bank_id = bank_id
+        self.validate_calls: list[str] = []
+        self.templates: list[str] = []
+        self.caller1_committed = asyncio.Event()
+        self.caller2_probed = asyncio.Event()
+        self.rc1 = RequestContext(tenant_id="tenant-caller-1")
+        self.rc2 = RequestContext(tenant_id="tenant-caller-2")
+        self._monkeypatch = monkeypatch
 
-    template_applied_count = 0
-    real_apply_template = memory._apply_default_bank_template
+    def arm(self, *, reject_caller2: bool) -> None:
+        real_apply = self.memory._apply_default_bank_template
 
-    async def spy_apply_template(b_id, ctx):
-        nonlocal template_applied_count
-        if b_id == bank_id:
-            template_applied_count += 1
-        return await real_apply_template(b_id, ctx)
+        async def spy_apply(b_id, ctx):
+            if b_id == self.bank_id:
+                self.templates.append(b_id)
+            return await real_apply(b_id, ctx)
 
-    monkeypatch.setattr(memory, "_apply_default_bank_template", spy_apply_template)
+        self._monkeypatch.setattr(self.memory, "_apply_default_bank_template", spy_apply)
 
-    caller1_committed_event = asyncio.Event()
-    caller2_probed_missing_event = asyncio.Event()
+        real_probe = bank_utils.bank_exists
 
-    real_get_if_exists = bank_utils.get_bank_profile_if_exists
+        async def spy_probe(pool, b_id):
+            result = await real_probe(pool, b_id)
+            if b_id == self.bank_id:
+                self.caller2_probed.set()
+            return result
 
-    async def spy_get_if_exists(pool, b_id):
-        res = await real_get_if_exists(pool, b_id)
-        if b_id == bank_id and not caller2_probed_missing_event.is_set():
-            caller2_probed_missing_event.set()
-        return res
+        self._monkeypatch.setattr(bank_utils, "bank_exists", spy_probe)
 
-    monkeypatch.setattr(bank_utils, "get_bank_profile_if_exists", spy_get_if_exists)
+        race = self
 
-    real_validate = validator.validate_create_bank
+        class _Validator:
+            async def validate_create_bank(self, ctx: CreateBankContext) -> ValidationResult:
+                race.validate_calls.append(ctx.bank_id)
+                if ctx.request_context and ctx.request_context.tenant_id == "tenant-caller-2":
+                    await race.caller1_committed.wait()
+                    if reject_caller2:
+                        return ValidationResult.reject("caller 2 quota exhausted", status_code=403)
+                return ValidationResult.accept()
 
-    async def synchronized_validate(ctx: CreateBankContext) -> ValidationResult:
-        if ctx.request_context and ctx.request_context.tenant_id == "tenant-caller-2":
-            # Caller 2: pause inside validation until Caller 1 has committed its insert
-            await caller1_committed_event.wait()
-        return await real_validate(ctx)
+        self.memory._operation_validator = _Validator()
 
-    validator.validate_create_bank = synchronized_validate
+    def start(self) -> tuple[asyncio.Task, asyncio.Task]:
+        async def caller1() -> bool:
+            await self.caller2_probed.wait()
+            try:
+                return await self.memory._ensure_bank_exists(self.bank_id, self.rc1)
+            finally:
+                self.caller1_committed.set()
 
-    async def run_caller1():
-        # Wait until Caller 2 has probed missing bank state
-        await caller2_probed_missing_event.wait()
-        res = await memory._ensure_bank_exists(bank_id, rc1)
-        caller1_committed_event.set()
-        return res
+        async def caller2() -> bool:
+            return await self.memory._ensure_bank_exists(self.bank_id, self.rc2)
 
-    async def run_caller2():
-        return await memory._ensure_bank_exists(bank_id, rc2)
-
-    # Start Caller 2 first so its probe runs before Caller 1 starts
-    task2 = asyncio.create_task(run_caller2())
-    task1 = asyncio.create_task(run_caller1())
-
-    res2, res1 = await asyncio.gather(task2, task1)
-
-    assert res1 is True, "Caller 1 was the winning insert and should report created=True"
-    assert res2 is False, "Caller 2 was the losing insert and should report created=False"
-    assert len(validator.create_bank_calls) == 2, "Both concurrent callers executed validation"
-    assert template_applied_count == 1, "Default bank template must be applied exactly once"
-
-    # Verify exactly 1 bank in database
-    profile = await bank_utils.get_bank_profile_if_exists(backend, bank_id)
-    assert profile is not None
-    assert profile["name"] == bank_id
+        # Caller 2 starts first so its probe is what unblocks caller 1.
+        task2 = asyncio.create_task(caller2())
+        task1 = asyncio.create_task(caller1())
+        return task1, task2
 
 
 @pytest.mark.asyncio
-async def test_ensure_bank_exists_creation_race_barrier_delayed_validation_rejected(
-    memory: MemoryEngine, monkeypatch: pytest.MonkeyPatch
+async def test_losing_a_creation_race_reports_not_created(
+    memory: MemoryEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    bank_name: Callable[[str], str],
 ) -> None:
-    """Barrier test: Caller 2 observes missing bank, Caller 1 commits, Caller 2 delayed validation is rejected."""
-    bank_id = f"test-opt-race-reject-{uuid.uuid4().hex[:8]}"
+    """The caller whose insert loses to a committed row reports created=False."""
+    bank_id = bank_name("race")
     backend = await memory._get_backend()
 
-    rc1 = RequestContext(tenant_id="tenant-caller-1")
-    rc2 = RequestContext(tenant_id="tenant-caller-2")
+    race = _CreationRace(memory, bank_id, monkeypatch)
+    race.arm(reject_caller2=False)
+    task1, task2 = race.start()
+    created1, created2 = await asyncio.gather(task1, task2)
 
-    validator = TrackingValidator()
-    memory._operation_validator = validator
+    assert created1 is True, "Caller 1 won the insert"
+    assert created2 is False, "Caller 2 lost the insert and must not claim creation"
+    assert race.validate_calls == [bank_id, bank_id], "Both callers validate — the documented contract"
+    assert race.templates == [bank_id], "Default bank template must be applied exactly once"
+    assert await bank_utils.bank_exists(backend, bank_id) is True
 
-    template_applied_count = 0
-    real_apply_template = memory._apply_default_bank_template
 
-    async def spy_apply_template(b_id, ctx):
-        nonlocal template_applied_count
-        if b_id == bank_id:
-            template_applied_count += 1
-        return await real_apply_template(b_id, ctx)
+@pytest.mark.asyncio
+async def test_late_rejection_leaves_the_winners_bank_intact(
+    memory: MemoryEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    bank_name: Callable[[str], str],
+) -> None:
+    """Rejecting the losing caller must not undo the bank the winner created."""
+    bank_id = bank_name("race-reject")
+    backend = await memory._get_backend()
 
-    monkeypatch.setattr(memory, "_apply_default_bank_template", spy_apply_template)
+    race = _CreationRace(memory, bank_id, monkeypatch)
+    race.arm(reject_caller2=True)
+    task1, task2 = race.start()
 
-    caller1_committed_event = asyncio.Event()
-    caller2_probed_missing_event = asyncio.Event()
-
-    real_get_if_exists = bank_utils.get_bank_profile_if_exists
-
-    async def spy_get_if_exists(pool, b_id):
-        res = await real_get_if_exists(pool, b_id)
-        if b_id == bank_id and not caller2_probed_missing_event.is_set():
-            caller2_probed_missing_event.set()
-        return res
-
-    monkeypatch.setattr(bank_utils, "get_bank_profile_if_exists", spy_get_if_exists)
-
-    async def synchronized_validate(ctx: CreateBankContext) -> ValidationResult:
-        validator.create_bank_calls.append(ctx)
-        if ctx.request_context and ctx.request_context.tenant_id == "tenant-caller-2":
-            # Caller 2: wait until Caller 1 has committed, then reject
-            await caller1_committed_event.wait()
-            return ValidationResult.reject("caller 2 quota exhausted", status_code=403)
-        return ValidationResult.accept()
-
-    validator.validate_create_bank = synchronized_validate
-
-    async def run_caller1():
-        await caller2_probed_missing_event.wait()
-        res = await memory._ensure_bank_exists(bank_id, rc1)
-        caller1_committed_event.set()
-        return res
-
-    async def run_caller2():
-        return await memory._ensure_bank_exists(bank_id, rc2)
-
-    task2 = asyncio.create_task(run_caller2())
-    task1 = asyncio.create_task(run_caller1())
-
-    res1 = await task1
-    assert res1 is True, "Caller 1 created bank successfully"
-
-    with pytest.raises(OperationValidationError) as exc_info:
+    assert await task1 is True
+    with pytest.raises(OperationValidationError, match="caller 2 quota exhausted"):
         await task2
 
-    assert "caller 2 quota exhausted" in str(exc_info.value)
-    assert len(validator.create_bank_calls) == 2
-    assert template_applied_count == 1, "Default bank template applied by Caller 1"
-
-    # Bank created by Caller 1 remains intact in database
-    profile = await bank_utils.get_bank_profile_if_exists(backend, bank_id)
-    assert profile is not None
-    assert profile["name"] == bank_id
+    assert race.validate_calls == [bank_id, bank_id]
+    assert race.templates == [bank_id]
+    assert await bank_utils.bank_exists(backend, bank_id) is True
 
 
 @pytest.mark.asyncio
-async def test_bank_utils_primitives_direct(memory: MemoryEngine) -> None:
-    """Test get_bank_profile_if_exists_on_conn and create_bank_row_on_conn directly."""
-    bank_id = f"test-opt-primitives-{uuid.uuid4().hex[:8]}"
+async def test_bank_utils_primitives(memory: MemoryEngine, bank_name: Callable[[str], str]) -> None:
+    """The extracted primitives behave standalone, including the ON CONFLICT arm."""
+    bank_id = bank_name("primitives")
     backend = await memory._get_backend()
 
     async with acquire_with_retry(backend) as conn:
         async with conn.transaction():
-            # Initially missing
+            assert await bank_utils.bank_exists_on_conn(conn, bank_id) is False
+            assert await bank_utils.get_bank_profile_if_exists_on_conn(conn, bank_id) is None
+
+            assert await bank_utils.create_bank_row_on_conn(conn, bank_id, ops=backend.ops) is True
+            # ON CONFLICT DO NOTHING: the second insert reports no creation.
+            assert await bank_utils.create_bank_row_on_conn(conn, bank_id, ops=backend.ops) is False
+
+            assert await bank_utils.bank_exists_on_conn(conn, bank_id) is True
             profile = await bank_utils.get_bank_profile_if_exists_on_conn(conn, bank_id)
-            assert profile is None
-
-            # First create: created=True
-            created = await bank_utils.create_bank_row_on_conn(conn, bank_id, ops=backend.ops)
-            assert created is True
-
-            # Second create (same tx or after): created=False (ON CONFLICT DO NOTHING)
-            created_again = await bank_utils.create_bank_row_on_conn(conn, bank_id, ops=backend.ops)
-            assert created_again is False
-
-            # Now exists
-            profile_after = await bank_utils.get_bank_profile_if_exists_on_conn(conn, bank_id)
-            assert profile_after is not None
-            assert profile_after["name"] == bank_id
+            assert profile is not None
+            assert profile["name"] == bank_id


### PR DESCRIPTION
## Problem

`_ensure_bank_exists` is the lazy bank-create every write path goes through. For a bank that already exists — the overwhelmingly common case — it did more work than it needed to:

- **Without a validator:** it went straight to `get_or_create_bank_profile`, which acquires a connection, opens a transaction, runs `SELECT name, disposition, mission`, parses the disposition JSON, and throws the profile away. Three round trips (`BEGIN`, `SELECT`, `COMMIT`) plus a JSON decode to answer a yes/no question.
- **With a validator:** it ran its own `SELECT 1` existence check to decide whether to call `validate_create_bank`, and then called `get_or_create_bank_profile*()` anyway — which repeated the SELECT. Two existence queries per call.

On the missing-bank path the second SELECT inside `get_or_create_bank_profile*()` was likewise redundant: the caller had just established the row wasn't there.

## Change

Hoist a single existence probe to the top of `_ensure_bank_exists`, shared by both the validator and non-validator paths, and return immediately when it says the bank is there. Everything below the probe now only runs on the create path.

New primitives in `bank_utils.py`, all of which existing code already contained in some form:

- `bank_exists_on_conn` / `bank_exists` — narrow `SELECT 1` probes. `bank_exists` deliberately runs no transaction; it is the read-only fast path.
- `create_bank_row_on_conn` — the `INSERT ... ON CONFLICT (bank_id) DO NOTHING RETURNING bank_id` plus per-bank vector index creation, lifted unchanged out of `get_or_create_bank_profile_on_conn`.
- `create_bank_if_missing` — the dedicated-connection variant, keeping the whole-transaction deadlock retry that `get_or_create_bank_profile` has.
- `get_bank_profile_if_exists_on_conn` — the connection-bound profile read, so `get_bank_profile_if_exists` and `get_or_create_bank_profile_on_conn` stop carrying two copies of it.

`get_or_create_bank_profile*` keep their exact previous behaviour, now composed from those pieces. `retain`'s `fact_storage.ensure_bank_exists` was a third hand-rolled copy of the same INSERT; it now delegates to `create_bank_row_on_conn`, so a bank born through retain is identical to one born through the profile helpers.

### Net effect per call

| case | before | after |
|---|---|---|
| existing bank, no validator | `BEGIN` + profile `SELECT` + `COMMIT` | one `SELECT 1` |
| existing bank, validator | `SELECT 1` + `BEGIN` + profile `SELECT` + `COMMIT` | one `SELECT 1` |
| missing bank, validator | `SELECT 1` + `BEGIN` + `SELECT` + `INSERT` + `COMMIT` | `SELECT 1` + `BEGIN` + `INSERT` + `COMMIT` |
| missing bank, no validator | one connection: `SELECT` + `INSERT` | two connections: `SELECT`, then `INSERT` |

The last row is the one regression, and it is deliberate: the validator hook between the probe and the insert may do arbitrary I/O, so a connection must not be held across it. It costs one extra acquisition exactly once per bank, on the call that creates it.

## Concurrency

The probe, the validator hook and the insert are **not** serialised, and cannot be — `validate_create_bank` is an extension hook, so neither an advisory lock nor a held connection may span it. Concurrent callers can therefore all observe the bank as missing and all run the validator; the unique constraint arbitrates, giving exactly one caller `created=True`, and only that caller applies the default bank template.

This is unchanged from before: on `main`, a caller that saw a missing bank already validated and *then* re-entered `get_or_create_bank_profile`. Hoisting the probe made the contract visible, it did not introduce it. It is now written down on `_ensure_bank_exists` and pinned by tests.

## Tests

`tests/test_ensure_bank_exists_optimization.py`:

- existing bank issues no insert and never reaches `validate_create_bank`, with and without a validator, on both the `conn=` and own-connection paths
- missing bank probes once, validates once, inserts once — and the follow-up call returns on the probe
- a rejected `validate_create_bank` leaves no row
- concurrent creation: exactly one `created=True`, exactly one default-template application
- barrier-driven creation race — caller 2 probes as missing, stalls inside its validator until caller 1 commits, then reaches its own insert — asserting `created=False` for the loser, and (in the rejected variant) that caller 1's bank survives caller 2's rejection
- the extracted primitives standalone, including the `ON CONFLICT` arm

`ruff check`, `ruff format`, `ty check` clean. `test_bank_utils`, `test_bank_lifecycle_deadlock_retry`, `test_repair_bank_vector_indexes`, `test_extensions` and the new file pass together (107 tests) — `test_repair_bank_vector_indexes` is the one that guards #2645, i.e. that every bank-create path still builds its per-bank vector indexes.
