### PR TITLE
fix(retain): unwrap nested conversation array before output-retry split

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -258,6 +258,11 @@ def _split_chunk_for_output_retry(chunk: str) -> tuple[str, str] | None:
         parsed = None
 
     if isinstance(parsed, list):
+        # Some integrations wrap a conversation array once more; normalize that
+        # shape before applying the existing array split logic.
+        if len(parsed) == 1 and isinstance(parsed[0], list) and all(isinstance(item, dict) for item in parsed[0]):
+            parsed = parsed[0]
+
         if len(parsed) >= 2:
             mid = len(parsed) // 2
             return json.dumps(parsed[:mid]), json.dumps(parsed[mid:])

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -38,6 +38,53 @@ def test_output_retry_split_preserves_conversation_array_boundaries():
     assert json.loads(second) == turns[2:]
 
 
+def test_output_retry_split_unwraps_nested_conversation_array():
+    """A nested conversation array should use the normal turn splitter."""
+    from hindsight_api.engine.retain.fact_extraction import _split_chunk_for_output_retry
+
+    turns = [
+        {"role": "user", "content": "alpha " * 40},
+        {"role": "assistant", "content": "bravo " * 40},
+        {"role": "user", "content": "charlie " * 40},
+        {"role": "assistant", "content": "delta " * 40},
+    ]
+
+    split = _split_chunk_for_output_retry(json.dumps([turns]))
+
+    assert split is not None
+    first, second = split
+    assert json.loads(first) == turns[:2]
+    assert json.loads(second) == turns[2:]
+
+
+def test_output_retry_split_unwraps_nested_single_conversation_turn():
+    """A nested single turn should reach the existing content splitter."""
+    from hindsight_api.engine.retain.fact_extraction import _split_chunk_for_output_retry
+
+    turn = {
+        "role": "user",
+        "content": "abcdefghijklmnopqrstuvwxyz" * 40,
+        "name": "casey",
+    }
+
+    split = _split_chunk_for_output_retry(json.dumps([[turn]]))
+
+    assert split is not None
+    first, second = split
+    first_turn = json.loads(first)[0]
+    second_turn = json.loads(second)[0]
+    assert first_turn["name"] == "casey"
+    assert second_turn["name"] == "casey"
+    assert first_turn["content"] + second_turn["content"] == turn["content"]
+
+
+def test_output_retry_split_leaves_unknown_nested_shapes_alone():
+    """Only a single-element list of turn dicts is unwrapped."""
+    from hindsight_api.engine.retain.fact_extraction import _split_chunk_for_output_retry
+
+    assert _split_chunk_for_output_retry(json.dumps([[1, 2, 3] * 200])) is None
+
+
 def test_output_retry_split_divides_single_oversized_turn_content():
     """A lone oversized conversation turn is split inside content and rewrapped."""
     from hindsight_api.engine.retain.fact_extraction import _split_chunk_for_output_retry


### PR DESCRIPTION
## The bug

`_split_chunk_for_output_retry` handles an `OutputTooLongError` by splitting the conversation array in half and retrying each half. It bails out when the array has fewer than 2 elements.

If an integration hands retain a conversation wrapped one level deeper than expected — `[[{...}, {...}, ...]]` instead of `[{...}, {...}, ...]` — the split sees a **single-element list**, cannot split it, and the whole chunk is dropped. Every turn in that conversation is silently lost: no error surfaces, no partial retain happens.

I hit this against a local model gateway, but nothing about the failure is gateway-specific: any producer that double-wraps the array loses the entire chunk on the first output-too-long retry.

## The fix

Normalize exactly one shape before the existing split logic runs: a single-element list whose only item is a list of dicts. Anything else — deeper nesting, mixed types, lists of non-dicts — is left untouched, so unknown payloads keep their current behaviour rather than being guessed at.

+5 lines in `fact_extraction.py`, no change to the split algorithm itself.

## Tests

Three cases added to `tests/test_fact_extraction_retry.py`:

- `test_output_retry_split_unwraps_nested_conversation_array` — the multi-turn case that used to be dropped now splits normally
- `test_output_retry_split_unwraps_nested_single_conversation_turn` — a nested single turn stays unsplittable, as it should
- `test_output_retry_split_leaves_unknown_nested_shapes_alone` — the guard does not over-reach

`tests/test_fact_extraction_retry.py`: 29 passed, 1 failed. The one failure is `test_output_too_long_error_is_a_single_class_across_modules`, which fails identically on a clean checkout of `main` in my environment (an optional-dependency import), so it is unrelated to this change.

## Context

This change was originally part of #3656. That PR merged with only the strict-schema flag fix; the unwrap did not land, so I am re-submitting it on its own with a clean history.