### PR TITLE
fix(retain): delete the removed chunks when a re-retain only removes content

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -3388,7 +3388,16 @@ async def _try_delta_retain(
     # Build content items for only the changed/new chunks
     delta_contents, delta_chunk_map = _build_delta_contents(contents, new_chunks_with_contents, chunks_to_process)
 
-    if not delta_contents:
+    # Only bail out to the metadata-only path when there is genuinely nothing to WRITE — not
+    # merely nothing to EXTRACT. A re-retain that only DELETES content (drop the last section of
+    # a document, leave the rest byte-identical) classifies as `changed=0 new=0 removed=N`, so
+    # `delta_contents` is empty while `removed_indices` is not. Returning here updated the
+    # document row to the shrunken body and deleted nothing: the removed sections' chunks and
+    # facts stayed recallable as part of a document that no longer contained them, and the state
+    # was stable — the document's stored hash now matched the new body, so re-submitting it was a
+    # no-op that never revisited the leftovers. The write path below deletes `removed_indices`
+    # whether or not it also has facts to insert, so let it run.
+    if not delta_contents and not removed_indices:
         return await _delta_metadata_only(
             pool,
             bank_id,

--- a/hindsight-api-slim/tests/test_delta_removed_chunks.py
+++ b/hindsight-api-slim/tests/test_delta_removed_chunks.py
@@ -1,0 +1,173 @@
+"""A re-retain that only REMOVES content must drop the removed chunks.
+
+Delta retain classifies the new body against the stored chunks as
+``unchanged / changed / new / removed``. Deleting the tail of a document and
+leaving the rest byte-identical produces ``changed=0 new=0 removed=N``: there is
+nothing to extract, but there is something to delete.
+
+``_try_delta_retain`` used to short-circuit to the metadata-only path as soon as
+the *extraction* list came back empty, which threw the non-empty ``removed`` set
+away. The document row was updated to the shrunken body while its chunks and
+their facts stayed exactly where they were, so the removed sections remained
+recallable as part of a document that no longer contained them — and the state
+was stable, because the stored ``content_hash`` now matched the new body, so
+re-submitting it was a no-op that never revisited the leftovers.
+
+The same edit combined with *any* other change was always correct (the write path
+deletes ``removed`` alongside the changed chunks it rewrites), which is what kept
+this invisible: it takes a pure deletion to hit.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from hindsight_api.config import clear_config_cache
+from hindsight_api.engine.retain import fact_extraction
+
+# One native chunk per section: each is just under retain_chunk_size and sections
+# are blank-line separated, so dropping a trailing section leaves every surviving
+# chunk byte-identical at the same chunk_index.
+_SECTION_REPEATS = 117
+_BASE_SECTIONS = 10
+_KEPT_SECTIONS = 6
+# Low enough that the replacement is sliced into several sequential retain_batch
+# calls, so the same deletion is exercised through the split transport path too.
+_OVERSIZED_BATCH_TOKENS = 300
+
+
+def _section(idx: int) -> str:
+    marker = f"MARKER{idx:02d}"
+    return f"Section {idx:02d} {marker}. " + f"{marker} filler word here. " * _SECTION_REPEATS
+
+
+def _body(section_indices) -> str:
+    return "\n\n".join(_section(i) for i in section_indices)
+
+
+@pytest.fixture(autouse=True)
+def _fast_retain_env(monkeypatch):
+    monkeypatch.setenv("HINDSIGHT_API_ENABLE_AUTO_CONSOLIDATION", "false")
+    monkeypatch.setenv("HINDSIGHT_API_ENABLE_OBSERVATIONS", "false")
+    clear_config_cache()
+    yield
+    clear_config_cache()
+
+
+class _ExtractionSpy:
+    """Records the content fed to LLM fact extraction on each call."""
+
+    def __init__(self) -> None:
+        self.texts: list[str] = []
+
+    def install(self, monkeypatch) -> None:
+        original = fact_extraction.extract_facts_from_contents
+
+        async def _spy(contents, *args, **kwargs):
+            self.texts.extend(c.content for c in contents)
+            return await original(contents, *args, **kwargs)
+
+        monkeypatch.setattr(fact_extraction, "extract_facts_from_contents", _spy)
+
+
+async def _stored_markers(memory, request_context, bank_id: str, document_id: str) -> list[str]:
+    units = await memory.list_memory_units(
+        bank_id, document_id=document_id, limit=4000, request_context=request_context
+    )
+    stored = "\n".join(str(u) for u in units["items"])
+    return [f"MARKER{i:02d}" for i in range(_BASE_SECTIONS) if f"MARKER{i:02d}" in stored]
+
+
+async def _retain(memory, request_context, bank_id: str, document_id: str, section_indices) -> None:
+    await memory.retain_async(
+        bank_id=bank_id,
+        content=_body(section_indices),
+        context="notes",
+        document_id=document_id,
+        request_context=request_context,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("case", "batch_tokens"),
+    [("within_budget", 100_000), ("oversized", _OVERSIZED_BATCH_TOKENS)],
+)
+async def test_pure_deletion_drops_the_removed_chunks(memory, request_context, monkeypatch, case, batch_tokens):
+    """Drop the last four sections, change nothing else — their facts must go."""
+    bank_id = f"test_removed_tail_{case}_{datetime.now(timezone.utc).timestamp()}"
+    document_id = "doc-removed-tail"
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_BATCH_TOKENS", str(batch_tokens))
+    clear_config_cache()
+    try:
+        await _retain(memory, request_context, bank_id, document_id, range(_BASE_SECTIONS))
+        assert await _stored_markers(memory, request_context, bank_id, document_id) == [
+            f"MARKER{i:02d}" for i in range(_BASE_SECTIONS)
+        ]
+
+        await _retain(memory, request_context, bank_id, document_id, range(_KEPT_SECTIONS))
+
+        markers = await _stored_markers(memory, request_context, bank_id, document_id)
+        assert markers == [f"MARKER{i:02d}" for i in range(_KEPT_SECTIONS)], (
+            "the sections the replacement dropped are still stored (or the surviving ones were lost)"
+        )
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_pure_deletion_only_deletes(memory, request_context, monkeypatch):
+    """The surviving chunks are byte-identical, so none of them is re-extracted.
+
+    Guards the other direction of the fix: letting the write path run for a
+    removal-only delta must not turn it into a full re-ingest.
+    """
+    bank_id = f"test_removed_no_reextract_{datetime.now(timezone.utc).timestamp()}"
+    document_id = "doc-removed-no-reextract"
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_BATCH_TOKENS", "100000")
+    clear_config_cache()
+    try:
+        await _retain(memory, request_context, bank_id, document_id, range(_BASE_SECTIONS))
+        spy = _ExtractionSpy()
+        spy.install(monkeypatch)
+        await _retain(memory, request_context, bank_id, document_id, range(_KEPT_SECTIONS))
+        assert spy.texts == [], f"a removal-only re-retain sent {len(spy.texts)} chunk(s) back through fact extraction"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_unchanged_re_retain_still_takes_the_metadata_only_path(memory, request_context, monkeypatch):
+    """Nothing changed at all — still no extraction, and every fact survives."""
+    bank_id = f"test_removed_noop_{datetime.now(timezone.utc).timestamp()}"
+    document_id = "doc-removed-noop"
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_BATCH_TOKENS", "100000")
+    clear_config_cache()
+    try:
+        await _retain(memory, request_context, bank_id, document_id, range(_BASE_SECTIONS))
+        before = await _stored_markers(memory, request_context, bank_id, document_id)
+        spy = _ExtractionSpy()
+        spy.install(monkeypatch)
+        await _retain(memory, request_context, bank_id, document_id, range(_BASE_SECTIONS))
+        assert spy.texts == [], "an unchanged re-retain re-extracted content"
+        assert await _stored_markers(memory, request_context, bank_id, document_id) == before
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_middle_deletion_still_drops_the_removed_section(memory, request_context, monkeypatch):
+    """Control: deleting a section from the MIDDLE shifts every later chunk, so
+    delta has changed chunks to extract and always deleted ``removed`` correctly.
+    Pinned so the removal-only fix is not mistaken for the whole behaviour."""
+    bank_id = f"test_removed_middle_{datetime.now(timezone.utc).timestamp()}"
+    document_id = "doc-removed-middle"
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_BATCH_TOKENS", "100000")
+    clear_config_cache()
+    kept = [i for i in range(_BASE_SECTIONS) if i != 3]
+    try:
+        await _retain(memory, request_context, bank_id, document_id, range(_BASE_SECTIONS))
+        await _retain(memory, request_context, bank_id, document_id, kept)
+        assert await _stored_markers(memory, request_context, bank_id, document_id) == [f"MARKER{i:02d}" for i in kept]
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## The bug

Delta retain classifies a replacement body against the stored chunks as
`unchanged / changed / new / removed`. Delete the tail of a document and leave the rest
byte-identical, and the diff is `changed=0 new=0 removed=N`: **nothing to extract, but
something to delete.**

`_try_delta_retain` bailed out to the metadata-only path as soon as the *extraction* list
came back empty:

```python
delta_contents, delta_chunk_map = _build_delta_contents(contents, new_chunks_with_contents, chunks_to_process)

if not delta_contents:          # <- non-empty removed_indices thrown away here
    return await _delta_metadata_only(...)
```

So the document row advanced to the shrunken body and **nothing was deleted**. The removed
sections' chunks and facts stayed recallable as part of a document that no longer contained
them — and the state was *stable*: the stored `content_hash` now matched the new body, so
re-submitting the same document was a no-op that never revisited the leftovers.

Measured on a 10-section document re-retained with the last 4 sections dropped:

|  | before | after |
|---|---|---|
| within `retain_batch_tokens` | all 10 sections still stored | 6 |
| over `retain_batch_tokens` (sliced transport) | all 10 sections still stored | 6 |

The same deletion combined with *any* other edit was always correct — the write path deletes
`removed_indices` alongside the changed chunks it rewrites — which is what kept this
invisible. It takes a **pure** deletion to hit. That also makes deleting a section from the
*middle* correct already: the removal shifts every later chunk, so delta has changed chunks
to extract and takes the write path.

## The fix

One condition. Bail out to metadata-only only when there is nothing to **write**, not merely
nothing to **extract**:

```python
if not delta_contents and not removed_indices:
    return await _delta_metadata_only(...)
```

The write path already deletes `removed_indices` whether or not it also has facts to insert,
and both write paths (Postgres and the store-owned Protocol-B one) handle an empty fact set:
`extract_facts_from_contents([])` returns before any LLM call, `insert_facts_batch` inserts
nothing, and `_store_document_bodies` re-puts the full new chunk set. A removal-only
re-retain therefore costs zero extraction — asserted below.

## Tests

`tests/test_delta_removed_chunks.py`:

* `test_pure_deletion_drops_the_removed_chunks[within_budget]` — **fails on `main`**
* `test_pure_deletion_drops_the_removed_chunks[oversized]` — **fails on `main`**
* `test_pure_deletion_only_deletes` — the surviving chunks are byte-identical, so a
  removal-only delta must not send anything back through fact extraction (guards the other
  direction: letting the write path run must not turn this into a full re-ingest)
* `test_unchanged_re_retain_still_takes_the_metadata_only_path` — a no-op re-retain still
  extracts nothing and keeps every fact
* `test_middle_deletion_still_drops_the_removed_section` — control for the case that was
  already correct

## Verification

* New file: 5 passed here, 2 failed on `main` (the two repro cases).
* `pytest tests/ -k "retain or delta or chunk or document or append or observation or recovery or oversized"`:
  **979 passed**. The 2 failures / 29 errors are pre-existing and environmental
  (`HINDSIGHT_API_LLM_API_KEY` — real-LLM tests); each was confirmed failing identically on
  clean `main`.
* `ruff check` / `ruff format --check` / `ty check hindsight_api/` clean; `check-unused.sh`
  reports nothing new.

## Relationship to #3666

#3666 targets the same area but was branched before #3660, which had already fixed the
symptoms it describes (stale-fact accumulation and full re-extraction on an oversized edit
— 4 of its 5 tests pass unmodified on current `main`). Its remaining test is the shrinking
tail, which is this bug.

#3666's approach — dropping `removed_indices` for every sliced retain — should not be
merged: on its own head it deletes content that is still in the document. Re-retaining a
10-section oversized document with section 0 edited and section 3 deleted:

```
BEFORE  00 01 02 03 04 05 06 07 08 09
#3666   00 01 02 03 04 05 06 07 08      deleted section 03 survives; live section 09 destroyed
main    00 01 02    04 05 06 07 08 09   correct
this PR 00 01 02    04 05 06 07 08 09   correct
```

Suggest closing #3666 in favour of this.
