### PR TITLE
fix(tests): run the maintenance-routine e2e against the current routine body

### DIFF
--- a/hindsight-api-slim/tests/test_maintenance_routines.py
+++ b/hindsight-api-slim/tests/test_maintenance_routines.py
@@ -9,10 +9,12 @@ table in a single round-trip. These tests drive them directly against pg0.
 import asyncio
 import importlib.util
 import uuid
-from types import SimpleNamespace
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+from alembic.config import Config
+from alembic.script import ScriptDirectory
 
 from hindsight_api.engine.memory_engine import MemoryEngine
 
@@ -239,7 +241,12 @@ async def test_schemas_with_expired_rows(memory: MemoryEngine):
 
 
 def _load_schema_local_migration():
-    """Import the #2638 schema-local install migration by path."""
+    """Import the #2638 schema-local install migration by path.
+
+    Pinned on purpose: the tests below assert what THIS migration's install
+    gating emits. Anything that runs the routine bodies must use
+    ``_load_current_routines_migration`` instead — see there.
+    """
     path = (
         Path(__file__).resolve().parent.parent
         / "hindsight_api/alembic/versions/b6d2f8a4c1e7_maintenance_routines_schema_local.py"
@@ -249,6 +256,65 @@ def _load_schema_local_migration():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+_VERSIONS_DIR = Path(__file__).resolve().parent.parent / "hindsight_api/alembic/versions"
+
+
+def _load_migration(path: Path):
+    spec = importlib.util.spec_from_file_location(f"_maint_routines_{path.stem}", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _current_routines_migration_path() -> Path:
+    """The newest migration that (re)defines ``banks_needing_consolidation``.
+
+    Resolved from the revision chain rather than hard-coded, because a test that
+    *executes* the routine must execute the body a real deployment ends up with.
+    Pinning the superseded ``b6d2f8a4c1e7`` body is what made
+    ``test_routines_callable_from_non_public_schema`` a recurring
+    ``DeadlockDetectedError`` flake under xdist: that body waits indefinitely for
+    AccessShareLock on every schema it scans, so a peer worker's concurrent
+    DROP closes a lock cycle and PostgreSQL kills one side. ``c8b4e2a71f95``
+    fixed exactly that — with a per-schema ``lock_timeout`` and skip arms — but
+    the test never installed it, so the fix could not reach the test that
+    reported the bug.
+    """
+    # walk_revisions() yields head -> base in topological order, so the first
+    # match is the definition a fully migrated database ends up with. Asked of
+    # Alembic rather than parsed here because the DAG has merge revisions with
+    # tuple down_revisions, which a line-wise parse gets wrong.
+    cfg = Config()
+    cfg.set_main_option("script_location", str(_VERSIONS_DIR.parent))
+    for script in ScriptDirectory.from_config(cfg).walk_revisions():
+        path = Path(script.path)
+        text = path.read_text()
+        if "banks_needing_consolidation" in text and "CREATE OR REPLACE FUNCTION" in text:
+            return path
+    raise AssertionError("no migration defines banks_needing_consolidation")
+
+
+def _load_current_routines_migration():
+    return _load_migration(_current_routines_migration_path())
+
+
+def test_current_routine_bodies_keep_the_concurrent_ddl_guard():
+    """Whichever migration owns the routine bodies must still skip a locked schema.
+
+    The guard is what stops the cross-schema scan from waiting on a tenant that is
+    being dropped or migrated, which is one half of a lock cycle
+    (``c8b4e2a71f95``). ``test_banks_needing_consolidation_skips_schema_locked_by_ddl``
+    proves the installed ``public`` copy behaves; this asserts a future
+    ``CREATE OR REPLACE`` cannot quietly drop the guard from the source it is
+    installed from.
+    """
+    body = _current_routines_migration_path().read_text()
+    assert "lock_timeout" in body
+    assert "lock_not_available" in body
+    assert "deadlock_detected" in body
 
 
 class _FakeAlembicContext:
@@ -322,10 +388,19 @@ async def test_routines_callable_from_non_public_schema(memory: MemoryEngine, re
     """End-to-end #2638: with the deployment schema set to a non-``public`` schema,
     the migration installs the routines there and ``fq_routine()`` resolves to that
     copy, which returns the same cross-tenant results as the ``public`` one.
+
+    Installs the CURRENT routine bodies, not ``b6d2f8a4c1e7``'s. #2638's install
+    gating has been carried forward unchanged by every migration since, but the
+    bodies have not: this test executes the routine against a live database that
+    xdist peers are creating and dropping schemas in, and the pre-``c8b4e2a71f95``
+    body waits indefinitely for AccessShareLock on every schema it scans. A peer's
+    concurrent DROP closes the lock cycle and PostgreSQL kills one side — a
+    recurring ``DeadlockDetectedError`` here, on a body no deployment runs.
+    ``_current_routines_migration_path`` keeps it on the real one.
     """
     from hindsight_api.engine import schema as schema_mod
 
-    migration = _load_schema_local_migration()
+    migration = _load_current_routines_migration()
     schema = f"tenant_{uuid.uuid4().hex[:8]}"
 
     bank_id = await _make_bank(memory, request_context, "nonpublic")


### PR DESCRIPTION
## The flake

`test_maintenance_routines.py::test_routines_callable_from_non_public_schema` fails
intermittently with `asyncpg.exceptions.DeadlockDetectedError`. Not new and not tied to any
one branch — most recently on **main's own run
[32142821174](https://github.com/vectorize-io/hindsight/actions/runs/32142821174)** (2026-08-18),
and again today on an unrelated PR.

```
Process 4732 waits for AccessShareLock on relation 20240; blocked by process 4645.
Process 4645 waits for AccessExclusiveLock on relation 20256; blocked by process 4732.
```

## Why it kept happening

The test installs the routines into a non-public schema and then **calls** one — but it loaded
the bodies from `b6d2f8a4c1e7`, which has been superseded. #2638's install *gating* is what the
test is about, and that has been carried forward unchanged. The *bodies* have not:

`c8b4e2a71f95` ("maintenance routines skip locked schemas") gave each per-schema query a
`lock_timeout` and `lock_not_available` / `deadlock_detected` skip arms, **for this exact
deadlock** — its own commit message cites this test. The older body has no such guard: it waits
indefinitely for `AccessShareLock` on every schema it scans while already holding
`AccessShareLock` on the ones it scanned earlier. Under xdist, where peer workers create and drop
schemas continuously, a peer's `DROP` closes the cycle and PostgreSQL kills one side.

So the fix landed, and never reached the test that reports the bug.

Measured directly — victim schema held under `ACCESS EXCLUSIVE` from a second connection,
routine called from a non-public copy with an 8s ceiling:

```
OLD body (b6d2f8a4c1e7, what the test installed): BLOCKED
NEW body (current chain head definition):         returned
```

## The fix

* Resolve the migration that owns the current bodies from the revision chain — via Alembic's
  `walk_revisions()`, so the DAG's merge revisions (tuple `down_revision`) resolve correctly —
  instead of hard-coding a path that silently rots the next time the bodies are replaced.
* Add `test_current_routine_bodies_keep_the_concurrent_ddl_guard`: whichever migration owns the
  bodies must still carry the skip arms. Fast, no DB.
* `_load_schema_local_migration` stays pinned to `b6d2f8a4c1e7` for the two tests that assert
  what *that* migration's install gating emits — those don't execute anything.

`test_banks_needing_consolidation_skips_schema_locked_by_ddl` already proves the installed
`public` copy behaves correctly; this just makes the non-public end-to-end test use the same body.

## Verification

`tests/test_maintenance_routines.py`: **24 passed**. `ruff check` / `ruff format --check` /
`ty check hindsight_api/` clean. Tests-only change.
