### PR TITLE
fix(control-plane): reload memories when search is cleared

### DIFF
--- a/hindsight-control-plane/src/components/data-view.tsx
+++ b/hindsight-control-plane/src/components/data-view.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { useTranslations } from "next-intl";
 import { client } from "@/lib/api";
 import { useBank } from "@/lib/bank-context";
+import { isSearchQueryCleared } from "@/lib/search-query";
 import { EntityChip, TagChip } from "@/components/ui/facet-chip";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -386,6 +387,18 @@ export function DataView({
     }
   };
 
+  const handleSearchQueryChange = (nextQuery: string) => {
+    const queryCleared = isSearchQueryCleared(searchQuery, nextQuery);
+    setSearchQuery(nextQuery);
+    if (!queryCleared || !currentBank) return;
+
+    setCurrentPage(1);
+    const { tags, match } = resolveTagQuery();
+    // The auto-loader intentionally waits for Enter for non-empty queries, so
+    // clearing an active query must explicitly restore the unfiltered dataset.
+    loadData(undefined, undefined, tags, match);
+  };
+
   // Single auto-loader for the graph data. This deliberately replaces what used
   // to be two effects (mount/context + filter change) that BOTH fired on mount,
   // doubling the initial /api/graph request (see issue #2158). When the context
@@ -477,7 +490,7 @@ export function DataView({
           <Spinner size="lg" variant="jump" className="mx-auto mb-3" />
           <p className="text-muted-foreground">{t("loadingMemories")}</p>
         </div>
-      ) : data && data.total_units === 0 && !hasActiveMemoryFilters ? (
+      ) : data && data.total_units === 0 && !hasActiveMemoryFilters && !loading ? (
         <div className="text-center py-20">
           <FileText className="w-10 h-10 mx-auto mb-4 text-muted-foreground/50" />
           <h3 className="text-base font-medium text-foreground mb-1">{t("noMemoriesYet")}</h3>
@@ -518,7 +531,7 @@ export function DataView({
                   <Input
                     type="text"
                     value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
+                    onChange={(e) => handleSearchQueryChange(e.target.value)}
                     onKeyDown={(e) => {
                       if (e.key === "Enter") {
                         e.preventDefault();

--- a/hindsight-control-plane/src/lib/search-query.ts
+++ b/hindsight-control-plane/src/lib/search-query.ts
@@ -1,0 +1,7 @@
+/**
+ * Search input changes are intentionally not part of DataView's auto-load
+ * dependencies. Only clearing an active query needs an explicit reload.
+ */
+export function isSearchQueryCleared(previousQuery: string, nextQuery: string): boolean {
+  return previousQuery.trim().length > 0 && nextQuery.trim().length === 0;
+}

--- a/hindsight-control-plane/tests/lib/search-query.test.ts
+++ b/hindsight-control-plane/tests/lib/search-query.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { isSearchQueryCleared } from "../../src/lib/search-query";
+
+describe("isSearchQueryCleared", () => {
+  it.each([
+    ["query", ""],
+    [" query ", "   "],
+  ])("recognizes an active query being cleared", (previousQuery, nextQuery) => {
+    expect(isSearchQueryCleared(previousQuery, nextQuery)).toBe(true);
+  });
+
+  it.each([
+    ["", ""],
+    ["query", "que"],
+    ["   ", ""],
+  ])("does not request a reload for %j -> %j", (previousQuery, nextQuery) => {
+    expect(isSearchQueryCleared(previousQuery, nextQuery)).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #3670.

When a zero-result text search was cleared, the Memories view kept the stale zero-result response and incorrectly replaced the search UI with the unfiltered empty-bank state.

This change explicitly reloads the unfiltered graph when an active query is cleared, while preserving tag/scope filters. The empty-bank state is also deferred while that reload is in flight so the search controls remain visible.

Validation:
- `./scripts/hooks/lint.sh`
- `npx tsc --noEmit`
- `npm test -- --run tests/lib/search-query.test.ts`
- `./.githooks/pre-commit`

The full control-plane suite has one pre-existing date-sensitive failure in `tests/lib/relative-time.test.ts`; 143 tests pass.