### PR TITLE
fix(llm): resume batch by persisted account identity, not re-selected member

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -804,6 +804,12 @@ class LLMProvider:
         # the caller resolves the server-level default, like the fields above.
         self.structured_output_forced_tool = structured_output_forced_tool
         self.ollama_num_ctx = _validate_ollama_num_ctx(ollama_num_ctx)
+        # Stored for account identity: Vertex AI auth is a service-account key file
+        # + project, which is what pins a specific account (two builds of the same
+        # model in different projects must not collide on batch recovery).
+        self._vertexai_project_id = vertexai_project_id
+        self._vertexai_region = vertexai_region or ("us-central1" if provider == "vertexai" else None)
+        self._vertexai_service_account_key = vertexai_service_account_key
         # Gemini safety settings (instance default; can be overridden per-request via context var)
         self.gemini_safety_settings = gemini_safety_settings
         # Gemini prompt caching: when True, retain extraction (and any future
@@ -1026,6 +1032,47 @@ class LLMProvider:
         if not await self._provider_impl.supports_batch_api():
             return None
         return self._provider_impl
+
+    async def account_identity(self) -> str:
+        """Stable identity of the account that would serve a batch.
+
+        Unlike ``provider`` (which only names the product, so two OpenAI members
+        with different credentials collide), this is a fingerprint of the fields
+        that actually pin a *specific account and endpoint*: provider kind,
+        base URL, model, and a digest of the credential material. It is
+        deterministic across restarts for an unchanged config, and changes when
+        the underlying account does — which is exactly what a crash-recovery
+        resume needs to detect.
+
+        The credential is hashed, never stored in plaintext, so persisting this
+        in operation ``result_metadata`` does not leak the API key. Declared
+        ``async`` so ``MultiLLMProvider`` (whose selection needs an ``await`` on a
+        member's ``supports_batch_api``) exposes the same interface.
+        """
+        import hashlib
+
+        cred = self.api_key or ""
+        # Vertex AI authenticates via a service-account key file instead of a
+        # plain API key; fold the project/region/key in so two builds don't collide.
+        if self.provider == "vertexai":
+            cred = cred or self._vertexai_service_account_key or ""
+            suffix = f"::{self._vertexai_project_id or ''}::{self._vertexai_region or ''}"
+        else:
+            suffix = ""
+        digest = hashlib.sha256(cred.encode("utf-8")).hexdigest()[:16]
+        return "::".join((self.provider, self.base_url or "", self.model, digest)) + suffix
+
+    async def resolve_batch_account(self, identity: str) -> Any | None:
+        """Return the impl that can serve a batch for ``identity``.
+
+        Single providers own exactly one account: return ``_provider_impl`` when
+        the persisted identity still matches this provider, else ``None`` so the
+        caller can surface a clear "member no longer configured" error instead of
+        silently polling the batch through a different account.
+        """
+        if await self.account_identity() == identity:
+            return self._provider_impl
+        return None
 
     async def call(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/multi_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/multi_llm.py
@@ -195,6 +195,38 @@ class MultiLLMProvider:
                 return impl
         return None
 
+    async def account_identity(self) -> str:
+        """Stable identity of the account the batch is (or would be) tied to.
+
+        Resolution mirrors ``batch_provider_impl`` exactly — the first
+        batch-capable member, else ``None`` semantics — so a chain reorder
+        between submit and resume is reflected the same way in both. The identity
+        is a fingerprint of the *specific account* (not just the provider name),
+        so a resume resolves to the same account only when it is truly the same
+        account; otherwise recovery fails loudly instead of polling the wrong one.
+        """
+        for member in self._members:
+            if await member.batch_provider_impl() is not None:
+                return await member.account_identity()
+        return await self._members[0].account_identity()
+
+    async def resolve_batch_account(self, identity: str) -> Any | None:
+        """Return the impl for the member whose persisted identity is ``identity``.
+
+        This is what makes crash recovery correct: it resolves to the exact
+        account that *submitted* the batch (by its stored identity), instead of
+        re-running ``batch_provider_impl`` which may select a different member
+        after the chain was reordered or a member's capability changed.
+
+        Returns ``None`` when no configured member carries that identity — the
+        caller then raises a clear "member no longer configured" error rather than
+        silently polling the batch through a different account.
+        """
+        for member in self._members:
+            if await member.account_identity() == identity:
+                return member._provider_impl
+        return None
+
     async def cleanup(self) -> None:
         for member in self._members:
             await member.cleanup()

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -2014,6 +2014,11 @@ async def extract_facts_from_contents_batch_api(
     # for a single provider it is the primary itself, and ``None`` when nothing
     # configured can serve a batch at all. The whole batch lifecycle (submit →
     # poll → retrieve) must target this ONE impl, so resolve it once and reuse it.
+    #
+    # NOTE: for a fresh submit we select via ``batch_provider_impl``; for a resume
+    # we instead resolve by the account *identity* persisted when the batch was
+    # submitted (see below), so a chain reorder between submit and resume never
+    # silently polls the batch through a different account.
     batch_impl = await llm_config.batch_provider_impl()
 
     if batch_impl is None:
@@ -2043,22 +2048,45 @@ async def extract_facts_from_contents_batch_api(
             batch_id = metadata.get("batch_id")
 
             if batch_id:
-                # Member selection is deterministic by declared order, but the
-                # chain configuration can change between the submit and the
-                # resume (a member added, removed, or given batch capacity). A
-                # batch_id only exists on the account that created it, so polling
-                # a different one would hang until the wall clock ran out and then
-                # report a provider error nobody can act on. Fail on the mismatch
-                # instead, naming both sides.
-                submitted_provider = metadata.get("batch_provider")
-                if submitted_provider and submitted_provider != batch_impl.provider:
-                    raise RuntimeError(
-                        f"Cannot resume batch {batch_id}: it was submitted to "
-                        f"'{submitted_provider}' but the retain LLM configuration now "
-                        f"serves batch from '{batch_impl.provider}'. Restore the LLM "
-                        f"member that submitted it, or fail this operation and retain again."
+                # Resolve the serving impl to the exact account that submitted the
+                # batch (``batch_account``), not the current ``batch_provider_impl``
+                # selection. If the chain was reordered or a member changed between
+                # submit and resume, the stored identity still finds the submitting
+                # member; if that account is no longer configured we fail loudly
+                # instead of polling the batch through a different account.
+                stored_account = metadata.get("batch_account")
+                if stored_account:
+                    resolved = await llm_config.resolve_batch_account(stored_account)
+                    if resolved is None:
+                        raise RuntimeError(
+                            f"Cannot resume batch {batch_id}: it was submitted through an "
+                            f"LLM account (identity '{stored_account}') that is no longer "
+                            f"configured. Refusing to poll it through a different account. "
+                            f"Restore the original member or re-run the retain."
+                        )
+                    batch_impl = resolved
+                    logger.info(
+                        f"Resuming existing batch: batch_id={batch_id} via stored account identity (crash recovery)"
                     )
-                logger.info(f"Resuming existing batch: batch_id={batch_id} (crash recovery)")
+                else:
+                    # Legacy metadata (written before ``batch_account`` existed).
+                    # Best-effort: fall back to the current selection, but guard on
+                    # the coarse provider name so a cross-provider mismatch still
+                    # fails loudly (the pre-``batch_account`` behaviour).
+                    if batch_impl is None or metadata.get("batch_provider") != batch_impl.provider:
+                        submitted_provider = metadata.get("batch_provider")
+                        raise RuntimeError(
+                            f"Cannot resume batch {batch_id}: it was submitted to "
+                            f"'{submitted_provider}' but the retain LLM configuration now "
+                            f"serves batch from '{None if batch_impl is None else batch_impl.provider}'. "
+                            f"Restore the LLM member that submitted it, or fail this "
+                            f"operation and retain again."
+                        )
+                    logger.warning(
+                        f"Resuming batch {batch_id} with legacy metadata (no batch_account); "
+                        f"resolving via current selection."
+                    )
+                    logger.info(f"Resuming existing batch: batch_id={batch_id} (crash recovery)")
 
     # Step 1: Chunk all contents and build batch requests (skip if resuming)
     all_chunks_info = []  # List of (chunk_text, content_index, chunk_index_in_content, event_date, context)
@@ -2114,9 +2142,14 @@ async def extract_facts_from_contents_batch_api(
         # CRITICAL: Store minimal batch state in operation metadata for crash recovery
         # This allows resuming polling if worker restarts
         if operation_id and pool:
+            # ``batch_account`` pins the exact submitting account (provider +
+            # endpoint + model + credential digest), so a later resume resolves to
+            # the same member even if the chain is reordered. ``batch_provider`` is
+            # kept for backward compatibility with old resume readers.
             batch_state = {
                 "batch_id": batch_id,
                 "batch_provider": batch_impl.provider,
+                "batch_account": await llm_config.account_identity(),
                 "chunk_count": len(batch_requests),
             }
 

--- a/hindsight-api-slim/tests/test_batch_api.py
+++ b/hindsight-api-slim/tests/test_batch_api.py
@@ -48,6 +48,10 @@ def mock_llm_config():
         return mock._provider_impl if await mock._provider_impl.supports_batch_api() else None
 
     mock.batch_provider_impl = _batch_provider_impl
+    # The batch path resolves the submitting account by a persisted identity
+    # (``batch_account``). Expose it as async matching the real LLMProvider.
+    mock.account_identity = AsyncMock(return_value="openai::https://api.openai.com/v1::gpt-4o-mini::mockdigest")
+    mock.resolve_batch_account = AsyncMock(return_value=mock._provider_impl)
     return mock
 
 

--- a/hindsight-api-slim/tests/test_llm_wrapper.py
+++ b/hindsight-api-slim/tests/test_llm_wrapper.py
@@ -346,3 +346,61 @@ def test_llm_provider_constructor_ignores_global_safety_settings(monkeypatch):
     assert provider.gemini_safety_settings is None  # not inherited from global config
 
     clear_config_cache()
+
+
+from hindsight_api.engine.llm_wrapper import LLMProvider
+
+
+def _mk_provider(provider="mock", api_key="", base_url="", model="m", **kw):
+    return LLMProvider(provider=provider, api_key=api_key, base_url=base_url, model=model, **kw)
+
+
+async def test_account_identity_is_stable_across_instances():
+    """The identity is deterministic for an unchanged config, so a resume after a
+    restart re-resolves to the same account."""
+    a = _mk_provider(api_key="secret-1", base_url="https://api.openai.com/v1", model="gpt-4o")
+    b = _mk_provider(api_key="secret-1", base_url="https://api.openai.com/v1", model="gpt-4o")
+    assert await a.account_identity() == await b.account_identity()
+
+
+async def test_account_identity_differs_by_credential():
+    """Two accounts sharing provider+endpoint+model but with different credentials
+    must not collide — the exact case ``batch_provider`` (provider name alone) got wrong."""
+    a = _mk_provider(api_key="secret-1", base_url="https://api.openai.com/v1", model="gpt-4o")
+    b = _mk_provider(api_key="secret-2", base_url="https://api.openai.com/v1", model="gpt-4o")
+    assert await a.account_identity() != await b.account_identity()
+
+
+async def test_account_identity_differs_by_endpoint_and_model():
+    a = _mk_provider(api_key="k", base_url="https://api.openai.com/v1", model="gpt-4o")
+    b = _mk_provider(api_key="k", base_url="https://api.groq.com/openai/v1", model="gpt-4o")
+    c = _mk_provider(api_key="k", base_url="https://api.openai.com/v1", model="gpt-4o-mini")
+    assert len({await a.account_identity(), await b.account_identity(), await c.account_identity()}) == 3
+
+
+async def test_account_identity_does_not_leak_credential():
+    ident = await _mk_provider(api_key="supersecretvalue").account_identity()
+    assert "supersecretvalue" not in ident
+
+
+async def test_account_identity_vertexai_differs_by_project():
+    try:
+        a = _mk_provider(provider="vertexai", model="gemini-2.5-flash", vertexai_project_id="proj-a")
+        b = _mk_provider(provider="vertexai", model="gemini-2.5-flash", vertexai_project_id="proj-b")
+    except Exception:
+        pytest.skip("Vertex AI provider not constructible in this environment")
+    assert await a.account_identity() != await b.account_identity()
+
+
+async def test_resolve_batch_account_matches_self_identity():
+    p = _mk_provider(api_key="k", base_url="https://api.openai.com/v1", model="gpt-4o")
+    ident = await p.account_identity()
+    assert await p.resolve_batch_account(ident) is p._provider_impl
+
+
+async def test_resolve_batch_account_returns_none_for_other_identity():
+    p = _mk_provider(api_key="k", base_url="https://api.openai.com/v1", model="gpt-4o")
+    other = await _mk_provider(
+        api_key="different", base_url="https://api.openai.com/v1", model="gpt-4o"
+    ).account_identity()
+    assert await p.resolve_batch_account(other) is None

--- a/hindsight-api-slim/tests/test_multi_llm_batch.py
+++ b/hindsight-api-slim/tests/test_multi_llm_batch.py
@@ -52,11 +52,19 @@ class _FakeBatchImpl:
 
 
 class _BatchMember:
-    """Fake LLMProvider member exposing the batch surface the chain delegates to."""
+    """Fake LLMProvider member exposing the batch surface the chain delegates to.
 
-    def __init__(self, name: str, supports_batch: bool, service_tier: str | None = None):
+    ``identity`` folds a per-account marker (mirroring the real credential
+    digest) so two members with the same provider kind are still distinct
+    accounts — the collision case ``batch_provider`` (the provider name) used to
+    hit. This lets the account-identity resume path be exercised without real
+    credentials.
+    """
+
+    def __init__(self, name: str, supports_batch: bool, service_tier: str | None = None, identity: str | None = None):
         self.provider = name
         self.model = f"{name}-model"
+        self._identity = identity or f"{name}::{name}-model"
         self._provider_impl = _FakeBatchImpl(name, supports_batch, service_tier)
 
     async def supports_batch_api(self) -> bool:
@@ -64,6 +72,12 @@ class _BatchMember:
 
     async def batch_provider_impl(self) -> _FakeBatchImpl | None:
         return self._provider_impl if await self.supports_batch_api() else None
+
+    async def account_identity(self) -> str:
+        return self._identity
+
+    async def resolve_batch_account(self, identity: str) -> _FakeBatchImpl | None:
+        return self._provider_impl if identity == self._identity else None
 
 
 class _FakeConn:
@@ -206,6 +220,112 @@ async def test_resume_fails_loudly_when_the_chain_no_longer_serves_that_provider
     different account would hang until the wall clock ran out and then report a
     provider error nobody can act on.
     """
+    groq = _BatchMember("groq", True)
+    pool = _FakePool({"batch_id": "batch_123", "batch_provider": "openai", "chunk_count": 1})
+
+    with pytest.raises(RuntimeError, match="Cannot resume batch batch_123"):
+        await extract_facts_from_contents_batch_api(
+            contents=[RetainContent(content="Alice moved to Paris in 2023.")],
+            llm_config=_chain(_BatchMember("deepseek", False), groq),
+            agent_name="test_agent",
+            config=_batch_config(),
+            pool=pool,
+            operation_id=str(uuid.uuid4()),
+            schema=None,
+        )
+
+    assert groq._provider_impl.calls == []
+
+
+# ── account-identity resume (post-merge review follow-up) ──────────────────────
+
+
+async def test_resume_resolves_to_submitting_account_after_reorder() -> None:
+    """Regression for the post-merge review: recovery must resume on the ACCOUNT
+    that submitted the batch, not the newly-selected first-capable member after a
+    chain reorder.
+
+    Scenario: the batch was submitted through openai-A (secondary). Between
+    submit and resume the operator reorders the chain so a different openai
+    account (openai-B) becomes first-capable, while openai-A moves down.
+    ``resolve_batch_account`` must still find openai-A by its persisted identity.
+    """
+    openai_a = _BatchMember("openai", True, identity="openai::acct-A")
+    submit_chain = _chain(_BatchMember("deepseek", False), openai_a)
+    submitting_impl = await submit_chain.batch_provider_impl()
+    persisted_identity = await submit_chain.account_identity()
+    assert submitting_impl is openai_a._provider_impl
+    assert persisted_identity == "openai::acct-A"
+
+    # After restart the chain is reordered: openai-B is now primary+first-capable
+    # and the original openai-A is a secondary.
+    openai_b = _BatchMember("openai", True, identity="openai::acct-B")
+    resume_chain = _chain(openai_b, openai_a)
+    # Naive re-selection would poll through the new primary (openai-B)...
+    assert await resume_chain.batch_provider_impl() is openai_b._provider_impl
+    assert await resume_chain.batch_provider_impl() is not submitting_impl
+    # ...but identity-driven recovery finds the submitting account (openai-A):
+    resolved = await resume_chain.resolve_batch_account(persisted_identity)
+    assert resolved is openai_a._provider_impl
+    assert resolved is submitting_impl
+
+
+async def test_resume_resolves_to_submitting_account_via_fact_extraction() -> None:
+    """End-to-end: the persisted ``batch_account`` is written at submit and used
+    on resume, so the batch polls through the SAME secondary account even after
+    the chain is reordered."""
+    openai_a = _BatchMember("openai", True, identity="openai::acct-A")
+    openai_b = _BatchMember("openai", True, identity="openai::acct-B")
+    submit_chain = _chain(_BatchMember("deepseek", False), openai_a)
+    persisted_identity = await submit_chain.account_identity()
+
+    # Resume with the stored identity; the new chain would naively pick openai-B.
+    pool = _FakePool(
+        {
+            "batch_id": "batch_123",
+            "batch_provider": "openai",
+            "batch_account": persisted_identity,
+            "chunk_count": 1,
+        }
+    )
+    await extract_facts_from_contents_batch_api(
+        contents=[RetainContent(content="Alice moved to Paris in 2023.")],
+        llm_config=_chain(openai_b, openai_a),
+        agent_name="test_agent",
+        config=_batch_config(),
+        pool=pool,
+        operation_id=str(uuid.uuid4()),
+        schema=None,
+    )
+
+    # Resumed on openai-A (the submitting account) — no re-submit, polls on A.
+    assert openai_a._provider_impl.calls == ["status", "retrieve"]
+    assert openai_b._provider_impl.calls == []
+
+
+async def test_resume_fails_when_submitting_account_no_longer_configured() -> None:
+    """If the account that submitted the batch is removed from the chain, recovery
+    must surface a clear failure rather than silently polling a different account."""
+    submit_chain = _chain(_BatchMember("deepseek", False), _BatchMember("openai", True))
+    persisted_identity = await submit_chain.account_identity()
+
+    resume_chain = _chain(_BatchMember("openai", True, identity="openai::acct-B"))
+    with pytest.raises(RuntimeError, match="Cannot resume batch batch_123"):
+        await extract_facts_from_contents_batch_api(
+            contents=[RetainContent(content="Alice moved to Paris in 2023.")],
+            llm_config=resume_chain,
+            agent_name="test_agent",
+            config=_batch_config(),
+            pool=_FakePool({"batch_id": "batch_123", "batch_account": persisted_identity, "chunk_count": 1}),
+            operation_id=str(uuid.uuid4()),
+            schema=None,
+        )
+
+
+async def test_resume_legacy_metadata_still_guards_by_provider() -> None:
+    """Metadata written before ``batch_account`` existed falls back to the
+    coarse provider-name guard (upstream behaviour) so a cross-provider mismatch
+    still fails loudly."""
     groq = _BatchMember("groq", True)
     pool = _FakePool({"batch_id": "batch_123", "batch_provider": "openai", "chunk_count": 1})
 


### PR DESCRIPTION
## Summary

Follow-up to **#3649**. Crash recovery re-resolved the batch-serving implementation with `batch_provider_impl()` (the *first* batch-capable member) and then polled the existing `batch_id` through whatever it picked, never consulting the account that actually **submitted** the batch. `result_metadata` stored only `batch_provider` (the provider *name*), which is not a stable account key: two members of the same provider with different credentials serialize identically, and a chain reorder between submit and resume could redirect polling to a different account entirely.

This persists a **stable account identity** at submit time — provider + endpoint + model + a credential digest (never the raw key; Vertex AI additionally folds project + region) — and resolves the serving implement by that identity on resume.

## Changes

- **`engine/llm_wrapper.py`** — `LLMProvider`: add `account_identity()` (stable, deterministic, credential-hashed) and `resolve_batch_account()`. Single-provider path returns `_provider_impl` only when the persisted identity still matches, else `None`.
- **`engine/multi_llm.py`** — `MultiLLMProvider`: add `account_identity()` (selection mirrors `batch_provider_impl`) and `resolve_batch_account()` (finds the member whose persisted identity matches).
- **`engine/retain/fact_extraction.py`** — persist `batch_account` alongside the legacy `batch_provider`; on resume, resolve the serving impl **by the stored identity**, failing loudly with a clear message when that account is no longer configured. Legacy metadata (written before `batch_account`) falls back to the previous provider-name guard, preserving existing behavior.

## Behavior

- **Fresh submit**: unchanged (`batch_provider_impl()` selects the first batch-capable member; `batch_account` is recorded from it).
- **Resume, chain unchanged**: resolves to the same member — no behavior change.
- **Resume after a reorder / member capability change**: resolves to the **submitting account** by identity, not to whatever is now first-capable. Previously this could poll the wrong account and hang until timeout.
- **Resume with the submitting account removed**: raises a clear `RuntimeError` (`Cannot resume batch ... account ... no longer configured`) instead of silently polling through a different account.
- **Single-provider deployments**: unchanged.

## Testing

- New unit tests in `test_llm_wrapper.py`: identity determinism across instances, distinction by credential/endpoint/model, no plaintext credential leak, Vertex AI distinction by project, and `resolve_batch_account` matching/mismatching.
- New/extended tests in `test_multi_llm_batch.py`: reorder resume resolves to the submitting account (unit + end-to-end through `extract_facts_from_contents_batch_api`), missing-account failure, and legacy provider-guard fallback.
- **68 unit tests green** (`test_llm_wrapper.py` + `test_multi_llm_batch.py`), **10 DB-backed batch tests green** (incl. crash recovery + worker recovery) run against the project's PostgreSQL.
- `ruff check` and `ruff format --check` clean on all touched files.

## Related

- #3649 (original — the reviewer flagged the recovery-account gap post-merge)
```
