### PR TITLE
fix(knowledge-base): include global observations in page scope

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -15249,6 +15249,9 @@ class MemoryEngine(MemoryEngineInterface):
         "fact_types": ["observation"],
         "exclude_mental_models": True,
         "refresh_after_consolidation": True,
+        # Preserve AND filtering for tagged memories while keeping global (untagged)
+        # observations visible to pages.
+        "tags_match": "all",
     }
 
     def _merge_page_trigger(self, trigger: dict[str, Any] | None, base: dict[str, Any] | None = None) -> dict[str, Any]:

--- a/hindsight-api-slim/tests/test_knowledge_base.py
+++ b/hindsight-api-slim/tests/test_knowledge_base.py
@@ -266,6 +266,7 @@ class TestTree:
         trigger = roots["Loose"]["trigger"]
         assert trigger["mode"] == "delta"
         assert trigger["fact_types"] == ["observation"]
+        assert trigger["tags_match"] == "all"
         assert trigger["exclude_mental_models"] is True
         assert trigger["refresh_after_consolidation"] is True
         # A folder has no backing mental model, so it has no refresh policy either —
@@ -310,19 +311,18 @@ class TestTree:
             )
 
     @pytest.mark.memory_backend_incompatible
-    async def test_tree_staleness_ignores_writes_outside_a_page_scope(self, api_client, memory, kb_bank):
-        """A write nowhere near a page's tags does not flag that page.
+    async def test_tree_staleness_includes_global_observations_in_every_page(self, api_client, memory, kb_bank):
+        """An untagged observation is global knowledge for every page.
 
-        The tree used to answer from one bank-wide watermark, so *any* write
-        flagged *every* page that had not read it — and since only an in-scope
-        write can move a page's own watermark, a page whose scope stayed quiet
-        stayed flagged forever while the refresh gate correctly refused to
-        refresh it (#3291). Each page is now asked about its own scope.
+        The tree and refresh gate resolve each page's own scope. The page default
+        deliberately keeps untagged observations in that scope, because those
+        rows represent bank-wide knowledge rather than a separate tag partition.
+        Tagged writes still only flag pages whose tag set contains them (#3291).
         """
         bank_id, ids = kb_bank
-        # Untagged: in scope for the untagged page (which defaults to tags_match
-        # "any" and so matches everything), out of scope for every tagged page
-        # (which default to all_strict).
+        # Untagged observations are global bank knowledge. They are in scope for
+        # every page, while tagged observations still need to satisfy a page's
+        # configured tag set.
         await self._insert_memory(memory, bank_id, [])
 
         resp = await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/tree")
@@ -332,15 +332,15 @@ class TestTree:
         billing = next(c for c in roots["Policies"]["children"] if c["name"] == "Billing")
 
         assert roots["Loose"]["is_stale"] is True, "an untagged page sees every memory in the bank"
-        assert orders["is_stale"] is False, "the write carried none of Orders' tags"
-        assert billing["is_stale"] is False, "the write carried none of Billing's tags"
+        assert orders["is_stale"] is True, "pages include untagged bank observations"
+        assert billing["is_stale"] is True, "pages include untagged bank observations"
 
     @pytest.mark.memory_backend_incompatible
     async def test_tree_flags_the_page_whose_own_scope_changed(self, api_client, memory, kb_bank):
-        """Only the page the write actually belongs to is flagged."""
+        """A tagged write flags its matching page, while the global page sees every write."""
         bank_id, ids = kb_bank
-        # Carries all of Orders' tags (all_strict is a superset test) and only one
-        # of Billing's, so it is in scope for Orders and not for Billing.
+        # Carries all of Orders' tags and only one of Billing's, so it is in scope
+        # for Orders and not for Billing.
         await self._insert_memory(memory, bank_id, ["type:runbook", "sales", "revenue"])
 
         resp = await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/tree")
@@ -496,6 +496,7 @@ class TestPageDefaults:
             "fact_types": ["observation"],
             "exclude_mental_models": True,
             "refresh_after_consolidation": True,
+            "tags_match": "all",
         }
         assert mm["max_tokens"] == 4096
         await memory.delete_bank(bank_id, request_context=request_context)
@@ -540,6 +541,7 @@ class TestPageDefaults:
             "fact_types": ["world", "experience", "observation"],
             "exclude_mental_models": True,
             "refresh_after_consolidation": True,
+            "tags_match": "all",
         }
         await memory.delete_bank(bank_id, request_context=request_context)
 
@@ -585,6 +587,7 @@ class TestPageDefaults:
         assert mm["trigger"]["mode"] == "delta"
         assert mm["trigger"]["fact_types"] == ["observation"]
         assert mm["trigger"]["exclude_mental_models"] is True
+        assert mm["trigger"]["tags_match"] == "all"
         # Moving onto a schedule clears the auto-refresh it was created with, in the
         # direction the create path never had to handle.
         assert "refresh_after_consolidation" not in mm["trigger"]
@@ -600,6 +603,7 @@ class TestPageDefaults:
         assert mm["trigger"]["refresh_after_consolidation"] is True
         assert "refresh_cron" not in mm["trigger"]
         assert mm["trigger"]["mode"] == "delta"
+        assert mm["trigger"]["tags_match"] == "all"
         await memory.delete_bank(bank_id, request_context=request_context)
 
     async def test_update_without_a_trigger_leaves_it_alone(self, memory: MemoryEngine, request_context):

--- a/hindsight-docs/docs/developer/api/knowledge-pages.mdx
+++ b/hindsight-docs/docs/developer/api/knowledge-pages.mdx
@@ -145,7 +145,8 @@ When `trigger` is omitted, the page is created with a document-oriented configur
   "mode": "delta",
   "fact_types": ["observation"],
   "exclude_mental_models": true,
-  "refresh_after_consolidation": true
+  "refresh_after_consolidation": true,
+  "tags_match": "all"
 }
 ```
 
@@ -157,6 +158,7 @@ This makes the page a living document built from consolidated observations only,
 | `exclude_mental_models: true` | A page never reflects on sibling pages. Without this, pages would cite each other and drift into a feedback loop where one wrong claim propagates across the knowledge base. |
 | `mode: "delta"` | Each refresh edits the existing document with what is new since the last refresh instead of regenerating it, so hand-tuned structure and wording survive. See [Refresh Mode](./mental-models#refresh-mode). |
 | `refresh_after_consolidation: true` | The page rewrites itself whenever consolidation produces new knowledge in its scope — gated by the same [staleness check](./mental-models#staleness-gating) as any mental model, so unrelated bank activity doesn't trigger rebuilds. |
+| `tags_match: "all"` | Page tags remain an AND filter for tagged memories, while untagged observations remain visible as bank-wide knowledge. |
 
 ### Page Lifecycle
 
@@ -169,7 +171,10 @@ This makes the page a living document built from consolidated observations only,
 Observations are what a page is *built from*, but it can still inspect the evidence underneath them: the refresh agent can expand a memory to its original chunk or document (unless `store_document_text` is disabled for the bank), and if `HINDSIGHT_API_REFLECT_SOURCE_FACTS_MAX_TOKENS` is enabled — off by default — observation search also returns each observation's grounding facts.
 
 :::caution
-A supplied `trigger` **replaces** these defaults, it does not merge with them. Sending `{"trigger": {"mode": "full"}}` also resets `fact_types` to all types, `exclude_mental_models` to `false`, and `refresh_after_consolidation` to `false`. Repeat the fields you want to keep.
+A supplied `trigger` patches these defaults: fields you omit keep their page defaults. Sending
+`{"trigger": {"mode": "full"}}` changes only the refresh mode; it keeps observation-only
+retrieval, page isolation, automatic refresh, and the non-strict tag matching unless you override
+those fields explicitly.
 :::
 
 Every [mental model trigger setting](./mental-models#trigger-settings) is accepted here — including `refresh_cron` for scheduled rebuilds instead of consolidation-driven ones, and `tag_groups` for compound tag scoping.

--- a/skills/hindsight-docs/references/developer/api/knowledge-pages.md
+++ b/skills/hindsight-docs/references/developer/api/knowledge-pages.md
@@ -191,7 +191,8 @@ When `trigger` is omitted, the page is created with a document-oriented configur
   "mode": "delta",
   "fact_types": ["observation"],
   "exclude_mental_models": true,
-  "refresh_after_consolidation": true
+  "refresh_after_consolidation": true,
+  "tags_match": "all"
 }
 ```
 
@@ -203,6 +204,7 @@ This makes the page a living document built from consolidated observations only,
 | `exclude_mental_models: true` | A page never reflects on sibling pages. Without this, pages would cite each other and drift into a feedback loop where one wrong claim propagates across the knowledge base. |
 | `mode: "delta"` | Each refresh edits the existing document with what is new since the last refresh instead of regenerating it, so hand-tuned structure and wording survive. See [Refresh Mode](./mental-models#refresh-mode). |
 | `refresh_after_consolidation: true` | The page rewrites itself whenever consolidation produces new knowledge in its scope — gated by the same [staleness check](./mental-models#staleness-gating) as any mental model, so unrelated bank activity doesn't trigger rebuilds. |
+| `tags_match: "all"` | Page tags remain an AND filter for tagged memories, while untagged observations remain visible as bank-wide knowledge. |
 
 ### Page Lifecycle
 
@@ -216,7 +218,10 @@ Observations are what a page is *built from*, but it can still inspect the evide
 
 > **🚨 Caution**
 >
-A supplied `trigger` **replaces** these defaults, it does not merge with them. Sending `{"trigger": {"mode": "full"}}` also resets `fact_types` to all types, `exclude_mental_models` to `false`, and `refresh_after_consolidation` to `false`. Repeat the fields you want to keep.
+A supplied `trigger` patches these defaults: fields you omit keep their page defaults. Sending
+`{"trigger": {"mode": "full"}}` changes only the refresh mode; it keeps observation-only
+retrieval, page isolation, automatic refresh, and the non-strict tag matching unless you override
+those fields explicitly.
 Every [mental model trigger setting](./mental-models#trigger-settings) is accepted here — including `refresh_cron` for scheduled rebuilds instead of consolidation-driven ones, and `tag_groups` for compound tag scoping.
 
 ---


### PR DESCRIPTION
Fixes  #3687
## Summary

Knowledge pages with tags inherited the generic `all_strict` refresh scope. Existing banks commonly contain untagged observations, so the graph seed query filtered every observation before synthesis and produced an empty page.

Knowledge-page defaults now use `tags_match: "all"`: tagged memories still need every page tag, while untagged observations remain available as bank-wide knowledge. The regression coverage checks page defaults, partial-trigger behavior, page staleness, and tagged-scope filtering. API documentation and its generated reference are updated.

## Verification

- `tests/test_knowledge_base.py`: 60 passed
- `tests/test_mental_model_consolidation_refresh_scope.py`: 6 passed
- `./scripts/hooks/lint.sh`: passed
- Documentation build: passed (with two pre-existing broken-anchor warnings)
