### PR TITLE
fix(openclaw): probe append support for local daemon

### DIFF
--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -92,6 +92,12 @@ export type AsyncRetainOperationIdCapability = "supported" | "unsupported" | "un
 let asyncRetainOperationIdCapability: AsyncRetainOperationIdCapability = "unknown";
 const MIN_VERSION_FOR_ASYNC_RETAIN_OPERATION_ID = "0.8.6";
 
+// The /version capability is deployment-wide, but store_document_text can be
+// overridden per bank. Cache the resolved value after the first retain for a
+// bank so dynamic bank routing does not add a config request to every turn.
+const bankAppendCapability = new Map<string, boolean>();
+const bankAppendCapabilityProbes = new Map<string, Promise<boolean | null>>();
+
 // Store the current plugin config for bank ID derivation
 let currentPluginConfig: PluginConfig | null = null;
 let serviceGeneration = 0;
@@ -127,6 +133,8 @@ export interface BankScopedClient {
     timeoutMs?: number
   ): Promise<RecallResponse>;
   setMissions(opts: BankMissionsUpdate): Promise<void>;
+  /** Return the bank's resolved config, or null when the config API is unavailable. */
+  getConfig(signal?: globalThis.AbortSignal): Promise<Record<string, unknown> | null>;
 }
 
 export interface BankMissionsUpdate {
@@ -136,6 +144,14 @@ export interface BankMissionsUpdate {
 }
 
 export function scopeClient(c: HindsightClient, bankId: string): BankScopedClient {
+  // Keep this optional at runtime: older published client versions and the
+  // lightweight test doubles do not expose getBankConfig yet.
+  const configReader = c as HindsightClient & {
+    getBankConfig?: (
+      bankId: string,
+      options?: { signal?: globalThis.AbortSignal }
+    ) => Promise<{ config?: Record<string, unknown> }>;
+  };
   return {
     bankId,
     async retain(req, capability = asyncRetainOperationIdCapability, signal) {
@@ -184,7 +200,60 @@ export function scopeClient(c: HindsightClient, bankId: string): BankScopedClien
         observationsMission: opts.observationsMission,
       });
     },
+    async getConfig(signal) {
+      if (typeof configReader.getBankConfig !== "function") return null;
+      const response = await configReader.getBankConfig(bankId, { signal });
+      return response?.config ?? null;
+    },
   };
+}
+
+/**
+ * Resolve append support for one bank. A failed or unavailable config probe is
+ * deliberately treated as unsupported: a per-turn document preserves the
+ * conversation, while an append submitted to a text-disabled bank can be
+ * accepted by the HTTP layer and fail later in the worker.
+ */
+async function resolveBankAppendSupport(
+  bankId: string,
+  scopedClient: BankScopedClient,
+  signal?: globalThis.AbortSignal
+): Promise<boolean> {
+  if (!supportsUpdateModeAppend) return false;
+
+  const cached = bankAppendCapability.get(bankId);
+  if (cached !== undefined) return cached;
+
+  const inFlight = bankAppendCapabilityProbes.get(bankId);
+  if (inFlight) return (await inFlight) ?? false;
+
+  const probe = (async (): Promise<boolean | null> => {
+    try {
+      const config = await scopedClient.getConfig(signal);
+      if (!config) {
+        debug(`[Hindsight] Could not read resolved config for bank ${bankId}; disabling append`);
+        return null;
+      }
+      // A missing field inherits the global setting reported by /version.
+      return typeof config.store_document_text === "boolean" ? config.store_document_text : true;
+    } catch (error) {
+      debug(
+        `[Hindsight] Bank config probe failed for ${bankId}; disabling append: ${String(error)}`
+      );
+      return null;
+    }
+  })();
+  bankAppendCapabilityProbes.set(bankId, probe);
+
+  try {
+    const result = await probe;
+    if (result !== null) bankAppendCapability.set(bankId, result);
+    return result ?? false;
+  } finally {
+    if (bankAppendCapabilityProbes.get(bankId) === probe) {
+      bankAppendCapabilityProbes.delete(bankId);
+    }
+  }
 }
 
 async function ensureBankDefaultsApplied(bankId: string, config: PluginConfig): Promise<void> {
@@ -1662,6 +1731,10 @@ async function detectAppendCapability(
   const firstProbe = !appendCapabilityProbed;
   appendCapabilityProbed = true;
   supportsUpdateModeAppend = supported;
+  // A reconnect can point at a different deployment or a changed global
+  // default, so bank-level results must be re-read with the new probe.
+  bankAppendCapability.clear();
+  bankAppendCapabilityProbes.clear();
   if (supported && capabilities) {
     debug(
       `[Hindsight] API version ${capabilities.version} supports update_mode=append with stored document text`
@@ -2091,7 +2164,9 @@ export default function (api: MoltbotPluginAPI) {
 
               // Initialize client pointed at the local daemon URL
               debug("[Hindsight] Creating HindsightClient (local daemon)...");
-              clientOptions = { baseUrl: hindsightServer.getBaseUrl() };
+              const localApiUrl = hindsightServer.getBaseUrl();
+              await detectAppendCapability(localApiUrl);
+              clientOptions = { baseUrl: localApiUrl };
               banksWithDefaultsApplied.clear();
               client = new HindsightClient(clientOptions);
 
@@ -2215,7 +2290,9 @@ export default function (api: MoltbotPluginAPI) {
 
             await hindsightServer.start();
 
-            clientOptions = { baseUrl: hindsightServer.getBaseUrl() };
+            const localApiUrl = hindsightServer.getBaseUrl();
+            await detectAppendCapability(localApiUrl);
+            clientOptions = { baseUrl: localApiUrl };
             banksWithDefaultsApplied.clear();
             client = new HindsightClient(clientOptions);
             const defaultBankId = deriveBankId(undefined, reinitPluginConfig);
@@ -2860,6 +2937,8 @@ ${memoriesFormatted}
             ? await refreshQueueOperationIdCapability(retainGeneration, retainSignal)
             : asyncRetainOperationIdCapability;
         if (!retainLifecycleIsCurrent()) return;
+        const appendSupportedForBank = await resolveBankAppendSupport(bankId, client, retainSignal);
+        if (!retainLifecycleIsCurrent()) return;
         const retainNow = Date.now();
         const retainRequest = buildRetainRequest(
           transcript,
@@ -2873,7 +2952,7 @@ ${memoriesFormatted}
               ? (pluginConfig.retainEveryNTurns ?? 1) + (pluginConfig.retainOverlapTurns ?? 0)
               : undefined,
             tags: inlineRetainTags,
-            appendSupported: supportsUpdateModeAppend,
+            appendSupported: appendSupportedForBank,
             operationId: createAsyncRetainOperationId(),
           }
         );
@@ -2886,6 +2965,38 @@ ${memoriesFormatted}
         const retainStart = pluginConfig.debugPerfTiming ? Date.now() : 0;
         let retainElapsedMs = 0;
         let retainOutcome: "ok" | "queued" | "error" = "error";
+        const markRetainSucceeded = (request: RetainRequest, usedFallback: boolean): void => {
+          retainOutcome = "ok";
+          log.trackRetain(bankId, messageCount);
+          if (usedFallback) {
+            log.warn(
+              `[Hindsight] Bank ${bankId} rejected append; retained this turn with a per-turn document`
+            );
+          }
+          debug(
+            `[Hindsight] Retained ${messageCount} messages to bank ${bankId} for session ${request.documentId}`
+          );
+
+          // After a successful retain, try flushing any queued items.
+          if (retainQueue) {
+            flushRetainQueue(undefined, undefined, undefined, retainGeneration, retainSignal).catch(
+              () => {}
+            );
+          }
+        };
+        const handleRetainFailure = (request: RetainRequest, error: unknown): void => {
+          // Queue the failed retain for later delivery (external API mode only).
+          if (retainQueue) {
+            retainQueue.enqueue(bankId, request, request.metadata);
+            retainOutcome = "queued";
+            const pending = retainQueue.size();
+            log.warn(
+              `API unreachable — retain queued (${pending} pending, bank: ${bankId}): ${error instanceof Error ? error.message : error}`
+            );
+          } else {
+            log.error("error retaining messages", error);
+          }
+        };
         try {
           // An unknown capability does not hold up the first send: there is
           // nothing on the server yet for it to duplicate, so omitting the wire
@@ -2895,31 +3006,24 @@ ${memoriesFormatted}
           await client.retain(retainRequest, retainOperationIdCapability, retainSignal);
           if (!retainLifecycleIsCurrent()) return;
           retainElapsedMs = pluginConfig.debugPerfTiming ? Date.now() - retainStart : 0;
-          retainOutcome = "ok";
-          log.trackRetain(bankId, messageCount);
-          debug(
-            `[Hindsight] Retained ${messageCount} messages to bank ${bankId} for session ${retainRequest.documentId}`
-          );
-
-          // After a successful retain, try flushing any queued items
-          if (retainQueue) {
-            flushRetainQueue(undefined, undefined, undefined, retainGeneration, retainSignal).catch(
-              () => {}
-            );
-          }
+          markRetainSucceeded(retainRequest, false);
         } catch (retainError) {
           if (!retainLifecycleIsCurrent()) return;
-          retainElapsedMs = pluginConfig.debugPerfTiming ? Date.now() - retainStart : 0;
-          // Queue the failed retain for later delivery (external API mode only)
-          if (retainQueue) {
-            retainQueue.enqueue(bankId, retainRequest, retainRequest.metadata);
-            retainOutcome = "queued";
-            const pending = retainQueue.size();
-            log.warn(
-              `API unreachable — retain queued (${pending} pending, bank: ${bankId}): ${retainError instanceof Error ? retainError.message : retainError}`
-            );
+          if (retainRequest.updateMode === "append" && isAppendRetainRejection(retainError)) {
+            const fallbackRequest = buildPerTurnFallbackRetainRequest(retainRequest);
+            try {
+              await client.retain(fallbackRequest, retainOperationIdCapability, retainSignal);
+              if (!retainLifecycleIsCurrent()) return;
+              retainElapsedMs = pluginConfig.debugPerfTiming ? Date.now() - retainStart : 0;
+              markRetainSucceeded(fallbackRequest, true);
+            } catch (fallbackError) {
+              if (!retainLifecycleIsCurrent()) return;
+              retainElapsedMs = pluginConfig.debugPerfTiming ? Date.now() - retainStart : 0;
+              handleRetainFailure(fallbackRequest, fallbackError);
+            }
           } else {
-            log.error("error retaining messages", retainError);
+            retainElapsedMs = pluginConfig.debugPerfTiming ? Date.now() - retainStart : 0;
+            handleRetainFailure(retainRequest, retainError);
           }
         }
 
@@ -3110,6 +3214,50 @@ export function buildRetainRequest(
     tags: mergedTags.length > 0 ? mergedTags : undefined,
     ...(options?.operationId ? { operationId: options.operationId } : {}),
     updateMode: useSessionScopedDoc ? "append" : undefined,
+  };
+}
+
+/** Return true when the API rejected append because the target bank cannot store text. */
+export function isAppendRetainRejection(error: unknown): boolean {
+  const candidate = error as { message?: unknown; details?: unknown } | null;
+  const parts = [
+    typeof candidate?.message === "string" ? candidate.message : String(error),
+    typeof candidate?.details === "string"
+      ? candidate.details
+      : JSON.stringify(candidate?.details ?? ""),
+  ]
+    .join(" ")
+    .toLowerCase();
+  return (
+    parts.includes("append") &&
+    (parts.includes("store_document_text") ||
+      parts.includes("document text storage") ||
+      parts.includes("not supported"))
+  );
+}
+
+/**
+ * Convert an append request to the legacy per-turn document path. This keeps
+ * the same transcript, metadata, and tags while avoiding an overwrite of a
+ * prior turn when the bank rejects append.
+ */
+export function buildPerTurnFallbackRetainRequest(request: RetainRequest): RetainRequest {
+  if (request.updateMode !== "append") return request;
+
+  const rawTurnIndex = request.metadata?.turn_index;
+  const parsedTurnIndex =
+    typeof rawTurnIndex === "string" ? Number.parseInt(rawTurnIndex, 10) : Number.NaN;
+  const turnSuffix = Number.isFinite(parsedTurnIndex)
+    ? String(parsedTurnIndex).padStart(6, "0")
+    : randomUUID();
+  const scope = request.metadata?.retention_scope === "window" ? "window" : "turn";
+  const baseDocumentId = request.documentId || "openclaw:session";
+
+  const { updateMode: _updateMode, operationId: _operationId, ...withoutAppend } = request;
+  return {
+    ...withoutAppend,
+    documentId: `${baseDocumentId}:${scope}:${turnSuffix}`,
+    operationId: createAsyncRetainOperationId(),
   };
 }
 

--- a/hindsight-integrations/openclaw/src/local-daemon-capability.test.ts
+++ b/hindsight-integrations/openclaw/src/local-daemon-capability.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MoltbotPluginAPI, PluginHookAgentContext, ServiceConfig } from "./types.js";
+
+const daemonMocks = vi.hoisted(() => ({
+  start: vi.fn(async () => undefined),
+  stop: vi.fn(async () => undefined),
+  checkHealth: vi.fn(async () => true),
+  getBaseUrl: vi.fn(() => "http://127.0.0.1:19077"),
+}));
+
+const clientMocks = vi.hoisted(() => ({
+  retain: vi.fn(async () => undefined),
+  getBankConfig: vi.fn(async () => ({ config: { store_document_text: true } })),
+}));
+
+vi.mock("@vectorize-io/hindsight-all", () => ({
+  HindsightServer: vi.fn(
+    class {
+      start = daemonMocks.start;
+      stop = daemonMocks.stop;
+      checkHealth = daemonMocks.checkHealth;
+      getBaseUrl = daemonMocks.getBaseUrl;
+    }
+  ),
+}));
+
+vi.mock("@vectorize-io/hindsight-client", () => ({
+  HindsightClient: vi.fn(
+    class {
+      retain = clientMocks.retain;
+      getBankConfig = clientMocks.getBankConfig;
+    }
+  ),
+}));
+
+import registerPlugin from "./index.js";
+
+interface PluginHarness {
+  service: ServiceConfig;
+  agentEnd: (event: unknown, ctx?: PluginHookAgentContext) => Promise<void>;
+}
+
+let activeService: ServiceConfig | undefined;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function makeHarness(): PluginHarness {
+  let registeredService: ServiceConfig | undefined;
+  let agentEndHandler:
+    | ((event: unknown, ctx?: PluginHookAgentContext) => void | Promise<void>)
+    | undefined;
+  const api: MoltbotPluginAPI = {
+    config: {
+      plugins: {
+        entries: {
+          "hindsight-openclaw": {
+            config: {
+              llmProvider: "ollama",
+              dynamicBankId: false,
+              bankId: "local-bank",
+              autoRecall: false,
+              autoRetain: true,
+              logLevel: "off",
+            },
+          },
+        },
+      },
+    },
+    registerService(service) {
+      registeredService = service;
+    },
+    on(event, handler) {
+      if (event === "agent_end") agentEndHandler = handler;
+    },
+    logger: {
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    },
+  };
+
+  registerPlugin(api);
+  if (!registeredService) throw new Error("service not registered");
+  if (!agentEndHandler) throw new Error("agent_end not registered");
+
+  return {
+    service: registeredService,
+    agentEnd: async (event, ctx) => {
+      await agentEndHandler(event, ctx);
+    },
+  };
+}
+
+async function retainOneTurn(harness: PluginHarness, session: string): Promise<void> {
+  await harness.agentEnd(
+    {
+      success: true,
+      messages: [
+        { role: "user", content: "Remember that my preferred editor theme is solarized." },
+        { role: "assistant", content: "I will remember that preference." },
+      ],
+    },
+    {
+      agentId: "main",
+      sessionKey: `agent:main:discord:direct:${session}`,
+      messageProvider: "discord",
+      channelId: `direct:${session}`,
+      senderId: "user:local-test",
+    }
+  );
+}
+
+function expectAppendRetain(session: string): void {
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  expect(fetchMock.mock.calls[0]?.[0]).toBe("http://127.0.0.1:19077/version");
+  expect(clientMocks.retain).toHaveBeenCalledWith(
+    "local-bank",
+    expect.any(String),
+    expect.objectContaining({
+      documentId: `openclaw:agent:main:discord:direct:${session}`,
+      updateMode: "append",
+      async: true,
+    })
+  );
+}
+
+beforeEach(() => {
+  daemonMocks.start.mockReset().mockResolvedValue(undefined);
+  daemonMocks.stop.mockReset().mockResolvedValue(undefined);
+  daemonMocks.checkHealth.mockReset().mockResolvedValue(true);
+  daemonMocks.getBaseUrl.mockReset().mockReturnValue("http://127.0.0.1:19077");
+  clientMocks.retain.mockReset().mockResolvedValue(undefined);
+  clientMocks.getBankConfig.mockReset().mockResolvedValue({
+    config: { store_document_text: true },
+  });
+  fetchMock = vi.fn(async (input: string | URL | Request) => {
+    const url = input instanceof Request ? input.url : input.toString();
+    if (url !== "http://127.0.0.1:19077/version") {
+      throw new Error(`unexpected request: ${url}`);
+    }
+    return new Response(
+      JSON.stringify({
+        api_version: "0.9.0",
+        features: { store_document_text: true },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  });
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(async () => {
+  if (activeService) {
+    await activeService.stop();
+    activeService = undefined;
+  }
+  vi.unstubAllGlobals();
+});
+
+describe("local daemon capability detection", () => {
+  it("uses append retention after the initial daemon start", async () => {
+    const harness = makeHarness();
+    activeService = harness.service;
+
+    await harness.service.start();
+    await retainOneTurn(harness, "initial");
+
+    expect(daemonMocks.start).toHaveBeenCalledTimes(1);
+    expectAppendRetain("initial");
+  });
+
+  it("uses append retention after recovering from an initial daemon start failure", async () => {
+    daemonMocks.start.mockRejectedValueOnce(new Error("initial daemon failed to start"));
+    const harness = makeHarness();
+    activeService = harness.service;
+
+    await harness.service.start();
+    await retainOneTurn(harness, "recovered");
+
+    expect(daemonMocks.start).toHaveBeenCalledTimes(2);
+    expectAppendRetain("recovered");
+  });
+
+  it("uses a per-turn document when the bank disables document text storage", async () => {
+    clientMocks.getBankConfig.mockResolvedValue({ config: { store_document_text: false } });
+    const harness = makeHarness();
+    activeService = harness.service;
+
+    await harness.service.start();
+    await retainOneTurn(harness, "text-disabled");
+
+    expect(clientMocks.retain).toHaveBeenCalledTimes(1);
+    expect(clientMocks.retain).toHaveBeenCalledWith(
+      "local-bank",
+      expect.any(String),
+      expect.objectContaining({
+        documentId: "openclaw:agent:main:discord:direct:text-disabled:turn:000001",
+        async: true,
+      })
+    );
+    expect(clientMocks.retain.mock.calls[0]?.[2].updateMode).toBeUndefined();
+  });
+
+  it("retries an append rejection with a per-turn document", async () => {
+    clientMocks.retain
+      .mockRejectedValueOnce(
+        new Error("update_mode='append' is not supported when document text storage is disabled")
+      )
+      .mockResolvedValueOnce(undefined);
+    const harness = makeHarness();
+    activeService = harness.service;
+
+    await harness.service.start();
+    await retainOneTurn(harness, "append-rejected");
+
+    expect(clientMocks.retain).toHaveBeenCalledTimes(2);
+    expect(clientMocks.retain.mock.calls[0]?.[2]).toEqual(
+      expect.objectContaining({
+        documentId: "openclaw:agent:main:discord:direct:append-rejected",
+        updateMode: "append",
+      })
+    );
+    expect(clientMocks.retain.mock.calls[1]?.[2]).toEqual(
+      expect.objectContaining({
+        documentId: "openclaw:agent:main:discord:direct:append-rejected:turn:000001",
+      })
+    );
+    expect(clientMocks.retain.mock.calls[1]?.[2].updateMode).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #3686
## Summary

- probe the embedded daemon capability endpoint after startup so supported deployments use append retention
- repeat the probe on local-daemon recovery initialization
- cover initial startup and recovery with lifecycle regression tests that assert stable session document IDs

## Testing

- `npm test` (322 tests)
- `npm run build`
- `./scripts/hooks/lint.sh`

