### PR TITLE
fix(control-plane): keep the memories search open when the query is cleared

### DIFF
--- a/hindsight-control-plane/src/components/data-view.tsx
+++ b/hindsight-control-plane/src/components/data-view.tsx
@@ -4,6 +4,11 @@ import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { useTranslations } from "next-intl";
 import { client } from "@/lib/api";
 import { useBank } from "@/lib/bank-context";
+import {
+  AppliedMemoryFilters,
+  hasActiveMemoryFilters,
+  shouldShowEmptyBankState,
+} from "@/lib/memory-filters";
 import { EntityChip, TagChip } from "@/components/ui/facet-chip";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -96,6 +101,13 @@ export function DataView({
   const [loading, setLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [tagFilters, setTagFilters] = useState<string[]>([]);
+  // The filters that actually produced the `data` currently on screen. This
+  // deliberately lags the live filter state: `searchQuery` only reaches the
+  // server on Enter, so deciding "is this bank empty?" from what the user has
+  // *typed* makes backspacing a zero-result search swap the results for the
+  // "no memories yet" screen — which unmounts the search box along with it
+  // (issue #3670).
+  const [appliedFilters, setAppliedFilters] = useState<AppliedMemoryFilters>({ q: "", tags: [] });
   // Observation scope filtering: the distinct scopes available, and the selected
   // one. `null` = all scopes; `[]` = the global (untagged) scope; otherwise an
   // exact tag set. Mutually exclusive with the free-form tag filter above.
@@ -169,6 +181,7 @@ export function DataView({
         chunk_id: chunkId,
       });
       setData(graphData);
+      setAppliedFilters({ q: q ?? "", tags: tags ?? [], tagsMatch });
 
       // Fetch consolidation status for observations
       if (factType === "observation") {
@@ -212,8 +225,9 @@ export function DataView({
     if (showInvalidated) return invalidatedRows;
     return data?.table_rows ?? [];
   }, [data, showInvalidated, invalidatedRows]);
-  const hasActiveMemoryFilters =
-    searchQuery.trim().length > 0 || tagFilters.length > 0 || selectedScope !== null;
+  // Read from the applied filters, not the live ones, so every "filtered vs.
+  // unfiltered" label describes the rows actually on screen.
+  const filtersActive = hasActiveMemoryFilters(appliedFilters);
 
   // Helper to get normalized link type
   const getLinkTypeCategory = (type: string | undefined): string => {
@@ -477,7 +491,7 @@ export function DataView({
           <Spinner size="lg" variant="jump" className="mx-auto mb-3" />
           <p className="text-muted-foreground">{t("loadingMemories")}</p>
         </div>
-      ) : data && data.total_units === 0 && !hasActiveMemoryFilters ? (
+      ) : data && shouldShowEmptyBankState(data.total_units, appliedFilters) ? (
         <div className="text-center py-20">
           <FileText className="w-10 h-10 mx-auto mb-4 text-muted-foreground/50" />
           <h3 className="text-base font-medium text-foreground mb-1">{t("noMemoriesYet")}</h3>
@@ -518,7 +532,18 @@ export function DataView({
                   <Input
                     type="text"
                     value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
+                    onChange={(e) => {
+                      const next = e.target.value;
+                      setSearchQuery(next);
+                      // Emptying the box is the one edit that doesn't need an
+                      // Enter to be unambiguous: re-run the query unfiltered so
+                      // the full list (and its total) comes straight back.
+                      if (next === "" && appliedFilters.q !== "" && currentBank) {
+                        setCurrentPage(1);
+                        const { tags, match } = resolveTagQuery();
+                        loadData(undefined, undefined, tags, match);
+                      }
+                    }}
                     onKeyDown={(e) => {
                       if (e.key === "Enter") {
                         e.preventDefault();
@@ -595,7 +620,7 @@ export function DataView({
                   </Button>
                 )}
                 <div className="text-sm text-muted-foreground">
-                  {hasActiveMemoryFilters ? (
+                  {filtersActive ? (
                     t("matchingMemories", { count: filteredTableRows.length })
                   ) : data.table_rows?.length < data.total_units ? (
                     <span>
@@ -1041,7 +1066,7 @@ export function DataView({
                     })()
                   ) : (
                     <div className="text-center py-12 text-muted-foreground">
-                      {hasActiveMemoryFilters ? t("noMemoriesMatchFilter") : t("noMemoriesFound")}
+                      {filtersActive ? t("noMemoriesMatchFilter") : t("noMemoriesFound")}
                     </div>
                   )}
                 </div>

--- a/hindsight-control-plane/src/lib/memory-filters.ts
+++ b/hindsight-control-plane/src/lib/memory-filters.ts
@@ -1,0 +1,44 @@
+/**
+ * Helpers for describing the memory rows a view is currently showing.
+ *
+ * These deliberately take the filters that were *applied* to the data on
+ * screen, not the ones the user is currently editing: the text search only
+ * reaches the server on Enter, so the two disagree for as long as someone is
+ * typing or backspacing.
+ */
+
+/** The filters that produced the memory rows currently on screen. */
+export interface AppliedMemoryFilters {
+  /** Free-text query sent as `q`. */
+  q: string;
+  /** Tag filter sent as `tags`. */
+  tags: string[];
+  /** `tags_match` mode; only a selected observation scope sends "exact". */
+  tagsMatch?: string;
+}
+
+/**
+ * Whether the rows on screen are a filtered subset of the bank.
+ *
+ * A selected observation scope is the only filter that sends
+ * `tags_match=exact`, which is how it stays detectable even when the scope
+ * itself is the empty (global) tag set.
+ */
+export function hasActiveMemoryFilters(applied: AppliedMemoryFilters): boolean {
+  return applied.q.trim().length > 0 || applied.tags.length > 0 || applied.tagsMatch === "exact";
+}
+
+/**
+ * Whether to show the "no memories yet" screen, which replaces the entire view
+ * — search box included — with an invitation to add a document.
+ *
+ * It must only fire for a genuinely empty bank. A search that matched nothing
+ * still has to render the filter bar, otherwise clearing the query is
+ * impossible without leaving the page (issue #3670).
+ */
+export function shouldShowEmptyBankState(
+  totalUnits: number | undefined,
+  applied: AppliedMemoryFilters
+): boolean {
+  return totalUnits === 0 && !hasActiveMemoryFilters(applied);
+}

--- a/hindsight-control-plane/tests/lib/memory-filters.test.ts
+++ b/hindsight-control-plane/tests/lib/memory-filters.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import {
+  AppliedMemoryFilters,
+  hasActiveMemoryFilters,
+  shouldShowEmptyBankState,
+} from "@/lib/memory-filters";
+
+const NONE: AppliedMemoryFilters = { q: "", tags: [] };
+
+describe("hasActiveMemoryFilters", () => {
+  it("is false with no filters applied", () => {
+    expect(hasActiveMemoryFilters(NONE)).toBe(false);
+  });
+
+  it("is false for a whitespace-only query", () => {
+    expect(hasActiveMemoryFilters({ q: "   ", tags: [] })).toBe(false);
+  });
+
+  it("is true for a text query", () => {
+    expect(hasActiveMemoryFilters({ q: "paris", tags: [] })).toBe(true);
+  });
+
+  it("is true for a tag filter", () => {
+    expect(hasActiveMemoryFilters({ q: "", tags: ["trip"] })).toBe(true);
+  });
+
+  it("is true for the global observation scope, whose tag set is empty", () => {
+    expect(hasActiveMemoryFilters({ q: "", tags: [], tagsMatch: "exact" })).toBe(true);
+  });
+});
+
+describe("shouldShowEmptyBankState", () => {
+  it("shows for an empty bank with no filters", () => {
+    expect(shouldShowEmptyBankState(0, NONE)).toBe(true);
+  });
+
+  it("does not show when the bank has memories", () => {
+    expect(shouldShowEmptyBankState(42, NONE)).toBe(false);
+  });
+
+  // Issue #3670: a search that matched nothing must keep the filter bar on
+  // screen, otherwise the query can't be cleared without leaving the page.
+  it("does not show for a search that matched nothing", () => {
+    expect(shouldShowEmptyBankState(0, { q: "zzzz", tags: [] })).toBe(false);
+  });
+
+  it("does not show for a tag filter that matched nothing", () => {
+    expect(shouldShowEmptyBankState(0, { q: "", tags: ["nope"] })).toBe(false);
+  });
+
+  it("does not show while the total is still unknown", () => {
+    expect(shouldShowEmptyBankState(undefined, NONE)).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #3670.

## The bug

On the Memories screen, searching for a term with no matches and then backspacing the box to empty replaced the whole view with **"No memories yet"** — in a bank that was full of memories. The search box went with it, so the only way back was to navigate to Home and return.

## Cause

The view decided *"is this bank empty?"* from the filters the user had **typed**, while `data` reflected the filters last **sent to the server**:

```tsx
const hasActiveMemoryFilters =
  searchQuery.trim().length > 0 || tagFilters.length > 0 || selectedScope !== null;
...
) : data && data.total_units === 0 && !hasActiveMemoryFilters ? (   // ← "No memories yet"
```

The text search only reaches the API on <kbd>Enter</kbd>. So after a search that matched nothing (`total_units === 0`), clearing the box flipped the check to `false` while the zero-result response was still on screen — and that branch replaces the entire view, search box included.

The same mismatch made the row count lie in the other direction: typing anything (before submitting) relabelled the unfiltered list from "5 total memories" to "5 matching memories".

## Fix

- Record the filters that actually produced the rows on screen (`appliedFilters`, set alongside `setData`), and gate the empty state and the matching/showing/total labels on those, so every label describes what is rendered. This also removes the same — briefer — flash when the last tag filter is removed.
- Clearing the box now re-runs the query unfiltered, so the full list and its total come straight back rather than waiting for another <kbd>Enter</kbd>.
- The predicate moved to `src/lib/memory-filters.ts` with unit tests, since the control plane has no component-test setup — all its tests are pure-lib under `tests/lib/`.

## Verification

Ran the API + control plane locally against a bank with 5 world facts and reproduced the report end to end.

- **Before** (fix stashed) — search `zzzz` → "0 matching memories"; backspace to empty → the search box, tabs content and constellation are replaced by "No memories yet / Add a document to start building this memory bank", exactly as reported.
- **After** — same steps: the search screen stays open and the header returns to "5 total memories" with the constellation restored, no extra <kbd>Enter</kbd> needed. Typing (before submitting) also keeps the honest "5 total memories" label instead of flipping to "matching".
- A genuinely empty bank still shows "No memories yet" — no regression.

`npx vitest run` — 17 files / 149 tests pass, including 10 new ones. `./scripts/hooks/lint.sh` clean; `knip` reports nothing for the new file.
