### PR TITLE
fix(retain): treat provider content-policy refusals as permanent (#3690)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_interface.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_interface.py
@@ -376,6 +376,21 @@ class OutputTooLongError(Exception):
     pass
 
 
+class ProviderContentPolicyError(RuntimeError):
+    """Raised when a provider refuses a request on content-policy (AUP) grounds.
+
+    A refusal is a deterministic function of the content, not a transient fault:
+    the same prompt earns the same refusal on every attempt. Retrying it — inside
+    the provider's transport loop or by re-running the whole worker task — burns
+    identical calls for a guaranteed-identical failure (issue #3690), so both
+    layers treat this as permanent: the provider raises it without retrying, and
+    ``_is_non_retryable_task_error`` marks the operation failed on first sight.
+
+    A ``RuntimeError`` subclass so existing ``except RuntimeError`` handlers
+    around LLM calls keep behaving as they did before the class existed.
+    """
+
+
 class ProviderRateLimitResetError(Exception):
     """Raised when an upstream provider says quota will reopen at a known time."""
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -62,7 +62,7 @@ from .db.ops_postgresql import pg_search_vector_expr
 from .db.postgresql import PostgreSQLBackend
 from .db.postgresql import apply_session_settings as _apply_session_settings
 from .db_budget import budgeted_operation
-from .llm_interface import ProviderRateLimitResetError
+from .llm_interface import ProviderContentPolicyError, ProviderRateLimitResetError
 from .llm_trace import (
     LLMRequestEntry,
     LLMRequestListResponse,
@@ -1098,6 +1098,10 @@ def _is_non_retryable_task_error(e: Exception) -> bool:
         isinstance(e, asyncpg.exceptions.IntegrityConstraintViolationError)
         or _is_oracledb_integrity_error(e)
         or _is_invalid_embedding_dimension_error(e)
+        # A provider content-policy refusal is a function of the content, not of
+        # the moment: re-running the task feeds the same chunk to the same model
+        # and earns the same refusal (issue #3690).
+        or isinstance(e, ProviderContentPolicyError)
     )
 
 

--- a/hindsight-api-slim/hindsight_api/engine/providers/claude_code_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/claude_code_llm.py
@@ -16,7 +16,13 @@ from typing import Any, Callable
 
 from pydantic import ValidationError
 
-from hindsight_api.engine.llm_interface import LLM_TOOL_CHOICE_AUTO, LLMInterface, LLMToolChoice, LLMToolChoiceMode
+from hindsight_api.engine.llm_interface import (
+    LLM_TOOL_CHOICE_AUTO,
+    LLMInterface,
+    LLMToolChoice,
+    LLMToolChoiceMode,
+    ProviderContentPolicyError,
+)
 from hindsight_api.engine.llm_trace import LLMResponseUsage, stash_response_usage
 from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
 from hindsight_api.metrics import get_metrics_collector
@@ -63,6 +69,27 @@ def _result_error_detail(message: Any) -> str:
     """
     detail = (message.result or "").strip() or message.subtype or "unknown error"
     return f"Claude Code reported an error: {detail}"
+
+
+#: The link a content-policy (AUP) refusal always carries, e.g. "API Error:
+#: Sonnet 4.5 can't help with this. Start a new session to continue.\n\nLearn
+#: more: https://www.anthropic.com/legal/aup". Matching the link rather than the
+#: apologetic prose keeps the test narrow: a false positive would turn an
+#: ordinary transient error into a permanent one (issue #3690).
+_POLICY_REFUSAL_MARKER = "anthropic.com/legal/aup"
+
+
+def _result_error(message: Any) -> Exception:
+    """Build the exception for an ``is_error`` ResultMessage.
+
+    A content-policy refusal is permanent, so it gets its own type: the retry
+    loops below re-raise it untouched instead of replaying the same prompt, and
+    the worker fails the task rather than rescheduling it.
+    """
+    text = _result_error_detail(message)
+    if _POLICY_REFUSAL_MARKER in text.lower():
+        return ProviderContentPolicyError(text)
+    return RuntimeError(text)
 
 
 class ClaudeCodeLLM(LLMInterface):
@@ -270,7 +297,7 @@ class ClaudeCodeLLM(LLMInterface):
                             # Surface the CLI's actual error text (e.g. quota
                             # exhaustion) instead of the SDK's subtype-based
                             # fallback exception (issue #2702).
-                            raise RuntimeError(_result_error_detail(message))
+                            raise _result_error(message)
 
                 # The Claude Agent SDK doesn't report exact counts; stash the same
                 # char/4 estimate the success path traces so a later parse/validate
@@ -370,6 +397,12 @@ class ClaudeCodeLLM(LLMInterface):
                 # Pydantic schema validation failure — retrying with the same
                 # input won't produce a different schema.  Raise immediately
                 # instead of burning quota on identical calls (#1412).
+                raise
+
+            except ProviderContentPolicyError:
+                # Content-policy refusal: the model declined this exact content,
+                # so every replay earns the same refusal. Raise immediately
+                # instead of spending the full retry budget on it (#3690).
                 raise
 
             except Exception as e:
@@ -627,7 +660,7 @@ class ClaudeCodeLLM(LLMInterface):
                                 # above and break before reaching this branch. Only a genuine
                                 # error with nothing to return should surface (issue #2702).
                                 if not tool_calls:
-                                    raise RuntimeError(_result_error_detail(message))
+                                    raise _result_error(message)
 
                 # Record metrics
                 duration = time.time() - start_time
@@ -660,6 +693,10 @@ class ClaudeCodeLLM(LLMInterface):
                     input_tokens=estimated_input,
                     output_tokens=estimated_output,
                 )
+
+            except ProviderContentPolicyError:
+                # Permanent refusal — see the same guard in call() (#3690).
+                raise
 
             except Exception as e:
                 last_exception = e

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -14,7 +14,7 @@ from typing import Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator
 
-from ..llm_interface import ProviderRateLimitResetError
+from ..llm_interface import ProviderContentPolicyError, ProviderRateLimitResetError
 from ..llm_wrapper import LLMConfig, OutputTooLongError, parse_llm_json, sanitize_llm_output
 from ..operation_metadata import RetainExtractionErrors
 from ..response_models import TokenUsage
@@ -1913,6 +1913,21 @@ async def extract_facts_from_text(
                     f"First failures: {failed_summary}. Provider detail: {quota_errors[0]}"
                 ),
             ) from quota_errors[0]
+
+        # A content-policy refusal is deterministic: the offending chunk earns
+        # the same refusal on every replay, so no amount of task-level retrying
+        # can complete this retain. Re-raise the permanent type (rather than a
+        # generic RuntimeError) so the worker fails the operation immediately
+        # instead of burning a full retry schedule on it (issue #3690). One
+        # refused chunk is enough — the retain cannot succeed while it is in the
+        # batch, whatever the other failures were.
+        policy_errors = [err for _, err in failed_chunks if isinstance(err, ProviderContentPolicyError)]
+        if policy_errors:
+            raise ProviderContentPolicyError(
+                f"Fact extraction refused by provider content policy: {len(policy_errors)} of "
+                f"{len(failed_chunks)} failed chunks ({len(chunks)} total) were refused; retrying cannot "
+                f"succeed. First failures: {failed_summary}"
+            ) from policy_errors[0]
 
         # Fail the entire retain — partial extraction is not acceptable.
         # All successfully extracted facts are discarded because the transaction

--- a/hindsight-api-slim/tests/test_content_policy_refusal_permanent.py
+++ b/hindsight-api-slim/tests/test_content_policy_refusal_permanent.py
@@ -1,0 +1,345 @@
+"""Regression tests for vectorize-io/hindsight#3690.
+
+A provider content-policy (AUP) refusal is a deterministic response to the
+content, not a transient fault. Before this fix it was treated as an ordinary
+error: the Claude Code provider replayed it through its full transport retry
+budget, ``extract_facts_from_text`` wrapped it in a generic ``RuntimeError``,
+and the worker rescheduled the whole task — which replayed the identical
+refusal all over again before finally failing the operation.
+
+These tests pin the permanence at all three layers:
+
+1. the provider raises ``ProviderContentPolicyError`` on the first attempt and
+   does not retry it (while ordinary errors are still retried),
+2. ``extract_facts_from_text`` re-raises the permanent type when any chunk was
+   refused, instead of flattening it into ``RuntimeError``,
+3. ``_is_non_retryable_task_error`` classifies it, so ``execute_task`` marks the
+   operation failed instead of raising ``RetryTaskAt``.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from hindsight_api.engine.llm_interface import ProviderContentPolicyError, ProviderRateLimitResetError
+from hindsight_api.engine.memory_engine import _is_non_retryable_task_error
+from hindsight_api.worker.exceptions import RetryTaskAt
+
+# Verbatim shape of the refusal from the issue's worker log.
+REFUSAL_TEXT = (
+    "API Error: Sonnet 4.5 can't help with this. Start a new session to continue.\n\n"
+    "Learn more: https://www.anthropic.com/legal/aup\n\n"
+    "Request ID: req_011CeEwAh8ESFmbMGca7ZkrG"
+)
+TRANSIENT_TEXT = "API Error: 500 Internal Server Error"
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: the provider does not retry a refusal
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeOptions:
+    """Stand-in for ClaudeAgentOptions; captures kwargs without importing the SDK."""
+
+    system_prompt: str | None = None
+    max_turns: int | None = None
+    allowed_tools: list[str] = field(default_factory=list)
+    tools: list[str] = field(default_factory=list)
+    env: dict[str, str] = field(default_factory=dict)
+    mcp_servers: dict[str, Any] = field(default_factory=dict)
+    model: str | None = None
+
+
+class _FakeAssistantMessage:
+    def __init__(self, content: list[Any]) -> None:
+        self.content = content
+
+
+class _FakeTextBlock:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _FakeResultMessage:
+    def __init__(self, subtype: str, is_error: bool, result: str | None) -> None:
+        self.subtype = subtype
+        self.is_error = is_error
+        self.result = result
+
+
+def _install_fake_sdk(monkeypatch, error_text: str, attempts: list[int]) -> None:
+    """Patch the Agent SDK so every query yields one is_error ResultMessage."""
+    import claude_agent_sdk
+
+    async def fake_query(prompt: str, options: _FakeOptions):
+        attempts.append(1)
+        yield _FakeResultMessage(subtype="success", is_error=True, result=error_text)
+
+    monkeypatch.setattr(claude_agent_sdk, "ClaudeAgentOptions", _FakeOptions)
+    monkeypatch.setattr(claude_agent_sdk, "AssistantMessage", _FakeAssistantMessage)
+    monkeypatch.setattr(claude_agent_sdk, "TextBlock", _FakeTextBlock)
+    monkeypatch.setattr(claude_agent_sdk, "ResultMessage", _FakeResultMessage)
+    monkeypatch.setattr(claude_agent_sdk, "query", fake_query)
+
+
+def _instantiate_provider():
+    from hindsight_api.engine.providers.claude_code_llm import ClaudeCodeLLM
+
+    return ClaudeCodeLLM(
+        provider="claude-code",
+        api_key="",
+        base_url="",
+        model="claude-haiku-4-5",
+        reasoning_effort="low",
+    )
+
+
+@pytest.mark.asyncio
+async def test_call_raises_permanent_error_without_retrying(monkeypatch):
+    """A refusal must fail on attempt 1 with the permanent type, not burn the budget."""
+    attempts: list[int] = []
+    _install_fake_sdk(monkeypatch, REFUSAL_TEXT, attempts)
+
+    with pytest.raises(ProviderContentPolicyError) as excinfo:
+        await _instantiate_provider().call(
+            messages=[{"role": "user", "content": "hi"}],
+            max_retries=3,
+            initial_backoff=0.0,
+            max_backoff=0.0,
+            scope="retain_extract_facts",
+        )
+
+    assert "anthropic.com/legal/aup" in str(excinfo.value)
+    assert len(attempts) == 1, f"refusal must not be retried, but the SDK was queried {len(attempts)} times"
+
+
+@pytest.mark.asyncio
+async def test_call_still_retries_ordinary_errors(monkeypatch):
+    """The permanence guard must be narrow: transient errors keep their retries."""
+    attempts: list[int] = []
+    _install_fake_sdk(monkeypatch, TRANSIENT_TEXT, attempts)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await _instantiate_provider().call(
+            messages=[{"role": "user", "content": "hi"}],
+            max_retries=2,
+            initial_backoff=0.0,
+            max_backoff=0.0,
+            scope="retain_extract_facts",
+        )
+
+    assert not isinstance(excinfo.value, ProviderContentPolicyError)
+    assert len(attempts) == 3, f"expected 1 initial attempt + 2 retries, got {len(attempts)}"
+
+
+@pytest.mark.asyncio
+async def test_call_with_tools_raises_permanent_error_without_retrying(monkeypatch):
+    """call_with_tools() classifies the refusal the same way call() does."""
+    import claude_agent_sdk
+
+    attempts: list[int] = []
+
+    class _FakeClient:
+        def __init__(self, options: _FakeOptions) -> None:
+            self.options = options
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def query(self, prompt: str) -> None:
+            return None
+
+        async def receive_response(self):
+            attempts.append(1)
+            yield _FakeResultMessage(subtype="success", is_error=True, result=REFUSAL_TEXT)
+
+    @dataclass
+    class _FakeSdkMcpTool:
+        name: str
+        description: str
+        input_schema: dict[str, Any]
+        handler: Any
+
+    def fake_create_sdk_mcp_server(name: str, version: str, tools=None):
+        return {"name": name, "version": version, "tools": tools}
+
+    monkeypatch.setattr(claude_agent_sdk, "ClaudeAgentOptions", _FakeOptions)
+    monkeypatch.setattr(claude_agent_sdk, "AssistantMessage", _FakeAssistantMessage)
+    monkeypatch.setattr(claude_agent_sdk, "TextBlock", _FakeTextBlock)
+    monkeypatch.setattr(claude_agent_sdk, "ResultMessage", _FakeResultMessage)
+    monkeypatch.setattr(claude_agent_sdk, "ToolUseBlock", type("ToolUseBlock", (), {}))
+    monkeypatch.setattr(claude_agent_sdk, "ClaudeSDKClient", _FakeClient)
+    monkeypatch.setattr(claude_agent_sdk, "SdkMcpTool", _FakeSdkMcpTool)
+    monkeypatch.setattr(claude_agent_sdk, "create_sdk_mcp_server", fake_create_sdk_mcp_server)
+
+    with pytest.raises(ProviderContentPolicyError):
+        await _instantiate_provider().call_with_tools(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[
+                {
+                    "function": {
+                        "name": "noop",
+                        "description": "no-op",
+                        "parameters": {"type": "object", "properties": {}},
+                    }
+                }
+            ],
+            max_retries=3,
+            initial_backoff=0.0,
+            max_backoff=0.0,
+            scope="test",
+        )
+
+    assert len(attempts) == 1, f"refusal must not be retried, but the SDK was queried {len(attempts)} times"
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: extract_facts_from_text keeps the permanent type
+# ---------------------------------------------------------------------------
+
+
+def _extraction_config() -> SimpleNamespace:
+    """Only the two fields extract_facts_from_text reads before chunk dispatch."""
+    return SimpleNamespace(retain_chunk_size=1000, retain_structured_chunk_size=1000)
+
+
+async def _run_extraction(chunk_errors: dict[int, Exception]):
+    """Extract from a 2-chunk text where the given chunk indices raise."""
+    from hindsight_api.engine.retain import fact_extraction
+
+    async def fake_chunk_extract(*, chunk_index: int, **_kwargs):
+        error = chunk_errors.get(chunk_index)
+        if error is not None:
+            raise error
+        return [], fact_extraction.TokenUsage()
+
+    with patch.object(fact_extraction, "_extract_facts_with_auto_split", side_effect=fake_chunk_extract):
+        return await fact_extraction.extract_facts_from_text(
+            text="First sentence. " * 100 + "\n\n" + "Second sentence. " * 100,
+            event_date=None,
+            llm_config=SimpleNamespace(),
+            agent_name="agent",
+            config=_extraction_config(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_refused_chunk_raises_permanent_error():
+    """One refused chunk makes the whole extraction permanently failed, not retryable."""
+    with pytest.raises(ProviderContentPolicyError) as excinfo:
+        await _run_extraction({0: ProviderContentPolicyError(f"Claude Code reported an error: {REFUSAL_TEXT}")})
+
+    assert "content policy" in str(excinfo.value).lower()
+    assert "chunk 0" in str(excinfo.value)
+    assert _is_non_retryable_task_error(excinfo.value) is True
+
+
+@pytest.mark.asyncio
+async def test_refusal_wins_over_a_sibling_quota_defer():
+    """A refusal alongside a deferrable quota error still fails permanently.
+
+    Deferring would reschedule the task for a batch that can never succeed: the
+    refused chunk is refused again whenever the quota reopens.
+    """
+    errors = {
+        0: ProviderRateLimitResetError(retry_at=datetime.now(UTC) + timedelta(hours=1), message="weekly limit"),
+        1: ProviderContentPolicyError(f"Claude Code reported an error: {REFUSAL_TEXT}"),
+    }
+    with pytest.raises(ProviderContentPolicyError):
+        await _run_extraction(errors)
+
+
+@pytest.mark.asyncio
+async def test_transient_chunk_failure_stays_retryable():
+    """Without a refusal the existing generic failure (and its retry) is unchanged."""
+    with pytest.raises(RuntimeError) as excinfo:
+        await _run_extraction({1: RuntimeError("connection reset by peer")})
+
+    assert not isinstance(excinfo.value, ProviderContentPolicyError)
+    assert _is_non_retryable_task_error(excinfo.value) is False
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: the worker fails the operation instead of rescheduling it
+# ---------------------------------------------------------------------------
+
+
+async def _ensure_bank(pool, bank_id: str) -> None:
+    await pool.execute(
+        "INSERT INTO banks (bank_id, name) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        bank_id,
+        bank_id,
+    )
+
+
+async def _create_pending_operation(pool, bank_id: str, operation_id: uuid.UUID) -> None:
+    payload = json.dumps(
+        {
+            "type": "batch_retain",
+            "operation_id": str(operation_id),
+            "bank_id": bank_id,
+            "contents": [{"content": "test", "document_id": "doc-1"}],
+        }
+    )
+    await pool.execute(
+        """
+        INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload)
+        VALUES ($1, $2, 'retain', 'pending', $3::jsonb)
+        """,
+        operation_id,
+        bank_id,
+        payload,
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_task_marks_refused_retain_failed_without_retry(memory):
+    """execute_task must fail the operation on the first refusal, not RetryTaskAt."""
+    bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+    operation_id = uuid.uuid4()
+
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    await _create_pending_operation(pool, bank_id, operation_id)
+
+    refusal = ProviderContentPolicyError(
+        "Fact extraction refused by provider content policy: 1 of 1 failed chunks (1 total) were refused; "
+        f"retrying cannot succeed. First failures: chunk 0: ProviderContentPolicyError: {REFUSAL_TEXT}"
+    )
+
+    task_dict = {
+        "type": "batch_retain",
+        "operation_id": str(operation_id),
+        "bank_id": bank_id,
+        "contents": [{"content": "test", "document_id": "doc-1"}],
+    }
+
+    with patch.object(memory, "_handle_batch_retain", side_effect=refusal):
+        try:
+            await memory.execute_task(task_dict)
+        except RetryTaskAt as exc:
+            pytest.fail(f"A content-policy refusal must not be retried, but execute_task raised {exc!r}")
+
+    row = await pool.fetchrow(
+        "SELECT status, error_message FROM async_operations WHERE operation_id = $1",
+        operation_id,
+    )
+    assert row is not None, "Operation row disappeared"
+    assert row["status"] == "failed", f"Expected status='failed' after a refusal, got {row['status']!r}"
+    assert "content policy" in (row["error_message"] or "").lower()
+
+    await pool.execute("DELETE FROM async_operations WHERE operation_id = $1", operation_id)
+    await pool.execute("DELETE FROM banks WHERE bank_id = $1", bank_id)


### PR DESCRIPTION
Fixes #3690.

## The problem

A content-policy (AUP) refusal travelled as a bare `RuntimeError`, so every layer treated it as transient:

1. the Claude Code provider replayed it through its full transport retry budget (4 attempts),
2. `extract_facts_from_text` flattened it into a generic `RuntimeError`,
3. the poller rescheduled the whole `batch_retain`, which replayed the identical refusal 4 more times,
4. the operation was finally marked `failed`.

Two full retry cycles for a response that is a deterministic function of the content — the same prompt earns the same refusal every time.

## The fix

Classify it, and short-circuit at each layer that was replaying it. The hooks already existed — `ProviderRateLimitResetError` has a defer branch and `_is_non_retryable_task_error` already covers integrity violations and embedding-dimension mismatches; a refusal simply had no carve-out.

- **`engine/llm_interface.py`** — new `ProviderContentPolicyError`. A `RuntimeError` subclass, so existing `except RuntimeError` handlers around LLM calls behave exactly as before.
- **`providers/claude_code_llm.py`** — `_result_error()` raises it when the CLI's error text carries the AUP link. Matching `anthropic.com/legal/aup` rather than the apologetic prose keeps the test narrow: a false positive would turn an ordinary transient error permanent. Both retry loops re-raise it untouched, mirroring the existing `ValidationError` guard.
- **`retain/fact_extraction.py`** — when *any* chunk was refused, re-raise the permanent type instead of the generic `RuntimeError`. Placed after the existing all-quota defer branch, so a refusal mixed with a quota error still wins: deferring would reschedule a batch that can never succeed, because the refused chunk is refused again whenever the quota reopens.
- **`memory_engine.py`** — `_is_non_retryable_task_error` recognizes it, so the poller marks the operation `failed` on first sight, with the refusal text in `error_message`.

## Scope

This is the "stop retrying it" half of the issue. The issue also asks for **partial success** — commit the chunks that succeeded and report `n retained, m skipped`. That is deliberately not here: it changes retain semantics and rubs against #1833's "never silently commit a document with 0 facts" invariant, so it deserves its own change. A refused chunk still fails the whole retain; it just fails fast now instead of burning two retry cycles first.

One related behaviour left as-is: `MultiLLMProvider._should_failover` still fails over on a refusal. That looks correct — another member may accept content the first refused — so in a chain the permanence takes effect once every member has refused.

## Tests

`tests/test_content_policy_refusal_permanent.py` pins each layer:

- the provider raises the permanent type after **1** SDK query instead of 4,
- ordinary errors still get their full retry budget (the guard is narrow),
- `call_with_tools` classifies it the same way,
- one refused chunk makes `extract_facts_from_text` raise the permanent type, and a refusal beats a sibling quota defer,
- a transient chunk failure stays retryable,
- `execute_task` marks the operation `failed` without raising `RetryTaskAt`.

`./scripts/hooks/lint.sh` and `uv run ty check hindsight_api/` are clean.
