### PR TITLE
fix(recall): skip over-budget facts instead of stopping, and never answer a match with nothing (#3688)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/fact_budget.py
+++ b/hindsight-api-slim/hindsight_api/engine/fact_budget.py
@@ -1,0 +1,87 @@
+"""Token-budget selection for the facts recall returns.
+
+Recall ranks its candidates and then hands back as many as ``max_tokens`` worth
+of fact text. Which facts make it into that answer is what this module decides —
+the same job :mod:`hindsight_api.engine.source_facts` does for the provenance
+map, and it answers to the same two properties (issues #3221, #3688):
+
+* the budget is spent in **rank order**, so truncation hits the tail of the
+  result list and the best-ranked facts are the ones that survive;
+* one oversized fact skips itself only — it does not evict every shorter fact
+  behind it.
+
+Recall also keeps a floor: as long as the caller asked for a positive budget, a
+run that matched something never answers with nothing. When no fact fits at all,
+the top-ranked one is returned whole and over budget, because the alternatives
+are worse — an empty answer reads as "this bank knows nothing about that", and a
+fact clipped mid-sentence would be a claim the memory never made.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FactSelection:
+    """The facts that fit the budget, plus what the budget cost."""
+
+    ids: list[str]
+    """Selected fact IDs, in rank order."""
+
+    total_tokens: int
+    """Tokens the selected facts spend. Exceeds the budget when the floor applied."""
+
+    truncated: bool
+    """True when at least one ranked fact was dropped to stay inside the budget.
+
+    Diagnostics only — it feeds the recall log line and trace. It is not worth
+    reporting to callers: a broad candidate set usually carries more text than any
+    sane budget, so on a bank of any size this is true on nearly every recall.
+    """
+
+
+def select_facts_within_budget(
+    *,
+    fact_ids_ordered: list[str],
+    text_by_id: dict[str, str],
+    max_tokens: int,
+    count_tokens: Callable[[str], int],
+) -> FactSelection:
+    """Pick the ranked facts that fit ``max_tokens``.
+
+    ``fact_ids_ordered`` must be in rank order — the budget is spent front to
+    back, so their order decides which facts survive when it runs out. IDs absent
+    from ``text_by_id`` are skipped without counting as truncation: those rows did
+    not resolve at all, which is a different condition from running out of budget.
+
+    A non-positive ``max_tokens`` selects nothing and the floor does not apply:
+    ``max_tokens=0`` is the documented way to ask for chunks without facts
+    (issue #364).
+    """
+    selected: list[str] = []
+    total_tokens = 0
+    skipped = False
+
+    for fact_id in fact_ids_ordered:
+        text = text_by_id.get(fact_id)
+        if text is None:
+            continue
+        fact_tokens = count_tokens(text)
+        if total_tokens + fact_tokens > max_tokens:
+            skipped = True
+            continue
+        total_tokens += fact_tokens
+        selected.append(fact_id)
+
+    if not selected and skipped and max_tokens > 0:
+        # Every candidate is individually over budget. Answering with nothing would be
+        # indistinguishable from "no such memory", so spend the floor on the top-ranked
+        # fact — the returned `total_tokens` shows the overshoot.
+        for fact_id in fact_ids_ordered:
+            text = text_by_id.get(fact_id)
+            if text is not None:
+                selected.append(fact_id)
+                total_tokens = count_tokens(text)
+                break
+
+    return FactSelection(ids=selected, total_tokens=total_tokens, truncated=skipped)

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -511,6 +511,7 @@ from enum import Enum
 
 from ..pg0 import EmbeddedPostgres, parse_pg0_url
 from .entity_resolver import EntityResolver
+from .fact_budget import select_facts_within_budget
 from .llm_wrapper import ConfiguredLLMProvider, LLMConfig, requires_api_key, sanitize_llm_output, sanitize_text
 from .mental_model_refresh import (
     MentalModelDeltaOperations,
@@ -7129,24 +7130,34 @@ class MemoryEngine(MemoryEngineInterface):
             # Step 6: Token budget filtering
             step_start = time.time()
 
-            # Convert to dict for token filtering (backward compatibility)
-            top_dicts = [sr.to_dict() for sr in top_scored]
-            filtered_dicts, total_tokens = self._filter_by_token_budget(top_dicts, max_tokens)
-
-            # Convert back to list of IDs and filter scored_results
-            filtered_ids = {d["id"] for d in filtered_dicts}
-            top_scored = [sr for sr in top_scored if sr.id in filtered_ids]
+            encoding = _get_tiktoken_encoding()
+            selection = select_facts_within_budget(
+                fact_ids_ordered=[sr.id for sr in top_scored],
+                text_by_id={sr.id: sr.retrieval.text for sr in top_scored},
+                max_tokens=max_tokens,
+                count_tokens=lambda text: len(encoding.encode(text)),
+            )
+            total_tokens = selection.total_tokens
+            selected_ids = set(selection.ids)
+            top_scored = [sr for sr in top_scored if sr.id in selected_ids]
 
             step_duration = time.time() - step_start
+            truncated_note = " (truncated)" if selection.truncated else ""
             log_buffer.append(
-                f"  [6] Token filtering: {len(top_scored)} results, {total_tokens}/{max_tokens} tokens in {step_duration:.3f}s"
+                f"  [6] Token filtering: {len(top_scored)} results, {total_tokens}/{max_tokens} tokens"
+                f"{truncated_note} in {step_duration:.3f}s"
             )
 
             if tracer:
                 tracer.add_phase_metric(
                     "token_filtering",
                     step_duration,
-                    {"results_selected": len(top_scored), "tokens_used": total_tokens, "max_tokens": max_tokens},
+                    {
+                        "results_selected": len(top_scored),
+                        "tokens_used": total_tokens,
+                        "max_tokens": max_tokens,
+                        "truncated": selection.truncated,
+                    },
                 )
 
             # Record visits + build the JSON-serializable result dicts. Timed as one
@@ -7578,41 +7589,6 @@ class MemoryEngine(MemoryEngineInterface):
             if not quiet:
                 logger.error("\n" + "\n".join(log_buffer), exc_info=True)
             raise RuntimeError(f"Failed to search memories ({type(e).__name__}): {e!r}") from e
-
-    def _filter_by_token_budget(
-        self, results: list[dict[str, Any]], max_tokens: int
-    ) -> tuple[list[dict[str, Any]], int]:
-        """
-        Filter results to fit within token budget.
-
-        Counts tokens only for the 'text' field using tiktoken (cl100k_base encoding).
-        Stops before including a fact that would exceed the budget.
-
-        Args:
-            results: List of search results
-            max_tokens: Maximum tokens allowed
-
-        Returns:
-            Tuple of (filtered_results, total_tokens_used)
-        """
-        encoding = _get_tiktoken_encoding()
-
-        filtered_results = []
-        total_tokens = 0
-
-        for result in results:
-            text = result.get("text", "")
-            text_tokens = len(encoding.encode(text))
-
-            # Check if adding this result would exceed budget
-            if total_tokens + text_tokens <= max_tokens:
-                filtered_results.append(result)
-                total_tokens += text_tokens
-            else:
-                # Stop before including a fact that would exceed limit
-                break
-
-        return filtered_results, total_tokens
 
     def _observations_via_source_match_sql(
         self,

--- a/hindsight-api-slim/tests/test_fact_budget_selection.py
+++ b/hindsight-api-slim/tests/test_fact_budget_selection.py
@@ -1,0 +1,111 @@
+"""Tests for the recall max_tokens selection (issue #3688).
+
+The budget must be spent in rank order, an oversized fact must skip only itself,
+a run that matched something must never answer with nothing, and any budget skip
+must be reported so a caller can tell a truncated answer from an empty bank.
+"""
+
+from hindsight_api.engine.fact_budget import select_facts_within_budget
+
+
+def _count_words(text: str) -> int:
+    """Stand-in tokenizer: one token per word, so budgets read literally."""
+    return len(text.split())
+
+
+def _select(texts: dict[str, str], max_tokens: int):
+    return select_facts_within_budget(
+        fact_ids_ordered=list(texts),
+        text_by_id=texts,
+        max_tokens=max_tokens,
+        count_tokens=_count_words,
+    )
+
+
+class TestBudgetPacking:
+    def test_budget_is_spent_in_rank_order(self):
+        """The top-ranked facts survive; the tail is what the budget drops."""
+        selection = _select({"rank-1": "one two", "rank-2": "three four", "rank-3": "five six"}, max_tokens=4)
+
+        assert selection.ids == ["rank-1", "rank-2"]
+        assert selection.total_tokens == 4
+        assert selection.truncated is True
+
+    def test_generous_budget_keeps_everything(self):
+        selection = _select({"f1": "a b c", "f2": "d e f"}, max_tokens=100)
+
+        assert selection.ids == ["f1", "f2"]
+        assert selection.total_tokens == 6
+        assert selection.truncated is False
+
+    def test_oversized_fact_does_not_evict_the_facts_behind_it(self):
+        """The regression from #3221, on the fact budget this time: one long fact
+        used to `break` the loop and drop every shorter fact ranked below it."""
+        texts = {"long": "a b c d e f g h", "short-1": "i j", "short-2": "k l"}
+
+        selection = _select(texts, max_tokens=5)
+
+        assert selection.ids == ["short-1", "short-2"]
+        assert selection.total_tokens == 4
+        assert selection.truncated is True
+
+    def test_unresolvable_ids_are_skipped_without_flagging_truncation(self):
+        """A missing text is a missing row, not a budget skip."""
+        selection = select_facts_within_budget(
+            fact_ids_ordered=["present", "absent"],
+            text_by_id={"present": "a b"},
+            max_tokens=100,
+            count_tokens=_count_words,
+        )
+
+        assert selection.ids == ["present"]
+        assert selection.truncated is False
+
+    def test_no_candidates_is_not_truncation(self):
+        selection = _select({}, max_tokens=100)
+
+        assert selection.ids == []
+        assert selection.total_tokens == 0
+        assert selection.truncated is False
+
+
+class TestFloor:
+    def test_a_match_is_never_answered_with_nothing(self):
+        """#3688: with every fact individually over budget, recall returned [],
+        which reads to an agent as 'this bank knows nothing about that'."""
+        texts = {"rank-1": "a b c d e", "rank-2": "f g h i j"}
+
+        selection = _select(texts, max_tokens=2)
+
+        assert selection.ids == ["rank-1"]
+        assert selection.truncated is True
+
+    def test_the_floor_reports_the_tokens_it_actually_spent(self):
+        """The overshoot is visible rather than silently reported as in-budget."""
+        selection = _select({"rank-1": "a b c d e"}, max_tokens=2)
+
+        assert selection.total_tokens == 5
+
+    def test_the_floor_takes_the_top_ranked_resolvable_fact(self):
+        selection = select_facts_within_budget(
+            fact_ids_ordered=["absent", "rank-1", "rank-2"],
+            text_by_id={"rank-1": "a b c", "rank-2": "d e f"},
+            max_tokens=1,
+            count_tokens=_count_words,
+        )
+
+        assert selection.ids == ["rank-1"]
+
+    def test_zero_budget_still_means_no_facts(self):
+        """max_tokens=0 is the documented way to ask for chunks only (issue #364),
+        so the floor must not smuggle a fact into that answer."""
+        selection = _select({"rank-1": "a b c"}, max_tokens=0)
+
+        assert selection.ids == []
+        assert selection.total_tokens == 0
+        assert selection.truncated is True
+
+    def test_negative_budget_selects_nothing(self):
+        selection = _select({"rank-1": "a b c"}, max_tokens=-1)
+
+        assert selection.ids == []

--- a/hindsight-api-slim/tests/test_recall_token_budget.py
+++ b/hindsight-api-slim/tests/test_recall_token_budget.py
@@ -1,0 +1,52 @@
+"""Recall never answers a match with nothing just because max_tokens is small (issue #3688).
+
+The packing rules themselves are covered by tests/test_fact_budget_selection.py;
+this walks the real recall path to check the budget is wired to it.
+"""
+
+import pytest
+
+from hindsight_api.engine.memory_engine import Budget
+
+
+@pytest.mark.asyncio
+async def test_tight_budget_returns_the_top_fact_whole(memory, request_context):
+    bank_id = "test-recall-token-budget"
+
+    try:
+        await memory.retain_async(
+            bank_id=bank_id,
+            content=(
+                "Priya leads the payments platform team in Berlin. "
+                "She migrated the settlement service from Kafka to Pulsar last spring. "
+                "Her team owns the reconciliation pipeline and the payout scheduler. "
+                "Priya reviews every schema change to the ledger tables herself."
+            ),
+            context="team notes",
+            request_context=request_context,
+        )
+
+        generous = await memory.recall_async(
+            bank_id=bank_id,
+            query="what does Priya work on",
+            max_tokens=4096,
+            budget=Budget.MID,
+            request_context=request_context,
+        )
+        assert len(generous.results) > 1, "fixture should yield several facts to spend a budget on"
+
+        # Every fact is individually over this budget — before #3688 the whole
+        # answer came back empty, which reads as "this bank knows nothing".
+        tight = await memory.recall_async(
+            bank_id=bank_id,
+            query="what does Priya work on",
+            max_tokens=1,
+            budget=Budget.MID,
+            request_context=request_context,
+        )
+        assert len(tight.results) == 1
+        assert tight.results[0].id == generous.results[0].id, "the surviving fact is the top-ranked one"
+        assert tight.results[0].text == generous.results[0].text, "the fact is returned whole, not clipped"
+
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-docs/docs/developer/api/recall.mdx
+++ b/hindsight-docs/docs/developer/api/recall.mdx
@@ -109,7 +109,11 @@ Controls retrieval depth and breadth. Accepted values are `low`, `mid` (default)
 
 ### max_tokens
 
-The maximum number of tokens the returned facts can collectively occupy. Defaults to `4096`. Only the `text` field of each fact is counted toward this budget — metadata, tags, entities, and other fields are not included. After reranking, facts are included in relevance order until this budget is exhausted — so you always get the most relevant memories that fit. Hindsight is designed for agents, which think in tokens rather than result counts: set `max_tokens` to however much of your context window you want to allocate to memories.
+The maximum number of tokens the returned facts can collectively occupy. Defaults to `4096`. Only the `text` field of each fact is counted toward this budget — metadata, tags, entities, and other fields are not included. After reranking, facts are included in relevance order until this budget is exhausted — so you always get the most relevant memories that fit. A fact too long for the remaining budget is skipped rather than ending the selection, so shorter facts ranked behind it still come back. Hindsight is designed for agents, which think in tokens rather than result counts: set `max_tokens` to however much of your context window you want to allocate to memories.
+
+:::note
+A query that matched something never comes back empty: if not even the top fact fits the budget, it is returned whole and over budget rather than clipped mid-sentence, because an empty result list would read as "this bank has no such memory" and a clipped fact would be a claim the memory never made. The one exception is `max_tokens=0`, which means "no facts" on purpose — it is how you ask for chunks alone.
+:::
 
 <Tabs>
 <TabItem value="python" label="Python">

--- a/hindsight-docs/docs/developer/retrieval.md
+++ b/hindsight-docs/docs/developer/retrieval.md
@@ -356,7 +356,7 @@ The boosts are intentionally conservative — they nudge the ranking without ove
 
 ### Stage 4: Token Truncation
 
-After scoring, results are sorted by `final_score` and selected top-down until the `max_tokens` budget is exhausted. Only the memory text counts toward the budget — metadata is free.
+After scoring, results are sorted by `final_score` and selected top-down until the `max_tokens` budget is exhausted. Only the memory text counts toward the budget — metadata is free. A result too long for what is left of the budget is skipped and the packing continues with the next one, so a single long fact does not cost you the shorter ones ranked behind it. If nothing fits at all, the top-ranked result is still returned whole, so a query that matched something is never answered with an empty list.
 
 ---
 

--- a/skills/hindsight-docs/references/developer/api/recall.md
+++ b/skills/hindsight-docs/references/developer/api/recall.md
@@ -201,8 +201,11 @@ hindsight memory recall my-bank "How are Alice and Bob connected?" --budget high
 
 ### max_tokens
 
-The maximum number of tokens the returned facts can collectively occupy. Defaults to `4096`. Only the `text` field of each fact is counted toward this budget — metadata, tags, entities, and other fields are not included. After reranking, facts are included in relevance order until this budget is exhausted — so you always get the most relevant memories that fit. Hindsight is designed for agents, which think in tokens rather than result counts: set `max_tokens` to however much of your context window you want to allocate to memories.
+The maximum number of tokens the returned facts can collectively occupy. Defaults to `4096`. Only the `text` field of each fact is counted toward this budget — metadata, tags, entities, and other fields are not included. After reranking, facts are included in relevance order until this budget is exhausted — so you always get the most relevant memories that fit. A fact too long for the remaining budget is skipped rather than ending the selection, so shorter facts ranked behind it still come back. Hindsight is designed for agents, which think in tokens rather than result counts: set `max_tokens` to however much of your context window you want to allocate to memories.
 
+> **📝 Note**
+>
+A query that matched something never comes back empty: if not even the top fact fits the budget, it is returned whole and over budget rather than clipped mid-sentence, because an empty result list would read as "this bank has no such memory" and a clipped fact would be a claim the memory never made. The one exception is `max_tokens=0`, which means "no facts" on purpose — it is how you ask for chunks alone.
 ### Python
 
 ```python

--- a/skills/hindsight-docs/references/developer/retrieval.md
+++ b/skills/hindsight-docs/references/developer/retrieval.md
@@ -356,7 +356,7 @@ The boosts are intentionally conservative — they nudge the ranking without ove
 
 ### Stage 4: Token Truncation
 
-After scoring, results are sorted by `final_score` and selected top-down until the `max_tokens` budget is exhausted. Only the memory text counts toward the budget — metadata is free.
+After scoring, results are sorted by `final_score` and selected top-down until the `max_tokens` budget is exhausted. Only the memory text counts toward the budget — metadata is free. A result too long for what is left of the budget is skipped and the packing continues with the next one, so a single long fact does not cost you the shorter ones ranked behind it. If nothing fits at all, the top-ranked result is still returned whole, so a query that matched something is never answered with an empty list.
 
 ---
 


### PR DESCRIPTION
Fixes #3688.

Recall's `max_tokens` filter stopped at the **first** fact that did not fit the remaining budget (`else: break`), so:

- a single long fact evicted every shorter fact ranked behind it, and
- when no fact fit at all — CJK facts of 100–200 tokens against `max_tokens=80` in the report — recall answered `[]`, which to an agent reads as "this bank has no such memory".

This is the same defect [#3221](https://github.com/vectorize-io/hindsight/issues/3221) fixed for the `source_facts` budget in #3419; that fix never reached the fact budget one function over. This applies the same rule there and adds the floor that case needs.

## What changed

`select_facts_within_budget` (new `engine/fact_budget.py`, mirroring `engine/source_facts.py`):

- **skip, don't stop** — a fact that overflows the remaining budget skips itself only, and packing continues with the facts behind it;
- **a match is never answered with nothing** — if not even the top-ranked fact fits, it comes back whole and over budget. Not clipped: `MemoryFact` has no `truncated` flag (unlike `ChunkInfo`), so a half-fact would be a claim the memory never made. `max_tokens=0` still means "no facts" — that is the documented way to ask for chunks alone (#364).

**The response surface is unchanged.** A `results_truncated` flag (symmetric with `source_facts_truncated`) was in the first version of this PR and was dropped: recall's candidate set has no relevance cutoff of its own, so "the budget dropped ranked facts" is true on nearly every call against a bank of any size — it would be noise, not signal. The floor already removes the ambiguity the issue reported, since a query that matched something can no longer come back empty. The `[6] Token filtering` log line and the trace phase still report truncation for diagnostics.

The overshoot is bounded by one fact's text and only happens on budgets no fact fits; internal recalls (`recall_max_tokens`, default 2048) never reach it.

## Tests

- `tests/test_fact_budget_selection.py` — packing in rank order, oversized fact does not evict the tail, the floor, `max_tokens=0`, unresolvable ids.
- `tests/test_recall_token_budget.py` — end-to-end through `recall_async`: `max_tokens=1` returns the top-ranked fact whole rather than an empty list.
