### PR TITLE
fix(retain): retry facts missing required text

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1492,6 +1492,7 @@ async def _extract_facts_from_chunk(
                     # In verbatim mode, 'what' is intentionally absent — text is backfilled from chunk
                     if extraction_mode != "verbatim":
                         logger.warning(f"Skipping fact {i}: missing 'what' field")
+                        has_malformed_facts = True
                         continue
 
                 # Critical field: fact_type — "assistant" maps to "experience", everything else is "world".
@@ -1660,6 +1661,9 @@ async def _extract_facts_from_chunk(
                     f"Got {len(raw_facts) - len(chunk_facts)} malformed facts out of {len(raw_facts)} on attempt {attempt + 1}/{outer_attempts}. Retrying..."
                 )
                 continue
+
+            if has_malformed_facts and not chunk_facts:
+                raise RuntimeError(f"Fact extraction failed: all facts were malformed after {outer_attempts} attempts")
 
             return chunk_facts, usage
 

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -253,11 +253,10 @@ async def test_top_level_fact_list_is_accepted_without_retry():
     [
         ({"text": "Alice visited Paris"}, 1, "Alice visited Paris"),
         ({"what": "Alice visited Paris"}, 1, "Alice visited Paris"),
-        ({}, 0, None),
     ],
 )
 async def test_fact_text_alias_is_recovered_without_accepting_empty_facts(fact_fields, expected_count, expected_text):
-    """Recover schema-drifted ``text`` facts while still skipping empty facts."""
+    """Recover schema-drifted ``text`` facts without spending a retry."""
     from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
 
     config = _make_config(llm_max_retries=0, retain_llm_max_retries=None)
@@ -289,6 +288,64 @@ async def test_fact_text_alias_is_recovered_without_accepting_empty_facts(fact_f
     assert len(facts) == expected_count
     if expected_text:
         assert expected_text in facts[0].fact
+
+
+@pytest.mark.asyncio
+async def test_missing_fact_text_retries_and_recovers():
+    """A schema-shaped fact without usable text must use the content retry budget."""
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
+
+    config = _make_config(llm_max_retries=1, retain_llm_max_retries=None)
+    llm_config = _make_llm_config(mock_response={})
+    llm_config.call.side_effect = [
+        ({"facts": [{"who": "Alice", "fact_type": "world"}]}, MagicMock()),
+        ({"facts": [{"what": "Alice visited Paris", "fact_type": "world"}]}, MagicMock()),
+    ]
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        facts, _usage = await _extract_facts_from_chunk(
+            chunk="Alice visited Paris.",
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            context="travel notes",
+            llm_config=llm_config,
+            config=config,
+            agent_name="test-agent",
+        )
+
+    assert llm_config.call.call_count == 2
+    assert [fact.fact for fact in facts] == ["Alice visited Paris"]
+
+
+@pytest.mark.asyncio
+async def test_missing_fact_text_fails_after_retries():
+    """Persistently malformed facts must not become a successful zero-fact retain."""
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
+
+    config = _make_config(llm_max_retries=1, retain_llm_max_retries=None)
+    llm_config = _make_llm_config(mock_response={"facts": [{"who": "Alice", "fact_type": "world"}]})
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        with pytest.raises(RuntimeError, match="all facts were malformed after 2 attempts"):
+            await _extract_facts_from_chunk(
+                chunk="Alice visited Paris.",
+                chunk_index=0,
+                total_chunks=1,
+                event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                context="travel notes",
+                llm_config=llm_config,
+                config=config,
+                agent_name="test-agent",
+            )
+
+    assert llm_config.call.call_count == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Facts without a usable `what`, `factual_core`, or `text` field are logged and skipped, but that branch does not mark the response as malformed. As a result, it bypasses the existing content retry and can let a non-empty retain finish with zero facts.

Fixes #3708.

## Fix

- Mark missing-text facts as malformed so the existing content retry budget is used.
- If every fact is still malformed after the retry budget is exhausted, raise instead of returning an empty successful result.
- Preserve the existing behavior for genuinely empty `facts` responses and for valid partial responses.

## Test

- `uv run pytest tests/test_fact_extraction_retry.py tests/test_content_policy_refusal_permanent.py -q` — 35 passed
- `uv run ruff check hindsight_api/engine/retain/fact_extraction.py tests/test_fact_extraction_retry.py`
- `uv run ruff format --check hindsight_api/engine/retain/fact_extraction.py tests/test_fact_extraction_retry.py`
- `git diff --check`

## Risk

Low and limited to malformed extraction output. Persistently malformed, non-empty fact arrays now fail loudly after the configured retries instead of being accepted as a zero-fact extraction. A valid retry or a valid partial response keeps the existing path.
