### PR TITLE
perf(recall): score observation expansion without re-joining the connected_sources CTE

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -915,6 +915,21 @@ class PostgreSQLOps(DataAccessOps):
         # Unnesting once and hash-joining connected_sources makes the work linear in
         # the number of source ids instead.
         #
+        # The score is computed against the materialized `connected_array` rather
+        # than by re-joining the `connected_sources` CTE. PostgreSQL cannot derive
+        # statistics for a CTE scan and falls back to a hardcoded estimate of 1 row;
+        # on an aged bank that CTE actually holds thousands (3,493 observed). Believing
+        # it was joining against a single row, the planner chose a nested loop and
+        # spent ~27.6s doing 31M row comparisons to emit 3,715 (issue #3714). Scoring
+        # by array membership against connected_array keeps the same set-wise semantics
+        # -- COUNT(DISTINCT) over shared source ids -- without exposing a join whose
+        # shape depends on an estimate the planner cannot make. MATERIALIZED does not
+        # help here: the problem is join selection, not repeated CTE evaluation.
+        #
+        # `score > 0` cannot filter anything the previous inner join kept: `&&` in
+        # `candidates` already guarantees at least one shared source id. It is retained
+        # so the rewrite is equivalent by construction rather than by invariant.
+        #
         # `connected_sources` caps each entity with row_number() rather than the
         # LATERAL + LIMIT that reads more naturally. Do not "simplify" it back
         # (issue #3510). The scoring join above is O(C + U) when planned as a hash
@@ -983,11 +998,12 @@ class PostgreSQLOps(DataAccessOps):
                   {window.clause("mu")}
             ),
             scored AS (
-                SELECT c.id, COUNT(DISTINCT cs.source_id)::float AS score
-                FROM candidates c
-                CROSS JOIN LATERAL unnest(c.source_memory_ids) AS s(source_id)
-                JOIN connected_sources cs ON cs.source_id = s.source_id
-                GROUP BY c.id
+                SELECT c.id, (
+                    SELECT COUNT(DISTINCT s.source_id)::float
+                    FROM unnest(c.source_memory_ids) AS s(source_id)
+                    WHERE s.source_id = ANY(ca.source_ids)
+                ) AS score
+                FROM candidates c, connected_array ca
             )
             SELECT
                 c.id, c.text, c.context, c.event_date, c.occurred_start,
@@ -996,6 +1012,7 @@ class PostgreSQLOps(DataAccessOps):
                 sc.score
             FROM candidates c
             JOIN scored sc ON sc.id = c.id
+            WHERE sc.score > 0
             ORDER BY sc.score DESC
             LIMIT $2
             """,

--- a/hindsight-api-slim/tests/test_observation_expansion_scoring.py
+++ b/hindsight-api-slim/tests/test_observation_expansion_scoring.py
@@ -233,3 +233,86 @@ async def test_per_entity_cap_bounds_hub_traversal(memory, request_context):
         assert outside not in scores, "the per-entity cap must exclude ids ranked below it"
     finally:
         await memory.delete_bank(bank_id=bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_scoring_does_not_rejoin_the_connected_sources_cte(memory, request_context):
+    """The scoring step must not re-join the opaque ``connected_sources`` CTE (#3714).
+
+    PostgreSQL cannot derive statistics for a CTE scan: it assumes 1 row. When the
+    score was computed by joining ``candidates`` against that CTE, an aged bank whose
+    CTE really held thousands of rows made the planner pick a nested loop and compare
+    tens of millions of rows to emit a few thousand -- ~27.6s for one recall arm, with
+    ``MATERIALIZED`` making no difference because the fault is join selection.
+
+    Asserting a wall-clock number would be flaky on shared CI, so this pins the
+    structural property that caused the blowup: the scoring CTE must not contain a
+    join against ``connected_sources``.
+    """
+    import inspect
+
+    from hindsight_api.engine.db.ops_postgresql import PostgreSQLOps
+
+    source = inspect.getsource(PostgreSQLOps.expand_observations)
+    scored = source[source.index("scored AS (") :]
+    scored = scored[: scored.index("LIMIT $2")]
+
+    assert "JOIN connected_sources" not in scored, (
+        "scoring must not join the connected_sources CTE -- PostgreSQL estimates a "
+        "CTE scan at 1 row and will choose a nested loop at real cardinality (#3714)"
+    )
+    assert "connected_array" in scored, "scoring should count shared sources against the materialized connected_array"
+
+
+@pytest.mark.asyncio
+async def test_scoring_is_exact_across_wide_fanout(memory, request_context):
+    """Shared-source counts stay exact when many candidates share many sources.
+
+    Guards the #3714 rewrite against an off-by-one or double-count at the fan-out
+    where the old nested loop used to blow up.
+    """
+    from hindsight_api.engine.db.ops import UpdatedWindow
+    from hindsight_api.engine.task_backend import fq_table
+
+    bank_id = f"test_obs_fanout_{uuid.uuid4().hex[:8]}"
+    try:
+        pool = await memory._get_pool()
+        backend = await memory._get_backend()
+        mu, ue, ml = fq_table("memory_units"), fq_table("unit_entities"), fq_table("memory_links")
+
+        async with pool.acquire() as conn:
+            await _ensure_bank(conn, bank_id)
+            entity_id = uuid.uuid4()
+            await conn.execute(
+                f"INSERT INTO {fq_table('entities')} (id, bank_id, canonical_name) VALUES ($1, $2, $3)",
+                entity_id,
+                bank_id,
+                "Hub",
+            )
+            facts = [await _insert_unit(conn, mu, bank_id, f"fact {i}", "world") for i in range(60)]
+            for fid in facts:
+                await conn.execute(f"INSERT INTO {ue} (unit_id, entity_id) VALUES ($1, $2)", fid, entity_id)
+
+            seed = await _insert_unit(conn, mu, bank_id, "seed obs", "observation", [facts[0]])
+            # Every candidate shares exactly the same 19 non-seed facts.
+            for i in range(40):
+                await _insert_unit(conn, mu, bank_id, f"cand {i}", "observation", facts[1:20])
+
+            rows = await backend.ops.expand_observations(
+                conn,
+                mu,
+                ue,
+                ml,
+                [seed],
+                100,
+                200,
+                UpdatedWindow(after=None, before=None, first_param_index=3),
+            )
+
+        assert rows.entity, "expansion must still return candidates"
+        assert all(r["score"] == 19.0 for r in rows.entity), (
+            "each candidate shares exactly 19 sources with the seed neighbourhood"
+        )
+        assert seed not in {r["id"] for r in rows.entity}
+    finally:
+        await memory.delete_bank(bank_id=bank_id, request_context=request_context)


### PR DESCRIPTION
## What

Scores observation graph expansion by array membership against the already-materialized `connected_array`, instead of re-joining the `connected_sources` CTE.

Fixes #3714.

## Why

PostgreSQL cannot derive statistics for a CTE scan, so it applies a hardcoded estimate of **1 row**. The `scored` CTE joined `candidates` against `connected_sources`, which on an aged bank actually holds thousands of rows — 3,493 in the reproduction.

Believing it was joining against one row, the planner chose a nested loop:

```
->  CTE Scan on connected_sources cs  (cost=0.00..0.02 rows=1 width=16)
                                      (actual time=0.001..2.120 rows=3493.00 loops=1)
->  Nested Loop  (cost=0.00..11.10 rows=211 width=32)
                 (actual time=19.493..27320.044 rows=3715.00 loops=1)
    Rows Removed by Join Filter: 31003646
Execution Time: 27633.224 ms
```

31M row comparisons to emit 3,715 rows. This is the same *class* of problem as #3085 (same function, "fast in isolation / pathological in production"), but a different join and a different mechanism — that fix addressed the semantic-link CTE and prepared-statement plans.

The misestimate widens as the bank ages: per #1725 consolidation appends to `source_memory_ids` without pruning, so `connected_sources` grows while the planner's assumption stays at 1. Young banks and test fixtures never reproduce it.

## Impact

On the affected deployment, this stage dominated recall — median across **155 production recalls**:

| stage | median | share |
|---|---:|---:|
| `[2]` parallel retrieval (contains `expand_observations`) | 24.12s | 54.4% |
| `[4]` reranking | 16.29s | 36.8% |
| `[1]` embedding | 0.056s | 0.1% |
| `[3]` RRF merge | 0.012s | 0.0% |

Recalls exceeding the service timeout failed outright with `ServiceException`; in a paired A/B one baseline arm took 64.55s and failed while every fixed arm completed.

## Results

Same bank (7,495 observations), same seeds:

| variant | execution | result sha256 |
|---|---:|---|
| current | 27,733 ms | `c059b18224acb29d` |
| current + `MATERIALIZED` | 27,629 ms | `c059b18224acb29d` |
| **this PR** | **753 ms** | `c059b18224acb29d` |

**37x faster, byte-identical output.**

`MATERIALIZED` alone changes nothing, which rules out repeated CTE evaluation and confirms the fault is join selection. `SET enable_nestloop=off` also fixes it (372ms) but is a session-wide sledgehammer, not a shipped fix.

## Correctness

Equivalence checked across **6 independent randomized seed sets**, comparing the full ordered `(id, score)` result by sha256 — all 6 matched exactly.

`WHERE sc.score > 0` preserves the previous inner-join semantics. In practice it never fires: `&&` in `candidates` already guarantees at least one shared source id (verified — zero score-0 rows across all 6 trials). It is kept so the rewrite is equivalent by construction rather than by invariant. The data also has no empty `source_memory_ids` arrays and no arrays containing NULL, verified rather than assumed.

## Tests

Two added to `test_observation_expansion_scoring.py`:

- `test_scoring_does_not_rejoin_the_connected_sources_cte` — pins the structural property that caused the blowup. Asserting wall-clock would be flaky on shared CI; asserting the scoring CTE contains no `JOIN connected_sources` is stable and catches a silent regression.
- `test_scoring_is_exact_across_wide_fanout` — guards against an off-by-one or double-count at the fan-out where the nested loop used to degrade.

The three pre-existing #3085 tests pass unchanged, including the duplicate-source-ids case that pins `COUNT(DISTINCT)` over `COUNT(*)`.

```
tests/test_observation_expansion_scoring.py  5 passed
related retrieval/graph/recall/observation suites: 527 passed, 28 skipped
```

The 13 errors in that broader run are `ValueError: LLM API key is required` (no `HINDSIGHT_API_LLM_API_KEY` in this environment) and are unrelated to this change — zero assertion failures. `ruff check` and `ruff format` clean.

## Note on the other half

This does not make recall fast on its own — it removes the largest stage and the timeout-driving work, taking median recall from ~44s to ~20s. The remaining floor is `[4]` reranking: the local `cross-encoder/ms-marco-MiniLM-L-6-v2` at 300 candidates on CPU, measured at 54.3 ms/candidate in production vs 23–25 ms/candidate for the same model standalone (contention; `RERANKER_LOCAL_MAX_CONCURRENT=4` × 4 torch threads on 10 cores). That is a separate concern with its own trade-offs — `DEFAULT_RERANKER_LOCAL_ALLOW_MPS = False` is deliberate given the documented allocator leak — so I have not touched it here. Happy to open a separate issue with those numbers if useful.
