### PR TITLE
fix(retain): derive mentioned_at from per-fact source timestamps

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -10,7 +10,8 @@ import json
 import logging
 import re
 from collections.abc import Iterator
-from datetime import datetime, timedelta
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from typing import Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator
@@ -160,6 +161,9 @@ class Fact(BaseModel):
     # Optional temporal fields
     occurred_start: str | None = None
     occurred_end: str | None = None
+    mentioned_at: str | None = None
+    # Pipeline-only provenance used by the offset step; never serialize it as fact data.
+    mentioned_at_from_source: bool = Field(default=False, exclude=True)
 
     # Optional location field
     where: str | None = Field(
@@ -198,6 +202,13 @@ class FactCausalRelation(BaseModel):
     )
 
 
+_MENTIONED_AT_FIELD_DESCRIPTION = (
+    "Timezone-aware ISO 8601 timestamp for when the source message or record directly stating this fact was written. "
+    "Prefer the extended form, such as YYYY-MM-DDTHH:MM:SSZ. This is not when the described event happened. "
+    "Return null when unavailable, invalid, or not uniquely attributable to this fact."
+)
+
+
 class ExtractedFact(BaseModel):
     """A single extracted fact."""
 
@@ -215,6 +226,7 @@ class ExtractedFact(BaseModel):
     fact_kind: str = Field(default="conversation", description="'event' or 'conversation'")
     occurred_start: str | None = Field(default=None, description="ISO timestamp for events")
     occurred_end: str | None = Field(default=None, description="ISO timestamp for event end")
+    mentioned_at: str | None = Field(default=None, description=_MENTIONED_AT_FIELD_DESCRIPTION)
     fact_type: Literal["world", "assistant"] = Field(
         description="'world' = objective/external facts, including user preferences, rules, corrections, and constraints even when stated during a conversation. 'assistant' = actions, experiences, or observations the assistant/agent actually performed."
     )
@@ -358,6 +370,7 @@ class ExtractedFactVerbose(BaseModel):
         default=None,
         description="WHEN the event ended (ISO timestamp). Only for events with duration. Leave null for conversations.",
     )
+    mentioned_at: str | None = Field(default=None, description=_MENTIONED_AT_FIELD_DESCRIPTION)
 
     fact_type: Literal["world", "assistant"] = Field(
         description="'world' = objective/external facts about the user, other people, events, general knowledge, preferences, rules, corrections, or constraints. 'assistant' = actions, experiences, or observations the assistant/agent actually performed (e.g., 'I changed X', 'I discovered Y')."
@@ -407,6 +420,7 @@ class ExtractedFactNoCausal(BaseModel):
     )
     occurred_start: str | None = Field(default=None, description="WHEN the event happened (ISO timestamp).")
     occurred_end: str | None = Field(default=None, description="WHEN the event ended (ISO timestamp).")
+    mentioned_at: str | None = Field(default=None, description=_MENTIONED_AT_FIELD_DESCRIPTION)
     fact_type: Literal["world", "assistant"] = Field(
         description="'world' = about the user/others, including user preferences, rules, corrections, and constraints. 'assistant' = actions or experiences the assistant/agent actually performed."
     )
@@ -1097,6 +1111,24 @@ Example: "Lost job → couldn't pay rent → moved apartment"
 - Fact 2: Moved apartment, causal_relations: [{target_index: 1, relation_type: "caused_by"}]"""
 
 
+MENTIONED_AT_SECTION = """
+
+══════════════════════════════════════════════════════════════════════════
+SOURCE TIMESTAMP (`mentioned_at`)
+══════════════════════════════════════════════════════════════════════════
+
+For every fact, return `mentioned_at` as the timezone-aware ISO 8601 time when the source message or record
+that directly states the fact was written.
+
+- Use only a timestamp visible in the source text and uniquely attributable to that fact.
+- Prefer the extended form, such as `2026-07-10T18:30:00Z` or `2026-07-10T18:30:00+02:00`,
+  but accept equivalent ISO 8601 source representations. The timestamp MUST include an explicit timezone.
+- This is not when the described event happened; use `occurred_start` / `occurred_end` for that.
+- Do not copy the request-level Event Date into `mentioned_at` and do not guess from text order.
+- If the source time is missing, invalid, lacks a timezone, or is ambiguous, return null.
+"""
+
+
 def _append_map_fields_prompt(fields: dict[str, "MapField"], lines: list[str], indent: int = 4) -> None:
     """Recursively append map field descriptions to the prompt lines."""
     pad = " " * indent
@@ -1258,6 +1290,13 @@ def _build_extraction_prompt_and_schema(config) -> tuple[str, type]:
     else:
         base_fact_class = ExtractedFactNoCausal
         base_response_class = FactExtractionResponseNoCausal
+
+    # Verbatim deliberately remains one raw fact per chunk. A chunk can contain
+    # several source records with different timestamps, so there is no honest
+    # per-fact attribution in that mode; it keeps the item-level event_date
+    # fallback instead.
+    if extraction_mode != "verbatim":
+        prompt = prompt + MENTIONED_AT_SECTION
 
     # Add entity labels section if configured and build dynamic schema
     entity_labels_raw = config.entity_labels
@@ -1493,6 +1532,9 @@ async def _extract_facts_from_chunk(
         agent_name,
         mission_preamble=_retain_mission_preamble(config),
     )
+    # Source evidence is invariant for this chunk, including across malformed
+    # response retries; parse it once before entering the retry loop.
+    source_instants = _source_instants_from_text(chunk) if extraction_mode != "verbatim" else frozenset()
 
     # Opt into context caching when the provider supports it. The prompt and
     # response_schema are bank-agnostic (the mission lives in the user message),
@@ -1782,9 +1824,15 @@ async def _extract_facts_from_chunk(
                     if validated_relations:
                         fact_data["causal_relations"] = validated_relations
 
-                # Set mentioned_at to the event_date (when the conversation/document occurred),
-                # or None when the caller opted into no timestamp.
-                fact_data["mentioned_at"] = event_date.isoformat() if event_date is not None else None
+                mentioned_at_resolution = (
+                    _resolve_mentioned_at(get_value("mentioned_at"), event_date, source_instants)
+                    if extraction_mode != "verbatim"
+                    else _MentionedAtResolution(value=event_date, from_source=False)
+                )
+                fact_data["mentioned_at"] = (
+                    mentioned_at_resolution.value.isoformat() if mentioned_at_resolution.value is not None else None
+                )
+                fact_data["mentioned_at_from_source"] = mentioned_at_resolution.from_source
 
                 # Build Fact model instance
                 try:
@@ -2453,6 +2501,11 @@ async def extract_facts_from_contents_batch_api(
 
         # Parse facts (reuse existing logic from _extract_facts_from_chunk)
         raw_facts = extraction_response_json.get("facts", [])
+        # Keep Batch and streaming on the same per-chunk source-evidence path;
+        # verbatim never consumes per-fact source timestamps.
+        source_instants = (
+            _source_instants_from_text(chunk_content) if config.retain_extraction_mode != "verbatim" else frozenset()
+        )
         chunk_facts = []
 
         for i, llm_fact in enumerate(raw_facts):
@@ -2611,9 +2664,15 @@ async def extract_facts_from_contents_batch_api(
                 if validated_relations:
                     fact_data["causal_relations"] = validated_relations
 
-            # Set mentioned_at to the event_date (when the conversation/document occurred),
-            # or None when the caller opted into no timestamp.
-            fact_data["mentioned_at"] = event_date.isoformat() if event_date is not None else None
+            mentioned_at_resolution = (
+                _resolve_mentioned_at(get_value("mentioned_at"), event_date, source_instants)
+                if config.retain_extraction_mode != "verbatim"
+                else _MentionedAtResolution(value=event_date, from_source=False)
+            )
+            fact_data["mentioned_at"] = (
+                mentioned_at_resolution.value.isoformat() if mentioned_at_resolution.value is not None else None
+            )
+            fact_data["mentioned_at_from_source"] = mentioned_at_resolution.from_source
 
             try:
                 fact = Fact(fact=combined_text, fact_type=fact_type, **fact_data)
@@ -2674,7 +2733,10 @@ async def extract_facts_from_contents_batch_api(
                 content_index=chunk_meta.content_index,
                 chunk_index=chunk_meta.chunk_index,
                 context=content.context,
-                mentioned_at=content.event_date,
+                mentioned_at=_parse_datetime(fact_from_llm.mentioned_at)
+                if fact_from_llm.mentioned_at
+                else content.event_date,
+                mentioned_at_from_source=fact_from_llm.mentioned_at_from_source,
                 metadata=content.metadata,
                 tags=content.tags,
                 observation_scopes=content.observation_scopes,
@@ -2857,8 +2919,7 @@ async def extract_facts_from_contents(
             chunk_facts = facts_from_llm[fact_idx_in_content : fact_idx_in_content + chunk_fact_count]
 
             for fact_from_llm in chunk_facts:
-                # Convert Fact model from LLM to ExtractedFactType dataclass
-                # mentioned_at is always the event_date (when the conversation/document occurred)
+                # Convert Fact model from LLM to ExtractedFactType dataclass.
                 extracted_fact = ExtractedFactType(
                     fact_text=fact_from_llm.fact,
                     fact_type=fact_from_llm.fact_type,
@@ -2874,8 +2935,10 @@ async def extract_facts_from_contents(
                     content_index=content_index,
                     chunk_index=chunk_global_idx,
                     context=content.context,
-                    # mentioned_at: always the event_date (when the conversation/document occurred)
-                    mentioned_at=content.event_date,
+                    mentioned_at=_parse_datetime(fact_from_llm.mentioned_at)
+                    if fact_from_llm.mentioned_at
+                    else content.event_date,
+                    mentioned_at_from_source=fact_from_llm.mentioned_at_from_source,
                     metadata=content.metadata,
                     tags=content.tags,
                     observation_scopes=content.observation_scopes,
@@ -2935,6 +2998,61 @@ def _parse_datetime(date_str: str):
         return None
 
 
+_SOURCE_ISO_TIMESTAMP_RE = re.compile(
+    r"(?<![\w+-])((?:\d{4}-\d{2}-\d{2}|\d{8})[Tt ]"
+    r"\d{2}:?\d{2}(?::?\d{2}(?:[.,]\d+)?)?"
+    r"(?:[Zz]|[+-]\d{2}(?::?\d{2})?))(?![\w+-])"
+)
+
+
+def _source_instants_from_text(source_text: str) -> frozenset[datetime]:
+    """Normalize explicit instants without assigning meaning to source-specific keys."""
+
+    return frozenset(
+        parsed.astimezone(timezone.utc)
+        for match in _SOURCE_ISO_TIMESTAMP_RE.finditer(source_text)
+        if (parsed := _parse_source_mentioned_at(match.group(1))) is not None
+    )
+
+
+def _parse_source_mentioned_at(value: Any) -> datetime | None:
+    """Accept timestamp-shaped ISO 8601 values whose timezone is explicit."""
+    if not isinstance(value, str):
+        return None
+
+    # The regex prevents substring and natural-language matching; isoparse
+    # validates common basic/extended ISO representations after that boundary.
+    match = _SOURCE_ISO_TIMESTAMP_RE.fullmatch(value)
+    if match is None:
+        return None
+
+    parsed = _parse_datetime(match.group(1))
+    if parsed is None or parsed.tzinfo is None or parsed.utcoffset() is None:
+        return None
+    return parsed
+
+
+@dataclass(frozen=True)
+class _MentionedAtResolution:
+    value: datetime | None
+    from_source: bool
+
+
+def _resolve_mentioned_at(
+    value: Any, event_date: datetime | None, source_instants: frozenset[datetime]
+) -> _MentionedAtResolution:
+    """Accept a source time only when its instant is present in source text.
+
+    This membership guard blocks pure hallucinations; it does not prove that
+    the instant semantically belongs to this particular fact.
+    """
+    source_mentioned_at = _parse_source_mentioned_at(value)
+    if source_mentioned_at is not None:
+        if source_mentioned_at.astimezone(timezone.utc) in source_instants:
+            return _MentionedAtResolution(value=source_mentioned_at, from_source=True)
+    return _MentionedAtResolution(value=event_date, from_source=False)
+
+
 def _convert_causal_relations(
     relations_from_llm, extraction_group_start_idx: int, extraction_group_size: int
 ) -> list[CausalRelationType]:
@@ -2962,11 +3080,12 @@ def _convert_causal_relations(
 
 def _add_temporal_offsets(facts: list[ExtractedFactType], contents: list[RetainContent]) -> None:
     """
-    Add time offsets to preserve fact ordering across all contents.
+    Add time offsets to temporal fallbacks and event dates to preserve fact ordering.
 
     This allows retrieval to distinguish between facts from different documents/conversations
     even when they have the same base event_date, and also between facts within the same
-    conversation.
+    conversation. Exact source ``mentioned_at`` values are not modified: multiple facts stated
+    in one source record legitimately share its timestamp.
 
     Uses absolute position across all facts to ensure unique timestamps.
 
@@ -2983,7 +3102,7 @@ def _add_temporal_offsets(facts: list[ExtractedFactType], contents: list[RetainC
             fact.occurred_start = parse_datetime_flexible(fact.occurred_start) + offset
         if fact.occurred_end:
             fact.occurred_end = parse_datetime_flexible(fact.occurred_end) + offset
-        if fact.mentioned_at:
+        if fact.mentioned_at and not fact.mentioned_at_from_source:
             fact.mentioned_at = parse_datetime_flexible(fact.mentioned_at) + offset
 
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/types.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/types.py
@@ -201,6 +201,9 @@ class ExtractedFact:
     observation_scopes: Literal["per_tag", "combined", "all_combinations", "shared"] | list[list[str]] | None = (
         None  # Observation scopes
     )
+    # Internal extraction provenance: only fallback timestamps receive the
+    # synthetic ordering offset. This is intentionally not persisted.
+    mentioned_at_from_source: bool = False
 
 
 @dataclass

--- a/hindsight-api-slim/tests/test_fact_mentioned_at_attribution.py
+++ b/hindsight-api-slim/tests/test_fact_mentioned_at_attribution.py
@@ -1,0 +1,78 @@
+"""Real-LLM coverage for per-fact source timestamp attribution (issue #2550)."""
+
+import dataclasses
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from hindsight_api import LLMConfig
+from hindsight_api.config import _get_raw_config
+from hindsight_api.engine.retain.fact_extraction import extract_facts_from_text
+from tests.llm_judge import assert_meets_criteria
+
+pytestmark = pytest.mark.hs_llm_core
+
+
+@pytest.mark.asyncio
+async def test_source_message_time_is_distinct_from_event_time() -> None:
+    """Facts inherit their own record time, while described event dates stay occurred dates."""
+    records = [
+        {
+            "timestamp": "2026-07-05T09:15:00Z",
+            "role": "user",
+            "content": "PostgreSQL is my favorite database.",
+        },
+        {
+            "timestamp": "2026-07-10T18:30:00+02:00",
+            "role": "user",
+            "content": "Svelte is my favorite frontend framework.",
+        },
+        {
+            "timestamp": "2026-07-12T08:00:00Z",
+            "role": "user",
+            "content": "The deployment occurred at 2022-04-03T12:00:00Z.",
+        },
+    ]
+    text = "\n".join(json.dumps(record) for record in records)
+    config = dataclasses.replace(
+        _get_raw_config(),
+        retain_extraction_mode="concise",
+        retain_extract_causal_links=False,
+    )
+
+    facts, _chunks, _usage = await extract_facts_from_text(
+        text=text,
+        event_date=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        llm_config=LLMConfig.from_env(),
+        agent_name="test-agent",
+        context="JSONL session where each record's timestamp is its source write time",
+        config=config,
+    )
+
+    assert facts, "Should extract at least one fact"
+    facts_summary = "\n".join(
+        f"- mentioned_at={fact.mentioned_at}; occurred_start={fact.occurred_start}; {fact.fact}" for fact in facts
+    )
+    await assert_meets_criteria(
+        response=facts_summary,
+        criteria=(
+            "The PostgreSQL preference is attributed to source time 2026-07-05T09:15:00Z; "
+            "the Svelte preference is attributed to source time 2026-07-10T18:30:00+02:00; "
+            "and the deployment fact is attributed to source-write time 2026-07-12T08:00:00Z. "
+            "The request-level Event Date of July 1 is not used for those timestamped records. "
+            "The preferences do not treat their source timestamps as event occurrence dates. "
+            "For the deployment fact, occurred_start is 2022-04-03T12:00:00Z or that complete event timestamp is "
+            "clearly retained in the fact text, while mentioned_at remains 2026-07-12T08:00:00Z. "
+            "The event timestamp 2022-04-03T12:00:00Z must not be promoted to mentioned_at even though it is also "
+            "a complete timezone-bearing timestamp visible in the same source record. Equivalent timezone "
+            "normalization is acceptable."
+        ),
+        context=(
+            "Each JSONL record contains its own source timestamp. mentioned_at means when the record directly stating "
+            "the fact was written; occurred_start means when the described event happened. The deployment record "
+            "intentionally contains both kinds of complete timestamp to test semantic attribution beyond the "
+            "source-presence guard."
+        ),
+        msg=f"Source timestamps must be attributed per fact without replacing event time. Facts: {facts_summary}",
+    )

--- a/hindsight-api-slim/tests/test_fact_mentioned_at_extraction.py
+++ b/hindsight-api-slim/tests/test_fact_mentioned_at_extraction.py
@@ -1,0 +1,410 @@
+"""Regression tests for per-fact source timestamp propagation (issue #2550)."""
+
+import dataclasses
+import json
+from datetime import datetime, timedelta, timezone
+from types import NoneType, SimpleNamespace
+from typing import cast, get_args
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import BaseModel
+
+from hindsight_api.config import HindsightConfig, _get_raw_config
+from hindsight_api.engine.llm_wrapper import LLMProvider
+from hindsight_api.engine.providers.mock_llm import MockLLM
+from hindsight_api.engine.response_models import TokenUsage
+from hindsight_api.engine.retain.fact_extraction import (
+    Fact,
+    _build_extraction_prompt_and_schema,
+    _resolve_mentioned_at,
+    _source_instants_from_text,
+    extract_facts_from_contents,
+    extract_facts_from_contents_batch_api,
+)
+from hindsight_api.engine.retain.orchestrator import _process_extracted_facts
+from hindsight_api.engine.retain.types import ExtractedFact, ProcessedFact, RetainContent
+from hindsight_api.engine.structured_output import strict_json_schema
+
+EVENT_DATE = datetime(2026, 7, 1, 8, 0, tzinfo=timezone.utc)
+FIRST_SOURCE_TIME = datetime(2026, 7, 5, 9, 15, tzinfo=timezone.utc)
+SECOND_SOURCE_TIME = datetime(2026, 7, 10, 18, 30, tzinfo=timezone(timedelta(hours=2)))
+OCCURRED_TIME = datetime(2022, 4, 3, 12, 0, tzinfo=timezone.utc)
+
+
+def _config(*, mode: str = "concise", batch: bool = False, causal: bool = False) -> HindsightConfig:
+    return dataclasses.replace(
+        _get_raw_config(),
+        retain_batch_enabled=batch,
+        retain_batch_poll_interval_seconds=0,
+        retain_chunk_size=4000,
+        retain_extraction_mode=mode,
+        retain_extract_causal_links=causal,
+        retain_llm_max_retries=0,
+        retain_mission=None,
+        llm_temperature_retain=0.1,
+        llm_strict_schema_retain=True,
+    )
+
+
+def _raw_facts() -> list[dict[str, str | None]]:
+    return [
+        {
+            "what": "The user's preferred database is PostgreSQL",
+            "fact_type": "world",
+            "fact_kind": "conversation",
+            "mentioned_at": FIRST_SOURCE_TIME.isoformat(),
+        },
+        {
+            "what": "The user moved to Berlin in 2022",
+            "fact_type": "world",
+            "fact_kind": "event",
+            "mentioned_at": SECOND_SOURCE_TIME.isoformat(),
+            "occurred_start": OCCURRED_TIME.isoformat(),
+            "occurred_end": OCCURRED_TIME.isoformat(),
+        },
+        {
+            "what": "The user prefers pnpm",
+            "fact_type": "world",
+            "fact_kind": "conversation",
+        },
+    ]
+
+
+def _streaming_llm(raw_facts: list[dict[str, str | None]]) -> MagicMock:
+    llm = MagicMock(spec=LLMProvider)
+    llm.provider = "mock"
+    llm._provider_impl = SimpleNamespace(supports_prompt_caching=lambda: False)
+    llm.call = AsyncMock(return_value=({"facts": raw_facts}, TokenUsage()))
+    return llm
+
+
+def _batch_llm(raw_facts: list[dict[str, str | None]]) -> MagicMock:
+    provider = SimpleNamespace(
+        provider="groq",
+        model="test-model",
+        supports_batch_api=AsyncMock(return_value=True),
+        submit_batch=AsyncMock(return_value={"batch_id": "batch-mentioned-at"}),
+        get_batch_status=AsyncMock(
+            return_value={
+                "status": "completed",
+                "request_counts": {"total": 1, "completed": 1, "failed": 0},
+            }
+        ),
+        retrieve_batch_results=AsyncMock(
+            return_value=[
+                {
+                    "custom_id": "chunk_0",
+                    "response": {
+                        "body": {
+                            "choices": [{"message": {"content": json.dumps({"facts": raw_facts})}}],
+                            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                        }
+                    },
+                }
+            ]
+        ),
+    )
+    llm = MagicMock(spec=LLMProvider)
+    llm.provider = "groq"
+    llm.model = "test-model"
+    llm._provider_impl = provider
+
+    async def _batch_provider_impl(*, account_key: str | None = None):
+        return provider
+
+    llm.batch_provider_impl = _batch_provider_impl
+    return llm
+
+
+def _content() -> RetainContent:
+    return RetainContent(
+        content="\n".join(
+            [
+                json.dumps(
+                    {
+                        "timestamp": "2026-07-05T09:15:00Z",
+                        "content": "The user's preferred database is PostgreSQL",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "created_at": "2026-07-10T16:30:00Z",
+                        "content": "The user moved to Berlin in 2022",
+                    }
+                ),
+            ]
+        ),
+        event_date=EVENT_DATE,
+        context="JSONL session",
+    )
+
+
+@pytest.mark.parametrize(
+    ("mode", "causal", "dynamic_labels"),
+    [
+        ("concise", True, False),
+        ("concise", False, False),
+        ("verbose", True, False),
+        ("concise", False, True),
+    ],
+)
+def test_semantic_extraction_schemas_request_nullable_mentioned_at(
+    mode: str, causal: bool, dynamic_labels: bool
+) -> None:
+    """Semantic extraction modes expose the per-fact source-time contract."""
+    config = _config(mode=mode, causal=causal)
+    if dynamic_labels:
+        config = dataclasses.replace(
+            config,
+            entity_labels=[{"key": "topic", "type": "value", "values": [{"value": "database"}]}],
+        )
+    prompt, response_model = _build_extraction_prompt_and_schema(config)
+    fact_model = get_args(cast(type[BaseModel], response_model).model_fields["facts"].annotation)[0]
+    mentioned_at_field = fact_model.model_fields["mentioned_at"]
+
+    assert set(get_args(mentioned_at_field.annotation)) == {str, NoneType}
+    assert "source message or record" in prompt
+    assert "not when the described event happened" in prompt
+    assert "explicit timezone" in prompt
+    assert "Prefer the extended form" in prompt
+
+    schema = strict_json_schema(response_model)
+    fact_ref = schema["properties"]["facts"]["items"]["$ref"].rsplit("/", 1)[-1]
+    fact_schema = schema["$defs"][fact_ref]
+    assert "mentioned_at" in fact_schema["properties"]
+    assert "mentioned_at" in fact_schema["required"]
+    if dynamic_labels:
+        assert "labels" in fact_model.model_fields
+        assert "labels" in fact_schema["required"]
+
+
+def test_verbatim_schema_keeps_one_entry_per_chunk_without_mentioned_at() -> None:
+    """Verbatim cannot attribute one raw multi-message chunk to one source time."""
+    prompt, response_model = _build_extraction_prompt_and_schema(_config(mode="verbatim"))
+    fact_model = get_args(cast(type[BaseModel], response_model).model_fields["facts"].annotation)[0]
+
+    assert "mentioned_at" not in fact_model.model_fields
+    assert "SOURCE TIMESTAMP" not in prompt
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("batch", [False, True], ids=["streaming", "batch"])
+async def test_semantic_paths_resolve_times_and_preserve_fallback_ordering(batch: bool) -> None:
+    """Both extraction paths keep source times exact and offset only fallbacks."""
+    extractor = extract_facts_from_contents_batch_api if batch else extract_facts_from_contents
+    facts, _chunks, _usage = await extractor(
+        contents=[_content()],
+        llm_config=_batch_llm(_raw_facts()) if batch else _streaming_llm(_raw_facts()),
+        agent_name="test-agent",
+        config=_config(batch=batch),
+    )
+
+    assert [fact.mentioned_at for fact in facts] == [
+        FIRST_SOURCE_TIME,
+        SECOND_SOURCE_TIME,
+        EVENT_DATE + timedelta(milliseconds=20),
+    ]
+    assert facts[0].occurred_start is None
+    assert facts[1].occurred_start == OCCURRED_TIME + timedelta(milliseconds=10)
+    assert facts[1].occurred_end == OCCURRED_TIME + timedelta(milliseconds=10)
+
+
+@pytest.mark.asyncio
+async def test_source_timestamp_does_not_cross_chunk_boundaries() -> None:
+    """A timestamp visible only in another chunk must fall back to the item time."""
+    first_line = json.dumps({"timestamp": FIRST_SOURCE_TIME.isoformat(), "content": "Prefers PostgreSQL"})
+    second_line = json.dumps({"timestamp": SECOND_SOURCE_TIME.isoformat(), "content": "Prefers Svelte"})
+    llm = _streaming_llm([])
+    llm.call = AsyncMock(
+        side_effect=[
+            (
+                {
+                    "facts": [
+                        {
+                            "what": "The user prefers PostgreSQL",
+                            "fact_type": "world",
+                            "fact_kind": "conversation",
+                            "mentioned_at": SECOND_SOURCE_TIME.isoformat(),
+                        }
+                    ]
+                },
+                TokenUsage(),
+            ),
+            (
+                {
+                    "facts": [
+                        {
+                            "what": "The user prefers Svelte",
+                            "fact_type": "world",
+                            "fact_kind": "conversation",
+                            "mentioned_at": FIRST_SOURCE_TIME.isoformat(),
+                        }
+                    ]
+                },
+                TokenUsage(),
+            ),
+        ]
+    )
+    config = dataclasses.replace(_config(), retain_chunk_size=1, retain_structured_chunk_size=1000)
+
+    facts, chunks, _usage = await extract_facts_from_contents(
+        contents=[RetainContent(content=f"{first_line}\n{second_line}", event_date=EVENT_DATE)],
+        llm_config=llm,
+        agent_name="test-agent",
+        config=config,
+    )
+
+    assert len(chunks) == 2
+    assert [fact.mentioned_at for fact in facts] == [EVENT_DATE, EVENT_DATE + timedelta(milliseconds=10)]
+    assert all(fact.mentioned_at_from_source is False for fact in facts)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("batch", [False, True], ids=["streaming", "batch"])
+async def test_verbatim_paths_use_item_fallback(batch: bool) -> None:
+    """Both paths use the item fallback; streaming also preserves one raw chunk fact."""
+    extractor = extract_facts_from_contents_batch_api if batch else extract_facts_from_contents
+    content = _content()
+    # The Batch fixture supplies a test-only `what` field solely to reach the
+    # current post-processing path; it is not a valid verbatim-output guarantee.
+    facts, _chunks, _usage = await extractor(
+        contents=[content],
+        llm_config=_batch_llm(_raw_facts()[:1]) if batch else _streaming_llm(_raw_facts()[:1]),
+        agent_name="test-agent",
+        config=_config(mode="verbatim", batch=batch),
+    )
+
+    assert facts
+    assert all(fact.mentioned_at == EVENT_DATE for fact in facts)
+    assert all(fact.mentioned_at_from_source is False for fact in facts)
+    if not batch:
+        assert len(facts) == 1
+        assert facts[0].fact_text == content.content
+
+
+@pytest.mark.parametrize(
+    ("candidate", "source_text", "event_date", "expected", "from_source"),
+    [
+        ("2026-07-05T09:15:00+00:00", "2026-07-05T09:15:00Z", EVENT_DATE, FIRST_SOURCE_TIME, True),
+        ("20260705T091500Z", "20260705T091500Z", EVENT_DATE, FIRST_SOURCE_TIME, True),
+        ("2026-07-05 09:15:00Z", "2026-07-05 09:15:00Z", EVENT_DATE, FIRST_SOURCE_TIME, True),
+        ("2026-07-05t09:15:00z", "2026-07-05t09:15:00z", EVENT_DATE, FIRST_SOURCE_TIME, True),
+        ("2026-07-05T09:15:00+0000", "2026-07-05T09:15:00+0000", EVENT_DATE, FIRST_SOURCE_TIME, True),
+        ("2026-07-11T09:00:00Z", _content().content, EVENT_DATE, EVENT_DATE, False),
+        ("not-a-timestamp", "not-a-timestamp", EVENT_DATE, EVENT_DATE, False),
+        ("2026-07-11T09:00:00", "2026-07-11T09:00:00", EVENT_DATE, EVENT_DATE, False),
+        ("20260705T091500Z", "120260705T091500Z", EVENT_DATE, EVENT_DATE, False),
+        ("20260705T091500Z", "event_20260705T091500Z_record", EVENT_DATE, EVENT_DATE, False),
+        (None, "no timestamp", None, None, False),
+    ],
+    ids=[
+        "timezone-equivalent-source",
+        "basic",
+        "space-separator",
+        "lowercase",
+        "basic-offset",
+        "hallucinated-valid",
+        "invalid",
+        "timezone-less",
+        "embedded-in-longer-number",
+        "embedded-in-identifier",
+        "no-source-or-fallback",
+    ],
+)
+def test_source_timestamp_resolution_contract(
+    candidate: str | None,
+    source_text: str,
+    event_date: datetime | None,
+    expected: datetime | None,
+    from_source: bool,
+) -> None:
+    resolution = _resolve_mentioned_at(candidate, event_date, _source_instants_from_text(source_text))
+
+    assert resolution.value == expected
+    assert resolution.from_source is from_source
+
+
+def test_provenance_is_not_serialized_or_carried_into_processed_fact() -> None:
+    fact = Fact(
+        fact="The user prefers PostgreSQL",
+        fact_type="world",
+        mentioned_at=FIRST_SOURCE_TIME.isoformat(),
+        mentioned_at_from_source=True,
+    )
+    assert "mentioned_at_from_source" not in fact.model_dump()
+    extracted = ExtractedFact(
+        fact_text="The user prefers PostgreSQL",
+        fact_type="world",
+        mentioned_at=FIRST_SOURCE_TIME,
+        mentioned_at_from_source=True,
+    )
+    # Exercise the actual retain mapper that feeds consolidation/storage.
+    mapped = _process_extracted_facts([extracted], [[0.0]])
+    assert isinstance(mapped.processed_facts[0], ProcessedFact)
+    assert mapped.processed_facts[0].mentioned_at == FIRST_SOURCE_TIME
+    assert "mentioned_at_from_source" not in vars(mapped.processed_facts[0])
+
+
+@pytest.mark.asyncio
+async def test_chunks_mode_keeps_item_level_fallback_ordering() -> None:
+    """The no-LLM chunks mode preserves its existing event-date fallback behavior."""
+    facts, _chunks, _usage = await extract_facts_from_contents(
+        contents=[
+            RetainContent(content="first raw chunk", event_date=EVENT_DATE),
+            RetainContent(content="second raw chunk", event_date=EVENT_DATE),
+        ],
+        llm_config=MagicMock(),
+        agent_name="test-agent",
+        config=_config(mode="chunks"),
+    )
+
+    assert [fact.mentioned_at for fact in facts] == [EVENT_DATE, EVENT_DATE + timedelta(milliseconds=10)]
+
+
+@pytest.mark.asyncio
+async def test_source_mentioned_at_is_readable_after_retain(memory, request_context) -> None:
+    """The public MemoryEngine read API exposes the persisted source timestamp."""
+    bank_id = "test_source_mentioned_at_public_read"
+    document_id = "source-mentioned-at-document"
+    provider = memory._retain_llm_config._provider_impl
+    assert isinstance(provider, MockLLM)
+    provider.set_mock_response(
+        {
+            "facts": [
+                {
+                    "what": "The user prefers PostgreSQL",
+                    "fact_type": "world",
+                    "fact_kind": "conversation",
+                    "mentioned_at": FIRST_SOURCE_TIME.isoformat(),
+                }
+            ]
+        }
+    )
+
+    try:
+        unit_ids = await memory.retain_async(
+            bank_id=bank_id,
+            content=json.dumps(
+                {
+                    "timestamp": FIRST_SOURCE_TIME.isoformat(),
+                    "content": "The user prefers PostgreSQL",
+                }
+            ),
+            event_date=EVENT_DATE,
+            document_id=document_id,
+            request_context=request_context,
+        )
+        assert len(unit_ids) == 1
+
+        page = await memory.list_memory_units(
+            bank_id,
+            fact_type="world",
+            document_id=document_id,
+            request_context=request_context,
+        )
+        assert len(page["items"]) == 1
+        assert datetime.fromisoformat(page["items"][0]["mentioned_at"]) == FIRST_SOURCE_TIME
+        assert "mentioned_at_from_source" not in page["items"][0]["metadata"]
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-docs/docs/developer/api/recall.mdx
+++ b/hindsight-docs/docs/developer/api/recall.mdx
@@ -469,7 +469,7 @@ ISO 8601 datetimes representing when the described event started and ended. Extr
 
 #### mentioned_at
 
-ISO 8601 datetime of when this fact was retained into the bank.
+ISO 8601 datetime of when the fact was mentioned in its source, falling back to the retain item's timestamp when no source time can be attributed.
 
 #### document_id
 

--- a/skills/hindsight-docs/references/developer/api/recall.md
+++ b/skills/hindsight-docs/references/developer/api/recall.md
@@ -711,7 +711,7 @@ ISO 8601 datetimes representing when the described event started and ended. Extr
 
 #### mentioned_at
 
-ISO 8601 datetime of when this fact was retained into the bank.
+ISO 8601 datetime of when the fact was mentioned in its source, falling back to the retain item's timestamp when no source time can be attributed.
 
 #### document_id
 


### PR DESCRIPTION
## Problem

Facts extracted from the same retain item currently inherit the item's `event_date` plus the existing synthetic offsets. For a multi-message session spanning several days, this can make `mentioned_at` inaccurate even when each source record contains its own timestamp.

## Changes

- During semantic fact extraction, ask the model for the timestamp of the source message or record that directly states each fact.
- Prefer timezone-aware ISO 8601 timestamps from source messages or records; fall back to the retain item's `event_date` when none is available.
- Preserve source timestamps without synthetic offsets; keep the existing offset behavior only for `event_date` fallbacks.
- Keep `occurred_start` / `occurred_end` as the time of the described event.
- Correct the `mentioned_at` definition in the recall documentation.

## Scope

PR #2952 documented how consolidation should interpret `mentioned_at`, but did not change how the field is derived. This Draft PR addresses a timestamp propagation gap related to Issue #2550: source-record timestamps do not reach a fact's `mentioned_at`.

This change only adjusts how `mentioned_at` is derived during retain. It does not change consolidation ordering or conflict resolution. The runtime check only verifies that a candidate timestamp appears in the current source chunk; the extraction model determines whether it belongs to that fact.

For documentation, this Draft updates only the central Recall field definition. Related wording in Reflect, MCP/API, generated clients, and examples is intentionally deferred until maintainers confirm the retain-side contract.

Before marking this PR ready for review, I would like to confirm whether deriving source timestamps during retain fact extraction is the intended approach.

## Tests

- Deterministic coverage for timestamp validation, `event_date` fallback, streaming and batch extraction, chunk isolation, existing fallback offset behavior, and the `mentioned_at` value returned by the public read API after a retain operation.
- A real-LLM judge test distinguishing source-message time from the time of the described event.

Related to Issue #2550.
