### PR TITLE
fix(db): exit when the connection pool has produced nothing for two minutes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -407,7 +407,7 @@ HINDSIGHT_API_LOG_LEVEL=info
 # seconds, so the supervisor can restart it. Liveness is deliberately DB-free, so
 # a pool that never recovers otherwise leaves the process up and permanently
 # unready. 0 disables it.
-# HINDSIGHT_API_DB_UNAVAILABLE_EXIT_SECONDS=600
+# HINDSIGHT_API_DB_UNAVAILABLE_EXIT_SECONDS=120
 
 # -----------------------------------------------------------------------------
 # Extensions (Optional)

--- a/.env.example
+++ b/.env.example
@@ -403,6 +403,12 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_LOOP_WATCHDOG_POLL_INTERVAL_MS=250
 # HINDSIGHT_API_DB_ACQUIRE_WARN_THRESHOLD_MS=1000
 
+# Exit the process when no pooled DB connection has been acquired for this many
+# seconds, so the supervisor can restart it. Liveness is deliberately DB-free, so
+# a pool that never recovers otherwise leaves the process up and permanently
+# unready. 0 disables it.
+# HINDSIGHT_API_DB_UNAVAILABLE_EXIT_SECONDS=600
+
 # -----------------------------------------------------------------------------
 # Extensions (Optional)
 # -----------------------------------------------------------------------------

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -587,6 +587,7 @@ ENV_LOOP_WATCHDOG_ENABLED = "HINDSIGHT_API_LOOP_WATCHDOG_ENABLED"
 ENV_LOOP_WATCHDOG_STALL_THRESHOLD_MS = "HINDSIGHT_API_LOOP_WATCHDOG_STALL_THRESHOLD_MS"
 ENV_LOOP_WATCHDOG_POLL_INTERVAL_MS = "HINDSIGHT_API_LOOP_WATCHDOG_POLL_INTERVAL_MS"
 ENV_DB_ACQUIRE_WARN_THRESHOLD_MS = "HINDSIGHT_API_DB_ACQUIRE_WARN_THRESHOLD_MS"
+ENV_DB_UNAVAILABLE_EXIT_SECONDS = "HINDSIGHT_API_DB_UNAVAILABLE_EXIT_SECONDS"
 
 # Vertex AI configuration
 ENV_LLM_VERTEXAI_PROJECT_ID = "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID"
@@ -1463,6 +1464,15 @@ DEFAULT_LOOP_WATCHDOG_ENABLED = True
 DEFAULT_LOOP_WATCHDOG_STALL_THRESHOLD_MS = 1000  # log a stall once the loop is unresponsive this long
 DEFAULT_LOOP_WATCHDOG_POLL_INTERVAL_MS = 250  # how often the watchdog thread pings the loop
 DEFAULT_DB_ACQUIRE_WARN_THRESHOLD_MS = 1000  # log a warning when a pool acquire waits this long
+# Exit the process when no pooled acquire has succeeded for this long, so the
+# supervisor can replace it. A pool can reach a state it never leaves -- every
+# acquire fails and the next caller repeats it forever -- and nothing else
+# recovers from that: liveness is deliberately database-free (a DB-touching probe
+# restarts every replica at once when the database is merely slow), so the pod
+# stays up and unready indefinitely. Ten minutes is long enough that a failover,
+# a restart, or a slow-query storm resolves well inside it; a full ten minutes
+# without a single successful acquire is not a slow database. 0 disables it.
+DEFAULT_DB_UNAVAILABLE_EXIT_SECONDS = 600.0
 
 # Audit log defaults
 DEFAULT_AUDIT_LOG_ENABLED = False  # Disabled by default
@@ -2699,6 +2709,7 @@ class HindsightConfig:
     loop_watchdog_stall_threshold_ms: int
     loop_watchdog_poll_interval_ms: int
     db_acquire_warn_threshold_ms: int
+    db_unavailable_exit_seconds: float
 
     # Audit log configuration
     # audit_log_enabled is hierarchical (env -> tenant -> bank): a deployment can
@@ -4076,6 +4087,9 @@ class HindsightConfig:
             ),
             db_acquire_warn_threshold_ms=int(
                 os.getenv(ENV_DB_ACQUIRE_WARN_THRESHOLD_MS, str(DEFAULT_DB_ACQUIRE_WARN_THRESHOLD_MS))
+            ),
+            db_unavailable_exit_seconds=float(
+                os.getenv(ENV_DB_UNAVAILABLE_EXIT_SECONDS, str(DEFAULT_DB_UNAVAILABLE_EXIT_SECONDS))
             ),
             # Audit log configuration (static, server-level only)
             audit_log_enabled=os.getenv(ENV_AUDIT_LOG_ENABLED, str(DEFAULT_AUDIT_LOG_ENABLED)).lower() == "true",

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -1469,10 +1469,13 @@ DEFAULT_DB_ACQUIRE_WARN_THRESHOLD_MS = 1000  # log a warning when a pool acquire
 # acquire fails and the next caller repeats it forever -- and nothing else
 # recovers from that: liveness is deliberately database-free (a DB-touching probe
 # restarts every replica at once when the database is merely slow), so the pod
-# stays up and unready indefinitely. Ten minutes is long enough that a failover,
-# a restart, or a slow-query storm resolves well inside it; a full ten minutes
-# without a single successful acquire is not a slow database. 0 disables it.
-DEFAULT_DB_UNAVAILABLE_EXIT_SECONDS = 600.0
+# stays up and unready indefinitely. Two minutes clears a CNPG failover (tens of
+# seconds) and a database restart with room to spare, so the ordinary causes
+# resolve well inside it; two minutes in which not one acquire succeeded is not a
+# slow database. Was 600s initially, which left a wedged process serving nothing
+# for ten minutes -- far longer than the failures it is meant to ride out.
+# 0 disables it.
+DEFAULT_DB_UNAVAILABLE_EXIT_SECONDS = 120.0
 
 # Audit log defaults
 DEFAULT_AUDIT_LOG_ENABLED = False  # Disabled by default

--- a/hindsight-api-slim/hindsight_api/engine/db_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/db_utils.py
@@ -4,11 +4,14 @@ Database utility functions for connection management with retry logic.
 
 import asyncio
 import logging
+import os
 import random
 import time
 from collections.abc import AsyncIterator
 from contextlib import AsyncExitStack, asynccontextmanager
 from typing import Any
+
+from ..config import get_config
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +19,52 @@ logger = logging.getLogger(__name__)
 DEFAULT_MAX_RETRIES = 3
 DEFAULT_BASE_DELAY = 0.5  # seconds
 DEFAULT_MAX_DELAY = 5.0  # seconds
+
+# Monotonic timestamp of the last acquire that succeeded. Seeded at import so a
+# process that has never reached the database still gets a full window before it
+# gives up, rather than exiting the moment its first acquire fails.
+#
+# The window is measured from the last SUCCESS, not from a count of failures: a
+# process serving little traffic may attempt an acquire only rarely, and a
+# counter would never trip. See DEFAULT_DB_UNAVAILABLE_EXIT_SECONDS in config for
+# why the process has to end itself at all.
+_last_acquire_success: float = time.monotonic()
+
+
+def _note_acquire_success() -> None:
+    """Record a working pool. Any success anywhere clears the failure window."""
+    global _last_acquire_success
+    _last_acquire_success = time.monotonic()
+
+
+def _exit_if_db_unavailable_too_long() -> None:
+    """Terminate the process when no acquire has succeeded for the whole window.
+
+    Called only after a call has exhausted its retries, so the common path is
+    untouched. Uses ``os._exit`` rather than raising: the exception would be
+    caught by whatever request handler happened to trigger it, and the process
+    would carry on in the same unusable state.
+    """
+    limit = get_config().db_unavailable_exit_seconds
+    if limit <= 0:
+        return
+    unavailable_for = time.monotonic() - _last_acquire_success
+    if unavailable_for < limit:
+        return
+    logger.critical(
+        "No database connection has been acquired for %.0fs (limit %.0fs). The pool is not "
+        "recovering; exiting so the supervisor can replace this process.",
+        unavailable_for,
+        limit,
+    )
+    # Flush before _exit: it skips atexit handlers, and losing the line above
+    # would leave an unexplained restart.
+    for handler in logging.getLogger().handlers:
+        try:
+            handler.flush()
+        except Exception:  # pragma: no cover - best effort
+            pass
+    os._exit(1)
 
 
 def _backoff_delay(attempt: int, base_delay: float, max_delay: float) -> float:
@@ -102,12 +151,12 @@ async def retry_with_backoff(
                     )
                 else:
                     logger.warning(
-                        f"Database operation failed (attempt {attempt + 1}/{max_retries + 1}): {e}. "
+                        f"Database operation failed (attempt {attempt + 1}/{max_retries + 1}): {e!r}. "
                         f"Retrying in {delay:.1f}s..."
                     )
                 await asyncio.sleep(delay)
             else:
-                logger.error(f"Database operation failed after {max_retries + 1} attempts: {e}")
+                logger.error(f"Database operation failed after {max_retries + 1} attempts: {e!r}")
     raise last_exception
 
 
@@ -146,19 +195,24 @@ async def acquire_with_retry(backend_or_pool: Any, max_retries: int = DEFAULT_MA
             for attempt in range(max_retries + 1):
                 try:
                     conn = await stack.enter_async_context(backend_or_pool.acquire())
+                    _note_acquire_success()
                     break
                 except Exception as e:
                     if not _is_retryable(e):
                         raise
                     if attempt < max_retries:
                         delay = _backoff_delay(attempt, DEFAULT_BASE_DELAY, DEFAULT_MAX_DELAY)
+                        # !r, not str(): several driver exceptions stringify to "",
+                        # which turns this line into "acquire failed: " and hides
+                        # whether the cause was auth, a timeout or an exhausted pool.
                         logger.warning(
-                            f"Database acquire failed (attempt {attempt + 1}/{max_retries + 1}): {e}. "
+                            f"Database acquire failed (attempt {attempt + 1}/{max_retries + 1}): {e!r}. "
                             f"Retrying in {delay:.1f}s..."
                         )
                         await asyncio.sleep(delay)
                     else:
-                        logger.error(f"Database acquire failed after {max_retries + 1} attempts: {e}")
+                        logger.error(f"Database acquire failed after {max_retries + 1} attempts: {e!r}")
+                        _exit_if_db_unavailable_too_long()
                         raise
 
             acquire_time = time.time() - start
@@ -174,7 +228,17 @@ async def acquire_with_retry(backend_or_pool: Any, max_retries: int = DEFAULT_MA
         async def acquire():
             return await pool.acquire()
 
-        conn = await retry_with_backoff(acquire, max_retries=max_retries)
+        try:
+            conn = await retry_with_backoff(acquire, max_retries=max_retries)
+        except Exception as e:
+            # Same reasoning as the backend path above: retries are spent and the
+            # pool may never come back on its own. Only connection failures count
+            # -- retry_with_backoff re-raises anything non-retryable on the first
+            # attempt, and a programming error says nothing about the database.
+            if _is_retryable(e):
+                _exit_if_db_unavailable_too_long()
+            raise
+        _note_acquire_success()
         acquire_time = time.time() - start
 
         if acquire_time > 0.05:

--- a/hindsight-api-slim/tests/test_db_utils.py
+++ b/hindsight-api-slim/tests/test_db_utils.py
@@ -6,16 +6,47 @@ user-code exception to surface as
 ``RuntimeError("generator didn't stop after athrow()")``, masking the real
 cause and producing identical failed-op rows in production (see the 1,934
 failed consolidations on ``shurick-memory`` in May 2026).
+
+Also covers the self-termination path: when a pool stops producing connections
+and never starts again, ``acquire_with_retry`` ends the process so a supervisor
+can replace it, since liveness is deliberately database-free and nothing else
+would.
 """
 
 from __future__ import annotations
 
 import asyncio
+import time
 from contextlib import asynccontextmanager
 
 import pytest
 
+from hindsight_api.config import ENV_DB_UNAVAILABLE_EXIT_SECONDS, clear_config_cache
+from hindsight_api.engine import db_utils
 from hindsight_api.engine.db_utils import _backoff_delay, acquire_with_retry
+
+
+@pytest.fixture
+def exit_window(monkeypatch):
+    """Capture ``os._exit`` and set the unavailability window from the env.
+
+    Returns a callable taking the window in seconds and how long ago the last
+    successful acquire was, and yielding the list that records exit codes.
+    """
+    exits: list[int] = []
+    monkeypatch.setattr(db_utils.os, "_exit", lambda code: exits.append(code))
+    monkeypatch.setattr(db_utils, "_backoff_delay", lambda *a, **k: 0.0)
+
+    def configure(window_s: float, last_success_age_s: float) -> list[int]:
+        monkeypatch.setenv(ENV_DB_UNAVAILABLE_EXIT_SECONDS, str(window_s))
+        clear_config_cache()
+        monkeypatch.setattr(db_utils, "_last_acquire_success", time.monotonic() - last_success_age_s)
+        return exits
+
+    yield configure
+    # The cache now holds a config built from the patched env; drop it so the
+    # next test rebuilds from the real environment.
+    clear_config_cache()
 
 
 class _FakeConnection:
@@ -100,3 +131,142 @@ def test_backoff_delay_is_jittered_and_bounded():
     # At/after saturation the cap holds: every sample <= max_delay.
     saturated = [_backoff_delay(20, base, max_delay) for _ in range(200)]
     assert all(max_delay / 2 <= d <= max_delay for d in saturated)
+
+
+class _FailingBackend:
+    """Backend whose every acquire raises a retryable connection error."""
+
+    _wraps_backend = True
+
+    @asynccontextmanager
+    async def acquire(self):
+        raise ConnectionError("pool is not producing connections")
+        yield  # pragma: no cover - unreachable, keeps this an async generator
+
+
+class _SlowThenOkBackend:
+    """Backend that fails a few acquires and then succeeds.
+
+    Stands in for a database that is briefly unreachable — a failover, a
+    restart — which must NOT be treated as a process that cannot recover.
+    """
+
+    _wraps_backend = True
+
+    def __init__(self, failures_before_success: int) -> None:
+        self.remaining_failures = failures_before_success
+
+    @asynccontextmanager
+    async def acquire(self):
+        if self.remaining_failures > 0:
+            self.remaining_failures -= 1
+            raise ConnectionError("temporarily unreachable")
+        yield _FakeConnection()
+
+
+@pytest.mark.asyncio
+async def test_exits_when_no_acquire_has_succeeded_for_the_whole_window(exit_window):
+    """A pool that never produces a connection must end the process.
+
+    Nothing else can: liveness is deliberately database-free, so a permanently
+    unusable pool otherwise fails readiness forever while the process stays up.
+    """
+    exits = exit_window(600.0, 601.0)  # last success is older than the window
+
+    with pytest.raises(ConnectionError):
+        async with acquire_with_retry(_FailingBackend(), max_retries=1):
+            pass  # pragma: no cover - acquire never succeeds
+
+    assert exits == [1], "process should have exited once after the window elapsed"
+
+
+@pytest.mark.asyncio
+async def test_does_not_exit_while_still_inside_the_window(exit_window):
+    """Failing acquires alone are not enough — the window must have elapsed.
+
+    This is the case a database restart produces, and exiting there would turn
+    a brief outage into a restart loop across every replica at once.
+    """
+    exits = exit_window(600.0, 5.0)
+
+    with pytest.raises(ConnectionError):
+        async with acquire_with_retry(_FailingBackend(), max_retries=1):
+            pass  # pragma: no cover - acquire never succeeds
+
+    assert exits == [], "must not exit while the database may still come back"
+
+
+@pytest.mark.asyncio
+async def test_a_successful_acquire_resets_the_window(exit_window):
+    """One success clears the clock, so intermittent failures never accumulate.
+
+    Without the reset, a process that fails an acquire now and then would
+    eventually exit even though the database is plainly working.
+    """
+    exits = exit_window(600.0, 599.0)
+
+    # Retries exhaust on the first two attempts, then it connects.
+    async with acquire_with_retry(_SlowThenOkBackend(2), max_retries=3) as conn:
+        assert conn is not None
+
+    assert exits == []
+    # The clock now reads from the success, not from the old timestamp.
+    assert time.monotonic() - db_utils._last_acquire_success < 1.0
+
+    # A later total failure therefore starts a fresh window rather than
+    # tripping immediately on the pre-existing staleness.
+    with pytest.raises(ConnectionError):
+        async with acquire_with_retry(_FailingBackend(), max_retries=1):
+            pass  # pragma: no cover - acquire never succeeds
+    assert exits == []
+
+
+@pytest.mark.asyncio
+async def test_exit_can_be_disabled(exit_window):
+    """Zero disables the behaviour outright, for operators who want it off."""
+    exits = exit_window(0.0, 86400.0)
+
+    with pytest.raises(ConnectionError):
+        async with acquire_with_retry(_FailingBackend(), max_retries=1):
+            pass  # pragma: no cover - acquire never succeeds
+
+    assert exits == []
+
+
+class _LegacyPool:
+    """asyncpg.Pool stand-in — no ``_wraps_backend``, so it takes the legacy path.
+
+    ``acquire_with_retry`` still supports raw pools alongside the backend
+    abstraction, and that path has its own acquire/retry code, so the exit
+    behaviour has to be asserted separately for it.
+    """
+
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    async def acquire(self):
+        raise self.error
+
+
+@pytest.mark.asyncio
+async def test_legacy_pool_path_also_exits(exit_window):
+    """The raw-pool path reaches the same dead end and must handle it the same."""
+    exits = exit_window(600.0, 601.0)
+
+    with pytest.raises(ConnectionError):
+        async with acquire_with_retry(_LegacyPool(ConnectionError("down")), max_retries=1):
+            pass  # pragma: no cover - acquire never succeeds
+
+    assert exits == [1]
+
+
+@pytest.mark.asyncio
+async def test_non_retryable_error_does_not_exit(exit_window):
+    """A bug in our own code is not evidence the database is unreachable."""
+    exits = exit_window(600.0, 601.0)
+
+    with pytest.raises(ValueError):
+        async with acquire_with_retry(_LegacyPool(ValueError("bad query")), max_retries=1):
+            pass  # pragma: no cover - acquire never succeeds
+
+    assert exits == []

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -2195,11 +2195,22 @@ you with an opaque restart.
 | `HINDSIGHT_API_LOOP_WATCHDOG_STALL_THRESHOLD_MS` | Log a stall once the loop is unresponsive for at least this long. | `1000` |
 | `HINDSIGHT_API_LOOP_WATCHDOG_POLL_INTERVAL_MS` | How often the watchdog thread pings the loop. | `250` |
 | `HINDSIGHT_API_DB_ACQUIRE_WARN_THRESHOLD_MS` | Log a warning (with pool stats) when acquiring a pooled connection waits at least this long. | `1000` |
+| `HINDSIGHT_API_DB_UNAVAILABLE_EXIT_SECONDS` | Exit the process when no pooled connection has been acquired for this long, so the supervisor can replace it. `0` disables. | `600` |
 
 The DB-pool acquire path also exposes `hindsight_db_pool_waiting` (callers currently
 queued for a connection) and the `hindsight_db_pool_acquire_wait` histogram. A slow
 or failing `/health` response additionally carries `db_acquire_ms`, `db_pool_waiting`,
 `db_pool_in_use`, and `db_pool_max` for triage.
+
+`HINDSIGHT_API_DB_UNAVAILABLE_EXIT_SECONDS` covers the case the metrics above only
+report: a pool that stops producing connections and never starts again. Liveness
+is deliberately database-free — a probe that queries the database restarts every
+replica at once whenever the database is merely slow — so nothing else brings such
+a process back. The window is measured from the last *successful* acquire, not
+from a count of failures, because a process serving little traffic may attempt an
+acquire only rarely. Set it comfortably longer than your longest expected
+failover or restart; a full window with no successful acquire is not a slow
+database.
 
 ### Metrics
 

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -2195,7 +2195,7 @@ you with an opaque restart.
 | `HINDSIGHT_API_LOOP_WATCHDOG_STALL_THRESHOLD_MS` | Log a stall once the loop is unresponsive for at least this long. | `1000` |
 | `HINDSIGHT_API_LOOP_WATCHDOG_POLL_INTERVAL_MS` | How often the watchdog thread pings the loop. | `250` |
 | `HINDSIGHT_API_DB_ACQUIRE_WARN_THRESHOLD_MS` | Log a warning (with pool stats) when acquiring a pooled connection waits at least this long. | `1000` |
-| `HINDSIGHT_API_DB_UNAVAILABLE_EXIT_SECONDS` | Exit the process when no pooled connection has been acquired for this long, so the supervisor can replace it. `0` disables. | `600` |
+| `HINDSIGHT_API_DB_UNAVAILABLE_EXIT_SECONDS` | Exit the process when no pooled connection has been acquired for this long, so the supervisor can replace it. `0` disables. | `120` |
 
 The DB-pool acquire path also exposes `hindsight_db_pool_waiting` (callers currently
 queued for a connection) and the `hindsight_db_pool_acquire_wait` histogram. A slow

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -407,7 +407,7 @@ HINDSIGHT_API_LOG_LEVEL=info
 # seconds, so the supervisor can restart it. Liveness is deliberately DB-free, so
 # a pool that never recovers otherwise leaves the process up and permanently
 # unready. 0 disables it.
-# HINDSIGHT_API_DB_UNAVAILABLE_EXIT_SECONDS=600
+# HINDSIGHT_API_DB_UNAVAILABLE_EXIT_SECONDS=120
 
 # -----------------------------------------------------------------------------
 # Extensions (Optional)

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -403,6 +403,12 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_LOOP_WATCHDOG_POLL_INTERVAL_MS=250
 # HINDSIGHT_API_DB_ACQUIRE_WARN_THRESHOLD_MS=1000
 
+# Exit the process when no pooled DB connection has been acquired for this many
+# seconds, so the supervisor can restart it. Liveness is deliberately DB-free, so
+# a pool that never recovers otherwise leaves the process up and permanently
+# unready. 0 disables it.
+# HINDSIGHT_API_DB_UNAVAILABLE_EXIT_SECONDS=600
+
 # -----------------------------------------------------------------------------
 # Extensions (Optional)
 # -----------------------------------------------------------------------------

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -2195,11 +2195,22 @@ you with an opaque restart.
 | `HINDSIGHT_API_LOOP_WATCHDOG_STALL_THRESHOLD_MS` | Log a stall once the loop is unresponsive for at least this long. | `1000` |
 | `HINDSIGHT_API_LOOP_WATCHDOG_POLL_INTERVAL_MS` | How often the watchdog thread pings the loop. | `250` |
 | `HINDSIGHT_API_DB_ACQUIRE_WARN_THRESHOLD_MS` | Log a warning (with pool stats) when acquiring a pooled connection waits at least this long. | `1000` |
+| `HINDSIGHT_API_DB_UNAVAILABLE_EXIT_SECONDS` | Exit the process when no pooled connection has been acquired for this long, so the supervisor can replace it. `0` disables. | `600` |
 
 The DB-pool acquire path also exposes `hindsight_db_pool_waiting` (callers currently
 queued for a connection) and the `hindsight_db_pool_acquire_wait` histogram. A slow
 or failing `/health` response additionally carries `db_acquire_ms`, `db_pool_waiting`,
 `db_pool_in_use`, and `db_pool_max` for triage.
+
+`HINDSIGHT_API_DB_UNAVAILABLE_EXIT_SECONDS` covers the case the metrics above only
+report: a pool that stops producing connections and never starts again. Liveness
+is deliberately database-free — a probe that queries the database restarts every
+replica at once whenever the database is merely slow — so nothing else brings such
+a process back. The window is measured from the last *successful* acquire, not
+from a count of failures, because a process serving little traffic may attempt an
+acquire only rarely. Set it comfortably longer than your longest expected
+failover or restart; a full window with no successful acquire is not a slow
+database.
 
 ### Metrics
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -2195,7 +2195,7 @@ you with an opaque restart.
 | `HINDSIGHT_API_LOOP_WATCHDOG_STALL_THRESHOLD_MS` | Log a stall once the loop is unresponsive for at least this long. | `1000` |
 | `HINDSIGHT_API_LOOP_WATCHDOG_POLL_INTERVAL_MS` | How often the watchdog thread pings the loop. | `250` |
 | `HINDSIGHT_API_DB_ACQUIRE_WARN_THRESHOLD_MS` | Log a warning (with pool stats) when acquiring a pooled connection waits at least this long. | `1000` |
-| `HINDSIGHT_API_DB_UNAVAILABLE_EXIT_SECONDS` | Exit the process when no pooled connection has been acquired for this long, so the supervisor can replace it. `0` disables. | `600` |
+| `HINDSIGHT_API_DB_UNAVAILABLE_EXIT_SECONDS` | Exit the process when no pooled connection has been acquired for this long, so the supervisor can replace it. `0` disables. | `120` |
 
 The DB-pool acquire path also exposes `hindsight_db_pool_waiting` (callers currently
 queued for a connection) and the `hindsight_db_pool_acquire_wait` histogram. A slow


### PR DESCRIPTION
## Problem

A connection pool can reach a state it never leaves. Every `acquire` fails, the retries in `acquire_with_retry` exhaust, the caller gets an exception, and the next caller repeats it forever. The process is up, serving nothing, and will stay that way indefinitely.

Nothing recovers from this today. Liveness is deliberately database-free — a probe that queries the database restarts every replica at once whenever the database is merely slow, which is worse than the problem it detects — so the pod stays alive and permanently unready with no path back.

This is not hypothetical. It was observed in a live environment following a database failure: once the database came back and was healthy again, the API processes did not recover with it. Their pools stayed dead and every request kept failing until the processes were restarted by hand.

## Change

`acquire_with_retry` now records the last acquire that succeeded. When a call has spent its retries and *nothing* has succeeded anywhere for the whole window, it logs at `critical`, flushes the log handlers, and exits so the supervisor can replace the process.

`HINDSIGHT_API_DB_UNAVAILABLE_EXIT_SECONDS`, default `120`, `0` disables.

Design notes, all captured in comments at the relevant lines:

- **The window is measured from the last success, not a failure count.** A process serving little traffic may attempt an acquire only rarely, and a counter would never trip.
- **Any single success clears it.** Intermittent failures never accumulate toward the limit.
- **Non-retryable errors don't count.** A bug in our own code says nothing about whether the database is reachable.
- **`os._exit`, not an exception.** A raise would be caught by whatever request handler happened to trigger it and the process would carry on in the same unusable state.
- **Two minutes.** It has to clear the ordinary causes — a CNPG failover takes tens of seconds, a database restart a little longer — because exiting during those would turn a brief degradation into a restart loop across every replica at once. Beyond that, shorter is better: the window is time a wedged process spends serving nothing. This started at 600s, which was far longer than anything it needs to ride out.

Both acquire paths are wired: the `DatabaseBackend` path and the legacy raw `asyncpg.Pool` path.

## Also

Three acquire/retry log lines switch from `{e}` to `{e!r}`. Several driver exceptions stringify to the empty string, so the final error rendered as `Database acquire failed after N attempts: ` with the cause silently dropped — you couldn't tell auth failure from timeout from an exhausted pool. This cost me real debugging time.

## Tests

Six new cases in `tests/test_db_utils.py`, driving the real config path via env + `clear_config_cache` rather than patching a module constant:

| Case | Expected |
|---|---|
| Sustained total failure past the window | exits once |
| Failing acquires, still inside the window | does **not** exit |
| A success mid-run | resets the clock; a later failure starts a fresh window |
| Window set to `0` | never exits |
| Legacy raw-pool path | exits the same way |
| Non-retryable error | does not exit |

Verified as a real regression test, not just a green run: neutralizing both call sites makes the exit test fail and leaves the other five passing, so it is proving the fix rather than the harness.

`./scripts/hooks/lint.sh` clean. Config flag follows the house convention — `ENV_`/`DEFAULT_` constants, `HindsightConfig` field, `from_env` wiring, `.env.example` plus the byte-identical `hindsight-embed` copy, and a row in `docs/developer/configuration.md` next to the existing pool-observability flags.
