### PR TITLE
fix(worker): detect stuck tasks by stage progress

### DIFF
--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -113,7 +113,7 @@ logger = logging.getLogger(__name__)
 PROGRESS_LOG_INTERVAL = 30
 
 # Stuck-task stack-dump thresholds (seconds). Each task gets one stack dump
-# per threshold it crosses (5min, 10min, 20min, 40min, 80min...).
+# per threshold its current stage crosses without making progress.
 STUCK_STACK_INITIAL_THRESHOLD_S = 300
 STUCK_STACK_MAX_THRESHOLD_S = 3600 * 6  # cap doubling at 6h
 
@@ -162,9 +162,10 @@ class ActiveTaskInfo:
     bg_task: "asyncio.Task[Any]"
     started_at: float
     stage_holder: StageHolder
-    # Largest stuck-stack threshold (seconds) for which we've already
-    # dumped a stack trace; used to suppress repeated dumps.
+    # Largest stuck-stack threshold (seconds) for the current stage. Resetting
+    # when the stage changes keeps a long, advancing task from looking wedged.
     last_stack_dump_threshold: int = 0
+    last_stack_dump_stage: str | None = None
     task_type: str = ""
 
 
@@ -1851,7 +1852,7 @@ class WorkerPoller:
             holder = info.stage_holder
             stage = holder.stage if holder is not None else "unknown"
             stage_age_s = (now - holder.updated_at) if holder is not None else 0.0
-            stuck_marker = "[STUCK?] " if age_s >= STUCK_STACK_INITIAL_THRESHOLD_S else ""
+            stuck_marker = "[STUCK?] " if stage_age_s >= STUCK_STACK_INITIAL_THRESHOLD_S else ""
             schema_part = f" schema={info.schema}" if info.schema else ""
             logger.info(
                 f"[WORKER_TASK] {stuck_marker}op={op_id} type={info.task_type} "
@@ -1859,22 +1860,28 @@ class WorkerPoller:
                 f"age={age_s:.0f}s stage={stage} stage_age={stage_age_s:.0f}s"
             )
 
-            self._maybe_dump_stuck_stack(op_id, info, age_s)
+            self._maybe_dump_stuck_stack(op_id, info, age_s, stage_age_s)
 
-    def _maybe_dump_stuck_stack(self, op_id: str, info: ActiveTaskInfo, age_s: float) -> None:
-        """Dump a coroutine stack for tasks that crossed a stuck threshold.
+    def _maybe_dump_stuck_stack(self, op_id: str, info: ActiveTaskInfo, age_s: float, stage_age_s: float) -> None:
+        """Dump a coroutine stack when a task's current stage stops progressing.
 
-        Each task gets one dump per threshold (5min, 10min, 20min, 40min...),
-        gated by `info.last_stack_dump_threshold` so logs don't flood for tasks
-        that legitimately take a long time (large LLM jobs, schema-retry loops).
+        Each stage gets one dump per threshold (5min, 10min, 20min, 40min...),
+        gated by `info.last_stack_dump_threshold` so logs do not flood while the
+        stalled stage remains unchanged. Total task age is retained in the log
+        for context but cannot distinguish a large, advancing job from a wedge.
         """
-        if age_s < STUCK_STACK_INITIAL_THRESHOLD_S:
+        stage = info.stage_holder.stage if info.stage_holder else "unknown"
+        if stage != info.last_stack_dump_stage:
+            info.last_stack_dump_stage = stage
+            info.last_stack_dump_threshold = 0
+
+        if stage_age_s < STUCK_STACK_INITIAL_THRESHOLD_S:
             return
 
-        # Find the largest doubling-threshold that the task has crossed.
+        # Find the largest doubling-threshold that the current stage has crossed.
         threshold = STUCK_STACK_INITIAL_THRESHOLD_S
         crossed = STUCK_STACK_INITIAL_THRESHOLD_S
-        while threshold <= age_s and threshold <= STUCK_STACK_MAX_THRESHOLD_S:
+        while threshold <= stage_age_s and threshold <= STUCK_STACK_MAX_THRESHOLD_S:
             crossed = threshold
             threshold *= 2
 
@@ -1886,10 +1893,10 @@ class WorkerPoller:
         try:
             buf = io.StringIO()
             info.bg_task.print_stack(file=buf, limit=15)
-            stage = info.stage_holder.stage if info.stage_holder else "unknown"
             logger.warning(
                 f"[STUCK_STACK] op={op_id} type={info.task_type} bank={info.bank_id} "
-                f"age={age_s:.0f}s threshold={crossed}s stage={stage}\n{buf.getvalue()}"
+                f"age={age_s:.0f}s stage_age={stage_age_s:.0f}s threshold={crossed}s "
+                f"stage={stage}\n{buf.getvalue()}"
             )
         except Exception as e:
             # Stack capture is best-effort - never crash the polling loop over it.

--- a/hindsight-api-slim/tests/test_worker_stuck_watchdog.py
+++ b/hindsight-api-slim/tests/test_worker_stuck_watchdog.py
@@ -1,0 +1,65 @@
+"""Progress-aware stuck-task watchdog coverage.
+
+A worker can process a large consolidation for much longer than the reporting
+threshold. That is healthy while its stage keeps advancing; a warning is useful
+only when one stage has stopped making progress.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+from hindsight_api.worker.poller import ActiveTaskInfo, WorkerPoller
+from hindsight_api.worker.stage import StageHolder
+
+
+def _make_poller() -> WorkerPoller:
+    return WorkerPoller(backend=MagicMock(), worker_id="w-test", executor=MagicMock())
+
+
+def _active_task(holder: StageHolder, started_at: float) -> ActiveTaskInfo:
+    return ActiveTaskInfo(
+        op_type="consolidation",
+        bank_id="bank-1",
+        schema=None,
+        bg_task=MagicMock(),
+        started_at=started_at,
+        stage_holder=holder,
+        task_type="consolidation",
+    )
+
+
+def test_stuck_watchdog_uses_stage_progress_and_resets_for_new_stage(caplog) -> None:
+    """Long tasks remain quiet until their current stage stops advancing."""
+    now = 1_000.0
+    holder = StageHolder(stage="consolidation.llm_batch.1", updated_at=now - 1)
+    info = _active_task(holder, started_at=0)
+    poller = _make_poller()
+
+    with caplog.at_level(logging.INFO, logger="hindsight_api.worker.poller"):
+        poller._log_per_task_lines({"op-1": info}, now)
+
+    assert "[STUCK?]" not in caplog.text
+    assert "[STUCK_STACK]" not in caplog.text
+
+    caplog.clear()
+    holder.updated_at = now - 301
+    poller._log_per_task_lines({"op-1": info}, now)
+
+    assert "[STUCK?]" in caplog.text
+    assert "[STUCK_STACK]" in caplog.text
+    assert info.last_stack_dump_threshold == 300
+
+    caplog.clear()
+    holder.stage = "consolidation.llm_batch.2"
+    holder.updated_at = now - 1
+    poller._log_per_task_lines({"op-1": info}, now)
+
+    assert "[STUCK?]" not in caplog.text
+    assert "[STUCK_STACK]" not in caplog.text
+
+    caplog.clear()
+    holder.updated_at = now - 301
+    poller._log_per_task_lines({"op-1": info}, now)
+
+    assert "[STUCK?]" in caplog.text
+    assert "[STUCK_STACK]" in caplog.text


### PR DESCRIPTION
Use the current stage age for worker stuck detection.

A large consolidation kept advancing through LLM batches but crossed the total-age threshold, producing false `STUCK` alerts and stack dumps.

- Advancing long-running tasks no longer emit `[STUCK?]` or stack dumps.
- An unchanged stage still emits escalating stack dumps after 5 minutes.
- Stack dumps retain total task age for context.

Test: `pytest tests/test_worker_stuck_watchdog.py -q`