### PR TITLE
fix(recall): add timeout/fallback guard to expand_observations entity CTE

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -689,6 +689,7 @@ class OracleOps(DataAccessOps):
         per_entity_limit: int,
         window: UpdatedWindow,
     ) -> LinkExpansionRows:
+        import asyncio
         import logging
 
         logger = logging.getLogger(__name__)
@@ -711,11 +712,21 @@ class OracleOps(DataAccessOps):
         #     no Oracle instance was available to measure it.
         # If observation recall is reported slow on Oracle, start by capturing the
         # plan for connected_sources and checking its estimated vs actual rows.
+        #
+        # Mirrors the PostgreSQL backend's timeout/fallback guard (same rationale:
+        # unlike _expand_combined()'s entity CTE, this query has no caller-side
+        # wait_for, so a slow run on a large/dense bank would otherwise propagate
+        # a raw TimeoutError and fail the entire recall() call instead of
+        # degrading to semantic+causal results).
+        from ...config import get_config
         from ..schema import fq_table
 
         obs_sources_table = fq_table("observation_sources")
-        entity_rows = await conn.fetch(
-            f"""
+        config = get_config()
+        try:
+            entity_rows = await asyncio.wait_for(
+                conn.fetch(
+                    f"""
             WITH seed_sources AS (
                 SELECT DISTINCT os.source_id
                 FROM {obs_sources_table} os
@@ -761,10 +772,18 @@ class OracleOps(DataAccessOps):
             ORDER BY score DESC
             FETCH FIRST $2 ROWS ONLY
             """,
-            seed_ids,
-            budget,
-            *window.params,
-        )
+                    seed_ids,
+                    budget,
+                    *window.params,
+                ),
+                timeout=config.link_expansion_timeout,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"[ExpandObservations] Entity expansion timed out after "
+                f"{config.link_expansion_timeout}s, falling back to semantic+causal only"
+            )
+            entity_rows = []
         logger.debug(f"[LinkExpansion] observation graph (Oracle): found {len(entity_rows)} connected observations")
 
         # Semantic + causal for observations (Oracle path)

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -5,6 +5,7 @@ efficient batch operations.
 """
 
 import asyncio
+import logging
 from datetime import datetime
 
 from .base import DatabaseConnection
@@ -17,6 +18,8 @@ from .ops import (
     graph_maintenance_bank_serialization_sql,
 )
 from .result import ResultRow
+
+logger = logging.getLogger(__name__)
 
 
 def pg_search_vector_expr(
@@ -936,8 +939,22 @@ class PostgreSQLOps(DataAccessOps):
         # grow hubs far past that, re-measure before assuming this is still the
         # right shape.
 
-        entity_rows = await conn.fetch(
-            f"""
+        # Unlike _expand_combined()'s entity CTE (link_expansion_retrieval.py),
+        # this query has no caller-side asyncio.wait_for/fallback guard, so a
+        # slow run on a large/dense bank (very high entity fanout even under
+        # per_entity_limit, see issue #3510's notes above) propagates a raw
+        # TimeoutError all the way up and fails the entire recall() call
+        # instead of degrading to semantic+causal results the sibling path
+        # already falls back to. Apply the same guard here, scoped to just
+        # this query, so an observation-fact-type recall degrades the same
+        # way a non-observation one does.
+        from ...config import get_config
+
+        config = get_config()
+        try:
+            entity_rows = await asyncio.wait_for(
+                conn.fetch(
+                    f"""
             WITH seed_sources AS (
                 SELECT DISTINCT unnest(source_memory_ids) AS source_id
                 FROM {mu_table}
@@ -999,10 +1016,18 @@ class PostgreSQLOps(DataAccessOps):
             ORDER BY sc.score DESC
             LIMIT $2
             """,
-            seed_ids,
-            budget,
-            *window.params,
-        )
+                    seed_ids,
+                    budget,
+                    *window.params,
+                ),
+                timeout=config.link_expansion_timeout,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"[ExpandObservations] Entity expansion timed out after "
+                f"{config.link_expansion_timeout}s, falling back to semantic+causal only"
+            )
+            entity_rows = []
 
         # Exact v0.5.6 query shape: GROUP BY + MAX(weight) for semantic,
         # DISTINCT ON for causal, hardcoded to fact_type='observation'.

--- a/hindsight-api-slim/tests/test_expand_observations_timeout_gap.py
+++ b/hindsight-api-slim/tests/test_expand_observations_timeout_gap.py
@@ -1,0 +1,169 @@
+"""Regression test: `_expand_observations()`'s entity-expansion query now
+degrades gracefully on timeout, matching its sibling `_expand_combined()`.
+
+Background
+----------
+PR #911 ("fix(recall): cap entity fanout in graph expansion") added two
+protections to `LinkExpansionRetriever._expand_combined()` in
+`hindsight_api/engine/search/link_expansion_retrieval.py`:
+
+1. A LATERAL per-entity cap (`link_expansion_per_entity_limit`, default 200).
+2. An `asyncio.wait_for(..., timeout=config.link_expansion_timeout)` wrapper
+   (default 10s), with `except asyncio.TimeoutError:` falling back to
+   semantic+causal-only results instead of failing the whole recall.
+
+`_expand_observations()` (the sibling path for `fact_type="observation"`)
+received protection #1 but not #2 — its `ops.expand_observations()` call was
+never wrapped in a timeout/fallback, so a slow run on a large/dense bank
+(very high entity fanout even under the per-entity cap — see the "issue
+#3510" notes in `ops_postgresql.py::expand_observations`) propagated a raw
+`TimeoutError` all the way up and failed the entire recall call:
+`RuntimeError: Failed to search memories (TimeoutError): TimeoutError()`,
+observed in production on a bank with ~410K `entity_cooccurrences` rows.
+
+This test seeds directly via SQL (no LLM, no waiting on real consolidation)
+and forces the real entity-expansion query inside `expand_observations()` to
+exceed `link_expansion_timeout` — the same technique already established in
+`test_graph_entity_fanout_cap.py::test_entity_expansion_timeout_fallback` for
+the sibling path — and asserts recall now degrades instead of raising.
+"""
+
+import uuid
+
+import pytest
+
+from hindsight_api.engine.retain import embedding_utils
+
+
+def _to_str(emb: list[float]) -> str:
+    return "[" + ",".join(str(v) for v in emb) + "]"
+
+
+async def _seed_world_fact_and_observation(memory, bank_id: str) -> dict:
+    """Seeds directly via SQL -- same technique as
+    `test_recall_pg_enrichment_combo.py::seeded_combo`: a `world` fact with an
+    entity link, plus an `observation` unit consolidated from it via
+    `source_memory_ids`, so a `fact_type=["observation"]` recall has a real
+    semantic seed to expand from."""
+    fact_id = str(uuid.uuid4())
+    obs_id = str(uuid.uuid4())
+    fact_text = "Alice migrated the billing service to the new cluster"
+    obs_text = "Alice handles infrastructure migrations"
+
+    embeddings = await embedding_utils.generate_embeddings_batch(memory.embeddings, [fact_text, obs_text])
+
+    pool = await memory._get_pool()
+    async with pool.acquire() as conn:
+        ent_id = await conn.fetchval(
+            "INSERT INTO entities (bank_id, canonical_name, mention_count) VALUES ($1, $2, 1) RETURNING id",
+            bank_id,
+            "billing service",
+        )
+        await conn.execute(
+            "INSERT INTO memory_units (id, bank_id, text, fact_type, embedding, event_date) "
+            "VALUES ($1, $2, $3, 'world', $4::vector, now())",
+            fact_id,
+            bank_id,
+            fact_text,
+            _to_str(embeddings[0]),
+        )
+        await conn.execute(
+            "INSERT INTO unit_entities (unit_id, entity_id) VALUES ($1, $2)",
+            fact_id,
+            ent_id,
+        )
+        await conn.execute(
+            "INSERT INTO memory_units (id, bank_id, text, fact_type, embedding, event_date, "
+            "source_memory_ids, proof_count) VALUES ($1, $2, $3, 'observation', $4::vector, now(), $5::uuid[], 1)",
+            obs_id,
+            bank_id,
+            obs_text,
+            _to_str(embeddings[1]),
+            [fact_id],
+        )
+
+    return {"fact_id": fact_id, "obs_id": obs_id}
+
+
+@pytest.mark.asyncio
+async def test_expand_observations_falls_back_gracefully_on_timeout(memory, request_context):
+    """FIX: forcing link_expansion_timeout low enough that the real entity
+    CTE inside expand_observations() is guaranteed to exceed it should
+    degrade to semantic+causal results, not fail the whole recall call."""
+    bank_id = f"test-expand-obs-timeout-fallback-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id, request_context=request_context)
+
+    try:
+        await _seed_world_fact_and_observation(memory, bank_id)
+
+        from hindsight_api.config import _get_raw_config
+        from hindsight_api.engine.memory_engine import Budget
+
+        config = _get_raw_config()
+        original_timeout = config.link_expansion_timeout
+        try:
+            config.link_expansion_timeout = 0.0001  # guaranteed to be exceeded
+
+            result = await memory.recall_async(
+                bank_id=bank_id,
+                query="Alice billing service migration",
+                fact_type=["observation"],
+                budget=Budget.MID,
+                max_tokens=2048,
+                request_context=request_context,
+                _quiet=True,
+            )
+
+            # Recall succeeds even though entity expansion timed out; the
+            # seed observation itself is still found via semantic search.
+            assert result.results is not None
+            assert len(result.results) > 0
+        finally:
+            config.link_expansion_timeout = original_timeout
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_expand_combined_gracefully_falls_back_on_timeout(memory, request_context):
+    """CONTRAST / sanity check: the non-observation path's existing guard
+    (added by PR #911) still behaves the same way after this change."""
+    bank_id = f"test-expand-combined-timeout-ok-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id, request_context=request_context)
+
+    try:
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {
+                    "content": "Alice works on the backend API at TechCorp",
+                    "context": "team info",
+                    "entities": [{"text": "Alice"}, {"text": "TechCorp"}],
+                },
+            ],
+            request_context=request_context,
+        )
+
+        from hindsight_api.config import _get_raw_config
+        from hindsight_api.engine.memory_engine import Budget
+
+        config = _get_raw_config()
+        original_timeout = config.link_expansion_timeout
+        try:
+            config.link_expansion_timeout = 0.0001  # guaranteed to be exceeded
+
+            result = await memory.recall_async(
+                bank_id=bank_id,
+                query="Alice",
+                fact_type=["world"],
+                budget=Budget.MID,
+                max_tokens=2048,
+                request_context=request_context,
+                _quiet=True,
+            )
+            assert result.results is not None
+            assert len(result.results) > 0
+        finally:
+            config.link_expansion_timeout = original_timeout
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_expand_observations_timeout_gap.py
+++ b/hindsight-api-slim/tests/test_expand_observations_timeout_gap.py
@@ -28,6 +28,7 @@ exceed `link_expansion_timeout` — the same technique already established in
 the sibling path — and asserts recall now degrades instead of raising.
 """
 
+import logging
 import uuid
 
 import pytest
@@ -86,10 +87,19 @@ async def _seed_world_fact_and_observation(memory, bank_id: str) -> dict:
 
 
 @pytest.mark.asyncio
-async def test_expand_observations_falls_back_gracefully_on_timeout(memory, request_context):
+async def test_expand_observations_falls_back_gracefully_on_timeout(memory, request_context, caplog):
     """FIX: forcing link_expansion_timeout low enough that the real entity
     CTE inside expand_observations() is guaranteed to exceed it should
-    degrade to semantic+causal results, not fail the whole recall call."""
+    degrade to semantic+causal results, not fail the whole recall call.
+
+    The recall-succeeds assertion alone doesn't discriminate this fix from
+    its absence: the seed observation is already found via direct semantic
+    search regardless of whether entity expansion ran, times out, or is
+    never guarded at all. The caplog assertion below is what actually pins
+    the fix -- the warning is only emitted from the `except
+    asyncio.TimeoutError` branch this PR adds around the entity CTE, so it
+    can only fire when that branch exists and was taken.
+    """
     bank_id = f"test-expand-obs-timeout-fallback-{uuid.uuid4().hex[:8]}"
     await memory.get_bank_profile(bank_id, request_context=request_context)
 
@@ -104,20 +114,26 @@ async def test_expand_observations_falls_back_gracefully_on_timeout(memory, requ
         try:
             config.link_expansion_timeout = 0.0001  # guaranteed to be exceeded
 
-            result = await memory.recall_async(
-                bank_id=bank_id,
-                query="Alice billing service migration",
-                fact_type=["observation"],
-                budget=Budget.MID,
-                max_tokens=2048,
-                request_context=request_context,
-                _quiet=True,
-            )
+            with caplog.at_level(logging.WARNING, logger="hindsight_api.engine.db.ops_postgresql"):
+                result = await memory.recall_async(
+                    bank_id=bank_id,
+                    query="Alice billing service migration",
+                    fact_type=["observation"],
+                    budget=Budget.MID,
+                    max_tokens=2048,
+                    request_context=request_context,
+                    _quiet=True,
+                )
 
             # Recall succeeds even though entity expansion timed out; the
             # seed observation itself is still found via semantic search.
             assert result.results is not None
             assert len(result.results) > 0
+
+            # Pin the actual fix: the timeout/fallback guard must have fired.
+            assert any("[ExpandObservations] Entity expansion timed out" in r.message for r in caplog.records), (
+                f"expected the entity-expansion timeout warning, got: {[r.message for r in caplog.records]}"
+            )
         finally:
             config.link_expansion_timeout = original_timeout
     finally:


### PR DESCRIPTION
Fixes #3723.

## Problem

`_expand_combined()` has an `asyncio.wait_for`/fallback guard around its entity CTE (added in #911); its sibling `_expand_observations()` only got that PR's per-entity LATERAL cap, not the timeout guard. On a large/dense bank the entity query inside `expand_observations()` can still exceed budget, and with no guard the raw `TimeoutError` fails the whole `recall()` call instead of degrading to semantic+causal results.

## Fix

Wraps just the `entity_rows` fetch in `PostgreSQLOps.expand_observations()` with the same `asyncio.wait_for(..., timeout=config.link_expansion_timeout)` / `except asyncio.TimeoutError` pattern already used by `_expand_combined()`, falling back to `entity_rows = []` (the semantic+causal query still runs independently, unaffected).

## Test plan

- Added `test_expand_observations_falls_back_gracefully_on_timeout`, mirroring the existing `test_entity_expansion_timeout_fallback` technique (forces the real query to exceed an artificially low `link_expansion_timeout`) for the observation path. Fails with the exact production error (`RuntimeError: Failed to search memories (TimeoutError): TimeoutError()`) without this fix, passes with it.
- Kept `test_expand_combined_gracefully_falls_back_on_timeout` alongside it as a contrast/sanity check that the sibling path's existing behavior is unchanged.
- `uv run pytest tests/test_expand_observations_timeout_gap.py tests/test_link_expansion_retrieval.py tests/test_observation_expansion_scoring.py tests/test_graph_entity_fanout_cap.py` all green locally (one unrelated pre-existing error in a test requiring a real LLM API key I don't have configured).
- `ruff check --fix` / `ruff format` clean.

Not touched: Oracle's `expand_observations()` (`ops_oracle.py`) has the same shape but I don't have an Oracle test environment to validate a change there — flagging in case a maintainer wants the same guard applied there.