### PR TITLE
fix(retain): sanitize model-derived fact text

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -13,6 +13,7 @@ from contextlib import AsyncExitStack, asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
 from json_repair import repair_json
+from pydantic import BaseModel
 
 # Vertex AI imports (conditional - for LLMProvider to pass credentials to GeminiLLM)
 try:
@@ -163,6 +164,9 @@ def _request_params(
     return params or None
 
 
+_UNSAFE_TEXT_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f\ud800-\udfff]")
+
+
 def sanitize_text(text: str | None) -> str | None:
     """
     Sanitize text by removing characters that break downstream systems.
@@ -186,12 +190,74 @@ def sanitize_text(text: str | None) -> str | None:
         return None
     if not text:
         return text
-    return re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f\ud800-\udfff]", "", text)
+    return _UNSAFE_TEXT_RE.sub("", text)
 
 
 # Back-compat alias: this helper was originally introduced to scrub LLM *output*;
 # it now also scrubs user *input* at ingress, hence the broader name.
 sanitize_llm_output = sanitize_text
+
+
+def sanitize_llm_value(value: Any) -> Any:
+    """
+    Recursively strip UTF-8-hostile characters from every string an LLM produced.
+
+    ``sanitize_text`` guards a single field. This guards a whole response — the
+    text a provider returned, the dict a structured call parsed, the pydantic
+    model it validated into, the ``(result, usage)`` tuple ``return_usage=True``
+    hands back — so that *every* LLM call is covered at one boundary instead of
+    each consumer remembering to scrub its own fields (see issue #3729).
+
+    It matters beyond embeddings. A lone surrogate is legal in a Python ``str``
+    but cannot be UTF-8 encoded, so it also breaks the cross-encoder's Rust
+    tokenizer at rerank time, asyncpg on the way into a ``text`` column, and
+    stdout logging. Sanitizing where the text enters the process means the
+    downstream stages never have to care which field it landed in.
+
+    Only strings are touched; ints, floats, datetimes and the like pass through
+    as-is. Every container returns the *same object* when nothing inside it
+    changed, so the overwhelmingly common clean response is not copied and
+    object identity (a validated response model, an enum member) survives
+    untouched.
+    """
+    if isinstance(value, str):
+        # A str subclass (a StrEnum member, say) comes back as itself unless it
+        # actually carries a hostile character — at which point a plain str is the
+        # only safe answer, and the alternative was a crash.
+        cleaned = _UNSAFE_TEXT_RE.sub("", value)
+        return cleaned if cleaned != value else value
+
+    if isinstance(value, BaseModel):
+        updates = {}
+        for name, field_value in value.__dict__.items():
+            cleaned = sanitize_llm_value(field_value)
+            if cleaned is not field_value:
+                updates[name] = cleaned
+        # ``model_copy`` skips validation, which is what we want: the values are
+        # already sanitized, and re-validating could reject a model the provider
+        # built with ``model_construct``.
+        return value.model_copy(update=updates) if updates else value
+
+    if isinstance(value, dict):
+        cleaned_dict = {}
+        changed = False
+        for key, item in value.items():
+            # Keys are sanitized too: a surrogate in a key is just as fatal once
+            # the dict is rendered to text or bound to a query parameter.
+            cleaned_key = sanitize_llm_value(key)
+            cleaned_item = sanitize_llm_value(item)
+            changed = changed or cleaned_key is not key or cleaned_item is not item
+            cleaned_dict[cleaned_key] = cleaned_item
+        return cleaned_dict if changed else value
+
+    # ``tuple`` is here for the ``return_usage=True`` shape, ``(result, TokenUsage)``.
+    if isinstance(value, (list, tuple)):
+        cleaned_items = [sanitize_llm_value(item) for item in value]
+        if all(cleaned is original for cleaned, original in zip(cleaned_items, value)):
+            return value
+        return cleaned_items if isinstance(value, list) else tuple(cleaned_items)
+
+    return value
 
 
 # ``OutputTooLongError`` is re-exported from ``llm_interface`` (the canonical
@@ -264,11 +330,18 @@ def parse_llm_json(raw: str) -> Any:
     degenerate-but-valid JSON (repetition loops or leaked scaffolding inside
     string values) parses fine here and is out of scope for this helper.
 
+    Every successful parse is passed through ``sanitize_llm_value``. Decoding is
+    where an un-encodable surrogate is *born*: a model that writes ``"\\ud83d"``
+    emits six harmless ASCII characters, and only ``json.loads`` turns them into a
+    lone surrogate no downstream stage can UTF-8 encode (#3729). Scrubbing the raw
+    text beforehand cannot see it; scrubbing the parsed object can.
+
     Args:
         raw: Raw text returned by the LLM.
 
     Returns:
-        Parsed Python object (dict, list, etc.).
+        Parsed Python object (dict, list, etc.), with model-authored strings
+        scrubbed of surrogates and control characters.
 
     Raises:
         json.JSONDecodeError: If the text cannot be parsed even after cleanup
@@ -284,7 +357,7 @@ def parse_llm_json(raw: str) -> Any:
         text = text.strip()
 
     try:
-        return json.loads(text)
+        return sanitize_llm_value(json.loads(text))
     except json.JSONDecodeError:
         # Some models (e.g. Gemini) embed raw control characters inside JSON
         # string values. Escape them rather than blank them out: a raw newline
@@ -295,7 +368,7 @@ def parse_llm_json(raw: str) -> Any:
         cleaned = _escape_control_chars_in_json(text)
 
     try:
-        return json.loads(cleaned)
+        return sanitize_llm_value(json.loads(cleaned))
     except json.JSONDecodeError:
         # Last resort: structural repair of malformed JSON. ``repair_json`` never
         # raises — unrecoverable input yields an empty result ("" / {} / []). Keep
@@ -305,7 +378,7 @@ def parse_llm_json(raw: str) -> Any:
         repaired = repair_json(cleaned, return_objects=True)
         if not repaired:
             raise
-        return repaired
+        return sanitize_llm_value(repaired)
 
 
 _PROVIDERS_WITHOUT_API_KEY = frozenset(
@@ -1217,7 +1290,11 @@ class LLMProvider:
             reset_request_context(request_token)
             reset_response_usage(usage_token)
 
-        return result
+        # Single scrub point for every structured/text LLM response in the engine:
+        # a model can emit a lone `\udXXX` escape that JSON decoding turns into an
+        # un-encodable surrogate, and the field it lands in is not knowable here
+        # (#3729). Clean output is returned unchanged, object identity included.
+        return sanitize_llm_value(result)
 
     async def call_with_tools(
         self,
@@ -1362,7 +1439,9 @@ class LLMProvider:
             reset_request_context(request_token)
             reset_response_usage(usage_token)
 
-        return result
+        # Same scrub for the tool-calling path: the agent's text content and every
+        # tool-call argument are model-authored and flow on to storage and reranking.
+        return sanitize_llm_value(result)
 
     def set_response_callback(self, fn: Any) -> None:
         """Set a callback invoked on each call() instead of the fixed mock response."""

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -4852,6 +4852,17 @@ class MemoryEngine(MemoryEngineInterface):
                 item["content"] = sanitize_text(item["content"]) or ""
             if item.get("context"):
                 item["context"] = sanitize_text(item["context"]) or ""
+            # Client-supplied entity names reach the same places the fact text does:
+            # they are appended to the embedded string and joined into `text_signals`
+            # for BM25, so an unpaired surrogate here crashes identically (#3729).
+            # Shape is ``[{"text": ..., "type": ...}]``; an entry whose text sanitizes
+            # away entirely is dropped rather than carried as a nameless entity.
+            if item.get("entities"):
+                item["entities"] = [
+                    {key: sanitize_text(value) or "" for key, value in entity.items()}
+                    for entity in item["entities"]
+                    if (sanitize_text(entity.get("text")) or "").strip()
+                ]
 
         # Apply batch-level document_id to contents that don't have their own (backwards compatibility)
         if document_id:

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -170,6 +170,14 @@ class Fact(BaseModel):
     entities: list[str] | None = None
     causal_relations: list["CausalRelation"] | None = None
 
+    @field_validator("fact")
+    @classmethod
+    def sanitize_fact_text(cls, value: str) -> str:
+        # Structured JSON parsing turns a model's ``\udXXX`` escape into a
+        # surrogate only after raw-output cleanup, so scrub the final text at
+        # the shared immediate/batch extraction boundary before storage or embedding (#3729).
+        return _sanitize_text(value) or ""
+
 
 class CausalRelation(BaseModel):
     """Causal relationship from this fact to a previous fact (stored format)."""

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -16,7 +16,7 @@ from typing import Any, Literal, cast
 from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator
 
 from ..llm_interface import ProviderContentPolicyError, ProviderRateLimitResetError
-from ..llm_wrapper import LLMConfig, OutputTooLongError, parse_llm_json, sanitize_llm_output
+from ..llm_wrapper import LLMConfig, OutputTooLongError, parse_llm_json, sanitize_llm_output, sanitize_llm_value
 from ..operation_metadata import RetainExtractionErrors
 from ..response_models import TokenUsage
 from ..structured_output import strict_json_schema
@@ -176,7 +176,26 @@ class Fact(BaseModel):
         # Structured JSON parsing turns a model's ``\udXXX`` escape into a
         # surrogate only after raw-output cleanup, so scrub the final text at
         # the shared immediate/batch extraction boundary before storage or embedding (#3729).
+        # ``LLMProvider.call`` already scrubs the response this is built from; this is the
+        # storage-side guarantee for any text that reaches ``Fact`` by another route.
         return _sanitize_text(value) or ""
+
+    @field_validator("entities")
+    @classmethod
+    def sanitize_entity_names(cls, value: list[str] | None) -> list[str] | None:
+        # Entity names are model-authored too, and they are not merely metadata: they
+        # are appended to the very string that gets embedded (``augment_texts_with_dates``)
+        # and joined into the ``text_signals`` column feeding BM25. A surrogate in a name
+        # crashes exactly where one in ``fact`` does. Names that sanitize away entirely
+        # are dropped rather than stored blank.
+        if value is None:
+            return None
+        cleaned_names = []
+        for name in value:
+            cleaned = _sanitize_text(name) or ""
+            if cleaned.strip():
+                cleaned_names.append(cleaned)
+        return cleaned_names
 
 
 class CausalRelation(BaseModel):
@@ -2371,7 +2390,10 @@ async def extract_facts_from_contents_batch_api(
     logger.info(f"Batch {batch_id} completed in {elapsed:.0f}s, retrieving results")
 
     # Step 4: Retrieve results
-    batch_results = await batch_impl.retrieve_batch_results(batch_id)
+    # Batch results are downloaded straight from the provider's output file, so they
+    # never pass through ``LLMProvider.call`` and miss the scrub it applies. Sanitize
+    # them here so the batch path gets the same guarantee as the sync one (#3729).
+    batch_results = sanitize_llm_value(await batch_impl.retrieve_batch_results(batch_id))
 
     # Map results by custom_id
     results_by_id = {result["custom_id"]: result for result in batch_results}

--- a/hindsight-api-slim/tests/test_batch_api.py
+++ b/hindsight-api-slim/tests/test_batch_api.py
@@ -915,3 +915,64 @@ async def test_batch_api_via_extract_facts_from_contents(
             await memory.delete_bank(bank_id, request_context=request_context)
         except Exception:
             pass
+
+
+@pytest.mark.asyncio
+async def test_batch_api_sanitizes_model_authored_text(mock_llm_config, hindsight_config):
+    """Batch results bypass ``LLMProvider.call``, so they need their own scrub (#3729).
+
+    A model can write ``\\udXXX`` in any string field of a batch response. The raw
+    JSONL carries harmless ASCII; the surrogate is born when the batch path parses it,
+    and from there the fact text and the entity names go straight to the embedder,
+    the reranker and an asyncpg bind.
+    """
+    batch_id = "batch_surrogate"
+    mock_llm_config._provider_impl.supports_batch_api = AsyncMock(return_value=True)
+    mock_llm_config._provider_impl.submit_batch = AsyncMock(
+        return_value={
+            "batch_id": batch_id,
+            "status": "validating",
+            "request_counts": {"total": 1, "completed": 0, "failed": 0},
+        }
+    )
+    mock_llm_config._provider_impl.get_batch_status = AsyncMock(
+        return_value={"status": "completed", "request_counts": {"total": 1, "completed": 1, "failed": 0}}
+    )
+    mock_llm_config._provider_impl.retrieve_batch_results = AsyncMock(
+        return_value=[
+            {
+                "custom_id": "chunk_0",
+                "response": {
+                    "body": {
+                        "choices": [
+                            {
+                                "message": {
+                                    "content": (
+                                        '{"facts": [{"what": "Alex laughed \ud83d", "when": "N/A", '
+                                        '"where": "N/A", "who": "Alex", "why": "N/A", "fact_type": "world", '
+                                        '"fact_kind": "conversation", "entities": ["Al\ud83dex"]}]}'
+                                    )
+                                }
+                            }
+                        ],
+                        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+                    }
+                },
+            }
+        ]
+    )
+
+    facts, _chunks, _usage = await extract_facts_from_contents_batch_api(
+        contents=[RetainContent(content="Alex laughed at the joke.")],
+        llm_config=mock_llm_config,
+        agent_name="test_agent",
+        config=hindsight_config,
+        pool=None,
+        operation_id=None,
+        schema=None,
+    )
+
+    assert len(facts) == 1
+    assert facts[0].fact_text.encode("utf-8")  # raised UnicodeEncodeError before the fix
+    assert "Alex laughed" in facts[0].fact_text
+    assert facts[0].entities == ["Alex"]

--- a/hindsight-api-slim/tests/test_input_robustness.py
+++ b/hindsight-api-slim/tests/test_input_robustness.py
@@ -3,14 +3,18 @@
 Covers the "server 500s on unusual-but-valid input" class:
 - #1883: content containing tokenizer special-token literals (e.g. ``<|endoftext|>``).
 - #1875: queries/content containing an unpaired UTF-16 surrogate (e.g. a half-emoji).
+- #3729: structured LLM fact output containing an unpaired surrogate.
 """
 
+import dataclasses
 from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from hindsight_api.engine.llm_wrapper import sanitize_llm_output, sanitize_text
 from hindsight_api.engine.reflect.tokenization import count_prompt_tokens
+from hindsight_api.engine.response_models import TokenUsage
 from hindsight_api.engine.token_encoding import count_tokens, get_token_encoding
 
 # A lone high surrogate — valid in a Python str, but rejected by the Rust
@@ -65,6 +69,63 @@ def test_sanitize_none_and_empty():
 
 def test_sanitize_llm_output_is_alias():
     assert sanitize_llm_output is sanitize_text
+
+
+@pytest.mark.asyncio
+async def test_fact_extraction_sanitizes_surrogates_generated_by_llm():
+    """Valid source can still produce a lone surrogate in structured LLM output."""
+    from hindsight_api.config import _get_raw_config
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
+
+    config = dataclasses.replace(
+        _get_raw_config(),
+        retain_llm_max_retries=0,
+        retain_extraction_mode="concise",
+        retain_extract_causal_links=False,
+        retain_mission=None,
+        llm_temperature_retain=0.1,
+        llm_strict_schema_retain=False,
+        entity_labels=None,
+        entities_allow_free_form=True,
+    )
+    llm = MagicMock(spec=LLMProvider)
+    llm.provider = "mock"
+    llm.call = AsyncMock(
+        return_value=(
+            {
+                "facts": [
+                    {
+                        "what": "Alex laughed 😂",
+                        "when": "N/A",
+                        "where": "N/A",
+                        "who": "Alex",
+                        "why": "The joke was funny \ude02",
+                        "fact_type": "world",
+                        "fact_kind": "conversation",
+                    }
+                ]
+            },
+            TokenUsage(),
+        )
+    )
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        facts, _usage = await _extract_facts_from_chunk(
+            chunk="Alex laughed at the joke.",
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2026, 8, 22, tzinfo=timezone.utc),
+            context="",
+            llm_config=llm,
+            config=config,
+        )
+
+    assert facts[0].fact == "Alex laughed 😂 | Involving: Alex | The joke was funny "
+    assert facts[0].fact.encode("utf-8")
 
 
 # --- Integration: full pipeline survives both inputs -----------------------------

--- a/hindsight-api-slim/tests/test_input_robustness.py
+++ b/hindsight-api-slim/tests/test_input_robustness.py
@@ -7,19 +7,28 @@ Covers the "server 500s on unusual-but-valid input" class:
 """
 
 import dataclasses
+import json
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from hindsight_api.engine.llm_wrapper import sanitize_llm_output, sanitize_text
+from hindsight_api.engine.llm_wrapper import (
+    LLMProvider,
+    parse_llm_json,
+    sanitize_llm_output,
+    sanitize_llm_value,
+    sanitize_text,
+)
 from hindsight_api.engine.reflect.tokenization import count_prompt_tokens
-from hindsight_api.engine.response_models import TokenUsage
+from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
+from hindsight_api.engine.retain.fact_extraction import Fact
 from hindsight_api.engine.token_encoding import count_tokens, get_token_encoding
 
 # A lone high surrogate — valid in a Python str, but rejected by the Rust
 # tokenizers behind the local embedder / cross-encoder and uncodable to UTF-8.
-LONE_SURROGATE = "deploy the \ud83d service"
+HIGH_SURROGATE = "\ud83d"
+LONE_SURROGATE = f"deploy the {HIGH_SURROGATE} service"
 SPECIAL_TOKEN_TEXT = "The fix was to sanitize the <|endoftext|> token before sending."
 
 
@@ -128,6 +137,152 @@ async def test_fact_extraction_sanitizes_surrogates_generated_by_llm():
     assert facts[0].fact.encode("utf-8")
 
 
+# --- Prong C: every LLM response is scrubbed at one boundary (#3729) ------------
+
+
+def test_sanitize_llm_value_returns_clean_input_unchanged():
+    """The common case must not copy: identity is preserved all the way down."""
+    payload = {"facts": [{"what": "café 🎉", "n": 3}], "ok": None, "flag": True, "score": 1.5}
+    assert sanitize_llm_value(payload) is payload
+    text = "plain text"
+    assert sanitize_llm_value(text) is text
+
+
+def test_sanitize_llm_value_scrubs_nested_strings_only():
+    payload = {"facts": [{"what": f"a{HIGH_SURROGATE}b", "count": 3, "ratio": 0.5, "missing": None}]}
+    cleaned = sanitize_llm_value(payload)
+    assert cleaned["facts"][0]["what"] == "ab"
+    # Non-text fields keep their type and value.
+    assert cleaned["facts"][0]["count"] == 3
+    assert cleaned["facts"][0]["ratio"] == 0.5
+    assert cleaned["facts"][0]["missing"] is None
+
+
+def test_sanitize_llm_value_scrubs_dict_keys():
+    cleaned = sanitize_llm_value({f"na{HIGH_SURROGATE}me": "Alex"})
+    assert cleaned == {"name": "Alex"}
+
+
+def test_sanitize_llm_value_scrubs_pydantic_models():
+    result = LLMToolCallResult(
+        content=f"answer{HIGH_SURROGATE}",
+        tool_calls=[LLMToolCall(id="call_1", name="recall", arguments={"query": f"q{HIGH_SURROGATE}"})],
+        output_tokens=42,
+    )
+    cleaned = sanitize_llm_value(result)
+    assert isinstance(cleaned, LLMToolCallResult)
+    assert cleaned.content == "answer"
+    assert cleaned.tool_calls[0].arguments == {"query": "q"}
+    # Numeric fields survive the copy.
+    assert cleaned.output_tokens == 42
+
+
+def test_sanitize_llm_value_preserves_return_usage_tuple_shape():
+    """``return_usage=True`` hands back ``(result, TokenUsage)`` — both must survive."""
+    usage = TokenUsage()
+    cleaned = sanitize_llm_value(({"text": f"x{HIGH_SURROGATE}"}, usage))
+    assert isinstance(cleaned, tuple) and len(cleaned) == 2
+    assert cleaned[0] == {"text": "x"}
+    assert cleaned[1] is usage
+
+
+def test_parse_llm_json_scrubs_surrogates_born_at_decode():
+    """The exact mechanism behind #3729.
+
+    A model writes the six ASCII characters ``\\ud83d``; nothing is wrong with the
+    raw text and scrubbing it there is a no-op. ``json.loads`` is what turns them
+    into a lone surrogate no downstream stage can UTF-8 encode, so the scrub has
+    to happen on the parsed object.
+    """
+    raw = '{"facts": [{"what": "Alex laughed \\ud83d", "entities": ["Al\\ud83dex"], "n": 3}]}'
+    assert sanitize_text(raw) == raw  # the escape is invisible before decoding
+
+    parsed = parse_llm_json(raw)
+
+    assert parsed["facts"][0]["what"] == "Alex laughed "
+    assert parsed["facts"][0]["entities"] == ["Alex"]
+    assert parsed["facts"][0]["n"] == 3
+    assert json.dumps(parsed).encode("utf-8")
+
+
+def test_parse_llm_json_keeps_valid_surrogate_pairs():
+    """Only *lone* surrogates go. A pair is how JSON spells an astral codepoint."""
+    raw = '{"what": "caf\\u00e9 \\ud83c\\udf89", "n": 1, "ok": true}'
+
+    assert parse_llm_json(raw) == {"what": "caf\u00e9 \U0001f389", "n": 1, "ok": True}
+
+
+@pytest.mark.asyncio
+async def test_llm_provider_call_sanitizes_response():
+    """Every structured/text LLM response is scrubbed inside ``LLMProvider.call``."""
+    llm = LLMProvider(provider="mock", api_key="", base_url="", model="mock-model")
+    llm.set_mock_response({"facts": [{"what": f"Alex laughed 😂{HIGH_SURROGATE}"}]})
+
+    result = await llm.call(messages=[{"role": "user", "content": "hi"}], skip_validation=True)
+
+    assert result["facts"][0]["what"] == "Alex laughed 😂"
+    assert result["facts"][0]["what"].encode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_llm_provider_call_with_tools_sanitizes_content_and_arguments():
+    """The reflect/agent path is model-authored too, arguments included."""
+    llm = LLMProvider(provider="mock", api_key="", base_url="", model="mock-model")
+    llm.set_mock_response(
+        LLMToolCallResult(
+            content=f"thinking{HIGH_SURROGATE}",
+            tool_calls=[LLMToolCall(id="call_1", name="recall", arguments={"query": f"deploy{HIGH_SURROGATE}"})],
+        )
+    )
+
+    result = await llm.call_with_tools(messages=[{"role": "user", "content": "hi"}], tools=[])
+
+    assert result.content == "thinking"
+    assert result.tool_calls[0].arguments["query"] == "deploy"
+    assert result.tool_calls[0].arguments["query"].encode("utf-8")
+
+
+# --- Prong D: entity names are text too (#3729) ---------------------------------
+
+
+def test_fact_model_sanitizes_entity_names():
+    """Entity names join the embedded string and the BM25 ``text_signals`` column."""
+    fact = Fact(fact="Alex shipped it", fact_type="world", entities=[f"Al{HIGH_SURROGATE}ex", "Kubernetes"])
+    assert fact.entities == ["Alex", "Kubernetes"]
+
+
+def test_fact_model_drops_entity_names_that_sanitize_away():
+    """A name made only of hostile characters is dropped, not stored blank."""
+    fact = Fact(fact="Alex shipped it", fact_type="world", entities=[HIGH_SURROGATE, "Alex"])
+    assert fact.entities == ["Alex"]
+
+
+def test_fact_model_leaves_valid_entity_names_alone():
+    fact = Fact(fact="Alex shipped it", fact_type="world", entities=["key:value", "café 🎉"])
+    assert fact.entities == ["key:value", "café 🎉"]
+
+
+def test_embedding_text_for_sanitized_fact_is_utf8_encodable():
+    """The end the crash actually happened at: the string handed to the embedder.
+
+    ``augment_texts_with_dates`` splices entity names into the fact text, so a
+    surrogate in either field reaches the tokenizer as one un-encodable string.
+    """
+    from hindsight_api.engine.retain import embedding_processing
+    from hindsight_api.engine.retain.types import ExtractedFact
+
+    fact = Fact(
+        fact=f"Alex laughed 😂{HIGH_SURROGATE}",
+        fact_type="world",
+        entities=[f"Al{HIGH_SURROGATE}ex"],
+    )
+    shim = ExtractedFact(fact_text=fact.fact, fact_type=fact.fact_type, entities=list(fact.entities or []))
+    (augmented,) = embedding_processing.augment_texts_with_dates([shim], lambda d: "today")
+
+    assert augmented.encode("utf-8")  # raised UnicodeEncodeError before the fix
+    assert augmented == "Alex laughed 😂 [Alex]"
+
+
 # --- Integration: full pipeline survives both inputs -----------------------------
 
 
@@ -169,6 +324,28 @@ async def test_retain_with_lone_surrogate_content(memory, request_context):
     unit_ids = await memory.retain_async(
         bank_id=bank_id,
         content="A half emoji \ud83d slipped into the transcript.",
+        request_context=request_context,
+    )
+    assert isinstance(unit_ids, list)
+
+
+@pytest.mark.asyncio
+async def test_retain_with_lone_surrogate_entity_name(memory, request_context):
+    """A client-supplied entity name with an unpaired surrogate must not 500 (#3729).
+
+    Entity names are spliced into the string handed to the embedder and joined
+    into the ``text_signals`` column, so they crash in the same two places the
+    fact text does — but nothing sanitized them at ingress.
+    """
+    bank_id = f"test_surrogate_entity_{datetime.now(timezone.utc).timestamp()}"
+    unit_ids = await memory.retain_batch_async(
+        bank_id=bank_id,
+        contents=[
+            {
+                "content": "The deploy service ships releases.",
+                "entities": [{"text": f"depl{HIGH_SURROGATE}oy"}, {"text": HIGH_SURROGATE}],
+            }
+        ],
         request_context=request_context,
     )
     assert isinstance(unit_ids, list)


### PR DESCRIPTION
## Summary

Fixes #3729.

Retain can receive valid UTF-8 source text yet still fail during embedding when the LLM emits a lone UTF-16 surrogate in a structured fact field. This change sanitizes the final model-derived fact text before either the immediate or batch retain path can store or embed it.

## Root cause

#1891 sanitizes client-provided content and context at engine ingress. Structured providers parse the LLM response later, and JSON decoding can turn a model-generated `\udXXX` escape into a Python string containing a lone surrogate. Both extraction paths then construct `Fact.fact` from that parsed output without another UTF-8-safety boundary, so the invalid code point reaches SentenceTransformers and raises `TextEncodeInput`.

## Fix

Add a Pydantic field validator to the final extracted `Fact` model and reuse the existing `sanitize_llm_output` behavior. `Fact` is the shared convergence point for immediate and batch extraction, so the correction is applied once at the boundary that owns the derived text.

The sanitizer removes impossible surrogate halves while preserving valid Unicode, including complete emoji. It does not change prompts, model interpretation, provider parsing, or user content semantics.

## Impact

- Prevents retrying and ultimately failing retain operations when structured LLM output contains a lone surrogate.
- Covers immediate and batch extraction without duplicated path-specific cleanup.
- Leaves the existing ingress defense for client-provided text unchanged.

## Tests

Added a deterministic regression that supplies valid source text and a structured LLM response containing both a valid emoji and a lone low surrogate. It fails on `main` because the resulting fact is not UTF-8 encodable, and passes with this change while preserving the valid emoji.

Verified locally:

```text
./scripts/hooks/lint.sh
PYTHONIOENCODING=utf-8:backslashreplace uv run pytest -n 0 tests/test_input_robustness.py -k 'not retain_with and not recall_with' -q
uv run pytest -n 0 tests/test_fact_extraction_retry.py -q
./scripts/hooks/check-unused.sh  # advisory; only pre-existing findings outside this diff
```

Prepared with AI coding-agent assistance; the linked issue contains the production evidence and reproduction details reviewed by the account owner.
