### PR TITLE
fix(embed): default macOS daemons to CPU inference

### DIFF
--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -765,6 +765,13 @@ class DaemonEmbedManager(EmbedManager):
         if "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT" not in env:
             env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(DEFAULT_DAEMON_IDLE_TIMEOUT)
 
+        # Local PyTorch inference can still crash in MPS during unattended
+        # daemon workloads on macOS. Prefer the stable CPU path by default,
+        # while preserving an explicit opt-in to MPS from the caller/profile.
+        if platform.system() == "Darwin":
+            env.setdefault("HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU", "1")
+            env.setdefault("HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU", "1")
+
         # Tell the daemon child it was already launched in a detached session
         # (via our Popen below) so daemonize() skips the redundant re-exec.
         env["_HINDSIGHT_DAEMON_CHILD"] = "1"

--- a/hindsight-embed/tests/test_profile_daemon_config.py
+++ b/hindsight-embed/tests/test_profile_daemon_config.py
@@ -304,6 +304,78 @@ def test_profile_env_propagates_arbitrary_hindsight_keys_to_daemon(temp_home, mo
     assert env.get("HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU") == "1"
 
 
+def test_macos_daemon_forces_local_inference_to_cpu_by_default(temp_home, monkeypatch):
+    """macOS daemon children should avoid MPS unless the user opts in."""
+    from unittest.mock import MagicMock, patch
+
+    from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
+
+    monkeypatch.delenv("HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU", raising=False)
+    monkeypatch.delenv("HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU", raising=False)
+    manager = DaemonEmbedManager()
+    captured: dict[str, dict[str, str]] = {}
+    popen_called = [False]
+
+    def fake_popen(cmd, env, **kwargs):
+        captured["env"] = env
+        popen_called[0] = True
+        proc = MagicMock()
+        proc.pid = 12345
+        return proc
+
+    def fake_is_running(profile=""):
+        return popen_called[0]
+
+    with (
+        patch("hindsight_embed.daemon_embed_manager.subprocess.Popen", side_effect=fake_popen),
+        patch("hindsight_embed.daemon_embed_manager.time.sleep"),
+        patch.object(manager, "_clear_port", return_value=True),
+        patch.object(manager, "_find_api_command", return_value=["hindsight-api"]),
+        patch.object(manager, "is_running", side_effect=fake_is_running),
+        patch("hindsight_embed.daemon_embed_manager.platform.system", return_value="Darwin"),
+    ):
+        manager._start_daemon(config={}, profile="")
+
+    assert captured["env"]["HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU"] == "1"
+    assert captured["env"]["HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU"] == "1"
+
+
+def test_macos_daemon_preserves_explicit_mps_opt_in(temp_home, monkeypatch):
+    """Explicit force-CPU overrides must win over the macOS defaults."""
+    from unittest.mock import MagicMock, patch
+
+    from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
+
+    monkeypatch.setenv("HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU", "0")
+    monkeypatch.setenv("HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU", "false")
+    manager = DaemonEmbedManager()
+    captured: dict[str, dict[str, str]] = {}
+    popen_called = [False]
+
+    def fake_popen(cmd, env, **kwargs):
+        captured["env"] = env
+        popen_called[0] = True
+        proc = MagicMock()
+        proc.pid = 12345
+        return proc
+
+    def fake_is_running(profile=""):
+        return popen_called[0]
+
+    with (
+        patch("hindsight_embed.daemon_embed_manager.subprocess.Popen", side_effect=fake_popen),
+        patch("hindsight_embed.daemon_embed_manager.time.sleep"),
+        patch.object(manager, "_clear_port", return_value=True),
+        patch.object(manager, "_find_api_command", return_value=["hindsight-api"]),
+        patch.object(manager, "is_running", side_effect=fake_is_running),
+        patch("hindsight_embed.daemon_embed_manager.platform.system", return_value="Darwin"),
+    ):
+        manager._start_daemon(config={}, profile="")
+
+    assert captured["env"]["HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU"] == "0"
+    assert captured["env"]["HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU"] == "false"
+
+
 def test_daemon_child_env_var_set_in_daemon_env(temp_home, monkeypatch):
     """hindsight-embed must set _HINDSIGHT_DAEMON_CHILD=1 so the daemon child
     skips the redundant re-exec in daemonize()."""


### PR DESCRIPTION
## Problem

Embedded daemons on Apple Silicon can still crash or hang in PyTorch MPS during consolidation. The daemon currently lets local embeddings and reranking auto-select MPS unless users discover and set both `force_cpu` flags themselves.

## Fix

Default both local inference paths to CPU when `DaemonEmbedManager` starts a child on macOS. Explicit environment or profile values remain authoritative, so users can still opt into MPS.

This restores the safety polarity that previously shipped in #1010, without changing Linux or Windows behavior.

## Test

- `uv run pytest tests/test_profile_daemon_config.py -q -k "macos_daemon or profile_env_propagates"` (3 passed)
- `uv run ruff check hindsight_embed/daemon_embed_manager.py`
- `uv run ruff format --check hindsight_embed/daemon_embed_manager.py tests/test_profile_daemon_config.py`
- `git diff --check`

The full file currently has three unrelated entrypoint-test failures in this slim local environment because `_find_api_command` detects missing local ML dependencies and falls back to `uvx`; all daemon-environment tests pass.

## Risk

macOS embedded consolidation is slower by default. Callers who prefer MPS can preserve it with explicit `HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU=0` and `HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU=0`.

Fixes #3727.