### PR TITLE
fix(coding-agents): find Claude sessions for underscore paths

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/history.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/history.test.ts
@@ -47,18 +47,50 @@ describe("local history import", () => {
     expect(JSON.stringify(r.sessions)).not.toContain("unrelated");
   });
 
-  it("reads Claude sessions when the repository path contains underscores", () => {
+  // Claude Code encodes EVERY non-alphanumeric character as `-`, not just `/` and `.`. Encoding
+  // only the separators left whole repositories invisible to `--import-conversations`: the install
+  // reported "no past sessions found on disk" while the transcripts sat there under the real name.
+  // A space is the common case in the field (`~/Documents/My Projects/...`), not just underscores.
+  it.each([
+    ["underscores", "/Users/x/dev/my_project", "-Users-x-dev-my-project"],
+    ["spaces", "/Users/x/My Projects/app", "-Users-x-My-Projects-app"],
+    ["mixed punctuation", "/Users/x/dev/hs+odd@repo v2", "-Users-x-dev-hs-odd-repo-v2"],
+    ["dots", "/Users/x/dev/repo.git", "-Users-x-dev-repo-git"],
+  ])("reads Claude sessions when the repository path contains %s", (_label, repo, encoded) => {
     const h = newHome();
-    const repo = "/Users/x/dev/my_project";
-    // Claude Code replaces underscores as well as path separators in its project directory names.
-    const dir = join(h, ".claude", "projects", "-Users-x-dev-my-project");
+    const dir = join(h, ".claude", "projects", encoded);
     mkdirSync(dir, { recursive: true });
-    writeFileSync(join(dir, "s1.jsonl"), `${claudeLine("user", "underscore repo", repo)}\n`);
+    writeFileSync(join(dir, "s1.jsonl"), `${claudeLine("user", "found me", repo)}\n`);
 
     const r = importLocalHistory("claude-code", repo, h);
 
     expect(r.sessions).toHaveLength(1);
-    expect(JSON.stringify(r.sessions)).toContain("underscore repo");
+    expect(JSON.stringify(r.sessions)).toContain("found me");
+  });
+
+  // Case is preserved and runs are NOT collapsed, so the encoding stays a 1:1 substitution.
+  it("preserves case and does not collapse runs of separators", () => {
+    const h = newHome();
+    expect(claudeProjectDir("/tmp/a-1/-crewAI", h)).toBe(
+      join(h, ".claude", "projects", "-tmp-a-1--crewAI")
+    );
+  });
+
+  // The lossy encoding must never be trusted on its own: `my_repo` and `my-repo` collide, so the
+  // cwd recorded INSIDE the transcript is what actually attributes a session to a repository.
+  it("does not import a sibling repository that encodes to the same directory name", () => {
+    const h = newHome();
+    const dir = join(h, ".claude", "projects", "-Users-x-dev-my-repo");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "s1.jsonl"),
+      `${claudeLine("user", "the other one", "/Users/x/dev/my-repo")}\n`
+    );
+
+    const r = importLocalHistory("claude-code", "/Users/x/dev/my_repo", h);
+
+    expect(r.sessions).toHaveLength(0);
+    expect(JSON.stringify(r.sessions)).not.toContain("the other one");
   });
 
   it("matches Codex rollouts by the cwd in their session_meta header", () => {

--- a/hindsight-integrations/coding-agents/src/core/history.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/history.test.ts
@@ -47,6 +47,20 @@ describe("local history import", () => {
     expect(JSON.stringify(r.sessions)).not.toContain("unrelated");
   });
 
+  it("reads Claude sessions when the repository path contains underscores", () => {
+    const h = newHome();
+    const repo = "/Users/x/dev/my_project";
+    // Claude Code replaces underscores as well as path separators in its project directory names.
+    const dir = join(h, ".claude", "projects", "-Users-x-dev-my-project");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "s1.jsonl"), `${claudeLine("user", "underscore repo", repo)}\n`);
+
+    const r = importLocalHistory("claude-code", repo, h);
+
+    expect(r.sessions).toHaveLength(1);
+    expect(JSON.stringify(r.sessions)).toContain("underscore repo");
+  });
+
   it("matches Codex rollouts by the cwd in their session_meta header", () => {
     const h = newHome();
     const day = join(h, ".codex", "sessions", "2026", "08", "03");

--- a/hindsight-integrations/coding-agents/src/core/history.ts
+++ b/hindsight-integrations/coding-agents/src/core/history.ts
@@ -50,9 +50,13 @@ export interface HistoryImport {
   unattributed?: number;
 }
 
-/** Claude encodes a project directory as its absolute path with separators and underscores replaced by `-`. */
+/** Claude encodes a project directory as its absolute path with EVERY non-alphanumeric character
+ *  replaced by `-` — separators, dots, underscores, spaces, `+`, `@`, all of them. Case is kept,
+ *  and runs are not collapsed (`/a-1/-b` -> `-a-1--b`), so this is a 1:1 character substitution.
+ *  Verified against Claude Code 2.1.241: `hs_under_test` -> `hs-under-test`, and
+ *  `hs+odd@repo v2` -> `hs-odd-repo-v2`. */
 export function claudeProjectDir(repoDir: string, home = homedir()): string {
-  return join(home, ".claude", "projects", repoDir.replace(/[/._]/g, "-"));
+  return join(home, ".claude", "projects", repoDir.replace(/[^a-zA-Z0-9]/g, "-"));
 }
 
 /** Is `dir` the repo itself or somewhere inside it? */
@@ -144,7 +148,7 @@ function claudeHistory(repoDir: string, home: string): HistoryImport {
   let unattributed = 0;
   for (const file of dirs.flatMap(jsonlFiles)) {
     // ONLY the cwd recorded inside the session may attribute it to a repo. Falling back to the
-    // directory name would be a guess: `/` and `.` both encode to `-`, so `repo-sub` is either the
+    // directory name would be a guess: every non-alphanumeric encodes to `-`, so `repo-sub` is either the
     // subdirectory `repo/sub` or an unrelated sibling repo — and a wrong guess files someone
     // else's conversation into this repo's memory, which is worse than importing nothing.
     // (Measured: 400/400 sampled sessions record a cwd, so this skips ~nothing in practice.)

--- a/hindsight-integrations/coding-agents/src/core/history.ts
+++ b/hindsight-integrations/coding-agents/src/core/history.ts
@@ -50,9 +50,9 @@ export interface HistoryImport {
   unattributed?: number;
 }
 
-/** Claude encodes a project directory as its absolute path with separators replaced by `-`. */
+/** Claude encodes a project directory as its absolute path with separators and underscores replaced by `-`. */
 export function claudeProjectDir(repoDir: string, home = homedir()): string {
-  return join(home, ".claude", "projects", repoDir.replace(/[/.]/g, "-"));
+  return join(home, ".claude", "projects", repoDir.replace(/[/._]/g, "-"));
 }
 
 /** Is `dir` the repo itself or somewhere inside it? */


### PR DESCRIPTION
## Problem

`--import-conversations` locates Claude Code transcripts by encoding the repository's absolute path into a directory name under `~/.claude/projects`.

Claude Code replaces `/`, `.`, and `_` with `-`, but `claudeProjectDir()` only replaced `/` and `.`. For a repository such as `/work/my_repo`, Claude writes sessions under:

```text
~/.claude/projects/-work-my-repo
```

The importer searched for:

```text
~/.claude/projects/-work-my_repo
```

Neither the exact-directory check nor its subdirectory-prefix check could match. The install completed successfully but reported `no past sessions found on disk`, even when Claude transcripts existed.

## Fix

Include `_` in the project-directory encoding:

```diff
-repoDir.replace(/[/.]/g, "-")
+repoDir.replace(/[/._]/g, "-")
```

The existing attribution guard remains unchanged. Directory names are only used to narrow the candidates; each transcript must still record a `cwd` within the requested repository before it is imported. This prevents the lossy encoding from pulling in a sibling repository whose path maps to the same directory name.

A regression test creates a transcript in Claude Code's underscore-to-hyphen directory and verifies that `importLocalHistory()` finds it.

## Verification

The regression failed against the previous implementation with `expected [] to have a length of 1`, then passed with the fix.

- `npm test -- --run src/core/history.test.ts` — 9 passed
- `npm test` — 629 passed across 53 test files
- `npm run build` — passed
- Prettier check for the two changed files — passed