### PR TITLE
fix(pg0): warn when the default database is auto-provisioned

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -17,6 +17,7 @@ import functools
 import inspect
 import json
 import logging
+import os
 import random
 import sys
 import time
@@ -39,12 +40,14 @@ from .._vector_index import (
 )
 from ..cancellation import OperationCancelledError
 from ..config import (
+    DEFAULT_DATABASE_URL,
     DEFAULT_MENTAL_MODEL_MIN_REFRESH_INTERVAL_SECONDS,
     DEFAULT_RECALL_CHUNKS_MAX_TOKENS,
     DEFAULT_RECALL_INCLUDE_CHUNKS,
     DEFAULT_RECALL_MAX_TOKENS,
     DEFAULT_REFLECT_SOURCE_FACTS_MAX_TOKENS,
     DEFAULT_STORE_DOCUMENT_TEXT,
+    ENV_DATABASE_URL,
     ENV_MODEL_INIT_TIMEOUT,
     HindsightConfig,
     LLMMemberConfig,
@@ -1805,6 +1808,14 @@ class MemoryEngine(MemoryEngineInterface):
         # Apply optimization flags from config if not explicitly provided
         self._skip_llm_verification = (
             skip_llm_verification if skip_llm_verification is not None else config.skip_llm_verification
+        )
+
+        # Keep the source of the database URL separate from its parsed value. An omitted URL
+        # intentionally selects the local pg0 default, but pg0 auto-selects a port and can
+        # therefore create a second database (possibly empty) beside an existing PostgreSQL instance
+        # (#3728). Explicit ``pg0`` configuration remains silent and opt-in.
+        self._database_url_was_unset = (
+            db_url is None and config.database_url == DEFAULT_DATABASE_URL and ENV_DATABASE_URL not in os.environ
         )
 
         # Apply defaults from config
@@ -4012,6 +4023,14 @@ class MemoryEngine(MemoryEngineInterface):
                 # Check if pg0 is already running before we start it
                 was_already_running = await pg0.is_running()
                 self.db_url = await pg0.ensure_running()
+                if self._database_url_was_unset and not was_already_running:
+                    logger.warning(
+                        "HINDSIGHT_API_DATABASE_URL is unset; started a NEW embedded pg0 instance at %s. "
+                        "It may be a separate, empty database from an existing PostgreSQL server. If you "
+                        "expected an existing memory bank, set HINDSIGHT_API_DATABASE_URL to its PostgreSQL "
+                        "connection URL.",
+                        mask_network_location(self.db_url),
+                    )
                 # Only track pg0 (to stop later) if WE started it
                 if not was_already_running:
                     self._pg0 = pg0

--- a/hindsight-api-slim/tests/test_pg0_url.py
+++ b/hindsight-api-slim/tests/test_pg0_url.py
@@ -1,5 +1,6 @@
 """Unit tests for pg0 URL parsing and MemoryEngine startup."""
 
+import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -140,3 +141,81 @@ async def test_memory_engine_forwards_pg0_credentials(
             username=expected_username,
             password=expected_password,
         )
+
+
+@pytest.mark.asyncio
+async def test_memory_engine_warns_when_unset_database_url_creates_pg0(monkeypatch, caplog) -> None:
+    """A new default pg0 instance must identify itself instead of looking like an existing DB."""
+    from hindsight_api.config import clear_config_cache
+
+    monkeypatch.delenv("HINDSIGHT_API_DATABASE_URL", raising=False)
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "none")
+    clear_config_cache()
+
+    try:
+        with patch("hindsight_api.engine.memory_engine.EmbeddedPostgres") as embedded_postgres:
+            pg0 = embedded_postgres.return_value
+            pg0.is_running = AsyncMock(return_value=False)
+            pg0.ensure_running = AsyncMock(return_value="postgresql://hindsight:hindsight@127.0.0.1:5433/hindsight")
+
+            engine = MemoryEngine(
+                memory_llm_provider="none",
+                memory_llm_model="none",
+                embeddings=_NoopEmbeddings(),
+                cross_encoder=_NoopCrossEncoder(),
+                query_analyzer=_NoopQueryAnalyzer(),
+                run_migrations=False,
+                task_backend=SyncTaskBackend(),
+                skip_llm_verification=True,
+            )
+            assert engine._backend is not None
+            engine._backend.initialize = AsyncMock(side_effect=_StopInitialization)  # type: ignore[method-assign]
+
+            with caplog.at_level(logging.WARNING, logger="hindsight_api.engine.memory_engine"):
+                with pytest.raises(_StopInitialization):
+                    await engine.initialize()
+
+        messages = [record.getMessage() for record in caplog.records]
+        warning = next(message for message in messages if "started a NEW embedded pg0" in message)
+        assert "127.0.0.1:5433/hindsight" in warning
+        assert "hindsight:hindsight" not in warning
+        assert "HINDSIGHT_API_DATABASE_URL" in warning
+    finally:
+        clear_config_cache()
+
+
+@pytest.mark.asyncio
+async def test_memory_engine_does_not_warn_when_default_pg0_is_reused(monkeypatch, caplog) -> None:
+    """Reusing an intentional local instance is not the silent-new-database case."""
+    from hindsight_api.config import clear_config_cache
+
+    monkeypatch.delenv("HINDSIGHT_API_DATABASE_URL", raising=False)
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "none")
+    clear_config_cache()
+
+    try:
+        with patch("hindsight_api.engine.memory_engine.EmbeddedPostgres") as embedded_postgres:
+            pg0 = embedded_postgres.return_value
+            pg0.is_running = AsyncMock(return_value=True)
+            pg0.ensure_running = AsyncMock(return_value="postgresql://hindsight:hindsight@127.0.0.1:5433/hindsight")
+
+            engine = MemoryEngine(
+                memory_llm_provider="none",
+                memory_llm_model="none",
+                embeddings=_NoopEmbeddings(),
+                cross_encoder=_NoopCrossEncoder(),
+                query_analyzer=_NoopQueryAnalyzer(),
+                run_migrations=False,
+                task_backend=SyncTaskBackend(),
+                skip_llm_verification=True,
+            )
+            assert engine._backend is not None
+            engine._backend.initialize = AsyncMock(side_effect=_StopInitialization)  # type: ignore[method-assign]
+
+            with caplog.at_level(logging.WARNING, logger="hindsight_api.engine.memory_engine"):
+                with pytest.raises(_StopInitialization):
+                    await engine.initialize()
+
+        assert not any("started a NEW embedded pg0" in record.getMessage() for record in caplog.records)
+    finally:
+        clear_config_cache()


### PR DESCRIPTION
## Summary

Fixes #3728. When `HINDSIGHT_API_DATABASE_URL` is omitted, the default `pg0` backend can auto-select a different port if another PostgreSQL instance is already listening. The daemon then starts against a separate database while `/health` still reports only `connected`.

## Verification

I reproduced the report on the fork `main` baseline by occupying `127.0.0.1:5432`: pg0 started a separate instance at `127.0.0.1:5433` and returned an empty-instance URI.

## Changes

- Detect the specific case where the URL was omitted and the default `pg0` instance is newly started.
- Emit a warning with the resolved, credential-masked PostgreSQL URL and explicit configuration guidance.
- Keep intentional `pg0` configuration and reuse of an already-running instance unchanged.
- Add regression coverage for new-instance warnings, credential masking, and reuse without false warnings.

## Validation

- `./scripts/hooks/lint.sh`
- `uv run ty check hindsight_api/engine/memory_engine.py`
- `uv run pytest tests/test_pg0_url.py tests/test_health_probes.py tests/test_server_module.py -q` (32 passed)
