### PR TITLE
fix(coding-agents): hide Windows child processes

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/bank.ts
+++ b/hindsight-integrations/coding-agents/src/core/bank.ts
@@ -51,7 +51,13 @@ export function getProjectRootFromGit(directory: string): string | null {
     const commonDir = execFileSync(
       "git",
       ["rev-parse", "--path-format=absolute", "--git-common-dir"],
-      { cwd: directory, encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"], timeout: 1000 }
+      {
+        cwd: directory,
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 1000,
+        windowsHide: true,
+      }
     ).trim();
     if (!commonDir) return null;
     // clones + `git worktree add`: common-dir is `<main root>/.git`; bare repos: the dir itself.

--- a/hindsight-integrations/coding-agents/src/core/daemon.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/daemon.test.ts
@@ -180,12 +180,13 @@ describe("startDaemonDetached", () => {
     const [cmd, args, opts] = spawn.mock.calls[0] as unknown as [
       string,
       string[],
-      { detached: boolean; stdio: string },
+      { detached: boolean; stdio: string; windowsHide: boolean },
     ];
     expect(cmd).toBe("node");
     expect(args[0]).toMatch(/daemon-start\.js$/);
     expect(opts.detached).toBe(true);
     expect(opts.stdio).toBe("ignore");
+    expect(opts.windowsHide).toBe(true);
     // An async spawn 'error' event would otherwise crash the hook process.
     expect(child.on).toHaveBeenCalledWith("error", expect.any(Function));
     expect(child.unref).toHaveBeenCalled();

--- a/hindsight-integrations/coding-agents/src/core/daemon.ts
+++ b/hindsight-integrations/coding-agents/src/core/daemon.ts
@@ -195,6 +195,7 @@ export function startDaemonDetached(
     const child = spawnFn("node", [starter, "--harness", harness], {
       detached: true,
       stdio: "ignore",
+      windowsHide: true,
     });
     // spawn() failures often surface ASYNCHRONOUSLY as an 'error' event; unhandled, that would
     // crash the hook.

--- a/hindsight-integrations/coding-agents/src/core/git.ts
+++ b/hindsight-integrations/coding-agents/src/core/git.ts
@@ -16,7 +16,11 @@ const US = "\x1f";
 const RS = "\x1e"; // record separator between commits in gitLogText
 
 function git(repo: string, ...args: string[]): string {
-  return execFileSync("git", ["-C", repo, ...args], { encoding: "utf8", maxBuffer: 1 << 28 });
+  return execFileSync("git", ["-C", repo, ...args], {
+    encoding: "utf8",
+    maxBuffer: 1 << 28,
+    windowsHide: true,
+  });
 }
 
 /** The bank-facing name for a repo — WORKTREE-AWARE (all worktrees produce the main checkout's

--- a/hindsight-integrations/coding-agents/src/core/seed.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/seed.test.ts
@@ -13,7 +13,7 @@ describe("startBackgroundSeed", () => {
     expect(spawn).toHaveBeenCalledWith(
       "node",
       ["/dist/deepen.js", "--repo", "/some/repo", "--gitlog-limit", String(DEFAULT_SEED_LIMIT)],
-      { detached: true, stdio: expect.anything() }
+      { detached: true, stdio: expect.anything(), windowsHide: true }
     );
     expect(spawn.mock.results[0].value.unref).toHaveBeenCalled();
   });
@@ -38,7 +38,7 @@ describe("startBackgroundSeed", () => {
     expect(spawn).toHaveBeenCalledWith(
       "node",
       ["/dist/deepen.js", "--repo", "/some/repo", "--gitlog-limit", "50"],
-      { detached: true, stdio: expect.anything() }
+      { detached: true, stdio: expect.anything(), windowsHide: true }
     );
   });
 
@@ -60,7 +60,7 @@ describe("startBackgroundSeed", () => {
         "--harness",
         "antigravity-cli",
       ],
-      { detached: true, stdio: expect.anything() }
+      { detached: true, stdio: expect.anything(), windowsHide: true }
     );
   });
 

--- a/hindsight-integrations/coding-agents/src/core/seed.ts
+++ b/hindsight-integrations/coding-agents/src/core/seed.ts
@@ -42,6 +42,7 @@ export function startBackgroundSeed(
       {
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
       }
     );
     // spawn() failures (ENOENT/EACCES/fd exhaustion/sandboxed environments) often arrive

--- a/hindsight-integrations/coding-agents/src/core/session-start.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.ts
@@ -98,7 +98,10 @@ async function gitSyncNote(args: {
   try {
     const { execFileSync } = await import("node:child_process");
     const n = Number(
-      execFileSync("git", ["-C", cwd, "rev-list", "--count", "HEAD"], { encoding: "utf8" }).trim()
+      execFileSync("git", ["-C", cwd, "rev-list", "--count", "HEAD"], {
+        encoding: "utf8",
+        windowsHide: true,
+      }).trim()
     );
     if (n > 0) target = Math.min(DEEPEN_DIFF_TARGET, n);
   } catch {

--- a/hindsight-integrations/coding-agents/src/core/status.ts
+++ b/hindsight-integrations/coding-agents/src/core/status.ts
@@ -48,6 +48,7 @@ function commitCount(repoDir: string): number | null {
   try {
     const out = execFileSync("git", ["-C", repoDir, "rev-list", "--count", "HEAD"], {
       encoding: "utf8",
+      windowsHide: true,
     });
     return Number(out.trim()) || 0;
   } catch {

--- a/hindsight-integrations/coding-agents/src/core/survey.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/survey.test.ts
@@ -83,6 +83,7 @@ describe("startCodebaseSurvey", () => {
     expect(options.cwd).toBe("/repo");
     expect(options.detached).toBe(true);
     expect(options.stdio).toBe("ignore");
+    expect(options.windowsHide).toBe(true);
     expect(options.env.HINDSIGHT_DISABLE_HOOKS).toBe("1");
 
     const child = spawn.mock.results[0].value;

--- a/hindsight-integrations/coding-agents/src/core/survey.ts
+++ b/hindsight-integrations/coding-agents/src/core/survey.ts
@@ -338,6 +338,7 @@ export function startCodebaseSurvey(
         cwd: repoDir,
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
         env: plan.env,
       });
       // spawn() failures (binary not found, EACCES, sandboxed environments) often arrive

--- a/hindsight-integrations/coding-agents/src/core/sync.ts
+++ b/hindsight-integrations/coding-agents/src/core/sync.ts
@@ -19,6 +19,7 @@ function gitTry(repo: string, ...args: string[]): string | null {
     return execFileSync("git", ["-C", repo, ...args], {
       encoding: "utf8",
       maxBuffer: 1 << 28,
+      windowsHide: true,
     }).trim();
   } catch {
     return null;

--- a/hindsight-integrations/coding-agents/src/deepen.ts
+++ b/hindsight-integrations/coding-agents/src/deepen.ts
@@ -228,7 +228,7 @@ async function main() {
           const shas = execFileSync(
             "git",
             ["-C", REPO!, "rev-list", `-n`, String(DEEPEN_DIFF_TARGET), "HEAD"],
-            { encoding: "utf8" }
+            { encoding: "utf8", windowsHide: true }
           )
             .trim()
             .split("\n")


### PR DESCRIPTION
## Problem

The coding-agents integration starts detached workers and invokes Git during session startup without `windowsHide`. In a hidden Windows host, these console-subsystem children can create blank or flashing console windows.

Fixes #3718.

## Fix

- set `windowsHide: true` on the detached seed, survey, and daemon spawns
- set it on runtime Git invocations used by bank resolution, ingestion, sync, and status reporting
- assert the option in the seed, survey, and daemon spawn tests

## Test

- focused Vitest suite: 91 passed
- full coding-agents suite: 628 passed
- `npm run build`
- `npx tsc --noEmit`
- package Prettier check
- `git diff --check`

The repository-wide lint completed every applicable formatter/type gate but its control-plane ESLint task could not start because that unrelated workspace dependency was not installed in the isolated worktree.

## Risk

Low. Node ignores `windowsHide` on non-Windows platforms; on Windows it only suppresses child console windows and does not change arguments, environment, stdio, or lifecycle.