### PR TITLE
docs(coding-agents): add Devin CLI to harness list in README intro (#3721)

### DIFF
--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -9,7 +9,7 @@ description: "One Hindsight memory plugin for coding agents — per-repo memory 
 
 Long-term project memory for **coding agents**, backed by [Hindsight](https://vectorize.io/hindsight).
 One package, several agents: a shared reflect-and-inject core with a thin entry point per agent
-(**opencode**, **Kilo CLI**, **Cline CLI**, **Prime Agent**, **DeepSeek Harness**, **Claude Code**, **Codex CLI**, **Antigravity CLI**, **Cursor CLI**, **GitHub Copilot CLI**, **Grok Build**). Ingestion is fully
+(**opencode**, **Kilo CLI**, **Cline CLI**, **Prime Agent**, **DeepSeek Harness**, **Claude Code**, **Codex CLI**, **Antigravity CLI**, **Cursor CLI**, **GitHub Copilot CLI**, **Devin CLI**, **Grok Build**). Ingestion is fully
 automatic — there is no setup command: a repo's git history and conversations flow into its memory
 bank in the background as you work.
 

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -2,7 +2,7 @@
 
 Long-term project memory for **coding agents**, backed by [Hindsight](https://vectorize.io/hindsight).
 One package, several agents: a shared reflect-and-inject core with a thin entry point per agent
-(**opencode**, **Kilo CLI**, **Cline CLI**, **Prime Agent**, **DeepSeek Harness**, **Claude Code**, **Codex CLI**, **Antigravity CLI**, **Cursor CLI**, **GitHub Copilot CLI**, **Grok Build**). Ingestion is fully
+(**opencode**, **Kilo CLI**, **Cline CLI**, **Prime Agent**, **DeepSeek Harness**, **Claude Code**, **Codex CLI**, **Antigravity CLI**, **Cursor CLI**, **GitHub Copilot CLI**, **Devin CLI**, **Grok Build**). Ingestion is fully
 automatic — there is no setup command: a repo's git history and conversations flow into its memory
 bank in the background as you work.
 

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -4,7 +4,7 @@
 
 Long-term project memory for **coding agents**, backed by [Hindsight](https://vectorize.io/hindsight).
 One package, several agents: a shared reflect-and-inject core with a thin entry point per agent
-(**opencode**, **Kilo CLI**, **Cline CLI**, **Prime Agent**, **DeepSeek Harness**, **Claude Code**, **Codex CLI**, **Antigravity CLI**, **Cursor CLI**, **GitHub Copilot CLI**, **Grok Build**). Ingestion is fully
+(**opencode**, **Kilo CLI**, **Cline CLI**, **Prime Agent**, **DeepSeek Harness**, **Claude Code**, **Codex CLI**, **Antigravity CLI**, **Cursor CLI**, **GitHub Copilot CLI**, **Devin CLI**, **Grok Build**). Ingestion is fully
 automatic — there is no setup command: a repo's git history and conversations flow into its memory
 bank in the background as you work.
 


### PR DESCRIPTION
## Summary

Fixes #3721

In `hindsight-integrations/coding-agents/README.md`, the introduction paragraph summarizes supported coding agents in bold text. Previously, it listed only 11 harnesses while the integration implements support for 12 harnesses (omitting **Devin CLI**).

This PR adds **Devin CLI** to the introduction summary list and synchronizes all downstream generated documentation.

---

## Issue & Consistency Matrix

| Harness | Integration Type | Per-Agent Section in README | Intro Paragraph (Before) | Intro Paragraph (After) |
| :--- | :--- | :---: | :---: | :---: |
| **opencode** | Persistent Plugin | ✅ | ✅ | ✅ |
| **Kilo CLI** | Persistent Plugin | ✅ | ✅ | ✅ |
| **Cline CLI** | Persistent Plugin | ✅ | ✅ | ✅ |
| **Prime Agent** | Persistent Plugin | ✅ | ✅ | ✅ |
| **DeepSeek Harness** | Persistent Plugin | ✅ | ✅ | ✅ |
| **Claude Code** | Hook-based | ✅ | ✅ | ✅ |
| **Codex CLI** | Hook-based | ✅ | ✅ | ✅ |
| **Antigravity CLI** | Hook-based | ✅ | ✅ | ✅ |
| **Cursor CLI** | Hook-based | ✅ | ✅ | ✅ |
| **GitHub Copilot CLI** | Hook-based | ✅ | ✅ | ✅ |
| **Devin CLI** | Hook-based | ✅ | ❌ *(Missing)* | ✅ *(Added)* |
| **Grok Build** | Hook-based | ✅ | ✅ | ✅ |

---

## Documentation Synchronization Flow

```mermaid
graph TD
    A["hindsight-integrations/coding-agents/README.md<br/>(Source of Truth)"] -->|"sync-coding-agents-doc.mjs"| B["hindsight-docs/docs-integrations/coding-agents.md<br/>(Docusaurus Site)"]
    B -->|"generate-docs-skill.sh"| C["skills/hindsight-docs/references/sdks/integrations/coding-agents.md<br/>(AI Skill References)"]
```

---

## Changes Made

| File | Type | Description |
| :--- | :--- | :--- |
| `hindsight-integrations/coding-agents/README.md` | Source | Added `**Devin CLI**` to the harness list in the intro paragraph |
| `hindsight-docs/docs-integrations/coding-agents.md` | Generated | Synchronized via `node hindsight-docs/scripts/sync-coding-agents-doc.mjs` |
| `skills/hindsight-docs/references/sdks/integrations/coding-agents.md` | Generated | Synchronized via `./scripts/generate-docs-skill.sh` |

---

## Verification

| Check / Hook | Command | Result |
| :--- | :--- | :---: |
| Doc Sync Verification | `node hindsight-docs/scripts/sync-coding-agents-doc.mjs --check` | Passed (`[coding-agents] ✅ docs page matches the README`) |
| Docs Skill Sync Hook | `./scripts/hooks/generate-docs-skill.sh` | Passed |
| Unused Code Check Hook | `./scripts/hooks/check-unused.sh` | Passed |
| Linter Hook | `./scripts/hooks/lint.sh` | Passed (`All lints passed ✓`) |