### PR TITLE
fix(integrations): resolve bare-hub project names

### DIFF
--- a/hindsight-integrations/claude-code/scripts/lib/bank.py
+++ b/hindsight-integrations/claude-code/scripts/lib/bank.py
@@ -29,6 +29,24 @@ DEFAULT_BANK_NAME = "claude-code"
 VALID_FIELDS = {"agent", "project", "session", "channel", "user"}
 
 
+def _is_bare_repository(common_dir: str) -> bool:
+    """Check the shared Git directory itself, independent of the current worktree."""
+    env = os.environ.copy()
+    env.pop("GIT_DIR", None)
+    env.pop("GIT_WORK_TREE", None)
+    try:
+        result = subprocess.run(
+            ["git", "-C", common_dir, "rev-parse", "--is-bare-repository"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env=env,
+        )
+        return result.returncode == 0 and result.stdout.strip() == "true"
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
 def _resolve_project_name(cwd: str, config: dict) -> str:
     """Resolve the project name from the working directory.
 
@@ -57,10 +75,14 @@ def _resolve_project_name(cwd: str, config: dict) -> str:
         )
         if result.returncode == 0:
             git_common_dir = result.stdout.strip()
-            # git-common-dir returns the .git directory of the main repo
-            # e.g. /home/user/myproject/.git → parent is /home/user/myproject
-            main_repo_path = os.path.dirname(git_common_dir)
-            return os.path.basename(main_repo_path)
+            common_name = os.path.basename(git_common_dir)
+            if common_name == ".git":
+                return os.path.basename(os.path.dirname(git_common_dir))
+            # Bare-hub plumbing is conventionally hidden (`.bare`, `.git-bare`). Keep standalone
+            # bare clone names stable instead of mapping every `/repos/*.git` to `repos`.
+            if common_name.startswith(".") and _is_bare_repository(git_common_dir):
+                return os.path.basename(os.path.dirname(git_common_dir))
+            return common_name
     except (OSError, subprocess.TimeoutExpired):
         pass
 

--- a/hindsight-integrations/claude-code/tests/test_bank.py
+++ b/hindsight-integrations/claude-code/tests/test_bank.py
@@ -5,7 +5,6 @@ import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from lib.bank import _resolve_project_name, derive_bank_id, ensure_bank_mission
 
 
@@ -138,6 +137,19 @@ class TestResolveProjectName:
         # Worktree at /tmp/worktrees/feature-x, main repo at /home/user/hindsight
         mock_run.return_value = self._mock_git("/home/user/hindsight/.git\n")
         assert _resolve_project_name("/tmp/worktrees/feature-x", _cfg()) == "hindsight"
+
+    @patch("lib.bank.subprocess.run")
+    def test_bare_hub_resolves_to_hidden_directory_parent(self, mock_run):
+        mock_run.side_effect = [
+            self._mock_git("/home/user/myrepo/.bare\n"),
+            self._mock_git("true\n"),
+        ]
+        assert _resolve_project_name("/home/user/myrepo/main", _cfg()) == "myrepo"
+
+    @patch("lib.bank.subprocess.run")
+    def test_standalone_bare_keeps_common_directory_name(self, mock_run):
+        mock_run.return_value = self._mock_git("/srv/repos/myproject.git\n")
+        assert _resolve_project_name("/srv/repos/myproject.git", _cfg()) == "myproject.git"
 
     @patch("lib.bank.subprocess.run")
     def test_disabled_falls_back_to_basename(self, mock_run):

--- a/hindsight-integrations/coding-agents/src/core/bank-bare-hub.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/bank-bare-hub.test.ts
@@ -1,0 +1,71 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { getProjectRootFromGit, projectNameOf } from "./bank";
+
+const fixtures: string[] = [];
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" }).trim();
+}
+
+function createBareHub(root: string, bareName: string): { hub: string; worktree: string } {
+  const hub = join(root, bareName === ".bare" ? "hub" : "git-bare-hub");
+  const bare = join(hub, bareName);
+  const seed = join(root, `${bareName}-seed`);
+  mkdirSync(hub, { recursive: true });
+  git(root, ["init", "--bare", "-q", bare]);
+  git(root, ["init", "-q", "-b", "main", seed]);
+  git(seed, ["config", "user.email", "test@example.invalid"]);
+  git(seed, ["config", "user.name", "Test"]);
+  git(seed, ["commit", "--allow-empty", "-qm", "seed"]);
+  git(seed, ["push", "-q", bare, "HEAD:refs/heads/main"]);
+  writeFileSync(join(hub, ".git"), `gitdir: ./${bareName}\n`);
+  const worktree = join(hub, "main");
+  git(bare, ["worktree", "add", "-q", worktree, "main"]);
+  return { hub, worktree };
+}
+
+describe("bare-hub project resolution", () => {
+  afterEach(() => {
+    for (const fixture of fixtures.splice(0)) rmSync(fixture, { recursive: true, force: true });
+  });
+
+  it.each([".bare", ".git-bare"])("uses the hub root for a %s layout", (bareName) => {
+    const root = mkdtempSync(join(tmpdir(), "hs-bare-hub-"));
+    fixtures.push(root);
+    const { hub, worktree } = createBareHub(root, bareName);
+    const canonicalHub = realpathSync(hub);
+
+    expect(getProjectRootFromGit(hub)).toBe(canonicalHub);
+    expect(getProjectRootFromGit(worktree)).toBe(canonicalHub);
+    expect(projectNameOf(join(worktree, "nested"))).toBe(basename(canonicalHub));
+  });
+
+  it("preserves the directory name for a standalone bare repository", () => {
+    const root = mkdtempSync(join(tmpdir(), "hs-standalone-bare-"));
+    fixtures.push(root);
+    const bare = join(root, "myproject.git");
+    git(root, ["init", "--bare", "-q", bare]);
+
+    expect(getProjectRootFromGit(bare)).toBe(realpathSync(bare));
+    expect(projectNameOf(bare)).toBe("myproject.git");
+  });
+
+  it("keeps ordinary repositories unchanged", () => {
+    const root = mkdtempSync(join(tmpdir(), "hs-ordinary-repo-"));
+    fixtures.push(root);
+    const repo = join(root, "myproject");
+    git(root, ["init", "-q", "-b", "main", repo]);
+    git(repo, ["config", "user.email", "test@example.invalid"]);
+    git(repo, ["config", "user.name", "Test"]);
+    git(repo, ["commit", "--allow-empty", "-qm", "seed"]);
+    const worktree = join(root, "feature");
+    git(repo, ["worktree", "add", "-q", "-b", "feature", worktree]);
+
+    expect(getProjectRootFromGit(repo)).toBe(realpathSync(repo));
+    expect(getProjectRootFromGit(worktree)).toBe(realpathSync(repo));
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/bank.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/bank.test.ts
@@ -34,6 +34,25 @@ describe("deriveBankId", () => {
     expect(deriveBankId({}, "/srv/git/myrepo.git")).toBe("coding-agent::myrepo.git");
   });
 
+  it("uses the hub name for a hidden bare repository shared by worktrees", () => {
+    mockExec.mockImplementation((_command, args) => {
+      if (args?.includes("--git-common-dir")) return "/home/me/myrepo/.bare\n";
+      if (args?.includes("--is-bare-repository")) return "true\n";
+      throw new Error("unexpected git command");
+    });
+    expect(deriveBankId({}, "/home/me/myrepo/main")).toBe("coding-agent::myrepo");
+    expect(mockExec).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a hidden non-bare common directory unchanged", () => {
+    mockExec.mockImplementation((_command, args) => {
+      if (args?.includes("--git-common-dir")) return "/home/me/project/.git-bare\n";
+      if (args?.includes("--is-bare-repository")) return "false\n";
+      throw new Error("unexpected git command");
+    });
+    expect(deriveBankId({}, "/home/me/project")).toBe("coding-agent::.git-bare");
+  });
+
   it("resolveWorktrees=false skips git and uses the directory basename", () => {
     mockExec.mockReturnValue("/home/me/dev/myrepo/.git\n");
     expect(deriveBankId({ resolveWorktrees: false }, "/home/me/dev/myrepo-wt")).toBe(

--- a/hindsight-integrations/coding-agents/src/core/bank.ts
+++ b/hindsight-integrations/coding-agents/src/core/bank.ts
@@ -54,10 +54,35 @@ export function getProjectRootFromGit(directory: string): string | null {
       { cwd: directory, encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"], timeout: 1000 }
     ).trim();
     if (!commonDir) return null;
-    // clones + `git worktree add`: common-dir is `<main root>/.git`; bare repos: the dir itself.
-    return basename(commonDir) === ".git" ? dirname(commonDir) : commonDir;
+    // Clones + `git worktree add`: common-dir is `<main root>/.git`.
+    if (basename(commonDir) === ".git") return dirname(commonDir);
+
+    // A bare-hub keeps its bare repository in a hidden plumbing directory (usually `.bare`),
+    // while a standalone bare clone uses its directory name as the project identity. Check the
+    // common dir itself because a linked worktree reports `false` for --is-bare-repository.
+    if (basename(commonDir).startsWith(".") && isBareRepository(commonDir)) {
+      return dirname(commonDir);
+    }
+
+    // Preserve the historical name for standalone bare repositories such as `myrepo.git`.
+    return commonDir;
   } catch {
     return null;
+  }
+}
+
+function isBareRepository(commonDir: string): boolean {
+  try {
+    return (
+      execFileSync("git", ["-C", commonDir, "rev-parse", "--is-bare-repository"], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 1000,
+        env: { ...process.env, GIT_DIR: undefined, GIT_WORK_TREE: undefined },
+      }).trim() === "true"
+    );
+  } catch {
+    return false;
   }
 }
 

--- a/hindsight-integrations/coding-agents/src/core/opt-in.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/opt-in.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, realpathSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -110,6 +110,33 @@ describe("optInOnly", () => {
     expect(isOptedIn(byPath, worktree)).toBe(true);
     expect(isOptedIn(byMap, worktree)).toBe(true);
     expect(deriveBankId(byMap, worktree, "claude-code")).toBe("client-x");
+  });
+
+  it("carries hub approval and mapping to bare-hub worktrees", () => {
+    const hub = join(root, "bare-hub");
+    const bare = join(hub, ".bare");
+    const seed = join(root, "bare-seed");
+    mkdirSync(hub, { recursive: true });
+    execFileSync("git", ["init", "--bare", "-q", bare]);
+    execFileSync("git", ["init", "-q", "-b", "main", seed]);
+    execFileSync("git", ["-C", seed, "config", "user.email", "test@example.invalid"]);
+    execFileSync("git", ["-C", seed, "config", "user.name", "Test"]);
+    execFileSync("git", ["-C", seed, "commit", "--allow-empty", "-qm", "seed"]);
+    execFileSync("git", ["-C", seed, "push", "-q", bare, "HEAD:refs/heads/main"]);
+    writeFileSync(join(hub, ".git"), "gitdir: ./.bare\n");
+    const worktree = join(root, "bare-worktree");
+    execFileSync("git", ["--git-dir", bare, "worktree", "add", "-q", worktree, "main"]);
+
+    const canonicalHub = realpathSync(hub);
+    const byPath = resolveConfig({ optInOnly: true, optInPaths: [canonicalHub] });
+    expect(isOptedIn(byPath, worktree)).toBe(true);
+
+    const byMap = resolveConfig({
+      optInOnly: true,
+      mapPathToBank: { [canonicalHub]: "bare-project" },
+    });
+    expect(isOptedIn(byMap, worktree)).toBe(true);
+    expect(deriveBankId(byMap, worktree, "codex")).toBe("bare-project");
   });
 
   // The session root reaches the removed worktree for EVERY harness; CLAUDE_PROJECT_DIR only

--- a/hindsight-integrations/omo/scripts/lib/bank.py
+++ b/hindsight-integrations/omo/scripts/lib/bank.py
@@ -10,6 +10,24 @@ DEFAULT_BANK_NAME = "omo"
 VALID_FIELDS = {"agent", "project", "session", "channel", "user"}
 
 
+def _is_bare_repository(common_dir: str) -> bool:
+    """Check the shared Git directory itself, independent of the current worktree."""
+    env = os.environ.copy()
+    env.pop("GIT_DIR", None)
+    env.pop("GIT_WORK_TREE", None)
+    try:
+        result = subprocess.run(
+            ["git", "-C", common_dir, "rev-parse", "--is-bare-repository"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env=env,
+        )
+        return result.returncode == 0 and result.stdout.strip() == "true"
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
 def _resolve_project_name(cwd: str, config: dict) -> str:
     """Resolve the project name from the working directory.
 
@@ -31,8 +49,14 @@ def _resolve_project_name(cwd: str, config: dict) -> str:
         )
         if result.returncode == 0:
             git_common_dir = result.stdout.strip()
-            main_repo_path = os.path.dirname(git_common_dir)
-            return os.path.basename(main_repo_path)
+            common_name = os.path.basename(git_common_dir)
+            if common_name == ".git":
+                return os.path.basename(os.path.dirname(git_common_dir))
+            # Bare-hub plumbing is conventionally hidden (`.bare`, `.git-bare`). Keep standalone
+            # bare clone names stable instead of mapping every `/repos/*.git` to `repos`.
+            if common_name.startswith(".") and _is_bare_repository(git_common_dir):
+                return os.path.basename(os.path.dirname(git_common_dir))
+            return common_name
     except (OSError, subprocess.TimeoutExpired):
         pass
 

--- a/hindsight-integrations/omo/tests/test_bank.py
+++ b/hindsight-integrations/omo/tests/test_bank.py
@@ -1,0 +1,30 @@
+"""Tests for lib/bank.py project and bank name resolution."""
+
+from unittest.mock import MagicMock, patch
+
+from lib.bank import _resolve_project_name
+
+
+def _cfg(**overrides):
+    config = {"resolveWorktrees": True}
+    config.update(overrides)
+    return config
+
+
+def _git_result(stdout, returncode=0):
+    result = MagicMock()
+    result.stdout = stdout
+    result.returncode = returncode
+    return result
+
+
+@patch("lib.bank.subprocess.run")
+def test_bare_hub_resolves_to_hidden_directory_parent(mock_run):
+    mock_run.side_effect = [_git_result("/home/user/myrepo/.bare\n"), _git_result("true\n")]
+    assert _resolve_project_name("/home/user/myrepo/main", _cfg()) == "myrepo"
+
+
+@patch("lib.bank.subprocess.run")
+def test_standalone_bare_keeps_common_directory_name(mock_run):
+    mock_run.return_value = _git_result("/srv/repos/myproject.git\n")
+    assert _resolve_project_name("/srv/repos/myproject.git", _cfg()) == "myproject.git"

--- a/hindsight-integrations/opencode/src/bank.test.ts
+++ b/hindsight-integrations/opencode/src/bank.test.ts
@@ -159,6 +159,32 @@ describe("deriveBankId", () => {
       expect(deriveBankId(config, "/srv/git/myrepo.git")).toBe("myrepo.git");
     });
 
+    it("uses the hub name for a hidden bare repository shared by worktrees", () => {
+      mockExec.mockImplementation((_, args) => {
+        if (args.includes("--git-common-dir")) return "/home/user/myrepo/.bare\n" as never;
+        if (args.includes("--is-bare-repository")) return "true\n" as never;
+        throw new Error("unexpected git command");
+      });
+      const config = makeConfig({
+        dynamicBankId: true,
+        dynamicBankGranularity: ["gitProject"],
+      });
+      expect(deriveBankId(config, "/home/user/myrepo/main")).toBe("myrepo");
+    });
+
+    it("keeps a hidden non-bare common directory unchanged", () => {
+      mockExec.mockImplementation((_, args) => {
+        if (args.includes("--git-common-dir")) return "/home/user/project/.git-bare\n" as never;
+        if (args.includes("--is-bare-repository")) return "false\n" as never;
+        throw new Error("unexpected git command");
+      });
+      const config = makeConfig({
+        dynamicBankId: true,
+        dynamicBankGranularity: ["gitProject"],
+      });
+      expect(deriveBankId(config, "/home/user/project")).toBe(".git-bare");
+    });
+
     it("falls back to directory basename when git is unavailable or directory is not a repo", () => {
       mockExec.mockImplementationOnce(() => {
         throw new Error("git: command not found");

--- a/hindsight-integrations/opencode/src/bank.ts
+++ b/hindsight-integrations/opencode/src/bank.ts
@@ -25,11 +25,10 @@ const VALID_FIELDS = new Set(["agent", "project", "gitProject", "channel", "user
 /**
  * Resolve the main worktree root for a directory inside a git repository.
  *
- * Uses `git rev-parse --path-format=absolute --git-common-dir`, which always
- * points to the .git directory of the *main* worktree, even when invoked from
- * a linked worktree (created with `git worktree add`). The parent of that path
- * is the main worktree root, so all linked worktrees of the same repo resolve
- * to the same root and end up sharing one memory bank.
+ * Uses `git rev-parse --path-format=absolute --git-common-dir`, which points to
+ * the shared metadata directory even when invoked from a linked worktree. For
+ * regular clones that directory is the main worktree's `.git`; for bare-hubs it
+ * is the bare directory beside the worktrees.
  *
  * Returns `null` when git is unavailable, the directory is not a repo, or the
  * git invocation fails for any other reason.
@@ -48,15 +47,35 @@ function getProjectRootFromGit(directory: string): string | null {
       }
     ).trim();
     if (!commonDir) return null;
-    // For typical clones and `git worktree add`, common-dir is `<root>/.git`,
-    // so the parent is the main worktree root. For bare repos, common-dir is
-    // the bare directory itself (e.g. `myrepo.git`); use it directly.
+    // For typical clones and `git worktree add`, common-dir is `<root>/.git`.
     if (basename(commonDir) === ".git") {
       return dirname(commonDir);
     }
+
+    // In a bare-hub, a hidden common dir such as `.bare` is plumbing beside the worktrees. A
+    // standalone bare clone is named by its own directory, so only unwrap hidden bare dirs.
+    if (basename(commonDir).startsWith(".") && isBareRepository(commonDir)) {
+      return dirname(commonDir);
+    }
+
     return commonDir;
   } catch {
     return null;
+  }
+}
+
+function isBareRepository(commonDir: string): boolean {
+  try {
+    return (
+      execFileSync("git", ["-C", commonDir, "rev-parse", "--is-bare-repository"], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 1000,
+        env: { ...process.env, GIT_DIR: undefined, GIT_WORK_TREE: undefined },
+      }).trim() === "true"
+    );
+  } catch {
+    return false;
   }
 }
 


### PR DESCRIPTION
## Resolution Flow

```mermaid
flowchart TD
    A[git rev-parse --git-common-dir] --> B{common dir basename}
    B -->|.git| C[Use parent directory]
    B -->|Hidden directory| D{common dir is bare repository?}
    D -->|Yes| E[Use hub parent directory]
    D -->|No| F[Keep common directory name]
    B -->|Other directory| G[Keep common directory name]
    C --> H[Stable project name]
    E --> H
    F --> H
    G --> H
    H --> I[Bank ID, project tag, gitlog ID, path approval]
```

## Summary

Fixes project identity resolution for bare-hub Git layouts described in #3712. The fix is applied consistently to coding-agents, OpenCode, Claude Code, and OMO so the same repository does not receive different bank IDs depending on the entry point.

## Problem

A bare-hub layout stores shared Git metadata in a hidden directory beside peer worktrees, for example `myrepo/.bare`, `myrepo/main`, and `myrepo/feature-x`. `git-common-dir` correctly returns `myrepo/.bare`, but the previous TypeScript implementation only unwrapped `.git`, so the project name became `.bare` and the default bank became `coding-agent::.bare`.

The previous Claude Code and OMO implementations always used the parent of `git-common-dir`. That happened to resolve bare-hubs, but incorrectly mapped standalone bare repositories such as `/repos/myproject.git` to `repos`, causing collisions between repositories in the same parent directory.

## Implementation

The four integrations now use the same resolution semantics. Regular repositories unwrap `.git`; hidden common directories are unwrapped only when the common directory itself reports `--is-bare-repository=true`; standalone bare repositories retain their own directory name. The bare check runs against the shared common directory, not the linked worktree, because a linked worktree is not itself bare.

The Git probe removes inherited `GIT_DIR` and `GIT_WORK_TREE` values in the Python implementations and uses `git -C <commonDir>` for an explicit repository target.

## Behavioral Effects

For bare-hubs, the resolved root changes from `.bare` to the hub directory. This makes hub-level `mapPathToBank` and `optInPaths` approval apply to all linked worktrees, matching the repository model. `projectNameOf()` and gitlog document IDs also move from `gitlog:.bare` to `gitlog:myrepo` for new documents.

Existing bank IDs, tags, and gitlog document IDs are not migrated. In particular, Claude Code and OMO users with standalone bare repositories may see a one-time bank ID migration from the previous parent-directory name to the corrected standalone repository name; old memories remain in the previous bank.

## Test Coverage

- Mock tests distinguish the `--git-common-dir` result from the follow-up bare-repository probe.
- Real Git fixtures cover `.bare`, `.git-bare`, standalone bare repositories, ordinary repositories, and linked worktrees.
- Coding-agents covers bare-hub approval and directory-to-bank mapping inheritance.

## Verification

Coding-agents: 635 tests passed. OpenCode: 122 passed and 3 skipped. OMO: 31 passed. Claude Code bank tests: 42 passed. TypeScript builds and changed-file Ruff checks passed. The full Claude Code suite has one unrelated pre-existing permission-scenario failure. The repository-wide lint hook is blocked in this environment because control-plane dependency `@eslint/js` is unavailable.
Fixes #3712