### PR TITLE
fix(coding-agents): tolerate hidden page triggers

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
@@ -286,7 +286,6 @@ describe("HindsightClient.seedPages", () => {
     expect(patches[0].body).toEqual({
       source_query: drifted.source_query,
       tags: drifted.tags,
-      trigger: buildPageTrigger(),
     });
   });
 
@@ -321,10 +320,9 @@ describe("HindsightClient.seedPages", () => {
     }
   });
 
-  // The common case in the field: a server older than #3572 reports no trigger at all, so the
-  // policy is unknowable and gets re-sent. Cheap, idempotent, and self-healing once the server
-  // starts answering — but it must still be trigger-ONLY, or every run rebuilds all five pages.
-  it("re-sends the trigger to a server that does not report one", async () => {
+  // A server older than #3572 does not report a page's trigger. That makes the policy unknowable,
+  // not divergent; sending a trigger-only PATCH would be rejected by servers older than #3549.
+  it("does not write when a server does not report a trigger", async () => {
     const calls: any[] = [];
     stubFetchRouted(calls, [
       {
@@ -342,9 +340,35 @@ describe("HindsightClient.seedPages", () => {
     const c = new HindsightClient({ apiUrl: "http://x", bank: "repo-a" });
     await c.seedPages();
 
+    expect(calls).toHaveLength(1); // the tree GET only
+    expect(calls.every((k) => k.method === "GET")).toBe(true);
+  });
+
+  it("still reconciles source-query drift when the server hides trigger", async () => {
+    const calls: any[] = [];
+    const drifted = PAGES[0];
+    stubFetchRouted(calls, [
+      {
+        match: (m, u) => m === "GET" && u.endsWith("/knowledge-base/tree"),
+        json: {
+          roots: PAGES.map((p, i) => ({
+            id: `kp-${i}`,
+            kind: "page",
+            name: p.name,
+            description: p === drifted ? "an older wording of the query" : p.source_query,
+          })),
+        },
+      },
+    ]);
+    const c = new HindsightClient({ apiUrl: "http://x", bank: "repo-a" });
+    await c.seedPages();
+
     const patches = calls.filter((k) => k.method === "PATCH");
-    expect(patches).toHaveLength(PAGES.length);
-    for (const patch of patches) expect(patch.body).toEqual({ trigger: buildPageTrigger() });
+    expect(patches).toHaveLength(1);
+    expect(patches[0].body).toEqual({
+      source_query: drifted.source_query,
+      tags: drifted.tags,
+    });
   });
 
   it("names the repository in every seeded query, so synthesis can exclude a dependency's facts", async () => {

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -24,7 +24,7 @@ export interface KnowledgeNode {
   /** The page's source query (OKF `description`) — what a re-sync compares against. */
   description?: string;
   /** The page's EFFECTIVE refresh policy, on servers new enough to report it (#3572). Absent
-   *  everywhere else, which `seedPages()` reads as "unknown, re-send it". */
+   *  everywhere else, which `seedPages()` reads as "unknown, leave it alone". */
   trigger?: { tags_match?: string };
   children?: KnowledgeNode[];
 }
@@ -618,23 +618,24 @@ export class HindsightClient {
           return;
         }
         if (r.status !== 409) created++;
-      } else if (
-        hit.description !== page.source_query ||
-        hit.trigger?.tags_match !== pageTrigger.tags_match
-      ) {
+      } else {
+        const sourceDrift = hit.description !== page.source_query;
+        // Older servers omit trigger from the tree, so an absent value means unknown rather
+        // than drift. Those servers also reject a trigger-only PATCH as an empty update.
+        const triggerDrift =
+          hit.trigger != null && hit.trigger.tags_match !== pageTrigger.tags_match;
+        if (!sourceDrift && !triggerDrift) continue;
+
         // The name IS the match key, so it can't drift; the source query and the trigger can.
-        // The trigger is re-sent because it is the only way a policy change reaches a page that
-        // already exists — `tags_match` (see PAGE_TAGS_MATCH) is a fix every previously seeded
-        // page needs, and a `pageTriggerType` change never reached one either. Servers that don't
-        // report a page's trigger on the tree yet answer "unknown" and get it re-sent every run:
-        // the PATCH is idempotent and schedules no refresh unless the source query also changed.
-        const patch: { trigger: PageTrigger; source_query?: string; tags?: string[] } = {
-          trigger: pageTrigger,
-        };
-        if (hit.description !== page.source_query) {
+        // The trigger is re-sent when the server reports it drifting, because it is the only way
+        // a policy change reaches a page that already exists. Servers that do not report a page's
+        // trigger leave its policy unknown; source-query drift can still be reconciled safely.
+        const patch: { trigger?: PageTrigger; source_query?: string; tags?: string[] } = {};
+        if (sourceDrift) {
           patch.source_query = page.source_query;
           patch.tags = page.tags;
         }
+        if (triggerDrift) patch.trigger = pageTrigger;
         const r = await this.req(
           "PATCH",
           this.bankUrl(`/knowledge-base/nodes/${encodeURIComponent(hit.id)}`),


### PR DESCRIPTION
## Summary

Fixes #3703.

This change makes coding-agents compatible with older Hindsight servers that do not expose page `trigger` values from the knowledge-base tree and reject `trigger`-only node updates.

## Failure Path

```mermaid
flowchart TD
    A[deepen starts] --> B[GET knowledge-base tree]
    B --> C{Existing page trigger returned?}
    C -->|No, old server| D[Trigger state is unknown]
    D --> E[Do not infer trigger drift]
    E --> F[No trigger-only PATCH]
    C -->|Yes| G{Trigger differs?}
    G -->|Yes| H[PATCH trigger]
    G -->|No| I[No write]
    B --> J{Source query differs?}
    J -->|Yes| K[PATCH source_query and tags]
    J -->|No| L[No source update]
```

## Compatibility Matrix

| Server response | Client action before | Client action after |
|---|---|---|
| `trigger` omitted, source query unchanged | Send `trigger`-only PATCH; old servers return `400` | No write; trigger remains unknown |
| `trigger` omitted, source query changed | Send source fields plus unsupported `trigger` | Send only `source_query` and `tags` |
| `trigger` returned and differs | Send trigger update | Send trigger update |
| `trigger` returned and matches | No write | No write |

## Root Cause

Servers before #3572 do not return page triggers from the tree. The client previously treated `undefined !== pageTrigger.tags_match` as trigger drift. On servers before #3549, the resulting trigger-only PATCH is parsed as an empty update and rejected with HTTP 400.

## Changes

- Treat an omitted trigger as unknown rather than divergent.
- Build PATCH bodies only from fields that are known to require synchronization.
- Preserve source-query and tag synchronization when the server hides trigger values.
- Add regression coverage for hidden triggers, source-query drift, and explicit trigger drift.

This change intentionally does not make page synchronization errors non-fatal for the entire deepen run; that can be handled separately from the compatibility fix.

## Verification

| Check | Result |
|---|---|
| `npm test` in `hindsight-integrations/coding-agents` | 629 tests passed |
| `npm run build` in `hindsight-integrations/coding-agents` | Passed |
| `git diff --check` | Passed |
