### PR TITLE
fix(windows): hide daemon subprocess windows

### DIFF
--- a/hindsight-all-npm/src/server.test.ts
+++ b/hindsight-all-npm/src/server.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { HindsightServer } from "./server.js";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock("child_process", () => ({ spawn: spawnMock }));
 
 describe("HindsightServer construction", () => {
   it("defaults base URL to http://127.0.0.1:8888", () => {
@@ -31,5 +34,26 @@ describe("HindsightServer construction", () => {
     const server = new HindsightServer({ port: 1, readyTimeoutMs: 100 });
     const healthy = await server.checkHealth();
     expect(healthy).toBe(false);
+  });
+
+  it("hides daemon command windows on Windows", async () => {
+    const child = {
+      stdout: { on: vi.fn() },
+      stderr: { on: vi.fn() },
+      on: vi.fn((event: string, handler: (code?: number) => void) => {
+        if (event === "exit") handler(0);
+        return child;
+      }),
+    };
+    spawnMock.mockReturnValueOnce(child);
+
+    const server = new HindsightServer();
+    await server.stop();
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      "uvx",
+      ["hindsight-embed@latest", "daemon", "--profile", "default", "stop"],
+      expect.objectContaining({ stdio: "pipe", windowsHide: true })
+    );
   });
 });

--- a/hindsight-all-npm/src/server.ts
+++ b/hindsight-all-npm/src/server.ts
@@ -102,7 +102,7 @@ export class HindsightServer {
     });
     const args = [...baseArgs, "daemon", "--profile", this.profile, "stop"];
 
-    const child = spawn(cmd, args, { stdio: "pipe" });
+    const child = spawn(cmd, args, { stdio: "pipe", windowsHide: true });
     this.pipeOutput(child, "daemon.stop");
 
     await new Promise<void>((resolve) => {
@@ -251,7 +251,7 @@ export class HindsightServer {
     env: NodeJS.ProcessEnv,
     label: string
   ): Promise<void> {
-    const child = spawn(cmd, args, { stdio: "pipe", env });
+    const child = spawn(cmd, args, { stdio: "pipe", env, windowsHide: true });
     let output = "";
     child.stdout?.on("data", (data: Buffer) => {
       const text = data.toString();

--- a/hindsight-integrations/coding-agents/src/core/daemon.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/daemon.test.ts
@@ -180,12 +180,13 @@ describe("startDaemonDetached", () => {
     const [cmd, args, opts] = spawn.mock.calls[0] as unknown as [
       string,
       string[],
-      { detached: boolean; stdio: string },
+      { detached: boolean; stdio: string; windowsHide: boolean },
     ];
     expect(cmd).toBe("node");
     expect(args[0]).toMatch(/daemon-start\.js$/);
     expect(opts.detached).toBe(true);
     expect(opts.stdio).toBe("ignore");
+    expect(opts.windowsHide).toBe(true);
     // An async spawn 'error' event would otherwise crash the hook process.
     expect(child.on).toHaveBeenCalledWith("error", expect.any(Function));
     expect(child.unref).toHaveBeenCalled();

--- a/hindsight-integrations/coding-agents/src/core/daemon.ts
+++ b/hindsight-integrations/coding-agents/src/core/daemon.ts
@@ -75,7 +75,11 @@ export async function isServerHealthy(baseUrl: string, timeoutMs = 2_000): Promi
 export function hasRustToolchain(): boolean {
   if (process.platform !== "darwin") return true; // wheels cover linux + windows
   try {
-    execFileSync("cargo", ["--version"], { stdio: "pipe", timeout: 10_000 });
+    execFileSync("cargo", ["--version"], {
+      stdio: "pipe",
+      timeout: 10_000,
+      windowsHide: true,
+    });
     return true;
   } catch {
     return false;
@@ -85,7 +89,11 @@ export function hasRustToolchain(): boolean {
 /** Is `uv`/`uvx` on PATH? The daemon is fetched and run through it. */
 export function hasUvx(): boolean {
   try {
-    execFileSync("uvx", ["--version"], { stdio: "pipe", timeout: 10_000 });
+    execFileSync("uvx", ["--version"], {
+      stdio: "pipe",
+      timeout: 10_000,
+      windowsHide: true,
+    });
     return true;
   } catch {
     return false;
@@ -144,7 +152,11 @@ export function detectLlm(env: NodeJS.ProcessEnv = process.env): LlmChoice | und
 
 function onPath(bin: string): boolean {
   try {
-    execFileSync("which", [bin], { stdio: "pipe", timeout: 5_000 });
+    execFileSync("which", [bin], {
+      stdio: "pipe",
+      timeout: 5_000,
+      windowsHide: true,
+    });
     return true;
   } catch {
     return false;
@@ -195,6 +207,7 @@ export function startDaemonDetached(
     const child = spawnFn("node", [starter, "--harness", harness], {
       detached: true,
       stdio: "ignore",
+      windowsHide: true,
     });
     // spawn() failures often surface ASYNCHRONOUSLY as an 'error' event; unhandled, that would
     // crash the hook.

--- a/hindsight-integrations/coding-agents/src/core/seed.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/seed.test.ts
@@ -13,7 +13,7 @@ describe("startBackgroundSeed", () => {
     expect(spawn).toHaveBeenCalledWith(
       "node",
       ["/dist/deepen.js", "--repo", "/some/repo", "--gitlog-limit", String(DEFAULT_SEED_LIMIT)],
-      { detached: true, stdio: expect.anything() }
+      { detached: true, stdio: expect.anything(), windowsHide: true }
     );
     expect(spawn.mock.results[0].value.unref).toHaveBeenCalled();
   });
@@ -38,7 +38,7 @@ describe("startBackgroundSeed", () => {
     expect(spawn).toHaveBeenCalledWith(
       "node",
       ["/dist/deepen.js", "--repo", "/some/repo", "--gitlog-limit", "50"],
-      { detached: true, stdio: expect.anything() }
+      { detached: true, stdio: expect.anything(), windowsHide: true }
     );
   });
 
@@ -60,7 +60,7 @@ describe("startBackgroundSeed", () => {
         "--harness",
         "antigravity-cli",
       ],
-      { detached: true, stdio: expect.anything() }
+      { detached: true, stdio: expect.anything(), windowsHide: true }
     );
   });
 

--- a/hindsight-integrations/coding-agents/src/core/seed.ts
+++ b/hindsight-integrations/coding-agents/src/core/seed.ts
@@ -42,6 +42,7 @@ export function startBackgroundSeed(
       {
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
       }
     );
     // spawn() failures (ENOENT/EACCES/fd exhaustion/sandboxed environments) often arrive

--- a/hindsight-integrations/coding-agents/src/core/survey.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/survey.test.ts
@@ -83,6 +83,7 @@ describe("startCodebaseSurvey", () => {
     expect(options.cwd).toBe("/repo");
     expect(options.detached).toBe(true);
     expect(options.stdio).toBe("ignore");
+    expect(options.windowsHide).toBe(true);
     expect(options.env.HINDSIGHT_DISABLE_HOOKS).toBe("1");
 
     const child = spawn.mock.results[0].value;

--- a/hindsight-integrations/coding-agents/src/core/survey.ts
+++ b/hindsight-integrations/coding-agents/src/core/survey.ts
@@ -338,6 +338,7 @@ export function startCodebaseSurvey(
         cwd: repoDir,
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
         env: plan.env,
       });
       // spawn() failures (binary not found, EACCES, sandboxed environments) often arrive


### PR DESCRIPTION
## Summary

Issue #3725 reports recurring visible `uv.exe` console windows during Claude Code sessions on Windows when Hindsight runs in local daemon mode.

## Root Cause

```mermaid
flowchart TD
    A[Coding-agent lifecycle] --> B[Daemon preflight]
    A --> C[Background seed]
    A --> D[Codebase survey]
    B --> E[uvx --version]
    B --> F[Detached daemon starter]
    F --> G[hindsight-all]
    G --> H[uvx profile and daemon commands]
    C --> I[Detached deepen engine]
    D --> J[Detached headless coding agent]
    E --> K[Visible Windows console]
    F --> K
    H --> K
    I --> K
    J --> K
```

Node.js child-process APIs default `windowsHide` to `false` on Windows. The daemon probes, detached daemon starter, background seed, codebase survey, and `hindsight-all` command runner therefore allowed console windows to appear during normal coding-agent lifecycle operations.

## Changes

| Component | Change | Effect |
| --- | --- | --- |
| Coding agents daemon probes | Add `windowsHide: true` to `cargo`, `uvx`, and PATH checks | Suppresses probe windows |
| Coding agents daemon starter | Add `windowsHide: true` to the detached Node process | Suppresses background starter windows |
| Background seed | Add `windowsHide: true` to the detached deepen engine | Suppresses session-start seed windows |
| Codebase survey | Add `windowsHide: true` to the detached headless agent | Suppresses cold-repository survey windows |
| `hindsight-all` | Add `windowsHide: true` to daemon `spawn()` calls | Suppresses `uvx` command windows |
| Regression tests | Assert hidden-window options across both packages | Prevents recurrence |

## Verification

- Coding agents daemon, seed, and survey tests: 38 passed.
- `hindsight-all` server tests: 10 passed.
- Repository lint passed.
- Prettier checks passed.
- `git diff --check` passed.

The fix is Windows-specific in effect and does not change process lifecycle timing, command arguments, or behavior on other platforms.
Fixes #3725
