### PR TITLE
fix(embed): use UTF-8 for profile env files

### DIFF
--- a/hindsight-embed/hindsight_embed/profile_manager.py
+++ b/hindsight-embed/hindsight_embed/profile_manager.py
@@ -416,7 +416,7 @@ class ProfileManager:
         # the profile carries the full documented option set as comments.
         from .env_template import render_config
 
-        config_path.write_text(render_config(config))
+        config_path.write_text(render_config(config), encoding="utf-8")
 
         # Metadata now only tracks discovery + timestamps; the port moved to .env.
         now_iso = datetime.now(timezone.utc).isoformat()
@@ -548,7 +548,7 @@ class ProfileManager:
         ov = _PortOverrides()
         if not config_path.exists():
             return ov
-        for line in config_path.read_text().splitlines():
+        for line in config_path.read_text(encoding="utf-8").splitlines():
             line = line.strip()
             if line.startswith("export "):
                 line = line[7:]
@@ -601,7 +601,7 @@ class ProfileManager:
             return config
 
         # Parse .env file
-        with open(paths.config) as f:
+        with open(paths.config, encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 # Skip comments and empty lines

--- a/hindsight-embed/tests/test_profile_manager.py
+++ b/hindsight-embed/tests/test_profile_manager.py
@@ -1,6 +1,8 @@
 """Tests for profile_manager module."""
 
+import builtins
 import json
+import pathlib
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -79,6 +81,33 @@ class TestProfileManager:
         assert "HINDSIGHT_API_PORT=" in config_content
         assert "port" not in metadata["profiles"]["test-profile"]
         assert "created_at" in metadata["profiles"]["test-profile"]
+
+    def test_profile_config_uses_utf8_when_locale_is_not_utf8(self, profile_manager, temp_hindsight_dir, monkeypatch):
+        """Profile templates remain readable with a legacy default code page."""
+        original_open = pathlib.Path.open
+        original_builtin_open = builtins.open
+
+        def add_legacy_encoding(args, kwargs):
+            mode = kwargs.get("mode", args[0] if args else "r")
+            if kwargs.get("encoding") is None and "b" not in mode:
+                kwargs["encoding"] = "gbk"
+
+        def legacy_locale_open(path, *args, **kwargs):
+            add_legacy_encoding(args, kwargs)
+            return original_open(path, *args, **kwargs)
+
+        def legacy_builtin_open(file, *args, **kwargs):
+            add_legacy_encoding(args, kwargs)
+            return original_builtin_open(file, *args, **kwargs)
+
+        monkeypatch.setattr(pathlib.Path, "open", legacy_locale_open)
+        monkeypatch.setattr(builtins, "open", legacy_builtin_open)
+
+        profile_manager.create_profile("legacy-locale", {"CUSTOM_DESCRIPTION": "memory — retained"})
+
+        config_path = temp_hindsight_dir / "profiles" / "legacy-locale.env"
+        assert "memory — retained" in config_path.read_text(encoding="utf-8")
+        assert profile_manager.load_profile_config("legacy-locale")["CUSTOM_DESCRIPTION"] == "memory — retained"
 
     def test_create_profile_invalid_name(self, profile_manager):
         """Test creating profile with invalid name fails."""


### PR DESCRIPTION
## Summary

- write generated profile `.env` files explicitly as UTF-8
- read profile ports and configuration explicitly as UTF-8
- cover profile creation and readback when the process default encoding is GBK

Fixes #3747.

## Testing

- `uv run pytest tests/test_profile_manager.py -q` (33 passed)
- `env -u ALL_PROXY -u HTTPS_PROXY -u HTTP_PROXY NO_PROXY=127.0.0.1,localhost uv run pytest -q` (188 passed)
- `uv run ruff check hindsight_embed/profile_manager.py tests/test_profile_manager.py`
- `uv run ruff format --check hindsight_embed/profile_manager.py tests/test_profile_manager.py`
