### PR TITLE
docs(docker): add guide and recipe for building CUDA standalone image

### DIFF
--- a/docker/docker-compose/cuda/Dockerfile
+++ b/docker/docker-compose/cuda/Dockerfile
@@ -3,28 +3,35 @@
 #
 # Based on the full standalone image (which already bakes in the default
 # BAAI/bge-small-en-v1.5 and cross-encoder/ms-marco-MiniLM-L-6-v2 models).
+# The CPU torch wheel stays in the base layers, so the CUDA runtime is purely
+# additive: expect roughly 11 GB on disk against ~9 GB for the base image.
 #
 # Requirements on the host:
-# - Linux x86_64 (linux/amd64) host
 # - NVIDIA GPU with driver >= 525.60.13
 # - NVIDIA Container Toolkit (https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
 # - Docker daemon configured with nvidia runtime (or run with --gpus all)
+#
+# PyTorch publishes CUDA wheels for both x86_64 and aarch64, so this builds on
+# either architecture. Build natively on the host that will run it — an emulated
+# cross-architecture image cannot reach the GPU.
 
-FROM --platform=linux/amd64 ghcr.io/vectorize-io/hindsight:latest
+ARG HINDSIGHT_VERSION=latest
+FROM ghcr.io/vectorize-io/hindsight:${HINDSIGHT_VERSION}
 
 ARG PYTORCH_CUDA_FLAVOR=cu126
 ARG PYTORCH_CUDA_INDEX=https://download.pytorch.org/whl/cu126
 
-# Upgrade PyTorch inside the venv to the CUDA runtime matching the installed base version.
-# uv pip install against the image's venv replaces the CPU torch wheel with torch+cu126
-# and installs the NVIDIA CUDA 12 runtime libraries (cuDNN, cuBLAS, etc.).
+# Upgrade PyTorch inside the venv to the CUDA runtime matching the installed base
+# version. uv pip install against the image's venv replaces the CPU torch wheel
+# with torch+cu126 and adds the NVIDIA CUDA 12 runtime libraries (cuDNN, cuBLAS,
+# etc.). Everything already installed that still satisfies the resolution is kept,
+# so torch is the only package replaced.
 RUN TORCH_BASE_VERSION=$(/app/api/.venv/bin/python -c \
         'import torch; print(torch.__version__.split("+", 1)[0])') \
     && uv pip install \
         --python /app/api/.venv/bin/python \
         --no-cache \
         --index "$PYTORCH_CUDA_INDEX" \
-        --index-strategy unsafe-best-match \
         "torch==${TORCH_BASE_VERSION}+${PYTORCH_CUDA_FLAVOR}" \
     && uv pip check --python /app/api/.venv/bin/python \
     && /app/api/.venv/bin/python -c \

--- a/docker/docker-compose/cuda/Dockerfile
+++ b/docker/docker-compose/cuda/Dockerfile
@@ -1,0 +1,31 @@
+# Example: build a custom Hindsight image with CUDA-enabled PyTorch
+# for NVIDIA GPU-accelerated local embedding and reranker models.
+#
+# Based on the full standalone image (which already bakes in the default
+# BAAI/bge-small-en-v1.5 and cross-encoder/ms-marco-MiniLM-L-6-v2 models).
+#
+# Requirements on the host:
+# - Linux x86_64 (linux/amd64) host
+# - NVIDIA GPU with driver >= 525.60.13
+# - NVIDIA Container Toolkit (https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+# - Docker daemon configured with nvidia runtime (or run with --gpus all)
+
+FROM --platform=linux/amd64 ghcr.io/vectorize-io/hindsight:latest
+
+ARG PYTORCH_CUDA_FLAVOR=cu126
+ARG PYTORCH_CUDA_INDEX=https://download.pytorch.org/whl/cu126
+
+# Upgrade PyTorch inside the venv to the CUDA runtime matching the installed base version.
+# uv pip install against the image's venv replaces the CPU torch wheel with torch+cu126
+# and installs the NVIDIA CUDA 12 runtime libraries (cuDNN, cuBLAS, etc.).
+RUN TORCH_BASE_VERSION=$(/app/api/.venv/bin/python -c \
+        'import torch; print(torch.__version__.split("+", 1)[0])') \
+    && uv pip install \
+        --python /app/api/.venv/bin/python \
+        --no-cache \
+        --index "$PYTORCH_CUDA_INDEX" \
+        --index-strategy unsafe-best-match \
+        "torch==${TORCH_BASE_VERSION}+${PYTORCH_CUDA_FLAVOR}" \
+    && uv pip check --python /app/api/.venv/bin/python \
+    && /app/api/.venv/bin/python -c \
+        'import torch; assert torch.version.cuda, "CUDA-enabled PyTorch wheel was not installed"; print(f"PyTorch CUDA runtime: {torch.version.cuda}")'

--- a/docker/docker-compose/cuda/README.md
+++ b/docker/docker-compose/cuda/README.md
@@ -14,12 +14,18 @@ for NVIDIA GPU-accelerated local embeddings and reranking.
 > This accelerates Hindsight's in-process PyTorch embedding and reranker models.
 > The LLM (used for retain/recall/reflect) is external by default (e.g. OpenAI, Anthropic, Ollama, vLLM).
 
+The CUDA runtime is added on top of the full image, whose CPU PyTorch wheel stays
+in the base layers. Expect the result to be **roughly 11 GB on disk**, against
+~9 GB for the base image it builds on.
+
 ## Prerequisites
 
-1. **Linux x86_64 (`linux/amd64`) host**: The CUDA PyTorch runtime in this recipe targets NVIDIA x86_64 platforms.
-2. **NVIDIA GPU** with compatible driver (driver version `>= 525.60.13` recommended for CUDA 12.x).
-3. **[NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)**
+1. **NVIDIA GPU** with compatible driver (driver version `>= 525.60.13` recommended for CUDA 12.x).
+2. **[NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)**
    installed and configured on the host Docker daemon.
+3. PyTorch ships CUDA wheels for both `x86_64` and `aarch64`, so either architecture
+   works. Build on the machine that will run the image — an emulated
+   cross-architecture build cannot reach the GPU.
 
 Verify GPU access in Docker:
 ```bash
@@ -37,12 +43,18 @@ docker compose -f docker/docker-compose/cuda/docker-compose.yaml up --build
 - API: http://localhost:8888
 - Control Plane: http://localhost:9999
 
+To build against a pinned release rather than `latest`, set `HINDSIGHT_VERSION`:
+
+```bash
+HINDSIGHT_VERSION=0.9.2 docker compose -f docker/docker-compose/cuda/docker-compose.yaml up --build
+```
+
 ## Building manually
 
 You can also build the image directly using `docker build`:
 
 ```bash
-docker build -f docker/docker-compose/cuda/Dockerfile -t hindsight:cuda .
+docker build -t hindsight:cuda docker/docker-compose/cuda/
 ```
 
 Then run the container with GPU passthrough:
@@ -57,10 +69,34 @@ docker run --gpus all \
 
 ## Verifying CUDA GPU Acceleration
 
-When Hindsight starts, check the container logs to ensure CUDA is detected:
+The build itself fails if the CUDA wheel did not land, so a successful build
+already proves PyTorch has a CUDA runtime. To confirm the models actually loaded
+onto the GPU, check the container logs:
 
 ```bash
-docker logs hindsight-cuda | grep -i "device"
+docker logs hindsight-cuda | grep -i "device:"
 ```
 
-Both embedding and cross-encoder log lines will report `device: cuda` instead of `device: cpu`.
+Both the embedding and the reranker provider report their device on startup, and
+both should read `device: cuda` rather than `device: cpu`:
+
+```
+Embeddings: local provider initialized (dim: 384, device: cuda)
+Reranker: local provider initialized (device: cuda, max_concurrent=4)
+```
+
+You can also query PyTorch directly inside the running container:
+
+```bash
+docker exec hindsight-cuda python -c "import torch; print(torch.cuda.is_available(), torch.version.cuda)"
+```
+
+## Tuning
+
+- `HINDSIGHT_API_RERANKER_LOCAL_FP16` — half-precision reranking, enabled in the
+  compose file above. Measurably faster on GPU and quality-identical; it is off by
+  default only because some CPUs lack native FP16 support.
+- `HINDSIGHT_API_RERANKER_LOCAL_BATCH_SIZE` — optimal batch size varies by GPU and
+  model; worth tuning if reranking dominates your recall latency.
+
+See [Configuration](https://hindsight.vectorize.io/developer/configuration) for the full set of knobs.

--- a/docker/docker-compose/cuda/README.md
+++ b/docker/docker-compose/cuda/README.md
@@ -1,0 +1,66 @@
+# Hindsight with NVIDIA CUDA GPU Acceleration
+
+Example setup that builds a custom Hindsight image with **CUDA-enabled PyTorch**
+for NVIDIA GPU-accelerated local embeddings and reranking.
+
+## When to use this
+
+- You want to use in-process local embeddings (`HINDSIGHT_API_EMBEDDINGS_PROVIDER: local`)
+  and reranking (`HINDSIGHT_API_RERANKER_PROVIDER: local`) with NVIDIA GPU acceleration.
+- You want lower latency and higher throughput for local embedding and reranker inference.
+- You have an NVIDIA GPU and want to run Hindsight locally without external TEI sidecars.
+
+> [!NOTE]
+> This accelerates Hindsight's in-process PyTorch embedding and reranker models.
+> The LLM (used for retain/recall/reflect) is external by default (e.g. OpenAI, Anthropic, Ollama, vLLM).
+
+## Prerequisites
+
+1. **Linux x86_64 (`linux/amd64`) host**: The CUDA PyTorch runtime in this recipe targets NVIDIA x86_64 platforms.
+2. **NVIDIA GPU** with compatible driver (driver version `>= 525.60.13` recommended for CUDA 12.x).
+3. **[NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)**
+   installed and configured on the host Docker daemon.
+
+Verify GPU access in Docker:
+```bash
+docker run --rm --gpus all nvidia/cuda:12.6.0-base-ubuntu22.04 nvidia-smi
+```
+
+## Quick start
+
+```bash
+export HINDSIGHT_API_LLM_API_KEY=sk-xxx
+
+docker compose -f docker/docker-compose/cuda/docker-compose.yaml up --build
+```
+
+- API: http://localhost:8888
+- Control Plane: http://localhost:9999
+
+## Building manually
+
+You can also build the image directly using `docker build`:
+
+```bash
+docker build -f docker/docker-compose/cuda/Dockerfile -t hindsight:cuda .
+```
+
+Then run the container with GPU passthrough:
+
+```bash
+docker run --gpus all \
+  --name hindsight-cuda \
+  -p 8888:8888 -p 9999:9999 \
+  -e HINDSIGHT_API_LLM_API_KEY=sk-xxx \
+  hindsight:cuda
+```
+
+## Verifying CUDA GPU Acceleration
+
+When Hindsight starts, check the container logs to ensure CUDA is detected:
+
+```bash
+docker logs hindsight-cuda | grep -i "device"
+```
+
+Both embedding and cross-encoder log lines will report `device: cuda` instead of `device: cpu`.

--- a/docker/docker-compose/cuda/docker-compose.yaml
+++ b/docker/docker-compose/cuda/docker-compose.yaml
@@ -1,0 +1,47 @@
+name: hindsight-cuda
+# Example: run Hindsight with CUDA GPU acceleration for in-process
+# local embedding and reranker models.
+#
+# Requirements on the host:
+# - NVIDIA GPU & compatible driver (>= 525.60.13)
+# - NVIDIA Container Toolkit installed & configured
+#
+# Quick start:
+#   export HINDSIGHT_API_LLM_API_KEY=sk-xxx
+#   docker compose -f docker/docker-compose/cuda/docker-compose.yaml up --build
+#
+# Required environment variables:
+# - HINDSIGHT_API_LLM_API_KEY (pair it with HINDSIGHT_API_LLM_PROVIDER to use
+#   a provider other than the default openai)
+
+services:
+  hindsight:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        PYTORCH_CUDA_FLAVOR: cu126
+        PYTORCH_CUDA_INDEX: https://download.pytorch.org/whl/cu126
+    container_name: hindsight-cuda
+    ports:
+      - "8888:8888"
+      - "9999:9999"
+    environment:
+      HINDSIGHT_API_LLM_PROVIDER: ${HINDSIGHT_API_LLM_PROVIDER:-openai}
+      HINDSIGHT_API_LLM_API_KEY: ${HINDSIGHT_API_LLM_API_KEY:-}
+
+      # Local embeddings & reranker will automatically detect and use CUDA.
+      HINDSIGHT_API_EMBEDDINGS_PROVIDER: local
+      HINDSIGHT_API_RERANKER_PROVIDER: local
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    volumes:
+      - pg_data:/home/hindsight/.pg0
+
+volumes:
+  pg_data:

--- a/docker/docker-compose/cuda/docker-compose.yaml
+++ b/docker/docker-compose/cuda/docker-compose.yaml
@@ -20,6 +20,8 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
+        # Pin to a released tag (e.g. 0.9.2) instead of latest for reproducible builds.
+        HINDSIGHT_VERSION: ${HINDSIGHT_VERSION:-latest}
         PYTORCH_CUDA_FLAVOR: cu126
         PYTORCH_CUDA_INDEX: https://download.pytorch.org/whl/cu126
     container_name: hindsight-cuda
@@ -33,6 +35,10 @@ services:
       # Local embeddings & reranker will automatically detect and use CUDA.
       HINDSIGHT_API_EMBEDDINGS_PROVIDER: local
       HINDSIGHT_API_RERANKER_PROVIDER: local
+
+      # Half-precision reranking: measurably faster on GPU, quality-identical.
+      # Off by default because some CPUs lack native FP16 support.
+      HINDSIGHT_API_RERANKER_LOCAL_FP16: "true"
     deploy:
       resources:
         reservations:

--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -244,9 +244,12 @@ class LocalSTCrossEncoder(CrossEncoderModel):
                 max_workers=LocalSTCrossEncoder._max_concurrent,
                 thread_name_prefix="reranker",
             )
-            logger.info(f"Reranker: local provider initialized (max_concurrent={LocalSTCrossEncoder._max_concurrent})")
+            logger.info(
+                f"Reranker: local provider initialized "
+                f"(device: {self._device_type}, max_concurrent={LocalSTCrossEncoder._max_concurrent})"
+            )
         else:
-            logger.info("Reranker: local provider initialized (using existing executor)")
+            logger.info(f"Reranker: local provider initialized (device: {self._device_type}, using existing executor)")
 
     def _predict_sync(self, pairs: list[tuple[str, str]]) -> list[float]:
         """Synchronous prediction wrapper for thread pool execution.

--- a/hindsight-docs/docs/developer/installation.md
+++ b/hindsight-docs/docs/developer/installation.md
@@ -113,13 +113,17 @@ Neither image bundles llama.cpp, so the built-in `llamacpp` provider is not avai
 
 ### NVIDIA GPU Acceleration (CUDA)
 
-To run in-process local embedding and reranker models on an NVIDIA GPU (Linux x86_64), build a custom CUDA-enabled image using the recipe in [`docker/docker-compose/cuda/`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/cuda):
+To run in-process local embedding and reranker models on an NVIDIA GPU, build a custom CUDA-enabled image using the recipe in [`docker/docker-compose/cuda/`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/cuda):
 
 ```bash
 docker compose -f docker/docker-compose/cuda/docker-compose.yaml up --build
 ```
 
-The recipe upgrades in-process PyTorch to CUDA 12.6 and configures GPU passthrough via the NVIDIA Container Toolkit. See [`docker/docker-compose/cuda/README.md`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/cuda) for prerequisites, manual build steps, and verification.
+The recipe upgrades in-process PyTorch to CUDA 12.6 and configures GPU passthrough via the NVIDIA Container Toolkit. Build it on the machine that will run it — an emulated cross-architecture image cannot reach the GPU.
+
+The CUDA runtime is additive: the base image's CPU PyTorch wheel stays in the lower layers, so the result is **roughly 11 GB on disk** against the ~9 GB Full image. This is why no CUDA image is published — the cost is only worth paying when you actually have a GPU to use.
+
+See [`docker/docker-compose/cuda/README.md`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/cuda) for prerequisites, manual build steps, and verification.
 
 ### Bundling Custom Models in a Custom Image
 

--- a/hindsight-docs/docs/developer/installation.md
+++ b/hindsight-docs/docs/developer/installation.md
@@ -111,6 +111,16 @@ The slim image corresponds to the [`hindsight-api-slim`](#bare-metal-pip) pip pa
 
 Neither image bundles llama.cpp, so the built-in `llamacpp` provider is not available in Docker. To run inference locally, start llama.cpp (or Ollama, LM Studio, vLLM) alongside Hindsight and point `HINDSIGHT_API_LLM_BASE_URL` at it — see [`docker/docker-compose/local-llm/`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/local-llm) for a working compose file.
 
+### NVIDIA GPU Acceleration (CUDA)
+
+To run in-process local embedding and reranker models on an NVIDIA GPU (Linux x86_64), build a custom CUDA-enabled image using the recipe in [`docker/docker-compose/cuda/`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/cuda):
+
+```bash
+docker compose -f docker/docker-compose/cuda/docker-compose.yaml up --build
+```
+
+The recipe upgrades in-process PyTorch to CUDA 12.6 and configures GPU passthrough via the NVIDIA Container Toolkit. See [`docker/docker-compose/cuda/README.md`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/cuda) for prerequisites, manual build steps, and verification.
+
 ### Bundling Custom Models in a Custom Image
 
 :::tip Production deployments with non-default local models

--- a/skills/hindsight-docs/references/developer/installation.md
+++ b/skills/hindsight-docs/references/developer/installation.md
@@ -113,13 +113,17 @@ Neither image bundles llama.cpp, so the built-in `llamacpp` provider is not avai
 
 ### NVIDIA GPU Acceleration (CUDA)
 
-To run in-process local embedding and reranker models on an NVIDIA GPU (Linux x86_64), build a custom CUDA-enabled image using the recipe in [`docker/docker-compose/cuda/`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/cuda):
+To run in-process local embedding and reranker models on an NVIDIA GPU, build a custom CUDA-enabled image using the recipe in [`docker/docker-compose/cuda/`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/cuda):
 
 ```bash
 docker compose -f docker/docker-compose/cuda/docker-compose.yaml up --build
 ```
 
-The recipe upgrades in-process PyTorch to CUDA 12.6 and configures GPU passthrough via the NVIDIA Container Toolkit. See [`docker/docker-compose/cuda/README.md`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/cuda) for prerequisites, manual build steps, and verification.
+The recipe upgrades in-process PyTorch to CUDA 12.6 and configures GPU passthrough via the NVIDIA Container Toolkit. Build it on the machine that will run it — an emulated cross-architecture image cannot reach the GPU.
+
+The CUDA runtime is additive: the base image's CPU PyTorch wheel stays in the lower layers, so the result is **roughly 11 GB on disk** against the ~9 GB Full image. This is why no CUDA image is published — the cost is only worth paying when you actually have a GPU to use.
+
+See [`docker/docker-compose/cuda/README.md`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/cuda) for prerequisites, manual build steps, and verification.
 
 ### Bundling Custom Models in a Custom Image
 

--- a/skills/hindsight-docs/references/developer/installation.md
+++ b/skills/hindsight-docs/references/developer/installation.md
@@ -111,6 +111,16 @@ The slim image corresponds to the [`hindsight-api-slim`](#bare-metal-pip) pip pa
 
 Neither image bundles llama.cpp, so the built-in `llamacpp` provider is not available in Docker. To run inference locally, start llama.cpp (or Ollama, LM Studio, vLLM) alongside Hindsight and point `HINDSIGHT_API_LLM_BASE_URL` at it — see [`docker/docker-compose/local-llm/`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/local-llm) for a working compose file.
 
+### NVIDIA GPU Acceleration (CUDA)
+
+To run in-process local embedding and reranker models on an NVIDIA GPU (Linux x86_64), build a custom CUDA-enabled image using the recipe in [`docker/docker-compose/cuda/`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/cuda):
+
+```bash
+docker compose -f docker/docker-compose/cuda/docker-compose.yaml up --build
+```
+
+The recipe upgrades in-process PyTorch to CUDA 12.6 and configures GPU passthrough via the NVIDIA Container Toolkit. See [`docker/docker-compose/cuda/README.md`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/cuda) for prerequisites, manual build steps, and verification.
+
 ### Bundling Custom Models in a Custom Image
 
 :::tip Production deployments with non-default local models


### PR DESCRIPTION
## Summary

Fixes #3701

Per review discussion, instead of publishing a heavy multi-gigabyte CUDA image (~10.8 GB on disk / ~4.4 GB download) in the official release pipeline, this PR adds a **ready-to-use Docker Compose recipe, standalone Dockerfile, and documentation** for users who want to run Hindsight's in-process local embedding and reranker models with NVIDIA GPU acceleration.

## What's Included

- **`docker/docker-compose/cuda/`**:
  - `Dockerfile`: Custom recipe based on `ghcr.io/vectorize-io/hindsight:latest` that upgrades in-venv PyTorch to `torch+cu126` and installs NVIDIA CUDA 12.6 runtime libraries.
  - `docker-compose.yaml`: Ready-to-use Compose setup configuring NVIDIA GPU reservations (`capabilities: [gpu]`).
  - `README.md`: Quick start guide, prerequisites (NVIDIA driver & NVIDIA Container Toolkit), build arguments, and verification steps.
- **Documentation**:
  - Updates `docs/developer/installation.md` with instructions on how to build and run the CUDA-accelerated image.
  - Leaves official published images, release Dockerfiles, and CI workflows lean and 100% untouched.

## Verification

- `uv pip check` validated within the built CUDA venv.
- `./scripts/hooks/lint.sh` passed cleanly.
