### PR TITLE
docs: explain how entity resolution decides to merge a name

### DIFF
--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1394,7 +1394,7 @@ Controls the retain (memory ingestion) pipeline.
 | `HINDSIGHT_API_RETAIN_WALL_TIMEOUT` | Wall-clock ceiling in seconds for one retain task in the worker. A retain that blocks indefinitely (lock contention, an unreachable LLM endpoint) is cancelled and marked `failed` instead of holding its worker slot until the process restarts, so it can be retried. Set well above your slowest healthy retain; `0` disables. | `3600` |
 | `HINDSIGHT_API_RETAIN_BATCH_TOKENS` | Max characters per sub-batch for async retain auto-splitting | `10000` |
 | `HINDSIGHT_API_RETAIN_CHUNK_BATCH_SIZE` | Max chunks per streaming batch when retain ingests long documents. Each chunk produces roughly 17 facts, so the default 100 chunks ≈ 1700 facts per batch. Lower to cap memory/LLM pressure on large documents; raise for smaller chunks. Configurable per bank. | `100` |
-| `HINDSIGHT_API_RETAIN_ENTITY_LOOKUP` | Entity lookup method during retain: `full` (exact match) or `trigram` (fuzzy trigram matching) | `trigram` |
+| `HINDSIGHT_API_RETAIN_ENTITY_LOOKUP` | How retain finds *candidate* existing entities for an extracted name: `trigram` probes the pg_trgm index for similar names, `full` loads every entity in the bank and keeps the ones whose name is an exact or substring match. Both then run the same scoring pass (see [How entity resolution decides](#how-entity-resolution-decides)) — so this is not only a performance choice, it changes which names can merge at all. | `trigram` |
 | `HINDSIGHT_API_RETAIN_ENTITY_RESOLUTION_BATCH_SIZE` | Max unique entity names per fuzzy candidate lookup query (`trigram` on PG, `oracle_fuzzy` on Oracle). Bounds query size so very wide retain batches don't time out a single `unnest(...)` join on banks with many entities. | `100` |
 | `HINDSIGHT_API_RETAIN_ENTITY_RESOLUTION_MAX_CANDIDATES` | Max candidates scored per entity mention. The fuzzy lookup keeps only this many best matches per name (ranked by trigram / Jaro-Winkler similarity) before the scoring pass. On banks holding thousands of near-identical names an uncapped candidate set turns one retain into minutes of CPU, which stalls the worker's health checks; matches ranked below the first ~100 never win anyway. Raise only if entities that should merge are being duplicated. | `200` |
 | `HINDSIGHT_API_RETAIN_DEFAULT_STRATEGY` | Default retain strategy name. When set, all retain calls without an explicit `strategy` parameter use this strategy. | - |
@@ -1426,6 +1426,59 @@ export HINDSIGHT_API_RETAIN_BATCH_ENABLED=true
 ```
 
 > **Entity labels** (`entity_labels`) and **free-form entity extraction** (`entities_allow_free_form`) are configured per bank via the [bank config API](/developer/api/memory-banks#retain-configuration), not as global environment variables — each bank can have its own controlled vocabulary. See [Entity Labels](/developer/retain#entity-labels) for details.
+
+#### How entity resolution decides
+
+Resolving an extracted name against the entities already in a bank happens in **two
+stages, and each stage uses a different measure of similarity**. That distinction matters
+before you tune any of the thresholds above: the number that is easiest to compute by
+hand is not the number that decides the match.
+
+**Stage 1 — which existing entities are considered.** With `trigram` (the default),
+Postgres returns entities whose lowercased canonical name is trigram-similar to the
+extracted name, gated by
+[`HINDSIGHT_API_ENTITY_TRGM_SIMILARITY_THRESHOLD`](#database-connection-pool) — **`0.15`**,
+which is deliberately looser than pg_trgm's own `0.3` default. At most
+`HINDSIGHT_API_RETAIN_ENTITY_RESOLUTION_MAX_CANDIDATES` survive, ranked by that
+similarity. With `full`, candidates are instead the entities whose name is an exact or
+substring match. Label entities never enter this stage; they resolve by exact match only.
+
+**Stage 2 — whether one of them is reused.** Each candidate is scored, and the best one
+is reused if it clears **`0.6`**. Otherwise a new entity is created.
+
+| Signal | Weight | What it measures |
+|--------|--------|------------------|
+| Name similarity | up to **0.5** | A character-sequence ratio between the two lowercased names (Python's `difflib.SequenceMatcher`) — **not** the trigram similarity from stage 1 |
+| Co-occurring entities | up to **0.3** | The fraction of the *other* entities extracted from the same fact that this candidate already co-occurs with |
+| Temporal proximity | up to **0.2** | How close the fact's date is to the candidate's `last_seen`, decaying linearly to zero at 7 days |
+
+Two consequences are worth knowing about:
+
+- **There is no minimum name similarity that rejects a candidate.** Name similarity is
+  capped at `0.5` of the `0.6` needed, so a name never merges on its own — but
+  co-occurrence and recency are worth `0.5` between them, so a *weak* name match can be
+  carried over the line by the bank's history alone. On a mature bank this is easy to
+  hit: an entity such as `user` co-occurs with nearly every fact, so it contributes
+  co-occurrence overlap that carries little actual information.
+- **The two stages can disagree, and short names disagree the most.** The sequence ratio
+  rewards a shared run of characters relative to the length of the names, so short names
+  score far higher on it than on trigram similarity. `Tigran` and `Iran` are trigram-similar
+  at `0.20` (barely admitted at stage 1) but sequence-similar at `0.80`, which is `0.40` of
+  the `0.6` threshold before any other signal is counted.
+
+**If unrelated entities are merging,** raise
+`HINDSIGHT_API_ENTITY_TRGM_SIMILARITY_THRESHOLD` — it is the only threshold exposed, and
+it works by keeping the candidate out of stage 2 entirely. `0.25` is a reasonable first
+step: it excludes coincidental pairs like the one above while genuine surface variants of
+the same name, which typically sit between `0.4` and `0.7`, still match. Note that it is
+applied as a Postgres session setting on every pool connection, so it is server-wide and
+cannot be overridden per bank. For names that must never be fuzzy-matched at all, model
+them as [entity labels](/developer/retain#entity-labels), or pass them yourself with
+[`resolve_entities: false`](/developer/api/retain#resolve_entities).
+
+**If variants that should merge are staying separate,** lower that threshold, and check
+that `HINDSIGHT_API_RETAIN_ENTITY_RESOLUTION_MAX_CANDIDATES` is not truncating the right
+candidate away on a bank with many similar names.
 
 #### Skip storing raw document text
 

--- a/hindsight-docs/docs/developer/retain.md
+++ b/hindsight-docs/docs/developer/retain.md
@@ -93,6 +93,8 @@ Because resolution keys off name similarity, close variants merge automatically.
 
 **Why it matters:** You can ask "What do I know about Alice?" and get everything, even if she was mentioned as "Alice Chen" in some conversations.
 
+Resolution is a judgement call, so it can go the other way too: on a bank with a lot of history, a short new name that resembles an existing entity — and that turns up alongside entities the existing one is already associated with — can be absorbed into it instead of becoming its own entity. If you see facts about a new person attached to an unrelated entity, [How entity resolution decides](/developer/configuration#how-entity-resolution-decides) explains what is being compared and which setting makes matching stricter.
+
 ### Context-Aware Disambiguation
 
 If "Alice" appears with "Google" and "Stanford" multiple times, a new "Alice" mentioning those is likely the same person. Hindsight uses co-occurrence patterns to disambiguate common names.

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1394,7 +1394,7 @@ Controls the retain (memory ingestion) pipeline.
 | `HINDSIGHT_API_RETAIN_WALL_TIMEOUT` | Wall-clock ceiling in seconds for one retain task in the worker. A retain that blocks indefinitely (lock contention, an unreachable LLM endpoint) is cancelled and marked `failed` instead of holding its worker slot until the process restarts, so it can be retried. Set well above your slowest healthy retain; `0` disables. | `3600` |
 | `HINDSIGHT_API_RETAIN_BATCH_TOKENS` | Max characters per sub-batch for async retain auto-splitting | `10000` |
 | `HINDSIGHT_API_RETAIN_CHUNK_BATCH_SIZE` | Max chunks per streaming batch when retain ingests long documents. Each chunk produces roughly 17 facts, so the default 100 chunks ≈ 1700 facts per batch. Lower to cap memory/LLM pressure on large documents; raise for smaller chunks. Configurable per bank. | `100` |
-| `HINDSIGHT_API_RETAIN_ENTITY_LOOKUP` | Entity lookup method during retain: `full` (exact match) or `trigram` (fuzzy trigram matching) | `trigram` |
+| `HINDSIGHT_API_RETAIN_ENTITY_LOOKUP` | How retain finds *candidate* existing entities for an extracted name: `trigram` probes the pg_trgm index for similar names, `full` loads every entity in the bank and keeps the ones whose name is an exact or substring match. Both then run the same scoring pass (see [How entity resolution decides](#how-entity-resolution-decides)) — so this is not only a performance choice, it changes which names can merge at all. | `trigram` |
 | `HINDSIGHT_API_RETAIN_ENTITY_RESOLUTION_BATCH_SIZE` | Max unique entity names per fuzzy candidate lookup query (`trigram` on PG, `oracle_fuzzy` on Oracle). Bounds query size so very wide retain batches don't time out a single `unnest(...)` join on banks with many entities. | `100` |
 | `HINDSIGHT_API_RETAIN_ENTITY_RESOLUTION_MAX_CANDIDATES` | Max candidates scored per entity mention. The fuzzy lookup keeps only this many best matches per name (ranked by trigram / Jaro-Winkler similarity) before the scoring pass. On banks holding thousands of near-identical names an uncapped candidate set turns one retain into minutes of CPU, which stalls the worker's health checks; matches ranked below the first ~100 never win anyway. Raise only if entities that should merge are being duplicated. | `200` |
 | `HINDSIGHT_API_RETAIN_DEFAULT_STRATEGY` | Default retain strategy name. When set, all retain calls without an explicit `strategy` parameter use this strategy. | - |
@@ -1426,6 +1426,59 @@ export HINDSIGHT_API_RETAIN_BATCH_ENABLED=true
 ```
 
 > **Entity labels** (`entity_labels`) and **free-form entity extraction** (`entities_allow_free_form`) are configured per bank via the [bank config API](api/memory-banks.md#retain-configuration), not as global environment variables — each bank can have its own controlled vocabulary. See [Entity Labels](retain.md#entity-labels) for details.
+
+#### How entity resolution decides
+
+Resolving an extracted name against the entities already in a bank happens in **two
+stages, and each stage uses a different measure of similarity**. That distinction matters
+before you tune any of the thresholds above: the number that is easiest to compute by
+hand is not the number that decides the match.
+
+**Stage 1 — which existing entities are considered.** With `trigram` (the default),
+Postgres returns entities whose lowercased canonical name is trigram-similar to the
+extracted name, gated by
+[`HINDSIGHT_API_ENTITY_TRGM_SIMILARITY_THRESHOLD`](#database-connection-pool) — **`0.15`**,
+which is deliberately looser than pg_trgm's own `0.3` default. At most
+`HINDSIGHT_API_RETAIN_ENTITY_RESOLUTION_MAX_CANDIDATES` survive, ranked by that
+similarity. With `full`, candidates are instead the entities whose name is an exact or
+substring match. Label entities never enter this stage; they resolve by exact match only.
+
+**Stage 2 — whether one of them is reused.** Each candidate is scored, and the best one
+is reused if it clears **`0.6`**. Otherwise a new entity is created.
+
+| Signal | Weight | What it measures |
+|--------|--------|------------------|
+| Name similarity | up to **0.5** | A character-sequence ratio between the two lowercased names (Python's `difflib.SequenceMatcher`) — **not** the trigram similarity from stage 1 |
+| Co-occurring entities | up to **0.3** | The fraction of the *other* entities extracted from the same fact that this candidate already co-occurs with |
+| Temporal proximity | up to **0.2** | How close the fact's date is to the candidate's `last_seen`, decaying linearly to zero at 7 days |
+
+Two consequences are worth knowing about:
+
+- **There is no minimum name similarity that rejects a candidate.** Name similarity is
+  capped at `0.5` of the `0.6` needed, so a name never merges on its own — but
+  co-occurrence and recency are worth `0.5` between them, so a *weak* name match can be
+  carried over the line by the bank's history alone. On a mature bank this is easy to
+  hit: an entity such as `user` co-occurs with nearly every fact, so it contributes
+  co-occurrence overlap that carries little actual information.
+- **The two stages can disagree, and short names disagree the most.** The sequence ratio
+  rewards a shared run of characters relative to the length of the names, so short names
+  score far higher on it than on trigram similarity. `Tigran` and `Iran` are trigram-similar
+  at `0.20` (barely admitted at stage 1) but sequence-similar at `0.80`, which is `0.40` of
+  the `0.6` threshold before any other signal is counted.
+
+**If unrelated entities are merging,** raise
+`HINDSIGHT_API_ENTITY_TRGM_SIMILARITY_THRESHOLD` — it is the only threshold exposed, and
+it works by keeping the candidate out of stage 2 entirely. `0.25` is a reasonable first
+step: it excludes coincidental pairs like the one above while genuine surface variants of
+the same name, which typically sit between `0.4` and `0.7`, still match. Note that it is
+applied as a Postgres session setting on every pool connection, so it is server-wide and
+cannot be overridden per bank. For names that must never be fuzzy-matched at all, model
+them as [entity labels](retain.md#entity-labels), or pass them yourself with
+[`resolve_entities: false`](api/retain.md#resolve_entities).
+
+**If variants that should merge are staying separate,** lower that threshold, and check
+that `HINDSIGHT_API_RETAIN_ENTITY_RESOLUTION_MAX_CANDIDATES` is not truncating the right
+candidate away on a bank with many similar names.
 
 #### Skip storing raw document text
 

--- a/skills/hindsight-docs/references/developer/retain.md
+++ b/skills/hindsight-docs/references/developer/retain.md
@@ -93,6 +93,8 @@ Because resolution keys off name similarity, close variants merge automatically.
 
 **Why it matters:** You can ask "What do I know about Alice?" and get everything, even if she was mentioned as "Alice Chen" in some conversations.
 
+Resolution is a judgement call, so it can go the other way too: on a bank with a lot of history, a short new name that resembles an existing entity — and that turns up alongside entities the existing one is already associated with — can be absorbed into it instead of becoming its own entity. If you see facts about a new person attached to an unrelated entity, [How entity resolution decides](configuration.md#how-entity-resolution-decides) explains what is being compared and which setting makes matching stricter.
+
 ### Context-Aware Disambiguation
 
 If "Alice" appears with "Google" and "Stanford" multiple times, a new "Alice" mentioning those is likely the same person. Hindsight uses co-occurrence patterns to disambiguate common names.


### PR DESCRIPTION
## Why

A user asked why a retain that correctly extracted a new person, `Tigran`, stored the fact
on a pre-existing country entity, `Iran`. They had done the obvious homework:
`similarity('tigran','iran') = 0.2`, below pg_trgm's `0.3` default, neither string a
substring of the other — so by every documented number, this merge should not happen.

Nothing in the docs explains why it does. The thresholds are documented one env var at a
time (`ENTITY_TRGM_SIMILARITY_THRESHOLD`, `ENTITY_INTRABATCH_MERGE_SIMILARITY`,
`RETAIN_ENTITY_LOOKUP`, `..._MAX_CANDIDATES`), and the natural reading of that list is that
trigram similarity is what decides a match. It isn't:

- the trigram threshold (default **0.15**, not pg_trgm's 0.3) only decides which existing
  entities are **considered**;
- the merge itself is a separate weighted score — `SequenceMatcher` name ratio (≤0.5),
  co-occurrence overlap (≤0.3), recency (≤0.2), merged above **0.6** — with no minimum name
  similarity of its own.

For `tigran`/`iran` the two measures disagree sharply: 0.20 by trigram, **0.80** by sequence
ratio, i.e. 0.40 of the 0.6 threshold before any other signal. Add co-occurrence with an
entity like `user` — which co-occurs with nearly every fact on a mature bank — and it merges.
That's also why it doesn't reproduce on a fresh bank: no co-occurrence history to add.

## What changed

- **`configuration.md`** — new *How entity resolution decides* section: the two stages, the
  three scoring signals and their weights, the 0.6 cutoff, the fact that no minimum name
  similarity rejects a candidate, the short-name divergence between the two measures, and
  what to change in either direction (with the caveat that the trigram threshold is a
  Postgres session setting, so it is server-wide and not per-bank).
- **`configuration.md`** — `RETAIN_ENTITY_LOOKUP` described `full` as "exact match". It is
  exact-**or-substring**, and both strategies feed the same scoring pass. Since `full` would
  never have admitted `Iran` for `Tigran` in the first place, the choice changes which names
  can merge, not just how fast the lookup is. Row rewritten.
- **`retain.md`** — one paragraph noting resolution can absorb a new name into an existing
  entity, linking to the reference section. Kept impact-only, no internals.
- Regenerated `skills/hindsight-docs/references/**`.

## Scope

Documentation only — it describes today's behaviour on 0.9.1. The behaviour itself is
separately questionable (admission and decision use different metrics, and only the
admission one is tunable); that is being tracked on its own, not fixed here.

## Verification

- `npm run build` in `hindsight-docs` passes; the only broken-anchor warnings are
  pre-existing, in the 2026-04-28 blog post.
- `./scripts/generate-docs-skill.sh` re-run; the skill diff is exactly these two files.
