### PR TITLE
fix(llamacpp): report a missing llama.cpp instead of endless connection errors

### DIFF
--- a/docker/standalone/start-all.sh
+++ b/docker/standalone/start-all.sh
@@ -87,6 +87,40 @@ check_pg0_writable() {
     return 1
 }
 
+# =============================================================================
+# API startup wait (#3733)
+#
+# This wrapper kills the container when the API has not answered /health in
+# time. That wait is a separate timer from the API's own initialization cap
+# (HINDSIGHT_API_MODEL_INIT_TIMEOUT) — the knob the docs point at when a
+# first-time model download legitimately needs longer. Raising only the
+# documented knob used to have no effect in Docker: the wrapper still killed
+# the container at its own default, so the download restarted from scratch on
+# every boot. Follow the API's cap when it is the longer of the two.
+# =============================================================================
+DEFAULT_API_STARTUP_WAIT_SECONDS=300
+API_STARTUP_WAIT_GRACE_SECONDS=30
+
+resolve_api_startup_wait_seconds() {
+    # An explicit wrapper setting always wins.
+    if [ -n "${HINDSIGHT_API_STARTUP_WAIT_SECONDS:-}" ]; then
+        echo "${HINDSIGHT_API_STARTUP_WAIT_SECONDS}"
+        return 0
+    fi
+
+    # The API reads its cap as a float, so tolerate values like "7200.0".
+    local model_init="${HINDSIGHT_API_MODEL_INIT_TIMEOUT:-}"
+    model_init="${model_init%%.*}"
+    if [[ "$model_init" =~ ^[0-9]+$ ]] && [ "$model_init" -gt "$DEFAULT_API_STARTUP_WAIT_SECONDS" ]; then
+        # Grace period so the API surfaces its own timeout error before the
+        # wrapper gives up on it.
+        echo "$((model_init + API_STARTUP_WAIT_GRACE_SECONDS))"
+        return 0
+    fi
+
+    echo "$DEFAULT_API_STARTUP_WAIT_SECONDS"
+}
+
 if [ "${HINDSIGHT_START_ALL_SOURCE_ONLY:-false}" = "true" ]; then
     return 0 2>/dev/null || exit 0
 fi
@@ -228,7 +262,7 @@ PIDS=()
 if [ "$ENABLE_API" = "true" ]; then
     cd /app/api
     API_HEALTH_URL="${HINDSIGHT_API_HEALTH_URL:-http://localhost:${HINDSIGHT_API_PORT:-8888}/health}"
-    API_STARTUP_WAIT_SECONDS="${HINDSIGHT_API_STARTUP_WAIT_SECONDS:-300}"
+    API_STARTUP_WAIT_SECONDS="$(resolve_api_startup_wait_seconds)"
 
     # Run API directly - Python's PYTHONUNBUFFERED=1 handles output buffering
     hindsight-api &
@@ -251,6 +285,9 @@ if [ "$ENABLE_API" = "true" ]; then
 
     if [ "$api_ready" != "true" ]; then
         echo "❌ API did not become healthy within ${API_STARTUP_WAIT_SECONDS}s"
+        echo "   If a legitimate first-time model download needs longer, raise"
+        echo "   HINDSIGHT_API_MODEL_INIT_TIMEOUT (this wait follows it) or set"
+        echo "   HINDSIGHT_API_STARTUP_WAIT_SECONDS to override this wait directly."
         exit 1
     fi
 else

--- a/docker/standalone/test-start-all.sh
+++ b/docker/standalone/test-start-all.sh
@@ -73,6 +73,41 @@ assert_contains "$nonempty_output" "WARNING: pg0 data directory exists"
 echo "start-all pg0 integrity checks passed"
 
 # =============================================================================
+# resolve_api_startup_wait_seconds (#3733)
+# =============================================================================
+assert_equals() {
+    local actual="$1"
+    local expected="$2"
+
+    if [ "$actual" != "$expected" ]; then
+        echo "Expected: $expected"
+        echo "Actual:   $actual"
+        exit 1
+    fi
+}
+
+# Neither knob set: the wrapper default.
+assert_equals "$(HINDSIGHT_API_STARTUP_WAIT_SECONDS= HINDSIGHT_API_MODEL_INIT_TIMEOUT= resolve_api_startup_wait_seconds)" "300"
+
+# The documented knob raised: the wrapper waits at least that long, so raising
+# it actually takes effect instead of being cut short at the default.
+assert_equals "$(HINDSIGHT_API_MODEL_INIT_TIMEOUT=7200 resolve_api_startup_wait_seconds)" "7230"
+
+# Floats are accepted — the API parses its cap as one.
+assert_equals "$(HINDSIGHT_API_MODEL_INIT_TIMEOUT=7200.0 resolve_api_startup_wait_seconds)" "7230"
+
+# A shorter cap never shortens the wrapper wait.
+assert_equals "$(HINDSIGHT_API_MODEL_INIT_TIMEOUT=60 resolve_api_startup_wait_seconds)" "300"
+
+# Garbage falls back to the default rather than breaking startup.
+assert_equals "$(HINDSIGHT_API_MODEL_INIT_TIMEOUT=abc resolve_api_startup_wait_seconds)" "300"
+
+# An explicit wrapper setting always wins.
+assert_equals "$(HINDSIGHT_API_STARTUP_WAIT_SECONDS=45 HINDSIGHT_API_MODEL_INIT_TIMEOUT=7200 resolve_api_startup_wait_seconds)" "45"
+
+echo "start-all API startup wait checks passed"
+
+# =============================================================================
 # check_pg0_writable (#1483)
 # These rely on filesystem permissions, which root bypasses; skip under root.
 # =============================================================================

--- a/hindsight-api-slim/hindsight_api/engine/providers/llamacpp_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/llamacpp_llm.py
@@ -12,6 +12,7 @@ Usage:
 """
 
 import asyncio
+import importlib.util
 import logging
 import os
 import signal
@@ -47,6 +48,26 @@ def _find_free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
+
+
+def _require_llama_cpp() -> None:
+    """Fail fast when the `local-llm` extra is missing.
+
+    Without it, `python -m llama_cpp.server` exits immediately with
+    ModuleNotFoundError, which the caller only ever sees as a connection error
+    against a port nothing listens on. Checked before the model download so a
+    ~3.5 GB fetch is not spent on a server that cannot start (issue #3733).
+    """
+    if importlib.util.find_spec("llama_cpp") is None:
+        raise RuntimeError(
+            "HINDSIGHT_API_LLM_PROVIDER=llamacpp needs the 'local-llm' extra, which is not "
+            "installed (no module named 'llama_cpp').\n"
+            "  • pip install 'hindsight-api-slim[local-llm]'\n"
+            "  • The published Docker image (ghcr.io/vectorize-io/hindsight) deliberately omits "
+            "llama-cpp-python. For Docker, run llama.cpp as a sidecar and point Hindsight at it "
+            "with HINDSIGHT_API_LLM_PROVIDER=openai + HINDSIGHT_API_LLM_BASE_URL: see "
+            "docker/docker-compose/local-llm/ in the repository."
+        )
 
 
 def _download_default_model() -> Path:
@@ -312,13 +333,16 @@ class LlamaCppLLM(LLMInterface):
 
         async with _shared_server_lock:
             if _shared_server is None:
+                # Refuse before downloading gigabytes for a server we cannot run.
+                _require_llama_cpp()
+
                 # Resolve and potentially download the model
                 model_path = _resolve_model_path(self._model_path_str)
                 logger.info(f"Using GGUF model: {model_path}")
 
                 # Start the shared llama.cpp server
                 port = _find_free_port()
-                _shared_server = LlamaCppServer(
+                server = LlamaCppServer(
                     model_path=model_path,
                     port=port,
                     gpu_layers=self._gpu_layers,
@@ -326,7 +350,20 @@ class LlamaCppLLM(LLMInterface):
                     chat_format=self._chat_format,
                     extra_args=self._extra_args,
                 )
-                await _shared_server.start()
+                # Publish only once the process is actually serving. Assigning
+                # first left a dead server installed for the lifetime of the
+                # process: every later call skipped startup and talked to a port
+                # nothing listens on, so the real failure surfaced once and then
+                # masqueraded as endless connection errors (issue #3733).
+                try:
+                    await server.start()
+                except BaseException:
+                    # A start that timed out can leave the subprocess alive and
+                    # holding the model in memory; reap it so a retry does not
+                    # stack another one on top.
+                    await server.stop()
+                    raise
+                _shared_server = server
 
         self._server = _shared_server
 

--- a/hindsight-api-slim/tests/test_llamacpp_server_lifecycle.py
+++ b/hindsight-api-slim/tests/test_llamacpp_server_lifecycle.py
@@ -1,0 +1,113 @@
+"""Regression coverage for llama.cpp server startup failures (issue #3733).
+
+The published Docker image omits `llama-cpp-python`, so `provider=llamacpp`
+there can only fail. It has to fail *legibly*: before the ~3.5 GB model
+download, and without leaving a dead server behind that turns every later call
+into an unexplained connection error.
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hindsight_api.engine.providers import llamacpp_llm
+from hindsight_api.engine.providers.llamacpp_llm import LlamaCppLLM
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_server():
+    """The provider caches one server per process; keep tests independent."""
+    llamacpp_llm._shared_server = None
+    yield
+    llamacpp_llm._shared_server = None
+
+
+def _provider() -> LlamaCppLLM:
+    return LlamaCppLLM(provider="llamacpp", api_key="", base_url="", model="test-model")
+
+
+@pytest.mark.asyncio
+async def test_missing_llama_cpp_fails_before_downloading_the_model(monkeypatch):
+    def _fail_if_called(*args, **kwargs):
+        raise AssertionError("model resolution must not run without llama_cpp installed")
+
+    real_find_spec = llamacpp_llm.importlib.util.find_spec
+    monkeypatch.setattr(
+        llamacpp_llm.importlib.util,
+        "find_spec",
+        lambda name, *args, **kwargs: None if name == "llama_cpp" else real_find_spec(name, *args, **kwargs),
+    )
+    monkeypatch.setattr(llamacpp_llm, "_resolve_model_path", _fail_if_called)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await _provider()._ensure_initialized()
+
+    message = str(exc_info.value)
+    # Both supported ways out of this state have to be spelled out: the extra
+    # for local installs, the sidecar for the published image.
+    assert "local-llm" in message
+    assert "docker/docker-compose/local-llm" in message
+
+
+@pytest.mark.asyncio
+async def test_failed_start_leaves_no_dead_server_behind(monkeypatch):
+    starts: list[str] = []
+
+    stops: list[str] = []
+
+    class FakeServer:
+        def __init__(self, **kwargs):
+            self.port = kwargs["port"]
+
+        @property
+        def base_url(self) -> str:
+            return f"http://127.0.0.1:{self.port}/v1"
+
+        async def start(self) -> None:
+            starts.append("start")
+            if len(starts) == 1:
+                raise RuntimeError("llama.cpp server exited with code 1")
+
+        async def stop(self) -> None:
+            stops.append("stop")
+
+    monkeypatch.setattr(llamacpp_llm, "_require_llama_cpp", lambda: None)
+    monkeypatch.setattr(llamacpp_llm, "_resolve_model_path", lambda path: Path("/models/test.gguf"))
+    monkeypatch.setattr(llamacpp_llm, "LlamaCppServer", FakeServer)
+
+    provider = _provider()
+    with pytest.raises(RuntimeError, match="exited with code 1"):
+        await provider._ensure_initialized()
+
+    # A server that never started must not be published as the shared one, and
+    # a subprocess that outlived a timed-out start must be reaped.
+    assert llamacpp_llm._shared_server is None
+    assert provider._delegate is None
+    assert stops == ["stop"]
+
+    # The next attempt genuinely retries startup instead of building a client
+    # against a port nothing listens on.
+    await provider._ensure_initialized()
+    assert starts == ["start", "start"]
+    assert provider._delegate is not None
+    assert provider._delegate.base_url == llamacpp_llm._shared_server.base_url
+
+
+@pytest.mark.asyncio
+async def test_started_server_is_shared_across_providers(monkeypatch):
+    started = AsyncMock()
+
+    class FakeServer:
+        def __init__(self, **kwargs):
+            self.base_url = "http://127.0.0.1:1234/v1"
+            self.start = started
+
+    monkeypatch.setattr(llamacpp_llm, "_require_llama_cpp", lambda: None)
+    monkeypatch.setattr(llamacpp_llm, "_resolve_model_path", lambda path: Path("/models/test.gguf"))
+    monkeypatch.setattr(llamacpp_llm, "LlamaCppServer", FakeServer)
+
+    await _provider()._ensure_initialized()
+    await _provider()._ensure_initialized()
+
+    assert started.await_count == 1

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -519,7 +519,13 @@ The indexed members are credential fields — never returned by the bank-config 
 
 ### Built-in llama.cpp
 
-The `llamacpp` provider runs a llama.cpp server as a managed subprocess — no external LLM server needed. On first run it auto-downloads a default GGUF model (~3.5 GB). Requires the `local-llm` extra: `pip install 'hindsight-api-slim[local-llm]'`.
+The `llamacpp` provider runs a llama.cpp server as a managed subprocess — no external LLM server needed. On first run it auto-downloads a default GGUF model (~3.5 GB) into `~/.hindsight/models`. Requires the `local-llm` extra: `pip install 'hindsight-api-slim[local-llm]'`.
+
+:::warning Not available in the Docker image
+The published `ghcr.io/vectorize-io/hindsight` image deliberately leaves llama.cpp out, so `HINDSIGHT_API_LLM_PROVIDER=llamacpp` cannot run there — it fails immediately with a message telling you so.
+
+For local inference in Docker, run llama.cpp as its own container and point Hindsight at its OpenAI-compatible API with `HINDSIGHT_API_LLM_PROVIDER=openai` and `HINDSIGHT_API_LLM_BASE_URL`. A ready-to-run setup is in [`docker/docker-compose/local-llm/`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/local-llm).
+:::
 
 | Variable | Description | Default |
 |----------|-------------|---------|
@@ -545,6 +551,8 @@ export HINDSIGHT_API_LLAMACPP_EXTRA_ARGS="--n_threads 8"
 
 :::note
 The llama.cpp server is shared across all LLM operations (retain, reflect, consolidation). Set `HINDSIGHT_API_LLM_MAX_CONCURRENT=2` to allow retain and consolidation to run concurrently without blocking each other.
+
+Auto-downloaded models land in `~/.hindsight/models`. Keep that directory on persistent storage — if it is discarded between restarts, every restart re-downloads the full model.
 :::
 
 ### Per-Operation LLM Configuration
@@ -1255,6 +1263,7 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | `HINDSIGHT_API_LOG_JSON_FIELDS` | Comma-separated allowlist of JSON log fields to emit (e.g. `severity,message,tenant`). Available: `severity`, `message`, `timestamp`, `logger`, `tenant`, `exception`. Empty = all fields. | `""` (all) |
 | `HINDSIGHT_API_MCP_ENABLED` | Enable MCP server at `/mcp/{bank_id}/` | `true` |
 | `HINDSIGHT_API_MODEL_INIT_TIMEOUT` | Wall-clock cap (seconds) on startup model/connection initialization. If embeddings, the cross-encoder, or LLM verification block (e.g. an offline model download or an unreachable provider), the server fails fast with a clear error instead of hanging forever. Increase if a legitimate first-time model download needs more time. | `300` |
+| `HINDSIGHT_API_STARTUP_WAIT_SECONDS` | **Docker image only.** How long the container waits for the API to answer `/health` before it stops and restarts. Raising `HINDSIGHT_API_MODEL_INIT_TIMEOUT` above the default raises this wait too, so a slow first-time model download is not cut short; set this to override the wait on its own. | `300`, or `HINDSIGHT_API_MODEL_INIT_TIMEOUT` + 30s when that is longer |
 
 ### Retrieval
 

--- a/hindsight-docs/docs/developer/installation.md
+++ b/hindsight-docs/docs/developer/installation.md
@@ -104,10 +104,12 @@ Set `HINDSIGHT_API_WORKER_ID` to a stable value (e.g., `-e HINDSIGHT_API_WORKER_
 
 | Variant | Size (AMD64) | Size (ARM64) | When to use |
 |---------|--------------|--------------|-------------|
-| **Full** (`latest`) | ~9 GB | ~3.7 GB | Default. Works out of the box with no external services except the LLM. |
+| **Full** (`latest`) | ~9 GB | ~3.7 GB | Default. Embeddings and reranking run in the image; the LLM is always external, including for local inference. |
 | **Slim** (`slim`) | ~500 MB | ~500 MB | Use when you already rely on external services for embeddings and reranking (OpenAI, Cohere, TEI). Significantly smaller image, faster deploys. Requires [external providers](./configuration#embeddings). |
 
 The slim image corresponds to the [`hindsight-api-slim`](#bare-metal-pip) pip package. See [Configuration](./configuration#embeddings) for external provider options.
+
+Neither image bundles llama.cpp, so the built-in `llamacpp` provider is not available in Docker. To run inference locally, start llama.cpp (or Ollama, LM Studio, vLLM) alongside Hindsight and point `HINDSIGHT_API_LLM_BASE_URL` at it — see [`docker/docker-compose/local-llm/`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/local-llm) for a working compose file.
 
 ### Bundling Custom Models in a Custom Image
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -519,7 +519,13 @@ The indexed members are credential fields — never returned by the bank-config 
 
 ### Built-in llama.cpp
 
-The `llamacpp` provider runs a llama.cpp server as a managed subprocess — no external LLM server needed. On first run it auto-downloads a default GGUF model (~3.5 GB). Requires the `local-llm` extra: `pip install 'hindsight-api-slim[local-llm]'`.
+The `llamacpp` provider runs a llama.cpp server as a managed subprocess — no external LLM server needed. On first run it auto-downloads a default GGUF model (~3.5 GB) into `~/.hindsight/models`. Requires the `local-llm` extra: `pip install 'hindsight-api-slim[local-llm]'`.
+
+:::warning Not available in the Docker image
+The published `ghcr.io/vectorize-io/hindsight` image deliberately leaves llama.cpp out, so `HINDSIGHT_API_LLM_PROVIDER=llamacpp` cannot run there — it fails immediately with a message telling you so.
+
+For local inference in Docker, run llama.cpp as its own container and point Hindsight at its OpenAI-compatible API with `HINDSIGHT_API_LLM_PROVIDER=openai` and `HINDSIGHT_API_LLM_BASE_URL`. A ready-to-run setup is in [`docker/docker-compose/local-llm/`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/local-llm).
+:::
 
 | Variable | Description | Default |
 |----------|-------------|---------|
@@ -545,6 +551,8 @@ export HINDSIGHT_API_LLAMACPP_EXTRA_ARGS="--n_threads 8"
 
 :::note
 The llama.cpp server is shared across all LLM operations (retain, reflect, consolidation). Set `HINDSIGHT_API_LLM_MAX_CONCURRENT=2` to allow retain and consolidation to run concurrently without blocking each other.
+
+Auto-downloaded models land in `~/.hindsight/models`. Keep that directory on persistent storage — if it is discarded between restarts, every restart re-downloads the full model.
 :::
 
 ### Per-Operation LLM Configuration
@@ -1255,6 +1263,7 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | `HINDSIGHT_API_LOG_JSON_FIELDS` | Comma-separated allowlist of JSON log fields to emit (e.g. `severity,message,tenant`). Available: `severity`, `message`, `timestamp`, `logger`, `tenant`, `exception`. Empty = all fields. | `""` (all) |
 | `HINDSIGHT_API_MCP_ENABLED` | Enable MCP server at `/mcp/{bank_id}/` | `true` |
 | `HINDSIGHT_API_MODEL_INIT_TIMEOUT` | Wall-clock cap (seconds) on startup model/connection initialization. If embeddings, the cross-encoder, or LLM verification block (e.g. an offline model download or an unreachable provider), the server fails fast with a clear error instead of hanging forever. Increase if a legitimate first-time model download needs more time. | `300` |
+| `HINDSIGHT_API_STARTUP_WAIT_SECONDS` | **Docker image only.** How long the container waits for the API to answer `/health` before it stops and restarts. Raising `HINDSIGHT_API_MODEL_INIT_TIMEOUT` above the default raises this wait too, so a slow first-time model download is not cut short; set this to override the wait on its own. | `300`, or `HINDSIGHT_API_MODEL_INIT_TIMEOUT` + 30s when that is longer |
 
 ### Retrieval
 

--- a/skills/hindsight-docs/references/developer/installation.md
+++ b/skills/hindsight-docs/references/developer/installation.md
@@ -104,10 +104,12 @@ Set `HINDSIGHT_API_WORKER_ID` to a stable value (e.g., `-e HINDSIGHT_API_WORKER_
 
 | Variant | Size (AMD64) | Size (ARM64) | When to use |
 |---------|--------------|--------------|-------------|
-| **Full** (`latest`) | ~9 GB | ~3.7 GB | Default. Works out of the box with no external services except the LLM. |
+| **Full** (`latest`) | ~9 GB | ~3.7 GB | Default. Embeddings and reranking run in the image; the LLM is always external, including for local inference. |
 | **Slim** (`slim`) | ~500 MB | ~500 MB | Use when you already rely on external services for embeddings and reranking (OpenAI, Cohere, TEI). Significantly smaller image, faster deploys. Requires [external providers](./configuration#embeddings). |
 
 The slim image corresponds to the [`hindsight-api-slim`](#bare-metal-pip) pip package. See [Configuration](./configuration#embeddings) for external provider options.
+
+Neither image bundles llama.cpp, so the built-in `llamacpp` provider is not available in Docker. To run inference locally, start llama.cpp (or Ollama, LM Studio, vLLM) alongside Hindsight and point `HINDSIGHT_API_LLM_BASE_URL` at it — see [`docker/docker-compose/local-llm/`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/local-llm) for a working compose file.
 
 ### Bundling Custom Models in a Custom Image
 


### PR DESCRIPTION
Fixes #3733.

The reporter ran the published image with `HINDSIGHT_API_LLM_PROVIDER=llamacpp`, watched a 3.5 GB download crash-loop, supplied the model by hand, and then got nothing but `APIConnectionError` against `127.0.0.1` on every retain and reflect. The thread's answer — use the llama.cpp sidecar — is right, but the experience getting there was three separate defects, and all three are fixed here.

### A failed start still installed the shared server

`_ensure_initialized` assigned the module global *before* awaiting `start()`:

```python
if _shared_server is None:
    _shared_server = LlamaCppServer(...)
    await _shared_server.start()   # raises: no module named 'llama_cpp'
```

After that raise the global is non-`None`, so every later call takes the "already started" branch, skips startup entirely, and builds an OpenAI client pointed at a port nothing listens on. The one honest error surfaced once — at boot, where LLM verification only warns so queued operations can survive a provider outage — and was masked as connection errors for the life of the process. Exactly what the issue logs show, and why the reporter never saw the `ModuleNotFoundError` our own `local-llm/README.md` promises.

The server is now published only once it is serving. A start that times out with the subprocess still alive is reaped, so a retry cannot stack a second model-holding process on top of the first.

### The model downloaded before anything checked it could be used

The dependency is now required up front, before `_resolve_model_path`, so an image without `llama-cpp-python` fails in milliseconds instead of after a multi-gigabyte download. The message names both ways out: the extra for local installs, the sidecar compose file for the published image.

### `HINDSIGHT_API_MODEL_INIT_TIMEOUT` could not do what the docs say

The reporter set it to 7200 and the container still died at exactly 300s, because `docker/standalone/start-all.sh` polls `/health` on its *own* timer (`HINDSIGHT_API_STARTUP_WAIT_SECONDS`, default 300, documented nowhere). Two timers, one documented, and the undocumented one wins — so the download restarted from zero on every boot.

The wrapper wait now follows `HINDSIGHT_API_MODEL_INIT_TIMEOUT` when that is the longer of the two, plus 30s of grace so the API reports its own timeout error first. An explicit `HINDSIGHT_API_STARTUP_WAIT_SECONDS` still overrides, and the failure message now names both knobs.

### Docs

`models.mdx` already stated the image boundary; the two pages the reporter actually read did not. The configuration page now carries a warning admonition pointing at the sidecar, the image variants row no longer reads as "everything but the LLM key", `HINDSIGHT_API_STARTUP_WAIT_SECONDS` is documented, and auto-downloaded models are noted as needing persistent storage (`~/.hindsight/models` is not one of the paths a typical compose file mounts).

### Deliberately not changed

A missing extra is a permanent misconfiguration, so there's an argument for aborting the boot rather than warning. Left as a warning to stay consistent with every other provider misconfiguration (a bad API key warns too) — with the difference that the warning now says what is wrong and every subsequent failure repeats it, instead of pointing at a dead socket.

### Tests

* `tests/test_llamacpp_server_lifecycle.py` — the missing extra raises before any model resolution; a failed start leaves no server cached, reaps the subprocess, and the next attempt genuinely retries; a successful start is still shared across providers.
* `docker/standalone/test-start-all.sh` — the wait resolver: default, raised init timeout (incl. float values), shorter timeout, garbage input, explicit override. Runs in CI already.
