### PR TITLE
fix(retain): retry and fail loudly on schema-drifted fact extraction (#3708)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1492,6 +1492,17 @@ async def _extract_facts_from_chunk(
                     # In verbatim mode, 'what' is intentionally absent — text is backfilled from chunk
                     if extraction_mode != "verbatim":
                         logger.warning(f"Skipping fact {i}: missing 'what' field")
+                        # Count it as malformed so the re-prompt below covers this case too.
+                        # A model that emits well-formed JSON with the wrong field shape (no
+                        # schema enforcement, e.g. JSON-mode-only models) otherwise drops every
+                        # fact on the first attempt and returns [] without ever retrying, and
+                        # the retain still completes — silent data loss (#3708).
+                        #
+                        # Only *absent* text keys count. A key that is present but empty or
+                        # "N/A" is the model saying "nothing to extract here", which re-prompting
+                        # cannot improve — skip it as quietly as before.
+                        if not any(key in llm_fact for key in ("what", "factual_core", "text")):
+                            has_malformed_facts = True
                         continue
 
                 # Critical field: fact_type — "assistant" maps to "experience", everything else is "world".
@@ -1660,6 +1671,22 @@ async def _extract_facts_from_chunk(
                     f"Got {len(raw_facts) - len(chunk_facts)} malformed facts out of {len(raw_facts)} on attempt {attempt + 1}/{outer_attempts}. Retrying..."
                 )
                 continue
+
+            # Every fact the model returned was unusable, on every attempt. Raise
+            # instead of returning [] so the failure reaches the worker's retry
+            # machinery and ultimately fails the operation loudly — the same rule the
+            # non-dict response above follows (#1833). Without this the retain commits
+            # a document with 0 memory units and reports `completed`, so callers cannot
+            # tell schema-drifted extraction from content that genuinely held no facts
+            # (#3708). A model that legitimately returns `"facts": []` never lands here:
+            # nothing was dropped, so has_malformed_facts stays False.
+            if has_malformed_facts and not chunk_facts:
+                raise RuntimeError(
+                    f"Fact extraction failed: all {len(raw_facts)} facts returned by the LLM were "
+                    f"unusable after {outer_attempts} attempts (wrong shape or missing required fields). "
+                    f"Model '{llm_config.model}' may not honour the extraction schema — consider enabling "
+                    f"HINDSIGHT_API_LLM_STRICT_SCHEMA_RETAIN or using a model with strict schema support."
+                )
 
             return chunk_facts, usage
 
@@ -2314,6 +2341,16 @@ async def extract_facts_from_contents_batch_api(
             if not what:
                 what = get_value("text")
             if not what:
+                # Same schema-drift signal as the streaming path (#3708): a fact object
+                # carrying none of the text keys means the model ignored the schema.
+                # The batch API cannot re-prompt a single request, so record it on the
+                # operation instead — that is what extraction_errors is for, and
+                # HINDSIGHT_API_FAIL_ON_EXTRACTION_ERRORS can escalate it to a failure.
+                # A key that is present but empty/"N/A" stays a quiet skip.
+                if not any(key in llm_fact for key in ("what", "factual_core", "text")):
+                    message = f"{custom_id}: fact {i} has no 'what'/'factual_core'/'text' field"
+                    logger.warning(message)
+                    extraction_errors.add(message)
                 continue
 
             when = get_value("when")

--- a/hindsight-api-slim/tests/test_batch_api.py
+++ b/hindsight-api-slim/tests/test_batch_api.py
@@ -12,7 +12,7 @@ import json
 import logging
 import uuid
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -320,6 +320,77 @@ async def test_batch_api_rejects_top_level_non_fact_list(mock_llm_config, test_c
     assert len(chunks) == 1
     assert chunks[0].fact_count == 0
     assert usage.total_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_batch_api_records_schema_drifted_facts_as_extraction_errors(
+    mock_llm_config, test_contents, hindsight_config
+):
+    """Issue #3708.
+
+    A fact object carrying none of the text keys means the model ignored the
+    schema. The batch API cannot re-prompt one request, so the drop has to reach
+    the operation's extraction_errors instead of only the server log. A 'what'
+    that IS present but empty is the model saying "nothing here" — stays quiet.
+    """
+    batch_id = "batch_schema_drift"
+    mock_llm_config._provider_impl.supports_batch_api = AsyncMock(return_value=True)
+    mock_llm_config._provider_impl.submit_batch = AsyncMock(return_value={"batch_id": batch_id})
+    mock_llm_config._provider_impl.get_batch_status = AsyncMock(
+        return_value={"status": "completed", "request_counts": {"total": 1, "completed": 1, "failed": 0}}
+    )
+    mock_llm_config._provider_impl.retrieve_batch_results = AsyncMock(
+        return_value=[
+            {
+                "custom_id": "chunk_0",
+                "response": {
+                    "body": {
+                        "choices": [
+                            {
+                                "message": {
+                                    "content": json.dumps(
+                                        {
+                                            "facts": [
+                                                {"when": "2024", "who": "Alice", "fact_type": "world"},
+                                                {"what": "", "fact_type": "world"},
+                                            ]
+                                        }
+                                    )
+                                }
+                            }
+                        ],
+                        "usage": {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150},
+                    }
+                },
+            }
+        ]
+    )
+
+    recorded = []
+
+    async def _capture(pool, operation_id, schema, errors):
+        recorded.append(errors)
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._write_batch_extraction_errors",
+        side_effect=_capture,
+    ):
+        facts, chunks, _usage = await extract_facts_from_contents_batch_api(
+            contents=[test_contents[0]],
+            llm_config=mock_llm_config,
+            agent_name="test_agent",
+            config=hindsight_config,
+            pool=None,
+            operation_id=None,
+            schema=None,
+        )
+
+    assert facts == []
+    assert chunks[0].fact_count == 0
+    assert len(recorded) == 1
+    # Only the fact with no text key at all is an error; the empty 'what' is not.
+    assert recorded[0].count == 1
+    assert recorded[0].sample == ["chunk_0: fact 0 has no 'what'/'factual_core'/'text' field"]
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -160,6 +160,9 @@ def _make_llm_config(mock_response):
 
     llm = MagicMock(spec=LLMProvider)
     llm.provider = "mock"
+    # Set explicitly: ``model`` is an instance attribute, so ``spec=LLMProvider``
+    # does not provide it, and the extraction error paths name the model.
+    llm.model = "mock-model"
     token_usage = MagicMock()
     token_usage.__add__ = lambda self, other: self
     llm.call = AsyncMock(return_value=(mock_response, token_usage))
@@ -249,15 +252,14 @@ async def test_top_level_fact_list_is_accepted_without_retry():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("fact_fields", "expected_count", "expected_text"),
+    ("fact_fields", "expected_text"),
     [
-        ({"text": "Alice visited Paris"}, 1, "Alice visited Paris"),
-        ({"what": "Alice visited Paris"}, 1, "Alice visited Paris"),
-        ({}, 0, None),
+        ({"text": "Alice visited Paris"}, "Alice visited Paris"),
+        ({"what": "Alice visited Paris"}, "Alice visited Paris"),
     ],
 )
-async def test_fact_text_alias_is_recovered_without_accepting_empty_facts(fact_fields, expected_count, expected_text):
-    """Recover schema-drifted ``text`` facts while still skipping empty facts."""
+async def test_fact_text_alias_is_recovered(fact_fields, expected_text):
+    """Recover schema-drifted ``text`` facts (the empty case is #3708 below)."""
     from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
 
     config = _make_config(llm_max_retries=0, retain_llm_max_retries=None)
@@ -286,9 +288,173 @@ async def test_fact_text_alias_is_recovered_without_accepting_empty_facts(fact_f
             agent_name="test-agent",
         )
 
-    assert len(facts) == expected_count
-    if expected_text:
-        assert expected_text in facts[0].fact
+    assert len(facts) == 1
+    assert expected_text in facts[0].fact
+
+
+def _drifted_fact(index: int) -> dict:
+    """A well-formed JSON fact object that carries none of the text keys (#3708)."""
+    return {"when": f"202{index}", "who": "Alice", "why": "vacation", "fact_type": "world"}
+
+
+@pytest.mark.asyncio
+async def test_schema_drifted_facts_are_retried_then_raise():
+    """Issue #3708.
+
+    A model without strict-schema support can return well-formed JSON whose fact
+    objects have the wrong shape (no 'what'/'factual_core'/'text'). Every fact is
+    then dropped. That must (a) count as malformed so the re-prompt loop runs, and
+    (b) raise once the retries are exhausted rather than returning [] — otherwise
+    the retain commits the document with 0 memory units and reports `completed`.
+    """
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
+
+    config = _make_config(llm_max_retries=2, retain_llm_max_retries=None)
+    llm_config = _make_llm_config(mock_response={"facts": [_drifted_fact(3), _drifted_fact(4)]})
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        with pytest.raises(RuntimeError, match="all 2 facts returned by the LLM were unusable"):
+            await _extract_facts_from_chunk(
+                chunk="Alice visited Paris in 2023.",
+                chunk_index=0,
+                total_chunks=1,
+                event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                context="travel notes",
+                llm_config=llm_config,
+                config=config,
+                agent_name="test-agent",
+            )
+
+    # Budget 2 => the initial request plus 2 re-prompts.
+    assert llm_config.call.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_schema_drifted_facts_do_not_discard_the_usable_ones():
+    """A partially drifted response keeps its valid facts and does not raise."""
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
+
+    config = _make_config(llm_max_retries=0, retain_llm_max_retries=None)
+    llm_config = _make_llm_config(
+        mock_response={
+            "facts": [
+                {"what": "Alice visited Paris", "when": "2023", "fact_type": "world"},
+                _drifted_fact(4),
+            ]
+        }
+    )
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        facts, _usage = await _extract_facts_from_chunk(
+            chunk="Alice visited Paris in 2023.",
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            context="travel notes",
+            llm_config=llm_config,
+            config=config,
+            agent_name="test-agent",
+        )
+
+    assert len(facts) == 1
+    assert "Alice visited Paris" in facts[0].fact
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("placeholder", ["", "N/A", None])
+async def test_placeholder_what_is_skipped_without_retry_or_raise(placeholder):
+    """A *present* but empty/"N/A" 'what' is the model saying "nothing here".
+
+    That is schema-conformant, so it must stay a quiet skip: no re-prompt (which
+    could not improve it) and no failure (#3708 must not turn "no facts in this
+    content" into a hard error).
+    """
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
+
+    config = _make_config(llm_max_retries=3, retain_llm_max_retries=None)
+    llm_config = _make_llm_config(mock_response={"facts": [{"what": placeholder, "fact_type": "world"}]})
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        facts, _usage = await _extract_facts_from_chunk(
+            chunk="ok thanks",
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            context="",
+            llm_config=llm_config,
+            config=config,
+            agent_name="test-agent",
+        )
+
+    assert facts == []
+    assert llm_config.call.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_facts_list_is_not_treated_as_schema_drift():
+    """``{"facts": []}`` is a valid "nothing to extract" answer, not a failure."""
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
+
+    config = _make_config(llm_max_retries=3, retain_llm_max_retries=None)
+    llm_config = _make_llm_config(mock_response={"facts": []})
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        facts, _usage = await _extract_facts_from_chunk(
+            chunk="ok thanks",
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            context="",
+            llm_config=llm_config,
+            config=config,
+            agent_name="test-agent",
+        )
+
+    assert facts == []
+    assert llm_config.call.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_verbatim_mode_tolerates_facts_without_what():
+    """In verbatim mode 'what' is intentionally absent — text is backfilled from
+    the chunk later, so those facts must not be counted as schema drift."""
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
+
+    config = dataclasses.replace(
+        _make_config(llm_max_retries=3, retain_llm_max_retries=None),
+        retain_extraction_mode="verbatim",
+    )
+    llm_config = _make_llm_config(mock_response={"facts": [{"fact_type": "world", "entities": ["Alice"]}]})
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        facts, _usage = await _extract_facts_from_chunk(
+            chunk="Alice visited Paris in 2023.",
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            context="travel notes",
+            llm_config=llm_config,
+            config=config,
+            agent_name="test-agent",
+        )
+
+    assert len(facts) == 1
+    assert llm_config.call.call_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #3708

## The defect

A model without strict-schema support can return well-formed JSON whose fact objects have the wrong shape — no `what`, `factual_core` or `text`. Every such fact is dropped in the lenient parser.

Two things then went wrong:

1. **No retry.** The `missing 'what'` skip was the only one of the three skip paths in the parse loop that did *not* set `has_malformed_facts`, so the re-prompt gate right below it never fired for schema drift. The sibling paths (non-dict entry, `Fact(...)` construction failure) both set it.
2. **No signal.** With every fact dropped, extraction returned `[]` on the very first attempt, the document was committed with 0 memory units, and the operation reported `completed`. The only trace was a server log line, so callers could not tell schema-drifted extraction from content that genuinely held no facts.

Reproduced as a unit test before the fix: a response of two facts carrying `when`/`who`/`why` but no `what`, with `llm_max_retries=3`, returned `[]` after exactly **1** LLM call. The same response with non-dict entries retried 3 times.

## The fix

**Streaming path** (`_extract_facts_from_chunk`)
- An *absent* text key now counts as malformed, so the existing re-prompt loop runs.
- If retries are exhausted and nothing usable came back, raise instead of returning `[]`. This is the rule the non-dict-response path has followed since #1833: `extract_facts_from_text` collects it, `extract_facts_from_contents` re-raises it, the worker's retry machinery takes over and ultimately fails the operation loudly rather than committing an empty document. The message names the model and points at `HINDSIGHT_API_LLM_STRICT_SCHEMA_RETAIN`.

**Batch path** (`extract_facts_from_contents_batch_api`)
- The Batch API cannot re-prompt a single request, so the drop is recorded in `extraction_errors` instead — the channel #2700 built. It surfaces in the operation's `result_metadata.extraction_errors_count` / `_sample` and can be escalated to a failed operation with `HINDSIGHT_API_FAIL_ON_EXTRACTION_ERRORS`. This path already recorded every other unusable-chunk case; per-fact drops were the gap.

## What deliberately did not change

The fix must not turn "this content has no facts" into a hard failure, so these all keep the old quiet behaviour, each with a test:

- `"facts": []` — a valid "nothing to extract" answer.
- A `what` that is **present** but empty or `"N/A"` — the model saying "nothing here"; re-prompting cannot improve it.
- Verbatim mode, where `what` is intentionally absent and the text is backfilled from the chunk.
- Partial drift — the usable facts are still returned, no raise.

## Tests

- `tests/test_fact_extraction_retry.py`: retry-then-raise (asserts `call_count == 3`, i.e. the re-prompt now actually runs), partial drift keeps its facts, and the three no-op cases above.
- `tests/test_batch_api.py`: a batch response mixing one key-absent fact with one empty-`what` fact records exactly **one** extraction error.
- The `({}, 0, None)` parametrize case of `test_fact_text_alias_is_recovered_without_accepting_empty_facts` asserted precisely the old silent-`[]` behaviour; it moved into the new #3708 raise test, and the alias half kept its name trimmed.

`pytest -k retain` → 422 passed, 19 skipped. Fact-extraction / batch / strict-schema suites → 106 passed. `./scripts/hooks/lint.sh` and `ty check` clean.

One pre-existing unrelated failure: `test_user_interaction_classified_as_experience` hard-asserts a real-Gemini world/experience ratio (`2 > 2`). Confirmed failing identically on the base commit with this branch stashed.
