### PR TITLE
fix(reflect): fail when a run produces no answer instead of storing a placeholder (#2959)

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -179,7 +179,7 @@ from hindsight_api.engine.mental_model_refresh import (
     RefreshMentalModelOperationDetails,
 )
 from hindsight_api.engine.providers.none_llm import LLMNotAvailableError
-from hindsight_api.engine.reflect import ReflectToolCallError
+from hindsight_api.engine.reflect import ReflectNoAnswerError, ReflectToolCallError
 from hindsight_api.engine.response_models import (
     VALID_RECALL_FACT_TYPES,
     DryRunExtractionResult,
@@ -5046,6 +5046,14 @@ def _register_routes(app: FastAPI):
             raise
         except LLMNotAvailableError as e:
             raise HTTPException(status_code=400, detail=str(e))
+        except ReflectNoAnswerError as e:
+            # The loop ran but produced no answer (a done call with an empty answer,
+            # a final synthesis that returned nothing). Reflect used to substitute a
+            # placeholder sentence and return 200, which read as a real answer to
+            # every caller and got stored as one (#2959). There is nothing to
+            # return, so this is a failure like any other.
+            logger.warning("Reflect produced no answer in bank %s: %s", bank_id, e)
+            raise HTTPException(status_code=500, detail=str(e))
         except ReflectToolCallError as e:
             # The configured model/transport can't drive reflect's tool-calling loop.
             # The request itself is fine, so this is a server-side (500) failure, not a

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -3677,18 +3677,17 @@ class MemoryEngine(MemoryEngineInterface):
         if not operation_id:
             return
 
-        from .reflect.agent import NO_ANSWER_TEXT
-
         content = refreshed.get("content") or ""
         stripped = content.strip()
         reflect_response = refreshed.get("reflect_response") or {}
         based_on = reflect_response.get("based_on") or {}
         outcome = RefreshMentalModelOutcomeMetadata(
             content_len=len(content),
-            # The no-answer stub and the pending placeholder complete
-            # wire-successful but carry no real synthesis — a length check
-            # alone would read them as populated.
-            populated_content=bool(stripped) and stripped not in (MENTAL_MODEL_PENDING_CONTENT, NO_ANSWER_TEXT),
+            # The pending placeholder completes wire-successful but carries no
+            # real synthesis — a length check alone would read it as populated.
+            # Reflect's own failure stubs are gone: a run with no answer now
+            # raises (#2959), so no refresh reaches here carrying one.
+            populated_content=bool(stripped) and stripped != MENTAL_MODEL_PENDING_CONTENT,
             based_on_counts={fact_type: len(facts or []) for fact_type, facts in based_on.items()},
             delta_ops_applied=len(reflect_response.get("delta_operations_applied") or []),
             delta_ops_skipped=len(reflect_response.get("delta_operations_skipped") or []),

--- a/hindsight-api-slim/hindsight_api/engine/reflect/__init__.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/__init__.py
@@ -7,13 +7,14 @@ The reflect agent uses an iterative loop with tools to:
 3. Expand memories (get chunk/document context)
 """
 
-from .agent import ReflectAgentResult, ReflectToolCallError, run_reflect_agent
+from .agent import ReflectAgentResult, ReflectNoAnswerError, ReflectToolCallError, run_reflect_agent
 from .models import ReflectAction, ReflectActionBatch
 
 __all__ = [
     "run_reflect_agent",
     "ReflectAgentResult",
     "ReflectToolCallError",
+    "ReflectNoAnswerError",
     "ReflectAction",
     "ReflectActionBatch",
 ]

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -61,10 +61,19 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_ITERATIONS = 10
 
-# Fallback answer when the LLM returns nothing usable. Consumers that need to
-# tell a real answer from this placeholder (e.g. refresh outcome metadata's
-# populated_content) compare against this constant rather than the literal.
-NO_ANSWER_TEXT = "No answer provided."
+
+class ReflectNoAnswerError(RuntimeError):
+    """The agent finished without producing an answer.
+
+    Reflect used to substitute a human-readable placeholder here ("No answer
+    provided.", or an iteration-limit sentence). Both are non-empty strings, so
+    every downstream emptiness check let them through and callers could not tell
+    a failed run from a real one -- a mental-model refresh persisted the
+    placeholder over a document built across months of refreshes and reported
+    ``completed`` with no error (#2959). A run that produced nothing is a
+    failure, so it raises like any other, and callers that write what reflect
+    returns simply never reach the write.
+    """
 
 
 class ReflectToolCallError(RuntimeError):
@@ -744,6 +753,15 @@ async def _run_reflect_agent_inner(
             prompt = build_reduce_prompt(query, list(claim_sections), bank_profile, context, max_tokens=max_tokens)
             answer = await _tracked_llm_call(prompt, "final", final_system, synthesis_max_completion_tokens)
 
+        if not (answer or "").strip():
+            # Tools were disabled for this call and the model still returned nothing.
+            # There is no answer to hand back, so the run failed -- see #2959 for why
+            # a placeholder here is worse than an exception.
+            raise ReflectNoAnswerError(
+                f"Reflect's final synthesis returned no text after {iterations_completed} iteration(s) "
+                f"over {len(chunks)} context chunk(s)."
+            )
+
         structured_output = None
         if response_schema and answer:
             struct = await _generate_structured_output(answer, response_schema, llm_config, reflect_id, max_tokens)
@@ -1144,17 +1162,13 @@ async def _run_reflect_agent_inner(
                 # Keep context history for fallback final prompt
                 context_history.append({"tool": tc.name, "input": input_dict, "output": output})
 
-    # Should not reach here
-    answer = "I was unable to formulate a complete answer within the iteration limit."
-    _log_completion(answer, max_iterations, forced=True)
-    return ReflectAgentResult(
-        text=answer,
-        iterations=max_iterations,
-        tools_called=total_tools_called,
-        tool_trace=tool_trace,
-        llm_trace=_get_llm_trace(),
-        usage=_get_usage(),
-        directives_applied=directives_applied,
+    # Unreachable in practice: the last iteration returns the forced synthesis
+    # above, so the loop cannot fall out of the bottom. Kept as a hard failure
+    # rather than a fallback sentence -- if it ever does fire, the run produced
+    # no answer, and inventing one here is exactly the silent overwrite of #2959.
+    raise ReflectNoAnswerError(
+        f"Reflect exhausted its {max_iterations} iteration(s) without producing an answer "
+        f"({total_tools_called} tool call(s) made)."
     )
 
 
@@ -1236,8 +1250,16 @@ async def _process_done_tool(
     else:
         answer = args.get("answer", "").strip()
     if not answer:
-        document = None
-        answer = NO_ANSWER_TEXT
+        # The model called ``done`` with nothing in it -- typically its output was
+        # cut off mid-tool-call by the completion cap, so the answer field arrived
+        # empty even though the evidence was gathered. Fail instead of standing in
+        # a placeholder: it is non-empty, so every downstream emptiness guard reads
+        # it as a real answer and stores it over working content (#2959).
+        raise ReflectNoAnswerError(
+            f"Reflect's done tool returned no answer (iteration {iterations}, "
+            f"{total_tools_called} tool call(s) made). The model's output may have been "
+            "truncated before the answer field was written."
+        )
 
     final_usage = usage
     if llm_config and max_tokens is not None and count_cl100k_tokens(answer) > max_tokens:

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -763,7 +763,8 @@ async def _run_reflect_agent_inner(
             )
 
         structured_output = None
-        if response_schema and answer:
+        # ``answer`` is non-empty past the guard above, so only the schema gates this.
+        if response_schema:
             struct = await _generate_structured_output(answer, response_schema, llm_config, reflect_id, max_tokens)
             structured_output = struct.structured_output
             total_input_tokens += struct.input_tokens

--- a/hindsight-api-slim/tests/test_mental_model_no_answer_preserved.py
+++ b/hindsight-api-slim/tests/test_mental_model_no_answer_preserved.py
@@ -1,0 +1,96 @@
+"""A reflect run that produced no answer must not touch the stored document (#2959).
+
+Reflect used to hand back the placeholder "No answer provided." whenever the
+``done`` tool arrived with a blank answer. The placeholder is non-empty, so
+``refresh_mental_model``'s "refuse to overwrite existing content with an empty
+render" guard (``not final_content.strip()``) let it through: a mental model
+built across months of refreshes was replaced by a 19-character string, and the
+async operation was recorded as ``completed`` with ``error_message: null`` —
+no failure signal anywhere to alert on.
+
+Reflect now raises instead of inventing text, so the refresh never reaches its
+write. These tests assert that end of it: the exception propagates and the
+stored document is byte-identical afterwards.
+"""
+
+import uuid
+
+import pytest
+
+from hindsight_api.engine.memory_engine import MemoryEngine
+from hindsight_api.engine.reflect import ReflectNoAnswerError
+
+EXISTING = "# Team\n\nAlice leads platform. Bob owns ingest.\n"
+
+
+async def _model_with_content(memory: MemoryEngine, request_context, bank_id: str) -> dict:
+    await memory.get_bank_profile(bank_id, request_context=request_context)
+    return await memory.create_mental_model(
+        bank_id=bank_id,
+        name="Team Info",
+        source_query="Tell me about the team",
+        content=EXISTING,
+        trigger={"mode": "full"},
+        request_context=request_context,
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_preserves_content_when_reflect_has_no_answer(memory, request_context, monkeypatch):
+    """The reported production case: evidence was gathered, the answer never arrived."""
+    bank_id = f"test-mm-no-answer-{uuid.uuid4().hex[:8]}"
+    try:
+        mm = await _model_with_content(memory, request_context, bank_id)
+
+        async def no_answer(**kwargs):
+            raise ReflectNoAnswerError("Reflect's done tool returned no answer (iteration 3, 5 tool call(s) made).")
+
+        monkeypatch.setattr(memory, "reflect_async", no_answer)
+
+        with pytest.raises(ReflectNoAnswerError):
+            await memory.refresh_mental_model(
+                bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+            )
+
+        preserved = await memory.get_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        assert preserved is not None
+        assert preserved["content"] == EXISTING, "A failed reflect overwrote the stored document (#2959)"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_refresh_does_not_advance_the_watermark_on_no_answer(memory, request_context, monkeypatch):
+    """The failed run must stay repeatable: nothing it never read may fall out of the window.
+
+    ``last_refreshed_at`` bounds the next delta refresh's window. Moving it for a
+    run that produced nothing would put the facts this refresh was triggered by
+    permanently behind the watermark, so no later refresh would ever see them.
+    """
+    bank_id = f"test-mm-no-answer-wm-{uuid.uuid4().hex[:8]}"
+    try:
+        mm = await _model_with_content(memory, request_context, bank_id)
+        before = await memory.get_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+
+        async def no_answer(**kwargs):
+            raise ReflectNoAnswerError("Reflect's final synthesis returned no text after 4 iteration(s).")
+
+        monkeypatch.setattr(memory, "reflect_async", no_answer)
+
+        with pytest.raises(ReflectNoAnswerError):
+            await memory.refresh_mental_model(
+                bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+            )
+
+        after = await memory.get_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        assert after is not None and before is not None
+        assert after["last_refreshed_at"] == before["last_refreshed_at"]
+        assert after["last_memory_seen_at"] == before["last_memory_seen_at"]
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_reflect_agent.py
+++ b/hindsight-api-slim/tests/test_reflect_agent.py
@@ -15,6 +15,7 @@ import pytest
 
 from hindsight_api.engine.llm_interface import LLM_TOOL_CHOICE_AUTO, LLMToolChoice
 from hindsight_api.engine.reflect.agent import (
+    ReflectNoAnswerError,
     ReflectToolCallError,
     _all_mental_models_are_usable_and_fresh,
     _cache_cleanup_tasks,
@@ -948,6 +949,125 @@ class TestContextOverflowBehavior:
         assert mock_llm.call_with_tools.call_count == 1
         # Final synthesis was called
         mock_llm.call.assert_called_once()
+
+
+class TestNoAnswerFailsHard:
+    """A run that produces no answer raises instead of inventing placeholder text (#2959).
+
+    Reflect used to substitute "No answer provided." (or an iteration-limit
+    sentence) whenever a terminal path came up empty. Both are non-empty strings,
+    so every downstream emptiness guard read them as a real answer: a mental-model
+    refresh persisted the stub over a document built across months of refreshes and
+    recorded the operation as ``completed`` with no error. There is no answer to
+    return in these cases, so the run fails.
+    """
+
+    @pytest.fixture
+    def mock_llm(self):
+        llm = MagicMock()
+        llm.provider = "openai"
+        llm.model = "gpt-test"
+        llm.call_with_tools = AsyncMock()
+        llm.call = AsyncMock(
+            return_value=(
+                "Synthesized answer from gathered evidence.",
+                TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15),
+            )
+        )
+        return llm
+
+    @pytest.fixture
+    def mock_functions(self):
+        return {
+            "search_mental_models_fn": AsyncMock(return_value={"mental_models": []}),
+            "search_observations_fn": AsyncMock(return_value={"observations": []}),
+            "recall_fn": AsyncMock(return_value={"memories": [{"id": "mem-1", "content": "test memory"}]}),
+            "expand_fn": AsyncMock(return_value={"memories": []}),
+        }
+
+    @staticmethod
+    def _recall_then(done_arguments: dict) -> list[LLMToolCallResult]:
+        """Gather evidence first, so ``done`` is not rejected by the evidence guardrail."""
+        return [
+            LLMToolCallResult(
+                tool_calls=[LLMToolCall(id="1", name="recall", arguments={"query": "test query"})],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(
+                tool_calls=[LLMToolCall(id="2", name="done", arguments=done_arguments)],
+                finish_reason="tool_calls",
+            ),
+        ]
+
+    async def _run(self, mock_llm, mock_functions):
+        return await run_reflect_agent(
+            llm_config=mock_llm,
+            bank_id="test-bank",
+            query="test query",
+            bank_profile={"name": "Test", "mission": "Testing"},
+            has_mental_models=False,
+            budget="low",
+            max_iterations=5,
+            **mock_functions,
+        )
+
+    @pytest.mark.asyncio
+    async def test_blank_done_answer_raises(self, mock_llm, mock_functions):
+        """The production trigger: output truncated mid-tool-call, so ``answer`` arrives empty."""
+        mock_llm.call_with_tools.side_effect = self._recall_then({"answer": "   ", "memory_ids": ["mem-1"]})
+
+        with pytest.raises(ReflectNoAnswerError) as exc_info:
+            await self._run(mock_llm, mock_functions)
+
+        assert "no answer" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_missing_done_answer_raises(self, mock_llm, mock_functions):
+        """``answer`` absent entirely, not just blank."""
+        mock_llm.call_with_tools.side_effect = self._recall_then({"memory_ids": ["mem-1"]})
+
+        with pytest.raises(ReflectNoAnswerError):
+            await self._run(mock_llm, mock_functions)
+
+    @pytest.mark.asyncio
+    async def test_empty_document_mode_answer_raises(self, mock_llm, mock_functions):
+        """Document mode that renders to nothing is the same failure as a blank answer."""
+        mock_llm.call_with_tools.side_effect = self._recall_then(
+            {"document": {"sections": []}, "memory_ids": ["mem-1"]}
+        )
+
+        with pytest.raises(ReflectNoAnswerError):
+            await self._run(mock_llm, mock_functions)
+
+    @pytest.mark.asyncio
+    async def test_empty_final_synthesis_raises(self, mock_llm, mock_functions):
+        """The forced final synthesis (tools disabled) returning nothing also fails."""
+        mock_llm.call.return_value = ("   ", TokenUsage(input_tokens=10, output_tokens=0, total_tokens=10))
+        # Gather evidence, then stop tool-calling: the agent falls through to the
+        # forced synthesis, which is where the empty text comes from.
+        mock_llm.call_with_tools.side_effect = [
+            LLMToolCallResult(
+                tool_calls=[LLMToolCall(id="1", name="recall", arguments={"query": "test query"})],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(content="", tool_calls=[], finish_reason="stop"),
+        ]
+
+        with pytest.raises(ReflectNoAnswerError) as exc_info:
+            await self._run(mock_llm, mock_functions)
+
+        assert "final synthesis" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_real_answer_still_returned(self, mock_llm, mock_functions):
+        """The guard must not touch a run that did produce an answer."""
+        mock_llm.call_with_tools.side_effect = self._recall_then(
+            {"answer": "The user has a cat named Luna.", "memory_ids": ["mem-1"]}
+        )
+
+        result = await self._run(mock_llm, mock_functions)
+
+        assert result.text == "The user has a cat named Luna."
 
 
 class TestDirectiveLeakageOnEmptyBank:

--- a/hindsight-api-slim/tests/test_refresh_outcome_metadata.py
+++ b/hindsight-api-slim/tests/test_refresh_outcome_metadata.py
@@ -18,12 +18,6 @@ from hindsight_api.api.http import OperationResponse, OperationStatusResponse
 from hindsight_api.engine.memory_engine import MemoryEngine
 from hindsight_api.worker.exceptions import RetryTaskAt
 
-# The reflect agent's fallback answer when the LLM returns nothing usable
-# (hindsight_api/engine/reflect/agent.py). Non-empty, so it survives the
-# empty-content guard in refresh_mental_model and completes wire-successful —
-# exactly the case populated_content must expose.
-NO_ANSWER_STUB = "No answer provided."
-
 
 @pytest.fixture
 async def bank_with_model(memory: MemoryEngine, request_context):
@@ -99,26 +93,6 @@ async def test_completed_refresh_enriches_result_metadata(bank_with_model, reque
     assert meta["content_len"] == 120
     assert meta["populated_content"] is True
     assert meta["based_on_counts"] == {"world": 3, "mental-models": 1}
-
-
-@pytest.mark.asyncio
-async def test_no_answer_stub_reads_as_unpopulated(bank_with_model, request_context, monkeypatch):
-    """The historical 19-char stub completes wire-successful but must not read as populated."""
-    memory, bank_id, mm = bank_with_model
-
-    operation_id = await _submit_with_fake_refresh(
-        memory, monkeypatch, bank_id, mm, request_context, _fake_refreshed(NO_ANSWER_STUB, {})
-    )
-
-    status = await memory.get_operation_status(
-        bank_id=bank_id, operation_id=operation_id, request_context=request_context
-    )
-    assert status["status"] == "completed"
-    meta = status["result_metadata"]
-
-    assert meta["content_len"] == len(NO_ANSWER_STUB)
-    assert meta["populated_content"] is False
-    assert meta["based_on_counts"] == {}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #2959.

## The bug

When the reflect agent finished without a usable answer, the code substituted a human-readable placeholder — `NO_ANSWER_TEXT` ("No answer provided.") for a `done` tool call with a blank `answer`, and an iteration-limit sentence when the loop fell through the bottom.

Both are non-empty strings. `refresh_mental_model`'s guard, whose stated purpose is to "refuse to overwrite existing content with an empty render", tests `if not final_content.strip():` — emptiness only. So the placeholder sailed past it and was written over the document, the refresh returned normally, and the async operation was recorded as `completed` with `error_message: null`.

A mental model built across months of refreshes became a 19-character string, with no failure signal anywhere to alert on. The reporter hit this on a self-hosted deployment: five models across two banks, each with a clean `completed` operation. `populated_content` in the refresh outcome metadata did recognise the stub, but it is computed *after* the write — it annotated the loss rather than preventing it, and did not cover the iteration-limit text at all.

## The fix

A run that produced no answer is a failure, so it raises — `ReflectNoAnswerError`, at the three points where the code already knows:

- `_process_done_tool`: the `done` call carried no `answer` (or a `document` that renders to nothing). The usual cause is the model's output being cut off mid-tool-call by the completion cap, so the field never arrived even though the evidence was gathered.
- `_forced_final_synthesis`: tools were disabled for the call and the model still returned nothing.
- The loop's unreachable fall-through, which used to invent the iteration-limit sentence.

Callers that write what reflect returns simply never reach the write, so the previous content is preserved by construction and **no new guard is needed on the refresh path** — which is why this supersedes the placeholder-guard PRs rather than adding to them.

`ReflectToolCallError` set the precedent for this shape in #3013 (a transport that can't tool-call fails loudly instead of having its free text salvaged as the answer). The new error sits beside it, including in the HTTP handler.

## What changes for callers

A reflect call that used to return **200** with `"No answer provided."` now returns **500** with a message naming which terminal path came up empty. That is the point: the 200 was a lie, and every consumer — the mental-model refresh most damagingly — had no way to tell it from a real answer. The MCP tool already surfaces exceptions as an error payload, so it needs no change. Refresh operations fail with a real `error_message` and retry under the worker's normal bounded policy.

`populated_content` no longer special-cases the no-answer stub: nothing can produce it any more, so what is stored and what is reported cannot drift.

## Tests

`tests/test_reflect_agent.py` — `TestNoAnswerFailsHard`: blank `answer`, missing `answer`, a `document` that renders empty, an empty final synthesis, and a control that a real answer still returns normally.

`tests/test_mental_model_no_answer_preserved.py` — the end-to-end half: when reflect raises, `refresh_mental_model` propagates and the stored document is byte-identical afterwards, with neither `last_refreshed_at` nor `last_memory_seen_at` moved (a failed run must stay repeatable — moving the watermark would put the facts that triggered it permanently behind the delta window).

The obsolete `test_no_answer_stub_reads_as_unpopulated` is removed: it asserted the behaviour of a string the code can no longer emit.

## Supersedes

- **#2960** — the issue's own PR. Same diagnosis; this fixes it at the source instead of adding an `answer_failure_reason` field for the refresh path to inspect.
- **#3580** — refuses placeholder candidates at the write. Its guard sits after the delta re-render, so in delta mode `final_content` is the re-rendered document and the placeholder is no longer recognisable; it also matched the iteration-limit text with `startswith`, which breaks the moment the copy is edited.
- **#3135** (for #2894) is a genuinely different trigger — recall returning nothing while the agent writes real prose — and is deliberately left alone.
