### PR TITLE
fix(db): log the exception class when a DB error has no message

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/db_utils.py
@@ -102,12 +102,12 @@ async def retry_with_backoff(
                     )
                 else:
                     logger.warning(
-                        f"Database operation failed (attempt {attempt + 1}/{max_retries + 1}): {e}. "
+                        f"Database operation failed (attempt {attempt + 1}/{max_retries + 1}): {e!r}. "
                         f"Retrying in {delay:.1f}s..."
                     )
                 await asyncio.sleep(delay)
             else:
-                logger.error(f"Database operation failed after {max_retries + 1} attempts: {e}")
+                logger.error(f"Database operation failed after {max_retries + 1} attempts: {e!r}")
     raise last_exception
 
 
@@ -152,13 +152,19 @@ async def acquire_with_retry(backend_or_pool: Any, max_retries: int = DEFAULT_MA
                         raise
                     if attempt < max_retries:
                         delay = _backoff_delay(attempt, DEFAULT_BASE_DELAY, DEFAULT_MAX_DELAY)
+                        # !r, not str(): asyncpg raises several of these with no
+                        # args, so str(e) is "" and the line renders as
+                        # "Database acquire failed ... : " — the one field that
+                        # says whether this was a dropped connection, a closed
+                        # pool or an acquire timeout. repr() always carries the
+                        # class name.
                         logger.warning(
-                            f"Database acquire failed (attempt {attempt + 1}/{max_retries + 1}): {e}. "
+                            f"Database acquire failed (attempt {attempt + 1}/{max_retries + 1}): {e!r}. "
                             f"Retrying in {delay:.1f}s..."
                         )
                         await asyncio.sleep(delay)
                     else:
-                        logger.error(f"Database acquire failed after {max_retries + 1} attempts: {e}")
+                        logger.error(f"Database acquire failed after {max_retries + 1} attempts: {e!r}")
                         raise
 
             acquire_time = time.time() - start

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -4479,7 +4479,11 @@ class MemoryEngine(MemoryEngineInterface):
             health.update(self._pool_health_stats(backend))
             return health
         except Exception as e:
-            return {"status": "unhealthy", "database": "error", "error": str(e)}
+            # repr, not str: asyncpg raises several connection/pool errors with
+            # no args, and str(e) is "" for those — the probe payload is what an
+            # operator reads first when the database looks down, so it must name
+            # the exception class even when the message is empty.
+            return {"status": "unhealthy", "database": "error", "error": repr(e)}
 
     @staticmethod
     def _pool_health_stats(backend: Any) -> dict:

--- a/hindsight-api-slim/tests/test_db_utils.py
+++ b/hindsight-api-slim/tests/test_db_utils.py
@@ -6,16 +6,22 @@ user-code exception to surface as
 ``RuntimeError("generator didn't stop after athrow()")``, masking the real
 cause and producing identical failed-op rows in production (see the 1,934
 failed consolidations on ``shurick-memory`` in May 2026).
+
+Also covers what the acquire/retry paths *log*: several asyncpg errors carry no
+message, so ``str(e)`` is "" and a failure rendered as
+``Database acquire failed after N attempts: `` — an outage with the cause
+blanked out.
 """
 
 from __future__ import annotations
 
 import asyncio
+import logging
 from contextlib import asynccontextmanager
 
 import pytest
 
-from hindsight_api.engine.db_utils import _backoff_delay, acquire_with_retry
+from hindsight_api.engine.db_utils import _backoff_delay, acquire_with_retry, retry_with_backoff
 
 
 class _FakeConnection:
@@ -100,3 +106,65 @@ def test_backoff_delay_is_jittered_and_bounded():
     # At/after saturation the cap holds: every sample <= max_delay.
     saturated = [_backoff_delay(20, base, max_delay) for _ in range(200)]
     assert all(max_delay / 2 <= d <= max_delay for d in saturated)
+
+
+class InterfaceError(Exception):
+    """Stands in for ``asyncpg.exceptions.InterfaceError``, raised with no args.
+
+    Named to match the driver deliberately: ``_is_retryable`` classifies by
+    ``type(exc).__name__``, so only this name reaches the retry-and-log path
+    under test. ``InterfaceError`` is also the case that matters most — asyncpg
+    raises it both for a dropped connection and for a pool that is closed and
+    will never serve again, and several of them carry no message at all.
+    """
+
+
+class _SilentlyFailingBackend:
+    """Backend whose acquires fail with an exception that stringifies to ""."""
+
+    _wraps_backend = True
+
+    @asynccontextmanager
+    async def acquire(self):
+        raise InterfaceError()
+        yield  # pragma: no cover - unreachable, keeps this an async generator
+
+
+@pytest.mark.asyncio
+async def test_acquire_failure_logs_name_exception_with_empty_str(monkeypatch, caplog):
+    """The acquire logs must name the exception even when it has no message.
+
+    ``str(e)`` is "" for a no-args driver error, which rendered the retry and
+    give-up lines as ``Database acquire failed after 2 attempts: `` — dropping
+    the single field that distinguishes a dropped connection from a closed pool
+    from an acquire timeout, and leaving an outage undiagnosable from the logs.
+    """
+    monkeypatch.setattr("hindsight_api.engine.db_utils._backoff_delay", lambda *a, **k: 0.0)
+
+    with caplog.at_level(logging.WARNING, logger="hindsight_api.engine.db_utils"):
+        with pytest.raises(InterfaceError):
+            async with acquire_with_retry(_SilentlyFailingBackend(), max_retries=1):
+                pass  # pragma: no cover - the acquire never succeeds
+
+    acquire_lines = [r.getMessage() for r in caplog.records if "Database acquire failed" in r.getMessage()]
+    assert acquire_lines, "the acquire path logged nothing at all"
+    for line in acquire_lines:
+        assert "InterfaceError" in line, f"log line dropped the exception class: {line!r}"
+
+
+@pytest.mark.asyncio
+async def test_retry_with_backoff_logs_name_exception_with_empty_str(monkeypatch, caplog):
+    """Same guarantee for the generic operation-retry path."""
+    monkeypatch.setattr("hindsight_api.engine.db_utils._backoff_delay", lambda *a, **k: 0.0)
+
+    async def always_fails():
+        raise InterfaceError()
+
+    with caplog.at_level(logging.WARNING, logger="hindsight_api.engine.db_utils"):
+        with pytest.raises(InterfaceError):
+            await retry_with_backoff(always_fails, max_retries=1)
+
+    op_lines = [r.getMessage() for r in caplog.records if "Database operation failed" in r.getMessage()]
+    assert op_lines, "the retry path logged nothing at all"
+    for line in op_lines:
+        assert "InterfaceError" in line, f"log line dropped the exception class: {line!r}"


### PR DESCRIPTION
## Problem

asyncpg raises several of its connection and pool errors with no args, so `str(e)` is the empty string for them. The acquire and retry paths in `db_utils.py` interpolated `str(e)`, so a real failure logged as:

```
Database acquire failed after 4 attempts:
```

The cause is silently dropped — exactly the field you need. `InterfaceError` alone covers three different conditions:

| asyncpg raise site | Meaning | Recoverable? |
|---|---|---|
| connection dropped | transient | yes, retry works |
| `'pool is closed'` / `'pool is closing'` (`pool.py:860,986`) | terminal | no — never, at any database health |
| `'pool is not initialized'` (`pool.py:984`) | terminal | no |

`_is_retryable` classifies by `type(exc).__name__`, so all three are retried identically and forever. The log was the only place that could have told them apart, and it printed nothing.

`health_check` had the same hole: it returned `str(e)` in the readiness payload's `error` field, which is the first thing an operator reads when the database looks down.

## Change

`repr()` instead of `str()` in four log lines in `db_utils.py` and in the `health_check` error field. `repr()` always carries the class name, empty message or not.

```
- Database acquire failed after 4 attempts:
+ Database acquire failed after 4 attempts: InterfaceError('pool is closed')
```

Same fix and same reasoning as `recall_async`'s wrapper message (#1384) — `memory_engine.py` already does this a few thousand lines further down, with a comment saying why.

## Tests

Two cases in `tests/test_db_utils.py`, one per path, asserting the exception class survives into the log when `str(e)` is empty. The stub is named `InterfaceError` deliberately: `_is_retryable` matches on `type(exc).__name__`, so nothing else reaches the code under test.

Verified as a regression test, not just a green run — reverting the four `{e!r}` back to `{e}` fails both new cases and leaves the two pre-existing ones passing.

`./scripts/hooks/lint.sh` clean, `ty` clean. No API surface change: the health payload goes out via `JSONResponse` with no response model, `error` is free text, and nothing in the CLI, embed daemon, or control plane parses it.

## Context

Split out of #3719, which paired this with a self-termination mechanism. That half is on hold: the pool-wedge it responds to has no diagnosis yet, and this change is what will supply one. See the discussion on #3719.
