### PR TITLE
fix(worker): serialise consolidation claims per bank within a batch (#3700)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops.py
@@ -48,8 +48,8 @@ def document_serialization_sql(table: str, alias: str) -> str:
     that were racing each other for one document are put in a line.
 
     A peer wedged in 'processing' holds its document until claim recovery
-    releases it, the same caveat ``graph_maintenance_bank_serialization_sql``
-    carries and the same general gap.
+    releases it, the same caveat ``bank_serialization_sql`` carries and the same
+    general gap.
 
     The candidate row is always 'pending' and the 'pending' branch is
     strictly-older, so the subquery can never match the candidate itself. The
@@ -78,40 +78,64 @@ def document_serialization_sql(table: str, alias: str) -> str:
     """
 
 
-def graph_maintenance_bank_serialization_sql(table: str, alias: str) -> str:
-    """SQL predicate serialising ``graph_maintenance`` claims per bank (#3230).
+_BANK_SERIALIZED_OPERATION_TYPES = ("graph_maintenance", "consolidation")
 
-    Every graph_maintenance run for a bank is interchangeable — the payload
-    carries only ``bank_id``, and ``run_graph_maintenance_job`` drains that bank's
-    queues — so a second concurrent run for one bank adds no work. It is worse than
-    useless: ``claim_graph_maintenance_batch`` locks queue rows ``FOR UPDATE``
-    *without* ``SKIP LOCKED`` (it is written assuming a single runner per bank),
-    so the runs convoy on each other's row locks while each holds a worker slot.
 
-    Same guarantee ``consolidation`` already gets from its ``bank_id != ALL(busy)``
-    exclusion, and the same caveat: a row wedged in 'processing' holds its bank
-    until something releases it (``hindsight-admin recover``, or a restart with a
-    stable ``HINDSIGHT_API_WORKER_ID`` so ``recover_own_tasks`` matches it). That
-    is a general gap in claim recovery, not specific to graph_maintenance.
+def bank_serialization_sql(table: str, alias: str, operation_type: str | None = None) -> str:
+    """SQL predicate keeping one bank to a single in-flight run, per operation type.
 
-    Two differences from the consolidation form, both forced by the shape of this
-    problem:
+    Applies to the operation types whose runs for a bank are *interchangeable*
+    — the payload carries only ``bank_id`` and the job drains that bank's whole
+    backlog — so a second concurrent run for the same bank recomputes the first
+    one's work and adds nothing:
 
-    * It is a **predicate**, not a separate claim phase. Pulling graph_maintenance
-      into its own phase after the generic shared-pool query would drop it below
-      every other operation type: it has no reserved-slot floor
-      (``WORKER_SLOT_TYPE_DEFAULTS`` gives consolidation 2 and graph_maintenance
-      0), and the poller's fairness pass calls ``claim_tasks`` with
-      ``shared_limit=1``, so a single pending retain would starve it indefinitely.
-      As a predicate it keeps competing by ``created_at``.
-    * It also suppresses every same-bank row but the oldest **within one batch**.
-      Excluding busy banks alone does not: with several pending rows and nothing
-      yet processing, one batch claims them all — the convoy, unchanged. Several
-      pending rows per bank are reachable through the recovery paths
+    * ``graph_maintenance`` (#3230). ``claim_graph_maintenance_batch`` locks
+      queue rows ``FOR UPDATE`` *without* ``SKIP LOCKED`` (it is written
+      assuming a single runner per bank), so concurrent runs also convoy on each
+      other's row locks while each holds a worker slot.
+    * ``consolidation`` (#3700). Two runs claimed together read the same
+      ``total_unconsolidated`` backlog and hand the same memories to the LLM
+      twice — pure duplicated inference on the slowest path in the system.
+
+    Ordering, not just exclusion, is the point, and both halves of the predicate
+    are needed:
+
+    * The ``processing`` branch is the guarantee across batches and across
+      workers: a bank with a run in flight is not claimed again.
+    * The strictly-older ``pending`` branch is the guarantee *within* one batch.
+      Excluding busy banks alone does not give it: with several pending rows and
+      nothing yet processing, one batch claims them all. Several pending rows per
+      bank are reachable through the recovery paths
       (``_reclaim_own_processing_tasks`` resets *all* of a worker's processing
       rows in one statement, from ``recover_own_tasks`` at startup and
       ``release_own_tasks`` at shutdown, plus ``_schedule_retry`` /
-      ``_defer_operation`` / ``hindsight-admin recover``).
+      ``_defer_operation`` / ``hindsight-admin recover``). It also covers the
+      window in which a peer is claimed but not yet committed as ``processing``:
+      a concurrent worker reads it as the older ``pending`` row and stands down.
+
+    This is a **predicate**, not a separate claim phase, because
+    ``graph_maintenance`` cannot afford to be one: it has no reserved-slot floor
+    (``WORKER_SLOT_TYPE_DEFAULTS`` gives consolidation 2 and graph_maintenance
+    0), and the poller's fairness pass calls ``claim_tasks`` with
+    ``shared_limit=1``, so a phase after the generic shared-pool query would let
+    a single pending retain starve it indefinitely. As a predicate it keeps
+    competing by ``created_at``. Consolidation has its own claim path (bank
+    priority tiers); the same predicate goes on every query there.
+
+    Suppression here only *defers* — unlike the submit-time dedup in
+    ``_submit_async_operation``, nothing is dropped. That is why scoped
+    consolidations (``observation_scopes``, which submit-time dedup deliberately
+    exempts because a scoped run covers only its tag subset) need no carve-out:
+    they queue behind the bank's in-flight run instead of racing it, and are
+    claimed on a later poll with a fresh watermark.
+
+    The caveat is unchanged: a row wedged in 'processing' holds its bank until
+    something releases it (``hindsight-admin recover``, or a restart with a
+    stable ``HINDSIGHT_API_WORKER_ID`` so ``recover_own_tasks`` matches it). That
+    is a general gap in claim recovery, not specific to these operation types.
+
+    Rows of any other operation type are unaffected, and banks are independent
+    of one another, so this costs no parallelism anywhere else.
 
     The candidate row is always 'pending' and the 'pending' branch is
     strictly-older, so the subquery can never match the candidate itself. The
@@ -121,20 +145,37 @@ def graph_maintenance_bank_serialization_sql(table: str, alias: str) -> str:
     Args:
         table: Fully-qualified async_operations table.
         alias: Alias of the outer candidate row in the calling query.
+        operation_type: The one type the calling query is already restricted to,
+            if it is restricted to one — consolidation has its own claim path.
+            Matches peers against that constant and drops the guard on the
+            candidate's type, which can only be true there. Leave unset for the
+            mixed-type claim queries, where the candidate's own type has to pick
+            its peers and rows of every other type must fall straight through.
+            Inlined into the SQL text, so it is checked against the known set.
     """
+    if operation_type is None:
+        types = ", ".join(f"'{t}'" for t in _BANK_SERIALIZED_OPERATION_TYPES)
+        candidate_guard = f"{alias}.operation_type NOT IN ({types}) OR "
+        peer_type = f"{alias}.operation_type"
+    elif operation_type in _BANK_SERIALIZED_OPERATION_TYPES:
+        candidate_guard = ""
+        peer_type = f"'{operation_type}'"
+    else:
+        raise ValueError(f"{operation_type} is not serialised per bank: {_BANK_SERIALIZED_OPERATION_TYPES}")
+
     return f"""
-        ({alias}.operation_type <> 'graph_maintenance' OR NOT EXISTS (
-            SELECT 1 FROM {table} gm_peer
-            WHERE gm_peer.bank_id = {alias}.bank_id
-              AND gm_peer.operation_type = 'graph_maintenance'
+        ({candidate_guard}NOT EXISTS (
+            SELECT 1 FROM {table} bank_peer
+            WHERE bank_peer.bank_id = {alias}.bank_id
+              AND bank_peer.operation_type = {peer_type}
               AND (
-                  gm_peer.status = 'processing'
-                  OR (gm_peer.status = 'pending'
-                      AND gm_peer.task_payload IS NOT NULL
-                      AND (gm_peer.next_retry_at IS NULL OR gm_peer.next_retry_at <= NOW())
-                      AND (gm_peer.created_at < {alias}.created_at
-                           OR (gm_peer.created_at = {alias}.created_at
-                               AND gm_peer.operation_id < {alias}.operation_id)))
+                  bank_peer.status = 'processing'
+                  OR (bank_peer.status = 'pending'
+                      AND bank_peer.task_payload IS NOT NULL
+                      AND (bank_peer.next_retry_at IS NULL OR bank_peer.next_retry_at <= NOW())
+                      AND (bank_peer.created_at < {alias}.created_at
+                           OR (bank_peer.created_at = {alias}.created_at
+                               AND bank_peer.operation_id < {alias}.operation_id)))
               )
         ))
     """
@@ -754,15 +795,11 @@ class DataAccessOps(ABC):
     ) -> list[ResultRow]:
         """Claim pending tasks from the async_operations table.
 
-        PG implementation can use NOT EXISTS + FOR UPDATE SKIP LOCKED in one query.
-        Oracle implementation uses two-step claims (query busy banks first, then
-        claim excluding them) to avoid ORA-02014.
-
-        Implementations must apply :func:`graph_maintenance_bank_serialization_sql`
-        to every query that can return a ``graph_maintenance`` row, so at most one
-        such row per bank is ever in flight, and :func:`document_serialization_sql`
-        to every query that can return a ``retain`` row, so at most one retain per
-        document is ever in flight.
+        Implementations must apply :func:`bank_serialization_sql` to every query
+        that can return a ``graph_maintenance`` or ``consolidation`` row, so at
+        most one such row per bank is ever in flight, and
+        :func:`document_serialization_sql` to every query that can return a
+        ``retain`` row, so at most one retain per document is ever in flight.
 
         Args:
             consolidation_bank_priority: Per-bank priority for consolidation scheduling.

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -15,8 +15,8 @@ from .ops import (
     LinkExpansionRows,
     TagListingParts,
     UpdatedWindow,
+    bank_serialization_sql,
     document_serialization_sql,
-    graph_maintenance_bank_serialization_sql,
 )
 from .result import DictResultRow as ResultRow
 
@@ -1159,7 +1159,6 @@ class OracleOps(DataAccessOps):
         self,
         conn,
         table: str,
-        busy_bank_ids: list[str],
         claimed_ids: list,
         limit: int,
         priority_map: dict[str, int] | None,
@@ -1173,7 +1172,7 @@ class OracleOps(DataAccessOps):
             return []
 
         if not priority_map:
-            return await self._claim_consolidation_plain(conn, table, busy_bank_ids, claimed_ids, limit)
+            return await self._claim_consolidation_plain(conn, table, claimed_ids, limit)
 
         # --- Tiered claiming (same algorithm as PG) ---
         specific_by_priority: dict[int, list[str]] = {}
@@ -1201,7 +1200,6 @@ class OracleOps(DataAccessOps):
                 rows = await self._claim_consolidation_like(
                     conn,
                     table,
-                    busy_bank_ids,
                     claimed_ids,
                     remaining,
                     specific_by_priority[pri],
@@ -1215,7 +1213,6 @@ class OracleOps(DataAccessOps):
                 rows = await self._claim_consolidation_not_like(
                     conn,
                     table,
-                    busy_bank_ids,
                     claimed_ids,
                     remaining,
                     all_specific_sql,
@@ -1231,104 +1228,64 @@ class OracleOps(DataAccessOps):
         self,
         conn,
         table,
-        busy_bank_ids,
         claimed_ids,
         limit,
     ) -> list:
         """Claim consolidation tasks with default created_at ordering."""
-        exclude_ids = claimed_ids if claimed_ids else None
-        if busy_bank_ids:
-            if exclude_ids:
-                return await conn.fetch(
-                    f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
-                    FROM {table}
-                    WHERE status = 'pending'
-                      AND task_payload IS NOT NULL
-                      AND operation_type = 'consolidation'
-                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                      AND bank_id != ALL($1::text[])
-                      AND operation_id != ALL($2::uuid[])
-                    ORDER BY created_at
-                    LIMIT $3
-                    FOR UPDATE SKIP LOCKED
-                    """,
-                    busy_bank_ids,
-                    exclude_ids,
-                    limit,
-                )
-            else:
-                return await conn.fetch(
-                    f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
-                    FROM {table}
-                    WHERE status = 'pending'
-                      AND task_payload IS NOT NULL
-                      AND operation_type = 'consolidation'
-                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                      AND bank_id != ALL($1::text[])
-                    ORDER BY created_at
-                    LIMIT $2
-                    FOR UPDATE SKIP LOCKED
-                    """,
-                    busy_bank_ids,
-                    limit,
-                )
-        else:
-            if exclude_ids:
-                return await conn.fetch(
-                    f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
-                    FROM {table}
-                    WHERE status = 'pending'
-                      AND task_payload IS NOT NULL
-                      AND operation_type = 'consolidation'
-                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                      AND operation_id != ALL($1::uuid[])
-                    ORDER BY created_at
-                    LIMIT $2
-                    FOR UPDATE SKIP LOCKED
-                    """,
-                    exclude_ids,
-                    limit,
-                )
-            else:
-                return await conn.fetch(
-                    f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
-                    FROM {table}
-                    WHERE status = 'pending'
-                      AND task_payload IS NOT NULL
-                      AND operation_type = 'consolidation'
-                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                    ORDER BY created_at
-                    LIMIT $1
-                    FOR UPDATE SKIP LOCKED
-                    """,
-                    limit,
-                )
+        if claimed_ids:
+            return await conn.fetch(
+                f"""
+                SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
+                FROM {table} o
+                WHERE o.status = 'pending'
+                  AND o.task_payload IS NOT NULL
+                  AND o.operation_type = 'consolidation'
+                  AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
+                  AND o.operation_id != ALL($1::uuid[])
+                  AND {bank_serialization_sql(table, "o", "consolidation")}
+                ORDER BY o.created_at
+                LIMIT $2
+                FOR UPDATE SKIP LOCKED
+                """,
+                claimed_ids,
+                limit,
+            )
+        return await conn.fetch(
+            f"""
+            SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
+            FROM {table} o
+            WHERE o.status = 'pending'
+              AND o.task_payload IS NOT NULL
+              AND o.operation_type = 'consolidation'
+              AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
+              AND {bank_serialization_sql(table, "o", "consolidation")}
+            ORDER BY o.created_at
+            LIMIT $1
+            FOR UPDATE SKIP LOCKED
+            """,
+            limit,
+        )
 
     async def _claim_consolidation_like(
         self,
         conn,
         table,
-        busy_bank_ids,
         claimed_ids,
         limit,
         sql_patterns,
     ) -> list:
         """Claim consolidation tasks from banks matching LIKE patterns."""
+        # bank_id is deliberately unqualified in the LIKE ANY / NOT LIKE ALL
+        # conditions here and in _claim_consolidation_not_like: db/oracle.py
+        # rewrites those forms by regex on a bare column name, so an "o."
+        # prefix would survive the rewrite as "o.(bank_id LIKE :p0 OR ...)".
+        # One table is in scope, so unqualified resolves to o.bank_id anyway.
         params: list = [sql_patterns]
         conditions = ["bank_id LIKE ANY($1::text[])"]
         idx = 2
 
-        if busy_bank_ids:
-            conditions.append(f"bank_id != ALL(${idx}::text[])")
-            params.append(busy_bank_ids)
-            idx += 1
-
         if claimed_ids:
-            conditions.append(f"operation_id != ALL(${idx}::uuid[])")
+            conditions.append(f"o.operation_id != ALL(${idx}::uuid[])")
             params.append(claimed_ids)
             idx += 1
 
@@ -1336,14 +1293,15 @@ class OracleOps(DataAccessOps):
         extra = " AND ".join(conditions)
         return await conn.fetch(
             f"""
-            SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
-            FROM {table}
-            WHERE status = 'pending'
-              AND task_payload IS NOT NULL
-              AND operation_type = 'consolidation'
-              AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+            SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
+            FROM {table} o
+            WHERE o.status = 'pending'
+              AND o.task_payload IS NOT NULL
+              AND o.operation_type = 'consolidation'
+              AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
+              AND {bank_serialization_sql(table, "o", "consolidation")}
               AND {extra}
-            ORDER BY created_at
+            ORDER BY o.created_at
             LIMIT ${idx}
             FOR UPDATE SKIP LOCKED
             """,
@@ -1354,7 +1312,6 @@ class OracleOps(DataAccessOps):
         self,
         conn,
         table,
-        busy_bank_ids,
         claimed_ids,
         limit,
         exclude_patterns,
@@ -1369,13 +1326,8 @@ class OracleOps(DataAccessOps):
             params.append(exclude_patterns)
             idx += 1
 
-        if busy_bank_ids:
-            conditions.append(f"bank_id != ALL(${idx}::text[])")
-            params.append(busy_bank_ids)
-            idx += 1
-
         if claimed_ids:
-            conditions.append(f"operation_id != ALL(${idx}::uuid[])")
+            conditions.append(f"o.operation_id != ALL(${idx}::uuid[])")
             params.append(claimed_ids)
             idx += 1
 
@@ -1383,13 +1335,14 @@ class OracleOps(DataAccessOps):
         extra_clause = (" AND " + " AND ".join(conditions)) if conditions else ""
         return await conn.fetch(
             f"""
-            SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
-            FROM {table}
-            WHERE status = 'pending'
-              AND task_payload IS NOT NULL
-              AND operation_type = 'consolidation'
-              AND (next_retry_at IS NULL OR next_retry_at <= NOW()){extra_clause}
-            ORDER BY created_at
+            SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
+            FROM {table} o
+            WHERE o.status = 'pending'
+              AND o.task_payload IS NOT NULL
+              AND o.operation_type = 'consolidation'
+              AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
+              AND {bank_serialization_sql(table, "o", "consolidation")}{extra_clause}
+            ORDER BY o.created_at
             LIMIT ${idx}
             FOR UPDATE SKIP LOCKED
             """,
@@ -1406,7 +1359,6 @@ class OracleOps(DataAccessOps):
         *,
         consolidation_bank_priority=None,
     ):
-        """Oracle two-step claiming to avoid ORA-02014 with NOT EXISTS + FOR UPDATE."""
         all_rows = []
         claimed_ids = []
 
@@ -1416,18 +1368,9 @@ class OracleOps(DataAccessOps):
                 continue
 
             if op_type == "consolidation":
-                busy_banks = await conn.fetch(
-                    f"""
-                    SELECT DISTINCT bank_id FROM {table}
-                    WHERE operation_type = 'consolidation' AND status = 'processing'
-                    """,
-                )
-                busy_bank_ids = [r["bank_id"] for r in busy_banks]
-
                 rows = await self._claim_consolidation_tasks(
                     conn,
                     table,
-                    busy_bank_ids,
                     claimed_ids,
                     limit,
                     consolidation_bank_priority,
@@ -1441,7 +1384,7 @@ class OracleOps(DataAccessOps):
                       AND o.task_payload IS NOT NULL
                       AND o.operation_type = $1
                       AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
-                      AND {graph_maintenance_bank_serialization_sql(table, "o")}
+                      AND {bank_serialization_sql(table, "o")}
                       AND {document_serialization_sql(table, "o")}
                     ORDER BY o.created_at
                     LIMIT $2
@@ -1459,7 +1402,7 @@ class OracleOps(DataAccessOps):
         remaining_shared = shared_limit
         if remaining_shared > 0:
             # 2a. Non-consolidation tasks. graph_maintenance stays in this
-            # created_at-ordered query — see graph_maintenance_bank_serialization_sql
+            # created_at-ordered query — see bank_serialization_sql
             # for why it is a predicate rather than a phase of its own.
             if claimed_ids:
                 rows = await conn.fetch(
@@ -1471,7 +1414,7 @@ class OracleOps(DataAccessOps):
                       AND o.operation_type != 'consolidation'
                       AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
                       AND o.operation_id != ALL($1::uuid[])
-                      AND {graph_maintenance_bank_serialization_sql(table, "o")}
+                      AND {bank_serialization_sql(table, "o")}
                       AND {document_serialization_sql(table, "o")}
                     ORDER BY o.created_at
                     LIMIT $2
@@ -1489,7 +1432,7 @@ class OracleOps(DataAccessOps):
                       AND o.task_payload IS NOT NULL
                       AND o.operation_type != 'consolidation'
                       AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
-                      AND {graph_maintenance_bank_serialization_sql(table, "o")}
+                      AND {bank_serialization_sql(table, "o")}
                       AND {document_serialization_sql(table, "o")}
                     ORDER BY o.created_at
                     LIMIT $1
@@ -1505,18 +1448,9 @@ class OracleOps(DataAccessOps):
 
             # 2b. Consolidation tasks (with bank-serialization + optional priority)
             if remaining_shared > 0:
-                busy_banks_2 = await conn.fetch(
-                    f"""
-                    SELECT DISTINCT bank_id FROM {table}
-                    WHERE operation_type = 'consolidation' AND status = 'processing'
-                    """,
-                )
-                busy_bank_ids_2 = [r["bank_id"] for r in busy_banks_2]
-
                 rows = await self._claim_consolidation_tasks(
                     conn,
                     table,
-                    busy_bank_ids_2,
                     claimed_ids,
                     remaining_shared,
                     consolidation_bank_priority,

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -13,8 +13,8 @@ from .ops import (
     LinkExpansionRows,
     TagListingParts,
     UpdatedWindow,
+    bank_serialization_sql,
     document_serialization_sql,
-    graph_maintenance_bank_serialization_sql,
 )
 from .result import ResultRow
 
@@ -1344,24 +1344,25 @@ class PostgreSQLOps(DataAccessOps):
         self,
         conn,
         table: str,
-        busy_bank_ids: list[str],
         claimed_ids: list,
         limit: int,
         priority_map: dict[str, int] | None,
     ) -> list:
         """Claim consolidation tasks with optional priority-based tiered ordering.
 
-        When *priority_map* is ``None``, uses the default ``ORDER BY created_at``
-        with bank-serialization (exclude busy banks).  When set, claims in
-        priority tiers — highest-priority banks first.  Specific patterns always
-        take precedence over the catch-all ``*`` entry.
+        When *priority_map* is ``None``, uses the default ``ORDER BY created_at``.
+        When set, claims in priority tiers — highest-priority banks first.
+        Specific patterns always take precedence over the catch-all ``*`` entry.
+
+        Every query here carries :func:`bank_serialization_sql`, so whichever
+        tier a bank is claimed in, at most one of its consolidations is taken.
         """
         if limit <= 0:
             return []
 
         # --- Fast path: no priority map -> current behavior ---
         if not priority_map:
-            return await self._claim_consolidation_plain(conn, table, busy_bank_ids, claimed_ids, limit)
+            return await self._claim_consolidation_plain(conn, table, claimed_ids, limit)
 
         # --- Tiered claiming ---
         # Separate specific patterns from catch-all.
@@ -1396,7 +1397,6 @@ class PostgreSQLOps(DataAccessOps):
                 rows = await self._claim_consolidation_like(
                     conn,
                     table,
-                    busy_bank_ids,
                     claimed_ids,
                     remaining,
                     specific_by_priority[pri],
@@ -1411,7 +1411,6 @@ class PostgreSQLOps(DataAccessOps):
                 rows = await self._claim_consolidation_not_like(
                     conn,
                     table,
-                    busy_bank_ids,
                     claimed_ids,
                     remaining,
                     all_specific_sql,
@@ -1427,104 +1426,64 @@ class PostgreSQLOps(DataAccessOps):
         self,
         conn,
         table,
-        busy_bank_ids,
         claimed_ids,
         limit,
     ) -> list:
         """Claim consolidation tasks with default created_at ordering."""
-        exclude_ids = claimed_ids if claimed_ids else None
-        if busy_bank_ids:
-            if exclude_ids:
-                return await conn.fetch(
-                    f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
-                    FROM {table}
-                    WHERE status = 'pending'
-                      AND task_payload IS NOT NULL
-                      AND operation_type = 'consolidation'
-                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                      AND bank_id != ALL($1::text[])
-                      AND operation_id != ALL($2::uuid[])
-                    ORDER BY created_at
-                    LIMIT $3
-                    FOR UPDATE SKIP LOCKED
-                    """,
-                    busy_bank_ids,
-                    exclude_ids,
-                    limit,
-                )
-            else:
-                return await conn.fetch(
-                    f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
-                    FROM {table}
-                    WHERE status = 'pending'
-                      AND task_payload IS NOT NULL
-                      AND operation_type = 'consolidation'
-                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                      AND bank_id != ALL($1::text[])
-                    ORDER BY created_at
-                    LIMIT $2
-                    FOR UPDATE SKIP LOCKED
-                    """,
-                    busy_bank_ids,
-                    limit,
-                )
-        else:
-            if exclude_ids:
-                return await conn.fetch(
-                    f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
-                    FROM {table}
-                    WHERE status = 'pending'
-                      AND task_payload IS NOT NULL
-                      AND operation_type = 'consolidation'
-                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                      AND operation_id != ALL($1::uuid[])
-                    ORDER BY created_at
-                    LIMIT $2
-                    FOR UPDATE SKIP LOCKED
-                    """,
-                    exclude_ids,
-                    limit,
-                )
-            else:
-                return await conn.fetch(
-                    f"""
-                    SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
-                    FROM {table}
-                    WHERE status = 'pending'
-                      AND task_payload IS NOT NULL
-                      AND operation_type = 'consolidation'
-                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                    ORDER BY created_at
-                    LIMIT $1
-                    FOR UPDATE SKIP LOCKED
-                    """,
-                    limit,
-                )
+        if claimed_ids:
+            return await conn.fetch(
+                f"""
+                SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
+                FROM {table} o
+                WHERE o.status = 'pending'
+                  AND o.task_payload IS NOT NULL
+                  AND o.operation_type = 'consolidation'
+                  AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
+                  AND o.operation_id != ALL($1::uuid[])
+                  AND {bank_serialization_sql(table, "o", "consolidation")}
+                ORDER BY o.created_at
+                LIMIT $2
+                FOR UPDATE SKIP LOCKED
+                """,
+                claimed_ids,
+                limit,
+            )
+        return await conn.fetch(
+            f"""
+            SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
+            FROM {table} o
+            WHERE o.status = 'pending'
+              AND o.task_payload IS NOT NULL
+              AND o.operation_type = 'consolidation'
+              AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
+              AND {bank_serialization_sql(table, "o", "consolidation")}
+            ORDER BY o.created_at
+            LIMIT $1
+            FOR UPDATE SKIP LOCKED
+            """,
+            limit,
+        )
 
     async def _claim_consolidation_like(
         self,
         conn,
         table,
-        busy_bank_ids,
         claimed_ids,
         limit,
         sql_patterns,
     ) -> list:
         """Claim consolidation tasks from banks matching LIKE patterns."""
+        # bank_id is deliberately unqualified in the LIKE ANY / NOT LIKE ALL
+        # conditions here and in _claim_consolidation_not_like: db/oracle.py
+        # rewrites those forms by regex on a bare column name, so an "o."
+        # prefix would survive the rewrite as "o.(bank_id LIKE :p0 OR ...)".
+        # One table is in scope, so unqualified resolves to o.bank_id anyway.
         params: list = [sql_patterns]
         conditions = ["bank_id LIKE ANY($1::text[])"]
         idx = 2
 
-        if busy_bank_ids:
-            conditions.append(f"bank_id != ALL(${idx}::text[])")
-            params.append(busy_bank_ids)
-            idx += 1
-
         if claimed_ids:
-            conditions.append(f"operation_id != ALL(${idx}::uuid[])")
+            conditions.append(f"o.operation_id != ALL(${idx}::uuid[])")
             params.append(claimed_ids)
             idx += 1
 
@@ -1532,14 +1491,15 @@ class PostgreSQLOps(DataAccessOps):
         extra = " AND ".join(conditions)
         return await conn.fetch(
             f"""
-            SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
-            FROM {table}
-            WHERE status = 'pending'
-              AND task_payload IS NOT NULL
-              AND operation_type = 'consolidation'
-              AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+            SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
+            FROM {table} o
+            WHERE o.status = 'pending'
+              AND o.task_payload IS NOT NULL
+              AND o.operation_type = 'consolidation'
+              AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
+              AND {bank_serialization_sql(table, "o", "consolidation")}
               AND {extra}
-            ORDER BY created_at
+            ORDER BY o.created_at
             LIMIT ${idx}
             FOR UPDATE SKIP LOCKED
             """,
@@ -1550,7 +1510,6 @@ class PostgreSQLOps(DataAccessOps):
         self,
         conn,
         table,
-        busy_bank_ids,
         claimed_ids,
         limit,
         exclude_patterns,
@@ -1565,13 +1524,8 @@ class PostgreSQLOps(DataAccessOps):
             params.append(exclude_patterns)
             idx += 1
 
-        if busy_bank_ids:
-            conditions.append(f"bank_id != ALL(${idx}::text[])")
-            params.append(busy_bank_ids)
-            idx += 1
-
         if claimed_ids:
-            conditions.append(f"operation_id != ALL(${idx}::uuid[])")
+            conditions.append(f"o.operation_id != ALL(${idx}::uuid[])")
             params.append(claimed_ids)
             idx += 1
 
@@ -1579,13 +1533,14 @@ class PostgreSQLOps(DataAccessOps):
         extra_clause = (" AND " + " AND ".join(conditions)) if conditions else ""
         return await conn.fetch(
             f"""
-            SELECT operation_id, operation_type, task_payload, retry_count, serialization_key, bank_id
-            FROM {table}
-            WHERE status = 'pending'
-              AND task_payload IS NOT NULL
-              AND operation_type = 'consolidation'
-              AND (next_retry_at IS NULL OR next_retry_at <= NOW()){extra_clause}
-            ORDER BY created_at
+            SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
+            FROM {table} o
+            WHERE o.status = 'pending'
+              AND o.task_payload IS NOT NULL
+              AND o.operation_type = 'consolidation'
+              AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
+              AND {bank_serialization_sql(table, "o", "consolidation")}{extra_clause}
+            ORDER BY o.created_at
             LIMIT ${idx}
             FOR UPDATE SKIP LOCKED
             """,
@@ -1611,18 +1566,9 @@ class PostgreSQLOps(DataAccessOps):
                 continue
 
             if op_type == "consolidation":
-                busy_banks = await conn.fetch(
-                    f"""
-                    SELECT DISTINCT bank_id FROM {table}
-                    WHERE operation_type = 'consolidation' AND status = 'processing'
-                    """,
-                )
-                busy_bank_ids = [r["bank_id"] for r in busy_banks]
-
                 rows = await self._claim_consolidation_tasks(
                     conn,
                     table,
-                    busy_bank_ids,
                     claimed_ids,
                     limit,
                     consolidation_bank_priority,
@@ -1636,7 +1582,7 @@ class PostgreSQLOps(DataAccessOps):
                       AND o.task_payload IS NOT NULL
                       AND o.operation_type = $1
                       AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
-                      AND {graph_maintenance_bank_serialization_sql(table, "o")}
+                      AND {bank_serialization_sql(table, "o")}
                       AND {document_serialization_sql(table, "o")}
                     ORDER BY o.created_at
                     LIMIT $2
@@ -1654,7 +1600,7 @@ class PostgreSQLOps(DataAccessOps):
         remaining_shared = shared_limit
         if remaining_shared > 0:
             # 2a. Non-consolidation tasks. graph_maintenance stays in this
-            # created_at-ordered query — see graph_maintenance_bank_serialization_sql
+            # created_at-ordered query — see bank_serialization_sql
             # for why it is a predicate rather than a phase of its own.
             if claimed_ids:
                 rows = await conn.fetch(
@@ -1666,7 +1612,7 @@ class PostgreSQLOps(DataAccessOps):
                       AND o.operation_type != 'consolidation'
                       AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
                       AND o.operation_id != ALL($1::uuid[])
-                      AND {graph_maintenance_bank_serialization_sql(table, "o")}
+                      AND {bank_serialization_sql(table, "o")}
                       AND {document_serialization_sql(table, "o")}
                     ORDER BY o.created_at
                     LIMIT $2
@@ -1684,7 +1630,7 @@ class PostgreSQLOps(DataAccessOps):
                       AND o.task_payload IS NOT NULL
                       AND o.operation_type != 'consolidation'
                       AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
-                      AND {graph_maintenance_bank_serialization_sql(table, "o")}
+                      AND {bank_serialization_sql(table, "o")}
                       AND {document_serialization_sql(table, "o")}
                     ORDER BY o.created_at
                     LIMIT $1
@@ -1700,18 +1646,9 @@ class PostgreSQLOps(DataAccessOps):
 
             # 2b. Consolidation tasks (with bank-serialization + optional priority)
             if remaining_shared > 0:
-                busy_banks_2 = await conn.fetch(
-                    f"""
-                    SELECT DISTINCT bank_id FROM {table}
-                    WHERE operation_type = 'consolidation' AND status = 'processing'
-                    """,
-                )
-                busy_bank_ids_2 = [r["bank_id"] for r in busy_banks_2]
-
                 rows = await self._claim_consolidation_tasks(
                     conn,
                     table,
-                    busy_bank_ids_2,
                     claimed_ids,
                     remaining_shared,
                     consolidation_bank_priority,

--- a/hindsight-api-slim/hindsight_api/engine/memories/pg/graph.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/pg/graph.py
@@ -610,7 +610,7 @@ async def relink_pass(
     bank running, so no need for SKIP LOCKED. Submit-time dedup alone does NOT
     give that — it only inspects 'pending' rows — so the guarantee comes from
     ``claim_tasks``, which refuses to claim a graph_maintenance row for a bank
-    that already has one in flight (``graph_maintenance_bank_serialization_sql``,
+    that already has one in flight (``bank_serialization_sql``,
     #3230). Without it these claims convoy: they lock queue rows ``FOR UPDATE``
     with no ``SKIP LOCKED``, so a second run blocks on the first while holding a
     worker slot.

--- a/hindsight-api-slim/tests/test_claim_bank_serialization.py
+++ b/hindsight-api-slim/tests/test_claim_bank_serialization.py
@@ -1,17 +1,23 @@
-"""Per-bank serialisation of graph_maintenance at claim time (#3230).
+"""Per-bank serialisation of claims, for graph_maintenance (#3230) and consolidation (#3700).
 
-Every graph_maintenance run for a bank is interchangeable — the payload carries
-only ``bank_id`` and ``run_graph_maintenance_job`` drains the whole queue — so a
-second concurrent run for one bank adds no work while convoying on the first
-run's queue-row locks (``claim_graph_maintenance_batch`` locks ``FOR UPDATE``
-with no ``SKIP LOCKED``) and holding a worker slot.
+Every run of either type for a bank is interchangeable — the payload carries
+only ``bank_id`` and the job drains that bank's whole backlog — so a second
+concurrent run for one bank recomputes the first one's work. graph_maintenance
+additionally convoys on the first run's queue-row locks
+(``claim_graph_maintenance_batch`` locks ``FOR UPDATE`` with no ``SKIP
+LOCKED``); consolidation hands the same memories to the LLM twice.
 
-``claim_tasks`` therefore refuses to claim a graph_maintenance row for a bank
-that already has one in flight, and takes at most one per bank per batch. It
-does that with a predicate on the ordinary shared-pool query rather than a
-claim phase of its own, so graph_maintenance keeps competing by ``created_at``
-instead of dropping below every other operation type — it has no reserved-slot
-floor, and the poller's fairness pass claims with ``shared_limit=1``.
+``claim_tasks`` therefore refuses to claim a row for a bank that already has one
+of that type in flight, and takes at most one per bank per batch. Excluding
+banks with a *processing* row is not enough on its own: several pending rows and
+nothing yet processing is reachable through every recovery path, and one batch
+would take them all (#3700 observed exactly that — two consolidations for one
+bank claimed at the same microsecond after a restart).
+
+It does that with a predicate on the ordinary claim queries rather than a claim
+phase of its own, so graph_maintenance keeps competing by ``created_at`` instead
+of dropping below every other operation type — it has no reserved-slot floor,
+and the poller's fairness pass claims with ``shared_limit=1``.
 
 These call ``ops.claim_tasks`` directly rather than ``WorkerPoller.claim_batch``
 so the slot limits under test are exact and not a function of ambient in-flight
@@ -57,7 +63,7 @@ def isolated_ops_schema(pg0_db_url):
     from hindsight_api.pg0 import resolve_database_url
 
     worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
-    schema = f"gmclaim_iso_{worker}"
+    schema = f"bankclaim_iso_{worker}"
 
     async def _provision() -> str:
         url = await resolve_database_url(pg0_db_url)
@@ -136,12 +142,12 @@ async def clean_operations(pool):
     """
     await pool.execute("DELETE FROM async_operations WHERE status = 'pending'")
     yield
-    await pool.execute("DELETE FROM async_operations WHERE bank_id LIKE 'test-gmclaim-%'")
+    await pool.execute("DELETE FROM async_operations WHERE bank_id LIKE 'test-bankclaim-%'")
 
 
 async def _make_bank(pool) -> str:
     """Create a bank with a unique id so concurrent runs can't collide."""
-    bank_id = f"test-gmclaim-{uuid.uuid4().hex[:8]}"
+    bank_id = f"test-bankclaim-{uuid.uuid4().hex[:8]}"
     await pool.execute(
         "INSERT INTO banks (bank_id, name) VALUES ($1, $2) ON CONFLICT DO NOTHING",
         bank_id,
@@ -160,10 +166,11 @@ async def _insert_op(
     claimed_at: datetime | None = None,
     next_retry_at: datetime | None = None,
     worker_id: str | None = None,
+    payload_extra: dict | None = None,
 ) -> uuid.UUID:
     """Insert one operation row with a claimable payload."""
     op_id = uuid.uuid4()
-    payload = json.dumps({"type": op_type, "bank_id": bank_id, "operation_id": str(op_id)})
+    payload = json.dumps({"type": op_type, "bank_id": bank_id, "operation_id": str(op_id), **(payload_extra or {})})
     await pool.execute(
         f"""
         INSERT INTO {_TABLE}
@@ -185,16 +192,23 @@ async def _insert_op(
     return op_id
 
 
-async def _claim(backend, *, shared: int = 10, reserved: dict[str, int] | None = None) -> set[str]:
+async def _claim(
+    backend,
+    *,
+    shared: int = 10,
+    reserved: dict[str, int] | None = None,
+    consolidation_bank_priority: dict[str, int] | None = None,
+) -> set[str]:
     """Run one claim cycle and return the claimed operation ids as strings."""
     async with backend.acquire() as conn:
         async with conn.transaction():
             rows = await backend.ops.claim_tasks(
                 conn,
                 _TABLE,
-                "test-gmclaim-worker",
+                "test-bankclaim-worker",
                 reserved or {},
                 shared,
+                consolidation_bank_priority=consolidation_bank_priority,
             )
     return {str(row["operation_id"]) for row in rows}
 
@@ -255,14 +269,21 @@ async def test_idle_bank_still_claimed_while_another_is_busy(pool, backend, clea
 
 @pytest.mark.asyncio
 async def test_other_operation_types_unaffected(pool, backend, clean_operations):
-    """A busy bank's non-graph_maintenance work is still claimed."""
+    """A busy bank's other work is still claimed — the guard is per operation type.
+
+    The peer subquery matches on the candidate's own operation_type, so a
+    running graph_maintenance holds back only graph_maintenance: retains and
+    consolidations for that bank keep flowing.
+    """
     bank = await _make_bank(pool)
     await _insert_op(pool, bank, "graph_maintenance", "processing", claimed_at=datetime.now(UTC))
     retain = await _insert_op(pool, bank, "retain")
+    consolidation = await _insert_op(pool, bank, "consolidation")
 
     claimed = await _claim(backend)
 
     assert str(retain) in claimed
+    assert str(consolidation) in claimed
 
 
 @pytest.mark.asyncio
@@ -306,6 +327,26 @@ async def test_retry_blocked_older_row_does_not_block_a_claimable_one(pool, back
     assert str(claimable) in claimed
 
 
+def test_fixed_type_call_sites_drop_the_candidate_guard():
+    """A query already restricted to one type gets the constant form.
+
+    The consolidation claim queries pin ``operation_type = 'consolidation'`` in
+    their own WHERE, so the guard on the candidate's type can only ever be true
+    there and the peer match is a constant, not a correlation. Emitting the
+    mixed-type form anyway reads as though a consolidation could be held back by
+    a graph_maintenance peer, which it never could.
+    """
+    from hindsight_api.engine.db.ops import bank_serialization_sql
+
+    fixed = bank_serialization_sql("async_operations", "o", "consolidation")
+    assert "NOT IN" not in fixed
+    assert "bank_peer.operation_type = 'consolidation'" in fixed
+
+    mixed = bank_serialization_sql("async_operations", "o")
+    assert "o.operation_type NOT IN ('graph_maintenance', 'consolidation')" in mixed
+    assert "bank_peer.operation_type = o.operation_type" in mixed
+
+
 def test_guard_survives_the_oracle_sql_rewrite():
     """The shared predicate must still be valid Oracle after db/oracle.py rewrites it.
 
@@ -315,7 +356,7 @@ def test_guard_survives_the_oracle_sql_rewrite():
     gone, and the ROWNUM row limit must land on the *outer* WHERE rather than the
     subquery's (the rewriter replaces only the first WHERE it sees).
     """
-    from hindsight_api.engine.db.ops import graph_maintenance_bank_serialization_sql
+    from hindsight_api.engine.db.ops import bank_serialization_sql
     from hindsight_api.engine.db.oracle import _rewrite_pg_to_oracle
 
     table = "async_operations"
@@ -325,7 +366,7 @@ def test_guard_survives_the_oracle_sql_rewrite():
         WHERE o.status = 'pending'
           AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
           AND o.operation_id != ALL($1::uuid[])
-          AND {graph_maintenance_bank_serialization_sql(table, "o")}
+          AND {bank_serialization_sql(table, "o")}
         ORDER BY o.created_at
         LIMIT $2
         FOR UPDATE SKIP LOCKED
@@ -338,7 +379,26 @@ def test_guard_survives_the_oracle_sql_rewrite():
     assert "FOR UPDATE SKIP LOCKED" in rewritten
     assert "WHERE ROWNUM <= :2 AND o.status = 'pending'" in rewritten
     # The correlated subquery keeps its own unmodified WHERE.
-    assert "WHERE gm_peer.bank_id = o.bank_id" in rewritten
+    assert "WHERE bank_peer.bank_id = o.bank_id" in rewritten
+
+    # The consolidation tiers pair the guard with LIKE ANY, whose rewrite is a
+    # regex on a *bare* column name — an "o." prefix would survive it as
+    # "o.(bank_id LIKE :p0 ...)", so that one column stays unqualified.
+    tiered = _rewrite_pg_to_oracle(
+        f"""
+        SELECT o.operation_id FROM {table} o
+        WHERE o.status = 'pending'
+          AND {bank_serialization_sql(table, "o", "consolidation")}
+          AND bank_id LIKE ANY($1::text[])
+        ORDER BY o.created_at
+        LIMIT $2
+        FOR UPDATE SKIP LOCKED
+        """
+    ).query
+
+    assert "LIKE ANY" not in tiered
+    assert "o./*LIKE_ANY" not in tiered
+    assert "WHERE ROWNUM <= :2 AND o.status = 'pending'" in tiered
 
 
 @pytest.mark.asyncio
@@ -380,3 +440,153 @@ async def test_reserved_and_shared_phases_do_not_double_claim(pool, backend, cle
 
     ours = [op for op in op_ids if str(op) in claimed]
     assert len(ours) == 1, f"expected exactly one same-bank claim across both phases, got {len(ours)}"
+
+
+# --- consolidation (#3700) ---------------------------------------------------
+#
+# Consolidation is claimed by its own path (bank priority tiers), so every
+# guarantee above has to be re-checked against those queries.
+
+
+@pytest.mark.asyncio
+async def test_consolidation_not_claimed_while_bank_has_run_in_flight(pool, backend, clean_operations):
+    """A pending consolidation is left alone while its bank has one processing."""
+    bank = await _make_bank(pool)
+    await _insert_op(pool, bank, "consolidation", "processing", claimed_at=datetime.now(UTC), worker_id="other")
+    pending = await _insert_op(pool, bank, "consolidation")
+
+    claimed = await _claim(backend)
+
+    assert str(pending) not in claimed
+    assert await _status_of(pool, pending) == "pending"
+
+
+@pytest.mark.asyncio
+async def test_consolidation_single_batch_claims_at_most_one_per_bank(pool, backend, clean_operations):
+    """One batch takes a single consolidation per bank — the oldest (#3700).
+
+    This is the case the busy-bank exclusion never covered: nothing is
+    processing, so no bank is busy, and one query took every pending row. The
+    reporter hit it after a restart, where ``_reclaim_own_processing_tasks``
+    returns all of a worker's processing rows to pending in one statement.
+    """
+    bank = await _make_bank(pool)
+    base = datetime.now(UTC) - timedelta(minutes=10)
+    op_ids = [await _insert_op(pool, bank, "consolidation", created_at=base + timedelta(seconds=i)) for i in range(5)]
+
+    claimed = await _claim(backend)
+
+    ours = [op for op in op_ids if str(op) in claimed]
+    assert len(ours) == 1, f"expected exactly one same-bank claim, got {len(ours)}"
+    assert ours[0] == op_ids[0], "the oldest pending row should be the one claimed"
+
+
+@pytest.mark.asyncio
+async def test_consolidation_reserved_pool_is_serialised_too(pool, backend, clean_operations):
+    """The reserved pool is serialised as well — the shape #3700 was reported in.
+
+    WORKER_SLOT_TYPE_DEFAULTS reserves 2 slots for consolidation, which is why
+    the reported worker logged "claimed 2 tasks (2 consolidation)" for one bank.
+    """
+    bank = await _make_bank(pool)
+    base = datetime.now(UTC) - timedelta(minutes=10)
+    op_ids = [await _insert_op(pool, bank, "consolidation", created_at=base + timedelta(seconds=i)) for i in range(5)]
+
+    claimed = await _claim(backend, shared=0, reserved={"consolidation": 2})
+
+    ours = [op for op in op_ids if str(op) in claimed]
+    assert len(ours) == 1, f"expected exactly one same-bank claim, got {len(ours)}"
+
+
+@pytest.mark.asyncio
+async def test_consolidation_reserved_and_shared_phases_do_not_double_claim(pool, backend, clean_operations):
+    """The reserved claim blocks the shared pool from taking a second one.
+
+    Both phases recomputed the busy-bank list from rows that are still 'pending'
+    inside the claim transaction, so neither saw the other's claim.
+    """
+    bank = await _make_bank(pool)
+    base = datetime.now(UTC) - timedelta(minutes=10)
+    op_ids = [await _insert_op(pool, bank, "consolidation", created_at=base + timedelta(seconds=i)) for i in range(3)]
+
+    claimed = await _claim(backend, shared=5, reserved={"consolidation": 1})
+
+    ours = [op for op in op_ids if str(op) in claimed]
+    assert len(ours) == 1, f"expected exactly one same-bank claim across both phases, got {len(ours)}"
+
+
+@pytest.mark.asyncio
+async def test_consolidation_priority_tiers_are_serialised(pool, backend, clean_operations):
+    """Both tiered claim queries carry the guard, and tiers cannot stack claims.
+
+    ``consolidation_bank_priority`` routes claims through the LIKE / NOT LIKE
+    variants instead of the plain one, and runs them once per priority level.
+    """
+    high_bank = await _make_bank(pool)
+    low_bank = await _make_bank(pool)
+    base = datetime.now(UTC) - timedelta(minutes=10)
+    high_ops = [
+        await _insert_op(pool, high_bank, "consolidation", created_at=base + timedelta(seconds=i)) for i in range(3)
+    ]
+    low_ops = [
+        await _insert_op(pool, low_bank, "consolidation", created_at=base + timedelta(seconds=i)) for i in range(3)
+    ]
+
+    claimed = await _claim(backend, consolidation_bank_priority={f"{high_bank}*": 10, "*": 1})
+
+    assert len([op for op in high_ops if str(op) in claimed]) == 1
+    assert len([op for op in low_ops if str(op) in claimed]) == 1
+
+
+@pytest.mark.asyncio
+async def test_consolidation_other_banks_keep_their_parallelism(pool, backend, clean_operations):
+    """The guard is per bank: a second bank's consolidation is claimed in the same batch."""
+    busy_bank = await _make_bank(pool)
+    idle_bank = await _make_bank(pool)
+    await _insert_op(pool, busy_bank, "consolidation", "processing", claimed_at=datetime.now(UTC))
+    blocked = await _insert_op(pool, busy_bank, "consolidation")
+    claimable = await _insert_op(pool, idle_bank, "consolidation")
+
+    claimed = await _claim(backend)
+
+    assert str(claimable) in claimed
+    assert str(blocked) not in claimed
+
+
+@pytest.mark.asyncio
+async def test_consolidation_retry_blocked_older_row_does_not_block_a_claimable_one(pool, backend, clean_operations):
+    """An older consolidation still in retry backoff must not hold up its bank."""
+    bank = await _make_bank(pool)
+    await _insert_op(
+        pool,
+        bank,
+        "consolidation",
+        created_at=datetime.now(UTC) - timedelta(minutes=5),
+        next_retry_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+    claimable = await _insert_op(pool, bank, "consolidation")
+
+    claimed = await _claim(backend)
+
+    assert str(claimable) in claimed
+
+
+@pytest.mark.asyncio
+async def test_scoped_consolidation_queues_behind_an_unscoped_one(pool, backend, clean_operations):
+    """A scoped consolidation is deferred, not dropped, while the bank is busy.
+
+    Submit-time dedup exempts scoped runs (``observation_scopes`` covers only a
+    tag subset, so an unscoped pending op must not swallow it), but claim-time
+    serialisation needs no such carve-out: nothing is discarded here, the scoped
+    run simply waits for the bank and is claimed on a later cycle — with a fresh
+    watermark, which is the whole reason consolidation is not deduped at submit.
+    """
+    bank = await _make_bank(pool)
+    running = await _insert_op(pool, bank, "consolidation", "processing", claimed_at=datetime.now(UTC))
+    scoped = await _insert_op(pool, bank, "consolidation", payload_extra={"observation_scopes": [["project"]]})
+
+    assert str(scoped) not in await _claim(backend)
+
+    await pool.execute(f"UPDATE {_TABLE} SET status = 'completed' WHERE operation_id = $1", running)
+
+    assert str(scoped) in await _claim(backend)


### PR DESCRIPTION
Fixes #3700.

## The defect

Consolidation was held to one run per bank by `bank_id != ALL(busy)`, where `busy` comes from a **separate `SELECT DISTINCT bank_id … status = 'processing'` issued before the claim query**. Nothing processing ⇒ no bank is busy ⇒ a single claim query takes *every* pending row for that bank. `FOR UPDATE SKIP LOCKED` doesn't help; the rows are distinct.

Several pending rows per bank is not an exotic state — it is what every recovery path produces. `_reclaim_own_processing_tasks` returns *all* of a worker's processing rows to pending in one statement (from `recover_own_tasks` at startup and `release_own_tasks` at shutdown), as do `_schedule_retry`, `_defer_operation` and `hindsight-admin recover`. A restart mid-backlog is enough.

Both runs then read the same `total_unconsolidated`, cut the same batches, and hand the same memories to the LLM — duplicated inference on the slowest path in the system.

Reproduced on all three consolidation claim paths:

| claim path | rows claimed for one bank (before) |
|---|---|
| reserved pool (`{"consolidation": 2}`) | 2 |
| shared pool (phase 2b) | 5 |
| reserved + shared in one cycle | 3 |

The reserved-pool number is the reported log verbatim — `WORKER_SLOT_TYPE_DEFAULTS` reserves 2 slots for consolidation, hence *"claimed 2 tasks (2 consolidation)"*. Phase 1 and phase 2b each recompute `busy` from rows that are still `pending` inside the claim transaction, so neither phase sees the other's claim.

## The fix

`graph_maintenance` got a predicate for exactly this in #3230. Rather than copy it, this generalises it: `graph_maintenance_bank_serialization_sql` → `bank_serialization_sql(table, alias)`, which matches peers on the candidate's own `operation_type` and covers both types. Every consolidation claim query carries it — the plain one and both bank-priority tiers (`LIKE` / `NOT LIKE`).

Its strictly-older-`pending` branch is what bounds a batch to one row per bank. It also closes a window the pre-query busy list structurally cannot see: a peer that another worker has claimed but not yet committed as `processing` still reads as the older `pending` row, so the second worker stands down.

That leaves `bank_id != ALL(busy)` exactly redundant — the predicate's `processing` branch is the same condition, evaluated fresher — so the busy-bank query and its filters are removed from both the PostgreSQL and Oracle ops. `_claim_consolidation_plain` collapses from four query variants to two.

## Scoped consolidations need no carve-out

The issue suggests mirroring the submit-time dedup's `observation_scopes` exemption. Deliberately not done, and there's a test pinning it: submit-time dedup **drops** work, so a pending unscoped op must not swallow a scoped one; claim-time suppression only **defers**. A scoped run queues behind the bank's in-flight run and is claimed on a later cycle — with a fresh watermark, which is the whole reason consolidation isn't deduped at submit. Carving scoped rows out of the predicate would instead let a scoped and an unscoped run for one bank be claimed *together*, re-breaking the invariant.

The documented invariant ("Consolidation's bank-serialization constraint … is preserved regardless of which pool claims the slot", `configuration.md`) needed no rewording — this makes it true.

## Tests

`test_graph_maintenance_claim_serialization.py` → `test_claim_bank_serialization.py`, since the predicate now serves both operation types. 7 new consolidation tests covering the reserved pool, the shared pool, both phases in one cycle, the priority tiers, retry-backoff liveness, cross-bank parallelism, and the scoped-deferral decision. Each was confirmed to fail without the fix — none are vacuous. `test_other_operation_types_unaffected` now also asserts a busy `graph_maintenance` doesn't hold back that bank's consolidation.

17 pass in that file; 205 across the worker / claim / consolidation suites. `lint.sh` and `ty` clean.

## Note on the branch

Branched from `origin/main`, not from the local working branch — that carried a duplicate of #3708, already merged upstream as `d8a71c313`.
