### PR TITLE
feat(coding-agents): add qwen-code as a hook harness

### DIFF
--- a/hindsight-control-plane/public/img/harness/qwen-code.svg
+++ b/hindsight-control-plane/public/img/harness/qwen-code.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="27.55 17.52 147.28 145.51">
+<path d="M174.82 108.75L155.38 75L165.64 57.75C166.46 56.31 166.46 54.53 165.64 53.09L155.38 35.84C154.86 34.91 153.87 34.33 152.78 34.33H114.88L106.14 19.03C105.62 18.1 104.63 17.52 103.54 17.52H83.3C82.21 17.52 81.22 18.1 80.7 19.03L61.26 52.77H41.02C39.93 52.77 38.94 53.35 38.42 54.28L28.16 71.53C27.34 72.97 27.34 74.75 28.16 76.19L45.52 107.5L36.78 122.8C35.96 124.24 35.96 126.02 36.78 127.46L47.04 144.71C47.56 145.64 48.55 146.22 49.64 146.22H87.54L96.28 161.52C96.8 162.45 97.79 163.03 98.88 163.03H119.12C120.21 163.03 121.2 162.45 121.72 161.52L141.16 127.78H158.52C159.61 127.78 160.6 127.2 161.12 126.27L171.38 109.02C172.2 107.58 172.2 105.8 171.38 104.36L174.82 108.75Z" fill="url(#paint0_radial)"/>
+<path d="M119.12 163.03H98.88L87.54 144.71H49.64L61.26 126.39H80.7L38.42 55.29H61.26L83.3 19.03L93.56 37.35L83.3 55.29H161.58L151.32 72.54L170.76 106.28H151.32L141.16 88.34L101.18 163.03H119.12Z" fill="white"/>
+<path d="M127.86 79.83H76.14L101.18 122.11L127.86 79.83Z" fill="url(#paint1_radial)"/>
+<defs>
+<radialGradient id="paint0_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(100 100) rotate(90) scale(100)">
+<stop stop-color="#665CEE"/>
+<stop offset="1" stop-color="#332E91"/>
+</radialGradient>
+<radialGradient id="paint1_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(100 100) rotate(90) scale(100)">
+<stop stop-color="#665CEE"/>
+<stop offset="1" stop-color="#332E91"/>
+</radialGradient>
+</defs>
+</svg>

--- a/hindsight-control-plane/src/lib/harness-logo.ts
+++ b/hindsight-control-plane/src/lib/harness-logo.ts
@@ -87,6 +87,7 @@ export const HARNESS_LOGO_REGISTRY: Record<string, HarnessLogoEntry> = {
   "grok-build": { id: "grok-build", label: "Grok Build", src: "/img/harness/grok-build.svg" },
   kilo: { id: "kilo", label: "Kilo CLI", src: "/img/harness/kilo.svg" },
   opencode: { id: "opencode", label: "OpenCode", src: "/img/harness/opencode.png" },
+  "qwen-code": { id: "qwen-code", label: "Qwen Code", src: "/img/harness/qwen-code.svg" },
   "prime-agent": {
     id: "prime-agent",
     label: "Prime Agent",

--- a/hindsight-control-plane/tests/lib/harness-logo.test.ts
+++ b/hindsight-control-plane/tests/lib/harness-logo.test.ts
@@ -51,6 +51,7 @@ describe("resolveHarnessLogo", () => {
     "kilo",
     "opencode",
     "prime-agent",
+    "qwen-code",
   ];
   // Ids the integration used to emit. Kept so documents already retained under
   // them keep their logo; a new id never belongs here.

--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -96,6 +96,20 @@ npx @vectorize-io/hindsight-coding-agents install grok-build
 
 Native hooks and MCP in `~/.grok/config.toml`, plus the companion skill.
 
+#### <img src="/img/harness/qwen-code.svg" alt="" width="20" height="20" /> Qwen Code
+
+```bash
+npx @vectorize-io/hindsight-coding-agents install qwen-code
+```
+
+Native hooks in `~/.qwen/settings.json`, plus MCP and the companion skill.
+
+> Qwen's hook `timeout` is in **milliseconds** (its own docs: "Timeout in milliseconds, default
+> 60000"), unlike every other supported agent, so the installed values are `30000/30000/60000`.
+> Recall fires on genuine submissions only — `UserPromptSubmit` also fires on tool-result
+> continuations, so interactive sessions recall once per prompt while headless (`qwen -p`),
+> `serve`, SDK and ACP sessions seed and retain but do not recall.
+
 #### <img src="/img/harness/antigravity-cli.png" alt="" width="20" height="20" /> Antigravity CLI
 
 ```bash

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -93,6 +93,20 @@ npx @vectorize-io/hindsight-coding-agents install grok-build
 
 Native hooks and MCP in `~/.grok/config.toml`, plus the companion skill.
 
+#### <img src="https://hindsight.vectorize.io/img/harness/qwen-code.svg" alt="" width="20" height="20" /> Qwen Code
+
+```bash
+npx @vectorize-io/hindsight-coding-agents install qwen-code
+```
+
+Native hooks in `~/.qwen/settings.json`, plus MCP and the companion skill.
+
+> Qwen's hook `timeout` is in **milliseconds** (its own docs: "Timeout in milliseconds, default
+> 60000"), unlike every other supported agent, so the installed values are `30000/30000/60000`.
+> Recall fires on genuine submissions only — `UserPromptSubmit` also fires on tool-result
+> continuations, so interactive sessions recall once per prompt while headless (`qwen -p`),
+> `serve`, SDK and ACP sessions seed and retain but do not recall.
+
 #### <img src="https://hindsight.vectorize.io/img/harness/antigravity-cli.png" alt="" width="20" height="20" /> Antigravity CLI
 
 ```bash

--- a/hindsight-integrations/coding-agents/e2e/Dockerfile.qwen-code
+++ b/hindsight-integrations/coding-agents/e2e/Dockerfile.qwen-code
@@ -1,0 +1,3 @@
+FROM hindsight-coding-agents-e2e-base
+ARG VERSION=latest
+RUN npm install --global "@qwen-code/qwen-code@${VERSION}" && command -v qwen

--- a/hindsight-integrations/coding-agents/package.json
+++ b/hindsight-integrations/coding-agents/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/vectorize-io/hindsight.git",
     "directory": "hindsight-integrations/coding-agents"
   },
-  "description": "Reflect-only Hindsight long-term memory for coding agents (harness-pluggable: opencode, \u2026), with automatic background ingestion (no setup CLI).",
+  "description": "Reflect-only Hindsight long-term memory for coding agents (harness-pluggable: opencode, …), with automatic background ingestion (no setup CLI).",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/hindsight-integrations/coding-agents/package.json
+++ b/hindsight-integrations/coding-agents/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/vectorize-io/hindsight.git",
     "directory": "hindsight-integrations/coding-agents"
   },
-  "description": "Reflect-only Hindsight long-term memory for coding agents (harness-pluggable: opencode, …), with automatic background ingestion (no setup CLI).",
+  "description": "Reflect-only Hindsight long-term memory for coding agents (harness-pluggable: opencode, \u2026), with automatic background ingestion (no setup CLI).",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -25,7 +25,10 @@
     "hindsight-codex-hook": "dist/codex-hook.js",
     "hindsight-antigravity-hook": "dist/antigravity-hook.js",
     "hindsight-antigravity-statusline": "dist/antigravity-statusline.js",
-    "hindsight-devin-hook": "dist/devin-hook.js"
+    "hindsight-devin-hook": "dist/devin-hook.js",
+    "hindsight-qwen-hook": "dist/qwen-hook.js",
+    "hindsight-qwen-sessionstart-hook": "dist/qwen-sessionstart-hook.js",
+    "hindsight-qwen-stop-hook": "dist/qwen-stop-hook.js"
   },
   "exports": {
     ".": {

--- a/hindsight-integrations/coding-agents/src/core/transcript-qwen.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript-qwen.test.ts
@@ -128,7 +128,7 @@ describe("readQwenTranscript", () => {
             {
               text:
                 "<task-notification>\n<task-id>general-purpose-call_f1b126b417f3491da3edc4c3</task-id>\n" +
-                "<status>completed</status>\n<summary>Agent \"Survey KV-cache prior art\" completed.</summary>\n" +
+                '<status>completed</status>\n<summary>Agent "Survey KV-cache prior art" completed.</summary>\n' +
                 "</task-notification>",
             },
           ],
@@ -301,7 +301,7 @@ describe("readQwenTranscript", () => {
     // provenance". An unanchored global regex over every part deletes real prose — and in a repo
     // whose subject IS this integration, quoting the tag is a prompt someone will really write.
     const quoting =
-      'why does <qwen:user-prompt-submit-context>foo</qwen:user-prompt-submit-context> show up twice?';
+      "why does <qwen:user-prompt-submit-context>foo</qwen:user-prompt-submit-context> show up twice?";
     writeFileSync(
       file,
       record({

--- a/hindsight-integrations/coding-agents/src/core/transcript-qwen.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript-qwen.test.ts
@@ -1,0 +1,495 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readQwenTranscript } from "./transcript-qwen";
+import { stripInjectedMemory } from "./transcript-util";
+
+let root: string;
+let file: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "hs-qwen-transcript-"));
+  file = join(root, "0fda5621-cda9-46c2-89dd-b9e4188a7b54.jsonl");
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+/** One record with Qwen's Claude-shaped envelope; `fields` carries what each case is about. */
+const record = (fields: Record<string, unknown>) =>
+  JSON.stringify({
+    uuid: "1e65de67-abad-4509-8998-d2d7409d14d0",
+    parentUuid: "59208e3b-d0b0-4472-9258-07bbedea4124",
+    sessionId: "0fda5621-cda9-46c2-89dd-b9e4188a7b54",
+    cwd: "/data/repos/qwen38-qua-moe",
+    version: "0.22.0",
+    gitBranch: "research/cpt-downcycling-phase6",
+    ...fields,
+  });
+
+/** Exactly what Qwen writes back after a UserPromptSubmit hook returns additionalContext: its own
+ *  wrapper around our block, with the INNER tags HTML-escaped by the host. */
+const injectedEcho = [
+  "<qwen:user-prompt-submit-context>",
+  "&lt;hindsight_memories&gt;",
+  "Relevant memories from past conversations (prioritize recent when conflicting).",
+  "- the uploader retries with exponential backoff [experience] (2026-08-22T08:56:50Z)",
+  "&lt;/hindsight_memories&gt;",
+  "</qwen:user-prompt-submit-context>",
+].join("\n");
+
+describe("readQwenTranscript", () => {
+  it("keeps real user prompts, assistant prose and compact action turns; drops system/tool_result/thought/synthetic-user records", () => {
+    const lines = [
+      // system telemetry — 54% of a real transcript, and never conversation: dropped
+      record({
+        type: "system",
+        provenance: "system",
+        subtype: "ui_telemetry",
+        systemPayload: {
+          uiEvent: {
+            "event.name": "qwen-code.api_response",
+            model: "qwen/qwen3.8-max",
+            status_code: 200,
+            duration_ms: 4193,
+          },
+        },
+      }),
+      // real user prompt: kept
+      record({
+        type: "user",
+        provenance: "real_user",
+        timestamp: "2026-08-24T06:07:26.836Z",
+        message: { role: "user", parts: [{ text: "Reply with exactly: probe-ok" }] },
+      }),
+      // assistant: the `thought` part is reasoning (dropped), the plain text is the answer (kept).
+      // Note message.role is Gemini's "model" — role comes from the record's `type`, not from here.
+      record({
+        type: "assistant",
+        provenance: "assistant_output",
+        timestamp: "2026-08-24T06:07:31.074Z",
+        model: "qwen/qwen3.8-max",
+        message: {
+          role: "model",
+          parts: [
+            {
+              text: 'The user wants me to reply with exactly "probe-ok". Let me do that.',
+              thought: true,
+            },
+            { text: "probe-ok" },
+          ],
+        },
+        usageMetadata: { promptTokenCount: 40485, candidatesTokenCount: 34 },
+      }),
+      // a functionCall-only assistant record becomes a compact role:"action" turn (name + target)
+      record({
+        type: "assistant",
+        provenance: "assistant_output",
+        message: {
+          role: "model",
+          parts: [
+            {
+              functionCall: {
+                id: "call_16257430bada4eef815199fc",
+                name: "list_directory",
+                args: { path: "/data/repos" },
+              },
+            },
+          ],
+        },
+      }),
+      // tool_result is its OWN record type, with message.role "user": dropped whole
+      record({
+        type: "tool_result",
+        provenance: "tool_result",
+        message: {
+          role: "user",
+          parts: [
+            {
+              functionResponse: {
+                id: "call_16257430bada4eef815199fc",
+                name: "list_directory",
+                response: { output: "Listed 181 item(s) in /data/repos:\n---\n[DIR] bdh" },
+              },
+            },
+          ],
+        },
+      }),
+      // `type:"user"` but MACHINE-authored: a background-task notification. Dropped on provenance —
+      // these outnumbered genuine prompts 307 to 69 in the corpus this reader was measured on.
+      record({
+        type: "user",
+        provenance: "system",
+        subtype: "notification",
+        message: {
+          role: "user",
+          parts: [
+            {
+              text:
+                "<task-notification>\n<task-id>general-purpose-call_f1b126b417f3491da3edc4c3</task-id>\n" +
+                "<status>completed</status>\n<summary>Agent \"Survey KV-cache prior art\" completed.</summary>\n" +
+                "</task-notification>",
+            },
+          ],
+        },
+      }),
+      // same class: a /loop cron re-entry, written as a user record
+      record({
+        type: "user",
+        provenance: "system",
+        subtype: "cron",
+        message: {
+          role: "user",
+          parts: [
+            {
+              text: "Base directory for this skill: /qwen-code/lib/bundled/loop",
+            },
+          ],
+        },
+      }),
+      // a human interjection mid-turn IS real: provenance says so, subtype does not disqualify it
+      record({
+        type: "user",
+        provenance: "real_user",
+        subtype: "mid_turn_user_message",
+        timestamp: "2026-08-22T00:23:23.004Z",
+        message: {
+          role: "user",
+          parts: [{ text: "Also, install whatever vast tooling you want." }],
+        },
+        systemPayload: { displayText: "Also, install whatever vast tooling you want." },
+      }),
+      // malformed line + non-object JSON + blank line: tolerated
+      "{ not json",
+      "null",
+      "",
+    ];
+    writeFileSync(file, lines.join("\n"));
+
+    const turns = readQwenTranscript(file);
+
+    expect(turns).toEqual([
+      {
+        role: "user",
+        content: "Reply with exactly: probe-ok",
+        timestamp: "2026-08-24T06:07:26.836Z",
+      },
+      { role: "assistant", content: "probe-ok", timestamp: "2026-08-24T06:07:31.074Z" },
+      { role: "action", content: "list_directory /data/repos" },
+      {
+        role: "user",
+        content: "Also, install whatever vast tooling you want.",
+        timestamp: "2026-08-22T00:23:23.004Z",
+      },
+    ]);
+  });
+
+  it("splits a mixed text + functionCall record into a prose turn plus one action turn each", () => {
+    writeFileSync(
+      file,
+      record({
+        type: "assistant",
+        provenance: "assistant_output",
+        timestamp: "2026-08-22T00:24:02.117Z",
+        message: {
+          role: "model",
+          parts: [
+            { text: "Checking the trainer, then running it.", thought: true },
+            { text: "Editing the stream, then running the probe." },
+            {
+              functionCall: {
+                id: "call_a1",
+                name: "edit",
+                args: {
+                  file_path: "/data/repos/bdh-attention/bdh_kv/stream.py",
+                  old_string: "steps.append(step)",
+                  new_string: "steps.append(step)  # noqa",
+                },
+              },
+            },
+            {
+              functionCall: {
+                id: "call_a2",
+                name: "run_shell_command",
+                args: { command: "python -m pytest -q", description: "Run the probe" },
+              },
+            },
+          ],
+        },
+      })
+    );
+
+    // Action lines carry the tool name + primary target only — no arguments, no output.
+    expect(readQwenTranscript(file)).toEqual([
+      {
+        role: "assistant",
+        content: "Editing the stream, then running the probe.",
+        timestamp: "2026-08-22T00:24:02.117Z",
+      },
+      {
+        role: "action",
+        content: "edit /data/repos/bdh-attention/bdh_kv/stream.py",
+        timestamp: "2026-08-22T00:24:02.117Z",
+      },
+      {
+        role: "action",
+        content: "run_shell_command python -m pytest -q",
+        timestamp: "2026-08-22T00:24:02.117Z",
+      },
+    ]);
+  });
+
+  it("strips Qwen's echo of our own injection, which the shared tag stripper cannot see because the host HTML-escapes the inner tags", () => {
+    // The premise of the harness-specific strip, asserted rather than assumed: MEMORY_TAG_RE
+    // matches RAW tags, and every injection Qwen writes back is escaped.
+    expect(stripInjectedMemory(injectedEcho)).toBe(injectedEcho);
+
+    // The real shape, and the only one with pairing evidence: the user's prompt part, then the
+    // echo part appended by the host as the FINAL part. Only the prompt survives — otherwise
+    // every Stop re-ingests the memories that turn's recall injected.
+    writeFileSync(
+      file,
+      record({
+        type: "user",
+        provenance: "real_user",
+        timestamp: "2026-08-24T06:07:26.836Z",
+        message: {
+          role: "user",
+          parts: [{ text: "Reply with exactly: probe-ok" }, { text: injectedEcho }],
+        },
+      })
+    );
+    expect(readQwenTranscript(file)).toEqual([
+      {
+        role: "user",
+        content: "Reply with exactly: probe-ok",
+        timestamp: "2026-08-24T06:07:26.836Z",
+      },
+    ]);
+  });
+
+  it("prefers systemPayload.displayText, the host's own pre-hook projection, over parsing parts", () => {
+    // The primary evidence in Qwen's contract: when `hookContext` is a string, `displayText` is
+    // the pre-hook prompt and "never includes the hook context". No tag matching is involved, so
+    // this path is immune to whatever the user happened to type.
+    writeFileSync(
+      file,
+      record({
+        type: "user",
+        provenance: "real_user",
+        timestamp: "2026-08-24T06:07:26.836Z",
+        systemPayload: { displayText: "what did we decide about vchord?", hookContext: "…" },
+        message: {
+          role: "user",
+          parts: [{ text: "expanded pre-hook prompt" }, { text: injectedEcho }],
+        },
+      })
+    );
+    expect(readQwenTranscript(file)).toEqual([
+      {
+        role: "user",
+        content: "what did we decide about vchord?",
+        timestamp: "2026-08-24T06:07:26.836Z",
+      },
+    ]);
+  });
+
+  it("does NOT treat tag-like text the user actually wrote as hook provenance", () => {
+    // Qwen's contract is explicit that the tag is "a provenance marker, not ... a general trust
+    // boundary" and that consumers "must not infer that arbitrary tag-like user text is hook
+    // provenance". An unanchored global regex over every part deletes real prose — and in a repo
+    // whose subject IS this integration, quoting the tag is a prompt someone will really write.
+    const quoting =
+      'why does <qwen:user-prompt-submit-context>foo</qwen:user-prompt-submit-context> show up twice?';
+    writeFileSync(
+      file,
+      record({
+        type: "user",
+        provenance: "real_user",
+        message: { role: "user", parts: [{ text: quoting }] },
+      })
+    );
+    expect(readQwenTranscript(file)).toEqual([{ role: "user", content: quoting }]);
+
+    // Same text mid-record, with a genuine echo appended after it: the echo goes, the prose stays.
+    writeFileSync(
+      file,
+      record({
+        type: "user",
+        provenance: "real_user",
+        message: { role: "user", parts: [{ text: quoting }, { text: injectedEcho }] },
+      })
+    );
+    expect(readQwenTranscript(file)).toEqual([{ role: "user", content: quoting }]);
+  });
+
+  it("strips injected memory that arrives unescaped inside a kept turn", () => {
+    writeFileSync(
+      file,
+      record({
+        type: "user",
+        provenance: "real_user",
+        message: {
+          role: "user",
+          parts: [{ text: "<hindsight_memories>\nleak\n</hindsight_memories>\nWhy retry?" }],
+        },
+      })
+    );
+    expect(readQwenTranscript(file)).toEqual([{ role: "user", content: "Why retry?" }]);
+  });
+
+  it("a functionCall whose args name no primary target still yields the bare tool name", () => {
+    writeFileSync(
+      file,
+      record({
+        type: "assistant",
+        provenance: "assistant_output",
+        message: {
+          role: "model",
+          parts: [
+            {
+              functionCall: {
+                id: "call_053a278ceaee48b99111b615",
+                name: "todo_write",
+                args: { todos: [{ id: "1", content: "Survey prior art", status: "in_progress" }] },
+              },
+            },
+          ],
+        },
+      })
+    );
+    expect(readQwenTranscript(file)).toEqual([{ role: "action", content: "todo_write" }]);
+  });
+
+  it("drops tool_result records entirely — even a huge one produces no turn", () => {
+    writeFileSync(
+      file,
+      record({
+        type: "tool_result",
+        provenance: "tool_result",
+        message: {
+          role: "user",
+          parts: [
+            {
+              functionResponse: {
+                id: "call_1",
+                name: "run_shell_command",
+                response: { output: "x".repeat(5000) },
+              },
+            },
+          ],
+        },
+      })
+    );
+    expect(readQwenTranscript(file)).toEqual([]);
+  });
+
+  it("requires a positive subagent marker — a bare record with no provenance is NOT a user turn", () => {
+    // The previous version of this test passed unchanged with agentId/isSidechain removed, so it
+    // never tested the boundary it documented. Absence of `subtype` is not evidence of a human:
+    // a field-stripped or corrupt record has neither. Only the subagent envelope earns the
+    // fallback, and a malformed `provenance` must never reach it at all.
+    const bare = JSON.stringify({
+      type: "user",
+      message: { role: "user", parts: [{ text: "no provenance, no envelope" }] },
+    });
+    writeFileSync(file, bare + "\n");
+    expect(readQwenTranscript(file)).toEqual([]);
+
+    for (const bad of [null, 42, { kind: "real_user" }, ["real_user"]]) {
+      writeFileSync(
+        file,
+        JSON.stringify({
+          type: "user",
+          provenance: bad,
+          agentId: "general-purpose-call_x",
+          isSidechain: true,
+          message: { role: "user", parts: [{ text: "malformed provenance" }] },
+        }) + "\n"
+      );
+      expect(readQwenTranscript(file), `provenance=${JSON.stringify(bad)}`).toEqual([]);
+    }
+  });
+
+  it("reads a subagent transcript, whose envelope carries no provenance at all", () => {
+    // ~/.qwen/projects/<slug>/subagents/<parentSessionId>/agent-<name>-<callId>.jsonl uses a THIRD
+    // envelope: agentId/agentName/isSidechain, no `provenance` and no `subtype`. A strict
+    // provenance === "real_user" test would read every one of these as synthetic and retain
+    // nothing, so the reader falls back the way Qwen's own legacySafeProvenance does.
+    const subagent = (fields: Record<string, unknown>) =>
+      JSON.stringify({
+        uuid: "d656e8f0-97ea-4d06-908a-51cb169b73bd",
+        parentUuid: null,
+        sessionId: "b3cbbf83-fea5-4308-8571-24d6f9c6bf47",
+        cwd: "/data/repos/bdh-attention",
+        version: "0.21.12",
+        agentId: "general-purpose-call_f1b126b417f3491da3edc4c3",
+        agentName: "general-purpose",
+        isSidechain: true,
+        ...fields,
+      });
+    writeFileSync(
+      file,
+      [
+        subagent({
+          type: "user",
+          timestamp: "2026-08-14T22:05:21.828Z",
+          message: { role: "user", parts: [{ text: "Survey the KV-cache prior art." }] },
+        }),
+        subagent({
+          type: "assistant",
+          timestamp: "2026-08-14T22:05:33.294Z",
+          message: {
+            role: "model",
+            parts: [
+              { text: "Planning the fetches.", thought: true },
+              { text: "Fetching the 7 sources." },
+              {
+                functionCall: {
+                  id: "call_c18036a2c14d489e81968305",
+                  name: "web_fetch",
+                  args: {
+                    url: "https://proceedings.mlr.press/v235/nawrot24a.html",
+                    prompt: "summarize",
+                  },
+                },
+              },
+            ],
+          },
+        }),
+      ].join("\n")
+    );
+
+    expect(readQwenTranscript(file)).toEqual([
+      {
+        role: "user",
+        content: "Survey the KV-cache prior art.",
+        timestamp: "2026-08-14T22:05:21.828Z",
+      },
+      {
+        role: "assistant",
+        content: "Fetching the 7 sources.",
+        timestamp: "2026-08-14T22:05:33.294Z",
+      },
+      {
+        role: "action",
+        content: "web_fetch https://proceedings.mlr.press/v235/nawrot24a.html",
+        timestamp: "2026-08-14T22:05:33.294Z",
+      },
+    ]);
+  });
+
+  it("fails open (returns []) when the file cannot be read", () => {
+    expect(readQwenTranscript(join(root, "nope.jsonl"))).toEqual([]);
+  });
+
+  it("fails open when transcript_path is a DIRECTORY — the fault is on the LAZY read", () => {
+    // Not the same case as a missing file, and the one that actually happens: on Linux a directory
+    // passes statSync AND openSync, then throws EISDIR on the first readSync — i.e. after the
+    // reader has already returned its generator. runRetainHook calls the reader outside
+    // buildRetain's catch, so an uncaught throw there rejects the whole Stop hook.
+    expect(() => readQwenTranscript(root)).not.toThrow();
+    expect(readQwenTranscript(root)).toEqual([]);
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/transcript-qwen.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript-qwen.ts
@@ -1,0 +1,248 @@
+/**
+ * Qwen Code session transcript (JSONL) reader — a HYBRID of the two schemas this package already
+ * parses, which is why it needs its own reader instead of reusing either.
+ *
+ * The ENVELOPE is Claude Code's, field for field: one record per line carrying
+ * `uuid`/`parentUuid`/`sessionId`/`timestamp`/`type`/`cwd`/`version`/`gitBranch`, stored at
+ * `~/.qwen/projects/<slugified-cwd>/chats/<sessionId>.jsonl` and handed to the Stop hook as
+ * `transcript_path`. The BODY is Gemini's: `message.parts[]` rather than `message.content[]`, and
+ * an assistant record's `message.role` reads **"model"** — so, exactly as in transcript.ts, role is
+ * driven from the record's own `type` and never from the redundant `message.role`.
+ *
+ * What we keep, normalized to the SAME `TransportTurn[]` shape as readClaudeTranscript so the live
+ * write-back (retainLiveSession) renders every harness identically:
+ *   - real user prompts
+ *   - assistant prose
+ *   - each `functionCall` part → a compact `role:"action"` turn (name + primary target, no args)
+ *
+ * What we drop:
+ *   - `type:"system"` records — UI telemetry, attribution/file-history snapshots, slash-command
+ *     invocations. Not conversation, and the BULK of the file: 5,385 of 9,962 records (54%) across
+ *     the live transcripts this reader was measured against.
+ *   - `type:"tool_result"` records (`functionResponse` parts) — tool OUTPUT, the mechanical noise
+ *     the shared `actionLine` convention exists to keep out of the bank. The matching CALL is a
+ *     `functionCall` part on the assistant record, so nothing is lost by dropping these whole.
+ *   - parts flagged `thought: true` — the model's reasoning, like Claude `thinking` and Codex
+ *     `reasoning`.
+ *   - SYNTHETIC user records. `type:"user"` is not a user turn in Qwen: background-task
+ *     notifications, cron re-entries and goal-runtime traffic are all written as `type:"user"`, and
+ *     they outnumbered genuine prompts 307 to 69 in the measured corpus. `provenance` is the
+ *     discriminator (see `isRealUser`) — Qwen's analogue of Claude's `isMeta` and dsh's
+ *     `source.kind === "user"`. Retaining them files machine scaffolding as the user's own words.
+ *
+ * Fail-open: never throws on a missing file, a malformed line, or a line that parses to a
+ * non-object JSON value (`null`, a number, an array, …).
+ */
+import type { TransportTurn } from "./chat";
+import { readJsonlTail } from "./jsonl";
+import { actionLine, stripInjectedMemory } from "./transcript-util";
+import { log } from "./log";
+
+/**
+ * Qwen ECHOES OUR OWN INJECTION BACK INTO ITS TRANSCRIPT, so removing it is load-bearing rather
+ * than defensive: left in, every Stop would re-ingest the memories that turn's recall had just
+ * injected — the retain→recall feedback loop `stripInjectedMemory` exists to prevent.
+ *
+ * That shared stripper cannot do it here. Qwen HTML-escapes `<`/`>` in `additionalContext` before
+ * the model sees it, so what lands on disk is `&lt;hindsight_memories&gt;` and `MEMORY_TAG_RE` —
+ * which matches raw tags — sees nothing. Measured: all 55 injections in the live corpus are stored
+ * escaped, 0 raw, and all 55 sit inside the wrapper.
+ *
+ * But the wrapper must NOT be matched as a substring anywhere. Qwen's hook contract is explicit
+ * that the tag is "a provenance marker, not ... a general trust boundary", that consumers "must
+ * not infer that arbitrary tag-like user text is hook provenance", and that hook output is escaped
+ * so it "cannot close or forge the tag". A regex replace over every text part therefore deletes
+ * genuine user-authored prose that merely quotes the tag — which, in a repo whose subject IS this
+ * integration, is a prompt someone will really write.
+ *
+ * Two pieces of evidence identify a real injection, per that contract:
+ *   1. `systemPayload.hookContext` is a string. Then `systemPayload.displayText` is the pre-hook
+ *      projection and "never includes the hook context", so it IS the user turn — use it directly
+ *      and ignore the parts.
+ *   2. Compatibility fallback for released `displayText`-only records: a COMPLETE tagged context
+ *      occupying the FINAL part, after at least one other part. Then drop that whole part.
+ * Anything else is left alone, including legacy bare-context records, which the contract says
+ * "keep their model-bound display behavior because the context cannot be separated reliably".
+ */
+const HOOK_CONTEXT_PART_RE =
+  /^\s*<qwen:user-prompt-submit-context>[\s\S]*<\/qwen:user-prompt-submit-context>\s*$/;
+
+/** Whether this part is ENTIRELY a hook-context wrapper (not merely one that mentions the tag). */
+function isWholeHookContextPart(part: Part): boolean {
+  return typeof part.text === "string" && HOOK_CONTEXT_PART_RE.test(part.text);
+}
+
+/** One entry of a Gemini `Content.parts[]` — the four shapes Qwen actually writes. */
+interface Part {
+  text?: string;
+  /** Model reasoning rides on a normal text part, flagged only by this. */
+  thought?: boolean;
+  functionCall?: { name?: string; args?: unknown };
+  functionResponse?: unknown;
+}
+
+interface TranscriptLine {
+  type?: string;
+  subtype?: string;
+  provenance?: string;
+  /** Written only for user-prompt records that carried UserPromptSubmit hook context. */
+  systemPayload?: { displayText?: unknown; hookContext?: unknown };
+  /** Subagent envelope markers. Present ONLY in subagent transcripts, which carry no provenance. */
+  agentId?: unknown;
+  isSidechain?: unknown;
+  timestamp?: string;
+  message?: {
+    role?: string;
+    parts?: Part[];
+  };
+}
+
+interface RenderedLine {
+  role: string;
+  content: string;
+}
+
+/**
+ * Whether a `type:"user"` record is something the HUMAN sent.
+ *
+ * When `provenance` is present it is authoritative — `real_user` (and its one interjection subtype,
+ * `mid_turn_user_message`) versus the `system`/`goal_runtime` scaffolding. When it is absent we
+ * fall back exactly the way Qwen's own `legacySafeProvenance` does, because SUBAGENT transcripts
+ * use a THIRD envelope — `{agentId, agentName, isSidechain, …}` with no `provenance` and no
+ * `subtype` — and a strict `provenance === "real_user"` test would read them as 100% synthetic and
+ * retain nothing at all.
+ */
+function isRealUser(line: TranscriptLine): boolean {
+  // Present and well-formed: authoritative, and the ONLY accepting case on a main transcript.
+  if (typeof line.provenance === "string") return line.provenance === "real_user";
+  // Present but malformed (null, a number, an object). Do NOT fall through to the subtype
+  // heuristic: an unrecognized provenance is unknown provenance, and unknown provenance on a
+  // record that HAS the field is not evidence of a human. Measured on the live corpus, every
+  // record in a main transcript carries a string provenance, so this can only be corruption.
+  if (line.provenance !== undefined) return false;
+  // Absent entirely: the subagent envelope, which is a different shape carrying neither
+  // `provenance` nor `subtype`. Require a positive marker of that shape rather than inferring it
+  // from the absence of a subtype — otherwise any field-stripped record reads as human.
+  const isSubagentEnvelope = line.agentId !== undefined || line.isSidechain !== undefined;
+  if (!isSubagentEnvelope) return false;
+  return line.subtype === undefined || line.subtype === "mid_turn_user_message";
+}
+
+/**
+ * Render one record's `parts` into turns: text parts join into one prose turn (Qwen's injected-
+ * context echo and any injected memory stripped); each `functionCall` becomes its own compact
+ * `role:"action"` turn (name + primary target, via `actionLine`); `thought` and `functionResponse`
+ * parts are dropped.
+ */
+function renderLine(parts: Part[] | undefined, type: string): RenderedLine[] {
+  if (!Array.isArray(parts)) return [];
+
+  // Compatibility pairing evidence (see HOOK_CONTEXT_PART_RE): a complete tagged context in the
+  // FINAL part, after at least one other part. Never a substring, never a lone part.
+  const last = parts.length > 1 ? parts[parts.length - 1] : undefined;
+  const dropLast =
+    !!last && typeof last === "object" && isWholeHookContextPart(last) ? parts.length - 1 : -1;
+
+  const texts: string[] = [];
+  const actions: RenderedLine[] = [];
+  for (const [i, part] of parts.entries()) {
+    if (!part || typeof part !== "object") continue;
+    if (i === dropLast) continue; // the injected-context part, positively identified
+    if (part.thought === true) continue; // model reasoning, like Claude `thinking`
+    if (typeof part.text === "string") {
+      const text = stripInjectedMemory(part.text).trim();
+      if (text) texts.push(text);
+    } else if (part.functionCall && typeof part.functionCall.name === "string") {
+      // `args` is a real object here (unlike Codex's raw JSON string), so no parse step.
+      actions.push({
+        role: "action",
+        content: actionLine(part.functionCall.name, part.functionCall.args),
+      });
+    }
+    // functionResponse: dropped — outputs are mechanical noise for extraction
+  }
+
+  const out: RenderedLine[] = [];
+  const joined = texts.join("\n").trim();
+  if (joined) out.push({ role: type, content: joined });
+  out.push(...actions);
+  return out;
+}
+
+/** Parse a Qwen Code chat JSONL into normalized turns (text + tool calls).
+ *  Drops system records, tool results, thought parts, synthetic user records, Qwen's echo of our
+ *  own injection, and empty turns. Never throws on bad lines. */
+export function readQwenTranscript(path: string): TransportTurn[] {
+  const turns: TransportTurn[] = [];
+  try {
+    collectQwenTurns(path, turns);
+  } catch (err) {
+    // The fail-open contract is only honoured if it covers LAZY I/O. readJsonlTail guards
+    // statSync/openSync, but the generator it returns reads on each iteration, and those reads
+    // throw here rather than at the call. A DIRECTORY passed as transcript_path is the real case:
+    // on Linux it passes both statSync and openSync, then throws EISDIR on the first readSync —
+    // after this function has already returned its generator. runRetainHook calls the reader
+    // OUTSIDE buildRetain's catch, so an uncaught throw rejects the whole Stop hook and the turn
+    // is never retained. Yield what we parsed before the fault instead.
+    log.warn("qwen-code", "transcript read failed — retaining what was parsed", {
+      path,
+      turns: turns.length,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  return turns;
+}
+
+/** The parse loop. Separated so a lazy read fault leaves the caller holding the partial result. */
+function collectQwenTurns(path: string, turns: TransportTurn[]): void {
+  for (const rawLine of readJsonlTail(path, { scope: "qwen-code" }).lines) {
+    const trimmed = rawLine.trim();
+    if (!trimmed) continue;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    // JSON.parse accepts non-object top-level values (`null`, numbers, booleans, arrays);
+    // guard here so a corrupt/truncated line can't reach a property access below and throw.
+    if (typeof parsed !== "object" || parsed === null) continue;
+    const line = parsed as TranscriptLine;
+
+    if (line.type !== "user" && line.type !== "assistant") continue;
+    if (line.type === "user" && !isRealUser(line)) continue;
+    if (typeof line.message !== "object" || line.message === null) continue;
+
+    // Primary pairing evidence: when `systemPayload.hookContext` is a string, `displayText` is
+    // the pre-hook projection and "never includes the hook context" (Qwen's hook contract), so it
+    // IS the user turn. Prefer it over reconstructing from parts — no tag matching involved.
+    // Tool calls cannot occur on such a record (it is a user prompt), so parts are not consulted.
+    const sp = line.systemPayload;
+    if (
+      line.type === "user" &&
+      sp &&
+      typeof sp === "object" &&
+      typeof sp.hookContext === "string" &&
+      typeof sp.displayText === "string"
+    ) {
+      const content = stripInjectedMemory(sp.displayText).trim();
+      if (content) {
+        const turn: TransportTurn = { role: "user", content };
+        if (typeof line.timestamp === "string") turn.timestamp = line.timestamp;
+        turns.push(turn);
+      }
+      continue;
+    }
+
+    // `type` is validated as "user" | "assistant" above; drive role from it (Qwen's assistant
+    // records carry the Gemini `message.role: "model"`, so the nested role is worse than redundant
+    // here). One record can yield a prose turn plus one action turn per tool call.
+    for (const rendered of renderLine(line.message.parts, line.type)) {
+      const turn: TransportTurn = { role: rendered.role, content: rendered.content };
+      if (typeof line.timestamp === "string") turn.timestamp = line.timestamp;
+      turns.push(turn);
+    }
+  }
+
+}

--- a/hindsight-integrations/coding-agents/src/core/transcript-qwen.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript-qwen.ts
@@ -244,5 +244,4 @@ function collectQwenTurns(path: string, turns: TransportTurn[]): void {
       turns.push(turn);
     }
   }
-
 }

--- a/hindsight-integrations/coding-agents/src/e2e/harnesses.ts
+++ b/hindsight-integrations/coding-agents/src/e2e/harnesses.ts
@@ -155,6 +155,37 @@ export const grokDockerSetup: HarnessDockerSetup = {
 };
 
 /**
+ * Qwen Code — `-p` runs one prompt and exits.
+ *
+ * Driven through the stub model: Qwen honours the OpenAI-compatible env triple, so no vendor
+ * account has to reach the container. `APPROVAL_MODE=yolo` keeps a tool call from blocking on a
+ * prompt no one is there to answer. Never pass `--safe-mode`: it disables hooks, which is the
+ * entire thing under test.
+ *
+ * RETENTION-ONLY, and for a different reason than grok-build's passive hook. Qwen's prompt spec
+ * keys on `submitted_prompt`, which the host attaches only to a genuine first-turn interactive TUI
+ * submission — `UserPromptSubmit` also fires on tool-result continuations, where `prompt` holds
+ * model-bound tool output, so keying on `prompt` would recall repeatedly against tool results.
+ * Headless `-p` (the only mode this E2E can drive), `serve`, the SDK and ACP carry no
+ * `submitted_prompt`, so runHook's `if (!prompt) return` suppresses recall and no memory block can
+ * reach the model here. Asserting injection would keep this harness permanently red for something
+ * no change on our side can fix. Session seeding, write-back and the MCP tools are still asserted.
+ */
+export const qwenDockerSetup: HarnessDockerSetup = {
+  name: "qwen-code",
+  hindsightHarness: "qwen-code",
+  installCommand: "hindsight-coding-agents install qwen-code",
+  stubModelEnv: (baseUrl) => ({
+    OPENAI_BASE_URL: `${baseUrl}/v1`,
+    OPENAI_API_KEY: "hindsight-e2e",
+    OPENAI_MODEL: "hindsight-e2e-stub",
+    APPROVAL_MODE: "yolo",
+  }),
+  injectsIntoModel: false,
+  command: (prompt) => ["qwen", "-p", prompt],
+};
+
+/**
  * Devin CLI — `-p` takes the prompt inline and exits.
  *
  * Credentials live in `~/.local/share/devin/credentials.toml`, NOT the `~/.config/devin/config.json`
@@ -241,6 +272,7 @@ export const ALL_HARNESS_SETUPS: HarnessDockerSetup[] = [
   cursorDockerSetup,
   copilotDockerSetup,
   grokDockerSetup,
+  qwenDockerSetup,
   devinDockerSetup,
   clineDockerSetup,
   primeAgentDockerSetup,

--- a/hindsight-integrations/coding-agents/src/harness/hook-lifecycle.test.ts
+++ b/hindsight-integrations/coding-agents/src/harness/hook-lifecycle.test.ts
@@ -8,6 +8,7 @@ const HOOK_HARNESS_NAMES: HookHarnessName[] = [
   "cursor-cli",
   "copilot-cli",
   "grok-build",
+  "qwen-code",
 ];
 
 describe("HOOK_HARNESSES lifecycle contract", () => {
@@ -83,5 +84,36 @@ describe("HOOK_HARNESSES lifecycle contract", () => {
         additionalContext: "context",
       },
     });
+  });
+
+  // The prompt hook must outlive the once-per-session reflect, or the FIRST prompt of every
+  // session is killed mid-flight and recall silently degrades to nothing. Nothing coupled these
+  // two numbers before: qwen-code's timeouts are MILLISECONDS while every other harness's are
+  // SECONDS, so a bare `>= 25_000` would pass vacuously for the seven seconds-based harnesses and
+  // a bare `>= 25` would pass vacuously for qwen. Normalising through the declared unit is what
+  // makes this catch a mutation in EITHER direction.
+  it("gives every prompt hook a budget above the once-per-session reflect cap", () => {
+    const HOOK_REFLECT_CAP_MS = 25_000;
+    for (const harness of HOOK_HARNESS_NAMES) {
+      const spec = HOOK_HARNESSES[harness];
+      const raw = spec.install.prompt.timeout;
+      if (raw === undefined) continue; // cursor-cli deliberately omits it — the host default applies
+      const ms = spec.timeoutUnit === "milliseconds" ? raw : raw * 1000;
+      expect(ms, `${harness} prompt timeout (${raw} ${spec.timeoutUnit ?? "seconds"})`).toBeGreaterThan(
+        HOOK_REFLECT_CAP_MS
+      );
+    }
+  });
+
+  // hostTimeoutSec is SECONDS for every harness, including qwen-code where the installed values
+  // are milliseconds. They describe the same budget, so they must agree once normalised.
+  it("keeps the installed stop timeout consistent with hostTimeoutSec", () => {
+    for (const harness of HOOK_HARNESS_NAMES) {
+      const spec = HOOK_HARNESSES[harness];
+      const raw = spec.install.stop.timeout;
+      if (raw === undefined) continue;
+      const ms = spec.timeoutUnit === "milliseconds" ? raw : raw * 1000;
+      expect(ms, `${harness} stop timeout vs hostTimeoutSec`).toBe(spec.retain.hostTimeoutSec * 1000);
+    }
   });
 });

--- a/hindsight-integrations/coding-agents/src/harness/hook-lifecycle.test.ts
+++ b/hindsight-integrations/coding-agents/src/harness/hook-lifecycle.test.ts
@@ -99,9 +99,10 @@ describe("HOOK_HARNESSES lifecycle contract", () => {
       const raw = spec.install.prompt.timeout;
       if (raw === undefined) continue; // cursor-cli deliberately omits it — the host default applies
       const ms = spec.timeoutUnit === "milliseconds" ? raw : raw * 1000;
-      expect(ms, `${harness} prompt timeout (${raw} ${spec.timeoutUnit ?? "seconds"})`).toBeGreaterThan(
-        HOOK_REFLECT_CAP_MS
-      );
+      expect(
+        ms,
+        `${harness} prompt timeout (${raw} ${spec.timeoutUnit ?? "seconds"})`
+      ).toBeGreaterThan(HOOK_REFLECT_CAP_MS);
     }
   });
 
@@ -113,7 +114,9 @@ describe("HOOK_HARNESSES lifecycle contract", () => {
       const raw = spec.install.stop.timeout;
       if (raw === undefined) continue;
       const ms = spec.timeoutUnit === "milliseconds" ? raw : raw * 1000;
-      expect(ms, `${harness} stop timeout vs hostTimeoutSec`).toBe(spec.retain.hostTimeoutSec * 1000);
+      expect(ms, `${harness} stop timeout vs hostTimeoutSec`).toBe(
+        spec.retain.hostTimeoutSec * 1000
+      );
     }
   });
 });

--- a/hindsight-integrations/coding-agents/src/harness/hook-lifecycle.ts
+++ b/hindsight-integrations/coding-agents/src/harness/hook-lifecycle.ts
@@ -13,6 +13,7 @@ import { readAntigravityTranscript } from "../core/transcript-antigravity";
 import { readCopilotTranscript } from "../core/transcript-copilot";
 import { grokTranscriptPath, readGrokTranscript } from "../core/transcript-grok";
 import { readDevinTranscript } from "../core/transcript-devin";
+import { readQwenTranscript } from "../core/transcript-qwen";
 
 export type HookHarnessName =
   | "claude-code"
@@ -21,18 +22,31 @@ export type HookHarnessName =
   | "cursor-cli"
   | "copilot-cli"
   | "devin-cli"
-  | "grok-build";
+  | "grok-build"
+  | "qwen-code";
 export type HookLifecycle = "sessionStart" | "prompt" | "stop";
 export type HookConfigStyle = "nested" | "flat";
 
 export interface HookInstallSpec {
   event: string;
   entry: string;
+  /** In `HookHarnessSpec.timeoutUnit` — NOT always seconds. See that field. */
   timeout?: number;
 }
 
+/**
+ * The unit the HOST reads `HookInstallSpec.timeout` in. Every host but Qwen Code uses seconds;
+ * Qwen passes the value straight to setTimeout, so 30 there means 30ms and the hook is dead before
+ * a Node process starts. Declaring the unit makes that difference checkable instead of a comment:
+ * the lifecycle test normalises through it, so changing Qwen's 30_000 to 30 without also changing
+ * this field now fails a test rather than silently shipping dead hooks.
+ */
+export type HookTimeoutUnit = "seconds" | "milliseconds";
+
 export interface HookHarnessSpec {
   configStyle: HookConfigStyle;
+  /** Defaults to "seconds" when absent — the unit every host but qwen-code uses. */
+  timeoutUnit?: HookTimeoutUnit;
   install: Record<HookLifecycle, HookInstallSpec>;
   sessionStart: SessionStartHookSpec;
   prompt: HookSpec;
@@ -62,6 +76,33 @@ const codexPrompt: HookSpec = {
   harness: "codex",
   parse: (ev) => ({
     prompt: (ev.prompt as string | undefined) ?? (ev.user_prompt as string | undefined),
+    cwd: ev.cwd as string | undefined,
+    sessionId: ev.session_id as string | undefined,
+  }),
+};
+
+/**
+ * Qwen Code speaks Claude Code's hook protocol field for field (session_id / transcript_path / cwd
+ * in, hookSpecificOutput.additionalContext + systemMessage out), so only `parse` differs — and it
+ * reads `submitted_prompt`, NOT `prompt`.
+ *
+ * `UserPromptSubmit` fires on tool-result continuations too, not just on submissions: Qwen's send
+ * loop labels the first turn `userQuery` and every continuation `toolResult`, and the hook's fire
+ * guard excludes only retry/steer/cron/notification/teammate/goal. On a continuation `prompt` holds
+ * whatever text is currently model-bound (a tool result), so keying on it would recall ~20 times per
+ * user turn against tool output. `submitted_prompt` is attached only when the turn is BOTH the first
+ * one and a real `userQuery`, which makes it the exact genuine-submission marker — and runHook's
+ * `if (!prompt) return` then suppresses every continuation with no core change.
+ *
+ * Cost, deliberately accepted: `submitted_prompt` is the interactive TUI's text projection, so
+ * headless (`qwen -p`), serve/SDK and ACP sessions carry none and never recall. They still get the
+ * SessionStart seed and the Stop write-back.
+ */
+const qwenPrompt: HookSpec = {
+  ...claudePrompt,
+  harness: "qwen-code",
+  parse: (ev) => ({
+    prompt: ev.submitted_prompt as string | undefined,
     cwd: ev.cwd as string | undefined,
     sessionId: ev.session_id as string | undefined,
   }),
@@ -343,6 +384,36 @@ export const HOOK_HARNESSES: Record<HookHarnessName, HookHarnessSpec> = {
         cwd: ev.cwd as string | undefined,
       }),
       readTranscript: readGrokTranscript,
+    },
+  },
+  "qwen-code": {
+    configStyle: "nested",
+    timeoutUnit: "milliseconds",
+    // TIMEOUTS ARE MILLISECONDS HERE, not seconds like every other harness in this table: Qwen
+    // passes a command hook's `timeout` straight to setTimeout ("Timeout in milliseconds, default
+    // 60000"). Writing 30/60 registers 30ms/60ms hooks, which die before a Node process starts —
+    // and the kill signals only the direct child, so the orphaned work still completes and the
+    // misconfiguration looks harmless. `retain.hostTimeoutSec` below stays SECONDS, as its name
+    // says; these two numbers are the same budget in different units for this harness alone.
+    // The prompt timeout must also stay above core/hook.ts's HOOK_REFLECT_CAP_MS (25_000).
+    install: {
+      sessionStart: { event: "SessionStart", entry: "qwen-sessionstart-hook.js", timeout: 30_000 },
+      prompt: { event: "UserPromptSubmit", entry: "qwen-hook.js", timeout: 30_000 },
+      stop: { event: "Stop", entry: "qwen-stop-hook.js", timeout: 60_000 },
+    },
+    sessionStart: standardSessionStart("qwen-code"),
+    prompt: qwenPrompt,
+    retain: {
+      hostTimeoutSec: 60,
+      harness: "qwen-code",
+      parse: (ev) => ({
+        sessionId: ev.session_id as string | undefined,
+        // Qwen supplies the path, but as the EMPTY STRING (not null, not absent) when chat
+        // recording is off — runRetainHook's `if (!transcriptPath) return` already covers that.
+        transcriptPath: ev.transcript_path as string | undefined,
+        cwd: ev.cwd as string | undefined,
+      }),
+      readTranscript: readQwenTranscript,
     },
   },
 };

--- a/hindsight-integrations/coding-agents/src/harness/registry.test.ts
+++ b/hindsight-integrations/coding-agents/src/harness/registry.test.ts
@@ -17,9 +17,10 @@ describe("HARNESS_NAMES", () => {
         "devin-cli",
         "copilot-cli",
         "grok-build",
+        "qwen-code",
       ])
     );
-    expect(HARNESS_NAMES).toHaveLength(12);
+    expect(HARNESS_NAMES).toHaveLength(13);
   });
 });
 
@@ -71,6 +72,18 @@ describe("registry covers every installable harness", () => {
   it("has no harness the installer wires but the registry rejects", async () => {
     const { INSTALLERS } = await import("../installer");
     const missing = INSTALLERS.map((i) => i.name).filter((n) => !HARNESS_NAMES.includes(n));
+    expect(missing).toEqual([]);
+  });
+
+  // The check above is DIRECTIONAL, and the other direction is just as broken: a harness in the
+  // registry with no installer is advertised by the README and rejected by `install <name>` with
+  // "unknown harness". Every hook harness must be installable — the plugin harnesses are wired by
+  // their own entrypoints and are exempt only because they still carry an INSTALLERS entry.
+  it("has no hook harness the registry names but the installer cannot wire", async () => {
+    const { INSTALLERS } = await import("../installer");
+    const { HOOK_HARNESSES } = await import("./hook-lifecycle");
+    const installable = new Set(INSTALLERS.map((i) => i.name));
+    const missing = Object.keys(HOOK_HARNESSES).filter((n) => !installable.has(n));
     expect(missing).toEqual([]);
   });
 });

--- a/hindsight-integrations/coding-agents/src/harness/registry.ts
+++ b/hindsight-integrations/coding-agents/src/harness/registry.ts
@@ -57,6 +57,7 @@ export const HARNESS_NAMES = [
   "devin-cli",
   "copilot-cli",
   "grok-build",
+  "qwen-code",
 ];
 
 const HOOK_BINS: Record<string, string> = {
@@ -67,6 +68,7 @@ const HOOK_BINS: Record<string, string> = {
   "devin-cli": "hindsight-devin-hook",
   "copilot-cli": "hindsight-copilot-hook",
   "grok-build": "hindsight-grok-hook",
+  "qwen-code": "hindsight-qwen-hook",
   // more hook harnesses: add a HookSpec entry point (see src/cursor-hook.ts) + a registration here.
 };
 

--- a/hindsight-integrations/coding-agents/src/installer.test.ts
+++ b/hindsight-integrations/coding-agents/src/installer.test.ts
@@ -181,9 +181,7 @@ describe("qwen-code installer", () => {
     // Qwen kills only the direct child so the orphaned work still completes.
     const ctx = makeCtx();
     expect(run(["install", "qwen-code"], ctx)).toBe(0);
-    const hooks = JSON.parse(
-      readFileSync(join(ctx.home, ".qwen", "settings.json"), "utf8")
-    ).hooks;
+    const hooks = JSON.parse(readFileSync(join(ctx.home, ".qwen", "settings.json"), "utf8")).hooks;
     const entry = (ev: string) => hooks[ev][0].hooks[0];
     expect(entry("SessionStart").timeout).toBe(30_000);
     expect(entry("UserPromptSubmit").timeout).toBe(30_000);

--- a/hindsight-integrations/coding-agents/src/installer.test.ts
+++ b/hindsight-integrations/coding-agents/src/installer.test.ts
@@ -21,6 +21,7 @@ const homes: string[] = [];
 
 function makeCtx(): InstallCtx & {
   claudeMcp: ReturnType<typeof vi.fn>;
+  qwenMcp: ReturnType<typeof vi.fn>;
   clinePlugin: ReturnType<typeof vi.fn>;
   nodeSqlite: ReturnType<typeof vi.fn>;
 } {
@@ -32,6 +33,9 @@ function makeCtx(): InstallCtx & {
     pkgRoot,
     dist: join(pkgRoot, "dist"),
     claudeMcp: vi.fn(() => true),
+    // qwen-code registers through the `qwen` CLI, exactly as claude-code does through `claude`.
+    // Stub it for the same reason: the suite must never execute a real host CLI.
+    qwenMcp: vi.fn(() => true),
     clinePlugin: vi.fn(() => true),
     // Stubbed like the CLI seams above, so the suite never depends on the Node running it.
     nodeSqlite: vi.fn(() => true),
@@ -167,6 +171,70 @@ describe("claude-code installer", () => {
     run(["install", "claude-code"], ctx);
     run(["uninstall", "claude-code"], ctx);
     expect(readJson(settingsPath(ctx)).hooks).toBeUndefined();
+  });
+});
+
+describe("qwen-code installer", () => {
+  it("install writes the 3 hook events with our dist commands and timeouts 30000/30000/60000", () => {
+    // NOT 30/30/60. Qwen reads this field as MILLISECONDS, so the seconds values every other
+    // harness uses would register 30ms/60ms hooks — dead before Node starts, and masked because
+    // Qwen kills only the direct child so the orphaned work still completes.
+    const ctx = makeCtx();
+    expect(run(["install", "qwen-code"], ctx)).toBe(0);
+    const hooks = JSON.parse(
+      readFileSync(join(ctx.home, ".qwen", "settings.json"), "utf8")
+    ).hooks;
+    const entry = (ev: string) => hooks[ev][0].hooks[0];
+    expect(entry("SessionStart").timeout).toBe(30_000);
+    expect(entry("UserPromptSubmit").timeout).toBe(30_000);
+    expect(entry("Stop").timeout).toBe(60_000);
+    for (const ev of ["SessionStart", "UserPromptSubmit", "Stop"]) {
+      expect(entry(ev).command).toContain(ctx.dist);
+      expect(entry(ev).type).toBe("command");
+    }
+  });
+
+  it("registers the MCP server through the qwen CLI, user scope", () => {
+    const ctx = makeCtx();
+    expect(run(["install", "qwen-code"], ctx)).toBe(0);
+    const argv = ctx.qwenMcp.mock.calls.map((c) => c[0].join(" "));
+    expect(argv.some((a) => a.startsWith("mcp remove"))).toBe(true);
+    expect(
+      argv.some((a) => a.includes("mcp add") && a.includes("HINDSIGHT_MCP_HARNESS=qwen-code"))
+    ).toBe(true);
+  });
+
+  it("preserves pre-existing foreign hook entries and appends ours", () => {
+    const ctx = makeCtx();
+    const path = join(ctx.home, ".qwen", "settings.json");
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(
+      path,
+      JSON.stringify({
+        hooks: { Stop: [{ hooks: [{ type: "command", command: "their-tool", timeout: 5000 }] }] },
+      })
+    );
+    expect(run(["install", "qwen-code"], ctx)).toBe(0);
+    const stop = JSON.parse(readFileSync(path, "utf8")).hooks.Stop;
+    expect(JSON.stringify(stop)).toContain("their-tool");
+    expect(JSON.stringify(stop)).toContain("qwen-stop-hook.js");
+  });
+
+  it("uninstall strips our entries and keeps foreign ones", () => {
+    const ctx = makeCtx();
+    const path = join(ctx.home, ".qwen", "settings.json");
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(
+      path,
+      JSON.stringify({
+        hooks: { Stop: [{ hooks: [{ type: "command", command: "their-tool", timeout: 5000 }] }] },
+      })
+    );
+    expect(run(["install", "qwen-code"], ctx)).toBe(0);
+    expect(run(["uninstall", "qwen-code"], ctx)).toBe(0);
+    const after = readFileSync(path, "utf8");
+    expect(after).toContain("their-tool");
+    expect(after).not.toContain("qwen-stop-hook.js");
   });
 });
 
@@ -711,6 +779,7 @@ describe("run() CLI behavior", () => {
       "cursor-cli",
       "copilot-cli",
       "grok-build",
+      "qwen-code",
       "cline-cli",
       "dsh",
     ]);
@@ -747,9 +816,10 @@ describe("MCP registrations name the calling harness", () => {
     const registrations = [
       ...filesUnder(ctx.home)
         .map((f) => readFileSync(f, "utf8"))
-        // claude-code registers through the `claude` CLI instead of a file we write, so its
-        // registration is the argv we handed the mock.
+        // claude-code and qwen-code register through their host CLI instead of a file we write,
+        // so their registration is the argv we handed the mock.
         .concat(ctx.claudeMcp.mock.calls.map((c) => c[0].join(" ")))
+        .concat(ctx.qwenMcp.mock.calls.map((c) => c[0].join(" ")))
         .filter((text) => text.includes("mcp-server.js")),
     ];
     expect(registrations.length).toBeGreaterThan(0);

--- a/hindsight-integrations/coding-agents/src/installer.ts
+++ b/hindsight-integrations/coding-agents/src/installer.ts
@@ -62,6 +62,8 @@ export interface InstallCtx {
   dist: string; // built entry points
   /** Runs `claude mcp ...`; injectable for tests. Returns false when the CLI isn't usable. */
   claudeMcp?: (args: string[]) => boolean;
+  /** Runs `qwen mcp ...`; injectable for tests. Returns false when the CLI isn't usable. */
+  qwenMcp?: (args: string[]) => boolean;
   /** Runs `cline plugin ...`; injectable for tests. Returns false when the CLI isn't usable. */
   clinePlugin?: (args: string[]) => boolean;
   /** Reports whether `node:sqlite` works in the node that runs hooks; injectable for tests. */
@@ -1207,6 +1209,70 @@ const dsh: HarnessInstaller = {
   },
 };
 
+const qwen: HarnessInstaller = {
+  name: "qwen-code",
+  detect: (c) => onPath("qwen") || existsSync(join(c.home, ".qwen")),
+  install(c) {
+    const path = join(c.home, ".qwen", "settings.json");
+    const settings = readJson(path);
+    settings.hooks = settings.hooks ?? {};
+    // Qwen's settings.json hook shape is Claude Code's, so the shared nested writer applies —
+    // the ONLY difference is the unit of `timeout`, which HOOK_HARNESSES already carries in ms.
+    mergeHarnessHooks(settings.hooks, "qwen-code", c.dist);
+    writeJson(path, settings);
+    c.log?.(`qwen-code: hooks merged into ${path}`);
+    installSkill(c, "qwen-code", join(c.home, ".qwen", "skills"));
+    const mcp = c.qwenMcp ?? defaultQwenMcp;
+    // Same rationale as claude-code: `qwen mcp add` refuses a name that already exists, so a
+    // re-install could never repoint a stale server. Remove first (a no-op when absent).
+    mcp(["mcp", "remove", "hindsight"]);
+    if (
+      mcp([
+        "mcp",
+        "add",
+        "-s",
+        "user",
+        "-e",
+        "HINDSIGHT_MCP_HARNESS=qwen-code",
+        "hindsight",
+        "node",
+        join(c.dist, "mcp-server.js"),
+      ])
+    ) {
+      c.log?.("qwen-code: MCP server registered (qwen mcp add, user scope)");
+    } else {
+      c.log?.(
+        `qwen-code: could not run \`qwen mcp add\` — register the tools manually:\n` +
+          `  qwen mcp add -s user -e HINDSIGHT_MCP_HARNESS=qwen-code hindsight node "${join(c.dist, "mcp-server.js")}"`
+      );
+    }
+  },
+  uninstall(c) {
+    const path = join(c.home, ".qwen", "settings.json");
+    if (existsSync(path)) {
+      const settings = readJson(path);
+      if (settings.hooks) {
+        stripHarnessHooks(settings.hooks, "qwen-code");
+        if (!Object.keys(settings.hooks).length) delete settings.hooks;
+        writeJson(path, settings);
+      }
+    }
+    const mcp = c.qwenMcp ?? defaultQwenMcp;
+    mcp(["mcp", "remove", "hindsight"]);
+    uninstallSkill(c, join(c.home, ".qwen", "skills"));
+    c.log?.("qwen-code: hooks + MCP registration + skill removed");
+  },
+};
+
+function defaultQwenMcp(args: string[]): boolean {
+  try {
+    execFileSync("qwen", args, { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export const INSTALLERS: HarnessInstaller[] = [
   opencode,
   kilo,
@@ -1218,6 +1284,7 @@ export const INSTALLERS: HarnessInstaller[] = [
   cursor,
   copilot,
   grok,
+  qwen,
   cline,
   dsh,
 ];

--- a/hindsight-integrations/coding-agents/src/qwen-hook.ts
+++ b/hindsight-integrations/coding-agents/src/qwen-hook.ts
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+/**
+ * hindsight-qwen-hook — the Qwen Code entry point (a `UserPromptSubmit` hook).
+ *
+ * Install (~/.qwen/settings.json):
+ *   { "hooks": { "UserPromptSubmit": [ { "hooks": [ { "type": "command",
+ *     "command": "hindsight-qwen-hook", "timeout": 30000 } ] } ] } }
+ *
+ * Qwen speaks Claude Code's hook protocol field for field, with two differences that matter here:
+ * `timeout` is MILLISECONDS (see HOOK_HARNESSES), and the genuine-submission marker is
+ * `submitted_prompt` rather than `prompt` — `UserPromptSubmit` also fires on tool-result
+ * continuations, where `prompt` holds model-bound tool output.
+ */
+import { runHarnessPrompt } from "./harness/hook-lifecycle";
+
+void runHarnessPrompt("qwen-code");

--- a/hindsight-integrations/coding-agents/src/qwen-sessionstart-hook.ts
+++ b/hindsight-integrations/coding-agents/src/qwen-sessionstart-hook.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+/**
+ * Qwen Code `SessionStart` hook. Runs the shared session-start lifecycle: configures the bank's
+ * knowledge pages, starts cold-repo seeding/deepening, and supplies the page roster. Qwen consumes
+ * the Claude-compatible `hookSpecificOutput.additionalContext` + `systemMessage` envelope.
+ */
+import { runHarnessSessionStart } from "./harness/hook-lifecycle";
+
+void runHarnessSessionStart("qwen-code");

--- a/hindsight-integrations/coding-agents/src/qwen-stop-hook.ts
+++ b/hindsight-integrations/coding-agents/src/qwen-stop-hook.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+/** Hindsight Qwen Code `Stop` hook: retain the completed agent-turn transcript. */
+import { runHarnessRetain } from "./harness/hook-lifecycle";
+
+void runHarnessRetain("qwen-code");

--- a/hindsight-integrations/coding-agents/tsup.config.ts
+++ b/hindsight-integrations/coding-agents/tsup.config.ts
@@ -25,6 +25,9 @@ export default defineConfig({
     // Prime Agent loads this module as an extension (default export) by absolute path from its
     // settings.json `extensions` array, so it must be self-contained like the hook bins.
     "prime-agent": "src/prime-agent.ts",
+    "qwen-hook": "src/qwen-hook.ts",
+    "qwen-sessionstart-hook": "src/qwen-sessionstart-hook.ts",
+    "qwen-stop-hook": "src/qwen-stop-hook.ts",
     "grok-hook": "src/grok-hook.ts",
     "grok-sessionstart-hook": "src/grok-sessionstart-hook.ts",
     "grok-stop-hook": "src/grok-stop-hook.ts",

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -91,6 +91,20 @@ npx @vectorize-io/hindsight-coding-agents install grok-build
 
 Native hooks and MCP in `~/.grok/config.toml`, plus the companion skill.
 
+####  Qwen Code
+
+```bash
+npx @vectorize-io/hindsight-coding-agents install qwen-code
+```
+
+Native hooks in `~/.qwen/settings.json`, plus MCP and the companion skill.
+
+> Qwen's hook `timeout` is in **milliseconds** (its own docs: "Timeout in milliseconds, default
+> 60000"), unlike every other supported agent, so the installed values are `30000/30000/60000`.
+> Recall fires on genuine submissions only — `UserPromptSubmit` also fires on tool-result
+> continuations, so interactive sessions recall once per prompt while headless (`qwen -p`),
+> `serve`, SDK and ACP sessions seed and retain but do not recall.
+
 ####  Antigravity CLI
 
 ```bash


### PR DESCRIPTION
Adds `qwen-code` to `HOOK_HARNESSES`, with its transcript reader, installer, entry points, tests, docs, control-plane logo entry and E2E setup.

Qwen Code's hook protocol is a deliberate Claude Code superset — same stdin envelope (`session_id` / `transcript_path` / `cwd` / `hook_event_name`), same `hookSpecificOutput.additionalContext` + `systemMessage` output, same exit semantics, and a `settings.json` shape byte-for-byte what `cmdHook()` already emits. The spec is therefore `claude-code`'s with three deltas. **All three are same-name/different-meaning, so none is visible from the diff** — that's the part worth reviewing.

### 1. `timeout` is milliseconds here, seconds everywhere else

Qwen passes a command hook's `timeout` straight to `setTimeout` — *"Timeout in milliseconds, default 60000"*, from its own bundled `docs/features/hooks.md`. Installed values are `30000/30000/60000`.

Writing `30`/`60` would register 30 ms hooks — and **that misconfiguration looks harmless in testing**, because Qwen spawns without `detached: true` and kills only the direct child, so the orphaned work still completes. You cannot validate the unit by observing that retain works.

Rather than leave that to a comment, `HookHarnessSpec` gains `timeoutUnit`, and two lifecycle tests normalise through it: the prompt budget must exceed `HOOK_REFLECT_CAP_MS` (25 000), and the installed stop timeout must equal `hostTimeoutSec * 1000`. Changing `30_000` → `30` fails the first; dropping `timeoutUnit` fails the second. A bare threshold cannot do this — `>= 25_000` passes vacuously for the seven seconds-based harnesses, `>= 25` passes vacuously for Qwen.

### 2. `parse` reads `submitted_prompt`, not `prompt`

`UserPromptSubmit` also fires on tool-result continuations, where `prompt` holds model-bound tool output — keying on it would recall roughly 20× per user turn against tool results. `submitted_prompt` is attached only when the turn is both the first and a genuine `userQuery`, and `runHook`'s `if (!prompt) return` then suppresses continuations with no core change.

**Accepted cost:** `submitted_prompt` is the interactive TUI's projection, so headless (`qwen -p`), `serve`, SDK and ACP sessions seed and retain but never recall. The E2E declares `injectsIntoModel: false` for that reason — a *different* reason from `grok-build`'s passive hook, and it is spelled out in the setup so it doesn't read as the same limitation.

### 3. `type: "user"` is not a user turn

`provenance` is the discriminator. Across a 22-transcript corpus, synthetic records (`notification` 285, `cron` 21, `goal_runtime` 1) outnumber `real_user` ones (69) by **4.4 : 1** — without the gate, background-task notifications and cron chatter are retained as things the user said.

`isRealUser` rejects a present-but-malformed `provenance` outright rather than falling through to a subtype heuristic, and requires a positive subagent marker (`agentId` / `isSidechain`) before accepting an absent one — subagent transcripts use a third envelope carrying neither `provenance` nor `subtype`, so a strict `real_user` test would read them as 100% synthetic and retain nothing. Verified against all 11 real subagent transcripts: 11/11 still accepted.

### The injected-context echo

Qwen echoes injected context back into its own transcript inside `<qwen:user-prompt-submit-context>`, with the inner tags HTML-escaped — so the shared `stripInjectedMemory`, which matches raw tags, cannot see it. Measured: 55 injections in the corpus, all escaped, 0 raw.

The reader removes it using the two forms of pairing evidence Qwen's contract defines: `systemPayload.hookContext` present → use `systemPayload.displayText` (the host's own pre-hook projection, no tag matching at all); otherwise a **complete** tagged context in the **final** part after at least one other part.

It deliberately does **not** match the tag as a substring. The contract is explicit that the tag is *"a provenance marker, not … a general trust boundary"* and that consumers *"must not infer that arbitrary tag-like user text is hook provenance"* — so a prompt merely quoting the tag is preserved intact, which there's a test for.

## Two things outside the harness itself

**`registry.test.ts` gains the reverse parity check.** The existing one is directional (installer → registry), so a harness present in the registry but missing from `INSTALLERS` passes it while `install <name>` returns `unknown harness`. That is exactly how this change was briefly broken during development — the README advertised a command the installer rejected, and the suite was green.

**`readQwenTranscript` catches lazy-read faults.** `readJsonlTail` guards `statSync`/`openSync`, but the generator reads at iteration, and `runRetainHook` calls the reader *outside* `buildRetain`'s catch. A directory passed as `transcript_path` passes both guards and then throws `EISDIR` on the first `readSync`, rejecting the whole Stop hook. I've handled it at this reader to keep the change additive — **the underlying gap is in the shared `jsonl.ts` and affects every harness**, and I think it deserves its own fix rather than riding along here. Happy to open that separately.

## Verification

- `npm test` — 675 pass
- `tsc --noEmit` clean, `npm run build` clean, `build-skill.mjs --check` in sync
- Live corpus regression: 22 transcripts → 80 user / 1587 assistant / 2234 action turns, **0 injected-memory leaks**

One note for anyone reproducing: `HINDSIGHT_BANK_ID` must be unset in the environment, or `config.test.ts`'s *"missing files yield defaults"* fails on the leaked value.

Logo asset is from [homarr-labs/dashboard-icons](https://github.com/homarr-labs/dashboard-icons) (`svg/qwen.svg`, Apache-2.0). Happy to swap it for an official mark if you'd prefer.

Kimi Code is the only other unsupported harness I looked at; I'm deliberately **not** proposing it here, since its injection contract isn't in its published docs and it would need a third `configStyle` for TOML.
