### PR TITLE
fix(retain, reflect): drop the source-language rule when an output language is set

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/prompts.py
@@ -1,6 +1,10 @@
 """Prompts for the consolidation engine."""
 
-from hindsight_api.engine.prompt_utils import escape_for_prompt, output_language_directive
+from hindsight_api.engine.prompt_utils import (
+    default_language_section,
+    escape_for_prompt,
+    output_language_directive,
+)
 
 # Default mission — tells the consolidator to track anything worth remembering.
 # Banks override this via `observations_mission` to scope what gets retained.
@@ -17,14 +21,13 @@ _MISSION_PRIORITY_NOTE = (
     "DECISION GUIDE, or OUTPUT FORMAT below, the MISSION takes priority."
 )
 
-# Default language rule — used only when HINDSIGHT_API_LLM_OUTPUT_LANGUAGE is
-# unset. Without it the whole prompt is English and multilingual models drift:
-# Chinese source facts intermittently produce English observations. Retain's
-# fact extraction carries the equivalent rule (see _BASE_FACT_EXTRACTION_PROMPT),
-# so this makes "preserve the source language" the pipeline-wide default. When an
-# output language IS configured, this section is omitted and
-# output_language_directive() takes over — the two must never both be present or
-# they contradict each other.
+# Consolidation's wording of the preserve-the-source-language rule; the selection
+# between it and an explicit output language belongs to default_language_section(),
+# which documents the invariant. Without this rule the whole prompt is English and
+# multilingual models drift: Chinese source facts intermittently produce English
+# observations. Retain's fact extraction carries the equivalent rule (see
+# _DEFAULT_LANGUAGE_RULE there), making "preserve the source language" the
+# pipeline-wide default.
 _DEFAULT_LANGUAGE_RULE = """## LANGUAGE
 
 Write every observation in the language of its own source facts — never translate them. Per observation, not per batch: when one merges facts of several languages, the majority wins. Proper nouns, identifiers, and units stay verbatim.
@@ -174,7 +177,7 @@ def build_consolidation_system_prompt(
     unset keeps each observation in the language of its own source facts (the
     default), set forces every observation into that one configured language.
     """
-    language_section = "" if llm_output_language else f"{_DEFAULT_LANGUAGE_RULE}\n\n"
+    language_section = default_language_section(_DEFAULT_LANGUAGE_RULE, llm_output_language)
     template = (
         "You are a memory consolidation system. Synthesize new facts into "
         "observations, merging with existing observations when appropriate.\n\n"

--- a/hindsight-api-slim/hindsight_api/engine/prompt_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/prompt_utils.py
@@ -53,9 +53,11 @@ def default_language_section(default_rule: str, language: str | None) -> str:
     explicit language drops the rule outright rather than arguing with it.
 
     ``default_rule`` is the pipeline's own wording (retain, consolidation and reflect each
-    say it differently); only the selection is shared. All three call this — nothing may
-    append a source-language rule of its own, or it reintroduces exactly the contradiction
-    this exists to remove. Returns the rule followed by a blank line, ready to prepend to a
+    say it differently); only the selection is shared. Every prompt that carries such a rule
+    calls this — retain, consolidation, and both of reflect's system prompts — and reflect's
+    ``done`` tool schema applies the same exclusion by hand. Nothing may append a
+    source-language rule of its own, or it reintroduces exactly the contradiction this
+    exists to remove. Returns the rule followed by a blank line, ready to prepend to a
     prompt body, or ``""`` when ``language`` is set.
     """
     return "" if language else f"{default_rule}\n\n"

--- a/hindsight-api-slim/hindsight_api/engine/prompt_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/prompt_utils.py
@@ -49,11 +49,13 @@ def default_language_section(default_rule: str, language: str | None) -> str:
     model drifts to English (or, per #181, to an unrelated language) and needs telling to
     keep the input's language. That rule flatly contradicts "translate everything into X",
     and the model resolves the contradiction in favour of the source-language rule — it is
-    phrased more forcefully and comes first — silently no-opping the setting. So an
+    phrased more forcefully and comes first — silently no-opping the setting (#3776). So an
     explicit language drops the rule outright rather than arguing with it.
 
     ``default_rule`` is the pipeline's own wording (retain, consolidation and reflect each
-    say it differently); only the selection is shared. Returns the rule followed by a blank
-    line, ready to prepend to a prompt body, or ``""`` when ``language`` is set.
+    say it differently); only the selection is shared. All three call this — nothing may
+    append a source-language rule of its own, or it reintroduces exactly the contradiction
+    this exists to remove. Returns the rule followed by a blank line, ready to prepend to a
+    prompt body, or ``""`` when ``language`` is set.
     """
     return "" if language else f"{default_rule}\n\n"

--- a/hindsight-api-slim/hindsight_api/engine/prompt_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/prompt_utils.py
@@ -39,3 +39,21 @@ def output_language_directive(language: str | None) -> str:
         f"All output text — including fact text, observations, entity names, "
         f"and the final response — must be in {language}."
     )
+
+
+def default_language_section(default_rule: str, language: str | None) -> str:
+    """The preserve-the-source-language rule, unless ``language`` overrides it.
+
+    The other half of :func:`output_language_directive`, and its mutual exclusion. Each
+    pipeline runs an all-English prompt, so with no configured language a multilingual
+    model drifts to English (or, per #181, to an unrelated language) and needs telling to
+    keep the input's language. That rule flatly contradicts "translate everything into X",
+    and the model resolves the contradiction in favour of the source-language rule — it is
+    phrased more forcefully and comes first — silently no-opping the setting. So an
+    explicit language drops the rule outright rather than arguing with it.
+
+    ``default_rule`` is the pipeline's own wording (retain, consolidation and reflect each
+    say it differently); only the selection is shared. Returns the rule followed by a blank
+    line, ready to prepend to a prompt body, or ``""`` when ``language`` is set.
+    """
+    return "" if language else f"{default_rule}\n\n"

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -729,6 +729,7 @@ async def _run_reflect_agent_inner(
                 context,
                 max_context_tokens=max_context_tokens,
                 max_tokens=max_tokens,
+                llm_output_language=llm_output_language,
             )
             answer = await _tracked_llm_call(prompt, "final", final_system, synthesis_max_completion_tokens)
         else:
@@ -750,7 +751,14 @@ async def _run_reflect_agent_inner(
                 )
             )
             # Reduce: one synthesis call over every chunk's claims.
-            prompt = build_reduce_prompt(query, list(claim_sections), bank_profile, context, max_tokens=max_tokens)
+            prompt = build_reduce_prompt(
+                query,
+                list(claim_sections),
+                bank_profile,
+                context,
+                max_tokens=max_tokens,
+                llm_output_language=llm_output_language,
+            )
             answer = await _tracked_llm_call(prompt, "final", final_system, synthesis_max_completion_tokens)
 
         if not (answer or "").strip():

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -523,6 +523,7 @@ async def _run_reflect_agent_inner(
         include_recall=include_recall,
         include_expand=include_expand,
         answer_as_document=answer_as_document,
+        llm_output_language=llm_output_language,
     )
     # Build set of enabled tool names to guard against LLM hallucinating disabled tool calls
     enabled_tools: frozenset[str] = frozenset(t["function"]["name"] for t in tools if t.get("type") == "function")

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -20,6 +20,7 @@ from .prompts import (
     _SPLIT_SYNTHESIS_WARN_CHUNKS,
     CLAIMS_SYSTEM_PROMPT,
     _extract_directive_rules,
+    build_agent_user_prompt,
     build_chunk_claims_prompt,
     build_final_prompt,
     build_final_system_prompt,
@@ -535,10 +536,11 @@ async def _run_reflect_agent_inner(
         include_observations=include_observations,
         budget=budget,
         answer_as_document=answer_as_document,
+        llm_output_language=llm_output_language,
     )
     messages: list[dict[str, Any]] = [
         {"role": "system", "content": system_prompt},
-        {"role": "user", "content": query},
+        {"role": "user", "content": build_agent_user_prompt(query, llm_output_language)},
     ]
 
     # Step-by-step context caching for the agentic tool loop.

--- a/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
@@ -109,6 +109,35 @@ def build_directives_reminder(directives: list[dict[str, Any]]) -> str:
     return "\n".join(parts)
 
 
+# The reasoning-loop language rule. Emitted only when no output language is configured
+# — see default_language_section(). Like _FINAL_LANGUAGE_RULE it defers to a directive
+# "above", and nothing ever put one there for a configured language: the rule stayed,
+# out-ranked the directive, and the done() answer came back in the question's language
+# on every run that never fell through to forced synthesis (#3776, review).
+_TOOLS_LANGUAGE_RULE = (
+    "## LANGUAGE RULE (default - directives take precedence)\n"
+    "- By default, detect the language of the user's question and respond in that SAME language.\n"
+    "- If the question is in Chinese, respond in Chinese. If in Japanese, respond in Japanese.\n"
+    "- IMPORTANT: The DIRECTIVES section above has HIGHER PRIORITY than this rule.\n"
+    "  If a directive specifies a language (e.g. 'Always respond in French'), follow the directive."
+)
+
+
+def build_agent_user_prompt(query: str, llm_output_language: str | None = None) -> str:
+    """The reasoning loop's opening user message: the question, closed by the directive.
+
+    The ``done()`` answer is written by the tool-calling model, whose system prompt is
+    :func:`build_system_prompt_for_tools`. For the same reason :func:`build_final_prompt`
+    carries the directive instead of :func:`build_final_system_prompt`, it goes on the user
+    message here rather than at the end of the system prompt: the question arrives after
+    the system prompt and out-ranks it. Tool results still follow over later turns, so
+    this is "last" for the question the model is answering, not for the whole
+    conversation — the system prompt dropping its contradicting rule is what makes the
+    directive uncontested (#3776).
+    """
+    return query + output_language_directive(llm_output_language)
+
+
 def build_system_prompt_for_tools(
     bank_profile: dict[str, Any],
     context: str | None = None,
@@ -117,6 +146,7 @@ def build_system_prompt_for_tools(
     include_observations: bool = True,
     budget: str | None = None,
     answer_as_document: bool = False,
+    llm_output_language: str | None = None,
 ) -> str:
     """
     Build the system prompt for tool-calling reflect agent.
@@ -138,6 +168,9 @@ def build_system_prompt_for_tools(
         has_mental_models: Whether the bank has any mental models (skip if not)
         include_observations: Whether search_observations is in the tool list.
         budget: Search depth budget - "low", "mid", or "high". Controls exploration thoroughness.
+        answer_as_document: Whether done() takes a structured document instead of markdown.
+        llm_output_language: Configured output language; drops the default language rule
+            (the directive itself goes on the user message, see build_agent_user_prompt).
     """
     name = bank_profile.get("name", "Assistant")
     mission = bank_profile.get("mission", "")
@@ -165,14 +198,15 @@ def build_system_prompt_for_tools(
         ]
     )
 
+    # Mutually exclusive with the configured output language — the rule is dropped
+    # outright rather than left to out-rank the directive (#3776). The directive itself
+    # is not appended here: it rides on the user message, see build_agent_user_prompt().
+    tools_language_section = default_language_section(_TOOLS_LANGUAGE_RULE, llm_output_language)
+    if tools_language_section:
+        parts.extend([tools_language_section.rstrip("\n"), ""])
+
     parts.extend(
         [
-            "## LANGUAGE RULE (default - directives take precedence)",
-            "- By default, detect the language of the user's question and respond in that SAME language.",
-            "- If the question is in Chinese, respond in Chinese. If in Japanese, respond in Japanese.",
-            "- IMPORTANT: The DIRECTIVES section above has HIGHER PRIORITY than this rule.",
-            "  If a directive specifies a language (e.g. 'Always respond in French'), follow the directive.",
-            "",
             "## CRITICAL RULES",
             "- ONLY use information from tool results - no external knowledge or guessing",
             "- You SHOULD synthesize, infer, and reason from the retrieved memories",

--- a/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
@@ -11,6 +11,7 @@ import json
 from datetime import datetime, timezone
 from typing import Any
 
+from ..prompt_utils import default_language_section, escape_for_prompt, output_language_directive
 from .tokenization import count_prompt_tokens
 
 # Fraction of max_context_tokens reserved for tool results in the final synthesis prompt.
@@ -666,10 +667,15 @@ def build_final_prompt(
     additional_context: str | None = None,
     max_context_tokens: int = 100_000,
     max_tokens: int | None = None,
+    llm_output_language: str | None = None,
 ) -> str:
     """Build the final prompt when forcing a text response (no tools).
 
     ``max_tokens`` is the soft visible-length target (see ``_length_directive``).
+
+    ``llm_output_language`` closes the prompt with :func:`output_language_directive`.
+    It rides on the USER message, not the system prompt, because it has to be the last
+    thing the model reads — see :func:`build_final_system_prompt` for the measurement.
 
     Callers overflow-proof this via ``split_context_history``: when the whole
     history fits one chunk this renders it directly, and the per-block budget
@@ -711,7 +717,7 @@ def build_final_prompt(
     if length_directive is not None:
         parts.append(length_directive)
 
-    return "\n".join(parts)
+    return "\n".join(parts) + output_language_directive(llm_output_language)
 
 
 #: System prompt for the intermediate (map) calls of split synthesis. They do
@@ -757,6 +763,7 @@ def build_reduce_prompt(
     bank_profile: dict,
     additional_context: str | None = None,
     max_tokens: int | None = None,
+    llm_output_language: str | None = None,
 ) -> str:
     """Build the final prompt that synthesizes the answer from per-chunk claims.
 
@@ -766,6 +773,9 @@ def build_reduce_prompt(
     in different sections — that is why the claims carry ``mentioned_at``: the
     supersession rule (latest statement wins) must be applied across sections,
     not within one.
+
+    Carries the output-language directive for the same reason, and in the same place, as
+    :func:`build_final_prompt` — this is the other prompt that writes a user-visible answer.
     """
     parts = _bank_identity_section(bank_profile, additional_context)
 
@@ -792,7 +802,7 @@ def build_reduce_prompt(
     if length_directive is not None:
         parts.append(length_directive)
 
-    return "\n".join(parts)
+    return "\n".join(parts) + output_language_directive(llm_output_language)
 
 
 _FINAL_SYSTEM_PROMPT_BASE = """CRITICAL: You MUST ONLY use information from retrieved tool results. NEVER make up names, people, events, or entities.
@@ -834,11 +844,10 @@ CRITICAL: This is a NON-CONVERSATIONAL system. NEVER ask follow-up questions, of
 # demands a specific one (the cause of flaky multilingual reflect tests).
 #
 # Emitted only when no output language is configured — see default_language_section().
-# The escape hatch below defers to a directive "above", but output_language_directive()
-# is appended at the very END of the prompt, so it never triggered: with a configured
-# language the model saw this rule first, phrased more forcefully, and answered in the
-# question's language instead. Retain and consolidation drop their rule for exactly this
-# reason (#3776); reflect now does too.
+# The escape hatch below defers to a directive "above", but nothing ever put one there:
+# with a configured language the model saw this rule, phrased more forcefully, and
+# answered in the question's language instead. Retain and consolidation drop their rule
+# for exactly this reason (#3776); reflect does too.
 _FINAL_LANGUAGE_RULE = (
     "## LANGUAGE\n"
     "- Respond in the SAME language as the user's question "
@@ -858,17 +867,20 @@ def build_final_system_prompt(
     ``directives`` are re-injected here (they live in the agent/reasoning prompt,
     but the final answer is a separate call) so output-constraining rules — most
     visibly response language — are honoured by the model that actually writes
-    the answer. When ``llm_output_language`` is set it forces that language
-    regardless of the query/source/directive language (config override wins), and
-    the answer-in-the-question's-language default is dropped rather than left to
-    contradict it.
-    """
-    from hindsight_api.engine.prompt_utils import (
-        default_language_section,
-        escape_for_prompt,
-        output_language_directive,
-    )
+    the answer.
 
+    ``llm_output_language`` drops the answer-in-the-question's-language default rather
+    than leaving it to contradict the directive. It does NOT add the directive here.
+    That is deliberate and measured: this prompt is the system message, and the question
+    and the retrieved data both arrive *after* it in the user message. Appending the
+    directive at the end of this string still leaves it out-ranked by everything the
+    model reads next — a Chinese question with the output language set to English came
+    back in Chinese 12 times out of 12 on gemini-2.5-flash-lite, and 0/5 on
+    gemini-2.5-flash, with no contradicting rule anywhere in the prompt. Moving the same
+    directive to the end of the user message is 12/12 and 5/5 English. So
+    :func:`build_final_prompt` and :func:`build_reduce_prompt` carry it instead, where it
+    is genuinely the last thing the model reads (#3776).
+    """
     role_section = escape_for_prompt(mission.strip()) if mission else _DEFAULT_FINAL_ROLE
 
     parts = [build_directives_section(directives) if directives else ""]
@@ -879,7 +891,7 @@ def build_final_system_prompt(
     # remain a cacheable prefix and only this timestamp falls outside the cache.
     parts.append(_current_datetime_section())
 
-    return "\n\n".join(p.strip() for p in parts if p.strip()) + output_language_directive(llm_output_language)
+    return "\n\n".join(p.strip() for p in parts if p.strip())
 
 
 # Backward-compatible constant for non-identity missions

--- a/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
@@ -832,6 +832,13 @@ CRITICAL: This is a NON-CONVERSATIONAL system. NEVER ask follow-up questions, of
 # be repeated for the answer-writing model. Without it, weaker models drift to
 # English even when the question/facts are in another language or a directive
 # demands a specific one (the cause of flaky multilingual reflect tests).
+#
+# Emitted only when no output language is configured — see default_language_section().
+# The escape hatch below defers to a directive "above", but output_language_directive()
+# is appended at the very END of the prompt, so it never triggered: with a configured
+# language the model saw this rule first, phrased more forcefully, and answered in the
+# question's language instead. Retain and consolidation drop their rule for exactly this
+# reason (#3776); reflect now does too.
 _FINAL_LANGUAGE_RULE = (
     "## LANGUAGE\n"
     "- Respond in the SAME language as the user's question "
@@ -852,15 +859,21 @@ def build_final_system_prompt(
     but the final answer is a separate call) so output-constraining rules — most
     visibly response language — are honoured by the model that actually writes
     the answer. When ``llm_output_language`` is set it forces that language
-    regardless of the query/source/directive language (config override wins).
+    regardless of the query/source/directive language (config override wins), and
+    the answer-in-the-question's-language default is dropped rather than left to
+    contradict it.
     """
-    from hindsight_api.engine.prompt_utils import escape_for_prompt, output_language_directive
+    from hindsight_api.engine.prompt_utils import (
+        default_language_section,
+        escape_for_prompt,
+        output_language_directive,
+    )
 
     role_section = escape_for_prompt(mission.strip()) if mission else _DEFAULT_FINAL_ROLE
 
     parts = [build_directives_section(directives) if directives else ""]
     parts.append(_FINAL_SYSTEM_PROMPT_BASE.format(role_section=role_section))
-    parts.append(_FINAL_LANGUAGE_RULE)
+    parts.append(default_language_section(_FINAL_LANGUAGE_RULE, llm_output_language))
     parts.append(build_directives_reminder(directives) if directives else "")
     # Volatile "now" reference last, so the static/per-bank instructions above
     # remain a cacheable prefix and only this timestamp falls outside the cache.

--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools_schema.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools_schema.py
@@ -136,6 +136,18 @@ TOOL_EXPAND = {
     },
 }
 
+# The done tool's own source-language rule, read at the moment the model writes the
+# answer. Mutually exclusive with a configured output language, like the rule in every
+# prompt (see prompt_utils.default_language_section): with a language set it is removed by
+# _done_tool_for_output_language, and the directive takes its place on the tool. Left in,
+# it out-ranked the directive from the very last position in the model's context — and it
+# pointed at "a language directive in the system prompt", where the directive no longer
+# lives (#3776).
+_DONE_ANSWER_DEFAULT_LANGUAGE = (
+    " LANGUAGE: By default, write in the SAME language as the user's question. However, if a "
+    "language directive in the system prompt specifies a different language, follow that directive instead."
+)
+
 TOOL_DONE_ANSWER = {
     "type": "function",
     "function": {
@@ -146,7 +158,11 @@ TOOL_DONE_ANSWER = {
             "properties": {
                 "answer": {
                     "type": "string",
-                    "description": "Your response as well-formatted markdown. Use headers, lists, bold/italic, and code blocks for clarity. NEVER include memory IDs, UUIDs, or 'Memory references' in this text - put IDs only in memory_ids array. LANGUAGE: By default, write in the SAME language as the user's question. However, if a language directive in the system prompt specifies a different language, follow that directive instead.",
+                    "description": (
+                        "Your response as well-formatted markdown. Use headers, lists, bold/italic, and code blocks "
+                        "for clarity. NEVER include memory IDs, UUIDs, or 'Memory references' in this text - put IDs "
+                        f"only in memory_ids array.{_DONE_ANSWER_DEFAULT_LANGUAGE}"
+                    ),
                 },
                 "memory_ids": {
                     "type": "array",
@@ -242,6 +258,24 @@ def _done_tool_for_document(base: dict) -> dict:
 TOOL_DONE_DOCUMENT = _done_tool_for_document(TOOL_DONE_ANSWER)
 
 
+def _done_tool_for_output_language(base: dict, language: str) -> dict:
+    """Replace a done tool's default source-language rule with the configured language.
+
+    The directive goes on the tool's own description rather than the ``answer`` field so it
+    reaches every variant the same way — the document variant has no ``answer`` field and
+    the directive-aware variant's ``answer`` carries the compliance rules instead.
+    """
+    tool = copy.deepcopy(base)
+    answer = tool["function"]["parameters"]["properties"].get("answer")
+    if answer is not None:
+        answer["description"] = answer["description"].replace(_DONE_ANSWER_DEFAULT_LANGUAGE, "")
+    tool["function"]["description"] += (
+        f" LANGUAGE: Write the answer exclusively in {language}, whatever language the question "
+        "and the retrieved memories are in."
+    )
+    return tool
+
+
 def _build_done_tool_with_directives(directive_rules: list[str]) -> dict:
     """
     Build the done tool schema with directive compliance field.
@@ -308,6 +342,7 @@ def get_reflect_tools(
     include_recall: bool = True,
     include_expand: bool = True,
     answer_as_document: bool = False,
+    llm_output_language: str | None = None,
 ) -> list[dict]:
     """
     Get the list of tools for the reflect agent.
@@ -330,6 +365,8 @@ def get_reflect_tools(
             of a markdown ``answer``. Used when the answer is stored as a
             document (mental-model refresh) so the model never writes the
             markdown that gets persisted.
+        llm_output_language: Configured output language. Swaps ``done``'s default
+            answer-in-the-question's-language rule for a directive to write in it.
 
     Returns:
         List of tool definitions in OpenAI format
@@ -351,6 +388,11 @@ def get_reflect_tools(
         done_tool = _build_done_tool_with_directives(directive_rules)
     else:
         done_tool = TOOL_DONE_ANSWER
-    tools.append(_done_tool_for_document(done_tool) if answer_as_document else done_tool)
+    if answer_as_document:
+        done_tool = _done_tool_for_document(done_tool)
+    # After the document swap: that replaces the tool description this appends to.
+    if llm_output_language:
+        done_tool = _done_tool_for_output_language(done_tool, llm_output_language)
+    tools.append(done_tool)
 
     return tools

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -815,16 +815,12 @@ def _iter_jsonl_chunks(text: str, max_chars: int, structured_limit: int) -> Iter
 # FACT EXTRACTION PROMPTS
 # =============================================================================
 
-# Emitted only when no output language is configured. Fact extraction runs on an
-# English prompt, so without this a multilingual model drifts to English (or, per
-# #181, to an unrelated language entirely) on non-English input. Consolidation
-# carries the equivalent rule, making "preserve the source language" the
-# pipeline-wide default.
-#
-# When HINDSIGHT_API_LLM_OUTPUT_LANGUAGE IS set this section is omitted and
-# output_language_directive() takes over — the two must never both be present or
-# they contradict each other, and the model follows this one because it comes
-# first and is phrased more forcefully.
+# Retain's wording of the preserve-the-source-language rule; the selection between it
+# and an explicit output language belongs to default_language_section(), which documents
+# the invariant. Without it, fact extraction runs on an all-English prompt and a
+# multilingual model drifts to English (or, per #181, to an unrelated language entirely)
+# on non-English input. Consolidation carries the equivalent rule, making "preserve the
+# source language" the pipeline-wide default.
 _DEFAULT_LANGUAGE_RULE = """LANGUAGE: MANDATORY — Detect the language of the input text and produce ALL output in that EXACT same language. You are STRICTLY FORBIDDEN from translating or switching to any other language. Every single word of your output must be in the same language as the input. Do NOT output in a different language under any circumstance."""
 
 
@@ -1227,49 +1223,34 @@ def _build_extraction_prompt_and_schema(config) -> tuple[str, type]:
     # CachedContent serves every bank, and the mission rides in the per-request
     # user message via _retain_mission_preamble(). The {retain_mission_section}
     # placeholder is kept (templates still reference it) but always empty here.
-    from hindsight_api.engine.prompt_utils import escape_for_prompt
+    from hindsight_api.engine.prompt_utils import default_language_section, escape_for_prompt
 
     retain_mission_section = ""
 
-    # An explicit output language wins outright: drop the preserve-the-source-language
-    # default rather than leave it to contradict "translate everything into X", which
-    # is the contradiction the model resolves in favour of the rule above. The directive
-    # appended at the end of this function then stands alone. Mirrors
-    # build_consolidation_system_prompt(). This toggle may change the cacheable prefix
-    # — it is low-cardinality and keyed by the cache fingerprint.
-    language_section = "" if config.llm_output_language else f"{_DEFAULT_LANGUAGE_RULE}\n\n"
+    # Mirrors build_consolidation_system_prompt(). This toggle may change the cacheable
+    # prefix — it is low-cardinality and keyed by the cache fingerprint.
+    language_section = default_language_section(_DEFAULT_LANGUAGE_RULE, config.llm_output_language)
 
-    # Select base prompt based on extraction mode
-    if extraction_mode == "custom":
-        if not config.retain_custom_instructions:
-            base_prompt = CONCISE_FACT_EXTRACTION_PROMPT
-            prompt = base_prompt.format(
-                language_section=language_section,
-                retain_mission_section=retain_mission_section,
-            )
-        else:
-            base_prompt = CUSTOM_FACT_EXTRACTION_PROMPT
-            prompt = base_prompt.format(
-                language_section=language_section,
-                retain_mission_section=retain_mission_section,
-                custom_instructions=escape_for_prompt(config.retain_custom_instructions),
-            )
+    # Select base prompt based on extraction mode. Every template takes the same two
+    # placeholders; only custom mode with instructions to substitute takes a third, so the
+    # modes differ in which constant they name, not in how they are filled.
+    mode_extras: dict[str, str] = {}
+    if extraction_mode == "custom" and config.retain_custom_instructions:
+        base_prompt = CUSTOM_FACT_EXTRACTION_PROMPT
+        mode_extras["custom_instructions"] = escape_for_prompt(config.retain_custom_instructions)
     elif extraction_mode == "verbose":
-        prompt = VERBOSE_FACT_EXTRACTION_PROMPT.format(
-            language_section=language_section,
-            retain_mission_section=retain_mission_section,
-        )
+        base_prompt = VERBOSE_FACT_EXTRACTION_PROMPT
     elif extraction_mode == "verbatim":
-        prompt = VERBATIM_FACT_EXTRACTION_PROMPT.format(
-            language_section=language_section,
-            retain_mission_section=retain_mission_section,
-        )
+        base_prompt = VERBATIM_FACT_EXTRACTION_PROMPT
     else:
+        # Concise is the default, and also what custom mode falls back to with no
+        # instructions configured — there is nothing to substitute into the custom template.
         base_prompt = CONCISE_FACT_EXTRACTION_PROMPT
-        prompt = base_prompt.format(
-            language_section=language_section,
-            retain_mission_section=retain_mission_section,
-        )
+    prompt = base_prompt.format(
+        language_section=language_section,
+        retain_mission_section=retain_mission_section,
+        **mode_extras,
+    )
 
     # Add causal relationships section if enabled
     # Verbatim mode never uses causal relations (no fact text to relate causally)

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1231,13 +1231,14 @@ def _build_extraction_prompt_and_schema(config) -> tuple[str, type]:
     # prefix — it is low-cardinality and keyed by the cache fingerprint.
     language_section = default_language_section(_DEFAULT_LANGUAGE_RULE, config.llm_output_language)
 
-    # Select base prompt based on extraction mode. Every template takes the same two
-    # placeholders; only custom mode with instructions to substitute takes a third, so the
-    # modes differ in which constant they name, not in how they are filled.
-    mode_extras: dict[str, str] = {}
+    # Select base prompt based on extraction mode. The modes differ in which constant they
+    # name, not in how it is filled: only the custom template references
+    # {custom_instructions}, and ``str.format`` ignores a keyword no template mentions, so
+    # all four can be filled by one call.
+    custom_instructions = ""
     if extraction_mode == "custom" and config.retain_custom_instructions:
         base_prompt = CUSTOM_FACT_EXTRACTION_PROMPT
-        mode_extras["custom_instructions"] = escape_for_prompt(config.retain_custom_instructions)
+        custom_instructions = escape_for_prompt(config.retain_custom_instructions)
     elif extraction_mode == "verbose":
         base_prompt = VERBOSE_FACT_EXTRACTION_PROMPT
     elif extraction_mode == "verbatim":
@@ -1249,7 +1250,7 @@ def _build_extraction_prompt_and_schema(config) -> tuple[str, type]:
     prompt = base_prompt.format(
         language_section=language_section,
         retain_mission_section=retain_mission_section,
-        **mode_extras,
+        custom_instructions=custom_instructions,
     )
 
     # Add causal relationships section if enabled

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -815,13 +815,24 @@ def _iter_jsonl_chunks(text: str, max_chars: int, structured_limit: int) -> Iter
 # FACT EXTRACTION PROMPTS
 # =============================================================================
 
+# Emitted only when no output language is configured. Fact extraction runs on an
+# English prompt, so without this a multilingual model drifts to English (or, per
+# #181, to an unrelated language entirely) on non-English input. Consolidation
+# carries the equivalent rule, making "preserve the source language" the
+# pipeline-wide default.
+#
+# When HINDSIGHT_API_LLM_OUTPUT_LANGUAGE IS set this section is omitted and
+# output_language_directive() takes over — the two must never both be present or
+# they contradict each other, and the model follows this one because it comes
+# first and is phrased more forcefully.
+_DEFAULT_LANGUAGE_RULE = """LANGUAGE: MANDATORY — Detect the language of the input text and produce ALL output in that EXACT same language. You are STRICTLY FORBIDDEN from translating or switching to any other language. Every single word of your output must be in the same language as the input. Do NOT output in a different language under any circumstance."""
+
+
 # Base prompt template (shared by concise and custom modes)
 # Uses {extraction_guidelines} placeholder for mode-specific instructions
 _BASE_FACT_EXTRACTION_PROMPT = """Extract SIGNIFICANT facts from text. Be SELECTIVE - only extract facts worth remembering long-term.
 
-LANGUAGE: MANDATORY — Detect the language of the input text and produce ALL output in that EXACT same language. You are STRICTLY FORBIDDEN from translating or switching to any other language. Every single word of your output must be in the same language as the input. Do NOT output in a different language under any circumstance.
-
-{retain_mission_section}{extraction_guidelines}
+{language_section}{retain_mission_section}{extraction_guidelines}
 
 ══════════════════════════════════════════════════════════════════════════
 FACT FORMAT - BE CONCISE
@@ -935,6 +946,7 @@ an experience or person."""
 
 # Assembled concise prompt
 CONCISE_FACT_EXTRACTION_PROMPT = _BASE_FACT_EXTRACTION_PROMPT.format(
+    language_section="{language_section}",
     retain_mission_section="{retain_mission_section}",
     extraction_guidelines=_CONCISE_GUIDELINES,
     examples=_CONCISE_EXAMPLES,
@@ -942,6 +954,7 @@ CONCISE_FACT_EXTRACTION_PROMPT = _BASE_FACT_EXTRACTION_PROMPT.format(
 
 # Custom prompt uses same base but without examples
 CUSTOM_FACT_EXTRACTION_PROMPT = _BASE_FACT_EXTRACTION_PROMPT.format(
+    language_section="{language_section}",
     retain_mission_section="{retain_mission_section}",
     extraction_guidelines="{custom_instructions}",
     examples="",  # No examples for custom mode
@@ -963,6 +976,7 @@ RULES:
 - fact_type: use "world" for user preferences, rules, corrections, constraints, traits, and other objective facts, even when stated during an assistant interaction. Use "assistant" only for actions or experiences the assistant/agent actually performed."""
 
 VERBATIM_FACT_EXTRACTION_PROMPT = _BASE_FACT_EXTRACTION_PROMPT.format(
+    language_section="{language_section}",
     retain_mission_section="{retain_mission_section}",
     extraction_guidelines=_VERBATIM_GUIDELINES,
     examples="",
@@ -972,9 +986,7 @@ VERBATIM_FACT_EXTRACTION_PROMPT = _BASE_FACT_EXTRACTION_PROMPT.format(
 # Verbose extraction prompt - detailed, comprehensive facts (legacy mode)
 VERBOSE_FACT_EXTRACTION_PROMPT = """Extract facts from text into structured format with FIVE required dimensions - BE EXTREMELY DETAILED.
 
-LANGUAGE: MANDATORY — Detect the language of the input text and produce ALL output in that EXACT same language. You are STRICTLY FORBIDDEN from translating or switching to any other language. Every single word of your output must be in the same language as the input. Do NOT output in a different language under any circumstance.
-
-{retain_mission_section}══════════════════════════════════════════════════════════════════════════
+{language_section}{retain_mission_section}══════════════════════════════════════════════════════════════════════════
 FACT FORMAT - ALL FIVE DIMENSIONS REQUIRED - MAXIMUM VERBOSITY
 ══════════════════════════════════════════════════════════════════════════
 
@@ -1219,30 +1231,43 @@ def _build_extraction_prompt_and_schema(config) -> tuple[str, type]:
 
     retain_mission_section = ""
 
+    # An explicit output language wins outright: drop the preserve-the-source-language
+    # default rather than leave it to contradict "translate everything into X", which
+    # is the contradiction the model resolves in favour of the rule above. The directive
+    # appended at the end of this function then stands alone. Mirrors
+    # build_consolidation_system_prompt(). This toggle may change the cacheable prefix
+    # — it is low-cardinality and keyed by the cache fingerprint.
+    language_section = "" if config.llm_output_language else f"{_DEFAULT_LANGUAGE_RULE}\n\n"
+
     # Select base prompt based on extraction mode
     if extraction_mode == "custom":
         if not config.retain_custom_instructions:
             base_prompt = CONCISE_FACT_EXTRACTION_PROMPT
             prompt = base_prompt.format(
+                language_section=language_section,
                 retain_mission_section=retain_mission_section,
             )
         else:
             base_prompt = CUSTOM_FACT_EXTRACTION_PROMPT
             prompt = base_prompt.format(
+                language_section=language_section,
                 retain_mission_section=retain_mission_section,
                 custom_instructions=escape_for_prompt(config.retain_custom_instructions),
             )
     elif extraction_mode == "verbose":
         prompt = VERBOSE_FACT_EXTRACTION_PROMPT.format(
+            language_section=language_section,
             retain_mission_section=retain_mission_section,
         )
     elif extraction_mode == "verbatim":
         prompt = VERBATIM_FACT_EXTRACTION_PROMPT.format(
+            language_section=language_section,
             retain_mission_section=retain_mission_section,
         )
     else:
         base_prompt = CONCISE_FACT_EXTRACTION_PROMPT
         prompt = base_prompt.format(
+            language_section=language_section,
             retain_mission_section=retain_mission_section,
         )
 

--- a/hindsight-api-slim/tests/test_llm_tools.py
+++ b/hindsight-api-slim/tests/test_llm_tools.py
@@ -2,6 +2,8 @@
 Tests for LLM tool calling functionality.
 """
 
+import json
+
 import pytest
 
 from hindsight_api.engine.llm_wrapper import LLMProvider
@@ -265,6 +267,32 @@ class TestReflectToolSchemas:
         done_tool = next(t for t in tools if t["function"]["name"] == "done")
         params = done_tool["function"]["parameters"]["properties"]
         assert "directive_compliance" in params
+
+    @pytest.mark.parametrize("directive_rules", [None, ["Always respond in French"]])
+    @pytest.mark.parametrize("answer_as_document", [False, True])
+    def test_get_reflect_tools_output_language_replaces_done_language_rule(self, directive_rules, answer_as_document):
+        """Every done() variant swaps its default source-language rule for the configured
+        language — the schema is read right as the answer is written, so a rule left there
+        out-ranks every directive that came before it (#3776)."""
+        from hindsight_api.engine.reflect.tools_schema import TOOL_DONE_ANSWER, get_reflect_tools
+
+        tools = get_reflect_tools(
+            directive_rules=directive_rules, answer_as_document=answer_as_document, llm_output_language="Spanish"
+        )
+        done_tool = next(t for t in tools if t["function"]["name"] == "done")
+
+        assert "exclusively in Spanish" in done_tool["function"]["description"]
+        assert "SAME language" not in json.dumps(done_tool)
+        # The module-level constant is never mutated.
+        assert "SAME language" in TOOL_DONE_ANSWER["function"]["parameters"]["properties"]["answer"]["description"]
+
+    def test_get_reflect_tools_unset_output_language_keeps_done_language_rule(self):
+        from hindsight_api.engine.reflect.tools_schema import get_reflect_tools
+
+        done_tool = next(t for t in get_reflect_tools() if t["function"]["name"] == "done")
+
+        assert "SAME language" in done_tool["function"]["parameters"]["properties"]["answer"]["description"]
+        assert "exclusively in" not in done_tool["function"]["description"]
 
     def test_get_reflect_tools_answer_mode(self):
         """Test getting reflect tools with answer output mode."""

--- a/hindsight-api-slim/tests/test_multilingual_bm25.py
+++ b/hindsight-api-slim/tests/test_multilingual_bm25.py
@@ -293,6 +293,42 @@ def test_reflect_unset_requires_source_language():
     assert "Respond exclusively in" not in prompt
 
 
+def test_reflect_agent_loop_directive_replaces_source_language_rule():
+    """The done() path — not just forced synthesis — honours the configured language.
+
+    Most reflect answers are written by the tool-calling model under
+    ``build_system_prompt_for_tools``; ``build_final_system_prompt`` only reaches the
+    model on the forced-synthesis fallback. Fixing the latter alone left a Chinese
+    question answered in Chinese on every run that completed normally.
+    """
+    from hindsight_api.engine.reflect.prompts import (
+        _TOOLS_LANGUAGE_RULE,
+        build_agent_user_prompt,
+        build_system_prompt_for_tools,
+    )
+
+    system_prompt = build_system_prompt_for_tools({"name": "Bank"}, llm_output_language="Korean")
+    user_prompt = build_agent_user_prompt("질문", llm_output_language="Korean")
+
+    assert _TOOLS_LANGUAGE_RULE not in system_prompt
+    assert output_language_directive("Korean") not in system_prompt, "the directive belongs on the user message"
+    assert user_prompt == "질문" + output_language_directive("Korean")
+
+
+def test_reflect_agent_loop_unset_requires_source_language():
+    from hindsight_api.engine.reflect.prompts import (
+        _TOOLS_LANGUAGE_RULE,
+        build_agent_user_prompt,
+        build_system_prompt_for_tools,
+    )
+
+    system_prompt = build_system_prompt_for_tools({"name": "Bank"}, llm_output_language=None)
+
+    assert _TOOLS_LANGUAGE_RULE in system_prompt
+    assert "Respond exclusively in" not in system_prompt
+    assert build_agent_user_prompt("question", llm_output_language=None) == "question"
+
+
 # ---------------------------------------------------------------------------
 # Migration shape regression test
 # ---------------------------------------------------------------------------

--- a/hindsight-api-slim/tests/test_multilingual_bm25.py
+++ b/hindsight-api-slim/tests/test_multilingual_bm25.py
@@ -94,6 +94,48 @@ def test_retain_directive_appears_after_base_prompt():
     assert directive_idx > 100
 
 
+@pytest.mark.parametrize("mode", ["concise", "verbose", "verbatim", "custom"])
+def test_retain_directive_replaces_source_language_rule(mode):
+    """An explicit output language wins outright: the source-language default is
+    dropped rather than left to contradict "translate everything into X".
+
+    Retain's default rule is phrased far more forcefully than the appended
+    directive ("STRICTLY FORBIDDEN from translating" vs "Respond exclusively
+    in X") and comes first, so leaving both in place makes the model keep
+    emitting source-language facts and silently no-ops the setting. Mirrors
+    ``test_consolidation_directive_replaces_source_language_rule``.
+    """
+    config = _baseline_config()
+    config.retain_extraction_mode = mode
+    config.retain_custom_instructions = "Extract only product mentions." if mode == "custom" else None
+    config.llm_output_language = "English"
+
+    prompt, _ = _build_extraction_prompt_and_schema(config)
+
+    assert "STRICTLY FORBIDDEN from translating" not in prompt
+    assert "in the same language as the input" not in prompt
+    assert "Respond exclusively in English" in prompt
+
+
+@pytest.mark.parametrize("mode", ["concise", "verbose", "verbatim", "custom"])
+def test_retain_unset_requires_source_language(mode):
+    """With no configured language, retain must still be told to keep the output
+    in the input's language (#181) - otherwise the all-English extraction prompt
+    makes multilingual models drift. Removing the rule outright would regress that,
+    so this pins the default half of the mutual exclusion.
+    """
+    config = _baseline_config()
+    config.retain_extraction_mode = mode
+    config.retain_custom_instructions = "Extract only product mentions." if mode == "custom" else None
+    config.llm_output_language = None
+
+    prompt, _ = _build_extraction_prompt_and_schema(config)
+
+    assert "LANGUAGE: MANDATORY" in prompt
+    assert "STRICTLY FORBIDDEN from translating" in prompt
+    assert "Respond exclusively in" not in prompt
+
+
 def test_retain_works_with_custom_mode():
     """Custom extraction mode + llm_output_language: directive must still appear."""
     config = _baseline_config()

--- a/hindsight-api-slim/tests/test_multilingual_bm25.py
+++ b/hindsight-api-slim/tests/test_multilingual_bm25.py
@@ -16,7 +16,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from hindsight_api.engine.prompt_utils import output_language_directive
-from hindsight_api.engine.reflect.prompts import build_final_system_prompt
+from hindsight_api.engine.reflect.prompts import (
+    build_final_prompt,
+    build_final_system_prompt,
+    build_reduce_prompt,
+)
 from hindsight_api.engine.retain.fact_extraction import (
     _DEFAULT_LANGUAGE_RULE as _RETAIN_DEFAULT_LANGUAGE_RULE,
 )
@@ -217,16 +221,45 @@ def test_consolidation_directive_does_not_break_format_placeholders():
 def test_reflect_unset_does_not_inject_directive():
     prompt = build_final_system_prompt(mission=None, llm_output_language=None)
     assert "Respond exclusively in" not in prompt
+    assert build_final_prompt("q", [], {"name": "Bank"}) == build_final_prompt(
+        "q", [], {"name": "Bank"}, llm_output_language=None
+    )
 
 
 def test_reflect_injects_directive():
-    prompt = build_final_system_prompt(mission=None, llm_output_language="Korean")
+    """Reflect's directive rides on the USER prompt, not the system prompt.
+
+    It has to be the last thing the model reads: the question and the retrieved data
+    follow the system prompt, and a directive stranded behind them loses (#3776 — see
+    ``build_final_system_prompt`` for the measurement).
+    """
+    prompt = build_final_prompt("질문", [], {"name": "Bank"}, llm_output_language="Korean")
     assert "Respond exclusively in Korean" in prompt
+    assert prompt.rstrip().endswith("must be in Korean."), "the directive must come last"
+
+
+def test_reflect_reduce_prompt_injects_directive():
+    """The split-synthesis path writes the answer too, so it carries the directive as well.
+
+    ``_forced_final_synthesis`` picks between ``build_final_prompt`` and
+    ``build_reduce_prompt`` on whether the retrieved data fits one chunk. A configured
+    output language that only worked below that threshold would be the same silent no-op
+    in a different disguise.
+    """
+    prompt = build_reduce_prompt("질문", ["- a claim"], {"name": "Bank"}, llm_output_language="Korean")
+    assert "Respond exclusively in Korean" in prompt
+    assert prompt.rstrip().endswith("must be in Korean."), "the directive must come last"
+
+
+def test_reflect_unset_does_not_inject_directive_into_the_user_prompt():
+    prompt = build_final_prompt("question", [], {"name": "Bank"}, llm_output_language=None)
+    assert "Respond exclusively in" not in prompt
 
 
 def test_reflect_preserves_mission_alongside_directive():
-    prompt = build_final_system_prompt(mission="Act as a financial analyst.", llm_output_language="Spanish")
-    assert "financial analyst" in prompt
+    system_prompt = build_final_system_prompt(mission="Act as a financial analyst.", llm_output_language="Spanish")
+    prompt = build_final_prompt("q", [], {"name": "Bank"}, llm_output_language="Spanish")
+    assert "financial analyst" in system_prompt
     assert "Respond exclusively in Spanish" in prompt
 
 
@@ -234,15 +267,18 @@ def test_reflect_directive_replaces_source_language_rule():
     """Reflect follows retain and consolidation: an explicit output language drops the
     answer-in-the-question's-language default instead of contradicting it.
 
-    The rule defers to "a directive above", but the output-language directive is appended
-    at the very END of the prompt — so before this it never took precedence, and a
-    configured language was silently no-opped for reflect answers.
+    The rule defers to "a directive above" and nothing ever put one there, so before this
+    it never took precedence and a configured language was silently no-opped. Dropping the
+    rule is only half of it — the directive also has to reach the model *after* the
+    question; ``test_reflect_injects_directive`` pins that half.
     """
     from hindsight_api.engine.reflect.prompts import _FINAL_LANGUAGE_RULE
 
-    prompt = build_final_system_prompt(mission=None, llm_output_language="Korean")
+    system_prompt = build_final_system_prompt(mission=None, llm_output_language="Korean")
+    prompt = build_final_prompt("질문", [], {"name": "Bank"}, llm_output_language="Korean")
 
-    assert _FINAL_LANGUAGE_RULE not in prompt
+    assert _FINAL_LANGUAGE_RULE not in system_prompt
+    assert output_language_directive("Korean") not in system_prompt, "the directive belongs on the user prompt"
     assert output_language_directive("Korean") in prompt
 
 

--- a/hindsight-api-slim/tests/test_multilingual_bm25.py
+++ b/hindsight-api-slim/tests/test_multilingual_bm25.py
@@ -230,6 +230,33 @@ def test_reflect_preserves_mission_alongside_directive():
     assert "Respond exclusively in Spanish" in prompt
 
 
+def test_reflect_directive_replaces_source_language_rule():
+    """Reflect follows retain and consolidation: an explicit output language drops the
+    answer-in-the-question's-language default instead of contradicting it.
+
+    The rule defers to "a directive above", but the output-language directive is appended
+    at the very END of the prompt — so before this it never took precedence, and a
+    configured language was silently no-opped for reflect answers.
+    """
+    from hindsight_api.engine.reflect.prompts import _FINAL_LANGUAGE_RULE
+
+    prompt = build_final_system_prompt(mission=None, llm_output_language="Korean")
+
+    assert _FINAL_LANGUAGE_RULE not in prompt
+    assert output_language_directive("Korean") in prompt
+
+
+def test_reflect_unset_requires_source_language():
+    """With no configured language the default rule must still be there — without it
+    weaker models drift to English on a non-English question."""
+    from hindsight_api.engine.reflect.prompts import _FINAL_LANGUAGE_RULE
+
+    prompt = build_final_system_prompt(mission=None, llm_output_language=None)
+
+    assert _FINAL_LANGUAGE_RULE in prompt
+    assert "Respond exclusively in" not in prompt
+
+
 # ---------------------------------------------------------------------------
 # Migration shape regression test
 # ---------------------------------------------------------------------------

--- a/hindsight-api-slim/tests/test_multilingual_bm25.py
+++ b/hindsight-api-slim/tests/test_multilingual_bm25.py
@@ -17,6 +17,9 @@ import pytest
 
 from hindsight_api.engine.prompt_utils import output_language_directive
 from hindsight_api.engine.reflect.prompts import build_final_system_prompt
+from hindsight_api.engine.retain.fact_extraction import (
+    _DEFAULT_LANGUAGE_RULE as _RETAIN_DEFAULT_LANGUAGE_RULE,
+)
 from hindsight_api.engine.retain.fact_extraction import _build_extraction_prompt_and_schema
 from hindsight_api.engine.search import retrieval as retrieval_mod
 from hindsight_api.engine.search.retrieval import tokenize_query
@@ -112,9 +115,8 @@ def test_retain_directive_replaces_source_language_rule(mode):
 
     prompt, _ = _build_extraction_prompt_and_schema(config)
 
-    assert "STRICTLY FORBIDDEN from translating" not in prompt
-    assert "in the same language as the input" not in prompt
-    assert "Respond exclusively in English" in prompt
+    assert _RETAIN_DEFAULT_LANGUAGE_RULE not in prompt
+    assert output_language_directive("English") in prompt
 
 
 @pytest.mark.parametrize("mode", ["concise", "verbose", "verbatim", "custom"])
@@ -131,8 +133,7 @@ def test_retain_unset_requires_source_language(mode):
 
     prompt, _ = _build_extraction_prompt_and_schema(config)
 
-    assert "LANGUAGE: MANDATORY" in prompt
-    assert "STRICTLY FORBIDDEN from translating" in prompt
+    assert _RETAIN_DEFAULT_LANGUAGE_RULE in prompt
     assert "Respond exclusively in" not in prompt
 
 
@@ -187,11 +188,14 @@ def test_consolidation_injects_directive():
 def test_consolidation_directive_replaces_source_language_rule():
     """An explicit output language wins outright: the source-language default is
     dropped rather than left to contradict "translate everything into X"."""
-    from hindsight_api.engine.consolidation.prompts import build_consolidation_system_prompt
+    from hindsight_api.engine.consolidation.prompts import (
+        _DEFAULT_LANGUAGE_RULE,
+        build_consolidation_system_prompt,
+    )
 
     prompt = build_consolidation_system_prompt(llm_output_language="Chinese")
-    assert "## LANGUAGE" not in prompt
-    assert "language of its own source facts" not in prompt
+    assert _DEFAULT_LANGUAGE_RULE not in prompt
+    assert output_language_directive("Chinese") in prompt
 
 
 def test_consolidation_directive_does_not_break_format_placeholders():

--- a/hindsight-api-slim/tests/test_reflect_agent.py
+++ b/hindsight-api-slim/tests/test_reflect_agent.py
@@ -284,6 +284,49 @@ class TestReflectAgentMocked:
         assert "name" not in tool_result
 
     @pytest.mark.asyncio
+    async def test_output_language_reaches_the_done_path(self, mock_llm, mock_functions):
+        """The tool-calling model — the one that writes done() — sees the configured
+        language: its system prompt drops the answer-in-the-question's-language rule and
+        the directive closes the user message. Forced synthesis is never reached here, so
+        fixing ``build_final_system_prompt`` alone would leave this call untouched (#3776).
+        """
+        mock_functions["search_mental_models_fn"].return_value = {
+            "mental_models": [{"id": "mm-1", "name": "User prefs", "content": "Fresh content.", "is_stale": False}]
+        }
+        mock_llm.call_with_tools.side_effect = [
+            self._mm_call(),
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(id="2", name="done", arguments={"answer": "Done.", "mental_model_ids": ["mm-1"]})
+                ],
+                finish_reason="tool_calls",
+            ),
+        ]
+
+        result = await run_reflect_agent(
+            llm_config=mock_llm,
+            bank_id="test-bank",
+            query="张伟负责什么工作？",
+            bank_profile={"name": "Test", "mission": ""},
+            has_mental_models=True,
+            budget="low",
+            max_iterations=5,
+            llm_output_language="English",
+            **mock_functions,
+        )
+
+        assert result.text == "Done."
+        mock_llm.call.assert_not_called()  # answered via done(), not forced synthesis
+        for call in mock_llm.call_with_tools.await_args_list:
+            messages = call.kwargs["messages"]
+            assert messages[0]["role"] == "system"
+            assert "respond in that SAME language" not in messages[0]["content"]
+            assert "Respond exclusively in English" not in messages[0]["content"]
+            assert messages[1]["role"] == "user"
+            assert messages[1]["content"].startswith("张伟负责什么工作？")
+            assert "Respond exclusively in English" in messages[1]["content"]
+
+    @pytest.mark.asyncio
     async def test_done_tool_answer_respects_max_tokens(self, mock_llm, mock_functions):
         mock_functions["search_mental_models_fn"].return_value = {
             "mental_models": [{"id": "mm-1", "name": "User prefs", "content": "Fresh content.", "is_stale": False}]

--- a/hindsight-api-slim/tests/test_reflect_agent.py
+++ b/hindsight-api-slim/tests/test_reflect_agent.py
@@ -325,6 +325,11 @@ class TestReflectAgentMocked:
             assert messages[1]["role"] == "user"
             assert messages[1]["content"].startswith("张伟负责什么工作？")
             assert "Respond exclusively in English" in messages[1]["content"]
+            # The done tool schema is the last thing the model reads before writing the
+            # answer; its own "SAME language" rule has to go too, or it wins from there.
+            done_tool = next(t for t in call.kwargs["tools"] if t["function"]["name"] == "done")
+            assert "SAME language" not in done_tool["function"]["parameters"]["properties"]["answer"]["description"]
+            assert "exclusively in English" in done_tool["function"]["description"]
 
     @pytest.mark.asyncio
     async def test_done_tool_answer_respects_max_tokens(self, mock_llm, mock_functions):

--- a/hindsight-api-slim/tests/test_reflect_prompt_builder.py
+++ b/hindsight-api-slim/tests/test_reflect_prompt_builder.py
@@ -596,6 +596,24 @@ def test_final_prompt_injects_directives_so_answer_obeys_them():
     assert "takes precedence over this default" in prompt
 
 
+def test_tools_prompt_includes_language_rule_when_no_output_language_is_set():
+    prompt = build_system_prompt_for_tools(BANK)
+    assert "## LANGUAGE RULE (default - directives take precedence)" in prompt
+    assert "respond in that SAME language" in prompt
+
+
+def test_tools_prompt_output_language_override_replaces_the_language_rule():
+    """The reasoning loop writes most answers via done(); it needs the same treatment as
+    the forced-synthesis prompt or the setting is a no-op on every normal run (#3776)."""
+    prompt = build_system_prompt_for_tools(BANK, llm_output_language="Spanish")
+    assert "## LANGUAGE RULE" not in prompt
+    assert "respond in that SAME language" not in prompt
+    assert "Respond exclusively in Spanish" not in prompt, "the directive belongs on the user message"
+    # Everything around the dropped rule is intact.
+    assert "## CRITICAL RULES" in prompt
+    assert "## Memory Bank: TestBank" in prompt
+
+
 def test_final_prompt_output_language_override_replaces_the_language_rule():
     """HINDSIGHT_API_LLM_OUTPUT_LANGUAGE forces a language regardless of query/directive.
 

--- a/hindsight-api-slim/tests/test_reflect_prompt_builder.py
+++ b/hindsight-api-slim/tests/test_reflect_prompt_builder.py
@@ -571,7 +571,7 @@ _FRENCH_DIRECTIVE = {
 }
 
 
-def test_final_prompt_always_includes_language_rule():
+def test_final_prompt_includes_language_rule_when_no_output_language_is_set():
     prompt = build_final_system_prompt()
     assert "The current date and time is 2026-08-09 14:32 UTC." in prompt
     assert "## LANGUAGE" in prompt
@@ -596,9 +596,16 @@ def test_final_prompt_injects_directives_so_answer_obeys_them():
     assert "takes precedence over this default" in prompt
 
 
-def test_final_prompt_output_language_override_is_appended_last():
-    """HINDSIGHT_API_LLM_OUTPUT_LANGUAGE forces a language regardless of query/directive."""
+def test_final_prompt_output_language_override_replaces_the_language_rule():
+    """HINDSIGHT_API_LLM_OUTPUT_LANGUAGE forces a language regardless of query/directive.
+
+    This used to assert the override merely came *after* the default rule, on the theory
+    that appending it last made it win. It did not: the rule is phrased more forcefully
+    and comes first, so the model kept answering in the question's language and the
+    setting was a no-op. The rule is now dropped outright when a language is configured,
+    the same resolution retain and consolidation use (#3776).
+    """
     prompt = build_final_system_prompt(llm_output_language="Spanish")
     assert "Respond exclusively in Spanish" in prompt
-    # The config override is appended after the default LANGUAGE rule so it wins.
-    assert prompt.index("Respond exclusively in Spanish") > prompt.index("## LANGUAGE")
+    assert "## LANGUAGE" not in prompt
+    assert "SAME language as the user's question" not in prompt

--- a/hindsight-api-slim/tests/test_reflect_prompt_builder.py
+++ b/hindsight-api-slim/tests/test_reflect_prompt_builder.py
@@ -600,12 +600,14 @@ def test_final_prompt_output_language_override_replaces_the_language_rule():
     """HINDSIGHT_API_LLM_OUTPUT_LANGUAGE forces a language regardless of query/directive.
 
     This used to assert the override merely came *after* the default rule, on the theory
-    that appending it last made it win. It did not: the rule is phrased more forcefully
-    and comes first, so the model kept answering in the question's language and the
-    setting was a no-op. The rule is now dropped outright when a language is configured,
-    the same resolution retain and consolidation use (#3776).
+    that appending it last made it win. It did not, twice over. The rule is phrased more
+    forcefully, so it had to be dropped rather than argued with — and even with the rule
+    gone, "last in the system prompt" is not last: the question and the retrieved data
+    arrive after it in the user message and out-rank it (measured 0/12 English on
+    gemini-2.5-flash-lite). So the system prompt now drops the rule and carries no
+    directive at all; ``build_final_prompt`` closes the user message with it (#3776).
     """
     prompt = build_final_system_prompt(llm_output_language="Spanish")
-    assert "Respond exclusively in Spanish" in prompt
     assert "## LANGUAGE" not in prompt
     assert "SAME language as the user's question" not in prompt
+    assert "Respond exclusively in Spanish" not in prompt, "the directive belongs on the user prompt"

--- a/hindsight-api-slim/tests/test_retain_reflect_output_language.py
+++ b/hindsight-api-slim/tests/test_retain_reflect_output_language.py
@@ -1,0 +1,158 @@
+"""A configured output language actually reaches retain's facts and reflect's answer (#3776).
+
+``HINDSIGHT_API_LLM_OUTPUT_LANGUAGE`` was a silent no-op for both: each prompt carried its
+own "never translate the source language" rule AND the appended translate-into-X directive,
+and the model resolved the contradiction in favour of the rule — it is phrased far more
+forcefully and comes first. Nothing errored; the facts were simply stored in the source
+language while ``/config`` reported the setting as active.
+
+That failure is invisible to the deterministic tests. Which rule text ends up in the prompt
+for a given config is pinned in ``test_multilingual_bm25.py``, and those assertions passed
+happily on the broken code — the old retain tests only ever asserted the directive was
+*present*, never that the contradicting rule was *absent*, which is exactly how this
+shipped. Whether the model then *obeys* the prompt is not something MockLLM or a string
+match can show, so these drive the real call and judge the output. Same split, and the same
+shape, as ``test_consolidation_output_language.py``.
+
+Scope: the **configured** half of the mutual exclusion, which nothing else covers for retain
+or reflect. The unset half — that the source-language rule is still there and still works,
+per #181 — is owned by ``test_multilingual.py`` behaviourally and by
+``test_retain_unset_requires_source_language`` / ``test_reflect_unset_requires_source_language``
+deterministically.
+
+Chinese source material, because the script gives a decisive gate the judge can be checked
+against: an English answer contains no CJK at all. Translating *into* the prompt's own
+language is also the easy direction for any multilingual model — a failure here is the
+prompt contradicting itself again, not the model being weak.
+"""
+
+import dataclasses
+from datetime import UTC, datetime
+
+import pytest
+
+from hindsight_api import LLMConfig
+from hindsight_api.config import _get_raw_config
+from hindsight_api.engine.reflect.prompts import build_final_prompt, build_final_system_prompt
+from hindsight_api.engine.retain.fact_extraction import extract_facts_from_text
+from tests.llm_judge import assert_meets_criteria
+
+pytestmark = pytest.mark.hs_llm_core
+
+
+def _has_cjk(text: str) -> bool:
+    """True when the text contains at least one CJK ideograph (U+4E00–U+9FFF)."""
+    return any("一" <= char <= "鿿" for char in text)
+
+
+# The shape of the production report in #3776: source content in one language, the operator
+# expecting every stored artifact in another. Chinese rather than the issue's Spanish so the
+# "did it translate?" check is a script test rather than a vocabulary guess.
+_CHINESE_SOURCE = """
+张伟是一位资深软件工程师，在腾讯工作了五年。他专门研究分布式系统，并领导了公司微服务架构的开发。
+团队使用Kubernetes进行容器编排，并部署到阿里云。他们遵循敏捷方法论，采用两周冲刺周期。
+合并前必须进行代码审查。
+"""
+
+
+@pytest.mark.asyncio
+async def test_retain_configured_output_language_overrides_source_language():
+    """Chinese input + ``llm_output_language="English"`` → English facts.
+
+    The bug: the extraction prompt's own rule ("STRICTLY FORBIDDEN from translating")
+    outranked the appended directive, so the facts came back in Chinese and the setting
+    did nothing. Dropping the rule when a language is configured is what makes this pass.
+    """
+    config = dataclasses.replace(_get_raw_config(), llm_output_language="English")
+
+    facts, _, _ = await extract_facts_from_text(
+        text=_CHINESE_SOURCE,
+        event_date=datetime(2024, 1, 15, tzinfo=UTC),
+        context="团队概述",
+        llm_config=LLMConfig.from_env(),
+        agent_name="TestUser",
+        config=config,
+    )
+
+    assert facts, "Should extract at least one fact from the Chinese source"
+    extracted = "\n".join(f"- {fact.fact}" for fact in facts)
+
+    # Decisive and script-based: any Chinese sentence left in the output means the
+    # contradicting rule won again, whatever the judge makes of the phrasing.
+    assert not _has_cjk(extracted), f"Facts were left in the source language: {extracted!r}"
+
+    await assert_meets_criteria(
+        response=extracted,
+        criteria=(
+            "Every fact is written in English, even though the source material was Chinese. "
+            "Proper nouns may be transliterated (e.g. 'Zhang Wei', 'Tencent') or left in their "
+            "original script; the sentences themselves must be English."
+        ),
+        context=(
+            "Fact extraction was given Chinese source text about a senior software engineer at "
+            "Tencent who works on distributed systems, and about a team using Kubernetes on "
+            "Alibaba Cloud with two-week sprints and mandatory code review. The output language "
+            "was configured to English, which must override the source language."
+        ),
+        msg="HINDSIGHT_API_LLM_OUTPUT_LANGUAGE must override the source language for retain facts",
+    )
+
+
+@pytest.mark.asyncio
+async def test_reflect_configured_output_language_overrides_question_language(llm_config):
+    """Chinese question and Chinese retrieved data + configured English → English answer.
+
+    Reflect needed BOTH halves of the fix, and this test is what proved the second one was
+    missing. Dropping the contradicting source-language rule is not enough on its own: with
+    the rule gone and only the directive left, the answer still came back in Chinese 12/12
+    on gemini-2.5-flash-lite and 5/5 on gemini-2.5-flash, because the directive sat at the
+    end of the SYSTEM prompt and the question and retrieved data both arrive after it. The
+    directive now rides at the end of the user message, which measured 12/12 and 5/5 English.
+
+    Drives the real synthesis call the way ``_forced_final_synthesis`` does: the same system
+    prompt from ``build_final_system_prompt`` and user prompt from ``build_final_prompt``, one
+    tool-less call, ``scope="reflect"``.
+    """
+    bank_profile = {"name": "工程团队记忆"}
+    query = "张伟负责什么工作？团队用什么部署？"
+    context_history = [
+        {
+            "tool": "recall",
+            "output": {
+                "results": [
+                    {"text": "张伟是资深软件工程师，专门研究分布式系统，并领导微服务架构的开发。"},
+                    {"text": "团队使用Kubernetes进行容器编排，并部署到阿里云。"},
+                ]
+            },
+        }
+    ]
+
+    system_prompt = build_final_system_prompt(bank_profile.get("mission"), "English", None)
+    prompt = build_final_prompt(query, context_history, bank_profile, llm_output_language="English")
+
+    answer = await llm_config.call(
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": prompt},
+        ],
+        scope="reflect",
+    )
+
+    assert answer.strip(), "The synthesis call should produce an answer"
+    assert not _has_cjk(answer), f"Answer was left in the question's language: {answer!r}"
+
+    await assert_meets_criteria(
+        response=answer,
+        criteria=(
+            "The answer is written in English, even though the question and the retrieved data "
+            "were both in Chinese. Proper nouns may be transliterated or left in their original "
+            "script; the sentences themselves must be English."
+        ),
+        context=(
+            "Reflect was asked, in Chinese, what Zhang Wei works on and what the team deploys "
+            "with. The retrieved facts were also in Chinese (distributed systems, microservice "
+            "architecture, Kubernetes, Alibaba Cloud). The output language was configured to "
+            "English, which must override the question's language."
+        ),
+        msg="HINDSIGHT_API_LLM_OUTPUT_LANGUAGE must override the question language for reflect answers",
+    )

--- a/hindsight-api-slim/tests/test_retain_reflect_output_language.py
+++ b/hindsight-api-slim/tests/test_retain_reflect_output_language.py
@@ -20,19 +20,23 @@ per #181 — is owned by ``test_multilingual.py`` behaviourally and by
 ``test_retain_unset_requires_source_language`` / ``test_reflect_unset_requires_source_language``
 deterministically.
 
-Chinese source material, because the script gives a decisive gate the judge can be checked
-against: an English answer contains no CJK at all. Translating *into* the prompt's own
-language is also the easy direction for any multilingual model — a failure here is the
-prompt contradicting itself again, not the model being weak.
+Chinese source material, because it is unambiguous to the judge: a sentence left in the
+source language is a different script, not a vocabulary guess. Translating *into* the
+prompt's own language is also the easy direction for any multilingual model — a failure here
+is the prompt contradicting itself again, not the model being weak. The language judgement
+is the judge's alone: a script gate on the output would reject the proper nouns
+(张伟 / 腾讯 / 阿里云) the criteria deliberately allow verbatim, and flake.
 """
 
 import dataclasses
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock
 
 import pytest
 
 from hindsight_api import LLMConfig
 from hindsight_api.config import _get_raw_config
+from hindsight_api.engine.reflect.agent import run_reflect_agent
 from hindsight_api.engine.reflect.prompts import build_final_prompt, build_final_system_prompt
 from hindsight_api.engine.retain.fact_extraction import extract_facts_from_text
 from tests.llm_judge import assert_meets_criteria
@@ -40,14 +44,9 @@ from tests.llm_judge import assert_meets_criteria
 pytestmark = pytest.mark.hs_llm_core
 
 
-def _has_cjk(text: str) -> bool:
-    """True when the text contains at least one CJK ideograph (U+4E00–U+9FFF)."""
-    return any("一" <= char <= "鿿" for char in text)
-
-
 # The shape of the production report in #3776: source content in one language, the operator
-# expecting every stored artifact in another. Chinese rather than the issue's Spanish so the
-# "did it translate?" check is a script test rather than a vocabulary guess.
+# expecting every stored artifact in another. Chinese rather than the issue's Spanish so a
+# sentence left untranslated is unmistakable to the judge.
 _CHINESE_SOURCE = """
 张伟是一位资深软件工程师，在腾讯工作了五年。他专门研究分布式系统，并领导了公司微服务架构的开发。
 团队使用Kubernetes进行容器编排，并部署到阿里云。他们遵循敏捷方法论，采用两周冲刺周期。
@@ -77,10 +76,6 @@ async def test_retain_configured_output_language_overrides_source_language():
     assert facts, "Should extract at least one fact from the Chinese source"
     extracted = "\n".join(f"- {fact.fact}" for fact in facts)
 
-    # Decisive and script-based: any Chinese sentence left in the output means the
-    # contradicting rule won again, whatever the judge makes of the phrasing.
-    assert not _has_cjk(extracted), f"Facts were left in the source language: {extracted!r}"
-
     await assert_meets_criteria(
         response=extracted,
         criteria=(
@@ -98,49 +93,16 @@ async def test_retain_configured_output_language_overrides_source_language():
     )
 
 
-@pytest.mark.asyncio
-async def test_reflect_configured_output_language_overrides_question_language(llm_config):
-    """Chinese question and Chinese retrieved data + configured English → English answer.
+_REFLECT_BANK_PROFILE = {"name": "工程团队记忆"}
+_REFLECT_QUERY = "张伟负责什么工作？团队用什么部署？"
+_REFLECT_MEMORIES = [
+    "张伟是资深软件工程师，专门研究分布式系统，并领导微服务架构的开发。",
+    "团队使用Kubernetes进行容器编排，并部署到阿里云。",
+]
 
-    Reflect needed BOTH halves of the fix, and this test is what proved the second one was
-    missing. Dropping the contradicting source-language rule is not enough on its own: with
-    the rule gone and only the directive left, the answer still came back in Chinese 12/12
-    on gemini-2.5-flash-lite and 5/5 on gemini-2.5-flash, because the directive sat at the
-    end of the SYSTEM prompt and the question and retrieved data both arrive after it. The
-    directive now rides at the end of the user message, which measured 12/12 and 5/5 English.
 
-    Drives the real synthesis call the way ``_forced_final_synthesis`` does: the same system
-    prompt from ``build_final_system_prompt`` and user prompt from ``build_final_prompt``, one
-    tool-less call, ``scope="reflect"``.
-    """
-    bank_profile = {"name": "工程团队记忆"}
-    query = "张伟负责什么工作？团队用什么部署？"
-    context_history = [
-        {
-            "tool": "recall",
-            "output": {
-                "results": [
-                    {"text": "张伟是资深软件工程师，专门研究分布式系统，并领导微服务架构的开发。"},
-                    {"text": "团队使用Kubernetes进行容器编排，并部署到阿里云。"},
-                ]
-            },
-        }
-    ]
-
-    system_prompt = build_final_system_prompt(bank_profile.get("mission"), "English", None)
-    prompt = build_final_prompt(query, context_history, bank_profile, llm_output_language="English")
-
-    answer = await llm_config.call(
-        messages=[
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": prompt},
-        ],
-        scope="reflect",
-    )
-
-    assert answer.strip(), "The synthesis call should produce an answer"
-    assert not _has_cjk(answer), f"Answer was left in the question's language: {answer!r}"
-
+async def _assert_reflect_answer_is_english(answer: str) -> None:
+    assert answer.strip(), "Reflect should produce an answer"
     await assert_meets_criteria(
         response=answer,
         criteria=(
@@ -156,3 +118,75 @@ async def test_reflect_configured_output_language_overrides_question_language(ll
         ),
         msg="HINDSIGHT_API_LLM_OUTPUT_LANGUAGE must override the question language for reflect answers",
     )
+
+
+@pytest.mark.asyncio
+async def test_reflect_done_path_configured_output_language_overrides_question_language(llm_config):
+    """Chinese question and Chinese memories + configured English → English ``done()`` answer.
+
+    This is the path that produces most reflect answers: the tool-calling loop under
+    ``build_system_prompt_for_tools``, ending in a ``done()`` call. The first cut of this fix
+    only reached ``build_final_system_prompt``, whose sole caller is the forced-synthesis
+    fallback, so a normal run still answered in Chinese — and the forced-path test below,
+    which assembles its prompts by hand, could not see it. This one drives the real agent
+    and asserts the answer did not come from the fallback.
+    """
+    recall_fn = AsyncMock(
+        return_value={
+            "memories": [
+                {"id": f"mem-{idx}", "text": text, "mentioned_at": "2024-01-15T00:00:00Z"}
+                for idx, text in enumerate(_REFLECT_MEMORIES, 1)
+            ]
+        }
+    )
+    result = await run_reflect_agent(
+        llm_config=llm_config,
+        bank_id="test-bank",
+        query=_REFLECT_QUERY,
+        bank_profile=_REFLECT_BANK_PROFILE,
+        search_mental_models_fn=AsyncMock(return_value={"mental_models": []}),
+        search_observations_fn=AsyncMock(return_value={"observations": []}),
+        recall_fn=recall_fn,
+        expand_fn=AsyncMock(return_value={"memories": []}),
+        has_mental_models=False,
+        include_observations=False,
+        budget="low",
+        llm_output_language="English",
+    )
+
+    assert not any(call.scope == "final" for call in result.llm_trace), (
+        "Answer came from forced synthesis, so the done() path was not exercised: "
+        f"{[call.scope for call in result.llm_trace]}"
+    )
+    await _assert_reflect_answer_is_english(result.text)
+
+
+@pytest.mark.asyncio
+async def test_reflect_forced_synthesis_configured_output_language_overrides_question_language(llm_config):
+    """Chinese question and Chinese retrieved data + configured English → English answer.
+
+    Reflect needed BOTH halves of the fix, and this test is what proved the second one was
+    missing. Dropping the contradicting source-language rule is not enough on its own: with
+    the rule gone and only the directive left, the answer still came back in Chinese 12/12
+    on gemini-2.5-flash-lite and 5/5 on gemini-2.5-flash, because the directive sat at the
+    end of the SYSTEM prompt and the question and retrieved data both arrive after it. The
+    directive now rides at the end of the user message, which measured 12/12 and 5/5 English.
+
+    Drives the real synthesis call the way ``_forced_final_synthesis`` does: the same system
+    prompt from ``build_final_system_prompt`` and user prompt from ``build_final_prompt``, one
+    tool-less call, ``scope="reflect"``.
+    """
+    context_history = [{"tool": "recall", "output": {"results": [{"text": text} for text in _REFLECT_MEMORIES]}}]
+
+    system_prompt = build_final_system_prompt(_REFLECT_BANK_PROFILE.get("mission"), "English", None)
+    prompt = build_final_prompt(_REFLECT_QUERY, context_history, _REFLECT_BANK_PROFILE, llm_output_language="English")
+
+    answer = await llm_config.call(
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": prompt},
+        ],
+        scope="reflect",
+    )
+
+    await _assert_reflect_answer_is_english(answer)


### PR DESCRIPTION
Fixes #3776.

> **Scope note.** #3776 reports retain only and says reflect works. Reflect turned out to have the same contradiction in three places (below), so this PR fixes both pipelines. It is one bug — a hardcoded "keep the source language" rule that out-ranks the appended `output_language_directive()` — applied at every site that had it, through one shared helper.

## Problem

`HINDSIGHT_API_LLM_OUTPUT_LANGUAGE` is silently a no-op for retain. The extraction prompt hardcodes a "detect the input language and never translate" rule near the top, and `output_language_directive()` appends the opposite instruction at the end — the prompt contradicts itself.

The model resolves that in favour of the first rule: it lands ~6KB earlier (position 221 vs 6595 in the concise prompt) and is phrased far more forcefully — "STRICTLY FORBIDDEN from translating" against "Respond exclusively in X". Facts keep getting stored in the source language while `/config` reports the setting as active.

Consolidation already solves exactly this. `build_consolidation_system_prompt()` omits its default rule when a language is configured, `consolidation/prompts.py:22-27` writes down the invariant ("the two must never both be present or they contradict each other"), and `test_consolidation_directive_replaces_source_language_rule` guards it. Retain never got the same treatment.

## Fix — retain

Hoist the rule into `_DEFAULT_LANGUAGE_RULE` and emit it through a `{language_section}` placeholder, deferred through the same two-stage `.format()` the mode templates already use for `{retain_mission_section}`. The selection lives in one shared helper, `prompt_utils.default_language_section()`, which retain, consolidation and reflect all call.

All four extraction modes carried the rule (the base template feeds concise/custom/verbatim; verbose had its own copy) and all four are fixed:

| mode | unset → rule / directive | set → rule / directive |
|---|---|---|
| concise | ✅ present / absent | ✅ absent / present |
| verbose | ✅ present / absent | ✅ absent / present |
| verbatim | ✅ present / absent | ✅ absent / present |
| custom | ✅ present / absent | ✅ absent / present |

**The rule is deliberately kept when no output language is set.** It exists for #181 (CONCISE mode drifting to Japanese/Chinese on English/Italian input), so removing it outright would regress that. This makes the two mutually exclusive rather than deleting either.

**The unset path is byte-identical to before this change** in all four modes — verified by diffing the built prompts against `main`.

On the cacheable prefix: `test_retain_cacheable_prefix_invariant_to_per_bank_freetext` already documents output language as a low-cardinality structural toggle that *may* change the prefix and is correctly keyed by the cache fingerprint, so gating on it is in line with the existing invariant. High-cardinality free-text (mission, custom instructions) still cannot leak in — that test passes unchanged.

### Verification against a live deployment

Reproduced on `0.9.1` with provider `openai-codex` / `gpt-5.6-luna` and `HINDSIGHT_API_LLM_OUTPUT_LANGUAGE=English`.

Spanish input:
> La decisión final fue que el proveedor `openai-codex` no soporta la API de lotes...

Before — stored fact still Spanish:
> El proveedor `openai-codex` no admite la API de lotes, por lo que el equipo fijó la variable correspondiente en falso...

After:
> The team determined that the `openai-codex` provider does not support the batch API and set the related feature flag to false; enabling it would break the retention process rather than accelerate it.

Russian and Chinese inputs likewise produced English only after the change. The `llm_requests` audit table confirmed both contradicting instructions were present in the same prompt beforehand.

## Fix — reflect (three sites, found in two rounds)

The issue assumed reflect was fine. It was not. Every place reflect stated a source-language rule did so unconditionally and deferred to "a directive above" that nothing ever put there:

| site | what wrote the answer | fix |
|---|---|---|
| `build_final_system_prompt` | forced-synthesis fallback (iteration cap, no tool call, context overflow) | rule via `default_language_section`; directive moved to the end of the **user** message (`build_final_prompt` / `build_reduce_prompt`) — see measurements below |
| `build_system_prompt_for_tools` | the `done()` tool call — **most reflect answers** (review, @Sanderhoff-alt) | rule hoisted to `_TOOLS_LANGUAGE_RULE`, via `default_language_section`; directive on the opening user message (`build_agent_user_prompt`) |
| `done` tool schema, `answer` description | read at the moment the answer is written, after everything else | `get_reflect_tools(llm_output_language=…)` strips the "SAME language" sentence and puts the directive on the tool description, so all three `done` variants (markdown / directive-aware / document) carry it |

The first round fixed only the first row. The LLM test then showed that even with the rule gone, "last in the system prompt" is not last — the question and the retrieved data arrive after it:

| reflect final synthesis | gemini-2.5-flash-lite | gemini-2.5-flash |
|---|---|---|
| directive last in the **system** prompt | 0/12 English | 0/5 English |
| directive last in the **user** message | 12/12 English | 5/5 English |

Retain needed no such move — its directive is followed from the system prompt. Extraction rewrites its input, where the instruction is the whole job; answering a question carries a strong prior to mirror the asker's language.

The review pointed out the second row: `build_final_system_prompt`'s sole caller is `_forced_final_synthesis`, so a normal run — ending in `done()` under `build_system_prompt_for_tools` — never saw the fix. Threading the setting there surfaced the third row, the tool schema's own rule, which is the genuinely-last thing the model reads on that path.

`default_language_section()`'s docstring now records the invariant: every prompt carrying such a rule selects it there, the `done` schema applies the same exclusion by hand, and nothing may append a rule of its own.

## Tests

Deterministic (`test_multilingual_bm25.py`, `test_reflect_prompt_builder.py`, `test_reflect_agent.py`, `test_llm_tools.py`):
- retain: `test_retain_directive_replaces_source_language_rule` (fails on all 4 modes without the fix) and `test_retain_unset_requires_source_language` (guards #181 — the rule must survive when unset).
- reflect: the same pair for `build_final_system_prompt`, for `build_system_prompt_for_tools` + `build_agent_user_prompt`, and for every `done` tool variant; plus a MockLLM run of `run_reflect_agent` to `done()` asserting the system prompt lacks the rule and the user message and tool schema carry the directive.

The existing retain tests only asserted the directive was *present*, never that the contradicting rule was *absent* — which is how this shipped.

Behavioural, `hs_llm_core` (`tests/test_retain_reflect_output_language.py`), mirroring `test_consolidation_output_language.py`, which had no retain or reflect counterpart. Chinese source material so an untranslated sentence is unmistakable to the judge; the language judgement is the judge's alone (a script gate would reject the proper nouns the criteria allow — review):
- `test_retain_configured_output_language_overrides_source_language` — real `extract_facts_from_text`.
- `test_reflect_done_path_configured_output_language_overrides_question_language` — real `run_reflect_agent` with mocked retrieval, asserting the answer did **not** come from forced synthesis (no `"final"` scope in `llm_trace`). Fails on the code before the second-round fix, passes after.
- `test_reflect_forced_synthesis_configured_output_language_overrides_question_language` — the exact system/user prompts and tool-less call `_forced_final_synthesis` makes.

Verified against `gemini-2.5-flash-lite` (the Core LLM job's model) and `gpt-4.1-mini` with Gemini as judge.

## Scope

Narrowed at review request — this PR is only the language fix, all prompt assembly. The #3756 retain-memory follow-ups originally stacked here (content-hash derivation, the sub-batch splitter, the screening cache, `_SubBatch.index`, `_flush()`, the benchmark imports) moved to #3787 and land on their own merits.
