### PR TITLE
fix(coding-agents): don't let a stray file at the dsh sessions root abort the history import

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/history.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/history.test.ts
@@ -1,12 +1,13 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { claudeProjectDir, importLocalHistory } from "./history";
 
 let home: string;
 afterEach(() => {
   if (home) rmSync(home, { recursive: true, force: true });
+  vi.unstubAllEnvs();
 });
 
 function newHome(): string {
@@ -125,6 +126,41 @@ describe("local history import", () => {
     const r = importLocalHistory("codex", "/repo/mine", h);
     expect(r.sessions).toHaveLength(1);
     expect(JSON.stringify(r.sessions)).toContain("found me");
+  });
+
+  // Regression: dshHistory guarded its root with existsSync — true for a regular file — and then
+  // called readdirSync on it unguarded, so a stray file at ~/.dsh/sessions threw ENOTDIR out of
+  // importLocalHistory, which documents that it never throws, and whose caller does not catch.
+  it("treats a regular file at the dsh sessions root as no sessions, not a crash", () => {
+    const h = newHome();
+    // The reader prefers $DSH_HOME over the home it is handed; a developer who runs dsh would
+    // otherwise have this test read their real sessions.
+    vi.stubEnv("DSH_HOME", join(h, ".dsh"));
+    mkdirSync(join(h, ".dsh"), { recursive: true });
+    writeFileSync(join(h, ".dsh", "sessions"), "not a folder");
+
+    const r = importLocalHistory("dsh", "/Users/x/dev/myrepo", h);
+    expect(r.supported).toBe(true);
+    expect(r.sessions).toEqual([]);
+  });
+
+  it("reads dsh sessions past a stray file where a project directory was expected", () => {
+    const h = newHome();
+    const repo = "/Users/x/dev/myrepo";
+    vi.stubEnv("DSH_HOME", join(h, ".dsh"));
+    const root = join(h, ".dsh", "sessions");
+    mkdirSync(join(root, "myrepo", "s1"), { recursive: true });
+    writeFileSync(
+      join(root, "myrepo", "s1", "session.jsonl"),
+      `${JSON.stringify({ id: "s1", cwd: repo })}\n` +
+        `${JSON.stringify({ type: "user/message", time: Date.parse("2026-08-14T10:00:00Z"), data: { role: "user", content: [{ type: "text", text: "real work" }], source: { kind: "user" } } })}\n`
+    );
+    writeFileSync(join(root, "stray"), "not a folder");
+
+    const r = importLocalHistory("dsh", repo, h);
+    expect(r.supported).toBe(true);
+    expect(r.sessions).toHaveLength(1);
+    expect(JSON.stringify(r.sessions)).toContain("real work");
   });
 
   it("reports SQLite-backed harnesses as unsupported with a reason, not an empty success", () => {

--- a/hindsight-integrations/coding-agents/src/core/history.ts
+++ b/hindsight-integrations/coding-agents/src/core/history.ts
@@ -234,7 +234,10 @@ function dshHistory(repoDir: string, home: string): HistoryImport {
   const root = process.env.DSH_HOME
     ? join(process.env.DSH_HOME, "sessions")
     : join(home, ".dsh", "sessions");
-  if (!existsSync(root)) return { supported: true, sessions: [] };
+  // listDir, not existsSync: a regular file at the sessions root passes existsSync and then makes
+  // readdirSync throw ENOTDIR out of importLocalHistory, which promises never to throw.
+  const projectDirs = listDir(root).map((project) => join(root, project));
+  if (projectDirs.length === 0) return { supported: true, sessions: [] };
   if (typeof zlib.zstdDecompressSync !== "function") {
     return {
       supported: false,
@@ -246,14 +249,8 @@ function dshHistory(repoDir: string, home: string): HistoryImport {
   }
   const sessions: ChatSession[] = [];
   let unattributed = 0;
-  for (const dir of readdirSync(root).map((project) => join(root, project))) {
-    let sessionDirs: string[];
-    try {
-      sessionDirs = readdirSync(dir).map((id) => join(dir, id));
-    } catch {
-      continue; // a stray file where a project directory was expected
-    }
-    for (const sessionDir of sessionDirs) {
+  for (const dir of projectDirs) {
+    for (const sessionDir of listDir(dir).map((id) => join(dir, id))) {
       const file = ["session.jsonl.zstd", "session.jsonl"]
         .map((name) => join(sessionDir, name))
         .find((candidate) => existsSync(candidate));


### PR DESCRIPTION
## Summary

Rebased onto main after #3812, which landed the `listDir` guard for the Claude reader plus its regression tests. What this branch still contributes is the dsh half of #3771:

- `dshHistory` guarded its root with `existsSync` — true for a regular **file** — and then called `readdirSync(root)` unguarded. A stray file at `~/.dsh/sessions` threw `ENOTDIR` out of `importLocalHistory`, which documents that it never throws, and out of `importConversations` in `installer.ts`, which has no catch of its own: the exact escape #3771 reports, for dsh instead of Claude.
- The root listing now goes through the module's `listDir`, and the per-project loop uses it too, so `dshHistory` drops its private try/catch. Side effect: the `existsSync` precheck and its TOCTOU window go away.

Closes #3771.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [ ] Documentation
- [ ] Refactor

## Test plan

- `src/core/history.test.ts` — new regression test seeds a regular file **at the sessions root**. Verified it fails with the reported error when `history.ts` is reverted to main (`Error: ENOTDIR: not a directory, scandir '…/.dsh/sessions'`) and passes with the change.
- Second test covers the per-project stray-file case, which had no `importLocalHistory` coverage for dsh. Both stub `$DSH_HOME` so they can't read a developer's real sessions.
- `npx vitest run src/core src/installer.test.ts` → 582 passed. `./scripts/hooks/lint.sh` clean.

## Notes for the reviewer

- Small behaviour change: an existing-but-empty sessions root now returns `supported: true, sessions: []` before the zstd capability check runs, instead of reporting "unsupported" on Node < 22.15. With nothing to decompress, that seemed the more honest answer; easy to reorder if you'd rather keep the old precedence.
- Left alone as out of scope: `codexHistory`'s walk is guarded at the opposite altitude (one unstattable entry discards everything found so far), `importLocalHistory` still has no top-level backstop for its never-throws contract, and `installer.ts` creates its tmpfile outside the try whose comment says a failed backfill must not fail the install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
