### PR TITLE
fix(retain): batch a document's chunk embeddings instead of one request per chunk

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -298,6 +298,8 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_EMBEDDINGS_PASSAGE_PREFIX="title: none | text: "
 # For TEI provider:
 # HINDSIGHT_API_EMBEDDINGS_TEI_URL=http://localhost:8080
+# Max texts per TEI /embed request; also the batch size retain coalesces a document's per-chunk embeddings up to
+# HINDSIGHT_API_EMBEDDINGS_TEI_BATCH_SIZE=32
 # For OpenAI-compatible embeddings:
 # HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY=sk-xxxx
 # HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL=text-embedding-3-small

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -399,6 +399,7 @@ ENV_EMBEDDINGS_ONNX_QUERY_PREFIX = "HINDSIGHT_API_EMBEDDINGS_ONNX_QUERY_PREFIX"
 ENV_EMBEDDINGS_ONNX_PASSAGE_PREFIX = "HINDSIGHT_API_EMBEDDINGS_ONNX_PASSAGE_PREFIX"
 ENV_EMBEDDINGS_ONNX_OUTPUT_NAME = "HINDSIGHT_API_EMBEDDINGS_ONNX_OUTPUT_NAME"
 ENV_EMBEDDINGS_TEI_URL = "HINDSIGHT_API_EMBEDDINGS_TEI_URL"
+ENV_EMBEDDINGS_TEI_BATCH_SIZE = "HINDSIGHT_API_EMBEDDINGS_TEI_BATCH_SIZE"
 ENV_EMBEDDINGS_OPENAI_API_KEY = "HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY"
 ENV_EMBEDDINGS_OPENAI_MODEL = "HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL"
 ENV_EMBEDDINGS_OPENAI_BASE_URL = "HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL"
@@ -990,6 +991,10 @@ DEFAULT_EMBEDDINGS_ONNX_QUERY_PREFIX = "query: "
 DEFAULT_EMBEDDINGS_ONNX_PASSAGE_PREFIX = "passage: "
 DEFAULT_EMBEDDINGS_OPENAI_MODEL = "text-embedding-3-small"
 DEFAULT_EMBEDDINGS_OPENAI_BATCH_SIZE = 100
+# Texts per TEI /embed request. Also the batch size the streaming retain producer
+# coalesces its per-chunk embedding calls up to (see embedding_coalescer), so raising
+# it is how a TEI deployment with headroom trades requests for larger ones.
+DEFAULT_EMBEDDINGS_TEI_BATCH_SIZE = 32
 DEFAULT_EMBEDDINGS_GEMINI_MODEL = "gemini-embedding-001"
 DEFAULT_EMBEDDINGS_GEMINI_OUTPUT_DIMENSIONALITY = 768
 DEFAULT_EMBEDDINGS_GEMINI_FORCE_IPV4 = False
@@ -2765,6 +2770,7 @@ class HindsightConfig:
     # Defaulted fields (source-compatible additions — existing direct constructor callers keep working).
     # Keep at the end of the dataclass; Python forbids non-default fields after default fields.
     embeddings_openai_batch_size: int = DEFAULT_EMBEDDINGS_OPENAI_BATCH_SIZE
+    embeddings_tei_batch_size: int = DEFAULT_EMBEDDINGS_TEI_BATCH_SIZE
     embeddings_openai_dimensions: int | None = None
     embeddings_query_prefix: str = DEFAULT_EMBEDDINGS_QUERY_PREFIX
     embeddings_passage_prefix: str = DEFAULT_EMBEDDINGS_PASSAGE_PREFIX
@@ -3506,6 +3512,11 @@ class HindsightConfig:
                 ENV_EMBEDDINGS_OPENAI_BATCH_SIZE,
                 os.getenv(ENV_EMBEDDINGS_OPENAI_BATCH_SIZE),
                 DEFAULT_EMBEDDINGS_OPENAI_BATCH_SIZE,
+            ),
+            embeddings_tei_batch_size=_parse_positive_int(
+                ENV_EMBEDDINGS_TEI_BATCH_SIZE,
+                os.getenv(ENV_EMBEDDINGS_TEI_BATCH_SIZE),
+                DEFAULT_EMBEDDINGS_TEI_BATCH_SIZE,
             ),
             embeddings_openai_dimensions=_parse_optional_positive_int(
                 ENV_EMBEDDINGS_OPENAI_DIMENSIONS,

--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -1692,7 +1692,12 @@ def create_embeddings_from_env() -> Embeddings:
         url = config.embeddings_tei_url
         if not url:
             raise ValueError(f"{ENV_EMBEDDINGS_TEI_URL} is required when {ENV_EMBEDDINGS_PROVIDER} is 'tei'")
-        return RemoteTEIEmbeddings(base_url=url, query_prefix=query_prefix, passage_prefix=passage_prefix)
+        return RemoteTEIEmbeddings(
+            base_url=url,
+            batch_size=config.embeddings_tei_batch_size,
+            query_prefix=query_prefix,
+            passage_prefix=passage_prefix,
+        )
     elif provider == "local":
         return LocalSTEmbeddings(
             model_name=config.embeddings_local_model,

--- a/hindsight-api-slim/hindsight_api/engine/retain/embedding_coalescer.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/embedding_coalescer.py
@@ -1,0 +1,225 @@
+"""Merge the streaming retain producer's per-chunk embedding calls into batched requests.
+
+The streaming producer fans out one task per chunk and each task embeds only its own
+chunk's facts. That is the right shape for the *extraction* path — every chunk needs
+its own LLM call and the fan-out lets those overlap — but it also makes every embedding
+call exactly one batch of one document wide. In ``chunks`` extraction mode extraction is
+a no-op, so that single round trip is the entire per-chunk cost and ingest throughput
+ends up bounded by it (issue #3784).
+
+``CoalescingEmbedder`` keeps the fan-out and moves the batching one layer down:
+concurrent callers park on a shared pending list, and each backend request carries
+whatever has accumulated. Nothing waits on a timer — a caller that arrives while a
+backend slot is free is dispatched on the very next event-loop tick — so a lone caller
+pays no added latency while a fan-out of N naturally forms batches of up to the
+backend's own per-request limit.
+"""
+
+import asyncio
+from collections import deque
+from dataclasses import dataclass
+
+from . import embedding_utils
+from .embedding_utils import EmbeddingsBackend
+
+# How many backend requests may be in flight at once. The dispatcher hands the first
+# request everything that is already runnable, so extra slots only come into play once
+# more than one batch worth of text is pending — there they let the overflow batches go
+# out concurrently instead of one after another. Kept small because each in-flight
+# request also occupies a thread of the default executor.
+MAX_CONCURRENT_REQUESTS = 4
+
+# Fallback per-request batch size for a backend that does not publish one (the local
+# SentenceTransformers and ONNX backends do their own internal batching).
+DEFAULT_MAX_BATCH_SIZE = 64
+
+
+@dataclass
+class _Waiter:
+    """One caller's texts and the future its embeddings are delivered to."""
+
+    texts: list[str]
+    future: asyncio.Future[list[list[float]]]
+
+
+@dataclass
+class CoalescerStats:
+    """What the coalescer actually sent, for the retain log.
+
+    Running totals rather than a per-request list: a large document produces
+    thousands of requests, and retain is the path that has to stay flat in
+    memory (#3756).
+    """
+
+    texts: int = 0
+    requests: int = 0
+    largest_request: int = 0
+
+    def record(self, batch_texts: int) -> None:
+        self.texts += batch_texts
+        self.requests += 1
+        self.largest_request = max(self.largest_request, batch_texts)
+
+    def describe(self) -> str:
+        if not self.requests:
+            return "Embeddings: no texts embedded"
+        return (
+            f"Embeddings: {self.texts} texts in {self.requests} backend request(s) "
+            f"(avg {self.texts / self.requests:.1f}, max {self.largest_request} texts per request)"
+        )
+
+
+def resolve_max_batch_size(embeddings_backend: EmbeddingsBackend) -> int:
+    """Batch at the backend's own per-request limit, not above it.
+
+    Every remote backend splits an oversized list into ``batch_size``-sized requests
+    *inside one executor thread*, so handing it more than that trades N concurrent
+    requests for N sequential ones. Sizing the coalescer's batches from the backend
+    means TEI's ``HINDSIGHT_API_EMBEDDINGS_TEI_BATCH_SIZE`` (and the OpenAI/Cohere/
+    ZeroEntropy equivalents) tunes the coalescer too, with no second knob.
+    """
+    backend_batch_size = getattr(embeddings_backend, "batch_size", None)
+    if isinstance(backend_batch_size, int) and backend_batch_size > 0:
+        return backend_batch_size
+    return DEFAULT_MAX_BATCH_SIZE
+
+
+class CoalescingEmbedder:
+    """Batches concurrent document-embedding requests into shared backend calls.
+
+    One instance serves ONE retain call. That is deliberate: the backends read the
+    ambient bank id for per-bank cost attribution (see ``bank_attribution``), so texts
+    from different banks must never share a request.
+
+    Duck-typed against the retain embedding path: ``embedding_processing.
+    generate_embeddings_batch`` dispatches to ``embed_documents_async`` when the object
+    it is handed exposes one, and falls back to the plain backend call otherwise.
+    """
+
+    def __init__(
+        self,
+        embeddings_backend: EmbeddingsBackend,
+        *,
+        max_batch_size: int | None = None,
+        max_concurrent_requests: int = MAX_CONCURRENT_REQUESTS,
+    ) -> None:
+        self._backend = embeddings_backend
+        self._max_batch_size = max_batch_size or resolve_max_batch_size(embeddings_backend)
+        self._slots = asyncio.Semaphore(max_concurrent_requests)
+        self._pending: deque[_Waiter] = deque()
+        self._dispatcher: asyncio.Task | None = None
+        self._in_flight: set[asyncio.Task] = set()
+        self._closed = False
+        self.stats = CoalescerStats()
+
+    @property
+    def dimension(self) -> int:
+        return self._backend.dimension
+
+    async def embed_documents_async(self, texts: list[str]) -> list[list[float]]:
+        """Embed ``texts`` as retained document text, sharing a request where possible."""
+        if not texts:
+            return []
+        if self._closed:
+            raise RuntimeError("CoalescingEmbedder is closed")
+        waiter = _Waiter(texts=texts, future=asyncio.get_running_loop().create_future())
+        self._pending.append(waiter)
+        self._ensure_dispatcher()
+        return await waiter.future
+
+    def close(self) -> None:
+        """Stop dispatching and cancel anything still parked.
+
+        Synchronous so it is safe in a ``finally`` that runs while the retain is being
+        cancelled — there is nothing to wait for. Requests already in flight are left
+        to finish; they hold their own reference to this object, deliver into futures
+        that are checked before use, and their ``finally`` finds the coalescer closed
+        so no further request is dispatched.
+        """
+        self._closed = True
+        dispatcher, self._dispatcher = self._dispatcher, None
+        if dispatcher is not None and not dispatcher.done():
+            dispatcher.cancel()
+        for waiter in self._pending:
+            if not waiter.future.done():
+                waiter.future.cancel()
+        self._pending.clear()
+
+    def _ensure_dispatcher(self) -> None:
+        if self._closed:
+            return
+        if self._dispatcher is None or self._dispatcher.done():
+            self._dispatcher = asyncio.create_task(self._dispatch_loop())
+
+    async def _dispatch_loop(self) -> None:
+        """Turn the pending list into backend requests until it runs dry.
+
+        Waiting for a free slot *before* taking the batch is what makes this coalesce:
+        while every slot is busy the pending list keeps growing, and the next request
+        carries all of it. When a slot is free the single ``sleep(0)`` is the only
+        delay — just enough for the callers that are already runnable (the producer
+        schedules its whole chunk fan-out in one go) to join this batch.
+        """
+        while self._pending:
+            await self._slots.acquire()
+            try:
+                await asyncio.sleep(0)
+                batch = self._take_batch()
+            except BaseException:
+                self._slots.release()
+                raise
+            if not batch:
+                self._slots.release()
+                return
+            request = asyncio.create_task(self._run_request(batch))
+            self._in_flight.add(request)
+            request.add_done_callback(self._in_flight.discard)
+
+    def _take_batch(self) -> list[_Waiter]:
+        """Pop whole waiters off the pending list up to the per-request text budget.
+
+        A waiter is never split across requests: keeping its texts together is what
+        lets ``_run_request`` slice the results back out by length alone. A single
+        waiter larger than the budget goes out on its own, where the backend applies
+        its own splitting.
+        """
+        batch: list[_Waiter] = []
+        budget = 0
+        while self._pending:
+            waiter = self._pending[0]
+            if batch and budget + len(waiter.texts) > self._max_batch_size:
+                break
+            batch.append(self._pending.popleft())
+            budget += len(waiter.texts)
+        return batch
+
+    async def _run_request(self, batch: list[_Waiter]) -> None:
+        try:
+            texts = [text for waiter in batch for text in waiter.texts]
+            try:
+                embeddings = await embedding_utils.generate_embeddings_batch(self._backend, texts)
+            except BaseException as exc:
+                # Every rider on a failed request has to see the failure — silently
+                # dropping them would commit the document with those facts missing.
+                for waiter in batch:
+                    if not waiter.future.done():
+                        waiter.future.set_exception(exc)
+                        # The caller may already be gone (a cancelled producer task).
+                        # Retrieve the exception so it is not reported as unhandled.
+                        waiter.future.exception()
+                if isinstance(exc, asyncio.CancelledError):
+                    raise
+                return
+            self.stats.record(len(texts))
+            offset = 0
+            for waiter in batch:
+                count = len(waiter.texts)
+                if not waiter.future.done():
+                    waiter.future.set_result(embeddings[offset : offset + count])
+                offset += count
+        finally:
+            self._slots.release()
+            # A waiter that arrived after the dispatch loop drained the list has no
+            # dispatcher to pick it up; restart one now that a slot is free again.
+            if self._pending:
+                self._ensure_dispatcher()

--- a/hindsight-api-slim/hindsight_api/engine/retain/embedding_processing.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/embedding_processing.py
@@ -51,7 +51,10 @@ async def generate_embeddings_batch(embeddings_model, texts: list[str]) -> list[
     Generate embeddings for a batch of texts.
 
     Args:
-        embeddings_model: Embeddings model instance
+        embeddings_model: Embeddings backend, or a wrapper around one that batches
+            concurrent callers together (``CoalescingEmbedder``, used by the streaming
+            retain producer — see issue #3784). Such a wrapper is recognised by its
+            ``embed_documents_async`` method; anything else is a plain backend.
         texts: List of text strings to embed
 
     Returns:
@@ -59,6 +62,10 @@ async def generate_embeddings_batch(embeddings_model, texts: list[str]) -> list[
     """
     if not texts:
         return []
+
+    embed_batched = getattr(embeddings_model, "embed_documents_async", None)
+    if embed_batched is not None:
+        return await embed_batched(texts)
 
     embeddings = await embedding_utils.generate_embeddings_batch(embeddings_model, texts)
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -282,6 +282,7 @@ from . import (
     fact_storage,
     link_creation,
 )
+from .embedding_coalescer import CoalescingEmbedder
 from .memory_budget import RetainMemoryBudget, estimate_chunk_bytes
 from .types import (
     CausalRelation,
@@ -2305,6 +2306,14 @@ async def _streaming_retain_batch(
             f"Document {effective_doc_id} was updated by a concurrent retain while this append was extracting"
         )
 
+    # Every chunk task embeds only its own chunk's facts, which makes each embedding
+    # call one text wide — and in `chunks` extraction mode, where there is no LLM call
+    # to overlap, that single round trip is the whole per-chunk cost (issue #3784).
+    # The coalescer keeps the fan-out and batches the concurrent embedding calls
+    # underneath it. One per retain: the backends read the ambient bank id for cost
+    # attribution, so texts from different banks must not share a request.
+    coalescing_embedder = CoalescingEmbedder(embeddings_model)
+
     # ---- LLM Producer ----
     # Fires all chunk extractions as concurrent tasks (bounded by the LLM
     # semaphore inside fact_extraction to 32 concurrent).  As each completes
@@ -2335,7 +2344,7 @@ async def _streaming_retain_batch(
                     llm_config,
                     agent_name,
                     config,
-                    embeddings_model,
+                    coalescing_embedder,
                     format_date_fn,
                     fact_type_override,
                     log_buffer,
@@ -2390,6 +2399,11 @@ async def _streaming_retain_batch(
             for extraction in tasks:
                 if not extraction.done():
                     extraction.cancel()
+            # Same reasoning for the coalescer: its dispatcher is a task of its own and
+            # a cancelled fan-out would otherwise leave it — and anything parked on
+            # it — alive for the life of the process.
+            coalescing_embedder.close()
+            log_buffer.append(f"[streaming] {coalescing_embedder.stats.describe()}")
 
     # ---- DB Consumer ----
     # Drains enriched chunks from the queue in batches and runs

--- a/hindsight-api-slim/tests/test_embedding_coalescer.py
+++ b/hindsight-api-slim/tests/test_embedding_coalescer.py
@@ -1,0 +1,210 @@
+"""Tests for the streaming retain producer's embedding coalescer (issue #3784).
+
+The producer fans out one task per chunk and each task embeds only its own chunk's
+facts, so every embedding call used to be one text wide — in ``chunks`` extraction
+mode that single round trip is the whole per-chunk cost. ``CoalescingEmbedder`` keeps
+the fan-out and batches the concurrent calls underneath it.
+"""
+
+import asyncio
+
+import pytest
+
+from hindsight_api.engine.retain.embedding_coalescer import (
+    DEFAULT_MAX_BATCH_SIZE,
+    CoalescingEmbedder,
+    resolve_max_batch_size,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class FakeBackend:
+    """Records every encode() call so tests can assert on request shape.
+
+    The vector encodes its own text so a mis-sliced result is caught, not just a
+    mis-counted one.
+    """
+
+    def __init__(self, *, batch_size: int | None = None, delay: float = 0.0) -> None:
+        self.calls: list[list[str]] = []
+        self.delay = delay
+        if batch_size is not None:
+            self.batch_size = batch_size
+
+    @property
+    def provider_name(self) -> str:
+        return "fake"
+
+    @property
+    def dimension(self) -> int:
+        return 2
+
+    async def initialize(self) -> None:
+        return None
+
+    def encode(self, texts: list[str]) -> list[list[float]]:
+        self.calls.append(list(texts))
+        if self.delay:
+            import time
+
+            time.sleep(self.delay)
+        return [[float(len(text)), float(hash(text) % 1000)] for text in texts]
+
+    def encode_documents(self, texts: list[str]) -> list[list[float]]:
+        return self.encode(texts)
+
+    def encode_query(self, texts: list[str]) -> list[list[float]]:
+        return self.encode(texts)
+
+
+def _expected(text: str) -> list[float]:
+    return [float(len(text)), float(hash(text) % 1000)]
+
+
+async def test_concurrent_callers_share_one_backend_request() -> None:
+    """The fan-out the producer creates collapses into a single encode() call."""
+    backend = FakeBackend(batch_size=100)
+    embedder = CoalescingEmbedder(backend)
+
+    texts = [f"chunk-{i}" for i in range(30)]
+    results = await asyncio.gather(*[embedder.embed_documents_async([text]) for text in texts])
+
+    assert len(backend.calls) == 1
+    assert backend.calls[0] == texts
+    assert results == [[_expected(text)] for text in texts]
+    assert embedder.stats.requests == 1
+    assert embedder.stats.texts == 30
+
+
+async def test_each_caller_gets_its_own_slice_in_order() -> None:
+    """Multi-text callers are sliced back out of the shared response by length."""
+    backend = FakeBackend(batch_size=100)
+    embedder = CoalescingEmbedder(backend)
+
+    groups = [["a"], ["bb", "ccc"], ["dddd", "eeeee", "ffffff"]]
+    results = await asyncio.gather(*[embedder.embed_documents_async(group) for group in groups])
+
+    assert len(backend.calls) == 1
+    assert results == [[_expected(text) for text in group] for group in groups]
+
+
+async def test_lone_caller_is_dispatched_without_waiting() -> None:
+    """A single caller pays no batching delay — nothing waits on a timer."""
+    backend = FakeBackend(batch_size=100)
+    embedder = CoalescingEmbedder(backend)
+
+    assert await embedder.embed_documents_async(["only"]) == [_expected("only")]
+    assert backend.calls == [["only"]]
+
+
+async def test_batches_never_exceed_the_backend_batch_size() -> None:
+    """Requests are sized from the backend's own per-request limit."""
+    backend = FakeBackend(batch_size=8)
+    embedder = CoalescingEmbedder(backend)
+
+    texts = [f"chunk-{i}" for i in range(25)]
+    results = await asyncio.gather(*[embedder.embed_documents_async([text]) for text in texts])
+
+    assert all(len(call) <= 8 for call in backend.calls)
+    assert [text for call in backend.calls for text in call] == texts
+    assert results == [[_expected(text)] for text in texts]
+
+
+async def test_caller_larger_than_the_budget_goes_out_alone() -> None:
+    """A waiter is never split: the backend applies its own splitting instead."""
+    backend = FakeBackend(batch_size=4)
+    embedder = CoalescingEmbedder(backend)
+
+    big = [f"big-{i}" for i in range(10)]
+    results = await asyncio.gather(
+        embedder.embed_documents_async(big),
+        embedder.embed_documents_async(["small"]),
+    )
+
+    assert big in backend.calls
+    assert results[0] == [_expected(text) for text in big]
+    assert results[1] == [_expected("small")]
+
+
+async def test_backend_failure_reaches_every_caller_in_the_batch() -> None:
+    """One bad request must fail all of its riders, not silently drop them."""
+
+    class ExplodingBackend(FakeBackend):
+        def encode(self, texts: list[str]) -> list[list[float]]:
+            raise RuntimeError("embeddings backend down")
+
+    embedder = CoalescingEmbedder(ExplodingBackend(batch_size=100))
+
+    results = await asyncio.gather(
+        *[embedder.embed_documents_async([f"chunk-{i}"]) for i in range(5)],
+        return_exceptions=True,
+    )
+
+    assert len(results) == 5
+    for result in results:
+        assert isinstance(result, Exception)
+        assert "embeddings backend down" in str(result)
+
+
+async def test_empty_input_never_reaches_the_backend() -> None:
+    backend = FakeBackend(batch_size=100)
+    embedder = CoalescingEmbedder(backend)
+
+    assert await embedder.embed_documents_async([]) == []
+    assert backend.calls == []
+
+
+async def test_close_cancels_parked_callers_and_stops_dispatching() -> None:
+    """A cancelled retain must not leave the dispatcher or a caller's future alive."""
+    backend = FakeBackend(batch_size=100, delay=0.05)
+    embedder = CoalescingEmbedder(backend, max_concurrent_requests=1)
+
+    first = asyncio.create_task(embedder.embed_documents_async(["first"]))
+    await asyncio.sleep(0)
+    # Parked behind the in-flight request, so it is still on the pending list.
+    parked = asyncio.create_task(embedder.embed_documents_async(["parked"]))
+    await asyncio.sleep(0)
+
+    embedder.close()
+
+    with pytest.raises(asyncio.CancelledError):
+        await parked
+    await asyncio.gather(first, return_exceptions=True)
+    assert embedder._dispatcher is None
+
+    with pytest.raises(RuntimeError, match="closed"):
+        await embedder.embed_documents_async(["after-close"])
+
+
+async def test_serves_more_batches_than_the_concurrency_limit() -> None:
+    """Every caller is served even when the pending list outruns the slot count."""
+    backend = FakeBackend(batch_size=2)
+    embedder = CoalescingEmbedder(backend, max_concurrent_requests=2)
+
+    texts = [f"chunk-{i}" for i in range(20)]
+    results = await asyncio.gather(*[embedder.embed_documents_async([text]) for text in texts])
+
+    assert results == [[_expected(text)] for text in texts]
+    assert sum(len(call) for call in backend.calls) == 20
+
+
+async def test_callers_arriving_after_a_drain_restart_the_dispatcher() -> None:
+    """A second wave with no dispatcher running still gets served."""
+    backend = FakeBackend(batch_size=100)
+    embedder = CoalescingEmbedder(backend)
+
+    await asyncio.gather(*[embedder.embed_documents_async([f"first-{i}"]) for i in range(3)])
+    await asyncio.gather(*[embedder.embed_documents_async([f"second-{i}"]) for i in range(3)])
+
+    assert len(backend.calls) == 2
+    assert backend.calls[1] == ["second-0", "second-1", "second-2"]
+
+
+async def test_resolve_max_batch_size_prefers_the_backend_limit() -> None:
+    assert resolve_max_batch_size(FakeBackend(batch_size=17)) == 17
+
+
+async def test_resolve_max_batch_size_falls_back_for_backends_without_one() -> None:
+    """Local backends do their own internal batching and publish no per-request limit."""
+    assert resolve_max_batch_size(FakeBackend()) == DEFAULT_MAX_BATCH_SIZE

--- a/hindsight-api-slim/tests/test_retain_chunks_embedding_batching.py
+++ b/hindsight-api-slim/tests/test_retain_chunks_embedding_batching.py
@@ -1,0 +1,140 @@
+"""Retain embeds a document's chunks in batches, not one request per chunk (#3784).
+
+In ``chunks`` extraction mode there is no LLM call to overlap, so the single-text
+embedding request the streaming producer used to issue per chunk *was* the entire
+per-chunk cost — ingest sat at a flat ~21 chunks/s regardless of document size. These
+tests assert on the shape of what reaches the embeddings backend, which is the thing
+that actually changed; wall-clock would be a flaky proxy for it.
+"""
+
+import os
+import uuid
+
+import pytest
+
+from hindsight_api.config import clear_config_cache
+from hindsight_api.models import RequestContext
+
+pytestmark = pytest.mark.asyncio
+
+
+class CountingEmbeddings:
+    """Wraps the session embeddings backend and records the shape of every encode()."""
+
+    # What the coalescer sizes its batches from.
+    batch_size = 100
+
+    def __init__(self, inner) -> None:
+        self._inner = inner
+        self.document_calls: list[int] = []
+
+    @property
+    def provider_name(self) -> str:
+        return "counting"
+
+    @property
+    def dimension(self) -> int:
+        return self._inner.dimension
+
+    async def initialize(self) -> None:
+        await self._inner.initialize()
+
+    def encode(self, texts: list[str]) -> list[list[float]]:
+        return self._inner.encode(texts)
+
+    def encode_documents(self, texts: list[str]) -> list[list[float]]:
+        self.document_calls.append(len(texts))
+        return self._inner.encode_documents(texts)
+
+    def encode_query(self, texts: list[str]) -> list[list[float]]:
+        return self._inner.encode_query(texts)
+
+
+@pytest.fixture
+def chunks_mode():
+    """Run retain in ``chunks`` extraction mode, where extraction is a no-op."""
+    saved = os.environ.get("HINDSIGHT_API_RETAIN_EXTRACTION_MODE")
+    os.environ["HINDSIGHT_API_RETAIN_EXTRACTION_MODE"] = "chunks"
+    clear_config_cache()
+    yield
+    if saved is None:
+        os.environ.pop("HINDSIGHT_API_RETAIN_EXTRACTION_MODE", None)
+    else:
+        os.environ["HINDSIGHT_API_RETAIN_EXTRACTION_MODE"] = saved
+    clear_config_cache()
+
+
+async def _prepare_bank(memory, bank_id: str) -> None:
+    """Keep the counters on the retain path only.
+
+    Auto-consolidation runs inline under the tests' synchronous task backend and
+    embeds each observation on its own, which has nothing to do with what the retain
+    producer sends.
+    """
+    await memory.update_bank_config(
+        bank_id,
+        {"enable_auto_consolidation": False, "enable_observations": False},
+        request_context=RequestContext(),
+    )
+
+
+def _document(sentences: int) -> str:
+    """A document whose sentences are all distinct, so no chunk is deduped away.
+
+    Long enough to span several chunks at the default ``retain_chunk_size``.
+    """
+    return " ".join(
+        f"Sentence number {index} describes topic {index} in unmistakable detail and at "
+        f"considerable length, so that the text around position {index} is unlike the text "
+        f"anywhere else in this document and hashes to a chunk of its own."
+        for index in range(sentences)
+    )
+
+
+async def test_chunks_mode_embeds_a_document_in_batched_requests(chunks_mode, memory):
+    """One document's chunks reach the backend together, not one request each."""
+    bank_id = f"test-3784-batched-{uuid.uuid4().hex[:8]}"
+    await _prepare_bank(memory, bank_id)
+    counting = CountingEmbeddings(memory.embeddings)
+    memory.embeddings = counting
+
+    unit_ids = await memory.retain_async(
+        bank_id,
+        _document(160),
+        document_id="doc-3784",
+        request_context=RequestContext(),
+    )
+
+    assert len(unit_ids) > 5, "test needs a genuinely multi-chunk document"
+    assert counting.document_calls, "no document embeddings were generated"
+    # The pre-fix path issued exactly one request per chunk, every one a single text.
+    assert len(counting.document_calls) < len(unit_ids)
+    assert max(counting.document_calls) > 1
+
+
+async def test_every_chunk_still_becomes_its_own_memory(chunks_mode, memory):
+    """Batching must not merge, drop, or reorder chunks."""
+    bank_id = f"test-3784-alignment-{uuid.uuid4().hex[:8]}"
+    await _prepare_bank(memory, bank_id)
+    counting = CountingEmbeddings(memory.embeddings)
+    memory.embeddings = counting
+
+    document = _document(120)
+    unit_ids = await memory.retain_async(
+        bank_id,
+        document,
+        document_id="doc-3784-alignment",
+        request_context=RequestContext(),
+    )
+
+    assert sum(counting.document_calls) == len(unit_ids)
+
+    listed = await memory.list_memory_units(
+        bank_id,
+        limit=len(unit_ids) + 10,
+        request_context=RequestContext(),
+    )
+    assert listed["total"] == len(unit_ids)
+    # chunks mode stores the raw chunk text, so every unit must be document text.
+    for unit in listed["items"]:
+        assert unit["text"] in document

--- a/hindsight-api-slim/tests/test_tei_embeddings.py
+++ b/hindsight-api-slim/tests/test_tei_embeddings.py
@@ -119,3 +119,56 @@ def test_persistent_too_many_requests_exhausts_retry_budget() -> None:
 
     assert attempts == 3
     assert isinstance(exc_info.value.__context__, httpx.HTTPStatusError)
+
+
+def test_default_tei_batch_size_is_32() -> None:
+    """Unset env keeps the historical 32 texts per /embed request."""
+    import os
+
+    from hindsight_api.config import HindsightConfig
+
+    saved_provider = os.environ.get("HINDSIGHT_API_LLM_PROVIDER")
+    saved_batch = os.environ.pop("HINDSIGHT_API_EMBEDDINGS_TEI_BATCH_SIZE", None)
+    os.environ["HINDSIGHT_API_LLM_PROVIDER"] = "mock"
+    try:
+        assert HindsightConfig.from_env().embeddings_tei_batch_size == 32
+    finally:
+        if saved_batch is not None:
+            os.environ["HINDSIGHT_API_EMBEDDINGS_TEI_BATCH_SIZE"] = saved_batch
+        if saved_provider is None:
+            os.environ.pop("HINDSIGHT_API_LLM_PROVIDER", None)
+        else:
+            os.environ["HINDSIGHT_API_LLM_PROVIDER"] = saved_provider
+
+
+def test_tei_batch_size_env_var_reaches_the_client() -> None:
+    """The configured batch size is what encode() splits on, not the hardcoded 32."""
+    import os
+
+    from hindsight_api.config import HindsightConfig, clear_config_cache
+    from hindsight_api.engine.embeddings import create_embeddings_from_env
+
+    saved = {
+        key: os.environ.get(key)
+        for key in (
+            "HINDSIGHT_API_LLM_PROVIDER",
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER",
+            "HINDSIGHT_API_EMBEDDINGS_TEI_URL",
+            "HINDSIGHT_API_EMBEDDINGS_TEI_BATCH_SIZE",
+        )
+    }
+    os.environ["HINDSIGHT_API_LLM_PROVIDER"] = "mock"
+    os.environ["HINDSIGHT_API_EMBEDDINGS_PROVIDER"] = "tei"
+    os.environ["HINDSIGHT_API_EMBEDDINGS_TEI_URL"] = "http://localhost:8080"
+    os.environ["HINDSIGHT_API_EMBEDDINGS_TEI_BATCH_SIZE"] = "128"
+    clear_config_cache()
+    try:
+        assert HindsightConfig.from_env().embeddings_tei_batch_size == 128
+        assert create_embeddings_from_env().batch_size == 128
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        clear_config_cache()

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -681,6 +681,7 @@ server-level only (not overridable per tenant/bank) and a change requires a rest
 | `HINDSIGHT_API_EMBEDDINGS_ONNX_PASSAGE_PREFIX` | Prefix applied to stored memory/document text before ONNX embedding. Keep `passage: ` for E5 models; set to empty for non-E5 models such as MiniLM or BGE. | `passage: ` |
 | `HINDSIGHT_API_EMBEDDINGS_ONNX_OUTPUT_NAME` | Optional ONNX output name to request when an exported graph exposes a pooled embedding output. | - |
 | `HINDSIGHT_API_EMBEDDINGS_TEI_URL` | TEI server URL | - |
+| `HINDSIGHT_API_EMBEDDINGS_TEI_BATCH_SIZE` | Max texts per TEI `/embed` request. Also the batch size retain coalesces a document's per-chunk embeddings up to, so raise it when the TEI deployment has headroom for larger requests | `32` |
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY` | OpenAI API key (falls back to `HINDSIGHT_API_LLM_API_KEY`) | - |
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL` | OpenAI embedding model | `text-embedding-3-small` |
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL` | Custom base URL for OpenAI-compatible API (e.g., Azure OpenAI) | - |

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -298,6 +298,8 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_EMBEDDINGS_PASSAGE_PREFIX="title: none | text: "
 # For TEI provider:
 # HINDSIGHT_API_EMBEDDINGS_TEI_URL=http://localhost:8080
+# Max texts per TEI /embed request; also the batch size retain coalesces a document's per-chunk embeddings up to
+# HINDSIGHT_API_EMBEDDINGS_TEI_BATCH_SIZE=32
 # For OpenAI-compatible embeddings:
 # HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY=sk-xxxx
 # HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL=text-embedding-3-small

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -681,6 +681,7 @@ server-level only (not overridable per tenant/bank) and a change requires a rest
 | `HINDSIGHT_API_EMBEDDINGS_ONNX_PASSAGE_PREFIX` | Prefix applied to stored memory/document text before ONNX embedding. Keep `passage: ` for E5 models; set to empty for non-E5 models such as MiniLM or BGE. | `passage: ` |
 | `HINDSIGHT_API_EMBEDDINGS_ONNX_OUTPUT_NAME` | Optional ONNX output name to request when an exported graph exposes a pooled embedding output. | - |
 | `HINDSIGHT_API_EMBEDDINGS_TEI_URL` | TEI server URL | - |
+| `HINDSIGHT_API_EMBEDDINGS_TEI_BATCH_SIZE` | Max texts per TEI `/embed` request. Also the batch size retain coalesces a document's per-chunk embeddings up to, so raise it when the TEI deployment has headroom for larger requests | `32` |
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY` | OpenAI API key (falls back to `HINDSIGHT_API_LLM_API_KEY`) | - |
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL` | OpenAI embedding model | `text-embedding-3-small` |
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL` | Custom base URL for OpenAI-compatible API (e.g., Azure OpenAI) | - |


### PR DESCRIPTION
Fixes #3784.

## The defect

In `chunks` extraction mode a retain issued **one embedding request per chunk**. The streaming
producer fans out one task per chunk and each task calls `_extract_and_embed([content], ...)`, so
`embedding_processing.generate_embeddings_batch` — which already takes a `list[str]` — was never
handed more than one text on that path.

That shape is right for the *extraction* path: every chunk needs its own LLM call and the fan-out
lets those overlap. In `chunks` mode extraction is a no-op, so the single round trip is the entire
per-chunk cost, and ingest ends up bounded by it.

Reproduced before touching anything — one request per chunk, `texts/request = 1.0`, at every
document size.

## The fix

Keep the fan-out and move the batching one layer down: `engine/retain/embedding_coalescer.py`.

Concurrent callers park on a shared pending list; the dispatcher waits for a free backend slot
**before** taking a batch — that is what makes it coalesce, since the pending list keeps growing
while every slot is busy — then yields once so every already-runnable caller joins that batch.
Nothing waits on a timer, so a caller that arrives while a slot is free is dispatched on the next
event-loop tick and pays **no** added latency.

Two deliberate constraints:

- **One coalescer per retain.** The backends read the ambient bank id for per-bank cost attribution
  (`bank_attribution.apply_bank_attribution` → the OpenAI `user` field), so texts from different
  banks must never share a request.
- **Batch size comes from the backend's own `batch_size`,** not a new knob. Every remote backend
  splits an oversized list into `batch_size`-sized requests *inside one executor thread*, so handing
  it more just trades N concurrent requests for N sequential ones.

Because of that second point this also adds `HINDSIGHT_API_EMBEDDINGS_TEI_BATCH_SIZE` (default 32,
previously hardcoded, mirroring `HINDSIGHT_API_RERANKER_TEI_BATCH_SIZE`) — it now tunes the TEI
request size *and* what the coalescer batches up to, with no second setting.

The retain log gains a per-document line so the shape is visible in production:

```
[streaming] Embeddings: 622 texts in 29 backend request(s) (avg 21.4, max 22 texts per request)
```

## Measured

Producer fan-out, 600 chunks, against a TEI stub (separate process — an in-process stub steals the
GIL and fabricates ~38 ms/call):

| stub latency | before | after |
|---|---|---|
| 2 ms | 601 chunks/s, 600 requests | **2874 chunks/s, 19 requests** |
| 10 ms | 977 chunks/s, 600 requests | **2894 chunks/s, 19 requests** |
| 30 ms | 443 chunks/s, 600 requests | **1728 chunks/s, 19 requests** |

End to end on a 900k-char document: **622 embed requests → 29**. Wall-clock end-to-end on a local
Postgres is a wash (median 4.27 s vs 4.47 s) — the write txn and the ANN pass account for
essentially all of it there, which is why the producer benchmark is the signal.

## The other half of the issue — why the fan-out isn't achieving its concurrency

The issue asks to confirm this, and the answer is **not** the embeddings. `DEFAULT_RETAIN_BATCH_TOKENS
= 10_000` (~32k chars ≈ 22 chunks at `retain_chunk_size` 1500) makes
`_split_contents_into_sub_batches` cut every document into ~22-chunk sub-batches that run
**sequentially**, each with its own document tracking, recovery chunk-hash scan and final ANN pass.
So `retain_chunk_batch_size = 100` is never reached — the log line `batch_size 100 — 1 batch` is
describing a slice that only ever holds 22 chunks. That is why the reported rate stays flat across
three orders of magnitude of document size, and it also caps how much this PR can batch (22 texts
per request instead of 32).

Left alone here on purpose: that budget exists to bound retain memory (#1571, #3756), so raising it
is its own trade-off with its own measurements. Worth its own issue.

## Tests

- `test_embedding_coalescer.py` — 12 unit tests: the fan-out collapses to one request, each caller
  gets its own slice back in order, a lone caller is dispatched without waiting, batches never
  exceed the backend limit, an over-budget caller goes alone, a backend failure reaches every rider
  on the request, `close()` cancels parked callers, callers arriving after a drain restart the
  dispatcher.
- `test_retain_chunks_embedding_batching.py` — 2 integration tests on the real retain path.
  Verified the first **fails without the fix** (12 requests of 1 text each).
- `test_tei_embeddings.py` — the new env var defaults to 32 and reaches the client.
- 1329 existing tests across retain / delta / chunk / embed / transfer / memory-defense pass.

https://claude.ai/code/session_01HVZ94d143NPSsZjbnvwqba
