### PR TITLE
fix(benchmarks): repair retain_memory's imports of removed engine symbols

### DIFF
--- a/hindsight-dev/benchmarks/perf/retain_memory.py
+++ b/hindsight-dev/benchmarks/perf/retain_memory.py
@@ -105,22 +105,22 @@ def build_document(target_chars: int) -> str:
 
 
 def run(doc_mb: int, chunk_size: int) -> list[Measurement]:
-    from hindsight_api.engine.memory_engine import _split_contents_into_sub_batches
+    from hindsight_api.engine.memory_engine import _iter_raw_sub_batches
     from hindsight_api.engine.retain import fact_extraction
-    from hindsight_api.engine.token_encoding import count_tokens_windowed
+    from hindsight_api.engine.token_encoding import count_tokens
 
     doc = build_document(doc_mb * 1024 * 1024)
     print(f"document: {len(doc):,} chars ({len(doc) / 1024 / 1024:.1f} MB), chunk_size={chunk_size}")
 
-    # Load tiktoken's encoding table before measuring. It is ~80 MB, paid once per process
-    # and shared with recall, so it is a worker's startup cost rather than a retain's.
-    count_tokens_windowed(_FILLER)
+    # Load the tokenizer's vocabulary before measuring. It is parsed once per process and
+    # shared with recall, so it is a worker's startup cost rather than a retain's.
+    count_tokens(_FILLER)
     print(f"resident before measurement: {_current_rss_mb():.1f} MB\n")
 
     return [
         measure(
-            "sizing check (windowed)",
-            lambda: count_tokens_windowed(doc),
+            "sizing check (count_tokens)",
+            lambda: count_tokens(doc),
             lambda n: f"{n:,} tokens",
         ),
         # What retain does: consume chunks one at a time, never holding the list. Both the
@@ -138,17 +138,22 @@ def run(doc_mb: int, chunk_size: int) -> list[Measurement]:
             lambda: fact_extraction.chunk_text(doc, chunk_size, structured_chunk_size=None),
             lambda chunks: f"{len(chunks):,} chunks",
         ),
-        # Also about one copy of the document: the returned slices ARE the document, cut up
-        # for the caller to process sequentially.
+        # The splitter's slices ARE the document, cut up for the caller to process
+        # sequentially, so collecting them cost about one copy of the document. #3770 made
+        # it yield instead, which is why this consumes the iterator rather than listing it:
+        # what it allocates now is one sub-batch, not the whole split.
         measure(
-            "split into sub-batches",
-            lambda: _split_contents_into_sub_batches(
-                [{"content": doc}],
-                _SUB_BATCH_TOKENS,
-                chunk_size=chunk_size,
-                structured_chunk_size=None,
+            "split into sub-batches (streamed)",
+            lambda: sum(
+                1
+                for _ in _iter_raw_sub_batches(
+                    [{"content": doc}],
+                    _SUB_BATCH_TOKENS,
+                    chunk_size=chunk_size,
+                    structured_chunk_size=None,
+                )
             ),
-            lambda split: f"{len(split.sub_batches):,} sub-batches",
+            lambda n: f"{n:,} sub-batches",
         ),
     ]
 


### PR DESCRIPTION
## Problem

`hindsight-dev/benchmarks/perf/retain_memory.py` could not start. Both symbols it
imports from the engine had been removed out from under it, so the benchmark died
in `run()` before measuring anything:

```
ImportError: cannot import name 'count_tokens_windowed' from 'hindsight_api.engine.token_encoding'
ImportError: cannot import name '_split_contents_into_sub_batches' from 'hindsight_api.engine.memory_engine'
```

Two separate PRs each removed one of them:

- **`count_tokens_windowed`** — deleted by #3788 (quicktok). `count()` returns an int
  without building a list of ids, so it allocates nothing and is *exact*; the windowed
  approximation #3756 introduced (encode a megabyte at a time, accept a fixed character
  cut that can split a token) has no reason to exist. Now calls `count_tokens`.
- **`_split_contents_into_sub_batches`** — replaced by the streaming
  `_iter_raw_sub_batches` in #3770. The row now consumes the iterator rather than
  listing it, which is what the retain loop actually does.

Also drops the comment describing tiktoken's ~80 MB encoding table, which no longer
applies, and renames the two affected rows so the labels match what they measure.

## Verification

`uv run --directory hindsight-dev python -m benchmarks.perf.retain_memory --mb 2`

```
step                                       time     allocated     retained   detail
-----------------------------------------------------------------------------------------------
sizing check (count_tokens)                0.0s         0.0 MB       +6.0 MB   517,107 tokens
chunking, streamed (iter_chunks)           0.2s         0.0 MB       +0.0 MB   1,437 chunks
chunking, materialised (chunk_text)        0.3s         2.1 MB       -6.2 MB   1,437 chunks
split into sub-batches (streamed)          0.4s         0.2 MB      -11.5 MB   54 sub-batches
```

The sizing row reporting 0.0 MB allocated — where it used to be the dominant cost, and
the whole reason #3756 was filed — is the count-only API, not a broken measurement.

## Notes (not addressed here)

- **Nothing runs this benchmark in CI** (`grep -rn 'benchmarks/perf' .github/workflows`
  → no hits), which is why it rotted twice without anyone noticing. Wiring it up is a
  bigger question than this fix — it wants a machine whose numbers are comparable
  run-to-run — so I've left it out.
- Seven docstrings/comments in `memory_engine.py` and `retain/orchestrator.py` still
  refer to `_split_contents_into_sub_batches` as though it exists. Out of scope for a
  benchmark fix; worth a follow-up sweep.
