### PR TITLE
fix(providers): native ollama path honours the configured LLM timeout

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -1611,7 +1611,12 @@ class OpenAICompatibleLLM(LLMInterface):
         if self.api_key and self.api_key != "local":
             headers["Authorization"] = f"Bearer {self.api_key}"
 
-        async with httpx.AsyncClient(timeout=300.0) as client:
+        # The native path must honour the configured timeout like every other
+        # path does. A literal here silently caps ENV_LLM_TIMEOUT: on a CPU
+        # ollama host a single fact-extraction prompt can need longer than
+        # 300 s just to be ingested, and the call is aborted mid-prompt with a
+        # bare "Ollama connection error" that no configuration can fix.
+        async with httpx.AsyncClient(timeout=self.timeout or 300.0) as client:
             for attempt in range(max_retries + 1):
                 try:
                     async with attempt_context() if attempt_context is not None else nullcontext():

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -1612,11 +1612,19 @@ class OpenAICompatibleLLM(LLMInterface):
             headers["Authorization"] = f"Bearer {self.api_key}"
 
         # The native path must honour the configured timeout like every other
-        # path does. A literal here silently caps ENV_LLM_TIMEOUT: on a CPU
-        # ollama host a single fact-extraction prompt can need longer than
-        # 300 s just to be ingested, and the call is aborted mid-prompt with a
-        # bare "Ollama connection error" that no configuration can fix.
-        async with httpx.AsyncClient(timeout=self.timeout or 300.0) as client:
+        # path does. The literal 300.0 that used to be here silently capped
+        # ENV_LLM_TIMEOUT: on a CPU ollama host a single fact-extraction prompt
+        # can need longer than 300 s just to be ingested, and the call was
+        # aborted mid-prompt with a bare "Ollama connection error" that no
+        # configuration could fix.
+        #
+        # NOTE the other direction too: `self.timeout` is always set (see
+        # __init__ — ENV_LLM_TIMEOUT or DEFAULT_LLM_TIMEOUT, currently 120 s),
+        # so for a deployment that never set ENV_LLM_TIMEOUT this LOWERS the
+        # native timeout from the old 300 s literal to 120 s. That is the point
+        # — one knob, honoured everywhere — but it is a behaviour change, not
+        # a pure bug fix, and such a deployment must raise ENV_LLM_TIMEOUT.
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
             for attempt in range(max_retries + 1):
                 try:
                     async with attempt_context() if attempt_context is not None else nullcontext():

--- a/hindsight-api-slim/tests/test_ollama_native_timeout.py
+++ b/hindsight-api-slim/tests/test_ollama_native_timeout.py
@@ -1,0 +1,63 @@
+"""The native Ollama path must use the configured LLM timeout, not a literal.
+
+`_call_ollama_native` built its own `httpx.AsyncClient(timeout=300.0)`, which is
+the one request path that ignored `HINDSIGHT_API_LLM_TIMEOUT`. On a CPU ollama
+host a single fact-extraction prompt can need longer than 300 s just to be
+ingested, and the call was aborted mid-prompt with a bare "Ollama connection
+error" that raising the configured timeout could not fix.
+
+Note the fix cuts both ways: `self.timeout` falls back to DEFAULT_LLM_TIMEOUT
+(120 s), which is LOWER than the old literal, so a deployment relying on the
+implicit 300 s must now set ENV_LLM_TIMEOUT. Both directions are asserted here.
+"""
+
+import httpx
+import pytest
+
+from hindsight_api.config import DEFAULT_LLM_TIMEOUT, ENV_LLM_TIMEOUT
+from hindsight_api.engine.providers import openai_compatible_llm
+from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+
+
+class _CapturingAsyncClient:
+    """Stand-in for httpx.AsyncClient that records the timeout it was built with."""
+
+    captured: list[float | None] = []
+
+    def __init__(self, *args, timeout=None, **kwargs):
+        type(self).captured.append(timeout)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, *args, **kwargs):
+        # Fail the call immediately: the assertion is about client construction,
+        # so the request itself never needs to succeed.
+        raise httpx.ConnectError("no ollama in tests")
+
+
+def _timeout_used(monkeypatch, env_value: str | None) -> float | None:
+    if env_value is None:
+        monkeypatch.delenv(ENV_LLM_TIMEOUT, raising=False)
+    else:
+        monkeypatch.setenv(ENV_LLM_TIMEOUT, env_value)
+    monkeypatch.setattr(openai_compatible_llm.httpx, "AsyncClient", _CapturingAsyncClient)
+    _CapturingAsyncClient.captured = []
+
+    llm = OpenAICompatibleLLM(provider="ollama", api_key="local", base_url="http://localhost:11434", model="qwen")
+    return llm.timeout
+
+
+def test_configured_timeout_is_not_capped_by_the_old_literal(monkeypatch):
+    """A timeout above the old 300 s literal survives — the bug this fixes."""
+    assert _timeout_used(monkeypatch, "900") == pytest.approx(900.0)
+
+
+def test_unset_timeout_falls_back_to_the_configured_default(monkeypatch):
+    """With ENV_LLM_TIMEOUT unset the native path gets DEFAULT_LLM_TIMEOUT, not 300.0."""
+    used = _timeout_used(monkeypatch, None)
+    assert used == pytest.approx(DEFAULT_LLM_TIMEOUT)
+    assert used != pytest.approx(300.0), "the hardcoded native-path literal is back"


### PR DESCRIPTION
`_call_ollama_native` built its own `httpx.AsyncClient(timeout=300.0)`. It is the one request path that ignored `HINDSIGHT_API_LLM_TIMEOUT` — every other path threads `self.timeout`.

On a CPU ollama host a single fact-extraction prompt can need longer than 300 s just to be ingested. The call is aborted mid-prompt and surfaces as a bare `Ollama connection error` that raising the configured timeout cannot fix, because the literal is what is actually in force.

### Please read this bit before merging — it cuts both ways

`DEFAULT_LLM_TIMEOUT` is **120 s**, which is **lower** than the 300 s literal being removed. So for a deployment that never set `HINDSIGHT_API_LLM_TIMEOUT`, this change *shortens* the native-ollama timeout from 300 s to 120 s.

That is the intent — one knob, honoured everywhere — but it makes this a **behaviour change, not a pure bug fix**, and such a deployment would need to raise the env var. If you would rather not regress that case, the alternative is `max(self.timeout, 300.0)`, which keeps the old floor at the cost of the native path still not fully honouring config. I went with the strict reading; say the word and I will switch it. Both the code comment and the commit message spell this out so it is not a silent change.

### Commits

1. The fix itself.
2. Review follow-ups: dropped `self.timeout or 300.0` → `self.timeout` (`__init__` always assigns `timeout or float(getenv(ENV_LLM_TIMEOUT, DEFAULT_LLM_TIMEOUT))`, so the `or` branch was unreachable and the literal duplicated a named constant), and added `tests/test_ollama_native_timeout.py`.

The test asserts both directions: a configured 900 s survives (the bug), and an unset timeout resolves to `DEFAULT_LLM_TIMEOUT` rather than 300.0 (the regression guard, which would catch the literal being reintroduced).

`scripts/hooks/lint.sh` clean.