### PR TITLE
test: restore the metrics collector global after each test

### DIFF
--- a/hindsight-api-slim/tests/conftest.py
+++ b/hindsight-api-slim/tests/conftest.py
@@ -111,6 +111,36 @@ def _cleanup_leaked_span_recorders():
             recorders.remove(recorder)
 
 
+@pytest.fixture(autouse=True)
+def _restore_metrics_collector():
+    """Undo an app startup's swap of the process-global metrics collector.
+
+    ``metrics._metrics_collector`` defaults to ``NoOpMetricsCollector``, and the
+    API lifespan replaces it with the real one (``create_metrics_collector()`` in
+    api/http.py) for the rest of the process — nothing restores it. Under xdist
+    that means every test scheduled after any app-starting test in the same worker
+    runs against the real collector.
+
+    That matters because the no-op swallows its arguments while the real collector
+    compares them: a test mocking an LLM response leaves
+    ``response.usage...cached_tokens`` a ``MagicMock``, and ``record_llm_call``'s
+    ``if cached_input_tokens > 0`` then raises ``TypeError: '>' not supported
+    between instances of 'MagicMock' and 'int'``. The victims move between runs
+    with the xdist schedule, which is what makes it read as random flakiness
+    (v0.9.2: 36 such failures in one run, a partly different set in the next).
+
+    ``test_metrics.py::test_returns_noop_by_default`` already saves and restores
+    this global by hand; this generalises that guard to every test, the same way
+    ``_cleanup_leaked_span_recorders`` above guards the recorder registry.
+    """
+    from hindsight_api import metrics
+
+    before = metrics._metrics_collector
+    yield
+    if metrics._metrics_collector is not before:
+        metrics._metrics_collector = before
+
+
 # Default pg0 instance configuration for tests
 DEFAULT_PG0_INSTANCE_NAME = "hindsight-test"
 DEFAULT_PG0_PORT = int(os.environ.get("HINDSIGHT_TEST_PG_PORT", "5556"))


### PR DESCRIPTION
## The problem

`hindsight_api.metrics._metrics_collector` is a module-level global that defaults to `NoOpMetricsCollector`. The API lifespan swaps it for the real collector (`create_metrics_collector()` in `api/http.py`) and nothing puts it back, so under xdist **every test scheduled after any app-starting test in the same worker runs against the real collector**.

That is not a neutral difference. The no-op swallows its arguments; the real collector compares them. A test that mocks an LLM response leaves `response.usage.prompt_tokens_details.cached_tokens` a `MagicMock`, and `record_llm_call`'s `if cached_input_tokens > 0` raises:

```
TypeError: '>' not supported between instances of 'MagicMock' and 'int'
```

Which tests fail depends on the xdist schedule, so the set moves between runs and reads as random flakiness. Every one of them passes in isolation.

## Measured on v0.9.2

`pytest tests/ -q -m "not hs_llm_mat and not hs_llm_core"` on a clean `v0.9.2` checkout produced **36** of these `TypeError`s. A second run of the same tree produced a partly different set — same code, different victims.

Hit hardest: `test_lmstudio_tool_choice.py`, `test_tool_path_reasoning_effort.py`, `test_tool_choice_required_downgrade.py`, `test_reasoning_effort_explicit_config.py`.

## The fix

Snapshot the global before each test, restore it after — the same guard the neighbouring `_cleanup_leaked_span_recorders` fixture already applies to the span-recorder registry. `test_metrics.py::test_returns_noop_by_default` also already does this by hand for itself; this generalises it to every test.

Test-only: no shipped behaviour changes.

## Reproducer

```python
# tests/test_aaa_probe.py — stands in for any app-starting test
from hindsight_api.metrics import create_metrics_collector, initialize_metrics

def test_probe():
    initialize_metrics(service_name="probe", service_version="0")
    create_metrics_collector()
```

```
pytest tests/test_aaa_probe.py tests/test_lmstudio_tool_choice.py \
       tests/test_tool_path_reasoning_effort.py -p no:randomly
```

Before: `2 failed, 16 passed`. After: `18 passed`.

## Notes

I checked that nothing depends on the real collector surviving a test: the only test that reads the live global is `test_llm_token_metrics.py::test_noop_collector_when_metrics_disabled`, which asserts it *is* the no-op — it is a latent victim of the same leak, so this makes it more reliable, not less. `test_base_path.py::test_base_path_metrics` reads the Prometheus registry via `generate_latest()`, not this global, and is unaffected.