### PR TITLE
fix(search): score pg_textsearch results per row

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
@@ -308,7 +308,7 @@ class PostgreSQLDialect(SQLDialect):
             # score so only genuine term matches survive into fusion/reranking.
             bm25_where_filter = f"AND -(search_vector <&> to_bm25query('idx_memory_units_text_search', tokenize({text_param}, 'llmlingua2'))) > {bm25_min_score:g}"
         elif text_search_extension == "pg_textsearch":
-            bm25_score_expr = f"-({text_param} <@> to_bm25query({text_param}, 'idx_memory_units_text_search'))"
+            bm25_score_expr = f"-(text <@> to_bm25query({text_param}, 'idx_memory_units_text_search'))"
             bm25_order_by = f"text <@> to_bm25query({text_param}, 'idx_memory_units_text_search') ASC"
             bm25_where_filter = ""
         elif text_search_extension == "pgroonga":

--- a/hindsight-api-slim/tests/test_db_abstraction.py
+++ b/hindsight-api-slim/tests/test_db_abstraction.py
@@ -287,6 +287,21 @@ class TestPostgreSQLDialect:
         )
         assert "> 2.5" in arm
 
+    def test_build_bm25_arm_pg_textsearch_scores_each_row(self, d):
+        arm = d.build_bm25_arm(
+            table="schema.memory_units",
+            cols="id, text",
+            fact_type="world",
+            bank_id_param="$2",
+            limit_param="$3",
+            text_param="$4",
+            text_search_extension="pg_textsearch",
+        )
+        expected_distance = "text <@> to_bm25query($4, 'idx_memory_units_text_search')"
+        assert f"-({expected_distance}) AS bm25_score" in arm
+        assert f"ORDER BY {expected_distance} ASC" in arm
+        assert "$4 <@>" not in arm
+
     def test_build_bm25_arm_pgroonga(self, d):
         arm = d.build_bm25_arm(
             table="schema.memory_units",


### PR DESCRIPTION
Fixes #3794.

The `pg_textsearch` score expression used the query parameter on both sides of `<@>`, so every result received the same keyword score. Use the row `text` column on the left, matching the existing `ORDER BY` expression.

Adds a regression test that verifies the score and ordering both use the row text while preserving the query bind parameter.

Validation:
- `pytest -n 2 tests/test_db_abstraction.py::TestPostgreSQLDialect` (38 passed)
- Ruff check and format check
- `ty check hindsight_api/engine/sql/postgresql.py`