### PR TITLE
fix: recover Codex OAuth refresh after shared auth rotation

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/codex_auth.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/codex_auth.py
@@ -431,34 +431,46 @@ class CodexAuthManager:
                         "Run 'codex auth login' to re-authenticate."
                     )
 
-                log_reason = f" ({reason})" if reason else ""
-                logger.info(f"Refreshing Codex OAuth access_token{log_reason}")
+                response: httpx.Response | None = None
+                refresh_attempt = 0
+                while True:
+                    log_reason = f" ({reason})" if reason else ""
+                    logger.info(f"Refreshing Codex OAuth access_token{log_reason}")
 
-                request_access_token = self.access_token
-                request_refresh_token = self.refresh_token
-                request_body = {
-                    "client_id": _CODEX_CLIENT_ID,
-                    "grant_type": "refresh_token",
-                    "refresh_token": request_refresh_token,
-                }
-                try:
-                    response = self._http_client.post(
-                        _CODEX_REFRESH_TOKEN_URL,
-                        json=request_body,
-                        headers={"Content-Type": "application/json"},
-                        timeout=30.0,
-                    )
-                except httpx.RequestError as e:
-                    raise RuntimeError(f"Codex OAuth refresh network error: {type(e).__name__}") from e
+                    request_access_token = self.access_token
+                    request_refresh_token = self.refresh_token
+                    request_body = {
+                        "client_id": _CODEX_CLIENT_ID,
+                        "grant_type": "refresh_token",
+                        "refresh_token": request_refresh_token,
+                    }
+                    try:
+                        response = self._http_client.post(
+                            _CODEX_REFRESH_TOKEN_URL,
+                            json=request_body,
+                            headers={"Content-Type": "application/json"},
+                            timeout=30.0,
+                        )
+                    except httpx.RequestError as e:
+                        raise RuntimeError(f"Codex OAuth refresh network error: {type(e).__name__}") from e
 
-                if response.status_code == 401:
+                    if response.status_code != 401:
+                        break
+
                     error_code = self._extract_oauth_error_code(response)
                     disk_tokens = self._load_tokens_from_file(self._auth_file)
                     if disk_tokens and (
                         disk_tokens.get("access_token") != request_access_token
                         or disk_tokens.get("refresh_token") != request_refresh_token
                     ):
+                        previous_refresh_token = self.refresh_token
                         self._adopt_tokens(disk_tokens)
+                        if self._token_is_fresh_with_known_expiry():
+                            return
+                        if self.refresh_token and self.refresh_token != previous_refresh_token and refresh_attempt == 0:
+                            refresh_attempt += 1
+                            logger.info("Retrying Codex OAuth refresh with newer refresh_token from auth.json")
+                            continue
                         return
                     if error_code in _CODEX_TERMINAL_REFRESH_ERROR_CODES:
                         raise CodexRefreshExpiredError(

--- a/hindsight-api-slim/hindsight_api/engine/providers/codex_auth.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/codex_auth.py
@@ -422,7 +422,13 @@ class CodexAuthManager:
             with _codex_auth_lock(self._auth_file):
                 disk_tokens = self._load_tokens_from_file(self._auth_file)
                 if disk_tokens and self._adopt_tokens(disk_tokens):
-                    if force or self._token_is_fresh_with_known_expiry():
+                    # Only skip the network refresh when the adopted token is
+                    # demonstrably usable. A reactive (force) caller is here
+                    # because the server rejected its token, and its one retry
+                    # is spent on whatever we return: adopting a token that is
+                    # merely *different* — but itself past expiry, or with an
+                    # unparseable exp — burns that retry on a second 401.
+                    if self._token_is_fresh_with_known_expiry():
                         return
 
                 if not self.refresh_token:
@@ -431,12 +437,11 @@ class CodexAuthManager:
                         "Run 'codex auth login' to re-authenticate."
                     )
 
-                response: httpx.Response | None = None
+                log_reason = f" ({reason})" if reason else ""
+                logger.info(f"Refreshing Codex OAuth access_token{log_reason}")
+
                 refresh_attempt = 0
                 while True:
-                    log_reason = f" ({reason})" if reason else ""
-                    logger.info(f"Refreshing Codex OAuth access_token{log_reason}")
-
                     request_access_token = self.access_token
                     request_refresh_token = self.refresh_token
                     request_body = {

--- a/hindsight-api-slim/tests/test_codex_oauth_refresh.py
+++ b/hindsight-api-slim/tests/test_codex_oauth_refresh.py
@@ -36,18 +36,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-
-@pytest.fixture(autouse=True)
-def _isolate_codex_home(tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Keep Codex auth tests from touching a developer's real Codex home."""
-    home = tmp_path_factory.mktemp("codex-home")
-    codex_home = home / ".codex"
-    codex_home.mkdir(parents=True)
-    monkeypatch.setenv("HOME", str(home))
-    monkeypatch.setenv("CODEX_HOME", str(codex_home))
-    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
-
-
 from hindsight_api.engine.providers.codex_llm import (
     _CODEX_CLIENT_ID,
     _CODEX_REFRESH_TOKEN_URL,
@@ -55,6 +43,23 @@ from hindsight_api.engine.providers.codex_llm import (
     CodexLLM,
     CodexRefreshExpiredError,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_codex_home(tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep Codex auth tests off the developer's (or CI's) real Codex home.
+
+    ``default_codex_auth_file()`` reads ``$CODEX_HOME`` and falls back to
+    ``Path.home() / ".codex"``, so any test that constructs a provider without
+    an explicit auth path would otherwise pick up real credentials on a machine
+    where Codex is actually logged in. Both inputs are redirected at a tmp dir.
+    """
+    home = tmp_path_factory.mktemp("codex-home")
+    codex_home = home / ".codex"
+    codex_home.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
 
 
 def _make_jwt(exp_unixtime: int | None) -> str:
@@ -509,8 +514,13 @@ def test_refresh_token_reused_retries_with_newer_disk_refresh_token_when_disk_ac
     assert manager.refresh_token == "rt-final"
 
 
-def test_force_refresh_token_reused_does_not_skip_refresh_when_disk_access_is_stale(tmp_path: Path):
-    """Reactive force refresh must still refresh when adopted disk access is stale."""
+def test_force_refresh_retries_with_newer_disk_refresh_token_after_reuse_401(tmp_path: Path):
+    """The reuse-401 retry is reachable from the reactive path too.
+
+    ``force=True`` bypasses the JWT-clock gate, so a token the client still
+    considers fresh (but the server rejected) reaches the refresh call and then
+    the same rotate-under-us recovery as the proactive path.
+    """
     old_fresh_access = _make_jwt(int(time.time()) + 3600)
     disk_stale_access = _make_jwt(int(time.time()) - 30)
     final_access = _make_jwt(int(time.time()) + 3600)
@@ -543,6 +553,51 @@ def test_force_refresh_token_reused_does_not_skip_refresh_when_disk_access_is_st
         manager.refresh_tokens(reason="reactive", force=True)
 
     assert requests == ["rt-old", "rt-disk-new"]
+    assert manager.access_token == final_access
+    assert manager.refresh_token == "rt-final"
+
+
+def test_force_refresh_does_not_skip_when_disk_already_rotated_to_a_stale_access_token(tmp_path: Path):
+    """Adopting a *different* on-disk token is not enough to skip the refresh.
+
+    Reactive callers get exactly one retry (``CodexOAuthEmbeddings.encode``
+    retries ``super().encode`` once on ``AuthenticationError``). If auth.json
+    was rotated by another Codex process long enough ago that its access token
+    has itself expired, returning it spends that retry on a second 401 and
+    fails the whole call. Only a token that is fresh by the JWT clock may
+    short-circuit the network refresh.
+    """
+    memory_access = _make_jwt(int(time.time()) + 3600)  # clock-fresh, but server rejected it
+    disk_stale_access = _make_jwt(int(time.time()) - 30)  # newer on disk, already expired
+    final_access = _make_jwt(int(time.time()) + 3600)
+
+    auth_file = _make_codex_auth_file(tmp_path, memory_access, refresh_token="rt-old")
+    manager = CodexAuthManager.from_file(auth_file)
+
+    # Another Codex process rotated auth.json before this caller takes the lock.
+    auth_file.write_text(
+        json.dumps(
+            {
+                "auth_mode": "chatgpt",
+                "tokens": {
+                    "access_token": disk_stale_access,
+                    "refresh_token": "rt-disk-new",
+                    "account_id": "acct-test",
+                },
+            }
+        )
+    )
+
+    requests: list[str] = []
+
+    def fake_post(url, **kwargs):
+        requests.append(kwargs["json"]["refresh_token"])
+        return _refresh_response(200, {"access_token": final_access, "refresh_token": "rt-final"})
+
+    with patch.object(manager._http_client, "post", new=fake_post):
+        manager.refresh_tokens(reason="reactive (401 from embeddings API)", force=True)
+
+    assert requests == ["rt-disk-new"], "force refresh returned without refreshing"
     assert manager.access_token == final_access
     assert manager.refresh_token == "rt-final"
 
@@ -750,8 +805,7 @@ def test_codex_oauth_embeddings_picks_up_refreshed_token_on_encode(tmp_path: Pat
     new_access = _make_jwt(int(time.time()) + 3600)
 
     _make_codex_auth_file(tmp_path, expired, refresh_token="rt-embed")
-    monkeypatch.delenv("CODEX_HOME", raising=False)
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
 
     emb = CodexOAuthEmbeddings(model="text-embedding-3-small", batch_size=10)
 
@@ -782,8 +836,7 @@ def test_codex_oauth_embeddings_reactive_refresh_on_401(tmp_path: Path, monkeypa
     new_access = _make_jwt(int(time.time()) + 7200)
 
     _make_codex_auth_file(tmp_path, fresh, refresh_token="rt-embed")
-    monkeypatch.delenv("CODEX_HOME", raising=False)
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
 
     emb = CodexOAuthEmbeddings(model="text-embedding-3-small", batch_size=10)
     emb._dimension = 1536

--- a/hindsight-api-slim/tests/test_codex_oauth_refresh.py
+++ b/hindsight-api-slim/tests/test_codex_oauth_refresh.py
@@ -36,6 +36,18 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+
+@pytest.fixture(autouse=True)
+def _isolate_codex_home(tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep Codex auth tests from touching a developer's real Codex home."""
+    home = tmp_path_factory.mktemp("codex-home")
+    codex_home = home / ".codex"
+    codex_home.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+
 from hindsight_api.engine.providers.codex_llm import (
     _CODEX_CLIENT_ID,
     _CODEX_REFRESH_TOKEN_URL,
@@ -421,6 +433,120 @@ def test_sibling_auth_manager_adopts_rotated_codex_credentials(tmp_path: Path):
     assert sibling.refresh_token == "rt-new"
 
 
+def test_refresh_token_reused_adopts_fresh_disk_access_token_without_second_refresh(tmp_path: Path):
+    """If auth.json has a fresh access token after reuse, adopt it without refreshing again."""
+    expired = _make_jwt(int(time.time()) - 60)
+    disk_access = _make_jwt(int(time.time()) + 3600)
+    auth_file = _make_codex_auth_file(tmp_path, expired, refresh_token="rt-old")
+
+    manager = CodexAuthManager.from_file(auth_file)
+    requests: list[str] = []
+
+    def fake_post(url, **kwargs):
+        request_json = kwargs["json"]
+        requests.append(request_json["refresh_token"])
+        auth_file.write_text(
+            json.dumps(
+                {
+                    "auth_mode": "chatgpt",
+                    "tokens": {
+                        "access_token": disk_access,
+                        "refresh_token": "rt-disk-new",
+                        "account_id": "acct-test",
+                    },
+                }
+            )
+        )
+        return _refresh_response(401, {"error": {"code": "refresh_token_reused"}})
+
+    with patch.object(manager._http_client, "post", new=fake_post):
+        manager.refresh_tokens(reason="test")
+
+    assert requests == ["rt-old"]
+    assert manager.access_token == disk_access
+    assert manager.refresh_token == "rt-disk-new"
+
+
+def test_refresh_token_reused_retries_with_newer_disk_refresh_token_when_disk_access_is_stale(tmp_path: Path):
+    """If auth.json moves but disk access is stale, retry once with disk refresh token."""
+    expired = _make_jwt(int(time.time()) - 60)
+    replacement_access = _make_jwt(int(time.time()) - 30)
+    final_access = _make_jwt(int(time.time()) + 3600)
+    auth_file = _make_codex_auth_file(tmp_path, expired, refresh_token="rt-old")
+
+    manager = CodexAuthManager.from_file(auth_file)
+    requests: list[str] = []
+
+    def fake_post(url, **kwargs):
+        request_json = kwargs["json"]
+        requests.append(request_json["refresh_token"])
+        if len(requests) == 1:
+            assert request_json["refresh_token"] == "rt-old"
+            # Simulate another Codex process rotating auth.json while this
+            # request is in flight, leaving an access token that is still stale
+            # for this caller but a newer refresh token that can recover.
+            auth_file.write_text(
+                json.dumps(
+                    {
+                        "auth_mode": "chatgpt",
+                        "tokens": {
+                            "access_token": replacement_access,
+                            "refresh_token": "rt-disk-new",
+                            "account_id": "acct-test",
+                        },
+                    }
+                )
+            )
+            return _refresh_response(401, {"error": {"code": "refresh_token_reused"}})
+        assert request_json["refresh_token"] == "rt-disk-new"
+        return _refresh_response(200, {"access_token": final_access, "refresh_token": "rt-final"})
+
+    with patch.object(manager._http_client, "post", new=fake_post):
+        manager.refresh_tokens(reason="test")
+
+    assert requests == ["rt-old", "rt-disk-new"]
+    assert manager.access_token == final_access
+    assert manager.refresh_token == "rt-final"
+
+
+def test_force_refresh_token_reused_does_not_skip_refresh_when_disk_access_is_stale(tmp_path: Path):
+    """Reactive force refresh must still refresh when adopted disk access is stale."""
+    old_fresh_access = _make_jwt(int(time.time()) + 3600)
+    disk_stale_access = _make_jwt(int(time.time()) - 30)
+    final_access = _make_jwt(int(time.time()) + 3600)
+    auth_file = _make_codex_auth_file(tmp_path, old_fresh_access, refresh_token="rt-old")
+
+    manager = CodexAuthManager.from_file(auth_file)
+    requests: list[str] = []
+
+    def fake_post(url, **kwargs):
+        request_json = kwargs["json"]
+        requests.append(request_json["refresh_token"])
+        if len(requests) == 1:
+            auth_file.write_text(
+                json.dumps(
+                    {
+                        "auth_mode": "chatgpt",
+                        "tokens": {
+                            "access_token": disk_stale_access,
+                            "refresh_token": "rt-disk-new",
+                            "account_id": "acct-test",
+                        },
+                    }
+                )
+            )
+            return _refresh_response(401, {"error": {"code": "refresh_token_reused"}})
+        assert request_json["refresh_token"] == "rt-disk-new"
+        return _refresh_response(200, {"access_token": final_access, "refresh_token": "rt-final"})
+
+    with patch.object(manager._http_client, "post", new=fake_post):
+        manager.refresh_tokens(reason="reactive", force=True)
+
+    assert requests == ["rt-old", "rt-disk-new"]
+    assert manager.access_token == final_access
+    assert manager.refresh_token == "rt-final"
+
+
 def test_parallel_auth_managers_share_one_refresh_for_same_auth_file(tmp_path: Path):
     """Separate managers in one process should single-flight per canonical auth path."""
     expired = _make_jwt(int(time.time()) - 60)
@@ -624,6 +750,7 @@ def test_codex_oauth_embeddings_picks_up_refreshed_token_on_encode(tmp_path: Pat
     new_access = _make_jwt(int(time.time()) + 3600)
 
     _make_codex_auth_file(tmp_path, expired, refresh_token="rt-embed")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
     emb = CodexOAuthEmbeddings(model="text-embedding-3-small", batch_size=10)
@@ -655,6 +782,7 @@ def test_codex_oauth_embeddings_reactive_refresh_on_401(tmp_path: Path, monkeypa
     new_access = _make_jwt(int(time.time()) + 7200)
 
     _make_codex_auth_file(tmp_path, fresh, refresh_token="rt-embed")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
     emb = CodexOAuthEmbeddings(model="text-embedding-3-small", batch_size=10)


### PR DESCRIPTION
## Summary

This hardens Codex OAuth refresh handling for long-lived Hindsight processes that share Codex CLI auth state with other processes (e.g. an interactive `codex` session rotating `auth.json` underneath the API server).

Two failure modes, both ending in a hard auth error on a perfectly recoverable state:

**1. Refresh token already rotated elsewhere (401 from the refresh endpoint).** Hindsight now re-reads `auth.json` under the shared lock and recovers when possible:

- If the disk access token is fresh, Hindsight adopts it and avoids an unnecessary second refresh.
- If the disk access token is stale but the disk refresh token changed, Hindsight retries refresh once with the newer disk refresh token.
- If disk credentials did not change or still cannot recover, Hindsight continues to surface the existing terminal auth error.

**2. `auth.json` already rotated *before* the lock was taken.** The pre-lock adopt path short-circuited on `force or _token_is_fresh_with_known_expiry()`, so a reactive caller returned any on-disk token that merely *differed* from the one in memory — including one already past its `exp`. Reactive callers get exactly one retry (`CodexOAuthEmbeddings.encode` retries `super().encode` once on `AuthenticationError`), so handing back a dead token spent that retry on a second 401 and failed the whole call. The short-circuit is now gated on the JWT clock alone.

Also drops a dead `response = None` initializer and hoists the "Refreshing…" log line out of the retry loop so it is not emitted twice per refresh.

## Test coverage

Regression coverage for both races, plus isolation so these tests never read a developer's or CI runner's real Codex credentials (`$CODEX_HOME` and `Path.home()` are both redirected at a tmp dir — without this, `test_codex_oauth_embeddings_picks_up_refreshed_token_on_encode` fails on any machine where Codex is actually logged in).

Each new test was confirmed to fail against the unpatched provider.

## Test Plan

- `uv run pytest -n0 tests/test_codex_oauth_refresh.py tests/test_codex_home_env.py tests/test_codex_request_headers.py tests/test_embeddings_openai_batch_size.py -q`
- Wider local sweep — all 8 `test_codex_*`, both `test_nous_*`, 3 embeddings suites: 107 passed
- `./scripts/hooks/lint.sh`
- `uv run ty check hindsight_api/engine/providers/codex_auth.py`
- `git diff --check`
