### PR TITLE
retain: rebuild an oversized item's sub-batch from its original span

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -813,6 +813,40 @@ def _pack_native_chunks(chunks: Iterable[str], tokens_per_batch: int) -> Iterato
         yield current
 
 
+def _span_of_native_chunks(
+    source: str,
+    chunks: list[str],
+    cursor: int,
+) -> tuple[str | None, int]:
+    """The original span of ``source`` covering a run of consecutive native chunks.
+
+    ``_rejoin_native_chunks`` reconstructs a run by guessing which separator sat between its
+    chunks — a merged JSON array, ``"\n\n"``, ``"\n"`` — and gives up when none of them
+    re-chunks back to the run it was given. Giving up is expensive: the caller then emits one
+    sub-batch per chunk, and a sub-batch's cost is largely fixed regardless of how many chunks it
+    carries, so a run that the guessing cannot reproduce becomes many retains instead of one.
+
+    The guessing is avoidable. The chunks came from ``source``, in order, so the text that produced
+    them is the slice from the first chunk's start to the last chunk's end — separators included,
+    whatever they were. Locating them costs a forward scan with a cursor that only moves right, so
+    a document is still walked once overall.
+
+    Returns ``(None, cursor)`` if any chunk cannot be located from ``cursor``, and the caller falls
+    back to the rejoin exactly as before. The caller also verifies that the slice re-chunks to the
+    same run, so a span that would change the split is rejected rather than trusted.
+    """
+    start = source.find(chunks[0], cursor)
+    if start < 0:
+        return None, cursor
+    end = start
+    for chunk in chunks:
+        found = source.find(chunk, end)
+        if found < 0:
+            return None, cursor
+        end = found + len(chunk)
+    return source[start:end], end
+
+
 def _rejoin_native_chunks(
     chunks: list[str],
     chunk_size: int,
@@ -984,8 +1018,20 @@ def _iter_raw_sub_batches(
             pending = _flush()
             if pending is not None:
                 yield pending
+            # Cursor into `content_str` for `_span_of_native_chunks`. Runs arrive in document
+            # order and only ever move forward, so one cursor serves them all and the document is
+            # scanned once rather than per run.
+            span_cursor = 0
             for run in _pack_native_chunks(_chunks_of(content_str), tokens_per_batch):
-                joined = _rejoin_native_chunks(run, chunk_size, structured_chunk_size)
+                # Prefer the ORIGINAL span over a guessed rejoin: it carries whatever separators
+                # the document actually used, so it reconstructs runs the guessing cannot. Verified
+                # the same way either candidate is — a slice that would change the split is
+                # rejected, not trusted.
+                joined, span_cursor = _span_of_native_chunks(content_str, run, span_cursor)
+                if joined is not None and len(run) > 1 and list(_chunks_of(joined)) != run:
+                    joined = None
+                if joined is None:
+                    joined = _rejoin_native_chunks(run, chunk_size, structured_chunk_size)
                 slices = [(joined, len(run))] if joined is not None else [(chunk, 1) for chunk in run]
                 for slice_text, slice_chunk_count in slices:
                     chunk_item = cast(RetainContentDict, {**item, "content": slice_text})

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -813,12 +813,25 @@ def _pack_native_chunks(chunks: Iterable[str], tokens_per_batch: int) -> Iterato
         yield current
 
 
+@dataclass(frozen=True)
+class _NativeChunkSpan:
+    """Where a run of native chunks came from in the document that produced it.
+
+    ``text`` is the slice of the source that yielded the run, or ``None`` when the run could
+    not be located in it. ``cursor`` is where the next run's search starts: the end of this
+    run when it was located, and the unchanged input cursor when it was not.
+    """
+
+    text: str | None
+    cursor: int
+
+
 def _span_of_native_chunks(
     source: str,
     chunks: list[str],
     cursor: int,
-) -> tuple[str | None, int]:
-    """The original span of ``source`` covering a run of consecutive native chunks.
+) -> _NativeChunkSpan:
+    r"""The original span of ``source`` covering a run of consecutive native chunks.
 
     ``_rejoin_native_chunks`` reconstructs a run by guessing which separator sat between its
     chunks — a merged JSON array, ``"\n\n"``, ``"\n"`` — and gives up when none of them
@@ -828,23 +841,32 @@ def _span_of_native_chunks(
 
     The guessing is avoidable. The chunks came from ``source``, in order, so the text that produced
     them is the slice from the first chunk's start to the last chunk's end — separators included,
-    whatever they were. Locating them costs a forward scan with a cursor that only moves right, so
-    a document is still walked once overall.
+    whatever they were. When the chunks are substrings of the source, locating them costs a forward
+    scan with a cursor that only moves right, so a document is still walked once overall.
 
-    Returns ``(None, cursor)`` if any chunk cannot be located from ``cursor``, and the caller falls
+    When they are NOT — ``iter_chunks`` re-serializes a JSON conversation array per chunk, and
+    rebuilds JSONL as ``"\n".join`` of its non-blank lines — no chunk is ever found, ``cursor``
+    cannot advance, and each attempt rescans the whole body from where it started. That is why the
+    caller stops attempting after the first miss: whether a document's chunks are substrings of it
+    is decided once, by the branch ``iter_chunks`` takes for the whole document, so one miss
+    settles it. Left unbounded it costs a full scan per run: splitting a 44 MB conversation into
+    its 985 sub-batches took 52s instead of 22s, and the gap grows with the square of the
+    document — the class of cost #3756 removed from this path.
+
+    Returns ``text=None`` if any chunk cannot be located from ``cursor``, and the caller falls
     back to the rejoin exactly as before. The caller also verifies that the slice re-chunks to the
     same run, so a span that would change the split is rejected rather than trusted.
     """
     start = source.find(chunks[0], cursor)
     if start < 0:
-        return None, cursor
+        return _NativeChunkSpan(text=None, cursor=cursor)
     end = start
     for chunk in chunks:
         found = source.find(chunk, end)
         if found < 0:
-            return None, cursor
+            return _NativeChunkSpan(text=None, cursor=cursor)
         end = found + len(chunk)
-    return source[start:end], end
+    return _NativeChunkSpan(text=source[start:end], cursor=end)
 
 
 def _rejoin_native_chunks(
@@ -1022,14 +1044,28 @@ def _iter_raw_sub_batches(
             # order and only ever move forward, so one cursor serves them all and the document is
             # scanned once rather than per run.
             span_cursor = 0
+            # Whether this document's chunks are substrings of it at all. A miss means they are
+            # not — a re-serialized JSON conversation, JSONL rebuilt from its non-blank lines —
+            # and that is a property of the whole document, not of one run. Every later attempt
+            # would miss too, and each miss rescans the body from `span_cursor` (which a miss
+            # cannot advance), so retrying costs a full scan per run. One miss settles it; the
+            # rejoin is what handles those shapes anyway.
+            span_locatable = True
             for run in _pack_native_chunks(_chunks_of(content_str), tokens_per_batch):
                 # Prefer the ORIGINAL span over a guessed rejoin: it carries whatever separators
                 # the document actually used, so it reconstructs runs the guessing cannot. Verified
                 # the same way either candidate is — a slice that would change the split is
-                # rejected, not trusted.
-                joined, span_cursor = _span_of_native_chunks(content_str, run, span_cursor)
-                if joined is not None and len(run) > 1 and list(_chunks_of(joined)) != run:
-                    joined = None
+                # rejected, not trusted. A single-chunk run needs no verification: its span is that
+                # chunk exactly, so there is nothing a re-chunk could disagree with.
+                joined = None
+                if span_locatable:
+                    span = _span_of_native_chunks(content_str, run, span_cursor)
+                    span_cursor = span.cursor
+                    joined = span.text
+                    if joined is None:
+                        span_locatable = False
+                    elif len(run) > 1 and list(_chunks_of(joined)) != run:
+                        joined = None
                 if joined is None:
                     joined = _rejoin_native_chunks(run, chunk_size, structured_chunk_size)
                 slices = [(joined, len(run))] if joined is not None else [(chunk, 1) for chunk in run]

--- a/hindsight-api-slim/tests/test_sub_batch_span_reconstruction.py
+++ b/hindsight-api-slim/tests/test_sub_batch_span_reconstruction.py
@@ -1,0 +1,160 @@
+"""A run of native chunks is reconstructed from its original span, not a guessed rejoin.
+
+``_pack_native_chunks`` groups consecutive chunks into runs worth ``tokens_per_batch``, and the
+text for a run then has to be rebuilt so the retain can be issued once for the whole run.
+
+``_rejoin_native_chunks`` rebuilds it by guessing which separator sat between the chunks — a merged
+JSON array, ``"\\n\\n".join``, ``"\\n".join`` — and accepts a candidate only if it re-chunks back to
+exactly the chunks it was given. When none of them reproduces the split it returns ``None`` and the
+caller falls back to one sub-batch per chunk. That fallback is correct but expensive: each
+sub-batch is a separate retain carrying a largely fixed cost, so a run of many chunks becomes many
+retains instead of one.
+
+The documents that trigger it are ordinary — any body whose chunk boundaries do not all sit on the
+separator the rejoin guesses. A link list separated by single newlines, long enough to spill past
+the chunk limit and followed by a short paragraph, is enough: the short trailing chunks merge once
+``"\\n\\n".join`` has rewritten the separators, so the rejoin cannot reproduce the original split.
+
+``_span_of_native_chunks`` avoids the guess: the chunks came from the source in order, so the text
+that produced them is the slice from the first chunk's start to the last chunk's end, carrying
+whatever separators the document actually used.
+"""
+
+from hindsight_api.engine.memory_engine import (
+    _iter_raw_sub_batches,
+    _pack_native_chunks,
+    _rejoin_native_chunks,
+    _span_of_native_chunks,
+)
+from hindsight_api.engine.retain.fact_extraction import chunk_text
+
+CHUNK_SIZE = 1500
+TOKENS_PER_BATCH = 10_000
+# Small enough that the repeated fixture exceeds it, which is what reaches the packing branch.
+PACKED_TOKENS = 800
+
+
+def _link(i: int) -> str:
+    return f"- [Service {i} Documentation](https://docs.example.com/compute/docs/instances/guide-{i})"
+
+
+def _document_with_mixed_separators() -> str:
+    """A body whose chunk boundaries do not all fall on the same separator.
+
+    Eighteen link lines joined by single newlines fill the first chunk and spill; the nineteenth
+    arrives after a blank line; a short turn follows. The chunker splits that into three, the last
+    two short enough to merge once rejoined.
+    """
+    return "\n".join(_link(i) for i in range(18)) + "\n\n" + _link(99) + "\n" + "[Turn 322] User: " + "word322 " * 4
+
+
+def test_the_rejoin_cannot_reproduce_this_split():
+    """The precondition: this body is one the separator guessing genuinely fails on.
+
+    Asserted so the test below is known to exercise the fallback path rather than passing
+    vacuously on a body the rejoin would have handled anyway.
+    """
+    body = _document_with_mixed_separators()
+    chunks = chunk_text(body, CHUNK_SIZE, structured_chunk_size=None)
+    assert len(chunks) > 1, "fixture must span several chunks to be meaningful"
+
+    rejoined = chunk_text("\n\n".join(chunks), CHUNK_SIZE, structured_chunk_size=None)
+    assert rejoined != chunks, (
+        "fixture no longer triggers the fallback: the guessed join now reproduces the split, "
+        "so this file would pass without testing anything"
+    )
+    assert _rejoin_native_chunks(chunks, CHUNK_SIZE, None) is None
+
+
+def test_a_run_survives_as_one_sub_batch_via_its_original_span():
+    """A packed run stays ONE sub-batch, where the rejoin would have fragmented it."""
+    body = _document_with_mixed_separators()
+    chunks = chunk_text(body, CHUNK_SIZE, structured_chunk_size=None)
+    runs = list(_pack_native_chunks(chunks, TOKENS_PER_BATCH))
+
+    # The body is far under the token budget, so packing must offer it as a single run.
+    assert len(runs) == 1, f"expected one run under a {TOKENS_PER_BATCH}-token budget, got {len(runs)}"
+
+    span, cursor = _span_of_native_chunks(body, runs[0], 0)
+    assert span is not None, "every chunk came from the body, so the span must be locatable"
+    assert cursor > 0
+
+    # The property that makes the span safe to use: it re-chunks to the run it came from, so the
+    # sub-batch's chunk_index accounting is the same as the splitter's.
+    assert chunk_text(span, CHUNK_SIZE, structured_chunk_size=None) == runs[0]
+
+
+def test_the_span_is_the_source_text_verbatim():
+    """The reconstruction carries the document's own separators, which is the whole point."""
+    body = _document_with_mixed_separators()
+    chunks = chunk_text(body, CHUNK_SIZE, structured_chunk_size=None)
+
+    span, _ = _span_of_native_chunks(body, chunks, 0)
+    assert span is not None
+    assert span in body, "the span must be a slice of the source, not a reconstruction of it"
+
+
+def test_the_cursor_only_moves_forward_across_runs():
+    """One cursor serves every run, so the document is scanned once rather than per run."""
+    body = _document_with_mixed_separators() * 3
+    chunks = chunk_text(body, CHUNK_SIZE, structured_chunk_size=None)
+    runs = list(_pack_native_chunks(chunks, 400))
+    assert len(runs) > 1, "fixture must produce several runs to exercise the cursor"
+
+    cursor = 0
+    seen = [cursor]
+    for run in runs:
+        span, cursor = _span_of_native_chunks(body, run, cursor)
+        assert span is not None
+        seen.append(cursor)
+    assert seen == sorted(seen), f"cursor moved backwards: {seen}"
+
+
+def test_an_unlocatable_chunk_falls_back_rather_than_guessing_wrong():
+    """A chunk that is not in the source yields None, so the caller uses the old path."""
+    body = _document_with_mixed_separators()
+    span, cursor = _span_of_native_chunks(body, ["text that is not in the document"], 0)
+    assert span is None
+    assert cursor == 0, "a failed lookup must not advance the cursor"
+
+
+def test_the_splitter_packs_runs_instead_of_fragmenting_per_chunk():
+    """The end-to-end property: a run the rejoin cannot rebuild is still retained ONCE.
+
+    The tests above pin the helper; this one pins what the helper is for, through
+    `_iter_raw_sub_batches` — the path retain actually takes.
+
+    The body has to EXCEED `tokens_per_batch` to reach the packing branch at all (a body under the
+    budget is emitted whole and the rejoin never runs), so the fixture is repeated and the budget
+    lowered until it does. Without the span reconstruction every one of these runs falls back to
+    one sub-batch per chunk.
+    """
+    body = "\n\n".join(_document_with_mixed_separators() for _ in range(4))
+    chunks = chunk_text(body, CHUNK_SIZE, structured_chunk_size=None)
+    runs = list(_pack_native_chunks(chunks, PACKED_TOKENS))
+
+    # Preconditions, so this cannot pass vacuously: several runs, each holding more than one chunk,
+    # and each one the guessed rejoin genuinely fails on.
+    assert len(runs) > 1
+    assert all(len(r) > 1 for r in runs), "every run must be multi-chunk for the packing to matter"
+    assert all(_rejoin_native_chunks(r, CHUNK_SIZE, None) is None for r in runs), (
+        "fixture must exercise the fallback the span reconstruction replaces"
+    )
+
+    subs = list(
+        _iter_raw_sub_batches(
+            [{"content": body}],
+            PACKED_TOKENS,
+            chunk_size=CHUNK_SIZE,
+            structured_chunk_size=None,
+        )
+    )
+
+    assert len(subs) == len(runs), (
+        f"expected one sub-batch per packed run ({len(runs)}), got {len(subs)} — the span "
+        f"reconstruction fell back to one sub-batch per chunk ({len(chunks)} chunks)"
+    )
+    # The count the splitter reports is what the caller advances chunk_index by, so it has to match
+    # the chunks each sub-batch's text really produces.
+    assert [s.chunk_count for s in subs] == [len(r) for r in runs]
+    assert sum(s.chunk_count for s in subs) == len(chunks)

--- a/hindsight-api-slim/tests/test_sub_batch_span_reconstruction.py
+++ b/hindsight-api-slim/tests/test_sub_batch_span_reconstruction.py
@@ -20,7 +20,11 @@ that produced them is the slice from the first chunk's start to the last chunk's
 whatever separators the document actually used.
 """
 
+import json
+
+from hindsight_api.engine import memory_engine
 from hindsight_api.engine.memory_engine import (
+    _NativeChunkSpan,
     _iter_raw_sub_batches,
     _pack_native_chunks,
     _rejoin_native_chunks,
@@ -75,13 +79,13 @@ def test_a_run_survives_as_one_sub_batch_via_its_original_span():
     # The body is far under the token budget, so packing must offer it as a single run.
     assert len(runs) == 1, f"expected one run under a {TOKENS_PER_BATCH}-token budget, got {len(runs)}"
 
-    span, cursor = _span_of_native_chunks(body, runs[0], 0)
-    assert span is not None, "every chunk came from the body, so the span must be locatable"
-    assert cursor > 0
+    span = _span_of_native_chunks(body, runs[0], 0)
+    assert span.text is not None, "every chunk came from the body, so the span must be locatable"
+    assert span.cursor > 0
 
     # The property that makes the span safe to use: it re-chunks to the run it came from, so the
     # sub-batch's chunk_index accounting is the same as the splitter's.
-    assert chunk_text(span, CHUNK_SIZE, structured_chunk_size=None) == runs[0]
+    assert chunk_text(span.text, CHUNK_SIZE, structured_chunk_size=None) == runs[0]
 
 
 def test_the_span_is_the_source_text_verbatim():
@@ -89,9 +93,9 @@ def test_the_span_is_the_source_text_verbatim():
     body = _document_with_mixed_separators()
     chunks = chunk_text(body, CHUNK_SIZE, structured_chunk_size=None)
 
-    span, _ = _span_of_native_chunks(body, chunks, 0)
-    assert span is not None
-    assert span in body, "the span must be a slice of the source, not a reconstruction of it"
+    span = _span_of_native_chunks(body, chunks, 0)
+    assert span.text is not None
+    assert span.text in body, "the span must be a slice of the source, not a reconstruction of it"
 
 
 def test_the_cursor_only_moves_forward_across_runs():
@@ -104,8 +108,9 @@ def test_the_cursor_only_moves_forward_across_runs():
     cursor = 0
     seen = [cursor]
     for run in runs:
-        span, cursor = _span_of_native_chunks(body, run, cursor)
-        assert span is not None
+        span = _span_of_native_chunks(body, run, cursor)
+        assert span.text is not None
+        cursor = span.cursor
         seen.append(cursor)
     assert seen == sorted(seen), f"cursor moved backwards: {seen}"
 
@@ -113,9 +118,9 @@ def test_the_cursor_only_moves_forward_across_runs():
 def test_an_unlocatable_chunk_falls_back_rather_than_guessing_wrong():
     """A chunk that is not in the source yields None, so the caller uses the old path."""
     body = _document_with_mixed_separators()
-    span, cursor = _span_of_native_chunks(body, ["text that is not in the document"], 0)
-    assert span is None
-    assert cursor == 0, "a failed lookup must not advance the cursor"
+    span = _span_of_native_chunks(body, ["text that is not in the document"], 0)
+    assert span.text is None
+    assert span.cursor == 0, "a failed lookup must not advance the cursor"
 
 
 def test_the_splitter_packs_runs_instead_of_fragmenting_per_chunk():
@@ -158,3 +163,58 @@ def test_the_splitter_packs_runs_instead_of_fragmenting_per_chunk():
     # the chunks each sub-batch's text really produces.
     assert [s.chunk_count for s in subs] == [len(r) for r in runs]
     assert sum(s.chunk_count for s in subs) == len(chunks)
+
+
+def _conversation_over_the_budget() -> str:
+    """A JSON conversation array big enough to take the oversized-item path.
+
+    ``iter_chunks`` re-serializes each chunk of a conversation array with its own ``[``/``]``,
+    so no chunk is ever a substring of the body — the shape the span reconstruction can never
+    locate, and the one ``_rejoin_native_chunks`` merges back into a single array instead.
+    """
+    turns = [{"role": "user", "content": f"message {i} " + "word " * 60} for i in range(400)]
+    return json.dumps(turns, ensure_ascii=False)
+
+
+def test_the_span_is_attempted_once_on_a_body_whose_chunks_are_not_substrings(monkeypatch):
+    """A body the span can never locate costs ONE attempt, not one per run.
+
+    A miss cannot advance the cursor, so every retry rescans the whole body from where the last
+    one started. Whether a document's chunks are substrings of it is settled by the branch
+    ``iter_chunks`` takes for the entire document, so retrying buys nothing and costs a full scan
+    per run: splitting a 44 MB conversation into its 985 sub-batches took 52s instead of 22s, and
+    the gap grows with the square of the document. That is the class of cost #3756 removed from
+    this path; it must not come back.
+    """
+    body = _conversation_over_the_budget()
+    chunks = chunk_text(body, CHUNK_SIZE, structured_chunk_size=None)
+    runs = list(_pack_native_chunks(chunks, PACKED_TOKENS))
+    assert len(runs) > 5, "fixture must produce many runs, or one attempt per run is not visible"
+
+    # The precondition: this really is a body the span cannot locate.
+    assert _span_of_native_chunks(body, runs[0], 0).text is None
+
+    attempts: list[int] = []
+    real = memory_engine._span_of_native_chunks
+
+    def _counting_span(source: str, run: list[str], cursor: int) -> _NativeChunkSpan:
+        attempts.append(cursor)
+        return real(source, run, cursor)
+
+    monkeypatch.setattr(memory_engine, "_span_of_native_chunks", _counting_span)
+
+    subs = list(
+        _iter_raw_sub_batches(
+            [{"content": body}],
+            PACKED_TOKENS,
+            chunk_size=CHUNK_SIZE,
+            structured_chunk_size=None,
+        )
+    )
+
+    assert len(attempts) == 1, (
+        f"the span was attempted {len(attempts)} times over {len(runs)} runs — each miss rescans "
+        f"the whole body, so this is quadratic in the document"
+    )
+    # The rejoin still does its job on this shape, so the runs are not fragmented either.
+    assert [sub.chunk_count for sub in subs] == [len(r) for r in runs]


### PR DESCRIPTION
## The problem

When a single item exceeds the sub-batch token budget, the splitter cuts it into native chunks,
packs consecutive chunks into runs, and rebuilds the text for each run so the run can be retained
once.

`_rejoin_native_chunks` rebuilds it by **guessing** which separator sat between the chunks — a
merged JSON array, `"\n\n".join`, `"\n".join` — and accepts a candidate only if it re-chunks back
to exactly the chunks it was given. When none reproduces the split it returns `None` and the caller
falls back to **one sub-batch per chunk**.

That fallback is correct but expensive: each sub-batch is a separate retain carrying a largely
fixed cost, so a run of many chunks becomes many retains instead of one.

The bodies that trigger it are ordinary — any document whose chunk boundaries do not all sit on the
separator the guessing tries. A link list separated by single newlines, long enough to spill past
the chunk limit and followed by a short paragraph, is enough: the short trailing chunks merge once
`"\n\n".join` has rewritten separators the body did not use, so the rejoin cannot reproduce the
original split.

## The fix

The guessing is avoidable. The chunks came from the source, in order, so the text that produced
them is the slice from the first chunk's start to the last chunk's end — separators included,
whatever they were. `_span_of_native_chunks` finds that slice with a forward-only cursor, so the
document is still walked once overall.

The slice is verified exactly as any rejoin candidate is: it must re-chunk to the run it came from.
A span that would change the split is rejected rather than trusted, and the old guessing stays as
the fallback. That keeps the `chunk_count` the splitter reports equal to what the sub-batch's text
really produces — which is what the caller advances `chunk_index` by.

## The span must not be retried on a body it can never locate

Locating a run means `find`ing its chunks in the source, which only works when the chunks are
substrings of it. When they are not, no chunk is found, **the cursor cannot advance**, and every
later run rescans the whole body from where the last attempt started.

That is not a corner case. It is settled once per document, by the branch `iter_chunks` takes for
the whole of it:

- a JSON conversation array is re-serialized per chunk, with its own `[`/`]`;
- JSONL is rebuilt as `"\n".join` of its non-blank lines, so a CRLF body or one with blank lines
  never matches either.

Both miss on 100% of runs. Splitting a 44 MB conversation into its 985 sub-batches took **52s
instead of 22s**, and the gap grows with the square of the document — the class of cost #3756
removed from this path.

So one miss now disables the span for the rest of that document and the rejoin takes over, which is
what handles those shapes anyway. A *verification* failure does not disable it: that one is
content-specific and costs only a bounded re-chunk, not a scan.

## Tests

`tests/test_sub_batch_span_reconstruction.py`. The end-to-end case goes through
`_iter_raw_sub_batches` (the path retain actually takes) and asserts a run survives as one
sub-batch.

Two things I checked so it cannot pass vacuously:

- the fixture's preconditions are asserted — several multi-chunk runs, each one the guessed rejoin
  genuinely fails on;
- the body has to **exceed** the token budget to reach the packing branch at all. My first version
  used a small fixture, passed with the fix reverted, and was therefore testing nothing. It now
  fails with the fix reverted, reporting one sub-batch per chunk instead of one per run.

`test_the_span_is_attempted_once_on_a_body_whose_chunks_are_not_substrings` pins the rescan guard
against a JSON conversation array: it counts the attempts and fails with 50 over 50 runs when the
guard is removed.

Fixes #3790.
