### PR TITLE
perf(retain): rebuild a chunk run from the body instead of guessing its separators (#3790)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -788,7 +788,64 @@ class _RetainChunkingConfig:
     structured_chunk_size: int | None
 
 
-def _pack_native_chunks(chunks: Iterable[str], tokens_per_batch: int) -> Iterator[list[str]]:
+@dataclass(frozen=True)
+class _ChunkSpan:
+    """Where a native chunk sits in the body it was cut from — ``body[start:end]``."""
+
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class _NativeChunk:
+    """A native chunk together with where it sits in the body it was cut from.
+
+    ``span`` is ``None`` when the chunk is not a verbatim slice of that body — the
+    JSON-conversation path re-serializes every chunk, so its chunks appear nowhere in the
+    original text.
+
+    Rejoining a run needs the exact text that sat between its chunks. Guessing that text
+    is what fragmented retain: a body mixing paragraph breaks and line breaks has chunk
+    boundaries on both, so no single join reproduces it and the run degraded to one
+    sub-batch per chunk (#3790). The span makes the join exact instead of probabilistic,
+    without the chunker having to hand its separators back.
+    """
+
+    text: str
+    span: _ChunkSpan | None
+
+
+def _iter_located_chunks(text: str, chunks: Iterable[str]) -> Iterator[_NativeChunk]:
+    """Pair each streamed chunk with its span in ``text``.
+
+    Chunking cuts ``text`` into contiguous pieces and strips the whitespace off each, so a
+    chunk begins at the first non-whitespace character after the previous one ended.
+    Locating is therefore a whitespace skip and a ``startswith``, never a search of the
+    body — this runs over every chunk of a document that may be tens of MB.
+
+    The first chunk that is not where it should be stops the tracking for the rest of the
+    document: chunks that are not slices of this text at all (a re-serialized conversation
+    array) would otherwise cost a full-body search each, and the run-level joins below
+    still cover that shape.
+    """
+    cursor = 0
+    located = True
+    for chunk in chunks:
+        if not located:
+            yield _NativeChunk(chunk, None)
+            continue
+        start = cursor
+        while start < len(text) and text[start].isspace():
+            start += 1
+        if not text.startswith(chunk, start):
+            located = False
+            yield _NativeChunk(chunk, None)
+            continue
+        cursor = start + len(chunk)
+        yield _NativeChunk(chunk, _ChunkSpan(start, cursor))
+
+
+def _pack_native_chunks(chunks: Iterable[_NativeChunk], tokens_per_batch: int) -> Iterator[list[_NativeChunk]]:
     """Group consecutive native chunks into runs of at most ``tokens_per_batch``.
 
     A single chunk over the budget becomes a run of its own: the native chunk is
@@ -800,10 +857,10 @@ def _pack_native_chunks(chunks: Iterable[str], tokens_per_batch: int) -> Iterato
     document rather than with a working set (#3756); a run is bounded by
     ``tokens_per_batch``, so this holds one sub-batch's worth at a time instead.
     """
-    current: list[str] = []
+    current: list[_NativeChunk] = []
     current_tokens = 0
     for chunk in chunks:
-        chunk_tokens = count_tokens(chunk)
+        chunk_tokens = count_tokens(chunk.text)
         if current and current_tokens + chunk_tokens > tokens_per_batch:
             yield current
             current, current_tokens = [], 0
@@ -813,27 +870,20 @@ def _pack_native_chunks(chunks: Iterable[str], tokens_per_batch: int) -> Iterato
         yield current
 
 
-def _rejoin_native_chunks(
-    chunks: list[str],
-    chunk_size: int,
-    structured_chunk_size: int | None,
-) -> str | None:
-    """Rebuild the sub-batch text for a run of consecutive native chunks.
+def _run_join_candidates(run: list[_NativeChunk], body: str) -> Iterator[str]:
+    """Texts that might rebuild ``run``'s sub-batch, most faithful first.
 
-    Returns the joined text only when re-chunking it reproduces ``chunks``
-    exactly — the alignment the whole split depends on. ``None`` means no
-    faithful join exists for this run and the caller must fall back to one
-    sub-batch per chunk, which ``chunk_text``'s idempotency guarantees.
+    The span slice comes first because it is the original text, separators and all, rather
+    than a guess at them. The joins after it stay because a chunk is not always a slice of
+    the body: a JSON conversation array is re-serialized per chunk, so its pieces have to
+    be merged back into one array — concatenating them as text yields "[...]\\n[...]",
+    which is not valid JSON and re-chunks as prose (#2409).
     """
-    from .retain import fact_extraction
+    first, last = run[0].span, run[-1].span
+    if first is not None and last is not None:
+        yield body[first.start : last.end]
 
-    if len(chunks) == 1:
-        return chunks[0]
-
-    candidates: list[str] = []
-    # A JSON conversation array is re-serialized per chunk, so its pieces have
-    # to be merged back into one array — concatenating them as text yields
-    # "[...]\n[...]", which is not valid JSON and re-chunks as prose (#2409).
+    chunks = [chunk.text for chunk in run]
     try:
         merged: list[Any] = []
         for chunk in chunks:
@@ -841,16 +891,83 @@ def _rejoin_native_chunks(
             if not isinstance(parsed, list):
                 raise ValueError("not a conversation array")
             merged.extend(parsed)
-        candidates.append(json.dumps(merged, ensure_ascii=False))
+        yield json.dumps(merged, ensure_ascii=False)
     except (json.JSONDecodeError, ValueError, TypeError):
         pass
-    candidates.append("\n\n".join(chunks))
-    candidates.append("\n".join(chunks))
+    yield "\n\n".join(chunks)
+    yield "\n".join(chunks)
 
-    for text in candidates:
-        if fact_extraction.chunk_text(text, chunk_size, structured_chunk_size=structured_chunk_size) == chunks:
-            return text
+
+@dataclass(frozen=True)
+class _RunSlice:
+    """One sub-batch's worth of a run: the text to retain and the native chunks it holds."""
+
+    text: str
+    chunk_count: int
+
+
+def _cut_run(
+    run: list[_NativeChunk],
+    body: str,
+    chunk_size: int,
+    structured_chunk_size: int | None,
+) -> _RunSlice | None:
+    """The longest faithful slice at the head of ``run``.
+
+    A slice is faithful only when re-chunking its text reproduces exactly the chunks it
+    stands for — the alignment the whole split depends on (#3282). ``None`` means not even
+    the first two chunks can travel together, and the caller ships the head chunk alone,
+    which ``chunk_text``'s per-chunk idempotency makes trivially safe.
+
+    When no candidate rebuilds the whole run, the leading chunks that the best candidate
+    did reproduce are retried as a run of their own rather than abandoning the lot. Chunk
+    packing restarts its greedy buffer after a piece it had to split recursively, so a run
+    beginning just after one of those has a head chunk that merges with its neighbour when
+    re-chunked in isolation — one bad boundary that used to cost the entire run (#3790).
+    """
+    from .retain import fact_extraction
+
+    head = run
+    while len(head) >= 2:
+        chunks = [chunk.text for chunk in head]
+        longest_prefix = 0
+        for candidate in _run_join_candidates(head, body):
+            produced = fact_extraction.chunk_text(candidate, chunk_size, structured_chunk_size=structured_chunk_size)
+            if produced == chunks:
+                return _RunSlice(candidate, len(chunks))
+            matched = 0
+            for stored, rebuilt in zip(chunks, produced):
+                if stored != rebuilt:
+                    break
+                matched += 1
+            longest_prefix = max(longest_prefix, matched)
+        # Clamped below what was tried: a candidate can reproduce every chunk and still
+        # trail extra ones, and retrying the same head would not terminate.
+        head = head[: min(longest_prefix, len(head) - 1)]
     return None
+
+
+def _iter_run_slices(
+    run: list[_NativeChunk],
+    body: str,
+    chunk_size: int,
+    structured_chunk_size: int | None,
+) -> Iterator[_RunSlice]:
+    """Cut ``run`` into as few sub-batch texts as alignment allows.
+
+    Yields slices covering the run in order, each holding a whole number of native chunks. Every retain carries a fixed cost that dwarfs the work in a
+    single chunk, so how coarsely a run can be cut is what decides whether a document
+    costs a dozen retains or hundreds of them (#3790).
+    """
+    index = 0
+    while index < len(run):
+        cut = _cut_run(run[index:], body, chunk_size, structured_chunk_size)
+        if cut is None:
+            yield _RunSlice(run[index].text, 1)
+            index += 1
+            continue
+        yield cut
+        index += cut.chunk_count
 
 
 @dataclass(frozen=True)
@@ -984,16 +1101,15 @@ def _iter_raw_sub_batches(
             pending = _flush()
             if pending is not None:
                 yield pending
-            for run in _pack_native_chunks(_chunks_of(content_str), tokens_per_batch):
-                joined = _rejoin_native_chunks(run, chunk_size, structured_chunk_size)
-                slices = [(joined, len(run))] if joined is not None else [(chunk, 1) for chunk in run]
-                for slice_text, slice_chunk_count in slices:
-                    chunk_item = cast(RetainContentDict, {**item, "content": slice_text})
+            located = _iter_located_chunks(content_str, _chunks_of(content_str))
+            for run in _pack_native_chunks(located, tokens_per_batch):
+                for run_slice in _iter_run_slices(run, content_str, chunk_size, structured_chunk_size):
+                    chunk_item = cast(RetainContentDict, {**item, "content": run_slice.text})
                     yield _RawSubBatch(
                         contents=[chunk_item],
                         origins=[original_idx],
                         body_override=content_str,
-                        chunk_count=slice_chunk_count,
+                        chunk_count=run_slice.chunk_count,
                     )
             continue
 

--- a/hindsight-api-slim/tests/test_batch_chunking.py
+++ b/hindsight-api-slim/tests/test_batch_chunking.py
@@ -8,6 +8,8 @@ import pytest
 
 from hindsight_api import MemoryEngine
 from hindsight_api.engine.memory_engine import (
+    _iter_located_chunks,
+    _iter_run_slices,
     _split_contents_into_async_children,
     count_tokens,
 )
@@ -117,6 +119,25 @@ def _jsonl_payload(lines: int = 200) -> str:
     return "\n".join(json.dumps({"i": i, "text": "line " + "x " * 80}) for i in range(lines))
 
 
+def _mixed_separator_payload(sections: int = 6) -> str:
+    """A body whose chunk boundaries land on single newlines AND on blank lines.
+
+    An ordinary markdown shape: a link list long enough to fill a chunk and spill, then a
+    blank line, then a short paragraph. Nothing about it is exotic — it is the shape that
+    used to defeat every rejoin candidate (issue #3790).
+    """
+    section = (
+        "\n".join(
+            f"- [Service {i} Documentation](https://docs.example.com/compute/docs/instances/guide-{i})"
+            for i in range(18)
+        )
+        + "\n\n- [Service 99 Documentation](https://docs.example.com/compute/docs/instances/guide-99)"
+        + "\n[Turn 322] User: "
+        + "word322 " * 4
+    )
+    return "\n\n".join(section for _ in range(sections))
+
+
 @pytest.mark.parametrize(
     "body",
     [
@@ -125,6 +146,7 @@ def _jsonl_payload(lines: int = 200) -> str:
         ),
         pytest.param(_conversation_payload(), id="json-conversation"),
         pytest.param(_jsonl_payload(), id="jsonl"),
+        pytest.param(_mixed_separator_payload(), id="mixed-separators"),
     ],
 )
 def test_split_slices_are_whole_native_chunks(body):
@@ -191,6 +213,59 @@ def test_split_falls_back_to_one_chunk_per_slice_when_no_faithful_join_exists(mo
 
     assert [b[0]["content"] for b in split.sub_batches] == chunks
     assert split.chunk_counts == [1, 1, 1]
+
+
+def test_split_packs_a_run_whose_chunks_sit_on_mixed_separators():
+    """A body separated by both blank lines and single newlines still packs into runs.
+
+    The rejoin used to guess the separator between two chunks. On a body that uses both,
+    every guess rewrote some boundary, the joined text re-chunked differently, and the run
+    degraded to one sub-batch per chunk. Each retain carries a fixed cost that dwarfs the
+    work in a single chunk, so that turned an ordinary document into ~30x the retains it
+    needed (issue #3790).
+    """
+    chunk_size = 1500
+    body = _mixed_separator_payload()
+    native_chunks = chunk_text(body, chunk_size)
+    assert len(native_chunks) > 10, "test payload must span many native chunks"
+
+    split = collect_sub_batches(
+        [{"content": body, "document_id": "doc-mixed-separators"}],
+        tokens_per_batch=2_000,
+        chunk_size=chunk_size,
+    )
+
+    assert min(split.chunk_counts) > 1, "every sub-batch should carry a run, not a lone chunk"
+    assert sum(split.chunk_counts) == len(native_chunks)
+
+
+def test_run_slices_regroup_after_a_boundary_that_cannot_be_rejoined():
+    """One unjoinable boundary costs one chunk, not the whole run.
+
+    Chunk packing restarts its greedy buffer after a piece it had to split recursively, so
+    the short tail it leaves never merges with the next paragraph in the document — but it
+    does when the run is re-chunked on its own. A run starting on such a tail therefore has
+    no faithful join, and shipping every one of its chunks alone was the expensive part of
+    issue #3790. The tail travels alone; the rest of the run stays whole.
+    """
+    chunk_size = 1500
+    paragraph = "\n".join(f"- entry {i} " + "x" * 60 for i in range(21))
+    body = "\n\n".join(
+        [paragraph, "short paragraph. " * 55] + [f"Paragraph {k}. " + "filler word here. " * 55 for k in range(8)]
+    )
+    native_chunks = chunk_text(body, chunk_size)
+    located = list(_iter_located_chunks(body, iter(native_chunks)))
+    # Drop the first chunk so the run begins on the recursion tail the paragraph left behind.
+    run = located[1:]
+
+    slices = list(_iter_run_slices(run, body, chunk_size, None))
+
+    assert [run_slice.chunk_count for run_slice in slices] == [1, len(run) - 1]
+    consumed = 0
+    for run_slice in slices:
+        expected = [chunk.text for chunk in run[consumed : consumed + run_slice.chunk_count]]
+        assert chunk_text(run_slice.text, chunk_size) == expected, "a slice must re-chunk to exactly its own chunks"
+        consumed += run_slice.chunk_count
 
 
 def test_split_slice_never_cuts_a_native_chunk_under_a_tiny_budget():


### PR DESCRIPTION
Fixes #3790.

`_iter_raw_sub_batches` packs an oversized item's native chunks into runs worth
`retain_batch_tokens`, then has to rebuild the text of each run. It rebuilt it by
*guessing* the separator — a merged JSON array, `"\n\n".join`, `"\n".join` — and
accepted a guess only when re-chunking it reproduced the run exactly. When none did,
the run degraded to one sub-batch per chunk. Each of those is a full retain carrying
a fixed cost that dwarfs the work in a single chunk, so an ordinary document ended up
issuing ~30x the retains it needed.

## What actually triggers it

Two independent things, and the first is not an edge case.

**Separator rewriting.** `"\n\n".join` inserts blank lines where the body had single
newlines. Any body whose chunk boundaries sit on *both* — an ordinary markdown
document — defeats every candidate. On 30 synthetic markdown-shaped documents at the
shipped defaults (`retain_chunk_size=3000`, `retain_batch_tokens=10_000`), **168 of
172 runs failed to rejoin**: 2,518 sub-batches where 172 would do. The issue's
"5 of 18 runs" is the mild case.

**Greedy-buffer reset.** `_iter_recursive_splits` flushes its packing buffer before
recursing into an over-budget piece, so the short tail it leaves never merges with the
next paragraph *in the document* — but it does when the run is re-chunked on its own.
A run beginning on such a tail has no faithful join at all, even a byte-exact one.

## The fix

**Carry the separators, by locating the chunks rather than threading them through the
chunker.** Every native chunk is a verbatim substring of the body, separated only by
whitespace, for every content shape except a JSON conversation array (whose chunks are
re-serialized, and which the existing merged-array candidate already covers). So
`_iter_located_chunks` pairs each streamed chunk with its span using a whitespace skip
and a `startswith` — no search of the body — and the rejoin becomes `body[start:end]`:
the original text, separators and all, instead of a guess at them. The candidate joins
stay as fallbacks, and the re-chunk verification is unchanged, so the #3282 alignment
invariant still gates every slice.

**Regroup after a boundary that cannot be rejoined.** When no candidate rebuilds the
whole run, `_cut_run` takes the leading chunks the best candidate *did* reproduce and
retries them as a run of their own. One bad boundary now costs one chunk instead of
the entire run.

Memory behaviour is unchanged: spans are two ints per chunk of a run already bounded
by `retain_batch_tokens`, chunks are still streamed, and the candidates are now yielded
one at a time instead of all being materialised at once (#3756).

## Measured

Sub-batches produced, at the shipped defaults:

| | 30 markdown docs | one 2.7 MB body | split time |
|---|---|---|---|
| before | 2,518 | 1,394 | 205 ms |
| after | **173** (172 runs is the floor) | **90** | 205 ms |

Splitting costs the same — the common case now verifies on the *first* candidate
instead of the third, which offsets the extra work on the rare failing run. At the
~1.1 s fixed cost per retain measured in the issue, the 2.7 MB body goes from ~25 min
of retain overhead to ~1.6 min.

Structured bodies (JSON conversation arrays, JSONL, JSONL with blank lines) are
unaffected — they already rejoined, and produce the same split as before.

## Tests

- `test_split_packs_a_run_whose_chunks_sit_on_mixed_separators` — the markdown shape
  from the issue. 18 chunks → 18 sub-batches before, 2 after.
- `test_run_slices_regroup_after_a_boundary_that_cannot_be_rejoined` — a run starting
  on a recursion tail ships `[1, rest]`, not one sub-batch per chunk.
- `test_split_slices_are_whole_native_chunks` gains a `mixed-separators` payload, so
  the alignment invariant is pinned for that shape alongside prose/JSON/JSONL.

The alignment invariant (every slice re-chunks to exactly its own chunks, and the
concatenation reproduces the document's native chunks) was additionally checked by
hand across prose, markdown, JSONL, JSONL-with-blank-lines, CRLF, unicode, tabs, a
200 KB single word, and JSON conversation arrays.

https://claude.ai/code/session_01TbssiuHs32rLNMPYutRwub
