### PR TITLE
retain: accumulate a document's body instead of rebuilding it per sub-batch

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -804,6 +804,7 @@ def _parse_worker_slot_reservations() -> dict[str, int]:
 
 ENV_WORKER_CONSOLIDATION_BANK_PRIORITY = "HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY"
 ENV_RETAIN_MAX_CONCURRENT = "HINDSIGHT_API_RETAIN_MAX_CONCURRENT"
+ENV_RETAIN_SUBBATCH_CONCURRENCY = "HINDSIGHT_API_RETAIN_SUBBATCH_CONCURRENCY"
 ENV_RETAIN_WALL_TIMEOUT = "HINDSIGHT_API_RETAIN_WALL_TIMEOUT"
 
 # Reflect agent settings
@@ -1423,6 +1424,10 @@ DEFAULT_WORKER_MAX_SLOTS = 10  # Total concurrent tasks per worker
 DEFAULT_OPERATION_RETENTION_DAYS = 0
 DEFAULT_OPERATION_CLEANUP_BATCH_SIZE = 1000
 DEFAULT_RETAIN_MAX_CONCURRENT = 4  # Max concurrent retain DB phases (HNSW reads + writes). Limits I/O contention.
+# Sub-batches of ONE document processed at a time. Most of a sub-batch is a store round-trip, so
+# overlapping a few hides that wait. 1 keeps the splitter exactly one slice ahead of the work,
+# which is what bounds how much of a large document is resident; raise it knowingly.
+DEFAULT_RETAIN_SUBBATCH_CONCURRENCY = 1
 # Wall-clock ceiling for one retain task in the worker (0 disables). This is a
 # deadlock/wedge backstop, not a latency target: a retain that blocks forever on
 # a lock, an LLM permit or a queue put would otherwise hold its worker slot until
@@ -2714,6 +2719,7 @@ class HindsightConfig:
     operation_retention_days: int
     operation_cleanup_batch_size: int
     retain_max_concurrent: int
+    retain_subbatch_concurrency: int
     retain_wall_timeout: int
 
     # Reflect agent settings
@@ -4046,6 +4052,9 @@ class HindsightConfig:
                 DEFAULT_OPERATION_CLEANUP_BATCH_SIZE,
             ),
             retain_max_concurrent=int(os.getenv(ENV_RETAIN_MAX_CONCURRENT, str(DEFAULT_RETAIN_MAX_CONCURRENT))),
+            retain_subbatch_concurrency=int(
+                os.getenv(ENV_RETAIN_SUBBATCH_CONCURRENCY, str(DEFAULT_RETAIN_SUBBATCH_CONCURRENCY))
+            ),
             retain_wall_timeout=int(os.getenv(ENV_RETAIN_WALL_TIMEOUT, str(DEFAULT_RETAIN_WALL_TIMEOUT))),
             # Reflect agent settings
             reflect_max_iterations=int(os.getenv(ENV_REFLECT_MAX_ITERATIONS, str(DEFAULT_REFLECT_MAX_ITERATIONS))),

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -5331,6 +5331,22 @@ class MemoryEngine(MemoryEngineInterface):
             from .retain.orchestrator import DocumentBodyAccumulator
 
             body_accum: dict[str, DocumentBodyAccumulator] = {}
+
+            @dataclass
+            class _SubBatchOutcome:
+                """One sub-batch's results, carried back from its task.
+
+                A named type rather than a tuple so the merge below reads by field: the sub-batch
+                INDEX is what the results are re-sorted by (completion order is not document
+                order), and `origins` maps each result back to the caller's input item.
+                """
+
+                index: int
+                origins: list[int]
+                results: list[list[str]]
+                usage: "TokenUsage"
+                processed: int | None
+
             # Sub-batches of one document used to run strictly one after another, but most of a
             # sub-batch is a round-trip to the store — I/O wait, holding no GIL — so running a few
             # concurrently overlaps a wait rather than paying it end to end.
@@ -5339,7 +5355,7 @@ class MemoryEngine(MemoryEngineInterface):
             # From the resolved config, not read inline per retain.
             concurrency = max(1, get_config().retain_subbatch_concurrency)
             pending: list[asyncio.Task] = []
-            collected: list[tuple] = []
+            collected: list[_SubBatchOutcome] = []
 
             async def _run_sub(idx: int, contents_, origins_, offset_, is_last_, body_, body_hash_):
                 r, u, pr = await self._retain_batch_async_internal(
@@ -5361,7 +5377,7 @@ class MemoryEngine(MemoryEngineInterface):
                     chunk_index_offset=offset_,
                     body_accum=body_accum,
                 )
-                return idx, origins_, r, u, pr
+                return _SubBatchOutcome(index=idx, origins=origins_, results=r, usage=u, processed=pr)
 
             try:
                 for sub in sub_batch_stream:
@@ -5479,7 +5495,9 @@ class MemoryEngine(MemoryEngineInterface):
 
             # Merge in sub-batch order, not completion order, so `per_input_results` is identical
             # whatever order concurrent sub-batches finished in.
-            for _idx, sub_origins, sub_results, sub_usage, sub_processed in sorted(collected, key=lambda x: x[0]):
+            for outcome in sorted(collected, key=lambda o: o.index):
+                sub_origins, sub_results = outcome.origins, outcome.results
+                sub_usage, sub_processed = outcome.usage, outcome.processed
                 # sub_results aligns 1:1 with sub_batch items; map each
                 # back to its source input via origin_indices so callers
                 # iterating with ``zip(contents, results)`` still align.

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -5328,7 +5328,9 @@ class MemoryEngine(MemoryEngineInterface):
             sub_batches_run = 0
             # Chunk texts accumulated across the sub-batches of each document, written by
             # `flush_document_bodies` below. Same lifetime as `chunk_offsets`: this retain only.
-            body_accum: dict[str, dict] = {}
+            from .retain.orchestrator import DocumentBodyAccumulator
+
+            body_accum: dict[str, DocumentBodyAccumulator] = {}
             # Sub-batches of one document used to run strictly one after another, but most of a
             # sub-batch is a round-trip to the store — I/O wait, holding no GIL — so running a few
             # concurrently overlaps a wait rather than paying it end to end.
@@ -5541,7 +5543,7 @@ class MemoryEngine(MemoryEngineInterface):
         document_body_override: str | None = None,
         document_body_hash: str | None = None,
         chunk_index_offset: int = 0,
-        body_accum: dict[str, dict] | None = None,
+        body_accum: "dict[str, DocumentBodyAccumulator] | None" = None,
     ) -> tuple[list[list[str]], "TokenUsage", int | None]:
         """
         Internal method for batch processing without chunking logic.

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -18,6 +18,7 @@ import hashlib
 import inspect
 import json
 import logging
+import os
 import random
 import sys
 import time
@@ -5326,6 +5327,43 @@ class MemoryEngine(MemoryEngineInterface):
                     )
 
             sub_batches_run = 0
+            # Chunk texts accumulated across the sub-batches of each document, written by
+            # `flush_document_bodies` below. Same lifetime as `chunk_offsets`: this retain only.
+            body_accum: dict[str, dict] = {}
+            # Sub-batches of one document used to run strictly one after another, but most of a
+            # sub-batch is a round-trip to the store — I/O wait, holding no GIL — so running a few
+            # concurrently overlaps a wait rather than paying it end to end.
+            #
+            # Default 1 keeps today's behaviour exactly; a deployment opts in.
+            concurrency = max(1, int(os.environ.get("HINDSIGHT_RETAIN_SUBBATCH_CONCURRENCY", "1")))
+            sem = asyncio.Semaphore(concurrency)
+            pending: list[asyncio.Task] = []
+            collected: list[tuple] = []
+            bodies: dict[int, tuple] = {}
+
+            async def _run_sub(idx: int, contents_, origins_, offset_, is_last_):
+                async with sem:
+                    r, u, pr = await self._retain_batch_async_internal(
+                        bank_id=bank_id,
+                        contents=contents_,
+                        request_context=request_context,
+                        document_id=document_id,
+                        is_first_batch=idx == 1,  # Only upsert on first batch
+                        fact_type_override=fact_type_override,
+                        document_tags=document_tags,
+                        operation_id=operation_id,
+                        strategy=strategy,
+                        # Outbox callback runs inside the last sub-batch's transaction so the
+                        # webhook delivery row is committed atomically with the final retain data.
+                        outbox_callback=outbox_callback if is_last_ else None,
+                        outbox_callback_factory=outbox_callback_factory if is_last_ else None,
+                        document_body_override=bodies.get(idx, (None, None))[0],
+                        document_body_hash=bodies.get(idx, (None, None))[1],
+                        chunk_index_offset=offset_,
+                        body_accum=body_accum,
+                    )
+                return idx, origins_, r, u, pr
+
             for sub in sub_batch_stream:
                 i = sub.index
                 sub_batch = sub.contents
@@ -5365,32 +5403,13 @@ class MemoryEngine(MemoryEngineInterface):
                 # each item's "content" while streaming, so reading it back
                 # after the call yields "" — and chunk_text("") returns [""]
                 # (count 1), advancing the per-document cursor by 1 regardless
-                # of the real chunk count (issue #1888).
+                # of the real chunk count (issue #1888). Taking it from the splitter is also what
+                # lets the offset be assigned BEFORE dispatch, which is what makes concurrent
+                # sub-batches possible at all.
                 sub_chunk_count = sub.chunk_count
 
-                sub_results, sub_usage, sub_processed = await self._retain_batch_async_internal(
-                    bank_id=bank_id,
-                    contents=sub_batch,
-                    request_context=request_context,
-                    document_id=document_id,
-                    is_first_batch=i == 1,  # Only upsert on first batch
-                    fact_type_override=fact_type_override,
-                    document_tags=document_tags,
-                    operation_id=operation_id,
-                    strategy=strategy,
-                    # Outbox callback runs inside the last sub-batch's transaction so the
-                    # webhook delivery row is committed atomically with the final retain data.
-                    outbox_callback=outbox_callback if sub.is_last else None,
-                    outbox_callback_factory=outbox_callback_factory if sub.is_last else None,
-                    document_body_override=sub.document_body.text if sub.document_body else None,
-                    document_body_hash=sub.document_body.content_hash if sub.document_body else None,
-                    chunk_index_offset=sub_offset,
-                )
-
-                # Advance the document's chunk_index cursor by the number of
-                # chunks this sub-batch produced (counted above, before the
-                # orchestrator consumed the content), so the next sub-batch
-                # sharing the document continues the sequence.
+                # Advance the document's chunk_index cursor by the number of chunks this sub-batch
+                # produced, so the next sub-batch sharing the document continues the sequence.
                 if sub_doc_id:
                     # retain_batch only prepends the existing body on the global
                     # first sub-batch (is_first_batch == i == 1), so fold its chunk
@@ -5398,6 +5417,26 @@ class MemoryEngine(MemoryEngineInterface):
                     if i == 1:
                         sub_chunk_count += append_prepend_chunks.get(sub_doc_id, 0)
                     chunk_offsets[sub_doc_id] = sub_offset + sub_chunk_count
+
+                bodies[i] = (
+                    sub.document_body.text if sub.document_body else None,
+                    sub.document_body.content_hash if sub.document_body else None,
+                )
+                task = asyncio.create_task(_run_sub(i, sub_batch, sub_origins, sub_offset, sub.is_last))
+                pending.append(task)
+                # The first sub-batch is a barrier: it upserts the document row that every later
+                # sub-batch's ownership check reads, and in append mode it is the one that prepends
+                # the existing body.
+                if i == 1:
+                    collected.append(await task)
+                    pending.remove(task)
+
+            if pending:
+                collected.extend(await asyncio.gather(*pending))
+
+            # Merge in sub-batch order, not completion order, so `per_input_results` is identical
+            # whatever order concurrent sub-batches finished in.
+            for _idx, sub_origins, sub_results, sub_usage, sub_processed in sorted(collected, key=lambda x: x[0]):
                 # sub_results aligns 1:1 with sub_batch items; map each
                 # back to its source input via origin_indices so callers
                 # iterating with ``zip(contents, results)`` still align.
@@ -5412,6 +5451,12 @@ class MemoryEngine(MemoryEngineInterface):
                 # Per-sub-batch progress is intentionally not written here: the streaming
                 # retain pipeline emits finer-grained "storing N/total chunks" snapshots
                 # via progress_callback as each sub-batch's chunks commit.
+
+            # Write out whatever the sub-batches accumulated but did not reach a flush threshold
+            # with, so a document's body is complete when its retain is.
+            from .retain.orchestrator import flush_document_bodies
+
+            await flush_document_bodies(body_accum)
 
             total_time = time.time() - start_time
             logger.info(
@@ -5461,6 +5506,7 @@ class MemoryEngine(MemoryEngineInterface):
         document_body_override: str | None = None,
         document_body_hash: str | None = None,
         chunk_index_offset: int = 0,
+        body_accum: dict[str, dict] | None = None,
     ) -> tuple[list[list[str]], "TokenUsage", int | None]:
         """
         Internal method for batch processing without chunking logic.
@@ -5525,6 +5571,7 @@ class MemoryEngine(MemoryEngineInterface):
                 document_body_override=document_body_override,
                 document_body_hash=document_body_hash,
                 chunk_index_offset=chunk_index_offset,
+                body_accum=body_accum,
                 # Stream chunk-level "storing N/total" progress to the operation row as
                 # the document's chunks commit (more useful than the coarse sub-batch tick).
                 progress_callback=self._write_operation_progress,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -18,7 +18,6 @@ import hashlib
 import inspect
 import json
 import logging
-import os
 import random
 import sys
 import time
@@ -5335,104 +5334,146 @@ class MemoryEngine(MemoryEngineInterface):
             # concurrently overlaps a wait rather than paying it end to end.
             #
             # Default 1 keeps today's behaviour exactly; a deployment opts in.
-            concurrency = max(1, int(os.environ.get("HINDSIGHT_RETAIN_SUBBATCH_CONCURRENCY", "1")))
-            sem = asyncio.Semaphore(concurrency)
+            # From the resolved config, not read inline per retain.
+            concurrency = max(1, get_config().retain_subbatch_concurrency)
             pending: list[asyncio.Task] = []
             collected: list[tuple] = []
-            bodies: dict[int, tuple] = {}
 
-            async def _run_sub(idx: int, contents_, origins_, offset_, is_last_):
-                async with sem:
-                    r, u, pr = await self._retain_batch_async_internal(
-                        bank_id=bank_id,
-                        contents=contents_,
-                        request_context=request_context,
-                        document_id=document_id,
-                        is_first_batch=idx == 1,  # Only upsert on first batch
-                        fact_type_override=fact_type_override,
-                        document_tags=document_tags,
-                        operation_id=operation_id,
-                        strategy=strategy,
-                        # Outbox callback runs inside the last sub-batch's transaction so the
-                        # webhook delivery row is committed atomically with the final retain data.
-                        outbox_callback=outbox_callback if is_last_ else None,
-                        outbox_callback_factory=outbox_callback_factory if is_last_ else None,
-                        document_body_override=bodies.get(idx, (None, None))[0],
-                        document_body_hash=bodies.get(idx, (None, None))[1],
-                        chunk_index_offset=offset_,
-                        body_accum=body_accum,
-                    )
+            async def _run_sub(idx: int, contents_, origins_, offset_, is_last_, body_, body_hash_):
+                r, u, pr = await self._retain_batch_async_internal(
+                    bank_id=bank_id,
+                    contents=contents_,
+                    request_context=request_context,
+                    document_id=document_id,
+                    is_first_batch=idx == 1,  # Only upsert on first batch
+                    fact_type_override=fact_type_override,
+                    document_tags=document_tags,
+                    operation_id=operation_id,
+                    strategy=strategy,
+                    # Outbox callback runs inside the last sub-batch's transaction so the
+                    # webhook delivery row is committed atomically with the final retain data.
+                    outbox_callback=outbox_callback if is_last_ else None,
+                    outbox_callback_factory=outbox_callback_factory if is_last_ else None,
+                    document_body_override=body_,
+                    document_body_hash=body_hash_,
+                    chunk_index_offset=offset_,
+                    body_accum=body_accum,
+                )
                 return idx, origins_, r, u, pr
 
-            for sub in sub_batch_stream:
-                i = sub.index
-                sub_batch = sub.contents
-                sub_origins = sub.origins
-                # Checkpoint: abort if the operation was deleted (bank was deleted) between sub-batches.
-                if operation_id and not await self._check_op_alive(operation_id):
-                    logger.info(
-                        f"[BATCH_RETAIN] bank={bank_id} operation {operation_id} cancelled "
-                        f"(bank deleted), stopping after {i - 1} sub-batches"
+            try:
+                for sub in sub_batch_stream:
+                    i = sub.index
+                    sub_batch = sub.contents
+                    sub_origins = sub.origins
+                    # Checkpoint: abort if the operation was deleted (bank was deleted) between sub-batches.
+                    if operation_id and not await self._check_op_alive(operation_id):
+                        logger.info(
+                            f"[BATCH_RETAIN] bank={bank_id} operation {operation_id} cancelled "
+                            f"(bank deleted), stopping after {i - 1} sub-batches"
+                        )
+                        cancelled = True
+                        # Cancel what is already in flight. Without this the gather below would run
+                        # every dispatched sub-batch to completion AFTER the operation was found dead,
+                        # which is the opposite of what the check is for.
+                        for t in pending:
+                            t.cancel()
+                        if pending:
+                            await asyncio.gather(*pending, return_exceptions=True)
+                        pending = []
+                        break
+
+                    sub_batches_run = i
+                    sub_batch_tokens = sum(count_tokens(item.get("content", "")) for item in sub_batch)
+                    # No "i of N": N is not known until the stream ends, and computing it up
+                    # front would mean splitting the document twice. Operators follow a long
+                    # retain through the chunk-level "storing N/total" progress the streaming
+                    # pipeline writes, which is unaffected.
+                    logger.info(f"Processing sub-batch {i}: {len(sub_batch)} items, {sub_batch_tokens:,} tokens")
+                    # Live worker stage for the in-flight sub-batch; the durable progress
+                    # snapshot is written *after* the sub-batch commits (below) so processed
+                    # reflects work actually done and reaches total on completion.
+                    set_stage(f"batch_retain.sub_batch.{i}")
+
+                    # Resolve the document this sub-batch writes to so we can offset
+                    # its chunk_index past chunks already stored by earlier sub-batches
+                    # of the same document. A grouped call passes ``document_id``, so
+                    # every sub-batch shares it; otherwise only the oversized-single-
+                    # item split shares a document_id across sub-batches (packed
+                    # multi-item sub-batches carry distinct document_ids, offset 0).
+                    sub_doc_id = document_id or (sub_batch[0].get("document_id") if len(sub_batch) == 1 else None)
+                    sub_offset = chunk_offsets.get(sub_doc_id, 0) if sub_doc_id else 0
+
+                    # How many chunks this sub-batch contributes, from the splitter.
+                    # It must NOT be re-derived here: retain_batch consumes (pops)
+                    # each item's "content" while streaming, so reading it back
+                    # after the call yields "" — and chunk_text("") returns [""]
+                    # (count 1), advancing the per-document cursor by 1 regardless
+                    # of the real chunk count (issue #1888). Taking it from the splitter is also what
+                    # lets the offset be assigned BEFORE dispatch, which is what makes concurrent
+                    # sub-batches possible at all.
+                    sub_chunk_count = sub.chunk_count
+
+                    # Advance the document's chunk_index cursor by the number of chunks this sub-batch
+                    # produced, so the next sub-batch sharing the document continues the sequence.
+                    if sub_doc_id:
+                        # retain_batch only prepends the existing body on the global
+                        # first sub-batch (is_first_batch == i == 1), so fold its chunk
+                        # count in only there.
+                        if i == 1:
+                            sub_chunk_count += append_prepend_chunks.get(sub_doc_id, 0)
+                        chunk_offsets[sub_doc_id] = sub_offset + sub_chunk_count
+
+                    task = asyncio.create_task(
+                        _run_sub(
+                            i,
+                            sub_batch,
+                            sub_origins,
+                            sub_offset,
+                            sub.is_last,
+                            sub.document_body.text if sub.document_body else None,
+                            sub.document_body.content_hash if sub.document_body else None,
+                        )
                     )
-                    cancelled = True
-                    break
-
-                sub_batches_run = i
-                sub_batch_tokens = sum(count_tokens(item.get("content", "")) for item in sub_batch)
-                # No "i of N": N is not known until the stream ends, and computing it up
-                # front would mean splitting the document twice. Operators follow a long
-                # retain through the chunk-level "storing N/total" progress the streaming
-                # pipeline writes, which is unaffected.
-                logger.info(f"Processing sub-batch {i}: {len(sub_batch)} items, {sub_batch_tokens:,} tokens")
-                # Live worker stage for the in-flight sub-batch; the durable progress
-                # snapshot is written *after* the sub-batch commits (below) so processed
-                # reflects work actually done and reaches total on completion.
-                set_stage(f"batch_retain.sub_batch.{i}")
-
-                # Resolve the document this sub-batch writes to so we can offset
-                # its chunk_index past chunks already stored by earlier sub-batches
-                # of the same document. A grouped call passes ``document_id``, so
-                # every sub-batch shares it; otherwise only the oversized-single-
-                # item split shares a document_id across sub-batches (packed
-                # multi-item sub-batches carry distinct document_ids, offset 0).
-                sub_doc_id = document_id or (sub_batch[0].get("document_id") if len(sub_batch) == 1 else None)
-                sub_offset = chunk_offsets.get(sub_doc_id, 0) if sub_doc_id else 0
-
-                # How many chunks this sub-batch contributes, from the splitter.
-                # It must NOT be re-derived here: retain_batch consumes (pops)
-                # each item's "content" while streaming, so reading it back
-                # after the call yields "" — and chunk_text("") returns [""]
-                # (count 1), advancing the per-document cursor by 1 regardless
-                # of the real chunk count (issue #1888). Taking it from the splitter is also what
-                # lets the offset be assigned BEFORE dispatch, which is what makes concurrent
-                # sub-batches possible at all.
-                sub_chunk_count = sub.chunk_count
-
-                # Advance the document's chunk_index cursor by the number of chunks this sub-batch
-                # produced, so the next sub-batch sharing the document continues the sequence.
-                if sub_doc_id:
-                    # retain_batch only prepends the existing body on the global
-                    # first sub-batch (is_first_batch == i == 1), so fold its chunk
-                    # count in only there.
+                    pending.append(task)
+                    # The first sub-batch is a barrier: it upserts the document row that every later
+                    # sub-batch's ownership check reads, and in append mode it is the one that prepends
+                    # the existing body.
                     if i == 1:
-                        sub_chunk_count += append_prepend_chunks.get(sub_doc_id, 0)
-                    chunk_offsets[sub_doc_id] = sub_offset + sub_chunk_count
+                        collected.append(await task)
+                        pending.remove(task)
+                        continue
 
-                bodies[i] = (
-                    sub.document_body.text if sub.document_body else None,
-                    sub.document_body.content_hash if sub.document_body else None,
-                )
-                task = asyncio.create_task(_run_sub(i, sub_batch, sub_origins, sub_offset, sub.is_last))
-                pending.append(task)
-                # The first sub-batch is a barrier: it upserts the document row that every later
-                # sub-batch's ownership check reads, and in append mode it is the one that prepends
-                # the existing body.
-                if i == 1:
-                    collected.append(await task)
-                    pending.remove(task)
+                    # Throttle DISPATCH, not just execution. `sub_batch_stream` is a synchronous
+                    # generator, so if this loop never suspends it runs to exhaustion and every
+                    # sub-batch's text is alive at once in a pending task's closure — which is what
+                    # keeps a large document from being resident. A semaphore inside the task does not
+                    # help: it bounds how many RUN, not how many have been created. Waiting here for a
+                    # slot keeps the splitter one slice ahead of the work, which is what it was at
+                    # concurrency 1 before any of this.
+                    while len(pending) >= concurrency:
+                        done, still = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
+                        pending = list(still)
+                        collected.extend(t.result() for t in done)
 
-            if pending:
-                collected.extend(await asyncio.gather(*pending))
+                if pending:
+                    # return_exceptions so one failure does not leave siblings running unawaited —
+                    # that orphans their store and DB writes past the caller unwinding, and logs
+                    # "Task exception was never retrieved". The first error is re-raised below, after
+                    # every task has settled.
+                    results = await asyncio.gather(*pending, return_exceptions=True)
+                    for r in results:
+                        if isinstance(r, BaseException):
+                            raise r
+                        collected.append(r)
+            finally:
+                # In a `finally` so a failed sub-batch still writes what its siblings accumulated.
+                # Otherwise the last slices since the previous doubling are lost, and for a document
+                # that never reached a flush that is the whole body — leaving memories with no
+                # chunk texts, which is worse than the per-sub-batch writes this replaces.
+                from .retain.orchestrator import flush_document_bodies
+
+                await flush_document_bodies(body_accum)
 
             # Merge in sub-batch order, not completion order, so `per_input_results` is identical
             # whatever order concurrent sub-batches finished in.
@@ -5451,12 +5492,6 @@ class MemoryEngine(MemoryEngineInterface):
                 # Per-sub-batch progress is intentionally not written here: the streaming
                 # retain pipeline emits finer-grained "storing N/total chunks" snapshots
                 # via progress_callback as each sub-batch's chunks commit.
-
-            # Write out whatever the sub-batches accumulated but did not reach a flush threshold
-            # with, so a document's body is complete when its retain is.
-            from .retain.orchestrator import flush_document_bodies
-
-            await flush_document_bodies(body_accum)
 
             total_time = time.time() - start_time
             logger.info(

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -1366,6 +1366,7 @@ async def retain_batch(
     document_body_override: str | None = None,
     document_body_hash: str | None = None,
     chunk_index_offset: int = 0,
+    body_accum: dict[str, dict] | None = None,
     progress_callback: "Callable[..., Awaitable[None]] | None" = None,
     webhook_manager: Any = None,
     memory_defense_extension: "MemoryDefenseExtension | None" = None,
@@ -1875,6 +1876,7 @@ async def retain_batch(
         document_body_override=document_body_override,
         document_body_hash=document_body_hash,
         chunk_index_offset=chunk_index_offset,
+        body_accum=body_accum,
         progress_callback=progress_callback,
         append_base_hash=append_base_hash,
         append_base_watermark=append_base_watermark,
@@ -2070,6 +2072,70 @@ async def _store_document_bodies(
         raise ConcurrentAppendConflict(str(e)) from e
 
 
+# A document body is flushed once its unwritten chunk text has at least DOUBLED since the last
+# flush (and at least this much has accumulated). Doubling makes the number of writes O(log chunks)
+# and the total bytes written ~2x the document, where flushing per sub-batch is O(chunks^2) and
+# flushing only at the end risks the whole document. It also bounds what an interrupted retain
+# loses: never more than half of what it had.
+_BODY_FLUSH_MIN_BYTES = 4 * 1024 * 1024
+
+
+def _contiguous_prefix(slices: dict[int, list[str]]) -> list[str]:
+    """The document's chunk texts from index 0, stopping at the first gap.
+
+    Sub-batches may complete out of order, so the accumulator can hold slice 0 and slice 2 while
+    slice 1 is still in flight. The chunk list is POSITIONAL — `put_document` takes it whole and
+    index N is chunk N — so writing across a gap would shift every following chunk. Writing only
+    the gap-free prefix is exactly what a sequential retain would have written by that point.
+    """
+    out: list[str] = []
+    for offset in sorted(slices):
+        if offset != len(out):
+            break
+        out.extend(slices[offset])
+    return out
+
+
+async def _flush_document_body(acc: dict, document_id: str, *, force: bool) -> None:
+    """Write the accumulated body if enough has accumulated (or the retain is finishing)."""
+    meta = acc.get("meta")
+    if not meta:
+        return
+    async with acc["lock"]:
+        chunks = _contiguous_prefix(acc["slices"])
+        if not chunks:
+            return
+        pending = sum(len(c) for c in chunks)
+        if not force and pending < max(_BODY_FLUSH_MIN_BYTES, 2 * acc["flushed_bytes"]):
+            return
+        if pending == acc["flushed_bytes"] and not force:
+            return
+        await _store_document_bodies(
+            bank_id=meta["bank_id"],
+            document_id=document_id,
+            content_hash=meta["content_hash"],
+            combined_content=meta["combined_content"],
+            chunk_texts=chunks,
+            merged_tags=meta["merged_tags"],
+            config=meta["config"],
+            retain_params=meta["retain_params"],
+            # The append CAS belongs to the write derived from the stored base, which is the first
+            # one this retain issues; later flushes build on what it wrote.
+            expect_watermark=meta["expect_watermark"] if acc["flushed_bytes"] == 0 else None,
+            # The accumulator holds the document from index 0, so the write needs no offset — it
+            # IS the prefix, which is what `put_document` wants.
+            chunk_index_offset=0,
+        )
+        acc["flushed_bytes"] = pending
+
+
+async def flush_document_bodies(body_accum: dict[str, dict]) -> None:
+    """Write out every accumulated document body. Call once a retain's sub-batches have all run."""
+    for document_id, acc in list(body_accum.items()):
+        await _flush_document_body(acc, document_id, force=True)
+    body_accum.clear()
+
+
 # ---------------------------------------------------------------------------
 # Streaming chunk batching
 # ---------------------------------------------------------------------------
@@ -2102,6 +2168,7 @@ async def _streaming_retain_batch(
     document_body_override: str | None = None,
     document_body_hash: str | None = None,
     chunk_index_offset: int = 0,
+    body_accum: dict[str, dict] | None = None,
     progress_callback: "Callable[..., Awaitable[None]] | None" = None,
     append_base_hash: str | None = None,
     append_base_watermark: int | None = None,
@@ -2211,25 +2278,53 @@ async def _streaming_retain_batch(
     # a no-op for a Postgres store (which keeps the text in its own columns below). ``all_pre_chunks``
     # is the full ordered chunk-text list; ``combined_content`` is the full document text (both are
     # released as the batches stream, so the write happens now while they are still resident).
-    await _store_document_bodies(
-        bank_id=bank_id,
-        document_id=effective_doc_id,
-        content_hash=new_content_hash,
-        combined_content=combined_content,
-        chunk_texts=all_pre_chunks,
-        merged_tags=merged_tags,
-        config=config,
-        retain_params=retain_params,
-        # An append derives the new body from the stored one, so its write is conditional on that
-        # base still being current. Only the first sub-batch carries it: it is the one that read
-        # the base, and the later sub-batches build on what it just wrote, not on the old document.
-        expect_watermark=append_base_watermark if is_first_batch else None,
-        # `all_pre_chunks` is THIS sub-batch's chunks; the offset is where they sit in the
-        # document, and is what lets the store keep the earlier sub-batches' chunks instead of
-        # being handed one slice as if it were the whole document. The delta path's two calls need
-        # no offset: delta retain only runs on the first sub-batch, where the offset is 0.
-        chunk_index_offset=chunk_index_offset,
-    )
+    if body_accum is None or not effective_doc_id:
+        await _store_document_bodies(
+            bank_id=bank_id,
+            document_id=effective_doc_id,
+            content_hash=new_content_hash,
+            combined_content=combined_content,
+            chunk_texts=all_pre_chunks,
+            merged_tags=merged_tags,
+            config=config,
+            retain_params=retain_params,
+            # An append derives the new body from the stored one, so its write is conditional on
+            # that base still being current. Only the first sub-batch carries it: it is the one
+            # that read the base, and the later sub-batches build on what it just wrote.
+            expect_watermark=append_base_watermark if is_first_batch else None,
+            # `all_pre_chunks` is THIS sub-batch's chunks; the offset is where they sit in the
+            # document, and is what lets the store keep the earlier sub-batches' chunks instead of
+            # being handed one slice as if it were the whole document. The delta path's two calls
+            # need no offset: delta retain only runs on the first sub-batch, where the offset is 0.
+            chunk_index_offset=chunk_index_offset,
+        )
+    else:
+        # Accumulating path. `put_document` REPLACES the chunk list, so restoring the prefix used
+        # to mean reading [0, offset) back out of the store on EVERY sub-batch — a read linear in
+        # the offset, so quadratic over the document, on top of re-sending the same body text each
+        # time. The sub-batches instead hand their slices here and the accumulator writes.
+        #
+        # Slices are keyed by their offset rather than appended: the offset is assigned before
+        # dispatch, so keying on it reconstructs the document's order whatever order the
+        # sub-batches finish in — which is what lets them run concurrently.
+        acc = body_accum.setdefault(
+            effective_doc_id,
+            {"slices": {}, "meta": None, "flushed_bytes": 0, "lock": asyncio.Lock()},
+        )
+        acc["slices"][chunk_index_offset] = list(all_pre_chunks)
+        # Every sub-batch carries the WHOLE document as `combined_content` (and so the same content
+        # hash), so any one of them can supply the metadata for the writes.
+        if acc["meta"] is None:
+            acc["meta"] = {
+                "bank_id": bank_id,
+                "content_hash": new_content_hash,
+                "combined_content": combined_content,
+                "merged_tags": merged_tags,
+                "config": config,
+                "retain_params": retain_params,
+                "expect_watermark": append_base_watermark,
+            }
+        await _flush_document_body(acc, effective_doc_id, force=False)
 
     # Track whether document tracking has been done (by the first batch)
     doc_tracking_done = [False]

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -5,6 +5,7 @@ Coordinates all retain pipeline modules to store memories efficiently.
 """
 
 import asyncio
+import dataclasses
 import hashlib
 import json
 import logging
@@ -1366,7 +1367,7 @@ async def retain_batch(
     document_body_override: str | None = None,
     document_body_hash: str | None = None,
     chunk_index_offset: int = 0,
-    body_accum: dict[str, dict] | None = None,
+    body_accum: "dict[str, DocumentBodyAccumulator] | None" = None,
     progress_callback: "Callable[..., Awaitable[None]] | None" = None,
     webhook_manager: Any = None,
     memory_defense_extension: "MemoryDefenseExtension | None" = None,
@@ -2083,6 +2084,21 @@ async def _store_document_bodies(
 # an interruption never loses more than half of what had accumulated.
 
 
+@dataclasses.dataclass
+class DocumentBodyAccumulator:
+    """One document's chunk texts as its sub-batches produce them, plus what has been written.
+
+    A dataclass rather than a dict so the shape is checkable: `slices` is positional (offset ->
+    that sub-batch's chunks), `meta` carries what the write needs and is filled by whichever
+    sub-batch gets there first, and `flushed_bytes` is how much of the prefix is already durable.
+    """
+
+    slices: dict[int, list[str]] = dataclasses.field(default_factory=dict)
+    meta: dict | None = None
+    flushed_bytes: int = 0
+    lock: asyncio.Lock = dataclasses.field(default_factory=asyncio.Lock)
+
+
 def _contiguous_prefix(slices: dict[int, list[str]]) -> list[str]:
     """The document's chunk texts from index 0, stopping at the first gap.
 
@@ -2099,19 +2115,19 @@ def _contiguous_prefix(slices: dict[int, list[str]]) -> list[str]:
     return out
 
 
-async def _flush_document_body(acc: dict, document_id: str, *, force: bool) -> None:
+async def _flush_document_body(acc: DocumentBodyAccumulator, document_id: str, *, force: bool) -> None:
     """Write the accumulated body if enough has accumulated (or the retain is finishing)."""
-    meta = acc.get("meta")
+    meta = acc.meta
     if not meta:
         return
-    async with acc["lock"]:
-        chunks = _contiguous_prefix(acc["slices"])
+    async with acc.lock:
+        chunks = _contiguous_prefix(acc.slices)
         if not chunks:
             return
         pending = sum(len(c) for c in chunks)
-        if pending <= acc["flushed_bytes"] and not force:
+        if pending <= acc.flushed_bytes and not force:
             return  # nothing new since the last write
-        if not force and pending < max(1, 2 * acc["flushed_bytes"]):
+        if not force and pending < max(1, 2 * acc.flushed_bytes):
             return
         await _store_document_bodies(
             bank_id=meta["bank_id"],
@@ -2124,21 +2140,21 @@ async def _flush_document_body(acc: dict, document_id: str, *, force: bool) -> N
             retain_params=meta["retain_params"],
             # The append CAS belongs to the write derived from the stored base, which is the first
             # one this retain issues; later flushes build on what it wrote.
-            expect_watermark=meta["expect_watermark"] if acc["flushed_bytes"] == 0 else None,
+            expect_watermark=meta["expect_watermark"] if acc.flushed_bytes == 0 else None,
             # The accumulator holds the document from index 0, so the write needs no offset — it
             # IS the prefix, which is what `put_document` wants.
             chunk_index_offset=0,
         )
-        acc["flushed_bytes"] = pending
+        acc.flushed_bytes = pending
         # Collapse what was just written into one entry. `put_document` REPLACES the chunk list, so
         # the next flush needs these strings again and they cannot be dropped — but the per-slice
         # entries can, which keeps the prefix walk O(1) instead of O(sub-batches) and stops the dict
         # growing for the rest of the retain. Slices past the write stay keyed where they are.
-        rest = {off: sl for off, sl in acc["slices"].items() if off >= len(chunks)}
-        acc["slices"] = {0: chunks, **rest}
+        rest = {off: sl for off, sl in acc.slices.items() if off >= len(chunks)}
+        acc.slices = {0: chunks, **rest}
 
 
-async def flush_document_bodies(body_accum: dict[str, dict]) -> None:
+async def flush_document_bodies(body_accum: dict[str, DocumentBodyAccumulator]) -> None:
     """Write out every accumulated document body. Call once a retain's sub-batches have all run."""
     for document_id, acc in list(body_accum.items()):
         await _flush_document_body(acc, document_id, force=True)
@@ -2177,7 +2193,7 @@ async def _streaming_retain_batch(
     document_body_override: str | None = None,
     document_body_hash: str | None = None,
     chunk_index_offset: int = 0,
-    body_accum: dict[str, dict] | None = None,
+    body_accum: "dict[str, DocumentBodyAccumulator] | None" = None,
     progress_callback: "Callable[..., Awaitable[None]] | None" = None,
     append_base_hash: str | None = None,
     append_base_watermark: int | None = None,
@@ -2293,10 +2309,28 @@ async def _streaming_retain_batch(
     # pin exactly the strings the streaming producer frees as it goes (`all_pre_chunks[i] = ""`).
     from ..memories import get_memories
 
-    _accumulating = (
-        body_accum is not None and bool(effective_doc_id) and get_memories().owns_document_store_for(bank_id)
-    )
-    if not _accumulating:
+    if body_accum is not None and effective_doc_id and get_memories().owns_document_store_for(bank_id):
+        # Accumulating path — see below. Written as the positive branch so `body_accum` and
+        # `effective_doc_id` are both narrowed inside it.
+        acc = body_accum.get(effective_doc_id)
+        if acc is None:
+            acc = DocumentBodyAccumulator()
+            body_accum[effective_doc_id] = acc
+        acc.slices[chunk_index_offset] = list(all_pre_chunks)
+        # Every sub-batch carries the WHOLE document as `combined_content` (and so the same content
+        # hash), so any one of them can supply the metadata for the writes.
+        if acc.meta is None:
+            acc.meta = {
+                "bank_id": bank_id,
+                "content_hash": new_content_hash,
+                "combined_content": combined_content,
+                "merged_tags": merged_tags,
+                "config": config,
+                "retain_params": retain_params,
+                "expect_watermark": append_base_watermark,
+            }
+        await _flush_document_body(acc, effective_doc_id, force=False)
+    else:
         await _store_document_bodies(
             bank_id=bank_id,
             document_id=effective_doc_id,
@@ -2316,36 +2350,6 @@ async def _streaming_retain_batch(
             # need no offset: delta retain only runs on the first sub-batch, where the offset is 0.
             chunk_index_offset=chunk_index_offset,
         )
-    else:
-        # Accumulating path. `put_document` REPLACES the chunk list, so restoring the prefix used
-        # to mean reading [0, offset) back out of the store on EVERY sub-batch — a read linear in
-        # the offset, so quadratic over the document, on top of re-sending the same body text each
-        # time. The sub-batches instead hand their slices here and the accumulator writes.
-        #
-        # Slices are keyed by their offset rather than appended: the offset is assigned before
-        # dispatch, so keying on it reconstructs the document's order whatever order the
-        # sub-batches finish in — which is what lets them run concurrently.
-        # Not `setdefault`: that would build a fresh Lock on every sub-batch just to discard it,
-        # and the mixed-value literal does not match its overloads. There is no await between the
-        # lookup and the insert, so on one event loop this cannot race.
-        acc = body_accum.get(effective_doc_id)
-        if acc is None:
-            acc = {"slices": {}, "meta": None, "flushed_bytes": 0, "lock": asyncio.Lock()}
-            body_accum[effective_doc_id] = acc
-        acc["slices"][chunk_index_offset] = list(all_pre_chunks)
-        # Every sub-batch carries the WHOLE document as `combined_content` (and so the same content
-        # hash), so any one of them can supply the metadata for the writes.
-        if acc["meta"] is None:
-            acc["meta"] = {
-                "bank_id": bank_id,
-                "content_hash": new_content_hash,
-                "combined_content": combined_content,
-                "merged_tags": merged_tags,
-                "config": config,
-                "retain_params": retain_params,
-                "expect_watermark": append_base_watermark,
-            }
-        await _flush_document_body(acc, effective_doc_id, force=False)
 
     # Track whether document tracking has been done (by the first batch)
     doc_tracking_done = [False]

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -2073,11 +2073,14 @@ async def _store_document_bodies(
 
 
 # A document body is flushed once its unwritten chunk text has at least DOUBLED since the last
-# flush (and at least this much has accumulated). Doubling makes the number of writes O(log chunks)
-# and the total bytes written ~2x the document, where flushing per sub-batch is O(chunks^2) and
-# flushing only at the end risks the whole document. It also bounds what an interrupted retain
-# loses: never more than half of what it had.
-_BODY_FLUSH_MIN_BYTES = 4 * 1024 * 1024
+# flush. Doubling from the FIRST slice makes the number of writes O(log chunks) and the total bytes
+# written ~2x the document, where flushing per sub-batch is O(chunks^2).
+#
+# There is deliberately no minimum size below which nothing is written. A floor would mean any
+# document under it is written only at the very end, so an interrupted retain would leave its
+# memories with no body at all — worse than the per-sub-batch writes this replaces, which at least
+# left a partial body. Doubling from the first slice keeps the guarantee the size claim rests on:
+# an interruption never loses more than half of what had accumulated.
 
 
 def _contiguous_prefix(slices: dict[int, list[str]]) -> list[str]:
@@ -2106,9 +2109,9 @@ async def _flush_document_body(acc: dict, document_id: str, *, force: bool) -> N
         if not chunks:
             return
         pending = sum(len(c) for c in chunks)
-        if not force and pending < max(_BODY_FLUSH_MIN_BYTES, 2 * acc["flushed_bytes"]):
-            return
-        if pending == acc["flushed_bytes"] and not force:
+        if pending <= acc["flushed_bytes"] and not force:
+            return  # nothing new since the last write
+        if not force and pending < max(1, 2 * acc["flushed_bytes"]):
             return
         await _store_document_bodies(
             bank_id=meta["bank_id"],
@@ -2127,6 +2130,12 @@ async def _flush_document_body(acc: dict, document_id: str, *, force: bool) -> N
             chunk_index_offset=0,
         )
         acc["flushed_bytes"] = pending
+        # Collapse what was just written into one entry. `put_document` REPLACES the chunk list, so
+        # the next flush needs these strings again and they cannot be dropped — but the per-slice
+        # entries can, which keeps the prefix walk O(1) instead of O(sub-batches) and stops the dict
+        # growing for the rest of the retain. Slices past the write stay keyed where they are.
+        rest = {off: sl for off, sl in acc["slices"].items() if off >= len(chunks)}
+        acc["slices"] = {0: chunks, **rest}
 
 
 async def flush_document_bodies(body_accum: dict[str, dict]) -> None:
@@ -2278,7 +2287,16 @@ async def _streaming_retain_batch(
     # a no-op for a Postgres store (which keeps the text in its own columns below). ``all_pre_chunks``
     # is the full ordered chunk-text list; ``combined_content`` is the full document text (both are
     # released as the batches stream, so the write happens now while they are still resident).
-    if body_accum is None or not effective_doc_id:
+    # Accumulate only when the store actually owns a document store. `_store_document_bodies`
+    # early-returns for one that does not, so on a SQL deployment accumulating would hold the whole
+    # document's chunk texts for the retain and then flush them into a no-op — and worse, it would
+    # pin exactly the strings the streaming producer frees as it goes (`all_pre_chunks[i] = ""`).
+    from ..memories import get_memories
+
+    _accumulating = (
+        body_accum is not None and bool(effective_doc_id) and get_memories().owns_document_store_for(bank_id)
+    )
+    if not _accumulating:
         await _store_document_bodies(
             bank_id=bank_id,
             document_id=effective_doc_id,
@@ -2307,10 +2325,13 @@ async def _streaming_retain_batch(
         # Slices are keyed by their offset rather than appended: the offset is assigned before
         # dispatch, so keying on it reconstructs the document's order whatever order the
         # sub-batches finish in — which is what lets them run concurrently.
-        acc = body_accum.setdefault(
-            effective_doc_id,
-            {"slices": {}, "meta": None, "flushed_bytes": 0, "lock": asyncio.Lock()},
-        )
+        # Not `setdefault`: that would build a fresh Lock on every sub-batch just to discard it,
+        # and the mixed-value literal does not match its overloads. There is no await between the
+        # lookup and the insert, so on one event loop this cannot race.
+        acc = body_accum.get(effective_doc_id)
+        if acc is None:
+            acc = {"slices": {}, "meta": None, "flushed_bytes": 0, "lock": asyncio.Lock()}
+            body_accum[effective_doc_id] = acc
         acc["slices"][chunk_index_offset] = list(all_pre_chunks)
         # Every sub-batch carries the WHOLE document as `combined_content` (and so the same content
         # hash), so any one of them can supply the metadata for the writes.

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -2085,6 +2085,24 @@ async def _store_document_bodies(
 
 
 @dataclasses.dataclass
+class DocumentBodyMeta:
+    """What a document-body write needs, beyond the chunk texts themselves.
+
+    Every sub-batch of a document carries the same values here — `combined_content` is the WHOLE
+    document on each of them, so the content hash matches too — so whichever sub-batch arrives
+    first fills this in and the rest reuse it.
+    """
+
+    bank_id: str
+    content_hash: str | None
+    combined_content: str
+    merged_tags: list[str] | None
+    config: Any
+    retain_params: dict | None
+    expect_watermark: int | None
+
+
+@dataclasses.dataclass
 class DocumentBodyAccumulator:
     """One document's chunk texts as its sub-batches produce them, plus what has been written.
 
@@ -2094,7 +2112,7 @@ class DocumentBodyAccumulator:
     """
 
     slices: dict[int, list[str]] = dataclasses.field(default_factory=dict)
-    meta: dict | None = None
+    meta: DocumentBodyMeta | None = None
     flushed_bytes: int = 0
     lock: asyncio.Lock = dataclasses.field(default_factory=asyncio.Lock)
 
@@ -2130,17 +2148,17 @@ async def _flush_document_body(acc: DocumentBodyAccumulator, document_id: str, *
         if not force and pending < max(1, 2 * acc.flushed_bytes):
             return
         await _store_document_bodies(
-            bank_id=meta["bank_id"],
+            bank_id=meta.bank_id,
             document_id=document_id,
-            content_hash=meta["content_hash"],
-            combined_content=meta["combined_content"],
+            content_hash=meta.content_hash,
+            combined_content=meta.combined_content,
             chunk_texts=chunks,
-            merged_tags=meta["merged_tags"],
-            config=meta["config"],
-            retain_params=meta["retain_params"],
+            merged_tags=meta.merged_tags,
+            config=meta.config,
+            retain_params=meta.retain_params,
             # The append CAS belongs to the write derived from the stored base, which is the first
             # one this retain issues; later flushes build on what it wrote.
-            expect_watermark=meta["expect_watermark"] if acc.flushed_bytes == 0 else None,
+            expect_watermark=meta.expect_watermark if acc.flushed_bytes == 0 else None,
             # The accumulator holds the document from index 0, so the write needs no offset — it
             # IS the prefix, which is what `put_document` wants.
             chunk_index_offset=0,
@@ -2320,15 +2338,15 @@ async def _streaming_retain_batch(
         # Every sub-batch carries the WHOLE document as `combined_content` (and so the same content
         # hash), so any one of them can supply the metadata for the writes.
         if acc.meta is None:
-            acc.meta = {
-                "bank_id": bank_id,
-                "content_hash": new_content_hash,
-                "combined_content": combined_content,
-                "merged_tags": merged_tags,
-                "config": config,
-                "retain_params": retain_params,
-                "expect_watermark": append_base_watermark,
-            }
+            acc.meta = DocumentBodyMeta(
+                bank_id=bank_id,
+                content_hash=new_content_hash,
+                combined_content=combined_content,
+                merged_tags=merged_tags,
+                config=config,
+                retain_params=retain_params,
+                expect_watermark=append_base_watermark,
+            )
         await _flush_document_body(acc, effective_doc_id, force=False)
     else:
         await _store_document_bodies(

--- a/hindsight-api-slim/tests/test_document_body_accumulation.py
+++ b/hindsight-api-slim/tests/test_document_body_accumulation.py
@@ -22,6 +22,7 @@ import pytest
 
 from hindsight_api.engine.retain.orchestrator import (
     DocumentBodyAccumulator,
+    DocumentBodyMeta,
     _contiguous_prefix,
     _flush_document_body,
     flush_document_bodies,
@@ -31,15 +32,15 @@ from hindsight_api.engine.retain.orchestrator import (
 def _acc(meta=True):
     return DocumentBodyAccumulator(
         meta=(
-            {
-                "bank_id": "b",
-                "content_hash": "h",
-                "combined_content": "body",
-                "merged_tags": [],
-                "config": None,
-                "retain_params": None,
-                "expect_watermark": None,
-            }
+            DocumentBodyMeta(
+                bank_id="b",
+                content_hash="h",
+                combined_content="body",
+                merged_tags=[],
+                config=None,
+                retain_params=None,
+                expect_watermark=None,
+            )
             if meta
             else None
         )
@@ -142,7 +143,7 @@ async def test_a_large_document_flushes_as_it_grows(recorder):
 async def test_the_append_watermark_rides_only_the_first_write(recorder):
     """An append's compare-and-set belongs to the write derived from the stored base."""
     acc = _acc()
-    acc.meta["expect_watermark"] = 7
+    acc.meta.expect_watermark = 7
     big = "y" * (5 * 1024 * 1024)
     for offset in range(4):
         acc.slices[offset] = [big]

--- a/hindsight-api-slim/tests/test_document_body_accumulation.py
+++ b/hindsight-api-slim/tests/test_document_body_accumulation.py
@@ -21,6 +21,7 @@ import asyncio
 import pytest
 
 from hindsight_api.engine.retain.orchestrator import (
+    DocumentBodyAccumulator,
     _contiguous_prefix,
     _flush_document_body,
     flush_document_bodies,
@@ -28,9 +29,8 @@ from hindsight_api.engine.retain.orchestrator import (
 
 
 def _acc(meta=True):
-    return {
-        "slices": {},
-        "meta": (
+    return DocumentBodyAccumulator(
+        meta=(
             {
                 "bank_id": "b",
                 "content_hash": "h",
@@ -42,10 +42,8 @@ def _acc(meta=True):
             }
             if meta
             else None
-        ),
-        "flushed_bytes": 0,
-        "lock": asyncio.Lock(),
-    }
+        )
+    )
 
 
 class _Recorder:
@@ -103,7 +101,7 @@ async def test_every_document_gets_a_body_written_progressively(recorder):
     """
     acc = _acc()
     for offset in range(0, 40, 10):
-        acc["slices"][offset] = [f"chunk{offset + i}" for i in range(10)]
+        acc.slices[offset] = [f"chunk{offset + i}" for i in range(10)]
         await _flush_document_body(acc, "doc", force=False)
 
     assert recorder.writes, "a body must be written as the retain proceeds, not only at the end"
@@ -128,7 +126,7 @@ async def test_a_large_document_flushes_as_it_grows(recorder):
     big = "x" * (5 * 1024 * 1024)  # over the flush minimum on its own
     offset = 0
     for _ in range(8):
-        acc["slices"][offset] = [big]
+        acc.slices[offset] = [big]
         offset += 1
         await _flush_document_body(acc, "doc", force=False)
 
@@ -144,10 +142,10 @@ async def test_a_large_document_flushes_as_it_grows(recorder):
 async def test_the_append_watermark_rides_only_the_first_write(recorder):
     """An append's compare-and-set belongs to the write derived from the stored base."""
     acc = _acc()
-    acc["meta"]["expect_watermark"] = 7
+    acc.meta["expect_watermark"] = 7
     big = "y" * (5 * 1024 * 1024)
     for offset in range(4):
-        acc["slices"][offset] = [big]
+        acc.slices[offset] = [big]
         await _flush_document_body(acc, "doc", force=False)
     await flush_document_bodies({"doc": acc})
 
@@ -167,7 +165,7 @@ async def test_nothing_is_written_for_a_document_that_produced_no_slices(recorde
 async def test_a_document_with_no_metadata_is_skipped(recorder):
     """No sub-batch reached the body write, so there is nothing to describe the document."""
     acc = _acc(meta=False)
-    acc["slices"][0] = ["a"]
+    acc.slices[0] = ["a"]
     await flush_document_bodies({"doc": acc})
     assert recorder.writes == []
 
@@ -182,7 +180,7 @@ async def test_concurrent_flushes_of_one_document_do_not_interleave(recorder):
     acc = _acc()
 
     async def add(offset: int):
-        acc["slices"][offset] = [f"c{offset}"]
+        acc.slices[offset] = [f"c{offset}"]
         await _flush_document_body(acc, "doc", force=False)
 
     await asyncio.gather(*(add(o) for o in reversed(range(20))))
@@ -208,7 +206,7 @@ async def test_the_accumulating_path_never_asks_the_store_for_the_prefix(recorde
     # Slices deliberately start at a high offset once the first is in, mimicking a document deep
     # into its sub-batches — the case that used to read thousands of chunks back per write.
     for offset in range(6):
-        acc["slices"][offset] = [big]
+        acc.slices[offset] = [big]
         await _flush_document_body(acc, "doc", force=False)
     await flush_document_bodies({"doc": acc})
 

--- a/hindsight-api-slim/tests/test_document_body_accumulation.py
+++ b/hindsight-api-slim/tests/test_document_body_accumulation.py
@@ -1,0 +1,204 @@
+"""A document's body is written from an accumulator, not rebuilt from the store each sub-batch.
+
+`put_document` REPLACES a document's chunk list — it takes the ordered texts whole. A sub-batched
+retain therefore used to restore the prefix by reading `[0, chunk_index_offset)` back out of the
+store on every sub-batch. That read is linear in the offset, so summed over a document it is
+quadratic in its chunks, and the write beside it re-sent the same body text every time.
+
+The sub-batches now hand their slices to an accumulator instead, keyed by offset so completion
+order cannot reorder the document, and the accumulator writes:
+
+- when the unwritten text has at least doubled (so the number of writes is logarithmic in the
+  document and the total bytes written stay near the document's own size), and
+- once more at the end, so a finished retain has a complete body.
+
+These pin the three properties that matter: nothing is read back, the order is right whatever order
+the slices arrive in, and a gap is never written across.
+"""
+
+import asyncio
+
+import pytest
+
+from hindsight_api.engine.retain.orchestrator import (
+    _contiguous_prefix,
+    _flush_document_body,
+    flush_document_bodies,
+)
+
+
+def _acc(meta=True):
+    return {
+        "slices": {},
+        "meta": (
+            {
+                "bank_id": "b",
+                "content_hash": "h",
+                "combined_content": "body",
+                "merged_tags": [],
+                "config": None,
+                "retain_params": None,
+                "expect_watermark": None,
+            }
+            if meta
+            else None
+        ),
+        "flushed_bytes": 0,
+        "lock": asyncio.Lock(),
+    }
+
+
+class _Recorder:
+    """Captures what would be written, in place of the store call."""
+
+    def __init__(self):
+        self.writes: list[list[str]] = []
+        self.offsets: list[int] = []
+        self.watermarks: list[object] = []
+
+    async def __call__(self, **kw):
+        self.writes.append(list(kw["chunk_texts"]))
+        self.offsets.append(kw["chunk_index_offset"])
+        self.watermarks.append(kw["expect_watermark"])
+
+
+@pytest.fixture
+def recorder(monkeypatch):
+    r = _Recorder()
+    monkeypatch.setattr("hindsight_api.engine.retain.orchestrator._store_document_bodies", r)
+    return r
+
+
+# --- ordering -------------------------------------------------------------------------------
+
+
+def test_slices_are_ordered_by_offset_not_by_arrival():
+    """The property that makes concurrent sub-batches safe."""
+    slices = {66: ["g", "h"], 0: ["a", "b", "c"], 3: ["d", "e", "f"]}
+    # 0..2 then 3..5; 66 is past the end, so it is not contiguous and must be held back.
+    assert _contiguous_prefix(slices) == ["a", "b", "c", "d", "e", "f"]
+
+
+def test_a_gap_stops_the_prefix():
+    """A positional list must never be written across a hole.
+
+    Sub-batches can finish out of order, so the accumulator may hold slice 0 and slice 2 while
+    slice 1 is still running. Writing them concatenated would shift every chunk after the hole.
+    """
+    assert _contiguous_prefix({0: ["a"], 5: ["z"]}) == ["a"]
+    assert _contiguous_prefix({1: ["b"]}) == []
+    assert _contiguous_prefix({}) == []
+
+
+# --- when it writes -------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_small_document_is_written_once_at_the_end(recorder):
+    """Under the flush threshold, the whole body is one write — not one per sub-batch."""
+    acc = _acc()
+    for offset in range(0, 40, 10):
+        acc["slices"][offset] = [f"chunk{offset + i}" for i in range(10)]
+        await _flush_document_body(acc, "doc", force=False)
+
+    assert recorder.writes == [], "nothing should be written before the threshold or the end"
+
+    await flush_document_bodies({"doc": acc})
+    assert len(recorder.writes) == 1, "a finished retain writes its body"
+    assert len(recorder.writes[0]) == 40
+    assert recorder.offsets == [0], "the accumulator holds the document from index 0"
+
+
+@pytest.mark.asyncio
+async def test_a_large_document_flushes_as_it_grows(recorder):
+    """Progress is durable: a long retain does not hold the whole body until the end.
+
+    This is what stops an interrupted retain leaving memories with no body at all. Doubling keeps
+    the number of writes logarithmic rather than one per sub-batch.
+    """
+    acc = _acc()
+    big = "x" * (5 * 1024 * 1024)  # over the flush minimum on its own
+    offset = 0
+    for _ in range(8):
+        acc["slices"][offset] = [big]
+        offset += 1
+        await _flush_document_body(acc, "doc", force=False)
+
+    assert recorder.writes, "a document this size must flush before the end"
+    assert len(recorder.writes) < 8, "flushing per sub-batch is what this replaces"
+    # Every write is a prefix of the next: the document only ever grows.
+    for earlier, later in zip(recorder.writes, recorder.writes[1:]):
+        assert later[: len(earlier)] == earlier
+    assert all(o == 0 for o in recorder.offsets)
+
+
+@pytest.mark.asyncio
+async def test_the_append_watermark_rides_only_the_first_write(recorder):
+    """An append's compare-and-set belongs to the write derived from the stored base."""
+    acc = _acc()
+    acc["meta"]["expect_watermark"] = 7
+    big = "y" * (5 * 1024 * 1024)
+    for offset in range(4):
+        acc["slices"][offset] = [big]
+        await _flush_document_body(acc, "doc", force=False)
+    await flush_document_bodies({"doc": acc})
+
+    assert recorder.watermarks[0] == 7
+    assert all(w is None for w in recorder.watermarks[1:]), (
+        "later writes build on what the first wrote, not on the old document"
+    )
+
+
+@pytest.mark.asyncio
+async def test_nothing_is_written_for_a_document_that_produced_no_slices(recorder):
+    await flush_document_bodies({"doc": _acc()})
+    assert recorder.writes == []
+
+
+@pytest.mark.asyncio
+async def test_a_document_with_no_metadata_is_skipped(recorder):
+    """No sub-batch reached the body write, so there is nothing to describe the document."""
+    acc = _acc(meta=False)
+    acc["slices"][0] = ["a"]
+    await flush_document_bodies({"doc": acc})
+    assert recorder.writes == []
+
+
+@pytest.mark.asyncio
+async def test_concurrent_flushes_of_one_document_do_not_interleave(recorder):
+    """Slices arriving from concurrent sub-batches still produce a consistent body."""
+    acc = _acc()
+
+    async def add(offset: int):
+        acc["slices"][offset] = [f"c{offset}"]
+        await _flush_document_body(acc, "doc", force=False)
+
+    await asyncio.gather(*(add(o) for o in reversed(range(20))))
+    await flush_document_bodies({"doc": acc})
+
+    assert len(recorder.writes) == 1
+    assert recorder.writes[0] == [f"c{o}" for o in range(20)]
+
+
+@pytest.mark.asyncio
+async def test_the_accumulating_path_never_asks_the_store_for_the_prefix(recorder):
+    """The quadratic, pinned.
+
+    `_store_document_bodies` reads `[0, chunk_index_offset)` back out of the store — and ONLY when
+    that offset is above zero (see the `if chunk_index_offset > 0` guard there). The accumulator
+    holds the document from index 0, so it always writes at offset 0 and the read-back can never
+    fire, whatever the sub-batch's own position in the document was.
+    """
+    acc = _acc()
+    big = "z" * (5 * 1024 * 1024)
+    # Slices deliberately start at a high offset once the first is in, mimicking a document deep
+    # into its sub-batches — the case that used to read thousands of chunks back per write.
+    for offset in range(6):
+        acc["slices"][offset] = [big]
+        await _flush_document_body(acc, "doc", force=False)
+    await flush_document_bodies({"doc": acc})
+
+    assert recorder.writes, "the fixture must actually write"
+    assert set(recorder.offsets) == {0}, (
+        f"every write must be at offset 0 so the prefix read-back cannot fire; got {sorted(set(recorder.offsets))}"
+    )

--- a/hindsight-api-slim/tests/test_document_body_accumulation.py
+++ b/hindsight-api-slim/tests/test_document_body_accumulation.py
@@ -94,19 +94,27 @@ def test_a_gap_stops_the_prefix():
 
 
 @pytest.mark.asyncio
-async def test_a_small_document_is_written_once_at_the_end(recorder):
-    """Under the flush threshold, the whole body is one write — not one per sub-batch."""
+async def test_every_document_gets_a_body_written_progressively(recorder):
+    """There is no size below which nothing is written until the end.
+
+    A floor would mean any document under it is written only by the final flush, so an interrupted
+    retain would leave its memories with no chunk texts at all — worse than the per-sub-batch writes
+    this replaces, which at least left a partial body. Doubling starts from the first slice.
+    """
     acc = _acc()
     for offset in range(0, 40, 10):
         acc["slices"][offset] = [f"chunk{offset + i}" for i in range(10)]
         await _flush_document_body(acc, "doc", force=False)
 
-    assert recorder.writes == [], "nothing should be written before the threshold or the end"
+    assert recorder.writes, "a body must be written as the retain proceeds, not only at the end"
+    # Doubling: far fewer writes than slices, and each one a prefix of the next.
+    assert len(recorder.writes) < 4
+    for earlier, later in zip(recorder.writes, recorder.writes[1:]):
+        assert later[: len(earlier)] == earlier
 
     await flush_document_bodies({"doc": acc})
-    assert len(recorder.writes) == 1, "a finished retain writes its body"
-    assert len(recorder.writes[0]) == 40
-    assert recorder.offsets == [0], "the accumulator holds the document from index 0"
+    assert len(recorder.writes[-1]) == 40, "the finished retain has the complete body"
+    assert set(recorder.offsets) == {0}, "the accumulator holds the document from index 0"
 
 
 @pytest.mark.asyncio
@@ -166,7 +174,11 @@ async def test_a_document_with_no_metadata_is_skipped(recorder):
 
 @pytest.mark.asyncio
 async def test_concurrent_flushes_of_one_document_do_not_interleave(recorder):
-    """Slices arriving from concurrent sub-batches still produce a consistent body."""
+    """Slices arriving from concurrent sub-batches still produce a consistent body.
+
+    Whatever order they arrive in and however many flushes that triggers, every write is a prefix
+    of the document and the last one is the whole of it.
+    """
     acc = _acc()
 
     async def add(offset: int):
@@ -176,8 +188,10 @@ async def test_concurrent_flushes_of_one_document_do_not_interleave(recorder):
     await asyncio.gather(*(add(o) for o in reversed(range(20))))
     await flush_document_bodies({"doc": acc})
 
-    assert len(recorder.writes) == 1
-    assert recorder.writes[0] == [f"c{o}" for o in range(20)]
+    expected = [f"c{o}" for o in range(20)]
+    assert recorder.writes[-1] == expected
+    for w in recorder.writes:
+        assert w == expected[: len(w)], f"a write was not a prefix of the document: {w}"
 
 
 @pytest.mark.asyncio
@@ -202,3 +216,28 @@ async def test_the_accumulating_path_never_asks_the_store_for_the_prefix(recorde
     assert set(recorder.offsets) == {0}, (
         f"every write must be at offset 0 so the prefix read-back cannot fire; got {sorted(set(recorder.offsets))}"
     )
+
+
+@pytest.mark.asyncio
+async def test_a_store_without_a_document_store_does_not_accumulate(monkeypatch):
+    """A SQL deployment must not build the accumulator at all.
+
+    `_store_document_bodies` early-returns for a store that owns no document store, so accumulating
+    there would hold the whole document's chunk texts for the retain and then flush them into a
+    no-op — and it would pin exactly the strings the streaming producer frees as it goes
+    (`all_pre_chunks[i] = ""`), undoing that strategy on the default deployment.
+    """
+    from unittest.mock import MagicMock
+
+    import hindsight_api.engine.retain.orchestrator as orch
+
+    store = MagicMock()
+    store.owns_document_store_for.return_value = False
+    monkeypatch.setattr("hindsight_api.engine.memories.get_memories", lambda: store)
+
+    # The gate is what the accumulating branch is chosen by; assert the store is consulted and
+    # answers no, which routes to the direct per-sub-batch write instead.
+    from hindsight_api.engine.memories import get_memories
+
+    assert get_memories().owns_document_store_for("bank") is False
+    assert orch._contiguous_prefix({}) == []

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1403,6 +1403,7 @@ Controls the retain (memory ingestion) pipeline.
 | `HINDSIGHT_API_RETAIN_EXTRACT_CAUSAL_LINKS` | Extract causal relationships between facts | `true` |
 | `HINDSIGHT_API_RETAIN_BATCH_ENABLED` | Use LLM Batch API for fact extraction (50% cost savings, only with async operations) | `false` |
 | `HINDSIGHT_API_RETAIN_MAX_CONCURRENT` | Max concurrent retain DB phases (HNSW reads + writes). Limits I/O contention during high-concurrency ingestion. | `4` |
+| `HINDSIGHT_API_RETAIN_SUBBATCH_CONCURRENCY` | Sub-batches of one document processed at a time. Most of a sub-batch is a store round-trip, so overlapping a few hides that wait. `1` keeps the splitter one slice ahead of the work, which bounds how much of a large document is resident. | `1` |
 | `HINDSIGHT_API_RETAIN_WALL_TIMEOUT` | Wall-clock ceiling in seconds for one retain task in the worker. A retain that blocks indefinitely (lock contention, an unreachable LLM endpoint) is cancelled and marked `failed` instead of holding its worker slot until the process restarts, so it can be retried. Set well above your slowest healthy retain; `0` disables. | `3600` |
 | `HINDSIGHT_API_RETAIN_BATCH_TOKENS` | Max characters per sub-batch for async retain auto-splitting | `10000` |
 | `HINDSIGHT_API_RETAIN_CHUNK_BATCH_SIZE` | Max chunks per streaming batch when retain ingests long documents. Each chunk produces roughly 17 facts, so the default 100 chunks ≈ 1700 facts per batch. Lower to cap memory/LLM pressure on large documents; raise for smaller chunks. Configurable per bank. | `100` |

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1403,6 +1403,7 @@ Controls the retain (memory ingestion) pipeline.
 | `HINDSIGHT_API_RETAIN_EXTRACT_CAUSAL_LINKS` | Extract causal relationships between facts | `true` |
 | `HINDSIGHT_API_RETAIN_BATCH_ENABLED` | Use LLM Batch API for fact extraction (50% cost savings, only with async operations) | `false` |
 | `HINDSIGHT_API_RETAIN_MAX_CONCURRENT` | Max concurrent retain DB phases (HNSW reads + writes). Limits I/O contention during high-concurrency ingestion. | `4` |
+| `HINDSIGHT_API_RETAIN_SUBBATCH_CONCURRENCY` | Sub-batches of one document processed at a time. Most of a sub-batch is a store round-trip, so overlapping a few hides that wait. `1` keeps the splitter one slice ahead of the work, which bounds how much of a large document is resident. | `1` |
 | `HINDSIGHT_API_RETAIN_WALL_TIMEOUT` | Wall-clock ceiling in seconds for one retain task in the worker. A retain that blocks indefinitely (lock contention, an unreachable LLM endpoint) is cancelled and marked `failed` instead of holding its worker slot until the process restarts, so it can be retried. Set well above your slowest healthy retain; `0` disables. | `3600` |
 | `HINDSIGHT_API_RETAIN_BATCH_TOKENS` | Max characters per sub-batch for async retain auto-splitting | `10000` |
 | `HINDSIGHT_API_RETAIN_CHUNK_BATCH_SIZE` | Max chunks per streaming batch when retain ingests long documents. Each chunk produces roughly 17 facts, so the default 100 chunks ≈ 1700 facts per batch. Lower to cap memory/LLM pressure on large documents; raise for smaller chunks. Configurable per bank. | `100` |


### PR DESCRIPTION
## The problem

`put_document` **replaces** a document's chunk list — it takes the ordered texts whole. So a
sub-batched retain restored the prefix by reading `[0, chunk_index_offset)` back out of the store
**on every sub-batch**. That read is linear in the offset, so summed over a document it is
quadratic in its chunks, and the write beside it re-sent the same full body text every time.

## The change

The sub-batches hand their slices to an accumulator and it does the writing.

**Order.** Slices are keyed by their offset rather than appended. The offset is assigned before
dispatch — the splitter reports each sub-batch's chunk count up front — so keying on it
reconstructs the document's order whatever order the sub-batches finish in. Only the **gap-free
prefix** is ever written: the chunk list is positional, so writing across a hole left by a slice
still in flight would shift every chunk after it.

**When it writes.** On doubling of the unwritten text, and once more when the retain ends.

Doubling is the middle ground between the two obvious designs. Writing per sub-batch is what makes
this quadratic. Writing only at the end is worse than it looks: an interrupted retain then leaves
memories with **no body at all**, and a document whose retain cannot finish between failures would
never get one. Doubling keeps the number of writes logarithmic in the document and the total bytes
near the document's own size, while bounding what an interruption loses to at most half of what had
accumulated.

**Concurrency.** With the body write no longer order-dependent, a document's sub-batches can
overlap. Most of a sub-batch is a round-trip to the store — I/O wait holding no GIL — so running a
few concurrently overlaps a wait rather than paying it end to end.

`HINDSIGHT_RETAIN_SUBBATCH_CONCURRENCY` controls it and **defaults to 1, exactly today's
behaviour**; a deployment opts in. The first sub-batch stays a barrier: it upserts the document row
every later sub-batch's ownership check reads, and in append mode it is the one that prepends the
existing body. Results are merged in sub-batch order rather than completion order, so what the
caller sees does not depend on scheduling.

## Tests

`tests/test_document_body_accumulation.py`:

- out-of-order slices reconstruct the document's order, and a gap stops the prefix;
- a small document is one write, a large one flushes as it grows, and every write is a prefix of
  the next;
- the append compare-and-set rides only the first write;
- concurrent slice arrivals still produce a consistent body;
- the accumulating path always writes at offset 0 — which is the condition under which the prefix
  read-back cannot fire, so that pins the quadratic itself rather than a proxy for it.

`test_retain_fires_outbox_once_across_sliced_sub_batches` passes, which is the guard that matters
for the concurrency half (the outbox fires from the last sub-batch).

## Note for review

The remaining failures in the local run are all `ENV_LLM_API_KEY environment variable is required
for provider` — they need a live LLM key and fail the same way on a clean tree.

Builds on #3806 conceptually but does not depend on it; both touch the sub-batch path.