### PR TITLE
fix(control-plane): reset knowledge state on bank switch

### DIFF
--- a/hindsight-control-plane/src/app/[locale]/banks/[bankId]/page.tsx
+++ b/hindsight-control-plane/src/app/[locale]/banks/[bankId]/page.tsx
@@ -718,7 +718,7 @@ export default function BankPage() {
                     </div>
                   </div>
 
-                  {knowledgeTab === "pages" && <KnowledgeBaseView />}
+                  {knowledgeTab === "pages" && <KnowledgeBaseView key={bankId} />}
                   {knowledgeTab === "models" && (
                     <div>
                       <p className="text-sm text-muted-foreground mb-4">

--- a/hindsight-control-plane/src/components/knowledge-base-view.tsx
+++ b/hindsight-control-plane/src/components/knowledge-base-view.tsx
@@ -50,6 +50,7 @@ import {
 } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";
 import { formatAbsoluteDateTime, formatRelativeTime } from "@/lib/relative-time";
+import { findRequestedKnowledgePageId } from "@/lib/knowledge-base-navigation";
 import { CompactMarkdown } from "./compact-markdown";
 import { StalenessBadge } from "./staleness-badge";
 import { FreshnessLine } from "./freshness-line";
@@ -201,6 +202,10 @@ export function KnowledgeBaseView() {
   }, [currentBank, loadTree]);
 
   const allNodes = useMemo(() => flatten(roots), [roots]);
+  const requestedPageId = useMemo(
+    () => findRequestedKnowledgePageId(roots, pageParam),
+    [roots, pageParam]
+  );
   // A synthetic top-level folder for the bank so the root itself is visible and
   // you can add folders/pages directly under it. Its "" id makes add-child create
   // at the root; it's never deletable (TreeRow hides delete for the root).
@@ -303,27 +308,29 @@ export function KnowledgeBaseView() {
     setActiveId((a) => (a === id ? (next[idx]?.id ?? next[idx - 1]?.id ?? null) : a));
   }, []);
 
-  // Deep-link: open the page named in ?page= (e.g. navigated from the Home card).
+  // Validate deep links against the loaded bank's tree before requesting them.
+  // Page ids belong to a bank, so a stale or shared URL must fall back locally
+  // instead of sending another bank's id and leaving the content pane empty.
   useEffect(() => {
-    if (pageParam && currentBank) openPage(pageParam);
-  }, [pageParam, currentBank, openPage]);
+    if (requestedPageId && currentBank) openPage(requestedPageId);
+  }, [requestedPageId, currentBank, openPage]);
 
   // Reset the once-per-bank auto-select guard when switching banks.
   useEffect(() => {
     autoSelectedRef.current = false;
   }, [currentBank]);
 
-  // Open the first page on entry so the content pane isn't empty — unless a page
-  // is deep-linked or already open. Fires once per bank (guarded), so closing a
-  // page doesn't snap it back open.
+  // Open the first page on entry so the content pane isn't empty. A valid deep
+  // link is handled above; an invalid or cross-bank id falls back here. Fires
+  // once per bank (guarded), so closing a page doesn't snap it back open.
   useEffect(() => {
-    if (autoSelectedRef.current || pageParam || selected || !allNodes.length) return;
+    if (autoSelectedRef.current || requestedPageId || selected || !allNodes.length) return;
     const firstPage = allNodes.find((n) => n.kind === "page");
     if (firstPage) {
       autoSelectedRef.current = true;
       openPage(firstPage.id);
     }
-  }, [allNodes, pageParam, selected, openPage]);
+  }, [allNodes, requestedPageId, selected, openPage]);
 
   const toggleFolder = useCallback((id: string) => {
     setExpanded((prev) => {

--- a/hindsight-control-plane/src/lib/knowledge-base-navigation.ts
+++ b/hindsight-control-plane/src/lib/knowledge-base-navigation.ts
@@ -1,0 +1,16 @@
+import type { KnowledgeNode } from "./api";
+
+export function findRequestedKnowledgePageId(
+  nodes: KnowledgeNode[],
+  requestedId: string | null
+): string | null {
+  if (!requestedId) return null;
+
+  for (const node of nodes) {
+    if (node.id === requestedId) return node.kind === "page" ? node.id : null;
+    const nested = findRequestedKnowledgePageId(node.children, requestedId);
+    if (nested) return nested;
+  }
+
+  return null;
+}

--- a/hindsight-control-plane/tests/lib/knowledge-base-navigation.test.ts
+++ b/hindsight-control-plane/tests/lib/knowledge-base-navigation.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import type { KnowledgeNode } from "@/lib/api";
+import { findRequestedKnowledgePageId } from "@/lib/knowledge-base-navigation";
+
+function node(
+  id: string,
+  kind: KnowledgeNode["kind"],
+  children: KnowledgeNode[] = []
+): KnowledgeNode {
+  return {
+    id,
+    kind,
+    name: id,
+    parent_id: null,
+    mental_model_id: kind === "page" ? `mm-${id}` : null,
+    managed: false,
+    description: null,
+    tags: [],
+    timestamp: null,
+    is_stale: null,
+    trigger: null,
+    children,
+  };
+}
+
+const tree = [node("folder-1", "folder", [node("page-nested", "page")]), node("page-root", "page")];
+
+describe("findRequestedKnowledgePageId", () => {
+  it("returns a nested page when it belongs to the loaded bank", () => {
+    expect(findRequestedKnowledgePageId(tree, "page-nested")).toBe("page-nested");
+  });
+
+  it("rejects a page id that is absent from the loaded bank", () => {
+    expect(findRequestedKnowledgePageId(tree, "page-from-another-bank")).toBeNull();
+  });
+
+  it("rejects folder ids", () => {
+    expect(findRequestedKnowledgePageId(tree, "folder-1")).toBeNull();
+  });
+
+  it("returns null when no page was requested", () => {
+    expect(findRequestedKnowledgePageId(tree, null)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Background

The knowledge-base view kept page and mental-model state from the previous bank during a bank switch. Effects could then request those stale IDs against the newly selected bank, producing 404 notifications. A `?page=` link containing a missing, folder, or foreign-bank ID also prevented automatic selection and left the content pane empty.

## Changes

- Remount the knowledge-base view when the selected bank changes so page, tab, and provenance state cannot cross bank boundaries.
- Validate `?page=` against the loaded bank tree before requesting it.
- Fall back to the first page when the requested ID is invalid for the current bank.
- Add unit coverage for valid, missing, folder, and absent page parameters.

## Verification

- `TZ=UTC npm test` (158 tests)
- `npm run build`
- `./scripts/hooks/lint.sh`
- `./scripts/hooks/check-unused.sh` (advisory; no new findings)
- Headless browser network QA:
  - switching between populated banks produced no failed API requests
  - a foreign-bank `?page=` produced no 404 and opened the current bank's first page
  - a valid `?page=` requested and opened the specified page with HTTP 200

Fixes #3807