### PR TITLE
fix(coding-agents): don't let one stray file abort the Claude import, and give Prime Agent the companion skill (#3771, #3772)

### DIFF
--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -126,7 +126,8 @@ A native plugin via `cline plugin install`, plus MCP and the companion skill.
 npx @vectorize-io/hindsight-coding-agents install prime-agent
 ```
 
-An extension entry in `~/.prime/agent/settings.json` — native tools, no MCP needed.
+An extension entry in `~/.prime/agent/settings.json` — native tools, no MCP needed — plus the
+companion skill in `~/.prime/agent/skills`.
 
 #### <img src="/img/harness/dsh.svg" alt="" width="20" height="20" /> DeepSeek Harness
 

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -123,7 +123,8 @@ A native plugin via `cline plugin install`, plus MCP and the companion skill.
 npx @vectorize-io/hindsight-coding-agents install prime-agent
 ```
 
-An extension entry in `~/.prime/agent/settings.json` — native tools, no MCP needed.
+An extension entry in `~/.prime/agent/settings.json` — native tools, no MCP needed — plus the
+companion skill in `~/.prime/agent/skills`.
 
 #### <img src="https://hindsight.vectorize.io/img/harness/dsh.svg" alt="" width="20" height="20" /> DeepSeek Harness
 

--- a/hindsight-integrations/coding-agents/src/core/history.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/history.test.ts
@@ -145,6 +145,40 @@ describe("local history import", () => {
   });
 });
 
+/**
+ * `importLocalHistory` documents that it never throws, and its caller (`--import-conversations`)
+ * takes it at its word. A stray entry must therefore cost that entry, not the whole run (#3771).
+ */
+describe("a junk entry costs itself, not the import", () => {
+  it("skips a regular file sitting where a Claude project directory was expected", () => {
+    const h = newHome();
+    const repo = "/Users/x/dev/myrepo";
+    const dir = claudeProjectDir(repo, h);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "s1.jsonl"), `${claudeLine("user", "the real session", repo)}\n`);
+    // Named like the project dir of a SUBDIRECTORY, so the prefix filter hands it to the listing;
+    // without the guard readdirSync threw ENOTDIR and nothing was imported.
+    writeFileSync(claudeProjectDir("/Users/x/dev/myrepo/sub", h), "not a folder");
+
+    const r = importLocalHistory("claude-code", repo, h);
+
+    expect(r.supported).toBe(true);
+    expect(r.sessions).toHaveLength(1);
+    expect(JSON.stringify(r.sessions)).toContain("the real session");
+  });
+
+  it("skips a regular file where ~/.claude/projects itself was expected", () => {
+    const h = newHome();
+    mkdirSync(join(h, ".claude"), { recursive: true });
+    writeFileSync(join(h, ".claude", "projects"), "not a folder");
+
+    const r = importLocalHistory("claude-code", "/Users/x/dev/myrepo", h);
+
+    expect(r.supported).toBe(true);
+    expect(r.sessions).toEqual([]);
+  });
+});
+
 describe("attribution must be proven, never guessed", () => {
   it("skips a Claude session that records no cwd instead of trusting the directory name", () => {
     const h = newHome();

--- a/hindsight-integrations/coding-agents/src/core/history.ts
+++ b/hindsight-integrations/coding-agents/src/core/history.ts
@@ -118,9 +118,24 @@ function firstLine(path: string, cap = 1_000_000): string | undefined {
   }
 }
 
+/**
+ * The entries of a directory, or none when there is nothing to list.
+ *
+ * `existsSync` answered only half of that: it is TRUE for a regular file sitting where a directory
+ * was expected — a stray `~/.claude/projects/-Users-x-dev-repo-sub` — and the `readdirSync` behind
+ * it then threw ENOTDIR out of `importLocalHistory`, which promises never to throw. One junk entry
+ * killed the whole `--import-conversations` run instead of costing that entry (#3771).
+ */
+function listDir(dir: string): string[] {
+  try {
+    return readdirSync(dir);
+  } catch {
+    return []; // missing, unreadable, or a stray file where a directory was expected
+  }
+}
+
 function jsonlFiles(dir: string): string[] {
-  if (!existsSync(dir)) return [];
-  return readdirSync(dir)
+  return listDir(dir)
     .filter((f) => f.endsWith(".jsonl"))
     .map((f) => join(dir, f));
 }
@@ -139,11 +154,9 @@ function claudeHistory(repoDir: string, home: string): HistoryImport {
   const root = join(home, ".claude", "projects");
   const exact = claudeProjectDir(repoDir, home);
   const prefix = exact + "-";
-  const dirs = existsSync(root)
-    ? readdirSync(root)
-        .map((d) => join(root, d))
-        .filter((d) => d === exact || d.startsWith(prefix))
-    : [];
+  const dirs = listDir(root)
+    .map((d) => join(root, d))
+    .filter((d) => d === exact || d.startsWith(prefix));
   const sessions: ChatSession[] = [];
   let unattributed = 0;
   for (const file of dirs.flatMap(jsonlFiles)) {

--- a/hindsight-integrations/coding-agents/src/installer.test.ts
+++ b/hindsight-integrations/coding-agents/src/installer.test.ts
@@ -913,7 +913,7 @@ describe("runtime staging", () => {
 });
 
 describe("skill install across skills-capable hosts", () => {
-  it("copies the packaged skill for claude/codex(~/.agents)/antigravity/cursor and uninstall removes each", () => {
+  it("copies the packaged skill for claude/codex(~/.agents)/antigravity/cursor/prime-agent and uninstall removes each", () => {
     const home = mkdtempSync(join(tmpdir(), "hs-inst-skill-"));
     const pkgRoot = mkdtempSync(join(tmpdir(), "hs-pkg-"));
     mkdirSync(join(pkgRoot, "skill"), { recursive: true });
@@ -927,6 +927,9 @@ describe("skill install across skills-capable hosts", () => {
       ["codex", join(home, ".agents", "skills")],
       ["antigravity-cli", join(home, ".gemini", "config", "skills")],
       ["cursor-cli", join(home, ".cursor", "skills")],
+      // Prime Agent's OWN root, never the shared ~/.agents one it also reads: uninstall removes a
+      // fixed directory name, so the shared root would take Codex's and dsh's copy with it (#3772).
+      ["prime-agent", join(home, ".prime", "agent", "skills")],
     ];
     run(["install", ...targets.map(([h]) => h)], ctx);
     for (const [, base] of targets) {
@@ -936,6 +939,31 @@ describe("skill install across skills-capable hosts", () => {
     for (const [, base] of targets) {
       expect(existsSync(join(base, "hindsight-coding-agent"))).toBe(false);
     }
+    rmSync(home, { recursive: true, force: true });
+    rmSync(pkgRoot, { recursive: true, force: true });
+  });
+
+  // uninstallSkill removes a fixed directory NAME, so a host installing into the shared
+  // agentskills root would delete the copy another host is still using.
+  it("uninstalling prime-agent leaves the shared ~/.agents copy Codex installed", () => {
+    const home = mkdtempSync(join(tmpdir(), "hs-inst-skill-"));
+    const pkgRoot = mkdtempSync(join(tmpdir(), "hs-pkg-"));
+    mkdirSync(join(pkgRoot, "skill"), { recursive: true });
+    writeFileSync(
+      join(pkgRoot, "skill", "SKILL.md"),
+      "---\nname: hindsight-coding-agent\n---\nbody"
+    );
+    const ctx = { home, pkgRoot, dist: join(pkgRoot, "dist"), claudeMcp: vi.fn(() => true) };
+
+    run(["install", "codex", "prime-agent"], ctx);
+    run(["uninstall", "prime-agent"], ctx);
+
+    expect(existsSync(join(home, ".agents", "skills", "hindsight-coding-agent", "SKILL.md"))).toBe(
+      true
+    );
+    expect(existsSync(join(home, ".prime", "agent", "skills", "hindsight-coding-agent"))).toBe(
+      false
+    );
     rmSync(home, { recursive: true, force: true });
     rmSync(pkgRoot, { recursive: true, force: true });
   });

--- a/hindsight-integrations/coding-agents/src/installer.ts
+++ b/hindsight-integrations/coding-agents/src/installer.ts
@@ -272,6 +272,10 @@ const opencode: HarnessInstaller = {
  * `dist/prime-agent.js` in the `extensions` array of `~/.prime/agent/settings.json`; Prime Agent
  * loads that file's default export at session start. The entry path contains MARKER (the package is
  * `hindsight-coding-agents`), so uninstall's MARKER filter removes exactly what install added.
+ *
+ * The skill goes to Prime Agent's OWN `~/.prime/agent/skills`, not the shared `~/.agents/skills`
+ * root it also reads: `uninstallSkill` removes a fixed directory name, so installing to the shared
+ * root would make `uninstall prime-agent` delete Codex's and dsh's copy too (#3772).
  */
 const primeAgent: HarnessInstaller = {
   name: "prime-agent",
@@ -283,18 +287,22 @@ const primeAgent: HarnessInstaller = {
     const exts: string[] = Array.isArray(cfg.extensions) ? cfg.extensions : [];
     cfg.extensions = [...exts.filter((p) => !String(p).includes(MARKER)), entry];
     writeJson(path, cfg);
+    installSkill(c, "prime-agent", join(c.home, ".prime", "agent", "skills"));
     c.log?.(`prime-agent: extension registered in ${path}`);
   },
   uninstall(c) {
     const path = join(c.home, ".prime", "agent", "settings.json");
-    if (!existsSync(path)) return;
-    const cfg = readJson(path);
-    if (Array.isArray(cfg.extensions)) {
-      cfg.extensions = cfg.extensions.filter((p: string) => !String(p).includes(MARKER));
-      if (!cfg.extensions.length) delete cfg.extensions;
-      writeJson(path, cfg);
+    if (existsSync(path)) {
+      const cfg = readJson(path);
+      if (Array.isArray(cfg.extensions)) {
+        cfg.extensions = cfg.extensions.filter((p: string) => !String(p).includes(MARKER));
+        if (!cfg.extensions.length) delete cfg.extensions;
+        writeJson(path, cfg);
+      }
     }
-    c.log?.("prime-agent: extension entry removed");
+    // Outside the settings guard on purpose: a hand-deleted settings.json must not strand the skill.
+    uninstallSkill(c, join(c.home, ".prime", "agent", "skills"));
+    c.log?.("prime-agent: extension entry + skill removed");
   },
 };
 

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -121,7 +121,8 @@ A native plugin via `cline plugin install`, plus MCP and the companion skill.
 npx @vectorize-io/hindsight-coding-agents install prime-agent
 ```
 
-An extension entry in `~/.prime/agent/settings.json` — native tools, no MCP needed.
+An extension entry in `~/.prime/agent/settings.json` — native tools, no MCP needed — plus the
+companion skill in `~/.prime/agent/skills`.
 
 ####  DeepSeek Harness
 


### PR DESCRIPTION
## Summary

Two independent coding-agents fixes, both small enough to share a PR.

**#3771 — a stray file aborted the whole Claude history import.** `claudeHistory` prefilters `~/.claude/projects` candidates by encoded NAME and hands each match to `jsonlFiles`, which gated on `existsSync` — TRUE for a regular **file** — and then `readdirSync`, which throws `ENOTDIR`. That escaped `importLocalHistory`, which documents that it never throws, and whose caller (`importConversations` in `installer.ts`) has no catch of its own: one junk entry killed the entire `--import-conversations` run instead of costing that entry.

The guard belongs in the listing rather than at the call site the issue suggested — `jsonlFiles` already owned "there is nothing here to list" via `existsSync`, and a stray file is that same case reached through a different errno. A `listDir` helper now holds it, which also closes the identical hole one level up (a regular file at `~/.claude/projects` was equally fatal) and sheds a `stat` per candidate directory plus its TOCTOU window. The dsh reader already handles its own case with a `try/catch` and is left alone.

**#3772 — Prime Agent never received the companion skill.** It documents the same discovery roots the other skills-capable hosts use, so it can load the skill and today only does so by accident, when the user also runs Codex or dsh and it picks ours up from the shared `~/.agents` root. `installSkill`/`uninstallSkill` are now wired into its adapter, into Prime Agent's **own** `~/.prime/agent/skills`: `uninstallSkill` removes a fixed directory name, so installing to the shared root would make `uninstall prime-agent` delete Codex's and dsh's copy. Uninstall's skill removal sits outside the `settings.json` guard so a hand-deleted settings file can't strand the skill.

Closes #3771.
Closes #3772.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [ ] Documentation
- [ ] Refactor

## Test plan

- `src/core/history.test.ts` — two new Claude regression tests: a stray file named like the project dir of a subdirectory (so the prefix filter hands it to the listing), and a regular file where `~/.claude/projects` itself belongs. Both were verified to fail on the pre-fix listing with the exact reported error (`ENOTDIR: not a directory, scandir '…/.claude/projects/-Users-x-dev-myrepo-sub'`), and the first still imports the real session alongside the junk entry.
- `src/installer.test.ts` — prime-agent joins the cross-host skill install/uninstall matrix, plus a test that installing Codex and Prime Agent and then uninstalling Prime Agent leaves the shared `~/.agents` copy intact.
- `npx vitest run --exclude 'src/e2e/**'` → 658 passed, 23 skipped. `./scripts/hooks/lint.sh` clean, `./scripts/hooks/check-unused.sh` shows nothing new.
- README regenerated through `npm run skill:build` + `sync-coding-agents-doc.mjs` after linting; only the docs page moved, the skill regions are untouched.

## Notes for the reviewer

- There are two open community PRs against these issues, opened before this one: #3778 (#3771) and #3775 (#3772, bundled with adding `pi` as a new harness). This PR takes the same `listDir` shape as #3778 for the first half, and does the Prime Agent half without the new harness. Close whichever set you don't want.
- Prime Agent is **not** added to `SKILL_DIRS` in `core/skill-sync.ts`: that self-update path runs from the stdin hook `session-start`, which persistent-plugin harnesses (prime-agent, dsh, opencode, Kilo, Cline) never reach — the known #3524-shaped gap, unchanged here. Prime Agent's copy refreshes on re-install like dsh's does.
- Left alone as behaviour changes rather than this fix: `codexHistory`'s walk is guarded at the opposite altitude (one unstattable entry discards every file found so far), and `importLocalHistory` still has no top-level backstop for its never-throws contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHvpDBNP3CXfVL88WnazmC
