### PR TITLE
test: restore the global metrics collector instead of leaking it (#3780)

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -198,6 +198,7 @@ from hindsight_api.metrics import (
     get_metrics_collector,
     initialize_metrics,
     normalize_http_endpoint,
+    reset_metrics_collector,
 )
 from hindsight_api.models import RequestContext
 
@@ -3858,7 +3859,11 @@ def create_app(
         poller_task = None
         loop_watchdog = None
 
-        # Initialize OpenTelemetry metrics
+        # Initialize OpenTelemetry metrics. Remember the collector we displace so
+        # shutdown can put it back: the collector is a module global, so an app
+        # that starts and stops otherwise leaves its own collector — holding a
+        # closed DB pool — installed for the rest of the process (#3780).
+        previous_metrics_collector = get_metrics_collector()
         try:
             prometheus_reader = initialize_metrics(service_name="hindsight-api", service_version="1.0.0")
             create_metrics_collector()
@@ -3969,6 +3974,9 @@ def create_app(
         from hindsight_api.tracing import shutdown_tracing
 
         shutdown_tracing()
+
+        # Put back whatever collector was installed before startup (#3780).
+        reset_metrics_collector(previous_metrics_collector)
 
     from hindsight_api import __version__
     from hindsight_api.config import get_config

--- a/hindsight-api-slim/hindsight_api/metrics.py
+++ b/hindsight-api-slim/hindsight_api/metrics.py
@@ -1116,7 +1116,24 @@ def create_metrics_collector() -> MetricsCollector:
     Create and set the global metrics collector.
 
     Should be called after initialize_metrics().
+
+    The collector it replaces is *not* remembered here — callers that can shut
+    down (the API lifespan, tests) should snapshot ``get_metrics_collector()``
+    first and hand it back to ``reset_metrics_collector()`` on teardown.
     """
     global _metrics_collector
     _metrics_collector = MetricsCollector()
     return _metrics_collector
+
+
+def reset_metrics_collector(collector: MetricsCollectorBase | None = None) -> None:
+    """
+    Restore the global metrics collector, undoing ``create_metrics_collector()``.
+
+    Pass the collector that was installed beforehand to put it back; with no
+    argument the process falls back to the default no-op collector. Without
+    this, an app that starts once leaves a live ``MetricsCollector`` (and its
+    reference to a now-closed DB pool) installed for the rest of the process.
+    """
+    global _metrics_collector
+    _metrics_collector = collector if collector is not None else NoOpMetricsCollector()

--- a/hindsight-api-slim/tests/conftest.py
+++ b/hindsight-api-slim/tests/conftest.py
@@ -111,6 +111,28 @@ def _cleanup_leaked_span_recorders():
             recorders.remove(recorder)
 
 
+@pytest.fixture(autouse=True)
+def _restore_global_metrics_collector():
+    """Fail-safe for the process-global metrics collector (#3780).
+
+    ``create_metrics_collector()`` swaps the module-global collector in
+    ``hindsight_api.metrics`` for a real ``MetricsCollector``. The API lifespan
+    now restores it on shutdown, but a test that starts the app and never runs
+    shutdown (or calls ``create_metrics_collector()`` itself) still leaves the
+    real collector installed for every test that follows in the same xdist
+    worker. ``NoOpMetricsCollector`` ignores its arguments while the real one
+    compares them, so provider tests that pass a bare ``MagicMock`` usage object
+    then blow up with "'>' not supported between instances of 'MagicMock' and
+    'int'" — in whichever files the worker happened to be given, which is why
+    the failure count moved every time someone added a test.
+    """
+    from hindsight_api import metrics as metrics_module
+
+    before = metrics_module.get_metrics_collector()
+    yield
+    metrics_module.reset_metrics_collector(before)
+
+
 # Default pg0 instance configuration for tests
 DEFAULT_PG0_INSTANCE_NAME = "hindsight-test"
 DEFAULT_PG0_PORT = int(os.environ.get("HINDSIGHT_TEST_PG_PORT", "5556"))

--- a/hindsight-api-slim/tests/test_metrics_collector_lifecycle.py
+++ b/hindsight-api-slim/tests/test_metrics_collector_lifecycle.py
@@ -1,0 +1,76 @@
+"""The process-global metrics collector must be restored, not leaked (#3780).
+
+``create_metrics_collector()`` replaces a module global. Before this, the API
+lifespan installed a real ``MetricsCollector`` and never put the previous one
+back, so a single app start poisoned the rest of the process: unlike
+``NoOpMetricsCollector``, the real collector inspects the values it is handed
+(``if cached_input_tokens > 0``), and the provider tests feed it bare
+``MagicMock`` usage objects. Whichever test files happened to run after an
+app-starting test in the same xdist worker then failed with "'>' not supported
+between instances of 'MagicMock' and 'int'".
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from hindsight_api.api.http import create_app
+from hindsight_api.metrics import (
+    MetricsCollector,
+    NoOpMetricsCollector,
+    create_metrics_collector,
+    get_metrics_collector,
+    initialize_metrics,
+    reset_metrics_collector,
+)
+
+
+@pytest.fixture(autouse=True)
+def _metrics_initialized():
+    """``MetricsCollector()`` needs a meter; the app's lifespan sets one up itself."""
+    initialize_metrics(service_name="hindsight-api-test", service_version="0.0.0")
+
+
+def test_reset_restores_the_given_collector():
+    sentinel = NoOpMetricsCollector()
+    reset_metrics_collector(sentinel)
+
+    create_metrics_collector()
+    assert isinstance(get_metrics_collector(), MetricsCollector)
+
+    reset_metrics_collector(sentinel)
+    assert get_metrics_collector() is sentinel
+
+
+def test_reset_without_argument_falls_back_to_noop():
+    create_metrics_collector()
+    assert isinstance(get_metrics_collector(), MetricsCollector)
+
+    reset_metrics_collector()
+    assert isinstance(get_metrics_collector(), NoOpMetricsCollector)
+
+
+@pytest.mark.asyncio
+async def test_app_lifespan_restores_the_collector_it_replaced():
+    """Starting and stopping the app must leave the global collector as it found it."""
+    # A stub engine: the lifespan only needs the attributes it touches, and
+    # initialize_memory=False keeps it away from the database entirely. A backend
+    # that reports no worker-poller support keeps the poller from starting
+    # whatever HINDSIGHT_API_WORKER_ENABLED says.
+    memory = MagicMock()
+    memory._pool = None
+    memory._backend.supports_worker_poller = False
+    memory.tenant_extension = None
+    memory._tenant_extension = None
+    memory.close = AsyncMock()
+
+    before = NoOpMetricsCollector()
+    reset_metrics_collector(before)
+
+    app = create_app(memory, initialize_memory=False)
+    async with app.router.lifespan_context(app):
+        # The app really does install its own collector — otherwise this test
+        # would pass for the wrong reason.
+        assert isinstance(get_metrics_collector(), MetricsCollector)
+
+    assert get_metrics_collector() is before


### PR DESCRIPTION
Fixes #3780.

## What was wrong

`create_metrics_collector()` replaces a module global in `metrics.py` and nothing ever put the previous collector back. `NoOpMetricsCollector` ignores its arguments; the real `MetricsCollector` inspects them (`if cached_input_tokens > 0`). Provider tests hand it a bare `MagicMock` usage object, so once anything installed the real collector, every test that ran after it in the same xdist worker was one `MagicMock` away from:

```
TypeError: '>' not supported between instances of 'MagicMock' and 'int'
```

Which files got hit was decided by xdist's distribution, so the failure count moved between runs of identical code — which is what made the suite useless as a signal.

The API lifespan is not the only poisoner. `worker/main.py:72` installs a collector as a side effect of *constructing* `create_worker_app`, and `tests/test_health_probes.py` builds that app with no lifespan at all.

## The fix

- **`metrics.py`** — `reset_metrics_collector(collector=None)`, the missing counterpart to `create_metrics_collector()`: puts back a previously installed collector, or the no-op default.
- **`api/http.py`** — the lifespan snapshots `get_metrics_collector()` before startup and restores it after `shutdown_tracing()`. Worth doing on its own merits: an app that starts and stops otherwise leaves its own collector, holding a reference to a now-closed DB pool, installed for the rest of the process.
- **`tests/conftest.py`** — an autouse fixture doing the same around every test, following the existing `_cleanup_leaked_span_recorders` fail-safe. This is the part that actually fixes the suite, since it also covers the construction-time paths that never run a shutdown.

## Verification

A/B with a real in-suite poisoner, no synthetic plugin — `test_health_probes.py` builds the worker app, `test_reasoning_effort_explicit_config.py` is one of the files the issue lists:

```
$ uv run pytest tests/test_health_probes.py tests/test_reasoning_effort_explicit_config.py -p no:randomly -n 0
  autouse fixture off: 13 failed, 12 passed
  autouse fixture on:  25 passed
```

`tests/test_metrics_collector_lifecycle.py` covers `reset_metrics_collector` both ways, plus a DB-free test that drives `app.router.lifespan_context` over a stub engine and asserts the collector is restored — and asserts the app really did install one first, so it cannot pass vacuously.

## Scope

- **No production fix, deliberately.** `_usage_from_openai_response` already coerces the field with `getattr(usage.prompt_tokens_details, "cached_tokens", 0) or 0`, so a real provider response yields `0`. Only a `MagicMock` reaches that comparison.
- **`create_worker_app` still installs the collector at construction time.** Harmless in production — that process runs until exit — and the autouse fixture covers the test consequence. Giving the worker app a lifespan is a restructure beyond this bug.
