### PR TITLE
fix(llm): raise OutputTooLongError when a non-streaming completion is truncated

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -317,7 +317,11 @@ def _first_choice_or_error(response: Any, *, provider: str, model: str, scope: s
 
 
 def _content_or_error(response: Any, *, provider: str, model: str, scope: str) -> tuple[str, Any]:
-    """Extract message.content while turning provider shape issues into useful errors."""
+    """Extract message.content, turning provider shape issues into useful errors.
+
+    Raises ``OutputTooLongError`` on a token-limit truncation and
+    ``ProviderResponseError`` on every other unusable success shape.
+    """
 
     choice = _first_choice_or_error(response, provider=provider, model=model, scope=scope)
     message = _message_for_choice(choice)
@@ -331,7 +335,18 @@ def _content_or_error(response: Any, *, provider: str, model: str, scope: str) -
 
     # chat.completions.create() signals truncation only through finish_reason; unlike
     # .parse(), it never raises LengthFinishReasonError for the handler in call() to convert.
-    # Checked before the content branch below: an empty response can still be a truncation.
+    # Checked before the content branch below: an empty response can still be a truncation,
+    # and reading it as empty content instead raises a *retryable* ProviderResponseError,
+    # which re-sends the same request against the same limit (#3811).
+    #
+    # Raised for every scope, not just the ones that recover from it. That matches the
+    # sibling OpenAI-shaped providers (litellm_llm, openai_responses_llm), and it means
+    # a truncated free-form answer — reflect synthesis, a mental-model page — now fails
+    # the call instead of being returned as if complete. Note this is the opposite of
+    # what gemini_llm does for the same signal (it logs a warning and returns the cut
+    # text, see #3365): there the truncation is common because reasoning tokens eat the
+    # visible budget, so failing every such call would be worse than surfacing it. The
+    # two can diverge only until one of them is shown wrong by a real workload.
     if finish_reason == "length":
         raise OutputTooLongError(
             f"LLM output exceeded token limits ({provider}/{model}, scope={scope}). "
@@ -349,7 +364,6 @@ def _content_or_error(response: Any, *, provider: str, model: str, scope: str) -
             f"refusal={bool(refusal)})",
             retryable=retryable,
         )
-
     return content, choice
 
 

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -340,6 +340,15 @@ def _content_or_error(response: Any, *, provider: str, model: str, scope: str) -
             f"refusal={bool(refusal)})",
             retryable=retryable,
         )
+
+    # chat.completions.create() signals truncation only through finish_reason; unlike
+    # .parse(), it never raises LengthFinishReasonError for the handler in call() to convert.
+    if finish_reason == "length":
+        raise OutputTooLongError(
+            f"LLM output exceeded token limits ({provider}/{model}, scope={scope}). "
+            "Input may need to be split into smaller chunks."
+        )
+
     return content, choice
 
 

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -331,12 +331,7 @@ def _content_or_error(response: Any, *, provider: str, model: str, scope: str) -
 
     # chat.completions.create() signals truncation only through finish_reason; unlike
     # .parse(), it never raises LengthFinishReasonError for the handler in call() to convert.
-    # This sits ahead of the empty-content branch below because a budget exhausted before the
-    # first visible token is still a truncation. Routing that to the retryable empty-content
-    # error would re-send the same request against the same limit rather than let the caller
-    # split its input. Both sibling providers raise ahead of their content read for the same
-    # reason: litellm_llm coerces content to "" first, and openai_responses_llm checks the
-    # incomplete status before reading output_text.
+    # Checked before the content branch below: an empty response can still be a truncation.
     if finish_reason == "length":
         raise OutputTooLongError(
             f"LLM output exceeded token limits ({provider}/{model}, scope={scope}). "

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -329,6 +329,20 @@ def _content_or_error(response: Any, *, provider: str, model: str, scope: str) -
             retryable=True,
         )
 
+    # chat.completions.create() signals truncation only through finish_reason; unlike
+    # .parse(), it never raises LengthFinishReasonError for the handler in call() to convert.
+    # This sits ahead of the empty-content branch below because a budget exhausted before the
+    # first visible token is still a truncation. Routing that to the retryable empty-content
+    # error would re-send the same request against the same limit rather than let the caller
+    # split its input. Both sibling providers raise ahead of their content read for the same
+    # reason: litellm_llm coerces content to "" first, and openai_responses_llm checks the
+    # incomplete status before reading output_text.
+    if finish_reason == "length":
+        raise OutputTooLongError(
+            f"LLM output exceeded token limits ({provider}/{model}, scope={scope}). "
+            "Input may need to be split into smaller chunks."
+        )
+
     content = _message_content(message)
     if content is None or content == "":
         tool_calls = _message_tool_calls(message)
@@ -339,14 +353,6 @@ def _content_or_error(response: Any, *, provider: str, model: str, scope: str) -
             f"finish_reason={finish_reason}, has_tool_calls={bool(tool_calls)}, "
             f"refusal={bool(refusal)})",
             retryable=retryable,
-        )
-
-    # chat.completions.create() signals truncation only through finish_reason; unlike
-    # .parse(), it never raises LengthFinishReasonError for the handler in call() to convert.
-    if finish_reason == "length":
-        raise OutputTooLongError(
-            f"LLM output exceeded token limits ({provider}/{model}, scope={scope}). "
-            "Input may need to be split into smaller chunks."
         )
 
     return content, choice

--- a/hindsight-api-slim/tests/test_openai_compatible_truncation.py
+++ b/hindsight-api-slim/tests/test_openai_compatible_truncation.py
@@ -38,7 +38,7 @@ def _make_llm() -> OpenAICompatibleLLM:
     )
 
 
-def _response(content: str, finish_reason: str):
+def _response(content: str, finish_reason: str) -> types.SimpleNamespace:
     return types.SimpleNamespace(
         choices=[
             types.SimpleNamespace(
@@ -101,7 +101,13 @@ async def test_structured_call_raises_output_too_long_without_retrying():
 @pytest.mark.asyncio
 async def test_freeform_call_raises_output_too_long_instead_of_returning_truncated_text():
     """Without a response_format there is no parse step, so a truncated body used to
-    be returned as a complete answer with nothing to signal the cut."""
+    be returned as a complete answer with nothing to signal the cut.
+
+    This is the shape every free-form scope takes -- reflect synthesis, a mental-model
+    page. Those have no ``OutputTooLongError`` handler, so raising here turns a
+    silently-cut answer into a failed call. That is the deliberate trade recorded at
+    the raise site in ``_content_or_error``, not an oversight.
+    """
     llm = _make_llm()
 
     with patch.object(llm._client.chat.completions, "create", new_callable=AsyncMock) as create:

--- a/hindsight-api-slim/tests/test_openai_compatible_truncation.py
+++ b/hindsight-api-slim/tests/test_openai_compatible_truncation.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 from hindsight_api.engine.llm_interface import OutputTooLongError
 from hindsight_api.engine.providers.openai_compatible_llm import (
     OpenAICompatibleLLM,
+    ProviderResponseError,
     _content_or_error,
 )
 
@@ -108,6 +109,58 @@ async def test_freeform_call_raises_output_too_long_instead_of_returning_truncat
         with pytest.raises(OutputTooLongError):
             await llm.call(
                 messages=[{"role": "user", "content": "summarize"}],
+                max_retries=3,
+            )
+
+    assert create.call_count == 1
+
+
+def test_content_or_error_raises_output_too_long_when_truncated_before_any_content():
+    """A budget exhausted before the first visible token is still a truncation.
+
+    A reasoning model can spend the whole completion budget on hidden reasoning and
+    return ``content=""`` with ``finish_reason="length"``. Reading that as empty
+    content would raise a retryable ``ProviderResponseError`` instead, which sends
+    the same request against the same limit rather than splitting the input.
+    """
+    with pytest.raises(OutputTooLongError) as excinfo:
+        _content_or_error(
+            _response("", "length"),
+            provider="openai",
+            model="gpt-4o-mini",
+            scope="retain_fact_extraction",
+        )
+
+    assert "retain_fact_extraction" in str(excinfo.value)
+
+
+def test_content_or_error_still_raises_provider_error_on_empty_content_without_truncation():
+    """Control: the empty-content path is unchanged for every other finish_reason."""
+    with pytest.raises(ProviderResponseError) as excinfo:
+        _content_or_error(
+            _response("", "stop"),
+            provider="openai",
+            model="gpt-4o-mini",
+            scope="retain_fact_extraction",
+        )
+
+    assert excinfo.value.retryable is True
+    assert "empty message content" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_empty_truncated_call_is_not_retried_against_the_same_limit():
+    """The cost of misclassifying this one: ``call()`` retries a retryable
+    ``ProviderResponseError``, so an empty truncation used to re-send the identical
+    request until the ladder ran out, and the auto-split never saw it."""
+    llm = _make_llm()
+
+    with patch.object(llm._client.chat.completions, "create", new_callable=AsyncMock) as create:
+        create.return_value = _response("", "length")
+        with pytest.raises(OutputTooLongError):
+            await llm.call(
+                messages=[{"role": "user", "content": "extract facts"}],
+                response_format=_Facts,
                 max_retries=3,
             )
 

--- a/hindsight-api-slim/tests/test_openai_compatible_truncation.py
+++ b/hindsight-api-slim/tests/test_openai_compatible_truncation.py
@@ -1,0 +1,114 @@
+"""Regression tests for issue #3811: truncated non-streaming responses.
+
+``chat.completions.create()`` reports a token-limit truncation only through
+``finish_reason``. It never raises ``LengthFinishReasonError``, so the handler in
+``call()`` that converts that exception into ``OutputTooLongError`` cannot fire for
+these call sites, and a truncated body used to be returned to the caller as if it
+were complete. For structured output that surfaced as a JSON parse error; for
+free-form output it was returned silently.
+
+The fact-extraction auto-split retries on ``OutputTooLongError``, so the truncation
+has to reach it as that class to be recoverable.
+"""
+
+import types
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from hindsight_api.engine.llm_interface import OutputTooLongError
+from hindsight_api.engine.providers.openai_compatible_llm import (
+    OpenAICompatibleLLM,
+    _content_or_error,
+)
+
+
+class _Facts(BaseModel):
+    facts: list[str]
+
+
+def _make_llm() -> OpenAICompatibleLLM:
+    return OpenAICompatibleLLM(
+        provider="openai",
+        api_key="sk-test",
+        base_url="",
+        model="gpt-4o-mini",
+    )
+
+
+def _response(content: str, finish_reason: str):
+    return types.SimpleNamespace(
+        choices=[
+            types.SimpleNamespace(
+                finish_reason=finish_reason,
+                message=types.SimpleNamespace(content=content, tool_calls=None, refusal=None),
+            )
+        ],
+        usage=types.SimpleNamespace(prompt_tokens=800, completion_tokens=4096, total_tokens=4896),
+        model="gpt-4o-mini",
+    )
+
+
+# The truncated body is valid JSON up to the cut, which is what made it parse-error
+# shaped rather than truncation shaped.
+_TRUNCATED_JSON = '{"facts": ["user deployed a three-node cluster", "the rollout'
+
+
+def test_content_or_error_raises_output_too_long_on_length_finish_reason():
+    with pytest.raises(OutputTooLongError) as excinfo:
+        _content_or_error(
+            _response(_TRUNCATED_JSON, "length"),
+            provider="openai",
+            model="gpt-4o-mini",
+            scope="retain_fact_extraction",
+        )
+
+    assert "retain_fact_extraction" in str(excinfo.value)
+
+
+def test_content_or_error_returns_content_when_generation_stopped_normally():
+    content, choice = _content_or_error(
+        _response('{"facts": []}', "stop"),
+        provider="openai",
+        model="gpt-4o-mini",
+        scope="retain_fact_extraction",
+    )
+
+    assert content == '{"facts": []}'
+    assert choice.finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_structured_call_raises_output_too_long_without_retrying():
+    """A truncated structured response is not a transient fault: retrying the same
+    prompt against the same limit truncates again, so it must surface at once."""
+    llm = _make_llm()
+
+    with patch.object(llm._client.chat.completions, "create", new_callable=AsyncMock) as create:
+        create.return_value = _response(_TRUNCATED_JSON, "length")
+        with pytest.raises(OutputTooLongError):
+            await llm.call(
+                messages=[{"role": "user", "content": "extract facts"}],
+                response_format=_Facts,
+                max_retries=3,
+            )
+
+    assert create.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_freeform_call_raises_output_too_long_instead_of_returning_truncated_text():
+    """Without a response_format there is no parse step, so a truncated body used to
+    be returned as a complete answer with nothing to signal the cut."""
+    llm = _make_llm()
+
+    with patch.object(llm._client.chat.completions, "create", new_callable=AsyncMock) as create:
+        create.return_value = _response("The three main causes are: first, the", "length")
+        with pytest.raises(OutputTooLongError):
+            await llm.call(
+                messages=[{"role": "user", "content": "summarize"}],
+                max_retries=3,
+            )
+
+    assert create.call_count == 1


### PR DESCRIPTION
## Root cause

`chat.completions.create()` reports a token-limit truncation only through `finish_reason`. It never raises `LengthFinishReasonError`, which is what the `except LengthFinishReasonError` handler in `call()` converts into `OutputTooLongError`. Both structured-output and free-form calls go through `create()`, so that handler cannot fire for either of them, and `_content_or_error` returned the truncated body as though it were complete.

What that looked like downstream:

- **Structured output:** the caller's `json.loads` failed on the cut, so a truncation surfaced as a JSON parse error. The retry ladder treated it as transient and re-sent a byte-identical request against the same token limit.
- **Free-form output:** the truncated text was returned as the answer, with nothing to signal that it had been cut.

`_extract_facts_with_auto_split` recovers from truncation by catching `OutputTooLongError` and splitting the chunk, so on this path it could never fire.

## Fix

Detect the truncation where the signal actually arrives and raise there. This matches the two sibling providers: `litellm_llm` raises on `finish_reason == "length"`, and `openai_responses_llm` raises when the response status is incomplete with reason `max_output_tokens`.

The check sits ahead of the content read, so a response that is truncated before any visible token raises `OutputTooLongError` too. An earlier revision of this PR put it after the empty-content branch and described that as deliberate. That was wrong, and koriyoshi2041 caught it in review: the empty-content branch sets `retryable = finish_reason not in {"content_filter"}`, so `length` came back retryable and `call()` re-sent the same request against the same limit instead of letting the auto-split run.

## Verification

- New `tests/test_openai_compatible_truncation.py`, now 7 tests: 5 fail on `main` and all 7 pass on this branch. Two of the 7 are controls that pass on both, one for a normal `finish_reason: "stop"` response and one for an empty response with a non-truncation finish reason, which still raises the retryable `ProviderResponseError`.
- The two tests for the empty truncation also fail at this PR's own earlier ordering, not only on `main`: the `call()` one logs 4 attempts against the same limit and then raises `ProviderResponseError`.
- The two `call()` tests assert `create.call_count == 1`, pinning that a truncation is not retried against the same limit.
- Ran the provider and fact-extraction suites (`test_fact_extraction_retry`, `test_multi_llm_provider`, `test_openai_responses_provider`, `test_deepseek_tool_call_compat`, `test_consolidation_retry_budget`, `test_xai_oauth_llm` and 8 more) on both `main` and this branch: the set of failures is identical, and all of them are pre-existing in `test_xai_oauth_llm.py` on `main`. `ruff check`, `ruff format --check` and `ty check hindsight_api` are clean, with a `ty` diagnostic profile identical to `main`.
- Not verified: any behaviour against a live provider. The tests drive a mocked `chat.completions.create`, so what they pin is this repo's handling of a truncated response shape, not that a given provider emits that shape.
- Also not run end to end: a truncated provider response travelling all the way into the auto-split. The two halves are covered separately, by the tests here and by the existing `test_fact_extraction_retry.py`, and the catch site at `fact_extraction.py:1907` takes the same `OutputTooLongError` class this raises, but I did not exercise the whole path in one test.

## Interaction with #3685

No textual conflict: #3685 edits the `JSONDecodeError` handler around line 1053 and this changes `_content_or_error` around line 343. They are complementary rather than competing, but the order matters, so it is worth stating. A truncated response no longer reaches that handler at all, because it raises before returning content. If it did reach it, `parse_llm_json` would repair the cut into valid but silently partial JSON, whereas raising lets the auto-split re-extract the whole chunk. Non-truncation malformed JSON is untouched by this change and still reaches #3685's repair path.

Fixes #3811

