### PR TITLE
fix(reflect): accept a top-level array of delta operations

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/reflect/delta_ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/delta_ops.py
@@ -270,6 +270,8 @@ def parse_delta_operation_list(raw: Any) -> DeltaOperationList:
         except json.JSONDecodeError as exc:
             last_error = exc
             continue
+        if isinstance(payload, list):
+            payload = {"operations": payload}
         if not isinstance(payload, dict) or "operations" not in payload:
             last_error = ValueError("delta payload must be an object with an operations array")
             continue

--- a/hindsight-api-slim/tests/test_delta_operation_parse.py
+++ b/hindsight-api-slim/tests/test_delta_operation_parse.py
@@ -112,3 +112,32 @@ def test_parse_delta_operation_list_all_invalid_raises():
 def test_parse_delta_operation_list_pydantic_instance():
     original = DeltaOperationList(operations=[AppendBlockOp(section_id="s", text="- a")])
     assert parse_delta_operation_list(original) is original
+
+
+def test_parse_delta_operation_list_top_level_array():
+    """A bare array of ops carries the same delta as the dict form (#3820)."""
+    op_list = parse_delta_operation_list('[{"op": "append_block", "section_id": "x", "text": "hi"}]')
+    assert len(op_list.operations) == 1
+    op = op_list.operations[0]
+    assert isinstance(op, AppendBlockOp)
+    assert op.section_id == "x"
+    assert op.text == "hi"
+
+
+def test_parse_delta_operation_list_top_level_array_skips_invalid_op():
+    """Ops in an array are validated one by one, exactly as they are inside the dict form."""
+    raw = (
+        '[{"op": "append_block", "section_id": "s", "text": "ok"}, '
+        '{"op": "replace_block", "section_id": "s", "text": "missing block_id"}]'
+    )
+    op_list = parse_delta_operation_list(raw)
+    assert len(op_list.operations) == 1
+    assert isinstance(op_list.operations[0], AppendBlockOp)
+    assert op_list.operations[0].text == "ok"
+
+
+def test_parse_delta_operation_list_top_level_array_all_invalid_raises():
+    """An array of v1 typed-block ops is still every-op-invalid, so it must still raise."""
+    raw = '[{"op": "append_block", "section_id": "s", "block": {"type": "paragraph", "text": "old shape"}}]'
+    with pytest.raises(DeltaAllOpsInvalidError):
+        parse_delta_operation_list(raw)


### PR DESCRIPTION
`parse_delta_operation_list` requires the parsed JSON to be a dict carrying an `operations` key. When a model emits the operations as a bare top-level array, which is legal JSON and structurally complete, the guard rejects the whole payload with `delta payload must be an object with an operations array`, so `_validate_operations_list` and `_finalize_operations` never see ops that are individually valid. At `llm_temperature_consolidation` (0.0) the output is deterministic for a given window, so the refresh then fails identically on every retry.

#3424 decoupled the transport cap and fixed the truncation case. This is the other malformation that shared that error message: here the JSON is complete, only its top-level container differs.

## Fix

Normalize a top-level list to `{"operations": <list>}` before the dict check, then fall through to the existing path. Per-op validation, invalid-op skipping and the all-ops-invalid error are unchanged, because the normalized payload reaches exactly the same code. The normalization only fires on a value that previously took the `continue` branch, so no payload that parses today changes behaviour.

## Verification

Run in a clean container at `8c01b89`:

- the three new tests in `tests/test_delta_operation_parse.py` fail on main with the `ValueError` above and pass on the branch
- across the ten test files that cover `delta_ops`, passes go from 228 to 231, the difference being these three; 80 errors appear identically on both arms and are a missing `pg0` extra in the container, not a regression
- `ruff check`, `ruff format --check` and `ty check hindsight_api` at the locked 0.14.9 and 0.0.8, with `ty` reporting the same 211 diagnostics on both arms
- install, `compileall` and the import smoke on 3.11 and 3.14, the ends of the `build-api-python-versions` matrix

What this does not cover: nothing here drives a live provider or a real refresh, so the end-to-end wedge stays your observation rather than something I reproduced. I also left the prose-wrapped case alone, since `_extract_balanced_json_object` still searches for a `{` and an array wrapped in commentary is unchanged.

One note on the sample payload in the report: its op carries the v1 `block` field, which `AppendBlockOp` does not define, so that exact snippet still raises, now as `DeltaAllOpsInvalidError` from per-op validation instead of on the top-level type. `test_parse_delta_operation_list_rejects_v1_block_payloads` pins that shape as invalid on purpose, so the tests here use `text`.

Fixes #3820
