### PR TITLE
fix(transfer): remap mental model evidence ids

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/transfer/export.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/export.py
@@ -675,6 +675,7 @@ async def _load_observations_from_store(
             continue
         observations.append(
             TransferObservation(
+                source_id=str(memory.unit_id),
                 text=memory.text,
                 tags=list(memory.tags or []),
                 event_date=memory.event_date,
@@ -777,6 +778,7 @@ async def _load_observations(
             continue
         observations.append(
             TransferObservation(
+                source_id=str(row["id"]),
                 text=row["text"],
                 tags=list(row["tags"] or []),
                 event_date=row["event_date"],
@@ -849,6 +851,7 @@ async def _load_facts(conn: Any, bank_id: str, doc_ids: list[str], include_lifec
         bucket = loaded.facts_by_doc.setdefault(doc_id, [])
         ordinal = len(bucket)
         fact = TransferFact(
+            source_id=str(row["id"]),
             text=row["text"],
             fact_type=row["fact_type"],
             context=row["context"],

--- a/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
@@ -81,6 +81,9 @@ class ImportResult:
     # Per-document outcomes, for the engine's post-retain hook. Not serialized
     # into operation result_metadata (the worker handler writes counts only).
     imported_documents: list[ImportedDocument] = field(default_factory=list)
+    # Source memory-unit id -> regenerated target id. Used by whole-bank import
+    # to repair mental-model evidence after the replayed facts are inserted.
+    remapped_unit_ids: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -89,6 +92,7 @@ class _ObservationOutcome:
 
     imported: int = 0
     skipped: int = 0
+    remapped_unit_ids: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -229,6 +233,10 @@ async def import_documents(
         )
         for ordinal, unit_id in zip(imported_facts.original_ordinals, imported_facts.unit_ids, strict=True):
             ref_map[(document.id, ordinal)] = unit_id
+        for ordinal, unit_id in zip(imported_facts.original_ordinals, imported_facts.unit_ids, strict=True):
+            source_id = document.facts[ordinal].source_id
+            if source_id is not None:
+                result.remapped_unit_ids[source_id] = unit_id
 
     if parsed.observations:
         outcome = await _import_observations(
@@ -241,6 +249,7 @@ async def import_documents(
         )
         result.observations_imported = outcome.imported
         result.observations_skipped = outcome.skipped
+        result.remapped_unit_ids.update(outcome.remapped_unit_ids)
 
     logger.info(
         "[transfer] Imported %d document(s), %d fact(s), %d observation(s) into bank %s "
@@ -603,6 +612,14 @@ async def import_bank(
         facts_imported=doc_result.facts_imported,
         observations_imported=doc_result.observations_imported,
     )
+
+    # Facts and observations are replayed with fresh ids, but mental-model rows
+    # keep their ids and are restored verbatim below. Repair their grounding
+    # references before insertion so current and historical based_on data points
+    # at the target bank's units rather than the source bank's units.
+    unit_id_map = doc_result.remapped_unit_ids
+    _remap_mental_model_evidence(parsed.bank_rows.get("mental_models", []), unit_id_map)
+    _remap_mental_model_evidence(parsed.bank_rows.get("mental_model_history", []), unit_id_map)
 
     # Re-embed restored mental models off-connection (the source embedding was
     # stripped on export), so no DB connection is held across the embedding call.
@@ -1014,6 +1031,8 @@ async def _import_observations(
                 source_uuids = [uuid.UUID(s) for s in sources]
                 all_source_ids.update(source_uuids)
                 await _link_observation_sources(conn, ops, bank_id, observation_uuid, source_uuids, obs.proof_count)
+                if obs.source_id is not None:
+                    outcome.remapped_unit_ids[obs.source_id] = str(observation_uuid)
 
             # Mark source facts consolidated so the target consolidator skips
             # them. COALESCE keeps the exact source timestamp already restored by
@@ -1029,6 +1048,53 @@ async def _import_observations(
 
     outcome.imported = len(resolved)
     return outcome
+
+
+def _remap_based_on_ids(payload: dict[str, Any] | None, unit_id_map: dict[str, str]) -> None:
+    """Rewrite memory-unit ids in a persisted reflect response after transfer.
+
+    Mental-model rows retain their ids during a whole-bank restore, while facts
+    and observations are replayed and receive new ids. The response is otherwise
+    copied verbatim, so update only evidence ids and preserve all generated text
+    and metadata. Older archives without source ids simply have no entries to
+    rewrite.
+    """
+    if not payload or not unit_id_map:
+        return
+    based_on = payload.get("based_on")
+    if not isinstance(based_on, dict):
+        return
+    for entries in based_on.values():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if isinstance(entry, dict):
+                source_id = entry.get("id")
+                if isinstance(source_id, str) and source_id in unit_id_map:
+                    entry["id"] = unit_id_map[source_id]
+
+
+def _remap_mental_model_evidence(rows: list[dict], unit_id_map: dict[str, str]) -> None:
+    """Repair current and historical mental-model reflect-response evidence."""
+    for row in rows:
+        reflect_response = _decode_json_object(row.get("reflect_response"))
+        if isinstance(reflect_response, dict):
+            _remap_based_on_ids(reflect_response, unit_id_map)
+            row["reflect_response"] = reflect_response
+        previous = _decode_json_object(row.get("previous_reflect_response"))
+        if isinstance(previous, dict):
+            _remap_based_on_ids(previous, unit_id_map)
+            row["previous_reflect_response"] = previous
+
+
+def _decode_json_object(value: Any) -> Any:
+    """Accept either decoded JSONB values or serialized JSON objects."""
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value
 
 
 async def _link_observation_sources(

--- a/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
@@ -1088,13 +1088,18 @@ def _remap_mental_model_evidence(rows: list[dict], unit_id_map: dict[str, str]) 
 
 
 def _decode_json_object(value: Any) -> Any:
-    """Accept either decoded JSONB values or serialized JSON objects."""
-    if not isinstance(value, str):
-        return value
-    try:
-        return json.loads(value)
-    except json.JSONDecodeError:
-        return value
+    """Accept decoded JSONB values and one or more serialized JSON layers."""
+    for _ in range(3):
+        if not isinstance(value, str):
+            return value
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError:
+            return value
+        if decoded == value:
+            return value
+        value = decoded
+    return value
 
 
 async def _link_observation_sources(

--- a/hindsight-api-slim/hindsight_api/engine/transfer/schema.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/schema.py
@@ -55,6 +55,9 @@ class TransferFact(BaseModel):
     """
 
     text: str
+    # The source id is carried only so whole-bank imports can rewrite persisted
+    # mental-model evidence after the fact is assigned a new target id.
+    source_id: str | None = None
     fact_type: str
     context: str | None = None
     # event_date is a fallback used only when both occurred_start and
@@ -110,6 +113,9 @@ class TransferObservation(BaseModel):
     requested, and only when every source resolves within the archive.
     """
 
+    # Observations also receive fresh ids on import, so their source id is
+    # needed when rewriting mental-model based_on references.
+    source_id: str | None = None
     text: str
     tags: list[str] = Field(default_factory=list)
     event_date: datetime | None = None

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -225,6 +225,25 @@ def test_export_bank_covers_schema():
     assert sum(len(b) for b in buckets) == len(classified), "a table is classified in more than one bucket"
 
 
+def test_remap_mental_model_evidence_updates_current_and_history():
+    """Transfer remapping changes only known memory-unit ids in both payloads."""
+    from hindsight_api.engine.transfer.importer import _remap_mental_model_evidence
+
+    rows = [
+        {
+            "reflect_response": {"based_on": {"world": [{"id": "old", "text": "fact"}]}},
+        },
+        {
+            "previous_reflect_response": json.dumps({"based_on": {"observation": [{"id": "obs-old"}]}}),
+        },
+    ]
+
+    _remap_mental_model_evidence(rows, {"old": "new", "obs-old": "obs-new"})
+
+    assert rows[0]["reflect_response"]["based_on"]["world"][0]["id"] == "new"
+    assert rows[1]["previous_reflect_response"]["based_on"]["observation"][0]["id"] == "obs-new"
+
+
 def test_topological_page_order_is_parent_first():
     """Nodes always sort so a parent precedes its children (self-FK safe)."""
     from hindsight_api.engine.transfer.importer import _topological_page_order
@@ -707,6 +726,79 @@ async def test_bank_export_import_exact_roundtrip(memory, request_context):
         assert after_semantic > 0, "semantic links should be regenerated on import"
         # Facts were re-embedded on import (no NULL vectors).
         assert after["null_embeddings"] == 0
+    finally:
+        await memory.delete_bank(bank, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_bank_roundtrip_remaps_mental_model_based_on_ids(memory, request_context):
+    """Whole-bank restore rewrites current and historical evidence ids.
+
+    Mental-model rows keep their ids, but replayed facts receive new ids. The
+    persisted reflect response must follow those new ids so provenance and
+    retraction checks continue to work after migration.
+    """
+    bank = _unique_bank("bank_mm_based_on")
+    try:
+        await _retain(memory, bank, "Alice works at Google.", request_context, "doc-1")
+        backend = await memory._get_backend()
+        async with acquire_with_retry(backend) as conn:
+            fact_id = await conn.fetchval(
+                f"SELECT id FROM {fq_table('memory_units')} WHERE bank_id = $1 AND fact_type = 'world' LIMIT 1", bank
+            )
+        await memory.create_mental_model(
+            bank,
+            name="Work model",
+            source_query="where does Alice work",
+            content="Alice works at Google.",
+            mental_model_id="mm-based-on",
+            request_context=request_context,
+        )
+        based_on = {"world": [{"id": str(fact_id), "text": "Alice works at Google."}]}
+        # Force persisted evidence because the public API generates this field
+        # during refresh and cannot create a deterministic source-id fixture.
+        async with acquire_with_retry(backend) as conn:
+            await conn.execute(
+                f"UPDATE {fq_table('mental_models')} SET reflect_response = $3::jsonb WHERE bank_id = $1 AND id = $2",
+                bank,
+                "mm-based-on",
+                json.dumps({"text": "Alice works at Google.", "based_on": based_on}),
+            )
+        await memory.update_mental_model(
+            bank,
+            mental_model_id="mm-based-on",
+            content="Alice works at Google, in California.",
+            request_context=request_context,
+        )
+
+        from hindsight_api.engine.transfer import export_bank
+
+        async with acquire_with_retry(backend) as conn:
+            archive = await export_bank(conn, bank)
+        await memory.delete_bank(bank, request_context=request_context)
+        await memory.import_bank_async(archive, request_context)
+
+        restored = await memory.get_mental_model(bank, "mm-based-on", detail="full", request_context=request_context)
+        restored_ids = {
+            fact["id"] for fact in (restored["reflect_response"] or {}).get("based_on", {}).get("world", [])
+        }
+        async with acquire_with_retry(backend) as conn:
+            live_ids = {
+                str(row["id"])
+                for row in await conn.fetch(
+                    f"SELECT id FROM {fq_table('memory_units')} WHERE bank_id = $1 AND fact_type = 'world'", bank
+                )
+            }
+        assert restored_ids <= live_ids
+        assert str(fact_id) not in restored_ids
+
+        history = await memory.get_mental_model_history(bank, "mm-based-on", request_context=request_context)
+        historical_ids = {
+            fact["id"] for fact in (history[0]["previous_reflect_response"] or {}).get("based_on", {}).get("world", [])
+        }
+        assert historical_ids <= live_ids
+        assert str(fact_id) not in historical_ids
     finally:
         await memory.delete_bank(bank, request_context=request_context)
 
@@ -1879,8 +1971,8 @@ async def test_export_bank_asks_for_the_store_when_the_caller_did_not_pass_one(m
     stayed. Asserted on archive contents, because an empty archive is exactly what the broken
     version returned successfully.
     """
-    from hindsight_api.engine.transfer import export as export_mod
     import hindsight_api.engine.memories as memories_mod
+    from hindsight_api.engine.transfer import export as export_mod
 
     # Patch the lookup, not `_resolve_memories` itself — the resolution is what is under test, and
     # `_resolve_memories` imports `get_memories` at call time.


### PR DESCRIPTION
## Summary

- preserve source memory-unit IDs in whole-bank transfer archives for remapping
- rewrite `reflect_response.based_on` references for current mental models and history after import
- cover serialized and decoded JSONB payloads, facts, and observations
- add unit and whole-bank round-trip regression tests

## Verification

- `./scripts/hooks/lint.sh` ✅
- focused remapping regression test ✅
- whole-bank integration regression test added; local execution is currently blocked by embedded PostgreSQL port `5567` already being occupied
