### PR TITLE
feat(templates): add Business Executive bank template

### DIFF
--- a/hindsight-docs/src/data/templates.json
+++ b/hindsight-docs/src/data/templates.json
@@ -48,6 +48,21 @@
       "manifest_file": "templates/personal-assistant.json"
     },
     {
+      "id": "business-executive",
+      "name": "Business Executive",
+      "description": "For executives and operators tracking clients, sales opportunities, project delivery, and product development from meeting transcripts. Extracts decisions, commitments, owners, and status changes, and builds pipeline, delivery, product, and relationship mental models. High literalism for precise recall of numbers, dates, and commitments.",
+      "category": "business",
+      "integrations": [
+        "hermes",
+        "hermes-desktop",
+        "langgraph",
+        "crewai",
+        "pydantic-ai",
+        "local-mcp"
+      ],
+      "manifest_file": "templates/business-executive.json"
+    },
+    {
       "id": "hermes-gateway-bot",
       "name": "Gateway / Community Bot",
       "description": "For agents that talk to many people across chat platforms (Telegram, Discord, Slack). Keeps per-person profiles distinct, learns each community's norms, and tracks open threads across users.",

--- a/hindsight-docs/src/data/templates.json
+++ b/hindsight-docs/src/data/templates.json
@@ -54,7 +54,6 @@
       "category": "business",
       "integrations": [
         "hermes",
-        "hermes-desktop",
         "langgraph",
         "crewai",
         "pydantic-ai",

--- a/hindsight-docs/src/data/templates.json
+++ b/hindsight-docs/src/data/templates.json
@@ -54,6 +54,7 @@
       "category": "business",
       "integrations": [
         "hermes",
+        "openclaw",
         "langgraph",
         "crewai",
         "pydantic-ai",

--- a/hindsight-docs/src/data/templates/business-executive.json
+++ b/hindsight-docs/src/data/templates/business-executive.json
@@ -1,0 +1,129 @@
+{
+  "version": "1",
+  "bank": {
+    "reflect_mission": "You are the memory of a busy executive. Recall the current state of clients, sales opportunities, project delivery, and product development — the decisions made, commitments outstanding, risks emerging, and who is responsible for what — so the executive walks into any meeting already caught up.",
+    "retain_mission": "Extract decisions and who made them, action items with their owners and due dates, commitments and promises, changes in a deal or opportunity's stage or value, project delivery status and blockers, product development progress and feedback, financial figures and targets, and the people and organizations involved. Prioritize concrete outcomes, status changes, and next steps over discussion and small talk.",
+    "enable_observations": true,
+    "observations_mission": "Synthesize the durable state of the business: each client or account and the relationship, each open opportunity with its stage and risks, each project's delivery status and blockers, product direction and the decisions behind it, and the commitments outstanding across all of them.",
+    "disposition_literalism": 5,
+    "disposition_skepticism": 3,
+    "disposition_empathy": 3,
+    "entities_allow_free_form": true,
+    "entity_labels": [
+      {
+        "key": "area",
+        "description": "The business area a memory is about. Classify by the dominant topic of the content.",
+        "type": "value",
+        "optional": true,
+        "tag": true,
+        "values": [
+          {"value": "sales", "description": "Clients, prospects, opportunities, pipeline, revenue"},
+          {"value": "delivery", "description": "Project and client delivery, implementation, milestones"},
+          {"value": "product", "description": "Product development, roadmap, features, user feedback"},
+          {"value": "operations", "description": "Internal operations, process, tooling, vendors"},
+          {"value": "people", "description": "Hiring, team, org, performance, relationships"},
+          {"value": "finance", "description": "Budgets, forecasts, targets, spend, financial results"},
+          {"value": "strategy", "description": "Company direction, priorities, positioning, partnerships"}
+        ]
+      },
+      {
+        "key": "deal_stage",
+        "description": "For sales conversations, the stage of the opportunity being discussed.",
+        "type": "value",
+        "optional": true,
+        "tag": true,
+        "values": [
+          {"value": "lead", "description": "Unqualified interest"},
+          {"value": "qualification", "description": "Assessing fit, budget, and authority"},
+          {"value": "proposal", "description": "Proposal or quote presented"},
+          {"value": "negotiation", "description": "Terms, pricing, or contract under negotiation"},
+          {"value": "closed_won", "description": "Deal signed"},
+          {"value": "closed_lost", "description": "Deal lost or abandoned"}
+        ]
+      },
+      {
+        "key": "status_signal",
+        "description": "Health signal for a project, deliverable, or initiative mentioned in the content.",
+        "type": "value",
+        "optional": true,
+        "tag": false,
+        "values": [
+          {"value": "on_track", "description": "Progressing as planned"},
+          {"value": "at_risk", "description": "In danger of slipping"},
+          {"value": "blocked", "description": "Cannot proceed without a resolution"},
+          {"value": "delayed", "description": "Behind schedule"},
+          {"value": "completed", "description": "Finished or delivered"}
+        ]
+      }
+    ]
+  },
+  "mental_models": [
+    {
+      "id": "sales-pipeline",
+      "name": "Sales Pipeline",
+      "source_query": "What open opportunities exist? For each, what is the client, the stage, the value, the key risks, and the next step? Which deals moved stage recently and why?",
+      "max_tokens": 2048,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    },
+    {
+      "id": "project-delivery",
+      "name": "Project Delivery Status",
+      "source_query": "What projects and client deliveries are in flight? For each, what is the status, the upcoming milestones, the blockers, and who owns it?",
+      "max_tokens": 2048,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    },
+    {
+      "id": "product-development",
+      "name": "Product Development",
+      "source_query": "What is happening in product development? What has shipped or is planned, what decisions were made, and what recurring feedback or requests are shaping the roadmap?",
+      "max_tokens": 1536,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    },
+    {
+      "id": "decisions-and-commitments",
+      "name": "Decisions & Commitments",
+      "source_query": "What decisions have been made, and what commitments, action items, or promises are outstanding? For each, who owns it and by when?",
+      "max_tokens": 1536,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    },
+    {
+      "id": "key-relationships",
+      "name": "Key People & Relationships",
+      "source_query": "Who are the important clients, stakeholders, and team members? For each, what is their role, what do they care about, and what is the state of the relationship?",
+      "max_tokens": 1536,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    }
+  ],
+  "directives": [
+    {
+      "name": "Lead with decisions, owners, and deadlines",
+      "content": "When recalling context, surface decisions made, commitments outstanding, and who owns what by when before background discussion. The executive needs to know what was decided and what is expected of whom.",
+      "priority": 10
+    },
+    {
+      "name": "Track status changes over time",
+      "content": "Note when a deal's stage, a project's status, or a product milestone changes, and what drove the change. The trajectory matters as much as the current state.",
+      "priority": 8
+    },
+    {
+      "name": "Flag risks and blockers",
+      "content": "Proactively surface risks, blockers, and at-risk items. If a commitment is slipping or a deal is stalling, say so rather than waiting to be asked.",
+      "priority": 7
+    },
+    {
+      "name": "Preserve attribution",
+      "content": "Keep who said, decided, or committed to what. Attribute statements to the person and the meeting or context they came from so accountability stays clear.",
+      "priority": 6
+    }
+  ]
+}

--- a/hindsight-docs/src/pages/templates/index.tsx
+++ b/hindsight-docs/src/pages/templates/index.tsx
@@ -41,7 +41,7 @@ const templatesData: Template[] = catalog.templates.map((entry) => {
   };
 });
 
-const CATEGORIES = ['all', 'chat', 'coding', 'assistant', 'orchestration', 'support', 'research'] as const;
+const CATEGORIES = ['all', 'chat', 'coding', 'assistant', 'business', 'orchestration', 'support', 'research'] as const;
 type Category = (typeof CATEGORIES)[number];
 
 const CATEGORY_LABELS: Record<Category, string> = {
@@ -49,6 +49,7 @@ const CATEGORY_LABELS: Record<Category, string> = {
   chat: 'Chat',
   coding: 'Coding',
   assistant: 'Assistant',
+  business: 'Business',
   orchestration: 'Orchestration',
   support: 'Support',
   research: 'Research',


### PR DESCRIPTION
## What

Adds a **Business Executive** bank template — a one-click importable bank for executives and operators who track **clients, sales opportunities, project delivery, and product development** from meeting transcripts.

Motivated by a support-thread request: users setting up a "second brain" for their business hit analysis paralysis trying to design the "perfect bank" from scratch and give up. This is a strong, opinionated default they can import and run with.

## What's in the template (`business-executive.json`)

- **Missions** — `retain_mission` focuses extraction on decisions, action items + owners + due dates, commitments, deal/stage changes, delivery status/blockers, product progress, and financials (deprioritizing small talk); paired `reflect_mission` and `observations_mission`.
- **Dispositions** — literalism 5 (precise recall of numbers, dates, commitments), skepticism 3, empathy 3.
- **Entity labels (controlled vocabulary)** — `area` and `deal_stage` (both promoted to recall **tags** via `tag: true`) and `status_signal`. This gives users meaningful, queryable tags **auto-extracted from transcripts**, on top of any deterministic tags their app/CRM sets. `entities_allow_free_form` stays on so people/companies/products are still captured.
- **5 mental models** — Sales Pipeline, Project Delivery Status, Product Development, Decisions & Commitments, Key People & Relationships (all refresh after consolidation).
- **4 directives** — lead with decisions/owners/deadlines, track status changes over time, flag risks & blockers, preserve attribution.

## Catalog / UI

- Catalog entry in `templates.json` (integrations: hermes, hermes-desktop, langgraph, crewai, pydantic-ai, local-mcp).
- Registers a new **`business`** category in the Templates Hub (`src/pages/templates/index.tsx`) so it gets its own filter pill.

## Validation

- `node scripts/check-templates.mjs` → **9/9 templates valid** (schema-conformant).
- `entity_labels` round-trips through the engine's `parse_entity_labels` / `LabelGroup` model, so it applies cleanly on import (not just schema-valid).

## Notes

Mental models are intentionally bank-wide (a template can't know a user's opportunity IDs up front). Per-opportunity tagged mental models remain the user's to add — tag transcripts with an `opportunity_id` and scope a model to it.