### PR TITLE
docs: update retain extraction mode documentation

### DIFF
--- a/hindsight-docs/docs/developer/api/bank-templates.mdx
+++ b/hindsight-docs/docs/developer/api/bank-templates.mdx
@@ -36,7 +36,7 @@ Browse the [Bank Templates Hub](/templates) for ready-to-use templates.
   "bank": {
     "reflect_mission": "...",
     "retain_mission": "...",
-    "retain_extraction_mode": "concise | verbose | custom | chunks",
+    "retain_extraction_mode": "concise | verbose | custom | verbatim | chunks",
     "retain_custom_instructions": "...",
     "retain_chunk_size": 2048,
     "retain_structured_chunk_size": 8192,
@@ -101,7 +101,7 @@ Schema](/bank-template-schema.json); each field means the same thing it does in
 |-------|------|-------------|
 | `reflect_mission` | string | Mission/context for reflect operations |
 | `retain_mission` | string | Steers what gets extracted during retain |
-| `retain_extraction_mode` | string | `concise`, `verbose`, `custom`, or `chunks` |
+| `retain_extraction_mode` | string | `concise`, `verbose`, `custom`, `verbatim`, or `chunks` |
 | `retain_custom_instructions` | string | Custom extraction prompt (requires `mode=custom`) |
 | `retain_chunk_size` | integer | Target max characters per content chunk |
 | `retain_structured_chunk_size` | integer | Max characters for a single JSONL line or conversation turn to keep whole; defaults to `retain_chunk_size` when unset |

--- a/hindsight-docs/docs/developer/api/memory-banks.mdx
+++ b/hindsight-docs/docs/developer/api/memory-banks.mdx
@@ -79,6 +79,8 @@ Controls how aggressively facts are extracted:
 | `concise` *(default)* | Selective — only facts worth remembering long-term |
 | `verbose` | Captures more detail per fact; slower and uses more tokens |
 | `custom` | Write your own extraction rules via `retain_custom_instructions` |
+| `verbatim` | Stores each chunk's original text as one memory; the LLM extracts metadata such as entities and dates |
+| `chunks` | Stores each chunk as one memory without an LLM call; only caller-provided entities are available |
 
 ### retain_custom_instructions
 

--- a/hindsight-docs/docs/developer/mcp-server.md
+++ b/hindsight-docs/docs/developer/mcp-server.md
@@ -566,7 +566,7 @@ The `config_updates` object accepts any bank-configurable field by its Python fi
 
 - `reflect_mission` — mission/context for Reflect operations
 - `retain_mission` — steers what gets extracted during `retain()`
-- `retain_extraction_mode` — `concise` (default), `verbose`, or `custom`
+- `retain_extraction_mode` — `concise` (default), `verbose`, `custom`, `verbatim`, or `chunks`
 - `retain_custom_instructions` — custom extraction prompt (active when mode is `custom`)
 - `retain_chunk_size` — target maximum characters for each content chunk
 - `retain_structured_chunk_size` — maximum characters for a single JSONL line or conversation turn to keep whole

--- a/hindsight-docs/docs/developer/retain.md
+++ b/hindsight-docs/docs/developer/retain.md
@@ -202,7 +202,7 @@ e.g. Always include technical decisions, API design choices, and architectural t
      Ignore meeting logistics, greetings, and social exchanges.
 ```
 
-The mission is injected into the extraction prompt alongside the built-in rules — it steers the LLM without replacing the extraction logic. It works with any extraction mode (`concise`, `verbose`, `custom`).
+The mission is injected into the extraction prompt alongside the built-in rules — it steers the LLM without replacing the extraction logic. It works with the LLM-based extraction modes (`concise`, `verbose`, `verbatim`, `custom`) and is ignored in `chunks` mode.
 
 For finer control, you can also change the **extraction mode**:
 
@@ -211,8 +211,10 @@ For finer control, you can also change the **extraction mode**:
 | `concise` *(default)* | General-purpose — selective, fast |
 | `verbose` | When you need richer facts with full context and relationships |
 | `custom` | When you want to write your own extraction rules entirely |
+| `verbatim` | When you need the original chunk text preserved, with LLM-extracted metadata such as entities and dates |
+| `chunks` | When you want to store chunks as-is with no LLM call or extracted metadata |
 
-Set `retain_mission` and `retain_extraction_mode` via the [bank config API](/developer/api/memory-banks#retain-configuration) or the [`HINDSIGHT_API_RETAIN_MISSION`](/developer/configuration#retain) environment variable.
+Set `retain_mission` and `retain_extraction_mode` via the [bank config API](/developer/api/memory-banks#retain-configuration), or with the [`HINDSIGHT_API_RETAIN_MISSION`](/developer/configuration#retain) and [`HINDSIGHT_API_RETAIN_EXTRACTION_MODE`](/developer/configuration#retain) environment variables.
 
 ### When a mission excludes everything in a document
 

--- a/skills/hindsight-docs/references/developer/api/bank-templates.md
+++ b/skills/hindsight-docs/references/developer/api/bank-templates.md
@@ -25,7 +25,7 @@ Browse the Bank Templates Hub for ready-to-use templates.
   "bank": {
     "reflect_mission": "...",
     "retain_mission": "...",
-    "retain_extraction_mode": "concise | verbose | custom | chunks",
+    "retain_extraction_mode": "concise | verbose | custom | verbatim | chunks",
     "retain_custom_instructions": "...",
     "retain_chunk_size": 2048,
     "retain_structured_chunk_size": 8192,
@@ -90,7 +90,7 @@ Schema; each field means the same thing it does in
 |-------|------|-------------|
 | `reflect_mission` | string | Mission/context for reflect operations |
 | `retain_mission` | string | Steers what gets extracted during retain |
-| `retain_extraction_mode` | string | `concise`, `verbose`, `custom`, or `chunks` |
+| `retain_extraction_mode` | string | `concise`, `verbose`, `custom`, `verbatim`, or `chunks` |
 | `retain_custom_instructions` | string | Custom extraction prompt (requires `mode=custom`) |
 | `retain_chunk_size` | integer | Target max characters per content chunk |
 | `retain_structured_chunk_size` | integer | Max characters for a single JSONL line or conversation turn to keep whole; defaults to `retain_chunk_size` when unset |

--- a/skills/hindsight-docs/references/developer/api/memory-banks.md
+++ b/skills/hindsight-docs/references/developer/api/memory-banks.md
@@ -72,6 +72,8 @@ Controls how aggressively facts are extracted:
 | `concise` *(default)* | Selective — only facts worth remembering long-term |
 | `verbose` | Captures more detail per fact; slower and uses more tokens |
 | `custom` | Write your own extraction rules via `retain_custom_instructions` |
+| `verbatim` | Stores each chunk's original text as one memory; the LLM extracts metadata such as entities and dates |
+| `chunks` | Stores each chunk as one memory without an LLM call; only caller-provided entities are available |
 
 ### retain_custom_instructions
 

--- a/skills/hindsight-docs/references/developer/mcp-server.md
+++ b/skills/hindsight-docs/references/developer/mcp-server.md
@@ -566,7 +566,7 @@ The `config_updates` object accepts any bank-configurable field by its Python fi
 
 - `reflect_mission` — mission/context for Reflect operations
 - `retain_mission` — steers what gets extracted during `retain()`
-- `retain_extraction_mode` — `concise` (default), `verbose`, or `custom`
+- `retain_extraction_mode` — `concise` (default), `verbose`, `custom`, `verbatim`, or `chunks`
 - `retain_custom_instructions` — custom extraction prompt (active when mode is `custom`)
 - `retain_chunk_size` — target maximum characters for each content chunk
 - `retain_structured_chunk_size` — maximum characters for a single JSONL line or conversation turn to keep whole

--- a/skills/hindsight-docs/references/developer/retain.md
+++ b/skills/hindsight-docs/references/developer/retain.md
@@ -202,7 +202,7 @@ e.g. Always include technical decisions, API design choices, and architectural t
      Ignore meeting logistics, greetings, and social exchanges.
 ```
 
-The mission is injected into the extraction prompt alongside the built-in rules — it steers the LLM without replacing the extraction logic. It works with any extraction mode (`concise`, `verbose`, `custom`).
+The mission is injected into the extraction prompt alongside the built-in rules — it steers the LLM without replacing the extraction logic. It works with the LLM-based extraction modes (`concise`, `verbose`, `verbatim`, `custom`) and is ignored in `chunks` mode.
 
 For finer control, you can also change the **extraction mode**:
 
@@ -211,8 +211,10 @@ For finer control, you can also change the **extraction mode**:
 | `concise` *(default)* | General-purpose — selective, fast |
 | `verbose` | When you need richer facts with full context and relationships |
 | `custom` | When you want to write your own extraction rules entirely |
+| `verbatim` | When you need the original chunk text preserved, with LLM-extracted metadata such as entities and dates |
+| `chunks` | When you want to store chunks as-is with no LLM call or extracted metadata |
 
-Set `retain_mission` and `retain_extraction_mode` via the [bank config API](api/memory-banks.md#retain-configuration) or the [`HINDSIGHT_API_RETAIN_MISSION`](configuration.md#retain) environment variable.
+Set `retain_mission` and `retain_extraction_mode` via the [bank config API](api/memory-banks.md#retain-configuration), or with the [`HINDSIGHT_API_RETAIN_MISSION`](configuration.md#retain) and [`HINDSIGHT_API_RETAIN_EXTRACTION_MODE`](configuration.md#retain) environment variables.
 
 ### When a mission excludes everything in a document
 


### PR DESCRIPTION
## Summary
- document all five `retain_extraction_mode` values in the current docs
- clarify `verbatim` versus `chunks` behavior
- fix the retain guide links for the extraction-mode environment variable

## Validation
- `npm run build` (from `hindsight-docs/)`
- `./scripts/hooks/lint.sh`
- `git diff --check`