### PR TITLE
fix(llm): detect folded vs unfolded reasoning tokens in OpenAI-compatible provider (#3851)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -1096,12 +1096,20 @@ class OpenAICompatibleLLM(LLMInterface):
                 if usage and getattr(usage, "completion_tokens_details", None):
                     thoughts_tokens = getattr(usage.completion_tokens_details, "reasoning_tokens", 0) or 0
                 # OpenAI-compatible providers fold reasoning tokens into
-                # ``completion_tokens`` (and thus ``total_tokens``), but the
-                # TokenUsage contract — and the Gemini provider — treat
-                # ``output_tokens``/``total_tokens`` as visible-only, surfacing
-                # reasoning separately in ``thoughts_tokens``. Subtract so the
-                # two fields don't double-count reasoning (cost over-attribution).
-                if thoughts_tokens:
+                # ``completion_tokens`` (and thus ``total_tokens``) when
+                # reasoning is included in the completion count.
+                # On gateways where reasoning tokens are reported separately,
+                # ``output_tokens`` (completion_tokens) is already visible-only,
+                # so subtracting would incorrectly clamp output to 0 (#3851).
+                #
+                # Detect folded shape: if abs((input_tokens + output_tokens) - total_tokens) < thoughts_tokens,
+                # reasoning is folded into output_tokens and must be subtracted out to avoid double counting.
+                is_folded_shape = (
+                    thoughts_tokens > 0
+                    and total_tokens > 0
+                    and abs((input_tokens + output_tokens) - total_tokens) < thoughts_tokens
+                )
+                if is_folded_shape:
                     output_tokens = max(0, output_tokens - thoughts_tokens)
                     total_tokens = max(0, total_tokens - thoughts_tokens)
 
@@ -1417,6 +1425,7 @@ class OpenAICompatibleLLM(LLMInterface):
                 usage = response.usage
                 input_tokens = usage.prompt_tokens or 0 if usage else 0
                 output_tokens = usage.completion_tokens or 0 if usage else 0
+                total_tokens = usage.total_tokens or 0 if usage else 0
                 cached_tokens = 0
                 if usage and getattr(usage, "prompt_tokens_details", None):
                     cached_tokens = getattr(usage.prompt_tokens_details, "cached_tokens", 0) or 0
@@ -1424,10 +1433,17 @@ class OpenAICompatibleLLM(LLMInterface):
                 if usage and getattr(usage, "completion_tokens_details", None):
                     thoughts_tokens = getattr(usage.completion_tokens_details, "reasoning_tokens", 0) or 0
                 # See ``call()``: OpenAI-compatible ``completion_tokens`` includes
-                # reasoning, so make ``output_tokens`` visible-only to avoid
-                # double-counting it against ``thoughts_tokens``.
-                if thoughts_tokens:
+                # reasoning only when folded (detected via abs((input + output) - total) < thoughts).
+                # Subtract only in the folded case so unfolded providers (where completion_tokens
+                # is already visible-only) don't clamp output to 0 (#3851).
+                is_folded_shape = (
+                    thoughts_tokens > 0
+                    and total_tokens > 0
+                    and abs((input_tokens + output_tokens) - total_tokens) < thoughts_tokens
+                )
+                if is_folded_shape:
                     output_tokens = max(0, output_tokens - thoughts_tokens)
+                    total_tokens = max(0, total_tokens - thoughts_tokens)
 
                 # See ``call()``: record the reasoning and cached counts too, so no
                 # billed token is dropped from the metrics counters.

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -1104,14 +1104,17 @@ class OpenAICompatibleLLM(LLMInterface):
                 #
                 # Detect folded shape: if abs((input_tokens + output_tokens) - total_tokens) < thoughts_tokens,
                 # reasoning is folded into output_tokens and must be subtracted out to avoid double counting.
-                is_folded_shape = (
-                    thoughts_tokens > 0
-                    and total_tokens > 0
-                    and abs((input_tokens + output_tokens) - total_tokens) < thoughts_tokens
+                # Detect folded shape: if reasoning tokens are present, check if completion_tokens
+                # includes reasoning tokens (folded). If total_tokens is omitted/0, default to folded shape.
+                is_folded_shape = thoughts_tokens > 0 and (
+                    total_tokens <= 0 or abs((input_tokens + output_tokens) - total_tokens) < thoughts_tokens
                 )
                 if is_folded_shape:
                     output_tokens = max(0, output_tokens - thoughts_tokens)
-                    total_tokens = max(0, total_tokens - thoughts_tokens)
+
+                # TokenUsage contract specifies total_tokens = input_tokens + output_tokens
+                # (visible-only total, excluding thoughts_tokens).
+                total_tokens = input_tokens + output_tokens
 
                 # Record LLM metrics. ``output_tokens`` is visible-only by now, so
                 # ``thoughts_tokens`` has to be recorded alongside it or the reasoning
@@ -1436,14 +1439,11 @@ class OpenAICompatibleLLM(LLMInterface):
                 # reasoning only when folded (detected via abs((input + output) - total) < thoughts).
                 # Subtract only in the folded case so unfolded providers (where completion_tokens
                 # is already visible-only) don't clamp output to 0 (#3851).
-                is_folded_shape = (
-                    thoughts_tokens > 0
-                    and total_tokens > 0
-                    and abs((input_tokens + output_tokens) - total_tokens) < thoughts_tokens
+                is_folded_shape = thoughts_tokens > 0 and (
+                    total_tokens <= 0 or abs((input_tokens + output_tokens) - total_tokens) < thoughts_tokens
                 )
                 if is_folded_shape:
                     output_tokens = max(0, output_tokens - thoughts_tokens)
-                    total_tokens = max(0, total_tokens - thoughts_tokens)
 
                 # See ``call()``: record the reasoning and cached counts too, so no
                 # billed token is dropped from the metrics counters.

--- a/hindsight-api-slim/tests/test_token_usage_cached_thoughts.py
+++ b/hindsight-api-slim/tests/test_token_usage_cached_thoughts.py
@@ -401,7 +401,8 @@ async def test_openai_compatible_call_unfolded_reasoning_does_not_clamp_output_t
     assert token_usage.output_tokens == 673
     assert token_usage.thoughts_tokens == 909
     assert token_usage.input_tokens == 3110
-    assert token_usage.total_tokens == 4692
+    # TokenUsage contract: total_tokens = input_tokens + output_tokens (excludes thoughts)
+    assert token_usage.total_tokens == 3110 + 673
 
 
 @pytest.mark.asyncio
@@ -445,3 +446,20 @@ async def test_openai_compatible_call_folded_reasoning_with_minor_proxy_token_va
     assert token_usage.thoughts_tokens == 48
 
 
+@pytest.mark.asyncio
+async def test_openai_compatible_call_missing_total_tokens_defaults_to_folded():
+    """#3851 edge case: When total_tokens is missing or 0 from a proxy, default to folded shape."""
+    llm = _openai_llm()
+    llm._client.chat.completions.create = AsyncMock(
+        return_value=_response(usage=_usage(reasoning=64, prompt=20, completion=83, total=0))
+    )
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        _, token_usage = await llm.call(
+            messages=[{"role": "user", "content": "Query"}],
+            response_format=_OkModel,
+            max_retries=0,
+            return_usage=True,
+        )
+    assert token_usage.output_tokens == 83 - 64
+    assert token_usage.thoughts_tokens == 64
+    assert token_usage.total_tokens == 20 + (83 - 64)

--- a/hindsight-api-slim/tests/test_token_usage_cached_thoughts.py
+++ b/hindsight-api-slim/tests/test_token_usage_cached_thoughts.py
@@ -377,3 +377,71 @@ async def test_openai_compatible_metrics_account_for_every_billed_output_token()
     assert recorded["output_tokens"] == completion - reasoning  # visible-only
     assert recorded["thoughts_tokens"] == reasoning
     assert recorded["output_tokens"] + recorded["thoughts_tokens"] == completion
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_call_unfolded_reasoning_does_not_clamp_output_tokens():
+    """#3851: Gateways that report reasoning tokens separately from completion_tokens
+    (e.g. Gemini 3.7 Flash behind an OpenAI proxy: prompt=3110, completion=673,
+    reasoning=909, total=4692) must NOT subtract reasoning_tokens from completion_tokens.
+    Doing so incorrectly clamped output_tokens to 0 when reasoning > completion."""
+    llm = _openai_llm()
+    # Separate/unfolded shape: prompt(3110) + completion(673) + reasoning(909) == total(4692)
+    llm._client.chat.completions.create = AsyncMock(
+        return_value=_response(usage=_usage(reasoning=909, prompt=3110, completion=673, total=4692))
+    )
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        _, token_usage = await llm.call(
+            messages=[{"role": "user", "content": "Extract facts"}],
+            response_format=_OkModel,
+            max_retries=0,
+            return_usage=True,
+        )
+    # Output tokens must remain 673, NOT clamped to 0
+    assert token_usage.output_tokens == 673
+    assert token_usage.thoughts_tokens == 909
+    assert token_usage.input_tokens == 3110
+    assert token_usage.total_tokens == 4692
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_call_with_tools_unfolded_reasoning_does_not_clamp_output_tokens():
+    """#3851: Streaming / tool call path must also preserve output_tokens on unfolded responses."""
+    llm = _openai_llm()
+    llm._client.chat.completions.create = AsyncMock(
+        return_value=_response(usage=_usage(reasoning=909, prompt=3110, completion=673, total=4692), content="done")
+    )
+    collector = MagicMock(spec=MetricsCollector)
+    with patch(
+        "hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector",
+        return_value=collector,
+    ):
+        result = await llm.call_with_tools(messages=[{"role": "user", "content": "hi"}], tools=[], max_retries=0)
+
+    assert result.output_tokens == 673
+    assert result.thoughts_tokens == 909
+    recorded = _recorded_llm_call(collector)
+    assert recorded["output_tokens"] == 673
+    assert recorded["thoughts_tokens"] == 909
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_call_folded_reasoning_with_minor_proxy_token_variance():
+    """#3851 edge case: Folded response with 1-token proxy total_tokens variance
+    (prompt=3340, completion=1337 [containing 48 reasoning], total=4678 instead of 4677)
+    is still detected as folded because abs((3340+1337) - 4678) = 1 < 48."""
+    llm = _openai_llm()
+    llm._client.chat.completions.create = AsyncMock(
+        return_value=_response(usage=_usage(reasoning=48, prompt=3340, completion=1337, total=4678))
+    )
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        _, token_usage = await llm.call(
+            messages=[{"role": "user", "content": "Query"}],
+            response_format=_OkModel,
+            max_retries=0,
+            return_usage=True,
+        )
+    assert token_usage.output_tokens == 1337 - 48
+    assert token_usage.thoughts_tokens == 48
+
+


### PR DESCRIPTION
## Fix

Fixes #3851 (reported by @gutocarollo) where `output_tokens` was logged and recorded as `0` for OpenAI-compatible gateways/proxies (e.g. LiteLLM proxy, Gemini 3.7 Flash, OpenRouter, or vLLM) that report reasoning tokens separately from `completion_tokens`.

Previously, `OpenAICompatibleLLM` unconditionally subtracted `thoughts_tokens` from `output_tokens` (`completion_tokens`). On unfolded responses where `completion_tokens` contains only visible generated text, this subtraction caused `output_tokens` to clamp to `0` whenever `reasoning_tokens > completion_tokens`, leading to false "empty output" telemetry (e.g., `input_tokens=2853, output_tokens=0, total_tokens=3178`).

---

## Technical Solution & Detection Differentiator

Updated `call()` and `complete()` in `openai_compatible_llm.py` to inspect the token structure before subtracting:

```python
is_folded_shape = (
    thoughts_tokens > 0
    and total_tokens > 0
    and abs((input_tokens + output_tokens) - total_tokens) < thoughts_tokens
)
if is_folded_shape:
    output_tokens = max(0, output_tokens - thoughts_tokens)
    total_tokens  = max(0, total_tokens  - thoughts_tokens)
