### PR TITLE
fix(llm): surface truncated compatible responses

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -322,6 +322,8 @@ def _content_or_error(response: Any, *, provider: str, model: str, scope: str) -
     choice = _first_choice_or_error(response, provider=provider, model=model, scope=scope)
     message = _message_for_choice(choice)
     finish_reason = _finish_reason_for_choice(choice)
+    if finish_reason == "length":
+        raise OutputTooLongError("LLM output exceeded token limits. Input may need to be split into smaller chunks.")
     if message is None:
         raise ProviderResponseError(
             f"Provider returned a choice without message ({provider}/{model}, scope={scope}, "

--- a/hindsight-api-slim/tests/test_openai_compatible_response_hardening.py
+++ b/hindsight-api-slim/tests/test_openai_compatible_response_hardening.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from pydantic import BaseModel
 
+from hindsight_api.engine.llm_interface import OutputTooLongError
 from hindsight_api.engine.providers.openai_compatible_llm import (
     OpenAICompatibleLLM,
     ProviderResponseError,
@@ -235,3 +236,21 @@ def test_rate_limit_retry_at_uses_latest_header_or_body_reset(
     assert retry_at is not None
     wait = (retry_at - datetime.now(UTC)).total_seconds()
     assert expected_seconds - 1 < wait <= expected_seconds + 1
+
+
+@pytest.mark.asyncio
+async def test_length_finish_reason_raises_output_too_long_without_retry():
+    llm = _llm()
+    response = _response(content='{"ok":')
+    response.choices[0].finish_reason = "length"
+    create = AsyncMock(return_value=response)
+    llm._client.chat.completions.create = create
+
+    with pytest.raises(OutputTooLongError):
+        await llm.call(
+            messages=[{"role": "user", "content": "Return whether this worked."}],
+            response_format=SimpleJsonResponse,
+            max_retries=2,
+        )
+
+    assert create.await_count == 1


### PR DESCRIPTION
## Summary

- map `finish_reason="length"` from OpenAI-compatible `.create()` responses to the canonical `OutputTooLongError`
- avoid retrying the same truncated JSON response as a generic parse failure
- add a regression proving the provider does not retry the request

This restores the existing retain auto-split path for the truncation case described in #3811.

## Tests

- `uv run pytest tests/test_openai_compatible_response_hardening.py -q` (9 passed)
- `./scripts/hooks/lint.sh`
- pre-commit hooks, including unused-code checks and lint
- `git diff --check`