### PR TITLE
fix(retain): bound the within-batch link passes so a delta cannot OOM the worker (#3848)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -6,7 +6,7 @@ import logging
 import re
 import time
 from collections.abc import Sequence
-from datetime import UTC
+from datetime import UTC, datetime
 
 from ..._vector_index import ann_search_tuning_settings, configured_vector_extension
 from ..causal_links import (
@@ -60,6 +60,11 @@ def _entity_resolve_flag(ent) -> bool:
 # more is wasted storage and write amplification.
 MAX_TEMPORAL_LINKS_PER_UNIT = 20
 
+# Rows of the within-batch similarity matrix computed per BLAS call. The transient
+# is (block_rows x n) floats, so this trades peak bytes against call overhead —
+# 256 rows is ~74 MB at the 36K facts a delta retain can hand over in one batch.
+_SEMANTIC_WITHIN_BATCH_BLOCK_ROWS = 256
+
 
 def _cap_links_per_unit(links: list[tuple], max_per_unit: int = MAX_TEMPORAL_LINKS_PER_UNIT) -> list[tuple]:
     """Keep only the top-N links per from_unit_id, ranked by weight descending.
@@ -89,6 +94,70 @@ def _cap_links_per_unit(links: list[tuple], max_per_unit: int = MAX_TEMPORAL_LIN
         result.extend(group_links[:max_per_unit])
 
     return result
+
+
+def _within_batch_temporal_links(
+    new_units: dict[str, tuple[datetime | None, str]],
+    time_window_hours: int,
+    max_per_unit: int = MAX_TEMPORAL_LINKS_PER_UNIT,
+) -> list[tuple]:
+    """Temporal links among the units of one batch, bounded to ``2 * max_per_unit`` each.
+
+    These are the pairs ``_cap_links_per_unit`` would have kept from an all-pairs
+    sweep, without materialising the pairs it would have thrown away.
+
+    Every same-``fact_type`` pair inside the window used to be appended before the
+    cap ran, so a batch carrying n same-day facts of one type built n*(n-1) tuples
+    in order to keep 20 per unit. That is merely wasteful at the ~1.7K facts a
+    streaming sub-batch holds (~600 MB, against a 128 MB budget) and fatal on a
+    delta, which hands over a whole document's changed chunks at once: 36K facts is
+    1.3 billion tuples, and the worker is OOM-killed inside the loop (#3848).
+
+    The cap is recoverable from a bounded candidate set because ``weight`` is a
+    non-increasing function of the gap: the top ``max_per_unit`` by weight ARE the
+    ``max_per_unit`` nearest in time. Sorting each fact_type group by event_date and
+    walking only the next ``max_per_unit`` entries therefore hands every unit its
+    nearest successors directly, and its nearest predecessors through the reverse
+    link each earlier unit writes — the ``2 * max_per_unit`` nearest overall, which
+    contains the ``max_per_unit`` the cap is about to choose.
+
+    Two consequences worth stating rather than discovering:
+
+    - The per-unit budget is spent on candidates, not enforced during generation.
+      Counting a unit's links as they are appended looks like a tighter bound and
+      is a worse one: the reverse links land first, so a unit hits the cap before
+      its own turn comes and keeps only predecessors — a graph biased to point
+      backwards, where the cap picks the nearest in both directions.
+    - Weight ties resolve differently than they did. Any gap past ~16.8h clamps to
+      0.3, so a unit with more than ``max_per_unit`` distant neighbours has more
+      tied candidates than places; which ones survived was already decided by dict
+      order, and is now decided by proximity.
+
+    The break is safe for the same reason the window is: the group is sorted, so
+    once a successor falls outside the window every later one does too.
+    """
+    by_fact_type: dict[str, list[tuple[str, datetime]]] = {}
+    for unit_id, (event_date, fact_type) in new_units.items():
+        if event_date is None:
+            continue  # Skip units without event_date for temporal linking
+        by_fact_type.setdefault(fact_type, []).append((unit_id, _normalize_datetime(event_date)))
+
+    links: list[tuple] = []
+    for group in by_fact_type.values():
+        if len(group) < 2:
+            continue
+        # Stable, so units sharing an event_date keep the order they were inserted in.
+        group.sort(key=lambda entry: entry[1])
+        for i, (unit_id, event_date_norm) in enumerate(group):
+            for other_id, other_event_date_norm in group[i + 1 : i + 1 + max_per_unit]:
+                time_diff_hours = (other_event_date_norm - event_date_norm).total_seconds() / 3600
+                if time_diff_hours > time_window_hours:
+                    break
+                weight = max(0.3, 1.0 - (time_diff_hours / time_window_hours))
+                # Create bidirectional links
+                links.append((unit_id, other_id, "temporal", weight, None))
+                links.append((other_id, unit_id, "temporal", weight, None))
+    return links
 
 
 def _lock_order_key(lnk: tuple) -> tuple[str, str, str, str]:
@@ -476,29 +545,7 @@ async def create_temporal_links_batch_per_fact(
 
         # Also compute temporal links WITHIN the new batch (new units to each other)
         if len(new_units) > 1:
-            # Convert new_units dict to candidate format for within-batch linking
-            new_unit_items = list(new_units.items())
-            for i, (unit_id, (event_date, fact_type)) in enumerate(new_unit_items):
-                if event_date is None:
-                    continue  # Skip units without event_date for temporal linking
-                unit_event_date_norm = _normalize_datetime(event_date)
-
-                # Compare with other new units (only those after this one to avoid duplicates)
-                for j in range(i + 1, len(new_unit_items)):
-                    other_id, (other_event_date, other_fact_type) = new_unit_items[j]
-                    if other_event_date is None:
-                        continue  # Skip units without event_date
-                    if fact_type != other_fact_type:
-                        continue  # Only link facts of the same type
-                    other_event_date_norm = _normalize_datetime(other_event_date)
-
-                    # Check if within time window
-                    time_diff_hours = abs((unit_event_date_norm - other_event_date_norm).total_seconds() / 3600)
-                    if time_diff_hours <= time_window_hours:
-                        weight = max(0.3, 1.0 - (time_diff_hours / time_window_hours))
-                        # Create bidirectional links
-                        links.append((unit_id, other_id, "temporal", weight, None))
-                        links.append((other_id, unit_id, "temporal", weight, None))
+            links.extend(_within_batch_temporal_links(new_units, time_window_hours))
 
         # Cap temporal links per unit to avoid write amplification;
         # retrieval only reads top 10-20 per unit anyway.
@@ -705,26 +752,35 @@ def compute_semantic_links_within_batch(
         new_embeddings_matrix[valid_embeddings] / norms[valid_embeddings, np.newaxis]
     )
 
-    for i, unit_id in enumerate(unit_ids):
-        if not valid_embeddings[i]:
-            continue
+    # One matrix product per block of rows, rather than one per unit against a
+    # freshly gathered copy of every other unit. `normalized[others]` is advanced
+    # indexing, so each of the n iterations it used to run allocated and filled an
+    # (n-1, dim) array: at the 36K facts a delta retain can hand over in one batch
+    # that is a 110 MB memcpy done 36,000 times, several minutes of a synchronous
+    # call with the event loop blocked behind it (#3848). The work is the same
+    # O(n^2 * dim) dot products either way; this hands them to BLAS in one call and
+    # keeps the transient at one block of similarity rows.
+    block_rows = _SEMANTIC_WITHIN_BATCH_BLOCK_ROWS
+    for start in range(0, len(unit_ids), block_rows):
+        stop = min(start + block_rows, len(unit_ids))
+        block_similarities = normalized_embeddings[start:stop] @ normalized_embeddings.T
+        # A unit with an unusable embedding is neither a source nor a target.
+        block_similarities[:, ~valid_embeddings] = -np.inf
 
-        other_indices = [j for j in range(len(unit_ids)) if j != i]
-        if not other_indices:
-            continue
+        for i in range(start, stop):
+            if not valid_embeddings[i]:
+                continue
 
-        other_embeddings = normalized_embeddings[other_indices]
-        similarities = np.dot(other_embeddings, normalized_embeddings[i])
-        similarities[~valid_embeddings[other_indices]] = -np.inf
+            similarities = block_similarities[i - start]
+            similarities[i] = -np.inf  # never link a unit to itself
 
-        above_threshold = np.where(similarities >= threshold)[0]
-        if len(above_threshold) > 0:
-            sorted_local_indices = above_threshold[np.argsort(-similarities[above_threshold])][:top_k]
-            for local_idx in sorted_local_indices:
-                other_idx = other_indices[local_idx]
-                other_id = unit_ids[other_idx]
-                similarity = float(min(1.0, max(0.0, similarities[local_idx])))
-                links.append((unit_id, other_id, "semantic", similarity, None))
+            above_threshold = np.where(similarities >= threshold)[0]
+            if len(above_threshold) > 0:
+                sorted_indices = above_threshold[np.argsort(-similarities[above_threshold])][:top_k]
+                for other_idx in sorted_indices:
+                    other_id = unit_ids[other_idx]
+                    similarity = float(min(1.0, max(0.0, similarities[other_idx])))
+                    links.append((unit_ids[i], other_id, "semantic", similarity, None))
 
     return links
 

--- a/hindsight-api-slim/tests/test_within_batch_link_bounds.py
+++ b/hindsight-api-slim/tests/test_within_batch_link_bounds.py
@@ -1,0 +1,245 @@
+"""Within-batch link generation stays bounded, and keeps picking the same links (#3848).
+
+Both passes below used to build every pair of the batch before narrowing to the
+handful per unit that survive. A streaming sub-batch (~1.7K facts) made that
+merely wasteful; delta retain hands over a whole document's changed chunks in one
+call, and at 36K facts the temporal pass OOM-killed the worker while the semantic
+pass blocked the event loop for minutes.
+
+The rewrites are pinned here against verbatim copies of what they replaced. The
+copies must stay verbatim: the moment a reference shares code with the live
+implementation it stops proving anything.
+"""
+
+from __future__ import annotations
+
+import random
+from datetime import UTC, datetime, timedelta
+
+import numpy as np
+import pytest
+
+from hindsight_api.engine.retain import link_utils
+from hindsight_api.engine.retain.link_utils import (
+    MAX_TEMPORAL_LINKS_PER_UNIT,
+    _cap_links_per_unit,
+    _normalize_datetime,
+    _within_batch_temporal_links,
+    compute_semantic_links_within_batch,
+)
+
+T0 = datetime(2026, 8, 28, 12, 0, 0, tzinfo=UTC)
+
+
+# --------------------------------------------------------------------------
+# Verbatim pre-#3848 implementations. Do not refactor, do not share code with
+# the live ones.
+# --------------------------------------------------------------------------
+
+
+def _legacy_within_batch_temporal_links(new_units: dict, time_window_hours: int = 24) -> list[tuple]:
+    links: list[tuple] = []
+    new_unit_items = list(new_units.items())
+    for i, (unit_id, (event_date, fact_type)) in enumerate(new_unit_items):
+        if event_date is None:
+            continue
+        unit_event_date_norm = _normalize_datetime(event_date)
+
+        for j in range(i + 1, len(new_unit_items)):
+            other_id, (other_event_date, other_fact_type) = new_unit_items[j]
+            if other_event_date is None:
+                continue
+            if fact_type != other_fact_type:
+                continue
+            other_event_date_norm = _normalize_datetime(other_event_date)
+
+            time_diff_hours = abs((unit_event_date_norm - other_event_date_norm).total_seconds() / 3600)
+            if time_diff_hours <= time_window_hours:
+                weight = max(0.3, 1.0 - (time_diff_hours / time_window_hours))
+                links.append((unit_id, other_id, "temporal", weight, None))
+                links.append((other_id, unit_id, "temporal", weight, None))
+    return links
+
+
+def _legacy_semantic_links_within_batch(unit_ids, embeddings, top_k=50, *, threshold) -> list[tuple]:
+    if len(unit_ids) < 2:
+        return []
+
+    links = []
+    new_embeddings_matrix = np.asarray(embeddings, dtype=float)
+    norms = np.linalg.norm(new_embeddings_matrix, axis=1)
+    valid_embeddings = np.isfinite(new_embeddings_matrix).all(axis=1) & np.isfinite(norms) & (norms > 0)
+    normalized_embeddings = np.zeros_like(new_embeddings_matrix)
+    normalized_embeddings[valid_embeddings] = (
+        new_embeddings_matrix[valid_embeddings] / norms[valid_embeddings, np.newaxis]
+    )
+
+    for i, unit_id in enumerate(unit_ids):
+        if not valid_embeddings[i]:
+            continue
+
+        other_indices = [j for j in range(len(unit_ids)) if j != i]
+        if not other_indices:
+            continue
+
+        other_embeddings = normalized_embeddings[other_indices]
+        similarities = np.dot(other_embeddings, normalized_embeddings[i])
+        similarities[~valid_embeddings[other_indices]] = -np.inf
+
+        above_threshold = np.where(similarities >= threshold)[0]
+        if len(above_threshold) > 0:
+            sorted_local_indices = above_threshold[np.argsort(-similarities[above_threshold])][:top_k]
+            for local_idx in sorted_local_indices:
+                other_idx = other_indices[local_idx]
+                other_id = unit_ids[other_idx]
+                similarity = float(min(1.0, max(0.0, similarities[local_idx])))
+                links.append((unit_id, other_id, "semantic", similarity, None))
+
+    return links
+
+
+def _units(spec: list[tuple[float, str]], prefix: str = "u") -> dict:
+    """Build a new_units mapping from (hours_offset, fact_type) pairs."""
+    return {f"{prefix}{i}": (T0 + timedelta(hours=offset), fact_type) for i, (offset, fact_type) in enumerate(spec)}
+
+
+def _by_source(links: list[tuple]) -> dict[str, list[tuple]]:
+    grouped: dict[str, list[tuple]] = {}
+    for link in links:
+        grouped.setdefault(str(link[0]), []).append(link)
+    return grouped
+
+
+class TestWithinBatchTemporalLinks:
+    def test_small_batch_is_identical_to_the_all_pairs_sweep(self):
+        """Under the per-unit cap the window covers everything, so nothing may differ."""
+        units = _units([(i * 0.5, "world") for i in range(MAX_TEMPORAL_LINKS_PER_UNIT)])
+
+        assert sorted(_within_batch_temporal_links(units, 24)) == sorted(_legacy_within_batch_temporal_links(units, 24))
+
+    def test_keeps_the_same_links_the_cap_would_have_kept(self):
+        """41 units, 0.4h apart: every gap distinct, none clamped, so the choice is determined."""
+        units = _units([(i * 0.4, "world") for i in range(41)])
+
+        new = _cap_links_per_unit(_within_batch_temporal_links(units, 24))
+        legacy = _cap_links_per_unit(_legacy_within_batch_temporal_links(units, 24))
+
+        assert sorted(new) == sorted(legacy)
+
+    def test_a_unit_keeps_neighbours_on_both_sides(self):
+        """The reverse links are what make a unit's predecessors reachable at all.
+
+        A per-unit budget spent during generation instead of on candidates puts
+        every one of these on the earlier side.
+        """
+        units = _units([(i * 0.4, "world") for i in range(41)])
+        middle = "u20"
+
+        kept = _cap_links_per_unit(_within_batch_temporal_links(units, 24))
+        targets = {str(link[1]) for link in kept if str(link[0]) == middle}
+
+        assert {t for t in targets if int(t[1:]) < 20}
+        assert {t for t in targets if int(t[1:]) > 20}
+
+    @pytest.mark.parametrize("seed", range(25))
+    def test_weights_match_the_all_pairs_sweep_on_random_batches(self, seed):
+        """Exact on every batch, ties included: the cap ranks by weight, and the
+        bounded candidate set contains the highest-weighted ones by construction."""
+        rng = random.Random(seed)
+        units = _units(
+            [(rng.uniform(0, 48), rng.choice(["world", "experience"])) for _ in range(rng.randint(2, 120))],
+        )
+
+        new = _by_source(_cap_links_per_unit(_within_batch_temporal_links(units, 24)))
+        legacy = _by_source(_cap_links_per_unit(_legacy_within_batch_temporal_links(units, 24)))
+
+        assert new.keys() == legacy.keys()
+        for unit_id, links in new.items():
+            assert sorted(link[3] for link in links) == sorted(link[3] for link in legacy[unit_id])
+
+    def test_candidates_per_unit_are_bounded(self):
+        """The bound the OOM was about: candidates per unit, not links after the cap."""
+        n = 5000
+        units = _units([(0.0, "world")] * n)  # every pair inside the window — the worst case
+
+        links = _within_batch_temporal_links(units, 24)
+
+        assert len(links) <= 2 * MAX_TEMPORAL_LINKS_PER_UNIT * n
+        assert all(len(group) <= 2 * MAX_TEMPORAL_LINKS_PER_UNIT for group in _by_source(links).values())
+        # What the all-pairs sweep would have built for the same batch.
+        assert len(links) < 0.01 * n * (n - 1)
+
+    def test_units_outside_the_window_do_not_link(self):
+        units = _units([(0.0, "world"), (1.0, "world"), (30.0, "world")])
+
+        targets = {(str(link[0]), str(link[1])) for link in _within_batch_temporal_links(units, 24)}
+
+        assert ("u0", "u1") in targets
+        assert ("u0", "u2") not in targets
+        assert ("u1", "u2") not in targets
+
+    def test_only_same_fact_type_links(self):
+        units = _units([(0.0, "world"), (0.5, "experience"), (1.0, "world")])
+
+        targets = {(str(link[0]), str(link[1])) for link in _within_batch_temporal_links(units, 24)}
+
+        assert targets == {("u0", "u2"), ("u2", "u0")}
+
+    def test_units_without_an_event_date_are_skipped(self):
+        units = {"u0": (T0, "world"), "u1": (None, "world"), "u2": (T0 + timedelta(hours=1), "world")}
+
+        targets = {(str(link[0]), str(link[1])) for link in _within_batch_temporal_links(units, 24)}
+
+        assert targets == {("u0", "u2"), ("u2", "u0")}
+
+    def test_naive_and_aware_event_dates_compare(self):
+        units = {"u0": (T0.replace(tzinfo=None), "world"), "u1": (T0 + timedelta(hours=1), "world")}
+
+        assert len(_within_batch_temporal_links(units, 24)) == 2
+
+
+class TestWithinBatchSemanticLinks:
+    @pytest.mark.parametrize("seed", range(10))
+    def test_matches_the_per_unit_implementation(self, seed):
+        rng = np.random.default_rng(seed)
+        n = rng.integers(2, 60)
+        embeddings = rng.normal(size=(n, 16))
+        unit_ids = [f"u{i}" for i in range(n)]
+
+        new = compute_semantic_links_within_batch(unit_ids, embeddings, top_k=8, threshold=0.1)
+        legacy = _legacy_semantic_links_within_batch(unit_ids, embeddings, top_k=8, threshold=0.1)
+
+        assert [(link[0], link[1], link[2]) for link in new] == [(link[0], link[1], link[2]) for link in legacy]
+        assert [link[3] for link in new] == pytest.approx([link[3] for link in legacy], abs=1e-12)
+
+    def test_matches_across_block_boundaries(self, monkeypatch):
+        """Blocking must not change which units are compared, only when."""
+        monkeypatch.setattr(link_utils, "_SEMANTIC_WITHIN_BATCH_BLOCK_ROWS", 3)
+        rng = np.random.default_rng(99)
+        embeddings = rng.normal(size=(11, 8))
+        unit_ids = [f"u{i}" for i in range(11)]
+
+        new = compute_semantic_links_within_batch(unit_ids, embeddings, top_k=5, threshold=0.0)
+        legacy = _legacy_semantic_links_within_batch(unit_ids, embeddings, top_k=5, threshold=0.0)
+
+        assert [(link[0], link[1]) for link in new] == [(link[0], link[1]) for link in legacy]
+        assert [link[3] for link in new] == pytest.approx([link[3] for link in legacy], abs=1e-12)
+
+    def test_invalid_embeddings_stay_excluded_across_blocks(self, monkeypatch):
+        monkeypatch.setattr(link_utils, "_SEMANTIC_WITHIN_BATCH_BLOCK_ROWS", 2)
+        embeddings = [[1.0, 0.0], [1.0, 0.0], [0.0, 0.0], [float("nan"), 1.0], [1.0, 0.0]]
+        unit_ids = ["a", "b", "zero", "nan", "c"]
+
+        links = compute_semantic_links_within_batch(unit_ids, embeddings, threshold=0.0)
+
+        assert not [link for link in links if "zero" in (link[0], link[1])]
+        assert not [link for link in links if "nan" in (link[0], link[1])]
+
+    def test_never_links_a_unit_to_itself(self, monkeypatch):
+        monkeypatch.setattr(link_utils, "_SEMANTIC_WITHIN_BATCH_BLOCK_ROWS", 2)
+        embeddings = [[1.0, 0.0]] * 7
+        unit_ids = [f"u{i}" for i in range(7)]
+
+        links = compute_semantic_links_within_batch(unit_ids, embeddings, threshold=0.0)
+
+        assert not [link for link in links if link[0] == link[1]]


### PR DESCRIPTION
Fixes #3848.

## What broke, and why now

Both passes that link a batch's new units to each other are quadratic in the batch, and both were sized by an assumption that stopped holding in v0.9.2: that a batch is a streaming sub-batch of ~1.7K facts.

Delta retain is not. Since #3660 an oversized replacement diffs the **complete** body — correctly; that is the fix for re-extracting and tombstoning the parts that had not changed — so slice 1 now owns every changed chunk of the document and hands ~36K facts to a single `_insert_facts_and_links`. The slice-local diff #3660 replaced had been the only thing bounding this, and it bounded it by being wrong (`unchanged=1 changed=0 new=0 removed=19` on a 20-chunk document, from that commit's own measurement). The streaming path's real bounds — `retain_chunk_batch_size`, `RetainMemoryBudget` from #3763 — live in `retain_batch`, and the delta path returns at orchestrator.py:1784, before reaching them.

So this is not "delta retain was always unbounded". It is a bound that was load-bearing and accidental, removed along with the bug that provided it.

## The fix

**Temporal.** Every same-`fact_type` pair inside the 24h window was appended before `_cap_links_per_unit` ran, so keeping 20 links per unit cost `n*(n-1)` tuples. The cap is recoverable from a bounded candidate set: `weight` is a non-increasing function of the gap, so the top 20 by weight *are* the 20 nearest in time. Sorting each `fact_type` group by `event_date` and walking the next 20 entries hands every unit its nearest successors, and its nearest predecessors through the reverse link each earlier unit writes — the 40 nearest overall, which contains the 20 the cap will choose.

This is the idiom `memory_engine.py:10201` already uses for entity-inferred links, down to the same `2*K` bound, rather than a new one.

**Semantic.** `normalized[other_indices]` is advanced indexing, so the per-unit loop allocated and filled an `(n-1, dim)` copy on every one of its `n` iterations. At 36K facts that is a 110 MB memcpy done 36,000 times, inside a synchronous call with the event loop blocked behind it. Same `O(n^2 * dim)` dot products, now one BLAS call per 256 rows instead of one per unit.

## Measured

One `fact_type` inside the window. tracemalloc for bytes, no tracemalloc for time:

| | peak MB | seconds |
|---|---|---|
| temporal n=2000 | 402.5 → **7.9** | 0.85 → **0.013** |
| temporal n=4000 | — | 3.60 → **0.027** |
| temporal n=8000 | — | 14.73 → **0.054** |
| semantic n=8000 | unchanged | 11.12 → **0.130** |

Temporal was 4.1× per doubling and is now 2.0×. Extrapolated to the ~36K facts of the document in #3848: ~130 GB, against the 6 GiB limit that issue reports. It crosses that seconds in, which is why the climb is never visible at 1-minute resolution — only the OOM.

Semantic's peak was never the problem; the copies were freed. Its ~4 minutes of blocked event loop was, and it is the wall the temporal fix alone would have exposed next: a worker that stops answering its liveness probe gets restarted into the same requeue loop, just with a different signature.

## What changes functionally

Nothing is lost relative to v0.9.1, and per-unit the **multiset of link weights is identical** to the all-pairs sweep — that is asserted exactly, ties included. Two deliberate differences:

- **The per-unit budget is spent on candidates, not enforced during generation.** Counting links as they are appended looks like a tighter bound and is a worse one: the reverse links land first, so a unit hits the cap before its own turn comes and keeps only predecessors — a graph biased backwards, where the cap picks the nearest on both sides. `test_a_unit_keeps_neighbours_on_both_sides` pins that.
- **Weight ties resolve differently.** Any gap past ~16.8h clamps to 0.3, so a unit with more than 20 distant neighbours has more tied candidates than places. Which ones survived was decided by dict order; it is now decided by proximity.

Under 21 same-type units in a batch the output is literally identical — the window covers everything, so nothing can differ.

## Tests

`test_within_batch_link_bounds.py` pins both rewrites against **verbatim** copies of what they replaced. The copies must stay verbatim: the moment a reference shares code with the live implementation it stops proving anything (same discipline as `test_chunking_streams.py` in #3763).

Verified non-vacuous by mutation:

| mutation | tests failed |
|---|---|
| per-unit budget enforced during generation | 16 |
| candidate window halved | 23 |
| self-exclusion dropped from the blocked semantic pass | 12 |

## Scope

This removes the two quadratic terms. It does not make an arbitrarily large delta safe — the remaining per-delta state is linear in delta size, which is headroom rather than a bound. Routing the delta path through the streaming pipeline's budget is filed as the follow-up in #3848 and is the change that actually closes it.

Supersedes #3853, whose approach to the temporal loop this follows — thanks @Sword-Saint69 for the diagnosis and the sliding-window shape.

https://claude.ai/code/session_017ufCz6qrNxn36Stug7ek8A
