### PR TITLE
feat(dsh): expose optional hindsightProjectMemory Cordis service

### DIFF
--- a/hindsight-integrations/coding-agents/src/dsh.test.ts
+++ b/hindsight-integrations/coding-agents/src/dsh.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
-import { createDshHooks, toDshParameters, type Workspace } from "./dsh";
+import {
+  apply,
+  createDshHooks,
+  createHindsightProjectMemoryService,
+  toDshParameters,
+  type HindsightProjectMemoryService,
+  type Workspace,
+} from "./dsh";
 import type { ToolSpec } from "./core/knowledge-tools";
 import { z } from "zod";
 
@@ -30,6 +37,78 @@ function fakeWorkspace(core: Partial<Workspace["core"]>): Workspace {
 }
 
 const enter = (messages: unknown[]) => async () => ({ kind: "enter" as const, messages }) as never;
+
+describe("hindsightProjectMemory service", () => {
+  it("registers the optional structural service during apply", () => {
+    const provide = vi.fn();
+    const ctx = {
+      provide,
+      on: vi.fn(),
+      inject: vi.fn(),
+    };
+
+    apply(ctx as never);
+
+    expect(provide).toHaveBeenCalledOnce();
+    expect(provide).toHaveBeenCalledWith(
+      "hindsightProjectMemory",
+      expect.objectContaining({ resolve: expect.any(Function) })
+    );
+  });
+
+  it("returns undefined for a workspace where memory is disabled", () => {
+    const service = createHindsightProjectMemoryService(
+      () => ({ cfg: { disabled: true }, bankId: "", client: {} }) as never
+    );
+
+    expect(service.resolve("/disabled-repo")).toBeUndefined();
+  });
+
+  it("binds recall and replacement retain to the resolved workspace bank", async () => {
+    const reflect = vi.fn(async () => "bank answer");
+    const retain = vi.fn(async () => {});
+    const resolveMemory = vi.fn(
+      () =>
+        ({
+          cfg: { disabled: false },
+          bankId: "repo-bank",
+          client: { reflect, retain },
+        }) as never
+    );
+    const service: HindsightProjectMemoryService =
+      createHindsightProjectMemoryService(resolveMemory);
+
+    const workspace = service.resolve("/repo")!;
+    expect(resolveMemory).toHaveBeenCalledWith("dsh", "/repo");
+    expect(workspace.bankId).toBe("repo-bank");
+
+    await expect(
+      workspace.recall("why was this chosen?", { budget: "medium", timeoutMs: 4321 })
+    ).resolves.toBe("bank answer");
+    expect(reflect).toHaveBeenCalledWith("why was this chosen?", {
+      budget: "medium",
+      timeoutMs: 4321,
+    });
+
+    await workspace.retain({
+      content: "Decision: keep the bridge public.",
+      context: "AgentTeams project integration",
+      documentId: "agentteams-bridge",
+      tags: ["agentteams", "project-memory"],
+      metadata: { source: "agentteams" },
+      operationId: "retain-1",
+      updateMode: "replace",
+    });
+    expect(retain).toHaveBeenCalledWith(
+      "Decision: keep the bridge public.",
+      "AgentTeams project integration",
+      "agentteams-bridge",
+      ["agentteams", "project-memory"],
+      "document",
+      { metadata: { source: "agentteams" }, operationId: "retain-1" }
+    );
+  });
+});
 
 describe("dsh pre-step injection", () => {
   it("recalls on the human prompt and appends the memory as a sourced message", async () => {

--- a/hindsight-integrations/coding-agents/src/dsh.ts
+++ b/hindsight-integrations/coding-agents/src/dsh.ts
@@ -23,7 +23,7 @@
  * and no version to keep in step — any dsh whose event names still match can load this file.
  */
 import { randomUUID } from "node:crypto";
-import { resolveHostMemory } from "./core/host-client";
+import { resolveHostMemory, type HostMemory } from "./core/host-client";
 import { diag } from "./core/diag";
 import type { ToolSpec } from "./core/knowledge-tools";
 import { log } from "./core/log";
@@ -58,8 +58,7 @@ interface DshUserMessage {
 }
 
 type PreStepDecision =
-  | { kind: "enter"; messages: DshUserMessage[] }
-  | { kind: "reject"; [key: string]: unknown };
+  { kind: "enter"; messages: DshUserMessage[] } | { kind: "reject"; [key: string]: unknown };
 
 interface PreStepPayload {
   agent: DshAgent;
@@ -68,6 +67,7 @@ interface PreStepPayload {
 
 /** The Cordis context surface this plugin uses. */
 interface DshContext {
+  provide(name: "hindsightProjectMemory", service: HindsightProjectMemoryService): void;
   on(
     event: "agent/session-start",
     listener: (payload: { agent: DshAgent }) => void
@@ -102,6 +102,58 @@ interface DshToolContext {
 /** `exec` as a dsh tool body receives it (only the caller matters to us). */
 interface DshToolRunContext {
   readonly agent?: DshAgent;
+}
+
+/** Options accepted by project-memory reflection. */
+export interface HindsightProjectMemoryRecallOptions {
+  budget?: string;
+  timeoutMs: number;
+}
+
+/** A structured project-memory write. Omitting `updateMode` and `replace` both replace the document. */
+export interface HindsightProjectMemoryRetainInput {
+  content: string;
+  context: string;
+  documentId: string;
+  tags: string[];
+  metadata?: Record<string, string>;
+  operationId?: string;
+  updateMode?: "replace";
+}
+
+/** Bank-bound memory surface exposed to AgentTeams and other project integrations. */
+export interface HindsightProjectMemoryWorkspace {
+  readonly bankId: string;
+  recall(query: string, options: HindsightProjectMemoryRecallOptions): Promise<string>;
+  retain(input: HindsightProjectMemoryRetainInput): Promise<void>;
+}
+
+/** Optional Cordis service; disabled workspaces resolve to `undefined`. */
+export interface HindsightProjectMemoryService {
+  resolve(directory: string): HindsightProjectMemoryWorkspace | undefined;
+}
+
+export type ResolveHindsightHostMemory = (harness: string, directory: string) => HostMemory;
+
+/** Build the public service over the same resolver used by dsh lifecycle and tool integrations. */
+export function createHindsightProjectMemoryService(
+  resolveMemory: ResolveHindsightHostMemory = resolveHostMemory
+): HindsightProjectMemoryService {
+  return {
+    resolve(directory) {
+      const { cfg, bankId, client } = resolveMemory(HARNESS, directory);
+      if (cfg.disabled) return undefined;
+      return {
+        bankId,
+        recall: (query, options) => client.reflect(query, options),
+        retain: (input) =>
+          client.retain(input.content, input.context, input.documentId, input.tags, "document", {
+            metadata: input.metadata,
+            operationId: input.operationId,
+          }),
+      };
+    },
+  };
 }
 
 // ── per-workspace runtime cache ─────────────────────────────────────────────────
@@ -383,6 +435,7 @@ function specsOf(workspace: Workspace): ToolSpec[] {
  * never throws, and a workspace we cannot resolve simply leaves that session unmemoried.
  */
 export function apply(ctx: DshContext): void {
+  ctx.provide("hindsightProjectMemory", createHindsightProjectMemoryService());
   const hooks = createDshHooks(workspaceForAgent);
   ctx.on("agent/session-start", hooks.sessionStart);
   // `prepend: true` puts this listener outermost, so the injection is appended AFTER every other


### PR DESCRIPTION
## What

Exposes an optional structural Cordis service \hindsightProjectMemory\ from the dsh integration, so project-scoped consumers (e.g. AgentTeams) can recall and retain bounded project memory without coupling to Hindsight internals:

- \esolve(directory)\ binds a workspace to its configured bank (disabled workspaces resolve to \undefined\)
- \ecall(query, { budget, timeoutMs })\ delegates to the bank's reflection
- \etain(input)\ performs structured document retain with operationId idempotency

Registered via \ctx.provide\ in \pply\; the existing dsh lifecycle and tool integrations are unchanged. 13 dsh tests pass including new service tests.

Companion change: NanmiCoder/dsh-agent-teams#PR (AgentTeams consumes the service via \hindsightBridge\).