### PR TITLE
feat(coding-agents): add semantic transcript hygiene beta

### DIFF
--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -408,11 +408,34 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `surveyBudgetUsd`       | `2`                                  | survey spend cap — Claude recipe only (`claude -p --max-budget-usd`); other agents rely on their read-only sandbox                                                                                                                                                                                                                                                                                                                                |
 | `surveyRefreshCommits`  | `20`                                 | re-run the survey at SessionStart once this many commits have accrued since the last one, so the structural pages track an architecture that keeps moving (`0` = survey a cold repo only, never again)                                                                                                                                                                                                                                            |
 | `retainSessions`        | `true`                               | session write-back, honored by every harness: hook harnesses write the transcript on Stop, plugin harnesses (opencode, Kilo) upsert it every turn plus an idle flush that captures the reply the per-turn pass can't see. Set `false` — globally, per harness, or per bank — to stop writing transcripts (the background history import stops with it) while recall, git ingest and the memory tools keep working                                 |
+| `transcriptHygiene`     | `"off"`                              | optional beta pass over already-normalized session turns before write-back. `"semantic-beta"` groups consecutive action breadcrumbs into one audited action turn while preserving user and assistant text. It is additive, opt-in, and can be enabled globally, per harness, or per bank                                                                                                                     |
 | `maxParallelRetains`    | `10`                                 | cap on concurrent retain-related requests: drain()'s per-op polls plus deepen's chat/git retain pools. The API rate-limits bursts, not single requests — if you see 429s, lower this rather than raising it                                                                                                                                                                                                                                       |
 | `logLevel`              | `"info"`                             | plugin-log verbosity (`"debug"` \| `"info"` \| `"warn"` \| `"error"`); `HINDSIGHT_LOG_LEVEL` env overrides                                                                                                                                                                                                                                                                                                                                        |
 | `gitIngest`             | `"message"`                          | git depth for seeding AND staying current (same engine): `"message"` = commit messages only (one doc, re-upserted when HEAD moves); `"full"` = messages + per-commit full diffs (progressive, newest first); `"none"` = git off                                                                                                                                                                                                                   |
 | `harnesses.<name>`      | —                                    | per-harness override of any field above                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `harness`               | `opencode`                           | **deepen engine only**: which session format `--conversations` is read as                                                                                                                                                                                                                                                                                                                                                                         |
+
+### Beta transcript hygiene
+
+The default retain path remains unchanged. Set `transcriptHygiene` to `"semantic-beta"` to test the
+beta reducer on session write-back:
+
+```jsonc
+{
+  "transcriptHygiene": "semantic-beta",
+  "harnesses": {
+    "codex": { "transcriptHygiene": "semantic-beta" },
+    "claude-code": { "transcriptHygiene": "off" }
+  }
+}
+```
+
+The beta pass runs after the harness reader has normalized Codex, Claude Code, Antigravity and
+other supported transcript formats into the shared JSONL turn shape. It does not rewrite user or
+assistant prose. It only groups adjacent `role:"action"` breadcrumbs, which keeps tool lineage
+available to extraction while reducing line pressure from action-heavy coding sessions. Each run
+emits a `transcript_hygiene_beta` diagnostic receipt with the input/output turn counts and grouped
+action counts.
 
 `pageTriggerType`/`pageTriggerCron` decide only **when** a page refreshes. **How** it refreshes
 belongs to the server: Hindsight creates a knowledge page with a delta refresh (each pass edits the

--- a/hindsight-integrations/coding-agents/skill/SKILL.md
+++ b/hindsight-integrations/coding-agents/skill/SKILL.md
@@ -210,11 +210,34 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `surveyBudgetUsd`       | `2`                                  | survey spend cap — Claude recipe only (`claude -p --max-budget-usd`); other agents rely on their read-only sandbox                                                                                                                                                                                                                                                                                                                                |
 | `surveyRefreshCommits`  | `20`                                 | re-run the survey at SessionStart once this many commits have accrued since the last one, so the structural pages track an architecture that keeps moving (`0` = survey a cold repo only, never again)                                                                                                                                                                                                                                            |
 | `retainSessions`        | `true`                               | session write-back, honored by every harness: hook harnesses write the transcript on Stop, plugin harnesses (opencode, Kilo) upsert it every turn plus an idle flush that captures the reply the per-turn pass can't see. Set `false` — globally, per harness, or per bank — to stop writing transcripts (the background history import stops with it) while recall, git ingest and the memory tools keep working                                 |
+| `transcriptHygiene`     | `"off"`                              | optional beta pass over already-normalized session turns before write-back. `"semantic-beta"` groups consecutive action breadcrumbs into one audited action turn while preserving user and assistant text. It is additive, opt-in, and can be enabled globally, per harness, or per bank                                                                                                                     |
 | `maxParallelRetains`    | `10`                                 | cap on concurrent retain-related requests: drain()'s per-op polls plus deepen's chat/git retain pools. The API rate-limits bursts, not single requests — if you see 429s, lower this rather than raising it                                                                                                                                                                                                                                       |
 | `logLevel`              | `"info"`                             | plugin-log verbosity (`"debug"` \| `"info"` \| `"warn"` \| `"error"`); `HINDSIGHT_LOG_LEVEL` env overrides                                                                                                                                                                                                                                                                                                                                        |
 | `gitIngest`             | `"message"`                          | git depth for seeding AND staying current (same engine): `"message"` = commit messages only (one doc, re-upserted when HEAD moves); `"full"` = messages + per-commit full diffs (progressive, newest first); `"none"` = git off                                                                                                                                                                                                                   |
 | `harnesses.<name>`      | —                                    | per-harness override of any field above                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `harness`               | `opencode`                           | **deepen engine only**: which session format `--conversations` is read as                                                                                                                                                                                                                                                                                                                                                                         |
+
+### Beta transcript hygiene
+
+The default retain path remains unchanged. Set `transcriptHygiene` to `"semantic-beta"` to test the
+beta reducer on session write-back:
+
+```jsonc
+{
+  "transcriptHygiene": "semantic-beta",
+  "harnesses": {
+    "codex": { "transcriptHygiene": "semantic-beta" },
+    "claude-code": { "transcriptHygiene": "off" }
+  }
+}
+```
+
+The beta pass runs after the harness reader has normalized Codex, Claude Code, Antigravity and
+other supported transcript formats into the shared JSONL turn shape. It does not rewrite user or
+assistant prose. It only groups adjacent `role:"action"` breadcrumbs, which keeps tool lineage
+available to extraction while reducing line pressure from action-heavy coding sessions. Each run
+emits a `transcript_hygiene_beta` diagnostic receipt with the input/output turn counts and grouped
+action counts.
 
 `pageTriggerType`/`pageTriggerCron` decide only **when** a page refreshes. **How** it refreshes
 belongs to the server: Hindsight creates a knowledge page with a delta refresh (each pass edits the

--- a/hindsight-integrations/coding-agents/src/core/config.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.test.ts
@@ -109,6 +109,32 @@ describe("maxParallelRetains", () => {
   });
 });
 
+describe("transcriptHygiene", () => {
+  const ENV = { ...process.env };
+  afterEach(() => {
+    process.env = { ...ENV };
+  });
+
+  it("defaults to off so the beta pass is opt-in", () => {
+    expect(resolveConfig({}).transcriptHygiene).toBe("off");
+  });
+
+  it("accepts semantic-beta from config and env fallback", () => {
+    expect(resolveConfig({ transcriptHygiene: "semantic-beta" }).transcriptHygiene).toBe(
+      "semantic-beta"
+    );
+    writeJson(globalCfg, {});
+    process.env.HINDSIGHT_TRANSCRIPT_HYGIENE = "semantic-beta";
+    expect(loadConfig({ path: globalCfg }).transcriptHygiene).toBe("semantic-beta");
+  });
+
+  it("ignores unknown values rather than enabling an unintended write-back transform", () => {
+    expect(resolveConfig({ transcriptHygiene: "aggressive" as never }).transcriptHygiene).toBe(
+      "off"
+    );
+  });
+});
+
 /**
  * #3590: the hindsight_reflect tool aborted at a hardcoded 120s. The tool's window is now its own
  * knob, defaulting ABOVE the server's 300s reflect wall timeout — and it inherits an explicitly

--- a/hindsight-integrations/coding-agents/src/core/config.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.ts
@@ -18,6 +18,11 @@ import { DEFAULT_SEED_LIMIT } from "./seed";
 import { isOptedIn } from "./bank";
 import { log } from "./log";
 import { DEFAULT_OBSERVATION_SCOPES, type ObservationScopes } from "./hindsight";
+import {
+  DEFAULT_TRANSCRIPT_HYGIENE,
+  TRANSCRIPT_HYGIENE_MODES,
+  type TranscriptHygieneMode,
+} from "./transcript-hygiene";
 
 /** Default config-file path: ~/.hindsight/coding-agent.json */
 export // HINDSIGHT_CONFIG joins the two env exceptions (diag/log files): it points at THE config file,
@@ -82,6 +87,10 @@ export interface RawConfig {
    *  cadence alike. Gates ONLY the transcript — recall, git ingest, seeding and the memory
    *  tools keep working (that is `disabled`'s job). */
   retainSessions?: boolean;
+  /** Optional beta pass over already-normalized session turns before write-back. Default "off".
+   *  "semantic-beta" groups consecutive action breadcrumbs into one audited action turn while
+   *  preserving user and assistant text. */
+  transcriptHygiene?: TranscriptHygieneMode;
   /** Cap on concurrent retain-related requests the client sends to the API (default 10):
    *  drain()'s per-operation polls and deepen's chat/git retain pools. A single request returning
    *  200 while bursts get 429s means the server is rate-limiting concurrency, not total volume —
@@ -181,6 +190,7 @@ export interface Config {
   harness: string;
   disabled: boolean;
   retainSessions: boolean;
+  transcriptHygiene: TranscriptHygieneMode;
   maxParallelRetains: number;
   reflectTimeoutMs: number;
   reflectToolTimeoutMs: number;
@@ -272,6 +282,16 @@ function resolveObservationScopes(raw: RawConfig["observationScopes"]): Observat
   return DEFAULT_OBSERVATION_SCOPES;
 }
 
+function resolveTranscriptHygiene(raw: RawConfig["transcriptHygiene"]): TranscriptHygieneMode {
+  if (raw === undefined) return DEFAULT_TRANSCRIPT_HYGIENE;
+  if ((TRANSCRIPT_HYGIENE_MODES as readonly string[]).includes(raw)) return raw;
+  log.warn(
+    "config",
+    `ignoring transcriptHygiene=${JSON.stringify(raw)} — expected off|semantic-beta`
+  );
+  return DEFAULT_TRANSCRIPT_HYGIENE;
+}
+
 /** Apply defaults to a raw (file) config. Pure — the single place the defaults live. */
 export function resolveConfig(raw: RawConfig = {}): Config {
   const serverMode = ["cloud", "self-hosted", "daemon"].includes(raw.serverMode as string)
@@ -306,6 +326,7 @@ export function resolveConfig(raw: RawConfig = {}): Config {
     harness: raw.harness ?? "opencode",
     disabled: raw.disabled ?? false,
     retainSessions: raw.retainSessions ?? true, // write sessions back by default, every harness
+    transcriptHygiene: resolveTranscriptHygiene(raw.transcriptHygiene),
     maxParallelRetains: raw.maxParallelRetains || 10,
     reflectTimeoutMs: raw.reflectTimeoutMs || 120000,
     // Inherit an explicitly-raised reflectTimeoutMs (that is what users reaching for a longer
@@ -418,6 +439,7 @@ const ENV_KEYS = {
   harness: "HINDSIGHT_HARNESS",
   disabled: "HINDSIGHT_DISABLED",
   retainSessions: "HINDSIGHT_RETAIN_SESSIONS",
+  transcriptHygiene: "HINDSIGHT_TRANSCRIPT_HYGIENE",
   maxParallelRetains: "HINDSIGHT_MAX_PARALLEL_RETAINS",
   reflectTimeoutMs: "HINDSIGHT_REFLECT_TIMEOUT_MS",
   reflectToolTimeoutMs: "HINDSIGHT_REFLECT_TOOL_TIMEOUT_MS",

--- a/hindsight-integrations/coding-agents/src/core/retain-hook.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.test.ts
@@ -9,6 +9,15 @@ import type { HindsightClient } from "./hindsight";
 import { buildRetain, runRetainHook } from "./retain-hook";
 import { memoryCursorStore, type RetainCursorStore } from "./retain-cursor";
 
+const SINGLE_RETAIN_CALL_COUNT = 1;
+const REF_ID_PLUS_GROUPED_ACTION_TURNS = 2;
+const FIRST_RETAIN_CALL_INDEX = 0;
+const GROUPED_ACTION_TURN_INDEX = 1;
+const RUN_HOOK_GROUPED_ACTION_COUNT = 2;
+const SEMANTIC_BETA_GROUPED_ACTION_COUNT = 3;
+const SEMANTIC_BETA_THREE_ACTIONS_HEADER = `Action breadcrumbs (${SEMANTIC_BETA_GROUPED_ACTION_COUNT} grouped):`;
+const SEMANTIC_BETA_TWO_ACTIONS_HEADER = `Action breadcrumbs (${RUN_HOOK_GROUPED_ACTION_COUNT} grouped):`;
+
 /** The Stop event `runRetainHook` reads from fd 0; every other read stays real. */
 let stdin = "";
 vi.mock("node:fs", async (importOriginal) => {
@@ -109,6 +118,46 @@ describe("buildRetain", () => {
     });
 
     expect(retainSpy).not.toHaveBeenCalled();
+  });
+
+  it("applies semantic-beta transcript hygiene before retain write-back", async () => {
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-01-01T00:00:00Z",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "tool_use", name: "Bash", input: { command: "npm test" } },
+            { type: "tool_use", name: "Edit", input: { file_path: "src/uploader.ts" } },
+            { type: "tool_use", name: "Bash", input: { command: "npm run build" } },
+          ],
+        },
+      }),
+    ];
+    writeFileSync(file, lines.join("\n"));
+
+    const retainSpy = vi.fn().mockResolvedValue(undefined);
+    const client = { retain: retainSpy } as unknown as HindsightClient;
+
+    await buildRetain({
+      harness: "claude-code",
+      sessionId: "sess-hygiene",
+      transcriptPath: file,
+      client,
+      transcriptHygiene: "semantic-beta",
+    });
+
+    expect(retainSpy).toHaveBeenCalledTimes(SINGLE_RETAIN_CALL_COUNT);
+    const [content] = retainSpy.mock.calls[FIRST_RETAIN_CALL_INDEX];
+    const parsed = (content as string)
+      .split("\n")
+      .map((line) => JSON.parse(line) as { role: string; content: string });
+    expect(parsed).toHaveLength(REF_ID_PLUS_GROUPED_ACTION_TURNS);
+    expect(parsed[GROUPED_ACTION_TURN_INDEX]).toMatchObject({
+      role: "action",
+      content: `${SEMANTIC_BETA_THREE_ACTIONS_HEADER}\n- Bash npm test\n- Edit src/uploader.ts\n- Bash npm run build`,
+    });
   });
 
   it("fails open on retain error", async () => {
@@ -320,6 +369,29 @@ describe("runRetainHook honors retainSessions", () => {
     const { retain, makeClient } = stubClient();
     await runRetainHook(spec, makeClient);
     expect(retain).toHaveBeenCalledTimes(1);
+  });
+
+  it("honors transcriptHygiene from the resolved config", async () => {
+    rawConfig = { transcriptHygiene: "semantic-beta" };
+    writeFileSync(
+      file,
+      [
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "tool_use", name: "Bash", input: { command: "npm test" } },
+              { type: "tool_use", name: "Read", input: { file_path: "README.md" } },
+            ],
+          },
+        }),
+      ].join("\n")
+    );
+    const { retain, makeClient } = stubClient();
+    await runRetainHook(spec, makeClient);
+    const [content] = retain.mock.calls[FIRST_RETAIN_CALL_INDEX];
+    expect(content as string).toContain(SEMANTIC_BETA_TWO_ACTIONS_HEADER);
   });
 
   it("retainSessions: false -> no write-back, and no client is even built", async () => {

--- a/hindsight-integrations/coding-agents/src/core/retain-hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.ts
@@ -26,6 +26,11 @@ import type { RetainCursorStore } from "./retain-cursor";
 import { buildRetainStamp, type RetainStamp } from "./retain-stamp";
 import { fileCursorStore, sessionRootDir } from "./session-cache";
 import { readClaudeTranscript } from "./transcript";
+import {
+  applyTranscriptHygiene,
+  DEFAULT_TRANSCRIPT_HYGIENE,
+  type TranscriptHygieneMode,
+} from "./transcript-hygiene";
 
 /** Headroom left before the host's kill: the response still has to come back after the last wait. */
 const HOST_DEADLINE_MARGIN_MS = 2000;
@@ -76,6 +81,8 @@ export async function buildRetain(args: {
   readTranscript?: TranscriptReader;
   /** Configured retainTags/retainMetadata, already resolved for this session (core/retain-stamp.ts). */
   stamp?: RetainStamp;
+  /** Optional beta transcript hygiene pass, already resolved from config. */
+  transcriptHygiene?: TranscriptHygieneMode;
   /** Injectable for tests; defaults to the per-session temp file (a Stop hook has no memory). */
   cursors?: RetainCursorStore;
   /** Absolute time the host will kill this process; bounds any rate-limit retry. */
@@ -84,7 +91,10 @@ export async function buildRetain(args: {
   const { harness, sessionId, transcriptPath, client } = args;
   const readTranscript = args.readTranscript ?? readClaudeTranscript;
 
-  const turns = readTranscript(transcriptPath);
+  const rawTurns = readTranscript(transcriptPath);
+  const hygiene = applyTranscriptHygiene(args.transcriptHygiene ?? DEFAULT_TRANSCRIPT_HYGIENE, rawTurns);
+  const turns = hygiene.turns;
+  if (hygiene.receipt.applied) diag(harness, "transcript_hygiene_beta", hygiene.receipt);
   if (turns.length === 0) return;
 
   const startTs = turns[0]?.timestamp ?? new Date().toISOString();
@@ -167,6 +177,7 @@ export async function runRetainHook(
     transcriptPath,
     client,
     readTranscript: spec.readTranscript,
+    transcriptHygiene: cfg.transcriptHygiene,
     retryUntil: hostDeadline,
     stamp: buildRetainStamp(cfg, {
       directory: cwd,

--- a/hindsight-integrations/coding-agents/src/core/transcript-hygiene.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript-hygiene.test.ts
@@ -1,0 +1,156 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { TransportTurn } from "./chat";
+import { readAntigravityTranscript } from "./transcript-antigravity";
+import { readCodexTranscript } from "./transcript-codex";
+import { readClaudeTranscript } from "./transcript";
+import { applyTranscriptHygiene } from "./transcript-hygiene";
+
+const CODEX_RESPONSE_ITEM_TYPE = "response_item";
+const CODEX_MESSAGE_PAYLOAD_TYPE = "message";
+const CODEX_FUNCTION_CALL_PAYLOAD_TYPE = "function_call";
+const EMPTY_ITEM_COUNT = 0;
+const ONE_ITEM_COUNT = 1;
+const TWO_ITEM_COUNT = 2;
+const THREE_ITEM_COUNT = 3;
+const FIRST_ITEM_INDEX = 0;
+const SECOND_ITEM_INDEX = 1;
+const TWO_ACTIONS_GROUP_HEADER = `Action breadcrumbs (${TWO_ITEM_COUNT} grouped):`;
+
+let root: string;
+let file: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "hs-transcript-hygiene-"));
+  file = join(root, "session.jsonl");
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function codexItem(payload: unknown): string {
+  return JSON.stringify({ type: CODEX_RESPONSE_ITEM_TYPE, payload });
+}
+
+function applyBeta(turns: TransportTurn[]) {
+  return applyTranscriptHygiene("semantic-beta", turns);
+}
+
+describe("applyTranscriptHygiene", () => {
+  it("is off by default and returns the same turns without rewriting user text", () => {
+    const turns = [{ role: "user", content: "keep my exact request" }];
+    const result = applyTranscriptHygiene("off", turns);
+    expect(result.turns).toBe(turns);
+    expect(result.receipt).toMatchObject({
+      applied: false,
+      inputTurns: turns.length,
+      outputTurns: turns.length,
+      userTurns: turns.length,
+      actionGroups: EMPTY_ITEM_COUNT,
+    });
+  });
+
+  it("groups consecutive action breadcrumbs while preserving surrounding prose order", () => {
+    const turns = [
+      { role: "user", content: "ship it" },
+      { role: "action", content: "Read src/a.ts" },
+      { role: "action", content: "Edit src/a.ts" },
+      { role: "assistant", content: "done" },
+      { role: "action", content: "Bash npm test" },
+    ];
+
+    const result = applyBeta(turns);
+
+    expect(result.turns).toEqual([
+      { role: "user", content: "ship it" },
+      {
+        role: "action",
+        content: `${TWO_ACTIONS_GROUP_HEADER}\n- Read src/a.ts\n- Edit src/a.ts`,
+      },
+      { role: "assistant", content: "done" },
+      { role: "action", content: "Bash npm test" },
+    ]);
+    expect(result.receipt).toMatchObject({
+      applied: true,
+      inputTurns: turns.length,
+      outputTurns: result.turns.length,
+      actionTurns: THREE_ITEM_COUNT,
+      actionGroups: ONE_ITEM_COUNT,
+      groupedActionTurns: TWO_ITEM_COUNT,
+    });
+  });
+
+  it("supports Codex normalized turns", () => {
+    writeFileSync(
+      file,
+      [
+        codexItem({
+          type: CODEX_MESSAGE_PAYLOAD_TYPE,
+          role: "user",
+          content: [{ type: "input_text", text: "compare both filters" }],
+        }),
+        codexItem({
+          type: CODEX_FUNCTION_CALL_PAYLOAD_TYPE,
+          name: "exec_command",
+          arguments: '{"command":"npm test"}',
+        }),
+        codexItem({
+          type: CODEX_FUNCTION_CALL_PAYLOAD_TYPE,
+          name: "exec_command",
+          arguments: '{"command":"npm run build"}',
+        }),
+      ].join("\n")
+    );
+
+    const result = applyBeta(readCodexTranscript(file));
+
+    expect(result.turns).toHaveLength(TWO_ITEM_COUNT);
+    expect(result.turns[SECOND_ITEM_INDEX].content).toContain(TWO_ACTIONS_GROUP_HEADER);
+  });
+
+  it("supports Claude normalized turns", () => {
+    writeFileSync(
+      file,
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "tool_use", name: "Bash", input: { command: "npm test" } },
+            { type: "tool_use", name: "Edit", input: { file_path: "src/core/chat.ts" } },
+          ],
+        },
+      })
+    );
+
+    const result = applyBeta(readClaudeTranscript(file));
+
+    expect(result.turns).toHaveLength(ONE_ITEM_COUNT);
+    expect(result.turns[FIRST_ITEM_INDEX].content).toContain("Edit src/core/chat.ts");
+  });
+
+  it("supports Antigravity normalized turns without inventing action breadcrumbs", () => {
+    writeFileSync(
+      file,
+      [
+        JSON.stringify({
+          type: "USER_INPUT",
+          content: "Retain this session.",
+          timestamp: "2026-01-01T00:00:00Z",
+        }),
+        JSON.stringify({ role: "assistant", content: "Stored." }),
+      ].join("\n")
+    );
+
+    const result = applyBeta(readAntigravityTranscript(file));
+
+    expect(result.turns).toEqual([
+      { role: "user", content: "Retain this session.", timestamp: "2026-01-01T00:00:00Z" },
+      { role: "assistant", content: "Stored." },
+    ]);
+    expect(result.receipt.actionGroups).toBe(EMPTY_ITEM_COUNT);
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/transcript-hygiene.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript-hygiene.ts
@@ -1,0 +1,161 @@
+import type { TransportTurn } from "./chat";
+
+export const TRANSCRIPT_HYGIENE_OFF = "off";
+export const TRANSCRIPT_HYGIENE_SEMANTIC_BETA = "semantic-beta";
+export const DEFAULT_TRANSCRIPT_HYGIENE = TRANSCRIPT_HYGIENE_OFF;
+export const TRANSCRIPT_HYGIENE_MODES = [
+  TRANSCRIPT_HYGIENE_OFF,
+  TRANSCRIPT_HYGIENE_SEMANTIC_BETA,
+] as const;
+
+export type TranscriptHygieneMode = (typeof TRANSCRIPT_HYGIENE_MODES)[number];
+
+const ACTION_ROLE = "action";
+const USER_ROLE = "user";
+const ASSISTANT_ROLE = "assistant";
+const ACTION_GROUP_HEADER = "Action breadcrumbs";
+const ACTION_GROUP_BULLET_PREFIX = "- ";
+const ACTION_GROUP_SEPARATOR = "\n";
+const EMPTY_ITEM_COUNT = 0;
+const SINGLE_ITEM_COUNT = 1;
+const FIRST_ITEM_INDEX = 0;
+const COUNT_INCREMENT = 1;
+const INLINE_WHITESPACE_RE = /\s+/g;
+
+export interface TranscriptHygieneReceipt {
+  mode: TranscriptHygieneMode;
+  applied: boolean;
+  inputTurns: number;
+  outputTurns: number;
+  userTurns: number;
+  assistantTurns: number;
+  actionTurns: number;
+  actionGroups: number;
+  groupedActionTurns: number;
+}
+
+export interface TranscriptHygieneResult {
+  turns: TransportTurn[];
+  receipt: TranscriptHygieneReceipt;
+}
+
+function countRoles(turns: TransportTurn[]): Pick<
+  TranscriptHygieneReceipt,
+  "userTurns" | "assistantTurns" | "actionTurns"
+> {
+  let userTurns = EMPTY_ITEM_COUNT;
+  let assistantTurns = EMPTY_ITEM_COUNT;
+  let actionTurns = EMPTY_ITEM_COUNT;
+
+  for (const turn of turns) {
+    if (turn.role === USER_ROLE) userTurns += COUNT_INCREMENT;
+    else if (turn.role === ASSISTANT_ROLE) assistantTurns += COUNT_INCREMENT;
+    else if (turn.role === ACTION_ROLE) actionTurns += COUNT_INCREMENT;
+  }
+
+  return { userTurns, assistantTurns, actionTurns };
+}
+
+function cleanActionContent(content: string): string {
+  return content.replace(INLINE_WHITESPACE_RE, " ").trim();
+}
+
+function renderActionGroup(actions: TransportTurn[]): string {
+  return [
+    `${ACTION_GROUP_HEADER} (${actions.length} grouped):`,
+    ...actions.map((action) => `${ACTION_GROUP_BULLET_PREFIX}${cleanActionContent(action.content)}`),
+  ].join(ACTION_GROUP_SEPARATOR);
+}
+
+function makeReceipt(args: {
+  mode: TranscriptHygieneMode;
+  applied: boolean;
+  inputTurns: TransportTurn[];
+  outputTurns: TransportTurn[];
+  actionGroups: number;
+  groupedActionTurns: number;
+}): TranscriptHygieneReceipt {
+  const roleCounts = countRoles(args.inputTurns);
+  return {
+    mode: args.mode,
+    applied: args.applied,
+    inputTurns: args.inputTurns.length,
+    outputTurns: args.outputTurns.length,
+    ...roleCounts,
+    actionGroups: args.actionGroups,
+    groupedActionTurns: args.groupedActionTurns,
+  };
+}
+
+/**
+ * Optional beta hygiene pass for already-normalized transcript turns.
+ *
+ * Harness readers keep user and assistant text clean first. This pass is deliberately narrower:
+ * it groups consecutive action breadcrumbs into one action turn, preserving the tool lineage while
+ * reducing line pressure on the server's conversation extractor. It never rewrites user prose.
+ */
+export function applyTranscriptHygiene(
+  mode: TranscriptHygieneMode,
+  turns: TransportTurn[]
+): TranscriptHygieneResult {
+  if (mode !== TRANSCRIPT_HYGIENE_SEMANTIC_BETA) {
+    return {
+      turns,
+      receipt: makeReceipt({
+        mode,
+        applied: false,
+        inputTurns: turns,
+        outputTurns: turns,
+        actionGroups: EMPTY_ITEM_COUNT,
+        groupedActionTurns: EMPTY_ITEM_COUNT,
+      }),
+    };
+  }
+
+  const output: TransportTurn[] = [];
+  let pendingActions: TransportTurn[] = [];
+  let actionGroups = EMPTY_ITEM_COUNT;
+  let groupedActionTurns = EMPTY_ITEM_COUNT;
+
+  const flushPendingActions = () => {
+    if (pendingActions.length === EMPTY_ITEM_COUNT) return;
+    if (pendingActions.length === SINGLE_ITEM_COUNT) {
+      output.push(pendingActions[FIRST_ITEM_INDEX]);
+      pendingActions = [];
+      return;
+    }
+
+    actionGroups += COUNT_INCREMENT;
+    groupedActionTurns += pendingActions.length;
+    output.push({
+      role: ACTION_ROLE,
+      content: renderActionGroup(pendingActions),
+      ...(pendingActions[FIRST_ITEM_INDEX].timestamp
+        ? { timestamp: pendingActions[FIRST_ITEM_INDEX].timestamp }
+        : {}),
+    });
+    pendingActions = [];
+  };
+
+  for (const turn of turns) {
+    if (turn.role === ACTION_ROLE) {
+      pendingActions.push(turn);
+      continue;
+    }
+    flushPendingActions();
+    output.push(turn);
+  }
+  flushPendingActions();
+
+  return {
+    turns: output,
+    receipt: makeReceipt({
+      mode,
+      applied: true,
+      inputTurns: turns,
+      outputTurns: output,
+      actionGroups,
+      groupedActionTurns,
+    }),
+  };
+}


### PR DESCRIPTION
Closes #3866

## Summary

This PR adds an opt-in beta transcript hygiene mode to `hindsight-integrations/coding-agents` session write-back.

It is intentionally **not a replacement** for the existing default filter. The default remains `off`; users must opt in with:

```jsonc
{
  "transcriptHygiene": "semantic-beta"
}
```

or the environment fallback:

```bash
HINDSIGHT_TRANSCRIPT_HYGIENE=semantic-beta
```

## What changed

- Added `src/core/transcript-hygiene.ts` with `applyTranscriptHygiene()`.
- Added config field `transcriptHygiene`, defaulting to `"off"`.
- Added environment fallback `HINDSIGHT_TRANSCRIPT_HYGIENE`.
- Wired the resolved config into `buildRetain()` / `runRetainHook()` before `retainLiveSession()`.
- Added `transcript_hygiene_beta` diagnostics with input/output turn counts and grouped action counts.
- Documented the beta in the README and regenerated the companion skill.
- Added tests for config, hook wiring, and Codex / Claude Code / Antigravity normalized transcript paths.

The beta pass runs after each harness reader has normalized its transcript into the shared `TransportTurn[]` shape. The implementation in this PR does **not** rewrite user or assistant prose. It groups adjacent `role:"action"` breadcrumbs, preserving tool lineage while reducing action-line pressure from coding sessions.

## Field evidence from a real session corpus

The benchmark below used the same frozen local Codex session snapshot:

- Source file: `/Users/augustocarollo/Developer/makershub-context-router/.curate/compression-benchmark-01a04629-chatgpt-codex-20260828T0440/_source/source.jsonl`
- Source bytes: `19,069,044`
- Source lines: `8,829`
- SHA-256: `d3fc22d9700547a36ab5fcc7889d724e2f875b620f32a16421f60ff12f3e069d`
- Source event counts: `response_item=6,408`, `event_msg=2,330`, `turn_context=47`, `world_state=31`, `compacted=11`, `session_meta=2`
- Source payload counts inside `response_item`: `message=2,522`, `reasoning=840`, `function_call=1,359`, `function_call_output=1,358`, `custom_tool_call=127`, `custom_tool_call_output=127`, `tool_search_call=28`, `tool_search_output=28`, `web_search_call=19`
- Source message roles: `user=81`, `assistant=868`, `developer=1,573`
- Source message chars: `user=556,477`, `assistant=257,485`, `developer=666,687`

### Recomputed benchmark table

This table compares the official plugin-equivalent Codex retain payload against the pure `semantic-hygiene` output produced by the context-router benchmark. It is a field comparison, not a claim that every number below is produced by the narrow grouping-only function in this PR.

| Metric | Official plugin equivalent | Pure `semantic-hygiene` benchmark | Winner |
|---|---:|---:|---|
| Final JSONL | `686,805 bytes` | `776,752 bytes` | Plugin |
| Share of raw source | `3.601%` | `4.073%` | Plugin |
| Reduction vs raw source | `96.399%` | `95.927%` | Plugin by a small margin |
| Absolute byte delta | baseline | `+89,947 bytes` | Plugin |
| Estimated token delta at 3.5 chars/token | baseline | `+25,699 tokens` | Plugin |
| Final JSONL lines | `2,301` | `1,009` | Hygiene |
| Preserved user turns | `73` | `81` | Hygiene |
| Preserved assistant turns | `868` | `868` | Tie |
| Assistant content chars | `257,485` | `257,485` | Tie |
| User content chars | `283,403` | `219,742` | Hygiene |
| User-side noisy content removed | baseline | `-63,661 chars`, `-22.463%` | Hygiene |
| Dialog hygiene replacements | no structured receipt | `94` | Hygiene |
| Dialog hygiene omitted chars | no structured receipt | `349,848` | Hygiene |
| Runtime-noise steps omitted | already filtered into compact actions | `6,980` | Different basis |
| Runtime-noise chars omitted | already filtered into compact actions | `4,443,305` | Different basis |

### Why the lower user-char count is valid

The pure `semantic-hygiene` benchmark preserved more user turns (`81` vs `73`) while producing fewer user chars (`219,742` vs `283,403`) because it stripped large injected/noisy blocks from inside user-visible text.

The measured dialog-hygiene receipt explains the delta:

| Removed pattern | Replacements | Omitted chars |
|---|---:|---:|
| `agents_instructions` | `5` | `334,119` |
| `hook_context_report_block` | `74` | `12,547` |
| `hook_prompt` | `2` | `1,828` |
| `reap_leaks_line` | `13` | `1,354` |
| **Total** | `94` | `349,848` |

So the apparent contradiction is expected: preserving additional small real user turns can still reduce total user text when large injected blocks are removed from other user messages.

## Separate grouped-action measurement

The grouped-action numbers come from a later hybrid run and should not be mixed into the pure benchmark table above.

- Hybrid report: `/Users/augustocarollo/Developer/makershub-context-router/.curate/session-01a04629-chatgpt-codex-grok-3way-20260828T0455/HYBRID-COMPRESSION-AND-COST-ESTIMATE.md`
- Source bytes: `20,366,443`
- Source lines: `9,447`
- Hybrid JSONL bytes: `948,707`
- Hybrid JSONL lines: `1,136`
- Hybrid Markdown bytes: `790,912`
- Action breadcrumbs: `1,638` tool calls grouped into `58` records / `119,544` content chars
- Runtime steps omitted: `5,837` / `3,447,126` chars
- Dialog hygiene: `95` replacements / `417,160` chars
- Delta vs drop-tools semantic-hygiene: `+139,334 bytes` / `+17.215%`
- Delta vs breadcrumb-per-line hybrid: `-381,673 bytes` / `-28.689%`

This is the evidence that supports the PR's grouping strategy specifically: action grouping costs more than dropping tools entirely, but it preserves auditable tool lineage while reducing line pressure compared with one action record per tool call.

## Interpretation

The beta should remain opt-in because the benchmark trade-off is not a pure byte-size win in every mode.

The useful distinction is:

- The official plugin-equivalent payload is smaller on raw bytes for this frozen Codex snapshot: `686,805` bytes vs `776,752` bytes.
- The pure hygiene benchmark keeps more real user turns and the same assistant content while removing large injected/noisy user-side material.
- The grouped-action hybrid measurement supports this PR's narrow implementation: preserve tool lineage, but collapse adjacent action breadcrumbs to reduce structured-line pressure.

The proposed mode is therefore best positioned as a beta alternative for teams that value cleaner semantic input, auditability, and compact tool lineage over minimum possible payload bytes.

## Cross-harness validation from the local corpus

A deterministic corpus validator was run against Codex, Claude and Antigravity session files. Result file:

`/Users/augustocarollo/Developer/makershub/tasks/curate-long-context-43f084a6/compression-corpus-validation.latest.json`

Summary:

- Run ID: `compression-corpus-c25e4ebbb6fd`
- Overall status: `PASS`
- Total cases: `1,821`
- Passed: `1,811`
- Skipped as non-conversation: `10`
- Failed: `0`

By harness:

| Harness | Cases | Passed | Skipped | Failed | Source bytes | Compressed JSONL bytes | Minimum reduction | Maximum elapsed time |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| Codex | `1,233` | `1,233` | `0` | `0` | `7,130,397,129` | `92,049,805` | `57.236%` | `1.867s` |
| Claude | `316` | `306` | `10` | `0` | `875,640,825` | `28,616,719` | `78.403%` | `1.535s` |
| Antigravity | `272` | `272` | `0` | `0` | `99,513,408` | `104,228,874` | n/a | n/a |

Antigravity currently showed canonical-style records that can expand slightly when preserving already compact canonical data. That is another reason to keep this feature as beta and opt-in rather than replacing the default.

## Tests

Run from `hindsight-integrations/coding-agents`:

```bash
npm test -- --run src/core/retain-hook.test.ts src/core/transcript-hygiene.test.ts src/core/config.test.ts src/docs-freshness.test.ts
# Test Files 4 passed (4)
# Tests 77 passed (77)

npm test
# Test Files 56 passed (56)
# Tests 668 passed (668)

npm run build
# ESM Build success
# DTS Build success
```

Also run from the repository root:

```bash
git diff --check
# no output
```

## Compatibility notes

- Existing users see no behavior change because `transcriptHygiene` defaults to `"off"`.
- Invalid config values fail closed to `"off"`.
- Per-harness and per-bank layering works through the existing config resolver.
- The code operates on the shared normalized turn model, so it does not introduce harness-specific parser forks.

