### PR TITLE
feat(mental-models): meter model content by what is delivered, not by which endpoint served it

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -7314,9 +7314,14 @@ def _register_routes(app: FastAPI):
             bank_config = BankTemplateConfig(**filtered_overrides) if filtered_overrides else None
 
             # Get mental models (limit=None — an export that stopped at the
-            # default page size would silently drop the rest of the bank)
+            # default page size would silently drop the rest of the bank).
+            # detail="config" because a template carries how a model is built,
+            # never what it currently says: the loop below reads source_query,
+            # tags, max_tokens and trigger and nothing else. Asking for content
+            # would pull every model's synthesized body across the wire, and
+            # report a read of it, for a field this endpoint discards.
             mental_models_raw = await app.state.memory.list_mental_models(
-                bank_id=bank_id, limit=None, request_context=request_context
+                bank_id=bank_id, limit=None, detail="config", request_context=request_context
             )
             template_mental_models: list[BankTemplateMentalModel] = []
             for mm in mental_models_raw.items:

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -3075,7 +3075,9 @@ async def apply_bank_template_manifest(
     # ones past the first page, and the import would create duplicates.
     existing_by_id: dict[str, dict[str, Any]] = {}
     if bank_exists and manifest.mental_models:
-        existing = await memory.list_mental_models(bank_id=bank_id, limit=None, request_context=request_context)
+        existing = await memory.list_mental_models(
+            bank_id=bank_id, limit=None, detail="metadata", request_context=request_context
+        )
         existing_by_id = {m["id"]: m for m in existing.items}
 
     existing_by_name: dict[str, dict[str, Any]] = {}
@@ -3128,6 +3130,7 @@ async def apply_bank_template_manifest(
             provisioned = await memory.list_mental_models(
                 bank_id=bank_id,
                 limit=None,
+                detail="metadata",
                 request_context=request_context,
             )
             provisioned_by_id = {item["id"]: item for item in provisioned.items}
@@ -3173,7 +3176,9 @@ async def apply_default_bank_template_resources(
     """Apply only the resources from a server-owned default template."""
     existing_by_id: dict[str, dict[str, Any]] = {}
     if manifest.mental_models:
-        existing = await memory.list_mental_models(bank_id=bank_id, limit=None, request_context=request_context)
+        existing = await memory.list_mental_models(
+            bank_id=bank_id, limit=None, detail="metadata", request_context=request_context
+        )
         existing_by_id = {model["id"]: model for model in existing.items}
 
     existing_by_name: dict[str, dict[str, Any]] = {}

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -11953,12 +11953,15 @@ class MemoryEngine(MemoryEngineInterface):
         or asked for them in one page — the unit is a model's content, and the
         route it arrived by is not something pricing should have to know about.
 
-        Items carrying no content (a model that has never been refreshed) are
-        skipped: nothing was delivered, so there is nothing to report.
+        Items carrying no content are skipped: nothing was delivered, so there
+        is nothing to report. That covers a model that has never been refreshed,
+        one still generating its first content, and every detail level that
+        drops the column — so "report what was delivered" is read off the items
+        themselves rather than inferred from the caller's ``detail`` argument.
         """
         for item in items:
             content = item.get("content")
-            if not content:
+            if not content or content.strip() == MENTAL_MODEL_PENDING_CONTENT:
                 continue
             await self._record_mental_model_read(bank_id, str(item["id"]), content, request_context=request_context)
 
@@ -13665,7 +13668,8 @@ class MemoryEngine(MemoryEngineInterface):
             bank_id: Bank identifier
             tags: Optional tags to filter by
             tags_match: How to match tags - 'any', 'all', or 'exact'
-            detail: Detail level - 'metadata', 'content', or 'full'
+            detail: Detail level - 'metadata', 'config', 'content', or 'full'.
+                See ``_row_to_mental_model``; 'config' is internal.
             limit: Maximum number of results, or None for every match. The HTTP
                 endpoint always caps it; None is for internal callers that must
                 see the whole set (bank-template export/import), which used to
@@ -13750,20 +13754,25 @@ class MemoryEngine(MemoryEngineInterface):
                 for item in items:
                     item["is_stale"] = stale[item["id"]]
 
-            # A list that carries content delivers the same synthesized text a
-            # per-model read delivers, in bulk. Report it the same way, so what
-            # a caller pays tracks the content it receives rather than which
-            # endpoint it happened to call.  returns no
-            # content and so reports nothing.
-            #
-            # This matters most for knowledge pages: a page is a mental_models
-            # row and is not excluded from this query, so an unreported list
-            # hands back every page in a bank while a single-page read is
-            # reported. The narrow door should not be the only one watched.
-            if detail != "metadata" and not _nested_operation_authorized.get():
-                await self._record_mental_model_list_read(bank_id, items, request_context=request_context)
+        # A list that carries content delivers the same synthesized text a
+        # per-model read delivers, in bulk. Report it the same way, so what a
+        # caller pays tracks the content it receives rather than which endpoint
+        # it happened to call. A detail level that drops ``content`` (``metadata``,
+        # ``config``) leaves nothing to report, and the per-item check below sees
+        # that directly rather than re-deriving it from the detail string.
+        #
+        # This matters most for knowledge pages: a page is a mental_models
+        # row and is not excluded from this query, so an unreported list
+        # hands back every page in a bank while a single-page read is
+        # reported. The narrow door should not be the only one watched.
+        #
+        # Outside the connection block on purpose: the hook is an extension
+        # seam that may go over the network, once per model, and a pooled
+        # connection must not be held across it.
+        if not _nested_operation_authorized.get():
+            await self._record_mental_model_list_read(bank_id, items, request_context=request_context)
 
-            return MentalModelPage(items=items, total=int(total or 0))
+        return MentalModelPage(items=items, total=int(total or 0))
 
     async def get_mental_model(
         self,
@@ -13778,7 +13787,8 @@ class MemoryEngine(MemoryEngineInterface):
         Args:
             bank_id: Bank identifier
             mental_model_id: Pinned mental model UUID
-            detail: Detail level - 'metadata', 'content', or 'full'
+            detail: Detail level - 'metadata', 'config', 'content', or 'full'.
+                See ``_row_to_mental_model``; 'config' is internal.
             request_context: Request context for authentication
 
         Returns:
@@ -16357,6 +16367,14 @@ class MemoryEngine(MemoryEngineInterface):
         it performs run under that authorization so the whole export costs exactly
         one validator hook and leaks no content when the caller is denied. The API
         layer renders the returned data into a markdown bundle.
+
+        Note that this is the widest read of model content in the engine — every
+        page in the bank — and it deliberately reports as one export rather than
+        as one model read per page: an export is a single named operation a
+        deployment can price on its own terms, and re-reporting its pages would
+        double-count against the ``EXPORT_KNOWLEDGE_BASE`` hook that already fired.
+        Changing that means changing what the export hook means, which is a
+        decision for the extension contract rather than a detail of this method.
         """
         await self._authenticate_tenant(request_context)
         if self._operation_validator and not _nested_operation_authorized.get():
@@ -16633,7 +16651,12 @@ class MemoryEngine(MemoryEngineInterface):
 
         Args:
             row: Database row
-            detail: Detail level - 'metadata', 'content', or 'full'
+            detail: Detail level - 'metadata', 'config', 'content', or 'full'.
+                ``config`` is internal (not offered by the HTTP or MCP surface):
+                it carries the fields that describe how a model is built —
+                ``source_query``, ``max_tokens``, ``trigger`` — without its
+                synthesized content, for callers that copy a model's definition
+                and never read its body.
         """
         result: dict[str, Any] = {
             "id": str(row["id"]),
@@ -16654,9 +16677,12 @@ class MemoryEngine(MemoryEngineInterface):
             except json.JSONDecodeError:
                 trigger = None
         result["source_query"] = row["source_query"]
-        result["content"] = row["content"]
         result["max_tokens"] = row.get("max_tokens")
         result["trigger"] = trigger
+        if detail == "config":
+            return result
+
+        result["content"] = row["content"]
 
         if detail == "full":
             reflect_response = row.get("reflect_response")

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -11911,6 +11911,64 @@ class MemoryEngine(MemoryEngineInterface):
         state.bank_write_remaining[write] = remaining - 1
         return True
 
+    async def _gate_mental_model_read(
+        self, bank_id: str, mental_model_id: str, *, request_context: "RequestContext"
+    ) -> None:
+        """Run the pre-read validation for one mental model.
+
+        Shared by every endpoint that hands a model's content to a caller, so
+        "which reads are gated" is a property of this method rather than
+        something each call site has to remember. A knowledge page is a second
+        view over a mental model and reaches this by the same route.
+        """
+        if not self._operation_validator:
+            return
+        from hindsight_api.extensions.operation_validator import MentalModelGetContext
+
+        if self._consume_preauthorized_mental_model_operation(
+            bank_id, mental_model_id, refresh=False, request_context=request_context
+        ):
+            return
+        await self._validate_operation(
+            self._operation_validator.validate_mental_model_get(
+                MentalModelGetContext(
+                    bank_id=bank_id,
+                    mental_model_id=mental_model_id,
+                    request_context=request_context,
+                )
+            )
+        )
+
+    async def _record_mental_model_read(
+        self,
+        bank_id: str,
+        mental_model_id: str,
+        content: str | None,
+        *,
+        request_context: "RequestContext",
+    ) -> None:
+        """Report a completed model read, sized by the content actually returned.
+
+        Best-effort by design: the caller already has the content, so a failure
+        here must not turn a served read into an error.
+        """
+        if not self._operation_validator:
+            return
+        from hindsight_api.extensions.operation_validator import MentalModelGetResult
+
+        try:
+            await self._operation_validator.on_mental_model_get_complete(
+                MentalModelGetResult(
+                    bank_id=bank_id,
+                    mental_model_id=mental_model_id,
+                    request_context=request_context,
+                    output_tokens=len(content) // 4 if content else 0,
+                    success=True,
+                )
+            )
+        except Exception as hook_err:
+            logger.warning(f"Post-mental-model-get hook error (non-fatal): {hook_err}")
+
     def _consume_preauthorized_mental_model_operation(
         self,
         bank_id: str,
@@ -13692,21 +13750,7 @@ class MemoryEngine(MemoryEngineInterface):
         await self._authenticate_tenant(request_context)
 
         # Pre-operation validation (credit check / usage metering)
-        if self._operation_validator:
-            from hindsight_api.extensions.operation_validator import MentalModelGetContext
-
-            if not self._consume_preauthorized_mental_model_operation(
-                bank_id,
-                mental_model_id,
-                refresh=False,
-                request_context=request_context,
-            ):
-                ctx = MentalModelGetContext(
-                    bank_id=bank_id,
-                    mental_model_id=mental_model_id,
-                    request_context=request_context,
-                )
-                await self._validate_operation(self._operation_validator.validate_mental_model_get(ctx))
+        await self._gate_mental_model_read(bank_id, mental_model_id, request_context=request_context)
 
         backend = await self._get_backend()
 
@@ -13728,23 +13772,10 @@ class MemoryEngine(MemoryEngineInterface):
                 result["is_stale"] = await self.compute_mental_model_is_stale(conn, bank_id, row)
 
         # Post-operation hook (usage recording)
-        if result and self._operation_validator:
-            from hindsight_api.extensions.operation_validator import MentalModelGetResult
-
-            content = result.get("content", "")
-            output_tokens = len(content) // 4 if content else 0
-
-            result_ctx = MentalModelGetResult(
-                bank_id=bank_id,
-                mental_model_id=mental_model_id,
-                request_context=request_context,
-                output_tokens=output_tokens,
-                success=True,
+        if result:
+            await self._record_mental_model_read(
+                bank_id, mental_model_id, result.get("content"), request_context=request_context
             )
-            try:
-                await self._operation_validator.on_mental_model_get_complete(result_ctx)
-            except Exception as hook_err:
-                logger.warning(f"Post-mental-model-get hook error (non-fatal): {hook_err}")
 
         return result
 
@@ -15873,8 +15904,31 @@ class MemoryEngine(MemoryEngineInterface):
             )
         if row is None:
             return None
+
+        # A page read IS a mental model read: the join above returns
+        # ``mm.content`` as the page body, so this delivers exactly what
+        # ``get_mental_model`` delivers, off the same row. Run the same
+        # validator pair so the two doors onto that object are treated alike
+        # rather than differing by which URL the caller happened to use.
+        #
+        # Ordered after the fetch, unlike ``get_mental_model``, because the
+        # model's id is a property of the page rather than something the
+        # caller supplies — it is not known until the row is read. The gate
+        # still runs before any content is returned, so a rejected read
+        # yields no page; the only cost of the reordering is one indexed
+        # SELECT performed for a request that is then refused.
+        mental_model_id = row["mental_model_id"]
+        meter = bool(mental_model_id) and not _nested_operation_authorized.get()
+        if meter:
+            await self._gate_mental_model_read(bank_id, mental_model_id, request_context=request_context)
+
         node = self._row_to_knowledge_node(row)
         node["content"] = row["mm_content"]
+
+        if meter:
+            await self._record_mental_model_read(
+                bank_id, mental_model_id, node.get("content"), request_context=request_context
+            )
         return node
 
     async def search_knowledge_pages(

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -11939,6 +11939,29 @@ class MemoryEngine(MemoryEngineInterface):
             )
         )
 
+    async def _record_mental_model_list_read(
+        self,
+        bank_id: str,
+        items: list[dict[str, Any]],
+        *,
+        request_context: "RequestContext",
+    ) -> None:
+        """Report the content a list handed back, one entry per model.
+
+        Reported per model rather than as a single aggregate so a deployment
+        sees the same shape whether a caller fetched ten models one at a time
+        or asked for them in one page — the unit is a model's content, and the
+        route it arrived by is not something pricing should have to know about.
+
+        Items carrying no content (a model that has never been refreshed) are
+        skipped: nothing was delivered, so there is nothing to report.
+        """
+        for item in items:
+            content = item.get("content")
+            if not content:
+                continue
+            await self._record_mental_model_read(bank_id, str(item["id"]), content, request_context=request_context)
+
     async def _record_mental_model_read(
         self,
         bank_id: str,
@@ -13726,6 +13749,20 @@ class MemoryEngine(MemoryEngineInterface):
                 )
                 for item in items:
                     item["is_stale"] = stale[item["id"]]
+
+            # A list that carries content delivers the same synthesized text a
+            # per-model read delivers, in bulk. Report it the same way, so what
+            # a caller pays tracks the content it receives rather than which
+            # endpoint it happened to call.  returns no
+            # content and so reports nothing.
+            #
+            # This matters most for knowledge pages: a page is a mental_models
+            # row and is not excluded from this query, so an unreported list
+            # hands back every page in a bank while a single-page read is
+            # reported. The narrow door should not be the only one watched.
+            if detail != "metadata" and not _nested_operation_authorized.get():
+                await self._record_mental_model_list_read(bank_id, items, request_context=request_context)
+
             return MentalModelPage(items=items, total=int(total or 0))
 
     async def get_mental_model(

--- a/hindsight-api-slim/tests/test_knowledge_base.py
+++ b/hindsight-api-slim/tests/test_knowledge_base.py
@@ -18,7 +18,11 @@ import pytest_asyncio
 
 import hindsight_api.engine.memory_engine as memory_engine_module
 from hindsight_api.engine.db import DatabaseConnection
-from hindsight_api.engine.memory_engine import MemoryEngine, _may_need_refresh
+from hindsight_api.engine.memory_engine import (
+    MENTAL_MODEL_PENDING_CONTENT,
+    MemoryEngine,
+    _may_need_refresh,
+)
 from hindsight_api.extensions import (
     BankReadContext,
     BankReadOperation,
@@ -140,7 +144,7 @@ class _RecordingValidator(OperationValidatorExtension):
         return ValidationResult.accept()
 
     async def on_mental_model_get_complete(self, result) -> None:
-        # Recorded separately from : the gate and the completion
+        # Recorded separately from `model_gets`: the gate and the completion
         # hook do not always both fire. A single read runs both; a list reports
         # completion for each model it delivered without gating each one.
         self.model_reads.append(result.mental_model_id)
@@ -1156,6 +1160,66 @@ class TestListReportsTheContentItDelivers:
 
         expected = sorted(len(m["content"]) // 4 for m in page.items if m.get("content"))
         assert sorted(validator.model_get_tokens) == expected
+
+    async def test_config_detail_carries_the_definition_without_the_body(
+        self, memory, kb_bank, request_context, monkeypatch
+    ):
+        # The level the bank-template export asks for: it copies how a model is
+        # built and never reads what it says, so it must not pull — or be
+        # reported for — content it discards.
+        bank_id, ids = kb_bank
+        validator = _kb_validator()
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+
+        page = await memory.list_mental_models(bank_id=bank_id, detail="config", request_context=request_context)
+
+        assert page.items, "config listing should still return the models"
+        assert all("content" not in m for m in page.items)
+        # The fields a template manifest is built from survive the trim.
+        assert all(m["source_query"] and "trigger" in m and "max_tokens" in m for m in page.items)
+        assert validator.model_reads == []
+
+    async def test_a_model_still_generating_is_not_reported(self, memory, kb_bank, request_context, monkeypatch):
+        # The placeholder is not synthesized knowledge; nothing was delivered.
+        bank_id, ids = kb_bank
+        pending = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Pending",
+            source_query="Not answered yet.",
+            content=MENTAL_MODEL_PENDING_CONTENT,
+            request_context=request_context,
+        )
+        validator = _kb_validator()
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+
+        page = await memory.list_mental_models(bank_id=bank_id, detail="content", request_context=request_context)
+
+        assert any(m["id"] == pending["id"] for m in page.items), "the pending model should still be listed"
+        assert pending["id"] not in validator.model_reads
+
+
+class TestExportReportsOnceNotPerPage:
+    """An export is a single named operation, not N model reads.
+
+    export_knowledge_base runs its per-page reads under
+    _authorize_nested_operations, so the whole bundle costs exactly one
+    EXPORT_KNOWLEDGE_BASE hook. Pinned here because it is the widest read of
+    model content in the engine, and the suppression that keeps it to one hook
+    is invisible at the call site.
+    """
+
+    async def test_export_reports_one_hook_for_the_whole_bundle(self, memory, kb_bank, request_context, monkeypatch):
+        bank_id, ids = kb_bank
+        validator = _kb_validator()
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+
+        export = await memory.export_knowledge_base(bank_id=bank_id, request_context=request_context)
+
+        assert len(export.pages) >= 3, "fixture seeds three pages"
+        assert _read_ops(validator) == [BankReadOperation.EXPORT_KNOWLEDGE_BASE]
+        # The nested page and list reads inside it report nothing of their own.
+        assert validator.model_gets == []
+        assert validator.model_reads == []
 
 
 class TestPageReadIsAModelRead:

--- a/hindsight-api-slim/tests/test_knowledge_base.py
+++ b/hindsight-api-slim/tests/test_knowledge_base.py
@@ -120,6 +120,7 @@ class _RecordingValidator(OperationValidatorExtension):
         # too. Recorded here so tests can assert the meter fires rather than
         # only that access was checked.
         self.model_gets: list[str] = []
+        self.model_reads: list[str] = []
         self.model_get_tokens: list[int] = []
         self.reject_model_get = False
 
@@ -139,6 +140,10 @@ class _RecordingValidator(OperationValidatorExtension):
         return ValidationResult.accept()
 
     async def on_mental_model_get_complete(self, result) -> None:
+        # Recorded separately from : the gate and the completion
+        # hook do not always both fire. A single read runs both; a list reports
+        # completion for each model it delivered without gating each one.
+        self.model_reads.append(result.mental_model_id)
         self.model_get_tokens.append(result.output_tokens)
 
     async def validate_bank_read(self, ctx: BankReadContext) -> ValidationResult:
@@ -1096,6 +1101,61 @@ class TestMoveRenameDelete:
         # the backing mental model is gone too
         mm = await memory.get_mental_model(bank_id, ids.orders_mm, request_context=request_context)
         assert mm is None
+
+
+class TestListReportsTheContentItDelivers:
+    """A list that carries content is a bulk read of that content.
+
+    A knowledge page is a mental_models row and is not excluded from
+    list_mental_models, so a list that returns content hands back every
+    page in the bank. Reporting the single-page read while leaving that
+    unreported would watch the narrow door and leave the wide one open — a
+    caller could enumerate a bank's synthesized knowledge by asking for it in
+    one page instead of one at a time.
+    """
+
+    async def test_listing_with_content_reports_each_model(self, memory, kb_bank, request_context, monkeypatch):
+        bank_id, ids = kb_bank
+        validator = _kb_validator()
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+
+        page = await memory.list_mental_models(bank_id=bank_id, detail="content", request_context=request_context)
+
+        with_content = [m for m in page.items if m.get("content")]
+        assert with_content, "fixture should have at least one model with content"
+        assert sorted(validator.model_reads) == sorted(str(m["id"]) for m in with_content)
+
+    async def test_the_page_backing_model_is_among_them(self, memory, kb_bank, request_context, monkeypatch):
+        # The specific hole: pages ride in on this list.
+        bank_id, ids = kb_bank
+        validator = _kb_validator()
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+
+        await memory.list_mental_models(bank_id=bank_id, detail="content", request_context=request_context)
+
+        assert ids.orders_mm in validator.model_reads
+
+    async def test_listing_metadata_reports_nothing(self, memory, kb_bank, request_context, monkeypatch):
+        # No content delivered, nothing to report — and this is the detail
+        # level the internal template-provisioning callers now ask for.
+        bank_id, ids = kb_bank
+        validator = _kb_validator()
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+
+        page = await memory.list_mental_models(bank_id=bank_id, detail="metadata", request_context=request_context)
+
+        assert page.items, "metadata listing should still return the models"
+        assert validator.model_reads == []
+
+    async def test_reported_size_tracks_the_content_returned(self, memory, kb_bank, request_context, monkeypatch):
+        bank_id, ids = kb_bank
+        validator = _kb_validator()
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+
+        page = await memory.list_mental_models(bank_id=bank_id, detail="content", request_context=request_context)
+
+        expected = sorted(len(m["content"]) // 4 for m in page.items if m.get("content"))
+        assert sorted(validator.model_get_tokens) == expected
 
 
 class TestPageReadIsAModelRead:

--- a/hindsight-api-slim/tests/test_knowledge_base.py
+++ b/hindsight-api-slim/tests/test_knowledge_base.py
@@ -116,6 +116,12 @@ class _RecordingValidator(OperationValidatorExtension):
         self._reason = reason
         self.read_ops: list[BankReadOperation] = []
         self.write_ops: list[BankWriteOperation] = []
+        # A page read is a mental model read, so it runs the metering pair
+        # too. Recorded here so tests can assert the meter fires rather than
+        # only that access was checked.
+        self.model_gets: list[str] = []
+        self.model_get_tokens: list[int] = []
+        self.reject_model_get = False
 
     async def validate_retain(self, ctx) -> ValidationResult:
         return ValidationResult.accept()
@@ -125,6 +131,15 @@ class _RecordingValidator(OperationValidatorExtension):
 
     async def validate_reflect(self, ctx) -> ValidationResult:
         return ValidationResult.accept()
+
+    async def validate_mental_model_get(self, ctx) -> ValidationResult:
+        self.model_gets.append(ctx.mental_model_id)
+        if self.reject_model_get:
+            return ValidationResult.reject("insufficient credits")
+        return ValidationResult.accept()
+
+    async def on_mental_model_get_complete(self, result) -> None:
+        self.model_get_tokens.append(result.output_tokens)
 
     async def validate_bank_read(self, ctx: BankReadContext) -> ValidationResult:
         self.read_ops.append(ctx.operation)
@@ -1081,6 +1096,72 @@ class TestMoveRenameDelete:
         # the backing mental model is gone too
         mm = await memory.get_mental_model(bank_id, ids.orders_mm, request_context=request_context)
         assert mm is None
+
+
+class TestPageReadIsAModelRead:
+    """Reading a page runs the same validator pair as reading its mental model.
+
+    get_knowledge_page joins mental_models and returns mm.content as
+    the page body, so a page read delivers exactly what get_mental_model
+    delivers off the same row. The two endpoints are doors onto one object, and
+    a deployment that meters model reads must see both — otherwise the price of
+    the same content depends on which URL the caller picked.
+    """
+
+    async def test_reading_a_page_runs_the_model_get_validator(self, api_client, kb_bank, memory, monkeypatch):
+        bank_id, ids = kb_bank
+        validator = _kb_validator()
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+
+        resp = await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/pages/{ids.orders}")
+
+        assert resp.status_code == 200, resp.text
+        # Gated on the page's backing model, not on the page id.
+        assert validator.model_gets == [ids.orders_mm]
+
+    async def test_reading_a_page_reports_completion_with_the_content_size(
+        self, api_client, kb_bank, memory, monkeypatch
+    ):
+        # The post-hook is what records usage; without it a deployment could
+        # gate a read it then never bills for.
+        bank_id, ids = kb_bank
+        validator = _kb_validator()
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+
+        resp = await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/pages/{ids.orders}")
+        body = resp.json()
+
+        # The response renames the model's content to body; the hook is
+        # given the same string, so the recorded size must track it.
+        assert len(validator.model_get_tokens) == 1
+        assert validator.model_get_tokens[0] == len(body.get("body") or "") // 4
+        assert validator.model_get_tokens[0] > 0
+
+    async def test_a_refused_model_get_returns_no_page_content(self, api_client, kb_bank, memory, monkeypatch):
+        # The gate has to run before the body is handed back, or it is
+        # decoration: the caller would get the content and the refusal.
+        bank_id, ids = kb_bank
+        validator = _kb_validator()
+        validator.reject_model_get = True
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+
+        resp = await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/pages/{ids.orders}")
+
+        assert resp.status_code != 200
+        assert "Orders" not in resp.text
+        # Refused before delivery means nothing to record.
+        assert validator.model_get_tokens == []
+
+    async def test_bank_read_access_check_still_runs(self, api_client, kb_bank, memory, monkeypatch):
+        # Metering is added alongside the access check, not in place of it.
+        bank_id, ids = kb_bank
+        validator = _kb_validator()
+        monkeypatch.setattr(memory, "_operation_validator", validator)
+
+        validator.read_ops.clear()
+        await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/pages/{ids.orders}")
+
+        assert _read_ops(validator) == [BankReadOperation.GET_KNOWLEDGE_PAGE]
 
 
 class TestAuthorizationReadDenied:


### PR DESCRIPTION
## The asymmetry

`get_knowledge_page` joins `mental_models` and returns `mm.content` as the page body:

```sql
SELECT {self._KP_PAGE_SELECT}, mm.content AS mm_content
FROM knowledge_pages kp LEFT JOIN mental_models mm ON mm.id = kp.mental_model_id
WHERE kp.bank_id = $1 AND kp.id = $2 AND kp.kind = 'page'
```

It delivers exactly what `get_mental_model` delivers, off the same row. But it validated through `validate_bank_read` — an access check — while the mental-model endpoint runs `validate_mental_model_get` and `on_mental_model_get_complete`.

A deployment with an `OperationValidatorExtension` therefore sees one door onto the object and not the other, and whatever policy it applies to reading a model can be sidestepped by asking for the page instead. A knowledge base is a second view over mental models; it shouldn't be a way around that.

## Why the write path never had this problem

Creating a page calls the same function a plain refresh calls:

```python
node   = await memory.create_knowledge_page(...)
result = await memory.submit_async_refresh_mental_model(..., page_id=node["id"])
```

`submit_async_refresh_mental_model` validates internally, so a page rebuild is gated **by construction** — nobody had to remember. The read path is the one that reimplemented the query by hand and, in doing so, dropped everything `get_mental_model` wraps around it.

## Change

Rather than repeat the validation blocks at a second call site — the same "remember to do it" shape that already failed once here — extract them:

```python
_gate_mental_model_read(bank_id, mental_model_id, request_context)
_record_mental_model_read(bank_id, mental_model_id, content, request_context)
```

`get_mental_model` and `get_knowledge_page` both call these, so *which reads are validated* is a property of one pair of methods rather than of each endpoint's memory.

**No extra query.** The page keeps its single join, which fetches page columns and model content in one round trip. Only the validation is shared, not the SQL.

## Two details worth review

**Ordering.** The gate runs *after* the row fetch on the page path, unlike `get_mental_model`, because the model's id is a property of the page rather than something the caller supplies — it isn't known until the row is read. Content is still withheld on refusal, so a rejected read yields no page; the only cost is one indexed SELECT for a request that is then refused.

**Missing models.** Pages whose backing model is absent (the `LEFT JOIN` yields NULL) are unchanged: no model, no model read, nothing to validate.

## Tests

Four new cases in `test_knowledge_base.py`:

- the page read runs the model-get validator against the page's **backing model id**, not the page id
- the completion hook reports the size of the content actually delivered
- a refused read returns no content **and** records nothing
- the bank-read access check still fires — added alongside, not instead

```
knowledge-base suite       64 passed
MCP + knowledge-search    245 passed
ruff check / format       clean
```

The mental-model suites report 1 failure and 11 errors both with and without this change (they need a live LLM key) — verified by stashing and re-running, counts identical.

---

## Second commit: the list was the wider door

Reporting the single-page read on its own watches the narrow door. `list_mental_models` reported nothing, at any detail level — and a knowledge page is a `mental_models` row that its query does not exclude:

```sql
SELECT id, bank_id, name, source_query, content, tags, ...
FROM mental_models
WHERE bank_id = $1 {tag_filter}
```

So `detail=content` returns every page's body in a bank, `limit` accepts up to 1000, and `offset` walks the rest. A caller could enumerate a bank's synthesized knowledge by asking for it in one page instead of one at a time — and `detail` defaults to `"full"` at the engine, HTTP and MCP layers.

**Report each model whose content was actually returned**, reusing the same per-model hook. No new hook and no new unit: what is delivered is a model's content either way, and the route it arrived by is not something a deployment's policy should have to know about. `detail=metadata` returns no content and reports nothing.

Reported per model rather than as one aggregate, so ten models fetched individually and ten fetched in a page look identical downstream.

### A caller-side fix that came with it

Three internal callers in the bank-template path were listing with the default detail — full content, `limit=None`, so the whole bank — while using the result only to build id-keyed maps. They now pass `detail="metadata"`.

That is correct on its own terms: they never read content, and the `source_query` they apply comes from the manifest rather than from the existing models. It also stops an unbounded content fetch on every template application, which is a plain efficiency win independent of reporting.

### Deliberately not gated

This reports what was delivered; it does not refuse the list up front. Gating a bulk read means a list can start returning 402, which is a behaviour change that deserves deciding on its own rather than arriving behind a reporting fix.

### Tests

- a content list reports one entry per model that had content, **including the page-backing model** — the specific hole
- a metadata list reports nothing
- the reported size tracks the content actually returned

Knowledge-base and MCP suites pass (298). The mental-model and reflect suites show 1 failure and 19 errors both with and without this change (they need a live LLM key), verified by stashing and re-running — counts identical.
