### PR TITLE
fix(api): round-trip the whole retain item so reprocess replays it faithfully

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -8208,6 +8208,12 @@ def _register_routes(app: FastAPI):
                     content_dict["observation_scopes"] = item.observation_scopes
                 if item.update_mode is not None:
                     content_dict["update_mode"] = item.update_mode
+                # Carried on the item, not just used as the grouping key: reprocess
+                # rebuilds its retain call from retain_params, so a strategy that
+                # never reaches the content dict never reaches retain_params either
+                # — and the reprocess silently re-extracts under the bank default.
+                if item.strategy:
+                    content_dict["strategy"] = item.strategy
                 strategy_groups[effective].append(content_dict)
 
             if request.async_:

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -11113,21 +11113,28 @@ class MemoryEngine(MemoryEngineInterface):
             "document_id": document_id,
             "update_mode": "replace",
         }
-        if retain_params.get("context"):
-            content_dict["context"] = retain_params["context"]
-        if retain_params.get("event_date"):
-            content_dict["event_date"] = retain_params["event_date"]
-        if retain_params.get("metadata"):
-            content_dict["metadata"] = retain_params["metadata"]
-        if retain_params.get("entities"):
-            content_dict["entities"] = retain_params["entities"]
+        # Replay everything the original retain supplied. Enumerating fields here
+        # is what let `strategy`, `entities` and `resolve_entities` go missing one
+        # by one: each was written by api_retain, never captured, and a reprocess
+        # quietly re-extracted under the bank's default strategy instead of the
+        # document's own. retain_params now holds exactly the replayable set (see
+        # _RETAIN_PARAMS_NOT_REPLAYED), so take it whole.
+        # `strategy` rides on the dict as well as being pulled out below. Excluding
+        # it here made the round trip survive exactly one reprocess: the call
+        # argument applied the right strategy, but _build_retain_params never saw it
+        # on the item, so retain_params came back without it and the NEXT reprocess
+        # fell back to the bank default again.
+        content_dict.update(retain_params)
+        # These three are the reprocess's own and must win over anything stored.
+        content_dict["content"] = original_text
+        content_dict["document_id"] = document_id
+        content_dict["update_mode"] = "replace"
 
         tags = doc.get("tags") or []
         if tags:
             content_dict["tags"] = tags
-        if retain_params.get("observation_scopes") is not None:
-            content_dict["observation_scopes"] = retain_params["observation_scopes"]
 
+        # A call-level argument rather than an item field, so it is pulled out.
         strategy = retain_params.get("strategy")
 
         result = await self.submit_async_retain(

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -362,6 +362,21 @@ def _resolve_narrator(profile_name: str, bank_id: str) -> str | None:
     return profile_name
 
 
+# What a reprocess must NOT replay, because it supplies its own: `content` is the
+# document's stored original_text, `document_id` and `update_mode` are set by the
+# reprocess itself, and `tags` live on the document row and are read from there.
+#
+# An EXCLUSION list rather than an inclusion one, deliberately. The inclusion list
+# this replaces silently dropped three fields in turn — `strategy`, `entities`, and
+# `resolve_entities` — each written by api_retain and each never captured, so a
+# reprocess re-extracted under the bank's default strategy with entity resolution
+# it was told not to do. Every one of those was invisible: the reprocess succeeds
+# and only the resulting facts are wrong. Inverting it makes the safe case the
+# default — a new retain field round-trips unless someone deliberately excludes it,
+# and the single source of truth becomes what api_retain puts on the content dict.
+_RETAIN_PARAMS_NOT_REPLAYED = frozenset({"content", "document_id", "update_mode", "tags"})
+
+
 def _build_retain_params(contents_dicts, document_tags=None, doc_contents=None):
     """Build retain_params and merged_tags from content dicts."""
     if doc_contents is not None:
@@ -379,18 +394,15 @@ def _build_retain_params(contents_dicts, document_tags=None, doc_contents=None):
     retain_params = {}
     if items:
         first_item = items[0]
-        if first_item.get("context"):
-            retain_params["context"] = first_item["context"]
-        if first_item.get("event_date"):
-            retain_params["event_date"] = (
-                first_item["event_date"].isoformat()
-                if hasattr(first_item["event_date"], "isoformat")
-                else str(first_item["event_date"])
-            )
-        if first_item.get("metadata"):
-            retain_params["metadata"] = first_item["metadata"]
-        if first_item.get("observation_scopes") is not None:
-            retain_params["observation_scopes"] = first_item["observation_scopes"]
+        for key, value in first_item.items():
+            if key in _RETAIN_PARAMS_NOT_REPLAYED or value is None:
+                continue
+            # event_date arrives as a datetime from some callers and a string from
+            # others; retain_params is JSON, so normalise here rather than at every
+            # reader.
+            if key == "event_date":
+                value = value.isoformat() if hasattr(value, "isoformat") else str(value)
+            retain_params[key] = value
 
     return retain_params, merged_tags
 

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -698,7 +698,11 @@ def _register_retain(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                 result = await memory.submit_async_retain(
                     bank_id=target_bank,
                     contents=[content_dict],
-                    strategy=content_dict.pop("strategy", None),
+                    # `get`, not `pop`: the list above holds this same dict, so popping would
+                    # strip `strategy` off the item before the call runs and retain_params
+                    # would not capture it — a later reprocess then re-extracts under the
+                    # bank's default strategy.
+                    strategy=content_dict.get("strategy"),
                     request_context=request_context,
                 )
                 return {
@@ -753,7 +757,11 @@ def _register_retain(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                 result = await memory.submit_async_retain(
                     bank_id=target_bank,
                     contents=[content_dict],
-                    strategy=content_dict.pop("strategy", None),
+                    # `get`, not `pop`: the list above holds this same dict, so popping would
+                    # strip `strategy` off the item before the call runs and retain_params
+                    # would not capture it — a later reprocess then re-extracts under the
+                    # bank's default strategy.
+                    strategy=content_dict.get("strategy"),
                     request_context=request_context,
                 )
                 return {
@@ -815,7 +823,11 @@ def _register_sync_retain(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsCo
                     bank_id=target_bank,
                     contents=[content_dict],
                     request_context=request_context,
-                    strategy=content_dict.pop("strategy", None),
+                    # `get`, not `pop`: the list above holds this same dict, so popping would
+                    # strip `strategy` off the item before the call runs and retain_params
+                    # would not capture it — a later reprocess then re-extracts under the
+                    # bank's default strategy.
+                    strategy=content_dict.get("strategy"),
                 )
                 memory_ids = [uid for batch in result for uid in batch]
                 return {
@@ -871,7 +883,11 @@ def _register_sync_retain(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsCo
                     bank_id=target_bank,
                     contents=[content_dict],
                     request_context=request_context,
-                    strategy=content_dict.pop("strategy", None),
+                    # `get`, not `pop`: the list above holds this same dict, so popping would
+                    # strip `strategy` off the item before the call runs and retain_params
+                    # would not capture it — a later reprocess then re-extracts under the
+                    # bank's default strategy.
+                    strategy=content_dict.get("strategy"),
                 )
                 memory_ids = [uid for batch in result for uid in batch]
                 return {

--- a/hindsight-api-slim/tests/test_retain_params_roundtrip.py
+++ b/hindsight-api-slim/tests/test_retain_params_roundtrip.py
@@ -1,0 +1,116 @@
+"""retain_params must round-trip whatever the caller supplied.
+
+reprocess_document rebuilds its retain call entirely from documents.retain_params.
+The inclusion list this replaces dropped three fields in turn — `strategy`,
+`entities`, `resolve_entities` — each written by api_retain and never captured, so
+a reprocess re-extracted under the bank's default strategy with entity resolution
+it had been told not to do. Every one was invisible: the reprocess succeeds and
+only the resulting facts are wrong.
+
+The rule is now an exclusion list, so a new retain field round-trips unless
+somebody deliberately excludes it, and api_retain's content dict is the single
+source of truth for what gets replayed.
+"""
+
+import re
+from pathlib import Path
+
+from hindsight_api.engine.retain import orchestrator as orch
+
+API_HTTP = Path(orch.__file__).resolve().parents[2] / "api" / "http.py"
+MEMORY_ENGINE = Path(orch.__file__).resolve().parents[2] / "engine" / "memory_engine.py"
+
+
+def _params(**item):
+    retain_params, _tags = orch._build_retain_params([item])
+    return retain_params
+
+
+def test_captures_the_fields_that_used_to_go_missing():
+    p = _params(
+        content="x",
+        strategy="survey",
+        entities=[{"text": "Widget", "type": "CONCEPT"}],
+        resolve_entities=False,
+    )
+    assert p["strategy"] == "survey"
+    assert p["entities"] == [{"text": "Widget", "type": "CONCEPT"}]
+    assert p["resolve_entities"] is False
+
+
+def test_excludes_what_a_reprocess_supplies_itself():
+    """Replaying these would fight the reprocess: content is the stored
+    original_text, and document_id/update_mode/tags are set by the reprocess."""
+    p = _params(
+        content="x", document_id="d1", update_mode="append", tags=["a"], context="ctx"
+    )
+    assert set(p) == {"context"}
+
+
+def test_absent_fields_are_not_invented():
+    assert _params(content="x") == {}
+
+
+def test_event_date_is_normalised_for_json():
+    from datetime import datetime
+
+    p = _params(content="x", event_date=datetime(2026, 1, 2, 3, 4, 5))
+    assert p["event_date"] == "2026-01-02T03:04:05"
+
+
+def test_a_new_field_round_trips_without_being_listed():
+    """The point of inverting the rule: the failure mode is now a deliberate
+    exclusion, not a silent omission."""
+    assert _params(content="x", some_future_field="v")["some_future_field"] == "v"
+
+
+def test_every_field_api_retain_sends_can_round_trip():
+    """Pairs the writer against the rule so they cannot drift apart.
+
+    api_retain's content dict is the source of truth for what a retain can carry.
+    Anything it sets that is neither excluded nor capturable is a field a reprocess
+    would silently lose — which is exactly how this bug arose three times.
+    """
+    written = set(re.findall(r'content_dict\["(\w+)"\]\s*=', API_HTTP.read_text()))
+    assert written, "could not locate api_retain's content dict assignments"
+
+    replayable = written - orch._RETAIN_PARAMS_NOT_REPLAYED
+    produced = _params(content="x", **{k: "v" for k in replayable})
+    missing = sorted(replayable - set(produced))
+    assert not missing, f"api_retain sends fields retain_params cannot carry: {missing}"
+
+
+def test_api_retain_puts_the_strategy_on_the_content_dict():
+    """Where the break actually was. api_retain used `strategy` only as the key it
+    grouped items by, so it never reached the dict _build_retain_params reads —
+    and capturing it in the orchestrator alone changed nothing."""
+    src = API_HTTP.read_text()
+    block = src[src.index("# Group items by strategy") :][:2500]
+    assert 'content_dict["strategy"] = item.strategy' in block
+
+
+def test_reprocess_replays_retain_params_wholesale():
+    """The reader half. Enumerating fields here is the other way the two sides
+    drift; it must take retain_params whole and override only its own three."""
+    src = MEMORY_ENGINE.read_text()
+    block = src[src.index("Rebuild the content dict from retain_params") :][:1800]
+    assert "content_dict.update(" in block, "reprocess still cherry-picks fields"
+    for own in ("content", "document_id", "update_mode"):
+        assert f'content_dict["{own}"]' in block, f"reprocess must set its own {own}"
+
+
+def test_reprocess_keeps_the_strategy_on_the_dict_so_it_survives_twice():
+    """Excluding `strategy` from the replayed dict survived exactly ONE reprocess.
+
+    reprocess pulls it out as a call argument, so the first re-extraction used the
+    right strategy — but _build_retain_params never saw it on the item, retain_params
+    came back without it, and a second reprocess fell back to the bank default.
+    Verified against a live server: two consecutive reprocesses of a survey marker
+    both held at 0 memory units only once the field rode on the dict as well.
+    """
+    src = MEMORY_ENGINE.read_text()
+    block = src[src.index("Rebuild the content dict from retain_params") :][:1800]
+    assert "content_dict.update(retain_params)" in block, (
+        "the replayed dict must carry strategy too, or retain_params loses it on "
+        "the first reprocess"
+    )

--- a/hindsight-api-slim/tests/test_retain_params_roundtrip.py
+++ b/hindsight-api-slim/tests/test_retain_params_roundtrip.py
@@ -13,12 +13,17 @@ source of truth for what gets replayed.
 """
 
 import re
+from datetime import datetime
 from pathlib import Path
+from typing import Any
 
+import pytest
+
+from hindsight_api.engine.memory_engine import MemoryEngine
 from hindsight_api.engine.retain import orchestrator as orch
 
 API_HTTP = Path(orch.__file__).resolve().parents[2] / "api" / "http.py"
-MEMORY_ENGINE = Path(orch.__file__).resolve().parents[2] / "engine" / "memory_engine.py"
+MCP_TOOLS = Path(orch.__file__).resolve().parents[2] / "mcp_tools.py"
 
 
 def _params(**item):
@@ -41,9 +46,7 @@ def test_captures_the_fields_that_used_to_go_missing():
 def test_excludes_what_a_reprocess_supplies_itself():
     """Replaying these would fight the reprocess: content is the stored
     original_text, and document_id/update_mode/tags are set by the reprocess."""
-    p = _params(
-        content="x", document_id="d1", update_mode="append", tags=["a"], context="ctx"
-    )
+    p = _params(content="x", document_id="d1", update_mode="append", tags=["a"], context="ctx")
     assert set(p) == {"context"}
 
 
@@ -52,8 +55,6 @@ def test_absent_fields_are_not_invented():
 
 
 def test_event_date_is_normalised_for_json():
-    from datetime import datetime
-
     p = _params(content="x", event_date=datetime(2026, 1, 2, 3, 4, 5))
     assert p["event_date"] == "2026-01-02T03:04:05"
 
@@ -82,35 +83,98 @@ def test_every_field_api_retain_sends_can_round_trip():
 
 def test_api_retain_puts_the_strategy_on_the_content_dict():
     """Where the break actually was. api_retain used `strategy` only as the key it
-    grouped items by, so it never reached the dict _build_retain_params reads —
-    and capturing it in the orchestrator alone changed nothing."""
+    grouped items by, so it never reached the dict _build_retain_params reads — and
+    capturing it in the orchestrator alone changed nothing. The pairing test above
+    cannot see this: a strategy that is never assigned simply drops out of the set
+    it compares."""
     src = API_HTTP.read_text()
     block = src[src.index("# Group items by strategy") :][:2500]
     assert 'content_dict["strategy"] = item.strategy' in block
 
 
-def test_reprocess_replays_retain_params_wholesale():
-    """The reader half. Enumerating fields here is the other way the two sides
-    drift; it must take retain_params whole and override only its own three."""
-    src = MEMORY_ENGINE.read_text()
-    block = src[src.index("Rebuild the content dict from retain_params") :][:1800]
-    assert "content_dict.update(" in block, "reprocess still cherry-picks fields"
-    for own in ("content", "document_id", "update_mode"):
-        assert f'content_dict["{own}"]' in block, f"reprocess must set its own {own}"
+def test_mcp_retain_leaves_the_strategy_on_the_item():
+    """The MCP tools pass the same dict they hand to retain, so `pop` would strip
+    `strategy` off it before the call ran (arguments evaluate left to right) and
+    retain_params would never see it — the api_retain bug, one layer over."""
+    src = MCP_TOOLS.read_text()
+    assert 'content_dict.pop("strategy"' not in src, (
+        "popping strategy off the content dict removes it from the item retain stores, "
+        "so a later reprocess falls back to the bank default"
+    )
+    assert src.count('strategy=content_dict.get("strategy")') == 4
 
 
-def test_reprocess_keeps_the_strategy_on_the_dict_so_it_survives_twice():
+class _StubEngine:
+    """Just enough MemoryEngine for reprocess_document: it reads a document and
+    submits a retain. Everything else the method touches is disabled."""
+
+    _operation_validator = None
+
+    def __init__(self, doc: dict[str, Any]) -> None:
+        self._doc = doc
+        self.submitted: list[tuple[dict[str, Any], str | None]] = []
+
+    async def _authenticate_tenant(self, request_context) -> None:
+        return None
+
+    async def get_document(self, document_id, bank_id, request_context=None):
+        return self._doc
+
+    async def submit_async_retain(self, bank_id, contents, strategy=None, request_context=None, **kwargs):
+        self.submitted.append((contents[0], strategy))
+        return {"operation_id": "op-1"}
+
+
+async def _reprocess(retain_params: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
+    """Run one reprocess over a document carrying ``retain_params``."""
+    engine = _StubEngine({"original_text": "STATUS: survey started", "retain_params": retain_params, "tags": ["t1"]})
+    await MemoryEngine.reprocess_document(engine, "bank-1", "doc-1", request_context=None)
+    return engine.submitted[0]
+
+
+@pytest.mark.asyncio
+async def test_reprocess_replays_what_the_retain_stored():
+    """The reader half: everything the caller supplied comes back on the replayed
+    item, and the reprocess's own three fields win over anything stored."""
+    stored = _params(
+        content="STATUS: survey started",
+        strategy="survey",
+        context="ctx",
+        metadata={"a": "b"},
+        entities=[{"text": "Widget", "type": "CONCEPT"}],
+        resolve_entities=False,
+        observation_scopes="shared",
+    )
+
+    item, strategy = await _reprocess(stored)
+
+    assert strategy == "survey"
+    assert item["entities"] == [{"text": "Widget", "type": "CONCEPT"}]
+    assert item["resolve_entities"] is False
+    assert item["context"] == "ctx"
+    assert item["metadata"] == {"a": "b"}
+    assert item["observation_scopes"] == "shared"
+    # The reprocess's own, whatever the stored params say.
+    assert item["content"] == "STATUS: survey started"
+    assert item["document_id"] == "doc-1"
+    assert item["update_mode"] == "replace"
+    assert item["tags"] == ["t1"]
+
+
+@pytest.mark.asyncio
+async def test_strategy_survives_more_than_one_reprocess():
     """Excluding `strategy` from the replayed dict survived exactly ONE reprocess.
 
     reprocess pulls it out as a call argument, so the first re-extraction used the
     right strategy — but _build_retain_params never saw it on the item, retain_params
-    came back without it, and a second reprocess fell back to the bank default.
-    Verified against a live server: two consecutive reprocesses of a survey marker
-    both held at 0 memory units only once the field rode on the dict as well.
+    came back without it, and a second reprocess fell back to the bank default. Feed
+    each reprocess's item back through the capture, as the retain pipeline does.
     """
-    src = MEMORY_ENGINE.read_text()
-    block = src[src.index("Rebuild the content dict from retain_params") :][:1800]
-    assert "content_dict.update(retain_params)" in block, (
-        "the replayed dict must carry strategy too, or retain_params loses it on "
-        "the first reprocess"
-    )
+    stored = _params(content="STATUS: survey started", strategy="survey")
+
+    for _ in range(3):
+        item, strategy = await _reprocess(stored)
+        assert strategy == "survey"
+        stored = _params(**item)
+
+    assert stored["strategy"] == "survey"


### PR DESCRIPTION
Closes #3873.

`reprocess_document` rebuilds its retain call entirely from `documents.retain_params`. Both sides enumerated fields by hand, and the two lists had drifted **three times over**: `strategy`, `entities` and `resolve_entities` are each written by `api_retain` and never captured. A reprocess therefore re-extracted the document under the bank's `retain_default_strategy`, with entity resolution it had been told not to do — invisibly, since the reprocess succeeds and only the resulting facts are wrong.

### The fix inverts the rule rather than extending the list

Adding the missing three would have left the same shape that already failed three times. Instead:

- `retain_params` captures **everything the caller supplied** except what a reprocess legitimately supplies itself — `content` (the stored `original_text`), `document_id` and `update_mode` (the reprocess sets its own), and `tags` (kept on the document row).
- `reprocess` replays `retain_params` **whole** instead of cherry-picking.

The failure mode becomes a deliberate exclusion rather than a silent omission, and `api_retain`'s content dict becomes the single source of truth for what a retain can carry.

Two details that are easy to get wrong, both found by testing rather than reading:

- **`api_retain` must put `strategy` ON the content dict**, not just use it as the key it groups items by. Without that it never reaches `_build_retain_params`, and fixing the orchestrator alone changes nothing.
- **`strategy` must ride on the replayed dict as well as being pulled out as the call argument.** Excluding it there survived exactly *one* reprocess: the call argument applied the right strategy, but `_build_retain_params` never saw it on the item, so `retain_params` came back without it and the next reprocess fell back to the bank default again.

### How it was found

A real bank. Three survey status markers — whose strategy instructs the extractor to return nothing — sat correctly at 0 memory units for hours, then produced facts the moment they were reprocessed. Document `created_at` 02:42, extracted-fact `created_at` 04:54: the reprocess. A git-commit mission pointed at a status line also invents state, yielding *"The codebase survey was completed and recorded as the baseline commit"* from a marker that only says a survey **started**.

It bites exactly when the endpoint is meant to help — it is documented as *"re-extracts facts using the current engine configuration. Useful when the LLM model, chunking strategy, or extraction settings have changed"*, which is when an operator reaches for it. Any bank using `retain_strategies` then gets its documents re-extracted under the wrong mission.

### Verification

Against a live 0.9.2 server, same marker content throughout:

| | units after retain | after reprocess 1 | after reprocess 2 | `retain_params.strategy` |
|---|---|---|---|---|
| patched | 0 | **0** | **0** | `'survey'` |
| unpatched | 0 | **1** | — | `None` |

Tests pin each half and pair `api_retain`'s content dict against the exclusion rule, so a newly added retain field cannot silently stop round-tripping.