### PR TITLE
fix(transfer): remap whole-bank mental model evidence

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
@@ -275,7 +275,10 @@ async def import_documents(
         result.observations_skipped = outcome.skipped
         result.remapped_unit_ids.update(outcome.remapped_unit_ids)
 
-    if parsed.mental_models or parsed.knowledge_pages:
+    # Whole-bank imports restore these rows after fact IDs are remapped below.
+    # Restoring them here first would make the later insert lose to ON CONFLICT
+    # and leave persisted mental-model evidence pointing at the source-bank IDs.
+    if parsed.manifest.archive_type != "bank" and (parsed.mental_models or parsed.knowledge_pages):
         mm_embeddings = await _regenerate_mental_model_embeddings(embeddings_model, parsed.mental_models)
         async with acquire_with_retry(backend) as conn:
             # Document archives serialize bank-row JSON values directly. Keep
@@ -1146,6 +1149,13 @@ def _remap_mental_model_evidence(rows: list[dict], unit_id_map: dict[str, str]) 
         if isinstance(previous, dict):
             _remap_based_on_ids(previous, unit_id_map)
             row["previous_reflect_response"] = previous
+        history_content = _decode_json_object(row.get("content"))
+        if isinstance(history_content, dict):
+            historical_response = _decode_json_object(history_content.get("previous_reflect_response"))
+            if isinstance(historical_response, dict):
+                _remap_based_on_ids(historical_response, unit_id_map)
+                history_content["previous_reflect_response"] = historical_response
+                row["content"] = history_content
 
 
 def _decode_json_object(value: Any) -> Any:


### PR DESCRIPTION
## Problem

Whole-bank import restores mental-model rows twice: once through the embedded document archive before regenerated fact IDs are known, then again through the bank-level restore after remapping. The second insert loses to `ON CONFLICT`, leaving current evidence pointed at source-bank fact UUIDs. Historical evidence also stores its prior reflect response inside `mental_model_history.content`, which the existing remapper does not descend into.

This is a follow-up to #3833.

## Change

- Skip document-level mental-model/page restoration for whole-bank archives; the bank importer remains the sole owner of those rows.
- Remap `content.previous_reflect_response.based_on` in mental-model history alongside current evidence.
- Preserve document-archive behavior unchanged.

## Verification

Before the patch:

    test_bank_roundtrip_remaps_mental_model_based_on_ids: FAILED
    restored_ids contained the deleted source fact UUID

After the patch:

    PYTHONPATH=<worktree>/hindsight-api-slim .venv/bin/pytest -q \
      hindsight-api-slim/tests/test_document_transfer.py::test_bank_roundtrip_remaps_mental_model_based_on_ids
    1 passed

    .venv/bin/ruff check hindsight-api-slim/hindsight_api/engine/transfer/importer.py
    All checks passed!
