### PR TITLE
fix(llm): normalize provider token usage counts

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
@@ -47,11 +47,17 @@ except ImportError:
 
 
 def _to_int(value: Any) -> int:
-    """Coerce Gemini's optional/string completion counts to int, defaulting to 0."""
-    try:
-        return int(value)
-    except (ValueError, TypeError):
+    """Coerce an SDK token count to a non-negative integer."""
+    if isinstance(value, bool):
         return 0
+    if isinstance(value, int):
+        return max(0, value)
+    if isinstance(value, str):
+        try:
+            return max(0, int(value))
+        except ValueError:
+            return 0
+    return 0
 
 
 def _usage_from_gemini_response(response: Any) -> LLMResponseUsage:
@@ -60,9 +66,9 @@ def _usage_from_gemini_response(response: Any) -> LLMResponseUsage:
     if not usage:
         return LLMResponseUsage()
     return LLMResponseUsage(
-        input_tokens=usage.prompt_token_count or 0,
-        output_tokens=usage.candidates_token_count or 0,
-        cached_tokens=getattr(usage, "cached_content_token_count", 0) or 0,
+        input_tokens=_to_int(getattr(usage, "prompt_token_count", 0)),
+        output_tokens=_to_int(getattr(usage, "candidates_token_count", 0)),
+        cached_tokens=_to_int(getattr(usage, "cached_content_token_count", 0)),
     )
 
 
@@ -481,10 +487,10 @@ class GeminiLLM(LLMInterface):
                 cached_tokens = 0
                 if hasattr(response, "usage_metadata") and response.usage_metadata:
                     usage = response.usage_metadata
-                    input_tokens = usage.prompt_token_count or 0
-                    output_tokens = usage.candidates_token_count or 0
-                    cached_input_tokens = getattr(usage, "cached_content_token_count", 0) or 0
-                    thoughts_tokens = getattr(usage, "thoughts_token_count", 0) or 0
+                    input_tokens = _to_int(getattr(usage, "prompt_token_count", 0))
+                    output_tokens = _to_int(getattr(usage, "candidates_token_count", 0))
+                    cached_input_tokens = _to_int(getattr(usage, "cached_content_token_count", 0))
+                    thoughts_tokens = _to_int(getattr(usage, "thoughts_token_count", 0))
                     # Tracing/TokenUsage consume ``cached_tokens``; metrics consume
                     # ``cached_input_tokens`` — same value, two downstream names.
                     cached_tokens = cached_input_tokens
@@ -854,10 +860,10 @@ class GeminiLLM(LLMInterface):
                 cached_input_tokens = 0
                 thoughts_tokens = 0
                 if response.usage_metadata:
-                    input_tokens = response.usage_metadata.prompt_token_count or 0
-                    output_tokens = response.usage_metadata.candidates_token_count or 0
-                    cached_input_tokens = getattr(response.usage_metadata, "cached_content_token_count", 0) or 0
-                    thoughts_tokens = getattr(response.usage_metadata, "thoughts_token_count", 0) or 0
+                    input_tokens = _to_int(getattr(response.usage_metadata, "prompt_token_count", 0))
+                    output_tokens = _to_int(getattr(response.usage_metadata, "candidates_token_count", 0))
+                    cached_input_tokens = _to_int(getattr(response.usage_metadata, "cached_content_token_count", 0))
+                    thoughts_tokens = _to_int(getattr(response.usage_metadata, "thoughts_token_count", 0))
 
                 # Record metrics
                 duration = time.time() - start_time

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -343,18 +343,30 @@ def _content_or_error(response: Any, *, provider: str, model: str, scope: str) -
     return content, choice
 
 
+def _token_count(value: Any) -> int:
+    """Return a non-negative provider token count, treating absent SDK fields as zero."""
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return max(0, value)
+    if isinstance(value, str):
+        try:
+            return max(0, int(value))
+        except ValueError:
+            return 0
+    return 0
+
+
 def _usage_from_openai_response(response: Any) -> LLMResponseUsage:
     """Extract prompt/completion/cached token counts from an OpenAI-shaped usage block."""
     usage = getattr(response, "usage", None)
-    input_tokens = (usage.prompt_tokens or 0) if usage else 0
-    output_tokens = (usage.completion_tokens or 0) if usage else 0
-    cached_tokens = 0
-    if usage and getattr(usage, "prompt_tokens_details", None):
-        cached_tokens = getattr(usage.prompt_tokens_details, "cached_tokens", 0) or 0
+    if not usage:
+        return LLMResponseUsage()
+    details = getattr(usage, "prompt_tokens_details", None)
     return LLMResponseUsage(
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-        cached_tokens=cached_tokens,
+        input_tokens=_token_count(getattr(usage, "prompt_tokens", 0)),
+        output_tokens=_token_count(getattr(usage, "completion_tokens", 0)),
+        cached_tokens=_token_count(getattr(details, "cached_tokens", 0)),
     )
 
 
@@ -1136,11 +1148,11 @@ class OpenAICompatibleLLM(LLMInterface):
                 response_usage = _usage_from_openai_response(response)
                 input_tokens = response_usage.input_tokens
                 output_tokens = response_usage.output_tokens
-                total_tokens = usage.total_tokens or 0 if usage else 0
+                total_tokens = _token_count(getattr(usage, "total_tokens", 0))
                 cached_tokens = response_usage.cached_tokens
                 thoughts_tokens = 0
                 if usage and getattr(usage, "completion_tokens_details", None):
-                    thoughts_tokens = getattr(usage.completion_tokens_details, "reasoning_tokens", 0) or 0
+                    thoughts_tokens = _token_count(getattr(usage.completion_tokens_details, "reasoning_tokens", 0))
                 # OpenAI-compatible providers fold reasoning tokens into
                 # ``completion_tokens`` (and thus ``total_tokens``), but the
                 # TokenUsage contract — and the Gemini provider — treat
@@ -1461,14 +1473,13 @@ class OpenAICompatibleLLM(LLMInterface):
                 # Record metrics
                 duration = time.time() - start_time
                 usage = response.usage
-                input_tokens = usage.prompt_tokens or 0 if usage else 0
-                output_tokens = usage.completion_tokens or 0 if usage else 0
-                cached_tokens = 0
-                if usage and getattr(usage, "prompt_tokens_details", None):
-                    cached_tokens = getattr(usage.prompt_tokens_details, "cached_tokens", 0) or 0
+                response_usage = _usage_from_openai_response(response)
+                input_tokens = response_usage.input_tokens
+                output_tokens = response_usage.output_tokens
+                cached_tokens = response_usage.cached_tokens
                 thoughts_tokens = 0
                 if usage and getattr(usage, "completion_tokens_details", None):
-                    thoughts_tokens = getattr(usage.completion_tokens_details, "reasoning_tokens", 0) or 0
+                    thoughts_tokens = _token_count(getattr(usage.completion_tokens_details, "reasoning_tokens", 0))
                 # See ``call()``: OpenAI-compatible ``completion_tokens`` includes
                 # reasoning, so make ``output_tokens`` visible-only to avoid
                 # double-counting it against ``thoughts_tokens``.

--- a/hindsight-api-slim/tests/test_provider_usage_normalization.py
+++ b/hindsight-api-slim/tests/test_provider_usage_normalization.py
@@ -1,0 +1,82 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from hindsight_api.engine.providers.gemini_llm import GeminiLLM
+from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+
+
+@pytest.mark.asyncio
+async def test_openai_call_normalizes_sparse_sdk_usage_before_metrics() -> None:
+    llm = OpenAICompatibleLLM(
+        provider="openai",
+        api_key="test-key",
+        base_url="https://example.test/v1",
+        model="gpt-4o-mini",
+    )
+    usage = SimpleNamespace(
+        prompt_tokens=MagicMock(),
+        completion_tokens=None,
+        total_tokens=MagicMock(),
+        prompt_tokens_details=SimpleNamespace(cached_tokens=MagicMock()),
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=MagicMock()),
+    )
+    response = SimpleNamespace(
+        usage=usage,
+        choices=[
+            SimpleNamespace(
+                finish_reason="stop",
+                message=SimpleNamespace(content="ok", tool_calls=None, refusal=None),
+            )
+        ],
+    )
+    llm._client.chat.completions.create = AsyncMock(return_value=response)
+    metrics = MagicMock()
+
+    with patch(
+        "hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector",
+        return_value=metrics,
+    ):
+        assert await llm.call(messages=[{"role": "user", "content": "hello"}], max_retries=0) == "ok"
+
+    recorded = metrics.record_llm_call.call_args.kwargs
+    assert recorded["input_tokens"] == 0
+    assert recorded["output_tokens"] == 0
+    assert recorded["cached_input_tokens"] == 0
+    assert recorded["thoughts_tokens"] == 0
+
+
+@pytest.mark.asyncio
+async def test_gemini_call_normalizes_sparse_sdk_usage_before_metrics() -> None:
+    llm = GeminiLLM(
+        provider="gemini",
+        api_key="test-key",
+        base_url="",
+        model="gemini-test",
+    )
+    response = SimpleNamespace(
+        text="ok",
+        usage_metadata=SimpleNamespace(
+            prompt_token_count=MagicMock(),
+            candidates_token_count=None,
+            cached_content_token_count=MagicMock(),
+            thoughts_token_count=MagicMock(),
+        ),
+        candidates=[SimpleNamespace(finish_reason="STOP")],
+    )
+    llm._client = MagicMock()
+    llm._client.aio.models.generate_content = AsyncMock(return_value=response)
+    metrics = MagicMock()
+
+    with patch(
+        "hindsight_api.engine.providers.gemini_llm.get_metrics_collector",
+        return_value=metrics,
+    ):
+        assert await llm.call(messages=[{"role": "user", "content": "hello"}], max_retries=0) == "ok"
+
+    recorded = metrics.record_llm_call.call_args.kwargs
+    assert recorded["input_tokens"] == 0
+    assert recorded["output_tokens"] == 0
+    assert recorded["cached_input_tokens"] == 0
+    assert recorded["thoughts_tokens"] == 0


### PR DESCRIPTION
## Problem

Optional token-usage fields from OpenAI-compatible and Gemini SDK responses are not guaranteed to be concrete integers. Missing attributes on SDK-shaped mocks, proxy response objects, or version-skewed SDK models can surface as sentinel objects. Those values currently reach arithmetic and metrics unchanged: OpenAI-compatible calls can raise `TypeError` while subtracting reasoning tokens, and Gemini records non-numeric metric values.

## Change

- Normalize provider token counts to non-negative integers at the SDK boundary.
- Apply the same normalization to prompt, completion, total, cached, and reasoning counts on plain and tool-call paths.
- Keep numeric strings supported; reject booleans, negative values, absent fields, and arbitrary objects as zero.
- Add end-to-end provider-call regressions that exercise metrics recording with sparse SDK-shaped usage objects.

## Verification

The new tests fail on current `main`:

    OpenAI: TypeError in max(0, output_tokens - thoughts_tokens)
    Gemini: metrics input_tokens is a MagicMock instead of 0

After the patch:

    pytest -q hindsight-api-slim/tests/test_provider_usage_normalization.py
    2 passed

    pytest -q \
      hindsight-api-slim/tests/test_openai_compatible_response_hardening.py \
      hindsight-api-slim/tests/test_gemini_cache.py
    35 passed

    ruff check <two provider modules> hindsight-api-slim/tests/test_provider_usage_normalization.py
    All checks passed!
