### PR TITLE
refactor(llm): centralize provider metadata

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -17,6 +17,19 @@ from dotenv import find_dotenv, load_dotenv
 
 from ._pg_search import normalize_pg_search_tokenizer
 from ._vector_index import validate_extension
+from .llm_provider_metadata import (
+    DEFAULT_LLM_MODEL as DEFAULT_LLM_MODEL,
+)
+from .llm_provider_metadata import (
+    DEFAULT_LLM_PROVIDER,
+    requires_api_key,
+)
+from .llm_provider_metadata import (
+    PROVIDER_DEFAULT_MODELS as PROVIDER_DEFAULT_MODELS,
+)
+from .llm_provider_metadata import (
+    get_default_model_for_provider as _get_default_model_for_provider,
+)
 from .utils import mask_network_location
 
 logger = logging.getLogger(__name__)
@@ -897,40 +910,6 @@ ENV_DISPOSITION_EMPATHY = "HINDSIGHT_API_DISPOSITION_EMPATHY"
 DEFAULT_DATABASE_BACKEND = "postgresql"
 DEFAULT_DATABASE_URL = "pg0"
 DEFAULT_DATABASE_SCHEMA = "public"
-DEFAULT_LLM_PROVIDER = "openai"
-
-# Provider-specific default models
-PROVIDER_DEFAULT_MODELS = {
-    "openai": "gpt-4o-mini",
-    "openai-responses": "gpt-5.6",
-    "anthropic": "claude-haiku-4-5",
-    "gemini": "gemini-3.5-flash",
-    "groq": "openai/gpt-oss-120b",
-    "minimax": "MiniMax-M3",
-    "deepseek": "deepseek-v4-flash",
-    "zai": "glm-4.5-flash",
-    "opencode-go": "deepseek-v4-flash",
-    "atlas": "deepseek-ai/deepseek-v4-pro",
-    "ollama": "gemma3:12b",
-    "ollama-cloud": "gemma3:12b",
-    "llamacpp": "gemma-4-e2b-it",
-    "lmstudio": "local-model",
-    "vertexai": "google/gemini-3.1-flash-lite",
-    "openai-codex": "gpt-5.4-mini",
-    "claude-code": "claude-sonnet-4-5-20250929",
-    "github-copilot": "gpt-5.6-terra",
-    "mock": "mock-model",
-    "none": "none",
-    "litellm": "gpt-4o-mini",
-    "bedrock": "us.amazon.nova-2-lite-v1:0",
-    "volcano": "doubao-pro-32k",
-    "openrouter": "qwen/qwen3.5-9b",
-    "requesty": "openai/gpt-4o-mini",
-    "fireworks": "accounts/fireworks/models/llama-v3p1-8b-instruct",
-    "nous": "deepseek/deepseek-v4-flash",
-    "xai-oauth": "grok-4.5",
-}
-DEFAULT_LLM_MODEL = "gpt-4o-mini"  # Fallback if provider not in table
 # Built-in llama.cpp defaults
 DEFAULT_LLAMACPP_GPU_LAYERS = -1  # -1 = offload all layers to GPU (Metal/CUDA)
 DEFAULT_LLAMACPP_CONTEXT_SIZE = 8192
@@ -1870,11 +1849,6 @@ def _parse_bank_priority(raw: str) -> dict[str, int]:
     return result
 
 
-def _get_default_model_for_provider(provider: str) -> str:
-    """Get the default model for a given provider."""
-    return PROVIDER_DEFAULT_MODELS.get(provider.lower(), DEFAULT_LLM_MODEL)
-
-
 def _parse_llm_router_config(env_var: str) -> dict | None:
     """
     Parse a LiteLLM Router configuration from a JSON env var.
@@ -1979,8 +1953,6 @@ def _parse_llm_members(prefix: str) -> list[LLMMemberConfig]:
     stops at the first index whose ``_PROVIDER`` is unset (so indices must be
     contiguous from 1). ``MODEL`` defaults to the provider's default model.
     """
-    from .engine.llm_wrapper import requires_api_key
-
     members: list[LLMMemberConfig] = []
     index = 1
     while True:

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -29,6 +29,7 @@ from ..config import (
     ENV_REFLECT_LLM_MAX_CONCURRENT,
     ENV_RETAIN_LLM_MAX_CONCURRENT,
 )
+from ..llm_provider_metadata import LLMProviderFactory, get_llm_provider_metadata, requires_api_key
 from .cache_affinity import parse_cache_affinity
 from .llm_interface import (
     LLM_TOOL_CHOICE_AUTO,
@@ -308,31 +309,6 @@ def parse_llm_json(raw: str) -> Any:
         return repaired
 
 
-_PROVIDERS_WITHOUT_API_KEY = frozenset(
-    {
-        "ollama",
-        "lmstudio",
-        "llamacpp",
-        "openai-codex",
-        "claude-code",
-        "github-copilot",
-        "mock",
-        "none",
-        "vertexai",
-        "litellm",
-        "litellmrouter",
-        "bedrock",
-        "nous",
-        "xai-oauth",
-    }
-)
-
-
-def requires_api_key(provider: str) -> bool:
-    """Return True if the given provider requires an API key to operate."""
-    return provider.lower() not in _PROVIDERS_WITHOUT_API_KEY
-
-
 def _validate_ollama_num_ctx(value: Any) -> int | None:
     """Validate a native Ollama context-window override."""
     if value is None:
@@ -418,6 +394,9 @@ def create_llm_provider(
     Returns:
         LLMInterface implementation for the specified provider.
     """
+    metadata = get_llm_provider_metadata(provider)
+    provider_lower = metadata.provider_id
+    base_url = base_url or metadata.default_base_url
     ollama_num_ctx = _validate_ollama_num_ctx(ollama_num_ctx)
 
     from .providers import (
@@ -436,7 +415,6 @@ def create_llm_provider(
         OpenAIResponsesLLM,
     )
 
-    provider_lower = provider.lower()
     if provider_lower == "gemini":
         from ..config import parse_gemini_service_tier
 
@@ -444,7 +422,7 @@ def create_llm_provider(
     else:
         gemini_service_tier = None
 
-    if provider_lower == "openai-codex":
+    if metadata.factory is LLMProviderFactory.OPENAI_CODEX:
         return CodexLLM(
             provider=provider,
             api_key=api_key,
@@ -454,7 +432,7 @@ def create_llm_provider(
             extra_body=extra_body,
         )
 
-    elif provider_lower == "claude-code":
+    elif metadata.factory is LLMProviderFactory.CLAUDE_CODE:
         return ClaudeCodeLLM(
             provider=provider,
             api_key=api_key,
@@ -463,7 +441,7 @@ def create_llm_provider(
             reasoning_effort=reasoning_effort,
         )
 
-    elif provider_lower == "github-copilot":
+    elif metadata.factory is LLMProviderFactory.GITHUB_COPILOT:
         return GitHubCopilotLLM(
             provider=provider,
             api_key=api_key,
@@ -473,7 +451,7 @@ def create_llm_provider(
             timeout=timeout,
         )
 
-    elif provider_lower == "mock":
+    elif metadata.factory is LLMProviderFactory.MOCK:
         return MockLLM(
             provider=provider,
             api_key=api_key,
@@ -482,7 +460,7 @@ def create_llm_provider(
             reasoning_effort=reasoning_effort,
         )
 
-    elif provider_lower == "none":
+    elif metadata.factory is LLMProviderFactory.NONE:
         return NoneLLM(
             provider=provider,
             api_key=api_key,
@@ -491,7 +469,7 @@ def create_llm_provider(
             reasoning_effort=reasoning_effort,
         )
 
-    elif provider_lower in ("gemini", "vertexai"):
+    elif metadata.factory is LLMProviderFactory.GEMINI:
         return GeminiLLM(
             provider=provider,
             api_key=api_key,
@@ -507,7 +485,7 @@ def create_llm_provider(
             extra_body=extra_body,
         )
 
-    elif provider_lower == "anthropic":
+    elif metadata.factory is LLMProviderFactory.ANTHROPIC:
         return AnthropicLLM(
             provider=provider,
             api_key=api_key,
@@ -518,7 +496,7 @@ def create_llm_provider(
             extra_body=extra_body,
         )
 
-    elif provider_lower == "litellm":
+    elif metadata.factory is LLMProviderFactory.LITELLM:
         return LiteLLMLLM(
             provider=provider,
             api_key=api_key,
@@ -531,7 +509,7 @@ def create_llm_provider(
             structured_output_forced_tool=structured_output_forced_tool,
         )
 
-    elif provider_lower == "litellmrouter":
+    elif metadata.factory is LLMProviderFactory.LITELLM_ROUTER:
         if not litellmrouter_config:
             raise ValueError(
                 "Provider 'litellmrouter' requires a config object. "
@@ -552,7 +530,7 @@ def create_llm_provider(
             structured_output_forced_tool=structured_output_forced_tool,
         )
 
-    elif provider_lower == "bedrock":
+    elif metadata.factory is LLMProviderFactory.BEDROCK:
         # Bedrock is a first-class alias backed by LiteLLM with auto-prefixed model names
         bedrock_model = model if model.startswith("bedrock/") else f"bedrock/{model}"
         return LiteLLMLLM(
@@ -568,7 +546,7 @@ def create_llm_provider(
             structured_output_forced_tool=structured_output_forced_tool,
         )
 
-    elif provider_lower == "llamacpp":
+    elif metadata.factory is LLMProviderFactory.LLAMACPP:
         from ..config import get_config
 
         config = get_config()
@@ -587,7 +565,7 @@ def create_llm_provider(
             extra_args=config.llamacpp_extra_args,
         )
 
-    elif provider_lower == "fireworks":
+    elif metadata.factory is LLMProviderFactory.FIREWORKS:
         # Fireworks online inference is OpenAI-compatible; FireworksLLM adds the
         # native (non-OpenAI) batch API on top. The existing LiteLLM
         # ``fireworks_ai/...`` online path (provider="litellm") is untouched.
@@ -602,7 +580,7 @@ def create_llm_provider(
             cache_affinity=cache_affinity,
         )
 
-    elif provider_lower == "nous":
+    elif metadata.factory is LLMProviderFactory.NOUS:
         # Nous Portal is OpenAI-compatible on the wire; NousLLM adds rotating
         # inference:invoke JWT auth read natively from ~/.hermes/auth.json
         # (no static api_key, no hermes_cli dependency — same shape as Codex).
@@ -622,7 +600,7 @@ def create_llm_provider(
             timeout=timeout,
         )
 
-    elif provider_lower == "xai-oauth":
+    elif metadata.factory is LLMProviderFactory.XAI_OAUTH:
         # SuperGrok subscription lane: api.x.ai spoken plainly, but the
         # credential is a device-code OAuth grant with proactive/reactive
         # refresh over a shared on-disk store, and xAI's 403 shapes need their
@@ -639,7 +617,7 @@ def create_llm_provider(
             timeout=timeout,
         )
 
-    elif provider_lower == "openai-responses":
+    elif metadata.factory is LLMProviderFactory.OPENAI_RESPONSES:
         # OpenAI Responses API (/v1/responses). Unlike chat/completions, it
         # supports reasoning + function tools together, so reflect's tool loop
         # can run with a real reasoning_effort. See OpenAIResponsesLLM.
@@ -655,21 +633,7 @@ def create_llm_provider(
             timeout=timeout,
         )
 
-    elif provider_lower in (
-        "openai",
-        "groq",
-        "ollama",
-        "ollama-cloud",
-        "lmstudio",
-        "minimax",
-        "deepseek",
-        "volcano",
-        "openrouter",
-        "requesty",
-        "zai",
-        "opencode-go",
-        "atlas",
-    ):
+    elif metadata.factory is LLMProviderFactory.OPENAI_COMPATIBLE:
         return OpenAICompatibleLLM(
             provider=provider,
             api_key=api_key,
@@ -773,16 +737,17 @@ class LLMProvider:
                 instead of ``response_format``, for the LiteLLM-backed providers - from
                 config (``HINDSIGHT_API_LLM_STRUCTURED_OUTPUT_FORCED_TOOL``).
 
-        This constructor uses every argument as passed and does not read global
-        ``HindsightConfig``: resolving the server-level default for a ``None`` argument is the
-        caller's responsibility (see ``MemoryEngine``'s per-op builds, ``_member_to_llm``, and
-        ``LLMProvider.from_env``). Keeping it config-free makes a provider's effective settings a
-        pure function of its arguments — which is what lets each member of a multi-LLM chain be
-        configured independently.
+        This constructor reads no global ``HindsightConfig``. It normalizes the
+        provider ID and empty base URL from canonical static provider metadata,
+        then uses all operation-specific arguments as passed. Resolving server-level
+        defaults for other ``None`` arguments remains the caller's responsibility
+        (see ``MemoryEngine``'s per-op builds, ``_member_to_llm``, and
+        ``LLMProvider.from_env``).
         """
-        self.provider = provider.lower()
+        metadata = get_llm_provider_metadata(provider)
+        self.provider = metadata.provider_id
         self.api_key = api_key
-        self.base_url = base_url
+        self.base_url = base_url or metadata.default_base_url
         self.model = model
         self.reasoning_effort = reasoning_effort
         # Per-request timeout (seconds). Used verbatim — the caller resolves the
@@ -822,68 +787,6 @@ class LLMProvider:
         # it — the setting has no visible effect in the response, so a silent
         # fallback to "none" would be indistinguishable from it working.
         self.cache_affinity = parse_cache_affinity(cache_affinity).value
-
-        # Validate provider
-        valid_providers = [
-            "openai",
-            "openai-responses",
-            "groq",
-            "ollama",
-            "ollama-cloud",
-            "gemini",
-            "anthropic",
-            "lmstudio",
-            "llamacpp",
-            "vertexai",
-            "openai-codex",
-            "claude-code",
-            "github-copilot",
-            "mock",
-            "none",
-            "minimax",
-            "deepseek",
-            "litellm",
-            "litellmrouter",
-            "bedrock",
-            "volcano",
-            "openrouter",
-            "requesty",
-            "zai",
-            "opencode-go",
-            "atlas",
-            "fireworks",
-            "nous",
-            "xai-oauth",
-        ]
-        if self.provider not in valid_providers:
-            raise ValueError(f"Invalid LLM provider: {self.provider}. Must be one of: {', '.join(valid_providers)}")
-
-        # Set default base URLs
-        if not self.base_url:
-            if self.provider == "groq":
-                self.base_url = "https://api.groq.com/openai/v1"
-            elif self.provider == "ollama":
-                self.base_url = "http://localhost:11434/v1"
-            elif self.provider == "ollama-cloud":
-                self.base_url = "https://ollama.com/v1"
-            elif self.provider == "lmstudio":
-                self.base_url = "http://localhost:1234/v1"
-            elif self.provider == "minimax":
-                self.base_url = "https://api.minimax.io/v1"
-            elif self.provider == "deepseek":
-                self.base_url = "https://api.deepseek.com"
-            elif self.provider == "openrouter":
-                self.base_url = "https://openrouter.ai/api/v1"
-            elif self.provider == "requesty":
-                self.base_url = "https://router.requesty.ai/v1"
-            elif self.provider == "zai":
-                self.base_url = "https://api.z.ai/api/coding/paas/v4"
-            elif self.provider == "opencode-go":
-                self.base_url = "https://opencode.ai/zen/go/v1"
-            elif self.provider == "atlas":
-                self.base_url = "https://api.atlascloud.ai/v1"
-            elif self.provider == "nous":
-                self.base_url = "https://inference-api.nousresearch.com/v1"
 
         # Prepare Vertex AI config (if applicable). Values are used as passed; the
         # caller resolves the global-config fallback (MemoryEngine builds /

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -510,10 +510,11 @@ if TYPE_CHECKING:
 
 from enum import Enum
 
+from ..llm_provider_metadata import requires_api_key
 from ..pg0 import EmbeddedPostgres, parse_pg0_url
 from .entity_resolver import EntityResolver
 from .fact_budget import select_facts_within_budget
-from .llm_wrapper import ConfiguredLLMProvider, LLMConfig, requires_api_key, sanitize_llm_output, sanitize_text
+from .llm_wrapper import ConfiguredLLMProvider, LLMConfig, sanitize_llm_output, sanitize_text
 from .mental_model_refresh import (
     MentalModelDeltaOperations,
     MentalModelDryRunRefreshResult,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -1982,17 +1982,6 @@ class MemoryEngine(MemoryEngineInterface):
         else:
             self.db_url = db_url
 
-        # Set default base URL if not provided
-        if memory_llm_base_url is None:
-            if memory_llm_provider.lower() == "groq":
-                memory_llm_base_url = "https://api.groq.com/openai/v1"
-            elif memory_llm_provider.lower() == "ollama":
-                memory_llm_base_url = "http://localhost:11434/v1"
-            elif memory_llm_provider.lower() == "ollama-cloud":
-                memory_llm_base_url = "https://ollama.com/v1"
-            else:
-                memory_llm_base_url = ""
-
         # Database backend and SQL dialect (created during initialize())
         self._database_backend_type = config.database_backend
         self._backend: DatabaseBackend | None = None

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -55,6 +55,7 @@ from hindsight_api.engine.llm_trace import LLMResponseUsage, stash_response_usag
 from hindsight_api.engine.providers.llm_debug import dump_request_on_4xx
 from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
 from hindsight_api.engine.structured_output import strict_json_schema
+from hindsight_api.llm_provider_metadata import OPENAI_COMPATIBLE_PROVIDERS, get_llm_provider_metadata
 from hindsight_api.metrics import get_metrics_collector
 from hindsight_api.worker.stage import set_stage
 
@@ -623,82 +624,30 @@ class OpenAICompatibleLLM(LLMInterface):
         """
         super().__init__(provider, api_key, base_url, model, reasoning_effort, **kwargs)
 
-        # Validate provider
-        valid_providers = [
-            "openai",
-            "groq",
-            "ollama",
-            "ollama-cloud",
-            "lmstudio",
-            "llamacpp",
-            "minimax",
-            "deepseek",
-            "volcano",
-            "openrouter",
-            "requesty",
-            "zai",
-            "opencode-go",
-            "atlas",
-            "fireworks",
-        ]
-        if self.provider not in valid_providers:
-            raise ValueError(f"OpenAICompatibleLLM only supports: {', '.join(valid_providers)}. Got: {self.provider}")
+        try:
+            metadata = get_llm_provider_metadata(self.provider)
+        except ValueError:
+            raise ValueError(
+                f"OpenAICompatibleLLM only supports: {', '.join(OPENAI_COMPATIBLE_PROVIDERS)}. Got: {self.provider}"
+            ) from None
+        if not metadata.openai_compatible:
+            raise ValueError(
+                f"OpenAICompatibleLLM only supports: {', '.join(OPENAI_COMPATIBLE_PROVIDERS)}. Got: {self.provider}"
+            )
 
-        # Set default base URLs
-        if not self.base_url:
-            if self.provider == "groq":
-                self.base_url = "https://api.groq.com/openai/v1"
-            elif self.provider == "ollama":
-                self.base_url = "http://localhost:11434/v1"
-            elif self.provider == "ollama-cloud":
-                self.base_url = "https://ollama.com/v1"
-            elif self.provider == "lmstudio":
-                self.base_url = "http://localhost:1234/v1"
-            elif self.provider == "minimax":
-                self.base_url = "https://api.minimax.io/v1"
-            elif self.provider == "deepseek":
-                self.base_url = "https://api.deepseek.com"
-            elif self.provider == "openrouter":
-                self.base_url = "https://openrouter.ai/api/v1"
-            elif self.provider == "requesty":
-                self.base_url = "https://router.requesty.ai/v1"
-            elif self.provider == "zai":
-                self.base_url = "https://api.z.ai/api/coding/paas/v4"
-            elif self.provider == "opencode-go":
-                self.base_url = "https://opencode.ai/zen/go/v1"
-            elif self.provider == "atlas":
-                self.base_url = "https://api.atlascloud.ai/v1"
-            elif self.provider == "fireworks":
-                # OpenAI-compatible inference host (online path). The batch API
-                # lives on a separate control-plane host — see FireworksLLM.
-                self.base_url = "https://api.fireworks.ai/inference/v1"
+        self.base_url = self.base_url or metadata.default_base_url
 
         # Normalize bare local base URLs (e.g. a user pasting the address shown
         # in the LM Studio UI) so the OpenAI SDK targets the `/v1` routes. See #2922.
         if self.provider in _V1_PATH_LOCAL_PROVIDERS and self.base_url:
             self.base_url = _ensure_v1_base_url(self.base_url)
 
-        # For ollama/lmstudio, use dummy key if not provided
-        if self.provider in ("ollama", "lmstudio") and not self.api_key:
+        # The OpenAI SDK requires a non-empty placeholder even for local providers.
+        if not metadata.requires_api_key and not self.api_key:
             self.api_key = "local"
 
-        # Validate API key for cloud providers
-        if (
-            self.provider
-            in (
-                "openai",
-                "groq",
-                "minimax",
-                "deepseek",
-                "openrouter",
-                "requesty",
-                "zai",
-                "opencode-go",
-                "atlas",
-                "ollama-cloud",
-            )
-            and not self.api_key
-        ):
+        # Validate API keys from the same provider policy as every other constructor.
+        if metadata.requires_api_key and not self.api_key:
             raise ValueError(f"API key is required for {self.provider}")
 
         # Service tier configuration (from config, not env vars)

--- a/hindsight-api-slim/hindsight_api/llm_provider_metadata.py
+++ b/hindsight-api-slim/hindsight_api/llm_provider_metadata.py
@@ -1,0 +1,213 @@
+"""Canonical metadata for every built-in LLM provider.
+
+This module has no engine or configuration dependencies. Configuration, provider
+construction, and direct OpenAI-compatible construction therefore share one
+closed provider vocabulary and one policy table.
+"""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+
+
+class LLMProviderFactory(str, Enum):
+    """Provider implementation selected by ``create_llm_provider``."""
+
+    OPENAI_COMPATIBLE = "openai-compatible"
+    OPENAI_RESPONSES = "openai-responses"
+    ANTHROPIC = "anthropic"
+    GEMINI = "gemini"
+    OPENAI_CODEX = "openai-codex"
+    CLAUDE_CODE = "claude-code"
+    GITHUB_COPILOT = "github-copilot"
+    MOCK = "mock"
+    NONE = "none"
+    LITELLM = "litellm"
+    LITELLM_ROUTER = "litellm-router"
+    BEDROCK = "bedrock"
+    LLAMACPP = "llamacpp"
+    FIREWORKS = "fireworks"
+    NOUS = "nous"
+    XAI_OAUTH = "xai-oauth"
+
+
+_OPENAI_COMPATIBLE_FACTORIES = frozenset(
+    {
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        LLMProviderFactory.LLAMACPP,
+        LLMProviderFactory.FIREWORKS,
+    }
+)
+
+
+@dataclass(frozen=True)
+class LLMProviderMetadata:
+    """Static policy shared by configuration and provider construction."""
+
+    provider_id: str
+    factory: LLMProviderFactory
+    requires_api_key: bool
+    default_model: str
+    default_base_url: str = ""
+
+    @property
+    def openai_compatible(self) -> bool:
+        """Whether ``OpenAICompatibleLLM`` can speak to this provider directly."""
+
+        return self.factory in _OPENAI_COMPATIBLE_FACTORIES
+
+
+_PROVIDER_METADATA = (
+    LLMProviderMetadata("openai", LLMProviderFactory.OPENAI_COMPATIBLE, True, "gpt-4o-mini"),
+    LLMProviderMetadata("openai-responses", LLMProviderFactory.OPENAI_RESPONSES, True, "gpt-5.6"),
+    LLMProviderMetadata("anthropic", LLMProviderFactory.ANTHROPIC, True, "claude-haiku-4-5"),
+    LLMProviderMetadata("gemini", LLMProviderFactory.GEMINI, True, "gemini-3.5-flash"),
+    LLMProviderMetadata(
+        "groq",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        True,
+        "openai/gpt-oss-120b",
+        "https://api.groq.com/openai/v1",
+    ),
+    LLMProviderMetadata(
+        "minimax",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        True,
+        "MiniMax-M3",
+        "https://api.minimax.io/v1",
+    ),
+    LLMProviderMetadata(
+        "deepseek",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        True,
+        "deepseek-v4-flash",
+        "https://api.deepseek.com",
+    ),
+    LLMProviderMetadata(
+        "zai",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        True,
+        "glm-4.5-flash",
+        "https://api.z.ai/api/coding/paas/v4",
+    ),
+    LLMProviderMetadata(
+        "opencode-go",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        True,
+        "deepseek-v4-flash",
+        "https://opencode.ai/zen/go/v1",
+    ),
+    LLMProviderMetadata(
+        "atlas",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        True,
+        "deepseek-ai/deepseek-v4-pro",
+        "https://api.atlascloud.ai/v1",
+    ),
+    LLMProviderMetadata(
+        "ollama",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        False,
+        "gemma3:12b",
+        "http://localhost:11434/v1",
+    ),
+    LLMProviderMetadata(
+        "ollama-cloud",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        True,
+        "gemma3:12b",
+        "https://ollama.com/v1",
+    ),
+    LLMProviderMetadata("llamacpp", LLMProviderFactory.LLAMACPP, False, "gemma-4-e2b-it"),
+    LLMProviderMetadata(
+        "lmstudio",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        False,
+        "local-model",
+        "http://localhost:1234/v1",
+    ),
+    LLMProviderMetadata("vertexai", LLMProviderFactory.GEMINI, False, "google/gemini-3.1-flash-lite"),
+    LLMProviderMetadata(
+        "openai-codex",
+        LLMProviderFactory.OPENAI_CODEX,
+        False,
+        "gpt-5.4-mini",
+        "https://chatgpt.com/backend-api",
+    ),
+    LLMProviderMetadata("claude-code", LLMProviderFactory.CLAUDE_CODE, False, "claude-sonnet-4-5-20250929"),
+    LLMProviderMetadata("github-copilot", LLMProviderFactory.GITHUB_COPILOT, False, "gpt-5.6-terra"),
+    LLMProviderMetadata("mock", LLMProviderFactory.MOCK, False, "mock-model"),
+    LLMProviderMetadata("none", LLMProviderFactory.NONE, False, "none"),
+    LLMProviderMetadata("litellm", LLMProviderFactory.LITELLM, False, "gpt-4o-mini"),
+    LLMProviderMetadata("litellmrouter", LLMProviderFactory.LITELLM_ROUTER, False, "gpt-4o-mini"),
+    LLMProviderMetadata("bedrock", LLMProviderFactory.BEDROCK, False, "us.amazon.nova-2-lite-v1:0"),
+    LLMProviderMetadata("volcano", LLMProviderFactory.OPENAI_COMPATIBLE, True, "doubao-pro-32k"),
+    LLMProviderMetadata(
+        "openrouter",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        True,
+        "qwen/qwen3.5-9b",
+        "https://openrouter.ai/api/v1",
+    ),
+    LLMProviderMetadata(
+        "requesty",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        True,
+        "openai/gpt-4o-mini",
+        "https://router.requesty.ai/v1",
+    ),
+    LLMProviderMetadata(
+        "fireworks",
+        LLMProviderFactory.FIREWORKS,
+        True,
+        "accounts/fireworks/models/llama-v3p1-8b-instruct",
+        "https://api.fireworks.ai/inference/v1",
+    ),
+    LLMProviderMetadata(
+        "nous",
+        LLMProviderFactory.NOUS,
+        False,
+        "deepseek/deepseek-v4-flash",
+        "https://inference-api.nousresearch.com/v1",
+    ),
+    LLMProviderMetadata("xai-oauth", LLMProviderFactory.XAI_OAUTH, False, "grok-4.5"),
+)
+
+_PROVIDER_METADATA_BY_ID = {metadata.provider_id: metadata for metadata in _PROVIDER_METADATA}
+if len(_PROVIDER_METADATA_BY_ID) != len(_PROVIDER_METADATA):
+    raise ValueError("Duplicate provider ID in canonical LLM provider metadata")
+
+LLM_PROVIDER_METADATA: Mapping[str, LLMProviderMetadata] = MappingProxyType(_PROVIDER_METADATA_BY_ID)
+SUPPORTED_LLM_PROVIDERS = frozenset(LLM_PROVIDER_METADATA)
+OPENAI_COMPATIBLE_PROVIDERS = tuple(
+    provider_id for provider_id, metadata in LLM_PROVIDER_METADATA.items() if metadata.openai_compatible
+)
+PROVIDER_DEFAULT_MODELS: Mapping[str, str] = MappingProxyType(
+    {provider_id: metadata.default_model for provider_id, metadata in LLM_PROVIDER_METADATA.items()}
+)
+DEFAULT_LLM_PROVIDER = "openai"
+DEFAULT_LLM_MODEL = LLM_PROVIDER_METADATA[DEFAULT_LLM_PROVIDER].default_model
+
+
+def get_llm_provider_metadata(provider: str) -> LLMProviderMetadata:
+    """Return canonical metadata for ``provider`` or reject an unknown ID."""
+
+    provider_id = provider.lower()
+    try:
+        return LLM_PROVIDER_METADATA[provider_id]
+    except KeyError:
+        supported = ", ".join(LLM_PROVIDER_METADATA)
+        raise ValueError(f"Unknown LLM provider {provider_id!r}. Must be one of: {supported}") from None
+
+
+def get_default_model_for_provider(provider: str) -> str:
+    """Return the provider's canonical default model."""
+
+    return get_llm_provider_metadata(provider).default_model
+
+
+def requires_api_key(provider: str) -> bool:
+    """Return whether the provider requires a top-level API key."""
+
+    return get_llm_provider_metadata(provider).requires_api_key

--- a/hindsight-api-slim/tests/test_llm_provider_metadata.py
+++ b/hindsight-api-slim/tests/test_llm_provider_metadata.py
@@ -1,0 +1,142 @@
+import pytest
+
+from hindsight_api.engine.llm_wrapper import create_llm_provider
+from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+from hindsight_api.llm_provider_metadata import (
+    DEFAULT_LLM_MODEL,
+    DEFAULT_LLM_PROVIDER,
+    LLM_PROVIDER_METADATA,
+    OPENAI_COMPATIBLE_PROVIDERS,
+    PROVIDER_DEFAULT_MODELS,
+    SUPPORTED_LLM_PROVIDERS,
+    LLMProviderFactory,
+    get_default_model_for_provider,
+    get_llm_provider_metadata,
+    requires_api_key,
+)
+
+EXPECTED_PROVIDERS = {
+    "anthropic",
+    "atlas",
+    "bedrock",
+    "claude-code",
+    "deepseek",
+    "fireworks",
+    "gemini",
+    "github-copilot",
+    "groq",
+    "litellm",
+    "litellmrouter",
+    "llamacpp",
+    "lmstudio",
+    "minimax",
+    "mock",
+    "none",
+    "nous",
+    "ollama",
+    "ollama-cloud",
+    "openai",
+    "openai-codex",
+    "openai-responses",
+    "opencode-go",
+    "openrouter",
+    "requesty",
+    "vertexai",
+    "volcano",
+    "xai-oauth",
+    "zai",
+}
+
+EXPECTED_OPENAI_COMPATIBLE = {
+    "atlas",
+    "deepseek",
+    "fireworks",
+    "groq",
+    "llamacpp",
+    "lmstudio",
+    "minimax",
+    "ollama",
+    "ollama-cloud",
+    "openai",
+    "opencode-go",
+    "openrouter",
+    "requesty",
+    "volcano",
+    "zai",
+}
+
+EXPECTED_WITHOUT_API_KEY = {
+    "bedrock",
+    "claude-code",
+    "github-copilot",
+    "litellm",
+    "litellmrouter",
+    "llamacpp",
+    "lmstudio",
+    "mock",
+    "none",
+    "nous",
+    "ollama",
+    "openai-codex",
+    "vertexai",
+    "xai-oauth",
+}
+
+
+def test_registry_is_total_over_the_builtin_provider_vocabulary() -> None:
+    assert set(LLM_PROVIDER_METADATA) == EXPECTED_PROVIDERS
+    assert SUPPORTED_LLM_PROVIDERS == EXPECTED_PROVIDERS
+    assert set(PROVIDER_DEFAULT_MODELS) == EXPECTED_PROVIDERS
+    assert {metadata.provider_id for metadata in LLM_PROVIDER_METADATA.values()} == EXPECTED_PROVIDERS
+    assert {metadata.factory for metadata in LLM_PROVIDER_METADATA.values()} == set(LLMProviderFactory)
+    assert all(metadata.default_model for metadata in LLM_PROVIDER_METADATA.values())
+    assert DEFAULT_LLM_PROVIDER in EXPECTED_PROVIDERS
+    assert DEFAULT_LLM_MODEL == LLM_PROVIDER_METADATA[DEFAULT_LLM_PROVIDER].default_model
+
+
+def test_derived_capability_and_api_key_views_match_the_provider_contract() -> None:
+    assert set(OPENAI_COMPATIBLE_PROVIDERS) == EXPECTED_OPENAI_COMPATIBLE
+    assert {provider for provider in EXPECTED_PROVIDERS if not requires_api_key(provider)} == EXPECTED_WITHOUT_API_KEY
+
+
+def test_config_reexports_the_same_derived_default_model_view() -> None:
+    from hindsight_api.config import PROVIDER_DEFAULT_MODELS as config_default_models
+
+    assert config_default_models is PROVIDER_DEFAULT_MODELS
+
+
+def test_lookup_normalizes_case_and_rejects_unknown_ids() -> None:
+    assert get_llm_provider_metadata("AnThRoPiC") is LLM_PROVIDER_METADATA["anthropic"]
+    assert get_default_model_for_provider("GEMINI") == "gemini-3.5-flash"
+
+    with pytest.raises(ValueError, match="Unknown LLM provider 'missing'"):
+        get_llm_provider_metadata("missing")
+    with pytest.raises(ValueError, match="Unknown LLM provider 'missing'"):
+        get_default_model_for_provider("missing")
+    with pytest.raises(ValueError, match="Unknown LLM provider 'missing'"):
+        requires_api_key("missing")
+    with pytest.raises(ValueError, match="Unknown LLM provider 'missing'"):
+        create_llm_provider("missing", "", "", "model", None)
+
+
+@pytest.mark.parametrize("provider", sorted(EXPECTED_OPENAI_COMPATIBLE))
+def test_every_compatible_descriptor_is_accepted_by_the_compatible_constructor(provider: str) -> None:
+    metadata = get_llm_provider_metadata(provider)
+    llm = OpenAICompatibleLLM(
+        provider=provider,
+        api_key="test-key" if metadata.requires_api_key else "",
+        base_url="",
+        model=metadata.default_model,
+    )
+
+    assert llm.provider == provider
+    assert llm.base_url == metadata.default_base_url
+    assert bool(llm.api_key)
+
+
+@pytest.mark.parametrize("provider", sorted(EXPECTED_OPENAI_COMPATIBLE - EXPECTED_WITHOUT_API_KEY))
+def test_every_compatible_cloud_provider_requires_its_key(provider: str) -> None:
+    metadata = get_llm_provider_metadata(provider)
+
+    with pytest.raises(ValueError, match=f"API key is required for {provider}"):
+        OpenAICompatibleLLM(provider=provider, api_key="", base_url="", model=metadata.default_model)


### PR DESCRIPTION
## Problem

Built-in provider identity and policy currently have several independent owners:

- default models in `config.PROVIDER_DEFAULT_MODELS`
- API-key exemptions in `llm_wrapper._PROVIDERS_WITHOUT_API_KEY`
- accepted providers in two constructor lists
- default base URLs in two separate conditional ladders
- factory routing in another provider-ID branch ladder

Adding a provider can update some surfaces while silently missing another.

## Change

Introduce one immutable descriptor registry for every built-in provider. Each descriptor owns:

- stable provider ID
- typed factory implementation variant
- API-key requirement
- default model
- default base URL
- derived OpenAI-compatible capability

Configuration, `LLMProvider`, `create_llm_provider`, direct `OpenAICompatibleLLM` construction, and memory-engine validation now consume that registry. The old maps, sets, accepted-provider lists, and base-URL ladders are removed rather than retained as parallel authorities. Existing config constants remain derived read-only views of the registry.

Unknown provider IDs now fail at the metadata lookup boundary instead of receiving the OpenAI fallback model and failing later during construction.

## Verification

    pytest -q \
      hindsight-api-slim/tests/test_llm_provider_metadata.py \
      hindsight-api-slim/tests/test_provider_default_models.py \
      hindsight-api-slim/tests/test_local_provider_base_url.py \
      hindsight-api-slim/tests/test_opencode_go_provider.py \
      hindsight-api-slim/tests/test_nous_provider.py
    58 passed

    pytest -q \
      hindsight-api-slim/tests/test_none_llm_provider.py \
      hindsight-api-slim/tests/test_llm_wrapper.py \
      hindsight-api-slim/tests/test_multi_llm_provider.py
    77 passed

    ruff check <changed Python paths>
    All checks passed!

    ruff format --check <changed Python paths>
    6 files already formatted

The registry law tests independently pin all 29 built-in IDs—including `atlas`, `fireworks`, `groq`, `nous`, `opencode-go`, and `requesty`—plus API-key and compatibility sets. A new factory variant or provider ID therefore fails until its complete descriptor and derived surfaces are updated.
