### PR TITLE
feat(config): add named inference profiles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,14 @@ HINDSIGHT_API_LLM_MODEL=gpt-4o-mini
 # no reasoning parameter is sent at all and each model runs at its own default effort.
 # HINDSIGHT_API_LLM_REASONING_EFFORT=low
 
+# Optional server-owned named route registry. The JSON file defines complete
+# default/retain/consolidation/reflect routes and resolves credentials through
+# api_key_env names. Banks store only a profile ID; route secrets stay server-side.
+# Setting a global selector makes these routes authoritative over legacy per-operation
+# LLM variables. Banks may select another registered ID through bank configuration.
+# HINDSIGHT_API_INFERENCE_PROFILES_FILE=/etc/hindsight/inference-profiles.json
+# HINDSIGHT_API_INFERENCE_PROFILE=production
+
 # Sampling temperature for internal LLM calls. Set a number in [0.0, 2.0], or `none`
 # to omit the temperature parameter entirely (required for models that reject explicit
 # temperatures, e.g. Azure gpt-5.5). The global override below applies to every operation;

--- a/hindsight-api-slim/README.md
+++ b/hindsight-api-slim/README.md
@@ -86,6 +86,34 @@ Configure via environment variables:
 | `HINDSIGHT_API_HOST` | Server bind address | `0.0.0.0` |
 | `HINDSIGHT_API_PORT` | Server port | `8888` |
 
+### Named inference profiles
+
+Use a server-owned profile registry when one deployment needs a fixed model route for each inference operation:
+
+```json
+{
+  "production": {
+    "default": {"provider": "deepseek", "model": "deepseek-v4-flash", "api_key_env": "DEEPSEEK_API_KEY"},
+    "retain": {"provider": "openai", "model": "retain-model", "api_key_env": "GATEWAY_API_KEY"},
+    "consolidation": {"provider": "openai", "model": "consolidation-model", "api_key_env": "GATEWAY_API_KEY"},
+    "reflect": {"provider": "anthropic", "model": "reflect-model", "api_key_env": "GATEWAY_API_KEY"}
+  }
+}
+```
+
+Set `HINDSIGHT_API_INFERENCE_PROFILES_FILE` to the registry path and
+`HINDSIGHT_API_INFERENCE_PROFILE` to the deployment profile ID. A bank can
+select a registered profile through its `inference_profile` config field. The
+bank stores only the profile ID; route definitions and credentials remain
+server-side. Profile IDs are lowercase identifiers, every profile defines all
+four operations, unknown fields fail startup, and every `api_key_env` reference
+must resolve.
+
+When `HINDSIGHT_API_ENABLE_BANK_LLM_HEALTH=true`, an authenticated
+`POST /v1/default/banks/{bank_id}/health/llm` probes the bank's effective
+retain, consolidation, and reflect routes. The response reports only
+connectivity status and latency.
+
 ### Example with External PostgreSQL
 
 ```bash

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1382,6 +1382,10 @@ class CreateBankRequest(BaseModel):
     )
 
     # Operational configuration (applied via config resolver)
+    inference_profile: str | None = Field(
+        default=None,
+        description="Name of a server-owned inference profile; routes and credentials remain server-side.",
+    )
     retain_mission: str | None = Field(
         default=None,
         description="Steers what gets extracted during retain(). Injected alongside built-in extraction rules.",
@@ -1468,6 +1472,7 @@ class CreateBankRequest(BaseModel):
         elif self.disposition is not None:
             updates["disposition_empathy"] = self.disposition.empathy
         for field_name in (
+            "inference_profile",
             "retain_mission",
             "retain_extraction_mode",
             "retain_custom_instructions",
@@ -2710,6 +2715,10 @@ class BankTemplateConfig(BaseModel):
     (API keys, base URLs) are intentionally excluded for security.
     """
 
+    inference_profile: str | None = Field(
+        default=None,
+        description="Name of a server-owned inference profile; route contents and credentials remain server-side",
+    )
     reflect_mission: str | None = Field(default=None, description="Mission/context for Reflect operations")
     retain_mission: str | None = Field(default=None, description="Steers what gets extracted during retain")
     retain_extraction_mode: str | None = Field(

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -6,12 +6,15 @@ All environment variables and their defaults are defined here.
 
 import json
 import logging
+import math
 import os
 import re
 import sys
 from dataclasses import dataclass, field, fields
 from datetime import datetime, timezone
-from typing import Any, Literal
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Literal, Mapping, cast
 
 from dotenv import find_dotenv, load_dotenv
 
@@ -22,13 +25,12 @@ from .llm_provider_metadata import (
 )
 from .llm_provider_metadata import (
     DEFAULT_LLM_PROVIDER,
+    get_default_model_for_provider,
+    get_llm_provider_metadata,
     requires_api_key,
 )
 from .llm_provider_metadata import (
     PROVIDER_DEFAULT_MODELS as PROVIDER_DEFAULT_MODELS,
-)
-from .llm_provider_metadata import (
-    get_default_model_for_provider as _get_default_model_for_provider,
 )
 from .utils import mask_network_location
 
@@ -162,6 +164,8 @@ ENV_LLM_PROVIDER = "HINDSIGHT_API_LLM_PROVIDER"
 ENV_LLM_API_KEY = "HINDSIGHT_API_LLM_API_KEY"
 ENV_LLM_MODEL = "HINDSIGHT_API_LLM_MODEL"
 ENV_LLM_BASE_URL = "HINDSIGHT_API_LLM_BASE_URL"
+ENV_INFERENCE_PROFILES_FILE = "HINDSIGHT_API_INFERENCE_PROFILES_FILE"
+ENV_INFERENCE_PROFILE = "HINDSIGHT_API_INFERENCE_PROFILE"
 ENV_LLM_MAX_CONCURRENT = "HINDSIGHT_API_LLM_MAX_CONCURRENT"
 ENV_LLM_MAX_RETRIES = "HINDSIGHT_API_LLM_MAX_RETRIES"
 ENV_LLM_INITIAL_BACKOFF = "HINDSIGHT_API_LLM_INITIAL_BACKOFF"
@@ -1269,6 +1273,7 @@ DEFAULT_STORE_DOCUMENT_TEXT = True  # Persist raw source text in documents.origi
 DEFAULT_ENABLE_DOCUMENT_EXPORT_API = True
 DEFAULT_ENABLE_DOCUMENT_IMPORT_API = True
 
+
 # Observations defaults (consolidated knowledge from facts)
 DEFAULT_ENABLE_OBSERVATIONS = True  # Observations enabled by default
 DEFAULT_ENABLE_AUTO_CONSOLIDATION = True  # Auto-consolidation after retain enabled by default
@@ -1655,6 +1660,14 @@ def _parse_str_list(value: str) -> list[str]:
     return [v.strip() for v in value.split(",") if v.strip()]
 
 
+def _parse_optional_int(raw: str | None) -> int | None:
+    return int(raw) if raw else None
+
+
+def _parse_optional_float(raw: str | None) -> float | None:
+    return float(raw) if raw else None
+
+
 def _parse_positive_int(name: str, raw: str | None, default: int) -> int:
     """
     Parse an env var that must be a positive integer (>= 1).
@@ -1867,6 +1880,362 @@ def _parse_llm_router_config(env_var: str) -> dict | None:
         raise ValueError(f"Invalid {env_var}: invalid JSON: {e}") from e
 
 
+INFERENCE_PROFILE_OPERATIONS = ("default", "retain", "consolidation", "reflect")
+_INFERENCE_PROFILE_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+_INFERENCE_PROFILE_ENV_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_INFERENCE_MODEL_FIELDS = frozenset(
+    {
+        "provider",
+        "model",
+        "api_key_env",
+        "base_url",
+        "reasoning_effort",
+        "max_retries",
+        "initial_backoff",
+        "max_backoff",
+        "timeout",
+        "extra_body",
+        "default_headers",
+        "groq_service_tier",
+        "openai_service_tier",
+        "bedrock_service_tier",
+        "gemini_service_tier",
+        "ollama_num_ctx",
+        "litellmrouter_config",
+    }
+)
+_REASONING_EFFORTS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max"})
+
+
+@dataclass(frozen=True)
+class InferenceModelProfile:
+    """One fully identified model route in a server-owned inference profile."""
+
+    provider: str
+    model: str
+    api_key_env: str | None = None
+    api_key: str | None = field(default=None, repr=False)
+    base_url: str | None = None
+    reasoning_effort: str | None = None
+    max_retries: int | None = None
+    initial_backoff: float | None = None
+    max_backoff: float | None = None
+    timeout: float | None = None
+    extra_body: Mapping[str, Any] | None = None
+    default_headers: Mapping[str, str] | None = None
+    litellmrouter_config: Mapping[str, Any] | None = None
+    groq_service_tier: str | None = None
+    openai_service_tier: str | None = None
+    bedrock_service_tier: str | None = None
+    gemini_service_tier: str | None = None
+    ollama_num_ctx: int | None = None
+
+
+@dataclass(frozen=True)
+class InferenceProfile:
+    """A total set of routes for every Hindsight inference operation."""
+
+    default: InferenceModelProfile
+    retain: InferenceModelProfile
+    consolidation: InferenceModelProfile
+    reflect: InferenceModelProfile
+
+    def route(self, operation: str) -> InferenceModelProfile:
+        if operation not in INFERENCE_PROFILE_OPERATIONS:
+            raise ValueError(f"Unknown inference profile operation {operation!r}")
+        return getattr(self, operation)
+
+
+def _strict_json_object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate field {key!r}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_json_constant(value: str) -> Any:
+    raise ValueError(f"non-finite JSON number {value!r}")
+
+
+def _parse_finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"non-finite JSON number {value!r}")
+    return parsed
+
+
+def _freeze_profile_json(value: Any) -> Any:
+    """Recursively freeze a validated JSON payload."""
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError(f"non-finite JSON number {value!r}")
+    if isinstance(value, dict):
+        return MappingProxyType({key: _freeze_profile_json(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return tuple(_freeze_profile_json(item) for item in value)
+    return value
+
+
+def _profile_nonempty_string(profile_id: str, operation: str, field_name: str, value: Any) -> str:
+    if not isinstance(value, str) or not value.strip() or value.strip() != value:
+        raise ValueError(
+            f"Inference profile {profile_id!r} operation {operation!r} field {field_name!r} "
+            "must be a non-empty string without surrounding whitespace"
+        )
+    return value
+
+
+def _profile_optional_number(
+    profile_id: str,
+    operation: str,
+    field_name: str,
+    value: Any,
+    *,
+    integer: bool = False,
+    allow_zero: bool = False,
+) -> int | float | None:
+    if value is None:
+        return None
+    expected = int if integer else (int, float)
+    if isinstance(value, bool) or not isinstance(value, expected):
+        kind = "integer" if integer else "number"
+        raise ValueError(
+            f"Inference profile {profile_id!r} operation {operation!r} field {field_name!r} must be a {kind}"
+        )
+    if not math.isfinite(float(value)):
+        raise ValueError(
+            f"Inference profile {profile_id!r} operation {operation!r} field {field_name!r} must be finite"
+        )
+    if value < 0 or (value == 0 and not allow_zero):
+        comparison = "non-negative" if allow_zero else "positive"
+        raise ValueError(
+            f"Inference profile {profile_id!r} operation {operation!r} field {field_name!r} must be {comparison}"
+        )
+    return value
+
+
+def _parse_inference_model_profile(
+    profile_id: str, operation: str, raw: Any, environment: dict[str, str]
+) -> InferenceModelProfile:
+    if not isinstance(raw, dict):
+        raise ValueError(f"Inference profile {profile_id!r} operation {operation!r} must be a JSON object")
+    unknown_fields = set(raw) - _INFERENCE_MODEL_FIELDS
+    if unknown_fields:
+        raise ValueError(
+            f"Inference profile {profile_id!r} operation {operation!r} has unknown fields: {sorted(unknown_fields)}"
+        )
+    missing_fields = {"provider", "model"} - set(raw)
+    if missing_fields:
+        raise ValueError(
+            f"Inference profile {profile_id!r} operation {operation!r} is missing required fields: "
+            f"{sorted(missing_fields)}"
+        )
+
+    provider = _profile_nonempty_string(profile_id, operation, "provider", raw["provider"]).lower()
+    try:
+        get_llm_provider_metadata(provider)
+    except ValueError:
+        raise ValueError(
+            f"Inference profile {profile_id!r} operation {operation!r} has unsupported provider {provider!r}"
+        ) from None
+    model = _profile_nonempty_string(profile_id, operation, "model", raw["model"])
+
+    api_key_env = raw.get("api_key_env")
+    api_key: str | None = None
+    if api_key_env is not None:
+        api_key_env = _profile_nonempty_string(profile_id, operation, "api_key_env", api_key_env)
+        if not _INFERENCE_PROFILE_ENV_PATTERN.fullmatch(api_key_env):
+            raise ValueError(
+                f"Inference profile {profile_id!r} operation {operation!r} has invalid api_key_env {api_key_env!r}"
+            )
+        api_key = environment.get(api_key_env)
+        if not api_key or not api_key.strip():
+            raise ValueError(
+                f"Inference profile {profile_id!r} operation {operation!r} references unresolved "
+                f"credential environment variable {api_key_env!r}"
+            )
+
+    if requires_api_key(provider) and api_key is None:
+        raise ValueError(
+            f"Inference profile {profile_id!r} operation {operation!r} provider {provider!r} requires api_key_env"
+        )
+
+    base_url = raw.get("base_url")
+    if base_url is not None:
+        base_url = _profile_nonempty_string(profile_id, operation, "base_url", base_url)
+
+    reasoning_effort = raw.get("reasoning_effort")
+    if reasoning_effort is not None:
+        reasoning_effort = _profile_nonempty_string(profile_id, operation, "reasoning_effort", reasoning_effort).lower()
+        if reasoning_effort not in _REASONING_EFFORTS:
+            raise ValueError(
+                f"Inference profile {profile_id!r} operation {operation!r} has unsupported "
+                f"reasoning_effort {reasoning_effort!r}"
+            )
+
+    extra_body = raw.get("extra_body")
+    if extra_body is not None and not isinstance(extra_body, dict):
+        raise ValueError(
+            f"Inference profile {profile_id!r} operation {operation!r} field 'extra_body' must be a JSON object"
+        )
+    default_headers = raw.get("default_headers")
+    if default_headers is not None and (
+        not isinstance(default_headers, dict)
+        or not all(isinstance(key, str) and key and isinstance(value, str) for key, value in default_headers.items())
+    ):
+        raise ValueError(
+            f"Inference profile {profile_id!r} operation {operation!r} field 'default_headers' "
+            "must be an object of non-empty string keys to string values"
+        )
+
+    litellmrouter_config = raw.get("litellmrouter_config")
+    if litellmrouter_config is not None and not isinstance(litellmrouter_config, dict):
+        raise ValueError(
+            f"Inference profile {profile_id!r} operation {operation!r} field "
+            "'litellmrouter_config' must be a JSON object"
+        )
+    if provider == "litellmrouter" and not litellmrouter_config:
+        raise ValueError(
+            f"Inference profile {profile_id!r} operation {operation!r} provider "
+            "'litellmrouter' requires a non-empty litellmrouter_config"
+        )
+    if provider != "litellmrouter" and litellmrouter_config is not None:
+        raise ValueError(
+            f"Inference profile {profile_id!r} operation {operation!r} field "
+            f"'litellmrouter_config' is unsupported for provider {provider!r}"
+        )
+
+    service_tiers = {
+        "groq_service_tier": ("groq", frozenset({"on_demand", "flex", "auto"})),
+        "openai_service_tier": ("openai", frozenset({"flex"})),
+        "bedrock_service_tier": ("bedrock", frozenset({"flex", "priority", "reserved"})),
+        "gemini_service_tier": ("gemini", frozenset({"flex"})),
+    }
+    parsed_tiers: dict[str, str | None] = {}
+    for field_name, (supported_provider, allowed_values) in service_tiers.items():
+        value = raw.get(field_name)
+        if value is not None:
+            value = _profile_nonempty_string(profile_id, operation, field_name, value).lower()
+            if provider != supported_provider or value not in allowed_values:
+                raise ValueError(
+                    f"Inference profile {profile_id!r} operation {operation!r} has unsupported "
+                    f"{field_name} value {value!r} for provider {provider!r}"
+                )
+        parsed_tiers[field_name] = value
+
+    max_retries = _profile_optional_number(
+        profile_id, operation, "max_retries", raw.get("max_retries"), integer=True, allow_zero=True
+    )
+    initial_backoff = _profile_optional_number(
+        profile_id, operation, "initial_backoff", raw.get("initial_backoff"), allow_zero=True
+    )
+    max_backoff = _profile_optional_number(
+        profile_id, operation, "max_backoff", raw.get("max_backoff"), allow_zero=True
+    )
+    if initial_backoff is not None and max_backoff is not None and initial_backoff > max_backoff:
+        raise ValueError(
+            f"Inference profile {profile_id!r} operation {operation!r} initial_backoff must not exceed max_backoff"
+        )
+    ollama_num_ctx = cast(
+        int | None,
+        _profile_optional_number(profile_id, operation, "ollama_num_ctx", raw.get("ollama_num_ctx"), integer=True),
+    )
+    if ollama_num_ctx is not None and provider not in {"ollama", "ollama-cloud"}:
+        raise ValueError(
+            f"Inference profile {profile_id!r} operation {operation!r} field 'ollama_num_ctx' "
+            f"is unsupported for provider {provider!r}"
+        )
+
+    return InferenceModelProfile(
+        provider=provider,
+        model=model,
+        api_key_env=api_key_env,
+        api_key=api_key,
+        base_url=base_url,
+        reasoning_effort=reasoning_effort,
+        max_retries=cast(int | None, max_retries),
+        initial_backoff=initial_backoff,
+        max_backoff=max_backoff,
+        timeout=_profile_optional_number(profile_id, operation, "timeout", raw.get("timeout")),
+        extra_body=_freeze_profile_json(extra_body) if extra_body is not None else None,
+        default_headers=_freeze_profile_json(default_headers) if default_headers is not None else None,
+        litellmrouter_config=(_freeze_profile_json(litellmrouter_config) if litellmrouter_config is not None else None),
+        groq_service_tier=parsed_tiers["groq_service_tier"],
+        openai_service_tier=parsed_tiers["openai_service_tier"],
+        bedrock_service_tier=parsed_tiers["bedrock_service_tier"],
+        gemini_service_tier=parsed_tiers["gemini_service_tier"],
+        ollama_num_ctx=ollama_num_ctx,
+    )
+
+
+def load_inference_profiles(
+    file_name: str | None, environment: dict[str, str] | None = None
+) -> Mapping[str, InferenceProfile]:
+    """Load and strictly validate the static named inference-profile registry."""
+    if not file_name:
+        return MappingProxyType({})
+    profile_path = Path(file_name).expanduser()
+    try:
+        raw_text = profile_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"Invalid {ENV_INFERENCE_PROFILES_FILE} {file_name!r}: {exc}") from exc
+    try:
+        parsed = json.loads(
+            raw_text,
+            object_pairs_hook=_strict_json_object_pairs,
+            parse_constant=_reject_nonfinite_json_constant,
+            parse_float=_parse_finite_json_float,
+        )
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise ValueError(f"Invalid {ENV_INFERENCE_PROFILES_FILE} {file_name!r}: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError(f"Invalid {ENV_INFERENCE_PROFILES_FILE}: root must be a JSON object")
+
+    environment = dict(os.environ) if environment is None else environment
+    profiles: dict[str, InferenceProfile] = {}
+    required_operations = set(INFERENCE_PROFILE_OPERATIONS)
+    for profile_id, raw_profile in parsed.items():
+        if not isinstance(profile_id, str) or not _INFERENCE_PROFILE_ID_PATTERN.fullmatch(profile_id):
+            raise ValueError(
+                f"Invalid inference profile id {profile_id!r}: expected lowercase letters, digits, or hyphens"
+            )
+        if not isinstance(raw_profile, dict):
+            raise ValueError(f"Inference profile {profile_id!r} must be a JSON object")
+        operation_keys = set(raw_profile)
+        missing_operations = required_operations - operation_keys
+        unknown_operations = operation_keys - required_operations
+        if missing_operations or unknown_operations:
+            details = []
+            if missing_operations:
+                details.append(f"missing operations {sorted(missing_operations)}")
+            if unknown_operations:
+                details.append(f"unknown operations {sorted(unknown_operations)}")
+            raise ValueError(f"Inference profile {profile_id!r} has " + " and ".join(details))
+        routes = {
+            operation: _parse_inference_model_profile(profile_id, operation, raw_profile[operation], environment)
+            for operation in INFERENCE_PROFILE_OPERATIONS
+        }
+        profiles[profile_id] = InferenceProfile(**routes)
+    return MappingProxyType(profiles)
+
+
+def validate_inference_profile_selector(
+    selector: Any,
+    profiles: Mapping[str, InferenceProfile],
+    *,
+    source: str = "inference_profile",
+) -> str | None:
+    """Validate a global, tenant, or bank selector against the static registry."""
+    if selector is None:
+        return None
+    if not isinstance(selector, str) or not _INFERENCE_PROFILE_ID_PATTERN.fullmatch(selector):
+        raise ValueError(f"Invalid {source} selector {selector!r}")
+    if selector not in profiles:
+        raise ValueError(f"Unknown {source} selector {selector!r}")
+    return selector
+
+
 @dataclass
 class LLMMemberConfig:
     """One extra LLM in a multi-LLM chain, configured via indexed env vars.
@@ -1972,7 +2341,7 @@ def _parse_llm_members(prefix: str) -> list[LLMMemberConfig]:
             LLMMemberConfig(
                 provider=provider,
                 api_key=api_key,
-                model=os.getenv(base + "MODEL") or _get_default_model_for_provider(provider),
+                model=os.getenv(base + "MODEL") or get_default_model_for_provider(provider),
                 base_url=os.getenv(base + "BASE_URL") or None,
                 reasoning_effort=os.getenv(base + "REASONING_EFFORT") or None,
                 extra_body=json.loads(os.getenv(base + "EXTRA_BODY", "null")),
@@ -2805,6 +3174,10 @@ class HindsightConfig:
     bm25_max_query_terms: int = DEFAULT_BM25_MAX_QUERY_TERMS
     bm25_selective_terms: bool = DEFAULT_BM25_SELECTIVE_TERMS
 
+    # Static registry plus bank-selectable identifier. Route secrets remain in the registry.
+    inference_profile: str | None = None
+    inference_profiles: Mapping[str, InferenceProfile] = field(default_factory=lambda: MappingProxyType({}))
+
     # Webhook SSRF hardening (static, server-level only — deliberately NOT
     # per-bank configurable: a tenant must not be able to re-open the private
     # ranges or turn response-body exfiltration back on for itself).
@@ -2846,6 +3219,8 @@ class HindsightConfig:
         "consolidation_llm_members",
         # Reranker failover chain — members embed api_keys and base_urls
         "reranker_members",
+        # Named profile routes contain resolved API keys and private endpoints.
+        "inference_profiles",
         # Base URLs (could expose infrastructure)
         "llm_base_url",
         "retain_llm_base_url",
@@ -2881,6 +3256,8 @@ class HindsightConfig:
     # These fields are manually tagged as safe to expose and modify.
     # Excludes credentials, infrastructure config, provider/model selection, and performance tuning.
     _CONFIGURABLE_FIELDS = {
+        # Selects one server-owned inference profile; route contents remain static.
+        "inference_profile",
         # MCP tool access control
         "mcp_enabled_tools",
         # Audit logging on/off, per bank. The actions allowlist and retention
@@ -3078,6 +3455,11 @@ class HindsightConfig:
 
     def validate(self) -> None:
         """Validate configuration values and raise errors for invalid combinations."""
+        validate_inference_profile_selector(
+            self.inference_profile,
+            self.inference_profiles,
+            source=ENV_INFERENCE_PROFILE,
+        )
         # Validate vector_extension
         validate_extension(self.vector_extension)
 
@@ -3157,8 +3539,8 @@ class HindsightConfig:
         # Validate gemini_service_tier
         self.llm_gemini_service_tier = parse_gemini_service_tier(self.llm_gemini_service_tier)
 
-        # When LLM provider is "none", force chunks-only mode and disable LLM-dependent features
-        if self.llm_provider == "none":
+        selected_profile = self.inference_profiles.get(self.inference_profile or "")
+        if selected_profile is None and self.llm_provider == "none":
             self.retain_extraction_mode = "chunks"
             self.enable_observations = False
             logger.info(
@@ -3173,16 +3555,26 @@ class HindsightConfig:
             retain_structured_chunk_size_name="HINDSIGHT_API_RETAIN_STRUCTURED_CHUNK_SIZE",
         )
 
-        validate_retain_completion_token_budget(
-            llm_provider=self.llm_provider,
-            retain_max_completion_tokens=self.retain_max_completion_tokens,
-            retain_chunk_size=self.retain_chunk_size,
-            retain_llm_model=self.retain_llm_model,
-            llm_model=self.llm_model,
-            retain_llm_provider=self.retain_llm_provider,
-            retain_max_completion_tokens_name="HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS",
-            retain_chunk_size_name="HINDSIGHT_API_RETAIN_CHUNK_SIZE",
-        )
+        if selected_profile is not None:
+            validate_retain_completion_token_budget(
+                llm_provider=selected_profile.retain.provider,
+                retain_max_completion_tokens=self.retain_max_completion_tokens,
+                retain_chunk_size=self.retain_chunk_size,
+                llm_model=selected_profile.retain.model,
+                retain_max_completion_tokens_name="HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS",
+                retain_chunk_size_name="HINDSIGHT_API_RETAIN_CHUNK_SIZE",
+            )
+        else:
+            validate_retain_completion_token_budget(
+                llm_provider=self.llm_provider,
+                retain_max_completion_tokens=self.retain_max_completion_tokens,
+                retain_chunk_size=self.retain_chunk_size,
+                retain_llm_model=self.retain_llm_model,
+                llm_model=self.llm_model,
+                retain_llm_provider=self.retain_llm_provider,
+                retain_max_completion_tokens_name="HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS",
+                retain_chunk_size_name="HINDSIGHT_API_RETAIN_CHUNK_SIZE",
+            )
 
         # Warn if local ML dependencies are missing when configured.
         # Don't hard-fail here — the actual ImportError fires at model init time
@@ -3243,9 +3635,20 @@ class HindsightConfig:
     @classmethod
     def from_env(cls) -> "HindsightConfig":
         """Create configuration from environment variables."""
-        # Get provider first to determine default model
-        llm_provider = os.getenv(ENV_LLM_PROVIDER, DEFAULT_LLM_PROVIDER)
-        llm_model = os.getenv(ENV_LLM_MODEL) or _get_default_model_for_provider(llm_provider)
+        inference_profiles = load_inference_profiles(os.getenv(ENV_INFERENCE_PROFILES_FILE))
+        inference_profile = validate_inference_profile_selector(
+            os.getenv(ENV_INFERENCE_PROFILE) or None,
+            inference_profiles,
+            source=ENV_INFERENCE_PROFILE,
+        )
+        legacy_routing = inference_profile is None
+        llm_provider = os.getenv(ENV_LLM_PROVIDER, DEFAULT_LLM_PROVIDER) if legacy_routing else "none"
+        llm_model = (
+            os.getenv(ENV_LLM_MODEL) or get_default_model_for_provider(llm_provider) if legacy_routing else "none"
+        )
+        retain_llm_provider = os.getenv(ENV_RETAIN_LLM_PROVIDER) or None if legacy_routing else None
+        reflect_llm_provider = os.getenv(ENV_REFLECT_LLM_PROVIDER) or None if legacy_routing else None
+        consolidation_llm_provider = os.getenv(ENV_CONSOLIDATION_LLM_PROVIDER) or None if legacy_routing else None
 
         # Parse per-type worker slot reservations (floors) once.
         worker_slot_reservations = _parse_worker_slot_reservations()
@@ -3281,26 +3684,46 @@ class HindsightConfig:
             llm_output_language=(os.getenv(ENV_LLM_OUTPUT_LANGUAGE) or None),
             # LLM
             llm_provider=llm_provider,
-            llm_api_key=os.getenv(ENV_LLM_API_KEY),
+            llm_api_key=os.getenv(ENV_LLM_API_KEY) if legacy_routing else None,
             llm_model=llm_model,
-            llm_base_url=os.getenv(ENV_LLM_BASE_URL) or None,
-            llm_max_concurrent=int(os.getenv(ENV_LLM_MAX_CONCURRENT, str(DEFAULT_LLM_MAX_CONCURRENT))),
-            llm_max_retries=int(os.getenv(ENV_LLM_MAX_RETRIES, str(DEFAULT_LLM_MAX_RETRIES))),
-            llm_initial_backoff=float(os.getenv(ENV_LLM_INITIAL_BACKOFF, str(DEFAULT_LLM_INITIAL_BACKOFF))),
-            llm_max_backoff=float(os.getenv(ENV_LLM_MAX_BACKOFF, str(DEFAULT_LLM_MAX_BACKOFF))),
-            llm_timeout=float(os.getenv(ENV_LLM_TIMEOUT, str(DEFAULT_LLM_TIMEOUT))),
-            llm_reasoning_effort=os.getenv(ENV_LLM_REASONING_EFFORT) or None,
+            llm_base_url=os.getenv(ENV_LLM_BASE_URL) or None if legacy_routing else None,
+            llm_max_concurrent=(
+                int(os.getenv(ENV_LLM_MAX_CONCURRENT, str(DEFAULT_LLM_MAX_CONCURRENT)))
+                if legacy_routing
+                else DEFAULT_LLM_MAX_CONCURRENT
+            ),
+            llm_max_retries=(
+                int(os.getenv(ENV_LLM_MAX_RETRIES, str(DEFAULT_LLM_MAX_RETRIES)))
+                if legacy_routing
+                else DEFAULT_LLM_MAX_RETRIES
+            ),
+            llm_initial_backoff=(
+                float(os.getenv(ENV_LLM_INITIAL_BACKOFF, str(DEFAULT_LLM_INITIAL_BACKOFF)))
+                if legacy_routing
+                else DEFAULT_LLM_INITIAL_BACKOFF
+            ),
+            llm_max_backoff=(
+                float(os.getenv(ENV_LLM_MAX_BACKOFF, str(DEFAULT_LLM_MAX_BACKOFF)))
+                if legacy_routing
+                else DEFAULT_LLM_MAX_BACKOFF
+            ),
+            llm_timeout=(
+                float(os.getenv(ENV_LLM_TIMEOUT, str(DEFAULT_LLM_TIMEOUT))) if legacy_routing else DEFAULT_LLM_TIMEOUT
+            ),
+            llm_reasoning_effort=os.getenv(ENV_LLM_REASONING_EFFORT) or None if legacy_routing else None,
             llm_groq_service_tier=os.getenv(ENV_LLM_GROQ_SERVICE_TIER, DEFAULT_LLM_GROQ_SERVICE_TIER),
             llm_openai_service_tier=os.getenv(ENV_LLM_OPENAI_SERVICE_TIER, DEFAULT_LLM_OPENAI_SERVICE_TIER),
             llm_bedrock_service_tier=os.getenv(ENV_LLM_BEDROCK_SERVICE_TIER) or None,
             llm_gemini_service_tier=(
                 parse_gemini_service_tier(os.getenv(ENV_LLM_GEMINI_SERVICE_TIER) or DEFAULT_LLM_GEMINI_SERVICE_TIER)
-                if llm_provider.lower() == "gemini"
-                else None
+                if legacy_routing and llm_provider.lower() == "gemini"
+                else DEFAULT_LLM_GEMINI_SERVICE_TIER
             ),
-            llm_extra_body=json.loads(os.getenv(ENV_LLM_EXTRA_BODY, "null")),
-            llm_default_headers=json.loads(os.getenv(ENV_LLM_DEFAULT_HEADERS, "null")),
-            llm_cache_affinity=os.getenv(ENV_LLM_CACHE_AFFINITY, DEFAULT_LLM_CACHE_AFFINITY) or None,
+            llm_extra_body=(json.loads(os.getenv(ENV_LLM_EXTRA_BODY, "null")) if legacy_routing else None),
+            llm_default_headers=(json.loads(os.getenv(ENV_LLM_DEFAULT_HEADERS, "null")) if legacy_routing else None),
+            llm_cache_affinity=(
+                os.getenv(ENV_LLM_CACHE_AFFINITY, DEFAULT_LLM_CACHE_AFFINITY) or None if legacy_routing else None
+            ),
             llm_strict_schema=os.getenv(ENV_LLM_STRICT_SCHEMA, str(DEFAULT_LLM_STRICT_SCHEMA)).lower() in ("true", "1"),
             llm_strict_schema_retain=_resolve_operation_strict_schema(ENV_LLM_STRICT_SCHEMA_RETAIN),
             llm_strict_schema_reflect=_resolve_operation_strict_schema(ENV_LLM_STRICT_SCHEMA_REFLECT),
@@ -3315,9 +3738,13 @@ class HindsightConfig:
             ),
             llm_send_bank_as_user=os.getenv(ENV_LLM_SEND_BANK_AS_USER, str(DEFAULT_LLM_SEND_BANK_AS_USER)).lower()
             in ("true", "1"),
-            llm_ollama_num_ctx=_parse_optional_positive_int(
-                ENV_LLM_OLLAMA_NUM_CTX,
-                os.getenv(ENV_LLM_OLLAMA_NUM_CTX),
+            llm_ollama_num_ctx=(
+                _parse_optional_positive_int(
+                    ENV_LLM_OLLAMA_NUM_CTX,
+                    os.getenv(ENV_LLM_OLLAMA_NUM_CTX),
+                )
+                if legacy_routing
+                else None
             ),
             llm_temperature_verification=_resolve_operation_temperature(
                 ENV_LLM_TEMPERATURE_VERIFICATION, DEFAULT_LLM_TEMPERATURE_VERIFICATION
@@ -3331,7 +3758,9 @@ class HindsightConfig:
             llm_temperature_consolidation=_resolve_operation_temperature(
                 ENV_LLM_TEMPERATURE_CONSOLIDATION, DEFAULT_LLM_TEMPERATURE_CONSOLIDATION
             ),
-            llm_litellmrouter_config=_parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG),
+            llm_litellmrouter_config=(
+                _parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG) if legacy_routing else None
+            ),
             # Vertex AI
             llm_vertexai_project_id=os.getenv(ENV_LLM_VERTEXAI_PROJECT_ID) or DEFAULT_LLM_VERTEXAI_PROJECT_ID,
             llm_vertexai_region=os.getenv(ENV_LLM_VERTEXAI_REGION, DEFAULT_LLM_VERTEXAI_REGION),
@@ -3354,102 +3783,130 @@ class HindsightConfig:
             in ("true", "1"),
             llamacpp_extra_args=os.getenv(ENV_LLAMACPP_EXTRA_ARGS) or DEFAULT_LLAMACPP_EXTRA_ARGS,
             # Per-operation LLM config (None = use default)
-            retain_llm_provider=os.getenv(ENV_RETAIN_LLM_PROVIDER) or None,
-            retain_llm_api_key=os.getenv(ENV_RETAIN_LLM_API_KEY) or None,
-            retain_llm_model=os.getenv(ENV_RETAIN_LLM_MODEL)
-            or (
-                _get_default_model_for_provider(os.getenv(ENV_RETAIN_LLM_PROVIDER))
-                if os.getenv(ENV_RETAIN_LLM_PROVIDER)
+            retain_llm_provider=retain_llm_provider,
+            retain_llm_api_key=os.getenv(ENV_RETAIN_LLM_API_KEY) or None if legacy_routing else None,
+            retain_llm_model=(
+                os.getenv(ENV_RETAIN_LLM_MODEL)
+                or (get_default_model_for_provider(retain_llm_provider) if retain_llm_provider else None)
+                if legacy_routing
                 else None
             ),
-            retain_llm_base_url=os.getenv(ENV_RETAIN_LLM_BASE_URL) or None,
+            retain_llm_base_url=os.getenv(ENV_RETAIN_LLM_BASE_URL) or None if legacy_routing else None,
             fireworks_account_id=os.getenv(ENV_FIREWORKS_ACCOUNT_ID) or None,
             fireworks_batch_base_url=os.getenv(ENV_FIREWORKS_BATCH_BASE_URL) or DEFAULT_FIREWORKS_BATCH_BASE_URL,
             fireworks_batch_max_wait_seconds=int(
                 os.getenv(ENV_FIREWORKS_BATCH_MAX_WAIT_SECONDS, str(DEFAULT_FIREWORKS_BATCH_MAX_WAIT_SECONDS))
             ),
-            retain_llm_max_concurrent=int(os.getenv(ENV_RETAIN_LLM_MAX_CONCURRENT))
-            if os.getenv(ENV_RETAIN_LLM_MAX_CONCURRENT)
-            else None,
-            retain_llm_max_retries=int(os.getenv(ENV_RETAIN_LLM_MAX_RETRIES))
-            if os.getenv(ENV_RETAIN_LLM_MAX_RETRIES)
-            else None,
-            retain_llm_initial_backoff=float(os.getenv(ENV_RETAIN_LLM_INITIAL_BACKOFF))
-            if os.getenv(ENV_RETAIN_LLM_INITIAL_BACKOFF)
-            else None,
-            retain_llm_max_backoff=float(os.getenv(ENV_RETAIN_LLM_MAX_BACKOFF))
-            if os.getenv(ENV_RETAIN_LLM_MAX_BACKOFF)
-            else None,
-            retain_llm_timeout=float(os.getenv(ENV_RETAIN_LLM_TIMEOUT)) if os.getenv(ENV_RETAIN_LLM_TIMEOUT) else None,
-            retain_llm_litellmrouter_config=_parse_llm_router_config(ENV_RETAIN_LLM_LITELLMROUTER_CONFIG),
-            retain_llm_reasoning_effort=os.getenv(ENV_RETAIN_LLM_REASONING_EFFORT) or None,
-            retain_llm_extra_body=json.loads(os.getenv(ENV_RETAIN_LLM_EXTRA_BODY, "null")),
-            retain_llm_cache_affinity=os.getenv(ENV_RETAIN_LLM_CACHE_AFFINITY) or None,
-            reflect_llm_provider=os.getenv(ENV_REFLECT_LLM_PROVIDER) or None,
-            reflect_llm_api_key=os.getenv(ENV_REFLECT_LLM_API_KEY) or None,
-            reflect_llm_model=os.getenv(ENV_REFLECT_LLM_MODEL)
-            or (
-                _get_default_model_for_provider(os.getenv(ENV_REFLECT_LLM_PROVIDER))
-                if os.getenv(ENV_REFLECT_LLM_PROVIDER)
+            retain_llm_max_concurrent=(
+                _parse_optional_int(os.getenv(ENV_RETAIN_LLM_MAX_CONCURRENT)) if legacy_routing else None
+            ),
+            retain_llm_max_retries=(
+                _parse_optional_int(os.getenv(ENV_RETAIN_LLM_MAX_RETRIES)) if legacy_routing else None
+            ),
+            retain_llm_initial_backoff=(
+                _parse_optional_float(os.getenv(ENV_RETAIN_LLM_INITIAL_BACKOFF)) if legacy_routing else None
+            ),
+            retain_llm_max_backoff=(
+                _parse_optional_float(os.getenv(ENV_RETAIN_LLM_MAX_BACKOFF)) if legacy_routing else None
+            ),
+            retain_llm_timeout=(_parse_optional_float(os.getenv(ENV_RETAIN_LLM_TIMEOUT)) if legacy_routing else None),
+            retain_llm_litellmrouter_config=(
+                _parse_llm_router_config(ENV_RETAIN_LLM_LITELLMROUTER_CONFIG) if legacy_routing else None
+            ),
+            retain_llm_reasoning_effort=(
+                os.getenv(ENV_RETAIN_LLM_REASONING_EFFORT) or None if legacy_routing else None
+            ),
+            retain_llm_extra_body=(
+                json.loads(os.getenv(ENV_RETAIN_LLM_EXTRA_BODY, "null")) if legacy_routing else None
+            ),
+            retain_llm_cache_affinity=(os.getenv(ENV_RETAIN_LLM_CACHE_AFFINITY) or None if legacy_routing else None),
+            reflect_llm_provider=reflect_llm_provider,
+            reflect_llm_api_key=os.getenv(ENV_REFLECT_LLM_API_KEY) or None if legacy_routing else None,
+            reflect_llm_model=(
+                os.getenv(ENV_REFLECT_LLM_MODEL)
+                or (get_default_model_for_provider(reflect_llm_provider) if reflect_llm_provider else None)
+                if legacy_routing
                 else None
             ),
-            reflect_llm_base_url=os.getenv(ENV_REFLECT_LLM_BASE_URL) or None,
-            reflect_llm_max_concurrent=int(os.getenv(ENV_REFLECT_LLM_MAX_CONCURRENT))
-            if os.getenv(ENV_REFLECT_LLM_MAX_CONCURRENT)
-            else None,
-            reflect_llm_max_retries=int(os.getenv(ENV_REFLECT_LLM_MAX_RETRIES))
-            if os.getenv(ENV_REFLECT_LLM_MAX_RETRIES)
-            else None,
-            reflect_llm_initial_backoff=float(os.getenv(ENV_REFLECT_LLM_INITIAL_BACKOFF))
-            if os.getenv(ENV_REFLECT_LLM_INITIAL_BACKOFF)
-            else None,
-            reflect_llm_max_backoff=float(os.getenv(ENV_REFLECT_LLM_MAX_BACKOFF))
-            if os.getenv(ENV_REFLECT_LLM_MAX_BACKOFF)
-            else None,
-            reflect_llm_timeout=float(os.getenv(ENV_REFLECT_LLM_TIMEOUT))
-            if os.getenv(ENV_REFLECT_LLM_TIMEOUT)
-            else None,
-            reflect_llm_litellmrouter_config=_parse_llm_router_config(ENV_REFLECT_LLM_LITELLMROUTER_CONFIG),
-            reflect_llm_reasoning_effort=os.getenv(ENV_REFLECT_LLM_REASONING_EFFORT) or None,
-            reflect_llm_extra_body=json.loads(os.getenv(ENV_REFLECT_LLM_EXTRA_BODY, "null")),
-            reflect_llm_cache_affinity=os.getenv(ENV_REFLECT_LLM_CACHE_AFFINITY) or None,
-            consolidation_llm_provider=os.getenv(ENV_CONSOLIDATION_LLM_PROVIDER) or None,
-            consolidation_llm_api_key=os.getenv(ENV_CONSOLIDATION_LLM_API_KEY) or None,
-            consolidation_llm_model=os.getenv(ENV_CONSOLIDATION_LLM_MODEL)
-            or (
-                _get_default_model_for_provider(os.getenv(ENV_CONSOLIDATION_LLM_PROVIDER))
-                if os.getenv(ENV_CONSOLIDATION_LLM_PROVIDER)
+            reflect_llm_base_url=os.getenv(ENV_REFLECT_LLM_BASE_URL) or None if legacy_routing else None,
+            reflect_llm_max_concurrent=(
+                _parse_optional_int(os.getenv(ENV_REFLECT_LLM_MAX_CONCURRENT)) if legacy_routing else None
+            ),
+            reflect_llm_max_retries=(
+                _parse_optional_int(os.getenv(ENV_REFLECT_LLM_MAX_RETRIES)) if legacy_routing else None
+            ),
+            reflect_llm_initial_backoff=(
+                _parse_optional_float(os.getenv(ENV_REFLECT_LLM_INITIAL_BACKOFF)) if legacy_routing else None
+            ),
+            reflect_llm_max_backoff=(
+                _parse_optional_float(os.getenv(ENV_REFLECT_LLM_MAX_BACKOFF)) if legacy_routing else None
+            ),
+            reflect_llm_timeout=(_parse_optional_float(os.getenv(ENV_REFLECT_LLM_TIMEOUT)) if legacy_routing else None),
+            reflect_llm_litellmrouter_config=(
+                _parse_llm_router_config(ENV_REFLECT_LLM_LITELLMROUTER_CONFIG) if legacy_routing else None
+            ),
+            reflect_llm_reasoning_effort=(
+                os.getenv(ENV_REFLECT_LLM_REASONING_EFFORT) or None if legacy_routing else None
+            ),
+            reflect_llm_extra_body=(
+                json.loads(os.getenv(ENV_REFLECT_LLM_EXTRA_BODY, "null")) if legacy_routing else None
+            ),
+            reflect_llm_cache_affinity=(os.getenv(ENV_REFLECT_LLM_CACHE_AFFINITY) or None if legacy_routing else None),
+            consolidation_llm_provider=consolidation_llm_provider,
+            consolidation_llm_api_key=(os.getenv(ENV_CONSOLIDATION_LLM_API_KEY) or None if legacy_routing else None),
+            consolidation_llm_model=(
+                os.getenv(ENV_CONSOLIDATION_LLM_MODEL)
+                or (get_default_model_for_provider(consolidation_llm_provider) if consolidation_llm_provider else None)
+                if legacy_routing
                 else None
             ),
-            consolidation_llm_base_url=os.getenv(ENV_CONSOLIDATION_LLM_BASE_URL) or None,
-            consolidation_llm_max_concurrent=int(os.getenv(ENV_CONSOLIDATION_LLM_MAX_CONCURRENT))
-            if os.getenv(ENV_CONSOLIDATION_LLM_MAX_CONCURRENT)
-            else None,
-            consolidation_llm_max_retries=int(os.getenv(ENV_CONSOLIDATION_LLM_MAX_RETRIES))
-            if os.getenv(ENV_CONSOLIDATION_LLM_MAX_RETRIES)
-            else None,
-            consolidation_llm_initial_backoff=float(os.getenv(ENV_CONSOLIDATION_LLM_INITIAL_BACKOFF))
-            if os.getenv(ENV_CONSOLIDATION_LLM_INITIAL_BACKOFF)
-            else None,
-            consolidation_llm_max_backoff=float(os.getenv(ENV_CONSOLIDATION_LLM_MAX_BACKOFF))
-            if os.getenv(ENV_CONSOLIDATION_LLM_MAX_BACKOFF)
-            else None,
-            consolidation_llm_timeout=float(os.getenv(ENV_CONSOLIDATION_LLM_TIMEOUT))
-            if os.getenv(ENV_CONSOLIDATION_LLM_TIMEOUT)
-            else None,
-            consolidation_llm_litellmrouter_config=_parse_llm_router_config(ENV_CONSOLIDATION_LLM_LITELLMROUTER_CONFIG),
-            consolidation_llm_reasoning_effort=os.getenv(ENV_CONSOLIDATION_LLM_REASONING_EFFORT) or None,
-            consolidation_llm_extra_body=json.loads(os.getenv(ENV_CONSOLIDATION_LLM_EXTRA_BODY, "null")),
-            consolidation_llm_cache_affinity=os.getenv(ENV_CONSOLIDATION_LLM_CACHE_AFFINITY) or None,
-            # Multi-LLM chains (indexed members + routing strategy)
-            llm_members=_parse_llm_members(""),
-            llm_strategy=_parse_llm_strategy(os.getenv(ENV_LLM_STRATEGY)),
-            retain_llm_members=_parse_llm_members("RETAIN_"),
-            retain_llm_strategy=_parse_llm_strategy(os.getenv(ENV_RETAIN_LLM_STRATEGY)),
-            reflect_llm_members=_parse_llm_members("REFLECT_"),
-            reflect_llm_strategy=_parse_llm_strategy(os.getenv(ENV_REFLECT_LLM_STRATEGY)),
-            consolidation_llm_members=_parse_llm_members("CONSOLIDATION_"),
-            consolidation_llm_strategy=_parse_llm_strategy(os.getenv(ENV_CONSOLIDATION_LLM_STRATEGY)),
+            consolidation_llm_base_url=(os.getenv(ENV_CONSOLIDATION_LLM_BASE_URL) or None if legacy_routing else None),
+            consolidation_llm_max_concurrent=(
+                _parse_optional_int(os.getenv(ENV_CONSOLIDATION_LLM_MAX_CONCURRENT)) if legacy_routing else None
+            ),
+            consolidation_llm_max_retries=(
+                _parse_optional_int(os.getenv(ENV_CONSOLIDATION_LLM_MAX_RETRIES)) if legacy_routing else None
+            ),
+            consolidation_llm_initial_backoff=(
+                _parse_optional_float(os.getenv(ENV_CONSOLIDATION_LLM_INITIAL_BACKOFF)) if legacy_routing else None
+            ),
+            consolidation_llm_max_backoff=(
+                _parse_optional_float(os.getenv(ENV_CONSOLIDATION_LLM_MAX_BACKOFF)) if legacy_routing else None
+            ),
+            consolidation_llm_timeout=(
+                _parse_optional_float(os.getenv(ENV_CONSOLIDATION_LLM_TIMEOUT)) if legacy_routing else None
+            ),
+            consolidation_llm_litellmrouter_config=(
+                _parse_llm_router_config(ENV_CONSOLIDATION_LLM_LITELLMROUTER_CONFIG) if legacy_routing else None
+            ),
+            consolidation_llm_reasoning_effort=(
+                os.getenv(ENV_CONSOLIDATION_LLM_REASONING_EFFORT) or None if legacy_routing else None
+            ),
+            consolidation_llm_extra_body=(
+                json.loads(os.getenv(ENV_CONSOLIDATION_LLM_EXTRA_BODY, "null")) if legacy_routing else None
+            ),
+            consolidation_llm_cache_affinity=(
+                os.getenv(ENV_CONSOLIDATION_LLM_CACHE_AFFINITY) or None if legacy_routing else None
+            ),
+            # A selected named profile owns all four routes and never inherits legacy chains.
+            llm_members=[] if inference_profile is not None else _parse_llm_members(""),
+            llm_strategy=None if inference_profile is not None else _parse_llm_strategy(os.getenv(ENV_LLM_STRATEGY)),
+            retain_llm_members=[] if inference_profile is not None else _parse_llm_members("RETAIN_"),
+            retain_llm_strategy=(
+                None if inference_profile is not None else _parse_llm_strategy(os.getenv(ENV_RETAIN_LLM_STRATEGY))
+            ),
+            reflect_llm_members=[] if inference_profile is not None else _parse_llm_members("REFLECT_"),
+            reflect_llm_strategy=(
+                None if inference_profile is not None else _parse_llm_strategy(os.getenv(ENV_REFLECT_LLM_STRATEGY))
+            ),
+            consolidation_llm_members=([] if inference_profile is not None else _parse_llm_members("CONSOLIDATION_")),
+            consolidation_llm_strategy=(
+                None
+                if inference_profile is not None
+                else _parse_llm_strategy(os.getenv(ENV_CONSOLIDATION_LLM_STRATEGY))
+            ),
+            inference_profile=inference_profile,
+            inference_profiles=inference_profiles,
             # Embeddings
             embeddings_provider=os.getenv(ENV_EMBEDDINGS_PROVIDER, DEFAULT_EMBEDDINGS_PROVIDER),
             # Generic name, falling back to the deprecated LiteLLM-SDK-specific alias.
@@ -4215,17 +4672,7 @@ class HindsightConfig:
         if self.llm_base_url:
             return self.llm_base_url
 
-        provider = self.llm_provider.lower()
-        if provider == "groq":
-            return "https://api.groq.com/openai/v1"
-        elif provider == "ollama":
-            return "http://localhost:11434/v1"
-        elif provider == "ollama-cloud":
-            return "https://ollama.com/v1"
-        elif provider == "lmstudio":
-            return "http://localhost:1234/v1"
-        else:
-            return ""
+        return get_llm_provider_metadata(self.llm_provider).default_base_url
 
     def get_python_log_level(self) -> int:
         """Get the Python logging level from the configured log level string."""
@@ -4274,19 +4721,27 @@ class HindsightConfig:
             logger.info(f"Read database (recall queries only): {mask_network_location(self.read_database_url)}")
         if self.migration_database_url:
             logger.info(f"Migration database: {mask_network_location(self.migration_database_url)}")
-        logger.info(f"LLM: provider={self.llm_provider}, model={self.llm_model}")
-        if self.retain_llm_provider or self.retain_llm_model:
-            retain_provider = self.retain_llm_provider or self.llm_provider
-            retain_model = self.retain_llm_model or self.llm_model
-            logger.info(f"LLM (retain): provider={retain_provider}, model={retain_model}")
-        if self.reflect_llm_provider or self.reflect_llm_model:
-            reflect_provider = self.reflect_llm_provider or self.llm_provider
-            reflect_model = self.reflect_llm_model or self.llm_model
-            logger.info(f"LLM (reflect): provider={reflect_provider}, model={reflect_model}")
-        if self.consolidation_llm_provider or self.consolidation_llm_model:
-            consolidation_provider = self.consolidation_llm_provider or self.llm_provider
-            consolidation_model = self.consolidation_llm_model or self.llm_model
-            logger.info(f"LLM (consolidation): provider={consolidation_provider}, model={consolidation_model}")
+        if self.inference_profile:
+            profile = self.inference_profiles[self.inference_profile]
+            routes = ", ".join(
+                f"{operation}={profile.route(operation).provider}/{profile.route(operation).model}"
+                for operation in INFERENCE_PROFILE_OPERATIONS
+            )
+            logger.info("Inference profile: %s (%s)", self.inference_profile, routes)
+        else:
+            logger.info(f"LLM: provider={self.llm_provider}, model={self.llm_model}")
+            if self.retain_llm_provider or self.retain_llm_model:
+                retain_provider = self.retain_llm_provider or self.llm_provider
+                retain_model = self.retain_llm_model or self.llm_model
+                logger.info(f"LLM (retain): provider={retain_provider}, model={retain_model}")
+            if self.reflect_llm_provider or self.reflect_llm_model:
+                reflect_provider = self.reflect_llm_provider or self.llm_provider
+                reflect_model = self.reflect_llm_model or self.llm_model
+                logger.info(f"LLM (reflect): provider={reflect_provider}, model={reflect_model}")
+            if self.consolidation_llm_provider or self.consolidation_llm_model:
+                consolidation_provider = self.consolidation_llm_provider or self.llm_provider
+                consolidation_model = self.consolidation_llm_model or self.llm_model
+                logger.info(f"LLM (consolidation): provider={consolidation_provider}, model={consolidation_model}")
         logger.info(f"Embeddings: provider={self.embeddings_provider}")
         logger.info(f"Reranker: provider={self.reranker_provider}")
         logger.info(f"Graph retriever: {self.graph_retriever}")

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -17,6 +17,19 @@ from dotenv import find_dotenv, load_dotenv
 
 from ._pg_search import normalize_pg_search_tokenizer
 from ._vector_index import validate_extension
+from .llm_provider_metadata import (
+    DEFAULT_LLM_MODEL as DEFAULT_LLM_MODEL,
+)
+from .llm_provider_metadata import (
+    DEFAULT_LLM_PROVIDER,
+    requires_api_key,
+)
+from .llm_provider_metadata import (
+    PROVIDER_DEFAULT_MODELS as PROVIDER_DEFAULT_MODELS,
+)
+from .llm_provider_metadata import (
+    get_default_model_for_provider as _get_default_model_for_provider,
+)
 from .utils import mask_network_location
 
 logger = logging.getLogger(__name__)
@@ -897,40 +910,6 @@ ENV_DISPOSITION_EMPATHY = "HINDSIGHT_API_DISPOSITION_EMPATHY"
 DEFAULT_DATABASE_BACKEND = "postgresql"
 DEFAULT_DATABASE_URL = "pg0"
 DEFAULT_DATABASE_SCHEMA = "public"
-DEFAULT_LLM_PROVIDER = "openai"
-
-# Provider-specific default models
-PROVIDER_DEFAULT_MODELS = {
-    "openai": "gpt-4o-mini",
-    "openai-responses": "gpt-5.6",
-    "anthropic": "claude-haiku-4-5",
-    "gemini": "gemini-3.5-flash",
-    "groq": "openai/gpt-oss-120b",
-    "minimax": "MiniMax-M3",
-    "deepseek": "deepseek-v4-flash",
-    "zai": "glm-4.5-flash",
-    "opencode-go": "deepseek-v4-flash",
-    "atlas": "deepseek-ai/deepseek-v4-pro",
-    "ollama": "gemma3:12b",
-    "ollama-cloud": "gemma3:12b",
-    "llamacpp": "gemma-4-e2b-it",
-    "lmstudio": "local-model",
-    "vertexai": "google/gemini-3.1-flash-lite",
-    "openai-codex": "gpt-5.4-mini",
-    "claude-code": "claude-sonnet-4-5-20250929",
-    "github-copilot": "gpt-5.6-terra",
-    "mock": "mock-model",
-    "none": "none",
-    "litellm": "gpt-4o-mini",
-    "bedrock": "us.amazon.nova-2-lite-v1:0",
-    "volcano": "doubao-pro-32k",
-    "openrouter": "qwen/qwen3.5-9b",
-    "requesty": "openai/gpt-4o-mini",
-    "fireworks": "accounts/fireworks/models/llama-v3p1-8b-instruct",
-    "nous": "deepseek/deepseek-v4-flash",
-    "xai-oauth": "grok-4.5",
-}
-DEFAULT_LLM_MODEL = "gpt-4o-mini"  # Fallback if provider not in table
 # Built-in llama.cpp defaults
 DEFAULT_LLAMACPP_GPU_LAYERS = -1  # -1 = offload all layers to GPU (Metal/CUDA)
 DEFAULT_LLAMACPP_CONTEXT_SIZE = 8192
@@ -1870,11 +1849,6 @@ def _parse_bank_priority(raw: str) -> dict[str, int]:
     return result
 
 
-def _get_default_model_for_provider(provider: str) -> str:
-    """Get the default model for a given provider."""
-    return PROVIDER_DEFAULT_MODELS.get(provider.lower(), DEFAULT_LLM_MODEL)
-
-
 def _parse_llm_router_config(env_var: str) -> dict | None:
     """
     Parse a LiteLLM Router configuration from a JSON env var.
@@ -1979,8 +1953,6 @@ def _parse_llm_members(prefix: str) -> list[LLMMemberConfig]:
     stops at the first index whose ``_PROVIDER`` is unset (so indices must be
     contiguous from 1). ``MODEL`` defaults to the provider's default model.
     """
-    from .engine.llm_wrapper import requires_api_key
-
     members: list[LLMMemberConfig] = []
     index = 1
     while True:

--- a/hindsight-api-slim/hindsight_api/config_resolver.py
+++ b/hindsight-api-slim/hindsight_api/config_resolver.py
@@ -9,9 +9,11 @@ multiple API servers.
 """
 
 import asyncio
+import copy
 import json
 import logging
-from dataclasses import asdict, dataclass, fields, replace
+from collections.abc import Mapping
+from dataclasses import dataclass, fields, replace
 from functools import lru_cache
 from types import UnionType
 from typing import TYPE_CHECKING, Any, Union, get_args, get_origin
@@ -21,10 +23,11 @@ from hindsight_api.config import (
     HindsightConfig,
     _get_raw_config,
     normalize_config_dict,
+    validate_inference_profile_selector,
     validate_retain_chunking_config,
     validate_retain_completion_token_budget,
 )
-from hindsight_api.engine.memory_engine import fq_table
+from hindsight_api.engine.schema import fq_table
 from hindsight_api.extensions.tenant import TenantExtension
 from hindsight_api.models import RequestContext
 
@@ -32,6 +35,25 @@ if TYPE_CHECKING:
     from hindsight_api.engine.db.base import DatabaseBackend
 
 logger = logging.getLogger(__name__)
+
+
+def _config_field_values(config: HindsightConfig) -> dict[str, Any]:
+    """Project dataclass fields without recursively copying static credentials."""
+    return {field.name: getattr(config, field.name) for field in fields(config)}
+
+
+def _safe_config_field_values(
+    config: HindsightConfig | Mapping[str, Any],
+    configurable_fields: set[str],
+    credential_fields: set[str],
+) -> dict[str, Any]:
+    """Copy only API-safe configurable fields."""
+    values = _config_field_values(config) if isinstance(config, HindsightConfig) else config
+    return {
+        key: copy.deepcopy(value)
+        for key, value in values.items()
+        if key in configurable_fields and key not in credential_fields
+    }
 
 
 class BankConfigPersistenceConflictError(ValueError):
@@ -158,22 +180,22 @@ class ConfigResolver:
 
     async def _resolve_parent_config_dict(self, bank_id: str, context: RequestContext | None = None) -> dict[str, Any]:
         """Resolve global + tenant config before bank-level overrides."""
-        config_dict = asdict(self._global_config)
+        config_dict = _config_field_values(self._global_config)
 
         if self.tenant_extension and context:
-            try:
-                tenant_overrides = await self.tenant_extension.get_tenant_config(context)
-                if tenant_overrides:
-                    # Normalize keys and filter to configurable fields only
-                    normalized_tenant = normalize_config_dict(tenant_overrides)
-                    configurable_tenant = {k: v for k, v in normalized_tenant.items() if k in self._configurable_fields}
-                    config_dict.update(configurable_tenant)
-                    logger.debug(
-                        f"Applied tenant config overrides for bank {bank_id}: {list(configurable_tenant.keys())}"
-                    )
-            except Exception as e:
-                logger.warning(f"Failed to load tenant config for bank {bank_id}: {e}")
+            tenant_overrides = await self.tenant_extension.get_tenant_config(context)
+            if tenant_overrides:
+                # Normalize keys and filter to configurable fields only
+                normalized_tenant = normalize_config_dict(tenant_overrides)
+                configurable_tenant = {k: v for k, v in normalized_tenant.items() if k in self._configurable_fields}
+                config_dict.update(configurable_tenant)
+                logger.debug(f"Applied tenant config overrides for bank {bank_id}: {list(configurable_tenant.keys())}")
 
+        validate_inference_profile_selector(
+            config_dict.get("inference_profile"),
+            self._global_config.inference_profiles,
+            source="tenant inference_profile",
+        )
         return config_dict
 
     async def resolve_full_config(self, bank_id: str, context: RequestContext | None = None) -> HindsightConfig:
@@ -202,9 +224,14 @@ class ConfigResolver:
         if bank_overrides:
             config_dict.update(bank_overrides)
             logger.debug(f"Applied bank config overrides for bank {bank_id}: {list(bank_overrides.keys())}")
+        validate_inference_profile_selector(
+            config_dict.get("inference_profile"),
+            self._global_config.inference_profiles,
+            source=f"bank {bank_id!r} inference_profile",
+        )
 
-        # Return full config object (dataclass doesn't have __init__ that accepts kwargs, so we update the object)
-        # Create a new config instance by copying the global config and updating fields
+        # Reconstruct from the shallow projection so static frozen payloads keep
+        # their canonical types and identities.
         resolved_config = HindsightConfig(**config_dict)
         # Multi-LLM chains and the reranker failover chain are static credential fields
         # (never tenant/bank-overridable), but asdict() above flattened their member
@@ -252,45 +279,33 @@ class ConfigResolver:
         Returns:
             Dict of allowed configurable fields only (never includes credentials or static fields)
         """
-        # Resolve full config with all hierarchical overrides
+        # Resolve full config, then copy only the safe projection before permissions.
         resolved_config = await self.resolve_full_config(bank_id, context)
-        config_dict = asdict(resolved_config)
-
-        # SECURITY: drop static/infrastructure + credential fields, then permission-filter.
-        filtered = self._strip_static_and_credential_fields(config_dict)
+        filtered = _safe_config_field_values(
+            resolved_config,
+            self._configurable_fields,
+            self._credential_fields,
+        )
         return await self._apply_permission_filter(filtered, bank_id, context)
-
-    def _strip_static_and_credential_fields(self, config_dict: dict[str, Any]) -> dict[str, Any]:
-        """Keep only configurable, non-credential fields.
-
-        SECURITY: excludes static/infrastructure fields and ALL credential fields
-        (API keys, base URLs, etc.) so a resolved config is safe to return over the API.
-        """
-        return {
-            k: v for k, v in config_dict.items() if k in self._configurable_fields and k not in self._credential_fields
-        }
 
     async def _apply_permission_filter(
         self, filtered: dict[str, Any], bank_id: str, context: RequestContext | None
     ) -> dict[str, Any]:
         """Further restrict already-stripped config to the tenant/bank permission allow-list.
 
-        On extension error, leaves ``filtered`` unchanged (parity with the historical
-        single-bank path: a permissions lookup failure must not leak or drop fields).
+        Extension errors propagate so permission lookup fails closed.
         """
         if not (self.tenant_extension and context):
             return filtered
-        try:
-            allowed_fields = await self.tenant_extension.get_allowed_config_fields(context, bank_id)
-            if allowed_fields is not None:  # None means "allow all"
-                filtered = {k: v for k, v in filtered.items() if k in allowed_fields}
-                logger.debug(
-                    f"Applied permission filter for bank {bank_id}: allowed={len(allowed_fields)} fields, "
-                    f"returned={len(filtered)} fields"
-                )
-        except Exception as e:
-            logger.warning(f"Failed to load permissions for bank {bank_id}: {e}")
-        return filtered
+        allowed_fields = await self.tenant_extension.get_allowed_config_fields(context, bank_id)
+        if allowed_fields is None:  # None means "allow all"
+            return filtered
+        permission_filtered = {k: v for k, v in filtered.items() if k in allowed_fields}
+        logger.debug(
+            f"Applied permission filter for bank {bank_id}: allowed={len(allowed_fields)} fields, "
+            f"returned={len(permission_filtered)} fields"
+        )
+        return permission_filtered
 
     async def get_bank_configs(
         self, bank_ids: list[str], context: RequestContext | None = None
@@ -309,22 +324,38 @@ class ConfigResolver:
             return {}
 
         # Global + tenant base, resolved once (tenant override is per-request, not per-bank).
-        base_dict = asdict(self._global_config)
+        base_dict = _safe_config_field_values(
+            self._global_config,
+            self._configurable_fields,
+            self._credential_fields,
+        )
         if self.tenant_extension and context:
-            try:
-                tenant_overrides = await self.tenant_extension.get_tenant_config(context)
-                if tenant_overrides:
-                    normalized_tenant = normalize_config_dict(tenant_overrides)
-                    base_dict.update({k: v for k, v in normalized_tenant.items() if k in self._configurable_fields})
-            except Exception as e:
-                logger.warning(f"Failed to load tenant config for bulk resolve: {e}")
+            tenant_overrides = await self.tenant_extension.get_tenant_config(context)
+            if tenant_overrides:
+                normalized_tenant = normalize_config_dict(tenant_overrides)
+                base_dict.update(
+                    {
+                        k: v
+                        for k, v in normalized_tenant.items()
+                        if k in self._configurable_fields and k not in self._credential_fields
+                    }
+                )
 
         # All bank overrides in one query, then merge + strip per bank.
         bank_overrides = await self._load_bank_configs(bank_ids)
-        stripped = {
-            bank_id: self._strip_static_and_credential_fields({**base_dict, **bank_overrides.get(bank_id, {})})
-            for bank_id in bank_ids
-        }
+        stripped: dict[str, dict[str, Any]] = {}
+        for bank_id in bank_ids:
+            merged = {**base_dict, **bank_overrides.get(bank_id, {})}
+            validate_inference_profile_selector(
+                merged.get("inference_profile"),
+                self._global_config.inference_profiles,
+                source=f"bank {bank_id!r} inference_profile",
+            )
+            stripped[bank_id] = _safe_config_field_values(
+                merged,
+                self._configurable_fields,
+                self._credential_fields,
+            )
 
         # Permission filter is per-bank; resolve concurrently when an extension is present.
         if not (self.tenant_extension and context):
@@ -344,19 +375,15 @@ class ConfigResolver:
         Returns:
             Dict of config overrides (only configurable fields, normalized keys)
         """
-        try:
-            async with self._backend.acquire() as conn:
-                row = await conn.fetchrow(
-                    f"""
-                    SELECT config FROM {fq_table("banks")} WHERE bank_id = $1
-                    """,
-                    bank_id,
-                )
-
-                if row and row["config"]:
-                    return self._active_bank_overrides(bank_id, row["config"])
-        except Exception as e:
-            logger.error(f"Failed to load bank config for {bank_id}: {e}")
+        async with self._backend.acquire() as conn:
+            row = await conn.fetchrow(
+                f"""
+                SELECT config FROM {fq_table("banks")} WHERE bank_id = $1
+                """,
+                bank_id,
+            )
+            if row and row["config"]:
+                return self._active_bank_overrides(bank_id, row["config"])
 
         return {}
 
@@ -386,20 +413,17 @@ class ConfigResolver:
         result: dict[str, dict[str, Any]] = {}
         if not bank_ids:
             return result
-        try:
-            async with self._backend.acquire() as conn:
-                rows = await conn.fetch(
-                    f"""
-                    SELECT bank_id, config FROM {fq_table("banks")} WHERE bank_id = ANY($1)
-                    """,
-                    bank_ids,
-                )
-                for row in rows:
-                    overrides = self._active_bank_overrides(row["bank_id"], row["config"])
-                    if overrides:
-                        result[row["bank_id"]] = overrides
-        except Exception as e:
-            logger.error(f"Failed to bulk-load bank configs: {e}")
+        async with self._backend.acquire() as conn:
+            rows = await conn.fetch(
+                f"""
+                SELECT bank_id, config FROM {fq_table("banks")} WHERE bank_id = ANY($1)
+                """,
+                bank_ids,
+            )
+            for row in rows:
+                overrides = self._active_bank_overrides(row["bank_id"], row["config"])
+                if overrides:
+                    result[row["bank_id"]] = overrides
         return result
 
     async def validate_bank_config_updates(
@@ -486,6 +510,12 @@ class ConfigResolver:
             except Exception as e:
                 logger.warning(f"Failed to check permissions for bank {bank_id}: {e}")
                 # Continue without permission check (fail open for backward compatibility)
+        if "inference_profile" in normalized_updates and normalized_updates["inference_profile"] is not None:
+            validate_inference_profile_selector(
+                normalized_updates["inference_profile"],
+                self._global_config.inference_profiles,
+                source=f"bank {bank_id!r} inference_profile",
+            )
 
         # Validate every value against its declared field type before the
         # field-specific checks below, so a wrong-shaped value is reported as such
@@ -500,7 +530,6 @@ class ConfigResolver:
                 parse_entity_labels(normalized_updates["entity_labels"])
             except Exception as e:
                 raise ValueError(f"Invalid entity_labels format: {e}")
-
         # Validate retain_strategies: reject empty string keys
         if "retain_strategies" in normalized_updates and normalized_updates["retain_strategies"]:
             empty_keys = [k for k in normalized_updates["retain_strategies"] if not str(k).strip()]

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -1266,36 +1266,32 @@ async def run_consolidation_job(
     Returns:
         Dict with consolidation results
     """
-    # Resolve bank-specific config with hierarchical overrides
-    config = await memory_engine._config_resolver.resolve_full_config(bank_id, request_context)
-
-    # Build a configured LLM wrapper that applies per-bank settings (e.g. safety settings)
-    # to every call without leaking across operations.
-    llm_config = memory_engine._consolidation_llm_config.with_config(config, bank_id=bank_id, operation="consolidation")
-
-    # Bind the operation trace context for the whole run so the create/update DB
-    # sites (deep inside _process_memory_batch) can accumulate the observations
-    # this consolidation produced and the source memories it consumed onto the
-    # trace — flushed onto every trace row on exit by attach_memory_ids.
-    trace_ctx = trace_context_of(llm_config)
-    trace_token = set_trace_context(trace_ctx) if trace_ctx is not None else None
-    try:
-        return await _run_consolidation_job(
-            memory_engine,
-            bank_id,
-            request_context,
-            config,
-            llm_config,
-            operation_id,
-            observation_scopes,
-            pending_refresh_tags,
+    async with memory_engine._bank_operation_scope(bank_id, request_context):
+        config = await memory_engine._resolve_full_config(bank_id, request_context)
+        llm_config = memory_engine._consolidation_llm_config.with_config(
+            config, bank_id=bank_id, operation="consolidation"
         )
-    finally:
-        if trace_token is not None:
-            reset_trace_context(trace_token)
-            # Fire-and-forget: patched on a background task, off the consolidation
-            # critical path.
-            memory_engine._llm_recorder.attach_memory_ids(trace_ctx)
+        if llm_config.provider == "none":
+            logger.debug(f"Consolidation disabled for bank {bank_id}: selected route is 'none'")
+            return {"skipped": True, "memories_processed": 0, "mental_models_updated": 0}
+
+        trace_ctx = trace_context_of(llm_config)
+        trace_token = set_trace_context(trace_ctx) if trace_ctx is not None else None
+        try:
+            return await _run_consolidation_job(
+                memory_engine,
+                bank_id,
+                request_context,
+                config,
+                llm_config,
+                operation_id,
+                observation_scopes,
+                pending_refresh_tags,
+            )
+        finally:
+            if trace_token is not None:
+                reset_trace_context(trace_token)
+                memory_engine._llm_recorder.attach_memory_ids(trace_ctx)
 
 
 async def _run_consolidation_job(

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -385,11 +385,9 @@ def create_llm_provider(
         vertexai_region: Vertex AI region (for VertexAI provider).
         vertexai_credentials: Vertex AI credentials object (for VertexAI provider).
         timeout: Per-request LLM timeout in seconds (resolved by the caller from the
-            per-operation/global config). Threaded into the providers that honour a
-            configurable request timeout (LiteLLM, LiteLLM Router, OpenAI-compatible,
-            Nous). ``None`` lets each provider fall back to its own default
-            (``HINDSIGHT_API_LLM_TIMEOUT`` / ``DEFAULT_LLM_TIMEOUT`` for those four;
-            Anthropic and Gemini keep their provider-specific defaults).
+            per-operation/global config). Threaded into Anthropic, Gemini/VertexAI,
+            LiteLLM, LiteLLM Router, OpenAI-compatible, Fireworks, and Nous providers.
+            ``None`` lets each provider apply its own default.
 
     Returns:
         LLMInterface implementation for the specified provider.
@@ -483,18 +481,23 @@ def create_llm_provider(
             gemini_service_tier=gemini_service_tier,
             prompt_cache_enabled=prompt_cache_enabled,
             extra_body=extra_body,
+            default_headers=default_headers,
+            timeout=timeout,
         )
 
     elif metadata.factory is LLMProviderFactory.ANTHROPIC:
-        return AnthropicLLM(
-            provider=provider,
-            api_key=api_key,
-            base_url=base_url,
-            model=model,
-            reasoning_effort=reasoning_effort,
-            default_headers=default_headers,
-            extra_body=extra_body,
-        )
+        anthropic_kwargs: dict[str, Any] = {
+            "provider": provider,
+            "api_key": api_key,
+            "base_url": base_url,
+            "model": model,
+            "reasoning_effort": reasoning_effort,
+            "default_headers": default_headers,
+            "extra_body": extra_body,
+        }
+        if timeout is not None:
+            anthropic_kwargs["timeout"] = timeout
+        return AnthropicLLM(**anthropic_kwargs)
 
     elif metadata.factory is LLMProviderFactory.LITELLM:
         return LiteLLMLLM(
@@ -578,6 +581,7 @@ def create_llm_provider(
             extra_body=extra_body,
             default_headers=default_headers,
             cache_affinity=cache_affinity,
+            timeout=timeout,
         )
 
     elif metadata.factory is LLMProviderFactory.NOUS:

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -29,6 +29,7 @@ from ..config import (
     ENV_REFLECT_LLM_MAX_CONCURRENT,
     ENV_RETAIN_LLM_MAX_CONCURRENT,
 )
+from ..llm_provider_metadata import LLMProviderFactory, get_llm_provider_metadata, requires_api_key
 from .cache_affinity import parse_cache_affinity
 from .llm_interface import (
     LLM_TOOL_CHOICE_AUTO,
@@ -308,31 +309,6 @@ def parse_llm_json(raw: str) -> Any:
         return repaired
 
 
-_PROVIDERS_WITHOUT_API_KEY = frozenset(
-    {
-        "ollama",
-        "lmstudio",
-        "llamacpp",
-        "openai-codex",
-        "claude-code",
-        "github-copilot",
-        "mock",
-        "none",
-        "vertexai",
-        "litellm",
-        "litellmrouter",
-        "bedrock",
-        "nous",
-        "xai-oauth",
-    }
-)
-
-
-def requires_api_key(provider: str) -> bool:
-    """Return True if the given provider requires an API key to operate."""
-    return provider.lower() not in _PROVIDERS_WITHOUT_API_KEY
-
-
 def _validate_ollama_num_ctx(value: Any) -> int | None:
     """Validate a native Ollama context-window override."""
     if value is None:
@@ -418,6 +394,9 @@ def create_llm_provider(
     Returns:
         LLMInterface implementation for the specified provider.
     """
+    metadata = get_llm_provider_metadata(provider)
+    provider_lower = metadata.provider_id
+    base_url = base_url or metadata.default_base_url
     ollama_num_ctx = _validate_ollama_num_ctx(ollama_num_ctx)
 
     from .providers import (
@@ -436,7 +415,6 @@ def create_llm_provider(
         OpenAIResponsesLLM,
     )
 
-    provider_lower = provider.lower()
     if provider_lower == "gemini":
         from ..config import parse_gemini_service_tier
 
@@ -444,7 +422,7 @@ def create_llm_provider(
     else:
         gemini_service_tier = None
 
-    if provider_lower == "openai-codex":
+    if metadata.factory is LLMProviderFactory.OPENAI_CODEX:
         return CodexLLM(
             provider=provider,
             api_key=api_key,
@@ -454,7 +432,7 @@ def create_llm_provider(
             extra_body=extra_body,
         )
 
-    elif provider_lower == "claude-code":
+    elif metadata.factory is LLMProviderFactory.CLAUDE_CODE:
         return ClaudeCodeLLM(
             provider=provider,
             api_key=api_key,
@@ -463,7 +441,7 @@ def create_llm_provider(
             reasoning_effort=reasoning_effort,
         )
 
-    elif provider_lower == "github-copilot":
+    elif metadata.factory is LLMProviderFactory.GITHUB_COPILOT:
         return GitHubCopilotLLM(
             provider=provider,
             api_key=api_key,
@@ -473,7 +451,7 @@ def create_llm_provider(
             timeout=timeout,
         )
 
-    elif provider_lower == "mock":
+    elif metadata.factory is LLMProviderFactory.MOCK:
         return MockLLM(
             provider=provider,
             api_key=api_key,
@@ -482,7 +460,7 @@ def create_llm_provider(
             reasoning_effort=reasoning_effort,
         )
 
-    elif provider_lower == "none":
+    elif metadata.factory is LLMProviderFactory.NONE:
         return NoneLLM(
             provider=provider,
             api_key=api_key,
@@ -491,7 +469,7 @@ def create_llm_provider(
             reasoning_effort=reasoning_effort,
         )
 
-    elif provider_lower in ("gemini", "vertexai"):
+    elif metadata.factory is LLMProviderFactory.GEMINI:
         return GeminiLLM(
             provider=provider,
             api_key=api_key,
@@ -507,7 +485,7 @@ def create_llm_provider(
             extra_body=extra_body,
         )
 
-    elif provider_lower == "anthropic":
+    elif metadata.factory is LLMProviderFactory.ANTHROPIC:
         return AnthropicLLM(
             provider=provider,
             api_key=api_key,
@@ -518,7 +496,7 @@ def create_llm_provider(
             extra_body=extra_body,
         )
 
-    elif provider_lower == "litellm":
+    elif metadata.factory is LLMProviderFactory.LITELLM:
         return LiteLLMLLM(
             provider=provider,
             api_key=api_key,
@@ -531,7 +509,7 @@ def create_llm_provider(
             structured_output_forced_tool=structured_output_forced_tool,
         )
 
-    elif provider_lower == "litellmrouter":
+    elif metadata.factory is LLMProviderFactory.LITELLM_ROUTER:
         if not litellmrouter_config:
             raise ValueError(
                 "Provider 'litellmrouter' requires a config object. "
@@ -552,7 +530,7 @@ def create_llm_provider(
             structured_output_forced_tool=structured_output_forced_tool,
         )
 
-    elif provider_lower == "bedrock":
+    elif metadata.factory is LLMProviderFactory.BEDROCK:
         # Bedrock is a first-class alias backed by LiteLLM with auto-prefixed model names
         bedrock_model = model if model.startswith("bedrock/") else f"bedrock/{model}"
         return LiteLLMLLM(
@@ -568,7 +546,7 @@ def create_llm_provider(
             structured_output_forced_tool=structured_output_forced_tool,
         )
 
-    elif provider_lower == "llamacpp":
+    elif metadata.factory is LLMProviderFactory.LLAMACPP:
         from ..config import get_config
 
         config = get_config()
@@ -587,7 +565,7 @@ def create_llm_provider(
             extra_args=config.llamacpp_extra_args,
         )
 
-    elif provider_lower == "fireworks":
+    elif metadata.factory is LLMProviderFactory.FIREWORKS:
         # Fireworks online inference is OpenAI-compatible; FireworksLLM adds the
         # native (non-OpenAI) batch API on top. The existing LiteLLM
         # ``fireworks_ai/...`` online path (provider="litellm") is untouched.
@@ -602,7 +580,7 @@ def create_llm_provider(
             cache_affinity=cache_affinity,
         )
 
-    elif provider_lower == "nous":
+    elif metadata.factory is LLMProviderFactory.NOUS:
         # Nous Portal is OpenAI-compatible on the wire; NousLLM adds rotating
         # inference:invoke JWT auth read natively from ~/.hermes/auth.json
         # (no static api_key, no hermes_cli dependency — same shape as Codex).
@@ -622,7 +600,7 @@ def create_llm_provider(
             timeout=timeout,
         )
 
-    elif provider_lower == "xai-oauth":
+    elif metadata.factory is LLMProviderFactory.XAI_OAUTH:
         # SuperGrok subscription lane: api.x.ai spoken plainly, but the
         # credential is a device-code OAuth grant with proactive/reactive
         # refresh over a shared on-disk store, and xAI's 403 shapes need their
@@ -639,7 +617,7 @@ def create_llm_provider(
             timeout=timeout,
         )
 
-    elif provider_lower == "openai-responses":
+    elif metadata.factory is LLMProviderFactory.OPENAI_RESPONSES:
         # OpenAI Responses API (/v1/responses). Unlike chat/completions, it
         # supports reasoning + function tools together, so reflect's tool loop
         # can run with a real reasoning_effort. See OpenAIResponsesLLM.
@@ -655,21 +633,7 @@ def create_llm_provider(
             timeout=timeout,
         )
 
-    elif provider_lower in (
-        "openai",
-        "groq",
-        "ollama",
-        "ollama-cloud",
-        "lmstudio",
-        "minimax",
-        "deepseek",
-        "volcano",
-        "openrouter",
-        "requesty",
-        "zai",
-        "opencode-go",
-        "atlas",
-    ):
+    elif metadata.factory is LLMProviderFactory.OPENAI_COMPATIBLE:
         return OpenAICompatibleLLM(
             provider=provider,
             api_key=api_key,
@@ -773,16 +737,17 @@ class LLMProvider:
                 instead of ``response_format``, for the LiteLLM-backed providers - from
                 config (``HINDSIGHT_API_LLM_STRUCTURED_OUTPUT_FORCED_TOOL``).
 
-        This constructor uses every argument as passed and does not read global
-        ``HindsightConfig``: resolving the server-level default for a ``None`` argument is the
-        caller's responsibility (see ``MemoryEngine``'s per-op builds, ``_member_to_llm``, and
-        ``LLMProvider.from_env``). Keeping it config-free makes a provider's effective settings a
-        pure function of its arguments — which is what lets each member of a multi-LLM chain be
-        configured independently.
+        This constructor reads no global ``HindsightConfig``. It normalizes the
+        provider ID and empty base URL from canonical static provider metadata,
+        then uses all operation-specific arguments as passed. Resolving server-level
+        defaults for other ``None`` arguments remains the caller's responsibility
+        (see ``MemoryEngine``'s per-op builds, ``_member_to_llm``, and
+        ``LLMProvider.from_env``).
         """
-        self.provider = provider.lower()
+        metadata = get_llm_provider_metadata(provider)
+        self.provider = metadata.provider_id
         self.api_key = api_key
-        self.base_url = base_url
+        self.base_url = base_url or metadata.default_base_url
         self.model = model
         self.reasoning_effort = reasoning_effort
         # Per-request timeout (seconds). Used verbatim — the caller resolves the
@@ -822,68 +787,6 @@ class LLMProvider:
         # it — the setting has no visible effect in the response, so a silent
         # fallback to "none" would be indistinguishable from it working.
         self.cache_affinity = parse_cache_affinity(cache_affinity).value
-
-        # Validate provider
-        valid_providers = [
-            "openai",
-            "openai-responses",
-            "groq",
-            "ollama",
-            "ollama-cloud",
-            "gemini",
-            "anthropic",
-            "lmstudio",
-            "llamacpp",
-            "vertexai",
-            "openai-codex",
-            "claude-code",
-            "github-copilot",
-            "mock",
-            "none",
-            "minimax",
-            "deepseek",
-            "litellm",
-            "litellmrouter",
-            "bedrock",
-            "volcano",
-            "openrouter",
-            "requesty",
-            "zai",
-            "opencode-go",
-            "atlas",
-            "fireworks",
-            "nous",
-            "xai-oauth",
-        ]
-        if self.provider not in valid_providers:
-            raise ValueError(f"Invalid LLM provider: {self.provider}. Must be one of: {', '.join(valid_providers)}")
-
-        # Set default base URLs
-        if not self.base_url:
-            if self.provider == "groq":
-                self.base_url = "https://api.groq.com/openai/v1"
-            elif self.provider == "ollama":
-                self.base_url = "http://localhost:11434/v1"
-            elif self.provider == "ollama-cloud":
-                self.base_url = "https://ollama.com/v1"
-            elif self.provider == "lmstudio":
-                self.base_url = "http://localhost:1234/v1"
-            elif self.provider == "minimax":
-                self.base_url = "https://api.minimax.io/v1"
-            elif self.provider == "deepseek":
-                self.base_url = "https://api.deepseek.com"
-            elif self.provider == "openrouter":
-                self.base_url = "https://openrouter.ai/api/v1"
-            elif self.provider == "requesty":
-                self.base_url = "https://router.requesty.ai/v1"
-            elif self.provider == "zai":
-                self.base_url = "https://api.z.ai/api/coding/paas/v4"
-            elif self.provider == "opencode-go":
-                self.base_url = "https://opencode.ai/zen/go/v1"
-            elif self.provider == "atlas":
-                self.base_url = "https://api.atlascloud.ai/v1"
-            elif self.provider == "nous":
-                self.base_url = "https://inference-api.nousresearch.com/v1"
 
         # Prepare Vertex AI config (if applicable). Values are used as passed; the
         # caller resolves the global-config fallback (MemoryEngine builds /

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -22,9 +22,9 @@ import random
 import sys
 import time
 import uuid
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Iterator
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Iterator, Mapping
 from contextlib import asynccontextmanager, contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Literal, NoReturn, ParamSpec, TypeVar, cast, overload
 
@@ -47,9 +47,12 @@ from ..config import (
     DEFAULT_REFLECT_SOURCE_FACTS_MAX_TOKENS,
     DEFAULT_STORE_DOCUMENT_TEXT,
     ENV_MODEL_INIT_TIMEOUT,
+    INFERENCE_PROFILE_OPERATIONS,
     HindsightConfig,
+    InferenceModelProfile,
     LLMMemberConfig,
     LLMStrategyConfig,
+    StaticConfigProxy,
     get_config,
 )
 from ..tracing import create_operation_span
@@ -94,6 +97,21 @@ _current_schema: contextvars.ContextVar[str | None] = contextvars.ContextVar("cu
 # downstream provider calls can attribute spend per bank — e.g. tagging the OpenAI `user`
 # field for cost gateways. None outside a bank-scoped operation.
 _current_bank_id: contextvars.ContextVar[str | None] = contextvars.ContextVar("current_bank_id", default=None)
+
+
+@dataclass(frozen=True)
+class _BankOperationState:
+    """Resolved routing state owned by one complete engine bank operation."""
+
+    engine: "MemoryEngine"
+    bank_id: str
+    config: HindsightConfig | None
+    request_context: "RequestContext | None"
+
+
+_current_bank_operation: contextvars.ContextVar[_BankOperationState | None] = contextvars.ContextVar(
+    "current_bank_operation", default=None
+)
 
 
 @dataclass
@@ -175,11 +193,11 @@ _R = TypeVar("_R")
 def _bind_bank_id(
     arg: str = "bank_id", key: str | None = None
 ) -> Callable[[Callable[_P, Awaitable[_R]]], Callable[_P, Awaitable[_R]]]:
-    """Bind ``_current_bank_id`` to an argument of the wrapped coroutine for the call's duration.
+    """Bind bank attribution and, for engine methods, resolved inference routing.
 
-    ``arg`` names the parameter carrying the bank id; ``key`` optionally pulls it out of a
-    dict-valued argument (e.g. ``task_dict["bank_id"]``). Token-based set/reset (including on
-    exception) keeps the binding scoped to the call.
+    Free functions retain the historical bank-only behavior. ``MemoryEngine``
+    methods enter the engine-owned operation scope, which resolves the selector
+    once and restores bank/profile state by ContextVar token on every exit path.
     """
 
     def decorate(func: Callable[_P, Awaitable[_R]]) -> Callable[_P, Awaitable[_R]]:
@@ -187,14 +205,33 @@ def _bind_bank_id(
 
         @functools.wraps(func)
         async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
-            value = sig.bind(*args, **kwargs).arguments.get(arg)
-            if key is not None and type(value) is dict:
-                value = value.get(key)
-            token = _current_bank_id.set(value if type(value) is str else None)
+            arguments = sig.bind(*args, **kwargs).arguments
+            value = arguments.get(arg)
+            task_dict = value if key is not None and type(value) is dict else None
+            if task_dict is not None:
+                value = task_dict.get(key)
+            bank_id = value if type(value) is str else None
+            engine = arguments.get("self")
+            operation_scope = getattr(engine, "_bank_operation_scope", None)
+            if operation_scope is not None:
+                request_context = arguments.get("request_context")
+                if task_dict is not None:
+                    from hindsight_api.models import RequestContext
+
+                    request_context = RequestContext(
+                        internal=True,
+                        tenant_id=task_dict.get("_tenant_id"),
+                        api_key_id=task_dict.get("_api_key_id"),
+                        retry_count=task_dict.get("_retry_count", 0),
+                    )
+                async with operation_scope(bank_id, request_context, resolve=False):
+                    return await func(*args, **kwargs)
+
+            bank_token = _current_bank_id.set(bank_id)
             try:
                 return await func(*args, **kwargs)
             finally:
-                _current_bank_id.reset(token)
+                _current_bank_id.reset(bank_token)
 
         return wrapper
 
@@ -606,7 +643,12 @@ class _LLMCallDefaults:
         }
 
 
-def _member_to_llm(member: "LLMMemberConfig", config: HindsightConfig, defaults: _LLMCallDefaults) -> LLMConfig:
+def _member_to_llm(
+    member: "LLMMemberConfig",
+    config: HindsightConfig | StaticConfigProxy,
+    defaults: _LLMCallDefaults,
+    reasoning_effort: str | None = None,
+) -> LLMConfig:
     """Build an LLMProvider from one indexed multi-LLM member.
 
     ``LLMProvider`` uses its arguments verbatim (it no longer reads global config),
@@ -625,9 +667,9 @@ def _member_to_llm(member: "LLMMemberConfig", config: HindsightConfig, defaults:
     return LLMConfig(
         provider=member.provider,
         api_key=member.api_key or "",
-        base_url=member.base_url,
+        base_url=member.base_url or "",
         model=member.model,
-        reasoning_effort=member.reasoning_effort or config.llm_reasoning_effort,
+        reasoning_effort=member.reasoning_effort or reasoning_effort or config.llm_reasoning_effort,
         extra_body=member.extra_body,
         default_headers=member.default_headers or config.llm_default_headers,
         cache_affinity=member.cache_affinity or config.llm_cache_affinity,
@@ -647,7 +689,7 @@ def _member_to_llm(member: "LLMMemberConfig", config: HindsightConfig, defaults:
 
 def _build_llm(
     base: LLMConfig,
-    config: HindsightConfig,
+    config: HindsightConfig | StaticConfigProxy,
     prefix: str,
     defaults: _LLMCallDefaults,
 ) -> "LLMConfig | MultiLLMProvider":
@@ -672,8 +714,53 @@ def _build_llm(
 
     if not strategy or not members:
         return base
-    extra = [_member_to_llm(m, config, defaults) for m in members]
+    extra = [_member_to_llm(m, config, defaults, base.reasoning_effort) for m in members]
     return MultiLLMProvider([base, *extra], strategy)
+
+
+def _mutable_json_copy(value: Any) -> Any:
+    """Copy an explicitly projected immutable JSON payload for a provider client."""
+    if isinstance(value, Mapping):
+        return {key: _mutable_json_copy(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_mutable_json_copy(item) for item in value]
+    return value
+
+
+def _profile_route_to_llm(
+    route: InferenceModelProfile,
+    runtime_config: HindsightConfig,
+) -> LLMConfig:
+    """Construct one named-profile route through the canonical provider implementation."""
+    router_config = route.litellmrouter_config if route.provider == "litellmrouter" else None
+    return LLMConfig(
+        provider=route.provider,
+        api_key=route.api_key or "",
+        base_url=route.base_url or "",
+        model=route.model,
+        reasoning_effort=route.reasoning_effort,
+        extra_body=_mutable_json_copy(route.extra_body),
+        default_headers=_mutable_json_copy(route.default_headers),
+        cache_affinity=runtime_config.llm_cache_affinity,
+        ollama_num_ctx=route.ollama_num_ctx,
+        bedrock_service_tier=route.bedrock_service_tier,
+        structured_output_forced_tool=runtime_config.llm_structured_output_forced_tool,
+        gemini_service_tier=route.gemini_service_tier,
+        groq_service_tier=route.groq_service_tier or runtime_config.llm_groq_service_tier,
+        openai_service_tier=route.openai_service_tier,
+        gemini_safety_settings=runtime_config.llm_gemini_safety_settings,
+        prompt_cache_enabled=runtime_config.llm_prompt_cache_enabled,
+        vertexai_project_id=runtime_config.llm_vertexai_project_id,
+        vertexai_region=runtime_config.llm_vertexai_region,
+        vertexai_service_account_key=runtime_config.llm_vertexai_service_account_key,
+        litellmrouter_config=_mutable_json_copy(router_config),
+        timeout=route.timeout if route.timeout is not None else runtime_config.llm_timeout,
+        max_retries=route.max_retries if route.max_retries is not None else runtime_config.llm_max_retries,
+        initial_backoff=(
+            route.initial_backoff if route.initial_backoff is not None else runtime_config.llm_initial_backoff
+        ),
+        max_backoff=route.max_backoff if route.max_backoff is not None else runtime_config.llm_max_backoff,
+    )
 
 
 async def validate_retain_batch_support(
@@ -1937,16 +2024,16 @@ class MemoryEngine(MemoryEngineInterface):
             skip_llm_verification: Skip LLM connection verification during initialization.
                                   Defaults to HINDSIGHT_API_SKIP_LLM_VERIFICATION env var or False.
         """
+        self._explicit_inference_routes = dict.fromkeys(INFERENCE_PROFILE_OPERATIONS, False)
         # Load config from environment for any missing parameters
         from ..config import _get_raw_config, get_config
 
         config = get_config()
-        # Gemini safety settings are bank-configurable, so the StaticConfigProxy from
-        # get_config() blocks reading them. The server-level default legitimately seeds
-        # each provider at construction (per-bank values are applied per-call via
-        # ConfiguredLLMProvider), so read it from the raw config. The other LLM fields
-        # below are static and safe to read off the proxy.
-        _llm_gemini_safety_settings = _get_raw_config().llm_gemini_safety_settings
+        raw_config = _get_raw_config()
+        # Gemini safety settings and the named-profile selector are bank-configurable,
+        # so the StaticConfigProxy blocks reading them. Their server defaults seed
+        # long-lived providers; ConfigResolver supplies the per-bank selector later.
+        _llm_gemini_safety_settings = raw_config.llm_gemini_safety_settings
 
         # Apply optimization flags from config if not explicitly provided
         self._skip_llm_verification = (
@@ -1957,14 +2044,21 @@ class MemoryEngine(MemoryEngineInterface):
         db_url = db_url or config.database_url
         memory_llm_provider = memory_llm_provider or config.llm_provider
 
-        # Force skip LLM verification when provider is "none" (no LLM to verify)
-        if memory_llm_provider == "none":
+        # There is nothing to verify only when both routing systems are disabled.
+        if memory_llm_provider == "none" and raw_config.inference_profile is None:
             self._skip_llm_verification = True
         memory_llm_api_key = memory_llm_api_key or config.llm_api_key
-        if not memory_llm_api_key and requires_api_key(memory_llm_provider):
+        if not memory_llm_api_key and requires_api_key(memory_llm_provider) and raw_config.inference_profile is None:
             raise ValueError("LLM API key is required. Set HINDSIGHT_API_LLM_API_KEY environment variable.")
+        memory_llm_api_key = memory_llm_api_key or ""
         memory_llm_model = memory_llm_model or config.llm_model
         memory_llm_base_url = memory_llm_base_url or config.get_llm_base_url() or None
+        suppress_legacy_routes = raw_config.inference_profile is not None
+        if suppress_legacy_routes:
+            memory_llm_provider = "none"
+            memory_llm_api_key = ""
+            memory_llm_model = "none"
+            memory_llm_base_url = ""
         # Track pg0 instance (if used)
         self._pg0: EmbeddedPostgres | None = None
 
@@ -2077,29 +2171,30 @@ class MemoryEngine(MemoryEngineInterface):
             vertexai_service_account_key=config.llm_vertexai_service_account_key,
             **default_call_defaults.as_kwargs(),
         )
-        self._llm_config = _build_llm(_default_base_llm, config, "", default_call_defaults)
+        self._legacy_llm_config = (
+            _default_base_llm
+            if suppress_legacy_routes
+            else _build_llm(_default_base_llm, config, "", default_call_defaults)
+        )
 
-        # Store client and model for convenience (deprecated: use _llm_config.call() instead).
-        # Read from the primary member so a multi-LLM chain behaves like the base config here.
-        self._llm_client = _default_base_llm._client
-        self._llm_model = _default_base_llm.model
+        # Deprecated convenience members are rebound after named routes are built.
 
         # Initialize per-operation LLM configs (fall back to default if not specified)
         # Retain LLM config - for fact extraction (benefits from strong structured output)
-        retain_provider = retain_llm_provider or config.retain_llm_provider or memory_llm_provider
-        retain_api_key = retain_llm_api_key or config.retain_llm_api_key or memory_llm_api_key
-        retain_model = retain_llm_model or config.retain_llm_model or memory_llm_model
-        retain_base_url = retain_llm_base_url or config.retain_llm_base_url or memory_llm_base_url
-        # Apply provider-specific base URL defaults for retain
-        if retain_base_url is None:
-            if retain_provider.lower() == "groq":
-                retain_base_url = "https://api.groq.com/openai/v1"
-            elif retain_provider.lower() == "ollama":
-                retain_base_url = "http://localhost:11434/v1"
-            elif retain_provider.lower() == "ollama-cloud":
-                retain_base_url = "https://ollama.com/v1"
-            else:
-                retain_base_url = ""
+        retain_provider = (
+            "none"
+            if suppress_legacy_routes
+            else retain_llm_provider or config.retain_llm_provider or memory_llm_provider
+        )
+        retain_api_key = (
+            "" if suppress_legacy_routes else retain_llm_api_key or config.retain_llm_api_key or memory_llm_api_key
+        )
+        retain_model = (
+            "none" if suppress_legacy_routes else retain_llm_model or config.retain_llm_model or memory_llm_model
+        )
+        retain_base_url = (
+            "" if suppress_legacy_routes else retain_llm_base_url or config.retain_llm_base_url or memory_llm_base_url
+        )
 
         _retain_base_llm = LLMConfig(
             provider=retain_provider,
@@ -2124,23 +2219,27 @@ class MemoryEngine(MemoryEngineInterface):
             vertexai_service_account_key=config.llm_vertexai_service_account_key,
             **retain_call_defaults.as_kwargs(),
         )
-        self._retain_llm_config = _build_llm(_retain_base_llm, config, "retain_", retain_call_defaults)
+        self._legacy_retain_llm_config = (
+            _retain_base_llm
+            if suppress_legacy_routes
+            else _build_llm(_retain_base_llm, config, "retain_", retain_call_defaults)
+        )
 
         # Reflect LLM config - for think/observe operations (can use lighter models)
-        reflect_provider = reflect_llm_provider or config.reflect_llm_provider or memory_llm_provider
-        reflect_api_key = reflect_llm_api_key or config.reflect_llm_api_key or memory_llm_api_key
-        reflect_model = reflect_llm_model or config.reflect_llm_model or memory_llm_model
-        reflect_base_url = reflect_llm_base_url or config.reflect_llm_base_url or memory_llm_base_url
-        # Apply provider-specific base URL defaults for reflect
-        if reflect_base_url is None:
-            if reflect_provider.lower() == "groq":
-                reflect_base_url = "https://api.groq.com/openai/v1"
-            elif reflect_provider.lower() == "ollama":
-                reflect_base_url = "http://localhost:11434/v1"
-            elif reflect_provider.lower() == "ollama-cloud":
-                reflect_base_url = "https://ollama.com/v1"
-            else:
-                reflect_base_url = ""
+        reflect_provider = (
+            "none"
+            if suppress_legacy_routes
+            else reflect_llm_provider or config.reflect_llm_provider or memory_llm_provider
+        )
+        reflect_api_key = (
+            "" if suppress_legacy_routes else reflect_llm_api_key or config.reflect_llm_api_key or memory_llm_api_key
+        )
+        reflect_model = (
+            "none" if suppress_legacy_routes else reflect_llm_model or config.reflect_llm_model or memory_llm_model
+        )
+        reflect_base_url = (
+            "" if suppress_legacy_routes else reflect_llm_base_url or config.reflect_llm_base_url or memory_llm_base_url
+        )
 
         _reflect_base_llm = LLMConfig(
             provider=reflect_provider,
@@ -2165,23 +2264,33 @@ class MemoryEngine(MemoryEngineInterface):
             vertexai_service_account_key=config.llm_vertexai_service_account_key,
             **reflect_call_defaults.as_kwargs(),
         )
-        self._reflect_llm_config = _build_llm(_reflect_base_llm, config, "reflect_", reflect_call_defaults)
+        self._legacy_reflect_llm_config = (
+            _reflect_base_llm
+            if suppress_legacy_routes
+            else _build_llm(_reflect_base_llm, config, "reflect_", reflect_call_defaults)
+        )
 
         # Consolidation LLM config - for mental model consolidation (can use efficient models)
-        consolidation_provider = consolidation_llm_provider or config.consolidation_llm_provider or memory_llm_provider
-        consolidation_api_key = consolidation_llm_api_key or config.consolidation_llm_api_key or memory_llm_api_key
-        consolidation_model = consolidation_llm_model or config.consolidation_llm_model or memory_llm_model
-        consolidation_base_url = consolidation_llm_base_url or config.consolidation_llm_base_url or memory_llm_base_url
-        # Apply provider-specific base URL defaults for consolidation
-        if consolidation_base_url is None:
-            if consolidation_provider.lower() == "groq":
-                consolidation_base_url = "https://api.groq.com/openai/v1"
-            elif consolidation_provider.lower() == "ollama":
-                consolidation_base_url = "http://localhost:11434/v1"
-            elif consolidation_provider.lower() == "ollama-cloud":
-                consolidation_base_url = "https://ollama.com/v1"
-            else:
-                consolidation_base_url = ""
+        consolidation_provider = (
+            "none"
+            if suppress_legacy_routes
+            else consolidation_llm_provider or config.consolidation_llm_provider or memory_llm_provider
+        )
+        consolidation_api_key = (
+            ""
+            if suppress_legacy_routes
+            else consolidation_llm_api_key or config.consolidation_llm_api_key or memory_llm_api_key
+        )
+        consolidation_model = (
+            "none"
+            if suppress_legacy_routes
+            else consolidation_llm_model or config.consolidation_llm_model or memory_llm_model
+        )
+        consolidation_base_url = (
+            ""
+            if suppress_legacy_routes
+            else consolidation_llm_base_url or config.consolidation_llm_base_url or memory_llm_base_url
+        )
 
         _consolidation_base_llm = LLMConfig(
             provider=consolidation_provider,
@@ -2206,9 +2315,27 @@ class MemoryEngine(MemoryEngineInterface):
             vertexai_service_account_key=config.llm_vertexai_service_account_key,
             **consolidation_call_defaults.as_kwargs(),
         )
-        self._consolidation_llm_config = _build_llm(
-            _consolidation_base_llm, config, "consolidation_", consolidation_call_defaults
+        self._legacy_consolidation_llm_config = (
+            _consolidation_base_llm
+            if suppress_legacy_routes
+            else _build_llm(_consolidation_base_llm, config, "consolidation_", consolidation_call_defaults)
         )
+        self._global_inference_profile = raw_config.inference_profile
+        # Eager executable projection of the canonical static registry. The
+        # HindsightConfig profiles remain the only route-definition authority.
+        self._inference_profile_llms = {
+            profile_id: {
+                operation: _profile_route_to_llm(
+                    profile.route(operation),
+                    raw_config,
+                )
+                for operation in INFERENCE_PROFILE_OPERATIONS
+            }
+            for profile_id, profile in raw_config.inference_profiles.items()
+        }
+        selected_default = self._inference_llm("default")
+        self._llm_client = selected_default._client
+        self._llm_model = selected_default.model
 
         # Initialize cross-encoder reranker (cached for performance)
         self._cross_encoder_reranker = CrossEncoderReranker(cross_encoder=cross_encoder)
@@ -2328,6 +2455,162 @@ class MemoryEngine(MemoryEngineInterface):
                 max_entries=config.bank_stats_cache_max_entries,
             )
 
+    @asynccontextmanager
+    async def _bank_operation_scope(
+        self,
+        bank_id: str | None,
+        request_context: "RequestContext | None" = None,
+        *,
+        resolve: bool = True,
+    ) -> AsyncIterator[HindsightConfig | None]:
+        """Own one bank's selector binding for the complete engine operation.
+
+        Decorated public methods enter lazily so authentication remains ahead of
+        tenant/bank config access. Their first ``_resolve_full_config`` call binds
+        the resolved selector into this token-owned scope. Direct callers may use
+        the eager default. Nested calls for the same engine and bank reuse the
+        resolved config, avoiding duplicate queries. Token reset restores caller
+        state after normal return, exceptions, cancellation, and child-task copies.
+        """
+        bank_token = _current_bank_id.set(bank_id)
+        try:
+            existing = _current_bank_operation.get()
+            resolved_config: HindsightConfig | None
+            if (
+                bank_id is not None
+                and existing is not None
+                and existing.engine is self
+                and existing.bank_id == bank_id
+                and existing.config is not None
+            ):
+                resolved_config = existing.config
+            elif resolve:
+                if bank_id is not None:
+                    resolved_config = await self._resolve_full_config(bank_id, request_context)
+                else:
+                    from ..config import _get_raw_config
+
+                    resolved_config = _get_raw_config()
+            else:
+                resolved_config = None
+
+            operation_state = (
+                _BankOperationState(
+                    engine=self,
+                    bank_id=bank_id,
+                    config=resolved_config,
+                    request_context=request_context,
+                )
+                if bank_id is not None
+                else None
+            )
+            operation_token = _current_bank_operation.set(operation_state)
+            try:
+                yield copy.copy(resolved_config) if resolved_config is not None else None
+            finally:
+                _current_bank_operation.reset(operation_token)
+        finally:
+            _current_bank_id.reset(bank_token)
+
+    async def _resolve_full_config(
+        self,
+        bank_id: str,
+        request_context: "RequestContext | None" = None,
+    ) -> HindsightConfig:
+        """Resolve once, then bind the selector into the active operation scope."""
+        operation = _current_bank_operation.get()
+        if (
+            request_context is None
+            and operation is not None
+            and operation.engine is self
+            and operation.bank_id == bank_id
+        ):
+            request_context = operation.request_context
+        if (
+            operation is not None
+            and operation.engine is self
+            and operation.bank_id == bank_id
+            and operation.config is not None
+        ):
+            return copy.copy(operation.config)
+
+        resolved_config = await self._config_resolver.resolve_full_config(
+            bank_id,
+            request_context,
+        )
+
+        if operation is not None and operation.engine is self and operation.bank_id == bank_id:
+            _current_bank_operation.set(replace(operation, config=resolved_config))
+        return copy.copy(resolved_config)
+
+    def _inference_llm(self, operation: str) -> "LLMConfig | MultiLLMProvider":
+        """Resolve the active named profile or an explicitly installed legacy test route."""
+        if not hasattr(self, "_inference_profile_llms"):
+            legacy_attribute = {
+                "default": "_legacy_llm_config",
+                "retain": "_legacy_retain_llm_config",
+                "reflect": "_legacy_reflect_llm_config",
+                "consolidation": "_legacy_consolidation_llm_config",
+            }[operation]
+            return getattr(self, legacy_attribute)
+        operation_state = _current_bank_operation.get()
+        profile_id = (
+            getattr(operation_state.config, "inference_profile", None)
+            if operation_state is not None and operation_state.engine is self and operation_state.config is not None
+            else self._global_inference_profile
+        )
+        if profile_id is not None and not self._explicit_inference_routes[operation]:
+            return self._inference_profile_llms[profile_id][operation]
+        legacy = {
+            "default": self._legacy_llm_config,
+            "retain": self._legacy_retain_llm_config,
+            "reflect": self._legacy_reflect_llm_config,
+            "consolidation": self._legacy_consolidation_llm_config,
+        }[operation]
+        if legacy is None:
+            raise RuntimeError(f"LLM route {operation!r} was not initialized")
+        return legacy
+
+    @property
+    def _llm_config(self) -> "LLMConfig | MultiLLMProvider":
+        return self._inference_llm("default")
+
+    @_llm_config.setter
+    def _llm_config(self, value: "LLMConfig | MultiLLMProvider") -> None:
+        self._legacy_llm_config = value
+        if hasattr(self, "_explicit_inference_routes"):
+            self._explicit_inference_routes["default"] = True
+
+    @property
+    def _retain_llm_config(self) -> "LLMConfig | MultiLLMProvider":
+        return self._inference_llm("retain")
+
+    @_retain_llm_config.setter
+    def _retain_llm_config(self, value: "LLMConfig | MultiLLMProvider") -> None:
+        self._legacy_retain_llm_config = value
+        if hasattr(self, "_explicit_inference_routes"):
+            self._explicit_inference_routes["retain"] = True
+
+    @property
+    def _reflect_llm_config(self) -> "LLMConfig | MultiLLMProvider":
+        return self._inference_llm("reflect")
+
+    @_reflect_llm_config.setter
+    def _reflect_llm_config(self, value: "LLMConfig | MultiLLMProvider | None") -> None:
+        self._legacy_reflect_llm_config = value
+        if hasattr(self, "_explicit_inference_routes"):
+            self._explicit_inference_routes["reflect"] = True
+
+    @property
+    def _consolidation_llm_config(self) -> "LLMConfig | MultiLLMProvider":
+        return self._inference_llm("consolidation")
+
+    @_consolidation_llm_config.setter
+    def _consolidation_llm_config(self, value: "LLMConfig | MultiLLMProvider") -> None:
+        self._legacy_consolidation_llm_config = value
+        if hasattr(self, "_explicit_inference_routes"):
+            self._explicit_inference_routes["consolidation"] = True
+
     @property
     def audit_logger(self) -> AuditLogger:
         """The audit logger for feature usage tracking."""
@@ -2353,7 +2636,7 @@ class MemoryEngine(MemoryEngineInterface):
         # applies the tenant permission filter (get_allowed_config_fields), so an
         # extension that makes audit_log_enabled read-only for a user would strip
         # the field here and silently revert gating to the deployment default.
-        config = await resolver.resolve_full_config(bank_id, context)
+        config = await self._resolve_full_config(bank_id, context)
         return config.audit_log_enabled
 
     @property
@@ -2889,11 +3172,6 @@ class MemoryEngine(MemoryEngineInterface):
         if not bank_id:
             raise ValueError("bank_id is required for consolidation task")
 
-        # Skip consolidation when LLM provider is "none"
-        if self._llm_config.provider == "none":
-            logger.info(f"[CONSOLIDATION] Skipping consolidation for bank {bank_id}: LLM provider is 'none'")
-            return {"memories_processed": 0, "skipped": True}
-
         from hindsight_api.models import RequestContext
 
         from .consolidation import run_consolidation_job
@@ -2906,6 +3184,7 @@ class MemoryEngine(MemoryEngineInterface):
             api_key_id=task_dict.get("_api_key_id"),
             retry_count=task_dict.get("_retry_count", 0),
         )
+        await self._resolve_full_config(bank_id, internal_context)
         result = await run_consolidation_job(
             memory_engine=self,
             bank_id=bank_id,
@@ -4126,6 +4405,37 @@ class MemoryEngine(MemoryEngineInterface):
             # Re-raise to rollback the transaction
             raise
 
+    async def _verify_llm_connections(self) -> None:
+        """Verify every active operation route before accepting work."""
+        if self._skip_llm_verification:
+            return
+
+        configs_to_verify = tuple(
+            (operation, self._inference_llm(operation)) for operation in INFERENCE_PROFILE_OPERATIONS
+        )
+        for config_name, llm_config in configs_to_verify:
+            try:
+                await llm_config.verify_connection()
+            except Exception as exc:
+                logger.warning(
+                    "LLM connection verification failed for '%s' config: %s. "
+                    "Server will start but LLM-dependent operations may fail "
+                    "until the provider is available.",
+                    config_name,
+                    exc,
+                )
+
+        if get_config().retain_batch_enabled:
+            supports_batch = await self._retain_llm_config._provider_impl.supports_batch_api()
+            if not supports_batch:
+                raise RuntimeError(
+                    f"Configuration error: HINDSIGHT_API_RETAIN_BATCH_ENABLED=true "
+                    f"but the retain LLM provider '{self._retain_llm_config.provider}' "
+                    f"does not support the batch API. Either switch to a provider "
+                    f"that supports batch operations (e.g. 'openai', 'groq', 'gemini') or "
+                    f"set HINDSIGHT_API_RETAIN_BATCH_ENABLED=false."
+                )
+
     async def initialize(self):
         """Initialize the connection pool, models, and background workers.
 
@@ -4271,7 +4581,7 @@ class MemoryEngine(MemoryEngineInterface):
 
         # Only verify LLM if not skipping
         if not self._skip_llm_verification:
-            init_tasks.append(verify_llm())
+            init_tasks.append(self._verify_llm_connections())
 
         # Run pg0 and selected model initializations in parallel.
         # Cap the whole thing with a wall-clock timeout so a hung init task
@@ -4689,13 +4999,18 @@ class MemoryEngine(MemoryEngineInterface):
 
         self._initialized = False
 
-        # Clean up LLM providers (e.g. stop llamacpp subprocess)
-        for llm_config in (
-            self._llm_config,
-            self._retain_llm_config,
-            self._reflect_llm_config,
-            self._consolidation_llm_config,
-        ):
+        llm_configs = [
+            self._legacy_llm_config,
+            self._legacy_retain_llm_config,
+            self._legacy_reflect_llm_config,
+            self._legacy_consolidation_llm_config,
+            *(route for profile_routes in self._inference_profile_llms.values() for route in profile_routes.values()),
+        ]
+        cleaned: set[int] = set()
+        for llm_config in llm_configs:
+            if id(llm_config) in cleaned:
+                continue
+            cleaned.add(id(llm_config))
             try:
                 await llm_config.cleanup()
             except Exception as e:
@@ -5667,14 +5982,13 @@ class MemoryEngine(MemoryEngineInterface):
         await self._get_backend()
 
         # Resolve bank-specific config for this operation
-        resolved_config = await self._config_resolver.resolve_full_config(bank_id, request_context)
+        resolved_config = await self._resolve_full_config(bank_id, request_context)
 
-        # Force chunks mode when LLM provider is "none" (no LLM available for fact extraction)
-        if self._llm_config.provider == "none":
+        # Derive disabled behavior from the final bank-selected routes.
+        if self._retain_llm_config.provider == "none":
             resolved_config.retain_extraction_mode = "chunks"
+        if self._consolidation_llm_config.provider == "none":
             resolved_config.enable_observations = False
-
-        # Apply strategy overrides: explicit strategy > bank default strategy
         from hindsight_api.config_resolver import apply_strategy
 
         effective_strategy = strategy or resolved_config.retain_default_strategy
@@ -6009,7 +6323,7 @@ class MemoryEngine(MemoryEngineInterface):
         # Imports insert across many per-document transactions, so the bank is
         # created up front on its own connection rather than coupled to a write.
         await self._ensure_bank_exists(bank_id, request_context)
-        resolved_config = await self._config_resolver.resolve_full_config(bank_id, request_context)
+        resolved_config = await self._resolve_full_config(bank_id, request_context)
         outbox_factory = self._build_retain_outbox_callback_factory(
             bank_id=bank_id, operation_id=None, schema=_current_schema.get()
         )
@@ -8208,7 +8522,7 @@ class MemoryEngine(MemoryEngineInterface):
                 logger.warning(f"Failed to invalidate bank stats cache after document deletion for bank {bank_id}: {e}")
 
         if invalidated_obs > 0:
-            config = await self._config_resolver.resolve_full_config(bank_id, request_context)
+            config = await self._resolve_full_config(bank_id, request_context)
             if config.enable_auto_consolidation:
                 try:
                     await self.submit_async_consolidation(bank_id=bank_id, request_context=request_context)
@@ -8437,7 +8751,7 @@ class MemoryEngine(MemoryEngineInterface):
                 await self._bank_stats_cache.invalidate(get_current_schema(), bank_id)
             except Exception as e:
                 logger.warning(f"Failed to invalidate bank stats cache after document update for bank {bank_id}: {e}")
-            config = await self._config_resolver.resolve_full_config(bank_id, request_context)
+            config = await self._resolve_full_config(bank_id, request_context)
             if config.enable_auto_consolidation:
                 try:
                     await self.submit_async_consolidation(bank_id=bank_id, request_context=request_context)
@@ -8592,7 +8906,7 @@ class MemoryEngine(MemoryEngineInterface):
                 )
 
         if bank_id_for_consolidation:
-            config = await self._config_resolver.resolve_full_config(bank_id_for_consolidation, request_context)
+            config = await self._resolve_full_config(bank_id_for_consolidation, request_context)
             if config.enable_auto_consolidation:
                 try:
                     await self.submit_async_consolidation(
@@ -8793,7 +9107,7 @@ class MemoryEngine(MemoryEngineInterface):
 
         for bank_id in banks_with_invalidated_obs:
             try:
-                config = await self._config_resolver.resolve_full_config(bank_id, request_context)
+                config = await self._resolve_full_config(bank_id, request_context)
                 if config.enable_auto_consolidation:
                     await self.submit_async_consolidation(bank_id=bank_id, request_context=request_context)
             except Exception as e:
@@ -9055,7 +9369,7 @@ class MemoryEngine(MemoryEngineInterface):
         await self._bank_stats_cache.invalidate(get_current_schema(), bank_id)
 
         if invalidated_obs > 0:
-            config = await self._config_resolver.resolve_full_config(bank_id, request_context)
+            config = await self._resolve_full_config(bank_id, request_context)
             if config.enable_auto_consolidation:
                 try:
                     await self.submit_async_consolidation(bank_id=bank_id, request_context=request_context)
@@ -9341,7 +9655,7 @@ class MemoryEngine(MemoryEngineInterface):
                         )
 
         if deleted_count > 0:
-            config = await self._config_resolver.resolve_full_config(bank_id, request_context)
+            config = await self._resolve_full_config(bank_id, request_context)
             if config.enable_auto_consolidation:
                 await self.submit_async_consolidation(bank_id=bank_id, request_context=request_context)
 
@@ -9491,7 +9805,7 @@ class MemoryEngine(MemoryEngineInterface):
         # so corrected entities are matched with the same rules retain uses.
         entity_labels = None
         if new_entities is not None:
-            edit_config = await self._config_resolver.resolve_full_config(bank_id, request_context)
+            edit_config = await self._resolve_full_config(bank_id, request_context)
             entity_labels = getattr(edit_config, "entity_labels", None)
 
         need_consolidation = False
@@ -9900,7 +10214,7 @@ class MemoryEngine(MemoryEngineInterface):
                     logger.warning(f"Failed to submit orphan-entity cleanup after a failed edit in bank {bank_id}: {e}")
 
         if need_consolidation:
-            config = await self._config_resolver.resolve_full_config(bank_id, request_context)
+            config = await self._resolve_full_config(bank_id, request_context)
             if config.enable_auto_consolidation:
                 try:
                     await self.submit_async_consolidation(bank_id=bank_id, request_context=request_context)
@@ -9925,6 +10239,7 @@ class MemoryEngine(MemoryEngineInterface):
 
         return await self.get_memory_unit(bank_id=bank_id, memory_id=memory_id, request_context=request_context)
 
+    @_bind_bank_id()
     async def run_consolidation(
         self,
         bank_id: str,
@@ -9942,6 +10257,7 @@ class MemoryEngine(MemoryEngineInterface):
             Dictionary with consolidation stats
         """
         await self._authenticate_tenant(request_context)
+        await self._resolve_full_config(bank_id, request_context)
         if self._operation_validator:
             from hindsight_api.extensions import BankWriteContext, BankWriteOperation
 
@@ -10320,6 +10636,7 @@ class MemoryEngine(MemoryEngineInterface):
         }
     )
 
+    @_bind_bank_id()
     async def extract_dry_run(
         self,
         bank_id: str,
@@ -10345,8 +10662,11 @@ class MemoryEngine(MemoryEngineInterface):
 
         # Resolve the tenant schema before touching any bank-scoped data (config, bank profile).
         await self._authenticate_tenant(request_context)
-        resolved_config = await self._config_resolver.resolve_full_config(bank_id, request_context)
-        if self._llm_config.provider == "none":
+        resolved_config = await self._resolve_full_config(bank_id, request_context)
+        availability_llm = (
+            self._retain_llm_config if resolved_config.inference_profile is not None else self._llm_config
+        )
+        if availability_llm.provider == "none":
             resolved_config.retain_extraction_mode = "chunks"
 
         for key, value in (overrides or {}).items():
@@ -11860,7 +12180,8 @@ class MemoryEngine(MemoryEngineInterface):
                 await self._validate_operation(self._operation_validator.validate_mental_model_get(get_context))
 
         if mental_model_ids:
-            self._raise_if_mental_model_refresh_unavailable()
+            async with self._bank_operation_scope(bank_id, request_context):
+                self._raise_if_mental_model_refresh_unavailable()
 
         # Create the bank only after every validation succeeds. Applying the default
         # template before installing the scope prevents its operations from
@@ -12162,6 +12483,7 @@ class MemoryEngine(MemoryEngineInterface):
         await bank_utils.set_bank_mission(self._backend, bank_id, mission)
         return {"bank_id": bank_id, "mission": mission}
 
+    @_bind_bank_id()
     async def merge_bank_mission(
         self,
         bank_id: str,
@@ -12190,6 +12512,7 @@ class MemoryEngine(MemoryEngineInterface):
             )
             await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
         await self._get_backend()
+        await self._resolve_full_config(bank_id, request_context)
         return await bank_utils.merge_bank_mission(self._backend, self._reflect_llm_config, bank_id, new_info)
 
     async def list_banks(
@@ -12324,12 +12647,13 @@ class MemoryEngine(MemoryEngineInterface):
         # crash logging, recall's embedder, or the reflect LLM call (see issue #1875).
         query = sanitize_text(query) or ""
         context = sanitize_text(context)
+        # Authenticate tenant and set schema in context (for fq_table()), then bind
+        # the bank-selected inference profile before inspecting or using its route.
+        await self._authenticate_tenant(request_context)
+        resolved_reflect_config = await self._resolve_full_config(bank_id, request_context)
 
-        # Use cached LLM config
         if self._reflect_llm_config is None:
             raise ValueError("Memory LLM API key not set. Set HINDSIGHT_API_LLM_API_KEY environment variable.")
-
-        # Block reflect when the reflect LLM provider is "none"
         if self._reflect_llm_config.provider == "none":
             from .providers.none_llm import LLMNotAvailableError
 
@@ -12337,9 +12661,6 @@ class MemoryEngine(MemoryEngineInterface):
                 "Reflect requires an LLM provider. Current provider is set to 'none'. "
                 "Set HINDSIGHT_API_LLM_PROVIDER to a real provider (e.g., openai, anthropic, gemini)."
             )
-
-        # Authenticate tenant and set schema in context (for fq_table())
-        await self._authenticate_tenant(request_context)
 
         # Cooperative cancellation checkpoint: if the client already disconnected
         # while this request waited to be scheduled, abort before doing any work
@@ -12371,8 +12692,6 @@ class MemoryEngine(MemoryEngineInterface):
         # NOTE: Mental models are NOT pre-loaded to keep the initial prompt small.
         # The agent can call lookup() to list available models if needed.
         # This is critical for banks with many mental models to avoid huge prompts.
-
-        resolved_reflect_config = await self._config_resolver.resolve_full_config(bank_id, request_context)
 
         # Compute max iterations based on budget
         config = get_config()
@@ -13330,6 +13649,7 @@ class MemoryEngine(MemoryEngineInterface):
             status = "auth_failed" if _is_auth_error(e) else "unreachable"
             return _LlmProbeOutcome(ok=False, status=status, latency_ms=(time.monotonic() - start) * 1000)
 
+    @_bind_bank_id()
     async def check_bank_llm(
         self,
         bank_id: str,
@@ -13352,6 +13672,7 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id, operation=BankReadOperation.GET_BANK_STATS, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        await self._resolve_full_config(bank_id, request_context)
 
         per_operation_llm = [
             ("retain", self._retain_llm_config),
@@ -14774,6 +15095,7 @@ class MemoryEngine(MemoryEngineInterface):
             outcome="content_written" if final_content.strip() != current_content else "content_unchanged",
         )
 
+    @_bind_bank_id()
     async def refresh_mental_model(
         self,
         bank_id: str,
@@ -14809,6 +15131,7 @@ class MemoryEngine(MemoryEngineInterface):
                 the same window again.
         """
         await self._authenticate_tenant(request_context)
+        await self._resolve_full_config(bank_id, request_context)
 
         # Get the current mental model
         mental_model = await self.get_mental_model(bank_id, mental_model_id, request_context=request_context)
@@ -18909,6 +19232,7 @@ class MemoryEngine(MemoryEngineInterface):
             # picks it up. Logged loudly so a persistent failure is visible.
             logger.exception(f"Vector index maintenance follow-up submit failed for bank {bank_id}")
 
+    @_bind_bank_id()
     async def submit_async_refresh_mental_model(
         self,
         bank_id: str,
@@ -18953,9 +19277,9 @@ class MemoryEngine(MemoryEngineInterface):
             suppressed, together with ``deduplicated=True``, so the caller can poll
             that one to completion either way.
         """
-        self._raise_if_mental_model_refresh_unavailable()
-
         await self._authenticate_tenant(request_context)
+        await self._resolve_full_config(bank_id, request_context)
+        self._raise_if_mental_model_refresh_unavailable()
 
         # Pre-operation validation (credit check)
         if self._operation_validator:
@@ -19060,7 +19384,8 @@ class MemoryEngine(MemoryEngineInterface):
 
     def _raise_if_mental_model_refresh_unavailable(self) -> None:
         """Reject refresh work before callers make any dependent writes."""
-        if self._llm_config.provider != "none":
+        availability_llm = self._reflect_llm_config
+        if availability_llm.provider != "none":
             return
 
         from .providers.none_llm import LLMNotAvailableError

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -510,10 +510,11 @@ if TYPE_CHECKING:
 
 from enum import Enum
 
+from ..llm_provider_metadata import requires_api_key
 from ..pg0 import EmbeddedPostgres, parse_pg0_url
 from .entity_resolver import EntityResolver
 from .fact_budget import select_facts_within_budget
-from .llm_wrapper import ConfiguredLLMProvider, LLMConfig, requires_api_key, sanitize_llm_output, sanitize_text
+from .llm_wrapper import ConfiguredLLMProvider, LLMConfig, sanitize_llm_output, sanitize_text
 from .mental_model_refresh import (
     MentalModelDeltaOperations,
     MentalModelDryRunRefreshResult,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -1982,17 +1982,6 @@ class MemoryEngine(MemoryEngineInterface):
         else:
             self.db_url = db_url
 
-        # Set default base URL if not provided
-        if memory_llm_base_url is None:
-            if memory_llm_provider.lower() == "groq":
-                memory_llm_base_url = "https://api.groq.com/openai/v1"
-            elif memory_llm_provider.lower() == "ollama":
-                memory_llm_base_url = "http://localhost:11434/v1"
-            elif memory_llm_provider.lower() == "ollama-cloud":
-                memory_llm_base_url = "https://ollama.com/v1"
-            else:
-                memory_llm_base_url = ""
-
         # Database backend and SQL dialect (created during initialize())
         self._database_backend_type = config.database_backend
         self._backend: DatabaseBackend | None = None

--- a/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
@@ -196,6 +196,15 @@ class GeminiLLM(LLMInterface):
         # (env: HINDSIGHT_API_LLM_EXTRA_BODY).
         self._extra_body: dict[str, Any] = kwargs.get("extra_body") or {}
 
+        timeout = kwargs.get("timeout")
+        self._http_options: dict[str, Any] = {}
+        if self.base_url:
+            self._http_options["base_url"] = self.base_url
+        if timeout is not None:
+            self._http_options["timeout"] = round(timeout * 1000)
+        if default_headers := kwargs.get("default_headers"):
+            self._http_options["headers"] = dict(default_headers)
+
         # Context-cache manager. Lazy-initialized on first cache lookup so
         # nothing happens for models/workloads that never reach it. The instance
         # default here is off (a directly-constructed GeminiLLM doesn't cache); the
@@ -214,7 +223,7 @@ class GeminiLLM(LLMInterface):
         if not self.api_key:
             raise ValueError("Gemini provider requires api_key")
 
-        self._client = genai.Client(api_key=self.api_key)
+        self._client = genai.Client(api_key=self.api_key, http_options=self._http_options or None)
         logger.info(f"Gemini API: model={self.model}")
 
     def _apply_service_tier(self, config_kwargs: dict[str, Any]) -> None:
@@ -273,6 +282,8 @@ class GeminiLLM(LLMInterface):
         }
         if credentials is not None:
             client_kwargs["credentials"] = credentials
+        if self._http_options:
+            client_kwargs["http_options"] = self._http_options
 
         self._client = genai.Client(**client_kwargs)
 

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -55,6 +55,7 @@ from hindsight_api.engine.llm_trace import LLMResponseUsage, stash_response_usag
 from hindsight_api.engine.providers.llm_debug import dump_request_on_4xx
 from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
 from hindsight_api.engine.structured_output import strict_json_schema
+from hindsight_api.llm_provider_metadata import OPENAI_COMPATIBLE_PROVIDERS, get_llm_provider_metadata
 from hindsight_api.metrics import get_metrics_collector
 from hindsight_api.worker.stage import set_stage
 
@@ -623,82 +624,30 @@ class OpenAICompatibleLLM(LLMInterface):
         """
         super().__init__(provider, api_key, base_url, model, reasoning_effort, **kwargs)
 
-        # Validate provider
-        valid_providers = [
-            "openai",
-            "groq",
-            "ollama",
-            "ollama-cloud",
-            "lmstudio",
-            "llamacpp",
-            "minimax",
-            "deepseek",
-            "volcano",
-            "openrouter",
-            "requesty",
-            "zai",
-            "opencode-go",
-            "atlas",
-            "fireworks",
-        ]
-        if self.provider not in valid_providers:
-            raise ValueError(f"OpenAICompatibleLLM only supports: {', '.join(valid_providers)}. Got: {self.provider}")
+        try:
+            metadata = get_llm_provider_metadata(self.provider)
+        except ValueError:
+            raise ValueError(
+                f"OpenAICompatibleLLM only supports: {', '.join(OPENAI_COMPATIBLE_PROVIDERS)}. Got: {self.provider}"
+            ) from None
+        if not metadata.openai_compatible:
+            raise ValueError(
+                f"OpenAICompatibleLLM only supports: {', '.join(OPENAI_COMPATIBLE_PROVIDERS)}. Got: {self.provider}"
+            )
 
-        # Set default base URLs
-        if not self.base_url:
-            if self.provider == "groq":
-                self.base_url = "https://api.groq.com/openai/v1"
-            elif self.provider == "ollama":
-                self.base_url = "http://localhost:11434/v1"
-            elif self.provider == "ollama-cloud":
-                self.base_url = "https://ollama.com/v1"
-            elif self.provider == "lmstudio":
-                self.base_url = "http://localhost:1234/v1"
-            elif self.provider == "minimax":
-                self.base_url = "https://api.minimax.io/v1"
-            elif self.provider == "deepseek":
-                self.base_url = "https://api.deepseek.com"
-            elif self.provider == "openrouter":
-                self.base_url = "https://openrouter.ai/api/v1"
-            elif self.provider == "requesty":
-                self.base_url = "https://router.requesty.ai/v1"
-            elif self.provider == "zai":
-                self.base_url = "https://api.z.ai/api/coding/paas/v4"
-            elif self.provider == "opencode-go":
-                self.base_url = "https://opencode.ai/zen/go/v1"
-            elif self.provider == "atlas":
-                self.base_url = "https://api.atlascloud.ai/v1"
-            elif self.provider == "fireworks":
-                # OpenAI-compatible inference host (online path). The batch API
-                # lives on a separate control-plane host — see FireworksLLM.
-                self.base_url = "https://api.fireworks.ai/inference/v1"
+        self.base_url = self.base_url or metadata.default_base_url
 
         # Normalize bare local base URLs (e.g. a user pasting the address shown
         # in the LM Studio UI) so the OpenAI SDK targets the `/v1` routes. See #2922.
         if self.provider in _V1_PATH_LOCAL_PROVIDERS and self.base_url:
             self.base_url = _ensure_v1_base_url(self.base_url)
 
-        # For ollama/lmstudio, use dummy key if not provided
-        if self.provider in ("ollama", "lmstudio") and not self.api_key:
+        # The OpenAI SDK requires a non-empty placeholder even for local providers.
+        if not metadata.requires_api_key and not self.api_key:
             self.api_key = "local"
 
-        # Validate API key for cloud providers
-        if (
-            self.provider
-            in (
-                "openai",
-                "groq",
-                "minimax",
-                "deepseek",
-                "openrouter",
-                "requesty",
-                "zai",
-                "opencode-go",
-                "atlas",
-                "ollama-cloud",
-            )
-            and not self.api_key
-        ):
+        # Validate API keys from the same provider policy as every other constructor.
+        if metadata.requires_api_key and not self.api_key:
             raise ValueError(f"API key is required for {self.provider}")
 
         # Service tier configuration (from config, not env vars)

--- a/hindsight-api-slim/hindsight_api/llm_provider_metadata.py
+++ b/hindsight-api-slim/hindsight_api/llm_provider_metadata.py
@@ -1,0 +1,213 @@
+"""Canonical metadata for every built-in LLM provider.
+
+This module has no engine or configuration dependencies. Configuration, provider
+construction, and direct OpenAI-compatible construction therefore share one
+closed provider vocabulary and one policy table.
+"""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+
+
+class LLMProviderFactory(str, Enum):
+    """Provider implementation selected by ``create_llm_provider``."""
+
+    OPENAI_COMPATIBLE = "openai-compatible"
+    OPENAI_RESPONSES = "openai-responses"
+    ANTHROPIC = "anthropic"
+    GEMINI = "gemini"
+    OPENAI_CODEX = "openai-codex"
+    CLAUDE_CODE = "claude-code"
+    GITHUB_COPILOT = "github-copilot"
+    MOCK = "mock"
+    NONE = "none"
+    LITELLM = "litellm"
+    LITELLM_ROUTER = "litellm-router"
+    BEDROCK = "bedrock"
+    LLAMACPP = "llamacpp"
+    FIREWORKS = "fireworks"
+    NOUS = "nous"
+    XAI_OAUTH = "xai-oauth"
+
+
+_OPENAI_COMPATIBLE_FACTORIES = frozenset(
+    {
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        LLMProviderFactory.LLAMACPP,
+        LLMProviderFactory.FIREWORKS,
+    }
+)
+
+
+@dataclass(frozen=True)
+class LLMProviderMetadata:
+    """Static policy shared by configuration and provider construction."""
+
+    provider_id: str
+    factory: LLMProviderFactory
+    requires_api_key: bool
+    default_model: str
+    default_base_url: str = ""
+
+    @property
+    def openai_compatible(self) -> bool:
+        """Whether ``OpenAICompatibleLLM`` can speak to this provider directly."""
+
+        return self.factory in _OPENAI_COMPATIBLE_FACTORIES
+
+
+_PROVIDER_METADATA = (
+    LLMProviderMetadata("openai", LLMProviderFactory.OPENAI_COMPATIBLE, True, "gpt-4o-mini"),
+    LLMProviderMetadata("openai-responses", LLMProviderFactory.OPENAI_RESPONSES, True, "gpt-5.6"),
+    LLMProviderMetadata("anthropic", LLMProviderFactory.ANTHROPIC, True, "claude-haiku-4-5"),
+    LLMProviderMetadata("gemini", LLMProviderFactory.GEMINI, True, "gemini-3.5-flash"),
+    LLMProviderMetadata(
+        "groq",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        True,
+        "openai/gpt-oss-120b",
+        "https://api.groq.com/openai/v1",
+    ),
+    LLMProviderMetadata(
+        "minimax",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        True,
+        "MiniMax-M3",
+        "https://api.minimax.io/v1",
+    ),
+    LLMProviderMetadata(
+        "deepseek",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        True,
+        "deepseek-v4-flash",
+        "https://api.deepseek.com",
+    ),
+    LLMProviderMetadata(
+        "zai",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        True,
+        "glm-4.5-flash",
+        "https://api.z.ai/api/coding/paas/v4",
+    ),
+    LLMProviderMetadata(
+        "opencode-go",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        True,
+        "deepseek-v4-flash",
+        "https://opencode.ai/zen/go/v1",
+    ),
+    LLMProviderMetadata(
+        "atlas",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        True,
+        "deepseek-ai/deepseek-v4-pro",
+        "https://api.atlascloud.ai/v1",
+    ),
+    LLMProviderMetadata(
+        "ollama",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        False,
+        "gemma3:12b",
+        "http://localhost:11434/v1",
+    ),
+    LLMProviderMetadata(
+        "ollama-cloud",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        True,
+        "gemma3:12b",
+        "https://ollama.com/v1",
+    ),
+    LLMProviderMetadata("llamacpp", LLMProviderFactory.LLAMACPP, False, "gemma-4-e2b-it"),
+    LLMProviderMetadata(
+        "lmstudio",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        False,
+        "local-model",
+        "http://localhost:1234/v1",
+    ),
+    LLMProviderMetadata("vertexai", LLMProviderFactory.GEMINI, False, "google/gemini-3.1-flash-lite"),
+    LLMProviderMetadata(
+        "openai-codex",
+        LLMProviderFactory.OPENAI_CODEX,
+        False,
+        "gpt-5.4-mini",
+        "https://chatgpt.com/backend-api",
+    ),
+    LLMProviderMetadata("claude-code", LLMProviderFactory.CLAUDE_CODE, False, "claude-sonnet-4-5-20250929"),
+    LLMProviderMetadata("github-copilot", LLMProviderFactory.GITHUB_COPILOT, False, "gpt-5.6-terra"),
+    LLMProviderMetadata("mock", LLMProviderFactory.MOCK, False, "mock-model"),
+    LLMProviderMetadata("none", LLMProviderFactory.NONE, False, "none"),
+    LLMProviderMetadata("litellm", LLMProviderFactory.LITELLM, False, "gpt-4o-mini"),
+    LLMProviderMetadata("litellmrouter", LLMProviderFactory.LITELLM_ROUTER, False, "gpt-4o-mini"),
+    LLMProviderMetadata("bedrock", LLMProviderFactory.BEDROCK, False, "us.amazon.nova-2-lite-v1:0"),
+    LLMProviderMetadata("volcano", LLMProviderFactory.OPENAI_COMPATIBLE, True, "doubao-pro-32k"),
+    LLMProviderMetadata(
+        "openrouter",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        True,
+        "qwen/qwen3.5-9b",
+        "https://openrouter.ai/api/v1",
+    ),
+    LLMProviderMetadata(
+        "requesty",
+        LLMProviderFactory.OPENAI_COMPATIBLE,
+        True,
+        "openai/gpt-4o-mini",
+        "https://router.requesty.ai/v1",
+    ),
+    LLMProviderMetadata(
+        "fireworks",
+        LLMProviderFactory.FIREWORKS,
+        True,
+        "accounts/fireworks/models/llama-v3p1-8b-instruct",
+        "https://api.fireworks.ai/inference/v1",
+    ),
+    LLMProviderMetadata(
+        "nous",
+        LLMProviderFactory.NOUS,
+        False,
+        "deepseek/deepseek-v4-flash",
+        "https://inference-api.nousresearch.com/v1",
+    ),
+    LLMProviderMetadata("xai-oauth", LLMProviderFactory.XAI_OAUTH, False, "grok-4.5"),
+)
+
+_PROVIDER_METADATA_BY_ID = {metadata.provider_id: metadata for metadata in _PROVIDER_METADATA}
+if len(_PROVIDER_METADATA_BY_ID) != len(_PROVIDER_METADATA):
+    raise ValueError("Duplicate provider ID in canonical LLM provider metadata")
+
+LLM_PROVIDER_METADATA: Mapping[str, LLMProviderMetadata] = MappingProxyType(_PROVIDER_METADATA_BY_ID)
+SUPPORTED_LLM_PROVIDERS = frozenset(LLM_PROVIDER_METADATA)
+OPENAI_COMPATIBLE_PROVIDERS = tuple(
+    provider_id for provider_id, metadata in LLM_PROVIDER_METADATA.items() if metadata.openai_compatible
+)
+PROVIDER_DEFAULT_MODELS: Mapping[str, str] = MappingProxyType(
+    {provider_id: metadata.default_model for provider_id, metadata in LLM_PROVIDER_METADATA.items()}
+)
+DEFAULT_LLM_PROVIDER = "openai"
+DEFAULT_LLM_MODEL = LLM_PROVIDER_METADATA[DEFAULT_LLM_PROVIDER].default_model
+
+
+def get_llm_provider_metadata(provider: str) -> LLMProviderMetadata:
+    """Return canonical metadata for ``provider`` or reject an unknown ID."""
+
+    provider_id = provider.lower()
+    try:
+        return LLM_PROVIDER_METADATA[provider_id]
+    except KeyError:
+        supported = ", ".join(LLM_PROVIDER_METADATA)
+        raise ValueError(f"Unknown LLM provider {provider_id!r}. Must be one of: {supported}") from None
+
+
+def get_default_model_for_provider(provider: str) -> str:
+    """Return the provider's canonical default model."""
+
+    return get_llm_provider_metadata(provider).default_model
+
+
+def requires_api_key(provider: str) -> bool:
+    """Return whether the provider requires a top-level API key."""
+
+    return get_llm_provider_metadata(provider).requires_api_key

--- a/hindsight-api-slim/hindsight_api/main.py
+++ b/hindsight-api-slim/hindsight_api/main.py
@@ -29,6 +29,7 @@ from .config import (
     ENV_ACCESS_LOG,
     ENV_HOST,
     ENV_WORKERS,
+    INFERENCE_PROFILE_OPERATIONS,
     HindsightConfig,
     _get_raw_config,
     load_dotenv_for_entrypoint,
@@ -87,6 +88,19 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 # Global reference for cleanup
 _memory: "MemoryEngine | None" = None
+
+
+def _startup_llm_identity(config: HindsightConfig) -> tuple[str, str]:
+    """Return a truthful banner identity for the active startup routing mode."""
+    if config.inference_profile is None:
+        return config.llm_provider, config.llm_model
+
+    profile = config.inference_profiles[config.inference_profile]
+    routes = ", ".join(
+        f"{operation}={profile.route(operation).provider}/{profile.route(operation).model}"
+        for operation in INFERENCE_PROFILE_OPERATIONS
+    )
+    return f"profile={config.inference_profile}", routes
 
 
 def _cleanup():
@@ -415,12 +429,14 @@ def main():
     if not is_daemon:
         from .banner import print_startup_info
 
+        startup_llm_provider, startup_llm_model = _startup_llm_identity(config)
+
         print_startup_info(
             host=args.host,
             port=args.port,
             database_url=config.database_url,
-            llm_provider=config.llm_provider,
-            llm_model=config.llm_model,
+            llm_provider=startup_llm_provider,
+            llm_model=startup_llm_model,
             embeddings_provider=config.embeddings_provider,
             reranker_provider=config.reranker_provider,
             mcp_enabled=config.mcp_enabled,

--- a/hindsight-api-slim/tests/test_bank_template_full_roundtrip.py
+++ b/hindsight-api-slim/tests/test_bank_template_full_roundtrip.py
@@ -39,6 +39,8 @@ costs in production.
 
 from __future__ import annotations
 
+import json
+from dataclasses import replace
 from datetime import datetime
 from typing import Any
 
@@ -48,8 +50,7 @@ import pytest_asyncio
 
 from hindsight_api.api import create_app
 from hindsight_api.api.http import BankTemplateConfig
-from hindsight_api.config import HindsightConfig
-
+from hindsight_api.config import INFERENCE_PROFILE_OPERATIONS, HindsightConfig, load_inference_profiles
 
 # One value per BankTemplateConfig field, each chosen to differ visibly from the
 # server default so a value that silently reverts is caught rather than matching
@@ -114,6 +115,7 @@ _SAMPLE_VALUES: dict[str, Any] = {
     "enable_auto_consolidation": False,
     "consolidation_max_memories_per_round": 42,
     "consolidation_llm_parallelism": 3,
+    "inference_profile": "template-profile",
     "recall_include_chunks": True,
     "recall_max_tokens": 9000,
     "recall_chunks_max_tokens": 4500,
@@ -125,12 +127,33 @@ _SAMPLE_VALUES: dict[str, Any] = {
 
 
 @pytest_asyncio.fixture
-async def api_client(memory):
+async def api_client(memory, tmp_path, bank_id):
     """In-process ASGI client — matches the fixture in tests/test_bank_templates.py."""
+    registry_path = tmp_path / "inference-profiles.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "template-profile": {
+                    operation: {"provider": "mock", "model": f"template-{operation}"}
+                    for operation in INFERENCE_PROFILE_OPERATIONS
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    memory._config_resolver._global_config = replace(
+        memory._config_resolver._global_config,
+        inference_profiles=load_inference_profiles(str(registry_path), environment={}),
+    )
     app = create_app(memory, initialize_memory=False)
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        yield client
+        try:
+            yield client
+        finally:
+            for suffix in ("_source", "_clone"):
+                response = await client.delete(f"/v1/default/banks/{bank_id}{suffix}")
+                assert response.status_code in (200, 404), response.text
 
 
 @pytest.fixture

--- a/hindsight-api-slim/tests/test_hierarchical_config.py
+++ b/hindsight-api-slim/tests/test_hierarchical_config.py
@@ -150,9 +150,10 @@ async def test_hierarchical_fields_categorization():
     assert "enable_graph_retrieval" in configurable
     assert "enable_reranking" in configurable
     assert "mental_model_min_refresh_interval_seconds" in configurable
+    assert "inference_profile" in configurable
 
     # Verify count is correct
-    assert len(configurable) == 47
+    assert len(configurable) == 48
 
     # Verify credential fields (NEVER exposed)
     assert "llm_api_key" in credentials

--- a/hindsight-api-slim/tests/test_inference_profiles.py
+++ b/hindsight-api-slim/tests/test_inference_profiles.py
@@ -1,0 +1,1144 @@
+import asyncio
+import json
+import logging
+from dataclasses import FrozenInstanceError
+from unittest.mock import patch
+
+import pytest
+
+from hindsight_api.banner import print_startup_info
+from hindsight_api.config import (
+    DEFAULT_LLM_MAX_RETRIES,
+    DEFAULT_LLM_TIMEOUT,
+    HindsightConfig,
+    clear_config_cache,
+    load_inference_profiles,
+)
+from hindsight_api.config_resolver import ConfigResolver
+from hindsight_api.engine import llm_wrapper
+from hindsight_api.engine.consolidation import consolidator
+from hindsight_api.engine.cross_encoder import CrossEncoderModel
+from hindsight_api.engine.embeddings import Embeddings
+from hindsight_api.engine.memory_engine import MemoryEngine
+from hindsight_api.engine.multi_llm import MultiLLMProvider
+from hindsight_api.llm_provider_metadata import LLM_PROVIDER_METADATA
+from hindsight_api.main import _startup_llm_identity
+from hindsight_api.models import RequestContext
+
+OPERATIONS = ("default", "retain", "consolidation", "reflect")
+
+
+class _DummyEmbeddings(Embeddings):
+    @property
+    def provider_name(self) -> str:
+        return "dummy"
+
+    @property
+    def dimension(self) -> int:
+        return 1
+
+    async def initialize(self) -> None:
+        pass
+
+    def encode(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0] for _ in texts]
+
+
+class _DummyCrossEncoder(CrossEncoderModel):
+    @property
+    def provider_name(self) -> str:
+        return "dummy"
+
+    async def initialize(self) -> None:
+        pass
+
+    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+        return [0.0] * len(pairs)
+
+
+def _make_memory(*, skip_llm_verification: bool = True, **kwargs) -> MemoryEngine:
+    return MemoryEngine(
+        db_url="postgresql://localhost/hindsight-profile-test",
+        embeddings=_DummyEmbeddings(),
+        cross_encoder=_DummyCrossEncoder(),
+        run_migrations=False,
+        skip_llm_verification=skip_llm_verification,
+        **kwargs,
+    )
+
+
+def _profile(model_prefix: str, **route_overrides: object) -> dict[str, dict[str, object]]:
+    return {
+        operation: {
+            "provider": "mock",
+            "model": f"{model_prefix}-{operation}",
+            **route_overrides,
+        }
+        for operation in OPERATIONS
+    }
+
+
+def _write_registry(tmp_path, registry: object):
+    path = tmp_path / "inference-profiles.json"
+    path.write_text(json.dumps(registry), encoding="utf-8")
+    return path
+
+
+class _FakeBankConfigConnection:
+    def __init__(self, backend: "_FakeBankConfigBackend") -> None:
+        self.backend = backend
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def fetchrow(self, query, bank_id):
+        self.backend.fetchrow_count += 1
+        return {"config": dict(self.backend.config_by_bank.get(bank_id, {}))}
+
+    async def fetch(self, query, bank_ids):
+        return [
+            {"bank_id": bank_id, "config": dict(self.backend.config_by_bank.get(bank_id, {}))} for bank_id in bank_ids
+        ]
+
+    async def execute(self, query, updates_json, bank_id):
+        self.backend.config_by_bank.setdefault(bank_id, {}).update(json.loads(updates_json))
+        return "UPDATE 1"
+
+
+class _FakeBankConfigBackend:
+    def __init__(self, config_by_bank: dict[str, dict[str, object]] | None = None) -> None:
+        self.config_by_bank = config_by_bank or {}
+        self.fetchrow_count = 0
+
+    def acquire(self):
+        return _FakeBankConfigConnection(self)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_inference_environment(monkeypatch):
+    for name in (
+        "HINDSIGHT_API_INFERENCE_PROFILES_FILE",
+        "HINDSIGHT_API_INFERENCE_PROFILE",
+        "HINDSIGHT_API_LLM_API_KEY",
+        "HINDSIGHT_API_LLM_STRATEGY",
+        "HINDSIGHT_API_LLM_1_PROVIDER",
+        "HINDSIGHT_API_LLM_1_API_KEY",
+        "HINDSIGHT_API_LLM_1_MODEL",
+        "HINDSIGHT_API_RETAIN_LLM_PROVIDER",
+        "HINDSIGHT_API_RETAIN_LLM_MODEL",
+        "HINDSIGHT_API_REFLECT_LLM_PROVIDER",
+        "HINDSIGHT_API_REFLECT_LLM_MODEL",
+        "HINDSIGHT_API_CONSOLIDATION_LLM_PROVIDER",
+        "HINDSIGHT_API_CONSOLIDATION_LLM_MODEL",
+        "PROFILE_API_KEY",
+        "HINDSIGHT_API_LLM_EXTRA_BODY",
+        "HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG",
+        "HINDSIGHT_API_LLM_MAX_RETRIES",
+        "HINDSIGHT_API_LLM_DEFAULT_HEADERS",
+        "HINDSIGHT_API_LLM_REASONING_EFFORT",
+        "HINDSIGHT_API_LLM_TIMEOUT",
+        "HINDSIGHT_API_RETAIN_LLM_MAX_RETRIES",
+        "HINDSIGHT_API_REFLECT_LLM_EXTRA_BODY",
+        "HINDSIGHT_API_CONSOLIDATION_LLM_LITELLMROUTER_CONFIG",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "mock")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_MODEL", "legacy-default")
+    clear_config_cache()
+    yield
+    clear_config_cache()
+
+
+@pytest.mark.parametrize(
+    ("registry", "match"),
+    [
+        ([], "root must be a JSON object"),
+        ({"Bad-Id": _profile("bad")}, "Invalid inference profile id"),
+        ({"incomplete": {"default": {"provider": "mock", "model": "one"}}}, "missing operations"),
+        (
+            {"unknown-operation": {**_profile("route"), "summarize": {"provider": "mock", "model": "x"}}},
+            "unknown operations",
+        ),
+        (
+            {"unknown-field": {**_profile("route"), "default": {"provider": "mock", "model": "x", "secret": "x"}}},
+            "unknown fields",
+        ),
+        (
+            {"missing-field": {**_profile("route"), "default": {"provider": "mock"}}},
+            "missing required fields",
+        ),
+        (
+            {"bad-provider": {**_profile("route"), "default": {"provider": "invented", "model": "x"}}},
+            "unsupported provider",
+        ),
+        (
+            {"bad-timeout": {**_profile("route"), "default": {"provider": "mock", "model": "x", "timeout": 0}}},
+            "must be positive",
+        ),
+        (
+            {
+                "bad-effort": {
+                    **_profile("route"),
+                    "default": {"provider": "mock", "model": "x", "reasoning_effort": "impossible"},
+                }
+            },
+            "unsupported reasoning_effort",
+        ),
+        (
+            {
+                "bad-tier": {
+                    **_profile("route"),
+                    "default": {"provider": "mock", "model": "x", "openai_service_tier": "flex"},
+                }
+            },
+            "unsupported openai_service_tier",
+        ),
+    ],
+)
+def test_registry_rejects_malformed_profiles(tmp_path, registry, match) -> None:
+    path = _write_registry(tmp_path, registry)
+    with pytest.raises(ValueError, match=match):
+        load_inference_profiles(str(path), environment={})
+
+
+def test_registry_rejects_invalid_json_duplicate_fields_and_nonfinite_numbers(tmp_path) -> None:
+    path = tmp_path / "invalid.json"
+    path.write_text("{not-json", encoding="utf-8")
+    with pytest.raises(ValueError, match="HINDSIGHT_API_INFERENCE_PROFILES_FILE"):
+        load_inference_profiles(str(path), environment={})
+
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text('{"profile": {"default": {}, "default": {}}}', encoding="utf-8")
+    with pytest.raises(ValueError, match="duplicate field"):
+        load_inference_profiles(str(duplicate), environment={})
+
+    for value in (float("nan"), float("inf"), float("-inf")):
+        nonfinite = tmp_path / "nonfinite.json"
+        registry = {"profile": _profile("route")}
+        registry["profile"]["default"]["timeout"] = value
+        nonfinite.write_text(json.dumps(registry), encoding="utf-8")
+        with pytest.raises(ValueError, match="non-finite JSON number"):
+            load_inference_profiles(str(nonfinite), environment={})
+
+    for literal in ("NaN", "Infinity", "-Infinity", "1e400"):
+        nested = tmp_path / "nested-nonfinite.json"
+        registry = {"profile": _profile("route", extra_body={"nested": [{"value": "NONFINITE"}]})}
+        nested.write_text(json.dumps(registry).replace('"NONFINITE"', literal), encoding="utf-8")
+        with pytest.raises(ValueError, match="non-finite JSON number"):
+            load_inference_profiles(str(nested), environment={})
+
+
+def test_registry_rejects_unresolved_credential_environment_name(tmp_path) -> None:
+    registry = {
+        "production": {
+            **_profile("route"),
+            "default": {
+                "provider": "openai",
+                "model": "gpt-profile",
+                "api_key_env": "MISSING_PROFILE_API_KEY",
+            },
+        }
+    }
+    path = _write_registry(tmp_path, registry)
+    with pytest.raises(ValueError, match="unresolved credential environment variable"):
+        load_inference_profiles(str(path), environment={})
+
+
+def test_global_selector_rejects_an_unknown_profile(tmp_path, monkeypatch) -> None:
+    path = _write_registry(tmp_path, {"production": _profile("production")})
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(path))
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILE", "missing")
+
+    with pytest.raises(ValueError, match="Unknown HINDSIGHT_API_INFERENCE_PROFILE selector"):
+        HindsightConfig.from_env()
+
+
+def test_selected_profile_constructs_all_four_operation_routes(tmp_path, monkeypatch) -> None:
+    registry = {
+        "production": {
+            operation: {
+                "provider": "mock",
+                "model": f"profile-{operation}",
+                "reasoning_effort": "high",
+                "timeout": index + 1,
+                "max_retries": index,
+            }
+            for index, operation in enumerate(OPERATIONS)
+        }
+    }
+    path = _write_registry(tmp_path, registry)
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(path))
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILE", "production")
+    clear_config_cache()
+
+    memory = _make_memory()
+
+    for index, operation in enumerate(OPERATIONS):
+        route = memory._inference_llm(operation)
+        assert route.provider == "mock"
+        assert route.model == f"profile-{operation}"
+        assert route.reasoning_effort == "high"
+        assert route.timeout == index + 1
+        assert route.max_retries == index
+
+
+def test_selected_profile_boots_without_any_legacy_llm_identity(tmp_path, monkeypatch) -> None:
+    path = _write_registry(tmp_path, {"profile-only": _profile("profile-only")})
+    for name in (
+        "HINDSIGHT_API_LLM_PROVIDER",
+        "HINDSIGHT_API_LLM_MODEL",
+        "HINDSIGHT_API_LLM_API_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(path))
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILE", "profile-only")
+    clear_config_cache()
+
+    memory = _make_memory()
+
+    assert memory._legacy_llm_config.provider == "none"
+    assert memory._legacy_retain_llm_config.provider == "none"
+    assert memory._legacy_consolidation_llm_config.provider == "none"
+    assert memory._legacy_reflect_llm_config.provider == "none"
+    for operation in OPERATIONS:
+        route = memory._inference_llm(operation)
+        assert route.provider == "mock"
+        assert route.model == f"profile-only-{operation}"
+
+
+@pytest.mark.asyncio
+async def test_selected_profile_startup_verifies_all_four_routes(tmp_path, monkeypatch) -> None:
+    path = _write_registry(tmp_path, {"profile-only": _profile("profile-only")})
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(path))
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILE", "profile-only")
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_BATCH_ENABLED", "false")
+    clear_config_cache()
+
+    memory = _make_memory(skip_llm_verification=False)
+    verified: list[str] = []
+    for operation in OPERATIONS:
+
+        async def verify(selected_operation: str = operation) -> None:
+            verified.append(selected_operation)
+
+        monkeypatch.setattr(memory._inference_llm(operation), "verify_connection", verify)
+
+    await memory._verify_llm_connections()
+
+    assert memory._skip_llm_verification is False
+    assert verified == list(OPERATIONS)
+
+
+@pytest.mark.asyncio
+async def test_bank_selector_overrides_the_global_selector(tmp_path, monkeypatch) -> None:
+    path = _write_registry(
+        tmp_path,
+        {
+            "global": _profile("global"),
+            "bank-route": _profile("bank"),
+        },
+    )
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(path))
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILE", "global")
+    clear_config_cache()
+
+    memory = _make_memory()
+    assert memory._reflect_llm_config.model == "global-reflect"
+
+    backend = _FakeBankConfigBackend({"selected-bank": {"inference_profile": "bank-route"}})
+    resolver = ConfigResolver(backend=backend)
+    resolved = await resolver.resolve_full_config("selected-bank")
+
+    # Config-only reads are pure: they cannot change the engine's ambient route.
+    assert resolved.inference_profile == "bank-route"
+    assert resolved.inference_profiles is resolver._global_config.inference_profiles
+    assert memory._llm_config.model == "global-default"
+    assert memory._retain_llm_config.model == "global-retain"
+    assert memory._consolidation_llm_config.model == "global-consolidation"
+    assert memory._reflect_llm_config.model == "global-reflect"
+
+    memory._config_resolver = resolver
+    async with memory._bank_operation_scope("selected-bank"):
+        assert memory._llm_config.model == "bank-default"
+        assert memory._retain_llm_config.model == "bank-retain"
+        assert memory._consolidation_llm_config.model == "bank-consolidation"
+        assert memory._reflect_llm_config.model == "bank-reflect"
+
+    assert memory._llm_config.model == "global-default"
+
+
+def test_unknown_bound_profile_fails_closed_instead_of_using_the_global_route() -> None:
+    memory = _make_memory()
+    memory._global_inference_profile = "missing-profile"
+
+    with pytest.raises(KeyError, match="missing-profile"):
+        memory._inference_llm("retain")
+
+
+def test_constructor_route_arguments_cannot_override_named_profile(tmp_path, monkeypatch) -> None:
+    profile = _profile(
+        "profile",
+        api_key_env="PROFILE_API_KEY",
+        base_url="https://profile.example/v1",
+    )
+    path = _write_registry(tmp_path, {"production": profile})
+    monkeypatch.setenv("PROFILE_API_KEY", "profile-secret")
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(path))
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILE", "production")
+    clear_config_cache()
+
+    memory = _make_memory(
+        memory_llm_provider="none",
+        memory_llm_api_key="constructor-default-secret",
+        memory_llm_model="constructor-default",
+        memory_llm_base_url="https://constructor-default.example/v1",
+        retain_llm_provider="none",
+        retain_llm_api_key="constructor-retain-secret",
+        retain_llm_model="constructor-retain",
+        retain_llm_base_url="https://constructor-retain.example/v1",
+    )
+
+    for operation in OPERATIONS:
+        route = memory._inference_llm(operation)
+        assert route.provider == "mock"
+        assert route.model == f"profile-{operation}"
+        assert route.api_key == "profile-secret"
+        assert route.base_url == "https://profile.example/v1"
+
+
+def test_legacy_operation_configuration_remains_active_without_a_profile(monkeypatch) -> None:
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_LLM_PROVIDER", "mock")
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_LLM_MODEL", "legacy-retain")
+    clear_config_cache()
+
+    memory = _make_memory()
+
+    assert memory._llm_config.model == "legacy-default"
+    assert memory._retain_llm_config.model == "legacy-retain"
+    assert memory._reflect_llm_config.model == "legacy-default"
+    assert memory._consolidation_llm_config.model == "legacy-default"
+
+
+def test_selected_profile_does_not_inherit_legacy_multi_llm_chain(tmp_path, monkeypatch) -> None:
+    path = _write_registry(tmp_path, {"production": _profile("profile")})
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(path))
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILE", "production")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_1_PROVIDER", "mock")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_1_MODEL", "legacy-fallback")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_STRATEGY", '{"mode": "failover"}')
+    clear_config_cache()
+
+    memory = _make_memory()
+
+    assert memory._legacy_llm_config.provider == "none"
+    for operation in OPERATIONS:
+        assert not isinstance(memory._inference_llm(operation), MultiLLMProvider)
+
+
+def test_selected_profile_ignores_invalid_legacy_route_environment(tmp_path, monkeypatch) -> None:
+    path = _write_registry(tmp_path, {"production": _profile("profile")})
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(path))
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILE", "production")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "invented")
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_LLM_PROVIDER", "invented")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_EXTRA_BODY", "{broken")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG", "{broken")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_MAX_RETRIES", "not-an-integer")
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_LLM_MAX_RETRIES", "not-an-integer")
+    monkeypatch.setenv("HINDSIGHT_API_REFLECT_LLM_EXTRA_BODY", "{broken")
+    monkeypatch.setenv("HINDSIGHT_API_CONSOLIDATION_LLM_LITELLMROUTER_CONFIG", "{broken")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_DEFAULT_HEADERS", '{"X-Legacy": "must-not-leak"}')
+    monkeypatch.setenv("HINDSIGHT_API_LLM_REASONING_EFFORT", "xhigh")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_TIMEOUT", "999")
+    clear_config_cache()
+
+    config = HindsightConfig.from_env()
+
+    assert config.inference_profile == "production"
+    assert config.llm_provider == "none"
+    assert config.retain_llm_provider is None
+
+    memory = _make_memory()
+    for operation in OPERATIONS:
+        route = memory._inference_llm(operation)
+        assert route.default_headers is None
+        assert route.reasoning_effort is None
+        assert route.timeout == DEFAULT_LLM_TIMEOUT
+        assert route.max_retries == DEFAULT_LLM_MAX_RETRIES
+
+
+@pytest.mark.asyncio
+async def test_unknown_bank_profile_is_rejected_on_update_and_resolution(tmp_path, monkeypatch) -> None:
+    path = _write_registry(tmp_path, {"production": _profile("production")})
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(path))
+    clear_config_cache()
+
+    backend = _FakeBankConfigBackend({"stored-bank": {"inference_profile": "missing"}})
+    resolver = ConfigResolver(backend=backend)
+
+    with pytest.raises(ValueError, match="Unknown bank 'stored-bank' inference_profile selector"):
+        await resolver.resolve_full_config("stored-bank")
+    with pytest.raises(ValueError, match="Unknown bank 'updated-bank' inference_profile selector"):
+        await resolver.validate_bank_config_updates("updated-bank", {"inference_profile": "missing"})
+
+
+@pytest.mark.asyncio
+async def test_bank_config_exposes_only_selector_and_never_profile_routes_or_secrets(tmp_path, monkeypatch) -> None:
+    secret = "profile-secret-that-must-not-leak"
+    routes = {
+        operation: {
+            "provider": "openai",
+            "model": f"secret-route-{operation}",
+            "api_key_env": "PROFILE_API_KEY",
+            "base_url": f"https://{operation}.private.example/v1",
+            "default_headers": {"X-Private-Route": operation},
+            "extra_body": {"private_route": operation},
+        }
+        for operation in OPERATIONS
+    }
+    path = _write_registry(tmp_path, {"production": routes})
+    monkeypatch.setenv("PROFILE_API_KEY", secret)
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(path))
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILE", "production")
+    clear_config_cache()
+
+    resolver = ConfigResolver(backend=_FakeBankConfigBackend())
+    bank_config = await resolver.get_bank_config("safe-bank")
+    serialized = json.dumps(bank_config, sort_keys=True)
+
+    assert bank_config["inference_profile"] == "production"
+    assert "inference_profiles" not in bank_config
+    assert secret not in serialized
+    assert "private.example" not in serialized
+    assert "X-Private-Route" not in serialized
+    assert "private_route" not in serialized
+
+    with pytest.raises(ValueError, match="credential fields"):
+        await resolver.validate_bank_config_updates("safe-bank", {"inference_profiles": {}})
+
+
+# Profile route transport
+
+
+def test_openai_constructor_receives_profile_transport_options(monkeypatch) -> None:
+    from hindsight_api.engine.providers import openai_compatible_llm
+
+    class FakeAsyncOpenAI:
+        def __init__(self, **kwargs) -> None:
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(openai_compatible_llm, "AsyncOpenAI", FakeAsyncOpenAI)
+    headers = {"X-Profile-Route": "production"}
+    routed = llm_wrapper.create_llm_provider(
+        provider="openai",
+        api_key="test-key",
+        base_url="",
+        model=LLM_PROVIDER_METADATA["openai"].default_model,
+        reasoning_effort="low",
+        openai_service_tier="flex",
+        default_headers=headers,
+    )
+
+    assert routed._client.kwargs["default_headers"] == headers
+    assert routed.openai_service_tier == "flex"
+
+
+def test_anthropic_constructor_receives_profile_transport_options() -> None:
+    headers = {"X-Profile-Route": "production"}
+    extra_body = {"temperature": 0.2}
+    with patch("anthropic.AsyncAnthropic") as client:
+        routed = llm_wrapper.create_llm_provider(
+            provider="anthropic",
+            api_key="test-key",
+            base_url="https://anthropic.example",
+            model=LLM_PROVIDER_METADATA["anthropic"].default_model,
+            reasoning_effort="low",
+            timeout=17.5,
+            default_headers=headers,
+            extra_body=extra_body,
+        )
+
+    assert client.call_args.kwargs["timeout"] == 17.5
+    assert client.call_args.kwargs["default_headers"] == headers
+    assert routed._extra_body == extra_body
+
+
+def test_anthropic_constructor_preserves_its_timeout_default() -> None:
+    with patch("anthropic.AsyncAnthropic") as client:
+        llm_wrapper.create_llm_provider(
+            provider="anthropic",
+            api_key="test-key",
+            base_url="",
+            model=LLM_PROVIDER_METADATA["anthropic"].default_model,
+            reasoning_effort="low",
+        )
+
+    assert client.call_args.kwargs["timeout"] == 300.0
+
+
+def test_gemini_constructor_receives_profile_transport_options(monkeypatch) -> None:
+    from hindsight_api.engine.providers import gemini_llm
+
+    class FakeClient:
+        def __init__(self, **kwargs) -> None:
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(gemini_llm.genai, "Client", FakeClient)
+    headers = {"X-Profile-Route": "production"}
+    routed = llm_wrapper.create_llm_provider(
+        provider="gemini",
+        api_key="test-key",
+        base_url="https://gemini.example",
+        model=LLM_PROVIDER_METADATA["gemini"].default_model,
+        reasoning_effort="low",
+        timeout=17.5,
+        default_headers=headers,
+    )
+
+    assert routed._client.kwargs["http_options"] == {
+        "base_url": "https://gemini.example",
+        "timeout": 17_500,
+        "headers": headers,
+    }
+
+
+def test_profile_registry_and_nested_payloads_are_deeply_immutable(tmp_path) -> None:
+    path = _write_registry(
+        tmp_path,
+        {
+            "immutable": _profile(
+                "immutable",
+                extra_body={"nested": {"items": [{"value": "original"}]}},
+                default_headers={"X-Route": "original"},
+            )
+        },
+    )
+    profiles = load_inference_profiles(str(path), environment={})
+    route = profiles["immutable"].default
+
+    with pytest.raises(TypeError):
+        profiles["other"] = profiles["immutable"]
+    with pytest.raises(FrozenInstanceError):
+        route.model = "mutated"
+    with pytest.raises(TypeError):
+        route.extra_body["nested"]["items"][0]["value"] = "mutated"
+    with pytest.raises(TypeError):
+        route.extra_body["nested"]["items"][0] = {"value": "mutated"}
+    with pytest.raises(TypeError):
+        route.default_headers["X-Route"] = "mutated"
+
+
+def test_litellmrouter_profile_requires_route_config(tmp_path) -> None:
+    routes = _profile("fallback")
+    routes["default"] = {"provider": "litellmrouter", "model": "default"}
+    path = _write_registry(tmp_path, {"router": routes})
+
+    with pytest.raises(ValueError, match="requires a non-empty litellmrouter_config"):
+        load_inference_profiles(str(path), environment={})
+
+
+def test_selected_litellmrouter_profile_is_eagerly_constructed_once(tmp_path, monkeypatch) -> None:
+    router_config = {
+        "model_list": [
+            {
+                "model_name": "default",
+                "litellm_params": {
+                    "model": "openai/gpt-4o-mini",
+                    "api_key": "router-secret",
+                },
+            }
+        ],
+        "num_retries": 0,
+    }
+    routes = _profile("fallback")
+    routes["default"] = {
+        "provider": "litellmrouter",
+        "model": "default",
+        "litellmrouter_config": router_config,
+    }
+    path = _write_registry(tmp_path, {"router": routes})
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(path))
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILE", "router")
+    clear_config_cache()
+
+    class FakeLiteLLMRouter:
+        def __init__(self, **kwargs) -> None:
+            self.config = kwargs["config"]
+            instances.append(self)
+
+    instances: list[FakeLiteLLMRouter] = []
+
+    from hindsight_api.engine import providers
+
+    monkeypatch.setattr(providers, "LiteLLMRouterLLM", FakeLiteLLMRouter)
+    memory = _make_memory()
+
+    selected = memory._inference_llm("default")
+    assert selected.provider == "litellmrouter"
+    assert len(instances) == 1
+    assert selected._provider_impl is instances[0]
+    assert instances[0].config == router_config
+
+    canonical_config = HindsightConfig.from_env().inference_profiles["router"].default.litellmrouter_config
+    with pytest.raises(TypeError):
+        canonical_config["model_list"][0]["litellm_params"]["api_key"] = "mutated"
+    instances[0].config["model_list"][0]["model_name"] = "mutated-client-copy"
+    assert canonical_config["model_list"][0]["model_name"] == "default"
+    assert len(instances) == 1
+
+
+# Engine-owned profile operation context
+
+
+@pytest.mark.asyncio
+async def test_profiled_then_legacy_bank_calls_do_not_leak_selector_state(tmp_path, monkeypatch) -> None:
+    path = _write_registry(tmp_path, {"profiled": _profile("profiled")})
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(path))
+    clear_config_cache()
+
+    memory = _make_memory()
+    backend = _FakeBankConfigBackend({"profiled-bank": {"inference_profile": "profiled"}})
+    memory._config_resolver = ConfigResolver(backend=backend)
+
+    async with memory._bank_operation_scope("profiled-bank"):
+        assert memory._llm_config.model == "profiled-default"
+    assert memory._llm_config.model == "legacy-default"
+
+    async with memory._bank_operation_scope("legacy-bank"):
+        assert memory._llm_config.model == "legacy-default"
+    assert memory._llm_config.model == "legacy-default"
+    assert backend.fetchrow_count == 2
+
+
+@pytest.mark.asyncio
+async def test_nested_and_exceptional_bank_scopes_restore_the_prior_profile(tmp_path, monkeypatch) -> None:
+    path = _write_registry(
+        tmp_path,
+        {
+            "outer": _profile("outer"),
+            "inner": _profile("inner"),
+        },
+    )
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(path))
+    clear_config_cache()
+
+    memory = _make_memory()
+    backend = _FakeBankConfigBackend(
+        {
+            "outer-bank": {"inference_profile": "outer"},
+            "inner-bank": {"inference_profile": "inner"},
+        }
+    )
+    memory._config_resolver = ConfigResolver(backend=backend)
+
+    async with memory._bank_operation_scope("outer-bank"):
+        assert memory._llm_config.model == "outer-default"
+        outer_queries = backend.fetchrow_count
+        async with memory._bank_operation_scope("outer-bank"):
+            assert memory._llm_config.model == "outer-default"
+        assert backend.fetchrow_count == outer_queries
+
+        with pytest.raises(RuntimeError, match="inner failed"):
+            async with memory._bank_operation_scope("inner-bank"):
+                assert memory._llm_config.model == "inner-default"
+                raise RuntimeError("inner failed")
+        assert memory._llm_config.model == "outer-default"
+
+    assert memory._llm_config.model == "legacy-default"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_and_child_tasks_keep_profile_context_isolated(tmp_path, monkeypatch) -> None:
+    path = _write_registry(
+        tmp_path,
+        {
+            "alpha": _profile("alpha"),
+            "beta": _profile("beta"),
+        },
+    )
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(path))
+    clear_config_cache()
+
+    memory = _make_memory()
+    backend = _FakeBankConfigBackend(
+        {
+            "alpha-bank": {"inference_profile": "alpha"},
+            "beta-bank": {"inference_profile": "beta"},
+        }
+    )
+    memory._config_resolver = ConfigResolver(backend=backend)
+
+    async def observe(bank_id: str) -> tuple[str, str]:
+        async with memory._bank_operation_scope(bank_id):
+            parent_model = memory._llm_config.model
+
+            async def observe_child() -> str:
+                await asyncio.sleep(0)
+                return memory._llm_config.model
+
+            child = asyncio.create_task(observe_child())
+            await asyncio.sleep(0)
+            return parent_model, await child
+
+    alpha, beta, legacy = await asyncio.gather(
+        observe("alpha-bank"),
+        observe("beta-bank"),
+        observe("legacy-bank"),
+    )
+
+    assert alpha == ("alpha-default", "alpha-default")
+    assert beta == ("beta-default", "beta-default")
+    assert legacy == ("legacy-default", "legacy-default")
+    assert memory._llm_config.model == "legacy-default"
+
+
+@pytest.mark.asyncio
+async def test_nested_scopes_from_two_engines_cannot_cross_route(tmp_path, monkeypatch) -> None:
+    first_dir = tmp_path / "first"
+    second_dir = tmp_path / "second"
+    first_dir.mkdir()
+    second_dir.mkdir()
+    first_path = _write_registry(
+        first_dir,
+        {
+            "first-global": _profile("first-global"),
+            "shared": _profile("first-shared"),
+        },
+    )
+    second_path = _write_registry(
+        second_dir,
+        {
+            "second-global": _profile("second-global"),
+            "shared": _profile("second-shared"),
+        },
+    )
+
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(first_path))
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILE", "first-global")
+    clear_config_cache()
+    first = _make_memory()
+
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(second_path))
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILE", "second-global")
+    clear_config_cache()
+    second = _make_memory()
+
+    first._config_resolver = ConfigResolver(
+        backend=_FakeBankConfigBackend({"first-bank": {"inference_profile": "shared"}})
+    )
+    async with first._bank_operation_scope("first-bank"):
+        assert first._llm_config.model == "first-shared-default"
+        assert second._llm_config.model == "second-global-default"
+
+    assert first._llm_config.model == "first-global-default"
+    assert second._llm_config.model == "second-global-default"
+
+
+@pytest.mark.asyncio
+async def test_bank_config_resolution_failure_prevents_provider_use(monkeypatch) -> None:
+    class FailingBackend:
+        def acquire(self):
+            raise RuntimeError("bank config unavailable")
+
+    memory = _make_memory()
+    memory._config_resolver = ConfigResolver(backend=FailingBackend())
+    provider_calls: list[str] = []
+
+    async def call_provider(_llm):
+        provider_calls.append("called")
+
+    with pytest.raises(RuntimeError, match="bank config unavailable"):
+        async with memory._bank_operation_scope("bank"):
+            await call_provider(memory._retain_llm_config)
+
+    assert provider_calls == []
+
+
+@pytest.mark.asyncio
+async def test_tenant_config_resolution_failure_prevents_provider_use() -> None:
+    class FailingTenantConfig:
+        async def get_tenant_config(self, _context):
+            raise RuntimeError("tenant config unavailable")
+
+    memory = _make_memory()
+    memory._config_resolver = ConfigResolver(
+        backend=_FakeBankConfigBackend(),
+        tenant_extension=FailingTenantConfig(),
+    )
+    provider_calls: list[str] = []
+
+    with pytest.raises(RuntimeError, match="tenant config unavailable"):
+        async with memory._bank_operation_scope(
+            "bank",
+            RequestContext(tenant_id="tenant"),
+        ):
+            provider_calls.append(memory._retain_llm_config.model)
+
+    assert provider_calls == []
+
+
+@pytest.mark.asyncio
+async def test_bank_health_uses_one_resolved_profile_query(tmp_path, monkeypatch) -> None:
+    path = _write_registry(tmp_path, {"health": _profile("health")})
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(path))
+    clear_config_cache()
+
+    memory = _make_memory()
+    backend = _FakeBankConfigBackend({"health-bank": {"inference_profile": "health"}})
+    memory._config_resolver = ConfigResolver(backend=backend)
+    memory._operation_validator = None
+    probed_models: list[str] = []
+
+    async def authenticate(_request_context) -> None:
+        return None
+
+    class ProbeOutcome:
+        ok = True
+        status = "connected"
+        latency_ms = 0.0
+
+    async def probe(llm):
+        probed_models.append(llm.model)
+        return ProbeOutcome()
+
+    monkeypatch.setattr(memory, "_authenticate_tenant", authenticate)
+    monkeypatch.setattr(memory, "_probe_llm", probe)
+
+    result = await memory.check_bank_llm("health-bank", request_context=RequestContext(internal=True))
+
+    assert result.bank_id == "health-bank"
+    assert probed_models == ["health-retain", "health-consolidation", "health-reflect"]
+    assert backend.fetchrow_count == 1
+    assert memory._llm_config.model == "legacy-default"
+
+
+@pytest.mark.asyncio
+async def test_worker_boundary_binds_and_resets_the_bank_profile(tmp_path, monkeypatch) -> None:
+    path = _write_registry(tmp_path, {"worker": _profile("worker")})
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(path))
+    clear_config_cache()
+
+    memory = _make_memory()
+    backend = _FakeBankConfigBackend({"worker-bank": {"inference_profile": "worker"}})
+    memory._config_resolver = ConfigResolver(backend=backend)
+    memory._audit_logger = None
+    selected_models: list[str] = []
+
+    async def handle_consolidation(_task_dict):
+        deep_config = await memory._resolve_full_config(
+            "worker-bank",
+            RequestContext(internal=True),
+        )
+        assert deep_config.inference_profile == "worker"
+        selected_models.append(memory._consolidation_llm_config.model)
+        return {"memories_processed": 0}
+
+    monkeypatch.setattr(memory, "_handle_consolidation", handle_consolidation)
+
+    await memory.execute_task({"type": "consolidation", "bank_id": "worker-bank"})
+
+    assert selected_models == ["worker-consolidation"]
+    assert backend.fetchrow_count == 1
+    assert memory._llm_config.model == "legacy-default"
+
+
+@pytest.mark.asyncio
+async def test_direct_consolidation_job_scopes_the_bank_profile_once(tmp_path, monkeypatch) -> None:
+    path = _write_registry(tmp_path, {"direct": _profile("direct")})
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(path))
+    clear_config_cache()
+
+    memory = _make_memory()
+    backend = _FakeBankConfigBackend({"direct-bank": {"inference_profile": "direct"}})
+    memory._config_resolver = ConfigResolver(backend=backend)
+    captured: dict[str, object] = {}
+
+    async def run_inner(
+        _memory_engine,
+        bank_id,
+        _request_context,
+        config,
+        llm_config,
+        _operation_id,
+        _observation_scopes,
+        _pending_refresh_tags,
+    ):
+        captured["bank_id"] = bank_id
+        captured["profile"] = config.inference_profile
+        captured["model"] = llm_config.model
+        return {"status": "completed"}
+
+    monkeypatch.setattr(consolidator, "_run_consolidation_job", run_inner)
+
+    result = await consolidator.run_consolidation_job(
+        memory,
+        "direct-bank",
+        RequestContext(internal=True),
+    )
+
+    assert result == {"status": "completed"}
+    assert captured == {
+        "bank_id": "direct-bank",
+        "profile": "direct",
+        "model": "direct-consolidation",
+    }
+    assert backend.fetchrow_count == 1
+    assert memory._llm_config.model == "legacy-default"
+
+
+@pytest.mark.asyncio
+async def test_bank_selected_consolidation_route_controls_direct_and_worker_execution(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    active = _profile("active")
+    disabled = _profile("disabled")
+    disabled["consolidation"] = {"provider": "none", "model": "none"}
+    path = _write_registry(tmp_path, {"active": active, "disabled": disabled})
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(path))
+
+    calls: list[tuple[str, str]] = []
+
+    async def run_inner(
+        _memory_engine,
+        bank_id,
+        _request_context,
+        config,
+        llm_config,
+        _operation_id,
+        _observation_scopes,
+        _pending_refresh_tags,
+    ):
+        calls.append((bank_id, llm_config.model))
+        assert config.enable_observations is True
+        return {"status": "completed", "bank_id": bank_id}
+
+    monkeypatch.setattr(consolidator, "_run_consolidation_job", run_inner)
+
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILE", "disabled")
+    clear_config_cache()
+    globally_disabled = _make_memory()
+    globally_disabled._config_resolver = ConfigResolver(
+        backend=_FakeBankConfigBackend({"active-bank": {"inference_profile": "active"}})
+    )
+
+    direct_active = await consolidator.run_consolidation_job(
+        globally_disabled,
+        "active-bank",
+        RequestContext(internal=True),
+    )
+    worker_active = await globally_disabled._handle_consolidation({"bank_id": "active-bank"})
+
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILE", "active")
+    clear_config_cache()
+    globally_active = _make_memory()
+    globally_active._config_resolver = ConfigResolver(
+        backend=_FakeBankConfigBackend({"disabled-bank": {"inference_profile": "disabled"}})
+    )
+
+    direct_disabled = await consolidator.run_consolidation_job(
+        globally_active,
+        "disabled-bank",
+        RequestContext(internal=True),
+    )
+    worker_disabled = await globally_active._handle_consolidation({"bank_id": "disabled-bank"})
+
+    assert direct_active["status"] == "completed"
+    assert worker_active["status"] == "completed"
+    assert calls == [
+        ("active-bank", "active-consolidation"),
+        ("active-bank", "active-consolidation"),
+    ]
+    disabled_result = {"skipped": True, "memories_processed": 0, "mental_models_updated": 0}
+    assert direct_disabled == disabled_result
+    assert worker_disabled == disabled_result
+
+
+def test_startup_logs_exclusively_report_selected_profile_routes(tmp_path, monkeypatch, caplog, capsys) -> None:
+    path = _write_registry(tmp_path, {"startup": _profile("startup")})
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(path))
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILE", "startup")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_MODEL", "unreachable-legacy-default")
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_LLM_MODEL", "unreachable-legacy-retain")
+    monkeypatch.setenv("HINDSIGHT_API_REFLECT_LLM_MODEL", "unreachable-legacy-reflect")
+    monkeypatch.setenv("HINDSIGHT_API_CONSOLIDATION_LLM_MODEL", "unreachable-legacy-consolidation")
+    clear_config_cache()
+
+    selected = HindsightConfig.from_env()
+    with caplog.at_level(logging.INFO, logger="hindsight_api.config"):
+        selected.log_config()
+    selected_messages = [record.getMessage() for record in caplog.records]
+
+    inference_messages = [message for message in selected_messages if message.startswith("Inference profile:")]
+    assert len(inference_messages) == 1
+    assert "Inference profile: startup" in inference_messages[0]
+    for operation in OPERATIONS:
+        assert f"{operation}=mock/startup-{operation}" in inference_messages[0]
+    assert not any(message.startswith("LLM:") or message.startswith("LLM (") for message in selected_messages)
+    assert "unreachable-legacy" not in "\n".join(selected_messages)
+    banner_provider, banner_model = _startup_llm_identity(selected)
+    assert banner_provider == "profile=startup"
+    assert banner_model == ", ".join(f"{operation}=mock/startup-{operation}" for operation in OPERATIONS)
+    print_startup_info(
+        host="127.0.0.1",
+        port=8888,
+        database_url="postgresql://localhost/hindsight",
+        llm_provider=banner_provider,
+        llm_model=banner_model,
+        embeddings_provider="dummy",
+        reranker_provider="dummy",
+    )
+    banner_output = capsys.readouterr().out
+    assert "profile=startup" in banner_output
+    for operation in OPERATIONS:
+        assert f"{operation}=mock/startup-{operation}" in banner_output
+    assert "unreachable-legacy" not in banner_output
+
+    caplog.clear()
+    monkeypatch.delenv("HINDSIGHT_API_INFERENCE_PROFILE")
+    clear_config_cache()
+    legacy = HindsightConfig.from_env()
+    with caplog.at_level(logging.INFO, logger="hindsight_api.config"):
+        legacy.log_config()
+    legacy_messages = [record.getMessage() for record in caplog.records]
+
+    assert "LLM: provider=mock, model=unreachable-legacy-default" in legacy_messages
+    assert "LLM (retain): provider=mock, model=unreachable-legacy-retain" in legacy_messages
+    assert "LLM (reflect): provider=mock, model=unreachable-legacy-reflect" in legacy_messages
+    assert "LLM (consolidation): provider=mock, model=unreachable-legacy-consolidation" in legacy_messages
+    assert not any(message.startswith("Inference profile:") for message in legacy_messages)
+    assert _startup_llm_identity(legacy) == ("mock", "unreachable-legacy-default")
+
+
+@pytest.mark.asyncio
+async def test_profile_selector_precedence_is_global_then_tenant_then_bank(tmp_path, monkeypatch) -> None:
+    path = _write_registry(
+        tmp_path,
+        {
+            "global": _profile("global"),
+            "tenant": _profile("tenant"),
+            "bank": _profile("bank"),
+        },
+    )
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILES_FILE", str(path))
+    monkeypatch.setenv("HINDSIGHT_API_INFERENCE_PROFILE", "global")
+    clear_config_cache()
+
+    class TenantProfiles:
+        async def get_tenant_config(self, _context):
+            return {"inference_profile": "tenant"}
+
+    resolver = ConfigResolver(
+        backend=_FakeBankConfigBackend({"bank-override": {"inference_profile": "bank"}}),
+        tenant_extension=TenantProfiles(),
+    )
+    context = RequestContext(tenant_id="tenant-id")
+
+    tenant_config = await resolver.resolve_full_config("tenant-default", context)
+    bank_config = await resolver.resolve_full_config("bank-override", context)
+
+    assert tenant_config.inference_profile == "tenant"
+    assert bank_config.inference_profile == "bank"

--- a/hindsight-api-slim/tests/test_llm_provider_metadata.py
+++ b/hindsight-api-slim/tests/test_llm_provider_metadata.py
@@ -1,0 +1,142 @@
+import pytest
+
+from hindsight_api.engine.llm_wrapper import create_llm_provider
+from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+from hindsight_api.llm_provider_metadata import (
+    DEFAULT_LLM_MODEL,
+    DEFAULT_LLM_PROVIDER,
+    LLM_PROVIDER_METADATA,
+    OPENAI_COMPATIBLE_PROVIDERS,
+    PROVIDER_DEFAULT_MODELS,
+    SUPPORTED_LLM_PROVIDERS,
+    LLMProviderFactory,
+    get_default_model_for_provider,
+    get_llm_provider_metadata,
+    requires_api_key,
+)
+
+EXPECTED_PROVIDERS = {
+    "anthropic",
+    "atlas",
+    "bedrock",
+    "claude-code",
+    "deepseek",
+    "fireworks",
+    "gemini",
+    "github-copilot",
+    "groq",
+    "litellm",
+    "litellmrouter",
+    "llamacpp",
+    "lmstudio",
+    "minimax",
+    "mock",
+    "none",
+    "nous",
+    "ollama",
+    "ollama-cloud",
+    "openai",
+    "openai-codex",
+    "openai-responses",
+    "opencode-go",
+    "openrouter",
+    "requesty",
+    "vertexai",
+    "volcano",
+    "xai-oauth",
+    "zai",
+}
+
+EXPECTED_OPENAI_COMPATIBLE = {
+    "atlas",
+    "deepseek",
+    "fireworks",
+    "groq",
+    "llamacpp",
+    "lmstudio",
+    "minimax",
+    "ollama",
+    "ollama-cloud",
+    "openai",
+    "opencode-go",
+    "openrouter",
+    "requesty",
+    "volcano",
+    "zai",
+}
+
+EXPECTED_WITHOUT_API_KEY = {
+    "bedrock",
+    "claude-code",
+    "github-copilot",
+    "litellm",
+    "litellmrouter",
+    "llamacpp",
+    "lmstudio",
+    "mock",
+    "none",
+    "nous",
+    "ollama",
+    "openai-codex",
+    "vertexai",
+    "xai-oauth",
+}
+
+
+def test_registry_is_total_over_the_builtin_provider_vocabulary() -> None:
+    assert set(LLM_PROVIDER_METADATA) == EXPECTED_PROVIDERS
+    assert SUPPORTED_LLM_PROVIDERS == EXPECTED_PROVIDERS
+    assert set(PROVIDER_DEFAULT_MODELS) == EXPECTED_PROVIDERS
+    assert {metadata.provider_id for metadata in LLM_PROVIDER_METADATA.values()} == EXPECTED_PROVIDERS
+    assert {metadata.factory for metadata in LLM_PROVIDER_METADATA.values()} == set(LLMProviderFactory)
+    assert all(metadata.default_model for metadata in LLM_PROVIDER_METADATA.values())
+    assert DEFAULT_LLM_PROVIDER in EXPECTED_PROVIDERS
+    assert DEFAULT_LLM_MODEL == LLM_PROVIDER_METADATA[DEFAULT_LLM_PROVIDER].default_model
+
+
+def test_derived_capability_and_api_key_views_match_the_provider_contract() -> None:
+    assert set(OPENAI_COMPATIBLE_PROVIDERS) == EXPECTED_OPENAI_COMPATIBLE
+    assert {provider for provider in EXPECTED_PROVIDERS if not requires_api_key(provider)} == EXPECTED_WITHOUT_API_KEY
+
+
+def test_config_reexports_the_same_derived_default_model_view() -> None:
+    from hindsight_api.config import PROVIDER_DEFAULT_MODELS as config_default_models
+
+    assert config_default_models is PROVIDER_DEFAULT_MODELS
+
+
+def test_lookup_normalizes_case_and_rejects_unknown_ids() -> None:
+    assert get_llm_provider_metadata("AnThRoPiC") is LLM_PROVIDER_METADATA["anthropic"]
+    assert get_default_model_for_provider("GEMINI") == "gemini-3.5-flash"
+
+    with pytest.raises(ValueError, match="Unknown LLM provider 'missing'"):
+        get_llm_provider_metadata("missing")
+    with pytest.raises(ValueError, match="Unknown LLM provider 'missing'"):
+        get_default_model_for_provider("missing")
+    with pytest.raises(ValueError, match="Unknown LLM provider 'missing'"):
+        requires_api_key("missing")
+    with pytest.raises(ValueError, match="Unknown LLM provider 'missing'"):
+        create_llm_provider("missing", "", "", "model", None)
+
+
+@pytest.mark.parametrize("provider", sorted(EXPECTED_OPENAI_COMPATIBLE))
+def test_every_compatible_descriptor_is_accepted_by_the_compatible_constructor(provider: str) -> None:
+    metadata = get_llm_provider_metadata(provider)
+    llm = OpenAICompatibleLLM(
+        provider=provider,
+        api_key="test-key" if metadata.requires_api_key else "",
+        base_url="",
+        model=metadata.default_model,
+    )
+
+    assert llm.provider == provider
+    assert llm.base_url == metadata.default_base_url
+    assert bool(llm.api_key)
+
+
+@pytest.mark.parametrize("provider", sorted(EXPECTED_OPENAI_COMPATIBLE - EXPECTED_WITHOUT_API_KEY))
+def test_every_compatible_cloud_provider_requires_its_key(provider: str) -> None:
+    metadata = get_llm_provider_metadata(provider)
+
+    with pytest.raises(ValueError, match=f"API key is required for {provider}"):
+        OpenAICompatibleLLM(provider=provider, api_key="", base_url="", model=metadata.default_model)

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -266,6 +266,8 @@ For non-English banks (especially CJK) and the language/extraction-language trad
 
 | Variable | Description | Default |
 |----------|-------------|---------|
+| `HINDSIGHT_API_INFERENCE_PROFILES_FILE` | Path to a server-owned JSON registry of complete `default`, `retain`, `consolidation`, and `reflect` model routes. Route credentials are referenced by environment-variable name and resolved only by the server. | Unset |
+| `HINDSIGHT_API_INFERENCE_PROFILE` | Global profile ID selected from `HINDSIGHT_API_INFERENCE_PROFILES_FILE`. When set, profile routes replace legacy global/per-operation LLM routing. Banks may select another registered ID through their `inference_profile` config field. | Unset |
 | `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-responses`, `openai-codex`, `claude-code`, `github-copilot`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `opencode-go`, `nous`, `xai-oauth`, `fireworks`, `ollama`, `ollama-cloud`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `requesty`, `none` | `openai` |
 | `HINDSIGHT_API_LLM_API_KEY` | API key for providers that require one; unused by `github-copilot` | - |
 | `HINDSIGHT_API_LLM_MODEL` | Model name | `gpt-5-mini` |
@@ -494,6 +496,23 @@ export HINDSIGHT_API_LLM_PROVIDER=none
 :::tip OpenAI Codex, Claude Code & Vertex AI Setup
 For detailed setup instructions for **OpenAI Codex** (ChatGPT Plus/Pro), **Claude Code** (Claude Pro/Max), and **Vertex AI** (Google Cloud), see the [Models documentation](./models#openai-codex-setup-chatgpt-pluspro).
 :::
+
+#### Named inference profiles
+
+A named inference profile is a complete, immutable set of four model routes owned by the server. Use it when one deployment serves banks with different model or gateway policies without storing credentials in bank configuration.
+
+The registry is one JSON object keyed by lowercase profile ID. Every profile must contain exactly `default`, `retain`, `consolidation`, and `reflect`:
+
+    {
+      "production": {
+        "default": {"provider": "openai", "model": "gpt-4o-mini", "api_key_env": "OPENAI_API_KEY"},
+        "retain": {"provider": "openai", "model": "gpt-4o-mini", "api_key_env": "OPENAI_API_KEY"},
+        "consolidation": {"provider": "anthropic", "model": "claude-sonnet-4-5", "api_key_env": "ANTHROPIC_API_KEY"},
+        "reflect": {"provider": "anthropic", "model": "claude-sonnet-4-5", "api_key_env": "ANTHROPIC_API_KEY"}
+      }
+    }
+
+Each route requires `provider` and `model`. Optional fields are `api_key_env`, `base_url`, `reasoning_effort`, `timeout`, `max_retries`, `initial_backoff`, `max_backoff`, `extra_body`, `default_headers`, provider service tiers, `ollama_num_ctx`, and `litellmrouter_config`. Unknown or duplicate fields, incomplete profiles, invalid provider options, unresolved credential variables, and unknown selectors fail at startup or bank-config update. Profile route contents are credential fields: bank config, templates, and health responses expose only the selected profile ID.
 
 ### LLM Router (LiteLLM Router)
 


### PR DESCRIPTION
## Summary

- add a server-owned JSON registry of named inference profiles, each defining complete default, retain, consolidation, and reflect routes
- let deployments select a global profile and banks/tenants select registered alternatives without storing route credentials in bank configuration
- bind resolved routes through operation-scoped context, including worker and direct-consolidation boundaries, with token-safe restoration across nesting, exceptions, cancellation, and concurrent tasks
- validate the closed schema strictly at startup and thread profile transport options through native Anthropic and Gemini clients
- document the registry, selectors, secret boundary, and precedence in the official configuration reference and environment example

## Stack

Draft and intentionally stacked on #3886. The first two commits are #3886's canonical provider metadata refactor; after that PR merges, this PR reduces to `feat(config): add named inference profiles`.

## Verification

- `pytest -q -n0 tests/test_inference_profiles.py tests/test_hierarchical_config.py tests/test_bank_template_full_roundtrip.py` — 73 passed
- `pytest -q -n0 tests/test_per_operation_llm_config.py tests/test_multi_llm_provider.py tests/test_none_llm_provider.py` — 49 passed
- `pytest -q -n0 tests/test_inference_profiles.py` after restacking — 43 passed
- Ruff check and format-check on all changed Python files
- `git diff --check`

The profile patch deliberately excludes downstream-specific protected-identity policy. It exports only the general server-owned routing mechanism.
