### PR TITLE
fix(consolidation): defer destructive deletes until replacements succeed

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -2189,8 +2189,7 @@ async def _process_memory_batch(
         perf.record_timing("llm", time.time() - t0)
         perf.record_llm_call(llm_result.obs_count, llm_result.prompt_chars)
 
-    # 4. Sequential execution of deletes / updates / creates
-    # Deletes run first to free observation slots before creates consume them.
+    # 4. Sequential execution of updates / creates / deletes
     # Track which memory indices participated so we can build per-memory results for stats
     per_memory_created: set[str] = set()
     per_memory_updated: set[str] = set()
@@ -2211,21 +2210,21 @@ async def _process_memory_batch(
         else None
     )
 
-    # Execute deletes first to free observation slots before creates consume them. Each delete
-    # is a single fast statement, so the whole loop shares one short-lived connection.
-    deleted_count = 0
-    if llm_result.deletes:
-        async with acquire_with_retry(pool) as conn:
-            for delete in llm_result.deletes:
-                # Security: the observation must be present in the unioned recall
-                if not any(str(obs.id) == delete.observation_id for obs in union_observations):
-                    logger.debug(
-                        f"Batch consolidation: rejected delete — observation {delete.observation_id} "
-                        f"not in unioned recall"
-                    )
-                    continue
-                await _execute_delete_action(conn=conn, bank_id=bank_id, observation_id=delete.observation_id, txn=txn)
-                deleted_count += 1
+    # Authorize deletes against the immutable recall snapshot now, but execute them only after
+    # every fallible update/create has succeeded.  In particular, embedding generation happens
+    # before a create's write transaction; deleting first turned an embedding failure into a
+    # durable half-commit that removed the old observation while leaving the replacement absent.
+    # Capacity is computed before this point and already caps CREATEs against the current count,
+    # so deferring deletes cannot exceed the configured observation limit.
+    authorized_delete_ids: list[str] = []
+    recalled_observation_ids = {str(obs.id) for obs in union_observations}
+    for delete in llm_result.deletes:
+        if delete.observation_id not in recalled_observation_ids:
+            logger.debug(
+                f"Batch consolidation: rejected delete — observation {delete.observation_id} not in unioned recall"
+            )
+            continue
+        authorized_delete_ids.append(delete.observation_id)
 
     for update in llm_result.updates:
         source_mems = [mem_by_id[fid] for fid in update.source_fact_ids if fid in mem_by_id]
@@ -2348,6 +2347,23 @@ async def _process_memory_batch(
         if action == "created":
             for m in source_mems:
                 per_memory_created.add(str(m["id"]))
+
+    # Destructive work is the final phase. Keep all requested deletes in one short SQL
+    # transaction so a failure cannot commit only a prefix of the delete set. For an external
+    # memories store, ``txn`` is the batch write-group handle; its deletes remain invisible until
+    # the outer witness commits, preserving the existing cross-store visibility contract.
+    deleted_count = 0
+    if authorized_delete_ids:
+        async with acquire_with_retry(pool) as conn:
+            async with conn.transaction():
+                for observation_id in authorized_delete_ids:
+                    await _execute_delete_action(
+                        conn=conn,
+                        bank_id=bank_id,
+                        observation_id=observation_id,
+                        txn=txn,
+                    )
+                    deleted_count += 1
 
     # Build per-memory result dicts for the stats tracker in the outer loop
     results: list[dict[str, Any]] = []

--- a/hindsight-api-slim/tests/test_consolidation_failure_isolation.py
+++ b/hindsight-api-slim/tests/test_consolidation_failure_isolation.py
@@ -26,7 +26,8 @@ import asyncio
 import json
 import re
 import uuid
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import asyncpg
 import pytest
@@ -34,14 +35,17 @@ import pytest
 from hindsight_api.config import _get_raw_config
 from hindsight_api.engine.consolidation import consolidator as consolidator_module
 from hindsight_api.engine.consolidation.consolidator import (
+    _BatchLLMResult,
     _ConsolidationBatchResponse,
     _CreateAction,
+    _DeleteAction,
     _gather_or_cancel,
+    _process_memory_batch,
     run_consolidation_job,
 )
 from hindsight_api.engine.memory_engine import MemoryEngine, _is_non_retryable_task_error
 from hindsight_api.engine.providers.mock_llm import MockLLM
-from hindsight_api.engine.response_models import RecallResult
+from hindsight_api.engine.response_models import MemoryFact, RecallResult
 
 
 class _RecallTimeout(Exception):
@@ -111,6 +115,45 @@ async def test_gather_or_cancel_reraises_original_exception_unwrapped():
 
     assert not isinstance(exc_info.value, BaseExceptionGroup)
     assert _is_non_retryable_task_error(exc_info.value) is True
+
+
+@pytest.mark.asyncio
+async def test_create_failure_does_not_execute_requested_delete():
+    """A replacement CREATE must succeed before its destructive DELETE runs."""
+    source_id = uuid.uuid4()
+    observation_id = uuid.uuid4()
+    recall = RecallResult(
+        results=[MemoryFact(id=str(observation_id), text="Old durable observation", fact_type="observation")]
+    )
+    llm_result = _BatchLLMResult(
+        creates=[_CreateAction(text="Replacement observation", source_fact_ids=[str(source_id)])],
+        deletes=[_DeleteAction(observation_id=str(observation_id))],
+    )
+    config = SimpleNamespace(
+        consolidation_dedup_threshold=1.0,
+        max_observations_per_scope=-1,
+        observation_scope_limits=[],
+    )
+    create_error = RuntimeError("simulated embedding failure")
+
+    with (
+        patch.object(consolidator_module, "_find_related_observations", AsyncMock(return_value=recall)),
+        patch.object(consolidator_module, "_consolidate_batch_with_llm", AsyncMock(return_value=llm_result)),
+        patch.object(consolidator_module, "_execute_create_action", AsyncMock(side_effect=create_error)),
+        patch.object(consolidator_module, "_execute_delete_action", AsyncMock()) as execute_delete,
+    ):
+        with pytest.raises(RuntimeError, match="simulated embedding failure"):
+            await _process_memory_batch(
+                pool=MagicMock(),
+                memory_engine=MagicMock(),
+                llm_config=MagicMock(),
+                bank_id="bank",
+                memories=[{"id": source_id, "text": "New evidence", "tags": []}],
+                request_context=MagicMock(),
+                config=config,
+            )
+
+    execute_delete.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/hindsight-api-slim/tests/test_consolidation_failure_isolation.py
+++ b/hindsight-api-slim/tests/test_consolidation_failure_isolation.py
@@ -27,6 +27,7 @@ import json
 import re
 import uuid
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import asyncpg
@@ -154,6 +155,133 @@ async def test_create_failure_does_not_execute_requested_delete():
             )
 
     execute_delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_delete_failure_rolls_back_the_entire_delete_set(memory: MemoryEngine, request_context):
+    """The final delete transaction must not commit only a prefix."""
+    bank_id = f"test-delete-rollback-{uuid.uuid4().hex[:8]}"
+    source_id = uuid.uuid4()
+    first_observation_id = uuid.uuid4()
+    second_observation_id = uuid.uuid4()
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    try:
+        # Seed history directly because the public API only creates history through an
+        # observation update; this test needs a pre-existing snapshot before deletion.
+        async with memory._pool.acquire() as conn:
+            await conn.executemany(
+                """
+                INSERT INTO memory_units (id, bank_id, text, fact_type, tags, observation_scopes, created_at)
+                VALUES ($1, $2, $3, 'observation', $4, $5::jsonb, now())
+                """,
+                [
+                    (first_observation_id, bank_id, "First durable observation", [], json.dumps(None)),
+                    (second_observation_id, bank_id, "Second durable observation", [], json.dumps(None)),
+                ],
+            )
+            await conn.executemany(
+                """
+                INSERT INTO observation_history (observation_id, bank_id, content, changed_at)
+                VALUES ($1, $2, $3::jsonb, now())
+                """,
+                [
+                    (
+                        first_observation_id,
+                        bank_id,
+                        json.dumps({"previous_text": "First observation before update"}),
+                    ),
+                    (
+                        second_observation_id,
+                        bank_id,
+                        json.dumps({"previous_text": "Second observation before update"}),
+                    ),
+                ],
+            )
+
+        recall = RecallResult(
+            results=[
+                MemoryFact(id=str(first_observation_id), text="First durable observation", fact_type="observation"),
+                MemoryFact(id=str(second_observation_id), text="Second durable observation", fact_type="observation"),
+            ]
+        )
+        llm_result = _BatchLLMResult(
+            deletes=[
+                _DeleteAction(observation_id=str(first_observation_id)),
+                _DeleteAction(observation_id=str(second_observation_id)),
+            ]
+        )
+        config = SimpleNamespace(
+            consolidation_dedup_threshold=1.0,
+            max_observations_per_scope=-1,
+            observation_scope_limits=[],
+        )
+        original_execute_delete = consolidator_module._execute_delete_action
+        successful_delete_count = 0
+
+        async def fail_on_second_delete(*, conn: Any, bank_id: str, observation_id: str, txn: Any = None) -> None:
+            nonlocal successful_delete_count
+            if successful_delete_count == 1:
+                raise RuntimeError("simulated second delete failure")
+            await original_execute_delete(
+                conn=conn,
+                bank_id=bank_id,
+                observation_id=observation_id,
+                txn=txn,
+            )
+            # The engine API uses another pooled connection and cannot observe this
+            # transaction's uncommitted state. Verify on the supplied connection that
+            # the first delete really happened before the second delete raises.
+            assert not await conn.fetchval(
+                "SELECT EXISTS(SELECT 1 FROM memory_units WHERE id = $1 AND bank_id = $2)",
+                uuid.UUID(observation_id),
+                bank_id,
+            )
+            assert not await conn.fetchval(
+                "SELECT EXISTS(SELECT 1 FROM observation_history WHERE observation_id = $1 AND bank_id = $2)",
+                uuid.UUID(observation_id),
+                bank_id,
+            )
+            successful_delete_count += 1
+
+        with (
+            patch.object(consolidator_module, "_find_related_observations", AsyncMock(return_value=recall)),
+            patch.object(consolidator_module, "_consolidate_batch_with_llm", AsyncMock(return_value=llm_result)),
+            patch.object(consolidator_module, "_execute_delete_action", fail_on_second_delete),
+        ):
+            with pytest.raises(RuntimeError, match="simulated second delete failure"):
+                await _process_memory_batch(
+                    pool=memory._pool,
+                    memory_engine=memory,
+                    llm_config=MagicMock(),
+                    bank_id=bank_id,
+                    memories=[{"id": source_id, "text": "New evidence", "tags": []}],
+                    request_context=request_context,
+                    config=config,
+                )
+
+        assert successful_delete_count == 1
+        observations = await memory.list_memory_units(
+            bank_id,
+            fact_type="observation",
+            limit=1000,
+            request_context=request_context,
+        )
+        assert {item["id"] for item in observations["items"]} == {
+            str(first_observation_id),
+            str(second_observation_id),
+        }
+        for observation_id in (first_observation_id, second_observation_id):
+            history = await memory.get_observation_history(
+                bank_id,
+                str(observation_id),
+                request_context=request_context,
+            )
+            assert history is not None
+            assert len(history) == 1
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- validate LLM-requested deletes against the recall snapshot, but defer them until all fallible updates and creates finish
- execute the final delete set in one short database transaction
- preserve the existing external-store write-group visibility contract

## Why

`_create_observation_directly` computes embeddings before opening its write transaction. Previously, consolidation deleted old observations first, so an embedding or later replacement-write failure could leave the old observation durably removed and no replacement written.

This change makes destructive work the final phase. A failed update or create now leaves the prior observations intact for retry; a failure inside a multi-delete phase rolls the SQL delete set back together. This addresses the deterministic delete-first failure mode reported in #3876 without claiming to resolve every cause discussed there.

## Tests

- added a regression proving a replacement-create failure never reaches the requested delete
- `pytest tests/test_consolidation_failure_isolation.py::test_create_failure_does_not_execute_requested_delete tests/test_consolidation_embedding_validation.py tests/test_consolidation_dedup.py -q -n 0` (47 passed)
- Ruff check and format check for both changed files
- Codex adversarial review approved after explicitly checking capacity, rollback, and cross-store visibility semantics
