### PR TITLE
docs(docker): reserve shared memory for embedded PostgreSQL

### DIFF
--- a/hindsight-docs/docs/developer/api/quickstart.mdx
+++ b/hindsight-docs/docs/developer/api/quickstart.mdx
@@ -43,7 +43,7 @@ API available at [http://localhost:8888](http://localhost:8888/docs)
 
 export OPENAI_API_KEY=sk-xxx
 
-docker run -it --pull always --name hindsight --restart unless-stopped -p 8888:8888 -p 9999:9999 \
+docker run -it --pull always --name hindsight --restart unless-stopped --shm-size=1g -p 8888:8888 -p 9999:9999 \
   -e HINDSIGHT_API_LLM_API_KEY=$OPENAI_API_KEY \
   -v $HOME/.hindsight-docker:/home/hindsight/.pg0 \
   ghcr.io/vectorize-io/hindsight:latest
@@ -51,6 +51,10 @@ docker run -it --pull always --name hindsight --restart unless-stopped -p 8888:8
 
 - **API**: http://localhost:8888
 - **Control Plane** (Web UI): http://localhost:9999
+
+:::note Shared memory for embedded PostgreSQL
+Docker allocates 64 MiB to `/dev/shm` by default. Hindsight's embedded PostgreSQL can exceed that limit while creating vector indexes, causing `could not resize shared memory segment ... No space left on device`. The quick start reserves 1 GiB as a safe baseline; actual requirements depend on the workload, index type, PostgreSQL settings, and parallelism. In Docker Compose, use `shm_size: 1gb` on the Hindsight service.
+:::
 
 :::tip Set a stable `HINDSIGHT_API_WORKER_ID` in production
 The worker uses the container hostname as its identity, which Docker sets to the container ID by default. That value changes on every restart, so any task that was being processed when the container went down stays parked under the old ID with no way for the new container to recognize it as its own.

--- a/hindsight-docs/docs/developer/api/quickstart.mdx
+++ b/hindsight-docs/docs/developer/api/quickstart.mdx
@@ -52,10 +52,6 @@ docker run -it --pull always --name hindsight --restart unless-stopped --shm-siz
 - **API**: http://localhost:8888
 - **Control Plane** (Web UI): http://localhost:9999
 
-:::note Shared memory for embedded PostgreSQL
-Docker allocates 64 MiB to `/dev/shm` by default. Hindsight's embedded PostgreSQL can exceed that limit while creating vector indexes, causing `could not resize shared memory segment ... No space left on device`. The quick start reserves 1 GiB as a safe baseline; actual requirements depend on the workload, index type, PostgreSQL settings, and parallelism. In Docker Compose, use `shm_size: 1gb` on the Hindsight service.
-:::
-
 :::tip Set a stable `HINDSIGHT_API_WORKER_ID` in production
 The worker uses the container hostname as its identity, which Docker sets to the container ID by default. That value changes on every restart, so any task that was being processed when the container went down stays parked under the old ID with no way for the new container to recognize it as its own.
 

--- a/hindsight-docs/docs/developer/installation.md
+++ b/hindsight-docs/docs/developer/installation.md
@@ -77,7 +77,7 @@ Run everything in one container with embedded PostgreSQL:
 ```bash
 export OPENAI_API_KEY=sk-xxx
 
-docker run -it --pull always --name hindsight --restart unless-stopped -p 8888:8888 -p 9999:9999 \
+docker run -it --pull always --name hindsight --restart unless-stopped --shm-size=1g -p 8888:8888 -p 9999:9999 \
   -e HINDSIGHT_API_LLM_API_KEY=$OPENAI_API_KEY \
   -v hindsight-data:/home/hindsight/.pg0 \
   ghcr.io/vectorize-io/hindsight:latest
@@ -85,6 +85,10 @@ docker run -it --pull always --name hindsight --restart unless-stopped -p 8888:8
 
 - **API Server**: http://localhost:8888
 - **Control Plane** (Web UI): http://localhost:9999
+
+:::note Shared memory for embedded PostgreSQL
+Docker allocates 64 MiB to `/dev/shm` by default. Hindsight's embedded PostgreSQL can exceed that limit while creating vector indexes, causing `could not resize shared memory segment ... No space left on device`. The quick start reserves 1 GiB as a safe baseline; actual requirements depend on the workload, index type, PostgreSQL settings, and parallelism. In Docker Compose, use `shm_size: 1gb` on the Hindsight service.
+:::
 
 :::note Persisting data: named volume vs. host bind mount
 The container runs as a non-root user (UID 1000). The `hindsight-data` **named volume** above is recommended — Docker creates it owned by the container user, so it works with no extra setup.

--- a/hindsight-docs/docs/developer/installation.md
+++ b/hindsight-docs/docs/developer/installation.md
@@ -86,10 +86,6 @@ docker run -it --pull always --name hindsight --restart unless-stopped --shm-siz
 - **API Server**: http://localhost:8888
 - **Control Plane** (Web UI): http://localhost:9999
 
-:::note Shared memory for embedded PostgreSQL
-Docker allocates 64 MiB to `/dev/shm` by default. Hindsight's embedded PostgreSQL can exceed that limit while creating vector indexes, causing `could not resize shared memory segment ... No space left on device`. The quick start reserves 1 GiB as a safe baseline; actual requirements depend on the workload, index type, PostgreSQL settings, and parallelism. In Docker Compose, use `shm_size: 1gb` on the Hindsight service.
-:::
-
 :::note Persisting data: named volume vs. host bind mount
 The container runs as a non-root user (UID 1000). The `hindsight-data` **named volume** above is recommended — Docker creates it owned by the container user, so it works with no extra setup.
 

--- a/hindsight-docs/versioned_docs/version-0.9/developer/api/quickstart.mdx
+++ b/hindsight-docs/versioned_docs/version-0.9/developer/api/quickstart.mdx
@@ -43,7 +43,7 @@ API available at [http://localhost:8888](http://localhost:8888/docs)
 
 export OPENAI_API_KEY=sk-xxx
 
-docker run -it --pull always --name hindsight --restart unless-stopped -p 8888:8888 -p 9999:9999 \
+docker run -it --pull always --name hindsight --restart unless-stopped --shm-size=1g -p 8888:8888 -p 9999:9999 \
   -e HINDSIGHT_API_LLM_API_KEY=$OPENAI_API_KEY \
   -v $HOME/.hindsight-docker:/home/hindsight/.pg0 \
   ghcr.io/vectorize-io/hindsight:latest
@@ -51,6 +51,10 @@ docker run -it --pull always --name hindsight --restart unless-stopped -p 8888:8
 
 - **API**: http://localhost:8888
 - **Control Plane** (Web UI): http://localhost:9999
+
+:::note Shared memory for embedded PostgreSQL
+Docker allocates 64 MiB to `/dev/shm` by default. Hindsight's embedded PostgreSQL can exceed that limit while creating vector indexes, causing `could not resize shared memory segment ... No space left on device`. The quick start reserves 1 GiB as a safe baseline; actual requirements depend on the workload, index type, PostgreSQL settings, and parallelism. In Docker Compose, use `shm_size: 1gb` on the Hindsight service.
+:::
 
 :::tip Set a stable `HINDSIGHT_API_WORKER_ID` in production
 The worker uses the container hostname as its identity, which Docker sets to the container ID by default. That value changes on every restart, so any task that was being processed when the container went down stays parked under the old ID with no way for the new container to recognize it as its own.

--- a/hindsight-docs/versioned_docs/version-0.9/developer/api/quickstart.mdx
+++ b/hindsight-docs/versioned_docs/version-0.9/developer/api/quickstart.mdx
@@ -52,10 +52,6 @@ docker run -it --pull always --name hindsight --restart unless-stopped --shm-siz
 - **API**: http://localhost:8888
 - **Control Plane** (Web UI): http://localhost:9999
 
-:::note Shared memory for embedded PostgreSQL
-Docker allocates 64 MiB to `/dev/shm` by default. Hindsight's embedded PostgreSQL can exceed that limit while creating vector indexes, causing `could not resize shared memory segment ... No space left on device`. The quick start reserves 1 GiB as a safe baseline; actual requirements depend on the workload, index type, PostgreSQL settings, and parallelism. In Docker Compose, use `shm_size: 1gb` on the Hindsight service.
-:::
-
 :::tip Set a stable `HINDSIGHT_API_WORKER_ID` in production
 The worker uses the container hostname as its identity, which Docker sets to the container ID by default. That value changes on every restart, so any task that was being processed when the container went down stays parked under the old ID with no way for the new container to recognize it as its own.
 

--- a/hindsight-docs/versioned_docs/version-0.9/developer/installation.md
+++ b/hindsight-docs/versioned_docs/version-0.9/developer/installation.md
@@ -77,7 +77,7 @@ Run everything in one container with embedded PostgreSQL:
 ```bash
 export OPENAI_API_KEY=sk-xxx
 
-docker run -it --pull always --name hindsight --restart unless-stopped -p 8888:8888 -p 9999:9999 \
+docker run -it --pull always --name hindsight --restart unless-stopped --shm-size=1g -p 8888:8888 -p 9999:9999 \
   -e HINDSIGHT_API_LLM_API_KEY=$OPENAI_API_KEY \
   -v hindsight-data:/home/hindsight/.pg0 \
   ghcr.io/vectorize-io/hindsight:latest
@@ -85,6 +85,10 @@ docker run -it --pull always --name hindsight --restart unless-stopped -p 8888:8
 
 - **API Server**: http://localhost:8888
 - **Control Plane** (Web UI): http://localhost:9999
+
+:::note Shared memory for embedded PostgreSQL
+Docker allocates 64 MiB to `/dev/shm` by default. Hindsight's embedded PostgreSQL can exceed that limit while creating vector indexes, causing `could not resize shared memory segment ... No space left on device`. The quick start reserves 1 GiB as a safe baseline; actual requirements depend on the workload, index type, PostgreSQL settings, and parallelism. In Docker Compose, use `shm_size: 1gb` on the Hindsight service.
+:::
 
 :::note Persisting data: named volume vs. host bind mount
 The container runs as a non-root user (UID 1000). The `hindsight-data` **named volume** above is recommended — Docker creates it owned by the container user, so it works with no extra setup.

--- a/hindsight-docs/versioned_docs/version-0.9/developer/installation.md
+++ b/hindsight-docs/versioned_docs/version-0.9/developer/installation.md
@@ -86,10 +86,6 @@ docker run -it --pull always --name hindsight --restart unless-stopped --shm-siz
 - **API Server**: http://localhost:8888
 - **Control Plane** (Web UI): http://localhost:9999
 
-:::note Shared memory for embedded PostgreSQL
-Docker allocates 64 MiB to `/dev/shm` by default. Hindsight's embedded PostgreSQL can exceed that limit while creating vector indexes, causing `could not resize shared memory segment ... No space left on device`. The quick start reserves 1 GiB as a safe baseline; actual requirements depend on the workload, index type, PostgreSQL settings, and parallelism. In Docker Compose, use `shm_size: 1gb` on the Hindsight service.
-:::
-
 :::note Persisting data: named volume vs. host bind mount
 The container runs as a non-root user (UID 1000). The `hindsight-data` **named volume** above is recommended — Docker creates it owned by the container user, so it works with no extra setup.
 


### PR DESCRIPTION
## Summary

- reserve 1 GiB of `/dev/shm` in the documented single-container Docker quick starts
- keep the current and versioned 0.9 installation/quick-start pages aligned

## Why

Hindsight 0.9.2 attempted to allocate a 533,794,976-byte PostgreSQL shared-memory segment during bank index creation. Under Docker's default 64 MiB `/dev/shm`, that failed with `DiskFullError: could not resize shared memory segment ... No space left on device`. Recreating the container with 1 GiB shared memory resolved the failure and restored successful recall and reflect operations.

Closes #3895.

## Verification

- `docker run --help` confirms `--shm-size` is supported
- `npm run build --workspace hindsight-docs`
  - code parity passed for 457 docs files
  - integration and template checks passed
  - Docusaurus production build completed successfully
- `git diff --check`
