### PR TITLE
fix(templates): defer empty-bank auto-refreshes until consolidation

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -3161,6 +3161,7 @@ async def apply_bank_template_manifest(
             existing_by_name,
             request_context,
             config_applied=bool(config_updates),
+            defer_until_consolidation=False,
         )
 
 
@@ -3194,6 +3195,7 @@ async def apply_default_bank_template_resources(
         existing_by_name,
         request_context,
         config_applied=False,
+        defer_until_consolidation=True,
     )
 
 
@@ -3206,6 +3208,7 @@ async def _apply_bank_template_resources(
     request_context: "RequestContext",
     *,
     config_applied: bool,
+    defer_until_consolidation: bool,
 ) -> "BankTemplateImportResponse":
     """Apply template resources after the caller has handled config and access."""
     created_ids: list[str] = []
@@ -3214,6 +3217,11 @@ async def _apply_bank_template_resources(
 
     if manifest.mental_models:
         for mm in manifest.mental_models:
+            # Server defaults are installed before a new bank has memories. Auto-refreshing models can wait for the
+            # first consolidation instead of occupying an LLM slot with a reflect that cannot produce content (#3875).
+            enqueue_initial_refresh = not (
+                defer_until_consolidation and mm.trigger is not None and mm.trigger.refresh_after_consolidation
+            )
             if mm.id in existing_mental_models:
                 await memory.update_mental_model(
                     bank_id=bank_id,
@@ -3225,12 +3233,13 @@ async def _apply_bank_template_resources(
                     trigger=mm.trigger.model_dump() if mm.trigger else None,
                     request_context=request_context,
                 )
-                result = await memory.submit_async_refresh_mental_model(
-                    bank_id=bank_id,
-                    mental_model_id=mm.id,
-                    request_context=request_context,
-                )
-                operation_ids.append(result["operation_id"])
+                if enqueue_initial_refresh:
+                    result = await memory.submit_async_refresh_mental_model(
+                        bank_id=bank_id,
+                        mental_model_id=mm.id,
+                        request_context=request_context,
+                    )
+                    operation_ids.append(result["operation_id"])
                 updated_ids.append(mm.id)
             else:
                 mental_model = await memory.create_mental_model(
@@ -3244,12 +3253,13 @@ async def _apply_bank_template_resources(
                     trigger=mm.trigger.model_dump() if mm.trigger else None,
                     request_context=request_context,
                 )
-                result = await memory.submit_async_refresh_mental_model(
-                    bank_id=bank_id,
-                    mental_model_id=mental_model["id"],
-                    request_context=request_context,
-                )
-                operation_ids.append(result["operation_id"])
+                if enqueue_initial_refresh:
+                    result = await memory.submit_async_refresh_mental_model(
+                        bank_id=bank_id,
+                        mental_model_id=mental_model["id"],
+                        request_context=request_context,
+                    )
+                    operation_ids.append(result["operation_id"])
                 created_ids.append(mm.id)
 
     directives_created: list[str] = []

--- a/hindsight-api-slim/tests/test_bank_templates.py
+++ b/hindsight-api-slim/tests/test_bank_templates.py
@@ -1,13 +1,20 @@
 """Integration tests for bank template import/export endpoints."""
 
 from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
 import pytest_asyncio
 
 from hindsight_api.api import create_app
-from hindsight_api.api.http import BankTemplateManifest, validate_bank_template
+from hindsight_api.api.http import (
+    BankTemplateManifest,
+    apply_bank_template_manifest,
+    apply_default_bank_template_resources,
+    validate_bank_template,
+)
 from hindsight_api.models import RequestContext
 
 
@@ -632,6 +639,7 @@ class TestDefaultBankTemplateEnvVar:
                     "id": "default-env-model",
                     "name": "Default Env Model",
                     "source_query": "What is the default?",
+                    "trigger": {"refresh_after_consolidation": True},
                 },
             ],
             "directives": [
@@ -657,6 +665,94 @@ class TestDefaultBankTemplateEnvVar:
         raw = _get_raw_config()
         monkeypatch.setattr(raw, "default_bank_template", default_template)
         yield default_template
+
+    @pytest.mark.asyncio
+    async def test_default_template_resources_do_not_refresh_empty_bank(self, default_template):
+        """Default resources wait for the bank's first consolidation before refreshing."""
+        memory = SimpleNamespace(
+            list_mental_models=AsyncMock(return_value=SimpleNamespace(items=[])),
+            list_directives=AsyncMock(return_value=SimpleNamespace(items=[])),
+            create_mental_model=AsyncMock(return_value={"id": "default-env-model"}),
+            create_directive=AsyncMock(),
+            submit_async_refresh_mental_model=AsyncMock(return_value={"operation_id": "empty-bank-refresh"}),
+        )
+
+        await apply_default_bank_template_resources(
+            memory=memory,
+            bank_id="empty-bank",
+            manifest=BankTemplateManifest.model_validate(default_template),
+            request_context=RequestContext(),
+        )
+
+        memory.create_mental_model.assert_awaited_once()
+        memory.submit_async_refresh_mental_model.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_manual_default_template_keeps_initial_refresh(self):
+        """Manual default models still get their only automatic initialization opportunity."""
+        memory = SimpleNamespace(
+            list_mental_models=AsyncMock(return_value=SimpleNamespace(items=[])),
+            create_mental_model=AsyncMock(return_value={"id": "manual-model"}),
+            submit_async_refresh_mental_model=AsyncMock(return_value={"operation_id": "manual-refresh"}),
+        )
+        manifest = BankTemplateManifest.model_validate(
+            {
+                "version": "1",
+                "mental_models": [
+                    {
+                        "id": "manual-model",
+                        "name": "Manual Model",
+                        "source_query": "What should initialize once?",
+                    }
+                ],
+            }
+        )
+
+        await apply_default_bank_template_resources(
+            memory=memory,
+            bank_id="empty-bank",
+            manifest=manifest,
+            request_context=RequestContext(),
+        )
+
+        memory.submit_async_refresh_mental_model.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_client_template_import_still_refreshes_mental_models(self):
+        """Client-requested imports preserve their immediate refresh behavior."""
+        authorization = MagicMock()
+        authorization.__aenter__ = AsyncMock(return_value=None)
+        authorization.__aexit__ = AsyncMock(return_value=None)
+        memory = SimpleNamespace(
+            get_bank_profile=AsyncMock(return_value={"bank_id": "existing-bank"}),
+            list_mental_models=AsyncMock(return_value=SimpleNamespace(items=[])),
+            bank_template_import_authorization=MagicMock(return_value=authorization),
+            create_mental_model=AsyncMock(return_value={"id": "client-model"}),
+            submit_async_refresh_mental_model=AsyncMock(return_value={"operation_id": "client-refresh"}),
+        )
+        manifest = BankTemplateManifest.model_validate(
+            {
+                "version": "1",
+                "mental_models": [
+                    {
+                        "id": "client-model",
+                        "name": "Client Model",
+                        "source_query": "What did the client request?",
+                        "trigger": {"refresh_after_consolidation": True},
+                    }
+                ],
+            }
+        )
+
+        response = await apply_bank_template_manifest(
+            memory=memory,
+            bank_id="existing-bank",
+            manifest=manifest,
+            request_context=RequestContext(),
+        )
+
+        memory.submit_async_refresh_mental_model.assert_awaited_once()
+        assert response.operation_ids == ["client-refresh"]
 
     @pytest.mark.asyncio
     async def test_default_template_applied_on_new_bank(self, api_client, bank_id, _patched_default_template):


### PR DESCRIPTION
## Summary

- defer the initial refresh for server-default mental models configured to refresh after consolidation
- preserve immediate refresh behavior for client imports and manual default mental models
- add regression coverage for all three scheduling paths

## Why

Server default templates are applied while freshly created banks have no memories. Enqueueing their auto-refreshing mental models at that point starts reflect operations that cannot produce content and can consume LLM worker slots ahead of the retain operations that would seed the bank.

The first consolidation already schedules these models once content exists. Manual default mental models without an automatic consolidation trigger retain their initial refresh so they do not remain at the placeholder indefinitely.

Fixes #3875

## Verification

- targeted bank-template regression tests — 3 passed
- `uv run ruff check hindsight_api/api/http.py tests/test_bank_templates.py`
- `uv run ruff format --check hindsight_api/api/http.py tests/test_bank_templates.py`
- `uv run ty check hindsight_api/api/http.py`
