### PR TITLE
fix(search): delegate pgroonga query tokenization to pgroonga_tokenize

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
@@ -100,13 +100,20 @@ def knowledge_bm25_arm(
         # pgroonga_score() only returns a real score off a pgroonga index scan and
         # silently reads 0 for every row otherwise, so the id tiebreak keeps the
         # arm's ordering deterministic if the planner ever picks another plan.
-        # pgroonga_query_escape neutralises operator characters in user text.
+        # Tokenize with pgroonga_tokenize (TokenBigram + NormalizerNFKC150) and join
+        # with disjunctive OR. Joining with OR aligns candidate recall with native
+        # tsvector's '|' recall strategy; precision is restored downstream via BM25
+        # ranking, RRF fusion, and Cross-Encoder reranking.
         score = f"pgroonga_score({a}.tableoid, {a}.ctid)"
         document = mental_models_text_document(a)
+        query_expr = (
+            f"(SELECT string_agg(pgroonga_query_escape(elem->>'value'), ' OR ') "
+            f"FROM unnest(pgroonga_tokenize({p}, 'tokenizer', 'TokenBigram', 'normalizer', 'NormalizerNFKC150')) AS elem)"
+        )
         return KnowledgeBm25Arm(
             score_expr=score,
             order_by=f"{score} DESC, {a}.id",
-            match_filter=f"AND {document} &@~ pgroonga_query_escape({p})",
+            match_filter=f"AND {document} &@~ {query_expr}",
         )
 
     # native: generated tsvector over name + content.
@@ -312,14 +319,22 @@ class PostgreSQLDialect(SQLDialect):
             bm25_order_by = f"text <@> to_bm25query({text_param}, 'idx_memory_units_text_search') ASC"
             bm25_where_filter = ""
         elif text_search_extension == "pgroonga":
-            # &@~ accepts pgroonga's query syntax. Escape the bind parameter so
-            # literal memory text containing operators like ">" or "(" is not
-            # parsed as a malformed query expression.
+            # &@~ accepts pgroonga's query syntax. Tokenize the raw query with
+            # pgroonga_tokenize using TokenBigram + NormalizerNFKC150 (the same
+            # configuration as the index DDL) and aggregate tokens with disjunctive OR.
+            # Joining with OR aligns PGroonga with native tsvector's '|' candidate
+            # generation strategy (broadening recall across all scripts); precision
+            # is restored downstream via BM25 score ranking, multi-arm RRF fusion,
+            # and Cross-Encoder reranking.
             bm25_score_expr = "pgroonga_score(tableoid, ctid)"
             bm25_order_by = f"{bm25_score_expr} DESC"
+            query_expr = (
+                f"(SELECT string_agg(pgroonga_query_escape(elem->>'value'), ' OR ') "
+                f"FROM unnest(pgroonga_tokenize({text_param}, 'tokenizer', 'TokenBigram', 'normalizer', 'NormalizerNFKC150')) AS elem)"
+            )
             bm25_where_filter = (
                 f"AND (COALESCE(text, '') || ' ' || COALESCE(context, '') || ' ' || COALESCE(text_signals, '')) "
-                f"&@~ pgroonga_query_escape({text_param})"
+                f"&@~ {query_expr}"
             )
         elif text_search_extension == "pg_search":
             # ParadeDB pg_search: BM25 index over (id, text, context, text_signals)
@@ -366,7 +381,7 @@ class PostgreSQLDialect(SQLDialect):
         text_search_extension: str = "native",
         max_query_terms: int | None = None,
     ) -> str:
-        if text_search_extension in ("vchord", "pg_textsearch", "pgroonga", "pg_search"):
+        if text_search_extension in ("vchord", "pg_textsearch", "pg_search", "pgroonga"):
             return query_text
         if max_query_terms is not None and max_query_terms > 0:
             tokens = tokens[:max_query_terms]

--- a/hindsight-api-slim/tests/test_db_abstraction.py
+++ b/hindsight-api-slim/tests/test_db_abstraction.py
@@ -312,11 +312,10 @@ class TestPostgreSQLDialect:
             text_param="$4",
             text_search_extension="pgroonga",
         )
-        # pgroonga uses the &@~ operator + pgroonga_score for ranking. Escape
-        # the query parameter so literal text containing pgroonga operators is
-        # not parsed as query syntax.
-        assert "&@~ pgroonga_query_escape($4)" in arm
-        assert "&@~ $4" not in arm
+        # pgroonga uses the &@~ operator + pgroonga_score for ranking with inline
+        # pgroonga_tokenize aggregation.
+        assert "&@~ (SELECT string_agg(pgroonga_query_escape(elem->>'value'), ' OR ')" in arm
+        assert "pgroonga_tokenize($4, 'tokenizer', 'TokenBigram', 'normalizer', 'NormalizerNFKC150')" in arm
         assert "pgroonga_score(tableoid, ctid)" in arm
         assert "to_tsquery" not in arm
 
@@ -364,10 +363,11 @@ class TestPostgreSQLDialect:
         assert result == "hello world"
 
     def test_prepare_bm25_text_pgroonga(self, d):
-        # Keep the user's text unchanged here; the SQL builder escapes the bind
-        # parameter at query time before invoking pgroonga's query parser.
         result = d.prepare_bm25_text(["hello", "world"], "hello world", text_search_extension="pgroonga")
         assert result == "hello world"
+
+        result = d.prepare_bm25_text(["网关计划任务"], "网关计划任务", text_search_extension="pgroonga")
+        assert result == "网关计划任务"
 
     def test_prepare_bm25_text_pg_search(self, d):
         result = d.prepare_bm25_text(["hello", "world"], "hello world", text_search_extension="pg_search")

--- a/hindsight-api-slim/tests/test_knowledge_bm25_dispatch.py
+++ b/hindsight-api-slim/tests/test_knowledge_bm25_dispatch.py
@@ -36,7 +36,8 @@ def test_native_uses_tsvector_operators():
 def test_pgroonga_uses_multilingual_expression_index():
     arm = _arm("pgroonga")
     assert arm.score_expr == "pgroonga_score(mm.tableoid, mm.ctid)"
-    assert arm.match_filter == "AND (COALESCE(mm.name, '') || ' ' || mm.content) &@~ pgroonga_query_escape($3)"
+    assert "pgroonga_tokenize($3, 'tokenizer', 'TokenBigram', 'normalizer', 'NormalizerNFKC150')" in arm.match_filter
+    assert "string_agg(pgroonga_query_escape(elem->>'value'), ' OR ')" in arm.match_filter
     # pgroonga_score() reads 0 off any plan that did not use the pgroonga index,
     # so the ordering carries a tiebreak instead of collapsing to input order.
     assert arm.order_by == "pgroonga_score(mm.tableoid, mm.ctid) DESC, mm.id"

--- a/hindsight-api-slim/tests/test_multilingual_bm25.py
+++ b/hindsight-api-slim/tests/test_multilingual_bm25.py
@@ -227,9 +227,24 @@ def test_postgresql_extension_bm25_keeps_raw_query_text():
     query = "Alpha beta alpha, gamma delta beta epsilon"
     tokens = tokenize_query(query)
 
-    assert (
-        PostgreSQLDialect().prepare_bm25_text(tokens, query, text_search_extension="vchord", max_query_terms=3) == query
+    for ext in ("vchord", "pg_search", "pg_textsearch", "pgroonga"):
+        assert (
+            PostgreSQLDialect().prepare_bm25_text(tokens, query, text_search_extension=ext, max_query_terms=3) == query
+        )
+
+
+def test_postgresql_pgroonga_bm25_arm_uses_pgroonga_tokenize():
+    arm = PostgreSQLDialect().build_bm25_arm(
+        table="memory_units",
+        cols="id, text",
+        fact_type="world",
+        bank_id_param="$2",
+        limit_param="$3",
+        text_param="$4",
+        text_search_extension="pgroonga",
     )
+    assert "pgroonga_tokenize($4, 'tokenizer', 'TokenBigram', 'normalizer', 'NormalizerNFKC150')" in arm
+    assert "string_agg(pgroonga_query_escape(elem->>'value'), ' OR ')" in arm
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #3892.

When using `HINDSIGHT_API_TEXT_SEARCH_EXTENSION=pgroonga` (`TokenBigram` + `NormalizerNFKC150`), natural-language Han/Kana/Hangul queries (CJK, Japanese, Korean) returned **0 BM25 hits** because PGroonga's `&@~` operator parsed unsegmented query strings as a single exact contiguous phrase.

This PR delegates PGroonga query-side tokenization directly to database-level `pgroonga_tokenize()` with `TokenBigram` and `NormalizerNFKC150` in SQL, aggregating generated tokens into disjunctive `OR` expressions.

---

## Architecture & Data Flow

```mermaid
flowchart LR
    subgraph BEFORE["❌ BEFORE (0 Recall Bug)"]
        direction TB
        Q1["User Query: 网关计划任务被安全软件删除"] --> P1["prepare_bm25_text / search_knowledge_pages"]
        P1 -->|"Raw query passthrough"| S1["PGroonga SQL (&@~)"]
        S1 -->|"Parsed as single exact contiguous phrase"| R1["0 BM25 Hits<br/>(Silent degradation to vector-only recall)"]
    end

    subgraph AFTER["✅ AFTER (Database-Level Delegation)"]
        direction TB
        Q2["User Query: 网关计划任务被安全软件删除"] --> P2["prepare_bm25_text / search_knowledge_pages"]
        P2 -->|"Verbatim passthrough ($3)"| S2["PostgreSQL InitPlan 1 (~0.03ms):<br/>pgroonga_tokenize($3, 'TokenBigram', 'NormalizerNFKC150')"]
        S2 -->|"string_agg with OR"| T2["'网关 OR 关计 OR 计划 OR 划任 OR 任务 OR 务被 OR ... OR 删除'"]
        T2 -->|"Disjunctive &@~ query"| R2["PGroonga Inverted Index Scan (~0.5ms)<br/>Full CJK BM25 Candidate Recall -> Fused via RRF"]
    end

    BEFORE ~~~ AFTER
```

---

## Query Matching Behavior (Before vs After)

| Category | Example Query | Before (`&@~ raw`) | After (`pgroonga_tokenize`) |
|---|---|---|---|
| **CJK Sentence** | `网关计划任务被删除` | Exact substring (0 hits) | `网关 OR 关计 OR 计划 OR 划任 OR 任务 OR 务被 OR 被删 OR 删除` |
| **Short Entity** | `镁钾片` | Exact phrase (`镁钾片`) | Bigrams (`镁钾 OR 钾片`) |
| **Mixed Query** | `pgroonga 性能测试` | `pgroonga` AND phrase | `pgroonga OR 性能 OR 能测 OR 测试` |
| **Latin / Cyrillic** | `café résumé` | `café` AND `résumé` | Whole words (`café OR résumé`) |

---

## Key Benefits & Technical Decisions

1. **100% Tokenizer & Normalizer Parity**:
   - Query tokenization is executed directly by Groonga's native C engine using the exact same `TokenBigram` and `NormalizerNFKC150` modules configured on the index DDL.
   - Script-specific character classification (Han/Kana/Hangul 2-grams vs Latin/Cyrillic/Greek whole words) and Unicode normalization (NFKC, half-width katakana, full-width ASCII) are handled symmetrically.
   - Eliminates the need to maintain Unicode regular expressions in Python.

2. **Passthrough Consistency Across Extension Backends**:
   - `prepare_bm25_text()` and `search_knowledge_pages()` treat `pgroonga` identically to `vchord`, `pg_search`, and `pg_textsearch` (passing the raw query string directly to SQL).

3. **Alignment with Disjunctive Recall Strategy**:
   - In PGroonga's default `&@~` syntax, space-separated keywords are evaluated as conjunctive `AND` (e.g. `"hello world"` -> `hello AND world`).
   - Aggregating with ` OR ` explicitly aligns PGroonga with Hindsight's native `tsvector` recall strategy (`" | ".join(tokens)`), broadening candidate generation across all scripts.
   - In Hindsight's multi-arm retrieval architecture, candidate recall prioritizes broad coverage; precision is restored downstream by BM25 score ranking, RRF fusion across vector and graph arms, and Cross-Encoder reranking.

4. **Execution Plan & Index Scan Efficiency**:
   - PostgreSQL evaluates the tokenization subquery once as an `InitPlan` (~0.03 ms) and executes an `Index Scan` over the PGroonga index:
     ```
     Bitmap Heap Scan on memory_units (actual time=0.559..0.562 rows=3)
       Recheck Cond: ... &@~ $0
       InitPlan 1 (returns $0)
         -> Aggregate (actual time=0.029..0.030 rows=1)
              -> Function Scan on elem (actual time=0.015..0.017 rows=12)
       -> Bitmap Index Scan on idx_mem_search (actual time=0.527 rows=3)
     ```

---

## Changes by Component

- `hindsight_api/engine/sql/postgresql.py`:
  - `build_bm25_arm`: Update `pgroonga` branch to construct inline `pgroonga_tokenize` aggregation with `&@~`.
  - `knowledge_bm25_arm`: Update `pgroonga` branch to use the same inline tokenization subquery.

---

## Tests

- `tests/test_db_abstraction.py`:
  - `test_build_bm25_arm_pgroonga`: Asserts SQL contains `pgroonga_tokenize` and `string_agg(..., ' OR ')`.
- `tests/test_knowledge_bm25_dispatch.py`:
  - `test_pgroonga_uses_multilingual_expression_index`: Asserts knowledge BM25 SQL uses `pgroonga_tokenize`.
- `tests/test_multilingual_bm25.py`:
  - `test_postgresql_extension_bm25_keeps_raw_query_text`: Asserts all 4 extension backends pass raw query.
  - `test_postgresql_pgroonga_bm25_arm_uses_pgroonga_tokenize`: Asserts recall BM25 arm builds `pgroonga_tokenize`.
