### PR TITLE
fix(retain): strip NUL from retain items instead of 500ing on the jsonb insert

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -632,6 +632,23 @@ class EntityInput(BaseModel):
     type: str | None = Field(default=None, description="Optional entity type (e.g., 'PERSON', 'ORG', 'CONCEPT')")
 
 
+def _strip_nul(value):
+    """Recursively remove NUL (U+0000) from strings, keys included.
+
+    PostgreSQL rejects U+0000 in both ``text`` and ``jsonb``, so it can never
+    reach storage; see ``MemoryItem.strip_nul_characters``.
+    """
+    if isinstance(value, str):
+        return value.replace("\x00", "") if "\x00" in value else value
+    if isinstance(value, dict):
+        return {_strip_nul(k): _strip_nul(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_strip_nul(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_strip_nul(v) for v in value)
+    return value
+
+
 class MemoryItem(BaseModel):
     """Single memory item for retain."""
 
@@ -685,6 +702,25 @@ class MemoryItem(BaseModel):
         default=None,
         description="Optional tags for visibility scoping. Memories with tags can be filtered during recall.",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def strip_nul_characters(cls, data):
+        """Drop NUL (U+0000) from every string in the item.
+
+        PostgreSQL cannot store U+0000 in ``text`` or ``jsonb``. An async retain
+        writes the whole item into ``async_operations.task_payload::jsonb``, so a
+        single NUL anywhere — content, context, metadata, a tag — aborts that
+        INSERT with ``UntranslatableCharacterError``. The request then fails with
+        a 500 and the memory is never queued, while the caller retries the same
+        payload forever. JSON permits ``\\u0000``, so clients legitimately send
+        it: text scraped from PDFs, log captures and chat exports all carry it.
+
+        Stripping is preferred over rejecting: the NUL is never meaningful
+        content — it is transport residue — and a 400 would lose the memory just
+        as completely as the 500 does today.
+        """
+        return _strip_nul(data)
 
     @field_validator("content")
     @classmethod

--- a/hindsight-api-slim/tests/test_retain.py
+++ b/hindsight-api-slim/tests/test_retain.py
@@ -3011,6 +3011,54 @@ def test_retain_request_per_item_strategy_field():
     logger.info("✓ per-item strategy grouping works correctly")
 
 
+def test_retain_request_strips_nul_characters():
+    """
+    Unit test: NUL (U+0000) is stripped from every string in an item.
+
+    PostgreSQL stores U+0000 in neither text nor jsonb, so an async retain
+    carrying one aborts the async_operations INSERT with
+    UntranslatableCharacterError — the request 500s and the memory is dropped.
+    JSON allows \\u0000, so clients do send it (PDF scrapes, log captures, chat
+    exports).
+    """
+    from hindsight_api.api.http import RetainRequest
+
+    request = RetainRequest.model_validate(
+        {
+            "items": [
+                {
+                    "content": "Alice\u0000 joined.",
+                    "context": "team\u0000 meeting",
+                    "document_id": "doc\u00001",
+                    "metadata": {"so\u0000urce": "sl\u0000ack", "nested": ["a\u0000b"]},
+                    "tags": ["te\u0000am"],
+                }
+            ],
+        }
+    )
+
+    item = request.items[0]
+    assert item.content == "Alice joined."
+    assert item.context == "team meeting"
+    assert item.document_id == "doc1"
+    assert item.metadata == {"source": "slack", "nested": ["ab"]}
+    assert item.tags == ["team"]
+
+    # Nothing anywhere in the item may still carry a NUL, since the whole item
+    # is what gets serialised into task_payload::jsonb.
+    assert "\u0000" not in json.dumps(item.model_dump(), default=str)
+    logger.info("✓ NUL stripped from content, context, document_id, metadata and tags")
+
+
+def test_retain_request_preserves_non_nul_text():
+    """Unit test: only U+0000 is removed — other unicode survives untouched."""
+    from hindsight_api.api.http import RetainRequest
+
+    text = "Über — naïve 🙂 \t newline\n kept"
+    request = RetainRequest.model_validate({"items": [{"content": text}]})
+    assert request.items[0].content == text
+
+
 @pytest.mark.asyncio
 async def test_named_strategy_applied_end_to_end(memory, request_context):
     """


### PR DESCRIPTION
## Problem

PostgreSQL cannot store `U+0000` in `text` or `jsonb`. `submit_async_retain` writes the whole retain item into `async_operations.task_payload::jsonb`, so one NUL anywhere in the payload aborts that INSERT:

```
asyncpg.exceptions.UntranslatableCharacterError: unsupported Unicode escape sequence
DETAIL:  \^@ cannot be converted to text.
```

The request returns HTTP 500 and the memory is never queued. The failure is deterministic for that payload, so a retrying client re-sends it forever and never stores it.

JSON permits `\^@`, so clients legitimately send it — text scraped from PDFs, log captures and chat exports all carry stray NULs.

## Reproduction (0.9.2)

```
POST /v1/default/banks/<bank>/memories
{"items":[{"content":"hello \^@ world","document_id":"x"}], "async": true}

-> HTTP 500  unsupported Unicode escape sequence
```

A NUL in `metadata` fails identically. The same payload with `"async": false` succeeds, and without the NUL both succeed — so only batched/async ingestion is affected, which makes this easy to miss: the payloads that carry a NUL are dropped while everything else keeps succeeding, so a bank shows gaps in its history rather than an outage, and nothing surfaces but 500s in the API log.

## Fix

A `MemoryItem` validator (`mode="before"`) strips `U+0000` from every string in the item — content, context, document_id, metadata (keys and nested values), tags. This covers the sync and async paths and any future consumer of the model.

Stripping rather than returning 400: the NUL is never meaningful content — it is transport residue — and a 400 would lose the memory just as completely as the 500 does today.

## Tests

- `test_retain_request_strips_nul_characters` — NUL removed from every field including nested metadata and dict keys, and asserted absent from the serialized item.
- `test_retain_request_preserves_non_nul_text` — other unicode (accents, em dash, emoji, tabs, newlines) passes through byte-for-byte.

